### PR TITLE
Windows nvcc workaround

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1516,7 +1516,7 @@ static void ggml_cuda_op(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                 // There is possibly a bug in the Windows nvcc compiler regarding instruction reordering or optimizing out local variables.
                 // Removing the first assert or changing the order of the arguments causes the second assert to fail.
                 // Removing both asserts results in i01_high becoming 0 which in turn results in garbage output.
-                // The root cause seems to be a problem with i0_offset_high becoming 0 when it should always be 1 (for single GPU).
+                // The root cause seems to be a problem with i0_offset_high becoming 0 when it should always be >0 (for single GPU).
                 GGML_ASSERT(i01_low == 0 || g_device_count > 1);
                 GGML_ASSERT(i01_high == ne01 || g_device_count > 1);
 

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1516,6 +1516,7 @@ static void ggml_cuda_op(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                 // There is possibly a bug in the Windows nvcc compiler regarding instruction reordering or optimizing out local variables. 
                 // Removing the first assert or changing the order of the arguments causes the second assert to fail. 
                 // Removing both asserts results in i01_high becoming 0 which in turn results in garbage output.
+                // The root cause seems to be a problem with i0_offset_high becoming 0 when it should always be 1 (for single GPU).
                 GGML_ASSERT(i01_low == 0 || g_device_count > 1);
                 GGML_ASSERT(i01_high == ne01 || g_device_count > 1);
                 

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1735,6 +1735,7 @@ void ggml_cuda_load_data(const char * fname, struct ggml_tensor * tensor, const 
             row_low -= row_low % GGML_CUDA_DMMV_Y;
             row_high = id == g_device_count - 1 ? nrows : nrows*g_tensor_split[id + 1];
             row_high -= row_high % GGML_CUDA_DMMV_Y;
+            GGML_ASSERT(nrows % GGML_CUDA_DMMV_Y == 0);
         } else {
             GGML_ASSERT(false);
         }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1513,13 +1513,13 @@ static void ggml_cuda_op(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                     }
                 }
 
-                // There is possibly a bug in the Windows nvcc compiler regarding instruction reordering or optimizing out local variables. 
-                // Removing the first assert or changing the order of the arguments causes the second assert to fail. 
+                // There is possibly a bug in the Windows nvcc compiler regarding instruction reordering or optimizing out local variables.
+                // Removing the first assert or changing the order of the arguments causes the second assert to fail.
                 // Removing both asserts results in i01_high becoming 0 which in turn results in garbage output.
                 // The root cause seems to be a problem with i0_offset_high becoming 0 when it should always be 1 (for single GPU).
                 GGML_ASSERT(i01_low == 0 || g_device_count > 1);
                 GGML_ASSERT(i01_high == ne01 || g_device_count > 1);
-                
+
                 const int64_t i01_diff = i01_high - i01_low;
                 if (i01_diff == 0) {
                     continue;

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1512,6 +1512,13 @@ static void ggml_cuda_op(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                         i01_high = row_high % ne01;
                     }
                 }
+
+                // There is possibly a bug in the Windows nvcc compiler regarding instruction reordering or optimizing out local variables. 
+                // Removing the first assert or changing the order of the arguments causes the second assert to fail. 
+                // Removing both asserts results in i01_high becoming 0 which in turn results in garbage output.
+                GGML_ASSERT(i01_low == 0 || g_device_count > 1);
+                GGML_ASSERT(i01_high == ne01 || g_device_count > 1);
+                
                 const int64_t i01_diff = i01_high - i01_low;
                 if (i01_diff == 0) {
                     continue;


### PR DESCRIPTION
With my GPU changes in https://github.com/ggerganov/llama.cpp/pull/1703 Windows users were reporting to get garbage outputs: https://github.com/ggerganov/llama.cpp/issues/1735 . I think the problem is a bug in the Windows CUDA compiler regarding instruction reordering or optimizing out local variables. The problem can be fixed by either making a debug build or by adding assert statements. This alone would not be indicative of a bug in the compiler since it's possible that I'm simply accidentally relying on undefined behavior somewhere that randomly happens to work correctly unless the compiler does certain optimizations. However, I found that adding an assert statement for one of the variables that I use for determining indices affects another assert statement for another variable.

Specifically: my code loops over `ne02` and `ne03` of the ggml tensors via `i02` and `i03` and then does a computation for each `i02` `i03` bin. For multiple GPUs the edge between GPU data regions for split tensors falls into one of those bins. I'm using `i01_low` and `ì01_high` to represent the lower and upper rows of a bin that a given GPU should work on. For a single GPU `i01_low == 0` and `i01_high == ne01` should always be true. However, for some reason `i01_high` is becoming 0 on Windows which in turn means that the GPU isn't actually doing any work. I triple-checked my code for determining the indices and I'm confident that it's correct. The only possible problem could be `nrows0` not being a multiple of `GGML_CUDA_DMMV_Y` but I've asserted that this is not the problem and the default value for `GGML_CUDA_DMMV_Y` is 1 anyways. I therefore think that the bug is caused by something outside llama.cpp and the most likely suspect is the compiler, especially since that is something that differs between Windows and Linux.

Feedback would be highly appreciated. In particular it would be useful for Windows users that experience the bug to check out this PR and to confirm whether the fix works. Also, please try disabling the first assert on line 1520 of `ggml-cuda.cu` and confirm that this causes an assertion error (if there is only a single GPU in the system).