### PR TITLE
Revert 7e53955 (#542) and fix properly

### DIFF
--- a/examples/embedding/CMakeLists.txt
+++ b/examples/embedding/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET embedding)
 add_executable(${TARGET} embedding.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/main/CMakeLists.txt
+++ b/examples/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET main)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/perplexity/CMakeLists.txt
+++ b/examples/perplexity/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET perplexity)
 add_executable(${TARGET} perplexity.cpp)
-target_link_libraries(${TARGET} PRIVATE common llama ggml ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/examples/quantize/CMakeLists.txt
+++ b/examples/quantize/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(TARGET quantize)
 add_executable(${TARGET} quantize.cpp)
-target_link_libraries(${TARGET} PRIVATE llama ggml ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)

--- a/llama.h
+++ b/llama.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 
 #ifdef LLAMA_SHARED
-#    ifdef _WIN32
+#    ifdef _WIN32 && !defined __MINGW32__
 #        ifdef LLAMA_BUILD
 #            define LLAMA_API __declspec(dllexport)
 #        else


### PR DESCRIPTION
Reverting https://github.com/ggerganov/llama.cpp/commit/7e5395575a3360598f2565c73c8a2ec0c0abbdb8 \(#542)

`ggml` shouldn't be linked twice as it's already linked to `llama` (probably `common` should be linked to `ggml` instead) .
ref: https://github.com/ggerganov/llama.cpp/commit/7e5395575a3360598f2565c73c8a2ec0c0abbdb8#commitcomment-106187813

- [x] Reverts https://github.com/ggerganov/llama.cpp/commit/7e5395575a3360598f2565c73c8a2ec0c0abbdb8 (#542)
- [x] Needs someone with minGW to post a proper solution that works (thanks @marcom).


