### PR TITLE
memcpy is not defined

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9,6 +9,7 @@
 #include <queue>
 #include <regex>
 #include <cassert>
+#include <cstring>
 
 // determine number of model parts based on the dimension
 static const std::unordered_map<int, int> LLAMA_N_PARTS = {


### PR DESCRIPTION
memcpy function defined in cstring missing

GCC: gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4)
OS: Fedora 37
Kernel: 6.1.14