### PR TITLE
Adding SSE instructions to ggml_vec_dot_q4_0_q8_0

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -472,7 +472,7 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 // quantization
 //
 
-#if __AVX__ || __AVX2__ || __AVX512F__ || __SSE3__
+#if __AVX__ || __AVX2__ || __AVX512F__ || defined(__SSE3__)
 // multiply int8_t, add results pairwise twice
 static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
     // Get absolute values of x vectors

--- a/ggml.c
+++ b/ggml.c
@@ -2155,8 +2155,8 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
 
     // First round without accumulation
     {
-        _mm_prefetch(&x[1] + sizeof(block_q4_0), _MM_HINT_T0);
-        _mm_prefetch(&y[1] + sizeof(block_q8_0), _MM_HINT_T0);
+        _mm_prefetch(&x[0] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[0] + sizeof(block_q8_0), _MM_HINT_T0);
 
         // Compute combined scale for the block 0 and 1
         const __m128 d_0_1 = _mm_mul_ps( _mm_set1_ps( x[0].d ), _mm_set1_ps( y[0].d ) );
@@ -2173,8 +2173,8 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
         bx_1 = _mm_sub_epi8(bx_1, off);
         const __m128i i32_1 = mul_sum_i8_pairs(bx_1, by_1);
 
-        _mm_prefetch(&x[2] + sizeof(block_q4_0), _MM_HINT_T0);
-        _mm_prefetch(&y[2] + sizeof(block_q8_0), _MM_HINT_T0);
+        _mm_prefetch(&x[1] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[1] + sizeof(block_q8_0), _MM_HINT_T0);
 
         // Compute combined scale for the block 2 and 3
         const __m128 d_2_3 = _mm_mul_ps( _mm_set1_ps( x[1].d ), _mm_set1_ps( y[1].d ) );
@@ -2206,8 +2206,8 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
 
     // Main loop
     for (int i = 2; i < nb; i+=2) {
-        _mm_prefetch(&x[i + 1] + sizeof(block_q4_0), _MM_HINT_T0);
-        _mm_prefetch(&y[i + 1] + sizeof(block_q8_0), _MM_HINT_T0);
+        _mm_prefetch(&x[i] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[i] + sizeof(block_q8_0), _MM_HINT_T0);
 
         // Compute combined scale for the block 0 and 1
         const __m128 d_0_1 = _mm_mul_ps( _mm_set1_ps( x[i].d ), _mm_set1_ps( y[i].d ) );
@@ -2224,8 +2224,8 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
         bx_1 = _mm_sub_epi8(bx_1, off);
         const __m128i i32_1 = mul_sum_i8_pairs(bx_1, by_1);
 
-        _mm_prefetch(&x[i + 2] + sizeof(block_q4_0), _MM_HINT_T0);
-        _mm_prefetch(&y[i + 2] + sizeof(block_q8_0), _MM_HINT_T0);
+        _mm_prefetch(&x[i] + 2 * sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[i] + 2 * sizeof(block_q8_0), _MM_HINT_T0);
 
         // Compute combined scale for the block 2 and 3
         const __m128 d_2_3 = _mm_mul_ps( _mm_set1_ps( x[i + 1].d ), _mm_set1_ps( y[i + 1].d ) );

--- a/ggml.c
+++ b/ggml.c
@@ -485,23 +485,6 @@ static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
     return _mm_madd_epi16(ones, dot);
 }
 
-// horizontally add 4 floats
-static inline float hsum_float_4(const __m128 x) {
-    __m128 res =_mm_hadd_ps(x, x);
-    res =_mm_hadd_ps(res, res);
-
-    return _mm_cvtss_f32(res);
-}
-
-// horizontally add 2x4 floats
-static inline float hsum_float_2x4(const __m128 x, const __m128 y) {
-    __m128 res =_mm_hadd_ps(x, y);
-    res =_mm_hadd_ps(res, res);
-    res =_mm_hadd_ps(res, res);
-
-    return _mm_cvtss_f32(res);
-}
-
 // horizontally add 4x4 floats
 static inline float hsum_float_4x4(const __m128 a, const __m128 b, const __m128 c, const __m128 d) {
     __m128 res_0 =_mm_hadd_ps(a, b);
@@ -511,7 +494,7 @@ static inline float hsum_float_4x4(const __m128 a, const __m128 b, const __m128 
     res =_mm_hadd_ps(res, res);
 
     return _mm_cvtss_f32(res);
-} 
+}
 #endif
 
 #if __AVX__ || __AVX2__ || __AVX512F__
@@ -2170,6 +2153,7 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
     __m128 acc_2 = _mm_setzero_ps();
     __m128 acc_3 = _mm_setzero_ps();
 
+    // First round without accumulation
     {
         _mm_prefetch(&x[1] + sizeof(block_q4_0), _MM_HINT_T0);
         _mm_prefetch(&y[1] + sizeof(block_q8_0), _MM_HINT_T0);

--- a/ggml.c
+++ b/ggml.c
@@ -485,18 +485,6 @@ static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
     return _mm_madd_epi16(ones, dot);
 }
 
-// horizontally add 4x4 floats
-static inline float hsum_float_4x4(const __m128 a, const __m128 b, const __m128 c, const __m128 d) {
-    __m128 res_0 =_mm_hadd_ps(a, b);
-    __m128 res_1 =_mm_hadd_ps(c, d);
-    __m128 res =_mm_hadd_ps(res_0, res_1);
-    res =_mm_hadd_ps(res, res);
-    res =_mm_hadd_ps(res, res);
-
-    return _mm_cvtss_f32(res);
-}
-#endif
-
 #if __AVX__ || __AVX2__ || __AVX512F__
 // horizontally add 8 floats
 static inline float hsum_float_8(const __m256 x) {
@@ -609,7 +597,19 @@ static inline __m128i packNibbles( __m128i bytes1, __m128i bytes2 )
     return _mm_packus_epi16( bytes1, bytes2);
 }
 #endif
+#elif defined(__SSSE3__)
+// horizontally add 4x4 floats
+static inline float hsum_float_4x4(const __m128 a, const __m128 b, const __m128 c, const __m128 d) {
+    __m128 res_0 =_mm_hadd_ps(a, b);
+    __m128 res_1 =_mm_hadd_ps(c, d);
+    __m128 res =_mm_hadd_ps(res_0, res_1);
+    res =_mm_hadd_ps(res, res);
+    res =_mm_hadd_ps(res, res);
+
+    return _mm_cvtss_f32(res);
+}
 #endif // __AVX__ || __AVX2__ || __AVX512F__
+#endif // defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__)
 
 #if __ARM_NEON
 

--- a/ggml.c
+++ b/ggml.c
@@ -472,7 +472,7 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 // quantization
 //
 
-#if __AVX__ || __AVX2__ || __AVX512F__ || defined(__SSE3__)
+#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__)
 // multiply int8_t, add results pairwise twice
 static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
     // Get absolute values of x vectors
@@ -2142,7 +2142,7 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
     }
 
     *s = hsum_float_8(acc);
