### PR TITLE
py : cleanup dependencies

### DIFF
--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -5,9 +5,10 @@ FROM ubuntu:$UBUNTU_VERSION as build
 RUN apt-get update && \
     apt-get install -y build-essential python3 python3-pip
 
+COPY requirements.txt requirements.txt
+
 RUN pip install --upgrade pip setuptools wheel \
-    && pip install numpy requests sentencepiece tqdm \
-    && pip install torch --index-url https://download.pytorch.org/whl/cpu
+    && pip install -r requirements.txt
 
 WORKDIR /app
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,6 @@
           inherit system;
         };
         llama-python = pkgs.python310.withPackages (ps: with ps; [
-          torch
           numpy
           sentencepiece
         ]);


### PR DESCRIPTION
after #545 we do not need `torch`, `tqdm` and `requests` in the dependencies

@sw why did you add `requests` in https://github.com/ggerganov/llama.cpp/pull/293#issuecomment-1475268793, I can't find it is used anywhere