### PR TITLE
add example of re-act pattern

### DIFF
--- a/examples/reason-act.sh
+++ b/examples/reason-act.sh
@@ -1,0 +1,16 @@
+
+#!/bin/bash
+
+cd `dirname $0`
+cd ..
+
+# get -m model parameter otherwise defer to default
+if [ "$1" == "-m" ]; then
+  MODEL="-m $1"
+fi
+
+./main $MODEL --color \
+    -f ./prompts/reason-act.txt \
+    -i --interactive-first \
+    --top_k 10000 --temp 0.2 --repeat_penalty 1 -t 7 -c 2048 \
+    -r "Question: " -r "Observation: " -n -1

--- a/examples/reason-act.sh
+++ b/examples/reason-act.sh
@@ -6,11 +6,12 @@ cd ..
 
 # get -m model parameter otherwise defer to default
 if [ "$1" == "-m" ]; then
-  MODEL="-m $1"
+  MODEL="-m $2 "
 fi
 
 ./main $MODEL --color \
     -f ./prompts/reason-act.txt \
     -i --interactive-first \
     --top_k 10000 --temp 0.2 --repeat_penalty 1 -t 7 -c 2048 \
-    -r "Question: " -r "Observation: " -n -1
+    -r "Question:" -r "Observation:" --in-prefix " " \
+    -n -1

--- a/prompts/reason-act.txt
+++ b/prompts/reason-act.txt
@@ -15,4 +15,4 @@ Answer: The calculate tool says it is 9.3333333333
 Question: What is capital of france?
 Thought: Do I need to use an action? No, I know the answer
 Answer: Paris is the capital of France
-Question: 
+Question:

--- a/prompts/reason-act.txt
+++ b/prompts/reason-act.txt
@@ -1,5 +1,5 @@
 You run in a loop of Thought, Action, Observation.
-At the end of the loop either Answer or restate your Toughts and Actions.
+At the end of the loop either Answer or restate your Thought and Action.
 Use Thought to describe your thoughts about the question you have been asked.
 Use Action to run one of these actions available to you:
 - calculate[python math expression]

--- a/prompts/reason-act.txt
+++ b/prompts/reason-act.txt
@@ -1,0 +1,18 @@
+You run in a loop of Thought, Action, Observation.
+At the end of the loop either Answer or restate your Toughts and Actions.
+Use Thought to describe your thoughts about the question you have been asked.
+Use Action to run one of these actions available to you:
+- calculate[python math expression]
+Observation will be the result of running those actions
+
+
+Question: What is 4 * 7 / 3?
+Thought: Do I need to use an action? Yes, I use calculate to do math
+Action: calculate[4 * 7 / 3]
+Observation: 9.3333333333
+Thought: Do I need to use an action? No, have the result
+Answer: The calculate tool says it is 9.3333333333
+Question: What is capital of france?
+Thought: Do I need to use an action? No, I know the answer
+Answer: Paris is the capital of France
+Question: 


### PR DESCRIPTION
Example implementing a version of the reason-act pattern. It's a neat example of what you can do with the 7B model, at least the instruction tuned versions. [Paper](https://arxiv.org/abs/2210.03629).

Adds `examples/reason-act.sh` and `prompts/reason-act.txt`. 

<img width="984" alt="image" src="https://user-images.githubusercontent.com/347/228367570-c3dede77-1120-4158-9f78-0a6f5dd5e42d.png">
