### PR TITLE
Apply formatting to python code

### DIFF
--- a/convert-gpt4all-to-ggml.py
+++ b/convert-gpt4all-to-ggml.py
@@ -15,11 +15,15 @@ from sentencepiece import SentencePieceProcessor
 
 HPARAMS = keys = ["vocab_size", "dim", "multiple_of", "n_heads", "n_layers"]
 
+
 def parse_args():
-    parser = argparse.ArgumentParser(description='Upgrade a GPT4All model to the current format')
-    parser.add_argument('gpt4all_model', help='path to gpt4all-lora-quantized.bin')
-    parser.add_argument('tokenizer_model', help='path to LLaMA tokenizer.model file')
+    parser = argparse.ArgumentParser(
+        description="Upgrade a GPT4All model to the current format"
+    )
+    parser.add_argument("gpt4all_model", help="path to gpt4all-lora-quantized.bin")
+    parser.add_argument("tokenizer_model", help="path to LLaMA tokenizer.model file")
     return parser.parse_args()
+
 
 def read_header(f_in):
     struct_fmt = "i" * (3 + len(HPARAMS))
@@ -27,24 +31,26 @@ def read_header(f_in):
     buf = f_in.read(struct_size)
     return struct.unpack(struct_fmt, buf)
 
+
 def write_header(f_out, header):
     (magic, vocab_size, dim, multiple_of, n_heads, n_layers, rot, ftype) = header
 
-    if magic != 0x67676d6c:
-        raise Exception('Invalid file magic. Must be an old style ggml file.')
+    if magic != 0x67676D6C:
+        raise Exception("Invalid file magic. Must be an old style ggml file.")
 
     values = [
-        0x67676d66, # magic: ggml in hex
-        1,          # file version
+        0x67676D66,  # magic: ggml in hex
+        1,  # file version
         vocab_size,
         dim,
         multiple_of,
         n_heads,
         n_layers,
         rot,
-        ftype
+        ftype,
     ]
     f_out.write(struct.pack("i" * len(values), *values))
+
 
 def write_tokens(fout, tokenizer):
     for i in range(tokenizer.vocab_size()):
@@ -71,11 +77,13 @@ def write_tokens(fout, tokenizer):
     fout.write(text)
     fout.write(struct.pack("f", 0.0))
 
+
 def read_tokens(f_in, tokenizer):
     for i in range(tokenizer.vocab_size()):
         len_b = f_in.read(4)
         (length,) = struct.unpack("i", len_b)
         f_in.read(length)
+
 
 def copy_all_data(f_out, f_in):
     while True:
@@ -84,9 +92,10 @@ def copy_all_data(f_out, f_in):
             break
         f_out.write(buf)
 
+
 def convert_one_file(path_in, tokenizer):
     path_tmp = f"{path_in}.tmp"
-    path_orig= f"{path_in}.orig"
+    path_orig = f"{path_in}.orig"
     print(f"converting {path_in}")
     with open(path_in, "rb") as f_in, open(path_tmp, "wb") as f_out:
         write_header(f_out, read_header(f_in))
@@ -96,12 +105,14 @@ def convert_one_file(path_in, tokenizer):
     os.rename(path_in, path_orig)
     os.rename(path_tmp, path_in)
 
+
 def main():
     args = parse_args()
 
     tokenizer = SentencePieceProcessor(args.tokenizer_model)
 
     convert_one_file(args.gpt4all_model, tokenizer)
+
 
 if __name__ == "__main__":
     main()

--- a/flake.lock
+++ b/flake.lock
@@ -1,43 +1,34 @@
 {
-  "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
+    "nodes": {
+        "flake-utils": {
+            "locked": {
+                "lastModified": 1676283394,
+                "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+                "owner": "numtide",
+                "repo": "flake-utils",
+                "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+                "type": "github",
+            },
+            "original": {"owner": "numtide", "repo": "flake-utils", "type": "github"},
+        },
+        "nixpkgs": {
+            "locked": {
+                "lastModified": 1678470307,
+                "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
+                "type": "github",
+            },
+            "original": {
+                "owner": "NixOS",
+                "ref": "nixos-unstable",
+                "repo": "nixpkgs",
+                "type": "github",
+            },
+        },
+        "root": {"inputs": {"flake-utils": "flake-utils", "nixpkgs": "nixpkgs"}},
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1678470307,
-        "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    }
-  },
-  "root": "root",
-  "version": 7
+    "root": "root",
+    "version": 7,
 }

--- a/quantize.py
+++ b/quantize.py
@@ -25,27 +25,36 @@ def main():
         quantize_script_binary = "quantize"
 
     parser = argparse.ArgumentParser(
-        prog='python3 quantize.py',
-        description='This script quantizes the given models by applying the '
-        f'"{quantize_script_binary}" script on them.'
+        prog="python3 quantize.py",
+        description="This script quantizes the given models by applying the "
+        f'"{quantize_script_binary}" script on them.',
     )
     parser.add_argument(
-        'models', nargs='+', choices=('7B', '13B', '30B', '65B'),
-        help='The models to quantize.'
+        "models",
+        nargs="+",
+        choices=("7B", "13B", "30B", "65B"),
+        help="The models to quantize.",
     )
     parser.add_argument(
-        '-r', '--remove-16', action='store_true', dest='remove_f16',
-        help='Remove the f16 model after quantizing it.'
+        "-r",
+        "--remove-16",
+        action="store_true",
+        dest="remove_f16",
+        help="Remove the f16 model after quantizing it.",
     )
     parser.add_argument(
-        '-m', '--models-path', dest='models_path',
+        "-m",
+        "--models-path",
+        dest="models_path",
         default=os.path.join(os.getcwd(), "models"),
-        help='Specify the directory where the models are located.'
+        help="Specify the directory where the models are located.",
     )
     parser.add_argument(
-        '-q', '--quantize-script-path', dest='quantize_script_path',
+        "-q",
+        "--quantize-script-path",
+        dest="quantize_script_path",
         default=os.path.join(os.getcwd(), quantize_script_binary),
-        help='Specify the path to the "quantize" script.'
+        help='Specify the path to the "quantize" script.',
     )
 
     # TODO: Revise this code
