### PR TITLE
convert.py: Support models which are stored in a single pytorch_model.bin

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1055,7 +1055,7 @@ def load_some_model(path: Path) -> ModelPlus:
         files = list(path.glob("model-00001-of-*.safetensors"))
         if not files:
             # Try the PyTorch patterns too, with lower priority
-            globs = ["consolidated.00.pth", "pytorch_model-00001-of-*.bin", "*.pt"]
+            globs = ["consolidated.00.pth", "pytorch_model-00001-of-*.bin", "*.pt", "pytorch_model.bin" ]
             files = [file for glob in globs for file in path.glob(glob)]
         if not files:
             # Try GGML too, but with lower priority, since if both a non-GGML

--- a/convert.py
+++ b/convert.py
@@ -121,7 +121,6 @@ def make_tensors_list() -> List[str]:
             f'layers.{i}.feed_forward.w1.weight',
             f'layers.{i}.feed_forward.w2.weight',
             f'layers.{i}.feed_forward.w3.weight',
-            f'layers.{i}.atttention_norm.weight',
             f'layers.{i}.ffn_norm.weight',
         ]
     return ret


### PR DESCRIPTION
Currently convert.py will error out when a pytorch model is released in a single .bin file. This one line PR fixes that. 

Before:
```
root@1c6b80974469:~/AutoGPTQ# ll /workspace/models/ehartford_WizardLM-13B-Uncensored/
total 25429958
drwxrwxrwx  2 root root     3002424 May 15 20:58 ./
drwxrwxrwx 21 root root     3038961 May 15 20:58 ../
-rw-rw-rw-  1 root root         933 May 15 20:58 README.md
-rw-rw-rw-  1 root root          21 May 15 20:58 added_tokens.json
-rw-rw-rw-  1 root root         554 May 15 20:58 config.json
-rw-rw-rw-  1 root root         137 May 15 20:58 generation_config.json
-rw-rw-rw-  1 root root         293 May 15 20:58 huggingface-metadata.txt
-rw-rw-rw-  1 root root 26031885999 May 15 21:04 pytorch_model.bin
-rw-rw-rw-  1 root root          96 May 15 20:58 special_tokens_map.json
-rw-rw-rw-  1 root root     1842847 May 15 20:58 tokenizer.json
-rw-rw-rw-  1 root root      499723 May 15 20:58 tokenizer.model
-rw-rw-rw-  1 root root         727 May 15 20:58 tokenizer_config.json

root@1c6b80974469:~/llama.cpp# python convert.py --outtype f16 --outfile /workspace/wizardlm-13B-uncensored/ggml/wizardLM-13B-Uncensored.fp16.bin /workspace/models/ehartford_WizardLM-13B-Uncensored
Traceback (most recent call last):
  File "/root/llama.cpp/convert.py", line 1169, in <module>
    main()
  File "/root/llama.cpp/convert.py", line 1149, in main
    model_plus = load_some_model(args.model)
  File "/root/llama.cpp/convert.py", line 1066, in load_some_model
    raise Exception(f"Can't find model in directory {path}")
Exception: Can't find model in directory /workspace/models/ehartford_WizardLM-13B-Uncensored
```

With this PR:
```
root@1c6b80974469:~/llama.cpp# python convert.py --outtype f16 --outfile /workspace/wizardlm-13B-uncensored/ggml/wizardLM-13B-Uncensored.fp16.bin /workspace/models/ehartford_WizardLM-13B-Uncensored
Building llama.cpp
Making unquantised GGML at /workspace/wizardlm-13B-uncensored/ggml//wizardLM-13B-Uncensored.fp16.ggml.bin
Loading model file /workspace/models/ehartford_WizardLM-13B-Uncensored/pytorch_model.bin
Loading vocab file /workspace/models/ehartford_WizardLM-13B-Uncensored/tokenizer.model
Writing vocab...
[  1/363] Writing tensor tok_embeddings.weight                  | size  32001 x   5120  | type UnquantizedDataType(name='F16')
...
```

Also, unrelated: remove line 124, which was a duplicated mis-spelt line that was doing nothing.