### PR TITLE
Metal implementation for all k_quants

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -52,6 +52,7 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(get_rows_q4_0);
     GGML_METAL_DECL_KERNEL(get_rows_q4_1);
     GGML_METAL_DECL_KERNEL(get_rows_q2_k);
+    GGML_METAL_DECL_KERNEL(get_rows_q3_k);
     GGML_METAL_DECL_KERNEL(get_rows_q4_k);
     GGML_METAL_DECL_KERNEL(get_rows_q6_k);
     GGML_METAL_DECL_KERNEL(rms_norm);
@@ -59,6 +60,7 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(mul_mat_q4_0_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q4_1_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q2_k_f32);
+    GGML_METAL_DECL_KERNEL(mul_mat_q3_k_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q4_k_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q6_k_f32);
     GGML_METAL_DECL_KERNEL(rope);
@@ -152,6 +154,7 @@ struct ggml_metal_context * ggml_metal_init(void) {
         GGML_METAL_ADD_KERNEL(get_rows_q4_0);
         GGML_METAL_ADD_KERNEL(get_rows_q4_1);
         GGML_METAL_ADD_KERNEL(get_rows_q2_k);
+        GGML_METAL_ADD_KERNEL(get_rows_q3_k);
         GGML_METAL_ADD_KERNEL(get_rows_q4_k);
         GGML_METAL_ADD_KERNEL(get_rows_q6_k);
         GGML_METAL_ADD_KERNEL(rms_norm);
@@ -159,6 +162,7 @@ struct ggml_metal_context * ggml_metal_init(void) {
         GGML_METAL_ADD_KERNEL(mul_mat_q4_0_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q4_1_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q2_k_f32);
+        GGML_METAL_ADD_KERNEL(mul_mat_q3_k_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q4_k_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q6_k_f32);
         GGML_METAL_ADD_KERNEL(rope);
@@ -574,6 +578,15 @@ void ggml_metal_graph_compute(
                                     nth1 = 16;
                                     [encoder setComputePipelineState:ctx->pipeline_mul_mat_q2_k_f32];
                                 } break;
+                            case GGML_TYPE_Q3_K:
+                                {
+                                    GGML_ASSERT(ne02 == 1);
+                                    GGML_ASSERT(ne12 == 1);
+
+                                    nth0 = 4;
+                                    nth1 = 16;
+                                    [encoder setComputePipelineState:ctx->pipeline_mul_mat_q3_k_f32];
+                                } break;
                             case GGML_TYPE_Q4_K:
                                 {
                                     GGML_ASSERT(ne02 == 1);
@@ -619,15 +632,12 @@ void ggml_metal_graph_compute(
                         if (src0t == GGML_TYPE_Q4_0 || src0t == GGML_TYPE_Q4_1) {
                             [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-                        } else if (src0t == GGML_TYPE_Q2_K) {
+                        } else if (src0t == GGML_TYPE_Q2_K ||
+                                   src0t == GGML_TYPE_Q3_K ||
+                                   src0t == GGML_TYPE_Q4_K ||
+                                   src0t == GGML_TYPE_Q6_K) {
                             [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, 1, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-                        } else if (src0t == GGML_TYPE_Q4_K) {
-                            [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
-                            [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-                        } else if (src0t == GGML_TYPE_Q6_K) {
-                            [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
-                            [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                         } else {
                             [encoder setThreadgroupMemoryLength:nth0*sizeof(float) atIndex:0];
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
@@ -645,6 +655,7 @@ void ggml_metal_graph_compute(
                         case GGML_TYPE_Q4_0: [encoder setComputePipelineState:ctx->pipeline_get_rows_q4_0]; break;
                         case GGML_TYPE_Q4_1: [encoder setComputePipelineState:ctx->pipeline_get_rows_q4_1]; break;
                         case GGML_TYPE_Q2_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q2_k]; break;
+                        case GGML_TYPE_Q3_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q3_k]; break;
                         case GGML_TYPE_Q4_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q4_k]; break;
                         case GGML_TYPE_Q6_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q6_k]; break;
                         default: GGML_ASSERT(false && "not implemented");

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -579,7 +579,7 @@ void ggml_metal_graph_compute(
                                     GGML_ASSERT(ne12 == 1);
 
                                     nth0 = 4;
-                                    nth1 = 16;
+                                    nth1 = 32;
                                     [encoder setComputePipelineState:ctx->pipeline_mul_mat_q2_k_f32];
                                 } break;
                             case GGML_TYPE_Q3_K:

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -54,6 +54,7 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(get_rows_q2_k);
     GGML_METAL_DECL_KERNEL(get_rows_q3_k);
     GGML_METAL_DECL_KERNEL(get_rows_q4_k);
+    GGML_METAL_DECL_KERNEL(get_rows_q5_k);
     GGML_METAL_DECL_KERNEL(get_rows_q6_k);
     GGML_METAL_DECL_KERNEL(rms_norm);
     GGML_METAL_DECL_KERNEL(mul_mat_f16_f32);
@@ -62,6 +63,7 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(mul_mat_q2_k_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q3_k_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q4_k_f32);
+    GGML_METAL_DECL_KERNEL(mul_mat_q5_k_f32);
     GGML_METAL_DECL_KERNEL(mul_mat_q6_k_f32);
     GGML_METAL_DECL_KERNEL(rope);
     GGML_METAL_DECL_KERNEL(cpy_f32_f16);
@@ -156,6 +158,7 @@ struct ggml_metal_context * ggml_metal_init(void) {
         GGML_METAL_ADD_KERNEL(get_rows_q2_k);
         GGML_METAL_ADD_KERNEL(get_rows_q3_k);
         GGML_METAL_ADD_KERNEL(get_rows_q4_k);
+        GGML_METAL_ADD_KERNEL(get_rows_q5_k);
         GGML_METAL_ADD_KERNEL(get_rows_q6_k);
         GGML_METAL_ADD_KERNEL(rms_norm);
         GGML_METAL_ADD_KERNEL(mul_mat_f16_f32);
@@ -164,6 +167,7 @@ struct ggml_metal_context * ggml_metal_init(void) {
         GGML_METAL_ADD_KERNEL(mul_mat_q2_k_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q3_k_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q4_k_f32);
+        GGML_METAL_ADD_KERNEL(mul_mat_q5_k_f32);
         GGML_METAL_ADD_KERNEL(mul_mat_q6_k_f32);
         GGML_METAL_ADD_KERNEL(rope);
         GGML_METAL_ADD_KERNEL(cpy_f32_f16);
@@ -596,6 +600,15 @@ void ggml_metal_graph_compute(
                                     nth1 = 16;
                                     [encoder setComputePipelineState:ctx->pipeline_mul_mat_q4_k_f32];
                                 } break;
+                            case GGML_TYPE_Q5_K:
+                                {
+                                    GGML_ASSERT(ne02 == 1);
+                                    GGML_ASSERT(ne12 == 1);
+
+                                    nth0 = 4;
+                                    nth1 = 16;
+                                    [encoder setComputePipelineState:ctx->pipeline_mul_mat_q5_k_f32];
+                                } break;
                             case GGML_TYPE_Q6_K:
                                 {
                                     GGML_ASSERT(ne02 == 1);
@@ -632,10 +645,12 @@ void ggml_metal_graph_compute(
                         if (src0t == GGML_TYPE_Q4_0 || src0t == GGML_TYPE_Q4_1) {
                             [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-                        } else if (src0t == GGML_TYPE_Q2_K ||
-                                   src0t == GGML_TYPE_Q3_K ||
-                                   src0t == GGML_TYPE_Q4_K ||
-                                   src0t == GGML_TYPE_Q6_K) {
+                        }
+                        else if (src0t == GGML_TYPE_Q2_K ||
+                                 src0t == GGML_TYPE_Q3_K ||
+                                 src0t == GGML_TYPE_Q4_K ||
+                                 src0t == GGML_TYPE_Q5_K ||
+                                 src0t == GGML_TYPE_Q6_K) {
                             [encoder setThreadgroupMemoryLength:nth0*nth1*sizeof(float) atIndex:0];
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, 1, 1) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                         } else {
@@ -657,6 +672,7 @@ void ggml_metal_graph_compute(
                         case GGML_TYPE_Q2_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q2_k]; break;
                         case GGML_TYPE_Q3_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q3_k]; break;
                         case GGML_TYPE_Q4_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q4_k]; break;
+                        case GGML_TYPE_Q5_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q5_k]; break;
                         case GGML_TYPE_Q6_K: [encoder setComputePipelineState:ctx->pipeline_get_rows_q6_k]; break;
                         default: GGML_ASSERT(false && "not implemented");
                     }

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -579,7 +579,7 @@ void ggml_metal_graph_compute(
                                     GGML_ASSERT(ne12 == 1);
 
                                     nth0 = 4;
-                                    nth1 = 32;
+                                    nth1 = 16;
                                     [encoder setComputePipelineState:ctx->pipeline_mul_mat_q2_k_f32];
                                 } break;
                             case GGML_TYPE_Q3_K:

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -741,12 +741,17 @@ static void dequantize_row_q3_k(device const block_q3_k * x, device float * y, i
 
         char4 scales;
 
+        int shift1 = 0;
+
         int ia = 0;
         int is = 4;
         float dl;
         for (int n = 0; n < QK_K; n += 128) {
+
             int shift = 0;
             for (int j = 0; j < 4; ++j) {
+
+                const int shift2 = 2*(j/2);
 
                 if (is == 4) {
                     scales = as_type<char4>(aux[ia++]);
@@ -767,6 +772,7 @@ static void dequantize_row_q3_k(device const block_q3_k * x, device float * y, i
                 m <<= 1;
             }
             q += 32;
+            shift1 += 4;
         }
 
     }
@@ -1062,12 +1068,14 @@ kernel void kernel_mul_mat_q3_k_f32(
         uint2 tpitg[[thread_position_in_threadgroup]],
         uint2  tptg[[threads_per_threadgroup]]) {
 
+    const uint32_t kmask1 = 0x03030303;
+    const uint32_t kmask2 = 0x0f0f0f0f;
+
+    uint32_t aux[2];
+
     const uint8_t m1 = 1;
     const uint8_t m3 = 3;
     const int8_t  m4 = 4;
-
-    const uint32_t kmask1 = 0x03030303;
-    const uint32_t kmask2 = 0x0f0f0f0f;
 
     const int nb = ne00/QK_K;
 
@@ -1080,104 +1088,63 @@ kernel void kernel_mul_mat_q3_k_f32(
     const int nth = tptg.x*tptg.y;
     const int ith = tptg.y*tpitg.x + tpitg.y;
 
-    uint32_t utmp[2];
+    const int step = QK_K / tptg.y;     // we expect this to be 16
+    const int iqs  = step * tpitg.y;    // 0...240 in steps of 16
+    const int ip   = iqs / 128;         // 0 or 1
+    const int il   = (iqs - 128*ip)/16; // 0...7
+    const int n    = 4;
+    const int l0   = n * il;
+    const int is   = l0/16;
+    const uint8_t m = m1 << (4*ip);
+    const uchar4 mask = {m, (uint8_t)(m << 1), (uint8_t)(m << 2), (uint8_t)(m << 3)};
 
-    const int iqs = 16*tpitg.y;
-    const int n = iqs/128;                // 0 or 1
-    const int r = iqs - 128*n;            // 0...120 in steps of 16
-    const int l = 4*(r/16);               // 0...28 in steps of 4
-    const int is = l/16;
-    const uint8_t m = 1 << (4*n);
-
-    const int shift1 = 4*n;
+    const int shift1 = 4*ip;
     const int shift2 = shift1 + 2;
+
+    //int8_t sc[4];
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        device const float   * y = yy + i * QK_K + 128*n + l;
-        device const uint8_t * q = x[i].qs + 32*n + l;
-        device const uint8_t * hm = x[i].hmask + l;
+        device const uint32_t * a = (device const uint32_t *)x[i].scales;
+        uint32_t tmp = a[2];
+        aux[0] = ((a[0] >> shift1) & kmask2) | (((tmp >> shift1) & kmask1) << 4);
+        aux[1] = ((a[1] >> shift1) & kmask2) | (((tmp >> shift2) & kmask1) << 4);
 
-        device const uint32_t * aux = (device const uint32_t *)x[i].scales;
-        utmp[0] = ((aux[0] >> shift1) & kmask2) | (((aux[2] >> shift1) & kmask1) << 4);
-        utmp[1] = ((aux[1] >> shift1) & kmask2) | (((aux[2] >> shift2) & kmask1) << 4);
+        device const uint8_t * q  = x[i].qs + 32*ip + l0;
+        device const uint8_t * hm = x[i].hmask + l0;
+        //device const uint8_t * scales = x[i].scales;
 
-        const char4 sc1 = as_type<char4>(utmp[0]);
-        const char4 sc2 = as_type<char4>(utmp[1]);
+        device const float * y = yy + i * QK_K + 128*ip + l0;
 
         const float dall = x[i].d;
 
-        float sum = 0;
-        for (int k = 0; k < 4; ++k) {
-            sum += y[k+ 0] * (sc1[is+0] - 32) * (((q[k] >> 0) & 3) - (hm[k] & (m << 0) ? 0 : 4))
-                 + y[k+32] * (sc1[is+2] - 32) * (((q[k] >> 2) & 3) - (hm[k] & (m << 1) ? 0 : 4))
-                 + y[k+64] * (sc2[is+0] - 32) * (((q[k] >> 4) & 3) - (hm[k] & (m << 2) ? 0 : 4))
-                 + y[k+96] * (sc2[is+2] - 32) * (((q[k] >> 6) & 3) - (hm[k] & (m << 3) ? 0 : 4));
+        const char4 sc1 = as_type<char4>(aux[0]);
+        const char4 sc2 = as_type<char4>(aux[1]);
+
+        //sc[0] = ((scales[is+0] >> shift1) & 0xF) | (((scales[is+ 8] >> shift1) & m3) << 4);
+        //sc[1] = ((scales[is+2] >> shift1) & 0xF) | (((scales[is+10] >> shift1) & m3) << 4);
+        //sc[2] = ((scales[is+4] >> shift1) & 0xF) | (((scales[is+ 8] >> shift2) & m3) << 4);
+        //sc[3] = ((scales[is+6] >> shift1) & 0xF) | (((scales[is+10] >> shift2) & m3) << 4);
+
+        float4 sums = {0.f, 0.f, 0.f, 0.f};
+        for (int l = 0; l < n; ++l) {
+            sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & m3) - ((hm[l] & mask[0]) ? 0 : m4));
+            sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & m3) - ((hm[l] & mask[1]) ? 0 : m4));
+            sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & m3) - ((hm[l] & mask[2]) ? 0 : m4));
+            sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & m3) - ((hm[l] & mask[3]) ? 0 : m4));
         }
 
-        sumf += sum * dall;
+        //sumf += dall * (sums[0] * (sc[0] - 32)
+        //              + sums[1] * (sc[1] - 32)
+        //              + sums[2] * (sc[2] - 32)
+        //              + sums[3] * (sc[3] - 32));
+        sumf += dall * (sums[0] * (sc1[is+0] - 32)
+                      + sums[1] * (sc1[is+2] - 32)
+                      + sums[2] * (sc2[is+0] - 32)
+                      + sums[3] * (sc2[is+2] - 32));
+
     }
-
-
-    //const int step = QK_K / tptg.y;     // we expect this to be 16
-    //const int iqs  = step * tpitg.y;    // 0...240 in steps of 16
-    //const int ip   = iqs / 128;         // 0 or 1
-    //const int il   = (iqs - 128*ip)/16; // 0...7
-    //const int n    = 4;
-    //const int l0   = n * il;
-    //const int is   = l0/16;
-    //const uint8_t m = m1 << (4*ip);
-    //const uchar4 mask = {m, (uint8_t)(m << 1), (uint8_t)(m << 2), (uint8_t)(m << 3)};
-
-    //const int shift1 = 4*ip;
-    //const int shift2 = shift1 + 2;
-
-    //int8_t sc[4];
-
-    //float sumf = 0;
-    //for (int i = tpitg.x; i < nb; i += tptg.x) {
-
-    //    device const uint8_t * q  = x[i].qs + 32*ip + l0;
-    //    device const uint8_t * hm = x[i].hmask + l0;
-    //    device const uint8_t * scales = x[i].scales;
-
-    //    device const float * y = yy + i * QK_K + 128*ip + l0;
-
-    //    const float dall = x[i].d;
-
-    //    sc[0] = ((scales[is+0] >> shift1) & 0xF) | (((scales[is+ 8] >> shift1) & m3) << 4);
-    //    sc[1] = ((scales[is+2] >> shift1) & 0xF) | (((scales[is+10] >> shift1) & m3) << 4);
-    //    sc[2] = ((scales[is+4] >> shift1) & 0xF) | (((scales[is+ 8] >> shift2) & m3) << 4);
-    //    sc[3] = ((scales[is+6] >> shift1) & 0xF) | (((scales[is+10] >> shift2) & m3) << 4);
-
-    //    //if (ip == 0) {
-    //    //    sc[0] = (scales[is+0] & 0xF) | (((scales[is+ 8] >> 0) & m3) << 4);
-    //    //    sc[1] = (scales[is+2] & 0xF) | (((scales[is+10] >> 0) & m3) << 4);
-    //    //    sc[2] = (scales[is+4] & 0xF) | (((scales[is+ 8] >> 2) & m3) << 4);
-    //    //    sc[3] = (scales[is+6] & 0xF) | (((scales[is+10] >> 2) & m3) << 4);
-    //    //} else {
-    //    //    sc[0] = (scales[is+0] >>  4) | (((scales[is+ 8] >> 4) & m3) << 4);
-    //    //    sc[1] = (scales[is+2] >>  4) | (((scales[is+10] >> 4) & m3) << 4);
-    //    //    sc[2] = (scales[is+4] >>  4) | (((scales[is+ 8] >> 6) & m3) << 4);
-    //    //    sc[3] = (scales[is+6] >>  4) | (((scales[is+10] >> 6) & m3) << 4);
-    //    //}
-
-
-    //    float4 sums = {0.f, 0.f, 0.f, 0.f};
-    //    for (int l = 0; l < n; ++l) {
-    //        sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & m3) - ((hm[l] & mask[0]) ? 0 : m4));
-    //        sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & m3) - ((hm[l] & mask[1]) ? 0 : m4));
-    //        sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & m3) - ((hm[l] & mask[2]) ? 0 : m4));
-    //        sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & m3) - ((hm[l] & mask[3]) ? 0 : m4));
-    //    }
-
-    //    sumf += dall * (sums[0] * (sc[0] - 32)
-    //                  + sums[1] * (sc[1] - 32)
-    //                  + sums[2] * (sc[2] - 32)
-    //                  + sums[3] * (sc[3] - 32));
-
-    //}
 
     sum[ith] = sumf;
 

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -650,6 +650,14 @@ typedef struct {
 } block_q4_k;
 
 typedef struct {
+    half d;                      // super-block scale for quantized scales
+    half dmin;                   // super-block scale for quantized mins
+    uint8_t scales[3*QK_K/64];   // scales and mins, quantized with 6 bits
+    uint8_t qh[QK_K/8];          // quants, high bit
+    uint8_t qs[QK_K/2];          // quants, low 4 bits
+} block_q5_k;
+
+typedef struct {
     uint8_t ql[QK_K/2];      // quants, lower 4 bits
     uint8_t qh[QK_K/4];      // quants, upper 2 bits
     int8_t  scales[QK_K/16]; // scales, quantized with 8 bits
@@ -767,6 +775,7 @@ static void dequantize_row_q4_k(device const block_q4_k * x, device float * y, i
     assert(k % QK_K == 0);
     const int nb = k / QK_K;
 
+
     for (int i = 0; i < nb; i++) {
 
         const float d = x[i].d;
@@ -786,6 +795,33 @@ static void dequantize_row_q4_k(device const block_q4_k * x, device float * y, i
         }
 
     }
+}
+
+static void dequantize_row_q5_k(device const block_q5_k * x, device float * y, int k) {
+    assert(k % QK_K == 0);
+    const int nb = k / QK_K;
+
+   for (int i = 0; i < nb; i++) {
+
+        const float d = (float)(x[i].d);
+        const float min = (float)(x[i].dmin);
+
+        device const uint8_t * ql = x[i].qs;
+        device const uint8_t * qh = x[i].qh;
+
+        int is = 0;
+        uint8_t u1 = 1, u2 = 2;
+        for (int j = 0; j < QK_K; j += 64) {
+            const uchar4 sc = get_scale_min_k4(is, x[i].scales);
+            const float d1 = d * sc[0]; const float m1 = min * sc[1];
+            const float d2 = d * sc[2]; const float m2 = min * sc[3];
+            for (int l = 0; l < 32; ++l) *y++ = d1 * ((ql[l] & 0xF) + (qh[l] & u1 ? 16 : 0)) - m1;
+            for (int l = 0; l < 32; ++l) *y++ = d2 * ((ql[l]  >> 4) + (qh[l] & u2 ? 16 : 0)) - m2;
+            ql += 32; is += 2;
+            u1 <<= 2; u2 <<= 2;
+        }
+    }
+
 }
 
 static void dequantize_row_q6_k(device const block_q6_k * x, device float * y, int k) {
@@ -865,6 +901,22 @@ kernel void kernel_get_rows_q4_k(
 
     dequantize_row_q4_k(
             (device const block_q4_k *) ((device char *) src0 + r*nb01),
+                       (device float *) ((device char *)  dst + i*nb1), ne00);
+}
+
+kernel void kernel_get_rows_q5_k(
+        device const  void * src0,
+        device const   int * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant  uint64_t & nb01,
+        constant  uint64_t & nb1,
+        uint tpig[[thread_position_in_grid]]) {
+    const int i = tpig;
+    const int r = ((device int32_t *) src1)[i];
+
+    dequantize_row_q5_k(
+            (device const block_q5_k *) ((device char *) src0 + r*nb01),
                        (device float *) ((device char *)  dst + i*nb1), ne00);
 }
 
@@ -1008,6 +1060,13 @@ kernel void kernel_mul_mat_q3_k_f32(
         uint2 tpitg[[thread_position_in_threadgroup]],
         uint2  tptg[[threads_per_threadgroup]]) {
 
+    const uint8_t m1 = 1;
+    const uint8_t m3 = 3;
+    const int8_t  m4 = 4;
+
+    //const uint32_t kmask1 = 0x03030303;
+    //const uint32_t kmask2 = 0x0f0f0f0f;
+
     const int nb = ne00/QK_K;
 
     const int64_t r0 = tgpig.x;
@@ -1026,59 +1085,64 @@ kernel void kernel_mul_mat_q3_k_f32(
     const int n    = 4;
     const int l0   = n * il;
     const int is   = l0/16;
-    const uint8_t m = 1 << (4*ip);
-    //const int shift1 = 4*ip;
-    //const int shift2 = 4*ip + 2;
+    const uint8_t m = m1 << (4*ip);
 
     int8_t sc[4];
+    //uin32_t utmp[2];
+    //char4 sc1, sc2;
+    //uint32_t aux[3];
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
         device const uint8_t * q  = x[i].qs + 32*ip + l0;
         device const uint8_t * hm = x[i].hmask + l0;
-        device const uint8_t * scales = x[i].scales + is;
+        device const uint8_t * scales = x[i].scales;
 
         device const float * y = yy + i * QK_K + 128*ip + l0;
 
         const float dall = x[i].d;
 
-        //sc[0] = ((scales[ 8] >> shift1) & 3) << 4;
-        //sc[1] = ((scales[10] >> shift1) & 3) << 4;
-        //sc[2] = ((scales[ 8] >> shift2) & 3) << 4;
-        //sc[3] = ((scales[10] >> shift2) & 3) << 4;
+        //aux[0] = (a[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+        //aux[1] = (a[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+        ////memcpy(aux, x[i].scales, 12);
+        //device const uint32_t * aux = (device const uint32_t *)x[i].scales;
         //if (ip == 0) {
-        //    sc[0] |= (scales[0] & 0xF);
-        //    sc[1] |= (scales[2] & 0xF);
-        //    sc[2] |= (scales[4] & 0xF);
-        //    sc[3] |= (scales[6] & 0xF);
+        //    sc1 = as_type<char4>((aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4));
+        //    sc2 = as_type<char4>((aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4));
+        //    //utmp[0] = (aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4);
+        //    //utmp[1] = (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4);
         //} else {
-        //    sc[0] |= (scales[0] >>  4);
-        //    sc[1] |= (scales[2] >>  4);
-        //    sc[2] |= (scales[4] >>  4);
-        //    sc[3] |= (scales[6] >>  4);
+        //    sc1 = as_type<char4>(((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4));
+        //    sc2 = as_type<char4>(((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4));
+        //    //utmp[0] = ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4);
+        //    //utmp[1] = ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4);
         //}
+
         if (ip == 0) {
-            sc[0] = (scales[0] & 0xF) | (((scales[ 8] >> 0) & 3) << 4);
-            sc[1] = (scales[2] & 0xF) | (((scales[10] >> 0) & 3) << 4);
-            sc[2] = (scales[4] & 0xF) | (((scales[ 8] >> 2) & 3) << 4);
-            sc[3] = (scales[6] & 0xF) | (((scales[10] >> 2) & 3) << 4);
+            sc[0] = (scales[is+0] & 0xF) | (((scales[is+ 8] >> 0) & m3) << 4);
+            sc[1] = (scales[is+2] & 0xF) | (((scales[is+10] >> 0) & m3) << 4);
+            sc[2] = (scales[is+4] & 0xF) | (((scales[is+ 8] >> 2) & m3) << 4);
+            sc[3] = (scales[is+6] & 0xF) | (((scales[is+10] >> 2) & m3) << 4);
         } else {
-            sc[0] = (scales[0] >>  4) | (((scales[ 8] >> 4) & 3) << 4);
-            sc[1] = (scales[2] >>  4) | (((scales[10] >> 4) & 3) << 4);
-            sc[2] = (scales[4] >>  4) | (((scales[ 8] >> 6) & 3) << 4);
-            sc[3] = (scales[6] >>  4) | (((scales[10] >> 6) & 3) << 4);
+            sc[0] = (scales[is+0] >>  4) | (((scales[is+ 8] >> 4) & m3) << 4);
+            sc[1] = (scales[is+2] >>  4) | (((scales[is+10] >> 4) & m3) << 4);
+            sc[2] = (scales[is+4] >>  4) | (((scales[is+ 8] >> 6) & m3) << 4);
+            sc[3] = (scales[is+6] >>  4) | (((scales[is+10] >> 6) & m3) << 4);
         }
+
+        uchar4 mask = {m, (uint8_t)(m << 1), (uint8_t)(m << 2), (uint8_t)(m << 3)};
 
         float4 sums = {0.f, 0.f, 0.f, 0.f};
         for (int l = 0; l < n; ++l) {
-            sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & 3) - (hm[l] & (m << 0) ? 0 : 4));
-            sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & 3) - (hm[l] & (m << 1) ? 0 : 4));
-            sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & 3) - (hm[l] & (m << 2) ? 0 : 4));
-            sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & 3) - (hm[l] & (m << 3) ? 0 : 4));
+            sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & m3) - ((hm[l] & mask[0]) ? 0 : m4));
+            sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & m3) - ((hm[l] & mask[1]) ? 0 : m4));
+            sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & m3) - ((hm[l] & mask[2]) ? 0 : m4));
+            sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & m3) - ((hm[l] & mask[3]) ? 0 : m4));
         }
 
         sumf += dall * (sums[0] * (sc[0] - 32) + sums[1] * (sc[1] - 32) + sums[2] * (sc[2] - 32) + sums[3] * (sc[3] - 32));
