### PR TITLE
Clean up QK and file and tensor types

### DIFF
--- a/convert-gpt4all-to-ggml.py
+++ b/convert-gpt4all-to-ggml.py
@@ -12,6 +12,7 @@ import os
 import struct
 import sys
 from sentencepiece import SentencePieceProcessor
+from ggml import *
 
 HPARAMS = keys = ["vocab_size", "dim", "multiple_of", "n_heads", "n_layers"]
 
@@ -32,6 +33,7 @@ def write_header(f_out, header):
 
     if magic != 0x67676d6c:
         raise Exception('Invalid file magic. Must be an old style ggml file.')
+    GGML_FILE(ftype)    # raise ValueError on invalid file type
 
     values = [
         0x67676d66, # magic: ggml in hex

--- a/convert-gptq-to-ggml.py
+++ b/convert-gptq-to-ggml.py
@@ -9,6 +9,7 @@ import struct
 import numpy as np
 import torch
 from sentencepiece import SentencePieceProcessor
+from ggml import *
 
 if len(sys.argv) != 4:
     print("Usage: convert-gptq-to-ggml.py llamaXXb-4bit.pt tokenizer.model out.bin\n")
@@ -143,7 +144,7 @@ def convert_q4(src_name, dst_name, permute=False):
                     .reshape(blob.shape))
 
     # header
-    write_header(shape, dst_name, 3) # ftype = Q4_1
+    write_header(shape, dst_name, GGML_FILE.Q4_1)
 
     # data
     blob.tofile(fout)

--- a/ggml.py
+++ b/ggml.py
@@ -1,0 +1,50 @@
+from enum import IntEnum
+
+
+class GGML_TYPE(IntEnum):
+    """Tensor types, corresponding to enum ggml_type in ggml.h"""
+
+    Q4_0 = 0
+    Q4_1 = 1
+    I8 = 2
+    I16 = 3
+    I32 = 4
+    F16 = 5
+    F32 = 6
+
+
+class GGML_FILE(IntEnum):
+    """File types, corresponding to enum e_ftype in llama.cpp"""
+
+    F32 = 0
+    F16 = 1
+    Q4_0 = 2
+    Q4_1 = 3
+
+
+ggml_type_from_ftype = {
+    GGML_FILE.F32: GGML_TYPE.F32,
+    GGML_FILE.F16: GGML_TYPE.F16,
+    GGML_FILE.Q4_0: GGML_TYPE.Q4_0,
+    GGML_FILE.Q4_1: GGML_TYPE.Q4_1,
+}
+
+GGML_BLCK_SIZE = {
+    GGML_TYPE.Q4_0: 32,
+    GGML_TYPE.Q4_1: 32,
+    GGML_TYPE.I8: 1,
+    GGML_TYPE.I16: 1,
+    GGML_TYPE.I32: 1,
+    GGML_TYPE.F16: 1,
+    GGML_TYPE.F32: 1,
+}
+
+GGML_TYPE_SIZE = {
+    GGML_TYPE.Q4_0: 4 + GGML_BLCK_SIZE[GGML_TYPE.Q4_0] // 2,
+    GGML_TYPE.Q4_1: 4 * 2 + GGML_BLCK_SIZE[GGML_TYPE.Q4_1] // 2,
+    GGML_TYPE.I8: 1,
+    GGML_TYPE.I16: 2,
+    GGML_TYPE.I32: 4,
+    GGML_TYPE.F16: 2,
+    GGML_TYPE.F32: 4,
+}

