### PR TITLE
Fix UTF-8 handling (including colors)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -931,16 +931,17 @@ int main(int argc, char ** argv) {
                     break;
                 }
             }
+
+            // reset color to default if we there is no pending user input
+            if (!input_noecho && params.use_color && embd_inp.size() == input_consumed) {
+                printf(ANSI_COLOR_RESET);
+            }
         }
 
         // display text
         if (!input_noecho) {
             for (auto id : embd) {
                 printf("%s", vocab.id_to_token[id].c_str());
-            }
-            // reset color to default if we there is no pending user input
-            if (params.use_color && embd_inp.size() <= input_consumed) {
-                printf(ANSI_COLOR_RESET);
             }
             fflush(stdout);
         }


### PR DESCRIPTION
Fixes #11 (including color handling). Largely based on #73 (props to @j-f1), but doesn't pull any additional dependencies.

Sample output from 13B model with default parameters:

```
main: prompt: '关于爱因斯坦的生平。他出生于'
main: number of tokens in prompt = 19
     1 -> ''
 31057 -> '关'
 30909 -> '于'
   234 -> '�'
   139 -> '�'
   180 -> '�'
 31570 -> '因'
 31824 -> '斯'
   232 -> '�'
   160 -> '�'
   169 -> '�'
 30210 -> '的'
 30486 -> '生'
 30606 -> '平'
 30267 -> '。'
 31221 -> '他'
 30544 -> '出'
 30486 -> '生'
 30909 -> '于'

sampling parameters: temp = 0.800000, top_k = 40, top_p = 0.950000, repeat_last_n = 64, repeat_penalty = 1.300000


关于爱因斯坦的生平。他出生于1856年，就是一位德国化学家、天文学家和温谐器研究者。20世紀最初时期在高飞航母中被发现，爱因斯坦对此使用
```