### PR TITLE
Use full range for q4_0 quantization

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -806,22 +806,31 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
         __m256 v3 = _mm256_loadu_ps( x + 24 );
         x += 32;
 
-        // Compute max(abs(e)) for the block
-        const __m256 signBit = _mm256_set1_ps( -0.0f );
-        __m256 maxAbs = _mm256_andnot_ps( signBit, v0 );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v1 ) );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v2 ) );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v3 ) );
+        // Compute max for the block
+        __m256 max  = _mm256_max_ps( v0, v1 );
+        __m256 maxTmp = _mm256_max_ps( v2, v3 );
+        max = _mm256_max_ps( max, maxTmp );
 
-        __m128 max4 = _mm_max_ps( _mm256_extractf128_ps( maxAbs, 1 ), _mm256_castps256_ps128( maxAbs ) );
+        __m128 max4 = _mm_max_ps( _mm256_extractf128_ps( max, 1 ), _mm256_castps256_ps128( max ) );
         max4 = _mm_max_ps( max4, _mm_movehl_ps( max4, max4 ) );
         max4 = _mm_max_ss( max4, _mm_movehdup_ps( max4 ) );
         const float maxScalar = _mm_cvtss_f32( max4 );
 
+        // Compute min for the block
+        __m256 min  = _mm256_min_ps( v0, v1 );
+        __m256 minTmp = _mm256_min_ps( v2, v3 );
+        min = _mm256_min_ps( min, minTmp );
+
+        __m128 min4 = _mm_min_ps( _mm256_extractf128_ps( min, 1 ), _mm256_castps256_ps128( min ) );
+        min4 = _mm_min_ps( min4, _mm_movehl_ps( min4, min4 ) );
+        min4 = _mm_min_ss( min4, _mm_movehdup_ps( min4 ) );
+        const float minScalar = _mm_cvtss_f32( min4 );
+
         // Quantize these floats
-        const float d = maxScalar / 7.0f;
+        const float magnitude = maxScalar >= fabsf(minScalar) ? maxScalar : minScalar;
+        const float d = magnitude / -8.0f;
         y[i].d = d;
-        const float id = ( maxScalar != 0.0f ) ? 7.0f / maxScalar : 0.0f;
+        const float id = ( magnitude != 0.0f ) ? -8.0f / magnitude : 0.0f;
         const __m256 mul = _mm256_set1_ps( id );
 
         // Apply the multiplier
@@ -854,9 +863,11 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
         const __m256i perm = _mm256_setr_epi32( 0, 4, 1, 5, 2, 6, 3, 7 );
         i0 = _mm256_permutevar8x32_epi32( i0, perm );
 
-        // Apply offset to translate the range from [ -7 .. +7 ] into [ +1 .. +15 ]
+        // Apply offset and clamp to translate the range from [ -8 .. +8 ] into [ +0 .. +15 ]
         const __m256i off = _mm256_set1_epi8( 8 );
         i0 = _mm256_add_epi8( i0, off );
+        const __m256i maxNibble = _mm256_set1_epi8( 15 );
+        i0 = _mm256_min_epi8( i0, maxNibble );
 
         // Compress the vector into 4 bit/value, and store
         __m128i res = packNibbles( i0 );
@@ -871,22 +882,31 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
         __m256 v3 = _mm256_loadu_ps( x + 24 );
         x += 32;
 
-        // Compute max(abs(e)) for the block
-        const __m256 signBit = _mm256_set1_ps( -0.0f );
-        __m256 maxAbs = _mm256_andnot_ps( signBit, v0 );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v1 ) );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v2 ) );
-        maxAbs = _mm256_max_ps( maxAbs, _mm256_andnot_ps( signBit, v3 ) );
+        // Compute max for the block
+        __m256 max  = _mm256_max_ps( v0, v1 );
+        __m256 maxTmp = _mm256_max_ps( v2, v3 );
+        max = _mm256_max_ps( max, maxTmp );
 
-        __m128 max4 = _mm_max_ps( _mm256_extractf128_ps( maxAbs, 1 ), _mm256_castps256_ps128( maxAbs ) );
+        __m128 max4 = _mm_max_ps( _mm256_extractf128_ps( max, 1 ), _mm256_castps256_ps128( max ) );
         max4 = _mm_max_ps( max4, _mm_movehl_ps( max4, max4 ) );
         max4 = _mm_max_ss( max4, _mm_movehdup_ps( max4 ) );
         const float maxScalar = _mm_cvtss_f32( max4 );
 
+        // Compute min for the block
+        __m256 min  = _mm256_min_ps( v0, v1 );
+        __m256 minTmp = _mm256_min_ps( v2, v3 );
+        min = _mm256_min_ps( min, minTmp );
+
+        __m128 min4 = _mm_min_ps( _mm256_extractf128_ps( min, 1 ), _mm256_castps256_ps128( min ) );
+        min4 = _mm_min_ps( min4, _mm_movehl_ps( min4, min4 ) );
+        min4 = _mm_min_ss( min4, _mm_movehdup_ps( min4 ) );
+        const float minScalar = _mm_cvtss_f32( min4 );
+
         // Quantize these floats
-        const float d = maxScalar / 7.0f;
+        const float magnitude = maxScalar >= fabsf(minScalar) ? maxScalar : minScalar;
+        const float d = magnitude / -8.0f;
         y[i].d = d;
-        const float id = ( maxScalar != 0.0f ) ? 7.0f / maxScalar : 0.0f;
+        const float id = ( magnitude != 0.0f ) ? -8.0f / magnitude : 0.0f;
         const __m256 mul = _mm256_set1_ps( id );
 
         // Apply the multiplier
@@ -927,10 +947,13 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
         ni0 = _mm_packs_epi16( ni0, ni2 );
         ni4 = _mm_packs_epi16( ni4, ni6 );
 
-        // Apply offset to translate the range from [ -7 .. +7 ] into [ +1 .. +15 ]
-        const __m128i off = _mm_set1_epi8( 8);
+        // Apply offset and clamp to translate the range from [ -8 .. +8 ] into [ +0 .. +15 ]
+        const __m128i off = _mm_set1_epi8( 8 );
         ni0 = _mm_add_epi8( ni0, off );
         ni4 = _mm_add_epi8( ni4, off );
+        const __m128i maxNibble = _mm_set1_epi8( 15 );
+        ni0 = _mm_min_epi8( ni0, maxNibble );
+        ni4 = _mm_min_epi8( ni4, maxNibble );
 
         // Compress the vector into 4 bit/value, and store
         __m128i res = packNibbles( ni0, ni4 );

--- a/ggml.c
+++ b/ggml.c
@@ -771,19 +771,24 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
 #elif __ARM_NEON
     for (int i = 0; i < nb; i++) {
         float32x4_t srcv [8];
-        float32x4_t asrcv[8];
-        float32x4_t amaxv[8];
+        float32x4_t maxv[8];
+        float32x4_t minv[8];
 
         for (int l = 0; l < 8; l++) srcv[l]  = vld1q_f32(x + i*32 + 4*l);
-        for (int l = 0; l < 8; l++) asrcv[l] = vabsq_f32(srcv[l]);
 
-        for (int l = 0; l < 4; l++) amaxv[2*l] = vmaxq_f32(asrcv[2*l], asrcv[2*l+1]);
-        for (int l = 0; l < 2; l++) amaxv[4*l] = vmaxq_f32(amaxv[4*l], amaxv[4*l+2]);
-        for (int l = 0; l < 1; l++) amaxv[8*l] = vmaxq_f32(amaxv[8*l], amaxv[8*l+4]);
+        for (int l = 0; l < 4; l++) maxv[2*l] = vmaxq_f32(srcv[2*l], srcv[2*l+1]);
+        for (int l = 0; l < 2; l++) maxv[4*l] = vmaxq_f32(maxv[4*l], maxv[4*l+2]);
+        for (int l = 0; l < 1; l++) maxv[8*l] = vmaxq_f32(maxv[8*l], maxv[8*l+4]);
 
-        const float amax = vmaxvq_f32(amaxv[0]);
+        for (int l = 0; l < 4; l++) minv[2*l] = vminq_f32(srcv[2*l], srcv[2*l+1]);
+        for (int l = 0; l < 2; l++) minv[4*l] = vminq_f32(minv[4*l], minv[4*l+2]);
+        for (int l = 0; l < 1; l++) minv[8*l] = vminq_f32(minv[8*l], minv[8*l+4]);
 
-        const float d = amax / ((1 << 3) - 1);
+        const float max = vmaxvq_f32(maxv[0]);
+        const float min = vminvq_f32(minv[0]);
+
+        const float magnitude = max >= fabsf(min) ? max : min;
+        const float d = magnitude / -8;
         const float id = d ? 1.0f/d : 0.0f;
 
         y[i].d = d;
@@ -792,9 +797,10 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
             const float32x4_t v  = vmulq_n_f32(srcv[l], id);
             const float32x4_t vf = vaddq_f32(v, vdupq_n_f32(8.5f));
             const int32x4_t   vi = vcvtq_s32_f32(vf);
+            const int32x4_t   vc = vminq_s32(vi, vdupq_n_s32(15));
 
-            y[i].qs[2*l + 0] = vgetq_lane_s32(vi, 0) | (vgetq_lane_s32(vi, 1) << 4);
-            y[i].qs[2*l + 1] = vgetq_lane_s32(vi, 2) | (vgetq_lane_s32(vi, 3) << 4);
+            y[i].qs[2*l + 0] = vgetq_lane_s32(vc, 0) | (vgetq_lane_s32(vc, 1) << 4);
+            y[i].qs[2*l + 1] = vgetq_lane_s32(vc, 2) | (vgetq_lane_s32(vc, 3) << 4);
         }
     }
 #elif defined(__AVX2__)


### PR DESCRIPTION
By preserving the sign of the highest magnitude value, we can make sure the highest value maps to -8 in our [-8, 7] range, which is currently unused. This is a bit of a freebie since the change is fully backwards compatible with the current format.

This was also noted in https://github.com/ggerganov/llama.cpp/issues/397#issuecomment-1480291055 but has not been fixed in the code yet.

This PR only updates the reference implementation, not the SIMD accelerated versions.