--- a/tests/test-quantize.c
+++ b/tests/test-quantize.c
@@ -3,32 +3,30 @@
 #include <assert.h>
 #include <math.h>
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 int main(void) {
-    const int qk0 = ggml_blck_size(GGML_TYPE_Q4_0);
-    const int qk1 = ggml_blck_size(GGML_TYPE_Q4_1);
-    const int qk_max = MAX(qk0, qk1);
-    float src[qk_max];
+    #define QK 32
+    assert(ggml_blck_size(GGML_TYPE_Q4_0) == QK);
+    assert(ggml_blck_size(GGML_TYPE_Q4_1) == QK);
+    float src[QK];
     uint8_t dst[24];
     int64_t hist[16];
 
-    for (int i = 0; i < qk_max; i++) {
+    for (int i = 0; i < QK; i++) {
         src[i] = (float)(i + 1);
     }
 
-    size_t size = ggml_quantize_q4_0(src, dst, qk0, qk0, hist);
+    size_t size = ggml_quantize_q4_0(src, dst, QK, QK, hist);
     assert(size == 20);
     float max_result = ((float *)dst)[0];
     float max_expected = src[31] / ((1 << 3) - 1);
     assert(max_result == max_expected);
-    for (int i = 0; i < qk0; i++) {
+    for (int i = 0; i < QK; i++) {
         uint8_t q4_result = (i % 2) ? (dst[sizeof(float) + i/2] >> 4) : (dst[sizeof(float) + i/2] & 0xF);
         uint8_t q4_expected = roundf(src[i] / max_expected) + 8;
         assert(q4_result == q4_expected);
     }
 
-    size = ggml_quantize_q4_1(src, dst, qk1, qk1, hist);
+    size = ggml_quantize_q4_1(src, dst, QK, QK, hist);
     assert(size == 24);
     float delta_result = ((float *)dst)[0];
     float delta_expected = (src[31] - src[0]) / ((1 << 4) - 1);
@@ -36,7 +34,7 @@ int main(void) {
     float min_result = ((float *)dst)[1];
     float min_expected = src[0];
     assert(min_result == min_expected);
-    for (int i = 0; i < qk1; i++) {
+    for (int i = 0; i < QK; i++) {
         uint8_t q4_result = (i % 2) ? (dst[sizeof(float)*2 + i/2] >> 4) : (dst[sizeof(float)*2 + i/2] & 0xF);
         uint8_t q4_expected = roundf((src[i] - min_expected) / delta_expected);
         assert(q4_result == q4_expected);

--- a/tests/test-quantize.c
+++ b/tests/test-quantize.c
@@ -3,28 +3,32 @@
 #include <assert.h>
 #include <math.h>
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
 int main(void) {
-    #define QK 32
-    float src[QK];
+    const int qk0 = ggml_blck_size(GGML_TYPE_Q4_0);
+    const int qk1 = ggml_blck_size(GGML_TYPE_Q4_1);
+    const int qk_max = MAX(qk0, qk1);
+    float src[qk_max];
     uint8_t dst[24];
     int64_t hist[16];
 
-    for (int i = 0; i < QK; i++) {
+    for (int i = 0; i < qk_max; i++) {
         src[i] = (float)(i + 1);
     }
 
-    size_t size = ggml_quantize_q4_0(src, dst, QK, QK, hist);
+    size_t size = ggml_quantize_q4_0(src, dst, qk0, qk0, hist);
     assert(size == 20);
     float max_result = ((float *)dst)[0];
     float max_expected = src[31] / ((1 << 3) - 1);
     assert(max_result == max_expected);
-    for (int i = 0; i < QK; i++) {
+    for (int i = 0; i < qk0; i++) {
         uint8_t q4_result = (i % 2) ? (dst[sizeof(float) + i/2] >> 4) : (dst[sizeof(float) + i/2] & 0xF);
         uint8_t q4_expected = roundf(src[i] / max_expected) + 8;
         assert(q4_result == q4_expected);
     }
 
-    size = ggml_quantize_q4_1(src, dst, QK, QK, hist);
+    size = ggml_quantize_q4_1(src, dst, qk1, qk1, hist);
     assert(size == 24);
     float delta_result = ((float *)dst)[0];
     float delta_expected = (src[31] - src[0]) / ((1 << 4) - 1);
@@ -32,7 +36,7 @@ int main(void) {
     float min_result = ((float *)dst)[1];
     float min_expected = src[0];
     assert(min_result == min_expected);
-    for (int i = 0; i < QK; i++) {
+    for (int i = 0; i < qk1; i++) {
         uint8_t q4_result = (i % 2) ? (dst[sizeof(float)*2 + i/2] >> 4) : (dst[sizeof(float)*2 + i/2] & 0xF);
         uint8_t q4_expected = roundf((src[i] - min_expected) / delta_expected);
         assert(q4_result == q4_expected);


### PR DESCRIPTION
(edit: the python changes will clash with #545)

This PR has several goals:
* reduce the number of integer literals strewn across the code base
* better ensure array and enum consistency
* clear up possible confusion about file and tensor types
* prepare the way for new quantization formats with QK != 32, as discussed in #456
* deduplicate python definitions

For the python scripts, I introduce a new file `ggml.py` at the top level, which contains definitions of the file and tensor types equivalent to those in ggml.h. I have formatted that with `black`, in case #611 returns from the dead.

The changes to the python files on one hand and C/C++ on the other are technically independent, but the discussion will overlap, so I'm keeping this in one draft. I will split it later if it makes sense.

I have tested conversion from pth to ggml with identical outputs, but I have not tested the other conversion scripts.

Open questions:
* should `enum e_ftype` be moved to `llama.h` (with sensible renaming)? This would allow us to eliminate the hard-coded 2,3 in the usage string of `quantize.cpp`, and maybe be useful elsewhere.
* how is file type 4 used? ~~I could not find any other parts of the code that would use this.~~ I see now, it's for GPTQ models. Should I add `FTYPE_GPTQ`?. https://github.com/ggerganov/llama.cpp/blob/3525899277d2e2bdc8ec3f0e6e40c47251608700/llama.cpp#L515
* Is `GGML_FILE` ok or should it be `LLAMA_FILE`? ggml.c doesn't deal with that type.

Some more comments below, looking for your thoughts on this...