### PR TITLE
Misc: Make the conversion script executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ls ./models
 python3 -m pip install torch numpy sentencepiece
 
 # convert the 7B model to ggml FP16 format
-python3 convert-pth-to-ggml.py models/7B/ 1
+./convert-pth-to-ggml.py models/7B/ 1
 
 # quantize the model to 4-bits
 ./quantize ./models/7B/ggml-model-f16.bin ./models/7B/ggml-model-q4_0.bin 2

--- a/convert-pth-to-ggml.py
+++ b/convert-pth-to-ggml.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Convert a LLaMA model checkpoint to a ggml compatible file
 #
 # Load the model using Torch


### PR DESCRIPTION
Not much, but has some benefits,
  - Shorter commands.
  - Help actual executable files to stand out.