### PR TITLE
ggml : various fixes

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -340,7 +340,7 @@ extern "C" {
 
     // n-dimensional tensor
     struct ggml_tensor {
-        enum ggml_type type;
+        enum ggml_type    type;
         enum ggml_backend backend;
 
         int     n_dims;
@@ -372,7 +372,7 @@ extern "C" {
 
         char name[32];
 
-        char padding[9]; // TODO: remove and add padding to name?
+        char padding[16];
     };
 
     // computation graph


### PR DESCRIPTION
- fix `ggml_rope()` when not inplace https://github.com/ggerganov/ggml/commit/788381e447d280b4fec35986e20eb210d41f207b
- fix `ggml_rope()` GPT-NeoX mode (hopefully) https://github.com/ggerganov/ggml/commit/788381e447d280b4fec35986e20eb210d41f207b
- fix data race in multi-threaded `ggml_diag_mask_inf()` operator https://github.com/ggerganov/ggml/commit/a483bb24456d75935e21d1e29ae24d74ecfa780e
- compatibility with scratch buffers

The `ggml_rope()` fixes are irrelevant for LLaMA since `n_rot == (n_embd / n_head)`, but it makes a difference for other models like GPT-J and GPT-NeoX where `n_rot < (n_embd / n_head)`. I'm still not sure if this is the correct implementation, especially for the GPT-NeoX mode, but results kind of seem a bit better than before.

The non-inplace multi-thread `ggml_diag_mask_inf()` was broken here: https://github.com/ggerganov/llama.cpp/pull/1428 . Again, irrelevant since in LLaMA forward we use `ggml_diag_mask_inf_inplace()`. Might be relevant to @xaedes 

The "scratch buffers" fix might be relevant for LLaMA. See the new `ggml_scratch_save()` and `ggml_scratch_load()` functions and their usage in `ggml.c`: https://github.com/ggerganov/llama.cpp/blob/fixes/ggml.c#LL3925C1-L3939C1
The scratch buffers are mechanism for reusing memory from previous ops when it is no longer needed. The current way of using them is manual and very error-prone. Will hopefully come up with something better in the future.
More info here: https://github.com/ggerganov/whisper.cpp/pull/431