### PR TITLE
fix cblas_sgemm call in ggml_compute_forward_mul_mat_*?

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -6265,7 +6265,7 @@ static void ggml_compute_forward_mul_mat_f32(
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
                         ne11, ne01, ne10,
                         1.0f,    y, ne10,
-                                 x, ne10,
+                                 x, ne00,
                         0.0f,    d, ne01);
             }
         }
@@ -6437,7 +6437,7 @@ static void ggml_compute_forward_mul_mat_f16_f32(
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
                         ne11, ne01, ne10,
                         1.0f,    y, ne10,
-                                 x, ne10,
+                                 x, ne00,
                         0.0f,    d, ne01);
             }
         }
@@ -6652,7 +6652,7 @@ static void ggml_compute_forward_mul_mat_q_f32(
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
                         ne11, ne01, ne10,
                         1.0f,    y, ne10,
-                                 x, ne10,
+                                 x, ne00,
                         0.0f,    d, ne01);
             }
         }


### PR DESCRIPTION
Hey, I was trying to understand how blas was used in llama.cpp and maybe i found a bug?

at least i dont understand why - the int after the x in cblas_sgemm calls should be the pitch(or stride) of array x. 
but x comes from src0 in all the ggml_compute_forward_mul_mat_*, so i am guessing the stride of src0 should be used, which is ne00?

sorry if i am missing something : (