### PR TITLE
Add batch files for automatic installation on Windows

### DIFF
--- a/Windows-installer.bat
+++ b/Windows-installer.bat
@@ -1,0 +1,39 @@
+@echo off
+::Install Llama.cpp depencidies, such as Python and CMake (for building llama.exe and quantize.exe)
+
+if not defined PYTHON (set PYTHON=python)
+if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
+
+%PYTHON% -V
+if %ERRORLEVEL% == 0 goto :create_venv
+echo Python is not installed, installing
+goto :install_python
+
+:install_python
+call bitsadmin /transfer Python-3.10.6 /download /priority FOREGROUND "https://www.python.org/ftp/python/3.10.6/python-3.10.6-amd64.exe" "%CD%/python-3.10.6-amd64.exe"
+python-3.10.6-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+call refreshenv
+goto :create_venv
+
+:: Should probably impliment check for pip before installing dependicies
+:create_venv
+:: Check if venv already exists
+dir "%VENV_DIR%\Scripts\Python.exe" -V
+if %ERRORLEVEL% == 0 goto :ititiate_venv
+
+:: Otherwise create new venv
+echo Creating venv in %VENV_DIR%
+%PYTHON% -m venv "%VENV_DIR%"
+if %ERRORLEVEL% == 0 goto :ititiate_venv
+echo Unable to create venv in "%VENV_DIR%"
+pause
+
+:ititiate_venv
+set PYTHON="%VENV_DIR%\Scripts\Python.exe"
+echo venv %PYTHON%
+goto :install_depencidies
+
+:install_depencidies
+%PYTHON% -m pip install cmake torch numpy sentencepiece %*
+echo Llama depencidies are now installed!
+pause

--- a/Windows-installer.bat
+++ b/Windows-installer.bat
@@ -1,5 +1,5 @@
 @echo off
-::Install Llama.cpp depencidies, such as Python and CMake (for building llama.exe and quantize.exe)
+::Install Llama.cpp dependencies, such as Python and CMake (for future building of llama.exe and quantize.exe)
 
 if not defined PYTHON (set PYTHON=python)
 if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
@@ -19,21 +19,25 @@ goto :create_venv
 :create_venv
 :: Check if venv already exists
 dir "%VENV_DIR%\Scripts\Python.exe" -V
-if %ERRORLEVEL% == 0 goto :ititiate_venv
+if %ERRORLEVEL% == 0 goto :initiate_venv
 
 :: Otherwise create new venv
 echo Creating venv in %VENV_DIR%
 %PYTHON% -m venv "%VENV_DIR%"
-if %ERRORLEVEL% == 0 goto :ititiate_venv
+if %ERRORLEVEL% == 0 goto :initiate_venv
 echo Unable to create venv in "%VENV_DIR%"
 pause
+exit
 
-:ititiate_venv
+:: Activate venv
+:initiate_venv
 set PYTHON="%VENV_DIR%\Scripts\Python.exe"
 echo venv %PYTHON%
-goto :install_depencidies
+goto :install_dependencies
 
-:install_depencidies
+:install_dependencies
 %PYTHON% -m pip install cmake torch numpy sentencepiece %*
-echo Llama depencidies are now installed!
+echo Llama.cpp dependencies are now installed!
+echo Put your LLaMA models into the models folder, and run model_conversion to convert and quantize them.
 pause
+exit

--- a/Windows-model_conversion.bat
+++ b/Windows-model_conversion.bat
@@ -1,0 +1,31 @@
+@echo off
+:: Convert models to 4 bit
+
+set "VENV_DIR=%~dp0%venv"
+set PYTHON="%VENV_DIR%\Scripts\Python.exe"
+echo venv is located at: %PYTHON%
+goto :convert_ggml
+
+:: Convert the 7B model to ggml FP16 format
+:convert_ggml
+%PYTHON% "convert-pth-to-ggml.py" models/7B/ 1
+if %ERRORLEVEL% == 1 goto :fast_quit
+goto :build_cmake
+
+:: Build llama.exe and quantize.exe
+:build_cmake
+cmake -S . -B build/ -D CMAKE_BUILD_TYPE=Release
+cmake --build build/ --config Release
+if %ERRORLEVEL% == 1 goto :fast_quit
+goto :quantize
+
+:quantize
+.\build\Release\quantize.exe .\models\7B\ggml-model-f16.bin .\models\7B\ggml-model-q4_0.bin 2
+echo All tasks completed successfully.
+pause
+exit
+
+:fast_quit
+echo Something went wrong!
+pause
+exit


### PR DESCRIPTION
This commit adds two new files, Windows-installer.bat and Windows-model_conversion.bat, both of which serve to make using llama.cpp on Windows easier.
Windows-installer.bat installs dependencies, such as Python, and Windows-model_conversion.bat converts the 7B model to FP16, and quantizises to 4 bit. 
Additionally, as Windows-model_conversion.bat builds llama.cpp with CMake, it should resolve issue #103.
Note that Windows-model_conversion.bat only currently processes 7B.

Occasionally, Windows-installer.bat will throw an "Unable to complete job - 0x80200002" error. This has no impact on the functionality of the bat file.

While the .bat files still have a few issues (tons of harmless errors if you run Windows-installer.bat after venv creation, Windows-model_conversion.bat only converting and quantizing the 7B model, etc.) being able to install llama.cpp automatically makes the project much easier to use than what we currently have.