### PR TITLE
Fix prompt cache saving and chat-persistent rollover

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -204,7 +204,7 @@ int main(int argc, char ** argv) {
 
     // if we will use the cache for the full prompt without reaching the end of the cache, force
     // reevaluation of the last token token to recalculate the cached logits
-    if (embd_inp.size() && n_matching_session_tokens == embd_inp.size() &&
+    if (!embd_inp.empty() && n_matching_session_tokens == embd_inp.size() &&
             session_tokens.size() > embd_inp.size()) {
         session_tokens.resize(embd_inp.size() - 1);
     }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -202,6 +202,13 @@ int main(int argc, char ** argv) {
         }
     }
 
+    // if we will use the cache for the full prompt without reaching the end of the cache, force
+    // reevaluation of the last token token to recalculate the cached logits
+    if (embd_inp.size() && n_matching_session_tokens == embd_inp.size() &&
+            session_tokens.size() > embd_inp.size()) {
+        session_tokens.resize(embd_inp.size() - 1);
+    }
+
     // number of tokens to keep when resetting context
     if (params.n_keep < 0 || params.n_keep > (int) embd_inp.size() || params.instruct) {
         params.n_keep = (int)embd_inp.size();
@@ -360,12 +367,6 @@ int main(int argc, char ** argv) {
                     }
                 }
                 if (i > 0) {
-                    // check if we've used up all the prompt but not all cached tokens
-                    if (embd.size() == i && n_session_consumed < (int) session_tokens.size()) {
-                        // force revaluation of the last token to recalculate logits
-                        i--;
-                        n_past--;
-                    }
                     embd.erase(embd.begin(), embd.begin() + i);
                 }
             }


### PR DESCRIPTION
Fixes #1670, by reworking the original fix for #1585 from #1609.

The original fix examined `embd` to determine if the prompt had been evaluated, but `embd` is limited to the batch size. In addition, that fix left `session_tokens` in its original state (i.e., the longer, cached prompt), while normal session evaluation truncates it at the first eval. This combination meant that any prompts with a cache hit on just the first batch (512 by default) would begin eval-ing ~from the second batch, and all of that eval would get appended to the end of the full, original cached prompt. This had the downstream effect of diverging the cache from the prompt and overrunning the context size in the cache, as seen in #1670.

For the fix, I opted to move the re-eval logic to main's initialization rather than at the eval stage. Here, it transforms `session_tokens` such that it will only match (prompt - 1) tokens.

**Testing**:

- for #1670, conducted a long chat with 30B, past the context rotation
- for #1585, applied the [Z/joke test](https://github.com/ggerganov/llama.cpp/pull/1550#issuecomment-1561030560) and got a joke that did not start with "Z"