### PR TITLE
Work around for recalculating logits in cached prompts (Fixes #1585)

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -361,7 +361,7 @@ int main(int argc, char ** argv) {
                 }
                 if (i > 0) {
                     // check if we've used up all the prompt but not all cached tokens
-                    if (embd.size() == i && n_session_consumed < session_tokens.size()) {
+                    if (embd.size() == i && n_session_consumed < (int) session_tokens.size()) {
                         // force revaluation of the last token to recalculate logits
                         i--;
                         n_past--;

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -360,6 +360,12 @@ int main(int argc, char ** argv) {
                     }
                 }
                 if (i > 0) {
+                    // check if we've used up all the prompt but not all cached tokens
+                    if (embd.size() == i && n_session_consumed < session_tokens.size()) {
+                        // force revaluation of the last token to recalculate logits
+                        i--;
+                        n_past--;
+                    }
                     embd.erase(embd.begin(), embd.begin() + i);
                 }
             }


### PR DESCRIPTION
This code just checks if we've used up all the given prompt but still have leftover tokens from the cache. In this case it instead leaves the last token in `embd` so it will be evaluated.

Evaluating one token isn't the end of the world, but it would be nice if it were faster. What I really wanted to do was something like this:
```
    llama_eval(ctx, embd.data(), 0, n_past - 1, params.n_threads);
```
But you can't eval 0 tokens.

I tried to edit `llama_eval_internal` to skip over the input calculations where `n_past` (`N`) is 0, but it's actually way more integrated than I expected. Perhaps there was something to #1281 after all. I think it would be nicer if `llama_eval` just supported 0 tokens, but it would also be nice to have a different api call that would evaluate the logits at a given position `n_past`. 

This API call could also be used for implementing the mockup in #1608 where you can click on a token and see alternatives.