### PR TITLE
AVX2 ggml_vec_dot_q4_0 performance improvement ~5%

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1975,6 +1975,10 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
 
         // This loop will be unrolled by the compiler    
         for (int u=0;u<UNROLL_COUNT;u++)  {
+            // Prefetch data used later in the loop
+            // TODO these numbers are device dependent shouldn't be hard coded derive
+            _mm_prefetch ( x[i+u].qs + 32*20, 1);	// to-do: document what 32*20 even is	
+	
             /* Compute combined scale for the block */ 
             const __m256 scale = _mm256_mul_ps( 
                     _mm256_broadcast_ss( &x[i+u].d ), 


### PR DESCRIPTION
Prefetches some data before it's usage
(basing on original work: https://github.com/ggerganov/llama.cpp/pull/295)

Before (usually 245 - 260 ms):
![prefetch_wo](https://user-images.githubusercontent.com/76458234/229905870-38a375df-e36a-4aed-a4b2-fc5db06371fe.png)

After (usually 226 - 234 ms): 
![prefetch_w](https://user-images.githubusercontent.com/76458234/229905879-00f81e7d-2d1d-4c2b-8564-82e99ee3e980.png)


Tested on Windows 10 + i7-10700k, needs further testing on different OSes and CPUs to make sure there's no unintentional issues hence draft. Also naming constants appropriately!