### PR TITLE
Documented CUDA reproducibility, added warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Building the program with BLAS support may lead to some performance improvements
     cmake --build . --config Release
     ```
 
+Note: Because llama.cpp uses multiple CUDA streams for matrix multiplication results [are not guaranteed to be reproducible](https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility). If you need reproducibility, set `GGML_CUDA_MAX_STREAMS` in the file `ggml-cuda.cu` to 1.
+
 ### Prepare Data & Run
 
 ```bash

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -100,6 +100,9 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         arg = argv[i];
 
         if (arg == "-s" || arg == "--seed") {
+#if defined(GGML_USE_CUBLAS)
+            fprintf(stderr, "WARNING: when using cuBLAS generation results are NOT guaranteed to be reproducible.\n");
+#endif
             if (++i >= argc) {
                 invalid_param = true;
                 break;

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -348,7 +348,7 @@ static void ggml_cuda_pool_free(void * ptr, size_t size) {
     CUDA_CHECK(cudaFree(ptr));
 }
 
-#define GGML_CUDA_MAX_STREAMS 8
+#define GGML_CUDA_MAX_STREAMS 8 // Set this to 1 for reproducible matrix multiplication.
 #define GGML_CUDA_MAX_EVENTS 64
 static cublasHandle_t g_cublasH = nullptr;
 static cudaStream_t g_cudaStreams[GGML_CUDA_MAX_STREAMS] = { nullptr };


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/1340 .

When I worked on CUDA acceleration I noticed that the text I generated was not the same as master despite setting the same seed. It seems that due to the use of multiple CUDA streams, [the reproducibility of cuBLAS matrix multiplication is not guaranteed](https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility) . This does not seem to affect perplexity scores but it can unnecessarily cost developers time when they search for non-existent bugs.

This PR documents the non-reproducible nature of cuBLAS. It adds warnings to the README and `ggml-cuda.cu`. Additionally, when using cuBLAS and setting a seed a warning is printed which states that reproducibility is not guaranteed.