### PR TITLE
Fix msys2 build error and warnings

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9,6 +9,7 @@
 #include "ggml.h"
 
 #include <array>
+#include <ctime>
 #include <cinttypes>
 #include <fstream>
 #include <random>

--- a/llama_util.h
+++ b/llama_util.h
@@ -43,7 +43,11 @@
     } while (0)
 
 #ifdef __GNUC__
+#ifdef __MINGW32__
+__attribute__((format(gnu_printf, 1, 2)))
+#else
 __attribute__((format(printf, 1, 2)))
+#endif
 #endif
 static std::string format(const char * fmt, ...) {
     va_list ap, ap2;
@@ -57,7 +61,7 @@ static std::string format(const char * fmt, ...) {
     va_end(ap2);
     va_end(ap);
     return std::string(buf.data(), size);
-};
+}
 
 struct llama_file {
     // use FILE * so we don't have to re-open the file to mmap


### PR DESCRIPTION
Currently, main fails to build on mingw (msys2) due to missing headers:
```
llama.cpp: In function 'llama_context* llama_init_from_file(const char*, llama_context_params)':
llama.cpp:1675:23: error: 'time' was not declared in this scope; did you mean 'ftime'?
 1675 |         params.seed = time(NULL);
      |                       ^~~~
      |                       ftime
```
This is solved by including `<ctime>`.

Also there are several warnings about printf formats:
```
llama.cpp: In function 'size_t checked_div(size_t, size_t)':
llama.cpp:258:39: warning: unknown conversion type character 'z' in format [-Wformat=]
  258 |         throw format("error dividing %zu / %zu", a, b);
      |                                       ^
```
As far as I know, this wraning is bogus and appears to be a bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95130
This is solved by using `gnu_printf` for format attribute when building for mingw. 