### PR TITLE
ADD libllama.so target for llama-cpp-python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,8 @@ perplexity: examples/perplexity/perplexity.cpp ggml.o llama.o common.o
 embedding: examples/embedding/embedding.cpp ggml.o llama.o common.o
 	$(CXX) $(CXXFLAGS) examples/embedding/embedding.cpp ggml.o llama.o common.o -o embedding $(LDFLAGS)
 
+libllama.so: llama.o ggml.o
+	$(CXX) $(CXXFLAGS) -shared -fPIC -o libllama.so llama.o ggml.o $(LDFLAGS)
 #
 # Tests
 #


### PR DESCRIPTION
I could get `llama-cpp-python` working but only when I built `libllama.so` with make and then replaced the copy of  `libllama.so` that came with  `llama-cpp-python` .

I wanted to add this here to help with the `llama-cpp-python` project.