### PR TITLE
Added missing host optimizations in CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ endif
 ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686))
 	# Use all CPU extensions that are available:
 	CFLAGS += -march=native -mtune=native
+	CXXFLAGS += -march=native -mtune=native
 endif
 ifneq ($(filter ppc64%,$(UNAME_M)),)
 	POWER9_M := $(shell grep "POWER9" /proc/cpuinfo)


### PR DESCRIPTION
It was expected that `-march=native -mtune=native` are applied to C++ code too.