### PR TITLE
10+% performance improvement of ggml_vec_dot_q4_0 on AVX2

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1959,45 +1959,75 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
     // Horizontal sum of all lanes of the accumulator
     sumf = _mm512_reduce_add_ps( acc0 ) + _mm512_reduce_add_ps( acc1 );
 #elif defined(__AVX2__)
+
     // Initialize accumulator with zeros
     __m256 acc = _mm256_setzero_ps();
 
+    /* Prepare the constants we will need during execution */        
+    const __m256i lowMask = _mm256_set1_epi8( 0xF );
+    const __m256i offset_8 = _mm256_set1_epi16( 8 );
+
+#define UNROLL_COUNT 8
+    // make sure we only unroll multiples of the block count
+    assert(nb % UNROLL_COUNT == 0);
+
     // Main loop
-    // TODO: figure a way to do this in a portable way
-    #ifdef __GNUC__
-    #pragma GCC unroll 16
-    #endif
-    for (int i = 0; i < nb; ++i) {
-        // Compute combined scale for the block
-        const __m256 d = _mm256_mul_ps( _mm256_broadcast_ss( &x[i].d ), _mm256_broadcast_ss( &y[i].d ) );
+    for (int i = 0; i < nb; i+=UNROLL_COUNT) {
 
-        // Load 16 bytes, and unpack 4 bit fields into bytes, making 32 bytes
-        __m256i bx = bytesFromNibbles( x[i].qs );
-        __m256i by = bytesFromNibbles( y[i].qs );
+        // This loop will be unrolled by the compiler    
+        for (int u=0;u<UNROLL_COUNT;u++)  {
+            /* Compute combined scale for the block */ 
+            const __m256 scale = _mm256_mul_ps( 
+                    _mm256_broadcast_ss( &x[i+u].d ), 
+                    _mm256_broadcast_ss( &y[i+u].d ) ); 
 
-        // Now we have a vector with bytes in [ 0 .. 15 ] interval. Offset them into [ -8 .. +7 ] interval.
-        const __m256i off = _mm256_set1_epi8( 8 );
-        bx = _mm256_sub_epi8( bx, off );
-        by = _mm256_sub_epi8( by, off );
+            /* get input from x 
+               Input: 32 Nibbles (16 bytes) at *x[i+u] 
+               Output: 2 vectors with 16 values of type int16_t (x_high_q, x_low_q) */             
+                                      
+            /* Load 16 bytes from memory */  
+            const __m128i tmp_x = _mm_loadu_si128( (const __m128i_u *) x[i+u].qs); 
+            /* Expand bytes into uint16_t values */                                 
+            const __m256i bytes_x = _mm256_cvtepu8_epi16(tmp_x); 
+            /* Unpack values into individual bytes */
+            __m256i x_low_q = _mm256_and_si256( lowMask, bytes_x );
+            const __m256i pre_shift_x_high_q = _mm256_andnot_si256( lowMask, bytes_x );
+            __m256i x_high_q = _mm256_srli_epi16( pre_shift_x_high_q, 4 );            
+            /* Now we have two vectors with bytes in [ 0 .. 15 ] interval.  Offset them into [ -8 .. +7 ] interval.  */
+            x_high_q = _mm256_sub_epi16( x_high_q, offset_8 ); 
+            x_low_q = _mm256_sub_epi16( x_low_q, offset_8 ); 
 
-        // Get absolute values of x vectors
-        const __m256i ax = _mm256_sign_epi8(bx, bx);
+            /* get input from y 
+               Input: 32 Nibbles (16 bytes) at *y[i+u] 
+               Output: 2 vectors with 16 values of type int16_t (y_high_q, y_low_q) */             
 
-        // Sign the values of the y vectors
-        const __m256i sy = _mm256_sign_epi8(by, bx);
+            /* Load 16 bytes from memory */  
+            const __m128i tmp_y = _mm_loadu_si128( (const __m128i_u *) y[i+u].qs); 
+            /* Expand bytes into uint16_t values */     
+            const __m256i bytes_y = _mm256_cvtepu8_epi16(tmp_y); 
+            /* Unpack values into individual bytes */
+            const __m256i pre_shift_y_high_q = _mm256_andnot_si256( lowMask, bytes_y ); 
+            __m256i y_high_q = _mm256_srli_epi16( pre_shift_y_high_q, 4 ); 
+            __m256i y_low_q = _mm256_and_si256( lowMask, bytes_y ); 
+            /* Now we have two vectors with bytes in [ 0 .. 15 ] interval.  Offset them into [ -8 .. +7 ] interval.  */
+            y_high_q = _mm256_sub_epi16( y_high_q, offset_8 ); 
+            y_low_q = _mm256_sub_epi16( y_low_q, offset_8 ); 
 
-        // Perform multiplication and create 16-bit values
-        const __m256i dot = _mm256_maddubs_epi16(ax, sy);
+            /* Compute products of int16_t integers, add pairwise, store as int32_t */     
+            __m256i xy_high_q = _mm256_madd_epi16( x_high_q, y_high_q ); 
+            __m256i xy_low_q = _mm256_madd_epi16( x_low_q, y_low_q ); 
 
-        const __m256i ones = _mm256_set1_epi16(1);
-        const __m256i i32 = _mm256_madd_epi16(ones, dot);
+            /* Accumulate the products of int32_t integers -> we now have a vector of 8 int_32t */ 
+            __m256i xy_q = _mm256_add_epi32( xy_high_q, xy_low_q ); 
 
-        // Convert int32_t to float
-        const __m256 p = _mm256_cvtepi32_ps( i32 );
+            /* Convert to vectore of 8 int32_t to 8 floats */ 
+            __m256 q = _mm256_cvtepi32_ps( xy_q ); 
 
-        // Apply the scale, and accumulate
-        acc = _mm256_fmadd_ps( d, p, acc );
-    }
+            /* Multiply q with scale and accumulate */ 
+            acc = _mm256_fmadd_ps( scale, q, acc );;    
+        }
+       
+    }   
 
     // Return horizontal sum of the acc vector
     __m128 res = _mm256_extractf128_ps( acc, 1 );
