### PR TITLE
Adding git in container package dependencies

### DIFF
--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -3,7 +3,7 @@ ARG UBUNTU_VERSION=22.04
 FROM ubuntu:$UBUNTU_VERSION as build
 
 RUN apt-get update && \
-    apt-get install -y build-essential python3 python3-pip
+    apt-get install -y build-essential python3 python3-pip git
 
 COPY requirements.txt requirements.txt
 

--- a/.devops/main.Dockerfile
+++ b/.devops/main.Dockerfile
@@ -3,7 +3,7 @@ ARG UBUNTU_VERSION=22.04
 FROM ubuntu:$UBUNTU_VERSION as build
 
 RUN apt-get update && \
-    apt-get install -y build-essential
+    apt-get install -y build-essential git
 
 WORKDIR /app
 


### PR DESCRIPTION
The build-info.sh script is invoking git on lines 6 and 11. However git is not installed by default in ubuntu base images.

This causes an unhandled exception to occur, which is silently passed during the build.

#1626 

For example: 
https://github.com/ggerganov/llama.cpp/actions/runs/5100538614/jobs/9168878817#step:6:1266 
https://github.com/ggerganov/llama.cpp/actions/runs/5100538614/jobs/9168878743#step:6:864