### PR TITLE
main : add option to save full output to session

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -118,14 +118,18 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.prompt = argv[i];
         } else if (arg == "-e") {
             escape_prompt = true;
+        } else if (arg == "--prompt-cache") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.path_prompt_cache = argv[i];
         } else if (arg == "--session") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;
             }
             params.path_session = argv[i];
-        } else if (arg == "--session-full") {
-            params.session_full = true;
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -344,6 +348,11 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         gpt_print_usage(argc, argv, default_params);
         exit(1);
     }
+    if (!params.path_session.empty() && !params.path_prompt_cache.empty()) {
+        fprintf(stderr, "error: only one of --prompt-cache or --session may be specified\n");
+        gpt_print_usage(argc, argv, default_params);
+        exit(1);
+    }
     if (escape_prompt) {
         process_escapes(params.prompt);
     }
@@ -369,8 +378,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -p PROMPT, --prompt PROMPT\n");
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
     fprintf(stderr, "  -e                    process prompt escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\)\n");
-    fprintf(stderr, "  --session FNAME       file to cache model state in (may be large!) (default: none)\n");
-    fprintf(stderr, "  --session-full        if specified, saves output to the session file in addition to prompt\n");
+    fprintf(stderr, "  --prompt-cache FNAME  file to cache prompt state for faster startup (default: none)\n");
+    fprintf(stderr, "  --session FNAME       file to store prompt and generations, allowing continuation (default: none)\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  --in-suffix STRING    string to suffix after user inputs with (default: empty)\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -124,12 +124,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.path_prompt_cache = argv[i];
-        } else if (arg == "--session") {
-            if (++i >= argc) {
-                invalid_param = true;
-                break;
-            }
-            params.path_session = argv[i];
+        } else if (arg == "--prompt-cache-all") {
+            params.prompt_cache_save_all = true;
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -348,11 +344,6 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         gpt_print_usage(argc, argv, default_params);
         exit(1);
     }
-    if (!params.path_session.empty() && !params.path_prompt_cache.empty()) {
-        fprintf(stderr, "error: only one of --prompt-cache or --session may be specified\n");
-        gpt_print_usage(argc, argv, default_params);
-        exit(1);
-    }
     if (escape_prompt) {
         process_escapes(params.prompt);
     }
@@ -379,7 +370,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
     fprintf(stderr, "  -e                    process prompt escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\)\n");
     fprintf(stderr, "  --prompt-cache FNAME  file to cache prompt state for faster startup (default: none)\n");
-    fprintf(stderr, "  --session FNAME       file to store prompt and generations, allowing continuation (default: none)\n");
+    fprintf(stderr, "  --prompt-cache-all    if specified, saves user input and generations to cache as well\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  --in-suffix STRING    string to suffix after user inputs with (default: empty)\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -124,6 +124,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.path_session = argv[i];
+        } else if (arg == "--session-full") {
+            params.session_full = true;
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -368,6 +370,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
     fprintf(stderr, "  -e                    process prompt escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\)\n");
     fprintf(stderr, "  --session FNAME       file to cache model state in (may be large!) (default: none)\n");
+    fprintf(stderr, "  --session-full        if specified, saves output to the session file in addition to prompt\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  --in-suffix STRING    string to suffix after user inputs with (default: empty)\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -344,6 +344,13 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         gpt_print_usage(argc, argv, default_params);
         exit(1);
     }
+    if (params.prompt_cache_all &&
+            (params.interactive || params.interactive_first ||
+             params.instruct || params.antiprompt.size())) {
+        fprintf(stderr, "error: --prompt-cache-all not supported in interactive mode yet\n");
+        gpt_print_usage(argc, argv, default_params);
+        exit(1);
+    }
     if (escape_prompt) {
         process_escapes(params.prompt);
     }

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -125,7 +125,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             }
             params.path_prompt_cache = argv[i];
         } else if (arg == "--prompt-cache-all") {
-            params.prompt_cache_save_all = true;
+            params.prompt_cache_all = true;
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -370,7 +370,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "                        prompt to start generation with (default: empty)\n");
     fprintf(stderr, "  -e                    process prompt escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\)\n");
     fprintf(stderr, "  --prompt-cache FNAME  file to cache prompt state for faster startup (default: none)\n");
