### PR TITLE
Add support for tokenize and untokenize of UTF-8 encoding in prompt/output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ models/*
 
 arm_neon.h
 compile_commands.json
+*.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ endif
 # Compile flags
 #
 
-CFLAGS   = -I.              -O3 -DNDEBUG -std=c11   -fPIC
-CXXFLAGS = -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC
-LDFLAGS  =
+CFLAGS   = -I.              -O3 -DNDEBUG -std=c11   -fPIC -g -I/opt/homebrew/include
+CXXFLAGS = -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -g -I/opt/homebrew/include
+LDFLAGS  = -L/opt/homebrew/lib -lsentencepiece
 
 # OS specific
 # TODO: support Windows

--- a/main.cpp
+++ b/main.cpp
@@ -886,6 +886,7 @@ int main(int argc, char ** argv) {
         printf(ANSI_COLOR_YELLOW);
     }
 
+    // buffering UTF-8 tokens like <0xE6>,<0xAC><0xA2> spanning across multiple output to make it complete.
     std::vector<gpt_vocab::id> buffids = {};
     while (remaining_tokens > 0) {
         // predict
@@ -949,9 +950,7 @@ int main(int argc, char ** argv) {
         // display text
         if (!input_noecho) {
             untokenize(sp, buffids, embd);
-            // for (auto id : embd) {
-            //     printf("%s", vocab.id_to_token[id].c_str());
-            // }
+
             // reset color to default if we there is no pending user input
             if (params.use_color && embd_inp.size() <= input_consumed) {
                 printf(ANSI_COLOR_RESET);

--- a/main.cpp
+++ b/main.cpp
@@ -886,6 +886,7 @@ int main(int argc, char ** argv) {
         printf(ANSI_COLOR_YELLOW);
     }
 
+    std::vector<gpt_vocab::id> buffids = {};
     while (remaining_tokens > 0) {
         // predict
         if (embd.size() > 0) {
@@ -947,7 +948,7 @@ int main(int argc, char ** argv) {
 
         // display text
         if (!input_noecho) {
-            untokenize(sp, embd);
+            untokenize(sp, buffids, embd);
             // for (auto id : embd) {
             //     printf("%s", vocab.id_to_token[id].c_str());
             // }

--- a/main.cpp
+++ b/main.cpp
@@ -947,9 +947,10 @@ int main(int argc, char ** argv) {
 
         // display text
         if (!input_noecho) {
-            for (auto id : embd) {
-                printf("%s", vocab.id_to_token[id].c_str());
-            }
+            untokenize(sp, embd);
+            // for (auto id : embd) {
+            //     printf("%s", vocab.id_to_token[id].c_str());
+            // }
             // reset color to default if we there is no pending user input
             if (params.use_color && embd_inp.size() <= input_consumed) {
                 printf(ANSI_COLOR_RESET);

--- a/main.cpp
+++ b/main.cpp
@@ -776,13 +776,14 @@ int main(int argc, char ** argv) {
 
     gpt_params params;
     params.model = "models/llama-7B/ggml-model.bin";
-
-    sentencepiece::SentencePieceProcessor sp;
-    sp.Load("./models/tokenizer.model");
+    params.tokenizer = "models/tokenizer.model";
 
     if (gpt_params_parse(argc, argv, params) == false) {
         return 1;
     }
+
+    sentencepiece::SentencePieceProcessor sp;
+    sp.Load(params.tokenizer);
 
     if (params.seed < 0) {
         params.seed = time(NULL);
@@ -823,12 +824,12 @@ int main(int argc, char ** argv) {
     std::vector<float> logits;
 
     // tokenize the prompt
-    std::vector<gpt_vocab::id> embd_inp = ::llama_tokenize(vocab, params.prompt, true);
+    std::vector<gpt_vocab::id> embd_inp = ::llama_tokenize(sp, vocab, params.prompt, true);
 
     params.n_predict = std::min(params.n_predict, model.hparams.n_ctx - (int) embd_inp.size());
 
     // tokenize the reverse prompt
-    std::vector<gpt_vocab::id> antiprompt_inp = ::llama_tokenize(vocab, params.antiprompt, false);
+    std::vector<gpt_vocab::id> antiprompt_inp = ::llama_tokenize(sp, vocab, params.antiprompt, false);
 
     printf("\n");
     printf("%s: prompt: '%s'\n", __func__, params.prompt.c_str());
@@ -999,7 +1000,7 @@ int main(int argc, char ** argv) {
                         buf[n_read+1] = 0;
                     }
 
-                    std::vector<gpt_vocab::id> line_inp = ::llama_tokenize(vocab, buf, false);
+                    std::vector<gpt_vocab::id> line_inp = ::llama_tokenize(sp, vocab, buf, false);
                     embd_inp.insert(embd_inp.end(), line_inp.begin(), line_inp.end());
 
                     remaining_tokens -= line_inp.size();

--- a/main.cpp
+++ b/main.cpp
@@ -11,11 +11,6 @@
 #include <string>
 #include <vector>
 #include <sentencepiece_processor.h>
-#include <stdexcept>
-#include <iostream>
-#include <bitset>
-#include <sstream>
-#include <regex>
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 #include <signal.h>

--- a/utils.cpp
+++ b/utils.cpp
@@ -542,85 +542,38 @@ size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t
     return (n/k)*row_size;
 }
 
-void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & buffids, std::vector<gpt_vocab::id> & embd)
+void untokenize(sentencepiece::SentencePieceProcessor &sp, std::vector<gpt_vocab::id> &buffids, std::vector<gpt_vocab::id> &embd)
 {
-    // std::string output = sp.DecodeIds(embd);
-    // printf("%s", output.c_str());
-    // return;
-            // Convert the IDs in embd to tokens using SentencePiece
-    // std::vector<gpt_vocab::id> pieces;
-    // for (const auto& id : embd) {
-    //    //std::string s = sp.DecodeIds(id);
+    for (auto id : embd)
+    {
+        std::string s = sp.IdToPiece(id); // vocab.id_to_token[id];
 
-    //     //s = std::regex_replace(s, std::regex("▁"), " ");
-
-    //     // if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
-    //     // {
-    //     //     s = sp.IdToPiece(id);
-    //     // }
-    //     //printf("%s", s.c_str());
-
-    //     pieces.push_back(id);
-    //     // if(s.length() > 1)
-    //     //     tokens.push_back(" ");
-    // }
-    // // Insert spaces between tokens
-    // // std::string text;
-    // // for (const auto& token : tokens) {
-    // //     // Add a space before the token if it is not the first token and it doesn't start with a special character
-    // //     if (!text.empty() && !(token[0] == '\0x25' && token[1] == '\0x81') && token[0] != ' ') {
-    // //         text += ' ';
-    // //     }
-    // //     text += sp.DecodePieces(tokens);
-    // // }
-    // //sp.DecodeIds(embd);
-    // std::string text =
-    // sp.DecodeIds(pieces);
-
-    //     printf("%s", text.c_str());
-    
-    std::string buff;
-        for (auto id : embd) {
-            std::string s = sp.IdToPiece(id); //vocab.id_to_token[id];
-             
-            if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
-            {
-                buffids.push_back(id);
-                // Extract the hexadecimal value from the token
-                std::string hex_value = s.substr(s.find("0x"));
-
-                // Convert the hexadecimal value to binary and print it
-                int decimal_value;
-                std::stringstream(hex_value) >> std::hex >> decimal_value;
-                std::bitset<8> binary_value(decimal_value);
-                
-                char* bytes = reinterpret_cast<char*>(&decimal_value);
-                buff = buff + std::string(bytes);
-                //printf("bufferring %s, total buffer: %s\n", s.c_str(), buff.c_str());
-            }
-            else if(s.find("▁") == 0)
-            {
-                if(!buff.empty())
-                {
-                    std::string txt = sp.DecodeIds(buffids);
-                    printf("%s", txt.c_str());
-                    buffids.clear();
-                    buff = "";
-                }
-                s = std::regex_replace(s, std::regex("▁"), " ");
-                //s.replace(0, 2, 1, ' ');
-                printf("%s", s.c_str());
-            }
-            else
-            {
-                if(!buff.empty())
-                {
-                    std::string txt = sp.DecodeIds(buffids);
-                    printf("%s", txt.c_str());
-                    buffids.clear();
-                    buff = "";
-                }
-                printf("%s", s.c_str());
-            }
+        if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
+        {
+            buffids.push_back(id);
+            std::string txt = sp.DecodeIds(buffids);
+            // printf("bufferring %s, total buffer: %s\n", s.c_str(), txt.c_str());
         }
+        else if (s.find("▁") == 0)
+        {
+            if (!buffids.empty())
+            {
+                std::string txt = sp.DecodeIds(buffids);
+                printf("%s", txt.c_str());
+                buffids.clear();
+            }
+            s = std::regex_replace(s, std::regex("▁"), " ");
+            printf("%s", s.c_str());
+        }
+        else
+        {
+            if (!buffids.empty())
+            {
+                std::string txt = sp.DecodeIds(buffids);
+                printf("%s", txt.c_str());
+                buffids.clear();
+            }
+            printf("%s", s.c_str());
+        }
+    }
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <regex>
 #include <sentencepiece_processor.h>
+#include <sstream>
 #include <iostream>
 #include <iterator>
 #include <string>
@@ -539,4 +540,66 @@ size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t
     }
 
     return (n/k)*row_size;
+}
+
+void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & embd)
+{
+            // Convert the IDs in embd to tokens using SentencePiece
+    // std::vector<gpt_vocab::id> pieces;
+    // for (const auto& id : embd) {
+    //    //std::string s = sp.DecodeIds(id);
+
+    //     //s = std::regex_replace(s, std::regex("▁"), " ");
+
+    //     // if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
+    //     // {
+    //     //     s = sp.IdToPiece(id);
+    //     // }
+    //     //printf("%s", s.c_str());
+
+    //     pieces.push_back(id);
+    //     // if(s.length() > 1)
+    //     //     tokens.push_back(" ");
+    // }
+    // // Insert spaces between tokens
+    // // std::string text;
+    // // for (const auto& token : tokens) {
+    // //     // Add a space before the token if it is not the first token and it doesn't start with a special character
+    // //     if (!text.empty() && !(token[0] == '\0x25' && token[1] == '\0x81') && token[0] != ' ') {
+    // //         text += ' ';
+    // //     }
+    // //     text += sp.DecodePieces(tokens);
+    // // }
+    // //sp.DecodeIds(embd);
+    // std::string text =
+    // sp.DecodeIds(pieces);
+
+    //     printf("%s", text.c_str());
+        for (auto id : embd) {
+            std::string s = sp.IdToPiece(id); //vocab.id_to_token[id];
+            
+            if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
+            {
+                // Extract the hexadecimal value from the token
+                std::string hex_value = s.substr(s.find("0x"));
+
+                // Convert the hexadecimal value to binary and print it
+                int decimal_value;
+                std::stringstream(hex_value) >> std::hex >> decimal_value;
+                std::bitset<8> binary_value(decimal_value);
+                
+                char* bytes = reinterpret_cast<char*>(&decimal_value);
+                printf("%s", bytes);
+            }
+            else if(s.find("▁") == 0)
+            {
+                s = std::regex_replace(s, std::regex("▁"), " ");
+                //s.replace(0, 2, 1, ' ');
+                printf("%s", s.c_str());
+            }
+            else
+            {
+                printf("%s", s.c_str());
+            }
+        }
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -5,11 +5,6 @@
 #include <fstream>
 #include <regex>
 #include <sentencepiece_processor.h>
-#include <sstream>
-#include <iostream>
-#include <iterator>
-#include <string>
-#include <math.h>
 
  #if defined(_MSC_VER) || defined(__MINGW32__)
  #include <malloc.h> // using malloc.h with MSC/MINGW

--- a/utils.cpp
+++ b/utils.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <fstream>
 #include <regex>
+#include <sentencepiece_processor.h>
 #include <iostream>
 #include <iterator>
 #include <string>
@@ -281,33 +282,30 @@ std::vector<gpt_vocab::id> llama_tokenize(const gpt_vocab & vocab, const std::st
 
     std::vector<gpt_vocab::id> res;
 
-    if (bos) {
-        res.push_back(1); // TODO: replace with vocab.bos
+    // if (bos) {
+    //     res.push_back(1); // TODO: replace with vocab.bos
+    // }
+
+    sentencepiece::SentencePieceProcessor sp;
+    sp.Load("./models/tokenizer.model");
+
+    std::vector<std::string> pieces;
+    return sp.EncodeAsIds(text);
+/*
+    for (const auto & piece : pieces) {
+        printf("piece: %s\n", piece.c_str());
+        if (vocab.token_to_id.count(piece) > 0) {
+            res.push_back(vocab.token_to_id.at(piece));
+        } else {
+            // handle unknown token
+        }
     }
 
-     //find the longest token that matches the text
-    int pos = 0;
-    while (true) {
-        int l = 0;
-        int t = 0;
-        for (const auto & kv : vocab.id_to_token) {
-            if (kv.second.size() < l) continue;
-            if (kv.second.size() > text.size() - pos) continue;
-            if (text.substr(pos, kv.second.size()) == kv.second) {
-                l = kv.second.size();
-                t = kv.first;
-            }
-        }
-
-        if (l == 0) {
-            break;
-        }
-
-        res.push_back(t);
-        pos += l;
+    for (const auto& id : res) {
+        printf("%d\n", id);
     }
 
-    return res;
+    return res;*/
 }
 
 bool gpt_vocab_init(const std::string & fname, gpt_vocab & vocab) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -51,6 +51,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.n_batch = std::stoi(argv[++i]);
         } else if (arg == "-m" || arg == "--model") {
             params.model = argv[++i];
+        } else if (arg == "--tokenizer") {
+            params.tokenizer = argv[++i];
         } else if (arg == "-i" || arg == "--interactive") {
             params.interactive = true;
         } else if (arg == "--interactive-start") {
@@ -98,6 +100,8 @@ void gpt_print_usage(int argc, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -b N, --batch_size N  batch size for prompt processing (default: %d)\n", params.n_batch);
     fprintf(stderr, "  -m FNAME, --model FNAME\n");
     fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());
+    fprintf(stderr, "  --tokenizer FNAME\n");
+    fprintf(stderr, "                        tokenizer path (default: %s)\n", params.model.c_str());
     fprintf(stderr, "\n");
 }
 
