### PR TITLE
Fixed the `quantize` parameter will be failed if we just follow the `Prepare Data & Run` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ python3 -m pip install -r requirements.txt
 python3 convert.py models/7B/
 
 # quantize the model to 4-bits (using q4_0 method)
-./quantize ./models/7B/ggml-model-f16.bin ./models/7B/ggml-model-q4_0.bin q4_0
+./quantize ./models/7B/ggml-model-f16.bin ./models/7B/ggml-model-q4_0.bin 2
 
 # run the inference
 ./main -m ./models/7B/ggml-model-q4_0.bin -n 128


### PR DESCRIPTION
We need to pass in type 2, 3 rather than q4_0, q4_1 etc.  
type = 2 - q4_0
type = 3 - q4_1