### PR TITLE
Improve ability to convert safetensors files.

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -750,7 +750,7 @@ def lazy_load_safetensors_file(fp: IO[bytes], path: Path) -> ModelPlus:
             return UnquantizedTensor(np.frombuffer(buf, dtype=numpy_dtype).reshape(shape))
         description = f'safetensors begin={begin} end={end} type={data_type} path={path}'
         return LazyTensor(load, shape, data_type, description)
-    model = {name: convert(info) for (name, info) in header.items()}
+    model = {name: convert(info) for (name, info) in header.items() if name != '__metadata__'}
     return ModelPlus(model=model, paths=[path], format='safetensors', vocab=None)
 
 
@@ -1037,6 +1037,10 @@ def load_some_model(path: Path) -> ModelPlus:
     if path.is_dir():
         globs = ["consolidated.00.pth", "pytorch_model-00001-of-*.bin", "*.pt"]
         files = [file for glob in globs for file in path.glob(glob)]
+        if not files:
+            # Check if it's a set of safetensors files
+            globs = ["model-00001-of-*.safetensors"]
+            files = [file for glob in globs for file in path.glob(glob)]
         if not files:
             # Try GGML too, but with lower priority, since if both a non-GGML
             # model and a GGML model exist in the same directory, we assume the

--- a/convert.py
+++ b/convert.py
@@ -1035,11 +1035,11 @@ def load_some_model(path: Path) -> ModelPlus:
     '''Load a model of any supported format.'''
     # Be extra-friendly and accept either a file or a directory:
     if path.is_dir():
-        globs = ["consolidated.00.pth", "pytorch_model-00001-of-*.bin", "*.pt"]
-        files = [file for glob in globs for file in path.glob(glob)]
+        # Check if it's a set of safetensors files first
+        files = list(path.glob("model-00001-of-*.safetensors"))
         if not files:
-            # Check if it's a set of safetensors files
-            globs = ["model-00001-of-*.safetensors"]
+            # Try the PyTorch patterns too, with lower priority
+            globs = ["consolidated.00.pth", "pytorch_model-00001-of-*.bin", "*.pt"]
             files = [file for glob in globs for file in path.glob(glob)]
         if not files:
             # Try GGML too, but with lower priority, since if both a non-GGML


### PR DESCRIPTION
When loading a safetensors file, ignore the metadata header.
If no pt or pth files are available, attempt to load safetensors files.
Edit: This has been changed to try to load safetensors files first, and only load the pt/pth/bin file if those aren't available.