### PR TITLE
Trace model outputs to a binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vs/
 .vscode/
 .DS_Store
+__pycache__
 
 build/
 build-em/

--- a/examples/common.h
+++ b/examples/common.h
@@ -32,6 +32,7 @@ struct gpt_params {
     std::string model  = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt = "";
     std::string input_prefix = ""; // string to prefix user inputs with
+    std::string trace_fn = "";
 
 
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
@@ -63,3 +64,19 @@ std::string gpt_random_prompt(std::mt19937 & rng);
 //
 
 std::vector<llama_token> llama_tokenize(struct llama_context * ctx, const std::string & text, bool add_bos);
+
+//
+// Trace utils
+//
+
+static constexpr uint32_t LLAMA_TRACE_VERSION = 0;
+static constexpr uint32_t LLAMA_TRACE_MAGIC = 0x67676d74; // 'ggmt' in hex
+
+// Open format: magic:int version:int n_vocab:int
+std::ofstream trace_open(const gpt_params & params, struct llama_context * ctx);
+
+// Write a record using the binary format: N:int {N}token_id:int {N*n_vocab}logits:float
+void trace_write_record(
+                     std::ofstream & out,
+    const std::vector<llama_token> & embd,
+              struct llama_context * ctx);

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -169,6 +169,7 @@ int main(int argc, char ** argv) {
         lparams.n_parts    = params.n_parts;
         lparams.seed       = params.seed;
         lparams.f16_kv     = params.memory_f16;
+        lparams.logits_all = !params.trace_fn.empty();
         lparams.use_mlock  = params.use_mlock;
 
         ctx = llama_init_from_file(params.model.c_str(), lparams);
@@ -204,6 +205,8 @@ int main(int argc, char ** argv) {
 
         return 0;
     }
+
+    std::ofstream trace_ofs = trace_open(params, ctx);
 
     // Add a space in front of the first character to match OG llama tokenizer behavior
     params.prompt.insert(0, 1, ' ');
@@ -339,6 +342,7 @@ int main(int argc, char ** argv) {
                 fprintf(stderr, "%s : failed to eval\n", __func__);
                 return 1;
             }
+            trace_write_record(trace_ofs, embd, ctx);
         }
 
         n_past += embd.size();
@@ -502,6 +506,7 @@ int main(int argc, char ** argv) {
 
     llama_print_timings(ctx);
     llama_free(ctx);
+    trace_ofs.close();
 
     set_console_state(CONSOLE_STATE_DEFAULT);
 

--- a/examples/traceparser/__init__.py
+++ b/examples/traceparser/__init__.py
@@ -1,0 +1,1 @@
+from .parser import open_trace

--- a/examples/traceparser/__main__.py
+++ b/examples/traceparser/__main__.py
@@ -1,0 +1,70 @@
+import argparse
+
+import numpy as np
+from sentencepiece import SentencePieceProcessor
+
+from . import open_trace
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Upgrade old ggml model files to the current format')
+    parser.add_argument('trace_file', help='tracefile to read')
+    parser.add_argument('--tokenizer', help='path to LLaMA tokenizer.model file',
+        dest='tokenizer_model_file', default='models/tokenizer.model')
+    parser.add_argument('--temp', help='Sampling temperature',
+        dest='temperature', default=0.8, type=float)
+    parser.add_argument('--top_k', help='top k tokens to sample', type=int)
+    parser.add_argument('--top_p', help='nucleus probability', type=float, default=1.0)
+    return parser.parse_args()
+
+
+def top_k_indices(logits, k):
+    idxs = np.argpartition(logits, -k)[-k:]
+    idxs = idxs[np.argsort(logits[idxs])][::-1]
+    return idxs
+
+def process_logits(logits, temp):
+    logits = logits / temp
+    logp = logits - logits.max()
+    p = np.exp(logp)
+    sum_p = p.sum()
+    entropy = -(p * logp).sum() / sum_p + np.log(sum_p)
+    p /= sum_p
+    #entropy = -(p * np.log(p)).sum()
+    return p, entropy
+
+def top_p(p, top_p):
+    if top_p < 1:
+        cumsum = 0.
+        for i in range(len(p)):
+            cumsum += p[i]
+            if cumsum >= top_p:
+                return i + 1
+    return len(p)
+
+def replicate_sampler(tokens, args, max_print=10):
+    log2 = np.log(2)
+    tokenizer = SentencePieceProcessor(args.tokenizer_model_file)
+    piece_repr = lambda tokid: repr(tokenizer.id_to_piece(int(tokid)))
+    for tokens, logits_arrs in f:
+        for tokid, logits in zip(tokens, logits_arrs):
+            idxs = None
+            if args.top_k is not None:
+                idxs = top_k_indices(logits, args.top_k)
+            else:
+                idxs = np.argsort(logits)[::-1]
+            logits = logits[idxs]
+            p, entropy = process_logits(logits, args.temperature)
+
+            n_top_p = top_p(p, args.top_p)
+            logits = logits[:n_top_p]
+            idxs = idxs[:n_top_p]
+
+            print(f'in:{piece_repr(tokid):10} logits: mean={logits.mean()=:5.2f} max={logits[0]:5.2f} entropy={entropy*log2:.2f} bits n={len(idxs)}')
+            print(' '*13, ' '.join(f'{piece_repr(candtok)}:{prob:.2f}' for candtok, prob in zip(idxs[:max_print], p)))
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    with open_trace(args.trace_file) as f:
+        print(f'n_vocab={f.n_vocab}')
+        replicate_sampler(f, args)

--- a/examples/traceparser/parser.py
+++ b/examples/traceparser/parser.py
@@ -1,0 +1,65 @@
+import struct
+import mmap
+
+import numpy as np
+
+
+def open_trace(fn):
+    base_header_fmt = "i" * 2
+    file = open(fn, "rb")
+    magic, version = struct.unpack(base_header_fmt, file.read(struct.calcsize(base_header_fmt)))
+    if magic != 0x67676d74:
+        raise ValueError('Invalid file magic. Must be a llama.cpp trace file')
+    parser_cls = TraceParserBase._parsers.get(version)
+    if parser_cls is None:
+        raise ValueError(f'Unknown version {version}')
+    return parser_cls(file)
+
+class TraceParserBase:
+    def __init__(self, file):
+        self.file = file
+        self.mmap = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
+        self.pos = file.tell() # Skip magic and version header
+        self.size = self.mmap.size()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.mmap.close()
+        self.file.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.pos >= self.size:
+            raise StopIteration
+        return self.parse_record()
+
+class TraceParserV0(TraceParserBase):
+    def __init__(self, file):
+        super().__init__(file)
+        header_fmt = 'i' # n_vocab
+        self.n_vocab, = struct.unpack_from(header_fmt, self.mmap, self.pos)
+        self.pos += struct.calcsize(header_fmt)
+
+    def parse_record(self):
+        pos = self.pos
+        n_vocab = self.n_vocab
+
+        header_fmt = 'i' # n_tokens
+        n_tokens, = struct.unpack_from(header_fmt, self.mmap, pos)
+        pos += struct.calcsize(header_fmt)
+        tokens = np.frombuffer(self.mmap, dtype=np.int32, count=n_tokens, offset=pos)
+        pos += tokens.itemsize * tokens.size
+        logits = np.frombuffer(self.mmap, dtype=np.float32, count=n_tokens * n_vocab, offset=pos)
+        pos += logits.itemsize * logits.size
+
+        assert pos <= self.size
+        self.pos = pos
+        return tokens, logits.reshape((n_tokens, n_vocab))
+
+TraceParserBase._parsers = {
+    0: TraceParserV0
+}


### PR DESCRIPTION
This adds a `--trace ` option that exports the decoder activations to a file. The format can be read with: 
```
python -m examples.traceparser trace.bin
```
It's a basic app that comes with a parser, designed to help building analysis tools and tests. For now, it only replicates the soft max and the top k and nucleus filtering.

The format is versioned and should be easily extendable with more data (eg. embeddings, insertions in caches).

I'm using it for the same purpose as #246  (which is retired now) - to perform numerical analysis in Python for exploring #331.

Is this approach acceptable and useful to others? 
This might become redundant once Python bindings allows to do the same thing in process memory, without going through a serialized format.