### PR TITLE
ggml_used_mem can segfault if called before any objects are created.

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4411,7 +4411,7 @@ void ggml_free(struct ggml_context * ctx) {
 }
 
 size_t ggml_used_mem(const struct ggml_context * ctx) {
-    return ctx->objects_end->offs + ctx->objects_end->size;
+    return ctx->objects_end == NULL ? 0 : ctx->objects_end->offs + ctx->objects_end->size;
 }
 
 size_t ggml_set_scratch(struct ggml_context * ctx, struct ggml_scratch scratch) {


### PR DESCRIPTION
`ggml_used_mem` currently blindly dereferences `ctx->objects_end`, however that pointer is initially `NULL` and is only set when objects are created.

This tiny change just has it return `0` in that case (presumably if no objects were ever created, no memory is used).