### PR TITLE
Trace output distributions to a log file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1017,6 +1017,11 @@ int main(int argc, char ** argv) {
             // decrement remaining sampling budget
             --remaining_tokens;
         } else {
+            if(log_file) {
+                const int n_vocab = model.hparams.n_vocab;
+                const float temp  = params.temp;
+                print_output(vocab, logits.data() + (logits.size() - n_vocab), temp);
+            }
             // some user input remains from prompt or interaction, forward it to processing
             while (embd_inp.size() > input_consumed) {
                 embd.push_back(embd_inp[input_consumed]);

--- a/main.cpp
+++ b/main.cpp
@@ -880,7 +880,7 @@ int main(int argc, char ** argv) {
 
     // tokenize the reverse prompt
     std::vector<std::vector<gpt_vocab::id>> antipromptv_inp;
-    
+
     for (auto antiprompt : params.antiprompt) {
         antipromptv_inp.push_back(::llama_tokenize(vocab, antiprompt, false));
     }
@@ -990,7 +990,7 @@ int main(int argc, char ** argv) {
                     logits[logits.size() - n_vocab + EOS_TOKEN_ID] = 0;
                 }
 
-                id = llama_sample_top_p_top_k(vocab, logits.data() + (logits.size() - n_vocab), last_n_tokens, repeat_penalty, top_k, top_p, temp, rng);
+                id = sample_top_k_top_p(vocab, logits.data() + (logits.size() - n_vocab), last_n_tokens, repeat_penalty, top_k, top_p, temp, rng);
 
                 last_n_tokens.erase(last_n_tokens.begin());
                 last_n_tokens.push_back(id);

--- a/utils.cpp
+++ b/utils.cpp
@@ -16,6 +16,8 @@
  #include <alloca.h>
  #endif
 
+FILE * log_file = NULL;
+
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
     // determine sensible default number of threads.
     // std::thread::hardware_concurrency may not be equal to the number of cores, or may return 0.
@@ -576,6 +578,7 @@ struct SoftMaxSampler {
                 break;
             }
         }
+        logprintf("%s: n: %d sum: %f\n", __func__, n, cumsum);
 
         // discrete_distribution renormalizes the subset of probabilities to sum to 1.0
         return std::discrete_distribution<>(probs.begin(), probs.begin() + n);
@@ -633,6 +636,7 @@ gpt_vocab::id sample_top_k_top_p(
     auto dist = probs.top_p(top_p);
     int sampled_tok_id = probs.sample(dist, rng);
 
+    probs.print(log_file, vocab, logits, 16, sampled_tok_id);
 
     return sampled_tok_id;
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -649,6 +649,21 @@ gpt_vocab::id sample_top_k_top_p(
     return sampled_tok_id;
 }
 
+gpt_vocab::id print_output(
+        const gpt_vocab & vocab,
+        const float * logits,
+        double temp) {
+    SoftMaxSampler probs;
+    probs.reset(vocab, logits, temp);
+    probs.top_k_sort();
+    probs.soft_max();
+
+    probs.print(log_file, vocab, logits, 16);
+
+    return probs.top();
+}
+
+
 
 size_t ggml_quantize_q4_0(float * src, void * dst, int n, int k, int qk, int64_t * hist) {
     const int nb = k / qk;

--- a/utils.cpp
+++ b/utils.cpp
@@ -521,18 +521,26 @@ struct SoftMaxSampler {
 
         // compute probs for the tokens
         double sum_p = 0.0;
+        double sum_act = 0.0;
+        double entropy = 0.0;
         for (const auto & kv : logits_id) {
+            sum_act += kv.first;
             double logp = kv.first - maxl;
             double p = exp(logp);
             probs.push_back(p);
             sum_p += p;
+            entropy -= p * logp;
         }
 
         // normalize the probs
         const double scale = 1.0 / sum_p;
+        entropy = entropy * scale + log(sum_p);
         for (auto & p : probs) {
             p *= scale;
         }
+
+        // Scaled activations stats & distribution info
+        logprintf( "%s: top_sact=%f mean_sact=%f top_p=%f entropy=%f\n", __func__, logits_id[0].first, sum_act / n, probs[0], entropy);
     }
 
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -591,6 +591,29 @@ struct SoftMaxSampler {
     ) const {
         return logits_id[dist(rng)].second;
     }
+
+    void print(FILE* log_file, const gpt_vocab & vocab, const float * logits, int max_print, int selected=-1) const {
+        if (log_file == nullptr) {
+            return;
+        }
+        int n = probs.size();
+        if (n > max_print) {
+            n = max_print;
+        }
+        for (int i = 0; i < n; i++) {
+            const auto& entry = logits_id[i];
+            const int id = entry.second;
+            const double scaled_logit = entry.first;
+            fprintf(log_file, "%s%d: '%s' p=%f act=%.3f temp=%.2f\n",
+                selected >= 0 && id == selected ? "->" : "  ",
+                i,
+                vocab.id_to_token.at(id).c_str(),
+                probs[i],
+                logits[id],
+                logits[id] / scaled_logit
+            );
+        }
+    }
 };
 
 gpt_vocab::id sample_top_k_top_p(

--- a/utils.h
+++ b/utils.h
@@ -106,6 +106,12 @@ gpt_vocab::id sample_top_k_top_p(
         double temp,
         std::mt19937 & rng);
 
+// Print would-be output after prompt samples
+gpt_vocab::id print_output(
+        const gpt_vocab & vocab,
+        const float * logits,
+        double temp);
+
 //
 // Quantization
 //

--- a/utils.h
+++ b/utils.h
@@ -8,6 +8,12 @@
 #include <random>
 #include <thread>
 
+#include <stdio.h>
+
+extern FILE * log_file;
+
+#define logprintf(...) { if (log_file) fprintf(log_file, __VA_ARGS__); }
+
 //
 // CLI argument parsing
 //

--- a/utils.h
+++ b/utils.h
@@ -90,7 +90,7 @@ bool gpt_vocab_init(const std::string & fname, gpt_vocab & vocab);
 //   - consider only the top K tokens
 //   - from them, consider only the top tokens with cumulative probability > P
 //
-gpt_vocab::id llama_sample_top_p_top_k(
+gpt_vocab::id sample_top_k_top_p(
         const gpt_vocab & vocab,
         const float * logits,
         std::vector<gpt_vocab::id> & last_n_tokens,
@@ -99,9 +99,6 @@ gpt_vocab::id llama_sample_top_p_top_k(
         double top_p,
         double temp,
         std::mt19937 & rng);
-
-// filer to top K tokens from list of logits
-void sample_top_k(std::vector<std::pair<double, gpt_vocab::id>> & logits_id, int top_k);
 
 //
 // Quantization


### PR DESCRIPTION
I do not expect this to be merged, but I figured it might help others. Although, I don't know if this is the right place.

This logs information to a `./out.log` (hard-coded) file. I wrote this throwaway code before the switch to stderr, which is why it uses a global file handle.
The refactoring of the sampler code should produce the same results than the master branch.

For each predicted token, it logs: 
```
in:' because' n_past=14, remaining_tokens=62, embd.size()=1, embd_inp.size()=13
soft_max: top_sact=25.503617 mean_sact=19.826111 top_p=0.357196 entropy=1.664120
top_p: n: 15 sum: 0.990421
->0: ' they' p=0.357196 act=17.853 temp=0.70
  1: ' I' p=0.231013 act=20.643 temp=0.82
  2: ' of' p=0.228527 act=17.540 temp=0.70
[...]
  15: ' the' p=0.000876 act=13.645 temp=0.70
```

* The `soft_max:` lines reports statistics of the top k tokens' logits (divided by temp) and entropy (in nats, not bits),
* `top_p:` line gives the number of retained tokens after the top p filtering, and the sum of their probabilities,
* Last, a list of the top 16 tokens, along with their respective probabilities, original logits, and the product of their temperature and eventual repetition penalty.. The drawn token is indicated by an `->`.

I will close this either when it becomes obsolete or when it can no longer be rebased.