### PR TITLE
Change CMake files to library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 # 3rd party libs
 option(LLAMA_ACCELERATE             "llama: enable Accelerate framework"                    ON)
 option(LLAMA_BLAS                   "llama: use BLAS"                                       OFF)
-option(LLAMA_BLAS_VENDOR            "llama: BLA_VENDOR from https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors" Generic)
+set(LLAMA_BLAS_VENDOR  "OpenBLAS" CACHE STRING "llama: BLA_VENDOR from https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors")
 option(LLAMA_CUBLAS                 "llama: use cuBLAS"                                     OFF)
 option(LLAMA_CLBLAST                "llama: use CLBlast"                                    OFF)
 
@@ -135,81 +135,6 @@ if (NOT MSVC)
     endif()
 endif()
 
-if (APPLE AND LLAMA_ACCELERATE)
-    find_library(ACCELERATE_FRAMEWORK Accelerate)
-    if (ACCELERATE_FRAMEWORK)
-        message(STATUS "Accelerate framework found")
-
-        add_compile_definitions(GGML_USE_ACCELERATE)
-        set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} ${ACCELERATE_FRAMEWORK})
-    else()
-        message(WARNING "Accelerate framework not found")
-    endif()
-endif()
-
-if (LLAMA_BLAS)
-    if (LLAMA_STATIC)
-        set(BLA_STATIC ON)
-    endif()
-    if ($(CMAKE_VERSION) VERSION_GREATER_EQUAL 3.22)
-        set(BLA_SIZEOF_INTEGER 8)
-    endif()
-    set(BLA_VENDOR ${LLAMA_BLAS_VENDOR})
-    find_package(BLAS)
-    if (BLAS_FOUND)
-        message(STATUS "BLAS found, Libraries: ${BLAS_LIBRARIES}")
-
-        add_compile_options(${BLAS_LINKER_FLAGS})
-        add_compile_definitions(GGML_USE_OPENBLAS)
-        set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} ${BLAS_LIBRARIES})
-
-        message("${BLAS_LIBRARIES} ${BLAS_INCLUDE_DIRS}")
-        include_directories(${BLAS_INCLUDE_DIRS})
-    else()
-        message(WARNING "BLAS not found, please refer to "
-        "https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors"
-        " to set correct LLAMA_BLAS_VENDOR")
-    endif()
-endif()
-
-if (LLAMA_CUBLAS)
-    cmake_minimum_required(VERSION 3.17)
-
-    find_package(CUDAToolkit)
-    if (CUDAToolkit_FOUND)
-        message(STATUS "cuBLAS found")
-
-        enable_language(CUDA)
-
-        set(GGML_CUDA_SOURCES ggml-cuda.cu ggml-cuda.h)
-
-        add_compile_definitions(GGML_USE_CUBLAS)
-
-        if (LLAMA_STATIC)
-            set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static)
-        else()
-            set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart CUDA::cublas CUDA::cublasLt)
-        endif()
-
-    else()
-        message(WARNING "cuBLAS not found")
-    endif()
-endif()
-
-if (LLAMA_CLBLAST)
-    find_package(CLBlast)
-    if (CLBlast_FOUND)
-        message(STATUS "CLBlast found")
-
-        set(GGML_OPENCL_SOURCES ggml-opencl.cpp ggml-opencl.h)
-
-        add_compile_definitions(GGML_USE_CLBLAST)
-
-        set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} clblast)
-    else()
-        message(WARNING "CLBlast not found")
-    endif()
-endif()
 
 if (LLAMA_ALL_WARNINGS)
     if (NOT MSVC)
@@ -363,19 +288,13 @@ endif()
 # Build libraries
 #
 
-add_library(ggml OBJECT
+add_library(ggml STATIC
             ggml.c
-            ggml.h
-            ${GGML_CUDA_SOURCES}
-            ${GGML_OPENCL_SOURCES})
+            ggml.h)
 
 target_include_directories(ggml PUBLIC .)
 target_compile_features(ggml PUBLIC c_std_11) # don't bump
