### PR TITLE
Better error when using both LoRA + GPU layers

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -412,6 +412,14 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         gpt_print_usage(argc, argv, default_params);
         exit(1);
     }
+
+#ifdef GGML_USE_CUBLAS
+    if (!params.lora_adapter.empty() && params.n_gpu_layers > 0) {
+        fprintf(stderr, "%s: error: the simultaneous use of LoRAs and GPU acceleration is not supported", __func__);
+        exit(1);
+    }
+#endif // GGML_USE_CUBLAS
+
     if (escape_prompt) {
         process_escapes(params.prompt);
     }


### PR DESCRIPTION
Related to https://github.com/ggerganov/llama.cpp/issues/1846 . Currently the ggml CUDA code runs on f32. Applying f16 LoRAs with working GPU acceleration therefore would require quite substantial changes and I don't consider this worth the effort at the moment. This PR adds an explicit error message stating that the simultaneous use of LoRAs and GPU acceleration is not supported.