### PR TITLE
Proof of concept: GPU-accelerated token generation

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -271,6 +271,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.use_color = true;
         } else if (arg == "--mlock") {
             params.use_mlock = true;
+        } else if (arg == "--gpu_layers") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.gpu_layers = std::stoi(argv[i]);
         } else if (arg == "--no-mmap") {
             params.use_mmap = false;
         } else if (arg == "--mtest") {
@@ -406,6 +412,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     if (llama_mmap_supported()) {
         fprintf(stderr, "  --no-mmap             do not memory-map model (slower load but may reduce pageouts if not using mlock)\n");
     }
+    fprintf(stderr, "  --gpu_layers          number of layers to store in VRAM");
     fprintf(stderr, "  --mtest               compute maximum memory usage\n");
     fprintf(stderr, "  --verbose-prompt      print prompt before generation\n");
     fprintf(stderr, "  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");
@@ -454,6 +461,7 @@ struct llama_context * llama_init_from_gpt_params(const gpt_params & params) {
     lparams.f16_kv     = params.memory_f16;
     lparams.use_mmap   = params.use_mmap;
     lparams.use_mlock  = params.use_mlock;
+    lparams.gpu_layers = params.gpu_layers;
     lparams.logits_all = params.perplexity;
     lparams.embedding  = params.embedding;
 

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -412,7 +412,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     if (llama_mmap_supported()) {
         fprintf(stderr, "  --no-mmap             do not memory-map model (slower load but may reduce pageouts if not using mlock)\n");
     }
-    fprintf(stderr, "  --gpu_layers          number of layers to store in VRAM");
+    fprintf(stderr, "  --gpu_layers          number of layers to store in VRAM\n");
     fprintf(stderr, "  --mtest               compute maximum memory usage\n");
     fprintf(stderr, "  --verbose-prompt      print prompt before generation\n");
     fprintf(stderr, "  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");

--- a/examples/common.h
+++ b/examples/common.h
@@ -68,6 +68,7 @@ struct gpt_params {
     bool perplexity        = false; // compute perplexity over the prompt
     bool use_mmap          = true;  // use mmap for faster loads
     bool use_mlock         = false; // use mlock to keep model in memory
+    int gpu_layers         = 0;     // number of layers to store in VRAM
     bool mem_test          = false; // compute maximum memory usage
     bool verbose_prompt    = false; // print prompt tokens before generation
 };

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -231,8 +231,7 @@ template <int block_size> static __global__ void dequantize_mul_mat_q4_0(const v
     const int row = blockIdx.x;
     const int tid = threadIdx.x;
 
-    __shared__ float tmp[block_size]; // separate sum for each thread
-    tmp[tid] = 0;
+    float partial_sum = 0; // separate sum for each thread
 
     for (int i = 0; i < ncols/block_size; i += 2) {
         const int col = i*block_size + 2*tid;
@@ -251,19 +250,17 @@ template <int block_size> static __global__ void dequantize_mul_mat_q4_0(const v
         const float v1 = (vi1 - 8)*d;
 
         // matrix multiplication
-        tmp[tid] += v0 * y[col + 0];
-        tmp[tid] += v1 * y[col + 1];
+        partial_sum += v0 * y[col + 0];
+        partial_sum += v1 * y[col + 1];
     }
 
     // sum up partial sums and write back result
-    for (int s=block_size/2; s>0; s>>=1) {
-        if (tid < s) {
-            tmp[tid] += tmp[tid + s];
-        }
-        __syncthreads();
+#pragma unroll
+    for (int mask=16; mask > 0; mask >>= 1) {
+        partial_sum += __shfl_xor_sync(0xffffffff, partial_sum, mask, 32);
     }
     if (tid == 0) {
-        dst[row] = tmp[0];
+        dst[row] = partial_sum;
     }
 }
 

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -14,6 +14,8 @@ void   ggml_cuda_mul_mat(const struct ggml_tensor * src0, const struct ggml_tens
 void * ggml_cuda_host_malloc(size_t size);
 void   ggml_cuda_host_free(void * ptr);
 
+void ggml_cuda_transform_tensor(struct ggml_tensor * tensor);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml.c
+++ b/ggml.c
@@ -4711,6 +4711,7 @@ struct ggml_tensor * ggml_new_tensor_impl(
 
     *result = (struct ggml_tensor) {
         /*.type         =*/ type,
+        /*.backend      =*/ GGML_BACKEND_CPU,
         /*.n_dims       =*/ n_dims,
         /*.ne           =*/ { 1, 1, 1, 1 },
         /*.nb           =*/ { 0, 0, 0, 0 },

--- a/ggml.h
+++ b/ggml.h
@@ -243,6 +243,11 @@ extern "C" {
         GGML_TYPE_COUNT,
     };
 
+    enum ggml_backend {
+        GGML_BACKEND_CPU = 0,
+        GGML_BACKEND_CUDA = 1,
+    };
+
     // model file types
     enum ggml_ftype {
         GGML_FTYPE_UNKNOWN     = -1,
@@ -323,6 +328,7 @@ extern "C" {
     // n-dimensional tensor
     struct ggml_tensor {
         enum ggml_type type;
+        enum ggml_backend backend;
 
         int     n_dims;
         int64_t ne[GGML_MAX_DIMS]; // number of elements
@@ -353,7 +359,7 @@ extern "C" {
 
         char name[32];
 
-        char padding[8]; // TODO: remove and add padding to name?
+        char padding[9]; // TODO: remove and add padding to name?
     };
 
     // computation graph

--- a/llama.cpp
+++ b/llama.cpp
@@ -9,6 +9,9 @@
 #include "llama.h"
 
 #include "ggml.h"
+#ifdef GGML_USE_CUBLAS
+#include "ggml-cuda.h"
+#endif
 
 #include <array>
 #include <ctime>
@@ -815,6 +818,7 @@ struct llama_context_params llama_context_default_params() {
         /*.vocab_only                  =*/ false,
         /*.use_mmap                    =*/ true,
         /*.use_mlock                   =*/ false,
+        /*.gpu_layers                  =*/ 0,
         /*.embedding                   =*/ false,
         /*.progress_callback           =*/ nullptr,
         /*.progress_callback_user_data =*/ nullptr,
@@ -877,6 +881,7 @@ static void llama_model_load_internal(
         ggml_type memory_type,
         bool use_mmap,
         bool use_mlock,
+        int gpu_layers,
         bool vocab_only,
         llama_progress_callback progress_callback,
         void * progress_callback_user_data) {
@@ -1011,6 +1016,18 @@ static void llama_model_load_internal(
     ml->load_all_data(progress_callback, progress_callback_user_data, use_mlock ? &lctx.model.mlock_mmap : NULL);
 
     model.mapping = std::move(ml->mapping);
+#ifdef GGML_USE_CUBLAS
+    for (int i = 0; i < std::min(gpu_layers, int(hparams.n_layer)); ++i) {
+        auto & layer = model.layers[i];
+        ggml_cuda_transform_tensor(layer.wq);
+        ggml_cuda_transform_tensor(layer.wk);
+        ggml_cuda_transform_tensor(layer.wv);
+        ggml_cuda_transform_tensor(layer.wo);
+        ggml_cuda_transform_tensor(layer.w1);
+        ggml_cuda_transform_tensor(layer.w2);
+        ggml_cuda_transform_tensor(layer.w3);
+    }
+#endif
 
     // loading time will be recalculate after the first eval, so
     // we take page faults deferred by mmap() into consideration
@@ -1024,11 +1041,12 @@ static bool llama_model_load(
         ggml_type memory_type,
         bool use_mmap,
         bool use_mlock,
+        int gpu_layers,
         bool vocab_only,
         llama_progress_callback progress_callback,
         void *progress_callback_user_data) {
     try {
-        llama_model_load_internal(fname, lctx, n_ctx, memory_type, use_mmap, use_mlock,
+        llama_model_load_internal(fname, lctx, n_ctx, memory_type, use_mmap, use_mlock, gpu_layers,
                                   vocab_only, progress_callback, progress_callback_user_data);
         return true;
     } catch (const std::string & err) {
@@ -2088,7 +2106,7 @@ struct llama_context * llama_init_from_file(
     ggml_type memory_type = params.f16_kv ? GGML_TYPE_F16 : GGML_TYPE_F32;
 
     if (!llama_model_load(path_model, *ctx, params.n_ctx, memory_type,
-                          params.use_mmap, params.use_mlock, params.vocab_only,
+                          params.use_mmap, params.use_mlock, params.gpu_layers, params.vocab_only,
                           params.progress_callback, params.progress_callback_user_data)) {
         fprintf(stderr, "%s: failed to load model\n", __func__);
         llama_free(ctx);

--- a/llama.h
+++ b/llama.h
@@ -63,6 +63,7 @@ extern "C" {
         bool vocab_only; // only load the vocabulary, no weights
         bool use_mmap;   // use mmap if possible
         bool use_mlock;  // force system to keep model in RAM
+        int gpu_layers;  // number of layers to store in VRAM
         bool embedding;  // embedding mode only
 
         // called with a progress value between 0 and 1, pass NULL to disable


### PR DESCRIPTION
TLDR: this PR implements CUDA GPU acceleration for token generation. Even on my relatively slow GTX 1070 this is significantly faster than using the CPU:

![gpu_speedup](https://github.com/ggerganov/llama.cpp/assets/18492268/b6a88225-854a-435e-8ab5-59f85d90463c)

To use it, provide the `main` binary with the `--gpu_layers` argument and specify how many layers should be GPU-accelerated. **Only q4_0 is implemented.**

Edit: build instructions (Linux):
```
git clone https://github.com/JohannesGaessler/llama.cpp llama.cpp-johannesgaessler
cd llama.cpp-johannesgaessler                               
git fetch
git switch dequantize-matmul-2
make LLAMA_CUBLAS=1
```
For building on Windows, read the [llama.cpp README](https://github.com/ggerganov/llama.cpp#build). **These build instructions are outdated. They will install the development version in this PR that, while still compatible with the old quantization format, is slower than the version on the master branch and only supports q4_0.**

### Background

The multiplication of two square matrices of size $N$ is a very compute-intensive operation: it requires $O(N^3)$ multiplications on $O(N^2)$ data values. However, if one of the matrices is thin in one dimension then the matrix multiplication becomes much more I/O-bound because it now requires $O(N^2)$ multiplications on $O(N^2)$ data values. When llama.cpp is generating new tokens it spends ~90% of its runtime doing matrix multiplications and those matrix multiplications are exclusively matrix vector multiplications that are maximally I/O bound. As a consequence the speed at which new tokens can be generated is essentially just proportional to memory bandwidth:

![memory_scaling_1](https://github.com/ggerganov/llama.cpp/assets/18492268/5fba0a0e-6d5b-41ca-b2eb-979c6aedbce1)

Notably the memory bandwidth on consumer GPUs is much higher than the memory bandwidth on consumer CPUs. I therefore looked into running at least part of llama.cpp on the GPU to speed up token generation. 

### Implementation

The GPU acceleration of token generation has two issues on master:

1. The dequantization of matrices on the GPU is too slow. I looked into faster dequantization kernels like https://github.com/ggerganov/llama.cpp/pull/1221 but even then the combined dequantization and matrix multiplication on a GTX 1070 was 2x slower than on the CPU. I therefore implemented a new CUDA kernel that does dequantization and matrix vector multiplication simultaneously.
2. Transferring quantized matrices to the GPU adds significant latency (4x more than the runtime of the optimized dequantization and matrix multiplication). I therefore implemented storing the quantized matrices in VRAM rather than RAM on a tensor-by-tensor basis. I added a property `backend` to `ggml_tensor` that specifies where the data is stored. The data then needs to be transferred to the GPU only once. The vectors are still transferred to the GPU every time but on my hardware this adds relatively low overhead (see below). An additional benefit of this approach is that this can potentially be used to reduce the memory footprint on the host because the quantized matrices only need to be stored on the GPU (not implemented). My system with 32GB RAM can start thrashing with 33b q5_1 so even my current 8GB of VRAM would be a huge quality of life improvement.

Only the repeating layers of LLaMa are accelerated. The fixed layers at the beginning and end of the neural networks are still CPU only for token generation.

### Results

On my hardware I found:

| Model    | Num layers | Baseline speed [t/s] (3200 MHz RAM) | Max. accelerated layers (8 GB VRAM) | Max. speed [t/s] (GTX 1070) | Max. speedup (GTX 1070) |
|----------|------------|-------------------------------------|-------------------------------------|-----------------------|-------------------------|
| 7b q4_0  |         32 |                                9.15 |                                  32 |                 12.50 |                    1.36 |
| 13 q4_0  |         40 |                                4.86 |                                  34 |                  6.42 |                    1.32 |
| 33b q4_0 |         60 |                                1.96 |                                  19 |                  2.22 |                    1.12 |

There is a significant speedup for all model sizes though the speedup is considerably larger for the smaller models where a larger percentage fits into VRAM. The plot at the beginning of the PR shows the scaling as a function of the percentage of the model in VRAM. This speedup is essentially the same for all models which suggests that large amounts of VRAM is key. For larger models the maximum potential speedup seems to be higher.

Profiling with `nvprof` suggests that copying vectors between host and device is not a bottleneck on my hardware:

<details>

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   89.16%  24.7485s     33915  729.72us  411.84us  2.2789ms  void dequantize_mul_mat_q4_0<int=32>(void const *, float const *, float*, int)
                    7.37%  2.04551s       133  15.380ms  8.5321ms  24.494ms  dequantize_block_q4_0(void const *, float*)
                    2.27%  629.46ms     34181  18.415us  2.9760us  5.8011ms  [CUDA memcpy HtoD]
                    0.74%  204.55ms       133  1.5380ms  818.69us  2.8980ms  void gemmSN_TN_kernel<float, int=128, int=16, int=2, int=4, int=2, int=2, bool=1, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float>>(cublasGemmSmallNParams<float const , cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, float>)
                    0.47%  129.91ms     34048  3.8150us  2.6880us  12.288us  [CUDA memcpy DtoH]
      API calls:   90.14%  27.5341s     34181  805.54us  72.691us  26.766ms  cudaDeviceSynchronize
                    4.49%  1.37286s         5  274.57ms  79.531ms  743.99ms  cudaMallocHost
                    2.27%  694.01ms     68229  10.171us  2.2800us  5.7958ms  cudaMemcpyAsync
                    1.57%  481.06ms         5  96.211ms  391.06us  275.79ms  cudaFreeHost
                    0.76%  232.09ms       953  243.53us  2.3100us  10.969ms  cuLibraryLoadData
                    0.41%  125.95ms     34181  3.6840us  2.8100us  32.480us  cudaLaunchKernel
                    0.11%  34.327ms       142  241.74us  2.6600us  4.2271ms  cudaMalloc
                    0.10%  29.636ms     34048     870ns     620ns  11.970us  cudaEventRecord
                    0.09%  26.234ms     34048     770ns     650ns  206.77us  cudaStreamWaitEvent
                    0.03%  8.4284ms         2  4.2142ms  3.8226ms  4.6058ms  cudaFree
                    0.02%  5.9012ms     34181     172ns     150ns  3.6300us  cudaGetLastError
                    0.00%  336.79us       336  1.0020us     130ns  43.360us  cuDeviceGetAttribute
                    0.00%  148.54us       766     193ns     130ns  1.1500us  cuGetProcAddress
                    0.00%  93.821us        16  5.8630us  1.4200us  57.391us  cudaStreamCreateWithFlags
                    0.00%  42.180us        82     514ns     400ns  1.9300us  cudaEventCreateWithFlags
                    0.00%  25.690us         3  8.5630us  7.3400us  10.850us  cuDeviceGetName
                    0.00%  5.7400us         3  1.9130us     460ns  4.7300us  cudaGetDevice
                    0.00%  5.2300us        14     373ns     270ns  1.2900us  cudaDeviceGetAttribute
                    0.00%  4.9400us         1  4.9400us  4.9400us  4.9400us  cuDeviceGetPCIBusId
                    0.00%  1.9400us         2     970ns     910ns  1.0300us  cuInit
                    0.00%  1.5500us         5     310ns     150ns     680ns  cuDeviceGetCount
                    0.00%     880ns         3     293ns     260ns     340ns  cuDeviceTotalMem
                    0.00%     840ns         4     210ns     130ns     420ns  cuDeviceGet
                    0.00%     590ns         3     196ns     170ns     240ns  cuModuleGetLoadingMode
                    0.00%     550ns         1     550ns     550ns     550ns  cudaGetSymbolAddress
                    0.00%     530ns         3     176ns     170ns     180ns  cuDeviceGetUuid
                    0.00%     310ns         2     155ns     150ns     160ns  cuDriverGetVersion
```

</details>

Of course, I would be very interested to see the results that people with faster GPUs get with this PR; I personally plan to buy an RTX 3090 now that I've asserted that I'll be able to make use of it.