### PR TITLE
Some improvements to loading the session with --prompt-cache

### DIFF
--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -272,7 +272,7 @@ These options help improve the performance and memory usage of the LLaMA models.
 
 ### Prompt Caching
 
--   `--prompt-cache FNAME`: Specify a file to cache the model state after the initial prompt. This can significantly speed up the startup time when you're using longer prompts. The file is created during the first run and is reused and updated in subsequent runs.
+-   `--prompt-cache FNAME`: Specify a file to cache the model state after the initial prompt. This can significantly speed up the startup time when you're using longer prompts. The file is created during the first run and is reused and updated in subsequent runs. **Note**: Restoring a cached prompt does not imply restoring the exact state of the session at the point it was saved. So even when specifying a specific seed, you are not guaranteed to get the same sequence of tokens as the original generation.
 
 ### Quantization
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -166,7 +166,7 @@ int main(int argc, char ** argv) {
     // tokenize the prompt
     std::vector<llama_token> embd_inp;
 
-    if (!params.prompt.empty() || session_tokens.empty()) {
+    if (params.interactive_first || params.instruct || !params.prompt.empty() || session_tokens.empty()) {
         // Add a space in front of the first character to match OG llama tokenizer behavior
         params.prompt.insert(0, 1, ' ');
 
@@ -191,7 +191,9 @@ int main(int argc, char ** argv) {
             }
             n_matching_session_tokens++;
         }
-        if (n_matching_session_tokens >= embd_inp.size()) {
+        if (params.prompt.empty() && n_matching_session_tokens == embd_inp.size()) {
+            fprintf(stderr, "%s: using full prompt from session file\n", __func__);
+        } else if (n_matching_session_tokens >= embd_inp.size()) {
             fprintf(stderr, "%s: session file has exact match for prompt!\n", __func__);
         } else if (n_matching_session_tokens < (embd_inp.size() / 2)) {
             fprintf(stderr, "%s: warning: session file has low similarity to prompt (%zu / %zu tokens); will mostly be reevaluated\n",

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -85,6 +85,9 @@ int main(int argc, char ** argv) {
 
     fprintf(stderr, "%s: build = %d (%s)\n", __func__, BUILD_NUMBER, BUILD_COMMIT);
 
+    // Save the initial seed parameter before overwriting it so it's possible to determine whether
+    // the user supplied a seed or not. This is useful when loading saved sessions.
+    int32_t initial_seed = params.seed;
     if (params.seed < 0) {
         params.seed = time(NULL);
     }
@@ -153,8 +156,11 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             session_tokens.resize(n_token_count_out);
-            if (params.seed != -1) {
+            if (initial_seed != -1) {
+                fprintf(stderr, "%s: seed argument overrides session file RNG state, will now use seed: %d\n", __func__, params.seed);
                 llama_set_rng_seed(ctx, params.seed);
+            } else {
+                fprintf(stderr, "%s: using RNG state from loaded session file rather than seed\n", __func__);
             }
 
             fprintf(stderr, "%s: loaded a session with prompt size of %d tokens\n", __func__, (int) session_tokens.size());

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -166,7 +166,7 @@ int main(int argc, char ** argv) {
     // tokenize the prompt
     std::vector<llama_token> embd_inp;
 
-    if (params.prompt.size() > 0 || session_tokens.size() == 0) {
+    if (!params.prompt.empty() || session_tokens.empty()) {
         // Add a space in front of the first character to match OG llama tokenizer behavior
         params.prompt.insert(0, 1, ' ');
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -85,9 +85,6 @@ int main(int argc, char ** argv) {
 
     fprintf(stderr, "%s: build = %d (%s)\n", __func__, BUILD_NUMBER, BUILD_COMMIT);
 
-    // Save the initial seed parameter before overwriting it so it's possible to determine whether
-    // the user supplied a seed or not. This is useful when loading saved sessions.
-    int32_t initial_seed = params.seed;
     if (params.seed < 0) {
         params.seed = time(NULL);
     }
@@ -156,12 +153,7 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             session_tokens.resize(n_token_count_out);
-            if (initial_seed != -1) {
-                fprintf(stderr, "%s: seed argument overrides session file RNG state, will now use seed: %d\n", __func__, params.seed);
-                llama_set_rng_seed(ctx, params.seed);
-            } else {
-                fprintf(stderr, "%s: using RNG state from loaded session file rather than seed\n", __func__);
-            }
+            llama_set_rng_seed(ctx, params.seed);
 
             fprintf(stderr, "%s: loaded a session with prompt size of %d tokens\n", __func__, (int) session_tokens.size());
         } else {


### PR DESCRIPTION
### `--seed` is ignored when loading session

Currently the `--seed` parameter is ignored when loading the prompt. However, a very common use case would be to save a prompt and then try several attempts at generation with different seeds.

The pull includes a simple change that just sets the RNG if specified. Two small notes:

1. There isn't a way to tell if `-seed` was actually actually specified as far as I know, only that it's not the default `-1` value. So `--seed -1` is the same as not including it: it won't override the cached seed.
2. The RNG won't be in the same state as if the seed had been specified originally. I.E. If you generate the cached prompt using `--seed 123` and then load it with `-seed 123` the subsequent tokens will not match. I don't think there's an easy way around this. It's not 100% ideal but still a lot better than just completely ignoring the parameter with no warning.

### Blank prompt overwrites cached one

When loading a cached prompt from a session, you have to specify the prompt again. Even worse, if you forget to enter a prompt you'll get your cached prompt overwritten by the blank one because of course it has low similarity.

This pull changes that behavior to simply use the tokens from the saved session if `params.prompt` is empty (in other words not set via `--prompt` or `--file`). 


Closes #1439 
