### PR TITLE
Use the same batch size threshold for enabling OpenBLAS and disabling ggml threading

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -856,7 +856,7 @@ static bool llama_eval_internal(
     // for big prompts, if BLAS is enabled, it is better to use only one thread
     // otherwise, the threads are spin-lock waiting for the BLAS calls and are degrading the performance
     ggml_cgraph gf = {};
-    gf.n_threads = N > 255 && ggml_cpu_has_blas() ? 1 : n_threads;
+    gf.n_threads = N >= 32 && ggml_cpu_has_blas() ? 1 : n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, tokens, N*ggml_element_size(embd));


### PR DESCRIPTION
Commit 4640eff2 disabled ggml's multi-threading when OpenBLAS is used for processing large prompts.
This avoids running two thread pools at the same time.

However, OpenBLAS is used by ggml on tensors with dims >= 32, but llama.cpp only reduce the number of threads for batch size > 255.

See also this discussion: https://github.com/ggerganov/llama.cpp/discussions/229#discussioncomment-5454503 and issue #578