### PR TITLE
Link with cblas when LLAMA_OPENBLAS is enabled.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ ifndef LLAMA_NO_ACCELERATE
 endif
 ifdef LLAMA_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas
-	LDFLAGS += -lopenblas
+	LDFLAGS += -lcblas -lopenblas
 endif
 ifdef LLAMA_GPROF
 	CFLAGS   += -pg


### PR DESCRIPTION
Please see #634 for the details about what this is intending to fix.
TL;DR: At least on Archlinux, linking when BLAS mode is on fails due to missing `cblas` symbols.

Closes #634