### PR TITLE
Handle C++ libraries without threading support.

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -62,8 +62,12 @@ int32_t get_num_physical_cores() {
 #elif defined(_WIN32)
     //TODO: Implement
 #endif
+#if __STDCPP_THREADS__ || _GLIBCXX_HAS_GTHREADS
     unsigned int n_threads = std::thread::hardware_concurrency();
     return n_threads > 0 ? (n_threads <= 4 ? n_threads : n_threads / 2) : 4;
+#else
+    return 1;
+#endif
 }
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {

--- a/examples/common.h
+++ b/examples/common.h
@@ -7,8 +7,11 @@
 #include <string>
 #include <vector>
 #include <random>
+#if __STDCPP_THREADS__ || _GLIBCXX_HAS_GTHREADS
 #include <thread>
+#endif
 #include <unordered_map>
+#include <chrono>
 
 //
 // CLI argument parsing

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -59,7 +59,7 @@ int main(int argc, char ** argv) {
     {
         fprintf(stderr, "\n");
         fprintf(stderr, "system_info: n_threads = %d / %d | %s\n",
-                params.n_threads, std::thread::hardware_concurrency(), llama_print_system_info());
+                params.n_threads, get_num_physical_cores(), llama_print_system_info());
     }
 
     int n_past = 0;

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char ** argv) {
     {
         fprintf(stderr, "\n");
         fprintf(stderr, "system_info: n_threads = %d / %d | %s\n",
-                params.n_threads, std::thread::hardware_concurrency(), llama_print_system_info());
+                params.n_threads, get_num_physical_cores(), llama_print_system_info());
     }
 
     // determine the maximum memory usage needed to do inference for the given n_batch and n_predict parameters

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -158,7 +158,7 @@ int main(int argc, char ** argv) {
     {
         fprintf(stderr, "\n");
         fprintf(stderr, "system_info: n_threads = %d / %d | %s\n",
-                params.n_threads, std::thread::hardware_concurrency(), llama_print_system_info());
+                params.n_threads, get_num_physical_cores(), llama_print_system_info());
     }
 
     perplexity(ctx, params);


### PR DESCRIPTION
Adds preprocessor checks for `__STDCPP_THREADS__` before making use of `std::thread`.

Standard definition of define: https://timsong-cpp.github.io/cppwp/n3337/cpp.predefined#2.6
Example of how header files function if it is not present: https://github.com/llvm-mirror/libcxx/blob/78d6a7767ed57b50122a161b91f59f19c9bd0d19/include/thread#L109

Test failures were because older versions of gcc didn't have `__STDCPP_THREADS__` yet.
- [x] added check for `_GLIBCXX_HAS_GTHREADS` for older gcc's
- [x] added chrono for perplexity example, which was previously coming in from one of the `<thread>` includes