### PR TITLE
Prevent usage of k-quants when tensor size is not a multiple of 256

### DIFF
--- a/examples/metal/metal.cpp
+++ b/examples/metal/metal.cpp
@@ -40,8 +40,10 @@ int main(int argc, char ** argv) {
     // this allocates all Metal resources and memory buffers
     auto * ctx_metal = ggml_metal_init();
 
-    ggml_metal_add_buffer(ctx_metal, "data", ggml_get_mem_buffer(ctx_data), ggml_get_mem_size(ctx_data));
-    ggml_metal_add_buffer(ctx_metal, "eval", ggml_get_mem_buffer(ctx_eval), ggml_get_mem_size(ctx_eval));
+    const size_t max_size_data = ggml_get_max_tensor_size(ctx_data);
+    const size_t max_size_eval = ggml_get_max_tensor_size(ctx_eval);
+    ggml_metal_add_buffer(ctx_metal, "data", ggml_get_mem_buffer(ctx_data), ggml_get_mem_size(ctx_data), max_size_data);
+    ggml_metal_add_buffer(ctx_metal, "eval", ggml_get_mem_buffer(ctx_eval), ggml_get_mem_size(ctx_eval), max_size_eval);
 
     // main
     {


### PR DESCRIPTION
The Falcon-7B model has tensors with 4544 columns. This is not divisible by 256, and as a result k-quants do not work for this model. See discussion in #1602. 

To prevent people wasting their time trying to make a new model work with k-quants where tensor size (more precisely, number of columns in a tensor) is not a multiple 256, which is the k-quants super-block size, this PR adds a check in `llama_model_quantize_internal`. It is a temporary fix until #1919 is solved.  