### PR TITLE
Fix crash when running train with CUDA enabled

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2634,6 +2634,10 @@ void ggml_cuda_free_scratch() {
 
 bool ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor){
     ggml_cuda_func_t func;
+
+    if (tensor->op == GGML_OP_NONE)
+        return true;
+
     const bool any_on_device = tensor->backend == GGML_BACKEND_GPU
         || tensor->src0->backend == GGML_BACKEND_GPU || tensor->src0->backend == GGML_BACKEND_GPU_SPLIT
         || (tensor->src1 != nullptr && tensor->src1->backend == GGML_BACKEND_GPU);


### PR DESCRIPTION
Although CUDA GPU is not used during training, CUDA will crash due to the assumption on tensor->src0 is not NULL. The assumption is wrong when op is GGML_OP_NONE, which is used for backward grad computing.