### PR TITLE
convert.py: add mapping for safetensors bf16

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -739,6 +739,7 @@ def lazy_load_torch_file(outer_fp: IO[bytes], path: Path) -> ModelPlus:
 
 
 SAFETENSORS_DATA_TYPES: Dict[str, DataType] = {
+    'BF16': DT_BF16,
     'F16': DT_F16,
     'F32': DT_F32,
     'I32': DT_I32,


### PR DESCRIPTION
Fixes #1473

I verified that a merged metharme-7b model is converted successfully (with https://github.com/akx/ggify) works as expected with their example prompt.