### PR TITLE
Don't crash on ftype (formerly f16) == 4

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -827,7 +827,9 @@ static const char *llama_ftype_name(enum llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_F16:  return "mostly F16";
         case LLAMA_FTYPE_MOSTLY_Q4_0: return "mostly Q4_0";
         case LLAMA_FTYPE_MOSTLY_Q4_1: return "mostly Q4_1";
-        default: LLAMA_ASSERT(false);
+        case LLAMA_FTYPE_MOSTLY_Q4_1_SOME_F16:
+                                      return "mostly Q4_1, some F16";
+        default:                      return "unknown, may not work";
     }
 }
 

--- a/llama.h
+++ b/llama.h
@@ -71,6 +71,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_F16  = 1,  // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q4_0 = 2,  // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q4_1 = 3,  // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_Q4_1_SOME_F16 = 4, // tok_embeddings.weight and output.weight are F16
     };
 
     LLAMA_API struct llama_context_params llama_context_default_params();


### PR DESCRIPTION
In #709 I did not add an enum value 4 for `ftype` (formerly `f16`), and made the function `llama_ftype_name` strict in that a `LLAMA_ASSERT` was raised. This made llama.cpp crash with such GPTQ model files.

Add `LLAMA_FTYPE_MOSTLY_Q4_1_SOME_F16 = 4` and relax `llama_ftype_name` so that it returns a helpful string, which will also help future experiments with file types.

Should fix #903