### PR TITLE
Added Arbitrary mixed quantization

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -25,6 +25,7 @@ static const std::map<std::string, llama_ftype> LLAMA_FTYPE_MAP = {
   {"q5_K_S", LLAMA_FTYPE_MOSTLY_Q5_K_S},
   {"q5_K_M", LLAMA_FTYPE_MOSTLY_Q5_K_M},
   {"q6_K",   LLAMA_FTYPE_MOSTLY_Q6_K},
+  {"qx_0",   LLAMA_FTYPE_MOSTLY_QX_0},
 };
 
 bool try_parse_ftype(const std::string & ftype_str, llama_ftype & ftype, std::string & ftype_str_out) {

--- a/ggml.c
+++ b/ggml.c
@@ -3203,7 +3203,7 @@ static void ggml_vec_dot_qx_0_q8_0(const int n, float * restrict s, const void *
 
     // row_data is a buffer which stores dequantized float values for a current block
     float f32_row_data[QKX_0];
-    
+
     // __AVX2__ doesn't seem to actually make much of a difference,
     // a lot of optimizing could possibly be done, including possibly using AVX2
     // for dequantization...?
@@ -3280,8 +3280,8 @@ static void ggml_vec_dot_qx_0_q8_0(const int n, float * restrict s, const void *
                     const uint8_t data_block_size = 64;
                     // we can take a full 64bit block
                     const uint8_t weights_per_u64_data_block = data_block_size / qbits;
-                    const uint8_t num_of_data_blocks_needed = 64 / weights_per_u64_data_block; // because we have 64 qbit-sized weights here 
-                    
+                    const uint8_t num_of_data_blocks_needed = 64 / weights_per_u64_data_block; // because we have 64 qbit-sized weights here
+
                     for (int i = 0; i < num_of_data_blocks_needed; i++) {
                         for (int k = 0; k < weights_per_u64_data_block; k ++) {
                             row_ptr[i * weights_per_u64_data_block + k] = qvals[(((const uint64_t *) data_start)[0] >> (k * qbits)) & ((1 << qbits) - 1)];
@@ -3340,14 +3340,14 @@ static void ggml_vec_dot_qx_0_q8_0(const int n, float * restrict s, const void *
                     __m128i test = _mm_loadu_si128((const __m128i *) (column[column_i].qs + i * 8));
                     __m256i work = _mm256_cvtepi8_epi32(test);
                     __m256 workf = _mm256_cvtepi32_ps(work);
-                    
+
                     // multiply with our 8 parts of the row at row_data
                     __m256 row = _mm256_loadu_ps(row_ptr + jb * QK8_0 + i * 8);
 
                     workf = _mm256_mul_ps(workf, row);
                     rolling_sum = _mm256_fmadd_ps(workf, column_multiplier, rolling_sum);
                 }
-                
+
                 #else
                 // scalar
                 float sub_sum = 0;
@@ -3370,11 +3370,11 @@ static void ggml_vec_dot_qx_0_q8_0(const int n, float * restrict s, const void *
         GGML_ASSERT(offset % 8 == 0);
         quant_row += offset / 8;
     }
-    
+
     #if defined(__AVX2__)
     float rolling_sum_vec[8];
     _mm256_store_ps(rolling_sum_vec, rolling_sum);
-    
+
     for (int i = 0; i < 8; i++) {
         *s += rolling_sum_vec[i];
     }
@@ -4530,7 +4530,7 @@ struct ggml_tensor * ggml_new_tensor_impl(
     }
 
     result->nb[0] = GGML_TYPE_SIZE[type];
-    
+
     if (type == GGML_TYPE_QX_0) {
         // QX_0 doesn't have a set stride size for a row; that value is stored in the "extra" part of the tensor
         result->nb[1] = 0;
@@ -10464,7 +10464,7 @@ static void ggml_compute_forward_mul_mat_q_f32(
         const int i3 = i03;
 
         void * src0_row;
-        
+
         if (type == GGML_TYPE_QX_0) {
             if (ir > 0) {
                 src0_row = (void *) ((char *) src0->data + ((uint64_t *) src0->extra)[ir - 1]);
@@ -10478,7 +10478,7 @@ static void ggml_compute_forward_mul_mat_q_f32(
 
         char * src1_col =          ((char *)      wdata + (      (0 + i12*ne11 + i13*ne12*ne11)*row_size));
         float * dst_col = (float *) ((char *) dst->data + (i0*nb0 + 0*nb1 + i2*nb2 + i3*nb3));
-        
+
         for (int64_t ic = 0; ic < ne11; ++ic) {
             vec_dot_q(ne00, &dst_col[ic*ne0], src0_row, (void *) (src1_col + ic*row_size));
         }
@@ -16528,7 +16528,7 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
     assert(n % QKX_0 == 0);
     assert(tensor_width % QKX_0 == 0);
     const int nb = n / QKX_0;
-    
+
     uint8_t * dst_8 = dst;
     uint64_t dst_offset = 0;
 
@@ -16544,7 +16544,7 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
     // this can be replaced with a max allowed RMSE, a set percentage of weights being within
     // a certain range, etc... The current implementation here is pretty much just an example
     float max_quantization_errors[5] = {0, 0.004, 0.004, 0, 0.004};
-    
+
 
     // How maximum quantization error is implemented here:
     //
@@ -16599,14 +16599,14 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
         }
 
         uint16_t total_bits = fp16_count * 16 + (QKX_0 - fp16_count) * qbits;
-        
+
         while ((total_bits % 8) != 0) {
             total_bits += 16 - qbits; // simulate the replacement of a quantized weight with a 16bit one (needed for a block's byte alignment)
         }
 
         float min_value = -(max_quantization_errors[qbits] * ((1 << qbits) - 1));
         float mult_range = 2 * max_quantization_errors[qbits];
-        
+
         // The quantizer starts at a QX_0_STARTING_QBITS quantized block (e.g. 4bits), but then
         // attempts to move to a lower precision defined by QX_0_START_OF_ATTEMPTED_QBITS.
         // It keeps looking to see if 3, 2 or 1 bit precision leads to a smaller file size.
@@ -16629,7 +16629,7 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
                 }
             }
             mean /= (QKX_0 - fp16_count);
-            
+
             uint16_t total_fp16s_in_test_qbit = 0;
             thresh = max_quantization_errors[test_qbit] * (1 << test_qbit);
 
@@ -16645,12 +16645,12 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
                     total_fp16s_in_test_qbit += 1;
                 }
             }
-            
+
             uint16_t total_bits_in_test_qbit = total_fp16s_in_test_qbit * 16 + test_qbit * (QKX_0 - total_fp16s_in_test_qbit);
             while ((total_bits_in_test_qbit % 8) != 0) {
                 total_bits_in_test_qbit += 16 - test_qbit; // simulate the replacement of a qbit weight with a 16bit one
             }
-            
+
             if (total_bits_in_test_qbit < total_bits) {
                 total_bits = total_bits_in_test_qbit;
                 qbits = test_qbit;
@@ -16686,7 +16686,7 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
 
             for (int j = 0; j < QKX_0; j++) {
                 float x = src[i * QKX_0 + j];
-                
+
                 // weight is not on 16bit
                 if ((fp16_indicators[j / 64] & ((uint64_t) 1 << (j % 64))) == 0) {
                     float diff = fabsf(x);
@@ -16717,25 +16717,27 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
         }
 
         dst_offset += (QKX_0 / 64) * sizeof(uint64_t);
-        
+
         // Each weight is stored as min_value + mult * quantized_weight
         // Similar to Zero-point quantization, or Q4_1
 
         // Write min value and multiplier to dst
         *((uint16_t*) (dst_8 + dst_offset)) = ggml_fp32_to_fp16(min_value);
         dst_offset += sizeof(uint16_t);
-        
+
         *((uint16_t*) (dst_8 + dst_offset)) = ggml_fp32_to_fp16(mult_range);
         dst_offset += sizeof(uint16_t);
-        
+
         // Store the "metadata" byte (for now it's just "qbits")
         *((uint8_t*) (dst_8 + dst_offset)) = qbits;
         dst_offset += sizeof(uint8_t);
 
 
         // Store the quantization pivots / points
-        float qvals[1 << qbits];
-        
+        // IMPORTANT: Change qvals's size depending on the maximum qbits expected
+        GGML_ASSERT(qbits <= 8);
+        float qvals[1 << 8];
+
         for (int j = 0; j < (1 << qbits); j++) {
             qvals[j] = min_value + (mult_range * j);
         }
@@ -16744,7 +16746,7 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
         uint32_t * data = (uint32_t*) (dst_8 + dst_offset);
 
         int fp16_count_chk = 0;
-        
+
         for (int j = 0; j < QKX_0; j++) {
             float x = src[i * QKX_0 + j];
 
@@ -16772,17 +16774,17 @@ size_t ggml_quantize_qx_0(const float * src, void * dst, int n, int64_t * hist, 
                 bit_offset += qbits;
             }
         }
-        
+
         // check that the reported fp16_count is coherent with the bits stored in fp16_indicators
         GGML_ASSERT(fp16_count == fp16_count_chk);
 
         // check that the number of bits from quantized values is divisible by 8
         GGML_ASSERT((((QKX_0 - fp16_count) * qbits) % 8) == 0);
-        
+
         dst_offset += ((QKX_0 - fp16_count) * qbits) / 8;
         dst_offset += fp16_count * 2;
     }
-    
+
     // store the total size of the tensor as the last element of extra_data
     extra_data[n / tensor_width - 1] = dst_offset;
 

--- a/ggml.h
+++ b/ggml.h
@@ -248,6 +248,7 @@ extern "C" {
         GGML_TYPE_Q5_K = 13,
         GGML_TYPE_Q6_K = 14,
         GGML_TYPE_Q8_K = 15,
+        GGML_TYPE_QX_0 = 16,
         GGML_TYPE_I8,
         GGML_TYPE_I16,
         GGML_TYPE_I32,
@@ -276,6 +277,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_Q4_K = 12, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q5_K = 13, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q6_K = 14, // except 1d tensors
+        GGML_FTYPE_MOSTLY_QX_0 = 15,  // except 1d tensors
     };
 
     // available tensor operations:
@@ -1135,13 +1137,14 @@ extern "C" {
     // quantization
     //
 
+    GGML_API size_t ggml_quantize_qx_0(const float * src, void * dst, int n,        int64_t * hist, uint64_t * extra_data, uint32_t tensor_width);
     GGML_API size_t ggml_quantize_q4_0(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q4_1(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q5_0(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q5_1(const float * src, void * dst, int n, int k, int64_t * hist);
     GGML_API size_t ggml_quantize_q8_0(const float * src, void * dst, int n, int k, int64_t * hist);
 
-    GGML_API size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, int start, int n, int64_t * hist);
+    GGML_API size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, int start, int n, int64_t * hist, uint64_t * extra_data, uint32_t tensor_width);
 
     //
     // system info

--- a/llama.cpp
+++ b/llama.cpp
@@ -883,12 +883,6 @@ struct llama_model_loader {
             if (lt.shards.at(0).extra_data_file_off != 0) {
                 lt.extra_data = (uint64_t *) ((uint8_t *) mapping->addr + lt.shards.at(0).extra_data_file_off);
             }
-            printf("load data for %s\n", lt.name.c_str());
-            
-            if (lt.extra_data != NULL) {
-                printf("extra_data_file_off: %zu, data: %p, extra_data: %p\n", lt.shards.at(0).extra_data_file_off, lt.data, lt.extra_data);
-                printf("extra_data for %s: %lu %lu ... %lu\n", lt.name.c_str(), lt.extra_data[0], lt.extra_data[1], lt.extra_data[lt.ne[1] - 1]);
-            }
             
         } else if (lt.split_type == SPLIT_NONE) {
             llama_file & file = file_loaders.at(lt.shards.at(0).file_idx)->file;

--- a/llama.h
+++ b/llama.h
@@ -113,6 +113,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q5_K_S        = 16,// except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q5_K_M        = 17,// except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q6_K          = 18,// except 1d tensors
+        LLAMA_FTYPE_MOSTLY_QX_0          = 19, // except 1d tensors
     };
 
     // model quantization parameters


### PR DESCRIPTION
Hi!

I added a quantization method called **QX_0**, which is mostly useful as a research tool for finding other good quantization methods.

The implementation allows for weights to be stored as an **arbitrary stream of bits** per block, which allows for virtually any quantization mixing to be tested. As of now, the implementation allows each weight to be stored either on 16 bits or a block-defined quantized bit precision, with each block being able to choose its quantization precision (4bit, 3bit, 2bit, 1bit, but the implementation allows for any other precision such as 5bit, 13bit, etc.).

The motivation behind weight precision mixing is similar to the idea behind Tim Dettmers' LLM.int8(), where a few "outlier" weights with values much larger than the ones of regular weights can badly throw off the quantization precision of the block. Managing these weights separately can greatly quantization accuracy while also having a minimal effect on file size since outliers are very rare.

To demo the implementation of this precision mixing, the current quantizer (ggml_quantize_qx_0) keeps **every single weight** of the model **within a defined maximum quantization error** from its original FP16 value, while also attempting to pick the best precision (4bit, 3bit, 2bit or 1bit) for each block (it's really interesting to see how different rows of blocks have different weight variances and thus require different precisions!). A lot of the implementation details are described in the comments of the qx_0 quantization function.

Most of the implementation is in `ggml_quantize_qx_0` (quantization) and `ggml_vec_dot_qx_0_q8_0` (dequantization + multiplication).


I should add, since the implementation behind QX_0 is very generalized, it's not really meant for inference use since it's pretty difficult to optimize. It's rather meant to be used as an **exploration / guidance tool** to see what quantization rules / mixing allow for great perplexity at a minimal file size. For example, one could use QX_0 to explore what rows within the model need higher precision / lower RMSE than others, and then develop a fast quantization scheme that only mixes 4bit and 2bit rows, for example.

![block](https://github.com/ggerganov/llama.cpp/assets/17289219/f0b8946b-ff41-414a-98bc-cc26d256b49c)

Above is the **overall structure of a QX_0 block**. This example block mixes 16bit and 2bit weights together (the metadata byte indicating that it's a 2bit quantized block), each weight corresponding to a single bit inside f16_indicator. 0 means that the weight is quantized, 1 means that its stored as full FP16. q_params are two FP16 numbers which store the offset and multiplier for dequantization, similar to how Q4_1 works. This can be easily changed within the code, since the structure of each block is pretty much arbitrary and is only known by the quantizer and dequantizer.