### PR TITLE
Fix missing parameters in `llama_init_from_gpt_params`

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -414,6 +414,8 @@ struct llama_context * llama_init_from_gpt_params(const gpt_params & params) {
     lparams.f16_kv     = params.memory_f16;
     lparams.use_mmap   = params.use_mmap;
     lparams.use_mlock  = params.use_mlock;
+    lparams.logits_all = params.perplexity;
+    lparams.embedding  = params.embedding;
 
     llama_context * lctx = llama_init_from_file(params.model.c_str(), lparams);
 


### PR DESCRIPTION
The perplexity and embedding tools were broken in a recent change, this fixes it.