### PR TITLE
Added install instructions for latest python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ python3 -m pip install torch numpy sentencepiece
 # torch: pip3 install torch -f https://download.pytorch.org/whl/torch_stable.html
 # sentencepiece
 # 1.) https://github.com/google/sentencepiece/actions - Select the lastest passing build and download the artifact file (At the bottom)
-# 2.) Copy \wheelhouse\sentencepiece-{Latest}-cp310-cp310-{YourOS_Architecture}.whl to your local folder
+# 2.) Copy \wheelhouse\sentencepiece-{Latest}-cp{PythonVersion}-cp{PythonVersion}-{YourOS_Architecture}.whl to your local folder
 # 3.) pip3 install .\sentencepiece-from-above.whl
 
 # convert the 7B model to ggml FP16 format

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ ls ./models
 
 # install Python dependencies
 python3 -m pip install torch numpy sentencepiece
+# For later versions of python3 that don't have official torch / sentencepiece packages on pip
+# torch: pip3 install torch -f https://download.pytorch.org/whl/torch_stable.html
+# sentencepiece
+# 1.) https://github.com/google/sentencepiece/actions - Select the lastest passing build and download the artifact file (At the bottom)
+# 2.) Copy \wheelhouse\sentencepiece-{Latest}-cp310-cp310-{YourOS_Architecture}.whl to your local folder
+# 3.) pip3 install .\sentencepiece-from-above.whl
 
 # convert the 7B model to ggml FP16 format
 python3 convert-pth-to-ggml.py models/7B/ 1


### PR DESCRIPTION
Added install instructions for the versions of `torch` and `sentencepiece` missing from the pip repo on the latest python3 - Used to get this working on Python 3.11.0