### PR TITLE
dynamic estimate of required memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,14 +75,17 @@ find_package(Threads REQUIRED)
 if (NOT MSVC)
     if (LLAMA_SANITIZE_THREAD)
         add_compile_options(-fsanitize=thread)
+        link_libraries(-fsanitize=thread)
     endif()
 
     if (LLAMA_SANITIZE_ADDRESS)
         add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+        link_libraries(-fsanitize=address)
     endif()
 
     if (LLAMA_SANITIZE_UNDEFINED)
         add_compile_options(-fsanitize=undefined)
+        link_libraries(-fsanitize=undefined)
     endif()
 endif()
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -632,7 +632,7 @@ static bool llama_eval_internal(
     auto & mem_at_token1 = lctx.mem_at_token1;
 
     // TODO: fix this hardcoded size
-    static size_t buf_size = size_t(n_ctx)*1024*1024;
+    static size_t buf_size = size_t(n_ctx)*size_t(N)*128*1024;
     static void * buf = malloc(buf_size);
 
     const size_t C0 = mem_at_token0; // ~base

--- a/main.cpp
+++ b/main.cpp
@@ -219,7 +219,7 @@ int main(int argc, char ** argv) {
     // (fill in mem_at_token0 and mem_at_token1)
     // TODO: better way to do that
     // TODO(Green-Sky): move to internal and detect first time usage
-    {
+    if (!params.perplexity) { // perplexity does not grow over time
         // we make 2 evals, of batchsize to take 2 measurements, to determine base and growth
         std::vector<llama_token> tmp(params.n_batch*2, 2);
         tmp[0] = llama_token_bos();

--- a/main.cpp
+++ b/main.cpp
@@ -216,10 +216,16 @@ int main(int argc, char ** argv) {
     }
 
     // determine the required inference memory per token:
+    // (fill in mem_at_token0 and mem_at_token1)
     // TODO: better way to do that
+    // TODO(Green-Sky): move to internal and detect first time usage
     {
-        const std::vector<llama_token> tmp = { 0, 1, 2, 3 };
-        llama_eval(ctx, tmp.data(), tmp.size(), 0, params.n_threads);
+        // we make 2 evals, of batchsize to take 2 measurements, to determine base and growth
+        std::vector<llama_token> tmp(params.n_batch*2, 2);
+        tmp[0] = llama_token_bos();
+
+        llama_eval(ctx,                tmp.data(), params.n_batch,              0, params.n_threads);
+        llama_eval(ctx, tmp.data()+params.n_batch, params.n_batch, params.n_batch, params.n_threads);
     }
 
     if (params.perplexity) {


### PR DESCRIPTION
uses observations made in #213 and replaces it.

fixes `ggml_new_tensor_impl: not enough space in the context's memory pool` and resulting Segfaults.

this is still as much of a hack as it was before, but this time it is working.

this could potentially fix a bunch of issues. ( fixes https://github.com/ggerganov/llama.cpp/issues/153 )