### PR TITLE
Docker - Fix publish docker image in GitHub Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,8 +40,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Build and push Docker image (versioned)
         if: github.event_name == 'push'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image (versioned)
         if: github.event_name == 'push'


### PR DESCRIPTION
In the PR that was resolved (#132), the action defined to publish the packages used the user and token of the author of the commit in master.

In this case, I have been yours, but I do not have permissions for such an action.

That is why I have modified the file, so that the owner's token is included as a secret with the name `GHCR_PAT`.

It is important to select the read:packages & write:packages permissions.


NOTE: Checks will fail until the secret is included.
