### PR TITLE
Handle signals properly on Windows

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -21,6 +21,9 @@
 #include <signal.h>
 #include <unistd.h>
 #elif defined (_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
 #include <signal.h>
 #endif
 
@@ -261,7 +264,10 @@ int main(int argc, char ** argv) {
         sigint_action.sa_flags = 0;
         sigaction(SIGINT, &sigint_action, NULL);
 #elif defined (_WIN32)
-        signal(SIGINT, sigint_handler);
+        auto console_ctrl_handler = [](DWORD ctrl_type) -> BOOL {
+            return (ctrl_type == CTRL_C_EVENT) ? (sigint_handler(SIGINT), true) : false;
+        };
+        SetConsoleCtrlHandler(static_cast<PHANDLER_ROUTINE>(console_ctrl_handler), true);
 #endif
 
         fprintf(stderr, "%s: interactive mode on.\n", __func__);
@@ -539,11 +545,6 @@ int main(int argc, char ** argv) {
                 // potentially set color to indicate we are taking user input
                 set_console_color(con_st, CONSOLE_COLOR_USER_INPUT);
 
-#if defined (_WIN32)
-                // Windows: must reactivate sigint handler after each signal
-                signal(SIGINT, sigint_handler);
-#endif
-
                 if (params.instruct) {
                     printf("\n> ");
                 }
@@ -626,10 +627,6 @@ int main(int argc, char ** argv) {
             is_interacting = true;
         }
     }
-
-#if defined (_WIN32)
-    signal(SIGINT, SIG_DFL);
-#endif
 
     llama_print_timings(ctx);
     llama_free(ctx);


### PR DESCRIPTION
This uses Window's `SetConsoleCtrlHandler` to handle ctrl+c.

We currently use `signal` but Windows' [official documentation for `signal`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=msvc-170) warns us:
> - Don't issue low-level or STDIO.H I/O routines (for example, **printf** or **fread**).
> - Don't call heap routines or any routine that uses the heap routines (for example, **malloc**, **_strdup**, or **_putenv**).
> - Don't use any function that generates a system call (for example, **_getcwd** or **time**).
> - Don't use **longjmp** unless the interrupt is caused by a floating-point exception (that is, sig is SIGFPE).
> - Don't use any overlay routines.

This wasn't a big deal before but since we now [print timings on ctrl+c exit (1021)](https://github.com/ggerganov/llama.cpp/commit/36b4f7e06406eed8a605cc9f2921d9244ef6a8e5), we should probably handle the signal properly.

The [documentation for `SetConsoleCtrlHandler`](https://learn.microsoft.com/en-us/windows/console/setconsolectrlhandler) has no such warning and their [example code](https://learn.microsoft.com/en-us/windows/console/registering-a-control-handler-function) even shows them using `printf`.

Another advantage to doing it this way is we don't have to reinitialize SIGINT every loop in main like we currently do.

The only downside I see to this is the inclusion of <windows.h>, but fortunately we can cut down on what the header pulls in by defining `WIN32_LEAN_AND_MEAN`. If this still isn't satisfactory, I can change this to do a little cluster of defines at the top as is done in [common.cpp](https://github.com/ggerganov/llama.cpp/blob/master/examples/common.cpp#L10).