-target_link_libraries(ggml PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
-
-if (BUILD_SHARED_LIBS)
-    set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif()
+target_link_libraries(ggml PUBLIC Threads::Threads)
 
 add_library(llama
             llama.cpp
@@ -384,18 +303,101 @@ add_library(llama
 
 target_include_directories(llama PUBLIC .)
 target_compile_features(llama PUBLIC cxx_std_11) # don't bump
-target_link_libraries(llama PRIVATE ggml ${LLAMA_EXTRA_LIBS})
+target_link_libraries(llama PRIVATE ggml)
 
 if (BUILD_SHARED_LIBS)
+    set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
     set_target_properties(llama PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(llama PRIVATE LLAMA_SHARED LLAMA_BUILD)
 endif()
 
-if (GGML_CUDA_SOURCES)
-    message(STATUS "GGML CUDA sources found, configuring CUDA architecture")
-    set_property(TARGET ggml PROPERTY CUDA_ARCHITECTURES OFF)
-    set_property(TARGET ggml PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
-    set_property(TARGET llama PROPERTY CUDA_ARCHITECTURES OFF)
+if (APPLE AND LLAMA_ACCELERATE)
+    find_library(ACCELERATE_FRAMEWORK Accelerate)
+    if (ACCELERATE_FRAMEWORK)
+        message(STATUS "Accelerate framework found")
+
+        add_compile_definitions(GGML_USE_ACCELERATE)
+        target_link_libraries(ggml PUBLIC ${ACCELERATE_FRAMEWORK})
+    else()
+        message(WARNING "Accelerate framework not found")
+    endif()
+endif()
+
+if (LLAMA_BLAS)
+    if (LLAMA_STATIC)
+        set(BLA_STATIC ON)
+    endif()
+    if ($(CMAKE_VERSION) VERSION_GREATER_EQUAL 3.22)
+        set(BLA_SIZEOF_INTEGER 8)
+    endif()
+    set(BLA_VENDOR ${LLAMA_BLAS_VENDOR})
+    find_package(BLAS)
+    if (BLAS_FOUND)
+        message(STATUS "BLAS found, Libraries: ${BLAS_LIBRARIES}")
+
+        target_link_options(ggml PUBLIC ${BLAS_LINKER_FLAGS})
+        target_compile_definitions(ggml PRIVATE GGML_USE_OPENBLAS)
+        target_link_libraries(ggml PUBLIC ${BLAS_LIBRARIES})
+
+        target_include_directories(ggml PRIVATE ${BLAS_INCLUDE_DIRS})
+    else()
+        message(WARNING "BLAS not found, please refer to "
+        "https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors"
+        " to set correct LLAMA_BLAS_VENDOR")
+    endif()
+endif()
+
+if (LLAMA_CUBLAS)
+    cmake_minimum_required(VERSION 3.17)
+
+    find_package(CUDAToolkit)
+    if (CUDAToolkit_FOUND)
+        message(STATUS "cuBLAS found")
+
+        enable_language(CUDA)
+
+        add_library(ggml-cuda STATIC
+                    ggml-cuda.cu
+                    ggml-cuda.h)
+
+        target_compile_definitions(ggml-cuda PUBLIC GGML_USE_CUBLAS)
+
+        set_property(TARGET ggml-cuda PROPERTY CUDA_ARCHITECTURES OFF)
+        set_property(TARGET ggml-cuda PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
+
+        if (LLAMA_STATIC)
+            target_link_libraries(ggml-cuda PRIVATE
+                CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static
+            )
+        else()
+            target_link_libraries(ggml-cuda PRIVATE
+                CUDA::cudart CUDA::cublas CUDA::cublasLt
+            )
+        endif()
+
+        target_link_libraries(ggml PUBLIC ggml-cuda)
+
+    else()
+        message(WARNING "cuBLAS not found")
+    endif()
+endif()
+
+if (LLAMA_CLBLAST)
+    find_package(CLBlast)
+    if (CLBlast_FOUND)
+        message(STATUS "CLBlast found")
+
+        add_library(ggml-opencl STATIC
+                    ggml-opencl.cpp
+                    ggml-opencl.h)
+
+        target_compile_definitions(ggml-opencl PUBLIC GGML_USE_CLBLAST)
+
+        target_link_libraries(ggml-opencl PUBLIC clblast)
+        target_link_libraries(ggml PUBLIC ggml-opencl)
+    else()
+        message(WARNING "CLBlast not found")
+    endif()
 endif()
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,10 +10,9 @@ find_package(Threads REQUIRED)
 
 set(TARGET common)
 
-add_library(${TARGET} OBJECT
-    common.h
-    common.cpp
-    )
+add_library(${TARGET} STATIC
+            common.h
+            common.cpp)
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
The main change here is to get rid of the file and library lists and use targets instead.

Here is an example of the dependencies of main.cpp when building with `LLAMA_CLBLAST=ON`:

<img src="https://github.com/ggerganov/llama.cpp/assets/795193/dc7b3081-e441-4a3a-b048-20abf416cb3a" height=600 />

`LLAMA_CUBLAS=ON`:

<img src="https://github.com/ggerganov/llama.cpp/assets/795193/423eb74b-7b8b-4fda-ba6f-591b9bbc9441" height=600 />

<details>
<summary>compile_commands.json for CUDA build</summary>

```json
[
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/cc -DGGML_USE_CUBLAS -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -mf16c -mfma -mavx -mavx2 -o CMakeFiles/ggml.dir/ggml.c.o -c /home/henri/src/llama.cpp/ggml.c",
  "file": "/home/henri/src/llama.cpp/ggml.c",
  "output": "CMakeFiles/ggml.dir/ggml.c.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -DGGML_USE_CUBLAS -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o CMakeFiles/llama.dir/llama.cpp.o -c /home/henri/src/llama.cpp/llama.cpp",
  "file": "/home/henri/src/llama.cpp/llama.cpp",
  "output": "CMakeFiles/llama.dir/llama.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/opt/cuda/bin/nvcc -forward-unknown-to-host-compiler -DGGML_USE_CUBLAS -isystem /opt/cuda/include -O3 -DNDEBUG -std=c++11 -mf16c -mfma -mavx -mavx2 -x cu -c /home/henri/src/llama.cpp/ggml-cuda.cu -o CMakeFiles/ggml-cuda.dir/ggml-cuda.cu.o",
  "file": "/home/henri/src/llama.cpp/ggml-cuda.cu",
  "output": "CMakeFiles/ggml-cuda.dir/ggml-cuda.cu.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o tests/CMakeFiles/test-quantize-fns.dir/test-quantize-fns.cpp.o -c /home/henri/src/llama.cpp/tests/test-quantize-fns.cpp",
  "file": "/home/henri/src/llama.cpp/tests/test-quantize-fns.cpp",
  "output": "tests/CMakeFiles/test-quantize-fns.dir/test-quantize-fns.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o tests/CMakeFiles/test-quantize-perf.dir/test-quantize-perf.cpp.o -c /home/henri/src/llama.cpp/tests/test-quantize-perf.cpp",
  "file": "/home/henri/src/llama.cpp/tests/test-quantize-perf.cpp",
  "output": "tests/CMakeFiles/test-quantize-perf.dir/test-quantize-perf.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o tests/CMakeFiles/test-sampling.dir/test-sampling.cpp.o -c /home/henri/src/llama.cpp/tests/test-sampling.cpp",
  "file": "/home/henri/src/llama.cpp/tests/test-sampling.cpp",
  "output": "tests/CMakeFiles/test-sampling.dir/test-sampling.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o tests/CMakeFiles/test-tokenizer-0.dir/test-tokenizer-0.cpp.o -c /home/henri/src/llama.cpp/tests/test-tokenizer-0.cpp",
  "file": "/home/henri/src/llama.cpp/tests/test-tokenizer-0.cpp",
  "output": "tests/CMakeFiles/test-tokenizer-0.dir/test-tokenizer-0.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/CMakeFiles/common.dir/common.cpp.o -c /home/henri/src/llama.cpp/examples/common.cpp",
  "file": "/home/henri/src/llama.cpp/examples/common.cpp",
  "output": "examples/CMakeFiles/common.dir/common.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/main/CMakeFiles/main.dir/main.cpp.o -c /home/henri/src/llama.cpp/examples/main/main.cpp",
  "file": "/home/henri/src/llama.cpp/examples/main/main.cpp",
  "output": "examples/main/CMakeFiles/main.dir/main.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/quantize/CMakeFiles/quantize.dir/quantize.cpp.o -c /home/henri/src/llama.cpp/examples/quantize/quantize.cpp",
  "file": "/home/henri/src/llama.cpp/examples/quantize/quantize.cpp",
  "output": "examples/quantize/CMakeFiles/quantize.dir/quantize.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/quantize-stats/CMakeFiles/quantize-stats.dir/quantize-stats.cpp.o -c /home/henri/src/llama.cpp/examples/quantize-stats/quantize-stats.cpp",
  "file": "/home/henri/src/llama.cpp/examples/quantize-stats/quantize-stats.cpp",
  "output": "examples/quantize-stats/CMakeFiles/quantize-stats.dir/quantize-stats.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/perplexity/CMakeFiles/perplexity.dir/perplexity.cpp.o -c /home/henri/src/llama.cpp/examples/perplexity/perplexity.cpp",
  "file": "/home/henri/src/llama.cpp/examples/perplexity/perplexity.cpp",
  "output": "examples/perplexity/CMakeFiles/perplexity.dir/perplexity.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/embedding/CMakeFiles/embedding.dir/embedding.cpp.o -c /home/henri/src/llama.cpp/examples/embedding/embedding.cpp",
  "file": "/home/henri/src/llama.cpp/examples/embedding/embedding.cpp",
  "output": "examples/embedding/CMakeFiles/embedding.dir/embedding.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/save-load-state/CMakeFiles/save-load-state.dir/save-load-state.cpp.o -c /home/henri/src/llama.cpp/examples/save-load-state/save-load-state.cpp",
  "file": "/home/henri/src/llama.cpp/examples/save-load-state/save-load-state.cpp",
  "output": "examples/save-load-state/CMakeFiles/save-load-state.dir/save-load-state.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/benchmark/CMakeFiles/benchmark.dir/benchmark-matmult.cpp.o -c /home/henri/src/llama.cpp/examples/benchmark/benchmark-matmult.cpp",
  "file": "/home/henri/src/llama.cpp/examples/benchmark/benchmark-matmult.cpp",
  "output": "examples/benchmark/CMakeFiles/benchmark.dir/benchmark-matmult.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/examples -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o examples/baby-llama/CMakeFiles/baby-llama.dir/baby-llama.cpp.o -c /home/henri/src/llama.cpp/examples/baby-llama/baby-llama.cpp",
  "file": "/home/henri/src/llama.cpp/examples/baby-llama/baby-llama.cpp",
  "output": "examples/baby-llama/CMakeFiles/baby-llama.dir/baby-llama.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/pocs -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o pocs/vdot/CMakeFiles/vdot.dir/vdot.cpp.o -c /home/henri/src/llama.cpp/pocs/vdot/vdot.cpp",
  "file": "/home/henri/src/llama.cpp/pocs/vdot/vdot.cpp",
  "output": "pocs/vdot/CMakeFiles/vdot.dir/vdot.cpp.o"
},
{
  "directory": "/home/henri/src/llama.cpp/build-cuda",
  "command": "/usr/bin/c++ -I/home/henri/src/llama.cpp/pocs -I/home/henri/src/llama.cpp/examples/. -I/home/henri/src/llama.cpp/. -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -mf16c -mfma -mavx -mavx2 -o pocs/vdot/CMakeFiles/q8dot.dir/q8dot.cpp.o -c /home/henri/src/llama.cpp/pocs/vdot/q8dot.cpp",
  "file": "/home/henri/src/llama.cpp/pocs/vdot/q8dot.cpp",
  "output": "pocs/vdot/CMakeFiles/q8dot.dir/q8dot.cpp.o"
}
]
```