### PR TITLE
Fix quantize script not finding models in parent directory

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -57,6 +57,7 @@ def main():
     # )
 
     args = parser.parse_args()
+    args.models_path = os.path.abspath(args.models_path)
 
     if not os.path.isfile(args.quantize_script_path):
         print(


### PR DESCRIPTION
Previously, `python quantize.py --models-path .. 7B 13B` would fail to find `../7B/ggml-model-f16.bin` Now, it computes the absolute path to the models and uses that instead which works.

Fixes #431