### PR TITLE
ggml: Fix internal overflow in ggml_time_us on Windows

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -403,21 +403,27 @@ void ggml_fp32_to_fp16_row(const float * x, ggml_fp16_t * y, size_t n) {
 //
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
-static int64_t timer_freq;
+static int64_t timer_freq, timer_start;
 void ggml_time_init(void) {
-    LARGE_INTEGER frequency;
-    QueryPerformanceFrequency(&frequency);
-    timer_freq = frequency.QuadPart;
+    LARGE_INTEGER t;
+    QueryPerformanceFrequency(&t);
+    timer_freq = t.QuadPart;
+
+    // The multiplication by 1000 or 1000000 below can cause an overflow if timer_freq
+    // and the uptime is high enough.
+    // We subtract the program start time to reduce the likelihood of that happening.
+    QueryPerformanceCounter(&t);
+    timer_start = t.QuadPart;
 }
 int64_t ggml_time_ms(void) {
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);
-    return (t.QuadPart * 1000) / timer_freq;
+    return ((t.QuadPart-timer_start) * 1000) / timer_freq;
 }
 int64_t ggml_time_us(void) {
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);
-    return (t.QuadPart * 1000000) / timer_freq;
+    return ((t.QuadPart-timer_start) * 1000000) / timer_freq;
 }
 #else
 void ggml_time_init(void) {}


### PR DESCRIPTION
The implementation of ggml_time_us() on Windows can realistically overflow and produce wrong data (It happened to me and messed up a bunch of benchmark results).

With a timer frequency of 10,000,000 ticks per second (which I have on my machine) the internal result of the multiplication (t.QuadPart * 1000000) overflows the 63 bits after 2^63 / 1000000 / 10000000 seconds. That's about 10.5 days. Because that product is then divided by the timer frequency, the upper bits are essentially lost and the calculated timings from using this function will be wrong.

This PR changes the code so that the startup time is subtracted. That means it won't overflow when the uptime of the OS crosses these 10 day, but only when the process runs longer than 10 days.

Ideally, you'd want to use something like [MulDiv](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-muldiv) for 64-bits to prevent the overflow entirely, but I couldn't find a simple implementation for that.