### PR TITLE
CI quick fix : Run other sanitizer builds even if one fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
   ubuntu-latest-cmake-sanitizer:
     runs-on: ubuntu-latest
 
+    continue-on-error: true
+
     strategy:
       matrix:
         sanitizer: [ADDRESS, THREAD, UNDEFINED]


### PR DESCRIPTION
Otherwise they all will be cancelled when the first one fails.