### PR TITLE
memory is not guaranteed to be aligned properly during ggml_init call from loading saved sessions

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -3122,8 +3122,6 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
         if (kv_size) {
             const size_t elt_size = ggml_element_size(kv_self.k);
 
-            //char buffer[4096];
-
             ggml_context * cpy_ctx = ggml_init({ 4096, NULL, /* no_alloc */ true });
             ggml_cgraph gf{};
             gf.n_threads = 1;
@@ -3230,9 +3228,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
 
             const size_t elt_size = ggml_element_size(kv_self.k);
 
-            char buffer[4096];
-
-            ggml_context * cpy_ctx = ggml_init({ sizeof(buffer), buffer, /* no_alloc */ true });
+            ggml_context * cpy_ctx = ggml_init({ 4096, NULL, /* no_alloc */ true });
             ggml_cgraph gf{};
             gf.n_threads = 1;
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -3122,9 +3122,9 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
         if (kv_size) {
             const size_t elt_size = ggml_element_size(kv_self.k);
 
-            char buffer[4096];
+            //char buffer[4096];
 
-            ggml_context * cpy_ctx = ggml_init({ sizeof(buffer), buffer, /* no_alloc */ true });
+            ggml_context * cpy_ctx = ggml_init({ 4096, NULL, /* no_alloc */ true });
             ggml_cgraph gf{};
             gf.n_threads = 1;
 


### PR DESCRIPTION
In the `llama_copy_state_data` function, when calling `ggml_init`, we are allocating a buffer outside and passing it into the `ggml_init` function.

This function seems to be mainly used during loading previous `eval`s from a session file.

This allocation is not guaranteed to have memory alignment required by the GGML internals, causing `ggml_assert_aligned(ctx->mem_buffer);` in `ggml.c:4103` to fail.

Namely, this happens with building on Android devices with `RelWithDebInfo`. (Though this works in both Debug and Release so is a hard one to catch.)

I've changed it so the allocation is done inside of GGML using the correct `GGML_ALIGNED_MALLOC` function.

This is tested to fix the assertion issue on Android platforms.

Based on my limited understanding, this change should not have any wide-spread effect on the rest of the code.