### PR TITLE
Windows fixes

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -1,3 +1,8 @@
+// Defines sigaction on msys:
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "common.h"
 #include "llama.h"
 

--- a/ggml.c
+++ b/ggml.c
@@ -1,4 +1,4 @@
-// Defines CLOCK_MONOTONIC and asprintf on Linux
+// Defines CLOCK_MONOTONIC on Linux
 #define _GNU_SOURCE
 
 #include "ggml.h"
@@ -50,6 +50,7 @@ typedef HANDLE pthread_t;
 
 typedef DWORD thread_ret_t;
 static int pthread_create(pthread_t* out, void* unused, thread_ret_t(*func)(void*), void* arg) {
+    (void) unused;
     HANDLE handle = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) func, arg, 0, NULL);
     if (handle == NULL)
     {
@@ -61,6 +62,7 @@ static int pthread_create(pthread_t* out, void* unused, thread_ret_t(*func)(void
 }
 
 static int pthread_join(pthread_t thread, void* unused) {
+    (void) unused;
     return (int) WaitForSingleObject(thread, INFINITE);
 }
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -1,3 +1,8 @@
+// Defines fileno on msys:
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "llama_util.h"
 #include "llama.h"
 #include "llama_internal.h"


### PR DESCRIPTION
Mostly for msys2 and mingw64 builds, which are different from each other and different from standard Visual Studio builds.  Isn't Windows fun?

- Define _GNU_SOURCE in more files (it's already used in ggml.c for Linux's sake).

- Don't use PrefetchVirtualMemory if not building for Windows 8 or later (mingw64 doesn't by default).  But warn the user about this situation since it's probably not intended.

- Check for NOMINMAX already being defined, which it is on mingw64.

- Actually use the `increment` variable (bug in my `pizza` PR).

- Suppress unused variable warnings in the fake pthread_create and pthread_join implementations for Windows.

- (not Windows-related) Remove mention of `asprintf` from comment; `asprintf` is no longer used.

Fixes #871.