### PR TITLE
Fix scripts to support cross-platform execution

### DIFF
--- a/quantize.sh
+++ b/quantize.sh
@@ -7,8 +7,22 @@ if ! [[ "$1" =~ ^[0-9]{1,2}B$ ]]; then
     exit 1
 fi
 
+# Determine the binary file extension based on the platform
+case "$(uname -s)" in
+    Linux*)
+        if grep -qE "(Microsoft|WSL)" /proc/version &> /dev/null ; then
+            ext=".exe" # WSL environment
+        else
+            ext=""
+        fi
+        ;;
+    Darwin*)    ext="";;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*) ext=".exe";;
+    *)          echo "Unknown platform"; exit 1;;
+esac
+
 for i in `ls models/$1/ggml-model-f16.bin*`; do
-    ./quantize "$i" "${i/f16/q4_0}" 2
+    ./quantize${ext} "$i" "${i/f16/q4_0}" 2
     if [[ "$2" == "--remove-f16" ]]; then
         rm "$i"
     fi


### PR DESCRIPTION
This change modifies the `quantize.sh` script so that it can run properly on different platforms (including the Windows platform in the WSL environment).