### PR TITLE
Reduce model loading time

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -73,11 +73,10 @@ struct llama_model {
 bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab & vocab, int n_ctx) {
     printf("%s: loading model from '%s' - please wait ...\n", __func__, fname.c_str());
 
-    const size_t f_buf_size = 1024*1024;
-    std::vector<char> f_buf(f_buf_size);
+    std::vector<char> f_buf(1024*1024);
 
     auto fin = std::ifstream(fname, std::ios::binary);
-    fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf_size);
+    fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf.size());
     if (!fin) {
         fprintf(stderr, "%s: failed to open '%s'\n", __func__, fname.c_str());
         return false;
@@ -315,7 +314,7 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
         printf("%s: loading model part %d/%d from '%s'\n", __func__, i+1, n_parts, fname_part.c_str());
 
         fin = std::ifstream(fname_part, std::ios::binary);
-        fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf_size);
+        fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf.size());
         fin.seekg(file_offset);
 
         // load weights

--- a/main.cpp
+++ b/main.cpp
@@ -74,10 +74,10 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
     printf("%s: loading model from '%s' - please wait ...\n", __func__, fname.c_str());
 
     const size_t f_buf_size = 1024*1024;
-    char *f_buf = (char *)malloc(f_buf_size);
+    std::vector<char> f_buf(f_buf_size);
 
     auto fin = std::ifstream(fname, std::ios::binary);
-    fin.rdbuf()->pubsetbuf(f_buf, f_buf_size);
+    fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf_size);
     if (!fin) {
         fprintf(stderr, "%s: failed to open '%s'\n", __func__, fname.c_str());
         return false;
@@ -315,7 +315,7 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
         printf("%s: loading model part %d/%d from '%s'\n", __func__, i+1, n_parts, fname_part.c_str());
 
         fin = std::ifstream(fname_part, std::ios::binary);
-        fin.rdbuf()->pubsetbuf(f_buf, f_buf_size);
+        fin.rdbuf()->pubsetbuf(f_buf.data(), f_buf_size);
         fin.seekg(file_offset);
 
         // load weights
@@ -500,8 +500,6 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
 
         fin.close();
     }
-
-    free(f_buf);
 
     return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,11 @@ struct llama_model {
 bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab & vocab, int n_ctx) {
     printf("%s: loading model from '%s' - please wait ...\n", __func__, fname.c_str());
 
+    const size_t f_buf_size = 1024*1024;
+    char *f_buf = (char *)malloc(f_buf_size);
+
     auto fin = std::ifstream(fname, std::ios::binary);
+    fin.rdbuf()->pubsetbuf(f_buf, f_buf_size);
     if (!fin) {
         fprintf(stderr, "%s: failed to open '%s'\n", __func__, fname.c_str());
         return false;
@@ -311,6 +315,7 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
         printf("%s: loading model part %d/%d from '%s'\n", __func__, i+1, n_parts, fname_part.c_str());
 
         fin = std::ifstream(fname_part, std::ios::binary);
+        fin.rdbuf()->pubsetbuf(f_buf, f_buf_size);
         fin.seekg(file_offset);
 
         // load weights
@@ -495,6 +500,8 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
 
         fin.close();
     }
+
+    free(f_buf);
 
     return true;
 }


### PR DESCRIPTION
Hello!

I noticed that the model loader is not using buffered IO, so I added a piece of code for buffering.
I measured the loading time only for llama 7B on my M1 Pro Macbook, but it reduced the time from 1316ms to 749ms.
