### PR TITLE
Fix build for gcc 8 and test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ env:
  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  ubuntu-latest-make:
-    runs-on: ubuntu-latest
+  ubuntu-focal-make:
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Clone
@@ -31,12 +31,12 @@ jobs:
         id: depends
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential
+          sudo apt-get install build-essential gcc-8
 
       - name: Build
         id: make_build
         run: |
-          make
+          CC=gcc-8 make
 
   ubuntu-latest-cmake:
     runs-on: ubuntu-latest
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
-      - ubuntu-latest-make
+      - ubuntu-focal-make
       - ubuntu-latest-cmake
       - macOS-latest-make
       - macOS-latest-cmake

--- a/ggml.c
+++ b/ggml.c
@@ -436,7 +436,7 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 static inline __m128i bytes_from_nibbles_16(const uint8_t * rsi)
 {
     // Load 8 bytes from memory
-    __m128i tmp = _mm_loadu_si64( ( const __m128i* )rsi );
+    __m128i tmp = _mm_loadl_epi64( ( const __m128i* )rsi );
 
     // Expand bytes into uint16_t values
     __m128i bytes = _mm_cvtepu8_epi16( tmp );


### PR DESCRIPTION
[GCC 8 doesn't know `_mm_loadu_si64`](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78782), use the equivalent `_mm_loadl_epi64` which generates the [same opcode](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_load*i64&ig_expand=4511,4444).

Set the `make` CI check to run on Ubuntu 20.04 and GCC 8 to prevent such problems in the future. Of course we might decide to drop support for these old versions some time in the future.

See a failing check [here](https://github.com/sw/llama.cpp/actions/runs/4788036192/jobs/8514087108).

Resolves #1120