### PR TITLE
make kv_f16 the default for api users

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -814,7 +814,7 @@ struct llama_context_params llama_context_default_params() {
         /*.n_ctx                       =*/ 512,
         /*.gpu_layers                  =*/ 0,
         /*.seed                        =*/ -1,
-        /*.f16_kv                      =*/ false,
+        /*.f16_kv                      =*/ true,
         /*.logits_all                  =*/ false,
         /*.vocab_only                  =*/ false,
         /*.use_mmap                    =*/ true,


### PR DESCRIPTION
imo it should have been the default.