### PR TITLE
change immintrin.h to intrin.h for compatibility

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -180,7 +180,7 @@ typedef double ggml_float;
 #undef bool
 #define bool _Bool
 #else
-#include <immintrin.h>
+#include <intrin.h>
 #endif
 #endif
 

--- a/ggml.c
+++ b/ggml.c
@@ -27,7 +27,7 @@
 #define static_assert(cond, msg) struct global_scope_noop_trick
 #endif
 
-#if defined(_WIN32)
+#if defined( )
 
 #include <windows.h>
 
@@ -180,7 +180,11 @@ typedef double ggml_float;
 #undef bool
 #define bool _Bool
 #else
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
 #endif
 #endif
 

--- a/ggml.c
+++ b/ggml.c
@@ -27,7 +27,7 @@
 #define static_assert(cond, msg) struct global_scope_noop_trick
 #endif
 
-#if defined( )
+#if defined(_WIN32)
 
 #include <windows.h>
 


### PR DESCRIPTION
Building on windows11 arm throws an error on this line. Seems like using intrin.h covers x86 and and arm