### PR TITLE
cmake: make llama an actual library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ add_library(utils OBJECT
 
 target_include_directories(utils PUBLIC .)
 target_compile_features(utils PUBLIC cxx_std_11) # don't bump
+target_link_libraries(utils PRIVATE ${LLAMA_EXTRA_LIBS})
 
 add_library(ggml OBJECT
             ggml.c
@@ -226,12 +227,13 @@ target_include_directories(ggml PUBLIC .)
 target_compile_features(ggml PUBLIC c_std_11) # don't bump
 target_link_libraries(ggml PRIVATE Threads::Threads ${LLAMA_EXTRA_LIBS})
 
-add_library(llama OBJECT
+add_library(llama
             llama.cpp
             llama.h)
 
 target_include_directories(llama PUBLIC .)
 target_compile_features(llama PUBLIC cxx_std_11) # don't bump
+target_link_libraries(llama PRIVATE utils ggml ${LLAMA_EXTRA_LIBS})
 
 #
 # Executables


### PR DESCRIPTION
this change allows you to `add_subidrectoy(llama.cpp)` and `target_link_libraries(target PRIVATE llama)`