### PR TITLE
[Proof of concept] threading: preemptive, local/global

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -10273,11 +10273,13 @@ void ggml_graph_compute(struct ggml_context * ctx, struct ggml_cgraph * cgraph) 
     }
 
 #ifdef GGML_GLOBAL_THREADS
-    // wakeup threads.
-    pthread_mutex_lock(&state_shared->mutex);
-    state_shared->wait_cmd = false;
-    pthread_cond_broadcast(&state_shared->cond);
-    pthread_mutex_unlock(&state_shared->mutex);
+    if (n_threads > 1) {
+        // wakeup threads.
+        pthread_mutex_lock(&state_shared->mutex);
+        state_shared->wait_cmd = false;
+        pthread_cond_broadcast(&state_shared->cond);
+        pthread_mutex_unlock(&state_shared->mutex);
+    }
 #endif
 
 #ifdef GGML_PERF

--- a/ggml.c
+++ b/ggml.c
@@ -33,17 +33,25 @@
 typedef volatile LONG atomic_int;
 typedef atomic_int atomic_bool;
 
-static void atomic_store(atomic_int* ptr, LONG val) {
+static inline void atomic_store(atomic_int* ptr, LONG val) {
     InterlockedExchange(ptr, val);
 }
-static LONG atomic_load(atomic_int* ptr) {
+static inline LONG atomic_load(atomic_int* ptr) {
     return InterlockedCompareExchange(ptr, 0, 0);
 }
-static LONG atomic_fetch_add(atomic_int* ptr, LONG inc) {
+static inline LONG atomic_fetch_add(atomic_int* ptr, LONG inc) {
     return InterlockedExchangeAdd(ptr, inc);
 }
-static LONG atomic_fetch_sub(atomic_int* ptr, LONG dec) {
+static inline LONG atomic_fetch_sub(atomic_int* ptr, LONG dec) {
     return atomic_fetch_add(ptr, -(dec));
+}
+
+static inline LONG atomic_flag_test_and_set(atomic_int* ptr) {
+    return InterlockedCompareExchange(ptr, 1, 0);
+}
+
+static inline LONG atomic_flag_test_clear(atomic_int* ptr) {
+    return InterlockedExchange(ptr, 0)
 }
 
 typedef HANDLE pthread_t;

--- a/ggml.c
+++ b/ggml.c
@@ -10041,7 +10041,7 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
 
 // Get supported task types (bit OR) for given forward op.
 // TODO: use static map.
-static int ggml_forward_op_tasks(enum ggml_op op) { 
+static int ggml_forward_op_tasks(enum ggml_op op) {
     switch (op) {
         case GGML_OP_DUP:
         case GGML_OP_ADD:
@@ -10412,7 +10412,7 @@ void ggml_graph_compute(struct ggml_context * ctx, struct ggml_cgraph * cgraph) 
                 params.wsize = cgraph->work ? ggml_nbytes(cgraph->work) : 0;
                 params.wdata = cgraph->work ? cgraph->work->data : NULL;
                 ggml_compute_forward(&params, node);
-            
+
                 // wait for tasks done.
                 if (n > 0) {
                     while (state_shared->n_done != n) {

--- a/ggml.c
+++ b/ggml.c
@@ -32,6 +32,7 @@
 
 typedef volatile LONG atomic_int;
 typedef atomic_int atomic_bool;
+typedef atomic_int atomic_flag;
 
 static inline void atomic_store(atomic_int* ptr, LONG val) {
     InterlockedExchange(ptr, val);
@@ -46,11 +47,11 @@ static inline LONG atomic_fetch_sub(atomic_int* ptr, LONG dec) {
     return atomic_fetch_add(ptr, -(dec));
 }
 
-static inline LONG atomic_flag_test_and_set(atomic_int* ptr) {
+static inline LONG atomic_flag_test_and_set(atomic_flag* ptr) {
     return InterlockedCompareExchange(ptr, 1, 0);
 }
 
-static inline LONG atomic_flag_test_clear(atomic_int* ptr) {
+static inline LONG atomic_flag_test_clear(atomic_flag* ptr) {
     return InterlockedExchange(ptr, 0)
 }
 
@@ -10270,7 +10271,6 @@ void ggml_graph_compute(struct ggml_context * ctx, struct ggml_cgraph * cgraph) 
             GGML_ASSERT(rc == 0);
         }
     }
-
 
 #ifdef GGML_GLOBAL_THREADS
     // wakeup threads.


### PR DESCRIPTION
The original motivation under this PR is try balancing between performance and energy. 
General speaking, no obvious speedup or slow down from my observations.

Main ideas:  
1. Spin + pause when compute a graph. Pause slightly increase performance (tested on Intel mac, 4 threads)
2. Preemptive task queue. This helps when thread speed is uneven, and if we could parallel sibling nodes.
3. Global threads are created once, wait/notify between graph. This can be adapted as session level thread pool. 
4. Avoid unnecessary scheduling according to node op type.

On Intel mac, I tested it with:
```
make && ./main -m ./models/7B/ggml-model-q4_0.bin -n 1024  --mlock --top_p 1 --top_k 1 -p "Tell me the size of earth and moon" -t 4
```

Where the `--top_p 1 --top_k 1` forces same output.

[EDIT] <del>it failed to compile on Windows, I'm not sure it will run as expected on Windows even if it had passed suddenly.</del>
Since this draft and proof of concept, I may not able to fix windows related bugs because I don't have Windows.