### PR TITLE
Avoid heavy V transpose operation + improvements

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -558,6 +558,16 @@ struct ggml_tensor * ggml_view_2d(
         size_t                nb1, // row stride in bytes
         size_t                offset);
 
+struct ggml_tensor * ggml_view_3d(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a,
+        int64_t               ne0,
+        int64_t               ne1,
+        int64_t               ne2,
+        size_t                nb1, // row   stride in bytes
+        size_t                nb2, // slice stride in bytes
+        size_t                offset);
+
 struct ggml_tensor * ggml_permute(
         struct ggml_context * ctx,
         struct ggml_tensor  * a,


### PR DESCRIPTION
## Human generated notes

I believe this should resolve: #603 #677 #767

When I deprecated the non-contiguous `ggml_mul_mat()` branch in #439, I grossly underestimated the cost of transposing the V matrix on every token. It's a very heavy memory operation, with tons of cache misses.

To solve this, we now store V in the KV cache in transposed state, so we don't need to do it for future tokens.

ggml :

- added ggml_view_3d()
- ggml_view_tensor() now inherits the stride too
- reimplement ggml_cpy() to account for dst stride
- no longer require tensor->data to be memory aligned

llama :

- compute RoPE on 32-bit tensors (should be more accurate)
- store RoPE-ed K in the KV cache
- store transposed V in the KV cache (significant speed-up)
- avoid unnecessary Q copy

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1868f6c</samp>

### Summary
:sparkles::zap::chart_with_upwards_trend:

<!--
1.  :sparkles: This emoji is often used to indicate new features or improvements, and it could be used to represent the addition of the `ggml_view_3d` function to the header file, as well as the overall enhancement of the ggml library for tensor operations and graph computation.
2.  :zap: This emoji is often used to indicate performance improvements or speed boosts, and it could be used to represent the removal of unnecessary checks, the optimization of the tensor duplication functions, and the use of RoPE for self-attention in the llama project.
3.  :chart_with_upwards_trend: This emoji is often used to indicate data analysis or visualization, and it could be used to represent the use of a 3D view tensor for the value matrix, and the addition of optional code for timing and plotting in the llama project.
-->
This pull request enhances the ggml library and the llama project by adding new tensor operations, optimizing existing ones, and using RoPE for self-attention. It also improves the debuggability of the llama project by adding optional timing and plotting code. The main files affected are `ggml.c`, `ggml.h`, and `llama.cpp`.

> _Sing, O Muse, of the mighty ggml, the wondrous library of tensors_
> _That skilled programmers devised with cunning and crafty art_
> _To aid the llama project, the swift and fluent speaker of words_
> _That emulates the GPT-2, the wise and powerful oracle of language_

### Walkthrough
* Optimize the self-attention mechanism in `llama_eval_internal` by using RoPE and view tensors ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL813-R841), [link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL861-R875))
* Improve the performance of tensor duplication operations by avoiding unnecessary checks and using memcpy when possible ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL4848), [link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL4865-R4992), [link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL4952), [link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL4969-R5086))
* Add a new function `ggml_view_3d` to create 3-dimensional view tensors from source tensors ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dR4521-R4551), [link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394R561-R570))
* Comment out alignment checks in `ggml_new_tensor_impl` to speed up tensor creation ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL3222-R3223))
* Copy byte strides in `ggml_view_tensor` to preserve the source tensor layout ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-6d9ce99fcb6f51ff76f59e479f6e6fc0bb62edef7442805d7a5bb15b23996b5dL3623-R3631))
* Add optional code for debugging and profiling in `llama_eval_internal` ([link](https://github.com/ggerganov/llama.cpp/pull/775/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL958-R967))

Edit:

Merging this since we observe M1 and Windows working good.
If you notice something not right, feel free to revert. But I think it should be good