### PR TITLE
Remove torch GPU dependencies from the Docker.full image

### DIFF
--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
     apt-get install -y build-essential python3 python3-pip
 
 RUN pip install --upgrade pip setuptools wheel \
-    && pip install numpy requests sentencepiece torch tqdm
+    && pip install numpy requests sentencepiece tqdm \
+    && pip install torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
 WORKDIR /app
 

--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 RUN pip install --upgrade pip setuptools wheel \
     && pip install numpy requests sentencepiece tqdm \
-    && pip install torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    && pip install torch --index-url https://download.pytorch.org/whl/cpu
 
 WORKDIR /app
 


### PR DESCRIPTION
## Changes
* Remove torch GPU dependencies as this is a CPU project

## Results
Full Image - 5.7GB reduction in size:
```
$ podman images
REPOSITORY                           TAG                  IMAGE ID      CREATED         SIZE
<none>                               master               e589ee9cb803  19 minutes ago  7.32 GB
<none>                               bsilvereagle         e1ea3ddecfd8  4 seconds ago   1.62 GB
```

## Maintenance Impacts

* ~`torch` is pinned to version `2.0.0` which is a departure from the README etc which do not pin~