### PR TITLE
Nix: Build shared library

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
           buildInputs = with pkgs; lib.optionals stdenv.isDarwin [
             darwin.apple_sdk.frameworks.Accelerate
           ];
+          makeFlags = with pkgs; lib.optionals (system == "aarch64-darwin") [
+            "CFLAGS=-D__ARM_FEATURE_DOTPROD=1"
+          ];
           buildPhase = ''
             make main quantize quantize-stats perplexity embedding vdot libllama.so
           '';


### PR DESCRIPTION
I couldn't get CMake to cooperate, so I ended up using the plain Makefile instead. I've tested the shared library as well as `llama` and `embedding` binaries. I already have this flake as an input in a personal repository, and this change works for me when integrated.

I do need an aarch64 Darwin user to verify that the `CFLAGS` work properly. @niklaskorz, does this work for you?

See also NixOS/nixpkgs#225058, since I know that it's controversial to have a flake.