### PR TITLE
Windows: reactivate sigint handler after each Ctrl-C

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -368,6 +368,11 @@ int main(int argc, char ** argv) {
                 // potentially set color to indicate we are taking user input
                 set_console_color(con_st, CONSOLE_COLOR_USER_INPUT);
 
+#if defined (_WIN32)
+                // Windows: must reactivate sigint handler after each signal
+                signal(SIGINT, sigint_handler);
+#endif
+
                 if (params.instruct) {
                     printf("\n> ");
                 }


### PR DESCRIPTION
When using main.exe on Windows in interactive mode, I found that only the first Ctrl-C would interrupt generation. If I later used Ctrl-C again, it always exited the application.

The reason appears to be what is described here: https://stackoverflow.com/questions/43959514/why-the-second-sigint-cant-be-captured-on-win32 - Windows will reset the SIGINT handler to default as soon as a signal was received.

My solution is to capture the signal again each time interactive mode is entered.