### PR TITLE
Add interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,29 @@ The number of files generated for each model is as follows:
 
 When running the larger models, make sure you have enough disk space to store all the intermediate files.
 
+### Interactive mode
+
+If you want a more ChatGPT-like experience, you can run in interactive mode by passing `-i` as a parameter.
+In this mode, you can always interrupt generation by pressing Ctrl+C and enter one or more lines of text which will be converted into tokens and appended to the current context. You can also specify a *reverse prompt* with the parameter `-r "reverse prompt string"`. This will result in user input being prompted whenever the exact tokens of the reverse prompt string are encountered in the generation. A typical use is to use a prompt which makes LLaMa emulate a chat between multiple users, say Alice and Bob, and pass `-r "Alice:"`.
+
+Here is an example few-shot interaction, invoked with the command
+```
+./main -m ./models/13B/ggml-model-q4_0.bin -t 8 --repeat_penalty 1.2 --temp 0.9 --top_p 0.9 -n 256 \
+                                           --color -i -r "User:" \
+                                           -p \
+"Transcript of a dialog, where the User interacts with an Assistant named Bob. Bob is helpful, kind, honest, good at writing, and never fails to answer the User's requests immediately and with precision.
+
+User: Hello, Bob.
+Bob: Hello. How may I help you today?
+User: Please tell me the largest city in Europe.
+Bob: Sure. The largest city in Europe is London, the capital of the United Kingdom.
+User:"
+```
+Note the use of `--color` to distinguish between user input and generated text.
+
+![image](https://user-images.githubusercontent.com/401380/224572787-d418782f-47b2-49c4-a04e-65bfa7ad4ec0.png)
+
+
 ## Limitations
 
 - Not sure if my tokenizer is correct. There are a few places where we might have a mistake:

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,9 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include <signal.h>
+#include <unistd.h>
 
 #define ANSI_COLOR_RED     "\x1b[31m"
 #define ANSI_COLOR_GREEN   "\x1b[32m"
@@ -955,7 +957,7 @@ int main(int argc, char ** argv) {
                 bool another_line=true;
                 while (another_line) {
                     char buf[256] = {0};
-                    size_t n_read;
+                    int n_read;
                     if(params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
                     scanf("%255[^\n]%n%*c", buf, &n_read);
                     if(params.use_color) printf(ANSI_COLOR_RESET);

--- a/utils.cpp
+++ b/utils.cpp
@@ -51,6 +51,11 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.model = argv[++i];
         } else if (arg == "-i" || arg == "--interactive") {
             params.interactive = true;
+        } else if (arg == "--interactive-start") {
+            params.interactive = true;
+            params.interactive_start = true;
+        } else if (arg == "--color") {
+            params.use_color = true;
         } else if (arg == "-r" || arg == "--reverse-prompt") {
             params.antiprompt = argv[++i];
         } else if (arg == "-h" || arg == "--help") {
@@ -72,6 +77,10 @@ void gpt_print_usage(int argc, char ** argv, const gpt_params & params) {
     fprintf(stderr, "options:\n");
     fprintf(stderr, "  -h, --help            show this help message and exit\n");
     fprintf(stderr, "  -i, --interactive     run in interactive mode\n");
+    fprintf(stderr, "  --interactive-start   run in interactive mode and poll user input at startup\n");
+    fprintf(stderr, "  -r PROMPT, --reverse-prompt PROMPT\n");
+    fprintf(stderr, "                        in interactive mode, poll user input upon seeing PROMPT\n");
+    fprintf(stderr, "  --color               colorise output to distinguish prompt and user input from generations\n");
     fprintf(stderr, "  -s SEED, --seed SEED  RNG seed (default: -1)\n");
     fprintf(stderr, "  -t N, --threads N     number of threads to use during computation (default: %d)\n", params.n_threads);
     fprintf(stderr, "  -p PROMPT, --prompt PROMPT\n");

--- a/utils.cpp
+++ b/utils.cpp
@@ -49,6 +49,10 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.n_batch = std::stoi(argv[++i]);
         } else if (arg == "-m" || arg == "--model") {
             params.model = argv[++i];
+        } else if (arg == "-i" || arg == "--interactive") {
+            params.interactive = true;
+        } else if (arg == "-r" || arg == "--reverse-prompt") {
+            params.antiprompt = argv[++i];
         } else if (arg == "-h" || arg == "--help") {
             gpt_print_usage(argc, argv, params);
             exit(0);
@@ -67,6 +71,7 @@ void gpt_print_usage(int argc, char ** argv, const gpt_params & params) {
     fprintf(stderr, "\n");
     fprintf(stderr, "options:\n");
     fprintf(stderr, "  -h, --help            show this help message and exit\n");
+    fprintf(stderr, "  -i, --interactive     run in interactive mode\n");
     fprintf(stderr, "  -s SEED, --seed SEED  RNG seed (default: -1)\n");
     fprintf(stderr, "  -t N, --threads N     number of threads to use during computation (default: %d)\n", params.n_threads);
     fprintf(stderr, "  -p PROMPT, --prompt PROMPT\n");

--- a/utils.h
+++ b/utils.h
@@ -29,8 +29,11 @@ struct gpt_params {
     std::string model = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt;
 
+    bool use_color = false; // use color to distinguish generations and inputs
+
     bool interactive = false; // interactive mode
-    std::string antiprompt = "User: "; // string upon seeing which more user input is prompted
+    bool interactive_start = false; // reverse prompt immediately
+    std::string antiprompt = ""; // string upon seeing which more user input is prompted
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/utils.h
+++ b/utils.h
@@ -28,6 +28,9 @@ struct gpt_params {
 
     std::string model = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt;
+
+    bool interactive = false; // interactive mode
+    std::string antiprompt = "User: "; // string upon seeing which more user input is prompted
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);


### PR DESCRIPTION
Add support for an interactive mode, where the user can interject to add more tokens to the context after generation started. (#23)

Features:

* Start accepting user input with Ctrl+C or upon encountering a designated "reverse prompt" string in the generation.
* Rudimentary optional ANSI color support to better distinguish user input from generated text.