### PR TITLE
llama, main : save state incrementally

### DIFF
--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -58,7 +58,7 @@ int main(int argc, char ** argv) {
     // Save state (rng, logits, embedding and kv_cache) to file
     {
         FILE *fp_write = fopen("dump_state.bin", "wb");
-        llama_copy_state_data(ctx, state_mem); // could also copy directly to memory mapped file
+        llama_copy_state_data(ctx, state_mem, 0); // could also copy directly to memory mapped file
         fwrite(state_mem, 1, state_size, fp_write);
         fclose(fp_write);
     }

--- a/llama.h
+++ b/llama.h
@@ -23,7 +23,7 @@
 #define LLAMA_FILE_MAGIC             'ggjt'
 #define LLAMA_FILE_MAGIC_UNVERSIONED 'ggml'
 #define LLAMA_SESSION_MAGIC          'ggsn'
-#define LLAMA_SESSION_VERSION        1
+#define LLAMA_SESSION_VERSION        2
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,15 +134,34 @@ extern "C" {
     // Copies the state to the specified destination address.
     // Destination needs to have allocated enough memory.
     // Returns the number of bytes copied
-    LLAMA_API size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dest);
+    LLAMA_API size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dest, int n_token_offset);
 
     // Set the state reading from the specified address
     // Returns the number of bytes read
     LLAMA_API size_t llama_set_state_data(struct llama_context * ctx, const uint8_t * src);
 
     // Save/load session file
-    LLAMA_API bool llama_load_session_file(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out);
-    LLAMA_API bool llama_save_session_file(struct llama_context * ctx, const char * path_session, const llama_token * tokens, size_t n_token_count);
+    LLAMA_API bool llama_load_session_file(
+        struct llama_context * ctx,
+                  const char * path_session,
+                 llama_token * tokens_out,
+                      size_t   n_token_capacity,
+                      size_t * n_token_count_out);
+
+    LLAMA_API bool llama_save_session_file(
+        struct llama_context * ctx,
+                  const char * path_session,
+           const llama_token * tokens,
+                      size_t   n_token_count);
+
+    LLAMA_API bool llama_init_session_file(struct llama_context * ctx, const char * path_session);
+
+    LLAMA_API bool llama_append_session_file(
+        struct llama_context * ctx,
+                  const char * path_session,
+                         int   n_token_offset,
+           const llama_token * tokens,
+                      size_t   n_token_count);
 
     // Run the llama inference to obtain the logits and probabilities for the next token.
     // tokens + n_tokens is the provided batch of new tokens to process


### PR DESCRIPTION
Updates get/set state and save/load session to support incremental changes to kv state. This lets us checkpoint the state after initial prompt eval and at the end of the session, saving only what changed. On reload, we only load what is needed, flexibly supporting both the "prompt cache" and "prompt continuation" use cases. Eventually, I envision this being used to e.g., sync state more frequently, or store branching evaluation states as deltas.

**Changes**

* updates `llama_copy_state_data` with an additional parameter specifying the token offset. Passing `0` gives the current behavior. Otherwise, only the `ntok - offset` most recent tokens are serialized.
* provides an incremental session saving API: `llama_init_session_file` and `llama_append_session_file`, the latter being called N times on successive batches of tokens and incremental state. The original `llama_save_session_file` is simply init + append once.
* session file layout changes and version is bumped, more on that below
* `llama_load_session_file` now stops reading after filling the provided token capacity (so loading the prompt from a larger session doesn't incur full cost)
* `main` takes advantage of these changes by saving state after prompt eval, on context swap, and on exit

**Approach**

The new session file format is the header followed by one or more segments of tokens + incremental state:
```
<... magic, version, hparams > | ( <u32> token_count | <token_count> tokens | <size_t> state_size | state )*
```

Each segment represents the incremental evaluation of successive sequences of tokens and the resulting change in state. The incremental state stores the final RNG and logits for that batch, the starting token offset, and the portion of KV state from that offset onward.

When loading saved state in `llama_load_session_file`, the caller provides the desired number of tokens (e.g., prompt length) to restore. As those tokens are read from successive segments, the state each segment is applied. Specifically, this means restoring the rng and logits and applying the KV state delta. Finally, if the requested tokens don't fit cleanly into a state segment, one less token is returned to force an evaluation and ensure correct logits at that position.

I also took this opportunity to clean up the initial session code in `main`.

**Testing**

1. Prompt startup time with session using `chat-13B` on 30B: 35s cold vs 2s warm
```
% ./examples/chat-13B.sh -m ~/llama-models/30B/ggml-model-q4_0.bin --session sessions/chat-1tok.30.bin -n 1
llama_print_timings:       total time = 34634.49 ms
% ./examples/chat-13B.sh -m ~/llama-models/30B/ggml-model-q4_0.bin --session sessions/chat-1tok.30.bin -n 1
llama_print_timings:       total time =  2308.30 ms
```
2. Repeat prompt invocations on a session yield the same results:
```
% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 5 -p 'The meaning of life is 4'
...
 The meaning of life is 42: Douglas Adams
...
llama_print_timings:       total time =  2188.90 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 5 -p 'The meaning of life is 4'
...
 The meaning of life is 42: Douglas Adams
...
llama_print_timings:       total time =   1320.01 ms
```
3. Growing prompt on successive invocations with session - run time is constant:
```
 % ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 15 -p 'The meaning of life is 4'
...
 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the
...
llama_print_timings:       total time =  3978.35 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 15 -p 'The meaning of life is 42: Douglas Adams
The Hitchhiker'\''s Guide to the'
...
 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the Galaxy, as it appears in the computer game adaptation of the series.
...
llama_print_timings:       total time =  3331.50 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 15 -p 'The meaning of life is 42: Douglas Adams
The Hitchhiker'\''s Guide to the Galaxy, as it appears in the computer game adaptation of the series.'
...
 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the Galaxy, as it appears in the computer game adaptation of the series.
It’s been a few years since I last read Douglas Adams
...
llama_print_timings:       total time =  3379.11 ms
```
4. Rerunning a prefix of saved prompt gives sensible results:
```
 % ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 15 -p 'The meaning of life is 4'
...
 The meaning of life is 42: Douglas Adams...

 % ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --seed 1 --session sessions/meaning-life-30.bin -n 15 -p 'The meaning of life ' 
...
 The meaning of life  and whether it has any purpose at all 
...
```
5. Session size is still reasonable (but will now scale with total number of tokens)
```
 % du -hs sessions/*
768M	sessions/chat-1tok.30.bin
 31M	sessions/meaning-life-30.bin
```
6. `examples/save-load-state` and non-session usage work