### PR TITLE
[Research] Steering vectors

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -461,7 +461,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -ngl N, --n-gpu-layers N\n");
     fprintf(stderr, "                        number of layers to store in VRAM\n");
     fprintf(stderr, "  --steering-add        add positive steering prompt\n");
-    fprintf(stderr, "  --steering-sub        add negativ steering prompt\n");
+    fprintf(stderr, "  --steering-sub        add negative steering prompt\n");
     fprintf(stderr, "  --steering-mul        steering strength (negative is reverse, default %.1f)\n", params.steering_mul);
     fprintf(stderr, "  --steering-source     layer for steering source (default %d)\n", params.steering_source);
     fprintf(stderr, "  --steering-layer      layer for steering insertion (default %d)\n", params.steering_layer);

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -362,12 +362,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.steering_mul = std::stof(argv[i]);
-        } else if (arg == "--steering-lyr") {
+        } else if (arg == "--steering-layer") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;
             }
-            params.steering_lyr = std::stoi(argv[i]);
+            params.steering_layer = std::stoi(argv[i]);
         } else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             gpt_print_usage(argc, argv, default_params);
@@ -454,6 +454,10 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     }
     fprintf(stderr, "  -ngl N, --n-gpu-layers N\n");
     fprintf(stderr, "                        number of layers to store in VRAM\n");
+    fprintf(stderr, "  --steering-add        add positive steering prompt\n");
+    fprintf(stderr, "  --steering-sub        add negativ steering prompt\n");
+    fprintf(stderr, "  --steering-mul        set steering strength (negative is reverse, default %.1f)\n", params.steering_mul);
+    fprintf(stderr, "  --steering-layer      set layer for steering (default %d)\n", params.steering_layer);
     fprintf(stderr, "  --mtest               compute maximum memory usage\n");
     fprintf(stderr, "  --verbose-prompt      print prompt before generation\n");
     fprintf(stderr, "  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -362,6 +362,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.steering_mul = std::stof(argv[i]);
+        } else if (arg == "--steering-source") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.steering_source = std::stoi(argv[i]);
         } else if (arg == "--steering-layer") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -456,8 +462,9 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "                        number of layers to store in VRAM\n");
     fprintf(stderr, "  --steering-add        add positive steering prompt\n");
     fprintf(stderr, "  --steering-sub        add negativ steering prompt\n");
-    fprintf(stderr, "  --steering-mul        set steering strength (negative is reverse, default %.1f)\n", params.steering_mul);
-    fprintf(stderr, "  --steering-layer      set layer for steering (default %d)\n", params.steering_layer);
+    fprintf(stderr, "  --steering-mul        steering strength (negative is reverse, default %.1f)\n", params.steering_mul);
+    fprintf(stderr, "  --steering-source     layer for steering source (default %d)\n", params.steering_source);
+    fprintf(stderr, "  --steering-layer      layer for steering insertion (default %d)\n", params.steering_layer);
     fprintf(stderr, "  --mtest               compute maximum memory usage\n");
     fprintf(stderr, "  --verbose-prompt      print prompt before generation\n");
     fprintf(stderr, "  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -344,6 +344,30 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.input_suffix = argv[i];
+        } else if (arg == "--steering-add") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.steering_add = argv[i];
+        } else if (arg == "--steering-sub") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.steering_sub = argv[i];
+        } else if (arg == "--steering-mul") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.steering_mul = std::stof(argv[i]);
+        } else if (arg == "--steering-lyr") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.steering_lyr = std::stoi(argv[i]);
         } else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             gpt_print_usage(argc, argv, default_params);

