### PR TITLE
Fix kv cache data pointers

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -2092,7 +2092,11 @@ void llama_set_kv_cache(
                          int   n_token_count) {
     // Make sure we have the same kv cache setup
     LLAMA_ASSERT(ctx->model.kv_self.buf.size == n_size);
+    void * k_data = ctx->model.kv_self.k->data; // remember data pointers
+    void * v_data = ctx->model.kv_self.v->data; // because their value is stored in buf and overwritten by memcpy
     memcpy(ctx->model.kv_self.buf.addr, kv_cache, n_size);
+    ctx->model.kv_self.k->data = k_data; // restore correct data pointers
+    ctx->model.kv_self.v->data = v_data;
     ctx->model.kv_self.n = n_token_count;
 }
 


### PR DESCRIPTION
Currently the functions to set the kv_cache will overwrite the data pointers of the k and v tensors, as the pointer address is stored in the memory block (kv_self.buf) itself and then overwritten by memcpy.

Restoring the cache only works correctly when restoring from the same runtime session as the data pointers will not have changed. 
I saw folks testing the kv_cache get and set by freeing the kv_cache ggml context, then making a new context and restoring to that. Probably the same memory block was allocated in the second context, so that it did not segfault.

When storing cache to file, restarting program and loading cache the pointers will be wrong and llama_eval will segfault.

To fix the problem, I remember the data pointers before memcpy overwrites kv_self.buf and then just restore them. 