### PR TITLE
Fixed color reset problem in interactive mode.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -752,6 +752,7 @@ static bool is_interacting = false;
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
 void sigint_handler(int signo) {
     printf(ANSI_COLOR_RESET);
+    printf("\n"); // this also force flush stdout.
     if (signo == SIGINT) {
         if (!is_interacting) {
             is_interacting=true;


### PR DESCRIPTION
In interactive mode:
```
Bob: Sure. The largest city in Europe is Moscow, the capital of Russia.
User: xxx
```
Press CTRL+C, the program exits, but terminal color still remains blue.

To ensure color reset, let's print '\n' in sigint_handler.