### PR TITLE
Add support for memory mapping models

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -19,7 +19,7 @@ int main(int argc, char ** argv) {
 
     // needed to initialize f16 tables
     {
-        struct ggml_init_params params = { 0, NULL };
+        struct ggml_init_params params = { 0, NULL, false };
         struct ggml_context * ctx = ggml_init(params);
         ggml_free(ctx);
     }

--- a/ggml.h
+++ b/ggml.h
@@ -316,6 +316,7 @@ struct ggml_init_params {
     // memory pool
     size_t mem_size;   // bytes
     void * mem_buffer; // if NULL, memory will be allocated internally
+    bool   no_alloc;   // don't allocate memory for the tensor data
 };
 
 void    ggml_time_init(void); // call this once at the beginning of the program

--- a/llama.cpp
+++ b/llama.cpp
@@ -12,11 +12,15 @@
 #include <cassert>
 #include <cstring>
 
-// headers for POSIX mmap
+// mmap
 #if defined (__unix__) || defined (__APPLE__)
 #   include <sys/mman.h>
 #   include <fcntl.h>
 #   include <unistd.h>
+#elif defined(_WIN32)
+#   define WIN32_LEAN_AND_MEAN
+#   include <Windows.h>
+//#include <Memoryapi.h>
 #endif
 
 #define LLAMA_USE_SCRATCH
@@ -312,8 +316,31 @@ static void mmap_file(const char* fname, void * &mm_addr, size_t &mm_length) {
         mm_addr = NULL;
         mm_length = 0;
     }
+#elif defined(_WIN32)
+    mm_addr = NULL;
+    
+    HANDLE hFile = CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    // not really necessary
+    LARGE_INTEGER fileSize;
+    GetFileSizeEx(hFile, &fileSize);
+    mm_length = fileSize;
+
+    HANDLE hMapping = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+    CloseHandle(hFile);
+
+    if (hMapping == NULL) {
+        return;
+    }
+
+    mm_addr = MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, 0);
+    CloseHandle(hMapping);
 #else
-    // TODO: windows support
+    mm_addr = NULL;
+    mm_length = 0;
     (void)(fname); // suppress warnings
 #endif
 }
@@ -322,8 +349,9 @@ static void munmap_file(void * addr, size_t length) {
 #if defined(MAP_FAILED)
     // POSIX
     munmap(addr, length);
+#elif defined(_WIN32)
+    UnmapViewOfFile(addr);
 #else
-    // TODO: windows support
     (void)(addr); // suppress warnings
     (void)(length);
 #endif

--- a/llama.cpp
+++ b/llama.cpp
@@ -150,8 +150,8 @@ struct llama_model {
     std::vector<uint8_t> buf;
 
     // model memory mapped file
-    void * mm_addr;
-    size_t mm_length;
+    void * mm_addr = NULL;
+    size_t mm_length = 0;
 
     // tensors
     int n_loaded;

--- a/llama.cpp
+++ b/llama.cpp
@@ -296,7 +296,7 @@ struct llama_context_params llama_context_default_params() {
 // model loading
 //
 
-void * mmap_file(const char* fname) {
+static void * mmap_file(const char* fname) {
 #if defined(MAP_FAILED)
     // POSIX mmap
     int fd = open(fname, O_RDONLY);

--- a/llama.cpp
+++ b/llama.cpp
@@ -315,7 +315,6 @@ void * mmap_file(const char* fname) {
 #endif
 }
 
-
 static bool llama_model_load(
         const std::string & fname,
         llama_context & lctx,
@@ -488,8 +487,6 @@ static bool llama_model_load(
             use_mmap = false;
         }
     }
-
-
 
     auto & ctx = model.ctx;
 


### PR DESCRIPTION
Significantly reduces model loading times, especially if they are already cached by the OS.

- Requires a single-part model to work, either a 7B model or any model converted with #545 (use with `--n_parts 1`).

- Only tested on Linux, needs to be tested with other POSIX-compatible operating systems. Should work on OS X as is.

- The tensors may not be aligned, which may cause performance issues or crashes on some microarchitectures. However, testing by @jart showed no issues so far. This needs to be fixed in the conversion script.

Still missing:
- [x] Unmap the file in `llama_free`
- [ ] Test with other POSIX operating systems
- [ ] Windows support
- [ ] Consider enabling CoW to support replacing some of the tensors

Co-authored with @jart.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ef9afe1</samp>

### Summary
:sparkles::zap::penguin:

<!--
1.  :sparkles: This emoji is often used to indicate new features or enhancements, and adding the `no_alloc` field and memory mapping support are both new features for GGML.
2.  :zap: This emoji is often used to indicate performance improvements or optimizations, and memory mapping can improve the loading speed and memory efficiency of GGML models.
3.  :penguin: This emoji is often used to indicate Linux or Unix-related changes, and using POSIX mmap is a Unix-specific feature that may not work on other platforms. Alternatively, one could use :computer: to indicate cross-platform changes, but since Windows support is not implemented yet, :penguin: may be more accurate.
-->
Added a feature to `llama.cpp` and `ggml.c` that allows loading and evaluating models from memory mapped files. This can improve performance and reduce memory usage for large models. Added a new parameter `no_alloc` to the `ggml_context` and `ggml_init_params` structs to control this feature. Implemented memory mapping for Unix-like systems and left a placeholder for Windows.

> _Sing, O Muse, of the swift and skillful programmers_
> _Who devised a clever way to load the models of GGML_
> _With no allocation of memory, but using the mapped addresses_
> _Of the files, like the Cyclops who forged the thunderbolts of Zeus._

### Walkthrough
*  Add a feature to support memory mapping of model files ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2422-R2424), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dR2706), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2820-R2822), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2904-R2906), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dR10169), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394R319), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR15-R21), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR299-R318), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR334), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL452-R496), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL461-R524), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR556), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL598-R638), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL739-R786))
  * Introduce a new field `no_alloc` in `ggml_context` and `ggml_init_params` to indicate whether the context should allocate memory for the tensor data or not ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2422-R2424), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394R319))
  * Initialize the `no_alloc` field from the `params` argument in `ggml_init` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dR2706))
  * Check the `no_alloc` field in `ggml_new_tensor_impl` to prevent allocating memory for the tensor data and to assign the `data` field to the memory mapped address if available ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2820-R2822), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL2904-R2906))
  * Set the `no_alloc` field to false in `ggml_opt` and `llama_eval_internal` to ensure that the optimization and evaluation processes allocate memory for the intermediate tensors as usual ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dR10169), [link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR899))
  * Add some headers for POSIX mmap to `llama.cpp` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR15-R21))
  * Add a new function `mmap_file` to `llama.cpp` to try to memory map a given file and return the mapped address or NULL on failure ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR299-R318))
  * Add some logic to `llama_model_load` to determine whether to use memory mapping or not based on the number of model parts and the success of `mmap_file` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL452-R496))
  * Skip adding the size of the tensors that can be memory mapped to the context size in `llama_model_load` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL461-R524))
  * Set the `no_alloc` field to the value of `use_mmap` in `llama_model_load` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR556))
  * Add a message to indicate whether memory mapping is used or not when loading a model part in `llama_model_load` ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL598-R638))
  * Handle the case of memory mapping in `llama_model_load` by setting the tensor data pointer to the offset from the mapped address and advancing the file pointer accordingly ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL739-R786))
* Set the `no_alloc` field to false in `kv_cache_init` to ensure that the key-value cache allocates memory for the tensors as usual ([link](https://github.com/ggerganov/llama.cpp/pull/586/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR256))

