### PR TITLE
Fix ppc64le build error and make cmake detect Power processors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,8 +359,11 @@ elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86_64|i686|AMD64)$")
             add_compile_options(-mavx512vnni)
         endif()
     endif()
+elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc64")
+    message(STATUS "PowerPC detected")
+    add_compile_options(-mcpu=native -mtune=native)
+    #TODO: Add  targets for Power8/Power9 (Altivec/VSX) and Power10(MMA) and query for big endian systems (ppc64/le/be)
 else()
-    # TODO: support PowerPC
     message(STATUS "Unknown architecture")
 endif()
 

--- a/ggml.c
+++ b/ggml.c
@@ -826,6 +826,7 @@ static void quantize_row_q4_0(const float * restrict x, void * restrict vy, int 
         float max = 0.0f;
         float min = 0.0f;
 
+        vector float asrcv [8];
         vector float srcv [8];
         vector float maxv[8];
         vector float minv[8];


### PR DESCRIPTION
Tiny PR to fix a build issue that was introduced by another PR which I mentioned here https://github.com/ggerganov/llama.cpp/commit/dd0eabc049fb1efc631cab8eb0a646808d704e18#r111444092
and added support to detect PowerPC via cmake