### PR TITLE
Remove python 3.10 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ python3 convert-pth-to-ggml.py models/7B/ 1
 ./main -m ./models/7B/ggml-model-q4_0.bin -n 128
 ```
 
-Currently, it's best to use Python 3.9 or Python 3.10, as `sentencepiece` has not yet published a wheel for Python 3.11.
-
 When running the larger models, make sure you have enough disk space to store all the intermediate files.
 
 ### Memory/Disk Requirements


### PR DESCRIPTION
This is unneeded as sentencepiece is now working with the latest version of python 3.11. 

See [google/sentencepiece/issues/810#issuecomment-1504980354](https://github.com/google/sentencepiece/issues/810#issuecomment-1504980354)