### PR TITLE
OpenCL: Fixes for older devices.

### DIFF
--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -302,7 +302,7 @@ void ggml_cl_init(void) {
         for (unsigned i = 0; i < n_selected_devices; i++) {
             struct cl_device * d = &selected_devices[i];
             if (strstr(d->name, user_device_string) != NULL) {
-                user_device_number = (int)i;
+                user_device_number = d->number;
                 break;
             }
         }
@@ -312,7 +312,7 @@ void ggml_cl_init(void) {
         }
     }
     if (user_device_number != -1) {
-        selected_devices = &selected_devices[user_device_number];
+        selected_devices = &devices[user_device_number];
         n_selected_devices = 1;
         default_device = &selected_devices[0];
     }

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -138,7 +138,6 @@ static cl_platform_id platform;
 static cl_device_id device;
 static cl_context context;
 static cl_command_queue queue;
-static cl_bool out_of_order;
 static cl_program program;
 static cl_kernel kernel_q4_0, kernel_q4_1, kernel_q5_0, kernel_q5_1, kernel_q8_0;
 static cl_mem cl_buffer_a, cl_buffer_qb, cl_buffer_b, cl_buffer_c;
@@ -214,11 +213,10 @@ void ggml_cl_init(void) {
         }
     }
 
-    text_buffer[0] = 0;
     device = NULL;
     char * GGML_OPENCL_DEVICE = getenv("GGML_OPENCL_DEVICE");
     if (GGML_OPENCL_DEVICE != NULL) {
-        cl_device_id devices[16];
+        cl_device_id devices[NDEV];
         cl_uint num_devices;
         clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, NDEV, devices, &num_devices);
 
@@ -284,10 +282,8 @@ void ggml_cl_init(void) {
         fprintf(stderr, "ggml_opencl: using device: '%s'\n", text_buffer);
     }
 
