### PR TITLE
RMSE-optimized quants for all quantization types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ option(LLAMA_ACCELERATE             "llama: enable Accelerate framework"        
 option(LLAMA_OPENBLAS               "llama: use OpenBLAS"                                   OFF)
 option(LLAMA_CUBLAS                 "llama: use cuBLAS"                                     OFF)
 
+# RMSE minimization when quantizing
+option(LLAMA_NO_RMSE                "llama: disable RMSE minimization"                      OFF)
+
 option(LLAMA_BUILD_TESTS            "llama: build tests"    ${LLAMA_STANDALONE})
 option(LLAMA_BUILD_EXAMPLES         "llama: build examples" ${LLAMA_STANDALONE})
 
@@ -97,6 +100,10 @@ if (NOT MSVC)
         add_compile_options(-fsanitize=undefined)
         link_libraries(-fsanitize=undefined)
     endif()
+endif()
+
+if (LLAMA_NO_RMSE)
+    add_compile_definitions(GGML_NO_RMSE)
 endif()
 
 if (APPLE AND LLAMA_ACCELERATE)

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ ifneq ($(filter armv8%,$(UNAME_M)),)
 	CFLAGS += -mfp16-format=ieee -mno-unaligned-access
 endif
 
+ifdef LLAMA_NO_RMSE
+	CFLAGS += -DGGML_NO_RMSE
+endif
+
 #
 # Print build information
 #

--- a/ggml.c
+++ b/ggml.c
@@ -2012,7 +2012,7 @@ static const quantize_fns_t quantize_fns[GGML_TYPE_COUNT] = {
     [GGML_TYPE_Q4_3] = {
         .dequantize_row_q         = dequantize_row_q4_3,
         .quantize_row_q           = quantize_row_q4_3,
-        .quantize_row_q_reference = (quantize_row_q_t) quantize_row_q4_3_reference, // TODO: RMSE optimization
+        .quantize_row_q_reference = (quantize_row_q_t) quantize_row_q4_3_reference,
         .quantize_row_q_dot       = quantize_row_q8_0,
         .vec_dot_q                = ggml_vec_dot_q4_3_q8_0,
     },

--- a/tests/test-quantize.c
+++ b/tests/test-quantize.c
@@ -1,0 +1,45 @@
+#include "ggml.h"
+#undef NDEBUG
+#include <assert.h>
+#include <math.h>
+
+int main(void) {
+// Sorry, but I have to disable these for RMSE-optimized quantization
+#ifdef GGML_NO_RMSE
+    #define QK 32
+    float src[QK];
+    uint8_t dst[24];
+    int64_t hist[16];
+
+    for (int i = 0; i < QK; i++) {
+        src[i] = (float)(i + 1);
+    }
+
+    size_t size = ggml_quantize_q4_0(src, dst, QK, QK, hist);
+    assert(size == 20);
+    float max_result = ((float *)dst)[0];
+    float max_expected = src[31] / ((1 << 3) - 1);
+    assert(max_result == max_expected);
+    for (int i = 0; i < QK; i++) {
+        uint8_t q4_result = (i % 2) ? (dst[sizeof(float) + i/2] >> 4) : (dst[sizeof(float) + i/2] & 0xF);
+        uint8_t q4_expected = roundf(src[i] / max_expected) + 8;
+        assert(q4_result == q4_expected);
+    }
+
+    size = ggml_quantize_q4_1(src, dst, QK, QK, hist);
+    assert(size == 24);
+    float delta_result = ((float *)dst)[0];
+    float delta_expected = (src[31] - src[0]) / ((1 << 4) - 1);
+    assert(delta_result == delta_expected);
+    float min_result = ((float *)dst)[1];
+    float min_expected = src[0];
+    assert(min_result == min_expected);
+    for (int i = 0; i < QK; i++) {
+        uint8_t q4_result = (i % 2) ? (dst[sizeof(float)*2 + i/2] >> 4) : (dst[sizeof(float)*2 + i/2] & 0xF);
+        uint8_t q4_expected = roundf((src[i] - min_expected) / delta_expected);
+        assert(q4_result == q4_expected);
+    }
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
The PR adds a new build option (`LLAMA_NO_RMSE`), which is off by default. When off, all current quantization types (`Q4_0, Q4_1, Q4_2, Q4_3`) are performed with RMSE minimization (on master RMSE minimization is enabled for `Q4_2` only and cannot easily be disabled).

This makes generation of quantized models quite a bit longer, but still in the same ballpark as it used to take before it was multi-threaded in PR #1075. 

With this option enabled, `Q4_3` gives a perplexity of `6.0344` for the 7B model, so 0.0273 lower than simple `Q4_3` quantization as reported by @ggerganov in #406. If I also enable his trick of not quantizing output tensors, perplexity becomes `6.0085`.

Perplexity result for `Q4_3` *without quantization of output tensors* for the 13B model is `5.3117`.

Details for these perplexity runs can be found in [here](https://github.com/ggerganov/llama.cpp/discussions/406#discussioncomment-5688096) (issue #406)

As far as I can tell, we are now on par with best known `GPTQ` result for 7B, and better for 13B by about `0.05`.   