### PR TITLE
Add clang-tidy reviews to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+---
+Checks: >
+    bugprone-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-implicit-widening-of-multiplication-result,
+    -bugprone-narrowing-conversions,
+    readability-*,
+    -readability-avoid-unconditional-preprocessor-if,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,
+    -readability-implicit-bool-conversion,
+    -readability-magic-numbers,
+    -readability-uppercase-literal-suffix,
+    clang-analyzer-*,
+    -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+    performance-*,
+    portability-*,
+FormatStyle: none

--- a/.github/workflows/tidy-post.yml
+++ b/.github/workflows/tidy-post.yml
@@ -1,0 +1,20 @@
+name: clang-tidy review post comments
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.13.0
+        # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
+        with:
+          # adjust options as necessary
+          lgtm_comment_body: ''
+          annotations: false
+          max_comments: 25

--- a/.github/workflows/tidy-review.yml
+++ b/.github/workflows/tidy-review.yml
@@ -1,0 +1,23 @@
+name: clang-tidy-review
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clang-tidy-review:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ZedThree/clang-tidy-review@v0.13.0
+      id: review
+      with:
+        lgtm_comment_body: ''
+        build_dir: build
+        cmake_command: cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+        split_workflow: true
+
+    - uses: ZedThree/clang-tidy-review/upload@v0.13.0


### PR DESCRIPTION
Adds clang-tidy static analyzer and linter checks to pull requests.

The failed checks are reported in the PR in a comment, see these for some examples:
https://github.com/slaren/llama.cpp/pull/11
https://github.com/slaren/llama.cpp/pull/12 (here it finds a bug in the command line parsing of `benchmark-matmult.cpp`)

I tried to remove some of the most pedantic checks, but there are still a lot of failed checks in the current code that should be addressed over time. However, the workflow action will only report the checks failed in the lines modified by the PR, so the current issues will not be blamed on new PRs (unless they happen to be in the lines modified by the PR).

To test the settings in `.clang-tidy` locally:
- Configure cmake with `-DCMAKE_EXPORT_COMPILE_COMMANDS=on`
- Run clang-tidy with the cmake build path in `-p` and the source file, for example:
`clang-tidy -p build llama.cpp`

Note that since this adds comments to the PRs, it requires adding write permissions to the workflows in the project settings.