### PR TITLE
[WIP] Improve performance on x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ endif
 # Compile flags
 #
 
-CFLAGS   = -I.              -O3 -DNDEBUG -std=c11   -fPIC
-CXXFLAGS = -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC
+CFLAGS   = -I.              -O3 -DNDEBUG -std=c11   -fPIC -D_GNU_SOURCE
+CXXFLAGS = -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -D_GNU_SOURCE
 LDFLAGS  =
 
 # OS specific


### PR DESCRIPTION
### Someone please take over this pull request? 

Unfortunately, I'm quite behind on a few other obligations so I won't be able to continue exploring here. Feel free to take this as an inspiration and make a production ready version!

-----------------------------------------------------------------------------------------------


I did some initial exploration on various ways to squeeze more performance out of the main loop on my ubuntu desktop with an i7-7700k CPU.

Code was complied with gcc-10 and invoked with
`./main -m ./models/7B/ggml-model-q4_0.bin -s 1679164839 -m ./models/7B/ggml-model-q4_0.bin -n 1280`

Since inference is usually memory bound, I specifically looked for ways to improve memory access. 
Seems like a combination of prefetch +CPU pinning + unroll can improve the performance by up to ~25% 

![Screen Shot 2023-03-18 at 5 27 10 PM](https://user-images.githubusercontent.com/7062320/226182432-ac88c39b-a6b4-4eb4-b555-1de3adfb6117.png)

These changes here is only tested on my machine and I suspect the code won't even compile for other platforms. 


