### PR TITLE
Respect the maximum number of tokens in interactive.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1055,13 +1055,19 @@ int main(int argc, char ** argv) {
         }
 
         // end of text token
-        if (embd.back() == 2) {
+        if (embd.size() && embd.back() == 2) {
             if (params.interactive) {
                 is_interacting = true;
             } else {
                 fprintf(stderr, " [end of text]\n");
                 break;
             }
+        }
+
+        // In interactive mode, respect the maximum number of tokens and drop back to user input when reached.
+        if (params.interactive && remaining_tokens <= 0) {
+            remaining_tokens = params.n_predict;
+            is_interacting = true;
         }
     }
 


### PR DESCRIPTION
Even in interactive mode the maximum number of specified tokens should be respected. Instead of ending the main loop, by falling back to user input mode.