### PR TITLE
expose build outputs via apps so that they can be invoked by nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,19 @@
           '';
           meta.mainProgram = "llama";
         };
+        apps.llama-server = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/llama-server";
+        };
+        apps.llama-embedding = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/embedding";
+        };
+        apps.llama = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/llama";
+        };
+        apps.default = self.apps.${system}.llama;
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             cmake


### PR DESCRIPTION
For example

nix run github:ggerganov/llama.cpp#llama-server -- -m /path/to/model
nix run github:ggerganov/llama.cpp#embedding -- -m /path/to/model -f /path/to/file

The default is still the llama app of course