### PR TITLE
Add CUDA_ARCHITECTURES to new target ggml_static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,10 @@ if (GGML_SOURCES_CUDA)
     message(STATUS "GGML CUDA sources found, configuring CUDA architecture")
     set_property(TARGET ggml  PROPERTY CUDA_ARCHITECTURES OFF)
     set_property(TARGET ggml  PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
+
+    set_property(TARGET ggml_static PROPERTY CUDA_ARCHITECTURES OFF)
+    set_property(TARGET ggml_static PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
+
     set_property(TARGET llama PROPERTY CUDA_ARCHITECTURES OFF)
 endif()
 


### PR DESCRIPTION
Shutdown CMAKE warning of CUDA_ARCHITECTURES is empty for target "ggml_static".