### PR TITLE
Change mmap parameters to avoid much swap thrashing

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -331,7 +331,7 @@ static void *mmap_file(const char *fname, uint64_t *mm_length) {
     int fd = open(fname, O_RDONLY);
     if (fd == -1) return 0;
     int64_t length = lseek(fd, 0, SEEK_END);
-    void *addr = mmap(NULL, length, PROT_READ, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, fd, 0);
+    void *addr = mmap(NULL, length, PROT_READ, MAP_SHARED | MAP_ANONYMOUS | MAP_POPULATE, fd, 0);
     close(fd);
     if (addr == MAP_FAILED) return 0;
 #endif

--- a/llama.cpp
+++ b/llama.cpp
@@ -331,7 +331,7 @@ static void *mmap_file(const char *fname, uint64_t *mm_length) {
     int fd = open(fname, O_RDONLY);
     if (fd == -1) return 0;
     int64_t length = lseek(fd, 0, SEEK_END);
-    void *addr = mmap(NULL, length, PROT_READ, MAP_SHARED, fd, 0);
+    void *addr = mmap(NULL, length, PROT_READ, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, fd, 0);
     close(fd);
     if (addr == MAP_FAILED) return 0;
 #endif


### PR DESCRIPTION
The introduction of loading the model through nmap, merged with this PR https://github.com/ggerganov/llama.cpp/pull/613 (picked up from https://github.com/ggerganov/llama.cpp/pull/586), while probably being a great idea, led to issues with swap thrashing for many users. While previously the model was completely loaded into RAM it now used swap (unless using --mlock, which requires certain user privileges), even when enough RAM was available, making performance unbearably slow.

I don't really know anything about these things. So I asked ChatGPT what could be the problem. And it gave me a hint that works wonders for me. I don't know how universally viable or useful this is, so it would be great if someone who has more expertise in these matters could double check. But I believe it is probably useful for many.

I can now even load the 65B model with my 32 GB of RAM and performance seems to be similar to what it was for the 30B model before.

Props to @slaren or @jart for introducing mmap loading. With this tweak it is now finally even performant as before for me (maybe better), while being able to combine RAM and swap memory in a useful way (first using RAM, then swap, that's what seems to be happening with this change now).

For reference, here my conversation with ChatGPT who suggested this tweak:

**trollkotze:**
> How can I avoid swap thrashing when allocating a huge chunk of memory with nmap?

**ChatGPT:**
> When allocating a large chunk of memory with mmap, swap thrashing can occur if the system tries to allocate more memory than what's available in both physical RAM and swap space. To avoid swap thrashing, consider the following steps:
> 1. Check available memory: Before allocating memory, check the available physical memory and swap space on your system. You can use commands like free -h or vmstat on Linux to check memory usage.
> 2. Request appropriate memory size: Be conservative in your memory allocation request. Allocate only the amount of memory you need and ensure that it fits within the available physical memory and swap space.
> 3. Use the MAP_NORESERVE flag: When using mmap, you can use the MAP_NORESERVE flag to prevent the system from reserving swap space for the allocated memory. This can be helpful if you don't expect the mapped memory to be fully used, but be cautious, as this may lead to a sudden out-of-memory (OOM) condition if you actually use more memory than what's available.
> 4. Use memory in smaller chunks: Instead of allocating a huge chunk of memory, consider allocating smaller chunks and managing them within your program. This can help reduce the impact on the system and avoid swap thrashing.
> 5. Monitor memory usage: Keep an eye on the memory usage of your program using system monitoring tools or custom code. If the memory usage starts to approach the limits of available physical memory and swap space, you can take appropriate action to avoid swap thrashing.
> 6. Increase available memory: If you find that your system is consistently running out of memory, consider adding more RAM or increasing the swap space.
> 7. Adjust the swappiness value: On Linux systems, you can modify the swappiness value to control how aggressively the kernel will use the swap space. A lower value will make the system less likely to swap out memory, which could help avoid swap thrashing. To temporarily change the swappiness value, use the following command:
```
sudo sysctl vm.swappiness=10
```
> 8. To make the change permanent, edit the `/etc/sysctl.conf` file and add or modify the following line:
```
vm.swappiness=10
```
> Remember, it's crucial to balance memory usage and system resources. Always allocate memory carefully and monitor your program's behavior to avoid swap thrashing and other performance issues.

**trollkotze:**
> I already reduced swappiness to 5. The strange thing is that before using nmap everything was loaded into RAM. Now almost no RAM seems to be used. Instead there's swap thrashing and very slow performance.

**ChatGPT:**
> It's possible that using mmap() with the wrong flags or settings is causing the memory to be swapped out aggressively, despite your low swappiness setting. When using mmap(), the kernel may decide to swap out memory pages depending on the flags and access patterns. Here are some suggestions to address the issue:
> 1. Use `MAP_POPULATE` flag: When calling `mmap()`, try adding the `MAP_POPULATE` flag. This flag tells the kernel to pre-fault and populate the memory mappings in advance. This may help reduce swap thrashing by making sure that the pages are already in memory when you access them.
```
void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
```
> 2. Access memory in a sequential manner: Accessing memory in a random or non-sequential manner can cause the kernel to swap out pages more aggressively. Try to access the mapped memory in a sequential manner, if possible, to avoid triggering swapping.
> 3. Incremental allocation: Instead of allocating a large chunk of memory at once, consider allocating smaller chunks incrementally and managing them within your program. This can help reduce the impact on the system and avoid swap thrashing.
> 4. Lock the memory with mlock(): If it's crucial to keep the mapped memory in RAM and avoid swapping, you can use the mlock() function to lock the memory. Note that this may require elevated privileges and can lead to resource exhaustion if not used carefully. Be cautious when using this approach and ensure you have a good understanding of your memory requirements.
```
// After mmap() call
if (mlock(addr, size) != 0) {
    perror("mlock");
    // Handle the error
}
```
> 5. Review your program's overall memory usage: Check if there are other parts of your program that could be consuming memory and causing the swap thrashing. Optimize your program's memory usage to ensure there is enough RAM available for the mapped memory.
> Remember, proper memory management is key to avoiding swap thrashing and maintaining good performance. Ensure that you use appropriate `mmap()` flags and access patterns, and monitor your program's memory usage to avoid issues.



I have just used the flags that ChatGPT suggested here: `MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE`.
Probably MAP_POPULATE is the most important one. Not sure about the others, but I just kept them all. And the swap thrashing issue is gone with that. So I'm happy. Thanks, ChatGPT! :D