### PR TITLE
Add missing compile definition to CMakeLists for k_quants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ endif()
 
 if (LLAMA_K_QUANTS)
     set(GGML_SOURCES_EXTRA ${GGML_SOURCES_EXTRA} k_quants.c k_quants.h)
+    add_compile_definitions(GGML_USE_K_QUANTS)
 endif()
 
 if (LLAMA_CLBLAST)


### PR DESCRIPTION
Commit to add the option to disable k_quants edaafec6cc1a573b01bc6e41eab731e8e631632e added GGML_USE_K_QUANTS, this needs to be set in CMakeLists.txt.