### PR TITLE
fixed color reset on exit

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1053,7 +1053,9 @@ int main(int argc, char ** argv) {
 
     ggml_free(model.ctx);
 
-    if(params.use_color) printf(ANSI_COLOR_RESET);
+    if (params.use_color) {
+        printf(ANSI_COLOR_RESET);
+    }
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1052,5 +1052,7 @@ int main(int argc, char ** argv) {
 
     ggml_free(model.ctx);
 
+    if(params.use_color) printf(ANSI_COLOR_RESET);
+
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -755,6 +755,7 @@ static bool is_interacting = false;
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 void sigint_handler(int signo) {
+    printf(ANSI_COLOR_RESET);
     if (signo == SIGINT) {
         if (!is_interacting) {
             is_interacting=true;


### PR DESCRIPTION
Fixes the color messing up the terminal when the program exits by printing an ANSI_COLOR_RESET.

Includes it in the SIGINT handler too. 