### PR TITLE
Include Python dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ make
 ls ./models
 65B 30B 13B 7B tokenizer_checklist.chk tokenizer.model
 
+# install Python dependencies
+python3 -m pip install torch numpy sentencepiece
+
 # convert the 7B model to ggml FP16 format
 python3 convert-pth-to-ggml.py models/7B/ 1
 


### PR DESCRIPTION
Should maybe note that you need Python 3.10 - because there's no `torch` wheel yet for Python 3.11.