### PR TITLE
Fix potential int8_t overflow in non-SIMD vec_dot

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2210,11 +2210,11 @@ static void ggml_vec_dot_q4_0(const int n, float * restrict s, const void * rest
             const uint8_t v0 = p0[j];
             const uint8_t v1 = p1[j];
 
-            const int8_t i0 = (int8_t) (v0 & 0xf) - 8;
-            const int8_t i1 = (int8_t) (v0 >> 4)  - 8;
+            const int i0 = (v0 & 0xf) - 8;
+            const int i1 = (v0 >> 4)  - 8;
 
-            const int8_t i2 = (int8_t) (v1 & 0xf) - 8;
-            const int8_t i3 = (int8_t) (v1 >> 4)  - 8;
+            const int i2 = (v1 & 0xf) - 8;
+            const int i3 = (v1 >> 4)  - 8;
 
             sumi += i0*i2 + i1*i3;
         }


### PR DESCRIPTION
As rightly pointed out by @jxy [here](https://github.com/ggerganov/llama.cpp/commit/6232f2d7fd7a22d5eeb62182b2f21fcf01359754#commitcomment-108812025), my changes in #703 limiting the calculation to `int8_t` might overflow.

-> Change the types to `int` instead.