### PR TITLE
Setting the ftype argument of the script as optional

### DIFF
--- a/convert-pth-to-ggml.py
+++ b/convert-pth-to-ggml.py
@@ -6,6 +6,6 @@ import convert
 
 parser = argparse.ArgumentParser(description='Convert a LLaMA model checkpoint to a ggml compatible file')
 parser.add_argument('dir_model',  help='directory containing the model checkpoint')
-parser.add_argument('ftype',      help='file type (0: float32, 1: float16)', type=int, choices=[0, 1], default=1)
+parser.add_argument('ftype',      help='file type (0: float32, 1: float16)', type=int, choices=[0, 1], default=1, nargs='?')
 args = parser.parse_args()
 convert.main(['--outtype', 'f16' if args.ftype == 1 else 'f32', '--', args.dir_model])


### PR DESCRIPTION
The 'ftype' positional argument of the convert-pth-to-ggml.py script has a default value set. However positional arguments  still act as mandatory, unless they are set to accept zero values.

This change will allow the script to execute even when user doesn't supply the `ftype` manually.

#1628 