### PR TITLE
CI: CMake: Separate build and test steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,19 +41,27 @@ jobs:
 
     steps:
       - name: Clone
+        id: checkout
         uses: actions/checkout@v1
 
       - name: Dependencies
+        id: depends
         run: |
           sudo apt-get update
           sudo apt-get install build-essential
 
       - name: Build
+        id: cmake_build
         run: |
           mkdir build
           cd build
           cmake ..
           cmake --build . --config Release
+
+      - name: Test
+        id: cmake_test
+        run: |
+          cd build
           ctest --output-on-failure
 
   macOS-latest-make:
@@ -79,18 +87,26 @@ jobs:
 
     steps:
       - name: Clone
+        id: checkout
         uses: actions/checkout@v1
 
       - name: Dependencies
+        id: depends
         run: |
           brew update
 
       - name: Build
+        id: cmake_build
         run: |
           mkdir build
           cd build
           cmake ..
           cmake --build . --config Release
+
+      - name: Test
+        id: cmake_test
+        run: |
+          cd build
           ctest --output-on-failure
 
   windows-latest-cmake:
@@ -107,7 +123,13 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          cmake --build . --config Release && ctest -C Release --output-on-failure
+          cmake --build . --config Release
+
+      - name: Test
+        id: cmake_test
+        run: |
+          cd build
+          ctest -C Release --output-on-failure
 
       - name: Get commit hash
         id: commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,7 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          cmake --build . --config Release
-          ctest -C Release --output-on-failure
+          cmake --build . --config Release && ctest -C Release --output-on-failure
 
       - name: Get commit hash
         id: commit


### PR DESCRIPTION
Otherwise the tests may be ran and pass even if the build has errors and thus the step itself can pass with errors in build

edit: separate build and test steps for all platforms.