### PR TITLE
Fix missing ggml link in cmake for executables in examples on w64-mingw32

### DIFF
--- a/examples/embedding/CMakeLists.txt
+++ b/examples/embedding/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET embedding)
 add_executable(${TARGET} embedding.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/main/CMakeLists.txt
+++ b/examples/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET main)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/perplexity/CMakeLists.txt
+++ b/examples/perplexity/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET perplexity)
 add_executable(${TARGET} perplexity.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/quantize/CMakeLists.txt
+++ b/examples/quantize/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET quantize)
 add_executable(${TARGET} quantize.cpp)
-target_link_libraries(${TARGET} PRIVATE llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE llama ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)


### PR DESCRIPTION
Without this I get linking errors on x86_64-w64-mingw32 (on linux I don't need this patch):

```
[01:33:38] [ 50%] Linking CXX executable ../../bin/main.exe
[01:33:38] cd /workspace/srcdir/llama.cpp/build/examples/main && /usr/bin/cmake -E cmake_link_script CMakeFiles/main.dir/link.txt --verbose=true
[01:33:38] /usr/bin/cmake -E rm -f CMakeFiles/main.dir/objects.a
[01:33:38] /opt/bin/x86_64-w64-mingw32-libgfortran5-cxx11/x86_64-w64-mingw32-ar qc CMakeFiles/main.dir/objects.a @CMakeFiles/main.dir/objects1.rsp
[01:33:38] /opt/bin/x86_64-w64-mingw32-libgfortran5-cxx11/x86_64-w64-mingw32-g++ --sysroot=/opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/ -O3 -DNDEBUG -Wl,--whole-archive CMakeFiles/main.dir/objects.a -Wl,--no-whole-archive -o ../../bin/main.exe -Wl,--out-implib,libmain.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/main.dir/linklibs.rsp
[01:33:38] /opt/x86_64-w64-mingw32/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld: CMakeFiles/main.dir/objects.a(common.cpp.obj):common.cpp:(.text+0x4c8): undefined reference to `ggml_mlock_supported'
[01:33:38] collect2: error: ld returned 1 exit status
```