### PR TITLE
Fix Makefile echo escape codes (by removing them).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,9 @@ clean:
 
 main: main.cpp ggml.o llama.o utils.o
 	$(CXX) $(CXXFLAGS) main.cpp ggml.o llama.o utils.o -o main $(LDFLAGS)
-	@echo "\x1b[36mrun ./main -h for help\x1b[0m"
+	@echo
+	@echo '====  Run ./main -h for help.  ===='
+	@echo
 
 quantize: quantize.cpp ggml.o llama.o utils.o
 	$(CXX) $(CXXFLAGS) quantize.cpp ggml.o llama.o utils.o -o quantize $(LDFLAGS)


### PR DESCRIPTION
Trivial change to fix output from the Makefile when printing the line about running with `-h` for help. To properly output the vt100/ANSI escape codes, it needs to be `echo -e` not just `echo` which will output the string like:

    \x1b[36mrun ./main -h for help\x1b[0m

The echo line also can use single quotes because variable interpolation isn't required here.