### PR TITLE
Define non-positive top_k; top_k range check

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1229,7 +1229,8 @@ static llama_vocab::id llama_sample_top_p_top_k(
         }
     }
 
-    sample_top_k(logits_id, top_k);
+    if (top_k > 0 && top_k < n_logits)
+        sample_top_k(logits_id, top_k);
 
     float maxl = -std::numeric_limits<float>::infinity();
     for (const auto & kv : logits_id) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -1229,8 +1229,9 @@ static llama_vocab::id llama_sample_top_p_top_k(
         }
     }
 
-    if (top_k > 0 && top_k < n_logits)
+    if (top_k > 0 && top_k < n_logits) {
         sample_top_k(logits_id, top_k);
+    }
 
     float maxl = -std::numeric_limits<float>::infinity();
     for (const auto & kv : logits_id) {


### PR DESCRIPTION
1. With `--top_k 0` expected that all logits will be sampled (by top_p)
2. Range check added to prevent from resizing logits more than vocab have. Resizing to more than vocab have causes token 0 to be appended to logits to be sampled