### PR TITLE
Add new binaries to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,9 @@
             mkdir -p $out/bin
             mv bin/main $out/bin/llama
             mv bin/quantize $out/bin/quantize
+            mv bin/embedding $out/bin/embedding
+            mv bin/perplexity $out/bin/perplexity
+
             echo "#!${llama-python}/bin/python" > $out/bin/convert-pth-to-ggml
             cat ${./convert-pth-to-ggml.py} >> $out/bin/convert-pth-to-ggml
             chmod +x $out/bin/convert-pth-to-ggml


### PR DESCRIPTION
"perplexity" and "embedding" are missing as binary outputs of the derivation