### PR TITLE
Add Manjaro CUDA include and lib dirs to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ ifdef LLAMA_OPENBLAS
 	LDFLAGS += -lopenblas
 endif
 ifdef LLAMA_CUBLAS
-	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include
-	LDFLAGS   += -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64
+	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I$(CUDA_PATH)/targets/x86_64-linux/include
+	LDFLAGS   += -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L$(CUDA_PATH)/targets/x86_64-linux/lib
 	OBJS      += ggml-cuda.o
 	NVCC      = nvcc
 	NVCCFLAGS = --forward-unknown-to-host-compiler -arch=native


### PR DESCRIPTION
I am using Manjaro and I installed CUDA via the package manager. The install location in my case is `/opt/cuda` which is also accessible via the environmental variable `CUDA_PATH`. However, the Makefile only uses the hard-coded location `/usr/local/cuda` to look up CUDA header files and libraries. Compiling with CUDA therefore does not run out-of-the-box on my machine.

This PR adds the paths that my CUDA install happens to be in to the Makefile. Alternatively it's possible to create a Makefile via cmake which automatically sets the correct include and lib directories for CUDA.