### PR TITLE
Continuous layouts for quantization q4_0c

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -8,6 +8,7 @@
 
 static const std::map<std::string, enum llama_ftype> LLAMA_FTYPE_MAP = {
   {"q4_0", LLAMA_FTYPE_MOSTLY_Q4_0},
+  {"q4_0c", LLAMA_FTYPE_MOSTLY_Q4_0C},
   {"q4_1", LLAMA_FTYPE_MOSTLY_Q4_1},
   {"q4_2", LLAMA_FTYPE_MOSTLY_Q4_2},
   {"q5_0", LLAMA_FTYPE_MOSTLY_Q5_0},

--- a/ggml.c
+++ b/ggml.c
@@ -2855,13 +2855,13 @@ static inline __m512 dot_q4_0c_fourblocks_avx512(
 ) {
     // load quantized bytes
     // TODO: change back to aligned loads
-    const __m512i xqs0123 = _mm512_loadu_epi64( xqs );
+    const __m512i xqs0123 = _mm512_loadu_si512( xqs );
     const __m512i low_nibble_mask = _mm512_set1_epi8( 0xf );
     const __m512i xqs01 = _mm512_and_si512( low_nibble_mask, xqs0123 );
     // TODO: try srlv/i?
     const __m512i xqs23 = _mm512_and_si512( low_nibble_mask, _mm512_srli_epi32( xqs0123, 4 ) );
-    const __m512i yqs01 = _mm512_loadu_epi64( yqs );
-    const __m512i yqs23 = _mm512_loadu_epi64( yqs + 2*QK8_0C );
+    const __m512i yqs01 = _mm512_loadu_si512( yqs );
+    const __m512i yqs23 = _mm512_loadu_si512( yqs + 2*QK8_0C );
 
     // load scales
     const __m512i scale_mask0 = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);

--- a/ggml.h
+++ b/ggml.h
@@ -237,6 +237,8 @@ extern "C" {
         GGML_TYPE_Q5_1 = 7,
         GGML_TYPE_Q8_0 = 8,
         GGML_TYPE_Q8_1 = 9,
+        GGML_TYPE_Q4_0C = 10,
+        GGML_TYPE_Q8_0C = 11,
         GGML_TYPE_I8,
         GGML_TYPE_I16,
         GGML_TYPE_I32,

--- a/ggml.h
+++ b/ggml.h
@@ -871,13 +871,14 @@ extern "C" {
     //
 
     GGML_API size_t ggml_quantize_q4_0(const float * src, void * dst, int n, int k, int64_t * hist);
+    GGML_API size_t ggml_quantize_q4_0c(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q4_1(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q4_2(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q5_0(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q5_1(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q8_0(const float * src, void * dst, int n, int k, int64_t * hist);
 
-    GGML_API size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, int start, int n, int64_t * hist);
+    GGML_API size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, int start, int n, int k, int64_t * hist);
 
     //
     // system info

--- a/llama.h
+++ b/llama.h
@@ -83,6 +83,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q8_0 = 7,  // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q5_0 = 8,  // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q5_1 = 9,  // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_Q4_0C = 20,  // except 1d tensors
     };
 
     LLAMA_API struct llama_context_params llama_context_default_params();

--- a/tests/test-quantize-perf.cpp
+++ b/tests/test-quantize-perf.cpp
@@ -228,7 +228,7 @@ int main(int argc, char * argv[]) {
         if (qfns.quantize_row_q && qfns.dequantize_row_q) {
             printf("%s\n", ggml_type_name(type));
 
-            if (params.op_quantize_row_q_reference) {
+            if (params.op_quantize_row_q_reference && qfns.quantize_row_q_reference) {
                 printf("  quantize_row_q_reference\n");
                 for (size_t size : params.test_sizes) {
                     printf("    %zu values (%.2f MB)\n", size, 4*size/(float)(1024*1024));
@@ -242,7 +242,7 @@ int main(int argc, char * argv[]) {
                 printf("\n");
             }
 
-            if (params.op_quantize_row_q) {
+            if (params.op_quantize_row_q && qfns.quantize_row_q) {
                 printf("  quantize_row_q\n");
                 for (size_t size : params.test_sizes) {
                     printf("    %zu values (%.2f MB)\n", size, 4*size/(float)(1024*1024));
@@ -256,7 +256,7 @@ int main(int argc, char * argv[]) {
                 printf("\n");
             }
 
-            if (params.op_dequantize_row_q) {
+            if (params.op_dequantize_row_q && qfns.dequantize_row_q) {
                 printf("  dequantize_row_q\n");
                 qfns.quantize_row_q(test_data1, test_q1, largest);
                 for (size_t size : params.test_sizes) {
@@ -271,7 +271,7 @@ int main(int argc, char * argv[]) {
                 printf("\n");
             }
 
-            if (params.op_quantize_row_q_dot) {
+            if (params.op_quantize_row_q_dot && qfns.quantize_row_q_dot) {
                 printf("  quantize_row_q_dot\n");
                 for (size_t size : params.test_sizes) {
                     printf("    %zu values (%.2f MB)\n", size, 4*size/(float)(1024*1024));
@@ -285,7 +285,7 @@ int main(int argc, char * argv[]) {
                 printf("\n");
             }
 
-            if (params.op_vec_dot_q) {
+            if (params.op_vec_dot_q && qfns.vec_dot_q) {
                 printf("  vec_dot_q\n");
                 qfns.quantize_row_q(test_data1, test_q1, largest);
                 qfns.quantize_row_q(test_data2, test_q2, largest);


### PR DESCRIPTION
Adds a q4_0c type that corresponds to the q4_0 layout but with a different memory layout.

Draft status, currently only accelerated for AVX-512, will add a PoC of Neon acceleration but wanted to put this out there since there is some experimentation with quantization formats going on now.

The layout consists of all the quantized values first in blocks of 128 nibbles, followed by all the scales.
The nibbles within a block are laid out consecutively in the lower nibbles, and then consecutively in the higher nibbles.
For dot products we use a q8_0c format, with all the qs bytes followed by all the scales.

The big win is for architectures with larger registers like AVX-512, that can now get two continuous blocks of qs by doing roughly
```
   xqs01  = xqs0123      & 0x0f0f...
   xqs23  = xqs0123 >> 4 & 0x0f0f...
```
The dot product implementation here borrows from @dfyz's implementation in #933, but becomes simpler because we don't need to do tricks with the byte layout.
Besides the simplified implementation there is also a small improvement in performance:
`llama_print_timings: prompt eval time =   665.66 ms /     6 tokens (  110.94 ms per token)`
`llama_print_timings:       total time = 15398.10 ms`
vs
`llama_print_timings: prompt eval time =   449.19 ms /     6 tokens (   74.86 ms per token)`
`llama_print_timings:       total time = 13557.80 ms`

The SIMD implementation with 128-bit registers like Neon should look very similar to the current implementations, with similar speeds. Possibly some benefit from doing only aligned loads.
The scalar implementations are slightly more complex but I do not see any degraded performance.

Perplexity should be exactly the same as q4_0.

<details>
<summary>Example timings (7B)</summary>

system_info: n_threads = 4 / 8 | AVX = 1 | AVX2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 | 

Current master q4_0:
```
llama_print_timings:        load time =   797.54 ms
llama_print_timings:      sample time =    69.77 ms /   100 runs   (    0.70 ms per run)
llama_print_timings: prompt eval time =   665.66 ms /     6 tokens (  110.94 ms per token)
llama_print_timings:        eval time = 14528.96 ms /    99 runs   (  146.76 ms per run)
llama_print_timings:       total time = 15398.10 ms
```

q4_0 with #933 
```
llama_print_timings:        load time =   751.74 ms
llama_print_timings:      sample time =    89.38 ms /   100 runs   (    0.89 ms per run)
llama_print_timings: prompt eval time =   620.75 ms /     6 tokens (  103.46 ms per token)
llama_print_timings:        eval time = 13475.35 ms /    99 runs   (  136.11 ms per run)
llama_print_timings:       total time = 14318.72 ms
```

continuous layout q4_0c:
```
llama_print_timings:        load time =   596.51 ms
llama_print_timings:      sample time =    73.39 ms /   100 runs   (    0.73 ms per run)
llama_print_timings: prompt eval time =   449.19 ms /     6 tokens (   74.86 ms per token)
llama_print_timings:        eval time = 12885.82 ms /    99 runs   (  130.16 ms per run)
llama_print_timings:       total time = 13557.80 ms
```
</details>

Todos:
- [X] AVX-512 acceleration
- [x] PoC ARM NEON acceleration
- [x] Investigate performance on M1
- [x] test out fully aligned loads by aligning the quantized file to 64 bytes

Future improvements:
- PoC for q4_2-like quantization 
- PoC 3-bit quantization
- Support row lengths not divisible by 128. I don't see any big obstacles, will require some extra code for the leftover block, and padding of rows to keep alignment.