### PR TITLE
Improve cuBLAS performance by using a memory pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,13 @@ ifdef LLAMA_OPENBLAS
 	LDFLAGS += -lopenblas
 endif
 ifdef LLAMA_CUBLAS
-	CFLAGS  += -DGGML_USE_CUBLAS -I/usr/local/cuda/include
-	LDFLAGS += -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64
-	OBJS	+= ggml-cuda.o
+	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include
+	LDFLAGS   += -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64
+	OBJS      += ggml-cuda.o
+	NVCC      = nvcc
+	NVCCFLAGS = --forward-unknown-to-host-linker -arch=native
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
-	nvcc -arch=native -c -o $@ $<
+	$(NVCC) $(NVCCFLAGS) $(CXXFLAGS) -c $< -o $@
 endif
 ifdef LLAMA_GPROF
 	CFLAGS   += -pg

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -154,11 +154,11 @@ void dequantize_row_q4_3_cuda(const void * vx, float * y, int k, cudaStream_t st
 // lock-free, thread safe buffer pool for cuda
 #define MAX_CUDA_BUFFERS 16
 struct cuda_buffer {
-    std::atomic_uintptr_t ptr;
-    size_t size;
+    std::atomic_uintptr_t ptr { 0 };
+    size_t size { 0 };
 };
 
-static struct cuda_buffer cuda_buffer_pool[MAX_CUDA_BUFFERS] = {0};
+static cuda_buffer cuda_buffer_pool[MAX_CUDA_BUFFERS];
 
 void * ggml_cuda_pool_malloc(size_t size, size_t * actual_size) {
     for (int i = 0; i < MAX_CUDA_BUFFERS; ++i) {

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -24,10 +24,8 @@ extern "C" {
         }                                                                               \
     } while (0)
 
-
-
-extern cublasHandle_t cublasH;
-extern cudaStream_t cudaStream;
+extern cublasHandle_t g_cublasH;
+extern cudaStream_t   g_cudaStream;
 
 void   ggml_init_cublas(void);
 void * ggml_cuda_pool_malloc(size_t size, size_t * actual_size);

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -1,6 +1,37 @@
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
+
+#define CUDA_CHECK(err)                                                                 \
+    do {                                                                                \
+        cudaError_t err_ = (err);                                                       \
+        if (err_ != cudaSuccess) {                                                      \
+            fprintf(stderr, "CUDA error %d at %s:%d: %s\n", err_, __FILE__, __LINE__,   \
+                cudaGetErrorString(err_));                                              \
+            exit(1);                                                                    \
+        }                                                                               \
+    } while (0)
+
+#define CUBLAS_CHECK(err)                                                               \
+    do {                                                                                \
+        cublasStatus_t err_ = (err);                                                    \
+        if (err_ != CUBLAS_STATUS_SUCCESS) {                                            \
+            fprintf(stderr, "cuBLAS error %d at %s:%d\n", err_, __FILE__, __LINE__);    \
+            exit(1);                                                                    \
+        }                                                                               \
+    } while (0)
+
+
+
+extern cublasHandle_t cublasH;
+extern cudaStream_t cudaStream;
+
+void   ggml_init_cublas(void);
+void * ggml_cuda_pool_malloc(size_t size, size_t * actual_size);
+void   ggml_cuda_pool_free(void * ptr, size_t size);
 
 void dequantize_row_q4_0_cuda(const void * vx, float * y, int k, cudaStream_t stream);
 void dequantize_row_q4_1_cuda(const void * vx, float * y, int k, cudaStream_t stream);


### PR DESCRIPTION
Previously, the cuda memory was allocated and freed as needed for each mat mul operation, which is very inefficient.
By using a memory pool, this is about 30-50% faster in my machine.

PR:
```
7B q4_0 3.59 seconds per pass - ETA 0.65 hours
7B f16  4.59 seconds per pass - ETA 0.83 hours
7B f32  6.68 seconds per pass - ETA 1.22 hours

 7B q4_0 llama_print_timings: prompt eval time =  5493.53 ms /   631 tokens (    8.71 ms per token)
13B q4_0 llama_print_timings: prompt eval time =  9003.90 ms /   631 tokens (   14.27 ms per token)
30B q4_0 llama_print_timings: prompt eval time = 19682.41 ms /   631 tokens (   31.19 ms per token)
```

Master:
```
7B q4_0 5.09 seconds per pass - ETA 0.93 hours

 7B q4_0 prompt eval time =  7840.48 ms /   631 tokens (   12.43 ms per token)
13B q4_0 prompt eval time = 13826.48 ms /   631 tokens (   21.91 ms per token)
```