### PR TITLE
Convert.py @staticmethod

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -695,7 +695,7 @@ class LazyUnpickler(pickle.Unpickler):
         description = f'storage data_type={data_type} path-in-zip={filename} path={self.zip_file.filename}'
         return LazyStorage(load=load, kind=pid[1], description=description)
 
-    @staticmethod
+   # @staticmethod
     def lazy_rebuild_tensor_v2(storage: Any, storage_offset: Any, size: Any, stride: Any,  # pyright: ignore[reportSelfClsParameterName]
                                requires_grad: Any, backward_hooks: Any, metadata: Any = None) -> LazyTensor:
         assert isinstance(storage, LazyStorage)

--- a/convert.py
+++ b/convert.py
@@ -706,7 +706,7 @@ class LazyUnpickler(pickle.Unpickler):
         description = f'pickled storage_offset={storage_offset} in {storage.description}'
         return LazyTensor(load, list(size), storage.kind.data_type, description)
 
-    @staticmethod
+    # @staticmethod
     def rebuild_from_type_v2(func, new_type, args, state):
         return func(*args)
 


### PR DESCRIPTION
At line 698, @staticmethod before lazy_rebuild_tensor_V2 throws error at unpickle.load() as not callable