@@ -75,12 +84,12 @@ def main():
         )
 
         if not os.path.isfile(f16_model_path_base):
-            print(f'The file %s was not found' % f16_model_path_base)
+            print(f"The file %s was not found" % f16_model_path_base)
             sys.exit(1)
 
         f16_model_parts_paths = map(
             lambda filename: os.path.join(f16_model_path_base, filename),
-            glob.glob(f"{f16_model_path_base}*")
+            glob.glob(f"{f16_model_path_base}*"),
         )
 
         for f16_model_part_path in f16_model_parts_paths:
@@ -93,9 +102,7 @@ def main():
                 )
                 sys.exit(1)
 
-            __run_quantize_script(
-                args.quantize_script_path, f16_model_part_path
-            )
+            __run_quantize_script(args.quantize_script_path, f16_model_part_path)
 
             if args.remove_f16:
                 os.remove(f16_model_part_path)
@@ -104,6 +111,7 @@ def main():
 # This was extracted to a top-level function for parallelization, if
 # implemented. See https://github.com/ggerganov/llama.cpp/pull/222/commits/f8db3d6cd91bf1a1342db9d29e3092bc12dd783c#r1140496406
 
+
 def __run_quantize_script(script_path, f16_model_part_path):
     """Run the quantize script specifying the path to it and the path to the
     f16 model to quantize.
@@ -111,8 +119,7 @@ def __run_quantize_script(script_path, f16_model_part_path):
 
     new_quantized_model_path = f16_model_part_path.replace("f16", "q4_0")
     subprocess.run(
-        [script_path, f16_model_part_path, new_quantized_model_path, "2"],
-        check=True
+        [script_path, f16_model_part_path, new_quantized_model_path, "2"], check=True
     )
 
 


### PR DESCRIPTION
It would be great if python code is appropriately formatted with [Black](https://github.com/psf/black) to improve the readability of code while following [psf](https://www.python.org/psf-landing/) foundation-based guidelines!

Usage is pretty simple:

`>black $file_name`

Happy to answer any questions :)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81b8748</samp>

### Summary
🎨📝🚚

<!--
1.  🎨 - This emoji is often used to indicate code style or formatting improvements, such as following PEP8 or other conventions.
2.  📝 - This emoji is often used to indicate adding or updating comments or documentation, such as explaining the logic or purpose of the code.
3.  🚚 - This emoji is often used to indicate moving or renaming files or folders, such as changing the extension or location of the scripts.
-->
Reformatted several Python scripts to follow PEP8 style and improve readability. No changes to functionality or logic. The scripts are used to convert different formats of graph models to the GGML format used by llama.cpp.

> _`convert-` scripts_
> _PEP8 style and readability_
> _autumn leaves of code_

### Walkthrough
*  Reformat all Python scripts to follow PEP8 style guide, such as breaking long lines, adding spaces and commas, using double quotes for strings, and adding blank lines between functions ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL75-R80),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL101-R108),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL115-R132),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL167-R186),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL176-R195),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL240-R263),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL255-R281),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL262-R292),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171L18-R27),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171L30-R43),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171L45-R54),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171R80),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171R87),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171L87-R98),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171R108),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171R116),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L23-R28),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L39-R43),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L46-R49),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L69-R88),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L91-R106),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L116-R127),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L131-R159),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L151-R174),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L158-R188),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cL13-R22),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cL25-R38),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cL40-R49),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cR69),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cR76),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cL76-R87),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cR97),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cR109),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L28-R57),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L78-R92),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L96-R105),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917R114),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L114-R122))
* Change magic numbers to uppercase hex in `write_header` functions of `convert-gpt4all-to-ggml.py`, `convert-gptq-to-ggml.py`, and `convert-unversioned-ggml-to-ggml.py` for consistency with other scripts ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-c672303f7aa753fa7b0f2323ac4cccb6312cc73a2a31191d595b5453df356171L30-R43),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L39-R43),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-dad6187d7ea247bde91c3129f33a52a393284c1dde6fbf3fb68d2c30b6aa5e6cL25-R38))
* Add comments for `rot` and `ftype` parameters in `convert-gptq-to-ggml.py` for clarity ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L46-R49),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L151-R174))
* Add parentheses around multi-line function signatures and expressions in `convert-ggml-to-pth.py` and `convert-gptq-to-ggml.py` for readability ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL176-R195),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L131-R159),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-5db85500edc015b1a76e3f715c8b724c9bec01084e6509c8972370bba1cc2871L158-R188))
* Add brackets around list comprehension in `convert-ggml-to-pth.py` for consistency ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-39b4aca81af2aa73020253f1dd9840237bdcf5500758e14a84092efc610c825dL262-R292))
* Remove unnecessary line breaks in `quantize.py` for compactness ([link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L96-R105),[link](https://github.com/ggerganov/llama.cpp/pull/611/files?diff=unified&w=0#diff-b6f0e6c8f1a97e53807ee8b3ad8a577c2db0cbeca5c52d061453fd13450ea917L114-R122))

