### PR TITLE
Feature: Added api for getting/setting the kv_cache

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1671,28 +1671,28 @@ int llama_model_quantize(
 // Returns the KV cache that will contain the context for the
 // ongoing prediction with the model.
 const uint8_t * llama_get_kv_cache(struct llama_context * ctx) {
-  return ctx->model.kv_self.buf.data();
+    return ctx->model.kv_self.buf.data();
 }
 
 // Returns the size of the KV cache
 size_t llama_get_kv_cache_size(struct llama_context * ctx) {
-  return ctx->model.kv_self.buf.size();
+    return ctx->model.kv_self.buf.size();
 }
 
 int llama_get_kv_cache_token_count(struct llama_context * ctx) {
-  return ctx->model.kv_self.n;
+    return ctx->model.kv_self.n;
 }
 
 // Sets the KV cache containing the current context for the model
 void llama_set_kv_cache(
         struct llama_context * ctx,
-                     const uint8_t * kv_cache,
-                        size_t n_size,
-                           int n_token_count) {
-  // Make sure we have the same kv cache setup
-  LLAMA_ASSERT(ctx->model.kv_self.buf.size() == n_size);
-  memcpy(ctx->model.kv_self.buf.data(), kv_cache, n_size);
-  ctx->model.kv_self.n = n_token_count;
+               const uint8_t * kv_cache,
+                      size_t   n_size,
+                         int   n_token_count) {
+    // Make sure we have the same kv cache setup
+    LLAMA_ASSERT(ctx->model.kv_self.buf.size() == n_size);
+    memcpy(ctx->model.kv_self.buf.data(), kv_cache, n_size);
+    ctx->model.kv_self.n = n_token_count;
 }
 
 int llama_eval(

--- a/llama.cpp
+++ b/llama.cpp
@@ -1670,7 +1670,7 @@ int llama_model_quantize(
 
 // Returns the KV cache that will contain the context for the
 // ongoing prediction with the model.
-uint8_t* llama_get_kv_cache(struct llama_context * ctx) {
+const uint8_t * llama_get_kv_cache(struct llama_context * ctx) {
   return ctx->model.kv_self.buf.data();
 }
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -1686,7 +1686,7 @@ int llama_get_kv_cache_token_count(struct llama_context * ctx) {
 // Sets the KV cache containing the current context for the model
 void llama_set_kv_cache(
         struct llama_context * ctx,
-                     uint8_t * kv_cache,
+                     const uint8_t * kv_cache,
                         size_t n_size,
                            int n_token_count) {
   // Make sure we have the same kv cache setup

--- a/llama.cpp
+++ b/llama.cpp
@@ -1668,6 +1668,33 @@ int llama_model_quantize(
     return 0;
 }
 
+// Returns the KV cache that will contain the context for the
+// ongoing prediction with the model.
+uint8_t* llama_get_kv_cache(struct llama_context * ctx) {
+  return ctx->model.kv_self.buf.data();
+}
+
+// Returns the size of the KV cache
+size_t llama_get_kv_cache_size(struct llama_context * ctx) {
+  return ctx->model.kv_self.buf.size();
+}
+
+int llama_get_kv_cache_token_count(struct llama_context * ctx) {
+  return ctx->model.kv_self.n;
+}
+
+// Sets the KV cache containing the current context for the model
+void llama_set_kv_cache(
+        struct llama_context * ctx,
+                     uint8_t * kv_cache,
+                        size_t n_size,
+                           int n_token_count) {
+  // Make sure we have the same kv cache setup
+  LLAMA_ASSERT(ctx->model.kv_self.buf.size() == n_size);
+  memcpy(ctx->model.kv_self.buf.data(), kv_cache, n_size);
+  ctx->model.kv_self.n = n_token_count;
+}
+
 int llama_eval(
         struct llama_context * ctx,
            const llama_token * tokens,

--- a/llama.h
+++ b/llama.h
@@ -96,7 +96,7 @@ extern "C" {
     // Sets the KV cache containing the current context for the model
     LLAMA_API void llama_set_kv_cache(
             struct llama_context * ctx,
-                         uint8_t * kv_cache,
+                         const uint8_t * kv_cache,
                             size_t n_size,
                                int n_token_count);
 

--- a/llama.h
+++ b/llama.h
@@ -83,6 +83,23 @@ extern "C" {
             const char * fname_out,
                    int   itype);
 
+    // Returns the KV cache that will contain the context for the
+    // ongoing prediction with the model.
+    LLAMA_API uint8_t* llama_get_kv_cache(struct llama_context * ctx);
+
+    // Returns the size of the KV cache
+    LLAMA_API size_t llama_get_kv_cache_size(struct llama_context * ctx);
+
+    // Returns the number of tokens in the KV cache
+    LLAMA_API int llama_get_kv_cache_token_count(struct llama_context * ctx);
+
+    // Sets the KV cache containing the current context for the model
+    LLAMA_API void llama_set_kv_cache(
+            struct llama_context * ctx,
+                         uint8_t * kv_cache,
+                            size_t n_size,
+                               int n_token_count);
+
     // Run the llama inference to obtain the logits and probabilities for the next token.
     // tokens + n_tokens is the provided batch of new tokens to process
     // n_past is the number of tokens to use from previous eval calls

--- a/llama.h
+++ b/llama.h
@@ -96,9 +96,9 @@ extern "C" {
     // Sets the KV cache containing the current context for the model
     LLAMA_API void llama_set_kv_cache(
             struct llama_context * ctx,
-                         const uint8_t * kv_cache,
-                            size_t n_size,
-                               int n_token_count);
+                   const uint8_t * kv_cache,
+                          size_t   n_size,
+                             int   n_token_count);
 
     // Run the llama inference to obtain the logits and probabilities for the next token.
     // tokens + n_tokens is the provided batch of new tokens to process

--- a/llama.h
+++ b/llama.h
@@ -85,7 +85,7 @@ extern "C" {
 
     // Returns the KV cache that will contain the context for the
     // ongoing prediction with the model.
-    LLAMA_API uint8_t* llama_get_kv_cache(struct llama_context * ctx);
+    LLAMA_API const uint8_t * llama_get_kv_cache(struct llama_context * ctx);
 
     // Returns the size of the KV cache
     LLAMA_API size_t llama_get_kv_cache_size(struct llama_context * ctx);


### PR DESCRIPTION
This PR contains a simple extension to the C-API for getting/setting the kv_cache so that an app can save the state of the kv_cache after providing a prompt and load this next time the app starts to avoid having to evaluate the prompt on startup.

The api provides access methods for retrieving the current memory buffer for the kv_cache and its token number. It also contains a method for setting the kv_cache from a memory buffer and a token count.

I did not start implementing the `--cache-prompt` argument since it is a bit more involved - we need to save some more state like the last_n_tokens and n_past parameter. We'd also need to hash the prompt, check if a prompt file existed etc.

Implements foundation for #64 