### PR TITLE
Fixed incorrectly applying RMS norm twice

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1657,11 +1657,7 @@ static bool llama_eval_internal(
     {
         cur = ggml_rms_norm(ctx0, inpL);
         offload_func_nr(cur);
-        ggml_set_name(cur, "rms_norm_inpL");
-
-        cur = ggml_rms_norm(ctx0, cur);
-        offload_func_nr(cur);
-        ggml_set_name(cur, "rms_norm_after");
+        ggml_set_name(cur, "rms_norm_2");
 
         // cur = cur*norm(broadcasted)
         cur = ggml_mul(ctx0, cur, model.norm);


### PR DESCRIPTION
As pointed out by @slaren I accidentally added a second instance of RMS norm in https://github.com/ggerganov/llama.cpp/pull/1703 and did not catch this during review. Because norms by definition do not have an effect when applied more than once this does not affect results but it's still incorrect.