### PR TITLE
Fix cmake error when using LLAMA_METAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,12 @@ if (LLAMA_CUBLAS)
     endif()
 endif()
 
+add_library(llama
+            llama.cpp
+            llama.h
+            llama-util.h
+            )
+
 if (LLAMA_METAL)
     find_library(FOUNDATION_LIBRARY         Foundation              REQUIRED)
     find_library(METAL_FRAMEWORK            Metal                   REQUIRED)
@@ -419,11 +425,7 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
-add_library(llama
-            llama.cpp
-            llama.h
-            llama-util.h
-            )
+
 
 target_include_directories(llama PUBLIC .)
 target_compile_features(llama PUBLIC cxx_std_11) # don't bump


### PR DESCRIPTION
The latest commit causes an error when running cmake with `LLAMA_METAL` enabled.


### Before:
```
spencer•repos/llama.cpp/build(master⚡)» cmake .. -DLLAMA_METAL=ON
-- Accelerate framework found
CMake Error at CMakeLists.txt:222 (set_target_properties):
  set_target_properties Can not find target to add properties to: llama


-- CMAKE_SYSTEM_PROCESSOR: arm64
-- ARM detected
-- Configuring incomplete, errors occurred!
```
### After:
```
spencer•repos/llama.cpp/build(cmake-fix⚡)» cmake ..
-- Accelerate framework found
-- CMAKE_SYSTEM_PROCESSOR: arm64
-- ARM detected
-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/spencer/ai/repos/llama.cpp/build
```

I don't really know cmake but moving `add_library(llama,...)` to above the first place the llama target is referenced seems to fix it.