### PR TITLE
Nix flake: set meta.mainProgram to llama

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             cat ${./convert-pth-to-ggml.py} >> $out/bin/convert-pth-to-ggml
             chmod +x $out/bin/convert-pth-to-ggml
           '';
+          meta.mainProgram = "llama";
         };
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [


### PR DESCRIPTION
This is so that `nix run` works.

CC @niklaskorz, @prusnak.