### PR TITLE
Enable Fused-Multiply-Add (FMA) and F16C/CVT16 vector extensions on MSVC

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -79,6 +79,16 @@ static int sched_yield (void) {
 typedef void* thread_ret_t;
 #endif
 
+// __FMA__ and __F16C__ are not defined in MSVC, however they are implied with AVX2/AVX512
+#if defined(_MSC_VER) && (defined(__AVX2__) || defined(__AVX512F__))
+#ifndef __FMA__
+#define __FMA__
+#endif
+#ifndef __F16C__
+#define __F16C__
+#endif
+#endif
+
 #ifdef __HAIKU__
 #define static_assert(cond, msg) _Static_assert(cond, msg)
 #endif
@@ -407,16 +417,9 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 
 #define QK 32
 
-#if __AVX2__ || __AVX512F__
-
-// __FMA__ is not defined in MSVC, however it is implied with AVX2/AVX512
-#if defined(_MSC_VER) && !defined(__FMA__)
-#define __FMA__
-#endif
-
 // AVX routines provided by GH user Const-me
 // ref: https://github.com/ggerganov/ggml/pull/27#issuecomment-1464934600
-
+#if __AVX2__ || __AVX512F__
 // Unpack 32 4-bit fields into 32 bytes
 // The output vector contains 32 bytes, each one in [ 0 .. 15 ] interval
 static inline __m256i bytesFromNibbles( const uint8_t* rsi )

--- a/ggml.c
+++ b/ggml.c
@@ -182,8 +182,13 @@ typedef double ggml_float;
 
 #ifdef __F16C__
 
+#ifdef _MSC_VER
+#define GGML_COMPUTE_FP16_TO_FP32(x) _mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(x)))
+#define GGML_COMPUTE_FP32_TO_FP16(x) _mm_extract_epi16(_mm_cvtps_ph(_mm_set_ss(x), 0), 0)
+#else
 #define GGML_COMPUTE_FP16_TO_FP32(x) _cvtsh_ss(x)
 #define GGML_COMPUTE_FP32_TO_FP16(x) _cvtss_sh(x, 0)
+#endif
 
 #elif defined(__POWER9_VECTOR__)
 

--- a/ggml.c
+++ b/ggml.c
@@ -87,6 +87,9 @@ typedef void* thread_ret_t;
 #ifndef __F16C__
 #define __F16C__
 #endif
+#ifndef __SSE3__
+#define __SSE3__
+#endif
 #endif
 
 #ifdef __HAIKU__

--- a/ggml.c
+++ b/ggml.c
@@ -407,9 +407,16 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 
 #define QK 32
 
+#if __AVX2__ || __AVX512F__
+
+// __FMA__ is not defined in MSVC, however it is implied with AVX2/AVX512
+#if defined(_MSC_VER) && !defined(__FMA__)
+#define __FMA__
+#endif
+
 // AVX routines provided by GH user Const-me
 // ref: https://github.com/ggerganov/ggml/pull/27#issuecomment-1464934600
-#if __AVX2__ || __AVX512F__
+
 // Unpack 32 4-bit fields into 32 bytes
 // The output vector contains 32 bytes, each one in [ 0 .. 15 ] interval
 static inline __m256i bytesFromNibbles( const uint8_t* rsi )


### PR DESCRIPTION
`__FMA__` and `__F16C__` are defined in GCC and Clang

`__FMA__` and `__F16C__` are not defined in MSVC, however they are implied with AVX2/AVX512
https://learn.microsoft.com/en-us/cpp/build/reference/arch-x64?view=msvc-160

Thus, enable FMA and F16C in MSVC if either AVX2/AVX512 is enabled
