### PR TITLE
Fix uninitialized var causing crash on Windows using MSVC.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -195,7 +195,7 @@ struct llama_model {
 
     // key + value cache for the self attention
     // TODO: move to llama_state
-    struct llama_kv_cache kv_self;
+    struct llama_kv_cache kv_self = {};
 
     // the model memory buffer
     llama_ctx_buffer buf;


### PR DESCRIPTION
Trying out the new "simple" example and it was crashing on Windows building with MSVC. More specifically the crash occurs when calling `llama_get_kv_cache_token_count` because `n` is uninitialized.