### PR TITLE
Add support for linux/arm64 platform during Docker Builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,5 +57,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
           tags: "ghcr.io/ggerganov/llama.cpp:${{ matrix.config.tag }}"
           file: ${{ matrix.config.dockerfile }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: "ghcr.io/ggerganov/llama.cpp:${{ matrix.config.tag }}-${{ env.COMMIT_SHA }}"
           file: ${{ matrix.config.dockerfile }}
 


### PR DESCRIPTION
Currently the Docker image is only published for linux/amd64. This PR adds support for published the linux/arm64 image.

This issue was encountered during this PR for Serge: https://github.com/nsarrazin/serge/pull/66

Source for this change: https://docs.docker.com/build/ci/github-actions/multi-platform/