### PR TITLE
Avoid the "non-contiguous X" branch in the Z = X * Y matrix multiplication

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -727,11 +727,13 @@ static bool llama_eval_internal(
 
             // V_trans = Vmem.view(n_embd/n_head, n_head, n_past + N).permute(1, 2, 0, 3).contiguous()
             struct ggml_tensor * V_trans =
-                ggml_permute(ctx0,
-                        ggml_reshape_3d(ctx0,
-                            ggml_view_1d(ctx0, model.memory_v, (n_past + N)*n_embd, il*n_ctx*ggml_element_size(model.memory_v)*n_embd),
-                            n_embd/n_head, n_head, n_past + N),
-                        1, 2, 0, 3);
+                ggml_cpy(ctx0,
+                    ggml_permute(ctx0,
+                            ggml_reshape_3d(ctx0,
+                                ggml_view_1d(ctx0, model.memory_v, (n_past + N)*n_embd, il*n_ctx*ggml_element_size(model.memory_v)*n_embd),
+                                n_embd/n_head, n_head, n_past + N),
+                            1, 2, 0, 3),
+                    ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, n_past + N, n_embd/n_head, n_head));
 
             // KQV = transpose(V) * KQ_soft_max
             struct ggml_tensor * KQV = ggml_mul_mat(ctx0, V_trans, KQ_soft_max);


### PR DESCRIPTION
ref #249 #95 

See https://github.com/ggerganov/llama.cpp/pull/407#issuecomment-1481674813

In the `mul_mat()` implementation currently we have 2 main branches:

- `src0` is contiguous in memory [(code)](https://github.com/ggerganov/llama.cpp/blob/d90112a0077c88c497a8b81c74cfebee3009d38e/ggml.c#L6480-L6521)
- `src0` is not contiguous in memory [(code)](https://github.com/ggerganov/llama.cpp/blob/d90112a0077c88c497a8b81c74cfebee3009d38e/ggml.c#L6521-L6570)

In the first branch we parallelize the computation along the `src0` rows. Each thread computes a dot product of `src0` row with `src1` column and writes the result into a cell of `dst`.

In the second branch we parallelize along the `src1` columns. Each thread computes multiply + add (mad) of a `src0` column with an element from `src1` and writes the result into a per-thread temporary buffer row. At the end of the multiplication, the results from all temporary buffers are accumulated into `dst`.

The second branch produces variation in the final result based on the used number of threads, since the result into a single `dst` cell is computed by adding different number of floating point terms, based on the used number of threads. It is a bit more efficient, but also uses a lot more memory due to the temporary buffers.

I am thinking that in view of having more stable results and also simplifying significantly the code in `ggml.c`, we should eliminate this second branch. The solution is to always make sure that `src0` is contiguous, which the user can always achieve with a simple `ggml_cpy()` call.

The benefits are quite a lot:
- no need to maintain `ggml_vec_mad_xxx()` functions - can be simply deleted
- reproducible results for different number of threads
- simpler `ggml_forward_mul_mat_xxx()` implementations
- less memory usage

The drawbacks:
- very slight performance degradation
