### PR TITLE
Automatic Arch Linux detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifndef UNAME_M
 UNAME_M := $(shell uname -m)
 endif
 
-ARCH_LINUX := $(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release)
+ARCH_LINUX := $(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release 2>/dev/null)
 ifdef ARCH_LINUX
 LDFLAGS_EXTRA += -lcblas
 endif

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ ifndef UNAME_M
 UNAME_M := $(shell uname -m)
 endif
 
+ARCH_LINUX1 := $(shell grep "Arch Linux" /etc/os-release 2>/dev/null)
+ARCH_LINUX2 := $(shell grep "ID_LIKE=arch" /etc/os-release 2>/dev/null)
+ifdef ARCH_LINUX1
+ARCH_ADD = -lcblas
+endif
+ifdef ARCH_LINUX2
+ARCH_ADD = -lcblas
+endif
+
 CCV := $(shell $(CC) --version | head -n 1)
 CXXV := $(shell $(CXX) --version | head -n 1)
 
@@ -107,7 +116,7 @@ ifndef LLAMA_NO_ACCELERATE
 endif
 ifdef LLAMA_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas
-	LDFLAGS += -lopenblas
+	LDFLAGS += -lopenblas $(ARCH_ADD)
 endif
 ifdef LLAMA_CUBLAS
 	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I$(CUDA_PATH)/targets/x86_64-linux/include

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,9 @@ ifndef UNAME_M
 UNAME_M := $(shell uname -m)
 endif
 
-ARCH_LINUX1 := $(shell grep "Arch Linux" /etc/os-release 2>/dev/null)
-ARCH_LINUX2 := $(shell grep "ID_LIKE=arch" /etc/os-release 2>/dev/null)
-ifdef ARCH_LINUX1
-ARCH_ADD = -lcblas
-endif
-ifdef ARCH_LINUX2
-ARCH_ADD = -lcblas
+ARCH_LINUX := $(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release)
+ifdef ARCH_LINUX
+LDFLAGS_EXTRA += -lcblas
 endif
 
 CCV := $(shell $(CC) --version | head -n 1)

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ ifndef LLAMA_NO_ACCELERATE
 endif
 ifdef LLAMA_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas
-	LDFLAGS += -lopenblas $(ARCH_ADD)
+	LDFLAGS += -lopenblas $(LDFLAGS_EXTRA)
 endif
 ifdef LLAMA_CUBLAS
 	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I$(CUDA_PATH)/targets/x86_64-linux/include

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,6 @@ ifndef UNAME_M
 UNAME_M := $(shell uname -m)
 endif
 
-ARCH_LINUX := $(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release 2>/dev/null)
-ifdef ARCH_LINUX
-LDFLAGS_EXTRA += -lcblas
-endif
-
 CCV := $(shell $(CC) --version | head -n 1)
 CXXV := $(shell $(CXX) --version | head -n 1)
 
@@ -112,7 +107,11 @@ ifndef LLAMA_NO_ACCELERATE
 endif
 ifdef LLAMA_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas
-	LDFLAGS += -lopenblas $(LDFLAGS_EXTRA)
+	ifneq ($(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release 2>/dev/null),)
+		LDFLAGS += -lopenblas -lcblas
+	else
+		LDFLAGS += -lopenblas
+	endif
 endif
 ifdef LLAMA_CUBLAS
 	CFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I$(CUDA_PATH)/targets/x86_64-linux/include

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ Building the program with BLAS support may lead to some performance improvements
       ```bash
       make LLAMA_OPENBLAS=1
       ```
-      Note: In order to build on Arch Linux with OpenBLAS support enabled you must edit the Makefile adding at the end of the line 105: `-lcblas`
 
     - On Windows:
 


### PR DESCRIPTION
This pull request adds a check in the Makefile in order to set automatically the -lcblas flag on Arch Linux. This change is based on koboldcpp's Makefile so the credit for this should go to @LostRuins.