### PR TITLE
main: add pledge call on OpenBSD

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -43,6 +43,13 @@ void sigint_handler(int signo) {
 #endif
 
 int main(int argc, char ** argv) {
+#if defined (__OpenBSD__)
+    if (pledge("stdio rpath", "") == -1) {
+        fprintf(stderr, "%s: error: pledge failed\n", __func__);
+        return 1;
+    }
+#endif
+
     gpt_params params;
     params.model = "models/llama-7B/ggml-model.bin";
 


### PR DESCRIPTION
I feel much more comfortable with running code from the internet, if it is using pledge. It gives me the guarantee that the program is not, e.g., using the network or writing to the file system. See [pledge's man page](https://man.openbsd.org/OpenBSD-7.3/pledge.2) for more info.

I have only added the pledge call to the examples/main program for now, since this is the only one I'm using on my machine. Ideally every main function in this repository would start with a pledge call, but I'm not yet familiar enough with the other programs to implement this. If this change is welcome, I'll create further pull requests in the future, when I'm starting to use other programs of this repo.