### PR TITLE
Build static lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ endif
 # Print build information
 #
 
+RANLIB ?= ranlib
+
 $(info I llama.cpp build info: )
 $(info I UNAME_S:  $(UNAME_S))
 $(info I UNAME_P:  $(UNAME_P))
@@ -130,6 +132,8 @@ $(info I CXXFLAGS: $(CXXFLAGS))
 $(info I LDFLAGS:  $(LDFLAGS))
 $(info I CC:       $(CCV))
 $(info I CXX:      $(CXXV))
+$(info I AR:       $(AR))
+$(info I RANLIB:   $(RANLIB))
 $(info )
 
 default: main quantize perplexity embedding
@@ -137,6 +141,10 @@ default: main quantize perplexity embedding
 #
 # Build library
 #
+
+libllama.a: ggml.o llama.o common.o
+	$(AR) rc $@ $^
+	$(RANLIB) $@
 
 ggml.o: ggml.c ggml.h
 	$(CC)  $(CFLAGS)   -c ggml.c -o ggml.o
@@ -150,20 +158,20 @@ common.o: examples/common.cpp examples/common.h
 clean:
 	rm -vf *.o main quantize perplexity embedding
 
-main: examples/main/main.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/main/main.cpp ggml.o llama.o common.o -o main $(LDFLAGS)
+main: examples/main/main.cpp libllama.a
+	$(CXX) $(CXXFLAGS) examples/main/main.cpp libllama.a -o main $(LDFLAGS)
 	@echo
 	@echo '====  Run ./main -h for help.  ===='
 	@echo
 
-quantize: examples/quantize/quantize.cpp ggml.o llama.o
-	$(CXX) $(CXXFLAGS) examples/quantize/quantize.cpp ggml.o llama.o -o quantize $(LDFLAGS)
+quantize: examples/quantize/quantize.cpp libllama.a
+	$(CXX) $(CXXFLAGS) examples/quantize/quantize.cpp libllama.a -o quantize $(LDFLAGS)
 
-perplexity: examples/perplexity/perplexity.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/perplexity/perplexity.cpp ggml.o llama.o common.o -o perplexity $(LDFLAGS)
+perplexity: examples/perplexity/perplexity.cpp libllama.a
+	$(CXX) $(CXXFLAGS) examples/perplexity/perplexity.cpp libllama.a -o perplexity $(LDFLAGS)
 
-embedding: examples/embedding/embedding.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/embedding/embedding.cpp ggml.o llama.o common.o -o embedding $(LDFLAGS)
+embedding: examples/embedding/embedding.cpp libllama.a
+	$(CXX) $(CXXFLAGS) examples/embedding/embedding.cpp libllama.a -o embedding $(LDFLAGS)
 
 #
 # Tests


### PR DESCRIPTION
`make` now creates a static library too.

I haven't modified CMake-related stuff. Not sure if that is needed.