--- a/examples/common.h
+++ b/examples/common.h
@@ -73,10 +73,10 @@ struct gpt_params {
     bool mem_test          = false; // compute maximum memory usage
     bool verbose_prompt    = false; // print prompt tokens before generation
 
-    std::string steering_add = "";
-    std::string steering_sub = "";
+    std::string steering_add;
+    std::string steering_sub;
     float       steering_mul = 1.0f;
-    int         steering_lyr = 20;
+    int         steering_layer = 15;
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/examples/common.h
+++ b/examples/common.h
@@ -77,6 +77,7 @@ struct gpt_params {
     std::string steering_sub;
     float       steering_mul = 1.0f;
     int         steering_layer = 15;
+    int         steering_source = 2;
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/examples/common.h
+++ b/examples/common.h
@@ -72,6 +72,11 @@ struct gpt_params {
     bool use_mlock         = false; // use mlock to keep model in memory
     bool mem_test          = false; // compute maximum memory usage
     bool verbose_prompt    = false; // print prompt tokens before generation
+
+    std::string steering_add = "";
+    std::string steering_sub = "";
+    float       steering_mul = 1.0f;
+    int         steering_lyr = 20;
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -176,28 +176,27 @@ int main(int argc, char ** argv) {
 
     if (!params.steering_add.empty() || !params.steering_sub.empty())
     {
-        params.steering_add.insert(0, 1, ' ');
-        params.steering_sub.insert(0, 1, ' ');
-
         auto add_tokens = ::llama_tokenize(ctx, params.steering_add, true);
         auto sub_tokens = ::llama_tokenize(ctx, params.steering_sub, true);
 
-        //if (add_tokens.size() != sub_tokens.size()) {
-        //    while (add_tokens.size() < sub_tokens.size()) {
-        //        add_tokens.push_back(llama_token_nl());
-        //    }
-        //    while (sub_tokens.size() < add_tokens.size()) {
-        //        sub_tokens.push_back(llama_token_nl());
-        //    }
-        //}
-        //const int N = embd_inp.size();
+
+        if (add_tokens.size() != sub_tokens.size()) {
+           while (add_tokens.size() < sub_tokens.size()) {
+               add_tokens.push_back(llama_token_nl());
+           }
+           while (sub_tokens.size() < add_tokens.size()) {
+               sub_tokens.push_back(llama_token_nl());
+           }
+        }
+
         llama_set_steering_write(ctx, params.steering_source, +1.0f);
         llama_eval(ctx, add_tokens.data(), std::min((int)add_tokens.size(), n_ctx), 0, params.n_threads);
 
-        llama_set_steering_write(ctx, params.steering_layer, -1.0f);
+        llama_set_steering_write(ctx, params.steering_source, -1.0f);
         llama_eval(ctx, sub_tokens.data(), std::min((int)sub_tokens.size(), n_ctx), 0, params.n_threads);
 
         llama_set_steering_read(ctx, params.steering_layer, params.steering_mul);
+	std::cout << "Steering: `" << params.steering_add << "` - `" << params.steering_sub << "` * " << params.steering_mul << "\n";
     }
 
     // debug message about similarity of saved session, if applicable

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -176,17 +176,23 @@ int main(int argc, char ** argv) {
 
     if (!params.steering_add.empty() || !params.steering_sub.empty())
     {
+        fprintf(stderr, "%s: steering: ('%s' - '%s') * %f\n",
+            __func__, params.steering_add.c_str(), params.steering_sub.c_str(), params.steering_mul);
+
+        params.steering_add.insert(0, 1, ' ');
+        params.steering_sub.insert(0, 1, ' ');
+
         auto add_tokens = ::llama_tokenize(ctx, params.steering_add, true);
         auto sub_tokens = ::llama_tokenize(ctx, params.steering_sub, true);
 
 
         if (add_tokens.size() != sub_tokens.size()) {
-           while (add_tokens.size() < sub_tokens.size()) {
-               add_tokens.push_back(llama_token_nl());
-           }
-           while (sub_tokens.size() < add_tokens.size()) {
-               sub_tokens.push_back(llama_token_nl());
-           }
+            while (add_tokens.size() < sub_tokens.size()) {
+                add_tokens.push_back(llama_token_nl());
+            }
+            while (sub_tokens.size() < add_tokens.size()) {
+                sub_tokens.push_back(llama_token_nl());
+            }
         }
 
         llama_set_steering_write(ctx, params.steering_source, +1.0f);
@@ -196,7 +202,6 @@ int main(int argc, char ** argv) {
         llama_eval(ctx, sub_tokens.data(), std::min((int)sub_tokens.size(), n_ctx), 0, params.n_threads);
 
         llama_set_steering_read(ctx, params.steering_layer, params.steering_mul);
-	std::cout << "Steering: `" << params.steering_add << "` - `" << params.steering_sub << "` * " << params.steering_mul << "\n";
     }
 
     // debug message about similarity of saved session, if applicable

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char ** argv) {
         //    }
         //}
         //const int N = embd_inp.size();
-        llama_set_steering_write(ctx, params.steering_layer, +1.0f);
+        llama_set_steering_write(ctx, params.steering_source, +1.0f);
         llama_eval(ctx, add_tokens.data(), std::min((int)add_tokens.size(), n_ctx), 0, params.n_threads);
 
         llama_set_steering_write(ctx, params.steering_layer, -1.0f);

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -430,6 +430,8 @@ int main(int argc, char ** argv) {
                 llama_save_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
             }
 
+            //llama_set_steering_off(ctx);
+
             llama_token id = 0;
 
             {

--- a/llama.cpp
+++ b/llama.cpp
@@ -279,6 +279,10 @@ struct llama_context {
     }
 };
 
+void llama_set_steering_off(struct llama_context * ctx) {
+    ctx->steering_mode = STEERING_OFF;
+}
+
 void llama_set_steering_write(struct llama_context * ctx, int layer, float mul) {
     ctx->steering_mode = STEERING_WRITE;
     ctx->steering_mul = mul;

--- a/llama.cpp
+++ b/llama.cpp
@@ -1169,7 +1169,7 @@ static bool llama_eval_internal(
     if (lctx.steering_mode != STEERING_OFF) {
         steer = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd, N);
         //steer->data = lctx.steering_vector.data() + n_past * n_embd * sizeof(float);
-        memcpy(steer->data, lctx.steering_vector.data() + n_past * n_embd * sizeof(float), ggml_nbytes(steer));
+        memcpy(steer->data, lctx.steering_vector.data() + n_past * n_embd, ggml_nbytes(steer));
     }
 
     struct ggml_tensor * inpL = ggml_get_rows(ctx0, model.tok_embeddings, embd);
@@ -1407,7 +1407,7 @@ static bool llama_eval_internal(
 
 
     if (lctx.steering_mode == STEERING_WRITE) {
-        memcpy(lctx.steering_vector.data() + n_past * n_embd * sizeof(float), steer->data, ggml_nbytes(steer));
+        memcpy(lctx.steering_vector.data() + n_past * n_embd, steer->data, ggml_nbytes(steer));
     }
 
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <sstream>
 #include <numeric>
+#include <iostream>
 
 #define LLAMA_USE_SCRATCH
 #define LLAMA_MAX_SCRATCH_BUFFERS 16
@@ -1187,8 +1188,8 @@ static bool llama_eval_internal(
                     ggml_add(ctx0, ggml_scale(ctx0, inpL, scal), steer), steer));
                 break;
             }
-            
-            inpL = ggml_add(ctx0, ggml_scale(ctx0, steer, scal), inpL);
+            // std::cout << "\nAdding steering vector to inpL " << il << "\n";
+            inpSA = ggml_add(ctx0, ggml_scale(ctx0, steer, scal), inpSA);
         }
 
         // norm

--- a/llama.cpp
+++ b/llama.cpp
@@ -229,6 +229,15 @@ struct llama_context {
     // input embedding (1-dimensional array: [n_embd])
     std::vector<float> embedding;
 
+    std::vector<float> steering_vector; // [n_ctx, n_embd]
+    int                steering_layer = 0;
+    int                steering_mode = 0;
+    float              steering_mul = 0.0f;
+
+    #define STEERING_OFF   0
+    #define STEERING_WRITE 2
+    #define STEERING_READ  3
+
     // memory buffers used to evaluate the model
     // TODO: move in llama_state
     llama_ctx_buffer buf_compute;
@@ -268,6 +277,17 @@ struct llama_context {
 #endif
     }
 };
+
+void llama_set_steering_write(struct llama_context * ctx, int layer, float mul) {
+    ctx->steering_mode = STEERING_WRITE;
+    ctx->steering_mul = mul;
+    ctx->steering_layer = layer;
+}
+void llama_set_steering_read(struct llama_context * ctx, int layer, float mul) {
+    ctx->steering_mode = STEERING_READ;
+    ctx->steering_mul = mul;
+    ctx->steering_layer = layer;
+}
 
 template <typename T>
 static T checked_mul(T a, T b) {
@@ -1141,6 +1161,12 @@ static bool llama_eval_internal(
     ggml_set_name(embd, "embd");
     memcpy(embd->data, tokens, N*ggml_element_size(embd));
 
+    struct ggml_tensor * steer;
+    if (lctx.steering_mode != STEERING_OFF) {
+        steer = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_ctx, n_embd);
+        memcpy(steer->data, lctx.steering_vector.data(), ggml_nbytes(steer));
+    }
+
     struct ggml_tensor * inpL = ggml_get_rows(ctx0, model.tok_embeddings, embd);
 
     for (int il = 0; il < n_layer; ++il) {
@@ -1149,6 +1175,18 @@ static bool llama_eval_internal(
         struct ggml_tensor * cur;
 
         lctx.use_buf(ctx0, 0);
+
+        if (lctx.steering_mode != STEERING_OFF && il == lctx.steering_layer) {
+            steer->data = lctx.steering_vector.data();
+
+            struct ggml_tensor * src = ggml_scale(ctx0, inpL, ggml_new_f32(ctx0, lctx.steering_mul));
+            struct ggml_tensor * dst = ggml_view_2d(ctx0, steer, n_embd, N, n_embd * sizeof(float), n_past * n_embd * sizeof(float));
+            if (lctx.steering_mode == STEERING_WRITE) {
+                ggml_build_forward_expand(&gf, ggml_cpy(ctx0, ggml_add(ctx0, src, dst), dst));
+            } else {
+                inpL = src;
+            }
+        }
 
         // norm
         {
@@ -1362,6 +1400,12 @@ static bool llama_eval_internal(
         embedding_out.resize(n_embd);
         memcpy(embedding_out.data(), (float *) ggml_get_data(embeddings) + (n_embd*(N - 1)), sizeof(float)*n_embd);
     }
+
+
+    if (lctx.steering_mode == STEERING_WRITE) {
+        memcpy(lctx.steering_vector.data(), steer->data, ggml_nbytes(steer));
+    }
+
 
     if (mem_per_token == 0) {
         mem_per_token = ggml_used_mem(ctx0)/N;
@@ -2184,6 +2228,8 @@ struct llama_context * llama_init_from_file(
 
         ctx->buf_scratch[0].resize(MEM_REQ_SCRATCH0().at(ctx->model.type));
         ctx->buf_scratch[1].resize(MEM_REQ_SCRATCH1().at(ctx->model.type));
+
+        ctx->steering_vector.resize(hparams.n_ctx * hparams.n_embd);
     }
 
     return ctx;

--- a/llama.h
+++ b/llama.h
@@ -191,6 +191,7 @@ extern "C" {
     LLAMA_API llama_token llama_token_eos();
     LLAMA_API llama_token llama_token_nl();
 
+    LLAMA_API void llama_set_steering_off(struct llama_context * ctx);
     LLAMA_API void llama_set_steering_write(struct llama_context * ctx, int layer, float mul);
     LLAMA_API void llama_set_steering_read(struct llama_context * ctx, int layer, float mul);
 

--- a/llama.h
+++ b/llama.h
@@ -191,6 +191,9 @@ extern "C" {
     LLAMA_API llama_token llama_token_eos();
     LLAMA_API llama_token llama_token_nl();
 
+    LLAMA_API void llama_set_steering_write(struct llama_context * ctx, int layer, float mul);
+    LLAMA_API void llama_set_steering_read(struct llama_context * ctx, int layer, float mul);
+
     // Sampling functions
 
     /// @details Repetition penalty described in CTRL academic paper https://arxiv.org/abs/1909.05858, with negative logit fix.


### PR DESCRIPTION
For #1460

Original paper: [Steering GPT-2-XL by adding an activation vector](https://www.lesswrong.com/posts/5spBue2z2tw4JuDCx/steering-gpt-2-xl-by-adding-an-activation-vector)

```sh
./main -m ... --seed 123 -n 64 \
  --steering-add "Love" \
  --steering-sub "Hate" \
  --steering-source 4 \
  --steering-layer 4 \
  --steering-mul 5 \
  --prompt "I hate you because "
```

> I hate you because I am not here to take care of you.
Love is not about me taking care of you, it's about you taking care of me. The best thing I can do for you, is be the person God made me to be, to love you as He loves you, and to show you

TODO: make a test script for all their examples and try to find the effect of the parameters.

---

I also wanted to see what the vectors look like so I imported them to Numpy and plotted them:
```py
import numpy as np
from matplotlib import pyplot as plt

steer = np.fromfile("~/src/llama.cpp/build/steering.bin", dtype=np.float32).reshape((512, -1))

fig, ax = plt.subplots(3)
for i in range(0, len(ax)):
    ax[i].imshow(steer[3+i, :].reshape((32, -1)))
```

![image](https://github.com/ggerganov/llama.cpp/assets/795193/5db74da3-18e2-4fce-ac60-19538236dbd2)
