### PR TITLE
Docker action shouldn't run on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,6 @@
 name: Publish Docker image
 
 on:
-  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
This action would run for every PR action which means it'll create a docker image every time the CI runs on contributions.