### PR TITLE
feat: '--in-prefix STRING' option

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -283,6 +283,10 @@ int main(int argc, char ** argv) {
                 fprintf(stderr, "Reverse prompt: '%s'\n", antiprompt.c_str());
             }
         }
+
+        if (!params.input_prefix.empty()) {
+            fprintf(stderr, "Input prefix: '%s'\n", params.input_prefix.c_str());
+        }
     }
     fprintf(stderr, "sampling parameters: temp = %f, top_k = %d, top_p = %f, repeat_last_n = %i, repeat_penalty = %f\n", params.temp, params.top_k, params.top_p, params.repeat_last_n, params.repeat_penalty);
     fprintf(stderr, "\n\n");
@@ -420,6 +424,11 @@ int main(int argc, char ** argv) {
                 }
 
                 std::string buffer;
+                if (!params.input_prefix.empty()) {
+                    buffer += params.input_prefix;
+                    printf(buffer.c_str());
+                }
+
                 std::string line;
                 bool another_line = true;
                 do {

--- a/utils.cpp
+++ b/utils.cpp
@@ -82,6 +82,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             exit(0);
         } else if (arg == "--random-prompt") {
             params.random_prompt = true;
+        } else if (arg == "--in-prefix") {
+            params.input_prefix = argv[++i];
         } else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             gpt_print_usage(argc, argv, params);
@@ -109,6 +111,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -p PROMPT, --prompt PROMPT\n");
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
+    fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  -f FNAME, --file FNAME\n");
     fprintf(stderr, "                        prompt file to start generation.\n");
     fprintf(stderr, "  -n N, --n_predict N   number of tokens to predict (default: %d)\n", params.n_predict);

--- a/utils.h
+++ b/utils.h
@@ -31,6 +31,7 @@ struct gpt_params {
 
     std::string model  = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt = "";
+    std::string input_prefix = ""; // string to prefix user inputs with
 
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
 


### PR DESCRIPTION
`--in-prefix STRING` command line option prefixes user inputs with `STRING`

For example, chatting with bob:
`./main -m ./models/llama-13B-ggml/ggml-model-q4_0.bin -n 256 --repeat_penalty 1.0 -f ./prompts/chat-with-bob.txt -i -r "User:" --in-prefix " "`
adds a space after the reverse prompt "User:"

So instead of 
```plain
Bob: How can I help you?
User:_
```
its
```plain
Bob: How can I help you?
User: _
```
and matches the original prompt better.

It could be useful for other prompts too, alignment or maybe testing multiple similar questions like "What do you think about X" or whatever.
