### PR TITLE
Allow "quantizing" to f16 and f32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ endif
 
 ifndef LLAMA_NO_K_QUANTS
 	CFLAGS   += -DGGML_USE_K_QUANTS
+	CXXFLAGS += -DGGML_USE_K_QUANTS
 	OBJS     += k_quants.o
 endif
 

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -17,101 +17,101 @@ struct quant_option {
 
 static const std::vector<struct quant_option> QUANT_OPTIONS = {
     {
-        "q4_0",
+        "Q4_0",
         LLAMA_FTYPE_MOSTLY_Q4_0,
-        "approx +0.2499 perplexity, 3.50G output @ 7B",
+        "approx +0.2499 perplexity, 3.50 GiB size @ 7B",
     },
     {
-        "q4_1",
+        "Q4_1",
         LLAMA_FTYPE_MOSTLY_Q4_1,
-        "approx +0.1846 perplexity, 3.90G output @ 7B",
+        "approx +0.1846 perplexity, 3.90 GiB size @ 7B",
     },
     {
-        "q5_0",
+        "Q5_0",
         LLAMA_FTYPE_MOSTLY_Q5_0,
-        "approx +0.0796 perplexity, 4.30G output @ 7B",
+        "approx +0.0796 perplexity, 4.30 GiB size @ 7B",
     },
     {
-        "q5_1",
+        "Q5_1",
         LLAMA_FTYPE_MOSTLY_Q5_1,
-        "approx +0.0415 perplexity, 4.70G output @ 7B",
+        "approx +0.0415 perplexity, 4.70 GiB size @ 7B",
     },
 #ifdef GGML_USE_K_QUANTS
     {
-        "q2_k",
+        "Q2_K",
         LLAMA_FTYPE_MOSTLY_Q2_K,
-        "approx +0.8698 perplexity, 2.67G output @ 7B",
+        "approx +0.8698 perplexity, 2.67 GiB size @ 7B",
     },
     {
-        "q3_k",
+        "Q3_K",
         LLAMA_FTYPE_MOSTLY_Q3_K_M,
-        "alias for q3_k_m"
+        "alias for Q3_K_M"
     },
     {
-        "q3_k_s",
+        "Q3_K_S",
         LLAMA_FTYPE_MOSTLY_Q3_K_S,
-        "approx +0.5505 perplexity, 2.75G output @ 7B",
+        "approx +0.5505 perplexity, 2.75 GiB size @ 7B",
     },
     {
-        "q3_k_m",
+        "Q3_K_M",
         LLAMA_FTYPE_MOSTLY_Q3_K_M,
-        "approx +0.2437 perplexity, 3.06G output @ 7B",
+        "approx +0.2437 perplexity, 3.06 GiB size @ 7B",
     },
     {
-        "q3_k_l",
+        "Q3_K_L",
         LLAMA_FTYPE_MOSTLY_Q3_K_L,
-        "approx +0.1803 perplexity, 3.35G output @ 7B",
+        "approx +0.1803 perplexity, 3.35 GiB size @ 7B",
     },
     {
-        "q4_k",
+        "Q4_K",
         LLAMA_FTYPE_MOSTLY_Q4_K_M,
-        "alias for q4_k_m",
+        "alias for Q4_K_M",
     },
     {
-        "q4_k_s",
+        "Q4_K_S",
         LLAMA_FTYPE_MOSTLY_Q4_K_S,
-        "approx +0.1149 perplexity, 3.56G output @ 7B",
+        "approx +0.1149 perplexity, 3.56 GiB size @ 7B",
     },
     {
-        "q4_k_m",
+        "Q4_K_M",
         LLAMA_FTYPE_MOSTLY_Q4_K_M,
-        "approx +0.0535 perplexity, 3.80G output @ 7B",
+        "approx +0.0535 perplexity, 3.80 GiB size @ 7B",
     },
     {
-        "q5_k",
+        "Q5_K",
         LLAMA_FTYPE_MOSTLY_Q5_K_M,
-        "alias for q5_k_m",
+        "alias for Q5_K_M",
     },
     {
-        "q5_k_s",
+        "Q5_K_S",
         LLAMA_FTYPE_MOSTLY_Q5_K_S,
-        "approx +0.0353 perplexity, 4.33G output @ 7B",
+        "approx +0.0353 perplexity, 4.33 GiB size @ 7B",
     },
     {
-        "q5_k_m",
+        "Q5_K_M",
         LLAMA_FTYPE_MOSTLY_Q5_K_M,
-        "approx +0.0142 perplexity, 4.45G output @ 7B",
+        "approx +0.0142 perplexity, 4.45 GiB size @ 7B",
     },
     {
-        "q6_k",
+        "Q6_K",
         LLAMA_FTYPE_MOSTLY_Q6_K,
-        "approx +0.0044 perplexity, 5.15G output @ 7B",
+        "approx +0.0044 perplexity, 5.15 GiB size @ 7B",
     },
 #endif
     {
-        "q8_0",
+        "Q8_0",
         LLAMA_FTYPE_MOSTLY_Q8_0,
-        "approx +0.0004 perplexity, 6.70G output @ 7B",
+        "approx +0.0004 perplexity, 6.70 GiB size @ 7B",
     },
     {
-        "f16",
+        "F16",
         LLAMA_FTYPE_MOSTLY_F16,
-        "no significant perplexity increase, 13.00G output @ 7B",
+        "no significant perplexity increase, 13.00 GiB size @ 7B",
     },
     {
-        "f32",
+        "F32",
         LLAMA_FTYPE_ALL_F32,
-        "full quality, 26.00G output @ 7B",
+        "full quality, 26.00 GiB size @ 7B",
     },
 };
 
@@ -120,7 +120,7 @@ bool try_parse_ftype(const std::string & ftype_str_in, llama_ftype & ftype, std:
     std::string ftype_str;
 
     for (auto ch : ftype_str_in) {
-        ftype_str.push_back(std::tolower(ch));
+        ftype_str.push_back(std::toupper(ch));
     }
     for (auto & it : QUANT_OPTIONS) {
         if (it.name == ftype_str) {

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -5,8 +5,6 @@
 #include <cstdio>
 #include <cstring>
 #include <vector>
-#include <iostream>
-#include <iomanip>
 #include <string>
 
 struct quant_option {
@@ -154,7 +152,7 @@ void usage(const char * executable) {
     fprintf(stderr, "  --leave-output-tensor: Will leave output.weight un(re)quantized. Increases model size but may also increase quality, especially when requantizing\n");
     fprintf(stderr, "Allowed quantization types:\n");
     for (auto & it : QUANT_OPTIONS) {
-        std::cout << "  " << std::setw(2) << it.ftype << "  or  " << std::setw(6) << it.name << "  :  " << it.desc << "\n";
+        printf("  %2d  or  %6s  :  %s\n", it.ftype, it.name.c_str(), it.desc.c_str());
     }
     exit(1);
 }

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -17,28 +17,28 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     {
         "Q4_0",
         LLAMA_FTYPE_MOSTLY_Q4_0,
-        "approx +0.2499 perplexity, 3.50 GiB size @ 7B",
+        " 3.50G, +0.2499 ppl @ 7B - small, very high quality loss - legacy, prefer using Q3_K_M",
     },
     {
         "Q4_1",
         LLAMA_FTYPE_MOSTLY_Q4_1,
-        "approx +0.1846 perplexity, 3.90 GiB size @ 7B",
+        " 3.90G, +0.1846 ppl @ 7B - small, substantial quality loss - legacy, prefer using Q3_K_L",
     },
     {
         "Q5_0",
         LLAMA_FTYPE_MOSTLY_Q5_0,
-        "approx +0.0796 perplexity, 4.30 GiB size @ 7B",
+        " 4.30G, +0.0796 ppl @ 7B - medium, balanced quality - legacy, prefer using Q4_K_M",
     },
     {
         "Q5_1",
         LLAMA_FTYPE_MOSTLY_Q5_1,
-        "approx +0.0415 perplexity, 4.70 GiB size @ 7B",
+        " 4.70G, +0.0415 ppl @ 7B - medium, low quality loss - legacy, prefer using Q5_K_M",
     },
 #ifdef GGML_USE_K_QUANTS
     {
         "Q2_K",
         LLAMA_FTYPE_MOSTLY_Q2_K,
-        "approx +0.8698 perplexity, 2.67 GiB size @ 7B",
+        " 2.67G, +0.8698 ppl @ 7B - smallest, extreme quality loss - not recommended",
     },
     {
         "Q3_K",
@@ -48,17 +48,17 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     {
         "Q3_K_S",
         LLAMA_FTYPE_MOSTLY_Q3_K_S,
-        "approx +0.5505 perplexity, 2.75 GiB size @ 7B",
+        " 2.75G, +0.5505 ppl @ 7B - very small, very high quality loss",
     },
     {
         "Q3_K_M",
         LLAMA_FTYPE_MOSTLY_Q3_K_M,
-        "approx +0.2437 perplexity, 3.06 GiB size @ 7B",
+        " 3.06G, +0.2437 ppl @ 7B - very small, very high quality loss",
     },
     {
         "Q3_K_L",
         LLAMA_FTYPE_MOSTLY_Q3_K_L,
-        "approx +0.1803 perplexity, 3.35 GiB size @ 7B",
+        " 3.35G, +0.1803 ppl @ 7B - small, substantial quality loss",
     },
     {
         "Q4_K",
@@ -68,12 +68,12 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     {
         "Q4_K_S",
         LLAMA_FTYPE_MOSTLY_Q4_K_S,
-        "approx +0.1149 perplexity, 3.56 GiB size @ 7B",
+        " 3.56G, +0.1149 ppl @ 7B - small, significant quality loss",
     },
     {
         "Q4_K_M",
         LLAMA_FTYPE_MOSTLY_Q4_K_M,
-        "approx +0.0535 perplexity, 3.80 GiB size @ 7B",
+        " 3.80G, +0.0535 ppl @ 7B - medium, balanced quality - *recommended*",
     },
     {
         "Q5_K",
@@ -83,33 +83,33 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     {
         "Q5_K_S",
         LLAMA_FTYPE_MOSTLY_Q5_K_S,
-        "approx +0.0353 perplexity, 4.33 GiB size @ 7B",
+        " 4.33G, +0.0353 ppl @ 7B - large, low quality loss - *recommended*",
     },
     {
         "Q5_K_M",
         LLAMA_FTYPE_MOSTLY_Q5_K_M,
-        "approx +0.0142 perplexity, 4.45 GiB size @ 7B",
+        " 4.45G, +0.0142 ppl @ 7B - large, very low quality loss - *recommended*",
     },
     {
         "Q6_K",
         LLAMA_FTYPE_MOSTLY_Q6_K,
-        "approx +0.0044 perplexity, 5.15 GiB size @ 7B",
+        " 5.15G, +0.0044 ppl @ 7B - very large, extremely low quality loss",
     },
 #endif
     {
         "Q8_0",
         LLAMA_FTYPE_MOSTLY_Q8_0,
-        "approx +0.0004 perplexity, 6.70 GiB size @ 7B",
+        " 6.70G, +0.0004 ppl @ 7B - very large, extremely low quality loss - not recommended",
     },
     {
         "F16",
         LLAMA_FTYPE_MOSTLY_F16,
-        "no significant perplexity increase, 13.00 GiB size @ 7B",
+        "13.00G              @ 7B - extremely large, virtually no quality loss - not recommended",
     },
     {
         "F32",
         LLAMA_FTYPE_ALL_F32,
-        "full quality, 26.00 GiB size @ 7B",
+        "26.00G              @ 7B - absolutely huge, lossless - not recommended",
     },
 };
 
@@ -144,15 +144,15 @@ bool try_parse_ftype(const std::string & ftype_str_in, llama_ftype & ftype, std:
 }
 
 // usage:
-//  ./quantize models/llama/ggml-model.bin [models/llama/ggml-model-quant.bin] type [nthreads]
+//  ./quantize [--allow-requantize] [--leave-output-tensor] models/llama/ggml-model.bin [models/llama/ggml-model-quant.bin] type [nthreads]
 //
 void usage(const char * executable) {
-    fprintf(stderr, "usage: %s [--help] [--allow-requantize] [--leave-output-tensor] model-f32.bin [model-quant.bin] type [nthreads]\n", executable);
+    fprintf(stderr, "usage: %s [--help] [--allow-requantize] [--leave-output-tensor] model-f32.bin [model-quant.bin] type [nthreads]\n\n", executable);
     fprintf(stderr, "  --allow-requantize: Allows requantizing tensors that have already been quantized. Warning: This can severely reduce quality compared to quantizing from 16bit or 32bit\n");
     fprintf(stderr, "  --leave-output-tensor: Will leave output.weight un(re)quantized. Increases model size but may also increase quality, especially when requantizing\n");
-    fprintf(stderr, "Allowed quantization types:\n");
+    fprintf(stderr, "\nAllowed quantization types:\n");
     for (auto & it : QUANT_OPTIONS) {
-        printf("  %2d  or  %6s  :  %s\n", it.ftype, it.name.c_str(), it.desc.c_str());
+        printf("  %2d  or  %-6s : %s\n", it.ftype, it.name.c_str(), it.desc.c_str());
     }
     exit(1);
 }

--- a/ggml.c
+++ b/ggml.c
@@ -16301,6 +16301,19 @@ size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, i
                 result = ggml_quantize_q6_K(src + start, block, n, n, hist);
             } break;
 #endif
+        case GGML_TYPE_F16:
+            {
+                int elemsize = sizeof(ggml_fp16_t);
+                ggml_fp32_to_fp16_row(src + start, (ggml_fp16_t *)dst + start, n);
+                result = n * elemsize;
+            } break;
+        case GGML_TYPE_F32:
+            {
+                int elemsize = sizeof(float);
+                result = n * elemsize;
+                memcpy((uint8_t *)dst + start * elemsize, src + start, result);
+
+            } break;
         default:
             assert(false);
     }

--- a/ggml.c
+++ b/ggml.c
@@ -16312,7 +16312,6 @@ size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, i
                 int elemsize = sizeof(float);
                 result = n * elemsize;
                 memcpy((uint8_t *)dst + start * elemsize, src + start, result);
-
             } break;
         default:
             assert(false);


### PR DESCRIPTION
Fix an issue where quantizing didn't respect LLAMA_NO_K_QUANTS

Add brief help to the list of quantization types in the quantize tool

Ignore case for quantization type arguments in the quantize tool