### PR TITLE
Add the dotnet binding info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ as the main playground for developing new features for the [ggml](https://github
 - Go: [go-skynet/go-llama.cpp](https://github.com/go-skynet/go-llama.cpp)
 - Node.js: [hlhr202/llama-node](https://github.com/hlhr202/llama-node)
 - Ruby: [yoshoku/llama_cpp.rb](https://github.com/yoshoku/llama_cpp.rb)
+- C#/.NET: [SciSharp/LLamaSharp](https://github.com/SciSharp/LLamaSharp)
 
 **UI:**
 


### PR DESCRIPTION
Hi, `SciSharp STACK` has made a C#/.NET Binding of llama.cpp, named [LLamaSharp](https://github.com/SciSharp/LLamaSharp). May I kindly ask if it can be added to readme to let more dotnet users know it? 

Currently it has provided the following features:
1. Basic APIs, including getting the embeddings, tokenization and detokenization, loading and inferring the model, etc.
2. Chat session, providing easy-to-use APIs to make a chat bot.
3. Quantization, providing an API to quantize the model in C#.
4. Integration of ASP.NET core, making it easy to deploy the chat service.
5. One-click installation, without compiling llama.cpp or other manipulations.

SciSharp STACK developers will maintain it and follow up llama.cpp. I believe we can make this .NET Binding better with the great works of `llama.cpp`! :)
