### PR TITLE
fix(avx): workaround for missing _mm256_set_m128i in GCC < 8

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -474,6 +474,8 @@ static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 // quantization
 //
 
+#define MM256_SET_M128I(a, b) _mm256_insertf128_si256(_mm256_castsi128_si256(b), (a), 1)
+
 #if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__)
 // multiply int8_t, add results pairwise twice
 static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
@@ -533,7 +535,7 @@ static inline __m256i bytes_from_bits_32(const uint8_t * x) {
 static inline __m256i bytes_from_nibbles_32(const uint8_t * rsi)
 {
     const __m128i tmp = _mm_loadu_si128((const __m128i *)rsi);
-    const __m256i bytes = _mm256_set_m128i(_mm_srli_epi16(tmp, 4), tmp);
+    const __m256i bytes = MM256_SET_M128I(_mm_srli_epi16(tmp, 4), tmp);
     const __m256i lowMask = _mm256_set1_epi8( 0xF );
     return _mm256_and_si256(lowMask, bytes);
 }
@@ -606,7 +608,7 @@ static inline __m256i bytes_from_bits_32(const uint8_t * x) {
     bytesh = _mm_or_si128(bytesh, bit_mask);
     bytesl = _mm_cmpeq_epi8(bytesl, _mm_set1_epi64x(-1));
     bytesh = _mm_cmpeq_epi8(bytesh, _mm_set1_epi64x(-1));
-    return _mm256_set_m128i(bytesh, bytesl);
+    return MM256_SET_M128I(bytesh, bytesl);
 }
 
 // Unpack 32 4-bit fields into 32 bytes
@@ -619,7 +621,7 @@ static inline __m256i bytes_from_nibbles_32(const uint8_t * rsi)
     const __m128i lowMask = _mm_set1_epi8(0xF);
     tmpl = _mm_and_si128(lowMask, tmpl);
     tmph = _mm_and_si128(lowMask, tmph);
-    return _mm256_set_m128i(tmph, tmpl);
+    return MM256_SET_M128I(tmph, tmpl);
 }
 
 // add int16_t pairwise and return as float vector
@@ -627,7 +629,7 @@ static inline __m256 sum_i16_pairs_float(const __m128i xh, const __m128i xl) {
     const __m128i ones = _mm_set1_epi16(1);
     const __m128i summed_pairsl = _mm_madd_epi16(ones, xl);
     const __m128i summed_pairsh = _mm_madd_epi16(ones, xh);
-    const __m256i summed_pairs = _mm256_set_m128i(summed_pairsh, summed_pairsl);
+    const __m256i summed_pairs = MM256_SET_M128I(summed_pairsh, summed_pairsl);
     return _mm256_cvtepi32_ps(summed_pairs);
 }
 
@@ -2290,7 +2292,7 @@ static void ggml_vec_dot_q4_0_q8_0(const int n, float * restrict s, const void *
         const __m128i i32_1 = mul_sum_i8_pairs(bx, by);
 
         // Convert int32_t to float
-        __m256 p = _mm256_cvtepi32_ps(_mm256_set_m128i(i32_0, i32_1));
+        __m256 p = _mm256_cvtepi32_ps(MM256_SET_M128I(i32_0, i32_1));
 
         // Apply the scale, and accumulate
         acc = _mm256_add_ps(_mm256_mul_ps( d, p ), acc);
@@ -2766,7 +2768,7 @@ static void ggml_vec_dot_q5_0_q8_0(const int n, float * restrict s, const void *
         __m128i bxh = _mm256_extractf128_si256(bx, 1);
         bxl = _mm_or_si128(bxl, bxhil);
         bxh = _mm_or_si128(bxh, bxhih);
-        bx = _mm256_set_m128i(bxh, bxl);
+        bx = MM256_SET_M128I(bxh, bxl);
 
         const __m256i by = _mm256_loadu_si256((const __m256i *)y[i].qs);
 
@@ -3022,7 +3024,7 @@ static void ggml_vec_dot_q5_1_q8_1(const int n, float * restrict s, const void *
         __m128i bxh = _mm256_extractf128_si256(bx, 1);
         bxl = _mm_or_si128(bxl, bxhil);
         bxh = _mm_or_si128(bxh, bxhih);
-        bx = _mm256_set_m128i(bxh, bxl);
+        bx = MM256_SET_M128I(bxh, bxl);
 
         const __m256 dy = _mm256_set1_ps(y[i].d);
         const __m256i by = _mm256_loadu_si256((const __m256i *)y[i].qs);


### PR DESCRIPTION
Fix issue https://github.com/ggerganov/llama.cpp/issues/1279

![image](https://github.com/ggerganov/llama.cpp/assets/13466943/d77a3493-58d4-4bec-8f57-49cc9037237a)

When using gcc < 8 (i.e., gcc-5 gcc-7), `_mm256_set_m128i` is unavailable and will fail the compilation.

Here I provide a workaround for missing `_mm256_set_m128` in GCC, the script I used to evaluate that the two expressions are equivalent:
```cpp
// eval.cc
// Copyright [2023-05-29] <sxc19@mails.tsinghua.edu.cn, Xingchen Song>
#include <iostream>
#include <immintrin.h>

#define MM256_SET_M128I_1(a, b) _mm256_set_m128i((a), (b))
#define MM256_SET_M128I_2(a, b) _mm256_insertf128_si256(_mm256_castsi128_si256(b), (a), 1)

int main() {
    std::cout << __GNUC__ << std::endl;
    // Sample input data
    __m128i i32[2];
    i32[0] = _mm_set_epi32(4, 3, 2, 1);
    i32[1] = _mm_set_epi32(8, 7, 6, 5);

    // Evaluate the first expression
    __m256 result1 = _mm256_cvtepi32_ps(MM256_SET_M128I_1(i32[0], i32[1]));

    // Evaluate the second expression
    __m256 result2 = _mm256_cvtepi32_ps(MM256_SET_M128I_2(i32[0], i32[1]));

    // Compare the results element-wise
    bool equal = true;
    for (int i = 0; i < 8; ++i) {
        printf("result1[%d] = %f, result2[%d] = %f\n", i, result1[i], i, result2[i]);
        if (result1[i] != result2[i]) {
            equal = false;
            break;
        }
    }

    // Print the comparison result
    if (equal) {
        std::cout << "The two expressions are equivalent." << std::endl;
    } else {
        std::cout << "The two expressions are not equivalent." << std::endl;
    }

    return 0;
}
```

![image](https://github.com/ggerganov/llama.cpp/assets/13466943/44410b0b-879e-4b71-8cd1-e88d261659a4)

Below is a double-check that gcc-5 & gcc-7 will fail due to the missing of `_mm256_set_m128`:

![image](https://github.com/ggerganov/llama.cpp/assets/13466943/56102ddf-38b9-41a8-bb6b-740391e8da99)

