### PR TITLE
Include examples/common.cpp in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,9 @@ endif()
 
 add_library(llama
             llama.cpp
-            llama.h)
+            llama.h
+            examples/common.cpp
+            examples/common.h)
 
 target_include_directories(llama PUBLIC .)
 target_compile_features(llama PUBLIC cxx_std_11) # don't bump


### PR DESCRIPTION
This is useful when building 3rdparty applications.

See https://github.com/iacore/llama-tui

This is a bodge. There are better ways to do this, probably.