### PR TITLE
gitignore: add several entries specific to Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build-metal/
 build-no-accel/
 build-sanitize-addr/
 build-sanitize-thread/
+out/
 
 models/*
 *.bin
@@ -40,6 +41,7 @@ models/*
 build-info.h
 arm_neon.h
 compile_commands.json
+CMakeSettings.json
 
 __pycache__
 


### PR DESCRIPTION
`out` - the default output dir of Visual Studio CMake projects
`CMakeSettings.json` - Visual Studio CMake config