@@ -2026,7 +2056,7 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
             bx = _mm_sub_epi8( bx, off );
             by = _mm_sub_epi8( by, off );
 
-	    // Get absolute values of x vectors
+            // Get absolute values of x vectors
             const __m128i ax = _mm_sign_epi8(bx, bx);
 
             // Sign the values of the y vectors

--- a/ggml.c
+++ b/ggml.c
@@ -1986,7 +1986,7 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
                Output: 2 vectors with 16 values of type int16_t (x_high_q, x_low_q) */             
                                       
             /* Load 16 bytes from memory */  
-            const __m128i tmp_x = _mm_loadu_si128( (const __m128i_u *) x[i+u].qs); 
+            const __m128i tmp_x = _mm_loadu_si128( ( const __m128i* ) x[i+u].qs); 
             /* Expand bytes into uint16_t values */                                 
             const __m256i bytes_x = _mm256_cvtepu8_epi16(tmp_x); 
             /* Unpack values into individual bytes */
@@ -2002,7 +2002,7 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
                Output: 2 vectors with 16 values of type int16_t (y_high_q, y_low_q) */             
 
             /* Load 16 bytes from memory */  
-            const __m128i tmp_y = _mm_loadu_si128( (const __m128i_u *) y[i+u].qs); 
+            const __m128i tmp_y = _mm_loadu_si128( (const __m128i* ) y[i+u].qs); 
             /* Expand bytes into uint16_t values */     
             const __m256i bytes_y = _mm256_cvtepu8_epi16(tmp_y); 
             /* Unpack values into individual bytes */

--- a/ggml.c
+++ b/ggml.c
@@ -1959,7 +1959,6 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
     // Horizontal sum of all lanes of the accumulator
     sumf = _mm512_reduce_add_ps( acc0 ) + _mm512_reduce_add_ps( acc1 );
 #elif defined(__AVX2__)
-
     // Initialize accumulator with zeros
     __m256 acc = _mm256_setzero_ps();
 
@@ -2024,7 +2023,7 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
             __m256 q = _mm256_cvtepi32_ps( xy_q ); 
 
             /* Multiply q with scale and accumulate */ 
-            acc = _mm256_fmadd_ps( scale, q, acc );;    
+            acc = _mm256_fmadd_ps( scale, q, acc );    
         }
        
     }   


### PR DESCRIPTION
UPDATE: 

@slaren  @rabidcopy @sw @howard0su 

First: Let me say "sorry" for the confusion: I was not clear in my original post as to what the baseline was. This was mainly, because #642 was merged AFTER I had branched to run my tests of which I have reported the results.

When I published this pull request, I had not realized that #642 existed, and also not that it had been merged. My results were therefore based on the pre-#642 code version.

I have re-run the benchmarks now with three versions: the "pre-PR642" AVX2 code, the AVX2 code from #642 and the AVX2 code from this PR (#654).

