### PR TITLE
Allow prechecking how much memory tensor creation will require

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4683,7 +4683,7 @@ struct ggml_tensor * ggml_new_tensor_impl(
     size_t size_needed = 0;
 
     if (!ggml_tensor_required_memory(ctx, type, n_dims, ne, data, &ctx_needed, &scratch_needed)) {
-        if (scratch_needed > 0 && ctx->scratch.size) {
+        if (scratch_needed > 0 && ctx->scratch.offs + scratch_needed > ctx->scratch.size) {
             GGML_PRINT("%s: not enough space in the scratch memory (needed %zu, available %zu)\n",
                     __func__, ctx->scratch.offs + scratch_needed, ctx->scratch.size);
         } else {

--- a/ggml.h
+++ b/ggml.h
@@ -422,6 +422,20 @@ extern "C" {
     GGML_API void    ggml_free(struct ggml_context * ctx);
 
     GGML_API size_t  ggml_used_mem(const struct ggml_context * ctx);
+    GGML_API size_t  ggml_used_scratch_mem(const struct ggml_context * ctx);
+
+    // Calculate the memory required to construct a tensor with the specified type,
+    // dimensions and shape. The last two arguments will be incremented by the
+    // required sizes so it's necessary to initialize them to 0 before calling this
+    // function for the first time.
+    GGML_API bool    ggml_tensor_required_memory(
+            struct ggml_context * ctx,
+            enum   ggml_type type,
+            int    n_dims,
+            const int64_t* ne,
+            void*  data,
+            size_t * required_ctx,
+            size_t * required_scratch);
 
     GGML_API size_t  ggml_set_scratch(struct ggml_context * ctx, struct ggml_scratch scratch);
 


### PR DESCRIPTION
Add `ggml_tensor_required_memory` function to calculate how much memory creating a tensor will require.

Also add `ggml_used_scratch_mem` function so applications can determine how much scratch memory was used. This trivial function will just return 0 if there's no current scratch buffer.

`ggml_tensor_required_memory` takes the same arguments as `ggml_new_tensor_impl` with the addition of two `size_t` pointers(`required_ctx`, and `required_scratch`). The logic is basically just a cut-and-paste from `ggml_new_tensor_impl`: It will calculate how much scratch and context memory is required and increment the the supplied `size_t` pointers by that amount. Then it returns `true`/`false` depending on whether those values fit in the context/scratch memory.

The reason it increments rather than just setting the `required_ctx`/`_scratch` arguments is to allow checking that multiple tensors will fit in advance of actually trying to create them. This could be considered a partial replacement for #1325 since memory limits are probably the most common reason for GGML to bail out during graph construction.

It also is something that can facilitate #1325 to recover in the case of operations that require creating multiple tensors like the map ops.

I converted `ggml_new_tensor_impl` to use the new function for its memory validation. Right now I think it's not taking full advantage of the change and recalculates some stuff.

**Note**: This isn't quite a draft, but it is lightly tested. It compiles without warnings for me and llama.cpp built on it can load/run inference on models. If this is something that would get merged, it would be a good idea to have better C programmers than me look at it closely.