### PR TITLE
Truncate prompt if longer than context + n_predict

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -782,8 +782,10 @@ int main(int argc, char ** argv) {
 
     // tokenize the prompt
     std::vector<gpt_vocab::id> embd_inp = ::llama_tokenize(vocab, params.prompt, true);
-
-    params.n_predict = std::min(params.n_predict, model.hparams.n_ctx - (int) embd_inp.size());
+    if (embd_inp.size() + params.n_predict > model.hparams.n_ctx) {
+        int offset = embd_inp.size() - model.hparams.n_ctx + params.n_predict;
+        embd_inp = std::vector<gpt_vocab::id>(embd_inp.begin() + offset, embd_inp.end());
+    }
 
     printf("\n");
     printf("%s: prompt: '%s'\n", __func__, params.prompt.c_str());


### PR DESCRIPTION
I think this is an improvement over the current behavior of outputting nothing at all when the prompt is too long. It's slightly ugly to see the truncated prompt in the terminal, but it is helpful to see exactly what was included in the prompt so you can tell what was truncated.

Maybe there's a better solution, IDK, just throwing a PR your way.