### PR TITLE
Save and restore prompt evaluation state for much faster startup times

### DIFF
--- a/examples/chat-13B.sh
+++ b/examples/chat-13B.sh
@@ -31,8 +31,6 @@ The transcript only includes text, it does not include markup like HTML and Mark
 
 $USER_NAME: Hello, $AI_NAME!
 $AI_NAME: Hello $USER_NAME! How may I help you today?
-$USER_NAME: What time is it?
-$AI_NAME: It is $(date +%H:%M).
 $USER_NAME: What year is it?
 $AI_NAME: We are in $(date +%Y).
 $USER_NAME: Please tell me the largest city in Europe.
@@ -50,4 +48,6 @@ $AI_NAME: The arguments are stored in process.argv.
     argv[3] is the second argument passed to the script and so on.
 $USER_NAME: Name a color.
 $AI_NAME: Blue
+$USER_NAME: What time is it?
+$AI_NAME: It is $(date +%H:%M).
 $USER_NAME:" "$@"

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -61,6 +61,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.prompt = argv[i];
+        } else if (arg == "--session") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.path_session = argv[i];
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -228,6 +234,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -t N, --threads N     number of threads to use during computation (default: %d)\n", params.n_threads);
     fprintf(stderr, "  -p PROMPT, --prompt PROMPT\n");
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
+    fprintf(stderr, "  --session FNAME       file to cache model state in (may be large!) (default: none)\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  -f FNAME, --file FNAME\n");

--- a/examples/common.h
+++ b/examples/common.h
@@ -31,6 +31,7 @@ struct gpt_params {
 
     std::string model  = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt = "";
+    std::string path_session = "";       // path to file for saving/loading model eval state
     std::string input_prefix = "";       // string to prefix user inputs with
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -2412,3 +2412,56 @@ std::vector<std::pair<std::string, struct ggml_tensor *>>& llama_internal_get_te
     return ctx->model.tensors_by_name;
 }
 
+size_t llama_load_session_file(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
+    // TODO leverage mmap
+    llama_file file(path_session, "rb");
+    const uint32_t magic = file.read_u32();
+    const uint32_t version = file.read_u32();
+
+    if (!(magic == 'ggsn' && version == 0)) {
+        fprintf(stderr, "%s : unknown (magic, version) for session file: %08x, %08x\n", __func__, magic, version);
+        return 0;
+    }
+
+    llama_hparams session_hparams;
+    file.read_raw(&session_hparams, sizeof(llama_hparams));
+
+    // REVIEW
+    if (session_hparams != ctx->model.hparams) {
+        fprintf(stderr, "%s : model hparams didn't match from session file!\n", __func__);
+        return 0;
+    }
+
+    const uint32_t n_token_count = file.read_u32();
+    LLAMA_ASSERT(n_token_capacity >= n_token_count);
+    file.read_raw(tokens_out, sizeof(llama_token) * n_token_count);
+    *n_token_count_out = n_token_count;
+
+    const size_t n_state_size = file.size - file.tell();
+    const size_t n_orig_state_size = llama_get_state_size(ctx);
+    if (n_state_size != n_orig_state_size) {
+        fprintf(stderr, "%s : failed to validate state size\n", __func__);
+    }
+    std::unique_ptr<uint8_t[]> state_data(new uint8_t[n_state_size]);
+    file.read_raw(state_data.get(), n_state_size);
+    return llama_set_state_data(ctx, state_data.get());
+}
+
+size_t llama_save_session_file(struct llama_context * ctx, const char * path_session, const llama_token * tokens, size_t n_token_count) {
+    // TODO save temp & swap
+    llama_file file(path_session, "wb");
+
+    const size_t n_state_size = llama_get_state_size(ctx);
+    std::unique_ptr<uint8_t[]> state_data(new uint8_t[n_state_size]);
+    llama_copy_state_data(ctx, state_data.get());
+
+    file.write_u32('ggsn'); // magic
+    file.write_u32(0); // version
+    file.write_raw(&ctx->model.hparams, sizeof(llama_hparams));
+
+    file.write_u32((uint32_t) n_token_count); // REVIEW
+    file.write_raw(tokens, sizeof(llama_token) * n_token_count);
+
+    file.write_raw(state_data.get(), n_state_size);
+    return n_state_size; // REVIEW
+}

