### PR TITLE
Show error message when -f fails

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -66,6 +66,11 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             std::ifstream file(argv[i]);
+            if (!file) {
+                fprintf(stderr, "error: failed to open file '%s'\n", argv[i]);
+                invalid_param = true;
+                break;
+            }
             std::copy(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), back_inserter(params.prompt));
             if (params.prompt.back() == '\n') {
                 params.prompt.pop_back();


### PR DESCRIPTION
Currently when -f is used with a non-existing or inaccessible file it fails silently, which can lead to confusion. This should fix that.