### PR TITLE
Support requantizing models instead of only allowing quantization from 16/32bit

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -2133,10 +2133,10 @@ static void llama_convert_tensor_internal(const llama_load_tensor & tensor, llam
     if (ggml_is_quantized(tensor.type)) {
         qtype = ggml_internal_get_quantize_fn(tensor.type);
         if (qtype.dequantize_row_q == NULL) {
-            throw format("type %s unsupported for integer quantization: no dequantization available", ggml_type_name(tensor.type));
+            throw std::runtime_error(format("type %s unsupported for integer quantization: no dequantization available", ggml_type_name(tensor.type)));
         }
     } else if (tensor.type != GGML_TYPE_F16) {
-        throw format("cannot dequantize/convert tensor type %s", ggml_type_name(tensor.type));
+        throw std::runtime_error(format("cannot dequantize/convert tensor type %s", ggml_type_name(tensor.type)));
     }
 
     if (nthread < 2) {
@@ -2299,7 +2299,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             if (tensor.type == GGML_TYPE_F32) {
                 f32_data = (float *) tensor.data;
             } else if (ggml_is_quantized(tensor.type) && !params->allow_requantize) {
-                throw format("requantizing from type %s is disabled", ggml_type_name(tensor.type));
+                throw std::runtime_error(format("requantizing from type %s is disabled", ggml_type_name(tensor.type)));
             } else {
                 llama_convert_tensor_internal(tensor, f32_conv_buf, nelements, nthread);
                 f32_data = (float *) f32_conv_buf.addr;

--- a/llama.cpp
+++ b/llama.cpp
@@ -865,6 +865,17 @@ struct llama_context_params llama_context_default_params() {
     return result;
 }
 
+struct llama_model_quantize_params llama_model_quantize_default_params() {
+    struct llama_model_quantize_params result = {
+        /*.nthread                     =*/ 0,
+        /*.ftype                       =*/ LLAMA_FTYPE_MOSTLY_Q5_1,
+        /*.allow_requantize            =*/ false,
+        /*.quantize_output_tensor      =*/ true,
+    };
+
+    return result;
+}
+
 bool llama_mmap_supported() {
     return llama_mmap::SUPPORTED;
 }
@@ -2112,9 +2123,12 @@ llama_token llama_sample_token(struct llama_context * ctx, llama_token_data_arra
 // quantization
 //
 
-static void llama_model_quantize_internal(const std::string & fname_inp, const std::string & fname_out, enum llama_ftype ftype, int nthread) {
+static void llama_model_quantize_internal(const std::string & fname_inp, const std::string & fname_out, const llama_model_quantize_params * params) {
     ggml_type quantized_type;
-    switch (ftype) {
+    llama_ftype ftype = params->ftype;
+    int nthread = params->nthread;
+
+    switch (params->ftype) {
         case LLAMA_FTYPE_MOSTLY_Q4_0: quantized_type = GGML_TYPE_Q4_0; break;
         case LLAMA_FTYPE_MOSTLY_Q4_1: quantized_type = GGML_TYPE_Q4_1; break;
         case LLAMA_FTYPE_MOSTLY_Q5_0: quantized_type = GGML_TYPE_Q5_0; break;
@@ -2140,7 +2154,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
 
     std::unique_ptr<llama_model_loader> model_loader(new llama_model_loader(fname_inp, /*use_mmap*/ false,
                                                                             /*vocab_only*/ false));
-    llama_file_saver file_saver(fname_out.c_str(), model_loader->file_loaders.at(0).get(), ftype);
+    llama_file_saver file_saver(fname_out.c_str(), model_loader->file_loaders.at(0).get(), params->ftype);
 
     int n_attention_wv    = 0;
     int n_feed_forward_w2 = 0;
@@ -2182,9 +2196,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         quantize &= (tensor.ne.size() == 2);
 
         // uncomment this to keep the output layer in FP16
-        //if (tensor.name == "output.weight") {
-        //    quantize = false;
-        //}
+        if (!params->quantize_output_tensor && tensor.name == "output.weight") {
+           quantize = false;
+        }
 
         enum ggml_type new_type;
         void * new_data;
@@ -2222,17 +2236,26 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             float * f32_data;
             size_t nelements = tensor.ne.at(0) * tensor.ne.at(1);
             llama_buffer f32_conv_buf;
+
             if (tensor.type == GGML_TYPE_F32) {
                 f32_data = (float *) tensor.data;
-            } else if (tensor.type == GGML_TYPE_F16) {
+            } else {
                 f32_conv_buf.resize(nelements * sizeof(float));
                 f32_data = (float *) f32_conv_buf.addr;
-                const auto * f16_data = (const ggml_fp16_t *) tensor.data;
-                for (size_t i = 0; i < nelements; i++) {
-                    f32_data[i] = ggml_fp16_to_fp32(f16_data[i]);
+                if (tensor.type == GGML_TYPE_F16) {
+                    const auto * f16_data = (const ggml_fp16_t *) tensor.data;
+                    for (size_t i = 0; i < nelements; i++) {
+                        f32_data[i] = ggml_fp16_to_fp32(f16_data[i]);
+                    }
+                } else if (!params->allow_requantize) {
+                    throw format("requantizing from type %s is disabled", ggml_type_name(tensor.type));
+                } else {
+                    quantize_fns_t qtype = ggml_internal_get_quantize_fn(tensor.type);
+                    if (qtype.dequantize_row_q == NULL) {
+                        throw format("type %s unsupported for integer quantization: no dequantization available", ggml_type_name(tensor.type));
+                    }
+                    qtype.dequantize_row_q((void *)tensor.data, f32_data, nelements);
                 }
-            } else {
-                throw std::runtime_error(format("type %s unsupported for integer quantization", ggml_type_name(tensor.type)));
             }
 
             printf("quantizing .. ");
@@ -2429,10 +2452,9 @@ void llama_free(struct llama_context * ctx) {
 int llama_model_quantize(
         const char * fname_inp,
         const char * fname_out,
-  enum llama_ftype   ftype,
-        int          nthread) {
+        const llama_model_quantize_params *params) {
     try {
-        llama_model_quantize_internal(fname_inp, fname_out, ftype, nthread);
+        llama_model_quantize_internal(fname_inp, fname_out, params);
         return 0;
     } catch (const std::exception & err) {
         fprintf(stderr, "%s: failed to quantize: %s\n", __func__, err.what());

--- a/llama.cpp
+++ b/llama.cpp
@@ -2160,7 +2160,7 @@ static void llama_convert_tensor_internal(const llama_load_tensor & tensor, llam
 
     std::vector<std::thread> workers;
     for (auto tnum = 0, in_buff_offs = 0, out_buff_offs = 0; tnum < nthread; tnum++) {
-        auto thr_blocks = blocks_per_thread + (tnum == nthread - 1 && spare_blocks ? spare_blocks : 0); // num blocks for this thread
+        auto thr_blocks = blocks_per_thread + (tnum == nthread - 1 ? spare_blocks : 0); // num blocks for this thread
         auto thr_elems = thr_blocks * block_size; // number of elements for this thread
         auto thr_block_bytes = thr_blocks * block_size_bytes; // number of input bytes for this thread
 

--- a/llama.h
+++ b/llama.h
@@ -105,7 +105,16 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q6_K          = 18,// except 1d tensors
     };
 
+    // model quantization parameters
+    typedef struct llama_model_quantize_params {
+        int nthread;                 // number of threads to use for quantizing, if <=0 will use std::thread::hardware_concurrency()
+        enum llama_ftype   ftype;    // quantize to this llama_ftype
+        bool allow_requantize;       // allow quantizing non-f32/f16 tensors
+        bool quantize_output_tensor; // quantize output.weight
+    } llama_model_quantize_params;
+
     LLAMA_API struct llama_context_params llama_context_default_params();
+    LLAMA_API struct llama_model_quantize_params llama_model_quantize_default_params();
 
     LLAMA_API bool llama_mmap_supported();
     LLAMA_API bool llama_mlock_supported();
@@ -127,14 +136,11 @@ extern "C" {
     // Frees all allocated memory
     LLAMA_API void llama_free(struct llama_context * ctx);
 
-    // TODO: not great API - very likely to change
     // Returns 0 on success
-    // nthread - how many threads to use. If <=0, will use std::thread::hardware_concurrency(), else the number given
     LLAMA_API int llama_model_quantize(
             const char * fname_inp,
             const char * fname_out,
-      enum llama_ftype   ftype,
-            int          nthread);
+            const llama_model_quantize_params * params);
 
     // Apply a LoRA adapter to a loaded model
     // path_base_model is the path to a higher quality model to use as a base for


### PR DESCRIPTION
This pull changes the llama.cpp API a bit for `llama_model_quantize` (but there was a comment saying it wasn't ideal and probably would change) so that it takes a structure with parameters. In addition to the existing parameters that were passed separately, I added a toggle for quantizing the output tensor and a toggle for allowing quantization of non-f32/f16 models.

`llama_quantize_model_internal` will now just dequantize data (if possible) and the option is enabled into the same buffer used for converting f16 to f32.

I also updated the `quantize` example to allow `--allow-requantize` and `--leave-output-tensor` flags.

***

I did a little experimentation with requantizing and the effect on perplexity (my system is pretty old so I only ran perplexity for 20 chunks).

Baseline is from a reliable source, so I presume it was quantized from 16bit or 32bit.

*edit: Reorganized to make comparison easier.*

### Requantizing (7b)

In order:

1. baseline 16/32bit to `q4_0`
2. `q8_0` to `q4_0`
3. `q8_0` to `q5_1`
4. `q8_0` to `q5_1` to `q4_0`

```plaintext
[1]4.4543,[2]4.9401,[3]5.8275,[4]6.4841,[5]6.5853,[6]6.5085,[7]6.6925,[8]6.8058,[9]7.1425,[10]7.3864,[11]7.5937,[12]7.6130,[13]7.5411,[14]7.6129,[15]7.8702,[16]7.4694,[17]7.3520,[18]7.3030,[19]6.9404,[20]6.9317
[1]4.5288,[2]5.0356,[3]5.9668,[4]6.6169,[5]6.7260,[6]6.6440,[7]6.8366,[8]6.9398,[9]7.2729,[10]7.5059,[11]7.7240,[12]7.7457,[13]7.6775,[14]7.7551,[15]8.0253,[16]7.6084,[17]7.4895,[18]7.4435,[19]7.0696,[20]7.0562
[1]4.2760,[2]4.7250,[3]5.6158,[4]6.2080,[5]6.3382,[6]6.2962,[7]6.4810,[8]6.5727,[9]6.9023,[10]7.1424,[11]7.3396,[12]7.3646,[13]7.2815,[14]7.3281,[15]7.5752,[16]7.2036,[17]7.0927,[18]7.0414,[19]6.6903,[20]6.6769
[1]4.4667,[2]5.0004,[3]5.9462,[4]6.5659,[5]6.6665,[6]6.5793,[7]6.7940,[8]6.8855,[9]7.2347,[10]7.4503,[11]7.6859,[12]7.7178,[13]7.6519,[14]7.7240,[15]7.9988,[16]7.5971,[17]7.4865,[18]7.4467,[19]7.0744,[20]7.0560
```

### Requantizing (7b) with `--leave-output-tensor`:

In order:

1. baseline 16/32bit to `q4_0` (model from HF, so output tensor is quantized)
2. `q8_0` to `q4_0`
3. `q8_0` to `q5_1`
4. `q8_0` to `q5_1` to `q4_0`

```plaintext
[1]4.4543,[2]4.9401,[3]5.8275,[4]6.4841,[5]6.5853,[6]6.5085,[7]6.6925,[8]6.8058,[9]7.1425,[10]7.3864,[11]7.5937,[12]7.6130,[13]7.5411,[14]7.6129,[15]7.8702,[16]7.4694,[17]7.3520,[18]7.3030,[19]6.9404,[20]6.9317
[1]4.4459,[2]4.9815,[3]5.9177,[4]6.5378,[5]6.6339,[6]6.5731,[7]6.7753,[8]6.8779,[9]7.2067,[10]7.4348,[11]7.6518,[12]7.6790,[13]7.6165,[14]7.6991,[15]7.9601,[16]7.5499,[17]7.4370,[18]7.3908,[19]7.0176,[20]7.0056
[1]4.2412,[2]4.7153,[3]5.5916,[4]6.1828,[5]6.3129,[6]6.2794,[7]6.4634,[8]6.5546,[9]6.8808,[10]7.1252,[11]7.3224,[12]7.3477,[13]7.2649,[14]7.3098,[15]7.5562,[16]7.1868,[17]7.0772,[18]7.0251,[19]6.6750,[20]6.6615
[1]4.4444,[2]4.9846,[3]5.9130,[4]6.5119,[5]6.6093,[6]6.5362,[7]6.7444,[8]6.8297,[9]7.1733,[10]7.3866,[11]7.6076,[12]7.6364,[13]7.5806,[14]7.6528,[15]7.9191,[16]7.5238,[17]7.4177,[18]7.3747,[19]7.0068,[20]6.9927
```

***

*edit: Added 33b data.*

### Requantizing (33b)

1. baseline 16/32bit to `q4_0` (model from HF, so output tensor is quantized)
2. `q8_0` to `q4_0`
3. `q8_0` to `q5_1`

```plaintext
[1]3.3109,[2]3.7188,[3]4.4459,[4]4.4308,[5]4.3045,[6]4.2951,[7]4.4645,[8]4.5540,[9]4.7997,[10]5.0184,[11]5.1678,[12]5.2154,[13]5.1869,[14]5.2832,[15]5.4346,[16]5.2159,[17]5.1890,[18]5.2093,[19]5.0047,[20]5.0191
[1]3.2961,[2]3.7156,[3]4.4491,[4]4.4430,[5]4.3123,[6]4.3066,[7]4.4731,[8]4.5590,[9]4.8058,[10]5.0216,[11]5.1757,[12]5.2206,[13]5.1922,[14]5.2890,[15]5.4426,[16]5.2195,[17]5.1936,[18]5.2127,[19]5.0071,[20]5.0200
[1]3.2718,[2]3.6866,[3]4.3905,[4]4.3015,[5]4.1522,[6]4.1477,[7]4.3241,[8]4.4095,[9]4.6493,[10]4.8555,[11]4.9919,[12]5.0429,[13]5.0230,[14]5.1008,[15]5.2511,[16]5.0435,[17]5.0283,[18]5.0551,[19]4.8627,[20]4.8862
```

### Requantizing (33b) with `--leave-output-tensor`

1. baseline 16/32bit to `q4_0` (model from HF, so output tensor is quantized)
2. `q8_0` to `q4_0`
3. `q8_0` to `q5_1`

```plaintext
[1]3.3109,[2]3.7188,[3]4.4459,[4]4.4308,[5]4.3045,[6]4.2951,[7]4.4645,[8]4.5540,[9]4.7997,[10]5.0184,[11]5.1678,[12]5.2154,[13]5.1869,[14]5.2832,[15]5.4346,[16]5.2159,[17]5.1890,[18]5.2093,[19]5.0047,[20]5.0191
[1]3.3002,[2]3.7089,[3]4.4329,[4]4.4210,[5]4.2862,[6]4.2820,[7]4.4499,[8]4.5344,[9]4.7764,[10]4.9896,[11]5.1435,[12]5.1857,[13]5.1619,[14]5.2533,[15]5.4052,[16]5.1854,[17]5.1579,[18]5.1782,[19]4.9747,[20]4.9863
[1]3.2716,[2]3.6796,[3]4.3823,[4]4.2942,[5]4.1472,[6]4.1420,[7]4.3172,[8]4.4032,[9]4.6420,[10]4.8490,[11]4.9853,[12]5.0357,[13]5.0165,[14]5.0950,[15]5.2441,[16]5.0365,[17]5.0206,[18]5.0471,[19]4.8551,[20]4.8781
```

***

There is some loss even from `q8_0` but it still might be worth doing in some cases. i.e. you can keep something like a `q8_0` around and make other quantizations if you need them based on performance/memory constraints.

I haven't done tests with larger models, but from what I've seen 7B models are generally the ones that quantization affects the most. So while it may be borderline for 7B, it might be a lot more reasonable for something like 33b, 65b models.

Since you have to explicitly enable requantizing,  I don't think allowing this is too dangerous for users.

**Note**: This is lightly tested and seems to work. I once was a C developer but that was a long time ago, C++ I can bumble my way through at best.