At least on my machine I get (for 100 iterations of the benchmark from #653) a 14% performance increase, which is similar to what @jart reported in https://github.com/ggerganov/llama.cpp/pull/654#issuecomment-1492357011.

I have therefore changed the title of the PR.  Again, sorry for the confusion.

Please let me know your thoughts.

### Results Summary (single thread performance)

| Codebase | FLOPS (single thread | % compared to pre 642 | % compared to with #642 |
| - | -: | -: | -: |
| pre #642 | 14769 FLOPS  | 100% | 76% |
| with #642 | 19443 FLOPS | 132% | 100% |
| with #654 | 22217 FLOPS | 150% | 114 % |

Please find the raw data of the benchmark runs here: [benchmark-data.csv](https://github.com/ggerganov/llama.cpp/files/11130535/benchmark-data.csv)

### Boxplot of the results:
![image](https://user-images.githubusercontent.com/13675545/229311600-6f718c65-e492-485a-8714-7758247bd43a.png)

### Technical details 
-  Machine: Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz, 16 GB RAM
-  Compiler & switches:
```
I CFLAGS:   -I.              -O3 -DNDEBUG -std=c11   -fPIC -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -Wno-unused-function -pthread -mavx -mavx2 -mfma -mf16c -msse3
I CXXFLAGS: -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -pthread
I LDFLAGS:  
I CC:       cc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
I CXX:      g++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
```


----
### PREVIOUS POST: 

(I leave it here for sake of transparency)
This change produces a ~1.5x performance increase of `ggml_vec_dot_q4_0` on AVX2.

- Avg. FLOPS per uSecond: 14797 (100%) for existing code 
- Avg. FLOPS per uSecond: 21828 (147%) for code in this pull request

Root causes for performance improvement:
- Existing code merges two m256i vectors in `bytesFromNibbles` and then seperates them again in `ggml_vec_dot_q4_0`
- Existing code uses C inline functions which are apparently a bit harder to optimize for the compiler
- Code in this pull request uses a combination of C macros and "by-hand" loop unrolling 

Benchmark data for code in master branch (commit 02c5b27e91a6d18cf1043d3a2d8dbc59610ac257)  - produced with tool from pull request [653](https://github.com/ggerganov/llama.cpp/pull/653).

| Iteration | NThreads | SizeX | SizeY | SizeZ | Required FLOPS | Elapsed uSeconds | FLOPS per uSecond |
| --------- | -------- | ----- | ----- | ----- | -------------- | ----------------- | ------------------ | 
|        0  |        1 | 11008 |  4096 |   128 |    11542724608 |            783404 |           14734.06 |
|        1  |        1 | 11008 |  4096 |   128 |    11542724608 |            781391 |           14772.02 |
|        2  |        1 | 11008 |  4096 |   128 |    11542724608 |            783799 |           14726.64 |
|        3  |        1 | 11008 |  4096 |   128 |    11542724608 |            777324 |           14849.31 |
|        4  |        1 | 11008 |  4096 |   128 |    11542724608 |            781041 |           14778.64 |
|        5  |        1 | 11008 |  4096 |   128 |    11542724608 |            778367 |           14829.41 |
|        6  |        1 | 11008 |  4096 |   128 |    11542724608 |            777931 |           14837.72 |
|        7  |        1 | 11008 |  4096 |   128 |    11542724608 |            780476 |           14789.34 |
|        8  |        1 | 11008 |  4096 |   128 |    11542724608 |            778450 |           14827.83 |
|        9  |        1 | 11008 |  4096 |   128 |    11542724608 |            778300 |           14830.69 |



Benchmark data for code in this pull request:


| Iteration | NThreads | SizeX | SizeY | SizeZ | Required FLOPS | Elapsed uSeconds | FLOPS per uSecond |
| --------- | -------- | ----- | ----- | ----- | -------------- | ----------------- | ------------------ | 
|         0 |        1 | 11008 |  4096 |   128 |    11542724608 |            552244 |           20901.49 |
|         1 |        1 | 11008 |  4096 |   128 |    11542724608 |            540733 |           21346.44 |
|         2 |        1 | 11008 |  4096 |   128 |    11542724608 |            555696 |           20771.65 |
|         3 |        1 | 11008 |  4096 |   128 |    11542724608 |            553204 |           20865.22 |
|         4 |        1 | 11008 |  4096 |   128 |    11542724608 |            546703 |           21113.34 |
|         5 |        1 | 11008 |  4096 |   128 |    11542724608 |            505609 |           22829.35 |
|         6 |        1 | 11008 |  4096 |   128 |    11542724608 |            505045 |           22854.84 |
|         7 |        1 | 11008 |  4096 |   128 |    11542724608 |            525141 |           21980.24 |
|         8 |        1 | 11008 |  4096 |   128 |    11542724608 |            506639 |           22782.94 |
|         9 |        1 | 11008 |  4096 |   128 |    11542724608 |            505468 |           22835.72 |
