### PR TITLE
Makefile: add missing `ggml-quants-k.o` to `server` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ embedding: examples/embedding/embedding.cpp build-info.h ggml.o llama.o common.o
 save-load-state: examples/save-load-state/save-load-state.cpp build-info.h ggml.o llama.o common.o ggml-quants-k.o $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-server: examples/server/server.cpp examples/server/httplib.h examples/server/json.hpp build-info.h ggml.o llama.o common.o $(OBJS)
+server: examples/server/server.cpp examples/server/httplib.h examples/server/json.hpp build-info.h ggml.o ggml-quants-k.o llama.o common.o $(OBJS)
 	$(CXX) $(CXXFLAGS) -Iexamples/server $(filter-out %.h,$(filter-out %.hpp,$^)) -o $@ $(LDFLAGS)
 
 build-info.h: $(wildcard .git/index) scripts/build-info.sh


### PR DESCRIPTION
Current versions are unable to build `server` since `ggml-quants-k` came in to being, resulting build failures similar to the following:

<details>

```
/usr/bin/ld: ggml.o: in function `ggml_quantize_chunk':
ggml.c:(.text+0x27c0b): undefined reference to `ggml_quantize_q2_k'
/usr/bin/ld: ggml.c:(.text+0x27c3b): undefined reference to `ggml_quantize_q3_k'
/usr/bin/ld: ggml.c:(.text+0x27c6f): undefined reference to `ggml_quantize_q4_k'
/usr/bin/ld: ggml.c:(.text+0x27cae): undefined reference to `ggml_quantize_q5_k'
/usr/bin/ld: ggml.c:(.text+0x27cea): undefined reference to `ggml_quantize_q6_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x1e0): undefined reference to `dequantize_row_q2_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x1e8): undefined reference to `quantize_row_q2_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x1f0): undefined reference to `quantize_row_q2_k_reference'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x1f8): undefined reference to `quantize_row_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x200): undefined reference to `ggml_vec_dot_q2_k_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x210): undefined reference to `dequantize_row_q3_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x218): undefined reference to `quantize_row_q3_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x220): undefined reference to `quantize_row_q3_k_reference'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x228): undefined reference to `quantize_row_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x230): undefined reference to `ggml_vec_dot_q3_k_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x240): undefined reference to `dequantize_row_q4_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x248): undefined reference to `quantize_row_q4_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x250): undefined reference to `quantize_row_q4_k_reference'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x258): undefined reference to `quantize_row_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x260): undefined reference to `ggml_vec_dot_q4_k_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x270): undefined reference to `dequantize_row_q5_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x278): undefined reference to `quantize_row_q5_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x280): undefined reference to `quantize_row_q5_k_reference'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x288): undefined reference to `quantize_row_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x290): undefined reference to `ggml_vec_dot_q5_k_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x2a0): undefined reference to `dequantize_row_q6_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x2a8): undefined reference to `quantize_row_q6_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x2b0): undefined reference to `quantize_row_q6_k_reference'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x2b8): undefined reference to `quantize_row_q8_k'
/usr/bin/ld: ggml.o:(.data.rel.ro+0x2c0): undefined reference to `ggml_vec_dot_q6_k_q8_k'
collect2: error: ld returned 1 exit status
```

</details>

This patch adds the missing dependency, resolving the build failure.