-#elif defined(__SSE3__)
+#elif defined(__SSSE3__)
     // set constants
     const __m128i lowMask = _mm_set1_epi8(0xF);
     const __m128i off = _mm_set1_epi8(8);

--- a/ggml.c
+++ b/ggml.c
@@ -2171,7 +2171,10 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
     __m128 acc_3 = _mm_setzero_ps();
 
     {
-        // Compute combined scale for the block
+        _mm_prefetch(&x[1] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[1] + sizeof(block_q8_0), _MM_HINT_T0);
+
+        // Compute combined scale for the block 0 and 1
         const __m128 d_0_1 = _mm_mul_ps( _mm_set1_ps( x[0].d ), _mm_set1_ps( y[0].d ) );
 
         const __m128i tmp_0_1 = _mm_loadu_si128((const __m128i *)x[0].qs);
@@ -2186,7 +2189,10 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
         bx_1 = _mm_sub_epi8(bx_1, off);
         const __m128i i32_1 = mul_sum_i8_pairs(bx_1, by_1);
 
-        // Compute combined scale for the block
+        _mm_prefetch(&x[2] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[2] + sizeof(block_q8_0), _MM_HINT_T0);
+
+        // Compute combined scale for the block 2 and 3
         const __m128 d_2_3 = _mm_mul_ps( _mm_set1_ps( x[1].d ), _mm_set1_ps( y[1].d ) );
 
         const __m128i tmp_2_3 = _mm_loadu_si128((const __m128i *)x[1].qs);
@@ -2216,7 +2222,10 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
 
     // Main loop
     for (int i = 2; i < nb; i+=2) {
-        // Compute combined scale for the block
+        _mm_prefetch(&x[i + 1] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[i + 1] + sizeof(block_q8_0), _MM_HINT_T0);
+
+        // Compute combined scale for the block 0 and 1
         const __m128 d_0_1 = _mm_mul_ps( _mm_set1_ps( x[i].d ), _mm_set1_ps( y[i].d ) );
 
         const __m128i tmp_0_1 = _mm_loadu_si128((const __m128i *)x[i].qs);
@@ -2230,6 +2239,9 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
         __m128i by_1 = _mm_loadu_si128((const __m128i *)(y[i].qs + 16));
         bx_1 = _mm_sub_epi8(bx_1, off);
         const __m128i i32_1 = mul_sum_i8_pairs(bx_1, by_1);
+
+        _mm_prefetch(&x[i + 2] + sizeof(block_q4_0), _MM_HINT_T0);
+        _mm_prefetch(&y[i + 2] + sizeof(block_q8_0), _MM_HINT_T0);
 
         // Compute combined scale for the block 2 and 3
         const __m128 d_2_3 = _mm_mul_ps( _mm_set1_ps( x[i + 1].d ), _mm_set1_ps( y[i + 1].d ) );


### PR DESCRIPTION
Hi, I am unfortunately on of the persons who have a computer without any AVX instructions, only sse instrucions.

So the runtimes to calculate the tokens are very bad.

For that I implemented ggml_vec_dot_q4_0_q8_0 with SSE instructions to gain some performance. I started with taking the avx parts and replace all 256 vector instructions with 128 vector instructions. After that I did some additional improvements to squeeze some more performance out of the routine.

Run command was

./main -s 1 -t 4 -n 128 ../models/7B/ggml-model-q4_0.bin -p "What is the meaning of life?"

What I started with without change at the code:

llama_print_timings:        load time = 14251.20 ms
llama_print_timings:      sample time =   129.15 ms /   128 runs   (    1.01 ms per token)
llama_print_timings: prompt eval time = 14050.58 ms /     8 tokens ( 1756.32 ms per token)
llama_print_timings:        eval time = 238504.60 ms /   127 runs   ( 1877.99 ms per token)
llama_print_timings:       total time = 252916.56 ms

What I got after just replacing the avx 256 instructions with sse 128 instructions:

llama_print_timings:        load time =  3349.09 ms
llama_print_timings:      sample time =    53.06 ms /    52 runs   (    1.02 ms per token)
llama_print_timings: prompt eval time =  3154.19 ms /     8 tokens (  394.27 ms per token)
llama_print_timings:        eval time = 23759.20 ms /    51 runs   (  465.87 ms per token)
llama_print_timings:       total time = 27174.93 ms

What I got after squeezing:

llama_print_timings:        load time =  2899.92 ms
llama_print_timings:      sample time =   127.62 ms /   128 runs   (    1.00 ms per token)
llama_print_timings: prompt eval time =  2705.68 ms /     8 tokens (  338.21 ms per token)
llama_print_timings:        eval time = 52500.58 ms /   127 runs   (  413.39 ms per token)
llama_print_timings:       total time = 55559.90 ms

Esspecially the squeezing part is just a feeling, as I would expect the compiler should do much of the improvements on its own, for example the prefetching. But all in all it feels like I get more performance, when I tell it more specific, what I want.