### PR TITLE
Fix race condition bug in non-inplace ggml_compute_forward_diag_mask_f32

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -10470,7 +10470,7 @@ static void ggml_compute_forward_diag_mask_f32(
     if (params->type == GGML_TASK_INIT || params->type == GGML_TASK_FINALIZE) {
         return;
     }
-    
+
     // TODO: handle transposed/permuted matrices
 
     const int n  = ggml_nrows(src0);

--- a/ggml.c
+++ b/ggml.c
@@ -10450,20 +10450,27 @@ static void ggml_compute_forward_diag_mask_f32(
     assert(src1->type == GGML_TYPE_I32);
     assert(ggml_nelements(src1) == 2);
 
-    if (params->type == GGML_TASK_INIT || params->type == GGML_TASK_FINALIZE) {
-        return;
-    }
-
     const int ith = params->ith;
     const int nth = params->nth;
 
     const int  n_past  =       ((int32_t *) src1->data)[0];
     const bool inplace = (bool)((int32_t *) src1->data)[1];
 
-    if (!inplace) {
-        ggml_compute_forward_dup_same_cont(params, src0, dst);
+    if (!inplace && (params->type == GGML_TASK_INIT)) {
+        // memcpy needs to be synchronized across threads to avoid race conditions.
+        // => do it in INIT phase
+        GGML_ASSERT(ggml_nelements(dst) == ggml_nelements(src0));
+        GGML_ASSERT(ggml_is_contiguous(dst) && ggml_is_contiguous(src0));
+        memcpy(
+            ((char *)  dst->data),
+            ((char *) src0->data),
+            ggml_nbytes(dst));
     }
 
+    if (params->type == GGML_TASK_INIT || params->type == GGML_TASK_FINALIZE) {
+        return;
+    }
+    
     // TODO: handle transposed/permuted matrices
 
     const int n  = ggml_nrows(src0);

--- a/ggml.c
+++ b/ggml.c
@@ -10506,7 +10506,6 @@ static void ggml_compute_forward_diag_mask_f32(
 
     const int  n_past  =       ((int32_t *) src1->data)[0];
     const bool inplace = (bool)((int32_t *) src1->data)[1];
-  
     assert(n_past >= 0);
 
     if (!inplace && (params->type == GGML_TASK_INIT)) {


### PR DESCRIPTION
test-grad0.c catched a bug in ggml_compute_forward_diag_mask_f32 when running in threaded mode.

This only affects non-inplace occurences of diag_mask.

memcpy needs to be synchronized across threads to avoid race conditions, so just do it in INIT phase.

Use memcpy instead of the dup function, because the dup function just returns in INIT phase.