### PR TITLE
Fix linker error for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(llama_add_test source)
     get_filename_component(TEST_TARGET ${source} NAME_WE)
     add_executable(${TEST_TARGET} ${source})
-    target_link_libraries(${TEST_TARGET} PRIVATE llama)
+    target_link_libraries(${TEST_TARGET} PRIVATE llama ggml)
     add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}> ${ARGN})
 endfunction()
 


### PR DESCRIPTION
Link tests with `ggml` to avoid these errors:
```
[build] test-quantize.c.obj : error LNK2019: unresolved external symbol ggml_quantize_q4_0 referenced in function main
[build] test-quantize.c.obj : error LNK2019: unresolved external symbol ggml_quantize_q4_1 referenced in function main
```