### PR TITLE
More accurate Q4_0 and Q4_1 quantizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,9 @@ endif()
 
 add_library(ggml OBJECT
             ggml.c
-            ggml.h)
+            ggml.h
+            ggml_extra.h
+            ggml_extra.cpp)
 
 target_include_directories(ggml PUBLIC .)
 target_compile_features(ggml PUBLIC c_std_11) # don't bump

--- a/Makefile
+++ b/Makefile
@@ -145,32 +145,35 @@ ggml.o: ggml.c ggml.h
 llama.o: llama.cpp llama.h llama_util.h llama_internal.h
 	$(CXX) $(CXXFLAGS) -c llama.cpp -o llama.o
 
+ggml_extra.o: ggml_extra.cpp ggml_extra.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
 common.o: examples/common.cpp examples/common.h
 	$(CXX) $(CXXFLAGS) -c examples/common.cpp -o common.o
 
 clean:
 	rm -vf *.o main quantize quantize-stats perplexity embedding
 
-main: examples/main/main.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/main/main.cpp ggml.o llama.o common.o -o main $(LDFLAGS)
+main: examples/main/main.cpp ggml.o llama.o common.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 	@echo
 	@echo '====  Run ./main -h for help.  ===='
 	@echo
 
-quantize: examples/quantize/quantize.cpp ggml.o llama.o
-	$(CXX) $(CXXFLAGS) examples/quantize/quantize.cpp ggml.o llama.o -o quantize $(LDFLAGS)
+quantize: examples/quantize/quantize.cpp ggml.o llama.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
-quantize-stats: examples/quantize-stats/quantize-stats.cpp ggml.o llama.o
-	$(CXX) $(CXXFLAGS) examples/quantize-stats/quantize-stats.cpp ggml.o llama.o -o quantize-stats $(LDFLAGS)
+quantize-stats: examples/quantize-stats/quantize-stats.cpp ggml.o llama.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
-perplexity: examples/perplexity/perplexity.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/perplexity/perplexity.cpp ggml.o llama.o common.o -o perplexity $(LDFLAGS)
+perplexity: examples/perplexity/perplexity.cpp ggml.o llama.o common.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
-embedding: examples/embedding/embedding.cpp ggml.o llama.o common.o
-	$(CXX) $(CXXFLAGS) examples/embedding/embedding.cpp ggml.o llama.o common.o -o embedding $(LDFLAGS)
+embedding: examples/embedding/embedding.cpp ggml.o llama.o common.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
-libllama.so: llama.o ggml.o
-	$(CXX) $(CXXFLAGS) -shared -fPIC -o libllama.so llama.o ggml.o $(LDFLAGS)
+libllama.so: llama.o ggml.o ggml_extra.o
+	$(CXX) $(CXXFLAGS) -shared -fPIC -o $@ $^ $(LDFLAGS)
 #
 # Tests
 #

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -307,7 +307,7 @@ int main(int argc, char ** argv) {
 
     // loop throught quantization types
     //for (int i = 0; i < GGML_TYPE_COUNT; i++) {
-    for (int i = 1; i < 2; i++) {
+    for (int i = 0; i < 1; i++) {
         if (!params.include_types.empty() && std::find(params.include_types.begin(), params.include_types.end(), i) == params.include_types.end()) {
             continue;
         }
@@ -315,12 +315,14 @@ int main(int argc, char ** argv) {
         if (i < 2 && checkNewQuantization) {
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ4_1;
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1;
-            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
+            ////qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
             //if (i == 1) qfns.dequantize_row_q = kDequantizeQ5_1;
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ5_1;
             //qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ5_1;
-            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ4_1K;
-            qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ4_1K;
+            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ4_1K;
+            //qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ4_1K;
+            qfns.quantize_row_q = i == 0 ? kQuantizeQ8Simple: kQuantizeQ4_1K;
+            qfns.dequantize_row_q = i == 0 ? kDequantizeQ8: kDequantizeQ4_1K;
         }
         if (qfns.quantize_row_q && qfns.dequantize_row_q) {
             if (params.verbose) {

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -307,7 +307,7 @@ int main(int argc, char ** argv) {
 
     // loop throught quantization types
     //for (int i = 0; i < GGML_TYPE_COUNT; i++) {
-    for (int i = 0; i < 1; i++) {
+    for (int i = 1; i < 2; i++) {
         if (!params.include_types.empty() && std::find(params.include_types.begin(), params.include_types.end(), i) == params.include_types.end()) {
             continue;
         }
@@ -317,8 +317,10 @@ int main(int argc, char ** argv) {
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1;
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
             //if (i == 1) qfns.dequantize_row_q = kDequantizeQ5_1;
-            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ5_1;
-            qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ5_1;
+            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ5_1;
+            //qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ5_1;
+            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ4_1K;
+            qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ4_1K;
         }
         if (qfns.quantize_row_q && qfns.dequantize_row_q) {
             if (params.verbose) {

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -307,7 +307,7 @@ int main(int argc, char ** argv) {
 
     // loop throught quantization types
     //for (int i = 0; i < GGML_TYPE_COUNT; i++) {
-    for (int i = 1; i < 2; i++) {
+    for (int i = 0; i < 1; i++) {
         if (!params.include_types.empty() && std::find(params.include_types.begin(), params.include_types.end(), i) == params.include_types.end()) {
             continue;
         }
@@ -315,8 +315,10 @@ int main(int argc, char ** argv) {
         if (i < 2 && checkNewQuantization) {
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ4_1;
             //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1;
-            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
-            if (i == 1) qfns.dequantize_row_q = kDequantizeQ5_1;
+            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
+            //if (i == 1) qfns.dequantize_row_q = kDequantizeQ5_1;
+            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0K : kQuantizeQ5_1;
+            qfns.dequantize_row_q = i == 0 ? kDequantizeQ4_0K : kDequantizeQ5_1;
         }
         if (qfns.quantize_row_q && qfns.dequantize_row_q) {
             if (params.verbose) {

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -306,13 +306,17 @@ int main(int argc, char ** argv) {
     std::vector<float> output_scratch(SCRATCH_ELEMENTS);
 
     // loop throught quantization types
-    for (int i = 0; i < GGML_TYPE_COUNT; i++) {
+    //for (int i = 0; i < GGML_TYPE_COUNT; i++) {
+    for (int i = 1; i < 2; i++) {
         if (!params.include_types.empty() && std::find(params.include_types.begin(), params.include_types.end(), i) == params.include_types.end()) {
             continue;
         }
         quantize_fns_t qfns = ggml_internal_get_quantize_fn(i);
         if (i < 2 && checkNewQuantization) {
-            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ4_1;
+            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ4_1;
+            //qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1;
+            qfns.quantize_row_q = i == 0 ? kQuantizeQ4_0 : kQuantizeQ5_1_Fast;
+            if (i == 1) qfns.dequantize_row_q = kDequantizeQ5_1;
         }
         if (qfns.quantize_row_q && qfns.dequantize_row_q) {
             if (params.verbose) {

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -14,6 +14,8 @@ int main(int argc, char ** argv) {
         fprintf(stderr, "usage: %s model-f32.bin model-quant.bin type\n", argv[0]);
         fprintf(stderr, "  type = 2 - q4_0\n");
         fprintf(stderr, "  type = 3 - q4_1\n");
+        fprintf(stderr, "  type = 4 - new q4_0\n");
+        fprintf(stderr, "  type = 5 - new q4_1\n");
         return 1;
     }
 

--- a/ggml.c
+++ b/ggml.c
@@ -536,10 +536,10 @@ static void quantize_row_q4_0_reference(const float * restrict x, block_q4_0 * r
 
             // On x86_64 and x86, round is amazingly slow.
             // Here it is best to just use this:
-            const uint8_t vi0 = (uint8_t)(v0 + 8.5f);
-            const uint8_t vi1 = (uint8_t)(v1 + 8.5f);
-            //const uint8_t vi0 = (int8_t)roundf(v0) + 8;
-            //const uint8_t vi1 = (int8_t)roundf(v1) + 8;
+            //const uint8_t vi0 = (uint8_t)(v0 + 8.5f);
+            //const uint8_t vi1 = (uint8_t)(v1 + 8.5f);
+            const uint8_t vi0 = (int8_t)roundf(v0) + 8;
+            const uint8_t vi1 = (int8_t)roundf(v1) + 8;
             // This is marginally slower (but still much faster than round())
             //const uint8_t vi0 = nearestInt(v0) + 8;
             //const uint8_t vi1 = nearestInt(v1) + 8;
@@ -835,8 +835,10 @@ static void quantize_row_q4_1_reference(const float * restrict x, void * restric
 
             // For some reason round() is amazingly slow on X86_64 and x86
             // Using this instead reduces the difference between AVX2 and scalar to less than ~15%
-            const uint8_t vi0 = nearestInt(v0); //roundf(v0);
-            const uint8_t vi1 = nearestInt(v1); //roundf(v1);
+            //const uint8_t vi0 = nearestInt(v0);
+            //const uint8_t vi1 = nearestInt(v1);
+            const uint8_t vi0 = roundf(v0);
+            const uint8_t vi1 = roundf(v1);
 
             assert(vi0 < 16);
             assert(vi1 < 16);

--- a/ggml.c
+++ b/ggml.c
@@ -2579,8 +2579,6 @@ inline static void ggml_vec_norm_inv_f32(const int n, float * s, const float * x
 static const int GGML_BLCK_SIZE[GGML_TYPE_COUNT] = {
     QK,
     QK,
-    QK,
-    QK,
     1,
     1,
     1,

--- a/ggml_extra.cpp
+++ b/ggml_extra.cpp
@@ -1,0 +1,204 @@
+#include "ggml_extra.h"
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <cassert>
+#include <thread>
+#include <atomic>
+#include <cstring>
+
+namespace {
+
+inline int toNearestInt(float fval) {
+    assert(fval <= 4194303.f);
+    constexpr float kSnapper=3<<22;
+    auto val = fval + kSnapper;
+    int i; std::memcpy(&i, &val, sizeof(int));
+    return (i & 0x007fffff) - 0x00400000;
+}
+
+float kQuantize0(int n, const float* X, int8_t* L, std::vector<std::pair<float,int>>& work, int nmin, int nmax) {
+    work.clear();
+    work.reserve(n*(nmax+2));
+    float max = 0; int imax = -1;
+    for (int i=0; i<n; ++i) {
+        float x = std::abs(X[i]);
+        if (x > max) { max = x; imax = i; }
+    }
+    if (imax < 0) {  // all X are zero
+        for (int i=0; i<n; ++i) L[i] = 0;
+        return 1.f;
+    }
+    float maxi = 1/max;
+    int kmin, kmax;
+    {
+        float scale0 = nmax*maxi;
+        double sumlx0 = 0; int suml20 = 0;
+        for (int i=0; i<n; ++i) {
+            int l = std::max(nmin, std::min(nmax, toNearestInt(scale0*X[i])));
+            sumlx0 += X[i]*l; suml20 += l*l;
+        }
+        auto df0 = suml20/scale0 - sumlx0;
+        if (df0 > 0) {
+            kmin = nmax-2; kmax = nmax + 1;
+        } else {
+            kmin = nmax/2; kmax = nmax+1;
+        }
+    }
+    for (int k=kmin; k<=kmax; ++k) work.push_back({(k + 0.501f)*maxi, imax});
+    float minScale = work.front().first;
+    float maxScale = work.back().first;
+    for (int i=0; i<n; ++i) {
+        L[i] = 0;
+        auto x = std::abs(X[i]);
+        if (i == imax || !x) continue;
+        int kkmin = std::max(0, int(minScale*x-0.501f));
+        int kkmax = std::min(kmax, int(maxScale*x));
+        auto xi = 1/x;
+        for (int k=kkmin; k<=kkmax; ++k) {
+            auto s = (k + 0.501f)*xi;
+            if (s > maxScale) break;
+            if (s > minScale) work.push_back({s,i});
+        }
+    }
+    std::sort(work.begin(), work.end());
+    float sumlx = 0; int suml2 = 0;
+    float s = work.front().first;
+    for (int i=0; i<n; ++i) {
+        int l = std::max(nmin, std::min(nmax, toNearestInt(s*X[i])));
+        sumlx += X[i]*l; suml2 += l*l;
+        L[i] = l;
+    }
+    float bestSumlx = sumlx, bestSumlx2 = sumlx*sumlx; int bestSuml2 = suml2; float bests = s;
+    float lasts = s;
+    for (int k=1; k<int(work.size()); ++k) {
+        s = work[k].first; int i = work[k].second;
+        int l = std::max(nmin, std::min(nmax, toNearestInt(s*X[i])));
+        if (l == L[i]) { lasts = s; continue; }
+        if (l > L[i]) {
+            sumlx += X[i];
+            suml2 += 1 + 2*L[i];
+        }
+        else {
+            sumlx -= X[i];
+            suml2 += 1 - 2*L[i];
+        }
+        L[i] = l;
+        float sumlx2 = sumlx*sumlx;
+        if ((s != lasts || k == int(work.size())-1) && suml2 > 0 && sumlx2*bestSuml2 > bestSumlx2*suml2) {
+            bestSumlx = sumlx; bestSumlx2 = sumlx2; bestSuml2 = suml2; bests = s;
+        }
+        lasts = s;
+    }
+    for (int i=0; i<n; ++i) L[i] = std::max(nmin, std::min(nmax, toNearestInt(bests*X[i])));
+    return bestSumlx/bestSuml2;
+}
+
+std::pair<float, float> kQuantize1(int n, const float* X, int8_t* L, std::vector<float>& tmpX,
+        std::vector<std::pair<float,int>>& work, int nmax) {
+    float min = X[0], max = X[1];
+    for (int i=1; i<n; ++i) {
+        min = std::min(min, X[i]); max = std::max(max, X[i]);
+    }
+    if (max == min) {
+        for (int i=0; i<n; ++i) L[i] = 0;
+        return {min, 1.f};
+    }
+    if (int(tmpX.size()) < n) tmpX.resize(n);
+    double a = min, b;
+    for (int itry=0; itry<3; ++itry) {
+        for (int i=0; i<n; ++i) tmpX[i] = X[i] - a;
+        kQuantize0(n, tmpX.data(), L, work, 0, 2*nmax+1);
+        double sumlx = 0, sumx = 0;
+        int suml2 = 0, suml = 0;
+        for (int i=0; i<n; ++i) {
+            auto l = L[i];
+            sumlx += X[i]*l;
+            suml2 += l*l;
+            suml  += l;
+            sumx  += X[i];
+        }
+        int64_t D = suml2*n - suml*suml;
+        a = (sumx*suml2 - sumlx*suml)/D;
+        b = (sumlx*n - sumx*suml)/D;
+    }
+    return {a, b};
+}
+
+void kQuantizeQ4(const float* GGML_RESTRICT x, void* GGML_RESTRICT buffer, int k, int type) {
+    constexpr int kChunkSize = 32*32*8;
+    constexpr int QK = 32;
+    constexpr int kBucketSize0 = QK/2 + sizeof(float);
+    constexpr int kBucketSize1 = QK/2 + 2*sizeof(float);
+    assert(k % QK == 0);
+
+    auto processOne = [type] (const float* X, int8_t* L, char* y, std::vector<std::pair<float, int>>& work, std::vector<float>& tmpX) {
+        if (type == 0) {
+            float scale = kQuantize0(QK, X, L, work, -7, 7);
+            std::memcpy(y, &scale, sizeof(scale)); y += sizeof(scale);
+            uint8_t* q = (uint8_t*)y;
+            for (int k=0; k<QK/2; ++k) q[k] = (L[2*k] + 8) | ((L[2*k+1] + 8) << 4);
+        } else {
+            auto result = kQuantize1(QK, X, L, tmpX, work, 7);
+            std::memcpy(y, &result.second, sizeof(result.second)); y += sizeof(result.second);
+            std::memcpy(y, &result.first,  sizeof(result.first));  y += sizeof(result.first);
+            uint8_t* q = (uint8_t*)y;
+            for (int k=0; k<QK/2; ++k) q[k] = L[2*k] | (L[2*k+1] << 4);
+        }
+    };
+
+    auto bucketSize = type == 0 ? kBucketSize0 : kBucketSize1;
+    auto y = (char*)buffer;
+    int nchunk = (k + kChunkSize-1)/kChunkSize;
+    if (nchunk < 2) {
+        std::vector<int8_t> L(QK);
+        std::vector<std::pair<float,int>> work;
+        std::vector<float> tmpX;
+        int nb = k / QK;
+        for (int i=0; i<nb; ++i) {
+            processOne(x + QK*i, L.data(), y, work, tmpX);
+            y += bucketSize; x += QK;
+        }
+        return;
+    }
+
+    std::atomic<int> counter(0);
+    auto compute = [&counter, x, y, k, bucketSize, &processOne] () {
+        std::vector<int8_t> L(QK);
+        std::vector<std::pair<float,int>> work;
+        std::vector<float> tmpX;
+        while (true) {
+            int first = counter.fetch_add(kChunkSize);
+            if (first >= k) break;
+            int last = first + kChunkSize;
+            if (last > k) last = k;
+            auto xi = x + first;
+            auto yi = y + (first/QK)*bucketSize;
+            int n = (last - first)/QK;
+            for (int i=0; i<n; ++i) {
+                processOne(xi, L.data(), yi, work, tmpX);
+                yi += bucketSize; xi += QK;
+            }
+        }
+    };
+    int nthread = std::min(nchunk, int(std::thread::hardware_concurrency()));
+    std::vector<std::thread> workers(nthread-1);
+    for (auto& w : workers) w = std::thread(compute);
+    compute();
+    for (auto& w : workers) w.join();
+}
+
+}
+
+extern "C" {
+
+void kQuantizeQ4_0(const float* x, void* buffer, int k) {
+    kQuantizeQ4(x, buffer, k, 0);
+}
+
+void kQuantizeQ4_1(const float* x, void* buffer, int k) {
+    kQuantizeQ4(x, buffer, k, 1);
+}
+
+}

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#ifdef  __cplusplus
+// restrict not standard in C++
+#define GGML_RESTRICT
+#else
+#define GGML_RESTRICT restrict
+#endif
+
+void kQuantizeQ4_0(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+
+void kQuantizeQ4_1(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+
+#ifdef  __cplusplus
+}
+#endif

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -31,6 +31,9 @@ void kDequantizeQ5_1(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int 
 void kQuantizeQ4_0K(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
 void kDequantizeQ4_0K(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
 
+void kQuantizeQ4_1K(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+void kDequantizeQ4_1K(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #ifdef  __cplusplus
+#include <cstdint>
+#include <cstddef>
 extern "C" {
+#else
+#include <stdint.h>
+#include <stddef.h>
 #endif
 
 #ifdef  __cplusplus
@@ -12,8 +17,10 @@ extern "C" {
 #endif
 
 void kQuantizeQ4_0(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+size_t kQuantizeQ4_0H(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
 
 void kQuantizeQ4_1(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+size_t kQuantizeQ4_1H(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
 
 #ifdef  __cplusplus
 }

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -28,6 +28,9 @@ void kQuantizeQ5_1_Fast(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int
 size_t kQuantizeQ5_1H_Fast(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
 void kDequantizeQ5_1(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
 
+void kQuantizeQ4_0K(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+void kDequantizeQ4_0K(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -34,6 +34,9 @@ void kDequantizeQ4_0K(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int
 void kQuantizeQ4_1K(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
 void kDequantizeQ4_1K(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
 
+void kQuantizeQ8Simple(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+void kDequantizeQ8(const void* GGML_RESTRICT x, float* GGML_RESTRICT y, int k);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml_extra.h
+++ b/ggml_extra.h
@@ -22,6 +22,12 @@ size_t kQuantizeQ4_0H(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k
 void kQuantizeQ4_1(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
 size_t kQuantizeQ4_1H(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
 
+void kQuantizeQ5_1(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+size_t kQuantizeQ5_1H(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
+void kQuantizeQ5_1_Fast(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k);
+size_t kQuantizeQ5_1H_Fast(const float* GGML_RESTRICT x, void* GGML_RESTRICT y, int k, int64_t* hist);
+void kDequantizeQ5_1(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int k);
+
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
### Update

After seeing PR #835, I pushed some more changes that only affect the `Q4_0` results. I now get
```
rmse = 0.00185228
```
for the 7B model. Perplexity becomes `6.2644`. This is the result on my MacBook with M2 Max. Running the same quantization on a Ryzen 7950X gives completely different results. The test is still running, but so far it looks like it will end up with a ~0.3 higher perplexity. ~I guess, there is a problem with the AVX2 version that is being used there~. @ggerganov  tells me that the difference I'm observing is simply due to using BLAS on the Mac and not using BLAS on the Ryzen 7950X.

### Update 2

OK, it looks like the low perplexities I'm getting are simply due to the fact that I'm running on the Mac, where BLAS is enabled by default. So, basically, most of the reduction in perplexity I'm observing is simply due to the full precision in matrix multiplications. I will rerun perplexity without BLAS (or with BLAS using the reference `Q4_0` quantization) and will post the results. This will better tell us how much one can gain from improving the quantization.

### Update 3

Perplexity of the 7B model with reference `Q4_0` quantization and BLAS enabled is `6.2838` after 655 chunks. So, basically, the ~25% reduction in MSE of the quantized weights results in a 0.02 improvement in perplexity. In contrast, full precision in matrix multiplications via BLAS improves perplexity by ~0.3. Which basically means that this PR is pretty pointless.  

### Update 4

Perplexity results for 7B and 13B with `Q4_0` and `Q4_1` are available [here](https://github.com/ggerganov/llama.cpp/discussions/406#discussioncomment-5593328)

A also added a POC for 5-bit quantization. Memory/disk usage is the same as the current `Q4_1` by using two `fp16` floats instead of two `fp32` floats. For each quantized value in a set of 32 weights, it stores 4 of the 5 bits as `Q4`. It then uses the 32 bits that are now not used due to `fp16` to store a flag if the corresponding value has the 5th bit set. The encoding/decoding ends up being not too bad at the end.

The improvement in `rmse` compared to `Q4_1` is dramatic. I get
```
rmse 0.00076131, maxerr 0.05273438, 95pct<0.0016, median<0.0006 
```
after a full round trip of quantization - dequantization.
<details>
iwan@MacBook-Pro:~/other/llama.cpp/build$ ./bin/quantize-stats -m ../../quant/models/7B/ggml-model-f16-new.bin -nq -p
Loading model
llama.cpp: loading model from ../../quant/models/7B/ggml-model-f16-new.bin
llama_model_load_internal: format     = ggjt v1 (latest) 
llama_model_load_internal: n_vocab    = 32000     
llama_model_load_internal: n_ctx      = 256       
llama_model_load_internal: n_embd     = 4096      
llama_model_load_internal: n_mult     = 256       
llama_model_load_internal: n_head     = 32        
llama_model_load_internal: n_layer    = 32        
llama_model_load_internal: n_rot      = 128       
llama_model_load_internal: f16        = 1         
llama_model_load_internal: n_ff       = 11008     
llama_model_load_internal: n_parts    = 1         
llama_model_load_internal: model size = 7B        
llama_model_load_internal: ggml ctx size =  59.11 KB
llama_model_load_internal: mem required  = 14645.07 MB (+ 2052.00 MB per state)
llama_init_from_file: kv self size  =  256.00 MB  
note: source model is f16
testing 291 layers with max size 131072000        
q4_1::tok_embeddings.weight                       : rmse 0.00067479, maxerr 0.00573730, 95pct<0.0014, median<0.0006
q4_1::norm.weight                                 : rmse 0.00464176, maxerr 0.02522278, 95pct<0.0098, median<0.0028
q4_1::output.weight                               : rmse 0.00067622, maxerr 0.00727844, 95pct<0.0014, median<0.0006
q4_1::layers.0.attention.wq.weight                : rmse 0.00113705, maxerr 0.01367188, 95pct<0.0024, median<0.0008
q4_1::layers.0.attention.wk.weight                : rmse 0.00112141, maxerr 0.02249146, 95pct<0.0024, median<0.0008
q4_1::layers.0.attention.wv.weight                : rmse 0.00045496, maxerr 0.00343323, 95pct<0.0010, median<0.0004
q4_1::layers.0.attention.wo.weight                : rmse 0.00040908, maxerr 0.01490784, 95pct<0.0008, median<0.0004
q4_1::layers.0.feed_forward.w1.weight             : rmse 0.00056531, maxerr 0.02049255, 95pct<0.0012, median<0.0006
q4_1::layers.0.feed_forward.w2.weight             : rmse 0.00068808, maxerr 0.01811218, 95pct<0.0014, median<0.0006
q4_1::layers.0.feed_forward.w3.weight             : rmse 0.00054793, maxerr 0.00539398, 95pct<0.0012, median<0.0006
q4_1::layers.0.attention_norm.weight              : rmse 0.00184961, maxerr 0.01128960, 95pct<0.0046, median<0.0004
q4_1::layers.0.ffn_norm.weight                    : rmse 0.00057309, maxerr 0.00354767, 95pct<0.0014, median<0.0004
q4_1::layers.1.attention.wq.weight                : rmse 0.00113066, maxerr 0.01373291, 95pct<0.0024, median<0.0008
q4_1::layers.1.attention.wk.weight                : rmse 0.00115275, maxerr 0.01394653, 95pct<0.0026, median<0.0008
q4_1::layers.1.attention.wv.weight                : rmse 0.00038954, maxerr 0.00264549, 95pct<0.0008, median<0.0004
q4_1::layers.1.attention.wo.weight                : rmse 0.00039675, maxerr 0.01858521, 95pct<0.0008, median<0.0004
q4_1::layers.1.feed_forward.w1.weight             : rmse 0.00071841, maxerr 0.01058960, 95pct<0.0014, median<0.0006
q4_1::layers.1.feed_forward.w2.weight             : rmse 0.00070427, maxerr 0.01712418, 95pct<0.0014, median<0.0006
q4_1::layers.1.feed_forward.w3.weight             : rmse 0.00068200, maxerr 0.00634003, 95pct<0.0014, median<0.0006
q4_1::layers.1.attention_norm.weight              : rmse 0.00113834, maxerr 0.00441742, 95pct<0.0022, median<0.0010
q4_1::layers.1.ffn_norm.weight                    : rmse 0.00045691, maxerr 0.00189972, 95pct<0.0012, median<0.0004
q4_1::layers.2.attention.wq.weight                : rmse 0.00122553, maxerr 0.01284790, 95pct<0.0026, median<0.0008
q4_1::layers.2.attention.wk.weight                : rmse 0.00126909, maxerr 0.01083374, 95pct<0.0026, median<0.0008
q4_1::layers.2.attention.wv.weight                : rmse 0.00046610, maxerr 0.00373840, 95pct<0.0010, median<0.0004
q4_1::layers.2.attention.wo.weight                : rmse 0.00047293, maxerr 0.02255249, 95pct<0.0010, median<0.0004
q4_1::layers.2.feed_forward.w1.weight             : rmse 0.00075789, maxerr 0.02072144, 95pct<0.0014, median<0.0006
q4_1::layers.2.feed_forward.w2.weight             : rmse 0.00070288, maxerr 0.02935791, 95pct<0.0014, median<0.0006
q4_1::layers.2.feed_forward.w3.weight             : rmse 0.00069113, maxerr 0.01350403, 95pct<0.0014, median<0.0006
q4_1::layers.2.attention_norm.weight              : rmse 0.00066977, maxerr 0.00357437, 95pct<0.0016, median<0.0004
q4_1::layers.2.ffn_norm.weight                    : rmse 0.00057539, maxerr 0.00602722, 95pct<0.0014, median<0.0002
q4_1::layers.3.attention.wq.weight                : rmse 0.00100399, maxerr 0.01467896, 95pct<0.0020, median<0.0008
q4_1::layers.3.attention.wk.weight                : rmse 0.00105630, maxerr 0.00891876, 95pct<0.0022, median<0.0008
q4_1::layers.3.attention.wv.weight                : rmse 0.00055252, maxerr 0.00350380, 95pct<0.0012, median<0.0006
q4_1::layers.3.attention.wo.weight                : rmse 0.00055156, maxerr 0.02120972, 95pct<0.0012, median<0.0006
q4_1::layers.3.feed_forward.w1.weight             : rmse 0.00076589, maxerr 0.00913620, 95pct<0.0014, median<0.0006
q4_1::layers.3.feed_forward.w2.weight             : rmse 0.00070594, maxerr 0.01667786, 95pct<0.0014, median<0.0006
q4_1::layers.3.feed_forward.w3.weight             : rmse 0.00070419, maxerr 0.00675297, 95pct<0.0014, median<0.0006
q4_1::layers.3.attention_norm.weight              : rmse 0.00064717, maxerr 0.00405121, 95pct<0.0016, median<0.0004
q4_1::layers.3.ffn_norm.weight                    : rmse 0.00052969, maxerr 0.00325775, 95pct<0.0014, median<0.0002
q4_1::layers.4.attention.wq.weight                : rmse 0.00102266, maxerr 0.01240540, 95pct<0.0020, median<0.0008
q4_1::layers.4.attention.wk.weight                : rmse 0.00103666, maxerr 0.00794220, 95pct<0.0022, median<0.0008
q4_1::layers.4.attention.wv.weight                : rmse 0.00055190, maxerr 0.00349617, 95pct<0.0012, median<0.0006
q4_1::layers.4.attention.wo.weight                : rmse 0.00055145, maxerr 0.01269531, 95pct<0.0012, median<0.0006
q4_1::layers.4.feed_forward.w1.weight             : rmse 0.00077576, maxerr 0.01290894, 95pct<0.0016, median<0.0006
q4_1::layers.4.feed_forward.w2.weight             : rmse 0.00070362, maxerr 0.02110291, 95pct<0.0014, median<0.0006
q4_1::layers.4.feed_forward.w3.weight             : rmse 0.00070692, maxerr 0.00906372, 95pct<0.0014, median<0.0006
q4_1::layers.4.attention_norm.weight              : rmse 0.00073026, maxerr 0.00402832, 95pct<0.0018, median<0.0004
q4_1::layers.4.ffn_norm.weight                    : rmse 0.00051424, maxerr 0.00222015, 95pct<0.0014, median<0.0002
q4_1::layers.5.attention.wq.weight                : rmse 0.00097000, maxerr 0.01222229, 95pct<0.0020, median<0.0008
q4_1::layers.5.attention.wk.weight                : rmse 0.00097998, maxerr 0.00923157, 95pct<0.0020, median<0.0008
q4_1::layers.5.attention.wv.weight                : rmse 0.00056170, maxerr 0.00393677, 95pct<0.0012, median<0.0006
q4_1::layers.5.attention.wo.weight                : rmse 0.00055888, maxerr 0.01965332, 95pct<0.0012, median<0.0006
q4_1::layers.5.feed_forward.w1.weight             : rmse 0.00079171, maxerr 0.00949097, 95pct<0.0016, median<0.0006
q4_1::layers.5.feed_forward.w2.weight             : rmse 0.00069678, maxerr 0.01489258, 95pct<0.0014, median<0.0006
q4_1::layers.5.feed_forward.w3.weight             : rmse 0.00070391, maxerr 0.00760412, 95pct<0.0014, median<0.0006
q4_1::layers.5.attention_norm.weight              : rmse 0.00064811, maxerr 0.00418091, 95pct<0.0014, median<0.0004
q4_1::layers.5.ffn_norm.weight                    : rmse 0.00048299, maxerr 0.00224304, 95pct<0.0014, median<0.0002
q4_1::layers.6.attention.wq.weight                : rmse 0.00097928, maxerr 0.01423645, 95pct<0.0020, median<0.0008
q4_1::layers.6.attention.wk.weight                : rmse 0.00100344, maxerr 0.00769806, 95pct<0.0020, median<0.0008
q4_1::layers.6.attention.wv.weight                : rmse 0.00056611, maxerr 0.00344467, 95pct<0.0012, median<0.0006
q4_1::layers.6.attention.wo.weight                : rmse 0.00056490, maxerr 0.01663208, 95pct<0.0012, median<0.0006
q4_1::layers.6.feed_forward.w1.weight             : rmse 0.00078077, maxerr 0.01182556, 95pct<0.0016, median<0.0006
q4_1::layers.6.feed_forward.w2.weight             : rmse 0.00070368, maxerr 0.01443481, 95pct<0.0014, median<0.0006
q4_1::layers.6.feed_forward.w3.weight             : rmse 0.00071282, maxerr 0.00653839, 95pct<0.0014, median<0.0006
q4_1::layers.6.attention_norm.weight              : rmse 0.00065040, maxerr 0.00478363, 95pct<0.0014, median<0.0004
q4_1::layers.6.ffn_norm.weight                    : rmse 0.00045547, maxerr 0.00253296, 95pct<0.0012, median<0.0002
q4_1::layers.7.attention.wq.weight                : rmse 0.00096305, maxerr 0.01339722, 95pct<0.0020, median<0.0008
q4_1::layers.7.attention.wk.weight                : rmse 0.00097201, maxerr 0.00742340, 95pct<0.0020, median<0.0008
q4_1::layers.7.attention.wv.weight                : rmse 0.00058344, maxerr 0.00369263, 95pct<0.0012, median<0.0006
q4_1::layers.7.attention.wo.weight                : rmse 0.00057667, maxerr 0.01287842, 95pct<0.0012, median<0.0006
q4_1::layers.7.feed_forward.w1.weight             : rmse 0.00077346, maxerr 0.00889587, 95pct<0.0016, median<0.0006
q4_1::layers.7.feed_forward.w2.weight             : rmse 0.00070649, maxerr 0.01315308, 95pct<0.0014, median<0.0006
q4_1::layers.7.feed_forward.w3.weight             : rmse 0.00071581, maxerr 0.00903320, 95pct<0.0014, median<0.0006
q4_1::layers.7.attention_norm.weight              : rmse 0.00078184, maxerr 0.00570679, 95pct<0.0018, median<0.0004
q4_1::layers.7.ffn_norm.weight                    : rmse 0.00041102, maxerr 0.00209045, 95pct<0.0010, median<0.0002
q4_1::layers.8.attention.wq.weight                : rmse 0.00094744, maxerr 0.01050568, 95pct<0.0020, median<0.0008
q4_1::layers.8.attention.wk.weight                : rmse 0.00094850, maxerr 0.00811768, 95pct<0.0020, median<0.0008
q4_1::layers.8.attention.wv.weight                : rmse 0.00057753, maxerr 0.00346375, 95pct<0.0012, median<0.0006
q4_1::layers.8.attention.wo.weight                : rmse 0.00057410, maxerr 0.01193237, 95pct<0.0012, median<0.0006
q4_1::layers.8.feed_forward.w1.weight             : rmse 0.00077391, maxerr 0.00781250, 95pct<0.0016, median<0.0006
q4_1::layers.8.feed_forward.w2.weight             : rmse 0.00070675, maxerr 0.01203918, 95pct<0.0014, median<0.0006
q4_1::layers.8.feed_forward.w3.weight             : rmse 0.00071790, maxerr 0.00637674, 95pct<0.0014, median<0.0006
q4_1::layers.8.attention_norm.weight              : rmse 0.00078496, maxerr 0.00555420, 95pct<0.0018, median<0.0004
q4_1::layers.8.ffn_norm.weight                    : rmse 0.00039499, maxerr 0.00217056, 95pct<0.0010, median<0.0002
q4_1::layers.9.attention.wq.weight                : rmse 0.00091703, maxerr 0.01177216, 95pct<0.0018, median<0.0008
q4_1::layers.9.attention.wk.weight                : rmse 0.00092338, maxerr 0.00704193, 95pct<0.0020, median<0.0006
q4_1::layers.9.attention.wv.weight                : rmse 0.00057349, maxerr 0.00370789, 95pct<0.0012, median<0.0006
q4_1::layers.9.attention.wo.weight                : rmse 0.00056955, maxerr 0.01493835, 95pct<0.0012, median<0.0006
q4_1::layers.9.feed_forward.w1.weight             : rmse 0.00076262, maxerr 0.01126099, 95pct<0.0016, median<0.0006
q4_1::layers.9.feed_forward.w2.weight             : rmse 0.00071218, maxerr 0.01254272, 95pct<0.0014, median<0.0006
q4_1::layers.9.feed_forward.w3.weight             : rmse 0.00072266, maxerr 0.01207066, 95pct<0.0014, median<0.0006
q4_1::layers.9.attention_norm.weight              : rmse 0.00083655, maxerr 0.00610352, 95pct<0.0020, median<0.0006
q4_1::layers.9.ffn_norm.weight                    : rmse 0.00036572, maxerr 0.00198364, 95pct<0.0010, median<0.0002
q4_1::layers.10.attention.wq.weight               : rmse 0.00091798, maxerr 0.00944328, 95pct<0.0018, median<0.0008
q4_1::layers.10.attention.wk.weight               : rmse 0.00092796, maxerr 0.00902557, 95pct<0.0020, median<0.0008
q4_1::layers.10.attention.wv.weight               : rmse 0.00059499, maxerr 0.00408936, 95pct<0.0012, median<0.0006
q4_1::layers.10.attention.wo.weight               : rmse 0.00059391, maxerr 0.01306152, 95pct<0.0012, median<0.0006
q4_1::layers.10.feed_forward.w1.weight            : rmse 0.00075719, maxerr 0.00927734, 95pct<0.0014, median<0.0006
q4_1::layers.10.feed_forward.w2.weight            : rmse 0.00071889, maxerr 0.01138306, 95pct<0.0014, median<0.0006
q4_1::layers.10.feed_forward.w3.weight            : rmse 0.00073179, maxerr 0.00698090, 95pct<0.0014, median<0.0006
q4_1::layers.10.attention_norm.weight             : rmse 0.00081416, maxerr 0.00582886, 95pct<0.0018, median<0.0004
q4_1::layers.10.ffn_norm.weight                   : rmse 0.00037315, maxerr 0.00198364, 95pct<0.0010, median<0.0002
q4_1::layers.11.attention.wq.weight               : rmse 0.00094457, maxerr 0.01239014, 95pct<0.0020, median<0.0008
q4_1::layers.11.attention.wk.weight               : rmse 0.00095987, maxerr 0.00829315, 95pct<0.0020, median<0.0008
q4_1::layers.11.attention.wv.weight               : rmse 0.00062563, maxerr 0.00389481, 95pct<0.0012, median<0.0006
q4_1::layers.11.attention.wo.weight               : rmse 0.00062213, maxerr 0.01336670, 95pct<0.0012, median<0.0006
q4_1::layers.11.feed_forward.w1.weight            : rmse 0.00075509, maxerr 0.00779724, 95pct<0.0014, median<0.0006
q4_1::layers.11.feed_forward.w2.weight            : rmse 0.00072435, maxerr 0.01480103, 95pct<0.0014, median<0.0006
q4_1::layers.11.feed_forward.w3.weight            : rmse 0.00073620, maxerr 0.00790024, 95pct<0.0014, median<0.0006
q4_1::layers.11.attention_norm.weight             : rmse 0.00081532, maxerr 0.00553894, 95pct<0.0020, median<0.0004
q4_1::layers.11.ffn_norm.weight                   : rmse 0.00034090, maxerr 0.00186920, 95pct<0.0008, median<0.0002
q4_1::layers.12.attention.wq.weight               : rmse 0.00090180, maxerr 0.01110840, 95pct<0.0018, median<0.0008
q4_1::layers.12.attention.wk.weight               : rmse 0.00091626, maxerr 0.00747681, 95pct<0.0020, median<0.0008
q4_1::layers.12.attention.wv.weight               : rmse 0.00060456, maxerr 0.00358963, 95pct<0.0012, median<0.0006
q4_1::layers.12.attention.wo.weight               : rmse 0.00061119, maxerr 0.00909424, 95pct<0.0012, median<0.0006
q4_1::layers.12.feed_forward.w1.weight            : rmse 0.00075938, maxerr 0.01080322, 95pct<0.0016, median<0.0006
q4_1::layers.12.feed_forward.w2.weight            : rmse 0.00072589, maxerr 0.01767731, 95pct<0.0014, median<0.0006
q4_1::layers.12.feed_forward.w3.weight            : rmse 0.00074074, maxerr 0.00480270, 95pct<0.0014, median<0.0006
q4_1::layers.12.attention_norm.weight             : rmse 0.00079187, maxerr 0.00598145, 95pct<0.0018, median<0.0006
q4_1::layers.12.ffn_norm.weight                   : rmse 0.00039970, maxerr 0.00243759, 95pct<0.0010, median<0.0002
q4_1::layers.13.attention.wq.weight               : rmse 0.00088012, maxerr 0.01113892, 95pct<0.0018, median<0.0006
q4_1::layers.13.attention.wk.weight               : rmse 0.00089455, maxerr 0.00920868, 95pct<0.0018, median<0.0006
q4_1::layers.13.attention.wv.weight               : rmse 0.00063239, maxerr 0.00388336, 95pct<0.0012, median<0.0006
q4_1::layers.13.attention.wo.weight               : rmse 0.00063344, maxerr 0.01577759, 95pct<0.0012, median<0.0006
q4_1::layers.13.feed_forward.w1.weight            : rmse 0.00075605, maxerr 0.00798798, 95pct<0.0014, median<0.0006
q4_1::layers.13.feed_forward.w2.weight            : rmse 0.00073209, maxerr 0.01325989, 95pct<0.0014, median<0.0006
q4_1::layers.13.feed_forward.w3.weight            : rmse 0.00074790, maxerr 0.00488091, 95pct<0.0014, median<0.0006
q4_1::layers.13.attention_norm.weight             : rmse 0.00073977, maxerr 0.00601959, 95pct<0.0014, median<0.0004
q4_1::layers.13.ffn_norm.weight                   : rmse 0.00043181, maxerr 0.00242615, 95pct<0.0010, median<0.0002
q4_1::layers.14.attention.wq.weight               : rmse 0.00088644, maxerr 0.00962925, 95pct<0.0018, median<0.0008
q4_1::layers.14.attention.wk.weight               : rmse 0.00089396, maxerr 0.00738525, 95pct<0.0018, median<0.0008
q4_1::layers.14.attention.wv.weight               : rmse 0.00063632, maxerr 0.00393677, 95pct<0.0012, median<0.0006
q4_1::layers.14.attention.wo.weight               : rmse 0.00063472, maxerr 0.01136780, 95pct<0.0012, median<0.0006
q4_1::layers.14.feed_forward.w1.weight            : rmse 0.00075503, maxerr 0.00747681, 95pct<0.0014, median<0.0006
q4_1::layers.14.feed_forward.w2.weight            : rmse 0.00073546, maxerr 0.01710510, 95pct<0.0014, median<0.0006
q4_1::layers.14.feed_forward.w3.weight            : rmse 0.00075066, maxerr 0.00717163, 95pct<0.0014, median<0.0006
q4_1::layers.14.attention_norm.weight             : rmse 0.00069518, maxerr 0.00553131, 95pct<0.0014, median<0.0004
q4_1::layers.14.ffn_norm.weight                   : rmse 0.00042802, maxerr 0.00244141, 95pct<0.0010, median<0.0002
q4_1::layers.15.attention.wq.weight               : rmse 0.00088594, maxerr 0.01150513, 95pct<0.0018, median<0.0006
q4_1::layers.15.attention.wk.weight               : rmse 0.00090233, maxerr 0.00720215, 95pct<0.0018, median<0.0006
q4_1::layers.15.attention.wv.weight               : rmse 0.00063824, maxerr 0.00362396, 95pct<0.0012, median<0.0006
q4_1::layers.15.attention.wo.weight               : rmse 0.00063629, maxerr 0.01213074, 95pct<0.0012, median<0.0006
q4_1::layers.15.feed_forward.w1.weight            : rmse 0.00075536, maxerr 0.00686646, 95pct<0.0014, median<0.0006
q4_1::layers.15.feed_forward.w2.weight            : rmse 0.00073590, maxerr 0.02175903, 95pct<0.0014, median<0.0006
q4_1::layers.15.feed_forward.w3.weight            : rmse 0.00075102, maxerr 0.00634384, 95pct<0.0014, median<0.0006
q4_1::layers.15.attention_norm.weight             : rmse 0.00072914, maxerr 0.00546265, 95pct<0.0016, median<0.0004
q4_1::layers.15.ffn_norm.weight                   : rmse 0.00046546, maxerr 0.00308990, 95pct<0.0012, median<0.0002
q4_1::layers.16.attention.wq.weight               : rmse 0.00087387, maxerr 0.01208496, 95pct<0.0018, median<0.0008
q4_1::layers.16.attention.wk.weight               : rmse 0.00089641, maxerr 0.00708771, 95pct<0.0018, median<0.0008
q4_1::layers.16.attention.wv.weight               : rmse 0.00067898, maxerr 0.00372696, 95pct<0.0014, median<0.0006
q4_1::layers.16.attention.wo.weight               : rmse 0.00067446, maxerr 0.01918030, 95pct<0.0014, median<0.0006
q4_1::layers.16.feed_forward.w1.weight            : rmse 0.00076073, maxerr 0.00684357, 95pct<0.0016, median<0.0006
q4_1::layers.16.feed_forward.w2.weight            : rmse 0.00073517, maxerr 0.01637268, 95pct<0.0014, median<0.0006
q4_1::layers.16.feed_forward.w3.weight            : rmse 0.00074853, maxerr 0.00637054, 95pct<0.0014, median<0.0006
q4_1::layers.16.attention_norm.weight             : rmse 0.00073561, maxerr 0.00589752, 95pct<0.0016, median<0.0004
q4_1::layers.16.ffn_norm.weight                   : rmse 0.00048578, maxerr 0.00316620, 95pct<0.0012, median<0.0002
q4_1::layers.17.attention.wq.weight               : rmse 0.00085523, maxerr 0.01348877, 95pct<0.0018, median<0.0006
q4_1::layers.17.attention.wk.weight               : rmse 0.00087332, maxerr 0.00699615, 95pct<0.0018, median<0.0006
q4_1::layers.17.attention.wv.weight               : rmse 0.00068333, maxerr 0.00382996, 95pct<0.0014, median<0.0006
q4_1::layers.17.attention.wo.weight               : rmse 0.00068313, maxerr 0.01434326, 95pct<0.0014, median<0.0006
q4_1::layers.17.feed_forward.w1.weight            : rmse 0.00076232, maxerr 0.00566864, 95pct<0.0016, median<0.0006
q4_1::layers.17.feed_forward.w2.weight            : rmse 0.00073823, maxerr 0.01303101, 95pct<0.0014, median<0.0006
q4_1::layers.17.feed_forward.w3.weight            : rmse 0.00075083, maxerr 0.00892830, 95pct<0.0014, median<0.0006
q4_1::layers.17.attention_norm.weight             : rmse 0.00066482, maxerr 0.00503540, 95pct<0.0014, median<0.0004
q4_1::layers.17.ffn_norm.weight                   : rmse 0.00051143, maxerr 0.00348663, 95pct<0.0012, median<0.0002
q4_1::layers.18.attention.wq.weight               : rmse 0.00084565, maxerr 0.01126099, 95pct<0.0018, median<0.0006
q4_1::layers.18.attention.wk.weight               : rmse 0.00085699, maxerr 0.00658417, 95pct<0.0018, median<0.0006
q4_1::layers.18.attention.wv.weight               : rmse 0.00068148, maxerr 0.00400162, 95pct<0.0014, median<0.0006
q4_1::layers.18.attention.wo.weight               : rmse 0.00068093, maxerr 0.01626587, 95pct<0.0014, median<0.0006
q4_1::layers.18.feed_forward.w1.weight            : rmse 0.00076836, maxerr 0.00660706, 95pct<0.0016, median<0.0006
q4_1::layers.18.feed_forward.w2.weight            : rmse 0.00073702, maxerr 0.01779175, 95pct<0.0014, median<0.0006
q4_1::layers.18.feed_forward.w3.weight            : rmse 0.00074808, maxerr 0.00534439, 95pct<0.0014, median<0.0006
q4_1::layers.18.attention_norm.weight             : rmse 0.00075162, maxerr 0.00507355, 95pct<0.0016, median<0.0004
q4_1::layers.18.ffn_norm.weight                   : rmse 0.00060263, maxerr 0.00396729, 95pct<0.0014, median<0.0002
q4_1::layers.19.attention.wq.weight               : rmse 0.00083017, maxerr 0.01272583, 95pct<0.0018, median<0.0006
q4_1::layers.19.attention.wk.weight               : rmse 0.00084088, maxerr 0.00719452, 95pct<0.0018, median<0.0006
q4_1::layers.19.attention.wv.weight               : rmse 0.00071467, maxerr 0.00441360, 95pct<0.0014, median<0.0006
q4_1::layers.19.attention.wo.weight               : rmse 0.00070940, maxerr 0.01687622, 95pct<0.0014, median<0.0006
q4_1::layers.19.feed_forward.w1.weight            : rmse 0.00077282, maxerr 0.00881958, 95pct<0.0016, median<0.0006
q4_1::layers.19.feed_forward.w2.weight            : rmse 0.00073796, maxerr 0.01264954, 95pct<0.0014, median<0.0006
q4_1::layers.19.feed_forward.w3.weight            : rmse 0.00074646, maxerr 0.00630951, 95pct<0.0014, median<0.0006
q4_1::layers.19.attention_norm.weight             : rmse 0.00077662, maxerr 0.00615692, 95pct<0.0016, median<0.0004
q4_1::layers.19.ffn_norm.weight                   : rmse 0.00062620, maxerr 0.00425720, 95pct<0.0016, median<0.0004
q4_1::layers.20.attention.wq.weight               : rmse 0.00084113, maxerr 0.01691055, 95pct<0.0018, median<0.0006
q4_1::layers.20.attention.wk.weight               : rmse 0.00085405, maxerr 0.00733185, 95pct<0.0018, median<0.0006
q4_1::layers.20.attention.wv.weight               : rmse 0.00073687, maxerr 0.00400925, 95pct<0.0014, median<0.0006
q4_1::layers.20.attention.wo.weight               : rmse 0.00072742, maxerr 0.01225281, 95pct<0.0014, median<0.0006
q4_1::layers.20.feed_forward.w1.weight            : rmse 0.00077668, maxerr 0.00712967, 95pct<0.0016, median<0.0006
q4_1::layers.20.feed_forward.w2.weight            : rmse 0.00073884, maxerr 0.01961899, 95pct<0.0014, median<0.0006
q4_1::layers.20.feed_forward.w3.weight            : rmse 0.00074688, maxerr 0.00490570, 95pct<0.0014, median<0.0006
q4_1::layers.20.attention_norm.weight             : rmse 0.00078771, maxerr 0.00583649, 95pct<0.0018, median<0.0004
q4_1::layers.20.ffn_norm.weight                   : rmse 0.00064492, maxerr 0.00514984, 95pct<0.0016, median<0.0002
q4_1::layers.21.attention.wq.weight               : rmse 0.00081337, maxerr 0.01411438, 95pct<0.0016, median<0.0006
q4_1::layers.21.attention.wk.weight               : rmse 0.00082242, maxerr 0.00918579, 95pct<0.0018, median<0.0006
q4_1::layers.21.attention.wv.weight               : rmse 0.00074255, maxerr 0.00424957, 95pct<0.0014, median<0.0006
q4_1::layers.21.attention.wo.weight               : rmse 0.00073171, maxerr 0.02182007, 95pct<0.0014, median<0.0006
q4_1::layers.21.feed_forward.w1.weight            : rmse 0.00078057, maxerr 0.00685120, 95pct<0.0016, median<0.0006
q4_1::layers.21.feed_forward.w2.weight            : rmse 0.00073872, maxerr 0.01074219, 95pct<0.0014, median<0.0006
q4_1::layers.21.feed_forward.w3.weight            : rmse 0.00074573, maxerr 0.00585175, 95pct<0.0014, median<0.0006
q4_1::layers.21.attention_norm.weight             : rmse 0.00085819, maxerr 0.00559998, 95pct<0.0018, median<0.0004
q4_1::layers.21.ffn_norm.weight                   : rmse 0.00070441, maxerr 0.00471497, 95pct<0.0018, median<0.0004
q4_1::layers.22.attention.wq.weight               : rmse 0.00082720, maxerr 0.01268435, 95pct<0.0016, median<0.0006
q4_1::layers.22.attention.wk.weight               : rmse 0.00083526, maxerr 0.00759888, 95pct<0.0018, median<0.0006
q4_1::layers.22.attention.wv.weight               : rmse 0.00073750, maxerr 0.00417137, 95pct<0.0014, median<0.0006
q4_1::layers.22.attention.wo.weight               : rmse 0.00073417, maxerr 0.02563477, 95pct<0.0014, median<0.0006
q4_1::layers.22.feed_forward.w1.weight            : rmse 0.00078155, maxerr 0.00765991, 95pct<0.0016, median<0.0006
q4_1::layers.22.feed_forward.w2.weight            : rmse 0.00074211, maxerr 0.01165771, 95pct<0.0014, median<0.0006
q4_1::layers.22.feed_forward.w3.weight            : rmse 0.00074905, maxerr 0.00787354, 95pct<0.0014, median<0.0006
q4_1::layers.22.attention_norm.weight             : rmse 0.00080074, maxerr 0.00627136, 95pct<0.0018, median<0.0004
q4_1::layers.22.ffn_norm.weight                   : rmse 0.00072412, maxerr 0.00478363, 95pct<0.0018, median<0.0004
q4_1::layers.23.attention.wq.weight               : rmse 0.00080186, maxerr 0.01232910, 95pct<0.0016, median<0.0006
q4_1::layers.23.attention.wk.weight               : rmse 0.00080485, maxerr 0.00798798, 95pct<0.0016, median<0.0006
q4_1::layers.23.attention.wv.weight               : rmse 0.00076730, maxerr 0.00468445, 95pct<0.0016, median<0.0006
q4_1::layers.23.attention.wo.weight               : rmse 0.00075430, maxerr 0.02246094, 95pct<0.0014, median<0.0006
q4_1::layers.23.feed_forward.w1.weight            : rmse 0.00078317, maxerr 0.00979614, 95pct<0.0016, median<0.0006
q4_1::layers.23.feed_forward.w2.weight            : rmse 0.00074451, maxerr 0.01216125, 95pct<0.0014, median<0.0006
q4_1::layers.23.feed_forward.w3.weight            : rmse 0.00075047, maxerr 0.00660706, 95pct<0.0014, median<0.0006
q4_1::layers.23.attention_norm.weight             : rmse 0.00099103, maxerr 0.00698853, 95pct<0.0018, median<0.0006
q4_1::layers.23.ffn_norm.weight                   : rmse 0.00077689, maxerr 0.00527191, 95pct<0.0020, median<0.0004
q4_1::layers.24.attention.wq.weight               : rmse 0.00080229, maxerr 0.01250458, 95pct<0.0016, median<0.0006
q4_1::layers.24.attention.wk.weight               : rmse 0.00080784, maxerr 0.00827789, 95pct<0.0016, median<0.0006
q4_1::layers.24.attention.wv.weight               : rmse 0.00077617, maxerr 0.00516891, 95pct<0.0016, median<0.0006
q4_1::layers.24.attention.wo.weight               : rmse 0.00076378, maxerr 0.01571655, 95pct<0.0014, median<0.0006
q4_1::layers.24.feed_forward.w1.weight            : rmse 0.00078416, maxerr 0.00661850, 95pct<0.0016, median<0.0006
q4_1::layers.24.feed_forward.w2.weight            : rmse 0.00074811, maxerr 0.01764297, 95pct<0.0014, median<0.0006
q4_1::layers.24.feed_forward.w3.weight            : rmse 0.00075464, maxerr 0.00608063, 95pct<0.0014, median<0.0006
q4_1::layers.24.attention_norm.weight             : rmse 0.00103406, maxerr 0.00711060, 95pct<0.0022, median<0.0004
q4_1::layers.24.ffn_norm.weight                   : rmse 0.00080069, maxerr 0.00546265, 95pct<0.0020, median<0.0004
q4_1::layers.25.attention.wq.weight               : rmse 0.00082454, maxerr 0.01164246, 95pct<0.0016, median<0.0006
q4_1::layers.25.attention.wk.weight               : rmse 0.00083484, maxerr 0.00672913, 95pct<0.0016, median<0.0006
q4_1::layers.25.attention.wv.weight               : rmse 0.00077909, maxerr 0.00453949, 95pct<0.0016, median<0.0006
q4_1::layers.25.attention.wo.weight               : rmse 0.00077046, maxerr 0.01708984, 95pct<0.0016, median<0.0006
q4_1::layers.25.feed_forward.w1.weight            : rmse 0.00078604, maxerr 0.00747681, 95pct<0.0016, median<0.0006
q4_1::layers.25.feed_forward.w2.weight            : rmse 0.00075059, maxerr 0.01087952, 95pct<0.0014, median<0.0006
q4_1::layers.25.feed_forward.w3.weight            : rmse 0.00075747, maxerr 0.00479889, 95pct<0.0014, median<0.0006
q4_1::layers.25.attention_norm.weight             : rmse 0.00097833, maxerr 0.00801086, 95pct<0.0020, median<0.0004
q4_1::layers.25.ffn_norm.weight                   : rmse 0.00076633, maxerr 0.00572205, 95pct<0.0018, median<0.0004
q4_1::layers.26.attention.wq.weight               : rmse 0.00081107, maxerr 0.01138306, 95pct<0.0016, median<0.0006
q4_1::layers.26.attention.wk.weight               : rmse 0.00082083, maxerr 0.00728607, 95pct<0.0016, median<0.0006
q4_1::layers.26.attention.wv.weight               : rmse 0.00080224, maxerr 0.00533295, 95pct<0.0016, median<0.0008
q4_1::layers.26.attention.wo.weight               : rmse 0.00079334, maxerr 0.01106262, 95pct<0.0016, median<0.0006
q4_1::layers.26.feed_forward.w1.weight            : rmse 0.00078547, maxerr 0.00971985, 95pct<0.0016, median<0.0006
q4_1::layers.26.feed_forward.w2.weight            : rmse 0.00075533, maxerr 0.01620483, 95pct<0.0014, median<0.0006
q4_1::layers.26.feed_forward.w3.weight            : rmse 0.00076290, maxerr 0.01182556, 95pct<0.0014, median<0.0006
q4_1::layers.26.attention_norm.weight             : rmse 0.00098486, maxerr 0.00781250, 95pct<0.0022, median<0.0004
q4_1::layers.26.ffn_norm.weight                   : rmse 0.00075499, maxerr 0.00534821, 95pct<0.0018, median<0.0002
q4_1::layers.27.attention.wq.weight               : rmse 0.00081180, maxerr 0.01181030, 95pct<0.0016, median<0.0006
q4_1::layers.27.attention.wk.weight               : rmse 0.00081854, maxerr 0.00698853, 95pct<0.0016, median<0.0006
q4_1::layers.27.attention.wv.weight               : rmse 0.00081606, maxerr 0.00493622, 95pct<0.0016, median<0.0008
q4_1::layers.27.attention.wo.weight               : rmse 0.00081198, maxerr 0.02349854, 95pct<0.0016, median<0.0008
q4_1::layers.27.feed_forward.w1.weight            : rmse 0.00078540, maxerr 0.01211548, 95pct<0.0016, median<0.0006
q4_1::layers.27.feed_forward.w2.weight            : rmse 0.00075951, maxerr 0.01426315, 95pct<0.0014, median<0.0006
q4_1::layers.27.feed_forward.w3.weight            : rmse 0.00076620, maxerr 0.01175487, 95pct<0.0014, median<0.0006
q4_1::layers.27.attention_norm.weight             : rmse 0.00097933, maxerr 0.00705719, 95pct<0.0022, median<0.0004
q4_1::layers.27.ffn_norm.weight                   : rmse 0.00077453, maxerr 0.00610352, 95pct<0.0018, median<0.0004
q4_1::layers.28.attention.wq.weight               : rmse 0.00079531, maxerr 0.01141357, 95pct<0.0016, median<0.0006
q4_1::layers.28.attention.wk.weight               : rmse 0.00079968, maxerr 0.00871277, 95pct<0.0016, median<0.0006
q4_1::layers.28.attention.wv.weight               : rmse 0.00082040, maxerr 0.00494003, 95pct<0.0016, median<0.0008
q4_1::layers.28.attention.wo.weight               : rmse 0.00082139, maxerr 0.01425171, 95pct<0.0016, median<0.0008
q4_1::layers.28.feed_forward.w1.weight            : rmse 0.00078189, maxerr 0.01318359, 95pct<0.0016, median<0.0006
q4_1::layers.28.feed_forward.w2.weight            : rmse 0.00076300, maxerr 0.01531982, 95pct<0.0014, median<0.0006
q4_1::layers.28.feed_forward.w3.weight            : rmse 0.00076984, maxerr 0.01034546, 95pct<0.0016, median<0.0006
q4_1::layers.28.attention_norm.weight             : rmse 0.00110201, maxerr 0.00842285, 95pct<0.0022, median<0.0004
q4_1::layers.28.ffn_norm.weight                   : rmse 0.00073544, maxerr 0.00648499, 95pct<0.0016, median<0.0004
q4_1::layers.29.attention.wq.weight               : rmse 0.00078770, maxerr 0.01138306, 95pct<0.0016, median<0.0006
q4_1::layers.29.attention.wk.weight               : rmse 0.00079442, maxerr 0.00746536, 95pct<0.0016, median<0.0006
q4_1::layers.29.attention.wv.weight               : rmse 0.00084494, maxerr 0.00521088, 95pct<0.0016, median<0.0008
q4_1::layers.29.attention.wo.weight               : rmse 0.00084553, maxerr 0.01846313, 95pct<0.0016, median<0.0008
q4_1::layers.29.feed_forward.w1.weight            : rmse 0.00078347, maxerr 0.00897980, 95pct<0.0016, median<0.0006
q4_1::layers.29.feed_forward.w2.weight            : rmse 0.00076542, maxerr 0.02725220, 95pct<0.0014, median<0.0006
q4_1::layers.29.feed_forward.w3.weight            : rmse 0.00077436, maxerr 0.00727081, 95pct<0.0016, median<0.0006
q4_1::layers.29.attention_norm.weight             : rmse 0.00114305, maxerr 0.00759888, 95pct<0.0024, median<0.0004
q4_1::layers.29.ffn_norm.weight                   : rmse 0.00069918, maxerr 0.00627136, 95pct<0.0014, median<0.0004
q4_1::layers.30.attention.wq.weight               : rmse 0.00079605, maxerr 0.01003265, 95pct<0.0016, median<0.0006
q4_1::layers.30.attention.wk.weight               : rmse 0.00080232, maxerr 0.00825500, 95pct<0.0016, median<0.0006
q4_1::layers.30.attention.wv.weight               : rmse 0.00083372, maxerr 0.00512314, 95pct<0.0016, median<0.0008
q4_1::layers.30.attention.wo.weight               : rmse 0.00084424, maxerr 0.02038574, 95pct<0.0016, median<0.0008
q4_1::layers.30.feed_forward.w1.weight            : rmse 0.00078815, maxerr 0.00737762, 95pct<0.0016, median<0.0006
q4_1::layers.30.feed_forward.w2.weight            : rmse 0.00078960, maxerr 0.05273438, 95pct<0.0014, median<0.0006
q4_1::layers.30.feed_forward.w3.weight            : rmse 0.00078154, maxerr 0.01219177, 95pct<0.0016, median<0.0006
q4_1::layers.30.attention_norm.weight             : rmse 0.00124695, maxerr 0.00775146, 95pct<0.0028, median<0.0006
q4_1::layers.30.ffn_norm.weight                   : rmse 0.00072293, maxerr 0.00625610, 95pct<0.0016, median<0.0004
q4_1::layers.31.attention.wq.weight               : rmse 0.00080764, maxerr 0.00848770, 95pct<0.0016, median<0.0006
q4_1::layers.31.attention.wk.weight               : rmse 0.00082763, maxerr 0.00734711, 95pct<0.0016, median<0.0006
q4_1::layers.31.attention.wv.weight               : rmse 0.00075143, maxerr 0.00494766, 95pct<0.0014, median<0.0006
q4_1::layers.31.attention.wo.weight               : rmse 0.00076344, maxerr 0.05163574, 95pct<0.0014, median<0.0006
q4_1::layers.31.feed_forward.w1.weight            : rmse 0.00082211, maxerr 0.01235199, 95pct<0.0016, median<0.0008
q4_1::layers.31.feed_forward.w2.weight            : rmse 0.00078318, maxerr 0.04278564, 95pct<0.0016, median<0.0006
q4_1::layers.31.feed_forward.w3.weight            : rmse 0.00081328, maxerr 0.01448441, 95pct<0.0016, median<0.0008
q4_1::layers.31.attention_norm.weight             : rmse 0.00141233, maxerr 0.00952148, 95pct<0.0028, median<0.0008
q4_1::layers.31.ffn_norm.weight                   : rmse 0.00107585, maxerr 0.00598907, 95pct<0.0024, median<0.0008
q4_1                                              : rmse 0.00076131, maxerr 0.05273438, 95pct<0.0016, median<0.0006

main:    total time = 391533.50 ms
</details>

### Update 5

Added a `Q4_0`-like quantization scheme that ends up with a RMSE of ~0.00159 (so basically the same as the best `Q4_1`). Basically, we split a group of 32 weights into two group of 16 and quantize these separately. We store the two scaling factors as `fp16`, ending up using the exact same amount of memory as the current `Q4_0` (5 bits per weight). A round trip of quantization - dequantization results in
```
rmse 0.00159265, maxerr 0.17480469, 95pct<0.0030, median<0.0012
```

<details>
iwan@MacBook-Pro:~/other/llama.cpp/build$ ./bin/quantize-stats -m ../../quant/models/7B/ggml-model-f16-new.bin -nq -p
Loading model
llama.cpp: loading model from ../../quant/models/7B/ggml-model-f16-new.bin
llama_model_load_internal: format     = ggjt v1 (latest)
llama_model_load_internal: n_vocab    = 32000
llama_model_load_internal: n_ctx      = 256
llama_model_load_internal: n_embd     = 4096
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 32
llama_model_load_internal: n_layer    = 32
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: f16        = 1
llama_model_load_internal: n_ff       = 11008
llama_model_load_internal: n_parts    = 1
llama_model_load_internal: model size = 7B
llama_model_load_internal: ggml ctx size =  59.11 KB
llama_model_load_internal: mem required  = 14645.07 MB (+ 2052.00 MB per state)
llama_init_from_file: kv self size  =  256.00 MB
note: source model is f16
testing 291 layers with max size 131072000
q4_0::tok_embeddings.weight                       : rmse 0.00140924, maxerr 0.01599121, 95pct<0.0028, median<0.0012
q4_0::norm.weight                                 : rmse 0.05220819, maxerr 0.17480469, 95pct<0.0300, median<0.0300
q4_0::output.weight                               : rmse 0.00141680, maxerr 0.02381897, 95pct<0.0028, median<0.0012
q4_0::layers.0.attention.wq.weight                : rmse 0.00245018, maxerr 0.04733276, 95pct<0.0052, median<0.0014
q4_0::layers.0.attention.wk.weight                : rmse 0.00240798, maxerr 0.06744385, 95pct<0.0050, median<0.0014
q4_0::layers.0.attention.wv.weight                : rmse 0.00095200, maxerr 0.00719070, 95pct<0.0020, median<0.0008
q4_0::layers.0.attention.wo.weight                : rmse 0.00085718, maxerr 0.03448486, 95pct<0.0018, median<0.0006
q4_0::layers.0.feed_forward.w1.weight             : rmse 0.00118121, maxerr 0.06396484, 95pct<0.0022, median<0.0010
q4_0::layers.0.feed_forward.w2.weight             : rmse 0.00143914, maxerr 0.04794312, 95pct<0.0028, median<0.0012
q4_0::layers.0.feed_forward.w3.weight             : rmse 0.00114520, maxerr 0.01708984, 95pct<0.0022, median<0.0010
q4_0::layers.0.attention_norm.weight              : rmse 0.00726788, maxerr 0.04315186, 95pct<0.0202, median<0.0014
q4_0::layers.0.ffn_norm.weight                    : rmse 0.00297167, maxerr 0.01489258, 95pct<0.0052, median<0.0024
q4_0::layers.1.attention.wq.weight                : rmse 0.00236875, maxerr 0.03283691, 95pct<0.0050, median<0.0014
q4_0::layers.1.attention.wk.weight                : rmse 0.00241936, maxerr 0.03659058, 95pct<0.0052, median<0.0014
q4_0::layers.1.attention.wv.weight                : rmse 0.00081523, maxerr 0.00643539, 95pct<0.0018, median<0.0006
q4_0::layers.1.attention.wo.weight                : rmse 0.00083170, maxerr 0.03112793, 95pct<0.0018, median<0.0006
q4_0::layers.1.feed_forward.w1.weight             : rmse 0.00150114, maxerr 0.03445435, 95pct<0.0028, median<0.0012
q4_0::layers.1.feed_forward.w2.weight             : rmse 0.00147360, maxerr 0.06106567, 95pct<0.0028, median<0.0012
q4_0::layers.1.feed_forward.w3.weight             : rmse 0.00142470, maxerr 0.02111816, 95pct<0.0028, median<0.0012
q4_0::layers.1.attention_norm.weight              : rmse 0.00535747, maxerr 0.01843262, 95pct<0.0100, median<0.0040
q4_0::layers.1.ffn_norm.weight                    : rmse 0.00342054, maxerr 0.00836182, 95pct<0.0062, median<0.0028
q4_0::layers.2.attention.wq.weight                : rmse 0.00256614, maxerr 0.03411865, 95pct<0.0052, median<0.0018
q4_0::layers.2.attention.wk.weight                : rmse 0.00266028, maxerr 0.03179932, 95pct<0.0056, median<0.0016
q4_0::layers.2.attention.wv.weight                : rmse 0.00097341, maxerr 0.00904083, 95pct<0.0020, median<0.0008
q4_0::layers.2.attention.wo.weight                : rmse 0.00099014, maxerr 0.03747559, 95pct<0.0020, median<0.0008
q4_0::layers.2.feed_forward.w1.weight             : rmse 0.00158309, maxerr 0.03842163, 95pct<0.0030, median<0.0012
q4_0::layers.2.feed_forward.w2.weight             : rmse 0.00146792, maxerr 0.06268311, 95pct<0.0028, median<0.0012
q4_0::layers.2.feed_forward.w3.weight             : rmse 0.00144345, maxerr 0.02966309, 95pct<0.0028, median<0.0012
q4_0::layers.2.attention_norm.weight              : rmse 0.00487176, maxerr 0.01904297, 95pct<0.0086, median<0.0038
q4_0::layers.2.ffn_norm.weight                    : rmse 0.00370989, maxerr 0.01013184, 95pct<0.0072, median<0.0028
q4_0::layers.3.attention.wq.weight                : rmse 0.00210723, maxerr 0.04635620, 95pct<0.0042, median<0.0014
q4_0::layers.3.attention.wk.weight                : rmse 0.00221153, maxerr 0.02807617, 95pct<0.0046, median<0.0014
q4_0::layers.3.attention.wv.weight                : rmse 0.00115453, maxerr 0.00730133, 95pct<0.0022, median<0.0010
q4_0::layers.3.attention.wo.weight                : rmse 0.00115204, maxerr 0.03686523, 95pct<0.0022, median<0.0010
q4_0::layers.3.feed_forward.w1.weight             : rmse 0.00160014, maxerr 0.02883911, 95pct<0.0030, median<0.0012
q4_0::layers.3.feed_forward.w2.weight             : rmse 0.00147493, maxerr 0.05181885, 95pct<0.0028, median<0.0012
q4_0::layers.3.feed_forward.w3.weight             : rmse 0.00147109, maxerr 0.02159119, 95pct<0.0028, median<0.0012
q4_0::layers.3.attention_norm.weight              : rmse 0.00675907, maxerr 0.02307129, 95pct<0.0122, median<0.0052
q4_0::layers.3.ffn_norm.weight                    : rmse 0.00368094, maxerr 0.01193237, 95pct<0.0074, median<0.0026
q4_0::layers.4.attention.wq.weight                : rmse 0.00214453, maxerr 0.04370117, 95pct<0.0042, median<0.0016
q4_0::layers.4.attention.wk.weight                : rmse 0.00216904, maxerr 0.02233887, 95pct<0.0044, median<0.0014
q4_0::layers.4.attention.wv.weight                : rmse 0.00115284, maxerr 0.00891113, 95pct<0.0022, median<0.0010
q4_0::layers.4.attention.wo.weight                : rmse 0.00115254, maxerr 0.03320312, 95pct<0.0022, median<0.0010
q4_0::layers.4.feed_forward.w1.weight             : rmse 0.00162055, maxerr 0.03872681, 95pct<0.0032, median<0.0012
q4_0::layers.4.feed_forward.w2.weight             : rmse 0.00146983, maxerr 0.04882812, 95pct<0.0028, median<0.0012
q4_0::layers.4.feed_forward.w3.weight             : rmse 0.00147666, maxerr 0.03454590, 95pct<0.0028, median<0.0012
q4_0::layers.4.attention_norm.weight              : rmse 0.00759098, maxerr 0.02697754, 95pct<0.0138, median<0.0060
q4_0::layers.4.ffn_norm.weight                    : rmse 0.00411936, maxerr 0.01220703, 95pct<0.0086, median<0.0030
q4_0::layers.5.attention.wq.weight                : rmse 0.00203095, maxerr 0.04281616, 95pct<0.0040, median<0.0014
q4_0::layers.5.attention.wk.weight                : rmse 0.00204840, maxerr 0.03198242, 95pct<0.0042, median<0.0014
q4_0::layers.5.attention.wv.weight                : rmse 0.00117341, maxerr 0.01441193, 95pct<0.0024, median<0.0010
q4_0::layers.5.attention.wo.weight                : rmse 0.00116686, maxerr 0.03796387, 95pct<0.0022, median<0.0010
q4_0::layers.5.feed_forward.w1.weight             : rmse 0.00165397, maxerr 0.03155518, 95pct<0.0032, median<0.0014
q4_0::layers.5.feed_forward.w2.weight             : rmse 0.00145557, maxerr 0.03903198, 95pct<0.0028, median<0.0012
q4_0::layers.5.feed_forward.w3.weight             : rmse 0.00147068, maxerr 0.02502441, 95pct<0.0028, median<0.0012
q4_0::layers.5.attention_norm.weight              : rmse 0.00806252, maxerr 0.03417969, 95pct<0.0154, median<0.0058
q4_0::layers.5.ffn_norm.weight                    : rmse 0.00421656, maxerr 0.01330566, 95pct<0.0086, median<0.0030
q4_0::layers.6.attention.wq.weight                : rmse 0.00204956, maxerr 0.04840088, 95pct<0.0042, median<0.0014
q4_0::layers.6.attention.wk.weight                : rmse 0.00209686, maxerr 0.01791382, 95pct<0.0042, median<0.0014
q4_0::layers.6.attention.wv.weight                : rmse 0.00118219, maxerr 0.00815582, 95pct<0.0024, median<0.0010
q4_0::layers.6.attention.wo.weight                : rmse 0.00117915, maxerr 0.03329468, 95pct<0.0024, median<0.0010
q4_0::layers.6.feed_forward.w1.weight             : rmse 0.00163119, maxerr 0.03842163, 95pct<0.0032, median<0.0012
q4_0::layers.6.feed_forward.w2.weight             : rmse 0.00147030, maxerr 0.04553223, 95pct<0.0028, median<0.0012
q4_0::layers.6.feed_forward.w3.weight             : rmse 0.00148939, maxerr 0.02365112, 95pct<0.0028, median<0.0012
q4_0::layers.6.attention_norm.weight              : rmse 0.00813445, maxerr 0.03381348, 95pct<0.0154, median<0.0058
q4_0::layers.6.ffn_norm.weight                    : rmse 0.00451214, maxerr 0.01354980, 95pct<0.0090, median<0.0032
q4_0::layers.7.attention.wq.weight                : rmse 0.00201399, maxerr 0.04580688, 95pct<0.0040, median<0.0014
q4_0::layers.7.attention.wk.weight                : rmse 0.00203167, maxerr 0.02160645, 95pct<0.0042, median<0.0014
q4_0::layers.7.attention.wv.weight                : rmse 0.00121886, maxerr 0.00846863, 95pct<0.0024, median<0.0010
q4_0::layers.7.attention.wo.weight                : rmse 0.00120427, maxerr 0.02935791, 95pct<0.0024, median<0.0010
q4_0::layers.7.feed_forward.w1.weight             : rmse 0.00161576, maxerr 0.02743530, 95pct<0.0032, median<0.0012
q4_0::layers.7.feed_forward.w2.weight             : rmse 0.00147621, maxerr 0.04199219, 95pct<0.0028, median<0.0012
q4_0::layers.7.feed_forward.w3.weight             : rmse 0.00149551, maxerr 0.02548218, 95pct<0.0028, median<0.0012
q4_0::layers.7.attention_norm.weight              : rmse 0.00890861, maxerr 0.02636719, 95pct<0.0164, median<0.0066
q4_0::layers.7.ffn_norm.weight                    : rmse 0.00473217, maxerr 0.01367188, 95pct<0.0094, median<0.0032
q4_0::layers.8.attention.wq.weight                : rmse 0.00198212, maxerr 0.04116821, 95pct<0.0040, median<0.0014
q4_0::layers.8.attention.wk.weight                : rmse 0.00198218, maxerr 0.02270508, 95pct<0.0040, median<0.0014
q4_0::layers.8.attention.wv.weight                : rmse 0.00120661, maxerr 0.00962830, 95pct<0.0024, median<0.0010
q4_0::layers.8.attention.wo.weight                : rmse 0.00119881, maxerr 0.02880859, 95pct<0.0024, median<0.0010
q4_0::layers.8.feed_forward.w1.weight             : rmse 0.00161643, maxerr 0.02868652, 95pct<0.0032, median<0.0012
q4_0::layers.8.feed_forward.w2.weight             : rmse 0.00147686, maxerr 0.03305054, 95pct<0.0028, median<0.0012
q4_0::layers.8.feed_forward.w3.weight             : rmse 0.00149971, maxerr 0.02107239, 95pct<0.0028, median<0.0012
q4_0::layers.8.attention_norm.weight              : rmse 0.00945429, maxerr 0.03265381, 95pct<0.0172, median<0.0072
q4_0::layers.8.ffn_norm.weight                    : rmse 0.00499407, maxerr 0.01416016, 95pct<0.0100, median<0.0036
q4_0::layers.9.attention.wq.weight                : rmse 0.00191681, maxerr 0.03723145, 95pct<0.0038, median<0.0014
q4_0::layers.9.attention.wk.weight                : rmse 0.00193005, maxerr 0.01721191, 95pct<0.0040, median<0.0014
q4_0::layers.9.attention.wv.weight                : rmse 0.00119795, maxerr 0.00854492, 95pct<0.0024, median<0.0010
q4_0::layers.9.attention.wo.weight                : rmse 0.00118937, maxerr 0.03378296, 95pct<0.0024, median<0.0010
q4_0::layers.9.feed_forward.w1.weight             : rmse 0.00159322, maxerr 0.03854370, 95pct<0.0030, median<0.0012
q4_0::layers.9.feed_forward.w2.weight             : rmse 0.00148821, maxerr 0.04580688, 95pct<0.0028, median<0.0012
q4_0::layers.9.feed_forward.w3.weight             : rmse 0.00150940, maxerr 0.04849243, 95pct<0.0030, median<0.0012
q4_0::layers.9.attention_norm.weight              : rmse 0.01032341, maxerr 0.03320312, 95pct<0.0186, median<0.0080
q4_0::layers.9.ffn_norm.weight                    : rmse 0.00516424, maxerr 0.01367188, 95pct<0.0104, median<0.0036
q4_0::layers.10.attention.wq.weight               : rmse 0.00191860, maxerr 0.03503418, 95pct<0.0038, median<0.0014
q4_0::layers.10.attention.wk.weight               : rmse 0.00194014, maxerr 0.01864624, 95pct<0.0040, median<0.0014
q4_0::layers.10.attention.wv.weight               : rmse 0.00124297, maxerr 0.01520538, 95pct<0.0024, median<0.0010
q4_0::layers.10.attention.wo.weight               : rmse 0.00123960, maxerr 0.02691650, 95pct<0.0024, median<0.0010
q4_0::layers.10.feed_forward.w1.weight            : rmse 0.00158127, maxerr 0.02433777, 95pct<0.0030, median<0.0012
q4_0::layers.10.feed_forward.w2.weight            : rmse 0.00150232, maxerr 0.04223633, 95pct<0.0028, median<0.0012
q4_0::layers.10.feed_forward.w3.weight            : rmse 0.00152846, maxerr 0.02325439, 95pct<0.0030, median<0.0012
q4_0::layers.10.attention_norm.weight             : rmse 0.01016605, maxerr 0.04028320, 95pct<0.0188, median<0.0076
q4_0::layers.10.ffn_norm.weight                   : rmse 0.00525648, maxerr 0.01490784, 95pct<0.0104, median<0.0038
q4_0::layers.11.attention.wq.weight               : rmse 0.00197494, maxerr 0.04412842, 95pct<0.0040, median<0.0014
q4_0::layers.11.attention.wk.weight               : rmse 0.00200654, maxerr 0.02586365, 95pct<0.0040, median<0.0014
q4_0::layers.11.attention.wv.weight               : rmse 0.00130740, maxerr 0.01310730, 95pct<0.0026, median<0.0010
q4_0::layers.11.attention.wo.weight               : rmse 0.00129915, maxerr 0.03100586, 95pct<0.0026, median<0.0010
q4_0::layers.11.feed_forward.w1.weight            : rmse 0.00157701, maxerr 0.02528381, 95pct<0.0030, median<0.0012
q4_0::layers.11.feed_forward.w2.weight            : rmse 0.00151437, maxerr 0.05520630, 95pct<0.0030, median<0.0012
q4_0::layers.11.feed_forward.w3.weight            : rmse 0.00153778, maxerr 0.02384949, 95pct<0.0030, median<0.0012
q4_0::layers.11.attention_norm.weight             : rmse 0.00937717, maxerr 0.03637695, 95pct<0.0172, median<0.0070
q4_0::layers.11.ffn_norm.weight                   : rmse 0.00517565, maxerr 0.01538086, 95pct<0.0104, median<0.0036
q4_0::layers.12.attention.wq.weight               : rmse 0.00188511, maxerr 0.03573608, 95pct<0.0038, median<0.0014
q4_0::layers.12.attention.wk.weight               : rmse 0.00191483, maxerr 0.02087402, 95pct<0.0040, median<0.0014
q4_0::layers.12.attention.wv.weight               : rmse 0.00126328, maxerr 0.00842285, 95pct<0.0024, median<0.0010
q4_0::layers.12.attention.wo.weight               : rmse 0.00127600, maxerr 0.02276611, 95pct<0.0024, median<0.0010
q4_0::layers.12.feed_forward.w1.weight            : rmse 0.00158607, maxerr 0.03125000, 95pct<0.0030, median<0.0012
q4_0::layers.12.feed_forward.w2.weight            : rmse 0.00151711, maxerr 0.05499268, 95pct<0.0030, median<0.0012
q4_0::layers.12.feed_forward.w3.weight            : rmse 0.00154733, maxerr 0.01757812, 95pct<0.0030, median<0.0012
q4_0::layers.12.attention_norm.weight             : rmse 0.01066279, maxerr 0.03515625, 95pct<0.0196, median<0.0082
q4_0::layers.12.ffn_norm.weight                   : rmse 0.00526677, maxerr 0.01623535, 95pct<0.0106, median<0.0036
q4_0::layers.13.attention.wq.weight               : rmse 0.00183954, maxerr 0.03576660, 95pct<0.0038, median<0.0014
q4_0::layers.13.attention.wk.weight               : rmse 0.00186986, maxerr 0.01885986, 95pct<0.0038, median<0.0014
q4_0::layers.13.attention.wv.weight               : rmse 0.00132139, maxerr 0.00842285, 95pct<0.0026, median<0.0010
q4_0::layers.13.attention.wo.weight               : rmse 0.00132272, maxerr 0.02880859, 95pct<0.0026, median<0.0010
q4_0::layers.13.feed_forward.w1.weight            : rmse 0.00157917, maxerr 0.02076721, 95pct<0.0030, median<0.0012
q4_0::layers.13.feed_forward.w2.weight            : rmse 0.00152975, maxerr 0.03314209, 95pct<0.0030, median<0.0012
q4_0::layers.13.feed_forward.w3.weight            : rmse 0.00156214, maxerr 0.01795959, 95pct<0.0030, median<0.0012
q4_0::layers.13.attention_norm.weight             : rmse 0.01080014, maxerr 0.03906250, 95pct<0.0202, median<0.0080
q4_0::layers.13.ffn_norm.weight                   : rmse 0.00527759, maxerr 0.01580811, 95pct<0.0106, median<0.0036
q4_0::layers.14.attention.wq.weight               : rmse 0.00185303, maxerr 0.03887939, 95pct<0.0038, median<0.0014
q4_0::layers.14.attention.wk.weight               : rmse 0.00186891, maxerr 0.01937866, 95pct<0.0038, median<0.0014
q4_0::layers.14.attention.wv.weight               : rmse 0.00132941, maxerr 0.00946045, 95pct<0.0026, median<0.0010
q4_0::layers.14.attention.wo.weight               : rmse 0.00132513, maxerr 0.02856445, 95pct<0.0026, median<0.0010
q4_0::layers.14.feed_forward.w1.weight            : rmse 0.00157694, maxerr 0.02264404, 95pct<0.0030, median<0.0012
q4_0::layers.14.feed_forward.w2.weight            : rmse 0.00153703, maxerr 0.05963135, 95pct<0.0030, median<0.0012
q4_0::layers.14.feed_forward.w3.weight            : rmse 0.00156792, maxerr 0.02243042, 95pct<0.0030, median<0.0012
q4_0::layers.14.attention_norm.weight             : rmse 0.00944150, maxerr 0.03662109, 95pct<0.0186, median<0.0066
q4_0::layers.14.ffn_norm.weight                   : rmse 0.00526855, maxerr 0.01635742, 95pct<0.0106, median<0.0036
q4_0::layers.15.attention.wq.weight               : rmse 0.00185226, maxerr 0.03628540, 95pct<0.0038, median<0.0014
q4_0::layers.15.attention.wk.weight               : rmse 0.00188623, maxerr 0.01896667, 95pct<0.0038, median<0.0014
q4_0::layers.15.attention.wv.weight               : rmse 0.00133306, maxerr 0.01000977, 95pct<0.0026, median<0.0010
q4_0::layers.15.attention.wo.weight               : rmse 0.00132875, maxerr 0.02636719, 95pct<0.0026, median<0.0010
q4_0::layers.15.feed_forward.w1.weight            : rmse 0.00157719, maxerr 0.02148438, 95pct<0.0030, median<0.0012
q4_0::layers.15.feed_forward.w2.weight            : rmse 0.00153784, maxerr 0.05371094, 95pct<0.0030, median<0.0012
q4_0::layers.15.feed_forward.w3.weight            : rmse 0.00156844, maxerr 0.01736450, 95pct<0.0030, median<0.0012
q4_0::layers.15.attention_norm.weight             : rmse 0.00926184, maxerr 0.04168701, 95pct<0.0186, median<0.0062
q4_0::layers.15.ffn_norm.weight                   : rmse 0.00522685, maxerr 0.01654053, 95pct<0.0104, median<0.0036
q4_0::layers.16.attention.wq.weight               : rmse 0.00182710, maxerr 0.04269409, 95pct<0.0036, median<0.0014
q4_0::layers.16.attention.wk.weight               : rmse 0.00187375, maxerr 0.02206421, 95pct<0.0038, median<0.0014
q4_0::layers.16.attention.wv.weight               : rmse 0.00141846, maxerr 0.00961304, 95pct<0.0028, median<0.0012
q4_0::layers.16.attention.wo.weight               : rmse 0.00140776, maxerr 0.04193115, 95pct<0.0028, median<0.0012
q4_0::layers.16.feed_forward.w1.weight            : rmse 0.00158873, maxerr 0.02014160, 95pct<0.0030, median<0.0012
q4_0::layers.16.feed_forward.w2.weight            : rmse 0.00153625, maxerr 0.05413818, 95pct<0.0030, median<0.0012
q4_0::layers.16.feed_forward.w3.weight            : rmse 0.00156343, maxerr 0.02308655, 95pct<0.0030, median<0.0012
q4_0::layers.16.attention_norm.weight             : rmse 0.00882078, maxerr 0.04125977, 95pct<0.0176, median<0.0062
q4_0::layers.16.ffn_norm.weight                   : rmse 0.00501514, maxerr 0.01635742, 95pct<0.0100, median<0.0034
q4_0::layers.17.attention.wq.weight               : rmse 0.00178805, maxerr 0.04727173, 95pct<0.0036, median<0.0014
q4_0::layers.17.attention.wk.weight               : rmse 0.00182524, maxerr 0.01977539, 95pct<0.0036, median<0.0014
q4_0::layers.17.attention.wv.weight               : rmse 0.00142757, maxerr 0.01419830, 95pct<0.0028, median<0.0012
q4_0::layers.17.attention.wo.weight               : rmse 0.00142669, maxerr 0.03002930, 95pct<0.0028, median<0.0012
q4_0::layers.17.feed_forward.w1.weight            : rmse 0.00159202, maxerr 0.01837158, 95pct<0.0030, median<0.0012
q4_0::layers.17.feed_forward.w2.weight            : rmse 0.00154283, maxerr 0.04699707, 95pct<0.0030, median<0.0012
q4_0::layers.17.feed_forward.w3.weight            : rmse 0.00156794, maxerr 0.02423096, 95pct<0.0030, median<0.0012
q4_0::layers.17.attention_norm.weight             : rmse 0.00863434, maxerr 0.03540039, 95pct<0.0174, median<0.0058
q4_0::layers.17.ffn_norm.weight                   : rmse 0.00526889, maxerr 0.01773071, 95pct<0.0106, median<0.0036
q4_0::layers.18.attention.wq.weight               : rmse 0.00176889, maxerr 0.03970337, 95pct<0.0036, median<0.0012
q4_0::layers.18.attention.wk.weight               : rmse 0.00179129, maxerr 0.01916504, 95pct<0.0036, median<0.0012
q4_0::layers.18.attention.wv.weight               : rmse 0.00142390, maxerr 0.00970459, 95pct<0.0028, median<0.0012
q4_0::layers.18.attention.wo.weight               : rmse 0.00142140, maxerr 0.03387451, 95pct<0.0028, median<0.0012
q4_0::layers.18.feed_forward.w1.weight            : rmse 0.00160467, maxerr 0.02200317, 95pct<0.0030, median<0.0012
q4_0::layers.18.feed_forward.w2.weight            : rmse 0.00153983, maxerr 0.06341553, 95pct<0.0030, median<0.0012
q4_0::layers.18.feed_forward.w3.weight            : rmse 0.00156218, maxerr 0.01829529, 95pct<0.0030, median<0.0012
q4_0::layers.18.attention_norm.weight             : rmse 0.00912104, maxerr 0.03564453, 95pct<0.0184, median<0.0060
q4_0::layers.18.ffn_norm.weight                   : rmse 0.00556628, maxerr 0.01904297, 95pct<0.0112, median<0.0038
q4_0::layers.19.attention.wq.weight               : rmse 0.00173669, maxerr 0.04415894, 95pct<0.0034, median<0.0012
q4_0::layers.19.attention.wk.weight               : rmse 0.00175806, maxerr 0.01998901, 95pct<0.0036, median<0.0012
q4_0::layers.19.attention.wv.weight               : rmse 0.00149304, maxerr 0.00927734, 95pct<0.0028, median<0.0012
q4_0::layers.19.attention.wo.weight               : rmse 0.00148160, maxerr 0.03442383, 95pct<0.0028, median<0.0012
q4_0::layers.19.feed_forward.w1.weight            : rmse 0.00161370, maxerr 0.03111267, 95pct<0.0032, median<0.0012
q4_0::layers.19.feed_forward.w2.weight            : rmse 0.00154201, maxerr 0.04092407, 95pct<0.0030, median<0.0012
q4_0::layers.19.feed_forward.w3.weight            : rmse 0.00155880, maxerr 0.02091980, 95pct<0.0030, median<0.0012
q4_0::layers.19.attention_norm.weight             : rmse 0.00947609, maxerr 0.04248047, 95pct<0.0192, median<0.0064
q4_0::layers.19.ffn_norm.weight                   : rmse 0.00561705, maxerr 0.02087402, 95pct<0.0110, median<0.0038
q4_0::layers.20.attention.wq.weight               : rmse 0.00176062, maxerr 0.05462646, 95pct<0.0034, median<0.0014
q4_0::layers.20.attention.wk.weight               : rmse 0.00178543, maxerr 0.02259827, 95pct<0.0036, median<0.0014
q4_0::layers.20.attention.wv.weight               : rmse 0.00153912, maxerr 0.01049805, 95pct<0.0030, median<0.0012
q4_0::layers.20.attention.wo.weight               : rmse 0.00151891, maxerr 0.02714539, 95pct<0.0030, median<0.0012
q4_0::layers.20.feed_forward.w1.weight            : rmse 0.00162212, maxerr 0.02268982, 95pct<0.0032, median<0.0012
q4_0::layers.20.feed_forward.w2.weight            : rmse 0.00154374, maxerr 0.06872559, 95pct<0.0030, median<0.0012
q4_0::layers.20.feed_forward.w3.weight            : rmse 0.00155945, maxerr 0.01570129, 95pct<0.0030, median<0.0012
q4_0::layers.20.attention_norm.weight             : rmse 0.00912985, maxerr 0.03491211, 95pct<0.0184, median<0.0060
q4_0::layers.20.ffn_norm.weight                   : rmse 0.00545571, maxerr 0.02185059, 95pct<0.0108, median<0.0036
q4_0::layers.21.attention.wq.weight               : rmse 0.00170287, maxerr 0.04907227, 95pct<0.0034, median<0.0012
q4_0::layers.21.attention.wk.weight               : rmse 0.00171981, maxerr 0.02088928, 95pct<0.0034, median<0.0012
q4_0::layers.21.attention.wv.weight               : rmse 0.00155078, maxerr 0.00872803, 95pct<0.0030, median<0.0012
q4_0::layers.21.attention.wo.weight               : rmse 0.00152792, maxerr 0.05682373, 95pct<0.0030, median<0.0012
q4_0::layers.21.feed_forward.w1.weight            : rmse 0.00163029, maxerr 0.02185059, 95pct<0.0032, median<0.0014
q4_0::layers.21.feed_forward.w2.weight            : rmse 0.00154296, maxerr 0.03689575, 95pct<0.0030, median<0.0012
q4_0::layers.21.feed_forward.w3.weight            : rmse 0.00155747, maxerr 0.01473236, 95pct<0.0030, median<0.0012
q4_0::layers.21.attention_norm.weight             : rmse 0.01051225, maxerr 0.03753662, 95pct<0.0210, median<0.0072
q4_0::layers.21.ffn_norm.weight                   : rmse 0.00564722, maxerr 0.02294922, 95pct<0.0110, median<0.0038
q4_0::layers.22.attention.wq.weight               : rmse 0.00173143, maxerr 0.04519653, 95pct<0.0034, median<0.0012
q4_0::layers.22.attention.wk.weight               : rmse 0.00174586, maxerr 0.01945496, 95pct<0.0034, median<0.0012
q4_0::layers.22.attention.wv.weight               : rmse 0.00154078, maxerr 0.00958252, 95pct<0.0030, median<0.0012
q4_0::layers.22.attention.wo.weight               : rmse 0.00153304, maxerr 0.06982422, 95pct<0.0030, median<0.0012
q4_0::layers.22.feed_forward.w1.weight            : rmse 0.00163221, maxerr 0.02517700, 95pct<0.0032, median<0.0014
q4_0::layers.22.feed_forward.w2.weight            : rmse 0.00154983, maxerr 0.04281616, 95pct<0.0030, median<0.0012
q4_0::layers.22.feed_forward.w3.weight            : rmse 0.00156437, maxerr 0.03030396, 95pct<0.0030, median<0.0012
q4_0::layers.22.attention_norm.weight             : rmse 0.01016588, maxerr 0.03649902, 95pct<0.0204, median<0.0070
q4_0::layers.22.ffn_norm.weight                   : rmse 0.00574030, maxerr 0.02175903, 95pct<0.0114, median<0.0038
q4_0::layers.23.attention.wq.weight               : rmse 0.00167802, maxerr 0.04333496, 95pct<0.0034, median<0.0012
q4_0::layers.23.attention.wk.weight               : rmse 0.00168389, maxerr 0.02124023, 95pct<0.0034, median<0.0012
q4_0::layers.23.attention.wv.weight               : rmse 0.00160218, maxerr 0.01093292, 95pct<0.0030, median<0.0012
q4_0::layers.23.attention.wo.weight               : rmse 0.00157519, maxerr 0.06591797, 95pct<0.0030, median<0.0012
q4_0::layers.23.feed_forward.w1.weight            : rmse 0.00163544, maxerr 0.03022766, 95pct<0.0032, median<0.0014
q4_0::layers.23.feed_forward.w2.weight            : rmse 0.00155510, maxerr 0.04754639, 95pct<0.0030, median<0.0012
q4_0::layers.23.feed_forward.w3.weight            : rmse 0.00156715, maxerr 0.02468872, 95pct<0.0030, median<0.0012
q4_0::layers.23.attention_norm.weight             : rmse 0.01194653, maxerr 0.04150391, 95pct<0.0236, median<0.0084
q4_0::layers.23.ffn_norm.weight                   : rmse 0.00592925, maxerr 0.02349854, 95pct<0.0120, median<0.0038
q4_0::layers.24.attention.wq.weight               : rmse 0.00167990, maxerr 0.04760742, 95pct<0.0034, median<0.0012
q4_0::layers.24.attention.wk.weight               : rmse 0.00169040, maxerr 0.02137756, 95pct<0.0034, median<0.0012
q4_0::layers.24.attention.wv.weight               : rmse 0.00162101, maxerr 0.00909424, 95pct<0.0032, median<0.0012
q4_0::layers.24.attention.wo.weight               : rmse 0.00159527, maxerr 0.04144287, 95pct<0.0030, median<0.0012
q4_0::layers.24.feed_forward.w1.weight            : rmse 0.00163766, maxerr 0.02067566, 95pct<0.0032, median<0.0014
q4_0::layers.24.feed_forward.w2.weight            : rmse 0.00156213, maxerr 0.05670166, 95pct<0.0030, median<0.0012
q4_0::layers.24.feed_forward.w3.weight            : rmse 0.00157601, maxerr 0.02043152, 95pct<0.0030, median<0.0012
q4_0::layers.24.attention_norm.weight             : rmse 0.01140493, maxerr 0.04980469, 95pct<0.0230, median<0.0076
q4_0::layers.24.ffn_norm.weight                   : rmse 0.00600982, maxerr 0.02331543, 95pct<0.0118, median<0.0040
q4_0::layers.25.attention.wq.weight               : rmse 0.00172559, maxerr 0.03808594, 95pct<0.0034, median<0.0012
q4_0::layers.25.attention.wk.weight               : rmse 0.00174477, maxerr 0.01940918, 95pct<0.0034, median<0.0014
q4_0::layers.25.attention.wv.weight               : rmse 0.00162673, maxerr 0.00921631, 95pct<0.0032, median<0.0012
q4_0::layers.25.attention.wo.weight               : rmse 0.00160901, maxerr 0.04428101, 95pct<0.0032, median<0.0012
q4_0::layers.25.feed_forward.w1.weight            : rmse 0.00164163, maxerr 0.01789856, 95pct<0.0032, median<0.0014
q4_0::layers.25.feed_forward.w2.weight            : rmse 0.00156754, maxerr 0.03286743, 95pct<0.0030, median<0.0012
q4_0::layers.25.feed_forward.w3.weight            : rmse 0.00158208, maxerr 0.01832581, 95pct<0.0030, median<0.0012
q4_0::layers.25.attention_norm.weight             : rmse 0.01000364, maxerr 0.04394531, 95pct<0.0204, median<0.0066
q4_0::layers.25.ffn_norm.weight                   : rmse 0.00582826, maxerr 0.02410889, 95pct<0.0114, median<0.0038
q4_0::layers.26.attention.wq.weight               : rmse 0.00169759, maxerr 0.03735352, 95pct<0.0034, median<0.0012
q4_0::layers.26.attention.wk.weight               : rmse 0.00171683, maxerr 0.02526855, 95pct<0.0034, median<0.0012
q4_0::layers.26.attention.wv.weight               : rmse 0.00167550, maxerr 0.01040649, 95pct<0.0032, median<0.0014
q4_0::layers.26.attention.wo.weight               : rmse 0.00165650, maxerr 0.02258301, 95pct<0.0032, median<0.0014
q4_0::layers.26.feed_forward.w1.weight            : rmse 0.00164058, maxerr 0.03396606, 95pct<0.0032, median<0.0014
q4_0::layers.26.feed_forward.w2.weight            : rmse 0.00157755, maxerr 0.04171753, 95pct<0.0030, median<0.0012
q4_0::layers.26.feed_forward.w3.weight            : rmse 0.00159313, maxerr 0.03059387, 95pct<0.0030, median<0.0012
q4_0::layers.26.attention_norm.weight             : rmse 0.01028290, maxerr 0.04541016, 95pct<0.0206, median<0.0070
q4_0::layers.26.ffn_norm.weight                   : rmse 0.00588573, maxerr 0.02441406, 95pct<0.0116, median<0.0038
q4_0::layers.27.attention.wq.weight               : rmse 0.00170066, maxerr 0.04006958, 95pct<0.0034, median<0.0012
q4_0::layers.27.attention.wk.weight               : rmse 0.00171133, maxerr 0.02406311, 95pct<0.0034, median<0.0012
q4_0::layers.27.attention.wv.weight               : rmse 0.00170459, maxerr 0.01264954, 95pct<0.0032, median<0.0014
q4_0::layers.27.attention.wo.weight               : rmse 0.00169575, maxerr 0.05517578, 95pct<0.0032, median<0.0014
q4_0::layers.27.feed_forward.w1.weight            : rmse 0.00164005, maxerr 0.02774048, 95pct<0.0032, median<0.0014
q4_0::layers.27.feed_forward.w2.weight            : rmse 0.00158663, maxerr 0.04428101, 95pct<0.0030, median<0.0012
q4_0::layers.27.feed_forward.w3.weight            : rmse 0.00160017, maxerr 0.04153442, 95pct<0.0030, median<0.0012
q4_0::layers.27.attention_norm.weight             : rmse 0.00993009, maxerr 0.03540039, 95pct<0.0202, median<0.0064
q4_0::layers.27.ffn_norm.weight                   : rmse 0.00599262, maxerr 0.02731323, 95pct<0.0118, median<0.0040
q4_0::layers.28.attention.wq.weight               : rmse 0.00166564, maxerr 0.04092407, 95pct<0.0034, median<0.0012
q4_0::layers.28.attention.wk.weight               : rmse 0.00167293, maxerr 0.02145386, 95pct<0.0034, median<0.0012
q4_0::layers.28.attention.wv.weight               : rmse 0.00171405, maxerr 0.01080322, 95pct<0.0034, median<0.0014
q4_0::layers.28.attention.wo.weight               : rmse 0.00171473, maxerr 0.02978516, 95pct<0.0034, median<0.0014
q4_0::layers.28.feed_forward.w1.weight            : rmse 0.00163294, maxerr 0.02809143, 95pct<0.0032, median<0.0012
q4_0::layers.28.feed_forward.w2.weight            : rmse 0.00159430, maxerr 0.05215454, 95pct<0.0030, median<0.0012
q4_0::layers.28.feed_forward.w3.weight            : rmse 0.00160784, maxerr 0.02539062, 95pct<0.0030, median<0.0012
q4_0::layers.28.attention_norm.weight             : rmse 0.01141754, maxerr 0.05895996, 95pct<0.0236, median<0.0074
q4_0::layers.28.ffn_norm.weight                   : rmse 0.00626150, maxerr 0.02587891, 95pct<0.0126, median<0.0040
q4_0::layers.29.attention.wq.weight               : rmse 0.00165014, maxerr 0.04244995, 95pct<0.0032, median<0.0012
q4_0::layers.29.attention.wk.weight               : rmse 0.00166139, maxerr 0.01962280, 95pct<0.0034, median<0.0012
q4_0::layers.29.attention.wv.weight               : rmse 0.00176460, maxerr 0.01135254, 95pct<0.0034, median<0.0014
q4_0::layers.29.attention.wo.weight               : rmse 0.00176555, maxerr 0.04040527, 95pct<0.0034, median<0.0014
q4_0::layers.29.feed_forward.w1.weight            : rmse 0.00163643, maxerr 0.02803040, 95pct<0.0032, median<0.0012
q4_0::layers.29.feed_forward.w2.weight            : rmse 0.00160070, maxerr 0.09802246, 95pct<0.0030, median<0.0012
q4_0::layers.29.feed_forward.w3.weight            : rmse 0.00161745, maxerr 0.02696228, 95pct<0.0032, median<0.0014
q4_0::layers.29.attention_norm.weight             : rmse 0.01053851, maxerr 0.04125977, 95pct<0.0208, median<0.0070
q4_0::layers.29.ffn_norm.weight                   : rmse 0.00697287, maxerr 0.02880859, 95pct<0.0138, median<0.0044
q4_0::layers.30.attention.wq.weight               : rmse 0.00166892, maxerr 0.04101562, 95pct<0.0032, median<0.0012
q4_0::layers.30.attention.wk.weight               : rmse 0.00167814, maxerr 0.01953125, 95pct<0.0034, median<0.0012
q4_0::layers.30.attention.wv.weight               : rmse 0.00174131, maxerr 0.01042175, 95pct<0.0034, median<0.0014
q4_0::layers.30.attention.wo.weight               : rmse 0.00176365, maxerr 0.04565430, 95pct<0.0034, median<0.0014
q4_0::layers.30.feed_forward.w1.weight            : rmse 0.00164651, maxerr 0.02940369, 95pct<0.0032, median<0.0014
q4_0::layers.30.feed_forward.w2.weight            : rmse 0.00163353, maxerr 0.11157227, 95pct<0.0030, median<0.0012
q4_0::layers.30.feed_forward.w3.weight            : rmse 0.00163264, maxerr 0.03038025, 95pct<0.0032, median<0.0014
q4_0::layers.30.attention_norm.weight             : rmse 0.01055359, maxerr 0.03906250, 95pct<0.0220, median<0.0070
q4_0::layers.30.ffn_norm.weight                   : rmse 0.00798581, maxerr 0.03295898, 95pct<0.0162, median<0.0052
q4_0::layers.31.attention.wq.weight               : rmse 0.00169262, maxerr 0.02526855, 95pct<0.0034, median<0.0012
q4_0::layers.31.attention.wk.weight               : rmse 0.00173245, maxerr 0.02009583, 95pct<0.0034, median<0.0012
q4_0::layers.31.attention.wv.weight               : rmse 0.00157056, maxerr 0.01557922, 95pct<0.0030, median<0.0012
q4_0::layers.31.attention.wo.weight               : rmse 0.00159227, maxerr 0.10278320, 95pct<0.0030, median<0.0012
q4_0::layers.31.feed_forward.w1.weight            : rmse 0.00171869, maxerr 0.02217102, 95pct<0.0034, median<0.0014
q4_0::layers.31.feed_forward.w2.weight            : rmse 0.00164236, maxerr 0.11260986, 95pct<0.0032, median<0.0012
q4_0::layers.31.feed_forward.w3.weight            : rmse 0.00170012, maxerr 0.03759766, 95pct<0.0032, median<0.0014
q4_0::layers.31.attention_norm.weight             : rmse 0.01264741, maxerr 0.04638672, 95pct<0.0230, median<0.0096
q4_0::layers.31.ffn_norm.weight                   : rmse 0.01198714, maxerr 0.02905273, 95pct<0.0224, median<0.0088
q4_0                                              : rmse 0.00159265, maxerr 0.17480469, 95pct<0.0030, median<0.0012

</details>

### Description

This PR adds new methods for `Q4_0` and `Q4_1` quantization that (almost) exactly solve the mixed integer minimization problem
```
Minimize Sum (x_i - b l_i)^2  subject to -7 <= l_i <=7      (Q4_0)
or
Minimize Sum (x_i - a - b l_i)^2   subject to 0 <= l_i <= 15 (Q4_1)
```
where the `x_i` are the original weights, the `l_i` are the quantized weights, and `a, b` are the conversion coefficients. It is almost exact because in some very rare degenerate cases the method may not find the global minimum. Guaranteeing that the global minimum is obtained is not worth because the difference in mean-square-error (MSE) to the guaranteed minimum is less than `0.01%` but costs at least 2-fold increase in computation time.

On the 7B model, the improved `Q4_0` quantization achieves ~14% reduction in MSE compared to the existing implementation. The improved `Q4_1` quantization is even better, achieving ~25% reduction in MSE compared to the existing `Q4_1`.

So far I have only measured perplexity for the the 7B model. I get `6.3539` for `Q4_0` and `6.0863` for `Q4_1` with the default context size.  

For the sake of compatibility, I have kept the format of the existing `Q4_0` and `Q4_1` quantization (i.e., one or two 32-bit floats followed by 16 `uint8_t` containing the quants), so that a model quantized with these new methods can be used without any other changes to the code. This is quite wasteful as the same 6 bits per weight that are used in `Q4_1` lead to a massive reduction in MSE if one switched to 5 bit quantization and `fp16` coefficients.  

The new quantization methods are meant to be used for quantizing the original model only. They are by far not fast enough for quantization of intermediate results (in single-threaded mode the new `Q4_0` is ~25 times slower and the new `Q4_1` about ~50 times slower than the corresponding existing implementations). 

The quantization function will automatically use multi-threading if the chunk of weights given for quantization is large enough. Plugged into the `quantize` example, it gets the job done in about 49 seconds for `Q4_0` on my MacBook (M2 Max) for the 7B model. `Q4_1` quantization of the 7B model takes ~190 seconds.

I have also added a change to the reference (i.e., scalar) versions of the `Q4_0` and `Q4_1` quantization implementations: replacing the `roundf()` function with a better conversions to `int` speeds the scalar implementation quite a bit, especially on `X86_64` (and `x86`) where the slowness of `round` is legendary. After this change, the reference implementation is only ~10% slower than the vectorized quantization on the two CPU's I have tried (M2 Max and Ryzen 7950X). 