### PR TITLE
print timings on ctrl+c exit

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -25,7 +25,7 @@
 #endif
 
 static console_state con_st;
-llama_context * ctx;
+static llama_context ** g_ctx;
 
 static bool is_interacting = false;
 
@@ -37,7 +37,7 @@ void sigint_handler(int signo) {
         if (!is_interacting) {
             is_interacting=true;
         } else {
-            llama_print_timings(ctx);
+            llama_print_timings(*g_ctx);
             _exit(130);
         }
     }
@@ -94,6 +94,9 @@ int main(int argc, char ** argv) {
 
 //    params.prompt = R"(// this function checks if the number n is prime
 //bool is_prime(int n) {)";
+    
+    llama_context * ctx;
+    g_ctx = &ctx;
 
     // load the model
     {

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -38,7 +38,6 @@ void sigint_handler(int signo) {
             is_interacting=true;
         } else {
             llama_print_timings(ctx);
-            llama_free(ctx);
             _exit(130);
         }
     }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 static console_state con_st;
+llama_context * ctx;
 
 static bool is_interacting = false;
 
@@ -36,6 +37,8 @@ void sigint_handler(int signo) {
         if (!is_interacting) {
             is_interacting=true;
         } else {
+            llama_print_timings(ctx);
+            llama_free(ctx);
             _exit(130);
         }
     }
@@ -92,8 +95,6 @@ int main(int argc, char ** argv) {
 
 //    params.prompt = R"(// this function checks if the number n is prime
 //bool is_prime(int n) {)";
-
-    llama_context * ctx;
 
     // load the model
     {


### PR DESCRIPTION
Currently the timing stats do not print when you use CTRL+C to exit interactive mode. This is the simplest way to fix that. 