### PR TITLE
Add osx-specific python install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ make
 ls ./models
 65B 30B 13B 7B tokenizer_checklist.chk tokenizer.model
 
+# install Python (osx)
+brew install pyenv
+pyenv install 3.10.10
+pyenv local 3.10.10
+
 # install Python dependencies
 # preferred versions: python 3.10 (not 3.11), torch 1.13.1+
 python3 -m pip install torch numpy sentencepiece


### PR DESCRIPTION
The existing instructions won't work on the default osx 12.4 setup using the system python install. This fixes that.