### PR TITLE
Fixed CUDA runtime version check

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -25,7 +25,7 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
         }                                                                               \
     } while (0)
 
-#if CUDART_VERSION >= 12
+#if CUDART_VERSION >= 12000
 #define CUBLAS_CHECK(err)                                                               \
     do {                                                                                \
         cublasStatus_t err_ = (err);                                                    \


### PR DESCRIPTION
In one of my PRs I changed the macro for cuBLAS errors to a more human-readable format. However, the function that I used is not available in all CUDA versions so I added a check against `CUDART_VERSION`. However, as it turns out I did that incorrectly and llama.cpp master doesn't compile on old CUDA versions. This PR fixes that.