--- a/llama.h
+++ b/llama.h
@@ -127,6 +127,10 @@ extern "C" {
     // Returns the number of bytes read
     LLAMA_API size_t llama_set_state_data(struct llama_context * ctx, const uint8_t * src);
 
+    // Save/load session file
+    LLAMA_API size_t llama_load_session_file(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out);
+    LLAMA_API size_t llama_save_session_file(struct llama_context * ctx, const char * path_session, const llama_token * tokens, size_t n_token_count);
+
     // Run the llama inference to obtain the logits and probabilities for the next token.
     // tokens + n_tokens is the provided batch of new tokens to process
     // n_past is the number of tokens to use from previous eval calls


### PR DESCRIPTION
Hi! I decided to take a stab at leveraging the new get / set state APIs to cache initial prompt evaluation in `main`. On my M2 at least, this feature lets me start up `chat-13B.sh` with 65B in seconds (after having run before).

**Overview**

* Adds `llama_load_session_file` and `llama_save_session_file` APIs to serialize the model state + a user-provided sequence of input tokens (more on that later)
* Adds a `--session` arg to `examples/main` that designates a file to load/save the session (creating on first run). Currently this is just used to speed up initial prompt evaluation, but could eventually e.g., restore conversations

**Approach**

Establishes a binary session file format that prepends some additional metadata to the state returned by `llama_copy_state_data`.

```
'ggst' | <u32> 0 | <llama_hparams> | <u32> inp_token_count | <token_count * llama_token> inp_tokens | <llama_state>
```

The embedded hparams is a sanity check that we don't load the state for a different model. The `inp_tokens` stream represents the sequence of input tokens whose evaluation led to `llama_state`.

When a past session is present during model evaluation, the session tokens are used (in `examples/main`) to determine the matching prefix length between the saved session and the current prompt (and technically input). These are skipped over using `n_past`. Regular evaluation then continues from the next token onward.

For convenience, a single `--session` arg in `examples/main` designates the file to save the session to (creating if needed) and load from on successive calls.

**Testing**

For interactive sessions, I tested this with `examples/chat-13B.sh` against quantized 30B and 65B:
```
examples/chat-13B.sh -m ~/llama-models/30B/ggml-model-q4_0.bin --session chat-session-30B.bin
```

I also tested the regular, non-session usage.

To measure performance I ran `chat-13B.sh`, modified to be non-interactive and generate only 10 tokens.

**Results**

Some rough timing results from my M2 running 30B on the prompt from `chat-13B.sh`.

Before this feature, ~37s startup:
```
llama_print_timings:        load time = 34743.04 ms
llama_print_timings:      sample time =    29.21 ms /    10 runs   (    2.92 ms per run)
llama_print_timings: prompt eval time = 34721.95 ms /   508 tokens (   68.35 ms per token)
llama_print_timings:        eval time =  1994.03 ms /     9 runs   (  221.56 ms per run)
llama_print_timings:       total time = 36766.42 ms
```

After this feature, first run, ~40s startup:
```
llama_print_timings:        load time = 35040.24 ms
llama_print_timings:      sample time =    29.48 ms /    10 runs   (    2.95 ms per run)
llama_print_timings: prompt eval time = 35024.65 ms /   508 tokens (   68.95 ms per token)
llama_print_timings:        eval time =  2001.31 ms /     9 runs   (  222.37 ms per run)
llama_print_timings:       total time = 39635.71 ms
```

After this feature, successive runs, ~5s:
```
llama_print_timings:        load time =  2874.73 ms
llama_print_timings:      sample time =    28.82 ms /    10 runs   (    2.88 ms per run)
llama_print_timings: prompt eval time =  2148.04 ms /    14 tokens (  153.43 ms per token)
llama_print_timings:        eval time =  1753.77 ms /     9 runs   (  194.86 ms per run)
llama_print_timings:       total time =  4657.45 ms
```

**Caveats**

* I don't have a deep understanding of `n_past`, just that it can be leveraged for this prefix behavior
* Session files are ~GBs large and don't leverage mmap, incurring a slight delay to save/load
* The session usage in `examples/main` is oriented to optimizing initial prompt evaluation time. It uses a heuristic to determine if the session should be (re-)saved, such that loading (near) identitcal prompts doesn't incur the seconds to write the session file