### PR TITLE
broken change: deprecate GGML_TASK_INIT and GGML_TASK_FINALIZE

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -444,6 +444,9 @@ extern "C" {
 
 
     // compute types
+
+    // NOTE: the INIT or FINALIZE pass is not scheduled unless explicitly enabled.
+    // This behavior was changed since https://github.com/ggerganov/llama.cpp/pull/1995.
     enum ggml_task_type {
         GGML_TASK_INIT = 0,
         GGML_TASK_COMPUTE,


### PR DESCRIPTION
Try resolve https://github.com/ggerganov/ggml/issues/284

- <del>comment warning for `GGML_TASK_FINALIZE` in `ggml.h`</del>
- removed codes using `GGML_TASK_FINALIZE` in `ggml.c`, including those in `ggml_graph_compute`.
- <del>print a warning message in `ggml_compute_forward` to warn unmerged incoming PR. Thread unsafe but should be OK. This message will be shown before prompt echo back in console.</del>

### Edit

I had missed a case that `ggml_compute_forward_cross_entropy_loss_f32()` is using `GGML_TASK_FINALIZE`.

Added a `finalizer lookup table` to patch this special case. Only one entry in it: `ggml_compute_forward_cross_entropy_loss_finalizer`. `ggml_graph_compute_thread()` was slightly updated.

Unable to test op `GGML_OP_CROSS_ENTROPY_LOSS` because the train always crash in the middle on my weak device.  The extracted finalizer is quite simple, so I think it's OK to bypass the test by me.

Verified the lookup table with `OP_MUL_MAT`,  the registered runner was called as expected.
Finally I removed GGML_TASK_FINALIZE.

### Update

Also deprecated GGML_TASK_INIT; no longer touch runner codes, because that's error prone. We can cleanup them later step by step.

The `GGML_OP_HAS_XXX` idea is stolen from  https://github.com/ggerganov/llama.cpp/commit/9d058c2096b9f1f300e1ee16f5740a6a0a342917 Credit @zrm

@ggerganov @xaedes @zrm