### PR TITLE
Properly invoke CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 #
 
 if (LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
-    enable_testing()
+    include(CTest)
     add_subdirectory(tests)
 endif ()
 


### PR DESCRIPTION
The CMakeLists.txt used `enable_testing()` without including CTest. This then caused the following errors to be printed:

```
[proc] Executing command: /home/i/.local/bin/ctest -j6 -C Debug -T test --output-on-failure
[ctest] Cannot find file: /home/i/coding/llama.cpp/build/DartConfiguration.tcl
[ctest] Cannot find file: /home/i/coding/llama.cpp/build/DartConfiguration.tcl
```

The proper way to use CTest is to `include(CTest)`, which automatically invokes `enable_testing()` and DartConfiguration.tcl gets generated.