### PR TITLE
Exit from interactive mode if input stream is bad

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -450,7 +450,10 @@ int main(int argc, char ** argv) {
                 std::string line;
                 bool another_line = true;
                 do {
-                    std::getline(std::cin, line);
+                    if (!std::getline(std::cin, line)) {
+                        // input stream is bad or EOF received
+                        return 0;
+                    }
                     if (line.empty() || line.back() != '\\') {
                         another_line = false;
                     } else {


### PR DESCRIPTION
Allow exiting the interactive prompt also with CTRL-D on Unix and CTRL-Z on Windows.

CTRL-D is so in my muscle memory, I never press anything else.