### PR TITLE
Interface improvements and `--multiline-input` (previously `--author-mode`)

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -274,10 +274,10 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.embedding = true;
         } else if (arg == "--interactive-first") {
             params.interactive_first = true;
-        } else if (arg == "--author-mode") {
-            params.author_mode = true;
         } else if (arg == "-ins" || arg == "--instruct") {
             params.instruct = true;
+        } else if (arg == "--multiline-input") {
+            params.multiline_input = true;
         } else if (arg == "--color") {
             params.use_color = true;
         } else if (arg == "--mlock") {
@@ -368,7 +368,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -i, --interactive     run in interactive mode\n");
     fprintf(stderr, "  --interactive-first   run in interactive mode and wait for input right away\n");
     fprintf(stderr, "  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
-    fprintf(stderr, "  --author-mode         allows you to write or paste multiple lines without ending each in '\\'\n");
+    fprintf(stderr, "  --multiline-input     allows you to write or paste multiple lines without ending each in '\\'\n");
     fprintf(stderr, "  -r PROMPT, --reverse-prompt PROMPT\n");
     fprintf(stderr, "                        run in interactive mode and poll user input upon seeing PROMPT (can be\n");
     fprintf(stderr, "                        specified more than once for multiple prompts).\n");
@@ -644,7 +644,7 @@ bool console_readline(console_state & con_st, std::string & line) {
         }
     }
 
-    bool has_more = con_st.author_mode;
+    bool has_more = con_st.multiline_input;
     if (is_special_char) {
         fputs("\b \b", stdout); // Move cursor back, print a space, and move cursor back again
 

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -622,7 +622,7 @@ bool console_readline(console_state & con_st, std::string & line) {
                 fputs("\b \b", stdout); // Move cursor back, print a space, and move cursor back again
                 remove_last_utf8_char(line);
             }
-        } else if (input_char < 32) {
+        } else if (static_cast<unsigned>(input_char) < 32) {
             // Ignore control characters
         } else {
 #if defined(_WIN32)

--- a/examples/common.h
+++ b/examples/common.h
@@ -60,7 +60,7 @@ struct gpt_params {
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately
-    bool author_mode       = false; // reverse the usage of `\`
+    bool multiline_input   = false; // reverse the usage of `\`
 
     bool instruct          = false; // instruction mode (used for Alpaca models)
     bool penalize_nl       = true;  // consider newlines as a repeatable token
@@ -109,7 +109,7 @@ enum console_color_t {
 };
 
 struct console_state {
-    bool author_mode = false;
+    bool multiline_input = false;
     bool use_color = false;
     console_color_t color = CONSOLE_COLOR_DEFAULT;
 #if !defined (_WIN32)

--- a/examples/common.h
+++ b/examples/common.h
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #if !defined (_WIN32)
+#include <stdio.h>
 #include <termios.h>
 #endif
 
@@ -112,7 +113,12 @@ struct console_state {
     bool multiline_input = false;
     bool use_color = false;
     console_color_t color = CONSOLE_COLOR_DEFAULT;
-#if !defined (_WIN32)
+
+    FILE* out = stdout;
+#if defined (_WIN32)
+    void* hConsole;
+#else
+    FILE* tty = nullptr;
     termios prev_state;
 #endif
 };

--- a/examples/common.h
+++ b/examples/common.h
@@ -10,6 +10,10 @@
 #include <thread>
 #include <unordered_map>
 
+#if !defined (_WIN32)
+#include <termios.h>
+#endif
+
 //
 // CLI argument parsing
 //
@@ -56,6 +60,7 @@ struct gpt_params {
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately
+    bool author_mode       = false; // reverse the usage of `\`
 
     bool instruct          = false; // instruction mode (used for Alpaca models)
     bool penalize_nl       = true;  // consider newlines as a repeatable token
@@ -104,13 +109,15 @@ enum console_color_t {
 };
 
 struct console_state {
+    bool author_mode = false;
     bool use_color = false;
     console_color_t color = CONSOLE_COLOR_DEFAULT;
+#if !defined (_WIN32)
+    termios prev_state;
+#endif
 };
 
-void set_console_color(console_state & con_st, console_color_t color);
-
-#if defined (_WIN32)
-void win32_console_init(bool enable_color);
-void win32_utf8_encode(const std::wstring & wstr, std::string & str);
-#endif
+void console_init(console_state & con_st);
+void console_cleanup(console_state & con_st);
+void console_set_color(console_state & con_st, console_color_t color);
+bool console_readline(console_state & con_st, std::string & line);

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -35,12 +35,12 @@ static bool is_interacting = false;
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
 void sigint_handler(int signo) {
-    set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
-    printf("\n"); // this also force flush stdout.
     if (signo == SIGINT) {
         if (!is_interacting) {
             is_interacting=true;
         } else {
+            console_cleanup(con_st);
+            printf("\n");
             llama_print_timings(*g_ctx);
             _exit(130);
         }
@@ -59,10 +59,9 @@ int main(int argc, char ** argv) {
     // save choice to use color for later
     // (note for later: this is a slightly awkward choice)
     con_st.use_color = params.use_color;
-
-#if defined (_WIN32)
-    win32_console_init(params.use_color);
-#endif
+    con_st.author_mode = params.author_mode;
+    console_init(con_st);
+    atexit([]() { console_cleanup(con_st); });
 
     if (params.perplexity) {
         printf("\n************\n");
@@ -275,12 +274,21 @@ int main(int argc, char ** argv) {
     std::fill(last_n_tokens.begin(), last_n_tokens.end(), 0);
 
     if (params.interactive) {
+        const char *control_message;
+        if (con_st.author_mode) {
+            control_message = " - To return control to LLaMa, end your input with '\\'.\n"
+                              " - To return control without starting a new line, end your input with '/'.\n";
+        } else {
+            control_message = " - Press Return to return control to LLaMa.\n"
+                              " - To return control without starting a new line, end your input with '/'.\n"
+                              " - If you want to submit another line, end your input with '\\'.\n";
+        }
         fprintf(stderr, "== Running in interactive mode. ==\n"
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
                " - Press Ctrl+C to interject at any time.\n"
 #endif
-               " - Press Return to return control to LLaMa.\n"
-               " - If you want to submit another line, end your input in '\\'.\n\n");
+               "%s\n", control_message);
+
         is_interacting = params.interactive_first;
     }
 
@@ -299,7 +307,7 @@ int main(int argc, char ** argv) {
     int n_session_consumed = 0;
 
     // the first thing we will do is to output the prompt, so set color accordingly
-    set_console_color(con_st, CONSOLE_COLOR_PROMPT);
+    console_set_color(con_st, CONSOLE_COLOR_PROMPT);
 
     std::vector<llama_token> embd;
 
@@ -498,7 +506,7 @@ int main(int argc, char ** argv) {
         }
         // reset color to default if we there is no pending user input
         if (input_echo && (int)embd_inp.size() == n_consumed) {
-            set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
+            console_set_color(con_st, CONSOLE_COLOR_DEFAULT);
         }
 
         // in interactive mode, and not currently processing queued inputs;
@@ -518,17 +526,12 @@ int main(int argc, char ** argv) {
                     if (last_output.find(antiprompt.c_str(), last_output.length() - antiprompt.length(), antiprompt.length()) != std::string::npos) {
                         is_interacting = true;
                         is_antiprompt = true;
-                        set_console_color(con_st, CONSOLE_COLOR_USER_INPUT);
-                        fflush(stdout);
                         break;
                     }
                 }
             }
 
             if (n_past > 0 && is_interacting) {
-                // potentially set color to indicate we are taking user input
-                set_console_color(con_st, CONSOLE_COLOR_USER_INPUT);
-
                 if (params.instruct) {
                     printf("\n> ");
                 }
@@ -542,31 +545,12 @@ int main(int argc, char ** argv) {
                 std::string line;
                 bool another_line = true;
                 do {
-#if defined(_WIN32)
-                    std::wstring wline;
-                    if (!std::getline(std::wcin, wline)) {
-                        // input stream is bad or EOF received
-                        return 0;
-                    }
-                    win32_utf8_encode(wline, line);
-#else
-                    if (!std::getline(std::cin, line)) {
-                        // input stream is bad or EOF received
-                        return 0;
-                    }
-#endif
-                    if (!line.empty()) {
-                        if (line.back() == '\\') {
-                            line.pop_back(); // Remove the continue character
-                        } else {
-                            another_line = false;
-                        }
-                        buffer += line + '\n'; // Append the line to the result
-                    }
+                    another_line = console_readline(con_st, line);
+                    buffer += line;
                 } while (another_line);
 
                 // done taking input, reset color
-                set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
+                console_set_color(con_st, CONSOLE_COLOR_DEFAULT);
 
                 // Add tokens to embd only if the input buffer is non-empty
                 // Entering a empty line lets the user pass control back
@@ -621,8 +605,6 @@ int main(int argc, char ** argv) {
 
     llama_print_timings(ctx);
     llama_free(ctx);
-
-    set_console_color(con_st, CONSOLE_COLOR_DEFAULT);
 
     return 0;
 }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char ** argv) {
     // save choice to use color for later
     // (note for later: this is a slightly awkward choice)
     con_st.use_color = params.use_color;
-    con_st.author_mode = params.author_mode;
+    con_st.multiline_input = params.multiline_input;
     console_init(con_st);
     atexit([]() { console_cleanup(con_st); });
 
@@ -275,7 +275,7 @@ int main(int argc, char ** argv) {
 
     if (params.interactive) {
         const char *control_message;
-        if (con_st.author_mode) {
+        if (con_st.multiline_input) {
             control_message = " - To return control to LLaMa, end your input with '\\'.\n"
                               " - To return control without starting a new line, end your input with '/'.\n";
         } else {


### PR DESCRIPTION
I wanted to make it easier for authors to use this in their writing process.

I've tested the code on both Linux and Windows. I don't see why it wouldn't also work on a Mac, but it would be nice to have confirmation of that.

I also apologize for the volume of lines changed but each change seemed tied to the next so I ended up putting it through as one commit. With any code changes, my goal was to make `main.cpp` simpler to read. There's still a lot that can be done, but I do believe the input loop is a lot cleaner now.

Changes:
* Adds `--author-mode` where we read from input *until* the user ends their line with a `\`
* Allows the user to end with `/` such that inference starting from that position (without the `\n`)
* Highlights the above-mentioned control characters (when `--color` is enabled) so it's harder to accidentally end a line with `\` or `/`
* Cleans up superfluous control characters and line breaks

Before:
![warning](https://user-images.githubusercontent.com/2416298/232747348-9a4d8670-2903-4700-9b8f-ba5bf2e83e4b.png)

After:
![A New Kind of Cheese](https://user-images.githubusercontent.com/2416298/232747468-637500e5-c88b-4489-ac94-377a576a0e41.png)
![ai overlord](https://user-images.githubusercontent.com/2416298/232747519-4ee13f31-f0b1-4fcf-9878-5a91526fc6f3.png)

<details>
  <summary>Detailed changes</summary>

Author mode allows one to write (or paste) multiple lines of text without ending each line in a `\`. LLM models do better the more context you give them, but the original input flow made this difficult. (Before pasting your writing you'd have to edit a `\` into each line or paste it to a file, save that file, and then pass that path in with `-f`. If you're doing multiple revisions, that can become overwhelming.

Another useful feature for writing is the ability to start inference in the middle of a line. It’s not uncommon for writers to get stuck in the middle of a paragraph or piece of dialogue. I wanted to provide a way for the language model to generate text from that point, but previously, the best one could do was to hit enter and have the code append a `\n` to the buffer before starting inference.

I considered making author mode the default and creating a `--chat-mode` option with the previous behavior (and implying chat mode with `--instruct`). However, I decided against changing the default interaction people were familiar with. As a compromise, I allow the `/` operator to work in both modes.

The other quality of life improvement I really wanted for writing with the AI was to get rid of all the superfluous newlines and control characters that jumble up your text while working. To do this and have it display properly, I had to change the code to read one char at a time. By reading one character at a time, we don't have to print the newline when the user hits enter. This allows the use of `/` and `\` to flow more smoothly and lets us clean up any control characters from the input before we start text inference. This also makes the Windows and Linux versions behave the same in regards to input buffering, for better and for worse. (For example, if you hit a key while it's inferring, it won't jumble up the text, but you also won't see your text while the model is loading.)

Another improvement I made for writing with the AI was to eliminate superfluous newlines and control characters that can clutter up text while working. To achieve this and display text properly, I changed the code to read one character at a time. To start with, when the user hits enter, we don’t have to print a newline. It allows for smoother use of `/` and and lets us remove any control characters from the input before starting text inference. This change also makes the Windows and Linux versions behave consistently in terms of input buffering, with both advantages and disadvantages. For instance, hitting a key while the model is inferring won’t mix it into the text on Linux anymore, but you also won’t see any of the input you type while the model is loading.

The other code changes are to `console_state`. It now holds the previous `termios` settings so we can safely reset the terminal on exit for POSIX systems. This also means including `termios.h`. The other change was to add the `author_mode` boolean. I thought about calling it `input_mode` and making an `enum` but unless we want to have different input modes for chat, instruct, etc, this is just simpler (and it's easily changed in the future).
</details>

I also considered finding a way of hiding that first space that's generated when priming the llama models since the original llama tokenizer also starts each prompt with a single space. Are we sure this is necessary? If so, would it be acceptable to just hide that first space?

<details>
<summary>Future possible changes</summary>

Further quality of life enhancements:
* Full support for left, right, ins, del, home, and end keys
  - I don't foresee any issues implementing this other than there just being a larger code base, which may be unwanted
  - At some point using a library like ncurses is better, but to keep the requirements to a minimum, adding this ourselves doesn't feel unreasonable
* Use color by default for interactive terminals (that aren't being piped)
  - Implemented with `isatty` on POSIX systems and `_isatty` on Windows
  - Programs like `grep` already do this
  - I would suggest adding `--color=always,never,auto` just like `grep` has but perhaps switch from `color=never` to `color=auto` on any interactive mode (for compatibility `--color` without an option would just indicate `always`)
* Change the cursor to indicate when the user is waiting on inference
  - We could probably only do this when `use_color` is true since changing the cursor will leave artifacts in stdout if piped
* Choose a different color for control characters `\` and `/`
  - I think the current colors are clear enough but if someone feels otherwise, it would be easy to use a different color
* Read input on another thread
  - This would give us the ability to process each line as it is added as opposed to waiting until all input has been entered. This will also allow us to take input a little earlier as the model is being primed with " "
  - Would make the program "feel" a little faster

Further code improvements:
* Replacing `last_n_tokens` with a ring-buffer
* Abstract away signal handling code to common to remove the last of the #ifdef blocks in `main.cpp` code
* Evaluate conversions from 'time_t' to 'int32_t' and 'time_t' to 'int32_t' and static cast them
</details>

Of the future possible changes, I think using the other control keys is most appealing to me. Followed by putting the input on a separate thread to allow context chugging on previous lines as the user writes subsequent lines. I'm not very active on github so I have no way of proving it, but I'm quite experience with threading and synchronization. Both of these (particularly the multithreading) may add more complexity to the code than is desired for an "example" program.

Edit: This is also a first step towards moving away from `Ctrl-C` to interrupt inference if that's desired. Once we are handling keys one a time like this, we can more easily make `Esc` (or any other key) interrupt inference.