### PR TITLE
Fix result validation in benchmark-q4_0-matmult

### DIFF
--- a/examples/benchmark/benchmark-q4_0-matmult.c
+++ b/examples/benchmark/benchmark-q4_0-matmult.c
@@ -24,7 +24,7 @@
 
 float tensor_sum_elements(struct ggml_tensor * tensor) {
     float sum = 0;
-    if (tensor->type==6) {
+    if (tensor->type==GGML_TYPE_F32) {
         for (int j = 0; j < tensor->ne[1]; j++) {
             for (int k = 0; k < tensor->ne[0]; k++) {
                 sum +=  ((float *) tensor->data)[j*tensor->ne[0]+k];


### PR DESCRIPTION
While working on #933, I noticed that the benchmark always prints zeroes instead of tensor sums:
```
------ Test 1 - Matrix Mult via F32 code ------------------------------------------------------------------------------
cgraph->n_threads=1
            m11: type = 0 ( FP32) ne = 11008 x  4096 x     1, nb = (    4, 44032, 180355072) - Sum of tensor m11 is   0.00
             m2: type = 0 ( FP32) ne = 11008 x   128 x     1, nb = (    4, 44032, 5636096) - Sum of tensor m2 is   0.00
    gf.nodes[0]: type = 0 ( FP32) ne =  4096 x   128 x     1, nb = (    4, 16384, 2097152) - Sum of tensor gf.nodes[0] is   0.00
...
```

This looks weird because these sums are later used to compare the result of quantized matrix multiplication against the result of regular one, so they are not supposed to be zero. This is my interpretation of why that happens:
  * `tensor_sum_elements()` only sums FP32 tensors and returns 0 for everything else
  * it checks if the provided tensor is FP32 by comparing its type with `6`
  * the benchmark was developed with a version of `ggml` where `6` [corresponded](https://github.com/SebastianApel/llama.cpp/blob/ed5f4fe00ecad67f951643011fef76c3c9e04007/ggml.h#L207) to `GGML_TYPE_F32`
  * however, the `ggml_type` definition was [changed](https://github.com/ggerganov/llama.cpp/commit/3e6e70d8e8917b5bd14c7c9f9b89a585f1ff0b31#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394R200) later so that `6` now means `GGML_TYPE_I32`
  * hence, `tensor_sum_elements()` now returns 0 when passed a tensor with `GGML_TYPE_F32`

As far as I can see, there are no compelling reasons to hardcode `6` in the type comparison. Changing `6` to `GGML_TYPE_F32` both makes the code correct (I hope) again and prevents similar errors in the future. Here's what the benchmark prints now:
```
------ Test 1 - Matrix Mult via F32 code ------------------------------------------------------------------------------
cgraph->n_threads=1
            m11: type = 0 ( FP32) ne = 11008 x  4096 x     1, nb = (    4, 44032, 180355072) - Sum of tensor m11 is 16777216.00
             m2: type = 0 ( FP32) ne = 11008 x   128 x     1, nb = (    4, 44032, 5636096) - Sum of tensor m2 is 2818048.00
    gf.nodes[0]: type = 0 ( FP32) ne =  4096 x   128 x     1, nb = (    4, 16384, 2097152) - Sum of tensor gf.nodes[0] is 11611394048.00
...
```