quantize-stats output: (see #728)
before(7B):
q4_0                                              : mse 0.00000492, maxerr 0.14257812, 95pct<0.0040, median<0.0018
q4_1                                              : mse 0.00000318, maxerr 0.12756348, 95pct<0.0034, median<0.0014
after(7B):
q4_0                                              : mse 0.00000386, maxerr 0.18200684, 95pct<0.0036, median<0.0016
q4_1                                              : mse 0.00000318, maxerr 0.12756348, 95pct<0.0034, median<0.0014



Most layers seem to have reduced maxerr, but the total max error is actually slightly higher
TODO: run perplexity

<details>
<summary>quantize-stats before (7B)</summary>

```
q4_0::layers.0.attention.wk.weight                : mse 0.00001216, maxerr 0.07836914, 95pct<0.0070, median<0.0022
q4_0::layers.0.attention.wo.weight                : mse 0.00000145, maxerr 0.03571428, 95pct<0.0024, median<0.0010
q4_0::layers.0.attention.wq.weight                : mse 0.00001269, maxerr 0.05469622, 95pct<0.0074, median<0.0020
q4_0::layers.0.attention.wv.weight                : mse 0.00000176, maxerr 0.00775364, 95pct<0.0026, median<0.0010
q4_0::layers.0.feed_forward.w1.weight             : mse 0.00000271, maxerr 0.08459473, 95pct<0.0030, median<0.0014
q4_0::layers.0.feed_forward.w2.weight             : mse 0.00000403, maxerr 0.05426896, 95pct<0.0036, median<0.0016
q4_0::layers.0.feed_forward.w3.weight             : mse 0.00000254, maxerr 0.02079773, 95pct<0.0030, median<0.0014
q4_0::layers.1.attention.wk.weight                : mse 0.00001151, maxerr 0.04473877, 95pct<0.0072, median<0.0020
q4_0::layers.1.attention.wo.weight                : mse 0.00000136, maxerr 0.03808594, 95pct<0.0024, median<0.0008
q4_0::layers.1.attention.wq.weight                : mse 0.00001098, maxerr 0.03996059, 95pct<0.0070, median<0.0020
q4_0::layers.1.attention.wv.weight                : mse 0.00000130, maxerr 0.00764084, 95pct<0.0022, median<0.0010
q4_0::layers.1.feed_forward.w1.weight             : mse 0.00000437, maxerr 0.04241943, 95pct<0.0038, median<0.0018
q4_0::layers.1.feed_forward.w2.weight             : mse 0.00000422, maxerr 0.06106567, 95pct<0.0038, median<0.0018
q4_0::layers.1.feed_forward.w3.weight             : mse 0.00000394, maxerr 0.02634103, 95pct<0.0036, median<0.0016
q4_0::layers.10.attention.wk.weight               : mse 0.00000732, maxerr 0.02239336, 95pct<0.0054, median<0.0020
q4_0::layers.10.attention.wo.weight               : mse 0.00000298, maxerr 0.03090122, 95pct<0.0032, median<0.0014
q4_0::layers.10.attention.wq.weight               : mse 0.00000716, maxerr 0.04156494, 95pct<0.0052, median<0.0020
q4_0::layers.10.attention.wv.weight               : mse 0.00000300, maxerr 0.01774597, 95pct<0.0032, median<0.0014
q4_0::layers.10.feed_forward.w1.weight            : mse 0.00000484, maxerr 0.02800424, 95pct<0.0040, median<0.0018
q4_0::layers.10.feed_forward.w2.weight            : mse 0.00000438, maxerr 0.05075073, 95pct<0.0038, median<0.0018
q4_0::layers.10.feed_forward.w3.weight            : mse 0.00000453, maxerr 0.02395630, 95pct<0.0038, median<0.0018
q4_0::layers.11.attention.wk.weight               : mse 0.00000783, maxerr 0.02528381, 95pct<0.0054, median<0.0020
q4_0::layers.11.attention.wo.weight               : mse 0.00000327, maxerr 0.03372192, 95pct<0.0034, median<0.0016
q4_0::layers.11.attention.wq.weight               : mse 0.00000759, maxerr 0.04904175, 95pct<0.0052, median<0.0022
q4_0::layers.11.attention.wv.weight               : mse 0.00000332, maxerr 0.01550729, 95pct<0.0034, median<0.0016
q4_0::layers.11.feed_forward.w1.weight            : mse 0.00000482, maxerr 0.02865601, 95pct<0.0040, median<0.0018
q4_0::layers.11.feed_forward.w2.weight            : mse 0.00000446, maxerr 0.06465366, 95pct<0.0038, median<0.0018
q4_0::layers.11.feed_forward.w3.weight            : mse 0.00000458, maxerr 0.02845764, 95pct<0.0038, median<0.0018
q4_0::layers.12.attention.wk.weight               : mse 0.00000713, maxerr 0.02630615, 95pct<0.0052, median<0.0020
q4_0::layers.12.attention.wo.weight               : mse 0.00000315, maxerr 0.02679443, 95pct<0.0032, median<0.0016
q4_0::layers.12.attention.wq.weight               : mse 0.00000690, maxerr 0.04470825, 95pct<0.0052, median<0.0020
q4_0::layers.12.attention.wv.weight               : mse 0.00000309, maxerr 0.00950840, 95pct<0.0032, median<0.0016
q4_0::layers.12.feed_forward.w1.weight            : mse 0.00000487, maxerr 0.04248047, 95pct<0.0040, median<0.0018
q4_0::layers.12.feed_forward.w2.weight            : mse 0.00000447, maxerr 0.06710379, 95pct<0.0038, median<0.0018
q4_0::layers.12.feed_forward.w3.weight            : mse 0.00000464, maxerr 0.02052089, 95pct<0.0040, median<0.0018
q4_0::layers.13.attention.wk.weight               : mse 0.00000680, maxerr 0.02060809, 95pct<0.0052, median<0.0020
q4_0::layers.13.attention.wo.weight               : mse 0.00000339, maxerr 0.03969029, 95pct<0.0034, median<0.0016
q4_0::layers.13.attention.wq.weight               : mse 0.00000658, maxerr 0.04226249, 95pct<0.0050, median<0.0020
q4_0::layers.13.attention.wv.weight               : mse 0.00000339, maxerr 0.00988333, 95pct<0.0034, median<0.0016
q4_0::layers.13.feed_forward.w1.weight            : mse 0.00000483, maxerr 0.02473232, 95pct<0.0040, median<0.0018
q4_0::layers.13.feed_forward.w2.weight            : mse 0.00000454, maxerr 0.03540039, 95pct<0.0038, median<0.0018
q4_0::layers.13.feed_forward.w3.weight            : mse 0.00000473, maxerr 0.02145386, 95pct<0.0040, median<0.0018
q4_0::layers.14.attention.wk.weight               : mse 0.00000678, maxerr 0.02231925, 95pct<0.0050, median<0.0020
q4_0::layers.14.attention.wo.weight               : mse 0.00000340, maxerr 0.03186035, 95pct<0.0034, median<0.0016
q4_0::layers.14.attention.wq.weight               : mse 0.00000667, maxerr 0.04726301, 95pct<0.0050, median<0.0020
q4_0::layers.14.attention.wv.weight               : mse 0.00000343, maxerr 0.01053074, 95pct<0.0034, median<0.0016
q4_0::layers.14.feed_forward.w1.weight            : mse 0.00000482, maxerr 0.02782331, 95pct<0.0040, median<0.0018
q4_0::layers.14.feed_forward.w2.weight            : mse 0.00000459, maxerr 0.06702532, 95pct<0.0038, median<0.0018
q4_0::layers.14.feed_forward.w3.weight            : mse 0.00000476, maxerr 0.02725874, 95pct<0.0040, median<0.0018
q4_0::layers.15.attention.wk.weight               : mse 0.00000692, maxerr 0.02291870, 95pct<0.0052, median<0.0020
q4_0::layers.15.attention.wo.weight               : mse 0.00000342, maxerr 0.02814592, 95pct<0.0034, median<0.0016
q4_0::layers.15.attention.wq.weight               : mse 0.00000667, maxerr 0.04160418, 95pct<0.0050, median<0.0020
q4_0::layers.15.attention.wv.weight               : mse 0.00000344, maxerr 0.01073456, 95pct<0.0034, median<0.0016
q4_0::layers.15.feed_forward.w1.weight            : mse 0.00000482, maxerr 0.02490234, 95pct<0.0040, median<0.0018
q4_0::layers.15.feed_forward.w2.weight            : mse 0.00000459, maxerr 0.07189941, 95pct<0.0038, median<0.0018
q4_0::layers.15.feed_forward.w3.weight            : mse 0.00000477, maxerr 0.02241516, 95pct<0.0040, median<0.0018
q4_0::layers.16.attention.wk.weight               : mse 0.00000683, maxerr 0.02305603, 95pct<0.0050, median<0.0020
q4_0::layers.16.attention.wo.weight               : mse 0.00000384, maxerr 0.04959106, 95pct<0.0036, median<0.0016
q4_0::layers.16.attention.wq.weight               : mse 0.00000649, maxerr 0.04993547, 95pct<0.0048, median<0.0020
q4_0::layers.16.attention.wv.weight               : mse 0.00000390, maxerr 0.01102993, 95pct<0.0036, median<0.0016
q4_0::layers.16.feed_forward.w1.weight            : mse 0.00000489, maxerr 0.02763585, 95pct<0.0040, median<0.0018
q4_0::layers.16.feed_forward.w2.weight            : mse 0.00000458, maxerr 0.07447161, 95pct<0.0038, median<0.0018
q4_0::layers.16.feed_forward.w3.weight            : mse 0.00000474, maxerr 0.02688599, 95pct<0.0040, median<0.0018
q4_0::layers.17.attention.wk.weight               : mse 0.00000648, maxerr 0.02310181, 95pct<0.0050, median<0.0020
q4_0::layers.17.attention.wo.weight               : mse 0.00000394, maxerr 0.03461565, 95pct<0.0036, median<0.0016
q4_0::layers.17.attention.wq.weight               : mse 0.00000622, maxerr 0.05617850, 95pct<0.0048, median<0.0020
q4_0::layers.17.attention.wv.weight               : mse 0.00000395, maxerr 0.01605225, 95pct<0.0036, median<0.0016
q4_0::layers.17.feed_forward.w1.weight            : mse 0.00000491, maxerr 0.02258301, 95pct<0.0040, median<0.0018
q4_0::layers.17.feed_forward.w2.weight            : mse 0.00000462, maxerr 0.05793108, 95pct<0.0038, median<0.0018
q4_0::layers.17.feed_forward.w3.weight            : mse 0.00000476, maxerr 0.03012085, 95pct<0.0040, median<0.0018
q4_0::layers.18.attention.wk.weight               : mse 0.00000624, maxerr 0.02255685, 95pct<0.0048, median<0.0018
q4_0::layers.18.attention.wo.weight               : mse 0.00000391, maxerr 0.03451974, 95pct<0.0036, median<0.0016
q4_0::layers.18.attention.wq.weight               : mse 0.00000608, maxerr 0.04820906, 95pct<0.0048, median<0.0018
q4_0::layers.18.attention.wv.weight               : mse 0.00000393, maxerr 0.00875637, 95pct<0.0036, median<0.0016
q4_0::layers.18.feed_forward.w1.weight            : mse 0.00000499, maxerr 0.02549744, 95pct<0.0040, median<0.0018
q4_0::layers.18.feed_forward.w2.weight            : mse 0.00000460, maxerr 0.07299805, 95pct<0.0038, median<0.0018
q4_0::layers.18.feed_forward.w3.weight            : mse 0.00000473, maxerr 0.02032471, 95pct<0.0040, median<0.0018
q4_0::layers.19.attention.wk.weight               : mse 0.00000602, maxerr 0.02365112, 95pct<0.0048, median<0.0018
q4_0::layers.19.attention.wo.weight               : mse 0.00000425, maxerr 0.03796387, 95pct<0.0038, median<0.0018
q4_0::layers.19.attention.wq.weight               : mse 0.00000587, maxerr 0.05416870, 95pct<0.0046, median<0.0018
q4_0::layers.19.attention.wv.weight               : mse 0.00000432, maxerr 0.01004791, 95pct<0.0038, median<0.0018
q4_0::layers.19.feed_forward.w1.weight            : mse 0.00000504, maxerr 0.03585815, 95pct<0.0040, median<0.0018
q4_0::layers.19.feed_forward.w2.weight            : mse 0.00000461, maxerr 0.04916382, 95pct<0.0038, median<0.0018
q4_0::layers.19.feed_forward.w3.weight            : mse 0.00000471, maxerr 0.02484567, 95pct<0.0040, median<0.0018
q4_0::layers.2.attention.wk.weight                : mse 0.00001387, maxerr 0.03720093, 95pct<0.0076, median<0.0024
q4_0::layers.2.attention.wo.weight                : mse 0.00000191, maxerr 0.04980469, 95pct<0.0026, median<0.0012
q4_0::layers.2.attention.wq.weight                : mse 0.00001285, maxerr 0.04199655, 95pct<0.0072, median<0.0026
q4_0::layers.2.attention.wv.weight                : mse 0.00000184, maxerr 0.01274654, 95pct<0.0026, median<0.0012
q4_0::layers.2.feed_forward.w1.weight             : mse 0.00000486, maxerr 0.04729353, 95pct<0.0040, median<0.0018
q4_0::layers.2.feed_forward.w2.weight             : mse 0.00000418, maxerr 0.09649658, 95pct<0.0036, median<0.0018
q4_0::layers.2.feed_forward.w3.weight             : mse 0.00000404, maxerr 0.03546143, 95pct<0.0036, median<0.0018
q4_0::layers.20.attention.wk.weight               : mse 0.00000620, maxerr 0.02835519, 95pct<0.0048, median<0.0020
q4_0::layers.20.attention.wo.weight               : mse 0.00000447, maxerr 0.03102329, 95pct<0.0038, median<0.0018
q4_0::layers.20.attention.wq.weight               : mse 0.00000603, maxerr 0.06380789, 95pct<0.0046, median<0.0020
q4_0::layers.20.attention.wv.weight               : mse 0.00000459, maxerr 0.01255689, 95pct<0.0040, median<0.0018
q4_0::layers.20.feed_forward.w1.weight            : mse 0.00000510, maxerr 0.03062439, 95pct<0.0042, median<0.0018
q4_0::layers.20.feed_forward.w2.weight            : mse 0.00000462, maxerr 0.07861328, 95pct<0.0038, median<0.0018
q4_0::layers.20.feed_forward.w3.weight            : mse 0.00000471, maxerr 0.02113124, 95pct<0.0040, median<0.0018
q4_0::layers.21.attention.wk.weight               : mse 0.00000576, maxerr 0.02944946, 95pct<0.0046, median<0.0018
q4_0::layers.21.attention.wo.weight               : mse 0.00000452, maxerr 0.05029297, 95pct<0.0038, median<0.0018
q4_0::layers.21.attention.wq.weight               : mse 0.00000565, maxerr 0.05474854, 95pct<0.0046, median<0.0018
q4_0::layers.21.attention.wv.weight               : mse 0.00000465, maxerr 0.00916617, 95pct<0.0040, median<0.0018
q4_0::layers.21.feed_forward.w1.weight            : mse 0.00000515, maxerr 0.02553013, 95pct<0.0042, median<0.0020
q4_0::layers.21.feed_forward.w2.weight            : mse 0.00000461, maxerr 0.04321289, 95pct<0.0038, median<0.0018
q4_0::layers.21.feed_forward.w3.weight            : mse 0.00000470, maxerr 0.01762608, 95pct<0.0040, median<0.0018
q4_0::layers.22.attention.wk.weight               : mse 0.00000593, maxerr 0.02319990, 95pct<0.0046, median<0.0018
q4_0::layers.22.attention.wo.weight               : mse 0.00000455, maxerr 0.05803570, 95pct<0.0038, median<0.0018
q4_0::layers.22.attention.wq.weight               : mse 0.00000584, maxerr 0.05233765, 95pct<0.0046, median<0.0018
q4_0::layers.22.attention.wv.weight               : mse 0.00000460, maxerr 0.00913565, 95pct<0.0040, median<0.0018
q4_0::layers.22.feed_forward.w1.weight            : mse 0.00000516, maxerr 0.03031921, 95pct<0.0042, median<0.0020
q4_0::layers.22.feed_forward.w2.weight            : mse 0.00000465, maxerr 0.05004447, 95pct<0.0040, median<0.0018
q4_0::layers.22.feed_forward.w3.weight            : mse 0.00000474, maxerr 0.03417097, 95pct<0.0040, median<0.0018
q4_0::layers.23.attention.wk.weight               : mse 0.00000553, maxerr 0.02395194, 95pct<0.0046, median<0.0018
q4_0::layers.23.attention.wo.weight               : mse 0.00000480, maxerr 0.05573380, 95pct<0.0040, median<0.0018
q4_0::layers.23.attention.wq.weight               : mse 0.00000549, maxerr 0.04861450, 95pct<0.0046, median<0.0018
q4_0::layers.23.attention.wv.weight               : mse 0.00000497, maxerr 0.01011222, 95pct<0.0040, median<0.0018
q4_0::layers.23.feed_forward.w1.weight            : mse 0.00000518, maxerr 0.04048811, 95pct<0.0042, median<0.0020
q4_0::layers.23.feed_forward.w2.weight            : mse 0.00000469, maxerr 0.04928589, 95pct<0.0040, median<0.0018
q4_0::layers.23.feed_forward.w3.weight            : mse 0.00000476, maxerr 0.02658953, 95pct<0.0040, median<0.0018
q4_0::layers.24.attention.wk.weight               : mse 0.00000557, maxerr 0.02485657, 95pct<0.0046, median<0.0018
q4_0::layers.24.attention.wo.weight               : mse 0.00000492, maxerr 0.03874861, 95pct<0.0040, median<0.0018
q4_0::layers.24.attention.wq.weight               : mse 0.00000550, maxerr 0.05524989, 95pct<0.0044, median<0.0018
q4_0::layers.24.attention.wv.weight               : mse 0.00000509, maxerr 0.00925663, 95pct<0.0042, median<0.0020
q4_0::layers.24.feed_forward.w1.weight            : mse 0.00000519, maxerr 0.02595520, 95pct<0.0042, median<0.0020
q4_0::layers.24.feed_forward.w2.weight            : mse 0.00000473, maxerr 0.07434082, 95pct<0.0040, median<0.0018
q4_0::layers.24.feed_forward.w3.weight            : mse 0.00000481, maxerr 0.02382333, 95pct<0.0040, median<0.0018
q4_0::layers.25.attention.wk.weight               : mse 0.00000593, maxerr 0.02381897, 95pct<0.0046, median<0.0020
q4_0::layers.25.attention.wo.weight               : mse 0.00000501, maxerr 0.05418178, 95pct<0.0040, median<0.0018
q4_0::layers.25.attention.wq.weight               : mse 0.00000580, maxerr 0.04802595, 95pct<0.0046, median<0.0018
q4_0::layers.25.attention.wv.weight               : mse 0.00000513, maxerr 0.00928388, 95pct<0.0042, median<0.0020
q4_0::layers.25.feed_forward.w1.weight            : mse 0.00000522, maxerr 0.02363586, 95pct<0.0042, median<0.0020
q4_0::layers.25.feed_forward.w2.weight            : mse 0.00000476, maxerr 0.04512678, 95pct<0.0040, median<0.0018
q4_0::layers.25.feed_forward.w3.weight            : mse 0.00000484, maxerr 0.02100045, 95pct<0.0040, median<0.0018
q4_0::layers.26.attention.wk.weight               : mse 0.00000573, maxerr 0.03003583, 95pct<0.0046, median<0.0018
q4_0::layers.26.attention.wo.weight               : mse 0.00000531, maxerr 0.02968707, 95pct<0.0042, median<0.0020
q4_0::layers.26.attention.wq.weight               : mse 0.00000562, maxerr 0.04742432, 95pct<0.0044, median<0.0018
q4_0::layers.26.attention.wv.weight               : mse 0.00000544, maxerr 0.01335907, 95pct<0.0042, median<0.0020
q4_0::layers.26.feed_forward.w1.weight            : mse 0.00000521, maxerr 0.04232788, 95pct<0.0042, median<0.0020
q4_0::layers.26.feed_forward.w2.weight            : mse 0.00000482, maxerr 0.05311366, 95pct<0.0040, median<0.0018
q4_0::layers.26.feed_forward.w3.weight            : mse 0.00000492, maxerr 0.03234427, 95pct<0.0040, median<0.0018
q4_0::layers.27.attention.wk.weight               : mse 0.00000570, maxerr 0.02717590, 95pct<0.0046, median<0.0018
q4_0::layers.27.attention.wo.weight               : mse 0.00000557, maxerr 0.06518555, 95pct<0.0042, median<0.0020
q4_0::layers.27.attention.wq.weight               : mse 0.00000564, maxerr 0.04687936, 95pct<0.0044, median<0.0018
q4_0::layers.27.attention.wv.weight               : mse 0.00000563, maxerr 0.01382010, 95pct<0.0044, median<0.0020
q4_0::layers.27.feed_forward.w1.weight            : mse 0.00000521, maxerr 0.03359985, 95pct<0.0042, median<0.0020
q4_0::layers.27.feed_forward.w2.weight            : mse 0.00000488, maxerr 0.05447388, 95pct<0.0040, median<0.0018
q4_0::layers.27.feed_forward.w3.weight            : mse 0.00000496, maxerr 0.04153442, 95pct<0.0040, median<0.0018
q4_0::layers.28.attention.wk.weight               : mse 0.00000545, maxerr 0.02662441, 95pct<0.0044, median<0.0018
q4_0::layers.28.attention.wo.weight               : mse 0.00000569, maxerr 0.03404018, 95pct<0.0044, median<0.0020
q4_0::layers.28.attention.wq.weight               : mse 0.00000541, maxerr 0.04815674, 95pct<0.0044, median<0.0018
q4_0::layers.28.attention.wv.weight               : mse 0.00000569, maxerr 0.01067243, 95pct<0.0044, median<0.0020
q4_0::layers.28.feed_forward.w1.weight            : mse 0.00000516, maxerr 0.03170776, 95pct<0.0042, median<0.0020
q4_0::layers.28.feed_forward.w2.weight            : mse 0.00000493, maxerr 0.05703735, 95pct<0.0040, median<0.0018
q4_0::layers.28.feed_forward.w3.weight            : mse 0.00000501, maxerr 0.03425816, 95pct<0.0040, median<0.0020
q4_0::layers.29.attention.wk.weight               : mse 0.00000537, maxerr 0.02471052, 95pct<0.0044, median<0.0018
q4_0::layers.29.attention.wo.weight               : mse 0.00000604, maxerr 0.04220146, 95pct<0.0044, median<0.0020
q4_0::layers.29.attention.wq.weight               : mse 0.00000531, maxerr 0.04730660, 95pct<0.0044, median<0.0018
q4_0::layers.29.attention.wv.weight               : mse 0.00000603, maxerr 0.01110731, 95pct<0.0044, median<0.0020
q4_0::layers.29.feed_forward.w1.weight            : mse 0.00000519, maxerr 0.03314209, 95pct<0.0042, median<0.0020
q4_0::layers.29.feed_forward.w2.weight            : mse 0.00000499, maxerr 0.09802246, 95pct<0.0040, median<0.0018
q4_0::layers.29.feed_forward.w3.weight            : mse 0.00000507, maxerr 0.03025600, 95pct<0.0040, median<0.0020
q4_0::layers.3.attention.wk.weight                : mse 0.00000954, maxerr 0.02493504, 95pct<0.0062, median<0.0022
q4_0::layers.3.attention.wo.weight                : mse 0.00000257, maxerr 0.03826904, 95pct<0.0030, median<0.0014
q4_0::layers.3.attention.wq.weight                : mse 0.00000872, maxerr 0.05447824, 95pct<0.0056, median<0.0022
q4_0::layers.3.attention.wv.weight                : mse 0.00000258, maxerr 0.00874329, 95pct<0.0030, median<0.0014
q4_0::layers.3.feed_forward.w1.weight             : mse 0.00000496, maxerr 0.03732300, 95pct<0.0040, median<0.0018
q4_0::layers.3.feed_forward.w2.weight             : mse 0.00000422, maxerr 0.06250000, 95pct<0.0038, median<0.0018
q4_0::layers.3.feed_forward.w3.weight             : mse 0.00000420, maxerr 0.02593994, 95pct<0.0038, median<0.0018
q4_0::layers.30.attention.wk.weight               : mse 0.00000549, maxerr 0.02535576, 95pct<0.0044, median<0.0018
q4_0::layers.30.attention.wo.weight               : mse 0.00000602, maxerr 0.06033325, 95pct<0.0044, median<0.0020
q4_0::layers.30.attention.wq.weight               : mse 0.00000545, maxerr 0.04311262, 95pct<0.0044, median<0.0018
q4_0::layers.30.attention.wv.weight               : mse 0.00000588, maxerr 0.01166643, 95pct<0.0044, median<0.0020
q4_0::layers.30.feed_forward.w1.weight            : mse 0.00000526, maxerr 0.02958679, 95pct<0.0042, median<0.0020
q4_0::layers.30.feed_forward.w2.weight            : mse 0.00000520, maxerr 0.14257812, 95pct<0.0040, median<0.0018
q4_0::layers.30.feed_forward.w3.weight            : mse 0.00000517, maxerr 0.04168701, 95pct<0.0042, median<0.0020
q4_0::layers.31.attention.wk.weight               : mse 0.00000586, maxerr 0.02397810, 95pct<0.0046, median<0.0018
q4_0::layers.31.attention.wo.weight               : mse 0.00000490, maxerr 0.11397886, 95pct<0.0040, median<0.0018
q4_0::layers.31.attention.wq.weight               : mse 0.00000561, maxerr 0.03053502, 95pct<0.0044, median<0.0018
q4_0::layers.31.attention.wv.weight               : mse 0.00000479, maxerr 0.01826041, 95pct<0.0040, median<0.0018
q4_0::layers.31.feed_forward.w1.weight            : mse 0.00000574, maxerr 0.03063965, 95pct<0.0044, median<0.0020
q4_0::layers.31.feed_forward.w2.weight            : mse 0.00000529, maxerr 0.11260986, 95pct<0.0042, median<0.0020
q4_0::layers.31.feed_forward.w3.weight            : mse 0.00000562, maxerr 0.04486084, 95pct<0.0044, median<0.0020
q4_0::layers.4.attention.wk.weight                : mse 0.00000918, maxerr 0.02430725, 95pct<0.0060, median<0.0022
q4_0::layers.4.attention.wo.weight                : mse 0.00000257, maxerr 0.03571430, 95pct<0.0030, median<0.0014
q4_0::layers.4.attention.wq.weight                : mse 0.00000902, maxerr 0.05325317, 95pct<0.0058, median<0.0022
q4_0::layers.4.attention.wv.weight                : mse 0.00000258, maxerr 0.01036835, 95pct<0.0030, median<0.0014
q4_0::layers.4.feed_forward.w1.weight             : mse 0.00000509, maxerr 0.04565430, 95pct<0.0040, median<0.0018
q4_0::layers.4.feed_forward.w2.weight             : mse 0.00000419, maxerr 0.06991141, 95pct<0.0038, median<0.0018
q4_0::layers.4.feed_forward.w3.weight             : mse 0.00000423, maxerr 0.03997803, 95pct<0.0038, median<0.0018
q4_0::layers.5.attention.wk.weight                : mse 0.00000817, maxerr 0.03778076, 95pct<0.0056, median<0.0020
q4_0::layers.5.attention.wo.weight                : mse 0.00000264, maxerr 0.04791260, 95pct<0.0030, median<0.0014
q4_0::layers.5.attention.wq.weight                : mse 0.00000805, maxerr 0.04947335, 95pct<0.0054, median<0.0022
q4_0::layers.5.attention.wv.weight                : mse 0.00000267, maxerr 0.01681519, 95pct<0.0030, median<0.0014
q4_0::layers.5.feed_forward.w1.weight             : mse 0.00000530, maxerr 0.03759766, 95pct<0.0042, median<0.0020
q4_0::layers.5.feed_forward.w2.weight             : mse 0.00000411, maxerr 0.05007935, 95pct<0.0036, median<0.0018
q4_0::layers.5.feed_forward.w3.weight             : mse 0.00000419, maxerr 0.02728271, 95pct<0.0038, median<0.0018
q4_0::layers.6.attention.wk.weight                : mse 0.00000854, maxerr 0.02463859, 95pct<0.0058, median<0.0022
q4_0::layers.6.attention.wo.weight                : mse 0.00000269, maxerr 0.04042272, 95pct<0.0030, median<0.0014
q4_0::layers.6.attention.wq.weight                : mse 0.00000817, maxerr 0.06672886, 95pct<0.0056, median<0.0022
q4_0::layers.6.attention.wv.weight                : mse 0.00000271, maxerr 0.00993238, 95pct<0.0030, median<0.0014
q4_0::layers.6.feed_forward.w1.weight             : mse 0.00000516, maxerr 0.04476929, 95pct<0.0042, median<0.0020
q4_0::layers.6.feed_forward.w2.weight             : mse 0.00000419, maxerr 0.06134033, 95pct<0.0038, median<0.0018
q4_0::layers.6.feed_forward.w3.weight             : mse 0.00000430, maxerr 0.02858843, 95pct<0.0038, median<0.0018
q4_0::layers.7.attention.wk.weight                : mse 0.00000803, maxerr 0.02537537, 95pct<0.0056, median<0.0020
q4_0::layers.7.attention.wo.weight                : mse 0.00000281, maxerr 0.03941128, 95pct<0.0030, median<0.0014
q4_0::layers.7.attention.wq.weight                : mse 0.00000790, maxerr 0.05334473, 95pct<0.0054, median<0.0020
q4_0::layers.7.attention.wv.weight                : mse 0.00000288, maxerr 0.01028442, 95pct<0.0032, median<0.0014
q4_0::layers.7.feed_forward.w1.weight             : mse 0.00000506, maxerr 0.03002494, 95pct<0.0042, median<0.0018
q4_0::layers.7.feed_forward.w2.weight             : mse 0.00000423, maxerr 0.04916382, 95pct<0.0038, median<0.0018
q4_0::layers.7.feed_forward.w3.weight             : mse 0.00000433, maxerr 0.03115845, 95pct<0.0038, median<0.0018
q4_0::layers.8.attention.wk.weight                : mse 0.00000764, maxerr 0.02466692, 95pct<0.0054, median<0.0020
q4_0::layers.8.attention.wo.weight                : mse 0.00000278, maxerr 0.03404018, 95pct<0.0030, median<0.0014
q4_0::layers.8.attention.wq.weight                : mse 0.00000764, maxerr 0.04733276, 95pct<0.0054, median<0.0020
q4_0::layers.8.attention.wv.weight                : mse 0.00000282, maxerr 0.01240540, 95pct<0.0032, median<0.0014
q4_0::layers.8.feed_forward.w1.weight             : mse 0.00000506, maxerr 0.03372192, 95pct<0.0042, median<0.0018
q4_0::layers.8.feed_forward.w2.weight             : mse 0.00000423, maxerr 0.04331752, 95pct<0.0038, median<0.0018
q4_0::layers.8.feed_forward.w3.weight             : mse 0.00000436, maxerr 0.02461243, 95pct<0.0038, median<0.0018
q4_0::layers.9.attention.wk.weight                : mse 0.00000723, maxerr 0.02087402, 95pct<0.0054, median<0.0020
q4_0::layers.9.attention.wo.weight                : mse 0.00000274, maxerr 0.03878348, 95pct<0.0030, median<0.0014
q4_0::layers.9.attention.wq.weight                : mse 0.00000715, maxerr 0.04925537, 95pct<0.0052, median<0.0020
q4_0::layers.9.attention.wv.weight                : mse 0.00000278, maxerr 0.00997925, 95pct<0.0030, median<0.0014
q4_0::layers.9.feed_forward.w1.weight             : mse 0.00000492, maxerr 0.04805647, 95pct<0.0040, median<0.0018
q4_0::layers.9.feed_forward.w2.weight             : mse 0.00000430, maxerr 0.04580688, 95pct<0.0038, median<0.0018
q4_0::layers.9.feed_forward.w3.weight             : mse 0.00000442, maxerr 0.04849243, 95pct<0.0038, median<0.0018
q4_0::output.weight                               : mse 0.00000394, maxerr 0.02912903, 95pct<0.0036, median<0.0016
q4_0::tok_embeddings.weight                       : mse 0.00000385, maxerr 0.01875523, 95pct<0.0036, median<0.0016
q4_0                                              : mse 0.00000492, maxerr 0.14257812, 95pct<0.0040, median<0.0018
q4_1::layers.0.attention.wk.weight                : mse 0.00000684, maxerr 0.04107666, 95pct<0.0054, median<0.0016
q4_1::layers.0.attention.wo.weight                : mse 0.00000092, maxerr 0.02982175, 95pct<0.0020, median<0.0008
q4_1::layers.0.attention.wq.weight                : mse 0.00000702, maxerr 0.02834333, 95pct<0.0056, median<0.0016
q4_1::layers.0.attention.wv.weight                : mse 0.00000114, maxerr 0.00560303, 95pct<0.0022, median<0.0008
q4_1::layers.0.feed_forward.w1.weight             : mse 0.00000175, maxerr 0.03655243, 95pct<0.0024, median<0.0012
q4_1::layers.0.feed_forward.w2.weight             : mse 0.00000259, maxerr 0.04300943, 95pct<0.0030, median<0.0014
q4_1::layers.0.feed_forward.w3.weight             : mse 0.00000165, maxerr 0.01006266, 95pct<0.0024, median<0.0012
q4_1::layers.1.attention.wk.weight                : mse 0.00000728, maxerr 0.02334900, 95pct<0.0058, median<0.0016
q4_1::layers.1.attention.wo.weight                : mse 0.00000086, maxerr 0.03453889, 95pct<0.0018, median<0.0008
q4_1::layers.1.attention.wq.weight                : mse 0.00000700, maxerr 0.01987410, 95pct<0.0056, median<0.0016
q4_1::layers.1.attention.wv.weight                : mse 0.00000083, maxerr 0.00478211, 95pct<0.0018, median<0.0008
q4_1::layers.1.feed_forward.w1.weight             : mse 0.00000283, maxerr 0.02051294, 95pct<0.0030, median<0.0014
q4_1::layers.1.feed_forward.w2.weight             : mse 0.00000272, maxerr 0.03843182, 95pct<0.0030, median<0.0014
q4_1::layers.1.feed_forward.w3.weight             : mse 0.00000255, maxerr 0.01320738, 95pct<0.0030, median<0.0014
q4_1::layers.10.attention.wk.weight               : mse 0.00000472, maxerr 0.01563987, 95pct<0.0044, median<0.0016
q4_1::layers.10.attention.wo.weight               : mse 0.00000193, maxerr 0.02667642, 95pct<0.0026, median<0.0012
q4_1::layers.10.attention.wq.weight               : mse 0.00000462, maxerr 0.02052003, 95pct<0.0042, median<0.0016
q4_1::layers.10.attention.wv.weight               : mse 0.00000194, maxerr 0.00943857, 95pct<0.0026, median<0.0012
q4_1::layers.10.feed_forward.w1.weight            : mse 0.00000314, maxerr 0.01556396, 95pct<0.0032, median<0.0014
q4_1::layers.10.feed_forward.w2.weight            : mse 0.00000283, maxerr 0.02537537, 95pct<0.0030, median<0.0014
q4_1::layers.10.feed_forward.w3.weight            : mse 0.00000294, maxerr 0.01292909, 95pct<0.0032, median<0.0014
q4_1::layers.11.attention.wk.weight               : mse 0.00000505, maxerr 0.01603444, 95pct<0.0044, median<0.0016
q4_1::layers.11.attention.wo.weight               : mse 0.00000212, maxerr 0.02708334, 95pct<0.0028, median<0.0012
q4_1::layers.11.attention.wq.weight               : mse 0.00000490, maxerr 0.02761781, 95pct<0.0042, median<0.0016
q4_1::layers.11.attention.wv.weight               : mse 0.00000215, maxerr 0.00829771, 95pct<0.0028, median<0.0012
q4_1::layers.11.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01594034, 95pct<0.0032, median<0.0014
q4_1::layers.11.feed_forward.w2.weight            : mse 0.00000288, maxerr 0.03227139, 95pct<0.0032, median<0.0014
q4_1::layers.11.feed_forward.w3.weight            : mse 0.00000297, maxerr 0.01712444, 95pct<0.0032, median<0.0014
q4_1::layers.12.attention.wk.weight               : mse 0.00000460, maxerr 0.01596579, 95pct<0.0042, median<0.0016
q4_1::layers.12.attention.wo.weight               : mse 0.00000205, maxerr 0.02017212, 95pct<0.0026, median<0.0012
q4_1::layers.12.attention.wq.weight               : mse 0.00000446, maxerr 0.02285360, 95pct<0.0042, median<0.0016
q4_1::layers.12.attention.wv.weight               : mse 0.00000200, maxerr 0.00573961, 95pct<0.0026, median<0.0012
q4_1::layers.12.feed_forward.w1.weight            : mse 0.00000316, maxerr 0.02284165, 95pct<0.0032, median<0.0014
q4_1::layers.12.feed_forward.w2.weight            : mse 0.00000289, maxerr 0.03540853, 95pct<0.0032, median<0.0014
q4_1::layers.12.feed_forward.w3.weight            : mse 0.00000301, maxerr 0.01079203, 95pct<0.0032, median<0.0014
q4_1::layers.13.attention.wk.weight               : mse 0.00000439, maxerr 0.01437837, 95pct<0.0042, median<0.0016
q4_1::layers.13.attention.wo.weight               : mse 0.00000220, maxerr 0.03025717, 95pct<0.0028, median<0.0012
q4_1::layers.13.attention.wq.weight               : mse 0.00000425, maxerr 0.02128702, 95pct<0.0040, median<0.0016
q4_1::layers.13.attention.wv.weight               : mse 0.00000219, maxerr 0.00622152, 95pct<0.0028, median<0.0012
q4_1::layers.13.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01500246, 95pct<0.0032, median<0.0014
q4_1::layers.13.feed_forward.w2.weight            : mse 0.00000294, maxerr 0.02633134, 95pct<0.0032, median<0.0014
q4_1::layers.13.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01099548, 95pct<0.0032, median<0.0014
q4_1::layers.14.attention.wk.weight               : mse 0.00000438, maxerr 0.01511636, 95pct<0.0042, median<0.0016
q4_1::layers.14.attention.wo.weight               : mse 0.00000221, maxerr 0.02438152, 95pct<0.0028, median<0.0012
q4_1::layers.14.attention.wq.weight               : mse 0.00000431, maxerr 0.02371013, 95pct<0.0040, median<0.0016
q4_1::layers.14.attention.wv.weight               : mse 0.00000222, maxerr 0.00633850, 95pct<0.0028, median<0.0012
q4_1::layers.14.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01666871, 95pct<0.0032, median<0.0014
q4_1::layers.14.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.03455403, 95pct<0.0032, median<0.0014
q4_1::layers.14.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01462197, 95pct<0.0032, median<0.0016
q4_1::layers.15.attention.wk.weight               : mse 0.00000446, maxerr 0.01495159, 95pct<0.0042, median<0.0016
q4_1::layers.15.attention.wo.weight               : mse 0.00000222, maxerr 0.02541506, 95pct<0.0028, median<0.0012
q4_1::layers.15.attention.wq.weight               : mse 0.00000431, maxerr 0.02229919, 95pct<0.0040, median<0.0016
q4_1::layers.15.attention.wv.weight               : mse 0.00000223, maxerr 0.00649338, 95pct<0.0028, median<0.0012
q4_1::layers.15.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01446533, 95pct<0.0032, median<0.0014
q4_1::layers.15.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.04414570, 95pct<0.0032, median<0.0014
q4_1::layers.15.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01306508, 95pct<0.0032, median<0.0016
q4_1::layers.16.attention.wk.weight               : mse 0.00000441, maxerr 0.01464437, 95pct<0.0040, median<0.0016
q4_1::layers.16.attention.wo.weight               : mse 0.00000250, maxerr 0.04169917, 95pct<0.0030, median<0.0014
q4_1::layers.16.attention.wq.weight               : mse 0.00000419, maxerr 0.02543133, 95pct<0.0040, median<0.0016
q4_1::layers.16.attention.wv.weight               : mse 0.00000253, maxerr 0.00660706, 95pct<0.0030, median<0.0014
q4_1::layers.16.feed_forward.w1.weight            : mse 0.00000317, maxerr 0.01479188, 95pct<0.0032, median<0.0014
q4_1::layers.16.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.03672282, 95pct<0.0032, median<0.0014
q4_1::layers.16.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01314189, 95pct<0.0032, median<0.0014
q4_1::layers.17.attention.wk.weight               : mse 0.00000418, maxerr 0.01311338, 95pct<0.0040, median<0.0016
q4_1::layers.17.attention.wo.weight               : mse 0.00000256, maxerr 0.02875367, 95pct<0.0030, median<0.0014
q4_1::layers.17.attention.wq.weight               : mse 0.00000401, maxerr 0.03082275, 95pct<0.0038, median<0.0016
q4_1::layers.17.attention.wv.weight               : mse 0.00000256, maxerr 0.00813599, 95pct<0.0030, median<0.0014
q4_1::layers.17.feed_forward.w1.weight            : mse 0.00000319, maxerr 0.01236165, 95pct<0.0032, median<0.0016
q4_1::layers.17.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02805888, 95pct<0.0032, median<0.0014
q4_1::layers.17.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01775716, 95pct<0.0032, median<0.0016
q4_1::layers.18.attention.wk.weight               : mse 0.00000403, maxerr 0.01377869, 95pct<0.0040, median<0.0014
q4_1::layers.18.attention.wo.weight               : mse 0.00000254, maxerr 0.03247070, 95pct<0.0030, median<0.0014
q4_1::layers.18.attention.wq.weight               : mse 0.00000392, maxerr 0.02439576, 95pct<0.0038, median<0.0014
q4_1::layers.18.attention.wv.weight               : mse 0.00000255, maxerr 0.00598729, 95pct<0.0030, median<0.0014
q4_1::layers.18.feed_forward.w1.weight            : mse 0.00000324, maxerr 0.01477051, 95pct<0.0034, median<0.0016
q4_1::layers.18.feed_forward.w2.weight            : mse 0.00000298, maxerr 0.03860271, 95pct<0.0032, median<0.0014
q4_1::layers.18.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01042479, 95pct<0.0032, median<0.0014
q4_1::layers.19.attention.wk.weight               : mse 0.00000388, maxerr 0.01365611, 95pct<0.0038, median<0.0014
q4_1::layers.19.attention.wo.weight               : mse 0.00000276, maxerr 0.03216144, 95pct<0.0030, median<0.0014
q4_1::layers.19.attention.wq.weight               : mse 0.00000378, maxerr 0.02803510, 95pct<0.0038, median<0.0014
q4_1::layers.19.attention.wv.weight               : mse 0.00000280, maxerr 0.00700684, 95pct<0.0030, median<0.0014
q4_1::layers.19.feed_forward.w1.weight            : mse 0.00000328, maxerr 0.01841432, 95pct<0.0034, median<0.0016
q4_1::layers.19.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02656788, 95pct<0.0032, median<0.0014
q4_1::layers.19.feed_forward.w3.weight            : mse 0.00000306, maxerr 0.01330259, 95pct<0.0032, median<0.0014
q4_1::layers.2.attention.wk.weight                : mse 0.00000883, maxerr 0.01976573, 95pct<0.0062, median<0.0020
q4_1::layers.2.attention.wo.weight                : mse 0.00000123, maxerr 0.03828126, 95pct<0.0020, median<0.0010
q4_1::layers.2.attention.wq.weight                : mse 0.00000823, maxerr 0.02216390, 95pct<0.0058, median<0.0020
q4_1::layers.2.attention.wv.weight                : mse 0.00000119, maxerr 0.00736135, 95pct<0.0020, median<0.0010
q4_1::layers.2.feed_forward.w1.weight             : mse 0.00000315, maxerr 0.03544718, 95pct<0.0032, median<0.0016
q4_1::layers.2.feed_forward.w2.weight             : mse 0.00000271, maxerr 0.05198061, 95pct<0.0030, median<0.0014
q4_1::layers.2.feed_forward.w3.weight             : mse 0.00000262, maxerr 0.01909560, 95pct<0.0030, median<0.0014
q4_1::layers.20.attention.wk.weight               : mse 0.00000400, maxerr 0.01639201, 95pct<0.0038, median<0.0016
q4_1::layers.20.attention.wo.weight               : mse 0.00000290, maxerr 0.02312827, 95pct<0.0032, median<0.0014
q4_1::layers.20.attention.wq.weight               : mse 0.00000388, maxerr 0.03564453, 95pct<0.0038, median<0.0016
q4_1::layers.20.attention.wv.weight               : mse 0.00000298, maxerr 0.00713094, 95pct<0.0032, median<0.0014
q4_1::layers.20.feed_forward.w1.weight            : mse 0.00000331, maxerr 0.01476848, 95pct<0.0034, median<0.0016
q4_1::layers.20.feed_forward.w2.weight            : mse 0.00000300, maxerr 0.04094645, 95pct<0.0032, median<0.0014
q4_1::layers.20.feed_forward.w3.weight            : mse 0.00000306, maxerr 0.01144791, 95pct<0.0032, median<0.0014
q4_1::layers.21.attention.wk.weight               : mse 0.00000371, maxerr 0.01407850, 95pct<0.0038, median<0.0014
q4_1::layers.21.attention.wo.weight               : mse 0.00000294, maxerr 0.04772949, 95pct<0.0032, median<0.0014
q4_1::layers.21.attention.wq.weight               : mse 0.00000363, maxerr 0.02847900, 95pct<0.0038, median<0.0014
q4_1::layers.21.attention.wv.weight               : mse 0.00000302, maxerr 0.00687256, 95pct<0.0032, median<0.0014
q4_1::layers.21.feed_forward.w1.weight            : mse 0.00000334, maxerr 0.01481831, 95pct<0.0034, median<0.0016
q4_1::layers.21.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02454491, 95pct<0.0032, median<0.0014
q4_1::layers.21.feed_forward.w3.weight            : mse 0.00000305, maxerr 0.00941722, 95pct<0.0032, median<0.0014
q4_1::layers.22.attention.wk.weight               : mse 0.00000382, maxerr 0.01457518, 95pct<0.0038, median<0.0016
q4_1::layers.22.attention.wo.weight               : mse 0.00000296, maxerr 0.05219725, 95pct<0.0032, median<0.0014
q4_1::layers.22.attention.wq.weight               : mse 0.00000375, maxerr 0.02614343, 95pct<0.0038, median<0.0016
q4_1::layers.22.attention.wv.weight               : mse 0.00000298, maxerr 0.00633164, 95pct<0.0032, median<0.0014
q4_1::layers.22.feed_forward.w1.weight            : mse 0.00000335, maxerr 0.01621208, 95pct<0.0034, median<0.0016
q4_1::layers.22.feed_forward.w2.weight            : mse 0.00000302, maxerr 0.02524516, 95pct<0.0032, median<0.0014
q4_1::layers.22.feed_forward.w3.weight            : mse 0.00000308, maxerr 0.01791126, 95pct<0.0032, median<0.0016
q4_1::layers.23.attention.wk.weight               : mse 0.00000355, maxerr 0.01381835, 95pct<0.0038, median<0.0014
q4_1::layers.23.attention.wo.weight               : mse 0.00000312, maxerr 0.05039060, 95pct<0.0032, median<0.0014
q4_1::layers.23.attention.wq.weight               : mse 0.00000352, maxerr 0.02543131, 95pct<0.0036, median<0.0014
q4_1::layers.23.attention.wv.weight               : mse 0.00000323, maxerr 0.00705466, 95pct<0.0034, median<0.0016
q4_1::layers.23.feed_forward.w1.weight            : mse 0.00000336, maxerr 0.02019602, 95pct<0.0034, median<0.0016
q4_1::layers.23.feed_forward.w2.weight            : mse 0.00000304, maxerr 0.02755737, 95pct<0.0032, median<0.0014
q4_1::layers.23.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01500538, 95pct<0.0032, median<0.0016
q4_1::layers.24.attention.wk.weight               : mse 0.00000358, maxerr 0.01357117, 95pct<0.0038, median<0.0014
q4_1::layers.24.attention.wo.weight               : mse 0.00000320, maxerr 0.03517246, 95pct<0.0032, median<0.0016
q4_1::layers.24.attention.wq.weight               : mse 0.00000353, maxerr 0.02697754, 95pct<0.0036, median<0.0014
q4_1::layers.24.attention.wv.weight               : mse 0.00000330, maxerr 0.00695597, 95pct<0.0034, median<0.0016
q4_1::layers.24.feed_forward.w1.weight            : mse 0.00000337, maxerr 0.01255596, 95pct<0.0034, median<0.0016
q4_1::layers.24.feed_forward.w2.weight            : mse 0.00000307, maxerr 0.03697109, 95pct<0.0032, median<0.0016
q4_1::layers.24.feed_forward.w3.weight            : mse 0.00000312, maxerr 0.01249239, 95pct<0.0032, median<0.0016
q4_1::layers.25.attention.wk.weight               : mse 0.00000382, maxerr 0.01319379, 95pct<0.0038, median<0.0016
q4_1::layers.25.attention.wo.weight               : mse 0.00000326, maxerr 0.03653157, 95pct<0.0034, median<0.0016
q4_1::layers.25.attention.wq.weight               : mse 0.00000373, maxerr 0.02534175, 95pct<0.0036, median<0.0016
q4_1::layers.25.attention.wv.weight               : mse 0.00000333, maxerr 0.00774231, 95pct<0.0034, median<0.0016
q4_1::layers.25.feed_forward.w1.weight            : mse 0.00000339, maxerr 0.01365763, 95pct<0.0034, median<0.0016
q4_1::layers.25.feed_forward.w2.weight            : mse 0.00000309, maxerr 0.02395630, 95pct<0.0032, median<0.0016
q4_1::layers.25.feed_forward.w3.weight            : mse 0.00000315, maxerr 0.01177013, 95pct<0.0032, median<0.0016
q4_1::layers.26.attention.wk.weight               : mse 0.00000370, maxerr 0.01424815, 95pct<0.0036, median<0.0016
q4_1::layers.26.attention.wo.weight               : mse 0.00000345, maxerr 0.02384442, 95pct<0.0034, median<0.0016
q4_1::layers.26.attention.wq.weight               : mse 0.00000361, maxerr 0.02352905, 95pct<0.0036, median<0.0016
q4_1::layers.26.attention.wv.weight               : mse 0.00000353, maxerr 0.00762227, 95pct<0.0034, median<0.0016
q4_1::layers.26.feed_forward.w1.weight            : mse 0.00000338, maxerr 0.02146912, 95pct<0.0034, median<0.0016
q4_1::layers.26.feed_forward.w2.weight            : mse 0.00000313, maxerr 0.02818197, 95pct<0.0032, median<0.0016
q4_1::layers.26.feed_forward.w3.weight            : mse 0.00000319, maxerr 0.02482224, 95pct<0.0032, median<0.0016
q4_1::layers.27.attention.wk.weight               : mse 0.00000367, maxerr 0.01493329, 95pct<0.0036, median<0.0016
q4_1::layers.27.attention.wo.weight               : mse 0.00000362, maxerr 0.05037433, 95pct<0.0034, median<0.0016
q4_1::layers.27.attention.wq.weight               : mse 0.00000361, maxerr 0.02156782, 95pct<0.0036, median<0.0016
q4_1::layers.27.attention.wv.weight               : mse 0.00000365, maxerr 0.00810165, 95pct<0.0036, median<0.0016
q4_1::layers.27.feed_forward.w1.weight            : mse 0.00000338, maxerr 0.02540493, 95pct<0.0034, median<0.0016
q4_1::layers.27.feed_forward.w2.weight            : mse 0.00000316, maxerr 0.02953517, 95pct<0.0032, median<0.0016
q4_1::layers.27.feed_forward.w3.weight            : mse 0.00000322, maxerr 0.02640279, 95pct<0.0032, median<0.0016
q4_1::layers.28.attention.wk.weight               : mse 0.00000351, maxerr 0.01595867, 95pct<0.0036, median<0.0014
q4_1::layers.28.attention.wo.weight               : mse 0.00000370, maxerr 0.02981770, 95pct<0.0036, median<0.0016
q4_1::layers.28.attention.wq.weight               : mse 0.00000347, maxerr 0.02494049, 95pct<0.0036, median<0.0014
q4_1::layers.28.attention.wv.weight               : mse 0.00000369, maxerr 0.00791423, 95pct<0.0036, median<0.0016
q4_1::layers.28.feed_forward.w1.weight            : mse 0.00000335, maxerr 0.02810669, 95pct<0.0034, median<0.0016
q4_1::layers.28.feed_forward.w2.weight            : mse 0.00000319, maxerr 0.03309225, 95pct<0.0032, median<0.0016
q4_1::layers.28.feed_forward.w3.weight            : mse 0.00000325, maxerr 0.02055053, 95pct<0.0032, median<0.0016
q4_1::layers.29.attention.wk.weight               : mse 0.00000346, maxerr 0.01428223, 95pct<0.0036, median<0.0014
q4_1::layers.29.attention.wo.weight               : mse 0.00000392, maxerr 0.03439641, 95pct<0.0036, median<0.0016
q4_1::layers.29.attention.wq.weight               : mse 0.00000340, maxerr 0.02388712, 95pct<0.0036, median<0.0014
q4_1::layers.29.attention.wv.weight               : mse 0.00000391, maxerr 0.00761922, 95pct<0.0036, median<0.0016
q4_1::layers.29.feed_forward.w1.weight            : mse 0.00000337, maxerr 0.02038574, 95pct<0.0034, median<0.0016
q4_1::layers.29.feed_forward.w2.weight            : mse 0.00000321, maxerr 0.05755107, 95pct<0.0032, median<0.0016
q4_1::layers.29.feed_forward.w3.weight            : mse 0.00000329, maxerr 0.01542050, 95pct<0.0034, median<0.0016
q4_1::layers.3.attention.wk.weight                : mse 0.00000611, maxerr 0.01627603, 95pct<0.0050, median<0.0018
q4_1::layers.3.attention.wo.weight                : mse 0.00000167, maxerr 0.03495282, 95pct<0.0024, median<0.0012
q4_1::layers.3.attention.wq.weight                : mse 0.00000552, maxerr 0.02804718, 95pct<0.0046, median<0.0018
q4_1::layers.3.attention.wv.weight                : mse 0.00000167, maxerr 0.00555267, 95pct<0.0024, median<0.0012
q4_1::layers.3.feed_forward.w1.weight             : mse 0.00000322, maxerr 0.02117920, 95pct<0.0032, median<0.0016
q4_1::layers.3.feed_forward.w2.weight             : mse 0.00000273, maxerr 0.03491618, 95pct<0.0030, median<0.0014
q4_1::layers.3.feed_forward.w3.weight             : mse 0.00000272, maxerr 0.01362103, 95pct<0.0030, median<0.0014
q4_1::layers.30.attention.wk.weight               : mse 0.00000353, maxerr 0.01795453, 95pct<0.0036, median<0.0014
q4_1::layers.30.attention.wo.weight               : mse 0.00000391, maxerr 0.04497075, 95pct<0.0036, median<0.0016
q4_1::layers.30.attention.wq.weight               : mse 0.00000347, maxerr 0.02401968, 95pct<0.0036, median<0.0014
q4_1::layers.30.attention.wv.weight               : mse 0.00000381, maxerr 0.00759277, 95pct<0.0036, median<0.0016
q4_1::layers.30.feed_forward.w1.weight            : mse 0.00000341, maxerr 0.01782125, 95pct<0.0034, median<0.0016
q4_1::layers.30.feed_forward.w2.weight            : mse 0.00000342, maxerr 0.12756348, 95pct<0.0032, median<0.0016
q4_1::layers.30.feed_forward.w3.weight            : mse 0.00000335, maxerr 0.02418011, 95pct<0.0034, median<0.0016
q4_1::layers.31.attention.wk.weight               : mse 0.00000375, maxerr 0.01362303, 95pct<0.0038, median<0.0016
q4_1::layers.31.attention.wo.weight               : mse 0.00000319, maxerr 0.10161138, 95pct<0.0032, median<0.0014
q4_1::layers.31.attention.wq.weight               : mse 0.00000357, maxerr 0.01820374, 95pct<0.0036, median<0.0016
q4_1::layers.31.attention.wv.weight               : mse 0.00000310, maxerr 0.00997696, 95pct<0.0032, median<0.0014
q4_1::layers.31.feed_forward.w1.weight            : mse 0.00000371, maxerr 0.02717184, 95pct<0.0036, median<0.0016
q4_1::layers.31.feed_forward.w2.weight            : mse 0.00000336, maxerr 0.09575176, 95pct<0.0034, median<0.0016
q4_1::layers.31.feed_forward.w3.weight            : mse 0.00000363, maxerr 0.03244019, 95pct<0.0034, median<0.0016
q4_1::layers.4.attention.wk.weight                : mse 0.00000589, maxerr 0.01599121, 95pct<0.0048, median<0.0018
q4_1::layers.4.attention.wo.weight                : mse 0.00000167, maxerr 0.02775061, 95pct<0.0024, median<0.0012
q4_1::layers.4.attention.wq.weight                : mse 0.00000573, maxerr 0.02762246, 95pct<0.0046, median<0.0018
q4_1::layers.4.attention.wv.weight                : mse 0.00000167, maxerr 0.00593816, 95pct<0.0024, median<0.0010
q4_1::layers.4.feed_forward.w1.weight             : mse 0.00000330, maxerr 0.02607116, 95pct<0.0034, median<0.0016
q4_1::layers.4.feed_forward.w2.weight             : mse 0.00000271, maxerr 0.04353638, 95pct<0.0030, median<0.0014
q4_1::layers.4.feed_forward.w3.weight             : mse 0.00000274, maxerr 0.02257079, 95pct<0.0030, median<0.0014
q4_1::layers.5.attention.wk.weight                : mse 0.00000527, maxerr 0.02016246, 95pct<0.0046, median<0.0016
q4_1::layers.5.attention.wo.weight                : mse 0.00000171, maxerr 0.04142249, 95pct<0.0024, median<0.0012
q4_1::layers.5.attention.wq.weight                : mse 0.00000516, maxerr 0.02691448, 95pct<0.0044, median<0.0016
q4_1::layers.5.attention.wv.weight                : mse 0.00000173, maxerr 0.00809692, 95pct<0.0024, median<0.0012
q4_1::layers.5.feed_forward.w1.weight             : mse 0.00000344, maxerr 0.02066040, 95pct<0.0034, median<0.0016
q4_1::layers.5.feed_forward.w2.weight             : mse 0.00000266, maxerr 0.02678931, 95pct<0.0030, median<0.0014
q4_1::layers.5.feed_forward.w3.weight             : mse 0.00000272, maxerr 0.01605021, 95pct<0.0030, median<0.0014
q4_1::layers.6.attention.wk.weight                : mse 0.00000552, maxerr 0.01503804, 95pct<0.0046, median<0.0018
q4_1::layers.6.attention.wo.weight                : mse 0.00000175, maxerr 0.03727213, 95pct<0.0024, median<0.0012
q4_1::layers.6.attention.wq.weight                : mse 0.00000526, maxerr 0.03130698, 95pct<0.0044, median<0.0018
q4_1::layers.6.attention.wv.weight                : mse 0.00000176, maxerr 0.00586955, 95pct<0.0024, median<0.0012
q4_1::layers.6.feed_forward.w1.weight             : mse 0.00000334, maxerr 0.02278137, 95pct<0.0034, median<0.0016
q4_1::layers.6.feed_forward.w2.weight             : mse 0.00000272, maxerr 0.03055978, 95pct<0.0030, median<0.0014
q4_1::layers.6.feed_forward.w3.weight             : mse 0.00000279, maxerr 0.01386768, 95pct<0.0030, median<0.0014
q4_1::layers.7.attention.wk.weight                : mse 0.00000518, maxerr 0.01637778, 95pct<0.0044, median<0.0016
q4_1::layers.7.attention.wo.weight                : mse 0.00000182, maxerr 0.02817380, 95pct<0.0026, median<0.0012
q4_1::layers.7.attention.wq.weight                : mse 0.00000509, maxerr 0.02885771, 95pct<0.0044, median<0.0016
q4_1::layers.7.attention.wv.weight                : mse 0.00000187, maxerr 0.00640869, 95pct<0.0026, median<0.0012
q4_1::layers.7.feed_forward.w1.weight             : mse 0.00000328, maxerr 0.01696777, 95pct<0.0034, median<0.0016
q4_1::layers.7.feed_forward.w2.weight             : mse 0.00000274, maxerr 0.02849120, 95pct<0.0030, median<0.0014
q4_1::layers.7.feed_forward.w3.weight             : mse 0.00000281, maxerr 0.01903725, 95pct<0.0030, median<0.0014
q4_1::layers.8.attention.wk.weight                : mse 0.00000493, maxerr 0.01597899, 95pct<0.0044, median<0.0016
q4_1::layers.8.attention.wo.weight                : mse 0.00000181, maxerr 0.02582398, 95pct<0.0026, median<0.0012
q4_1::layers.8.attention.wq.weight                : mse 0.00000492, maxerr 0.02330780, 95pct<0.0044, median<0.0016
q4_1::layers.8.attention.wv.weight                : mse 0.00000183, maxerr 0.00699462, 95pct<0.0026, median<0.0012
q4_1::layers.8.feed_forward.w1.weight             : mse 0.00000328, maxerr 0.01851404, 95pct<0.0034, median<0.0016
q4_1::layers.8.feed_forward.w2.weight             : mse 0.00000274, maxerr 0.02776897, 95pct<0.0030, median<0.0014
q4_1::layers.8.feed_forward.w3.weight             : mse 0.00000283, maxerr 0.01309204, 95pct<0.0030, median<0.0014
q4_1::layers.9.attention.wk.weight                : mse 0.00000468, maxerr 0.01326293, 95pct<0.0044, median<0.0016
q4_1::layers.9.attention.wo.weight                : mse 0.00000178, maxerr 0.03066409, 95pct<0.0024, median<0.0012
q4_1::layers.9.attention.wq.weight                : mse 0.00000461, maxerr 0.02470907, 95pct<0.0042, median<0.0016
q4_1::layers.9.attention.wv.weight                : mse 0.00000180, maxerr 0.00619888, 95pct<0.0026, median<0.0012
q4_1::layers.9.feed_forward.w1.weight             : mse 0.00000319, maxerr 0.02470452, 95pct<0.0034, median<0.0014
q4_1::layers.9.feed_forward.w2.weight             : mse 0.00000278, maxerr 0.02815247, 95pct<0.0030, median<0.0014
q4_1::layers.9.feed_forward.w3.weight             : mse 0.00000286, maxerr 0.02717841, 95pct<0.0032, median<0.0014
q4_1::output.weight                               : mse 0.00000251, maxerr 0.01462148, 95pct<0.0030, median<0.0014
q4_1::tok_embeddings.weight                       : mse 0.00000250, maxerr 0.01170197, 95pct<0.0030, median<0.0014
q4_1                                              : mse 0.00000318, maxerr 0.12756348, 95pct<0.0034, median<0.0014

```
</details>

<details>
<summary>quantize-stats after (7B)</summary>

```
note: source model is f16
testing 226 layers with max size 131072000, allocating 1572864000 bytes
q4_0::layers.0.attention.wk.weight                : mse 0.00000946, maxerr 0.07012939, 95pct<0.0062, median<0.0018
q4_0::layers.0.attention.wo.weight                : mse 0.00000114, maxerr 0.04718018, 95pct<0.0022, median<0.0008
q4_0::layers.0.attention.wq.weight                : mse 0.00000990, maxerr 0.04913330, 95pct<0.0066, median<0.0018
q4_0::layers.0.attention.wv.weight                : mse 0.00000138, maxerr 0.00809479, 95pct<0.0024, median<0.0010
q4_0::layers.0.feed_forward.w1.weight             : mse 0.00000213, maxerr 0.06494141, 95pct<0.0026, median<0.0012
q4_0::layers.0.feed_forward.w2.weight             : mse 0.00000315, maxerr 0.05014038, 95pct<0.0032, median<0.0016
q4_0::layers.0.feed_forward.w3.weight             : mse 0.00000199, maxerr 0.01788330, 95pct<0.0026, median<0.0012
q4_0::layers.1.attention.wk.weight                : mse 0.00000900, maxerr 0.04061890, 95pct<0.0064, median<0.0018
q4_0::layers.1.attention.wo.weight                : mse 0.00000107, maxerr 0.06164551, 95pct<0.0020, median<0.0008
q4_0::layers.1.attention.wq.weight                : mse 0.00000860, maxerr 0.03482056, 95pct<0.0062, median<0.0018
q4_0::layers.1.attention.wv.weight                : mse 0.00000101, maxerr 0.00719452, 95pct<0.0020, median<0.0008
q4_0::layers.1.feed_forward.w1.weight             : mse 0.00000343, maxerr 0.03784180, 95pct<0.0034, median<0.0016
q4_0::layers.1.feed_forward.w2.weight             : mse 0.00000331, maxerr 0.05532837, 95pct<0.0032, median<0.0016
q4_0::layers.1.feed_forward.w3.weight             : mse 0.00000309, maxerr 0.02270508, 95pct<0.0032, median<0.0016
q4_0::layers.10.attention.wk.weight               : mse 0.00000574, maxerr 0.02407837, 95pct<0.0048, median<0.0018
q4_0::layers.10.attention.wo.weight               : mse 0.00000233, maxerr 0.03552246, 95pct<0.0028, median<0.0014
q4_0::layers.10.attention.wq.weight               : mse 0.00000561, maxerr 0.03735352, 95pct<0.0046, median<0.0018
q4_0::layers.10.attention.wv.weight               : mse 0.00000235, maxerr 0.01551819, 95pct<0.0028, median<0.0014
q4_0::layers.10.feed_forward.w1.weight            : mse 0.00000380, maxerr 0.02473450, 95pct<0.0036, median<0.0016
q4_0::layers.10.feed_forward.w2.weight            : mse 0.00000344, maxerr 0.04382324, 95pct<0.0034, median<0.0016
q4_0::layers.10.feed_forward.w3.weight            : mse 0.00000355, maxerr 0.02250671, 95pct<0.0034, median<0.0016
q4_0::layers.11.attention.wk.weight               : mse 0.00000614, maxerr 0.02574158, 95pct<0.0048, median<0.0018
q4_0::layers.11.attention.wo.weight               : mse 0.00000256, maxerr 0.03140259, 95pct<0.0030, median<0.0014
q4_0::layers.11.attention.wq.weight               : mse 0.00000594, maxerr 0.04638672, 95pct<0.0046, median<0.0018
q4_0::layers.11.attention.wv.weight               : mse 0.00000260, maxerr 0.01353455, 95pct<0.0030, median<0.0014
q4_0::layers.11.feed_forward.w1.weight            : mse 0.00000378, maxerr 0.02500916, 95pct<0.0036, median<0.0016
q4_0::layers.11.feed_forward.w2.weight            : mse 0.00000349, maxerr 0.05606079, 95pct<0.0034, median<0.0016
q4_0::layers.11.feed_forward.w3.weight            : mse 0.00000359, maxerr 0.02583313, 95pct<0.0034, median<0.0016
q4_0::layers.12.attention.wk.weight               : mse 0.00000559, maxerr 0.02272034, 95pct<0.0046, median<0.0018
q4_0::layers.12.attention.wo.weight               : mse 0.00000247, maxerr 0.02410889, 95pct<0.0028, median<0.0014
q4_0::layers.12.attention.wq.weight               : mse 0.00000541, maxerr 0.03787231, 95pct<0.0046, median<0.0018
q4_0::layers.12.attention.wv.weight               : mse 0.00000243, maxerr 0.00985718, 95pct<0.0028, median<0.0014
q4_0::layers.12.feed_forward.w1.weight            : mse 0.00000382, maxerr 0.03527832, 95pct<0.0036, median<0.0016
q4_0::layers.12.feed_forward.w2.weight            : mse 0.00000350, maxerr 0.05621338, 95pct<0.0034, median<0.0016
q4_0::layers.12.feed_forward.w3.weight            : mse 0.00000364, maxerr 0.01757812, 95pct<0.0034, median<0.0016
q4_0::layers.13.attention.wk.weight               : mse 0.00000533, maxerr 0.02510071, 95pct<0.0046, median<0.0016
q4_0::layers.13.attention.wo.weight               : mse 0.00000265, maxerr 0.04525757, 95pct<0.0030, median<0.0014
q4_0::layers.13.attention.wq.weight               : mse 0.00000516, maxerr 0.03643799, 95pct<0.0044, median<0.0016
q4_0::layers.13.attention.wv.weight               : mse 0.00000265, maxerr 0.01044464, 95pct<0.0030, median<0.0014
q4_0::layers.13.feed_forward.w1.weight            : mse 0.00000379, maxerr 0.02149963, 95pct<0.0036, median<0.0016
q4_0::layers.13.feed_forward.w2.weight            : mse 0.00000356, maxerr 0.03344727, 95pct<0.0034, median<0.0016
q4_0::layers.13.feed_forward.w3.weight            : mse 0.00000371, maxerr 0.01843262, 95pct<0.0036, median<0.0016
q4_0::layers.14.attention.wk.weight               : mse 0.00000532, maxerr 0.02272034, 95pct<0.0044, median<0.0018
q4_0::layers.14.attention.wo.weight               : mse 0.00000267, maxerr 0.03359985, 95pct<0.0030, median<0.0014
q4_0::layers.14.attention.wq.weight               : mse 0.00000523, maxerr 0.04104614, 95pct<0.0044, median<0.0018
q4_0::layers.14.attention.wv.weight               : mse 0.00000269, maxerr 0.00988770, 95pct<0.0030, median<0.0014
q4_0::layers.14.feed_forward.w1.weight            : mse 0.00000378, maxerr 0.02416992, 95pct<0.0036, median<0.0016
q4_0::layers.14.feed_forward.w2.weight            : mse 0.00000360, maxerr 0.05963135, 95pct<0.0034, median<0.0016
q4_0::layers.14.feed_forward.w3.weight            : mse 0.00000373, maxerr 0.02426147, 95pct<0.0036, median<0.0016
q4_0::layers.15.attention.wk.weight               : mse 0.00000542, maxerr 0.02012634, 95pct<0.0046, median<0.0018
q4_0::layers.15.attention.wo.weight               : mse 0.00000268, maxerr 0.02880859, 95pct<0.0030, median<0.0014
q4_0::layers.15.attention.wq.weight               : mse 0.00000523, maxerr 0.03628540, 95pct<0.0044, median<0.0018
q4_0::layers.15.attention.wv.weight               : mse 0.00000270, maxerr 0.00939941, 95pct<0.0030, median<0.0014
q4_0::layers.15.feed_forward.w1.weight            : mse 0.00000378, maxerr 0.02140808, 95pct<0.0036, median<0.0016
q4_0::layers.15.feed_forward.w2.weight            : mse 0.00000360, maxerr 0.06188965, 95pct<0.0034, median<0.0016
q4_0::layers.15.feed_forward.w3.weight            : mse 0.00000374, maxerr 0.02241516, 95pct<0.0036, median<0.0016
q4_0::layers.16.attention.wk.weight               : mse 0.00000535, maxerr 0.01998901, 95pct<0.0044, median<0.0018
q4_0::layers.16.attention.wo.weight               : mse 0.00000301, maxerr 0.04467773, 95pct<0.0032, median<0.0014
q4_0::layers.16.attention.wq.weight               : mse 0.00000509, maxerr 0.04324341, 95pct<0.0044, median<0.0018
q4_0::layers.16.attention.wv.weight               : mse 0.00000306, maxerr 0.00990295, 95pct<0.0032, median<0.0014
q4_0::layers.16.feed_forward.w1.weight            : mse 0.00000383, maxerr 0.02427673, 95pct<0.0036, median<0.0016
q4_0::layers.16.feed_forward.w2.weight            : mse 0.00000359, maxerr 0.05804443, 95pct<0.0034, median<0.0016
q4_0::layers.16.feed_forward.w3.weight            : mse 0.00000371, maxerr 0.02345276, 95pct<0.0036, median<0.0016
q4_0::layers.17.attention.wk.weight               : mse 0.00000508, maxerr 0.01977539, 95pct<0.0044, median<0.0018
q4_0::layers.17.attention.wo.weight               : mse 0.00000309, maxerr 0.02990723, 95pct<0.0032, median<0.0014
q4_0::layers.17.attention.wq.weight               : mse 0.00000487, maxerr 0.04873657, 95pct<0.0042, median<0.0018
q4_0::layers.17.attention.wv.weight               : mse 0.00000310, maxerr 0.01419830, 95pct<0.0032, median<0.0014
q4_0::layers.17.feed_forward.w1.weight            : mse 0.00000385, maxerr 0.01963806, 95pct<0.0036, median<0.0016
q4_0::layers.17.feed_forward.w2.weight            : mse 0.00000362, maxerr 0.04980469, 95pct<0.0034, median<0.0016
q4_0::layers.17.feed_forward.w3.weight            : mse 0.00000373, maxerr 0.02487183, 95pct<0.0036, median<0.0016
q4_0::layers.18.attention.wk.weight               : mse 0.00000489, maxerr 0.01959229, 95pct<0.0044, median<0.0016
q4_0::layers.18.attention.wo.weight               : mse 0.00000307, maxerr 0.05526733, 95pct<0.0032, median<0.0014
q4_0::layers.18.attention.wq.weight               : mse 0.00000477, maxerr 0.04193115, 95pct<0.0042, median<0.0016
q4_0::layers.18.attention.wv.weight               : mse 0.00000308, maxerr 0.00922394, 95pct<0.0032, median<0.0014
q4_0::layers.18.feed_forward.w1.weight            : mse 0.00000391, maxerr 0.02268982, 95pct<0.0036, median<0.0016
q4_0::layers.18.feed_forward.w2.weight            : mse 0.00000360, maxerr 0.06439209, 95pct<0.0034, median<0.0016
q4_0::layers.18.feed_forward.w3.weight            : mse 0.00000371, maxerr 0.01829529, 95pct<0.0036, median<0.0016
q4_0::layers.19.attention.wk.weight               : mse 0.00000471, maxerr 0.02081299, 95pct<0.0042, median<0.0016
q4_0::layers.19.attention.wo.weight               : mse 0.00000333, maxerr 0.04681396, 95pct<0.0034, median<0.0016
q4_0::layers.19.attention.wq.weight               : mse 0.00000460, maxerr 0.04876709, 95pct<0.0042, median<0.0016
q4_0::layers.19.attention.wv.weight               : mse 0.00000339, maxerr 0.01137543, 95pct<0.0034, median<0.0016
q4_0::layers.19.feed_forward.w1.weight            : mse 0.00000395, maxerr 0.03121948, 95pct<0.0036, median<0.0016
q4_0::layers.19.feed_forward.w2.weight            : mse 0.00000361, maxerr 0.04312134, 95pct<0.0034, median<0.0016
q4_0::layers.19.feed_forward.w3.weight            : mse 0.00000369, maxerr 0.02177429, 95pct<0.0034, median<0.0016
q4_0::layers.2.attention.wk.weight                : mse 0.00001086, maxerr 0.03179932, 95pct<0.0066, median<0.0022
q4_0::layers.2.attention.wo.weight                : mse 0.00000149, maxerr 0.04443359, 95pct<0.0022, median<0.0010
q4_0::layers.2.attention.wq.weight                : mse 0.00001007, maxerr 0.03594971, 95pct<0.0064, median<0.0022
q4_0::layers.2.attention.wv.weight                : mse 0.00000144, maxerr 0.01062012, 95pct<0.0022, median<0.0010
q4_0::layers.2.feed_forward.w1.weight             : mse 0.00000381, maxerr 0.04077148, 95pct<0.0036, median<0.0016
q4_0::layers.2.feed_forward.w2.weight             : mse 0.00000328, maxerr 0.09649658, 95pct<0.0032, median<0.0016
q4_0::layers.2.feed_forward.w3.weight             : mse 0.00000317, maxerr 0.03201294, 95pct<0.0032, median<0.0016
q4_0::layers.20.attention.wk.weight               : mse 0.00000486, maxerr 0.02493286, 95pct<0.0042, median<0.0016
q4_0::layers.20.attention.wo.weight               : mse 0.00000350, maxerr 0.03179932, 95pct<0.0034, median<0.0016
q4_0::layers.20.attention.wq.weight               : mse 0.00000473, maxerr 0.05462646, 95pct<0.0042, median<0.0016
q4_0::layers.20.attention.wv.weight               : mse 0.00000360, maxerr 0.01089478, 95pct<0.0034, median<0.0016
q4_0::layers.20.feed_forward.w1.weight            : mse 0.00000400, maxerr 0.02357483, 95pct<0.0036, median<0.0016
q4_0::layers.20.feed_forward.w2.weight            : mse 0.00000362, maxerr 0.06982422, 95pct<0.0034, median<0.0016
q4_0::layers.20.feed_forward.w3.weight            : mse 0.00000369, maxerr 0.01661682, 95pct<0.0034, median<0.0016
q4_0::layers.21.attention.wk.weight               : mse 0.00000451, maxerr 0.02557373, 95pct<0.0042, median<0.0016
q4_0::layers.21.attention.wo.weight               : mse 0.00000354, maxerr 0.07818604, 95pct<0.0034, median<0.0016
q4_0::layers.21.attention.wq.weight               : mse 0.00000443, maxerr 0.05007935, 95pct<0.0040, median<0.0016
q4_0::layers.21.attention.wv.weight               : mse 0.00000365, maxerr 0.01040649, 95pct<0.0036, median<0.0016
q4_0::layers.21.feed_forward.w1.weight            : mse 0.00000403, maxerr 0.02252197, 95pct<0.0036, median<0.0016
q4_0::layers.21.feed_forward.w2.weight            : mse 0.00000362, maxerr 0.03781128, 95pct<0.0034, median<0.0016
q4_0::layers.21.feed_forward.w3.weight            : mse 0.00000368, maxerr 0.01501465, 95pct<0.0034, median<0.0016
q4_0::layers.22.attention.wk.weight               : mse 0.00000465, maxerr 0.01992798, 95pct<0.0042, median<0.0016
q4_0::layers.22.attention.wo.weight               : mse 0.00000357, maxerr 0.09454346, 95pct<0.0034, median<0.0016
q4_0::layers.22.attention.wq.weight               : mse 0.00000458, maxerr 0.04550171, 95pct<0.0040, median<0.0016
q4_0::layers.22.attention.wv.weight               : mse 0.00000361, maxerr 0.01099396, 95pct<0.0034, median<0.0016
q4_0::layers.22.feed_forward.w1.weight            : mse 0.00000405, maxerr 0.02517700, 95pct<0.0036, median<0.0018
q4_0::layers.22.feed_forward.w2.weight            : mse 0.00000365, maxerr 0.04281616, 95pct<0.0034, median<0.0016
q4_0::layers.22.feed_forward.w3.weight            : mse 0.00000371, maxerr 0.03140259, 95pct<0.0036, median<0.0016
q4_0::layers.23.attention.wk.weight               : mse 0.00000433, maxerr 0.02102661, 95pct<0.0040, median<0.0016
q4_0::layers.23.attention.wo.weight               : mse 0.00000377, maxerr 0.04870605, 95pct<0.0036, median<0.0016
q4_0::layers.23.attention.wq.weight               : mse 0.00000430, maxerr 0.04418945, 95pct<0.0040, median<0.0016
q4_0::layers.23.attention.wv.weight               : mse 0.00000390, maxerr 0.01161957, 95pct<0.0036, median<0.0016
q4_0::layers.23.feed_forward.w1.weight            : mse 0.00000406, maxerr 0.03436279, 95pct<0.0036, median<0.0018
q4_0::layers.23.feed_forward.w2.weight            : mse 0.00000367, maxerr 0.04855347, 95pct<0.0034, median<0.0016
q4_0::layers.23.feed_forward.w3.weight            : mse 0.00000373, maxerr 0.02526855, 95pct<0.0036, median<0.0016
q4_0::layers.24.attention.wk.weight               : mse 0.00000436, maxerr 0.02143860, 95pct<0.0040, median<0.0016
q4_0::layers.24.attention.wo.weight               : mse 0.00000386, maxerr 0.05621338, 95pct<0.0036, median<0.0016
q4_0::layers.24.attention.wq.weight               : mse 0.00000431, maxerr 0.04943848, 95pct<0.0040, median<0.0016
q4_0::layers.24.attention.wv.weight               : mse 0.00000399, maxerr 0.01126862, 95pct<0.0036, median<0.0016
q4_0::layers.24.feed_forward.w1.weight            : mse 0.00000407, maxerr 0.02159119, 95pct<0.0036, median<0.0018
q4_0::layers.24.feed_forward.w2.weight            : mse 0.00000371, maxerr 0.06005859, 95pct<0.0034, median<0.0016
q4_0::layers.24.feed_forward.w3.weight            : mse 0.00000377, maxerr 0.02104187, 95pct<0.0036, median<0.0016
q4_0::layers.25.attention.wk.weight               : mse 0.00000464, maxerr 0.02005005, 95pct<0.0040, median<0.0016
q4_0::layers.25.attention.wo.weight               : mse 0.00000393, maxerr 0.04763794, 95pct<0.0036, median<0.0016
q4_0::layers.25.attention.wq.weight               : mse 0.00000455, maxerr 0.03808594, 95pct<0.0040, median<0.0016
q4_0::layers.25.attention.wv.weight               : mse 0.00000402, maxerr 0.01160431, 95pct<0.0036, median<0.0016
q4_0::layers.25.feed_forward.w1.weight            : mse 0.00000409, maxerr 0.02044678, 95pct<0.0036, median<0.0018
q4_0::layers.25.feed_forward.w2.weight            : mse 0.00000373, maxerr 0.03298950, 95pct<0.0036, median<0.0016
q4_0::layers.25.feed_forward.w3.weight            : mse 0.00000380, maxerr 0.01884460, 95pct<0.0036, median<0.0016
q4_0::layers.26.attention.wk.weight               : mse 0.00000449, maxerr 0.02630615, 95pct<0.0040, median<0.0016
q4_0::layers.26.attention.wo.weight               : mse 0.00000416, maxerr 0.02603149, 95pct<0.0038, median<0.0018
q4_0::layers.26.attention.wq.weight               : mse 0.00000440, maxerr 0.03735352, 95pct<0.0040, median<0.0016
q4_0::layers.26.attention.wv.weight               : mse 0.00000426, maxerr 0.01278687, 95pct<0.0038, median<0.0018
q4_0::layers.26.feed_forward.w1.weight            : mse 0.00000409, maxerr 0.03500366, 95pct<0.0036, median<0.0018
q4_0::layers.26.feed_forward.w2.weight            : mse 0.00000378, maxerr 0.04370117, 95pct<0.0036, median<0.0016
q4_0::layers.26.feed_forward.w3.weight            : mse 0.00000386, maxerr 0.03059387, 95pct<0.0036, median<0.0016
q4_0::layers.27.attention.wk.weight               : mse 0.00000446, maxerr 0.02406311, 95pct<0.0040, median<0.0016
q4_0::layers.27.attention.wo.weight               : mse 0.00000437, maxerr 0.07098389, 95pct<0.0038, median<0.0018
q4_0::layers.27.attention.wq.weight               : mse 0.00000442, maxerr 0.04006958, 95pct<0.0040, median<0.0016
q4_0::layers.27.attention.wv.weight               : mse 0.00000441, maxerr 0.01357269, 95pct<0.0038, median<0.0018
q4_0::layers.27.feed_forward.w1.weight            : mse 0.00000408, maxerr 0.02963257, 95pct<0.0036, median<0.0018
q4_0::layers.27.feed_forward.w2.weight            : mse 0.00000383, maxerr 0.04663086, 95pct<0.0036, median<0.0016
q4_0::layers.27.feed_forward.w3.weight            : mse 0.00000389, maxerr 0.04153442, 95pct<0.0036, median<0.0016
q4_0::layers.28.attention.wk.weight               : mse 0.00000427, maxerr 0.02304077, 95pct<0.0040, median<0.0016
q4_0::layers.28.attention.wo.weight               : mse 0.00000446, maxerr 0.05538940, 95pct<0.0038, median<0.0018
q4_0::layers.28.attention.wq.weight               : mse 0.00000424, maxerr 0.04208374, 95pct<0.0040, median<0.0016
q4_0::layers.28.attention.wv.weight               : mse 0.00000446, maxerr 0.01184082, 95pct<0.0038, median<0.0018
q4_0::layers.28.feed_forward.w1.weight            : mse 0.00000405, maxerr 0.03170776, 95pct<0.0036, median<0.0016
q4_0::layers.28.feed_forward.w2.weight            : mse 0.00000387, maxerr 0.05294800, 95pct<0.0036, median<0.0016
q4_0::layers.28.feed_forward.w3.weight            : mse 0.00000393, maxerr 0.03025818, 95pct<0.0036, median<0.0016
q4_0::layers.29.attention.wk.weight               : mse 0.00000421, maxerr 0.01965332, 95pct<0.0040, median<0.0016
q4_0::layers.29.attention.wo.weight               : mse 0.00000473, maxerr 0.04461670, 95pct<0.0040, median<0.0018
q4_0::layers.29.attention.wq.weight               : mse 0.00000417, maxerr 0.04244995, 95pct<0.0038, median<0.0016
q4_0::layers.29.attention.wv.weight               : mse 0.00000473, maxerr 0.01258850, 95pct<0.0040, median<0.0018
q4_0::layers.29.feed_forward.w1.weight            : mse 0.00000407, maxerr 0.03314209, 95pct<0.0036, median<0.0016
q4_0::layers.29.feed_forward.w2.weight            : mse 0.00000391, maxerr 0.09802246, 95pct<0.0036, median<0.0016
q4_0::layers.29.feed_forward.w3.weight            : mse 0.00000397, maxerr 0.02760315, 95pct<0.0036, median<0.0016
q4_0::layers.3.attention.wk.weight                : mse 0.00000748, maxerr 0.02275085, 95pct<0.0054, median<0.0020
q4_0::layers.3.attention.wo.weight                : mse 0.00000202, maxerr 0.05377197, 95pct<0.0026, median<0.0012
q4_0::layers.3.attention.wq.weight                : mse 0.00000683, maxerr 0.04766846, 95pct<0.0050, median<0.0020
q4_0::layers.3.attention.wv.weight                : mse 0.00000202, maxerr 0.00859070, 95pct<0.0026, median<0.0012
q4_0::layers.3.feed_forward.w1.weight             : mse 0.00000389, maxerr 0.03158569, 95pct<0.0036, median<0.0016
q4_0::layers.3.feed_forward.w2.weight             : mse 0.00000331, maxerr 0.05627441, 95pct<0.0034, median<0.0016
q4_0::layers.3.feed_forward.w3.weight             : mse 0.00000329, maxerr 0.02278137, 95pct<0.0034, median<0.0016
q4_0::layers.30.attention.wk.weight               : mse 0.00000430, maxerr 0.02133179, 95pct<0.0040, median<0.0016
q4_0::layers.30.attention.wo.weight               : mse 0.00000472, maxerr 0.06579590, 95pct<0.0040, median<0.0018
q4_0::layers.30.attention.wq.weight               : mse 0.00000427, maxerr 0.04168701, 95pct<0.0038, median<0.0016
q4_0::layers.30.attention.wv.weight               : mse 0.00000461, maxerr 0.01303864, 95pct<0.0040, median<0.0018
q4_0::layers.30.feed_forward.w1.weight            : mse 0.00000412, maxerr 0.02958679, 95pct<0.0038, median<0.0016
q4_0::layers.30.feed_forward.w2.weight            : mse 0.00000410, maxerr 0.18200684, 95pct<0.0036, median<0.0016
q4_0::layers.30.feed_forward.w3.weight            : mse 0.00000405, maxerr 0.03591919, 95pct<0.0036, median<0.0018
q4_0::layers.31.attention.wk.weight               : mse 0.00000459, maxerr 0.02066040, 95pct<0.0040, median<0.0016
q4_0::layers.31.attention.wo.weight               : mse 0.00000385, maxerr 0.17346191, 95pct<0.0036, median<0.0016
q4_0::layers.31.attention.wq.weight               : mse 0.00000440, maxerr 0.02816772, 95pct<0.0040, median<0.0016
q4_0::layers.31.attention.wv.weight               : mse 0.00000375, maxerr 0.01520538, 95pct<0.0036, median<0.0016
q4_0::layers.31.feed_forward.w1.weight            : mse 0.00000450, maxerr 0.02647400, 95pct<0.0038, median<0.0018
q4_0::layers.31.feed_forward.w2.weight            : mse 0.00000414, maxerr 0.11260986, 95pct<0.0036, median<0.0018
q4_0::layers.31.feed_forward.w3.weight            : mse 0.00000440, maxerr 0.04486084, 95pct<0.0038, median<0.0018
q4_0::layers.4.attention.wk.weight                : mse 0.00000719, maxerr 0.02165222, 95pct<0.0052, median<0.0020
q4_0::layers.4.attention.wo.weight                : mse 0.00000202, maxerr 0.04003906, 95pct<0.0026, median<0.0012
q4_0::layers.4.attention.wq.weight                : mse 0.00000707, maxerr 0.04748535, 95pct<0.0052, median<0.0020
q4_0::layers.4.attention.wv.weight                : mse 0.00000202, maxerr 0.00906372, 95pct<0.0026, median<0.0012
q4_0::layers.4.feed_forward.w1.weight             : mse 0.00000399, maxerr 0.03872681, 95pct<0.0036, median<0.0016
q4_0::layers.4.feed_forward.w2.weight             : mse 0.00000328, maxerr 0.05072021, 95pct<0.0032, median<0.0016
q4_0::layers.4.feed_forward.w3.weight             : mse 0.00000331, maxerr 0.03533936, 95pct<0.0034, median<0.0016
q4_0::layers.5.attention.wk.weight                : mse 0.00000640, maxerr 0.03253174, 95pct<0.0050, median<0.0018
q4_0::layers.5.attention.wo.weight                : mse 0.00000207, maxerr 0.04260254, 95pct<0.0026, median<0.0012
q4_0::layers.5.attention.wq.weight                : mse 0.00000631, maxerr 0.04281616, 95pct<0.0048, median<0.0018
q4_0::layers.5.attention.wv.weight                : mse 0.00000209, maxerr 0.01441193, 95pct<0.0026, median<0.0012
q4_0::layers.5.feed_forward.w1.weight             : mse 0.00000416, maxerr 0.03350830, 95pct<0.0038, median<0.0018
q4_0::layers.5.feed_forward.w2.weight             : mse 0.00000322, maxerr 0.04428101, 95pct<0.0032, median<0.0016
q4_0::layers.5.feed_forward.w3.weight             : mse 0.00000329, maxerr 0.02728271, 95pct<0.0034, median<0.0016
q4_0::layers.6.attention.wk.weight                : mse 0.00000670, maxerr 0.02120972, 95pct<0.0050, median<0.0020
q4_0::layers.6.attention.wo.weight                : mse 0.00000211, maxerr 0.05706787, 95pct<0.0026, median<0.0012
q4_0::layers.6.attention.wq.weight                : mse 0.00000641, maxerr 0.04986572, 95pct<0.0048, median<0.0020
q4_0::layers.6.attention.wv.weight                : mse 0.00000212, maxerr 0.00904083, 95pct<0.0028, median<0.0012
q4_0::layers.6.feed_forward.w1.weight             : mse 0.00000404, maxerr 0.04025269, 95pct<0.0036, median<0.0016
q4_0::layers.6.feed_forward.w2.weight             : mse 0.00000329, maxerr 0.04974365, 95pct<0.0032, median<0.0016
q4_0::layers.6.feed_forward.w3.weight             : mse 0.00000337, maxerr 0.02461243, 95pct<0.0034, median<0.0016
q4_0::layers.7.attention.wk.weight                : mse 0.00000629, maxerr 0.02215576, 95pct<0.0050, median<0.0018
q4_0::layers.7.attention.wo.weight                : mse 0.00000220, maxerr 0.03393555, 95pct<0.0028, median<0.0012
q4_0::layers.7.attention.wq.weight                : mse 0.00000619, maxerr 0.04800415, 95pct<0.0048, median<0.0018
q4_0::layers.7.attention.wv.weight                : mse 0.00000226, maxerr 0.00874329, 95pct<0.0028, median<0.0012
q4_0::layers.7.feed_forward.w1.weight             : mse 0.00000397, maxerr 0.02743530, 95pct<0.0036, median<0.0016
q4_0::layers.7.feed_forward.w2.weight             : mse 0.00000331, maxerr 0.04418945, 95pct<0.0034, median<0.0016
q4_0::layers.7.feed_forward.w3.weight             : mse 0.00000340, maxerr 0.02548218, 95pct<0.0034, median<0.0016
q4_0::layers.8.attention.wk.weight                : mse 0.00000599, maxerr 0.02326965, 95pct<0.0048, median<0.0018
q4_0::layers.8.attention.wo.weight                : mse 0.00000218, maxerr 0.03485107, 95pct<0.0028, median<0.0012
q4_0::layers.8.attention.wq.weight                : mse 0.00000598, maxerr 0.04147339, 95pct<0.0048, median<0.0018
q4_0::layers.8.attention.wv.weight                : mse 0.00000221, maxerr 0.01078796, 95pct<0.0028, median<0.0012
q4_0::layers.8.feed_forward.w1.weight             : mse 0.00000397, maxerr 0.02899170, 95pct<0.0036, median<0.0016
q4_0::layers.8.feed_forward.w2.weight             : mse 0.00000332, maxerr 0.03820801, 95pct<0.0034, median<0.0016
q4_0::layers.8.feed_forward.w3.weight             : mse 0.00000342, maxerr 0.02285767, 95pct<0.0034, median<0.0016
q4_0::layers.9.attention.wk.weight                : mse 0.00000567, maxerr 0.02212524, 95pct<0.0048, median<0.0018
q4_0::layers.9.attention.wo.weight                : mse 0.00000215, maxerr 0.03619385, 95pct<0.0028, median<0.0012
q4_0::layers.9.attention.wq.weight                : mse 0.00000560, maxerr 0.04025269, 95pct<0.0046, median<0.0018
q4_0::layers.9.attention.wv.weight                : mse 0.00000218, maxerr 0.00840759, 95pct<0.0028, median<0.0012
q4_0::layers.9.feed_forward.w1.weight             : mse 0.00000386, maxerr 0.04083252, 95pct<0.0036, median<0.0016
q4_0::layers.9.feed_forward.w2.weight             : mse 0.00000337, maxerr 0.04580688, 95pct<0.0034, median<0.0016
q4_0::layers.9.feed_forward.w3.weight             : mse 0.00000346, maxerr 0.04849243, 95pct<0.0034, median<0.0016
q4_0::output.weight                               : mse 0.00000308, maxerr 0.02610779, 95pct<0.0032, median<0.0014
q4_0::tok_embeddings.weight                       : mse 0.00000302, maxerr 0.01635742, 95pct<0.0032, median<0.0014
q4_0                                              : mse 0.00000386, maxerr 0.18200684, 95pct<0.0036, median<0.0016
q4_1::layers.0.attention.wk.weight                : mse 0.00000684, maxerr 0.04107666, 95pct<0.0054, median<0.0016
q4_1::layers.0.attention.wo.weight                : mse 0.00000092, maxerr 0.02982175, 95pct<0.0020, median<0.0008
q4_1::layers.0.attention.wq.weight                : mse 0.00000702, maxerr 0.02834333, 95pct<0.0056, median<0.0016
q4_1::layers.0.attention.wv.weight                : mse 0.00000114, maxerr 0.00560303, 95pct<0.0022, median<0.0008
q4_1::layers.0.feed_forward.w1.weight             : mse 0.00000175, maxerr 0.03655243, 95pct<0.0024, median<0.0012
q4_1::layers.0.feed_forward.w2.weight             : mse 0.00000259, maxerr 0.04300943, 95pct<0.0030, median<0.0014
q4_1::layers.0.feed_forward.w3.weight             : mse 0.00000165, maxerr 0.01006266, 95pct<0.0024, median<0.0012
q4_1::layers.1.attention.wk.weight                : mse 0.00000728, maxerr 0.02334900, 95pct<0.0058, median<0.0016
q4_1::layers.1.attention.wo.weight                : mse 0.00000086, maxerr 0.03453889, 95pct<0.0018, median<0.0008
q4_1::layers.1.attention.wq.weight                : mse 0.00000700, maxerr 0.01987410, 95pct<0.0056, median<0.0016
q4_1::layers.1.attention.wv.weight                : mse 0.00000083, maxerr 0.00478211, 95pct<0.0018, median<0.0008
q4_1::layers.1.feed_forward.w1.weight             : mse 0.00000283, maxerr 0.02051294, 95pct<0.0030, median<0.0014
q4_1::layers.1.feed_forward.w2.weight             : mse 0.00000272, maxerr 0.03843182, 95pct<0.0030, median<0.0014
q4_1::layers.1.feed_forward.w3.weight             : mse 0.00000255, maxerr 0.01320738, 95pct<0.0030, median<0.0014
q4_1::layers.10.attention.wk.weight               : mse 0.00000472, maxerr 0.01563987, 95pct<0.0044, median<0.0016
q4_1::layers.10.attention.wo.weight               : mse 0.00000193, maxerr 0.02667642, 95pct<0.0026, median<0.0012
q4_1::layers.10.attention.wq.weight               : mse 0.00000462, maxerr 0.02052003, 95pct<0.0042, median<0.0016
q4_1::layers.10.attention.wv.weight               : mse 0.00000194, maxerr 0.00943857, 95pct<0.0026, median<0.0012
q4_1::layers.10.feed_forward.w1.weight            : mse 0.00000314, maxerr 0.01556396, 95pct<0.0032, median<0.0014
q4_1::layers.10.feed_forward.w2.weight            : mse 0.00000283, maxerr 0.02537537, 95pct<0.0030, median<0.0014
q4_1::layers.10.feed_forward.w3.weight            : mse 0.00000294, maxerr 0.01292909, 95pct<0.0032, median<0.0014
q4_1::layers.11.attention.wk.weight               : mse 0.00000505, maxerr 0.01603444, 95pct<0.0044, median<0.0016
q4_1::layers.11.attention.wo.weight               : mse 0.00000212, maxerr 0.02708334, 95pct<0.0028, median<0.0012
q4_1::layers.11.attention.wq.weight               : mse 0.00000490, maxerr 0.02761781, 95pct<0.0042, median<0.0016
q4_1::layers.11.attention.wv.weight               : mse 0.00000215, maxerr 0.00829771, 95pct<0.0028, median<0.0012
q4_1::layers.11.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01594034, 95pct<0.0032, median<0.0014
q4_1::layers.11.feed_forward.w2.weight            : mse 0.00000288, maxerr 0.03227139, 95pct<0.0032, median<0.0014
q4_1::layers.11.feed_forward.w3.weight            : mse 0.00000297, maxerr 0.01712444, 95pct<0.0032, median<0.0014
q4_1::layers.12.attention.wk.weight               : mse 0.00000460, maxerr 0.01596579, 95pct<0.0042, median<0.0016
q4_1::layers.12.attention.wo.weight               : mse 0.00000205, maxerr 0.02017212, 95pct<0.0026, median<0.0012
q4_1::layers.12.attention.wq.weight               : mse 0.00000446, maxerr 0.02285360, 95pct<0.0042, median<0.0016
q4_1::layers.12.attention.wv.weight               : mse 0.00000200, maxerr 0.00573961, 95pct<0.0026, median<0.0012
q4_1::layers.12.feed_forward.w1.weight            : mse 0.00000316, maxerr 0.02284165, 95pct<0.0032, median<0.0014
q4_1::layers.12.feed_forward.w2.weight            : mse 0.00000289, maxerr 0.03540853, 95pct<0.0032, median<0.0014
q4_1::layers.12.feed_forward.w3.weight            : mse 0.00000301, maxerr 0.01079203, 95pct<0.0032, median<0.0014
q4_1::layers.13.attention.wk.weight               : mse 0.00000439, maxerr 0.01437837, 95pct<0.0042, median<0.0016
q4_1::layers.13.attention.wo.weight               : mse 0.00000220, maxerr 0.03025717, 95pct<0.0028, median<0.0012
q4_1::layers.13.attention.wq.weight               : mse 0.00000425, maxerr 0.02128702, 95pct<0.0040, median<0.0016
q4_1::layers.13.attention.wv.weight               : mse 0.00000219, maxerr 0.00622152, 95pct<0.0028, median<0.0012
q4_1::layers.13.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01500246, 95pct<0.0032, median<0.0014
q4_1::layers.13.feed_forward.w2.weight            : mse 0.00000294, maxerr 0.02633134, 95pct<0.0032, median<0.0014
q4_1::layers.13.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01099548, 95pct<0.0032, median<0.0014
q4_1::layers.14.attention.wk.weight               : mse 0.00000438, maxerr 0.01511636, 95pct<0.0042, median<0.0016
q4_1::layers.14.attention.wo.weight               : mse 0.00000221, maxerr 0.02438152, 95pct<0.0028, median<0.0012
q4_1::layers.14.attention.wq.weight               : mse 0.00000431, maxerr 0.02371013, 95pct<0.0040, median<0.0016
q4_1::layers.14.attention.wv.weight               : mse 0.00000222, maxerr 0.00633850, 95pct<0.0028, median<0.0012
q4_1::layers.14.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01666871, 95pct<0.0032, median<0.0014
q4_1::layers.14.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.03455403, 95pct<0.0032, median<0.0014
q4_1::layers.14.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01462197, 95pct<0.0032, median<0.0016
q4_1::layers.15.attention.wk.weight               : mse 0.00000446, maxerr 0.01495159, 95pct<0.0042, median<0.0016
q4_1::layers.15.attention.wo.weight               : mse 0.00000222, maxerr 0.02541506, 95pct<0.0028, median<0.0012
q4_1::layers.15.attention.wq.weight               : mse 0.00000431, maxerr 0.02229919, 95pct<0.0040, median<0.0016
q4_1::layers.15.attention.wv.weight               : mse 0.00000223, maxerr 0.00649338, 95pct<0.0028, median<0.0012
q4_1::layers.15.feed_forward.w1.weight            : mse 0.00000313, maxerr 0.01446533, 95pct<0.0032, median<0.0014
q4_1::layers.15.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.04414570, 95pct<0.0032, median<0.0014
q4_1::layers.15.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01306508, 95pct<0.0032, median<0.0016
q4_1::layers.16.attention.wk.weight               : mse 0.00000441, maxerr 0.01464437, 95pct<0.0040, median<0.0016
q4_1::layers.16.attention.wo.weight               : mse 0.00000250, maxerr 0.04169917, 95pct<0.0030, median<0.0014
q4_1::layers.16.attention.wq.weight               : mse 0.00000419, maxerr 0.02543133, 95pct<0.0040, median<0.0016
q4_1::layers.16.attention.wv.weight               : mse 0.00000253, maxerr 0.00660706, 95pct<0.0030, median<0.0014
q4_1::layers.16.feed_forward.w1.weight            : mse 0.00000317, maxerr 0.01479188, 95pct<0.0032, median<0.0014
q4_1::layers.16.feed_forward.w2.weight            : mse 0.00000297, maxerr 0.03672282, 95pct<0.0032, median<0.0014
q4_1::layers.16.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01314189, 95pct<0.0032, median<0.0014
q4_1::layers.17.attention.wk.weight               : mse 0.00000418, maxerr 0.01311338, 95pct<0.0040, median<0.0016
q4_1::layers.17.attention.wo.weight               : mse 0.00000256, maxerr 0.02875367, 95pct<0.0030, median<0.0014
q4_1::layers.17.attention.wq.weight               : mse 0.00000401, maxerr 0.03082275, 95pct<0.0038, median<0.0016
q4_1::layers.17.attention.wv.weight               : mse 0.00000256, maxerr 0.00813599, 95pct<0.0030, median<0.0014
q4_1::layers.17.feed_forward.w1.weight            : mse 0.00000319, maxerr 0.01236165, 95pct<0.0032, median<0.0016
q4_1::layers.17.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02805888, 95pct<0.0032, median<0.0014
q4_1::layers.17.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01775716, 95pct<0.0032, median<0.0016
q4_1::layers.18.attention.wk.weight               : mse 0.00000403, maxerr 0.01377869, 95pct<0.0040, median<0.0014
q4_1::layers.18.attention.wo.weight               : mse 0.00000254, maxerr 0.03247070, 95pct<0.0030, median<0.0014
q4_1::layers.18.attention.wq.weight               : mse 0.00000392, maxerr 0.02439576, 95pct<0.0038, median<0.0014
q4_1::layers.18.attention.wv.weight               : mse 0.00000255, maxerr 0.00598729, 95pct<0.0030, median<0.0014
q4_1::layers.18.feed_forward.w1.weight            : mse 0.00000324, maxerr 0.01477051, 95pct<0.0034, median<0.0016
q4_1::layers.18.feed_forward.w2.weight            : mse 0.00000298, maxerr 0.03860271, 95pct<0.0032, median<0.0014
q4_1::layers.18.feed_forward.w3.weight            : mse 0.00000307, maxerr 0.01042479, 95pct<0.0032, median<0.0014
q4_1::layers.19.attention.wk.weight               : mse 0.00000388, maxerr 0.01365611, 95pct<0.0038, median<0.0014
q4_1::layers.19.attention.wo.weight               : mse 0.00000276, maxerr 0.03216144, 95pct<0.0030, median<0.0014
q4_1::layers.19.attention.wq.weight               : mse 0.00000378, maxerr 0.02803510, 95pct<0.0038, median<0.0014
q4_1::layers.19.attention.wv.weight               : mse 0.00000280, maxerr 0.00700684, 95pct<0.0030, median<0.0014
q4_1::layers.19.feed_forward.w1.weight            : mse 0.00000328, maxerr 0.01841432, 95pct<0.0034, median<0.0016
q4_1::layers.19.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02656788, 95pct<0.0032, median<0.0014
q4_1::layers.19.feed_forward.w3.weight            : mse 0.00000306, maxerr 0.01330259, 95pct<0.0032, median<0.0014
q4_1::layers.2.attention.wk.weight                : mse 0.00000883, maxerr 0.01976573, 95pct<0.0062, median<0.0020
q4_1::layers.2.attention.wo.weight                : mse 0.00000123, maxerr 0.03828126, 95pct<0.0020, median<0.0010
q4_1::layers.2.attention.wq.weight                : mse 0.00000823, maxerr 0.02216390, 95pct<0.0058, median<0.0020
q4_1::layers.2.attention.wv.weight                : mse 0.00000119, maxerr 0.00736135, 95pct<0.0020, median<0.0010
q4_1::layers.2.feed_forward.w1.weight             : mse 0.00000315, maxerr 0.03544718, 95pct<0.0032, median<0.0016
q4_1::layers.2.feed_forward.w2.weight             : mse 0.00000271, maxerr 0.05198061, 95pct<0.0030, median<0.0014
q4_1::layers.2.feed_forward.w3.weight             : mse 0.00000262, maxerr 0.01909560, 95pct<0.0030, median<0.0014
q4_1::layers.20.attention.wk.weight               : mse 0.00000400, maxerr 0.01639201, 95pct<0.0038, median<0.0016
q4_1::layers.20.attention.wo.weight               : mse 0.00000290, maxerr 0.02312827, 95pct<0.0032, median<0.0014
q4_1::layers.20.attention.wq.weight               : mse 0.00000388, maxerr 0.03564453, 95pct<0.0038, median<0.0016
q4_1::layers.20.attention.wv.weight               : mse 0.00000298, maxerr 0.00713094, 95pct<0.0032, median<0.0014
q4_1::layers.20.feed_forward.w1.weight            : mse 0.00000331, maxerr 0.01476848, 95pct<0.0034, median<0.0016
q4_1::layers.20.feed_forward.w2.weight            : mse 0.00000300, maxerr 0.04094645, 95pct<0.0032, median<0.0014
q4_1::layers.20.feed_forward.w3.weight            : mse 0.00000306, maxerr 0.01144791, 95pct<0.0032, median<0.0014
q4_1::layers.21.attention.wk.weight               : mse 0.00000371, maxerr 0.01407850, 95pct<0.0038, median<0.0014
q4_1::layers.21.attention.wo.weight               : mse 0.00000294, maxerr 0.04772949, 95pct<0.0032, median<0.0014
q4_1::layers.21.attention.wq.weight               : mse 0.00000363, maxerr 0.02847900, 95pct<0.0038, median<0.0014
q4_1::layers.21.attention.wv.weight               : mse 0.00000302, maxerr 0.00687256, 95pct<0.0032, median<0.0014
q4_1::layers.21.feed_forward.w1.weight            : mse 0.00000334, maxerr 0.01481831, 95pct<0.0034, median<0.0016
q4_1::layers.21.feed_forward.w2.weight            : mse 0.00000299, maxerr 0.02454491, 95pct<0.0032, median<0.0014
q4_1::layers.21.feed_forward.w3.weight            : mse 0.00000305, maxerr 0.00941722, 95pct<0.0032, median<0.0014
q4_1::layers.22.attention.wk.weight               : mse 0.00000382, maxerr 0.01457518, 95pct<0.0038, median<0.0016
q4_1::layers.22.attention.wo.weight               : mse 0.00000296, maxerr 0.05219725, 95pct<0.0032, median<0.0014
q4_1::layers.22.attention.wq.weight               : mse 0.00000375, maxerr 0.02614343, 95pct<0.0038, median<0.0016
q4_1::layers.22.attention.wv.weight               : mse 0.00000298, maxerr 0.00633164, 95pct<0.0032, median<0.0014
q4_1::layers.22.feed_forward.w1.weight            : mse 0.00000335, maxerr 0.01621208, 95pct<0.0034, median<0.0016
q4_1::layers.22.feed_forward.w2.weight            : mse 0.00000302, maxerr 0.02524516, 95pct<0.0032, median<0.0014
q4_1::layers.22.feed_forward.w3.weight            : mse 0.00000308, maxerr 0.01791126, 95pct<0.0032, median<0.0016
q4_1::layers.23.attention.wk.weight               : mse 0.00000355, maxerr 0.01381835, 95pct<0.0038, median<0.0014
q4_1::layers.23.attention.wo.weight               : mse 0.00000312, maxerr 0.05039060, 95pct<0.0032, median<0.0014
q4_1::layers.23.attention.wq.weight               : mse 0.00000352, maxerr 0.02543131, 95pct<0.0036, median<0.0014
q4_1::layers.23.attention.wv.weight               : mse 0.00000323, maxerr 0.00705466, 95pct<0.0034, median<0.0016
q4_1::layers.23.feed_forward.w1.weight            : mse 0.00000336, maxerr 0.02019602, 95pct<0.0034, median<0.0016
q4_1::layers.23.feed_forward.w2.weight            : mse 0.00000304, maxerr 0.02755737, 95pct<0.0032, median<0.0014
q4_1::layers.23.feed_forward.w3.weight            : mse 0.00000309, maxerr 0.01500538, 95pct<0.0032, median<0.0016
q4_1::layers.24.attention.wk.weight               : mse 0.00000358, maxerr 0.01357117, 95pct<0.0038, median<0.0014
q4_1::layers.24.attention.wo.weight               : mse 0.00000320, maxerr 0.03517246, 95pct<0.0032, median<0.0016
q4_1::layers.24.attention.wq.weight               : mse 0.00000353, maxerr 0.02697754, 95pct<0.0036, median<0.0014
q4_1::layers.24.attention.wv.weight               : mse 0.00000330, maxerr 0.00695597, 95pct<0.0034, median<0.0016
q4_1::layers.24.feed_forward.w1.weight            : mse 0.00000337, maxerr 0.01255596, 95pct<0.0034, median<0.0016
q4_1::layers.24.feed_forward.w2.weight            : mse 0.00000307, maxerr 0.03697109, 95pct<0.0032, median<0.0016
q4_1::layers.24.feed_forward.w3.weight            : mse 0.00000312, maxerr 0.01249239, 95pct<0.0032, median<0.0016
q4_1::layers.25.attention.wk.weight               : mse 0.00000382, maxerr 0.01319379, 95pct<0.0038, median<0.0016
q4_1::layers.25.attention.wo.weight               : mse 0.00000326, maxerr 0.03653157, 95pct<0.0034, median<0.0016
q4_1::layers.25.attention.wq.weight               : mse 0.00000373, maxerr 0.02534175, 95pct<0.0036, median<0.0016
q4_1::layers.25.attention.wv.weight               : mse 0.00000333, maxerr 0.00774231, 95pct<0.0034, median<0.0016
q4_1::layers.25.feed_forward.w1.weight            : mse 0.00000339, maxerr 0.01365763, 95pct<0.0034, median<0.0016
q4_1::layers.25.feed_forward.w2.weight            : mse 0.00000309, maxerr 0.02395630, 95pct<0.0032, median<0.0016
q4_1::layers.25.feed_forward.w3.weight            : mse 0.00000315, maxerr 0.01177013, 95pct<0.0032, median<0.0016
q4_1::layers.26.attention.wk.weight               : mse 0.00000370, maxerr 0.01424815, 95pct<0.0036, median<0.0016
q4_1::layers.26.attention.wo.weight               : mse 0.00000345, maxerr 0.02384442, 95pct<0.0034, median<0.0016
q4_1::layers.26.attention.wq.weight               : mse 0.00000361, maxerr 0.02352905, 95pct<0.0036, median<0.0016
q4_1::layers.26.attention.wv.weight               : mse 0.00000353, maxerr 0.00762227, 95pct<0.0034, median<0.0016
q4_1::layers.26.feed_forward.w1.weight            : mse 0.00000338, maxerr 0.02146912, 95pct<0.0034, median<0.0016
q4_1::layers.26.feed_forward.w2.weight            : mse 0.00000313, maxerr 0.02818197, 95pct<0.0032, median<0.0016
q4_1::layers.26.feed_forward.w3.weight            : mse 0.00000319, maxerr 0.02482224, 95pct<0.0032, median<0.0016
q4_1::layers.27.attention.wk.weight               : mse 0.00000367, maxerr 0.01493329, 95pct<0.0036, median<0.0016
q4_1::layers.27.attention.wo.weight               : mse 0.00000362, maxerr 0.05037433, 95pct<0.0034, median<0.0016
q4_1::layers.27.attention.wq.weight               : mse 0.00000361, maxerr 0.02156782, 95pct<0.0036, median<0.0016
q4_1::layers.27.attention.wv.weight               : mse 0.00000365, maxerr 0.00810165, 95pct<0.0036, median<0.0016
q4_1::layers.27.feed_forward.w1.weight            : mse 0.00000338, maxerr 0.02540493, 95pct<0.0034, median<0.0016
q4_1::layers.27.feed_forward.w2.weight            : mse 0.00000316, maxerr 0.02953517, 95pct<0.0032, median<0.0016
q4_1::layers.27.feed_forward.w3.weight            : mse 0.00000322, maxerr 0.02640279, 95pct<0.0032, median<0.0016
q4_1::layers.28.attention.wk.weight               : mse 0.00000351, maxerr 0.01595867, 95pct<0.0036, median<0.0014
q4_1::layers.28.attention.wo.weight               : mse 0.00000370, maxerr 0.02981770, 95pct<0.0036, median<0.0016
q4_1::layers.28.attention.wq.weight               : mse 0.00000347, maxerr 0.02494049, 95pct<0.0036, median<0.0014
q4_1::layers.28.attention.wv.weight               : mse 0.00000369, maxerr 0.00791423, 95pct<0.0036, median<0.0016
q4_1::layers.28.feed_forward.w1.weight            : mse 0.00000335, maxerr 0.02810669, 95pct<0.0034, median<0.0016
q4_1::layers.28.feed_forward.w2.weight            : mse 0.00000319, maxerr 0.03309225, 95pct<0.0032, median<0.0016
q4_1::layers.28.feed_forward.w3.weight            : mse 0.00000325, maxerr 0.02055053, 95pct<0.0032, median<0.0016
q4_1::layers.29.attention.wk.weight               : mse 0.00000346, maxerr 0.01428223, 95pct<0.0036, median<0.0014
q4_1::layers.29.attention.wo.weight               : mse 0.00000392, maxerr 0.03439641, 95pct<0.0036, median<0.0016
q4_1::layers.29.attention.wq.weight               : mse 0.00000340, maxerr 0.02388712, 95pct<0.0036, median<0.0014
q4_1::layers.29.attention.wv.weight               : mse 0.00000391, maxerr 0.00761922, 95pct<0.0036, median<0.0016
q4_1::layers.29.feed_forward.w1.weight            : mse 0.00000337, maxerr 0.02038574, 95pct<0.0034, median<0.0016
q4_1::layers.29.feed_forward.w2.weight            : mse 0.00000321, maxerr 0.05755107, 95pct<0.0032, median<0.0016
q4_1::layers.29.feed_forward.w3.weight            : mse 0.00000329, maxerr 0.01542050, 95pct<0.0034, median<0.0016
q4_1::layers.3.attention.wk.weight                : mse 0.00000611, maxerr 0.01627603, 95pct<0.0050, median<0.0018
q4_1::layers.3.attention.wo.weight                : mse 0.00000167, maxerr 0.03495282, 95pct<0.0024, median<0.0012
q4_1::layers.3.attention.wq.weight                : mse 0.00000552, maxerr 0.02804718, 95pct<0.0046, median<0.0018
q4_1::layers.3.attention.wv.weight                : mse 0.00000167, maxerr 0.00555267, 95pct<0.0024, median<0.0012
q4_1::layers.3.feed_forward.w1.weight             : mse 0.00000322, maxerr 0.02117920, 95pct<0.0032, median<0.0016
q4_1::layers.3.feed_forward.w2.weight             : mse 0.00000273, maxerr 0.03491618, 95pct<0.0030, median<0.0014
q4_1::layers.3.feed_forward.w3.weight             : mse 0.00000272, maxerr 0.01362103, 95pct<0.0030, median<0.0014
q4_1::layers.30.attention.wk.weight               : mse 0.00000353, maxerr 0.01795453, 95pct<0.0036, median<0.0014
q4_1::layers.30.attention.wo.weight               : mse 0.00000391, maxerr 0.04497075, 95pct<0.0036, median<0.0016
q4_1::layers.30.attention.wq.weight               : mse 0.00000347, maxerr 0.02401968, 95pct<0.0036, median<0.0014
q4_1::layers.30.attention.wv.weight               : mse 0.00000381, maxerr 0.00759277, 95pct<0.0036, median<0.0016
q4_1::layers.30.feed_forward.w1.weight            : mse 0.00000341, maxerr 0.01782125, 95pct<0.0034, median<0.0016
q4_1::layers.30.feed_forward.w2.weight            : mse 0.00000342, maxerr 0.12756348, 95pct<0.0032, median<0.0016
q4_1::layers.30.feed_forward.w3.weight            : mse 0.00000335, maxerr 0.02418011, 95pct<0.0034, median<0.0016
q4_1::layers.31.attention.wk.weight               : mse 0.00000375, maxerr 0.01362303, 95pct<0.0038, median<0.0016
q4_1::layers.31.attention.wo.weight               : mse 0.00000319, maxerr 0.10161138, 95pct<0.0032, median<0.0014
q4_1::layers.31.attention.wq.weight               : mse 0.00000357, maxerr 0.01820374, 95pct<0.0036, median<0.0016
q4_1::layers.31.attention.wv.weight               : mse 0.00000310, maxerr 0.00997696, 95pct<0.0032, median<0.0014
q4_1::layers.31.feed_forward.w1.weight            : mse 0.00000371, maxerr 0.02717184, 95pct<0.0036, median<0.0016
q4_1::layers.31.feed_forward.w2.weight            : mse 0.00000336, maxerr 0.09575176, 95pct<0.0034, median<0.0016
q4_1::layers.31.feed_forward.w3.weight            : mse 0.00000363, maxerr 0.03244019, 95pct<0.0034, median<0.0016
q4_1::layers.4.attention.wk.weight                : mse 0.00000589, maxerr 0.01599121, 95pct<0.0048, median<0.0018
q4_1::layers.4.attention.wo.weight                : mse 0.00000167, maxerr 0.02775061, 95pct<0.0024, median<0.0012
q4_1::layers.4.attention.wq.weight                : mse 0.00000573, maxerr 0.02762246, 95pct<0.0046, median<0.0018
q4_1::layers.4.attention.wv.weight                : mse 0.00000167, maxerr 0.00593816, 95pct<0.0024, median<0.0010
q4_1::layers.4.feed_forward.w1.weight             : mse 0.00000330, maxerr 0.02607116, 95pct<0.0034, median<0.0016
q4_1::layers.4.feed_forward.w2.weight             : mse 0.00000271, maxerr 0.04353638, 95pct<0.0030, median<0.0014
q4_1::layers.4.feed_forward.w3.weight             : mse 0.00000274, maxerr 0.02257079, 95pct<0.0030, median<0.0014
q4_1::layers.5.attention.wk.weight                : mse 0.00000527, maxerr 0.02016246, 95pct<0.0046, median<0.0016
q4_1::layers.5.attention.wo.weight                : mse 0.00000171, maxerr 0.04142249, 95pct<0.0024, median<0.0012
q4_1::layers.5.attention.wq.weight                : mse 0.00000516, maxerr 0.02691448, 95pct<0.0044, median<0.0016
q4_1::layers.5.attention.wv.weight                : mse 0.00000173, maxerr 0.00809692, 95pct<0.0024, median<0.0012
q4_1::layers.5.feed_forward.w1.weight             : mse 0.00000344, maxerr 0.02066040, 95pct<0.0034, median<0.0016
q4_1::layers.5.feed_forward.w2.weight             : mse 0.00000266, maxerr 0.02678931, 95pct<0.0030, median<0.0014
q4_1::layers.5.feed_forward.w3.weight             : mse 0.00000272, maxerr 0.01605021, 95pct<0.0030, median<0.0014
q4_1::layers.6.attention.wk.weight                : mse 0.00000552, maxerr 0.01503804, 95pct<0.0046, median<0.0018
q4_1::layers.6.attention.wo.weight                : mse 0.00000175, maxerr 0.03727213, 95pct<0.0024, median<0.0012
q4_1::layers.6.attention.wq.weight                : mse 0.00000526, maxerr 0.03130698, 95pct<0.0044, median<0.0018
q4_1::layers.6.attention.wv.weight                : mse 0.00000176, maxerr 0.00586955, 95pct<0.0024, median<0.0012
q4_1::layers.6.feed_forward.w1.weight             : mse 0.00000334, maxerr 0.02278137, 95pct<0.0034, median<0.0016
q4_1::layers.6.feed_forward.w2.weight             : mse 0.00000272, maxerr 0.03055978, 95pct<0.0030, median<0.0014
q4_1::layers.6.feed_forward.w3.weight             : mse 0.00000279, maxerr 0.01386768, 95pct<0.0030, median<0.0014
q4_1::layers.7.attention.wk.weight                : mse 0.00000518, maxerr 0.01637778, 95pct<0.0044, median<0.0016
q4_1::layers.7.attention.wo.weight                : mse 0.00000182, maxerr 0.02817380, 95pct<0.0026, median<0.0012
q4_1::layers.7.attention.wq.weight                : mse 0.00000509, maxerr 0.02885771, 95pct<0.0044, median<0.0016
q4_1::layers.7.attention.wv.weight                : mse 0.00000187, maxerr 0.00640869, 95pct<0.0026, median<0.0012
q4_1::layers.7.feed_forward.w1.weight             : mse 0.00000328, maxerr 0.01696777, 95pct<0.0034, median<0.0016
q4_1::layers.7.feed_forward.w2.weight             : mse 0.00000274, maxerr 0.02849120, 95pct<0.0030, median<0.0014
q4_1::layers.7.feed_forward.w3.weight             : mse 0.00000281, maxerr 0.01903725, 95pct<0.0030, median<0.0014
q4_1::layers.8.attention.wk.weight                : mse 0.00000493, maxerr 0.01597899, 95pct<0.0044, median<0.0016
q4_1::layers.8.attention.wo.weight                : mse 0.00000181, maxerr 0.02582398, 95pct<0.0026, median<0.0012
q4_1::layers.8.attention.wq.weight                : mse 0.00000492, maxerr 0.02330780, 95pct<0.0044, median<0.0016
q4_1::layers.8.attention.wv.weight                : mse 0.00000183, maxerr 0.00699462, 95pct<0.0026, median<0.0012
q4_1::layers.8.feed_forward.w1.weight             : mse 0.00000328, maxerr 0.01851404, 95pct<0.0034, median<0.0016
q4_1::layers.8.feed_forward.w2.weight             : mse 0.00000274, maxerr 0.02776897, 95pct<0.0030, median<0.0014
q4_1::layers.8.feed_forward.w3.weight             : mse 0.00000283, maxerr 0.01309204, 95pct<0.0030, median<0.0014
q4_1::layers.9.attention.wk.weight                : mse 0.00000468, maxerr 0.01326293, 95pct<0.0044, median<0.0016
q4_1::layers.9.attention.wo.weight                : mse 0.00000178, maxerr 0.03066409, 95pct<0.0024, median<0.0012
q4_1::layers.9.attention.wq.weight                : mse 0.00000461, maxerr 0.02470907, 95pct<0.0042, median<0.0016
q4_1::layers.9.attention.wv.weight                : mse 0.00000180, maxerr 0.00619888, 95pct<0.0026, median<0.0012
q4_1::layers.9.feed_forward.w1.weight             : mse 0.00000319, maxerr 0.02470452, 95pct<0.0034, median<0.0014
q4_1::layers.9.feed_forward.w2.weight             : mse 0.00000278, maxerr 0.02815247, 95pct<0.0030, median<0.0014
q4_1::layers.9.feed_forward.w3.weight             : mse 0.00000286, maxerr 0.02717841, 95pct<0.0032, median<0.0014
q4_1::output.weight                               : mse 0.00000251, maxerr 0.01462148, 95pct<0.0030, median<0.0014
q4_1::tok_embeddings.weight                       : mse 0.00000250, maxerr 0.01170197, 95pct<0.0030, median<0.0014
q4_1                                              : mse 0.00000318, maxerr 0.12756348, 95pct<0.0034, median<0.0014

main:    total time = 240118.23 ms
```
</details>