### PR TITLE
fix instruct mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -363,7 +363,7 @@ int main(int argc, char ** argv) {
             }
 
             // replace end of text token with newline token when in interactive mode
-            if (id == llama_token_eos() && params.interactive) {
+            if (id == llama_token_eos() && params.interactive && !params.instruct) {
                 id = llama_token_newline.front();
                 if (params.antiprompt.size() != 0) {
                     // tokenize and inject first reverse prompt
@@ -464,8 +464,12 @@ int main(int argc, char ** argv) {
 
         // end of text token
         if (embd.back() == llama_token_eos()) {
-            fprintf(stderr, " [end of text]\n");
-            break;
+            if (params.instruct) {
+                is_interacting = true;
+            } else {
+                fprintf(stderr, " [end of text]\n");
+                break;
+            }
         }
 
         // In interactive mode, respect the maximum number of tokens and drop back to user input when reached.


### PR DESCRIPTION
Changes to EOS behavior in interactive mode and reverse prompt handling by #333 broke instruct mode by erroneously injecting instruct mode's reverse prompt and an extra newline. This restores instruct mode's previous behavior unmodified. Tested thoroughly. All non-interactive/interactive/interactive + reverse prompt/instruct modes work correctly now with expected EOS behavior for each mode. Sorry for the mild breakage!