### PR TITLE
Added support for _POSIX_MAPPED_FILES if defined in source

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,8 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#elif defined (_POSIX_MAPPED_FILES)
+#include <sys/mman.h>
 #endif
 
 #define ROUNDUP(X, K) (((X) + (K)-1) & -(K))

--- a/mmap.h
+++ b/mmap.h
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) && !(defined (_POSIX_MAPPED_FILES))
 #ifndef __MINGW32__
 #include <Windows.h>
 #else


### PR DESCRIPTION
I have created my own library for mingw32 that includes the POSIX functions that the source needs to compile. That is how I will support llama.cpp for windows using mingw32 compilation in mys2. Compiled successfully using:
make LDFLAGS='-D_POSIX_MAPPED_FILES -lmingw32_extended'