### PR TITLE
Efficient preloading for mmap()

### DIFF
--- a/llama_util.h
+++ b/llama_util.h
@@ -30,6 +30,8 @@
     #include <windows.h>
     #include <io.h>
     #include <stdio.h> // for _fseeki64
+#else
+    #include <unistd.h>
 #endif
 
 #define LLAMA_ASSERT(x) \


### PR DESCRIPTION
It's only psychological nice to have the program jump to the inference part directly after mmap load.
The entire model is loaded during first inference which means it influences our inference timings with SSD/disk latency. 
There is currently no way to compare the first inference due to that.
There was some discussion that the model is "sparse" so mmap would save memory - that's not correct. So we can preload it.

This function iterated through the pages right after mmap(), it reads the absolute minimum required to force the OS to fully cache the file.
It is tested on Windows and works.
Needs a test on Linux
It should be considered to be default on when mmap is used, I'm not sure if there is a downside that outweights the benefits.