### PR TITLE
build Docker images with AVX2 only

### DIFF
--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /app
 
 COPY . .
 
-RUN make
+RUN LLAMA_AVX2_ONLY=1 make
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.devops/main.Dockerfile
+++ b/.devops/main.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN make
+RUN LLAMA_AVX2_ONLY=1 make
 
 FROM ubuntu:$UBUNTU_VERSION as runtime
 

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,14 @@ endif
 # TODO: probably these flags need to be tweaked on some architectures
 #       feel free to update the Makefile for your architecture and send a pull request or issue
 ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686))
-	# Use all CPU extensions that are available:
-	CFLAGS   += -march=native -mtune=native
-	CXXFLAGS += -march=native -mtune=native
-
-	# Usage AVX-only
-	#CFLAGS   += -mfma -mf16c -mavx
-	#CXXFLAGS += -mfma -mf16c -mavx
+	ifdef LLAMA_AVX2_ONLY
+		CFLAGS   += -mfma -mf16c -mavx2
+		CXXFLAGS += -mfma -mf16c -mavx2
+	else
+		# Use all CPU extensions that are available:
+		CFLAGS   += -march=native -mtune=native
+		CXXFLAGS += -march=native -mtune=native
+	endif
 endif
 ifneq ($(filter ppc64%,$(UNAME_M)),)
 	POWER9_M := $(shell grep "POWER9" /proc/cpuinfo)


### PR DESCRIPTION
Docker images produced by CI fail on (at least) my Alder Lake machine.

I believe the purpose of the Docker build is to provide an easy way to start generating tokens. Targeting AVX2-only seems like a reasonable compromise between performance and compatibility.

(This PR is pretty minimal. Maybe it would be better to have several different images targeting different microarchitectures. I still think this minimal change is an improvement, though.)

Related:

- https://github.com/ggerganov/llama.cpp/issues/537
- https://github.com/ggerganov/llama.cpp/issues/776