### PR TITLE
py : bump sentencepiece to 0.1.98 to support Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.24
-sentencepiece==0.1.97
+sentencepiece==0.1.98


### PR DESCRIPTION
fixes https://github.com/ggerganov/llama.cpp/issues/974