### PR TITLE
Optimize non-SIMD Q4 vector dot product

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2160,18 +2160,20 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
         const uint8_t * restrict p0 = x[i].qs;
         const uint8_t * restrict p1 = y[i].qs;
 
+        int sumi = 0;
         for (int j = 0; j < QK/2; j++) {
             const uint8_t v0 = p0[j];
             const uint8_t v1 = p1[j];
 
-            const float f0 = d0*((int8_t) (v0 & 0xf) - 8);
-            const float f1 = d0*((int8_t) (v0 >> 4)  - 8);
+            const int8_t i0 = (int8_t) (v0 & 0xf) - 8;
+            const int8_t i1 = (int8_t) (v0 >> 4)  - 8;
 
-            const float f2 = d1*((int8_t) (v1 & 0xf) - 8);
-            const float f3 = d1*((int8_t) (v1 >> 4)  - 8);
+            const int8_t i2 = (int8_t) (v1 & 0xf) - 8;
+            const int8_t i3 = (int8_t) (v1 >> 4)  - 8;
 
-            sumf += f0*f2 + f1*f3;
+            sumi += i0*i2 + i1*i3;
         }
+        sumf += d0 * d1 * sumi;
     }
 #endif
 


### PR DESCRIPTION
This should help the poor souls running llama.cpp without a supported SIMD optimization.

First, the good stuff: per-token eval times in milliseconds:

With `-march=native -mtune=native`, but SIMD optimization code in `ggml_vec_dot_q` disabled:

|      | recent master (6e7801d) | this PR |
| ---- | ----------------------- | ------- |
| Q4_0 | 2488                    |  1320   |
| Q4_1 | 2315                    | ~~2023~~ |

Without `-march=native -mtune=native`, which causes the scalar code to be used without requiring modification:

|      | recent master (6e7801d) | this PR |
| ---- | ----------------------- | ------- |
| Q4_0 | 2840                    | 1330    |
| Q4_1 | 2388                    | ~~2083~~ |

Of course it would be interesting to see measurements from machines that actually do not have any SIMD circuits.
I would like to hear if this causes a regression in speed anywhere.
I can only really imagine this if floating point operations were faster than integer operations, because that's what we're trading here.
Beware of the recent change to the `Makefile` (c4f89d8), and possible differences to `CMakeLists.txt`, if you run your own tests.

The disadvantage is that this would once again cause a change in output due to floating point non-associativity / rounding.

I'll repost my snippet here, though admittedly this uses `double`s:
```
$ echo 'main(){printf("%.16f\n%.16f\n",.7+.2+.1,.7+.1+.2);}' | gcc -x c - && ./a.out
0.9999999999999999
1.0000000000000000
```
We had changes like this before, and I understand that not having reproducible results makes some people unhappy.
I don't see us achieving this across the processor-specific optimizations without a severe regression in performance.