### PR TITLE
fix: add POSIX functionality for Linux compilation

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1,4 +1,6 @@
-#define _POSIX_C_SOURCE 200809L
+// Defines CLOCK_MONOTONIC on Linux
+#define _POSIX_C_SOURCE 199309L
+
 #include "ggml.h"
 
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/ggml.c
+++ b/ggml.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include "ggml.h"
 
 #if defined(_MSC_VER) || defined(__MINGW32__)


### PR DESCRIPTION
Small fix to compile binaries properly on Linux: 
- defines `CLOCK_MONOTONIC` in `ggml.c`
- Closes #54 