-    fprintf(stderr, "  --prompt-cache-all    if specified, saves user input and generations to cache as well\n");
+    fprintf(stderr, "  --prompt-cache-all    if specified, saves user input and generations to cache as well.\n");
+    fprintf(stderr, "                        not supported with --interactive or other interactive options\n");
     fprintf(stderr, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stderr, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");
     fprintf(stderr, "  --in-suffix STRING    string to suffix after user inputs with (default: empty)\n");

--- a/examples/common.h
+++ b/examples/common.h
@@ -58,6 +58,7 @@ struct gpt_params {
     bool random_prompt     = false; // do not randomize prompt if none provided
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
+    bool session_full      = false; // save the output to the session file in addition to prompt
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately

--- a/examples/common.h
+++ b/examples/common.h
@@ -54,11 +54,11 @@ struct gpt_params {
     std::string lora_adapter = "";  // lora adapter path
     std::string lora_base = "";     // base model path for the lora adapter
 
-    bool memory_f16            = true;  // use f16 instead of f32 for memory kv
-    bool random_prompt         = false; // do not randomize prompt if none provided
-    bool use_color             = false; // use color to distinguish generations and inputs
-    bool interactive           = false; // interactive mode
-    bool prompt_cache_save_all = false; // save user input and generations to prompt cache
+    bool memory_f16        = true;  // use f16 instead of f32 for memory kv
+    bool random_prompt     = false; // do not randomize prompt if none provided
+    bool use_color         = false; // use color to distinguish generations and inputs
+    bool interactive       = false; // interactive mode
+    bool prompt_cache_all  = false; // save user input and generations to prompt cache
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately

--- a/examples/common.h
+++ b/examples/common.h
@@ -46,9 +46,10 @@ struct gpt_params {
 
     std::string model  = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt = "";
-    std::string path_session = "";       // path to file for saving/loading model eval state
-    std::string input_prefix = "";       // string to prefix user inputs with
-    std::string input_suffix = "";       // string to suffix user inputs with
+    std::string path_prompt_cache = "";  // path to file for saving/loading prompt eval state
+    std::string path_session      = "";  // file for saving/loading prompt and generations
+    std::string input_prefix      = "";  // string to prefix user inputs with
+    std::string input_suffix      = "";  // string to suffix user inputs with
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
 
     std::string lora_adapter = "";  // lora adapter path
@@ -58,7 +59,6 @@ struct gpt_params {
     bool random_prompt     = false; // do not randomize prompt if none provided
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
-    bool session_full      = false; // save the output to the session file in addition to prompt
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately

--- a/examples/common.h
+++ b/examples/common.h
@@ -47,7 +47,6 @@ struct gpt_params {
     std::string model  = "models/lamma-7B/ggml-model.bin"; // model path
     std::string prompt = "";
     std::string path_prompt_cache = "";  // path to file for saving/loading prompt eval state
-    std::string path_session      = "";  // file for saving/loading prompt and generations
     std::string input_prefix      = "";  // string to prefix user inputs with
     std::string input_suffix      = "";  // string to suffix user inputs with
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
@@ -55,10 +54,11 @@ struct gpt_params {
     std::string lora_adapter = "";  // lora adapter path
     std::string lora_base = "";     // base model path for the lora adapter
 
-    bool memory_f16        = true;  // use f16 instead of f32 for memory kv
-    bool random_prompt     = false; // do not randomize prompt if none provided
-    bool use_color         = false; // use color to distinguish generations and inputs
-    bool interactive       = false; // interactive mode
+    bool memory_f16            = true;  // use f16 instead of f32 for memory kv
+    bool random_prompt         = false; // do not randomize prompt if none provided
+    bool use_color             = false; // use color to distinguish generations and inputs
+    bool interactive           = false; // interactive mode
+    bool prompt_cache_save_all = false; // save user input and generations to prompt cache
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -270,9 +270,9 @@ These options help improve the performance and memory usage of the LLaMA models.
 
 -   `-b N, --batch_size N`: Set the batch size for prompt processing (default: 512). This large batch size benefits users who have BLAS installed and enabled it during the build. If you don't have BLAS enabled ("BLAS=0"), you can use a smaller number, such as 8, to see the prompt progress as it's evaluated in some situations.
 
-### Session Caching
+### Prompt Caching
 
--   `--session FNAME`: Specify a file to load/save the session, which caches the model state after the initial prompt. This can significantly speed up the startup time when you're using longer prompts. The session file is created during the first run and is reused in subsequent runs. If you change your prompt such that 75% or less of the session is reusable, the existing session file will be overwritten with a new, updated version to maintain optimal performance.
+-   `--prompt-cache FNAME`: Specify a file to cache the model state after the initial prompt. This can significantly speed up the startup time when you're using longer prompts. The file is created during the first run and is reused and updated in subsequent runs.
 
 ### Quantization
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -235,11 +235,6 @@ int main(int argc, char ** argv) {
     }
 
     if (params.interactive) {
-        if (params.prompt_cache_all) {
-            fprintf(stderr, "error: --prompt-cache-all not supported in interactive mode yet\n");
-            return 1;
-        }
-
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
         struct sigaction sigint_action;
         sigint_action.sa_handler = sigint_handler;

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -139,8 +139,10 @@ int main(int argc, char ** argv) {
     // Add a space in front of the first character to match OG llama tokenizer behavior
     params.prompt.insert(0, 1, ' ');
 
-    std::string path_session = params.path_session;
+    std::string path_session =
+        !params.path_session.empty() ? params.path_session : params.path_prompt_cache;
     std::vector<llama_token> session_tokens;
+    bool resume_session = !params.path_session.empty();
 
     if (!path_session.empty()) {
         fprintf(stderr, "%s: attempting to load saved session from '%s'\n", __func__, path_session.c_str());
@@ -323,8 +325,8 @@ int main(int argc, char ** argv) {
                 // insert n_left/2 tokens at the start of embd from last_n_tokens
                 embd.insert(embd.begin(), last_n_tokens.begin() + n_ctx - n_left/2 - embd.size(), last_n_tokens.end() - embd.size());
 
-                // stop saving session if we run out of context
-                if (!path_session.empty() && params.session_full) {
+                // stop saving session if we run out of context, saving whatever was evaled
+                if (!path_session.empty() && resume_session) {
                     llama_save_session_file(ctx, path_session.c_str(),
                         session_tokens.data(), session_tokens.size());
                 }
@@ -603,7 +605,7 @@ int main(int argc, char ** argv) {
         }
     }
 
-    if (!path_session.empty() && params.session_full) {
+    if (!path_session.empty() && resume_session) {
         fprintf(stderr, "\n%s: saving final output to session file '%s'\n", __func__, path_session.c_str());
         llama_save_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
     }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -139,10 +139,9 @@ int main(int argc, char ** argv) {
     // Add a space in front of the first character to match OG llama tokenizer behavior
     params.prompt.insert(0, 1, ' ');
 
-    std::string path_session =
-        !params.path_session.empty() ? params.path_session : params.path_prompt_cache;
+    std::string path_session    = params.path_prompt_cache;
+    const bool session_save_all = params.prompt_cache_save_all;
     std::vector<llama_token> session_tokens;
-    bool resume_session = !params.path_session.empty();
 
     if (!path_session.empty()) {
         fprintf(stderr, "%s: attempting to load saved session from '%s'\n", __func__, path_session.c_str());
@@ -325,8 +324,8 @@ int main(int argc, char ** argv) {
                 // insert n_left/2 tokens at the start of embd from last_n_tokens
                 embd.insert(embd.begin(), last_n_tokens.begin() + n_ctx - n_left/2 - embd.size(), last_n_tokens.end() - embd.size());
 
-                // stop saving session if we run out of context, saving whatever was evaled
-                if (!path_session.empty() && resume_session) {
+                // stop saving session if we run out of context
+                if (!path_session.empty() && session_save_all) {
                     llama_save_session_file(ctx, path_session.c_str(),
                         session_tokens.data(), session_tokens.size());
                 }
@@ -605,7 +604,7 @@ int main(int argc, char ** argv) {
         }
     }
 
-    if (!path_session.empty() && resume_session) {
+    if (!path_session.empty() && session_save_all) {
         fprintf(stderr, "\n%s: saving final output to session file '%s'\n", __func__, path_session.c_str());
         llama_save_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
     }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char ** argv) {
     // Add a space in front of the first character to match OG llama tokenizer behavior
     params.prompt.insert(0, 1, ' ');
 
-    std::string path_session    = params.path_prompt_cache;
+    std::string path_session = params.path_prompt_cache;
     std::vector<llama_token> session_tokens;
 
     if (!path_session.empty()) {


### PR DESCRIPTION
EDITED after updates

This is a much scaled-back change in place of #1310. Renames `--session` to `--prompt-cache` and adds a new option, `--prompt-cache-all`, that causes user input and generations to be saved to the session/cache as well. This new option allows for fast continuation of generations (with additional input).

**Testing**
* `--prompt-cache` just saves the initial prompt:
```
% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin -n 5 -p 'The meaning of life is 4'     
...

 The meaning of life is 42
Posted on
llama_print_timings:        load time =  1785.67 ms
llama_print_timings:      sample time =     3.42 ms /     5 runs   (    0.68 ms per run)
llama_print_timings: prompt eval time =  1770.00 ms /     8 tokens (  221.25 ms per token)
llama_print_timings:        eval time =   702.82 ms /     4 runs   (  175.70 ms per run)
llama_print_timings:       total time =  2574.34 ms
% du -hs cache/meaning-life.30.bin                                                                                       
 12M	cache/meaning-life.30.bin
% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin -n 5 -p 'The meaning of life is 4'
...
 The meaning of life is 42
Posted on
llama_print_timings:        load time =   741.91 ms
llama_print_timings:      sample time =     3.38 ms /     5 runs   (    0.68 ms per run)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token)
llama_print_timings:        eval time =  1037.25 ms /     4 runs   (  259.31 ms per run)
llama_print_timings:       total time =  1270.93 ms
```
* `--prompt-cache-all` saves prompt + generations, allowing ~constant generation time for continuing generation on successive calls:
```
% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin --prompt-cache-all --seed 1 -n 15 -p 'The meaning of life is 4'
...
 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the
main: saving final output to session file 'sessions/meaning-life.30.bin'

llama_print_timings:        load time =  1323.96 ms
llama_print_timings:      sample time =    10.38 ms /    15 runs   (    0.69 ms per run)
llama_print_timings: prompt eval time =  1303.54 ms /     8 tokens (  162.94 ms per token)
llama_print_timings:        eval time =  2447.48 ms /    14 runs   (  174.82 ms per run)
llama_print_timings:       total time =  3959.82 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin --prompt-cache-all --seed 1 -n 15 -p 'The meaning of life is 42: Douglas Adams 
quote> The Hitchhiker'\''s Guide to the'
...

 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the Galaxy, as it appears in the computer game adaptation of the series.
...
llama_print_timings:        load time =   692.69 ms
llama_print_timings:      sample time =    10.34 ms /    15 runs   (    0.69 ms per run)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token)
llama_print_timings:        eval time =  2969.64 ms /    15 runs   (  197.98 ms per run)
llama_print_timings:       total time =  3349.01 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin --prompt-cache-all --seed 1 -n 15 -p 'The meaning of life is 42: Douglas Adams
The Hitchhiker'\''s Guide to the Galaxy, as it appears in the computer game adaptation of the series.'
...

 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the Galaxy, as it appears in the computer game adaptation of the series.
It’s been a few years since I last read Douglas Adams’
...
llama_print_timings:        load time =   686.97 ms
llama_print_timings:      sample time =    10.31 ms /    15 runs   (    0.69 ms per run)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token)
llama_print_timings:        eval time =  2979.24 ms /    15 runs   (  198.62 ms per run)
llama_print_timings:       total time =  3382.80 ms

% ./main -m ~/llama-models/30B/ggml-model-q4_0.bin --prompt-cache cache/meaning-life.30.bin --prompt-cache-all --seed 1 -n 15 -p 'The meaning of life is 42: Douglas Adams
The Hitchhiker'\''s Guide to the Galaxy, as it appears in the computer game adaptation of the series.
quote> It’s been a few years since I last read Douglas Adams’'
...
 The meaning of life is 42: Douglas Adams
The Hitchhiker's Guide to the Galaxy, as it appears in the computer game adaptation of the series.
It’s been a few years since I last read Douglas Adams’ “Hitchhikers” novels. They are really funny
...
llama_print_timings:        load time =   693.08 ms
llama_print_timings:      sample time =    10.30 ms /    15 runs   (    0.69 ms per run)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token)
llama_print_timings:        eval time =  2971.47 ms /    15 runs   (  198.10 ms per run)
llama_print_timings:       total time =  3405.97 ms
```
- also tested non-session usage and `chat-13B.sh` with prompt cache