### PR TITLE
fix(ggml): compile error on centos 7.9 and gcc7

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __linux__
+#define _POSIX_C_SOURCE 199309L
+#endif
+
 //
 // GGML Tensor Library
 //


### PR DESCRIPTION
fix build error on CentOS 7.9 and gcc7/gcc9

```bash
ggml.c:309:19: error: ‘CLOCK_MONOTONIC’ undeclared (first use in this function)
     clock_gettime(CLOCK_MONOTONIC, &ts);
```

Here is my OS version
```bash
$ lsb_release -a
LSB Version:    :core-4.1-amd64:core-4.1-noarch:cxx-4.1-amd64:cxx-4.1-noarch:desktop-4.1-amd64:desktop-4.1-noarch:languages-4.1-amd64:languages-4.1-noarch:printing-4.1-amd64:printing-4.1-noarch
Distributor ID: CentOS
Description:    CentOS Linux release 7.9.2009 (Core)
Release:        7.9.2009
Codename:       Core
```

After fix it works.
```bash
I llama.cpp build info: 
I UNAME_S:  Linux
I UNAME_P:  x86_64
I UNAME_M:  x86_64
I CFLAGS:   -I.              -O3 -DNDEBUG -std=c11   -fPIC -pthread -mavx -mavx2 -mfma -mf16c -msse3
I CXXFLAGS: -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -pthread
I LDFLAGS:  
I CC:       cc (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)
I CXX:      g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)
```