### PR TITLE
Multi-thread `ggml_cpy()`

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4938,12 +4938,6 @@ static void ggml_compute_forward_dup_f16(
 
     const int thread_num = params->ith;
     const int total_threads = params->nth;
-    const int64_t regions = ne03 * ne02 * ne01 * ne00;
-
-    const int64_t regions_per_thread = (regions + total_threads - 1) / total_threads;
-
-    const int64_t thread_start_region = regions_per_thread * thread_num;
-    const int64_t thread_stop_region = MIN(thread_start_region + regions_per_thread, regions);
 
     int region_index = 0;
 
@@ -4952,9 +4946,9 @@ static void ggml_compute_forward_dup_f16(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        if (region_index > thread_stop_region) break;
 
-                        if (region_index++ >= thread_start_region) {
+                        // Interleave execution so that in a 4 thread run thread 0 copies regions 0,4,8, ...
+                        if ((region_index++ % total_threads) == thread_num) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                             char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
@@ -4984,9 +4978,8 @@ static void ggml_compute_forward_dup_f16(
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
 
-                        if (region_index > thread_stop_region) break;
-
-                        if (region_index++ >= thread_start_region) {
+                        // Interleave execution so that in a 4 thread run thread 0 copies regions 0,4,8, ...
+                        if ((region_index++ % total_threads) == thread_num) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                                   char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
@@ -5053,12 +5046,6 @@ static void ggml_compute_forward_dup_f32(
 
     const int thread_num = params->ith;
     const int total_threads = params->nth;
-    const int64_t regions = ne03 * ne02 * ne01 * ne00;
-
-    const int64_t regions_per_thread = (regions + total_threads - 1) / total_threads;
-
-    const int64_t thread_start_region = regions_per_thread * thread_num;
-    const int64_t thread_stop_region = MIN(thread_start_region + regions_per_thread, regions);
 
     int region_index = 0;
 
@@ -5067,9 +5054,9 @@ static void ggml_compute_forward_dup_f32(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        if (region_index > thread_stop_region) break;
 
-                        if (region_index++ >= thread_start_region) {
+                        // Interleave execution so that in a 4 thread run thread 0 copies regions 0,4,8, ...
+                        if ((region_index++ % total_threads) == thread_num) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                             char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
@@ -5098,9 +5085,7 @@ static void ggml_compute_forward_dup_f32(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        if (region_index > thread_stop_region) break;
-
-                        if (region_index++ >= thread_start_region) {
+                        if ((region_index++ % total_threads) == thread_num) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                             char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 

--- a/ggml.c
+++ b/ggml.c
@@ -4936,16 +4936,32 @@ static void ggml_compute_forward_dup_f16(
     int64_t i12 = 0;
     int64_t i13 = 0;
 
+    const int thread_num = params->ith;
+    const int total_threads = params->nth;
+    const int64_t regions = ne03 * ne02 * ne01 * ne00;
+
+    const int64_t regions_per_thread = (regions + total_threads - 1) / total_threads;
+
+    const int64_t thread_start_region = regions_per_thread * thread_num;
+    const int64_t thread_stop_region = MIN(thread_start_region + regions_per_thread, regions);
+
+    int region_index = 0;
+
     if (dst->type == GGML_TYPE_F16) {
         for (int64_t i03 = 0; i03 < ne03; i03++) {
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
+                        if (region_index > thread_stop_region) break;
 
-                        memcpy(dst_ptr, src0_ptr, sizeof(ggml_fp16_t));
+                        if (region_index++ >= thread_start_region) {
+                            const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
+                            char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
+                            memcpy(dst_ptr, src0_ptr, sizeof(ggml_fp16_t));
+                        }
+
+                        // Regardless, we have to keep the dst counters updated
                         if (++i10 == ne00) {
                             i10 = 0;
                             if (++i11 == ne01) {
@@ -4967,11 +4983,17 @@ static void ggml_compute_forward_dup_f16(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
-                        *(float *) dst_ptr = GGML_FP16_TO_FP32(*(const ggml_fp16_t *) src0_ptr);
+                        if (region_index > thread_stop_region) break;
 
+                        if (region_index++ >= thread_start_region) {
+                            const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
+                                  char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
+
+                            *(float *) dst_ptr = GGML_FP16_TO_FP32(*(const ggml_fp16_t *) src0_ptr);
+                        }
+
+                        // Regardless, we have to keep the dst counters updated
                         if (++i10 == ne00) {
                             i10 = 0;
                             if (++i11 == ne01) {
@@ -5029,7 +5051,6 @@ static void ggml_compute_forward_dup_f32(
     int64_t i12 = 0;
     int64_t i13 = 0;
 
-
     const int thread_num = params->ith;
     const int total_threads = params->nth;
     const int64_t regions = ne03 * ne02 * ne01 * ne00;
@@ -5046,11 +5067,9 @@ static void ggml_compute_forward_dup_f32(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-
                         if (region_index > thread_stop_region) break;
 
-
-                        if (region_index >= thread_start_region) {
+                        if (region_index++ >= thread_start_region) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                             char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
@@ -5079,10 +5098,9 @@ static void ggml_compute_forward_dup_f32(
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = 0; i01 < ne01; i01++) {
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-
                         if (region_index > thread_stop_region) break;
 
-                        if (region_index >= thread_start_region) {
+                        if (region_index++ >= thread_start_region) {
                             const char * src0_ptr = ((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
                             char * dst_ptr  = ((char *)  dst->data + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);
 
@@ -7302,7 +7320,6 @@ static void ggml_compute_forward_rope_f32(
 
     // row index used to determine which thread to use
     int ir = 0;
-    int i = 0;
 
     for (int64_t i3 = 0; i3 < ne3; i3++) {
         for (int64_t i2 = (mode == 0 ? 0 : n_past); i2 < ne2; i2++) {
@@ -7312,7 +7329,6 @@ static void ggml_compute_forward_rope_f32(
                 if (ir   > ir1) break;
 
                 for (int i0 = 0; i0 < n_dims; i0 += 2) {
-                    ++i;
                     const float theta = powf(10000.0, ((float)-i0)/n_dims);
 
                     const float cos_theta = cosf(p*theta);
@@ -7330,7 +7346,6 @@ static void ggml_compute_forward_rope_f32(
             }
         }
     }
-
 }
 
 static void ggml_compute_forward_rope_f16(


### PR DESCRIPTION
This is an attempt at https://github.com/ggerganov/llama.cpp/issues/782. 

Apologies if this is the wrong approach, learning the codebase! 

Tested on Mac i7-1068NG7. Change in performance seems to be very small, if any:

Before:
```
========================================
perf_total_per_op_us[            NONE] =   0.000 ms
perf_total_per_op_us[             DUP] =   0.000 ms
perf_total_per_op_us[             ADD] =   0.346 ms
perf_total_per_op_us[             SUB] =   0.000 ms
perf_total_per_op_us[             MUL] =   0.492 ms
perf_total_per_op_us[             DIV] =   0.000 ms
perf_total_per_op_us[             SQR] =   0.000 ms
perf_total_per_op_us[            SQRT] =   0.000 ms
perf_total_per_op_us[             SUM] =   0.000 ms
perf_total_per_op_us[            MEAN] =   0.000 ms
perf_total_per_op_us[          REPEAT] =   0.000 ms
perf_total_per_op_us[             ABS] =   0.000 ms
perf_total_per_op_us[             SGN] =   0.000 ms
perf_total_per_op_us[             NEG] =   0.000 ms
perf_total_per_op_us[            STEP] =   0.000 ms
perf_total_per_op_us[            RELU] =   0.000 ms
perf_total_per_op_us[            GELU] =   0.000 ms
perf_total_per_op_us[            SILU] =   1.182 ms
perf_total_per_op_us[            NORM] =   0.000 ms
perf_total_per_op_us[        RMS_NORM] =   0.670 ms
perf_total_per_op_us[         MUL_MAT] = 249.842 ms
perf_total_per_op_us[           SCALE] =   0.097 ms
perf_total_per_op_us[             CPY] =   2.084 ms
perf_total_per_op_us[         RESHAPE] =   0.138 ms
perf_total_per_op_us[            VIEW] =   0.138 ms
perf_total_per_op_us[         PERMUTE] =   0.098 ms
perf_total_per_op_us[       TRANSPOSE] =   0.031 ms
perf_total_per_op_us[        GET_ROWS] =   0.003 ms
perf_total_per_op_us[   DIAG_MASK_INF] =   0.037 ms
perf_total_per_op_us[        SOFT_MAX] =   0.336 ms
perf_total_per_op_us[            ROPE] =   2.216 ms
perf_total_per_op_us[      CONV_1D_1S] =   0.000 ms
perf_total_per_op_us[      CONV_1D_2S] =   0.000 ms
perf_total_per_op_us[      FLASH_ATTN] =   0.000 ms
perf_total_per_op_us[        FLASH_FF] =   0.000 ms
========================================
```
```
llama_print_timings:        load time =  2801.11 ms
llama_print_timings:      sample time =   162.00 ms /   128 runs   (    1.27 ms per run)
llama_print_timings: prompt eval time =  1553.28 ms /     7 tokens (  221.90 ms per token)
llama_print_timings:        eval time = 26238.64 ms /   127 runs   (  206.60 ms per run)
llama_print_timings:       total time = 29204.85 ms
```

After:
```
perf_total_per_op_us[            NONE] =   0.000 ms
perf_total_per_op_us[             DUP] =   0.000 ms
perf_total_per_op_us[             ADD] =   0.412 ms
perf_total_per_op_us[             SUB] =   0.000 ms
perf_total_per_op_us[             MUL] =   0.477 ms
perf_total_per_op_us[             DIV] =   0.000 ms
perf_total_per_op_us[             SQR] =   0.000 ms
perf_total_per_op_us[            SQRT] =   0.000 ms
perf_total_per_op_us[             SUM] =   0.000 ms
perf_total_per_op_us[            MEAN] =   0.000 ms
perf_total_per_op_us[          REPEAT] =   0.000 ms
perf_total_per_op_us[             ABS] =   0.000 ms
perf_total_per_op_us[             SGN] =   0.000 ms
perf_total_per_op_us[             NEG] =   0.000 ms
perf_total_per_op_us[            STEP] =   0.000 ms
perf_total_per_op_us[            RELU] =   0.000 ms
perf_total_per_op_us[            GELU] =   0.000 ms
perf_total_per_op_us[            SILU] =   1.307 ms
perf_total_per_op_us[            NORM] =   0.000 ms
perf_total_per_op_us[        RMS_NORM] =   0.658 ms
perf_total_per_op_us[         MUL_MAT] = 284.981 ms
perf_total_per_op_us[           SCALE] =   0.097 ms
perf_total_per_op_us[             CPY] =   1.749 ms
perf_total_per_op_us[         RESHAPE] =   0.142 ms
perf_total_per_op_us[            VIEW] =   0.149 ms
perf_total_per_op_us[         PERMUTE] =   0.108 ms
perf_total_per_op_us[       TRANSPOSE] =   0.034 ms
perf_total_per_op_us[        GET_ROWS] =   0.898 ms
perf_total_per_op_us[   DIAG_MASK_INF] =   0.042 ms
perf_total_per_op_us[        SOFT_MAX] =   0.528 ms
perf_total_per_op_us[            ROPE] =   1.741 ms
perf_total_per_op_us[      CONV_1D_1S] =   0.000 ms
perf_total_per_op_us[      CONV_1D_2S] =   0.000 ms
perf_total_per_op_us[      FLASH_ATTN] =   0.000 ms
perf_total_per_op_us[        FLASH_FF] =   0.000 ms
```
```
llama_print_timings:        load time =  2540.09 ms
llama_print_timings:      sample time =   154.58 ms /   128 runs   (    1.21 ms per run)
llama_print_timings: prompt eval time =  1481.09 ms /     7 tokens (  211.58 ms per token)
llama_print_timings:        eval time = 24397.64 ms /   127 runs   (  192.11 ms per run)
llama_print_timings:       total time = 27095.16 ms
```
(The GGML_PERF outputs and the print timings outputs are separate runs, all are the 2nd invocation after building, using the same command)

Additionally, I'm having a bit of trouble testing the f16 codepath for this - I'm sure I'm doing something silly, but even when running with an f16 model, I'm not seeing src0->type ever equal GGML_TYPE_F16. Any tips for building?

Thanks!