### PR TITLE
Be nice to CI machines by not allocating buffers

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1608,7 +1608,7 @@ struct llama_context * llama_init_from_file(
     }
 
     // reserve memory for context buffers
-    {
+    if (!params.vocab_only) {
         if (!kv_cache_init(ctx->model.hparams, ctx->model.kv_self, memory_type, ctx->model.hparams.n_ctx)) {
             fprintf(stderr, "%s: kv_cache_init() failed for self-attention cache\n", __func__);
             llama_free(ctx);


### PR DESCRIPTION
...for vocab_only=true

Unless I'm misunderstanding the code base completely, the huge buffers are not needed for tokenizing.

Fixes #582.

~~`convert-pth-to-ggml.py` with `vocab_only=1` produces identical files.~~ nvm, that doesn't use the C/C++ code.