### PR TITLE
Arch Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,7 @@ endif # LLAMA_NO_ACCELERATE
 
 ifdef LLAMA_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas -I/usr/include/openblas
-	ifneq ($(shell grep -e "Arch Linux" -e "ID_LIKE=arch" /etc/os-release 2>/dev/null),)
-		LDFLAGS += -lopenblas -lcblas
-	else
-		LDFLAGS += -lopenblas
-	endif
+	LDFLAGS += -lopenblas
 endif # LLAMA_OPENBLAS
 
 ifdef LLAMA_BLIS


### PR DESCRIPTION
With the upcoming changes in Arch related to the openblas package the Makefile workaround is no longer needed.

[Change announcement](https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/REXPJGNLOMBZAB47D5JYX4B3TM62YJTD/)

This change requires the user to install the new blas-openblas package.

The package is in the extra-testing repository right now so I'll keep this pr as draft until it gets merged on the stable repo.

