### PR TITLE
use weights_only in conversion script to prevent model arbitrary code execution

### DIFF
--- a/convert-pth-to-ggml.py
+++ b/convert-pth-to-ggml.py
@@ -86,7 +86,7 @@ for p in range(n_parts):
     if (p > 0):
         fname_out = sys.argv[1] + "/ggml-model-" + ftype_str[ftype] + ".bin" + "." + str(p)
 
-    model = torch.load(fname_model, map_location="cpu")
+    model = torch.load(fname_model, map_location="cpu", weights_only=True)
 
     fout = open(fname_out, "wb")
 


### PR DESCRIPTION
this restricts malicious weights from executing arbitrary code by restricting the unpickler to only loading tensors, primitive types, and dictionaries.

see torch.load docs

https://pytorch.org/docs/stable/generated/torch.load.html

i tested this and it seems to work the same as before