### PR TITLE
Add missing struct annotation

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -123,7 +123,7 @@ extern "C" {
 
     // TODO: improve the last_n_tokens interface ?
     LLAMA_API llama_token llama_sample_top_p_top_k(
-              llama_context * ctx,
+       struct llama_context * ctx,
           const llama_token * last_n_tokens_data,
                         int   last_n_tokens_size,
                         int   top_k,


### PR DESCRIPTION
`llama_sample_top_p_top_k` was missing the struct annotation on line 126.

This causes a compiler issue when being parsed by the Kotlin C interop generator.

This commit fixes the above issue by adding the struct annotation.