### PR TITLE
Add OpenBuddy model into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ as the main playground for developing new features for the [ggml](https://github
 - [X] [Vigogne (French)](https://github.com/bofenghuang/vigogne)
 - [X] [Vicuna](https://github.com/ggerganov/llama.cpp/discussions/643#discussioncomment-5533894)
 - [X] [Koala](https://bair.berkeley.edu/blog/2023/04/03/koala/)
+- [X] [OpenBuddy 🐶 (Multilingual)](https://github.com/OpenBuddy/OpenBuddy)
 
 **Bindings:**
 


### PR DESCRIPTION
Thanks for inviting us to add our model into the README.md! We are more than happy to do that.

We have added a 🐶 emoji next to the name of our model, OpenBuddy. The reason for choosing this emoji is that both the name and the logo of OpenBuddy are related to dogs, and it symbolizes our hope that our model can become a loyal companion to everyone.

However, if you think that the addition of the emoji might affect the visual consistency of the list, please feel free to remove it.

Once again, thank you for the invitation. We will also be working on refining prompts and test shell scripts specifically designed for the `llama.cpp`, to make our model easier to test and research on personal computers. We will share these once they are completed.