### PR TITLE
Fixed possible macro redefinition

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -23,7 +23,9 @@
 #include <unistd.h>
 #elif defined (_WIN32)
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <signal.h>
 #endif


### PR DESCRIPTION
MinGW libstdc++ may define `NOMINMAX` unconditionally. This fixes the case when it is already defined.