### PR TITLE
FIX: "inline" -> "static inline" for bytesFromNibbles and packNibbles

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -364,7 +364,7 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 #if __AVX2__
 // Unpack 32 4-bit fields into 32 bytes
 // The output vector contains 32 bytes, each one in [ 0 .. 15 ] interval
-inline __m256i bytesFromNibbles( const uint8_t* rsi )
+static inline __m256i bytesFromNibbles( const uint8_t* rsi )
 {
     // Load 16 bytes from memory
     __m128i tmp = _mm_loadu_si128( ( const __m128i* )rsi );
@@ -381,7 +381,7 @@ inline __m256i bytesFromNibbles( const uint8_t* rsi )
     return bytes;
 }
 
-inline __m128i packNibbles( __m256i bytes )
+static inline __m128i packNibbles( __m256i bytes )
 {
     // Move bits within 16-bit lanes from 0000_abcd_0000_efgh into 0000_0000_abcd_efgh
     const __m256i lowByte = _mm256_set1_epi16( 0xFF );


### PR DESCRIPTION
Without the "static" quantifier, it fails to compile in clang:

```
ld.lld: error: undefined symbol: packNibbles
>>> referenced by ggml.c:520 (llama_cpp/ggml.c:520)
>>>               .../llama_cpp/__ggml__/__objects__/ggml.c.pic.o:(quantize_row_q4_0)

ld.lld: error: undefined symbol: bytesFromNibbles
>>> referenced by ggml.c:1434 (llama_cpp/ggml.c:1434)
>>>               .../llama_cpp/__ggml__/__objects__/ggml.c.pic.o:(ggml_vec_dot_q4_0)
>>> referenced by ggml.c:1435 (llama_cpp/ggml.c:1435)
>>>               .../llama_cpp/__ggml__/__objects__/ggml.c.pic.o:(ggml_vec_dot_q4_0)
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
```