@@ -274,39 +278,11 @@ std::vector<gpt_vocab::id> gpt_tokenize(const gpt_vocab & vocab, const std::stri
     return tokens;
 }
 
-std::vector<gpt_vocab::id> llama_tokenize(const gpt_vocab & vocab, const std::string & text, bool bos) {
-    //auto res = gpt_tokenize(vocab, text);
-
-    //if (bos) {
-    //    res.insert(res.begin(), 1); // TODO: replace with vocab.bos
-    //}
-
+std::vector<gpt_vocab::id> llama_tokenize(sentencepiece::SentencePieceProcessor & sp, const gpt_vocab & vocab, const std::string & text, bool bos) {
     std::vector<gpt_vocab::id> res;
-
-    // if (bos) {
-    //     res.push_back(1); // TODO: replace with vocab.bos
-    // }
-
-    sentencepiece::SentencePieceProcessor sp;
-    sp.Load("./models/tokenizer.model");
 
     std::vector<std::string> pieces;
     return sp.EncodeAsIds(text);
-/*
-    for (const auto & piece : pieces) {
-        printf("piece: %s\n", piece.c_str());
-        if (vocab.token_to_id.count(piece) > 0) {
-            res.push_back(vocab.token_to_id.at(piece));
-        } else {
-            // handle unknown token
-        }
-    }
-
-    for (const auto& id : res) {
-        printf("%d\n", id);
-    }
-
-    return res;*/
 }
 
 bool gpt_vocab_init(const std::string & fname, gpt_vocab & vocab) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -544,6 +544,9 @@ size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t
 
 void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & embd)
 {
+    // std::string output = sp.DecodeIds(embd);
+    // printf("%s", output.c_str());
+    // return;
             // Convert the IDs in embd to tokens using SentencePiece
     // std::vector<gpt_vocab::id> pieces;
     // for (const auto& id : embd) {
@@ -575,6 +578,7 @@ void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_voca
     // sp.DecodeIds(pieces);
 
     //     printf("%s", text.c_str());
+    std::string buff;
         for (auto id : embd) {
             std::string s = sp.IdToPiece(id); //vocab.id_to_token[id];
             
@@ -589,16 +593,27 @@ void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_voca
                 std::bitset<8> binary_value(decimal_value);
                 
                 char* bytes = reinterpret_cast<char*>(&decimal_value);
-                printf("%s", bytes);
+                buff = buff + std::string(bytes);
+                //printf("bufferring %s, total buffer: %s\n", s.c_str(), buff.c_str());
             }
             else if(s.find("▁") == 0)
             {
+                if(!buff.empty())
+                {
+                    printf("%s", buff.c_str());
+                    buff = "";
+                }
                 s = std::regex_replace(s, std::regex("▁"), " ");
                 //s.replace(0, 2, 1, ' ');
                 printf("%s", s.c_str());
             }
             else
             {
+                if(!buff.empty())
+                {
+                    printf("%s", buff.c_str());
+                    buff = "";
+                }
                 printf("%s", s.c_str());
             }
         }

