### PR TITLE
Adding unary and binary map operations

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -3677,7 +3677,6 @@ struct ggml_tensor * ggml_dup_inplace(
     return ggml_dup_impl(ctx, a, true);
 }
 
-
 // ggml_add
 
 struct ggml_tensor * ggml_add_impl(
@@ -9073,19 +9072,7 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_dup(params, tensor->src0, tensor);
             } break;
-        case GGML_OP_MAP_UNARY:
-            {
-                const ggml_unary_op_f32_t fun = *((ggml_unary_op_f32_t *)tensor->opt[0]->data);
-                ggml_compute_forward_map_unary(params, tensor->src0, tensor, fun);
-            }
-            break;
-        case GGML_OP_MAP_BINARY:
-            {
-                const ggml_binary_op_f32_t fun = *((ggml_binary_op_f32_t *)tensor->opt[0]->data);
-                ggml_compute_forward_map_binary(params, tensor->src0, tensor->src1, tensor, fun);
-            }
-            break;
-            case GGML_OP_ADD:
+        case GGML_OP_ADD:
             {
                 ggml_compute_forward_add(params, tensor->src0, tensor->src1, tensor);
             } break;
@@ -9224,6 +9211,18 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_flash_ff(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1], tensor->opt[2], tensor);
             } break;
+        case GGML_OP_MAP_UNARY:
+            {
+                const ggml_unary_op_f32_t fun = *((ggml_unary_op_f32_t *)tensor->opt[0]->data);
+                ggml_compute_forward_map_unary(params, tensor->src0, tensor, fun);
+            }
+            break;
+        case GGML_OP_MAP_BINARY:
+            {
+                const ggml_binary_op_f32_t fun = *((ggml_binary_op_f32_t *)tensor->opt[0]->data);
+                ggml_compute_forward_map_binary(params, tensor->src0, tensor->src1, tensor, fun);
+            }
+            break;
         case GGML_OP_NONE:
             {
                 // nop

--- a/ggml.h
+++ b/ggml.h
@@ -253,6 +253,9 @@ enum ggml_op {
     GGML_OP_FLASH_ATTN,
     GGML_OP_FLASH_FF,
 
+    GGML_OP_MAP_UNARY,
+    GGML_OP_MAP_BINARY,
+
     GGML_OP_COUNT,
 };
 
@@ -418,6 +421,17 @@ float * ggml_get_data_f32(const struct ggml_tensor * tensor);
 struct ggml_tensor * ggml_dup(
         struct ggml_context * ctx,
         struct ggml_tensor  * a);
+
+struct ggml_tensor *ggml_map_unary(
+    struct ggml_context *ctx,
+    struct ggml_tensor *a,
+    void (*const fun)(int, float *, float *));
+
+struct ggml_tensor *ggml_map_binary(
+    struct ggml_context *ctx,
+    struct ggml_tensor *a,
+    struct ggml_tensor *b,
+    void (*const fun)(int, float *, float *, float *));
 
 struct ggml_tensor * ggml_add(
         struct ggml_context * ctx,

--- a/ggml.h
+++ b/ggml.h
@@ -422,17 +422,6 @@ struct ggml_tensor * ggml_dup(
         struct ggml_context * ctx,
         struct ggml_tensor  * a);
 
-struct ggml_tensor *ggml_map_unary(
-    struct ggml_context *ctx,
-    struct ggml_tensor *a,
-    void (*const fun)(int, float *, float *));
-
-struct ggml_tensor *ggml_map_binary(
-    struct ggml_context *ctx,
-    struct ggml_tensor *a,
-    struct ggml_tensor *b,
-    void (*const fun)(int, float *, float *, float *));
-
 struct ggml_tensor * ggml_add(
         struct ggml_context * ctx,
         struct ggml_tensor  * a,
@@ -665,6 +654,21 @@ struct ggml_tensor * ggml_flash_ff(
         struct ggml_tensor  * b1,
         struct ggml_tensor  * c0,
         struct ggml_tensor  * c1);
+
+// Mapping operations
+typedef void (*ggml_unary_op_f32_t)(const int, float *, const float *);
+typedef void (*ggml_binary_op_f32_t)(const int, float *, const float *, const float *);
+
+struct ggml_tensor * ggml_map_unary_f32(
+        struct ggml_context        * ctx,
+        struct ggml_tensor         * a,
+        const  ggml_unary_op_f32_t fun);
+
+struct ggml_tensor * ggml_map_binary_f32(
+        struct ggml_context         * ctx,
+        struct ggml_tensor          * a,
+        struct ggml_tensor          * b,
+        const  ggml_binary_op_f32_t fun);
 
 //
 // automatic differentiation


### PR DESCRIPTION
Proof of concept support for mapping arbitrary unary/binary operations with GGML.

This would require support models that require operations that aren't currently implemented, even if it was in a basic/less than optimally performant way.

I was a C developer in a past life, but it's been a long time. This _does_ appear to work (using map functions from Rust even) but it may not be safe.

While this most likely isn't in a state to be merged, is it something that could in theory get included? I'm willing to work with the powers that be. (Also, wasn't sure exactly where to submit this. It seems like the main `ggml` is significantly different from the `llama.cpp` one.)