### PR TITLE
Add Accelerate/BLAS when using Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,10 @@ let package = Package(
             path: ".",
             sources: ["ggml.c", "llama.cpp"],
             publicHeadersPath: "spm-headers",
-            cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32"])]
+            cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32", "-DGGML_USE_ACCELERATE"])],
+            linkerSettings: [
+                .linkedFramework("Accelerate")
+            ]
         ),
     ],
     cxxLanguageStandard: .cxx11

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             path: ".",
             sources: ["ggml.c", "llama.cpp"],
             publicHeadersPath: "spm-headers",
-            cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32", "-DGGML_USE_ACCELERATE"])],
+            cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32"]), .define("GGML_USE_ACCELERATE")],
             linkerSettings: [
                 .linkedFramework("Accelerate")
             ]


### PR DESCRIPTION
Hey!

This repo and the community are amazing, props to the maintainers :)

I am playing around with the added Swift bindings for Mac/iOS and I noticed that BLAS didn't appear to be enabled at runtime with the default `Package.swift` file even when I explicitly added the `Accelerate` framework on my target, looks like b/c some preprocessor directives weren't make their way to ggml.

**Before:**

<img width="1840" alt="Screenshot 2023-04-04 at 3 55 59 PM" src="https://user-images.githubusercontent.com/332583/229834580-bed46b7a-3144-49b1-9a04-a25d5b053c87.png">

**After:**

<img width="1840" alt="Screenshot 2023-04-04 at 3 55 29 PM" src="https://user-images.githubusercontent.com/332583/229834630-49de40bd-d8e2-459b-8ef4-d0c4747421c3.png">