--- a/utils.cpp
+++ b/utils.cpp
@@ -542,7 +542,7 @@ size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t
     return (n/k)*row_size;
 }
 
-void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & embd)
+void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & buffids, std::vector<gpt_vocab::id> & embd)
 {
     // std::string output = sp.DecodeIds(embd);
     // printf("%s", output.c_str());
@@ -578,12 +578,14 @@ void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_voca
     // sp.DecodeIds(pieces);
 
     //     printf("%s", text.c_str());
+    
     std::string buff;
         for (auto id : embd) {
             std::string s = sp.IdToPiece(id); //vocab.id_to_token[id];
-            
+             
             if (s.find("<0x") == 0 && s[s.length() - 1] == '>')
             {
+                buffids.push_back(id);
                 // Extract the hexadecimal value from the token
                 std::string hex_value = s.substr(s.find("0x"));
 
@@ -600,7 +602,9 @@ void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_voca
             {
                 if(!buff.empty())
                 {
-                    printf("%s", buff.c_str());
+                    std::string txt = sp.DecodeIds(buffids);
+                    printf("%s", txt.c_str());
+                    buffids.clear();
                     buff = "";
                 }
                 s = std::regex_replace(s, std::regex("▁"), " ");
@@ -611,7 +615,9 @@ void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_voca
             {
                 if(!buff.empty())
                 {
-                    printf("%s", buff.c_str());
+                    std::string txt = sp.DecodeIds(buffids);
+                    printf("%s", txt.c_str());
+                    buffids.clear();
                     buff = "";
                 }
                 printf("%s", s.c_str());

--- a/utils.h
+++ b/utils.h
@@ -105,5 +105,5 @@ void sample_top_k(std::vector<std::pair<double, gpt_vocab::id>> & logits_id, int
 size_t ggml_quantize_q4_0(float * src, void * dst, int n, int k, int qk, int64_t * hist);
 size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t * hist);
 
-void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & embd);
+void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & buffids, std::vector<gpt_vocab::id> & embd);
 

--- a/utils.h
+++ b/utils.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <random>
 #include <thread>
+#include <sentencepiece_processor.h>
+#include <sstream>
 
 //
 // CLI argument parsing
@@ -102,3 +104,6 @@ void sample_top_k(std::vector<std::pair<double, gpt_vocab::id>> & logits_id, int
 
 size_t ggml_quantize_q4_0(float * src, void * dst, int n, int k, int qk, int64_t * hist);
 size_t ggml_quantize_q4_1(float * src, void * dst, int n, int k, int qk, int64_t * hist);
+
+void untokenize(sentencepiece::SentencePieceProcessor & sp, std::vector<gpt_vocab::id> & embd);
+

--- a/utils.h
+++ b/utils.h
@@ -8,7 +8,6 @@
 #include <random>
 #include <thread>
 #include <sentencepiece_processor.h>
-#include <sstream>
 
 //
 // CLI argument parsing

--- a/utils.h
+++ b/utils.h
@@ -29,6 +29,7 @@ struct gpt_params {
     int32_t n_batch = 8; // batch size for prompt processing
 
     std::string model = "models/lamma-7B/ggml-model.bin"; // model path
+    std::string tokenizer = "models/tokenizer.model";   // tokenizer path
     std::string prompt;
 
     bool use_color = false; // use color to distinguish generations and inputs
@@ -75,7 +76,7 @@ std::vector<gpt_vocab::id> gpt_tokenize(const gpt_vocab & vocab, const std::stri
 
 // TODO: this is probably wrong, but I cannot figure out how this tokenizer works ..
 // ref: https://github.com/google/sentencepiece
-std::vector<gpt_vocab::id> llama_tokenize(const gpt_vocab & vocab, const std::string & text, bool bos);
+std::vector<gpt_vocab::id> llama_tokenize(sentencepiece::SentencePieceProcessor & sp, const gpt_vocab & vocab, const std::string & text, bool bos);
 
 // load the tokens from encoder.json
 bool gpt_vocab_init(const std::string & fname, gpt_vocab & vocab);


### PR DESCRIPTION
The tokenization process of LLaMA is filled with magic numbers and not easily replicable. However, I have found that using the SentencePiece library works well. It's possible that the original LLaMA model also used SentencePiece for its tokenization.

test prompt: '我静静的坐在雨中，思考着'
I sit quietly in the rain, thinking

This sentence was heavily tokenized to <0x??>, making it very difficult to replicate.

<img width="1024" alt="Screenshot 2023-03-13 at 5 14 58 PM" src="https://user-images.githubusercontent.com/2835415/224657649-c7f605b5-1778-46d2-b23c-662280a63180.png">
