### PR TITLE
LLAMA_DEBUG adds debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,11 @@ CFLAGS   = -I.              -O3 -std=c11   -fPIC
 CXXFLAGS = -I. -I./examples -O3 -std=c++11 -fPIC
 LDFLAGS  =
 
-ifndef LLAMA_DEBUG
+ifdef LLAMA_DEBUG
+	CFLAGS   += -O0 -g
+	CXXFLAGS += -O0 -g
+	LDFLAGS  += -g
+else
 	CFLAGS   += -DNDEBUG
 	CXXFLAGS += -DNDEBUG
 endif


### PR DESCRIPTION
With this PR, if `LLAMA_DEBUG` is set debugging symbols for use with e.g. the GNU Debugger are added to the binaries. Optimizations are also turned off to prevent local variables from being optimized out.