### PR TITLE
Do not close file after mmap (Windows version)

### DIFF
--- a/llama_util.h
+++ b/llama_util.h
@@ -202,7 +202,6 @@ struct llama_mmap {
 
         HANDLE hMapping = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
         DWORD error = GetLastError();
-        CloseHandle(hFile);
 
         if (hMapping == NULL) {
             throw format("CreateFileMappingA failed: %s", llama_format_win_err(error).c_str());


### PR DESCRIPTION
This is the Windows version of #1017. Just as with Unix-based systems, closing the same handle twice is mostly harmless, but when working on #1010, I noticed that the duplicated `CloseHandle()` triggers an "Invalid handle" exception in the debugger:
```
(3f00.2cbc): Invalid handle - code c0000008 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
ntdll!KiRaiseUserExceptionDispatcher+0x3a:
00007ffb`5e072d6a 8b8424c0000000  mov     eax,dword ptr [rsp+0C0h] ss:0000008e`6cffd230=c0000008
```

You can skip this exception and continue debugging, but I think it's better to fix this properly.