### PR TITLE
Fixed embeddings when offloading non-repeating layers

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1654,7 +1654,7 @@ static bool llama_eval_internal(
 
         // cur = cur*norm(broadcasted)
         cur = ggml_mul(ctx0, cur, model.norm);
-        offload_func_nr(cur);
+        // offload_func_nr(cur); // TODO CPU + GPU mirrored backend
         ggml_set_name(cur, "result_norm");
 
         embeddings = cur;


### PR DESCRIPTION
Currently retrieving embeddings seem to be broken on master when offloading the non-repeating layers as reported by https://github.com/ggerganov/llama.cpp/pull/1873 . This PR fixes this by setting the backend of the embeddings layer to `GGML_BACKEND_CPU`. This is a comparatively simple fix and does not impose a measurable performance difference.