### PR TITLE
metal : fix failure to load model

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -86,6 +86,7 @@ struct ggml_metal_context * ggml_metal_init(void) {
 
     ctx->device = MTLCreateSystemDefaultDevice();
     ctx->queue  = [ctx->device newCommandQueue];
+    ctx->n_buffers = 0;
 
     // determine if we can use MPS
     if (MPSSupportsMTLDevice(ctx->device)) {


### PR DESCRIPTION
The number of buffers in the ggml context was left uninitialized. This leads to sporadic failures to load the model on startup. It is actually strange that the failure occurred so infrequently.