### PR TITLE
force int cast

### DIFF
--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -49,7 +49,7 @@ def translate_tensor_name(t: str) -> str:
 def write_file_header(fout: TextIO, params: Dict[str, Any]) -> None:
     fout.write(b"ggla"[::-1])  # magic (ggml lora)
     fout.write(struct.pack("i", 1))  # file version
-    fout.write(struct.pack("ii", params["r"], params["lora_alpha"]))
+    fout.write(struct.pack("ii", params["r"], int(params["lora_alpha"])))
 
 
 def write_tensor_header(

--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -49,11 +49,11 @@ def translate_tensor_name(t: str) -> str:
 def write_file_header(fout: TextIO, params: Dict[str, Any]) -> None:
     fout.write(b"ggla"[::-1])  # magic (ggml lora)
     fout.write(struct.pack("i", 1))  # file version
-    fout.write(struct.pack("i", params["r"])
+    fout.write(struct.pack("i", params["r"]))
     # https://opendelta.readthedocs.io/en/latest/modules/deltas.html says that `lora_alpha` is an int
     # but some models ship a float value instead
     # let's convert to int, but fail if lossless conversion is not possible
-    assert int(lora_alpha) == lora_alpha, "cannot convert float to int losslessly"
+    assert int(params["lora_alpha"]) == params["lora_alpha"], "cannot convert float to int losslessly"
     fout.write(struct.pack("i", int(params["lora_alpha"])))
 
 
@@ -94,7 +94,7 @@ if params["peft_type"] != "LORA":
     print(f"Error: unsupported adapter type {params['peft_type']}, expected LORA")
     sys.exit(1)
 
-if params["fan_in_fan_out"] == True:
+if params["fan_in_fan_out"] is True:
     print("Error: param fan_in_fan_out is not supported")
     sys.exit(1)
 

--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -49,7 +49,12 @@ def translate_tensor_name(t: str) -> str:
 def write_file_header(fout: TextIO, params: Dict[str, Any]) -> None:
     fout.write(b"ggla"[::-1])  # magic (ggml lora)
     fout.write(struct.pack("i", 1))  # file version
-    fout.write(struct.pack("ii", params["r"], int(params["lora_alpha"])))
+    fout.write(struct.pack("i", params["r"])
+    # https://opendelta.readthedocs.io/en/latest/modules/deltas.html says that `lora_alpha` is an int
+    # but some models ship a float value instead
+    # let's convert to int, but fail if lossless conversion is not possible
+    assert int(lora_alpha) == lora_alpha, "cannot convert float to int losslessly"
+    fout.write(struct.pack("i", int(params["lora_alpha"])))
 
 
 def write_tensor_header(


### PR DESCRIPTION
 .0 in the config file for the lora_alpha param
and I got this error 
```
fout.write(struct.pack("ii", int(params["r"]), params["lora_alpha"]))
struct.error: required argument is not an integer
```
I just cast 