### PR TITLE
Could this be a typo?

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -7898,7 +7898,7 @@ static void ggml_compute_forward_add_q_f32(
 
         void  * src0_row = (void *) ((char *) src0->data + (i01*nb01 + i02*nb02 + i03*nb03));
         float * src1_row = (float *)((char *) src1->data + (i11*nb11 + i12*nb12 + i13*nb13));
-        void  * dst_row  = (void *) ((char *)  dst->data + ( i1*nb1  +  i2*nb2  +  i3*nb0));
+        void  * dst_row  = (void *) ((char *)  dst->data + ( i1*nb1  +  i2*nb2  +  i3*nb3));
 
         assert(ne00 % 32 == 0);
 


### PR DESCRIPTION
In the function ggml_compute_forward_add_q_f32, there seems to be a typo when calculating the address for dest_row.