### PR TITLE
cmake: revert CUDA arch default to 52, 61 if f16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,15 @@ if (LLAMA_CUBLAS)
             set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart CUDA::cublas CUDA::cublasLt)
         endif()
 
+    if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        if (LLAMA_CUDA_DMMV_F16)
+            set(CMAKE_CUDA_ARCHITECTURES "61") # needed for f16 CUDA intrinsics
+        else()
+            set(CMAKE_CUDA_ARCHITECTURES "52") # lowest CUDA 12 standard
+        endif()
+    endif()
+    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
+
     else()
         message(WARNING "cuBLAS not found")
     endif()
@@ -491,22 +500,6 @@ if (BUILD_SHARED_LIBS)
     if (LLAMA_METAL)
         set_target_properties(llama PROPERTIES RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.metal")
     endif()
-endif()
-
-if (GGML_SOURCES_CUDA)
-    message(STATUS "GGML CUDA sources found, configuring CUDA architecture")
-    set_property(TARGET ggml  PROPERTY CUDA_ARCHITECTURES "native")
-    set_property(TARGET ggml  PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
-
-    set_property(TARGET ggml_static PROPERTY CUDA_ARCHITECTURES "native")
-    set_property(TARGET ggml_static PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
-
-    if (BUILD_SHARED_LIBS)
-        set_property(TARGET ggml_shared PROPERTY CUDA_ARCHITECTURES "native")
-        set_property(TARGET ggml_shared PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
-    endif()
-
-    set_property(TARGET llama PROPERTY CUDA_ARCHITECTURES "native")
 endif()
 
 


### PR DESCRIPTION
In https://github.com/ggerganov/llama.cpp/pull/1913 I changed cmake to use `native` as the CUDA arch (like the Makefile does). However, this seems to cause compilation issues for some users which seems to be related to cmake version, see https://github.com/ggerganov/llama.cpp/pull/1946. This PR restores the default cmake CUDA arch to `compute_52`. If `LLAMA_CUDA_DMMV_F16` is set the arch is instead set to `compute_61`. [When I tested it using an RTX 3090](https://github.com/ggerganov/llama.cpp/pull/1946#issuecomment-1600356433), I was not able to discern a performance difference from using `native` over `compute_52`. This PR does **not** fix the inconsistent behavior between make and cmake.