### PR TITLE
Fix handling of "invalid property" when creating OpenCL command queue

### DIFF
--- a/ggml-opencl.cpp
+++ b/ggml-opencl.cpp
@@ -488,7 +488,7 @@ void ggml_cl_init(void) {
     CL_CHECK((context = clCreateContext(properties, 1, &device, NULL, NULL, &err), err));
 
     CL_CHECK((queue = clCreateCommandQueue(context, device, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err),
-        (err != CL_INVALID_PROPERTY && err != CL_INVALID_VALUE ? err :
+        (err != CL_INVALID_QUEUE_PROPERTIES && err != CL_INVALID_VALUE ? err :
         (queue = clCreateCommandQueue(context, device, 0, &err), err)
     )));
 


### PR DESCRIPTION
The `clCreateCommandQueue()` function will return the error code `CL_INVALID_QUEUE_PROPERTIES` when passed unsupported properties, not `CL_INVALID_PROPERTY` as the original code was checking for.

[Relevant API docs.](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clCreateCommandQueue.html)

With this change, I can run the CLBlast support with the Rusticl driver of Mesa 23.1.0 on Linux.