### PR TITLE
make : find include dir for OpenBLAS header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,26 @@ if (LLAMA_BLAS)
         add_compile_definitions(GGML_USE_OPENBLAS)
         set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} ${BLAS_LIBRARIES})
 
+        # check include dir
+        if (NOT BLAS_INCLUDE_DIRS)
+            # find header file
+            set(BLAS_INCLUDE_SEARCH_PATHS
+                /usr/include
+                /usr/include/openblas
+                /usr/include/openblas-base
+                /usr/local/include
+                /usr/local/include/openblas
+                /usr/local/include/openblas-base
+                /opt/OpenBLAS/include
+                $ENV{OpenBLAS_HOME}
+                $ENV{OpenBLAS_HOME}/include
+            )
+            find_path(BLAS_INC NAMES cblas.h PATHS ${BLAS_INCLUDE_SEARCH_PATHS})
+            add_compile_options(-I${BLAS_INC})
+            set(BLAS_INCLUDE_DIRS ${BLAS_INC})
+            message(STATUS "Found header file in ${BLAS_INC}")
+        endif()
+
         message("${BLAS_LIBRARIES} ${BLAS_INCLUDE_DIRS}")
         include_directories(${BLAS_INCLUDE_DIRS})
     else()


### PR DESCRIPTION

Hi, Gerganov. Thank you for sharing awesome thing.
Latest source meets following compile error on Linux environment.

```
[ 16%] Building C object CMakeFiles/ggml.dir/ggml.c.o
/home/user/github/llama.cpp/llama.cpp/ggml.c:156:10: fatal error: cblas.h: No such file or directory
  156 | #include <cblas.h>
      |          ^~~~~~~~~
compilation terminated.
CMakeFiles/ggml.dir/build.make:75: recipe for target 'CMakeFiles/ggml.dir/ggml.c.o' failed
make[3]: *** [CMakeFiles/ggml.dir/ggml.c.o] Error 1
CMakeFiles/Makefile2:359: recipe for target 'CMakeFiles/ggml.dir/all' failed
make[2]: *** [CMakeFiles/ggml.dir/all] Error 2
```
Because BLAS cmake package can't find include header directory.
I added some code to CMakeLists.txt to resolve above issue.

Please confirm my pull-request.
Thanks.