### PR TITLE
fix #1224 reverse prompt and multi line

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -551,12 +551,14 @@ int main(int argc, char ** argv) {
                         return 0;
                     }
 #endif
-                    if (line.empty() || line.back() != '\\') {
-                        another_line = false;
-                    } else {
-                        line.pop_back(); // Remove the continue character
+                    if(!line.empty()){
+                        if (line.back() == '\\') {
+                            line.pop_back(); // Remove the continue character
+                        } else {
+                            another_line = false;
+                        }
+                        buffer += line + '\n'; // Append the line to the result
                     }
-                    buffer += line + '\n'; // Append the line to the result
                 } while (another_line);
 
                 // done taking input, reset color

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -551,7 +551,7 @@ int main(int argc, char ** argv) {
                         return 0;
                     }
 #endif
-                    if(!line.empty()){
+                    if (!line.empty()) {
                         if (line.back() == '\\') {
                             line.pop_back(); // Remove the continue character
                         } else {


### PR DESCRIPTION
Fixes #1224 
In the original code, when an empty line is encountered, it stops the user from entering, although in reality, an empty line can be a side effect of the previous input and should simply be ignored.