### PR TITLE
chat-persistent.sh : GNU Grep compatibility

### DIFF
--- a/examples/chat-persistent.sh
+++ b/examples/chat-persistent.sh
@@ -23,8 +23,8 @@ CUR_PROMPT_CACHE="${CHAT_SAVE_DIR}/current-cache.bin"
 NEXT_PROMPT_FILE="${CHAT_SAVE_DIR}/next-prompt.txt"
 NEXT_PROMPT_CACHE="${CHAT_SAVE_DIR}/next-cache.bin"
 
-SESSION_SIZE_MSG_PATTERN='main: session file matches \d+ / \d+'
-SAMPLE_TIME_MSG_PATTERN='sample time =\s+\d+.\d+ ms /\s+\d+'
+SESSION_SIZE_MSG_PATTERN='main: session file matches [[:digit:]]+ / [[:digit:]]+'
+SAMPLE_TIME_MSG_PATTERN='sample time =[[:space:]]+[[:digit:]]+.[[:digit:]]+ ms /[[:space:]]+[[:digit:]]+'
 SED_DELETE_MESSAGES="/^(${USER_NAME}:|${AI_NAME}:|\\.\\.\\.)/,\$d"
 
 CTX_SIZE=2048


### PR DESCRIPTION
[<abbr>GNU</abbr> Grep](https://www.gnu.org/software/grep/) does not support the `\d` backslash expression[^1]. Use bracket expressions instead.

[^1]: Actually, it does, with the `-P` option. But that is a <abbr>GNU</abbr> extension. Bracketed character class expressions are specified in <abbr>POSIX</abbr> and should be compatible with all implementations.