### PR TITLE
ggml : Allow usage of CLBlast alongside Accelerate.framework

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -137,6 +137,9 @@ inline static void* ggml_aligned_malloc(size_t size) {
 
 #if defined(GGML_USE_ACCELERATE)
 #include <Accelerate/Accelerate.h>
+#if defined(GGML_USE_CLBLAST) // allow usage of CLBlast alongside Accelerate functions
+#include "ggml-opencl.h"
+#endif
 #elif defined(GGML_USE_OPENBLAS)
 #include <cblas.h>
 #elif defined(GGML_USE_CUBLAS)


### PR DESCRIPTION
Minor edit in ggml.c which originally would prevent OpenCL from loading completely if GGML_USE_ACCELERATE was defined. Considerable speedup in prompt eval time.

Example timings with a long prompt

Accelerate only
```
llama_print_timings:        load time =  7336.19 ms
llama_print_timings:      sample time =    93.78 ms /   132 runs   (    0.71 ms per run)
llama_print_timings: prompt eval time = 25906.03 ms /   262 tokens (   98.88 ms per token)
llama_print_timings:        eval time = 15965.80 ms /   132 runs   (  120.95 ms per run)
llama_print_timings:       total time = 602607.10 ms
```

Accelerate + CLBlast
```
llama_print_timings:        load time =   414.94 ms
llama_print_timings:      sample time =    85.91 ms /   120 runs   (    0.72 ms per run)
llama_print_timings: prompt eval time =  9738.70 ms /   262 tokens (   37.17 ms per token)
llama_print_timings:        eval time = 13286.57 ms /   120 runs   (  110.72 ms per run)
llama_print_timings:       total time = 41768.89 ms
```