### PR TITLE
First rough draft of recoverable errors feature.

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4245,10 +4245,8 @@ struct ggml_context {
 
     struct ggml_scratch scratch;
     struct ggml_scratch scratch_save;
-#ifdef GGML_RECOVERABLE_ERRORS
     enum ggml_errcode last_error_code;
     char last_error_msg[GGML_ERROR_BUFFER_LEN];
-#endif
 };
 
 struct ggml_context_container {
@@ -4638,8 +4636,8 @@ enum ggml_errcode ggml_last_error_code(struct ggml_context * ctx) {
     return ctx->last_error_code;
 }
 
-char * ggml_last_error_msg(struct ggml_context * ctx) {
-    return ctx->last_error_code == GGML_ERRCODE_SUCCESS ? "Success" : &ctx->last_error_msg;
+const char * ggml_last_error_msg(struct ggml_context * ctx) {
+    return ctx->last_error_code == GGML_ERRCODE_SUCCESS ? "Success" : (const char *)&ctx->last_error_msg;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ggml.c
+++ b/ggml.c
@@ -4570,10 +4570,8 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
         /*.objects_end        =*/ NULL,
         /*.scratch            =*/ { 0, 0, NULL, },
         /*.scratch_save       =*/ { 0, 0, NULL, },
-#ifdef GGML_RECOVERABLE_ERRORS
         /*.last_error_code    =*/ GGML_ERRCODE_SUCCESS,
         /*.last_error_msg     =*/ { 0 },
-#endif
     };
 
     GGML_ASSERT(ctx->mem_buffer != NULL);
@@ -4628,7 +4626,6 @@ size_t ggml_set_scratch(struct ggml_context * ctx, struct ggml_scratch scratch) 
     return result;
 }
 
-#ifdef GGML_RECOVERABLE_ERRORS
 // enum ggml_errcode ggml_clear_error(struct ggml_context * ctx) {
 //     enum ggml_errcode last_code = ctx->last_error_code;
 
@@ -4644,7 +4641,6 @@ enum ggml_errcode ggml_last_error_code(struct ggml_context * ctx) {
 char * ggml_last_error_msg(struct ggml_context * ctx) {
     return ctx->last_error_code == GGML_ERRCODE_SUCCESS ? "Success" : &ctx->last_error_msg;
 }
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ggml.h
+++ b/ggml.h
@@ -206,6 +206,7 @@
     } while (0)
 
 #define GGML_RECOVERABLE_ERRORS
+#define GGML_ERROR_BUFFER_LEN 256
 #ifndef GGML_RECOVERABLE_ERRORS
 #define GGML_RECOVERABLE_ASSERT(_ctx, _code, x, ...) \
     do { \
@@ -217,7 +218,6 @@
     } while (0)
 
 #else
-#define GGML_ERROR_BUFFER_LEN 256
 #define GGML_RECOVERABLE_ASSERT(ctx, errcode, x, ...) \
     do { \
         if ((ctx)->last_error_code != GGML_ERRCODE_SUCCESS) { \
@@ -468,7 +468,7 @@ extern "C" {
     //         struct ggml_context * ctx);
     GGML_API enum ggml_errcode ggml_last_error_code(
             struct ggml_context * ctx);
-    GGML_API char * ggml_last_error_msg(
+    GGML_API const char * ggml_last_error_msg(
             struct ggml_context * ctx);
 
     GGML_API struct ggml_tensor * ggml_new_tensor(

--- a/ggml.h
+++ b/ggml.h
@@ -464,14 +464,12 @@ extern "C" {
 
     GGML_API size_t  ggml_set_scratch(struct ggml_context * ctx, struct ggml_scratch scratch);
 
-#ifdef GGML_RECOVERABLE_ERRORS
     // GGML_API enum ggml_errcode ggml_clear_error(
     //         struct ggml_context * ctx);
     GGML_API enum ggml_errcode ggml_last_error_code(
             struct ggml_context * ctx);
     GGML_API char * ggml_last_error_msg(
             struct ggml_context * ctx);
-#endif
 
     GGML_API struct ggml_tensor * ggml_new_tensor(
             struct ggml_context * ctx,


### PR DESCRIPTION
@ggerganov 

Context: https://github.com/ggerganov/ggml/issues/123

Unfortunately (like always) this turned out to be more complicated than I initially expected.

At first I was planning to make it possible to acknowledge and clear an error, but there are some cases where recovery seems impossible like my map functions for example: Because they have to create another tensor and there's no way to free a tensor clearing the error would still leave that tensor allocated.

Probably need to scrap that plan and say "Once an error occurs, you need to free that `ggml_context` and start over". I think that's fine. (Right now those specific functions will abort if tensor creation fails after the first step, but assuming the context is just considered dead then returning `NULL` will be okay.)

Also, the way I implemented this is if you ignore an error and just keep trying to use the context, then it will abort.

Right now, this just adds the basic scaffolding. I also had to add `NULL` propagation to basically all functions that make a tensor. This could be simplified with a define instead of having to have a bunch of `if (blah == NULL) return NULL;` statements but for this sketch I'm keeping it simple.

This converts the asserts in `ggml_add_impl` and `ggml_new_tensor_impl` to be recoverable. There's also code cleanup, etc that would need to be done before this is actually ready to become a real pull.

Right now `GGML_RECOVERABLE_ERRORS` is just `#define`ed for testing. I have verified that it compiles (on Linux at least) and can run a model. I haven't tested triggering the asserts yet.

Before I continue with the rest, I want to make sure that I'm generally on the right track. What do you think?

