### PR TITLE
fix get_num_physical_cores()

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -31,18 +31,18 @@ int32_t get_num_physical_cores() {
 #ifdef __linux__
     // enumerate the set of thread siblings, num entries is num cores
     std::unordered_set<std::string> siblings;
-    for(uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
+    for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
         std::ifstream thread_siblings("/sys/devices/system/cpu"
             + std::to_string(cpu) + "/topology/thread_siblings");
-        if(!thread_siblings.is_open()) {
+        if (!thread_siblings.is_open()) {
             break; // no more cpus
         }
         std::string line;
-        if(std::getline(thread_siblings, line)) {
+        if (std::getline(thread_siblings, line)) {
             siblings.insert(line);
         }
     }
-    if(siblings.size() > 0) {
+    if (siblings.size() > 0) {
         return static_cast<int32_t>(siblings.size());
     }
 #elif defined(__APPLE__) && defined(__MACH__)

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <algorithm>
 #include <sstream>
+#include <unordered_set>
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <sys/types.h>
@@ -28,21 +29,21 @@
 
 int32_t get_num_physical_cores() {
 #ifdef __linux__
-    std::ifstream cpuinfo("/proc/cpuinfo");
-    std::string line;
-    while (std::getline(cpuinfo, line)) {
-        std::size_t pos = line.find("cpu cores");
-        if (pos != std::string::npos) {
-            pos = line.find(": ", pos);
-            if (pos != std::string::npos) {
-                try {
-                    // Extract the number and return it
-                    return static_cast<int32_t>(std::stoul(line.substr(pos + 2)));
-                } catch (const std::invalid_argument &) {
-                    // Ignore if we could not parse
-                }
-            }
+    // enumerate the set of thread siblings, num entries is num cores
+    std::unordered_set<std::string> siblings;
+    for(uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
+        std::ifstream thread_siblings("/sys/devices/system/cpu"
+            + std::to_string(cpu) + "/topology/thread_siblings");
+        if(!thread_siblings.is_open()) {
+            break; // no more cpus
         }
+        std::string line;
+        if(std::getline(thread_siblings, line)) {
+            siblings.insert(line);
+        }
+    }
+    if(siblings.size() > 0) {
+        return static_cast<int32_t>(siblings.size());
     }
 #elif defined(__APPLE__) && defined(__MACH__)
     int32_t num_physical_cores;


### PR DESCRIPTION
had been broken on complex topologies because "cpu cores" in /proc/cpuinfo is per-"physical id"