-    out_of_order = CL_TRUE;
     queue = clCreateCommandQueue(context, device, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err);
     if (err == CL_INVALID_PROPERTY || err == CL_INVALID_VALUE) {
-        out_of_order = CL_FALSE;
         queue = clCreateCommandQueue(context, device, 0, &err);
     }
     CL_CHECK(err, "clCreateCommandQueue");

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -233,7 +233,7 @@ void ggml_cl_init(void) {
         else CL_CHECK(clGetDeviceIDsError);
         p->devices = p->n_devices > 0 ? &devices[n_devices] : NULL;
         p->default_device = NULL;
-        
+
         for (unsigned j = 0; j < p->n_devices; j++) {
             struct cl_device * d = &devices[n_devices];
             d->number = n_devices++;
@@ -269,14 +269,14 @@ void ggml_cl_init(void) {
     if (user_device_string != NULL && sscanf(user_device_string, " %u", &n) == 1 && n < n_devices) {
         user_device_number = (int)n;
     }
-    
+
     struct cl_device * selected_devices = devices;
     unsigned n_selected_devices = n_devices;
 
     if (user_platform_number == -1 && user_platform_string != NULL && user_platform_string[0] != 0) {
         for (unsigned i = 0; i < n_platforms; i++) {
             struct cl_platform * p = &platforms[i];
-            if (strstr(p->name, user_platform_string) != NULL || 
+            if (strstr(p->name, user_platform_string) != NULL ||
                 strstr(p->vendor, user_platform_string) != NULL) {
                 user_platform_number = (int)i;
                 break;

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -60,8 +60,8 @@ __kernel void dequantize_row_q4_0(__global struct block_q4_0* x, __global float*
     const int x0 = (x[i].qs[j] & 0xf) - 8;
     const int x1 = (x[i].qs[j] >>  4) - 8;
 
-    y[i*qk + j + 0   ] = x0*d;
-    y[i*qk + j + qk/2] = x1*d;
+    y[i*32 + j + 0 ] = x0*d;
+    y[i*32 + j + 16] = x1*d;
 }
 
 __kernel void dequantize_row_q4_1(__global struct block_q4_1* x, __global float* y) {
@@ -74,8 +74,8 @@ __kernel void dequantize_row_q4_1(__global struct block_q4_1* x, __global float*
     const int x0 = (x[i].qs[j] & 0xf);
     const int x1 = (x[i].qs[j] >>  4);
 
-    y[i*qk + j + 0   ] = x0*d + m;
-    y[i*qk + j + qk/2] = x1*d + m;
+    y[i*32 + j + 0 ] = x0*d + m;
+    y[i*32 + j + 16] = x1*d + m;
 }
 
 __kernel void dequantize_row_q5_0(__global struct block_q5_0* x, __global float* y) {
@@ -92,8 +92,8 @@ __kernel void dequantize_row_q5_0(__global struct block_q5_0* x, __global float*
     const int32_t x0 = ((x[i].qs[j] & 0xf) | xh_0) - 16;
     const int32_t x1 = ((x[i].qs[j] >>  4) | xh_1) - 16;
 
-    y[i*qk + j + 0   ] = x0*d;
-    y[i*qk + j + qk/2] = x1*d;
+    y[i*32 + j + 0 ] = x0*d;
+    y[i*32 + j + 16] = x1*d;
 }
 
 __kernel void dequantize_row_q5_1(__global struct block_q5_1* x, __global float* y) {
@@ -111,8 +111,8 @@ __kernel void dequantize_row_q5_1(__global struct block_q5_1* x, __global float*
     const int x0 = (x[i].qs[j] & 0xf) | xh_0;
     const int x1 = (x[i].qs[j] >>  4) | xh_1;
 
-    y[i*qk + j + 0   ] = x0*d + m;
-    y[i*qk + j + qk/2] = x1*d + m;
+    y[i*32 + j + 0 ] = x0*d + m;
+    y[i*32 + j + 16] = x1*d + m;
 }
 
 __kernel void dequantize_row_q8_0(__global struct block_q8_0* x, __global float* y) {
@@ -120,7 +120,7 @@ __kernel void dequantize_row_q8_0(__global struct block_q8_0* x, __global float*
     const uint j = get_local_id(0);
 
     const float d = x[i].d;
-    y[i*qk + j] = x[i].qs[j]*d;
+    y[i*32 + j] = x[i].qs[j]*d;
 }
 
 );

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -17,13 +17,13 @@ typedef uchar uint8_t;
 typedef int int32_t;
 typedef uint uint32_t;
 
-struct block_q4_0
+struct __attribute__ ((packed)) block_q4_0
 {
     float d;
     uint8_t qs[16]; /* QK4_0 / 2 */
 };
 
-struct block_q4_1
+struct __attribute__ ((packed)) block_q4_1
 {
     float d;
     float m;
@@ -37,7 +37,7 @@ struct __attribute__ ((packed)) block_q5_0
     uint8_t qs[16]; /* QK5_0 / 2 */
 };
 
-struct block_q5_1
+struct __attribute__ ((packed)) block_q5_1
 {
     half d;
     half m;
@@ -45,7 +45,7 @@ struct block_q5_1
     uint8_t qs[16]; /* QK5_1 / 2 */
 };
 
-struct block_q8_0
+struct __attribute__ ((packed)) block_q8_0
 {
     float d;
     int8_t qs[32]; /* QK8_0 */

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -16,48 +16,48 @@ typedef uchar uint8_t;
 typedef int int32_t;
 typedef uint uint32_t;
 
-constant uint QK4_0 = 32;
+//constant uint QK4_0 = 32;
 struct block_q4_0
 {
     float d;
-    uint8_t qs[QK4_0 / 2];
+    uint8_t qs[16]; // QK4_0 / 2
 };
 
-constant uint QK4_1 = 32;
+//constant uint QK4_1 = 32;
 struct block_q4_1
 {
     float d;
     float m;
-    uint8_t qs[QK4_1 / 2];
+    uint8_t qs[16]; // QK4_1 / 2
 };
 
-constant uint QK5_0 = 32;
+//constant uint QK5_0 = 32;
 struct __attribute__ ((packed)) block_q5_0
 {
     half d;
     uint32_t qh;
-    uint8_t qs[QK5_0 / 2];
+    uint8_t qs[16]; // QK5_0 / 2
 };
 
-constant uint QK5_1 = 32;
+//constant uint QK5_1 = 32;
 struct block_q5_1
 {
     half d;
     half m;
     uint32_t qh;
-    uint8_t qs[QK5_1 / 2];
+    uint8_t qs[16]; // QK5_1 / 2
 };
 
-constant uint QK8_0 = 32;
+//constant uint QK8_0 = 32;
 struct block_q8_0
 {
     float d;
-    uint8_t qs[QK8_0];
+    uint8_t qs[16]; // QK8_0 / 2
 };
 
 
 __kernel void dequantize_row_q4_0(__global struct block_q4_0* x, __global float* y) {
-    constant uint qk = QK4_0;
+    constant uint qk = 32; // QK4_0;
 
     const uint i = get_global_id(0) / qk;
     const uint j = get_local_id(0);
@@ -72,7 +72,7 @@ __kernel void dequantize_row_q4_0(__global struct block_q4_0* x, __global float*
 }
 
 __kernel void dequantize_row_q4_1(__global struct block_q4_1* x, __global float* y) {
-    constant uint qk = QK4_1;
+    constant uint qk = 32; // QK4_1;
 
     const uint i = get_global_id(0) / qk;
     const uint j = get_local_id(0);
@@ -88,7 +88,7 @@ __kernel void dequantize_row_q4_1(__global struct block_q4_1* x, __global float*
 }
 
 __kernel void dequantize_row_q5_0(__global struct block_q5_0* x, __global float* y) {
-    constant uint qk = QK5_0;
+    constant uint qk = 32; // QK5_0;
 
     const uint i = get_global_id(0) / qk;
     const uint j = get_local_id(0);
@@ -108,7 +108,7 @@ __kernel void dequantize_row_q5_0(__global struct block_q5_0* x, __global float*
 }
 
 __kernel void dequantize_row_q5_1(__global struct block_q5_1* x, __global float* y) {
-    constant uint qk = QK5_1;
+    constant uint qk = 32; // QK5_1;
 
     const uint i = get_global_id(0) / qk;
     const uint j = get_local_id(0);
@@ -129,7 +129,7 @@ __kernel void dequantize_row_q5_1(__global struct block_q5_1* x, __global float*
 }
 
 __kernel void dequantize_row_q8_0(__global struct block_q8_0* x, __global float* y) {
-    constant uint qk = QK8_0;
+    constant uint qk = 32; // QK8_0;
     const uint i = get_global_id(0) / qk;
     const uint j = get_local_id(0);
 

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -229,8 +229,8 @@ void ggml_cl_init(void) {
 
         cl_device_id device_ids[NDEV];
         cl_int clGetDeviceIDsError = clGetDeviceIDs(p->id, CL_DEVICE_TYPE_ALL, NDEV, device_ids, &p->n_devices);
-        if (clGetDeviceIDsError == CL_DEVICE_NOT_FOUND) p->n_devices = 0;
-        else CL_CHECK(clGetDeviceIDsError);
+        if (clGetDeviceIDsError == CL_DEVICE_NOT_FOUND) { p->n_devices = 0; }
+        else { CL_CHECK(clGetDeviceIDsError); }
         p->devices = p->n_devices > 0 ? &devices[n_devices] : NULL;
         p->default_device = NULL;
 

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -229,8 +229,11 @@ void ggml_cl_init(void) {
 
         cl_device_id device_ids[NDEV];
         cl_int clGetDeviceIDsError = clGetDeviceIDs(p->id, CL_DEVICE_TYPE_ALL, NDEV, device_ids, &p->n_devices);
-        if (clGetDeviceIDsError == CL_DEVICE_NOT_FOUND) { p->n_devices = 0; }
-        else { CL_CHECK(clGetDeviceIDsError); }
+        if (clGetDeviceIDsError == CL_DEVICE_NOT_FOUND) {
+            p->n_devices = 0;
+        } else {
+            CL_CHECK(clGetDeviceIDsError);
+        }
         p->devices = p->n_devices > 0 ? &devices[n_devices] : NULL;
         p->default_device = NULL;
 

--- a/ggml-opencl.c
+++ b/ggml-opencl.c
@@ -12,6 +12,7 @@
 #define MULTILINE_QUOTE(...) #__VA_ARGS__
 static const char * program_source = MULTILINE_QUOTE(
 
+typedef char int8_t;
 typedef uchar uint8_t;
 typedef int int32_t;
 typedef uint uint32_t;
@@ -47,7 +48,7 @@ struct block_q5_1
 struct block_q8_0
 {
     float d;
-    uint8_t qs[16]; /* QK8_0 / 2 */
+    int8_t qs[32]; /* QK8_0 */
 };
 
 


### PR DESCRIPTION
Remove `constant` in array definitions, we can't use defines because CPP does not process the kernel code normally with the way it is included in the code.

The platform and device selection should also be improved, it is now possible to use a string to match platforms:

- `GGML_OPENCL_PLATFORM`
- `GGML_OPENCL_DEVICE`

```sh
# default:
./main ...

# AMD:
GGML_OPENCL_PLATFORM=AMD ./main ...
```

etc... But I changed the name of the env variable, because it is not really related to CLBlast itself, only OpenCL in general.

Issue: #1429

Two mallocs and frees removed as well :)