### PR TITLE
optimize rope function to avoid call powf in the loop

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -7279,19 +7279,20 @@ static void ggml_compute_forward_rope_f32(
     // row index used to determine which thread to use
     int ir = 0;
 
+    const float theta_scale = powf(10000.0, ((float)-2)/n_dims);
+
     for (int64_t i3 = 0; i3 < ne3; i3++) {
         for (int64_t i2 = (mode == 0 ? 0 : n_past); i2 < ne2; i2++) {
             const int p = (mode == 0 ? n_past + i2 : i2);
             for (int64_t i1 = 0; i1 < ne1; i1++) {
                 if (ir++ < ir0) continue;
                 if (ir   > ir1) break;
-
+                float theta = (float)p;
                 for (int i0 = 0; i0 < n_dims; i0 += 2) {
-                    const float theta = powf(10000.0, ((float)-i0)/n_dims);
+                    const float cos_theta = cosf(theta);
+                    const float sin_theta = sinf(theta);
 
-                    const float cos_theta = cosf(p*theta);
-                    const float sin_theta = sinf(p*theta);
-
+                    theta *= theta_scale;
                     const float * const src = (float *)((char *) src0->data + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
                           float * dst_data  = (float *)((char *)  dst->data + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
 
@@ -7352,19 +7353,20 @@ static void ggml_compute_forward_rope_f16(
     // row index used to determine which thread to use
     int ir = 0;
 
+    const float theta_scale = powf(10000.0, ((float)-2)/n_dims);
+
     for (int64_t i3 = 0; i3 < ne3; i3++) {
         for (int64_t i2 = (mode == 0 ? 0 : n_past); i2 < ne2; i2++) {
             const int p = (mode == 0 ? n_past + i2 : i2);
             for (int64_t i1 = 0; i1 < ne1; i1++) {
                 if (ir++ < ir0) continue;
                 if (ir   > ir1) break;
-
+                float theta = (float)p;
                 for (int i0 = 0; i0 < n_dims; i0 += 2) {
-                    const float theta = powf(10000.0, ((float)-i0)/n_dims);
+                    const float cos_theta = cosf(theta);
+                    const float sin_theta = sinf(theta);
 
-                    const float cos_theta = cosf(p*theta);
-                    const float sin_theta = sinf(p*theta);
-
+                    theta *= theta_scale;
                     const ggml_fp16_t * const src = (ggml_fp16_t *)((char *) src0->data + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
                           ggml_fp16_t * dst_data  = (ggml_fp16_t *)((char *)  dst->data + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
 


### PR DESCRIPTION
This slightly improves the perf.

Before:
llama_print_timings:        load time =  6973.64 ms
llama_print_timings:      sample time =   345.88 ms /   128 runs   (    2.70 ms per run)
llama_print_timings: prompt eval time =  6227.73 ms /    29 tokens (  214.75 ms per token)
llama_print_timings:        eval time = 34661.36 ms /   127 runs   (  272.92 ms per run)
llama_print_timings:       total time = 41992.88 ms

After:
llama_print_timings:        load time =  7668.98 ms
llama_print_timings:      sample time =   345.03 ms /   128 runs   (    2.70 ms per run)
llama_print_timings: prompt eval time =  6906.97 ms /    29 tokens (  238.17 ms per token)
llama_print_timings:        eval time = 33445.33 ms /   127 runs   (  263.35 ms per run)
llama_print_timings:       total time = 41471.40 ms

