### PR TITLE
Fix magic in convert-gptq-to-ggml.py

### DIFF
--- a/convert-gptq-to-ggml.py
+++ b/convert-gptq-to-ggml.py
@@ -36,7 +36,7 @@ fname_out = sys.argv[3]
 
 fout = open(fname_out, "wb")
 
-fout.write(struct.pack("i", 0x67676d66)) # magic: ggmf in hex
+fout.write(struct.pack("i", 0x67676a74)) # magic: ggjt in hex
 fout.write(struct.pack("i", 1)) # file version
 fout.write(struct.pack("i", n_vocab))
 fout.write(struct.pack("i", n_embd))


### PR DESCRIPTION
PR https://github.com/ggerganov/llama.cpp/pull/613 did the correct thing to align tensors to match the new format, but forgot to change the magic in `convert-gptq-to-ggml.py`. This PR fixes this.