+        //sumf += dall * (sums[0] * (sc1[is] - 32) + sums[1] * (sc1[is+2] - 32) + sums[2] * (sc2[is] - 32) + sums[3] * (sc2[is+2] - 32));
 
     }
 
@@ -1176,6 +1240,104 @@ kernel void kernel_mul_mat_q4_k_f32(
 
     }
 
+    sum[ith] = sumf;
+
+    //
+    // Accumulate the sum from all threads in the threadgroup
+    // This version is slightly faster than the commented out one below,
+    // which I copy-pasted from ggerganov's q4_0 dot product for metal.
+    //
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith%4 == 0) {
+        for (int i = 1; i < 4; ++i) sum[ith] += sum[ith + i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith%16 == 0) {
+        for (int i = 4; i < 16; i += 4) sum[ith] += sum[ith + i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith == 0) {
+        for (int i = 16; i < nth; i += 16) sum[0] += sum[i];
+        dst[r1*ne0 + r0] = sum[0];
+    }
+
+    //// accumulate the sum from all threads in the threadgroup
+    //threadgroup_barrier(mem_flags::mem_threadgroup);
+    //for (uint i = nth/2; i > 0; i /= 2) {
+    //    if (ith < i) {
+    //        sum[ith] += sum[ith + i];
+    //    }
+    //    threadgroup_barrier(mem_flags::mem_threadgroup);
+    //}
+
+    //if (ith == 0) {
+    //    dst[r1*ne0 + r0] = sum[0];
+    //}
+}
+
+kernel void kernel_mul_mat_q5_k_f32(
+        device const  void * src0,
+        device const float * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant   int64_t & ne01,
+        constant  uint64_t & nb00,
+        constant  uint64_t & nb01,
+        constant  uint64_t & nb02,
+        constant   int64_t & ne10,
+        constant   int64_t & ne11,
+        constant  uint64_t & nb10,
+        constant  uint64_t & nb11,
+        constant  uint64_t & nb12,
+        constant   int64_t & ne0,
+        constant   int64_t & ne1,
+        threadgroup float  * sum [[threadgroup(0)]],
+        uint2 tgpig[[threadgroup_position_in_grid]],
+        uint2  tpig[[thread_position_in_grid]],               // we don't use this for now
+        uint2 tpitg[[thread_position_in_threadgroup]],
+        uint2  tptg[[threads_per_threadgroup]]) {
+
+    const int nb = ne00/QK_K;
+
+    const int64_t r0 = tgpig.x;
+    const int64_t r1 = tgpig.y;
+
+    device const block_q5_k * x = (device const block_q5_k *) src0 + r0*nb;
+    device const float     * yy = (device const float      *) src1 + r1*ne10;
+
+    const int nth = tptg.x*tptg.y;
+    const int ith = tptg.y*tpitg.x + tpitg.y;
+
+    const int tid = tpitg.y;   // 0...16
+    const int il  = tid/4;     // 0...3
+    const int ir  = tid%4;     // 0...3
+    const int n   = 8;
+    const int is  = 2*il;
+
+    const uint8_t hm1 = 1u << is;
+    const uint8_t hm2 = hm1 << 1;
+
+    float sumf = 0;
+    for (int i = tpitg.x; i < nb; i += tptg.x) {
+
+        device const uint8_t * ql = (x + i)->qs + 32*il + n*ir;
+        device const uint8_t * qh = (x + i)->qh + n*ir;
+        device const float   * y  = yy + i*QK_K + 64*il + n*ir;
+        device const uint8_t * scales = (x + i)->scales;
+
+        const float dall = (float)((x + i)->d);
+        const float dmin = (float)((x + i)->dmin);
+
+        const uchar4 sc = get_scale_min_k4(is, scales);
+
+        float4 s = {0.f, 0.f, 0.f, 0.f};
+        for (int l = 0; l < n; ++l) {
+            s[0] += y[l+ 0] * ((ql[l] & 0xF) + (qh[l] & hm1 ? 16 : 0)); s[1] += y[l+ 0];
+            s[2] += y[l+32] * ((ql[l] >>  4) + (qh[l] & hm2 ? 16 : 0)); s[3] += y[l+32];
+        }
+        sumf += dall * (s[0] * sc[0] + s[2] * sc[2]) - dmin * (s[1] * sc[1] + s[3] * sc[3]);
+
+    }
     sum[ith] = sumf;
 
     //

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -727,39 +727,48 @@ static void dequantize_row_q3_k(device const block_q3_k * x, device float * y, i
     const uint32_t kmask1 = 0x03030303;
     const uint32_t kmask2 = 0x0f0f0f0f;
 
-    uint32_t aux[4];
-    thread const int8_t * scales = (thread const int8_t *)aux;
+    //uint32_t aux[4];
+    uint16_t aux[8];
+    thread const int8_t * scales = (thread const int8_t*)aux;
 
     for (int i = 0; i < nb; i++) {
 
-        const float d_all = (float)x[i].d;
+        const float d_all = (float)(x[i].d);
 
         device const uint8_t * q = x[i].qs;
-        device const uint8_t * hm = x[i].hmask;
+        device const uint8_t * h = x[i].hmask;
         uint8_t m = 1;
 
-        device const uint32_t * a = (device const uint32_t *)x[i].scales;
-        uint32_t tmp = a[2];
-        aux[2] = ((a[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
-        aux[3] = ((a[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
-        aux[0] = (a[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
-        aux[1] = (a[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+        //device const uint32_t * a = (device const uint32_t *)x[i].scales;
+        //aux[0] = (a[0] & kmask2) | (((a[2] >> 0) & kmask1) << 4);
+        //aux[1] = (a[1] & kmask2) | (((a[2] >> 2) & kmask1) << 4);
+        //aux[2] = ((a[0] >> 4) & kmask2) | (((a[2] >> 4) & kmask1) << 4);
+        //aux[3] = ((a[1] >> 4) & kmask2) | (((a[2] >> 6) & kmask1) << 4);
+
+        device const uint16_t * a = (device const uint16_t *)x[i].scales;
+        aux[0] = (a[0] & kmask2) | (((a[4] >> 0) & kmask1) << 4);
+        aux[1] = (a[1] & kmask2) | (((a[5] >> 0) & kmask1) << 4);
+        aux[2] = (a[2] & kmask2) | (((a[4] >> 2) & kmask1) << 4);
+        aux[3] = (a[3] & kmask2) | (((a[5] >> 2) & kmask1) << 4);
+        aux[4] = ((a[0] >> 4) & kmask2) | (((a[4] >> 4) & kmask1) << 4);
+        aux[5] = ((a[1] >> 4) & kmask2) | (((a[5] >> 4) & kmask1) << 4);
+        aux[6] = ((a[2] >> 4) & kmask2) | (((a[4] >> 6) & kmask1) << 4);
+        aux[7] = ((a[3] >> 4) & kmask2) | (((a[5] >> 6) & kmask1) << 4);
 
         int is = 0;
         float dl;
         for (int n = 0; n < QK_K; n += 128) {
-
             int shift = 0;
             for (int j = 0; j < 4; ++j) {
 
                 dl = d_all * (scales[is++] - 32);
                 for (int l = 0; l < 16; ++l) {
-                    *y++ = dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((hm[l+ 0] & m) ? 0 : 4));
+                    *y++ = dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
                 }
 
                 dl = d_all * (scales[is++] - 32);
                 for (int l = 0; l < 16; ++l) {
-                    *y++ = dl * ((int8_t)((q[l+16] >> shift) & 3) - ((hm[l+16] & m) ? 0 : 4));
+                    *y++ = dl * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
                 }
 
                 shift += 2;
@@ -1052,8 +1061,10 @@ kernel void kernel_mul_mat_q3_k_f32(
         uint2 tpitg[[thread_position_in_threadgroup]],
         uint2  tptg[[threads_per_threadgroup]]) {
 
-    const uint32_t kmask1 = 0x03030303;
-    const uint32_t kmask2 = 0x0f0f0f0f;
+    //const uint32_t kmask1 = 0x03030303;
+    //const uint32_t kmask2 = 0x0f0f0f0f;
+    const uint16_t kmask1 = 0x0303;
+    const uint16_t kmask2 = 0x0f0f;
 
     const uint8_t m3 = 3;
     const int8_t  m4 = 4;
@@ -1069,79 +1080,73 @@ kernel void kernel_mul_mat_q3_k_f32(
     const int nth = tptg.x*tptg.y;
     const int ith = tptg.y*tpitg.x + tpitg.y;
 
-    const int tid  = tpitg.y;
-    const int il   = tid/4;             // 0...3   0 -> 0...63, 1 -> 64...127, 2 -> 128...191, 3 -> 192...255
-    const int ip   = il / 2;            // 0 or 1  0 -> use 1st 32 q's (0...127), 1 -> 2nd 32 (128...255)
-    const int is   = il % 2;            // 0 or 1  0 -> 0...63, 128...191, 1 -> 64...127, 192...255
-    const int ir   = tid - 4*il;        // 0...3
-    const int n    = 4;
-    const int l0   = n * ir;            // first index for this thread within a group of 32 (0, 4, 8, 12)
-    // 0...31 use 1<<0, 32...63 use 1<<1, 64...95 use 1<<2, 96...128 use 1<<3, etc.
-    // we process 64*il...64*il+63 -> 1st mask is 1<<(2*il), second is 1<<(2*il+1)
-    // masks for high bit
-    const uint8_t m = 1 << (2*il);
-    const uchar2 mask = {m, (uint8_t)(m << 1)};
+    const int tid = tpitg.y;        // expecting 16
+    const int ip  = tid/8;          // 0 or 1
+    const int il  = tid/2 - 4*ip;   // 0...3
+    const int ir  = tid%2;
+    const int n   = 8;
+    const int l0  = n*ir;
 
-    const int shift1 = 4*ip;   // 1st shift for scale. must be 0 (0...127) or 4 (128...255)
-    const int shift2 = 2*il;   // 2nd shift for scale. 0, 2, 4, or 6
-    // 1st shift for quants must be 0 in 0...31, 2 in 32...64, 4 in 64...96, 6 in 96...128, then agsin 0, 2, etc.
-    const int shift3 = 4*is;
-    const int shift4 = shift3 + 2;
-
-    const int q_offset = 32*ip + l0;
-    const int y_offset = 64*il + l0;
+    uint16_t aux[8];
+    thread const int8_t * scales = (thread const int8_t*)aux;
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        // Copied from the C de-quantization code
-        //aux[0] = ((a[0] >> 0) & kmask2) | (((a[2] >> 0) & kmask1) << 4);
-        //aux[1] = ((a[1] >> 0) & kmask2) | (((a[2] >> 2) & kmask1) << 4);
+        const float d_all = (float)(x[i].d);
+
+        device const uint8_t * q = x[i].qs + 32*ip + l0;
+        device const uint8_t * h = x[i].hmask + l0;
+        device const float   * y = yy + i * QK_K + 128*ip + 32*il + l0;
+
+        //device const uint32_t * a = (device const uint32_t *)x[i].scales;
+        //aux[0] = (a[0] & kmask2) | (((a[2] >> 0) & kmask1) << 4);
+        //aux[1] = (a[1] & kmask2) | (((a[2] >> 2) & kmask1) << 4);
         //aux[2] = ((a[0] >> 4) & kmask2) | (((a[2] >> 4) & kmask1) << 4);
         //aux[3] = ((a[1] >> 4) & kmask2) | (((a[2] >> 6) & kmask1) << 4);
 
-        ////  0....63 we need a[0] with shift=0, a[2] with shift 0
-        //// 64...127 we need a[1] with shift=0, a[2] with shift 2
-        ////128...191 we need a[0] with shift=4, a[2] with shift 4
-        ////192...255 we need a[1] with shift=4, a[2] with shift 6
-        //// a[is] >> (4*ip) & 0xF | a[2] >> (2*il) & 3
-        device const uint32_t * a = (device const uint32_t *)x[i].scales;
-        const char4 sc = as_type<char4>(((a[is] >> shift1) & kmask2) | (((a[2] >> shift2) & kmask1) << 4));
+        device const uint16_t * a = (device const uint16_t *)x[i].scales;
+        aux[0] = (a[0] & kmask2) | (((a[4] >> 0) & kmask1) << 4);
+        aux[1] = (a[1] & kmask2) | (((a[5] >> 0) & kmask1) << 4);
+        aux[2] = (a[2] & kmask2) | (((a[4] >> 2) & kmask1) << 4);
+        aux[3] = (a[3] & kmask2) | (((a[5] >> 2) & kmask1) << 4);
+        aux[4] = ((a[0] >> 4) & kmask2) | (((a[4] >> 4) & kmask1) << 4);
+        aux[5] = ((a[1] >> 4) & kmask2) | (((a[5] >> 4) & kmask1) << 4);
+        aux[6] = ((a[2] >> 4) & kmask2) | (((a[4] >> 6) & kmask1) << 4);
+        aux[7] = ((a[3] >> 4) & kmask2) | (((a[5] >> 6) & kmask1) << 4);
 
-        // Here I was thinking "what if the above is not processed correctly because x[i].scales is not 4-byte
-        // aligned?". If that was the issue, using a uint16_t pointer should solve it as x[i].scales is 2-byte aligned.
-        // It does not solve the problem, it just makes it run slower.
-        //device const uint16_t * a = (device const uint16_t *)x[i].scales;
-        //const char2 sc1 = as_type<char2>((uint16_t)(((a[2*is+0] >> shift1) & kmask2) | (((a[4] >> shift2) & kmask1) << 4)));
-        //const char2 sc2 = as_type<char2>((uint16_t)(((a[2*is+1] >> shift1) & kmask2) | (((a[5] >> shift2) & kmask1) << 4)));
+        uint8_t m = 1 << (4*ip + il);
+        int is = 8*ip + 2*il;
+        float dl;
+        //for (int n = 0; n < QK_K; n += 128) {
+            int shift = 2*il;
+            //for (int j = 0; j < 4; ++j) {
 
-        device const uint8_t * q  = x[i].qs + q_offset;
-        device const uint8_t * h = x[i].hmask + l0;
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < n; ++l) {
+                    sumf += y[l+ 0] * dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
+                }
 
-        device const float * y = yy + i * QK_K + y_offset;
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < n; ++l) {
+                    sumf += y[l+16] * dl * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
+                }
 
-        const float dall = (float)x[i].d;
-
-        float4 sums = {0.f, 0.f, 0.f, 0.f};
-        for (int l = 0; l < n; ++l) {
-            sums[0] += y[l+ 0] * ((int8_t)((q[l+ 0] >> shift3) & m3) - ((h[l+ 0] & mask[0]) ? 0 : m4));
-            sums[1] += y[l+16] * ((int8_t)((q[l+16] >> shift3) & m3) - ((h[l+16] & mask[0]) ? 0 : m4));
-            sums[2] += y[l+32] * ((int8_t)((q[l+ 0] >> shift4) & m3) - ((h[l+ 0] & mask[1]) ? 0 : m4));
-            sums[3] += y[l+48] * ((int8_t)((q[l+16] >> shift4) & m3) - ((h[l+16] & mask[1]) ? 0 : m4));
-        }
-
-        sumf += dall * (sums[0] * (sc[0] - 32)
-                      + sums[1] * (sc[1] - 32)
-                      + sums[2] * (sc[2] - 32)
-                      + sums[3] * (sc[3] - 32));
-        //sumf += dall * (sums[0] * (sc1[0] - 32)
-        //              + sums[1] * (sc1[1] - 32)
-        //              + sums[2] * (sc2[0] - 32)
-        //              + sums[3] * (sc2[1] - 32));
-
+                y += 32;
+                shift += 2;
+                m <<= 1;
+            //}
+            //q += 32;
+        //}
     }
 
     sum[ith] = sumf;
+
+    //threadgroup_barrier(mem_flags::mem_threadgroup);
+    //if (ith == 0) {
+    //    for (int i = 1; i < nth; ++i) sum[0] += sum[i];
+    //    dst[r1*ne0 + r0] = sum[0];
+    //}
 
     //
     // Accumulate the sum from all threads in the threadgroup

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -1092,7 +1092,18 @@ kernel void kernel_mul_mat_q3_k_f32(
     const int shift = 2*il;
     const int is = 8*ip + 2*il;
 
-    //const int shift2 = 4*ip;
+        // is = 0 -> shift1 = 0, shift2 = 0, accessing aux[0] -> (a[0] & kmask2) | (((a[4] >> 0) & kmask1) << 4);          ip = 0, il = 0
+        // is = 2 -> shift1 = 0, shift2 = 0, accessing aux[1] -> (a[1] & kmask2) | (((a[5] >> 0) & kmask1) << 4);          ip = 0, il = 1
+        // is = 4 -> shift1 = 0, shift2 = 2, accessing aux[2] -> (a[2] & kmask2) | (((a[4] >> 2) & kmask1) << 4);          ip = 0, il = 2
+        // is = 6 -> shift1 = 0, shift2 = 2, accessing aux[3] -> (a[3] & kmask2) | (((a[5] >> 2) & kmask1) << 4);          ip = 0, il = 3
+        // is = 8 -> shift1 = 4, shift2 = 4, accessing aux[4] -> ((a[0] >> 4) & kmask2) | (((a[4] >> 4) & kmask1) << 4);   ip = 1, il = 0
+        // is =10 -> shift1 = 4, shift2 = 4, accessing aux[5] -> ((a[1] >> 4) & kmask2) | (((a[5] >> 4) & kmask1) << 4);   ip = 1, il = 1
+        // is =12 -> shift1 = 4, shift2 = 6, accessing aux[6] -> ((a[2] >> 4) & kmask2) | (((a[4] >> 6) & kmask1) << 4);   ip = 1, il = 2
+        // is =14 -> shift1 = 4, shift2 = 6, accessing aux[7] -> ((a[3] >> 4) & kmask2) | (((a[5] >> 6) & kmask1) << 4);   ip = 1, il = 3
+
+    const int s_shift1 = 4*ip;
+    const int s_shift2 = s_shift1 + 2*(il/2);
+    const int ik = 4 + (il%2);
 
     uint16_t aux[8];
     thread const int8_t * scales = (thread const int8_t*)aux;
@@ -1110,48 +1121,40 @@ kernel void kernel_mul_mat_q3_k_f32(
         device const float   * y = yy + i * QK_K + y_offset;
 
         device const uint16_t * a = (device const uint16_t *)x[i].scales;
-        aux[0] = (a[0] & kmask2) | (((a[4] >> 0) & kmask1) << 4);
-        aux[1] = (a[1] & kmask2) | (((a[5] >> 0) & kmask1) << 4);
-        aux[2] = (a[2] & kmask2) | (((a[4] >> 2) & kmask1) << 4);
-        aux[3] = (a[3] & kmask2) | (((a[5] >> 2) & kmask1) << 4);
-        aux[4] = ((a[0] >> 4) & kmask2) | (((a[4] >> 4) & kmask1) << 4);
-        aux[5] = ((a[1] >> 4) & kmask2) | (((a[5] >> 4) & kmask1) << 4);
-        aux[6] = ((a[2] >> 4) & kmask2) | (((a[4] >> 6) & kmask1) << 4);
-        aux[7] = ((a[3] >> 4) & kmask2) | (((a[5] >> 6) & kmask1) << 4);
-
-        float dl;
-
-        //dl = d_all * (scales[is+0] - 32);
-        //for (int l = 0; l < n; ++l) {
-        //    sumf += y[l+ 0] * dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
-        //}
-
-        //dl = d_all * (scales[is+1] - 32);
-        //for (int l = 0; l < n; ++l) {
-        //    sumf += y[l+16] * dl * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
-        //}
+        const char2 scales = as_type<char2>((uint16_t)(((a[il] >> s_shift1) & kmask2) | (((a[ik] >> s_shift2) & kmask1) << 4)));
 
         float s = 0;
         for (int l = 0; l < n; ++l) {
             s += y[l+ 0] * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
         }
-        sumf += s * d_all * (scales[is+0] - 32);
+        sumf += s * d_all * (scales[0] - 32);
 
         s = 0;
         for (int l = 0; l < n; ++l) {
             s += y[l+16] * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
         }
-        sumf += s * d_all * (scales[is+1] - 32);
+        sumf += s * d_all * (scales[1] - 32);
+
+        //const float d1 = d_all * (scales[0] - 32);
+        //for (int l = 0; l < n; ++l) {
+        //    sumf += y[l+ 0] * d1 * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
+        //}
+
+        //const float d2 = d_all * (scales[1] - 32);
+        //for (int l = 0; l < n; ++l) {
+        //    sumf += y[l+16] * d2 * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
+        //}
+
+        //float2 s = {0.f, 0.f};
+        //for (int l = 0; l < n; ++l) {
+        //    s[0] += y[l+ 0] * ((int8_t)((q[l+ 0] >> shift) & 3) - ((h[l+ 0] & m) ? 0 : 4));
+        //    s[1] += y[l+16] * ((int8_t)((q[l+16] >> shift) & 3) - ((h[l+16] & m) ? 0 : 4));
+        //}
+        //sumf += d_all * (s[0] * (scales[0] - 32) + s[1] * (scales[1] - 32));
 
     }
 
     sum[ith] = sumf;
-
-    //threadgroup_barrier(mem_flags::mem_threadgroup);
-    //if (ith == 0) {
-    //    for (int i = 1; i < nth; ++i) sum[0] += sum[i];
-    //    dst[r1*ne0 + r0] = sum[0];
-    //}
 
     //
     // Accumulate the sum from all threads in the threadgroup

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -318,8 +318,8 @@ kernel void kernel_mul_mat_q4_0_f32(
     device const block_q4_0 * x = (device const block_q4_0 *) src0 + r0*nb;
     device const float      * y = (device const float      *) src1 + r1*ne10;
 
-    const uint nth = tptg.x*tptg.y;
-    const uint ith = tptg.y*tpitg.x + tpitg.y;
+    const int nth = tptg.x*tptg.y;
+    const int ith = tptg.y*tpitg.x + tpitg.y;
 
     const int ix = tpitg.y/4;           // 0 or 1
     const int iy = tpitg.y - 4*ix;      // 0...3
@@ -636,6 +636,13 @@ typedef struct {
 } block_q2_k;
 
 typedef struct {
+    uint8_t hmask[QK_K/8];     // quants - high bit
+    uint8_t qs[QK_K/4];        // quants - low 2 bits
+    uint8_t scales[3*QK_K/64]; // scales, quantized with 6 bits
+    half d;                    // super-block scale
+} block_q3_k;
+
+typedef struct {
     half d;             // super-block scale for quantized scales
     half dmin;          // super-block scale for quantized mins
     uint8_t scales[3*QK_K/64]; // scales and mins, quantized with 6 bits
@@ -696,6 +703,64 @@ static void dequantize_row_q2_k(device const block_q2_k * x, device float * y, i
         }
 
     }
+}
+
+static void dequantize_row_q3_k(device const block_q3_k * x, device float * y, int k) {
+    assert(k % QK_K == 0);
+    const int nb = k / QK_K;
+
+    const uint32_t kmask1 = 0x03030303;
+    const uint32_t kmask2 = 0x0f0f0f0f;
+
+    uint32_t aux[4];
+
+    for (int i = 0; i < nb; i++) {
+
+        const float d_all = (float)x[i].d;
+
+        device const uint8_t * q = x[i].qs;
+        device const uint8_t * hm = x[i].hmask;
+        uint8_t m = 1;
+
+        device const uint32_t * a = (device const uint32_t *)x[i].scales;
+        uint32_t tmp = a[2];
+        aux[2] = ((a[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+        aux[3] = ((a[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+        aux[0] = (a[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+        aux[1] = (a[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+
+        char4 scales;
+
+        int ia = 0;
+        int is = 4;
+        float dl;
+        for (int n = 0; n < QK_K; n += 128) {
+            int shift = 0;
+            for (int j = 0; j < 4; ++j) {
+
+                if (is == 4) {
+                    scales = as_type<char4>(aux[ia++]);
+                    is = 0;
+                }
+
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < 16; ++l) {
+                    *y++ = dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((hm[l+ 0] & m) ? 0 : 4));
+                }
+
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < 16; ++l) {
+                    *y++ = dl * ((int8_t)((q[l+16] >> shift) & 3) - ((hm[l+16] & m) ? 0 : 4));
+                }
+
+                shift += 2;
+                m <<= 1;
+            }
+            q += 32;
+        }
+
+    }
+
 }
 
 static void dequantize_row_q4_k(device const block_q4_k * x, device float * y, int k) {
@@ -768,6 +833,22 @@ kernel void kernel_get_rows_q2_k(
 
     dequantize_row_q2_k(
             (device const block_q2_k *) ((device char *) src0 + r*nb01),
+                       (device float *) ((device char *)  dst + i*nb1), ne00);
+}
+
+kernel void kernel_get_rows_q3_k(
+        device const  void * src0,
+        device const   int * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant  uint64_t & nb01,
+        constant  uint64_t & nb1,
+        uint tpig[[thread_position_in_grid]]) {
+    const int i = tpig;
+    const int r = ((device int32_t *) src1)[i];
+
+    dequantize_row_q3_k(
+            (device const block_q3_k *) ((device char *) src0 + r*nb01),
                        (device float *) ((device char *)  dst + i*nb1), ne00);
 }
 
@@ -903,19 +984,123 @@ kernel void kernel_mul_mat_q2_k_f32(
         for (int i = 16; i < nth; i += 16) sum[0] += sum[i];
         dst[r1*ne0 + r0] = sum[0];
     }
+}
 
-    //// accumulate the sum from all threads in the threadgroup
-    //threadgroup_barrier(mem_flags::mem_threadgroup);
-    //for (uint i = nth/2; i > 0; i /= 2) {
-    //    if (ith < i) {
-    //        sum[ith] += sum[ith + i];
-    //    }
-    //    threadgroup_barrier(mem_flags::mem_threadgroup);
-    //}
+kernel void kernel_mul_mat_q3_k_f32(
+        device const  void * src0,
+        device const float * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant   int64_t & ne01,
+        constant  uint64_t & nb00,
+        constant  uint64_t & nb01,
+        constant  uint64_t & nb02,
+        constant   int64_t & ne10,
+        constant   int64_t & ne11,
+        constant  uint64_t & nb10,
+        constant  uint64_t & nb11,
+        constant  uint64_t & nb12,
+        constant   int64_t & ne0,
+        constant   int64_t & ne1,
+        threadgroup float  * sum [[threadgroup(0)]],
+        uint2 tgpig[[threadgroup_position_in_grid]],
+        uint2  tpig[[thread_position_in_grid]],               // we don't use this for now
+        uint2 tpitg[[thread_position_in_threadgroup]],
+        uint2  tptg[[threads_per_threadgroup]]) {
 
-    //if (ith == 0) {
-    //    dst[r1*ne0 + r0] = sum[0];
-    //}
+    const int nb = ne00/QK_K;
+
+    const int64_t r0 = tgpig.x;
+    const int64_t r1 = tgpig.y;
+
+    device const block_q3_k * x = (device const block_q3_k *) src0 + r0*nb;
+    device const float     * yy = (device const float      *) src1 + r1*ne10;
+
+    const int nth = tptg.x*tptg.y;
+    const int ith = tptg.y*tpitg.x + tpitg.y;
+
+    const int step = QK_K / tptg.y;     // we expect this to be 16
+    const int iqs  = step * tpitg.y;    // 0...240 in steps of 16
+    const int ip   = iqs / 128;         // 0 or 1
+    const int il   = (iqs - 128*ip)/16; // 0...7
+    const int n    = 4;
+    const int l0   = n * il;
+    const int is   = l0/16;
+    const uint8_t m = 1 << (4*ip);
+    //const int shift1 = 4*ip;
+    //const int shift2 = 4*ip + 2;
+
+    int8_t sc[4];
+
+    float sumf = 0;
+    for (int i = tpitg.x; i < nb; i += tptg.x) {
+
+        device const uint8_t * q  = x[i].qs + 32*ip + l0;
+        device const uint8_t * hm = x[i].hmask + l0;
+        device const uint8_t * scales = x[i].scales + is;
+
+        device const float * y = yy + i * QK_K + 128*ip + l0;
+
+        const float dall = x[i].d;
+
+        //sc[0] = ((scales[ 8] >> shift1) & 3) << 4;
+        //sc[1] = ((scales[10] >> shift1) & 3) << 4;
+        //sc[2] = ((scales[ 8] >> shift2) & 3) << 4;
+        //sc[3] = ((scales[10] >> shift2) & 3) << 4;
+        //if (ip == 0) {
+        //    sc[0] |= (scales[0] & 0xF);
+        //    sc[1] |= (scales[2] & 0xF);
+        //    sc[2] |= (scales[4] & 0xF);
+        //    sc[3] |= (scales[6] & 0xF);
+        //} else {
+        //    sc[0] |= (scales[0] >>  4);
+        //    sc[1] |= (scales[2] >>  4);
+        //    sc[2] |= (scales[4] >>  4);
+        //    sc[3] |= (scales[6] >>  4);
+        //}
+        if (ip == 0) {
+            sc[0] = (scales[0] & 0xF) | (((scales[ 8] >> 0) & 3) << 4);
+            sc[1] = (scales[2] & 0xF) | (((scales[10] >> 0) & 3) << 4);
+            sc[2] = (scales[4] & 0xF) | (((scales[ 8] >> 2) & 3) << 4);
+            sc[3] = (scales[6] & 0xF) | (((scales[10] >> 2) & 3) << 4);
+        } else {
+            sc[0] = (scales[0] >>  4) | (((scales[ 8] >> 4) & 3) << 4);
+            sc[1] = (scales[2] >>  4) | (((scales[10] >> 4) & 3) << 4);
+            sc[2] = (scales[4] >>  4) | (((scales[ 8] >> 6) & 3) << 4);
+            sc[3] = (scales[6] >>  4) | (((scales[10] >> 6) & 3) << 4);
+        }
+
+        float4 sums = {0.f, 0.f, 0.f, 0.f};
+        for (int l = 0; l < n; ++l) {
+            sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & 3) - (hm[l] & (m << 0) ? 0 : 4));
+            sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & 3) - (hm[l] & (m << 1) ? 0 : 4));
+            sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & 3) - (hm[l] & (m << 2) ? 0 : 4));
+            sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & 3) - (hm[l] & (m << 3) ? 0 : 4));
+        }
+
+        sumf += dall * (sums[0] * (sc[0] - 32) + sums[1] * (sc[1] - 32) + sums[2] * (sc[2] - 32) + sums[3] * (sc[3] - 32));
+
+    }
+
+    sum[ith] = sumf;
+
+    //
+    // Accumulate the sum from all threads in the threadgroup
+    //
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith%4 == 0) {
+        for (int i = 1; i < 4; ++i) sum[ith] += sum[ith + i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith%16 == 0) {
+        for (int i = 4; i < 16; i += 4) sum[ith] += sum[ith + i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (ith == 0) {
+        for (int i = 16; i < nth; i += 16) sum[0] += sum[i];
+        dst[r1*ne0 + r0] = sum[0];
+    }
+
 }
 
 kernel void kernel_mul_mat_q4_k_f32(
@@ -942,8 +1127,8 @@ kernel void kernel_mul_mat_q4_k_f32(
     device const block_q4_k * x = (device const block_q4_k *) src0 + r0*nb;
     device const float     * yy = (device const float      *) src1 + r1*ne10;
 
-    const uint nth = tptg.x*tptg.y;
-    const uint ith = tptg.y*tpitg.x + tpitg.y;
+    const int nth = tptg.x*tptg.y;
+    const int ith = tptg.y*tpitg.x + tpitg.y;
 
     const int tid = tpitg.y;   // 0...16
     const int il  = tid/4;     // 0...3
@@ -1051,8 +1236,8 @@ kernel void kernel_mul_mat_q6_k_f32(
     device const block_q6_k * x = (device const block_q6_k *) src0 + r0*nb;
     device const float     * yy = (device const float      *) src1 + r1*ne10;
 
-    const uint nth = tptg.x*tptg.y;
-    const uint ith = tptg.y*tpitg.x + tpitg.y;
+    const int nth = tptg.x*tptg.y;
+    const int ith = tptg.y*tpitg.x + tpitg.y;
 
     // Note: we absolutely assume that tptg.y = 16 and QK_K = 256!
     const int iqs  = 16 * tpitg.y;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -1064,8 +1064,8 @@ kernel void kernel_mul_mat_q3_k_f32(
     const uint8_t m3 = 3;
     const int8_t  m4 = 4;
 
-    //const uint32_t kmask1 = 0x03030303;
-    //const uint32_t kmask2 = 0x0f0f0f0f;
+    const uint32_t kmask1 = 0x03030303;
+    const uint32_t kmask2 = 0x0f0f0f0f;
 
     const int nb = ne00/QK_K;
 
@@ -1078,73 +1078,104 @@ kernel void kernel_mul_mat_q3_k_f32(
     const int nth = tptg.x*tptg.y;
     const int ith = tptg.y*tpitg.x + tpitg.y;
 
-    const int step = QK_K / tptg.y;     // we expect this to be 16
-    const int iqs  = step * tpitg.y;    // 0...240 in steps of 16
-    const int ip   = iqs / 128;         // 0 or 1
-    const int il   = (iqs - 128*ip)/16; // 0...7
-    const int n    = 4;
-    const int l0   = n * il;
-    const int is   = l0/16;
-    const uint8_t m = m1 << (4*ip);
+    uint32_t utmp[2];
 
-    int8_t sc[4];
-    //uin32_t utmp[2];
-    //char4 sc1, sc2;
-    //uint32_t aux[3];
+    const int iqs = 16*tpitg.y;
+    const int n = iqs/128;                // 0 or 1
+    const int r = iqs - 128*n;            // 0...120 in steps of 16
+    const int l = 4*(r/16);               // 0...28 in steps of 4
+    const int is = l/16;
+    const uint8_t m = 1 << (4*n);
+
+    const int shift1 = 4*n;
+    const int shift2 = shift1 + 2;
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        device const uint8_t * q  = x[i].qs + 32*ip + l0;
-        device const uint8_t * hm = x[i].hmask + l0;
-        device const uint8_t * scales = x[i].scales;
+        device const float   * y = yy + i * QK_K + 128*n + l;
+        device const uint8_t * q = x[i].qs + 32*n + l;
+        device const uint8_t * hm = x[i].hmask + l;
 
-        device const float * y = yy + i * QK_K + 128*ip + l0;
+        device const uint32_t * aux = (device const uint32_t *)x[i].scales;
+        utmp[0] = ((aux[0] >> shift1) & kmask2) | (((aux[2] >> shift1) & kmask1) << 4);
+        utmp[1] = ((aux[1] >> shift1) & kmask2) | (((aux[2] >> shift2) & kmask1) << 4);
+
+        const char4 sc1 = as_type<char4>(utmp[0]);
+        const char4 sc2 = as_type<char4>(utmp[1]);
 
         const float dall = x[i].d;
 
-        //aux[0] = (a[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
-        //aux[1] = (a[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
-        ////memcpy(aux, x[i].scales, 12);
-        //device const uint32_t * aux = (device const uint32_t *)x[i].scales;
-        //if (ip == 0) {
-        //    sc1 = as_type<char4>((aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4));
-        //    sc2 = as_type<char4>((aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4));
-        //    //utmp[0] = (aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4);
-        //    //utmp[1] = (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4);
-        //} else {
-        //    sc1 = as_type<char4>(((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4));
-        //    sc2 = as_type<char4>(((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4));
-        //    //utmp[0] = ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4);
-        //    //utmp[1] = ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4);
-        //}
-
-        if (ip == 0) {
-            sc[0] = (scales[is+0] & 0xF) | (((scales[is+ 8] >> 0) & m3) << 4);
-            sc[1] = (scales[is+2] & 0xF) | (((scales[is+10] >> 0) & m3) << 4);
-            sc[2] = (scales[is+4] & 0xF) | (((scales[is+ 8] >> 2) & m3) << 4);
-            sc[3] = (scales[is+6] & 0xF) | (((scales[is+10] >> 2) & m3) << 4);
-        } else {
-            sc[0] = (scales[is+0] >>  4) | (((scales[is+ 8] >> 4) & m3) << 4);
-            sc[1] = (scales[is+2] >>  4) | (((scales[is+10] >> 4) & m3) << 4);
-            sc[2] = (scales[is+4] >>  4) | (((scales[is+ 8] >> 6) & m3) << 4);
-            sc[3] = (scales[is+6] >>  4) | (((scales[is+10] >> 6) & m3) << 4);
+        float sum = 0;
+        for (int k = 0; k < 4; ++k) {
+            sum += y[k+ 0] * (sc1[is+0] - 32) * (((q[k] >> 0) & 3) - (hm[k] & (m << 0) ? 0 : 4))
+                 + y[k+32] * (sc1[is+2] - 32) * (((q[k] >> 2) & 3) - (hm[k] & (m << 1) ? 0 : 4))
+                 + y[k+64] * (sc2[is+0] - 32) * (((q[k] >> 4) & 3) - (hm[k] & (m << 2) ? 0 : 4))
+                 + y[k+96] * (sc2[is+2] - 32) * (((q[k] >> 6) & 3) - (hm[k] & (m << 3) ? 0 : 4));
         }
 
-        uchar4 mask = {m, (uint8_t)(m << 1), (uint8_t)(m << 2), (uint8_t)(m << 3)};
-
-        float4 sums = {0.f, 0.f, 0.f, 0.f};
-        for (int l = 0; l < n; ++l) {
-            sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & m3) - ((hm[l] & mask[0]) ? 0 : m4));
-            sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & m3) - ((hm[l] & mask[1]) ? 0 : m4));
-            sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & m3) - ((hm[l] & mask[2]) ? 0 : m4));
-            sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & m3) - ((hm[l] & mask[3]) ? 0 : m4));
-        }
-
-        sumf += dall * (sums[0] * (sc[0] - 32) + sums[1] * (sc[1] - 32) + sums[2] * (sc[2] - 32) + sums[3] * (sc[3] - 32));
-        //sumf += dall * (sums[0] * (sc1[is] - 32) + sums[1] * (sc1[is+2] - 32) + sums[2] * (sc2[is] - 32) + sums[3] * (sc2[is+2] - 32));
-
+        sumf += sum * dall;
     }
+
+
+    //const int step = QK_K / tptg.y;     // we expect this to be 16
+    //const int iqs  = step * tpitg.y;    // 0...240 in steps of 16
+    //const int ip   = iqs / 128;         // 0 or 1
+    //const int il   = (iqs - 128*ip)/16; // 0...7
+    //const int n    = 4;
+    //const int l0   = n * il;
+    //const int is   = l0/16;
+    //const uint8_t m = m1 << (4*ip);
+    //const uchar4 mask = {m, (uint8_t)(m << 1), (uint8_t)(m << 2), (uint8_t)(m << 3)};
+
+    //const int shift1 = 4*ip;
+    //const int shift2 = shift1 + 2;
+
+    //int8_t sc[4];
+
+    //float sumf = 0;
+    //for (int i = tpitg.x; i < nb; i += tptg.x) {
+
+    //    device const uint8_t * q  = x[i].qs + 32*ip + l0;
+    //    device const uint8_t * hm = x[i].hmask + l0;
+    //    device const uint8_t * scales = x[i].scales;
+
+    //    device const float * y = yy + i * QK_K + 128*ip + l0;
+
+    //    const float dall = x[i].d;
+
+    //    sc[0] = ((scales[is+0] >> shift1) & 0xF) | (((scales[is+ 8] >> shift1) & m3) << 4);
+    //    sc[1] = ((scales[is+2] >> shift1) & 0xF) | (((scales[is+10] >> shift1) & m3) << 4);
+    //    sc[2] = ((scales[is+4] >> shift1) & 0xF) | (((scales[is+ 8] >> shift2) & m3) << 4);
+    //    sc[3] = ((scales[is+6] >> shift1) & 0xF) | (((scales[is+10] >> shift2) & m3) << 4);
+
+    //    //if (ip == 0) {
+    //    //    sc[0] = (scales[is+0] & 0xF) | (((scales[is+ 8] >> 0) & m3) << 4);
+    //    //    sc[1] = (scales[is+2] & 0xF) | (((scales[is+10] >> 0) & m3) << 4);
+    //    //    sc[2] = (scales[is+4] & 0xF) | (((scales[is+ 8] >> 2) & m3) << 4);
+    //    //    sc[3] = (scales[is+6] & 0xF) | (((scales[is+10] >> 2) & m3) << 4);
+    //    //} else {
+    //    //    sc[0] = (scales[is+0] >>  4) | (((scales[is+ 8] >> 4) & m3) << 4);
+    //    //    sc[1] = (scales[is+2] >>  4) | (((scales[is+10] >> 4) & m3) << 4);
+    //    //    sc[2] = (scales[is+4] >>  4) | (((scales[is+ 8] >> 6) & m3) << 4);
+    //    //    sc[3] = (scales[is+6] >>  4) | (((scales[is+10] >> 6) & m3) << 4);
+    //    //}
+
+
+    //    float4 sums = {0.f, 0.f, 0.f, 0.f};
+    //    for (int l = 0; l < n; ++l) {
+    //        sums[0] += y[l+ 0] * ((int8_t)((q[l] >> 0) & m3) - ((hm[l] & mask[0]) ? 0 : m4));
+    //        sums[1] += y[l+32] * ((int8_t)((q[l] >> 2) & m3) - ((hm[l] & mask[1]) ? 0 : m4));
+    //        sums[2] += y[l+64] * ((int8_t)((q[l] >> 4) & m3) - ((hm[l] & mask[2]) ? 0 : m4));
+    //        sums[3] += y[l+96] * ((int8_t)((q[l] >> 6) & m3) - ((hm[l] & mask[3]) ? 0 : m4));
+    //    }
+
+    //    sumf += dall * (sums[0] * (sc[0] - 32)
+    //                  + sums[1] * (sc[1] - 32)
+    //                  + sums[2] * (sc[2] - 32)
+    //                  + sums[3] * (sc[3] - 32));
+
+    //}
 
     sum[ith] = sumf;
 

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -971,7 +971,7 @@ kernel void kernel_mul_mat_q4_k_f32(
 
     const uint16_t kmask1 = 0x3f3f;
     const uint16_t kmask2 = 0x0f0f;
-    const uint16_t kmask3 = 0x0303;
+    const uint16_t kmask3 = 0xc0c0;
 
     const int nb = ne00/QK_K;
 
@@ -991,16 +991,15 @@ kernel void kernel_mul_mat_q4_k_f32(
 
     const int im = il/2;  // 0 or 1. 0 computes 0,32 + 128,160, 1 computes 64,96 + 192,224
     const int in = il%2;
+    const int l0 = n*(2*ir + in);
 
     sum[ith] = 0.0f;
-
-    //uchar2 sc1, sc2;
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        device const uint8_t * q1 = (x + i)->qs + 32*im + n*(2*ir + in);
-        device const float   * y1 = yy + i*QK_K + 64*im + n*(2*ir + in);
+        device const uint8_t * q1 = (x + i)->qs + 32*im + l0;
+        device const float   * y1 = yy + i*QK_K + 64*im + l0;
         device const uint8_t * q2 = q1 + 64;
         device const float   * y2 = y1 + 128;
 
@@ -1011,21 +1010,16 @@ kernel void kernel_mul_mat_q4_k_f32(
 
         const uchar2 sc1 = as_type<uchar2>((uint16_t)(a[im+0] & kmask1));
         const uchar2 sc2 = as_type<uchar2>((uint16_t)(a[im+2] & kmask1));
-        const uchar2 sc3 = as_type<uchar2>((uint16_t)(((a[im+4] >> 0) & kmask2) | (((a[im+0] >> 6) & kmask3) << 4)));
-        const uchar2 sc4 = as_type<uchar2>((uint16_t)(((a[im+4] >> 4) & kmask2) | (((a[im+2] >> 6) & kmask3) << 4)));
+        const uchar2 sc3 = as_type<uchar2>((uint16_t)(((a[im+4] >> 0) & kmask2) | ((a[im+0] & kmask3) >> 2)));
+        const uchar2 sc4 = as_type<uchar2>((uint16_t)(((a[im+4] >> 4) & kmask2) | ((a[im+2] & kmask3) >> 2)));
 
-        float4 s1 = {0.f, 0.f, 0.f, 0.f};
-        float4 s2 = {0.f, 0.f, 0.f, 0.f};
+        float2 s = {0.f, 0.f};
         for (int l = 0; l < n; ++l) {
-            s1[0] += y1[l+ 0] * (q1[l] & 0xF); s1[1] += y1[l+ 0];
-            s1[2] += y1[l+32] * (q1[l] >>  4); s1[3] += y1[l+32];
-            s2[0] += y2[l+ 0] * (q2[l] & 0xF); s2[1] += y2[l+ 0];
-            s2[2] += y2[l+32] * (q2[l] >>  4); s2[3] += y2[l+32];
+            s[0] += y1[l] * sc1[0] * (q1[l] & 0xF) + y1[l+32] * sc1[1] * (q1[l] >> 4)
+                  + y2[l] * sc3[0] * (q2[l] & 0xF) + y2[l+32] * sc3[1] * (q2[l] >> 4);
+            s[1] += y1[l] * sc2[0] + y1[l+32] * sc2[1] + y2[l] * sc4[0] + y2[l+32] * sc4[1];
         }
-        sumf += dall * (s1[0] * sc1[0] + s1[2] * sc1[1]
-                     +  s2[0] * sc3[0] + s2[2] * sc3[1])
-              - dmin * (s1[1] * sc2[0] + s1[3] * sc2[1]
-                     +  s2[1] * sc4[0] + s2[3] * sc4[1]);
+        sumf += dall * s[0] - dmin * s[1];
 
     }
     sum[ith] = sumf;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -986,42 +986,82 @@ kernel void kernel_mul_mat_q4_k_f32(
 
     const int tid = tpitg.y;   // 0...16
     const int il  = tid/4;     // 0...3
-    const int ir  = tid%4;     // 0...3
+    //const int ir  = tid%4;     // 0...3
+    const int ir  = tid - 4*il;// 0...3
     const int n   = 4;
 
     const int im = il/2;  // 0 or 1. 0 computes 0,32 + 128,160, 1 computes 64,96 + 192,224
     const int in = il%2;
+
     const int l0 = n*(2*ir + in);
+    const int q_offset = 32*im + l0;
+    const int y_offset = 64*im + l0;
 
     sum[ith] = 0.0f;
+
+    //uint16_t aux_scales[4];
+    //thread uint8_t * sc = (thread uint8_t *)aux_scales;
+
+    //uint32_t aux32[4];
+    //thread const uint8_t * sc = (thread const uint8_t *)aux32;
+
+    uchar2 sc1, sc2, sc3, sc4;
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        device const uint8_t * q1 = (x + i)->qs + 32*im + l0;
-        device const float   * y1 = yy + i*QK_K + 64*im + l0;
+        device const uint8_t * q1 = (x + i)->qs + q_offset;
         device const uint8_t * q2 = q1 + 64;
+        device const float   * y1 = yy + i*QK_K + y_offset;
         device const float   * y2 = y1 + 128;
-
-        device const uint16_t * a = (device const uint16_t *)(x + i)->scales;
 
         const float dall = (float)((x + i)->d);
         const float dmin = (float)((x + i)->dmin);
 
-        const uchar2 sc1 = as_type<uchar2>((uint16_t)(a[im+0] & kmask1));
-        const uchar2 sc2 = as_type<uchar2>((uint16_t)(a[im+2] & kmask1));
-        const uchar2 sc3 = as_type<uchar2>((uint16_t)(((a[im+4] >> 0) & kmask2) | ((a[im+0] & kmask3) >> 2)));
-        const uchar2 sc4 = as_type<uchar2>((uint16_t)(((a[im+4] >> 4) & kmask2) | ((a[im+2] & kmask3) >> 2)));
+        //device const uint32_t * a = (device const uint32_t *)(x + i)->scales;
+        //aux32[0] = a[0] & 0x3f3f3f3f;  // scales for 0, 32, 64, 96
+        //aux32[1] = a[1] & 0x3f3f3f3f;  // mins   for 0, 32, 64, 96
+        //aux32[2] = ((a[2] >> 0) & 0x0f0f0f0f) | ((a[0] & 0xc0c0c0c0) >> 2); // scales for 128, 160, 192, 224
+        //aux32[3] = ((a[2] >> 4) & 0x0f0f0f0f) | ((a[1] & 0xc0c0c0c0) >> 2); // mins   for 128, 160, 192, 224
 
-        float2 s = {0.f, 0.f};
+        //aux_scales[0] = (uint16_t)(a[im+0] & kmask1);
+        //aux_scales[1] = (uint16_t)(((a[im+4] >> 0) & kmask2) | ((a[im+0] & kmask3) >> 2));
+        //aux_scales[2] = (uint16_t)(a[im+2] & kmask1);
+        //aux_scales[3] = (uint16_t)(((a[im+4] >> 4) & kmask2) | ((a[im+2] & kmask3) >> 2));
+
+        device const uint16_t * a = (device const uint16_t *)(x + i)->scales;
+        sc1 = as_type<uchar2>((uint16_t)(a[im+0] & kmask1));
+        sc2 = as_type<uchar2>((uint16_t)(a[im+2] & kmask1));
+        sc3 = as_type<uchar2>((uint16_t)(((a[im+4] >> 0) & kmask2) | ((a[im+0] & kmask3) >> 2)));
+        sc4 = as_type<uchar2>((uint16_t)(((a[im+4] >> 4) & kmask2) | ((a[im+2] & kmask3) >> 2)));
+
+        //float2 s = {0.f, 0.f};
+        float4 s = {0.f, 0.f, 0.f, 0.f};
+        float smin = 0;
         for (int l = 0; l < n; ++l) {
-            s[0] += y1[l] * sc1[0] * (q1[l] & 0xF) + y1[l+32] * sc1[1] * (q1[l] >> 4)
-                  + y2[l] * sc3[0] * (q2[l] & 0xF) + y2[l+32] * sc3[1] * (q2[l] >> 4);
-            s[1] += y1[l] * sc2[0] + y1[l+32] * sc2[1] + y2[l] * sc4[0] + y2[l+32] * sc4[1];
+
+            ////s[0] += y1[l] * sc[0] * (q1[l] & 0xF) + y1[l+32] * sc[1] * (q1[l] >> 4)
+            ////      + y2[l] * sc[2] * (q2[l] & 0xF) + y2[l+32] * sc[3] * (q2[l] >> 4);
+            ////s[1] += y1[l] * sc[4] + y1[l+32] * sc[5] + y2[l] * sc[6] + y2[l+32] * sc[7];
+
+            ////s[0] += y1[l] * sc[2*im+0] * (q1[l] & 0xF) + y1[l+32] * sc[2*im+1] * (q1[l] >> 4)
+            ////      + y2[l] * sc[2*im+8] * (q2[l] & 0xF) + y2[l+32] * sc[2*im+9] * (q2[l] >> 4);
+            ////s[1] += y1[l] * sc[2*im+4] + y1[l+32] * sc[2*im+5] + y2[l] * sc[2*im+12] + y2[l+32] * sc[2*im+13];
+
+            //s[0] += y1[l] * sc1[0] * (q1[l] & 0xF) + y1[l+32] * sc1[1] * (q1[l] >> 4)
+            //      + y2[l] * sc3[0] * (q2[l] & 0xF) + y2[l+32] * sc3[1] * (q2[l] >> 4);
+            //s[1] += y1[l] * sc2[0] + y1[l+32] * sc2[1] + y2[l] * sc4[0] + y2[l+32] * sc4[1];
+
+            s[0] += y1[l] * (q1[l] & 0xF); s[1] += y1[l+32] * (q1[l] >> 4);
+            s[2] += y2[l] * (q2[l] & 0xF); s[3] += y2[l+32] * (q2[l] >> 4);
+            smin += y1[l] * sc2[0] + y1[l+32] * sc2[1] + y2[l] * sc4[0] + y2[l+32] * sc4[1];
+
         }
-        sumf += dall * s[0] - dmin * s[1];
+        //sumf += dall * s[0] - dmin * s[1];
+        sumf += dall * (s[0] * sc1[0] + s[1] * sc1[1] + s[2] * sc3[0] + s[3] * sc3[1]) - dmin * smin;
 
     }
+
     sum[ith] = sumf;
 
     //

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -667,12 +667,14 @@ typedef struct {
 static inline uchar4 get_scale_min_k4(int j, device const uint8_t * q) {
     uchar4 r;
     if (j < 4) {
-        r[0] = q[j+0] & 63; r[1] = q[j+4] & 63;
-        r[2] = q[j+1] & 63; r[3] = q[j+5] & 63;
+        r[0] = q[j+0] & 63;
+        r[2] = q[j+1] & 63;
+        r[1] = q[j+4] & 63;
+        r[3] = q[j+5] & 63;
     } else {
         r[0] = (q[j+4] & 0xF) | ((q[j-4] >> 6) << 4);
-        r[1] = (q[j+4] >>  4) | ((q[j-0] >> 6) << 4);
         r[2] = (q[j+5] & 0xF) | ((q[j-3] >> 6) << 4);
+        r[1] = (q[j+4] >>  4) | ((q[j-0] >> 6) << 4);
         r[3] = (q[j+5] >>  4) | ((q[j+1] >> 6) << 4);
     }
     return r;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -969,6 +969,10 @@ kernel void kernel_mul_mat_q4_k_f32(
         uint2 tpitg[[thread_position_in_threadgroup]],
         uint2  tptg[[threads_per_threadgroup]]) {
 
+    const uint16_t kmask1 = 0x3f3f;
+    const uint16_t kmask2 = 0x0f0f;
+    const uint16_t kmask3 = 0x0303;
+
     const int nb = ne00/QK_K;
 
     const int64_t r0 = tgpig.x;
@@ -983,29 +987,45 @@ kernel void kernel_mul_mat_q4_k_f32(
     const int tid = tpitg.y;   // 0...16
     const int il  = tid/4;     // 0...3
     const int ir  = tid%4;     // 0...3
-    const int n   = 8;
-    const int is  = 2*il;
+    const int n   = 4;
+
+    const int im = il/2;  // 0 or 1. 0 computes 0,32 + 128,160, 1 computes 64,96 + 192,224
+    const int in = il%2;
 
     sum[ith] = 0.0f;
+
+    //uchar2 sc1, sc2;
 
     float sumf = 0;
     for (int i = tpitg.x; i < nb; i += tptg.x) {
 
-        device const uint8_t * q = (x + i)->qs + 32*il + n*ir;
-        device const float   * y = yy + i*QK_K + 64*il + n*ir;
-        device const uint8_t * scales = (x + i)->scales;
+        device const uint8_t * q1 = (x + i)->qs + 32*im + n*(2*ir + in);
+        device const float   * y1 = yy + i*QK_K + 64*im + n*(2*ir + in);
+        device const uint8_t * q2 = q1 + 64;
+        device const float   * y2 = y1 + 128;
+
+        device const uint16_t * a = (device const uint16_t *)(x + i)->scales;
 
         const float dall = (float)((x + i)->d);
         const float dmin = (float)((x + i)->dmin);
 
-        const uchar4 sc = get_scale_min_k4(is, scales);
+        const uchar2 sc1 = as_type<uchar2>((uint16_t)(a[im+0] & kmask1));
+        const uchar2 sc2 = as_type<uchar2>((uint16_t)(a[im+2] & kmask1));
+        const uchar2 sc3 = as_type<uchar2>((uint16_t)(((a[im+4] >> 0) & kmask2) | (((a[im+0] >> 6) & kmask3) << 4)));
+        const uchar2 sc4 = as_type<uchar2>((uint16_t)(((a[im+4] >> 4) & kmask2) | (((a[im+2] >> 6) & kmask3) << 4)));
 
-        float4 s = {0.f, 0.f, 0.f, 0.f};
+        float4 s1 = {0.f, 0.f, 0.f, 0.f};
+        float4 s2 = {0.f, 0.f, 0.f, 0.f};
         for (int l = 0; l < n; ++l) {
-            s[0] += y[l+ 0] * (q[l] & 0xF); s[1] += y[l+ 0];
-            s[2] += y[l+32] * (q[l] >>  4); s[3] += y[l+32];
+            s1[0] += y1[l+ 0] * (q1[l] & 0xF); s1[1] += y1[l+ 0];
+            s1[2] += y1[l+32] * (q1[l] >>  4); s1[3] += y1[l+32];
+            s2[0] += y2[l+ 0] * (q2[l] & 0xF); s2[1] += y2[l+ 0];
+            s2[2] += y2[l+32] * (q2[l] >>  4); s2[3] += y2[l+32];
         }
-        sumf += dall * (s[0] * sc[0] + s[2] * sc[2]) - dmin * (s[1] * sc[1] + s[3] * sc[3]);
+        sumf += dall * (s1[0] * sc1[0] + s1[2] * sc1[1]
+                     +  s2[0] * sc3[0] + s2[2] * sc3[1])
+              - dmin * (s1[1] * sc2[0] + s1[3] * sc2[1]
+                     +  s2[1] * sc4[0] + s2[3] * sc4[1]);
 
     }
     sum[ith] = sumf;

--- a/llama.cpp
+++ b/llama.cpp
@@ -2390,12 +2390,10 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             printf("size = %8.3f MB\n", tensor.size/1024.0/1024.0);
         } else {
             new_type = quantized_type;
-            // TODO: temporary disabled until Metal / OpenCL support is available
-            //       ref: https://github.com/ggerganov/llama.cpp/issues/1711
-            //if (tensor.name == "output.weight") {
-            //    new_type = GGML_TYPE_Q6_K;
-            //}
-            if (tensor.name.find("attention.wv.weight") != std::string::npos) {
+            if (tensor.name == "output.weight") {
+                new_type = GGML_TYPE_Q6_K;
+            }
+            else if (tensor.name.find("attention.wv.weight") != std::string::npos) {
                 if      (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q2_K) new_type = GGML_TYPE_Q4_K;
                 else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q5_K;
                 else if ((ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q5_K_M) &&


### PR DESCRIPTION
Performance is not quite as good as `Q4_0` and `Q4_1`. The k-quantization needs to do quite a bit of more work when performing dot products, but that somehow did not matter on the other platforms (`AVX2, ARM_NEON, CUDA`). On Metal we see a significant difference:

|Quantization|Time/token in ms|
|--:|--:|
|Q4_0| 23.0 |
|Q4_1| 23.3 |
|Q2_K| 25.5 |
|Q3_K_M|28.1|
|Q4_K_S|25.3|
|Q5_K_S|27.8|
|Q6_K|27.3|

Times given are for the 7B model on a M2 Max 30-core GPU.