### PR TITLE
Implement get_num_physical_cores() for Windows

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -60,7 +60,7 @@ int32_t get_num_physical_cores() {
     GetLogicalProcessorInformationEx(RelationAll, nullptr, &length);
 
     // Allocate memory for the buffer
-    buffer = static_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(malloc(length));
+    buffer = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(new char[length]);
 
     // Things to count
     unsigned int physical_cores = 0;
@@ -108,10 +108,10 @@ int32_t get_num_physical_cores() {
                 physical_cores, physical_performance_cores, physical_efficiency_cores,
                 logical_cores, logical_performance_cores, logical_efficiency_cores);
     } else {
-        printf("Failed to get processor information. Error: %u\n", GetLastError());
+        fprintf(stderr, "Failed to get processor information. Error: %u\n", GetLastError());
     }
 
-    free(buffer);
+    delete[] buffer;
 
     if (physical_performance_cores > 0) {
         return static_cast<int32_t>(physical_performance_cores);

--- a/examples/common.h
+++ b/examples/common.h
@@ -67,7 +67,7 @@ struct gpt_params {
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);
 
-void gpt_print_usage(int argc, char ** argv, const gpt_params & params);
+void gpt_print_usage(int argc, char ** argv);
 
 std::string gpt_random_prompt(std::mt19937 & rng);
 


### PR DESCRIPTION
This implements `get_num_physical_cores` on Windows. It uses `GetLogicalProcessorInformationEx` to tease out the number of physical cores and the number of those that are efficiency class 0. This should also address #572 on Windows, but on Windows only. I think something similar will have to be done for the other `get_num_physical_cores` paths in other OSs.

The only other thing this does it move the default param generation from `gpt_params_parse` to `gpt_print_usage` where it's used. Without this `gpt_params_parse` is called twice. Once for the instantiation in `main` and once for the instantiation in `gpt_params_parse`. This isn't terrible but it also means get_num_physical_cores() is called twice no matter what.

This works on all the Windows systems I tested it on, but none of mine have performance cores. According to the documentation, this should work in those cases as well but I would like to verify it with someone who has P/E cores.

This code also prints the number of cores found to stderr and that should be removed once we've verified it works with P/E core CPU systems. Preferably before we commit, but anything is fine.

I'll edit this to keep it up to date, this is the entirety of the logic with the extra debugging lines removed. No lines will need to be added or modified to remove that extra information, so it'll just be a bunch of `-`s.
```C++
    // Call GetLogicalProcessorInformationEx again with the allocated buffer
    if (GetLogicalProcessorInformationEx(
            RelationAll,
            reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(buffer),
            &length)) {
        DWORD offset = 0;

        while (offset < length) {
            auto info = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(buffer + offset);

            if (info->Relationship == RelationProcessorCore) {
                physical_cores += info->Processor.GroupCount;

                for (WORD i = 0; i < info->Processor.GroupCount; ++i) {
                    // Assuming EfficiencyClass 0 represents performance cores, and others represent efficiency cores
                    if (info->Processor.EfficiencyClass == 0) {
                        physical_performance_cores++;
                    }
                }
            }
            offset += info->Size;
        }
    }

    if (physical_performance_cores > 0) {
        return static_cast<int32_t>(physical_performance_cores);
    } else if (physical_cores > 0) {
        return static_cast<int32_t>(physical_cores);
    }
```