### PR TITLE
Use safe loading for .pth checkpoint

### DIFF
--- a/convert-gptq-to-ggml.py
+++ b/convert-gptq-to-ggml.py
@@ -18,7 +18,7 @@ fname_model = sys.argv[1]
 fname_tokenizer = sys.argv[2]
 dir_out = sys.argv[3]
 
-model = torch.load(fname_model, map_location="cpu")
+model = torch.load(fname_model, map_location="cpu", weights_only=True)
 
 n_vocab, n_embd = model['model.embed_tokens.weight'].shape
 n_layer = 1 + max(int(m.group(1)) for name in model

--- a/convert-pth-to-ggml.py
+++ b/convert-pth-to-ggml.py
@@ -264,7 +264,7 @@ def main():
             fout.seek(offset_of_tensors)
             print(f"Processing part {part_id+1} of {n_parts}\n")
             fname_model = f"{dir_model}/consolidated.0{part_id}.pth"
-            model = torch.load(fname_model, map_location="cpu")
+            model = torch.load(fname_model, map_location="cpu", weights_only=True)
             process_and_write_variables(fout, model, ftype, part_id, n_parts)
             del model
 


### PR DESCRIPTION
This change ensures that only weights can be loaded from the checkpoints, which is the case for the official llama checkpoints. It reduces the potential impact of a malicious checkpoint.

This argument has been available since at least PyTorch 1.13, but I haven't checked earlier versions. If you need to support older versions of PyTorch, please let me know and I can modify the code to be backward compatible.