### PR TITLE
Update baby-llama.cpp

### DIFF
--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -149,7 +149,7 @@ struct llama_hparams_lora {
     uint32_t n_lora  = 64;
 
     bool operator!=(const llama_hparams & other) const {
-        return memcmp(this, &other, sizeof(llama_hparams));
+        return memcmp(this, &other, sizeof(llama_hparams)) != 0;
     }
 };
 

--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -148,10 +148,9 @@ struct llama_hparams_lora {
     uint32_t n_rot   = 64;
     uint32_t n_lora  = 64;
 
-    bool operator!=(const llama_hparams & other) const {
-        return memcmp(this, &other, sizeof(llama_hparams)) != 0;
+    bool operator!=(const llama_hparams_lora & other) const {
+        return memcmp(this, &other, sizeof(llama_hparams_lora)) != 0;
     }
-};
 
 struct llama_layer {
     // normalization

--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -151,6 +151,7 @@ struct llama_hparams_lora {
     bool operator!=(const llama_hparams_lora & other) const {
         return memcmp(this, &other, sizeof(llama_hparams_lora)) != 0;
     }
+};
 
 struct llama_layer {
     // normalization


### PR DESCRIPTION
Seems to be an error in the implementation of the operator!= function. It attempts to compare the this pointer (a llama_hparams_lora object) with the other pointer (a llama_hparams object) using memcmp. This can lead to incorrect results because the sizes of the objects being compared (sizeof(llama_hparams) and sizeof(llama_hparams_lora)) are different, should now be able to compare two llama_hparams_lora objects for inequality.