### PR TITLE
fixed the git repo name on the usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Here are the step for the LLaMA-7B model:
 
 ```bash
 # build this repo
-git clone https://github.com/ggerganov/llama.cpp
+git clone https://github.com/ggerganov/llama.git
 cd llama.cpp
 make
 


### PR DESCRIPTION
The original command didn't allow cloning, as the suffix was set to .cpp instead of .git