### PR TITLE
examples : switch input_noecho to input_echo to remove negation

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -250,7 +250,7 @@ int main(int argc, char ** argv) {
     }
 
     bool is_antiprompt = false;
-    bool input_noecho  = false;
+    bool input_echo  = true;
 
     int n_past     = 0;
     int n_remain   = params.n_predict;
@@ -340,7 +340,7 @@ int main(int argc, char ** argv) {
             embd.push_back(id);
 
             // echo this to console
-            input_noecho = false;
+            input_echo = true;
 
             // decrement remaining sampling budget
             --n_remain;
@@ -358,14 +358,14 @@ int main(int argc, char ** argv) {
         }
 
         // display text
-        if (!input_noecho) {
+        if (input_echo) {
             for (auto id : embd) {
                 printf("%s", llama_token_to_str(ctx, id));
             }
             fflush(stdout);
         }
         // reset color to default if we there is no pending user input
-        if (!input_noecho && (int)embd_inp.size() == n_consumed) {
+        if (input_echo && (int)embd_inp.size() == n_consumed) {
             set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
         }
 
@@ -460,7 +460,7 @@ int main(int argc, char ** argv) {
                     n_remain -= line_inp.size();
                 }
 
-                input_noecho = true; // do not echo this again
+                input_echo = false; // do not echo this again
             }
 
             if (n_past > 0) {


### PR DESCRIPTION
This PR modifies the example to change the boolean `input_noecho` to `input_echo` to remove negation.

I was reading thru the code, and thought it would probably make it easier for further refactoring later.

Thanks to everyone who has been committing to this project!