### PR TITLE
Add exit call to interactive mode.

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -437,6 +437,15 @@ int main(int argc, char ** argv) {
                     n_remain -= line_inp.size();
                 }
 
+                // exit gracefully when the word "exit" is typed.
+                if (buffer.length() == 5 && strncmp(buffer.c_str(), "exit", 4) == 0) {
+                    printf("Exit call given, printing stats and exiting.\n");
+                    llama_print_timings(ctx);
+                    llama_free(ctx);
+                    set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
+                    return 0;
+                }
+
                 input_noecho = true; // do not echo this again
             }
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -27,6 +27,8 @@ static console_state con_st;
 
 static bool is_interacting = false;
 
+llama_context * ctx;
+
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
 void sigint_handler(int signo) {
     set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
@@ -35,6 +37,9 @@ void sigint_handler(int signo) {
         if (!is_interacting) {
             is_interacting=true;
         } else {
+            //printf("Exit call given, printing stats and exiting.\n");
+            llama_print_timings(ctx);
+            llama_free(ctx);
             _exit(130);
         }
     }
@@ -91,8 +96,6 @@ int main(int argc, char ** argv) {
 
 //    params.prompt = R"(// this function checks if the number n is prime
 //bool is_prime(int n) {)";
-
-    llama_context * ctx;
 
     // load the model
     {
@@ -435,15 +438,6 @@ int main(int argc, char ** argv) {
                     }
 
                     n_remain -= line_inp.size();
-                }
-
-                // exit gracefully when the word "exit" is typed.
-                if (buffer.length() == 5 && strncmp(buffer.c_str(), "exit", 4) == 0) {
-                    printf("Exit call given, printing stats and exiting.\n");
-                    llama_print_timings(ctx);
-                    llama_free(ctx);
-                    set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
-                    return 0;
                 }
 
                 input_noecho = true; // do not echo this again


### PR DESCRIPTION
Problem:
The timing stats do not print when using "ctrl+c" to quit interactive mode. With all the problems I have been having with model speed I needed the stats to print out when I was finished running prompts.  

Solution:
There is almost never a time the prompt is only a single word. So we check for input length equals 5, and if this is true check the word "exit" was entered in lower case. 

This to me was the simplest solution to the problem, but maybe I am wrong. Maybe there is an easier way to handle this, I am open to discussion and changes. However using this solution its possible to add more commands to the program as required.