### PR TITLE
Allow cmake to build ggml as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ endif()
 # Build libraries
 #
 
-add_library(ggml STATIC
+add_library(ggml OBJECT
             ggml.c
             ggml.h
             ${GGML_SOURCES_CUDA}
@@ -423,8 +423,10 @@ target_include_directories(ggml PUBLIC . ${LLAMA_EXTRA_INCLUDES})
 target_compile_features(ggml PUBLIC c_std_11) # don't bump
 target_link_libraries(ggml PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
 
+add_library(ggml_static STATIC $<TARGET_OBJECTS:ggml>)
 if (BUILD_SHARED_LIBS)
     set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    add_library(ggml_shared SHARED $<TARGET_OBJECTS:ggml>)
 endif()
 
 add_library(llama

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ endif()
 # Build libraries
 #
 
-add_library(ggml
+add_library(ggml STATIC
             ggml.c
             ggml.h
             ${GGML_SOURCES_CUDA}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ endif()
 # Build libraries
 #
 
-add_library(ggml OBJECT
+add_library(ggml
             ggml.c
             ggml.h
             ${GGML_SOURCES_CUDA}


### PR DESCRIPTION
@Green-Sky (since you said I could tag you for cmake stuff)

Is there any reason not to do this so when using cmake `ggml` gets built as a library and not only a `.o` file?

Right now it's really awkward to build with `cmake` and use `ggml` in something like a binding because you have to manage all the extra files like `k_quants.o`, `ggml-cuda.o`, etc manually.

I know almost nothing about `cmake`. All I can say is it _seems_ like this change doesn't break anything on Linux compiling with default flags, cuBLAS, CLBLAST. I don't have a way to test stuff like Metal or Accelerate.

**edit**: It appears the answer to my question is "because it breaks Windows"... But why?

**edit 2**: Seems like it only breaks Windows with `-DBUILD_SHARED_LIBS=ON` (I can't tell if the second commit did anything since the workflows got cancelled before).