### PR TITLE
Avoid hardcoding a space at the beginning of the prompt.

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -137,9 +137,6 @@ int main(int argc, char ** argv) {
         return 0;
     }
 
-    // Add a space in front of the first character to match OG llama tokenizer behavior
-    params.prompt.insert(0, 1, ' ');
-
     std::string path_session = params.path_session;
     std::vector<llama_token> session_tokens;
 
@@ -214,9 +211,6 @@ int main(int argc, char ** argv) {
     if (params.antiprompt.size() != 0 || params.interactive_first) {
         params.interactive = true;
     }
-
-    // determine newline token
-    auto llama_token_newline = ::llama_tokenize(ctx, "\n", false);
 
     if (params.verbose_prompt) {
         fprintf(stderr, "\n");
@@ -456,7 +450,7 @@ int main(int argc, char ** argv) {
 
             // replace end of text token with newline token when in interactive mode
             if (id == llama_token_eos() && params.interactive && !params.instruct) {
-                id = llama_token_newline.front();
+                id = llama_token_nl();
                 if (params.antiprompt.size() != 0) {
                     // tokenize and inject first reverse prompt
                     const auto first_antiprompt = ::llama_tokenize(ctx, params.antiprompt.front(), false);


### PR DESCRIPTION
Added in https://github.com/ggerganov/llama.cpp/pull/242 without a strong rationale.
Users can already insert a space manually at the beginning of the prompt if desired.

For example, I cannot get rid of token 15629 -> `' Manager'`. I am wanted it to be 3260 -> `'Manager'`:
```
main: prompt: ' Manager's Persona: Manager I work with in my company.
Manager: I am waiting.'
main: number of tokens in prompt = 22
     1 -> ''
 15629 -> ' Manager'
 29915 -> '''
 29879 -> 's'
  5196 -> ' Person'
 29874 -> 'a'
 29901 -> ':'
 15629 -> ' Manager'
   306 -> ' I'
   664 -> ' work'
   411 -> ' with'
   297 -> ' in'
   590 -> ' my'
  5001 -> ' company'
 29889 -> '.'
    13 -> '
'
  3260 -> 'Manager'
 29901 -> ':'
   306 -> ' I'
   626 -> ' am'
 10534 -> ' waiting'
 29889 -> '.'
```