### PR TITLE
Implement scalar sum over all rows in ggml_compute_forward_sum_f32

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -6811,15 +6811,20 @@ static void ggml_compute_forward_sum_f32(
     const size_t nb02 = src0->nb[2];
     const size_t nb03 = src0->nb[3];
 
+    ggml_float sum     = 0;
+    float      row_sum = 0;
+
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
                 ggml_vec_sum_f32(ne00,
-                        (float *) (dst->data),
+                        &row_sum,
                         (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03));
+                sum += row_sum;
             }
         }
     }
+    ((float *) dst->data)[0] = sum;
 }
 
 static void ggml_compute_forward_sum(


### PR DESCRIPTION
I was trying the test-grad0 test from ggml and this way I found a bug in ggml_compute_forward_sum_f32.
Only the sum of the last processed row was written to dst:

https://github.com/ggerganov/llama.cpp/blob/8a0f8673ba1cdc6aa6df27a9fbc698431ca70e8d/ggml.c#L3201-L3210

https://github.com/ggerganov/llama.cpp/blob/8a0f8673ba1cdc6aa6df27a9fbc698431ca70e8d/ggml.c#L6782-L6790

With this PR the sum over all rows is accumulated and then written to dst.

What is not so nice about it, is that the row sum is converted from ggml_float to float, losing precision during accumulation.

---

Was computing single sum over all rows like I did meant by this TODO?
https://github.com/ggerganov/llama.cpp/blob/8a0f8673ba1cdc6aa6df27a9fbc698431ca70e8d/ggml.h#L486-L489

