### PR TITLE
Add a missing step to the gpt4all instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,15 @@ cadaver, cauliflower, cabbage (vegetable), catalpa (tree) and Cailleach.
 
 - Obtain the `gpt4all-lora-quantized.bin` model
 - It is distributed in the old `ggml` format which is now obsoleted
-- You have to convert it to the new format using [./convert-gpt4all-to-ggml.py](./convert-gpt4all-to-ggml.py):
+- You have to convert it to the new format using [./convert-gpt4all-to-ggml.py](./convert-gpt4all-to-ggml.py). You may also need to
+convert the model from the old format to the new format with [./migrate-ggml-2023-03-30-pr613.py](./migrate-ggml-2023-03-30-pr613.py):
 
   ```bash
   python3 convert-gpt4all-to-ggml.py models/gpt4all-7B/gpt4all-lora-quantized.bin ./models/tokenizer.model 
+  python3 migrate-ggml-2023-03-30-pr613.py models/gpt4all-7B/gpt4all-lora-quantized.bin models/gpt4all-7B/gpt4all-lora-quantized-new.bin
   ```
   
-- You can now use the newly generated `gpt4all-lora-quantized.bin` model in exactly the same way as all other models
+- You can now use the newly generated `gpt4all-lora-quantized-new.bin` model in exactly the same way as all other models
 - The original model is saved in the same folder with a suffix `.orig`
 
 ### Obtaining and verifying the Facebook LLaMA original model and Stanford Alpaca model data


### PR DESCRIPTION
`migrate-ggml-2023-03-30-pr613.py` is needed to get gpt4all running.

When following the README instructions for gpt4all, I encounted the following error:
```ShellSession
data/llama.cpp$ python3 convert-gpt4all-to-ggml.py models/gpt4all-models/gpt4all-lora-quantized.bin models/tokenizer.model

/data/llama.cpp$ ./main -m models/gpt4all-models/gpt4all-lora-unfiltered-quantized.bin -n 128
main: seed = 1680382134
llama_model_load: loading model from 'models/gpt4all-models/gpt4all-lora-unfiltered-quantized.bin' - please wait ...
models/gpt4all-models/gpt4all-lora-unfiltered-quantized.bin: invalid model file (bad magic [got 0x67676d66 want 0x67676a74])
    you most likely need to regenerate your ggml files
    the benefit is you'll get 10-100x faster load times
    see https://github.com/ggerganov/llama.cpp/issues/91
    use convert-pth-to-ggml.py to regenerate from original pth
    use migrate-ggml-2023-03-30-pr613.py if you deleted originals
llama_init_from_file: failed to load model
main: error: failed to load model 'models/gpt4all-models/gpt4all-lora-unfiltered-quantized.bin'
```

I think the gpt4all conversion script is a bit out of date and produces files that need to be converted with `migrate-ggml-2023-03-30-pr613.py`.

I was able to run `python3 migrate-ggml-2023-03-30-pr613.py models/gpt4all-models/gpt4all-lora-unfiltered-quantized.bin models/gpt4all-models/gpt4all-lora-unfiltered-quantized-pr613.bin` which seemed to do the trick. After that, `./main -m models/gpt4all-models/gpt4all-lora-unfiltered-quantized-pr613.bin` ran successfully!

This PR updates the README to add that `migrate-ggml-2023-03-30-pr613.py` step.