### PR TITLE
add alpaca support into docker scripts

### DIFF
--- a/.devops/tools.sh
+++ b/.devops/tools.sh
@@ -21,15 +21,17 @@ elif [[ $arg1 == '--download' || $arg1 == '-d' ]]; then
 elif [[ $arg1 == '--all-in-one' || $arg1 == '-a' ]]; then
     echo "Downloading model..."
     python3 ./download-pth.py "$1" "$2"
-    echo "Converting PTH to GGML..."
-    for i in `ls $1/$2/ggml-model-f16.bin*`; do
-        if [ -f "${i/f16/q4_0}" ]; then
-            echo "Skip model quantization, it already exists: ${i/f16/q4_0}"
-        else
-            echo "Converting PTH to GGML: $i into ${i/f16/q4_0}..."
-            ./quantize "$i" "${i/f16/q4_0}" 2
-        fi
-    done
+    if [[ $2 != 'alpaca' ]]; then
+        echo "Converting PTH to GGML..."
+        for i in `ls $1/$2/ggml-model-f16.bin*`; do
+            if [ -f "${i/f16/q4_0}" ]; then
+                echo "Skip model quantization, it already exists: ${i/f16/q4_0}"
+            else
+                echo "Converting PTH to GGML: $i into ${i/f16/q4_0}..."
+                ./quantize "$i" "${i/f16/q4_0}" 2
+            fi
+        done
+    fi;
 else
     echo "Unknown command: $arg1"
     echo "Available commands: "

--- a/download-pth.py
+++ b/download-pth.py
@@ -11,6 +11,26 @@ if len(sys.argv) < 3:
 modelsDir = sys.argv[1]
 model = sys.argv[2]
 
+resolved_path = os.path.abspath(os.path.join(modelsDir, model))
+os.makedirs(resolved_path, exist_ok=True)
+
+if model == 'alpaca':
+    dest_path = os.path.abspath(os.path.join(resolved_path, "ggml-alpaca-7b-q4.bin"))
+    if os.path.exists(dest_path):
+        print(f"Skip file download, it already exists: {dest_path}")
+        sys.exit(1)
+
+    response = requests.get("https://gateway.estuary.tech/gw/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC", stream=True)
+    with open(dest_path, 'wb') as f:
+        with tqdm(unit='B', unit_scale=True, miniters=1, desc="ggml-alpaca-7b-q4.bin") as t:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:
+                    f.write(chunk)
+                    t.update(len(chunk))
+    
+    sys.exit(0)
+
+
 num = {
     "7B": 1,
     "13B": 2,
@@ -19,7 +39,7 @@ num = {
 }
 
 if model not in num:
-    print(f"Error: model {model} is not valid, provide 7B, 13B, 30B or 65B")
+    print(f"Error: model {model} is not valid, provide 7B, 13B, 30B, 65B or alpaca")
     sys.exit(1)
 
 print(f"Downloading model {model}")
@@ -29,8 +49,6 @@ files = ["checklist.chk", "params.json"]
 for i in range(num[model]):
     files.append(f"consolidated.0{i}.pth")
 
-resolved_path = os.path.abspath(os.path.join(modelsDir, model))
-os.makedirs(resolved_path, exist_ok=True)
 
 for file in files:
     dest_path = os.path.join(resolved_path, file)


### PR DESCRIPTION
I have seen that support has been added in the master branch to the alpaca model, I have included the model in the docker scripts.

Now you can try like this:

```bash
docker run -v /llama/models:/models ghcr.io/ggerganov/llama.cpp:full --all-in-one "/models/" alpaca
```

```bash
docker run -it -v /llama/models:/models ghcr.io/ggerganov/llama.cpp:full --run -m /models/alpaca/ggml-alpaca-7b-q4.bin -p "Below is an instruction that describes a task Write a response that appropriately completes the request.
" -ins --top_k 10000 --temp 0.96 --repeat_penalty 1 -t 7
```