### PR TITLE
ggml : change ggml_graph_compute() API to not require context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ on:
     paths: ['**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu']
 
 env:
- BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  GGML_NLOOP: 3
+  GGML_NITER: 1
 
 jobs:
   ubuntu-focal-make:
@@ -40,10 +42,6 @@ jobs:
 
   ubuntu-latest-cmake:
     runs-on: ubuntu-latest
-
-    env:
-      GGML_NLOOP: 3
-      GGML_NITER: 1
 
     steps:
       - name: Clone
@@ -72,10 +70,6 @@ jobs:
 
   ubuntu-latest-cmake-sanitizer:
     runs-on: ubuntu-latest
-
-    env:
-      GGML_NLOOP: 3
-      GGML_NITER: 1
 
     continue-on-error: true
 
@@ -131,10 +125,6 @@ jobs:
   macOS-latest-cmake:
     runs-on: macos-latest
 
-    env:
-      GGML_NLOOP: 3
-      GGML_NITER: 1
-
     steps:
       - name: Clone
         id: checkout
@@ -163,10 +153,6 @@ jobs:
 
   windows-latest-cmake:
     runs-on: windows-latest
-
-    env:
-      GGML_NLOOP: 3
-      GGML_NITER: 1
 
     env:
       OPENBLAS_VERSION: 0.3.23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ jobs:
   ubuntu-latest-cmake:
     runs-on: ubuntu-latest
 
+    env:
+      GGML_NLOOP: 3
+      GGML_NITER: 1
+
     steps:
       - name: Clone
         id: checkout
@@ -64,10 +68,14 @@ jobs:
         id: cmake_test
         run: |
           cd build
-          ctest --verbose
+          ctest --verbose --timeout 900
 
   ubuntu-latest-cmake-sanitizer:
     runs-on: ubuntu-latest
+
+    env:
+      GGML_NLOOP: 3
+      GGML_NITER: 1
 
     continue-on-error: true
 
@@ -99,7 +107,7 @@ jobs:
         id: cmake_test
         run: |
           cd build
-          ctest --verbose
+          ctest --verbose --timeout 900
 
   macOS-latest-make:
     runs-on: macos-latest
@@ -122,6 +130,10 @@ jobs:
 
   macOS-latest-cmake:
     runs-on: macos-latest
+
+    env:
+      GGML_NLOOP: 3
+      GGML_NITER: 1
 
     steps:
       - name: Clone
@@ -147,10 +159,15 @@ jobs:
         id: cmake_test
         run: |
           cd build
-          ctest --verbose
+          ctest --verbose --timeout 900
 
   windows-latest-cmake:
     runs-on: windows-latest
+
+    env:
+      GGML_NLOOP: 3
+      GGML_NITER: 1
+
     env:
       OPENBLAS_VERSION: 0.3.23
       OPENCL_VERSION: 2023.04.17
@@ -249,7 +266,7 @@ jobs:
         if: ${{ matrix.build != 'clblast' && (matrix.build != 'avx512' || env.HAS_AVX512F == '1') }} # Test AVX-512 only when possible
         run: |
           cd build
-          ctest -C Release --verbose
+          ctest -C Release --verbose --timeout 900
 
       - name: Get commit hash
         id: commit

--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -1569,6 +1569,8 @@ int main(int argc, char ** argv) {
     int n_tokens = model.hparams.n_ctx;
     int n_vocab  = model.hparams.n_vocab;
 
+    auto compute_plan_buffer = std::vector<uint8_t>();
+
     for (int ex=0; ex<n_examples; ++ex) {
         struct ggml_init_params params = {
             /*.mem_size   =*/ compute_size,
@@ -1598,13 +1600,10 @@ int main(int argc, char ** argv) {
         {
             struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
             if (plan.work_size > 0) {
-                plan.work_data = malloc(plan.work_size);
-                GGML_ASSERT(plan.work_data);
+                compute_plan_buffer.resize(plan.work_size);
+                plan.work_data = compute_plan_buffer.data();
             }
             ggml_graph_compute(&plan, &gf);
-            if (plan.work_data) {
-                free(plan.work_data);
-            }
         }
 
         float error_before_opt = ggml_get_f32_1d(e, 0);
@@ -1625,13 +1624,10 @@ int main(int argc, char ** argv) {
         {
             struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
             if (plan.work_size > 0) {
-                plan.work_data = malloc(plan.work_size);
-                GGML_ASSERT(plan.work_data);
+                compute_plan_buffer.resize(plan.work_size);
+                plan.work_data = compute_plan_buffer.data();
             }
             ggml_graph_compute(&plan, &gf);
-            if (plan.work_data) {
-                free(plan.work_data);
-            }
         }
 
         float error_after_opt = ggml_get_f32_1d(e, 0);
@@ -1689,13 +1685,10 @@ int main(int argc, char ** argv) {
             {
                 struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
                 if (plan.work_size > 0) {
-                    plan.work_data = malloc(plan.work_size);
-                    GGML_ASSERT(plan.work_data);
+                    compute_plan_buffer.resize(plan.work_size);
+                    plan.work_data = compute_plan_buffer.data();
                 }
                 ggml_graph_compute(&plan, &gf);
-                if (plan.work_data) {
-                    free(plan.work_data);
-                }
             }
 
             struct ggml_tensor * best_samples = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, sample_ctx);

--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -1569,7 +1569,7 @@ int main(int argc, char ** argv) {
     int n_tokens = model.hparams.n_ctx;
     int n_vocab  = model.hparams.n_vocab;
 
-    auto compute_plan_buffer = std::vector<uint8_t>();
+    std::vector<uint8_t> work_buffer;
 
     for (int ex=0; ex<n_examples; ++ex) {
         struct ggml_init_params params = {
@@ -1598,12 +1598,12 @@ int main(int argc, char ** argv) {
         ggml_build_forward_expand(&gf, e);
 
         {
-            struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
-            if (plan.work_size > 0) {
-                compute_plan_buffer.resize(plan.work_size);
-                plan.work_data = compute_plan_buffer.data();
+            struct ggml_cplan pf = ggml_graph_plan(&gf, /*n_threads*/ 1);
+            if (pf.work_size > 0) {
+                work_buffer.resize(pf.work_size);
+                pf.work_data = work_buffer.data();
             }
-            ggml_graph_compute(&plan, &gf);
+            ggml_graph_compute(&gf, &pf);
         }
 
         float error_before_opt = ggml_get_f32_1d(e, 0);
@@ -1622,12 +1622,12 @@ int main(int argc, char ** argv) {
         ggml_build_forward_expand(&gf, e);
 
         {
-            struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
-            if (plan.work_size > 0) {
-                compute_plan_buffer.resize(plan.work_size);
-                plan.work_data = compute_plan_buffer.data();
+            struct ggml_cplan pf = ggml_graph_plan(&gf, /*n_threads*/ 1);
+            if (pf.work_size > 0) {
+                work_buffer.resize(pf.work_size);
+                pf.work_data = work_buffer.data();
             }
-            ggml_graph_compute(&plan, &gf);
+            ggml_graph_compute(&gf, &pf);
         }
 
         float error_after_opt = ggml_get_f32_1d(e, 0);
@@ -1683,12 +1683,12 @@ int main(int argc, char ** argv) {
             ggml_build_forward_expand(&gf, logits);
 
             {
-                struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, /*n_threads*/ 1);
-                if (plan.work_size > 0) {
-                    compute_plan_buffer.resize(plan.work_size);
-                    plan.work_data = compute_plan_buffer.data();
+                struct ggml_cplan pf = ggml_graph_plan(&gf, /*n_threads*/ 1);
+                if (pf.work_size > 0) {
+                    work_buffer.resize(pf.work_size);
+                    pf.work_data = work_buffer.data();
                 }
-                ggml_graph_compute(&plan, &gf);
+                ggml_graph_compute(&gf, &pf);
             }
 
             struct ggml_tensor * best_samples = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, sample_ctx);

--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -164,15 +164,15 @@ int main(int argc, char ** argv)  {
     TENSOR_DUMP(m11);
     TENSOR_DUMP(m2);
 
-    auto compute_plan_buffer = std::vector<uint8_t>();
+    std::vector<uint8_t> work_buffer;
 
     {
-        auto plan = ggml_graph_compute_make_plan(&gf, benchmark_params.n_threads);
-        if (plan.work_size > 0) {
-            compute_plan_buffer.resize(plan.work_size);
-            plan.work_data = compute_plan_buffer.data();
+        ggml_cplan pf = ggml_graph_plan(&gf, benchmark_params.n_threads);
+        if (pf.work_size > 0) {
+            work_buffer.resize(pf.work_size);
+            pf.work_data = work_buffer.data();
         }
-        ggml_graph_compute(&plan, &gf);
+        ggml_graph_compute(&gf, &pf);
     }
 
     TENSOR_DUMP(gf.nodes[0]);
@@ -228,12 +228,12 @@ int main(int argc, char ** argv)  {
         long long int start = ggml_time_us();
         //printf("Running ggml_graph_compute\n");
         {
-            auto plan = ggml_graph_compute_make_plan(&gf31, benchmark_params.n_threads);
-            if (plan.work_size > 0) {
-                compute_plan_buffer.resize(plan.work_size);
-                plan.work_data = compute_plan_buffer.data();
+            ggml_cplan pf31 = ggml_graph_plan(&gf31, benchmark_params.n_threads);
+            if (pf31.work_size > 0) {
+                work_buffer.resize(pf31.work_size);
+                pf31.work_data = work_buffer.data();
             }
-            ggml_graph_compute(&plan, &gf31);
+            ggml_graph_compute(&gf31, &pf31);
         }
 
         long long int stop = ggml_time_us();
@@ -268,12 +268,12 @@ int main(int argc, char ** argv)  {
 
         // Running a different graph computation to make sure we override the CPU cache lines
         {
-            auto plan = ggml_graph_compute_make_plan(&gf32, benchmark_params.n_threads);
-            if (plan.work_size > 0) {
-                compute_plan_buffer.resize(plan.work_size);
-                plan.work_data = compute_plan_buffer.data();
+            ggml_cplan pf32 = ggml_graph_plan(&gf32, benchmark_params.n_threads);
+            if (pf32.work_size > 0) {
+                work_buffer.resize(pf32.work_size);
+                pf32.work_data = work_buffer.data();
             }
-            ggml_graph_compute(&plan, &gf32);
+            ggml_graph_compute(&gf32, &pf32);
         }
     }
     printf("\n");

--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -164,16 +164,15 @@ int main(int argc, char ** argv)  {
     TENSOR_DUMP(m11);
     TENSOR_DUMP(m2);
 
+    auto compute_plan_buffer = std::vector<uint8_t>();
+
     {
-        struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, benchmark_params.n_threads);
+        auto plan = ggml_graph_compute_make_plan(&gf, benchmark_params.n_threads);
         if (plan.work_size > 0) {
-            plan.work_data = malloc(plan.work_size);
-            GGML_ASSERT(plan.work_data);
+            compute_plan_buffer.resize(plan.work_size);
+            plan.work_data = compute_plan_buffer.data();
         }
         ggml_graph_compute(&plan, &gf);
-        if (plan.work_data) {
-            free(plan.work_data);
-        }
     }
 
     TENSOR_DUMP(gf.nodes[0]);
@@ -229,15 +228,12 @@ int main(int argc, char ** argv)  {
         long long int start = ggml_time_us();
         //printf("Running ggml_graph_compute\n");
         {
-            struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf31, benchmark_params.n_threads);
+            auto plan = ggml_graph_compute_make_plan(&gf31, benchmark_params.n_threads);
             if (plan.work_size > 0) {
-                plan.work_data = malloc(plan.work_size);
-                GGML_ASSERT(plan.work_data);
+                compute_plan_buffer.resize(plan.work_size);
+                plan.work_data = compute_plan_buffer.data();
             }
             ggml_graph_compute(&plan, &gf31);
-            if (plan.work_data) {
-                free(plan.work_data);
-            }
         }
 
         long long int stop = ggml_time_us();
@@ -272,15 +268,12 @@ int main(int argc, char ** argv)  {
 
         // Running a different graph computation to make sure we override the CPU cache lines
         {
-            struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf32, benchmark_params.n_threads);
+            auto plan = ggml_graph_compute_make_plan(&gf32, benchmark_params.n_threads);
             if (plan.work_size > 0) {
-                plan.work_data = malloc(plan.work_size);
-                GGML_ASSERT(plan.work_data);
+                compute_plan_buffer.resize(plan.work_size);
+                plan.work_data = compute_plan_buffer.data();
             }
             ggml_graph_compute(&plan, &gf32);
-            if (plan.work_data) {
-                free(plan.work_data);
-            }
         }
     }
     printf("\n");

--- a/examples/metal/metal.cpp
+++ b/examples/metal/metal.cpp
@@ -35,10 +35,9 @@ int main(int argc, char ** argv) {
     struct ggml_context * ctx_eval = NULL;
 
     struct ggml_cgraph gf = ggml_graph_import(fname_cgraph, &ctx_data, &ctx_eval);
-    gf.n_threads = 1;
 
     // this allocates all Metal resources and memory buffers
-    auto * ctx_metal = ggml_metal_init();
+    auto * ctx_metal = ggml_metal_init(1);
 
     const size_t max_size_data = ggml_get_max_tensor_size(ctx_data);
     const size_t max_size_eval = ggml_get_max_tensor_size(ctx_eval);

--- a/examples/train-text-from-scratch/train-text-from-scratch.cpp
+++ b/examples/train-text-from-scratch/train-text-from-scratch.cpp
@@ -1426,11 +1426,9 @@ struct ggml_tensor * forward_batch_wo_cache_flash_attn_train(
 
     gf->n_nodes = 0;
     gf->n_leafs = 0;
-    gf->work_size = 0;
     gf->perf_runs = 0;
     gf->perf_cycles = 0;
     gf->perf_time_us = 0;
-    gf->work = NULL;
 
     const auto & hparams = model->hparams;
     //const int n_ctx      = hparams.n_ctx;

--- a/ggml-metal.h
+++ b/ggml-metal.h
@@ -34,8 +34,12 @@ extern "C" {
 
 struct ggml_metal_context;
 
-struct ggml_metal_context * ggml_metal_init(void);
+// number of command buffers to use
+struct ggml_metal_context * ggml_metal_init(int n_cb);
 void ggml_metal_free(struct ggml_metal_context * ctx);
+
+// set the number of command buffers to use
+void ggml_metal_set_n_cb(struct ggml_metal_context * ctx, int n_cb);
 
 // creates a mapping between a host memory buffer and a device memory buffer
 // - make sure to map all buffers used in the graph before calling ggml_metal_graph_compute

--- a/ggml.c
+++ b/ggml.c
@@ -15974,7 +15974,7 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
     const struct ggml_cgraph * cgraph = state->shared->cgraph;
 
     const struct ggml_graph_compute_plan * plan = state->shared->plan;
-    const int *n_tasks_arr = plan->n_tasks;
+    const int * n_tasks_arr = plan->n_tasks;
 
     const int n_threads = state->shared->n_threads;
     set_numa_thread_affinity(state->ith, n_threads);
@@ -16490,6 +16490,7 @@ void ggml_graph_compute(struct ggml_graph_compute_plan * plan, struct ggml_cgrap
     }
 }
 
+// TODO: avoid allocating memory frequently.
 static void ggml_graph_compute_sugar(struct ggml_cgraph * cgraph, int n_threads) {
     struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(cgraph, n_threads);
     if (plan.work_size > 0) {

--- a/ggml.c
+++ b/ggml.c
@@ -16176,31 +16176,29 @@ struct ggml_cplan ggml_graph_plan(struct ggml_cgraph * cgraph, int n_threads) {
                     if (ggml_cuda_can_mul_mat(node->src0, node->src1, node)) {
                         n_tasks = 1; // TODO: this actually is doing nothing
                                      //       the threads are still spinning
-                    }
-                    else
+                    } else
 #elif defined(GGML_USE_CLBLAST)
-                        if (ggml_cl_can_mul_mat(node->src0, node->src1, node)) {
-                            n_tasks = 1; // TODO: this actually is doing nothing
-                                         //       the threads are still spinning
-                            cur = ggml_cl_mul_mat_get_wsize(node->src0, node->src1, node);
-                        }
-                        else
+                    if (ggml_cl_can_mul_mat(node->src0, node->src1, node)) {
+                        n_tasks = 1; // TODO: this actually is doing nothing
+                                     //       the threads are still spinning
+                        cur = ggml_cl_mul_mat_get_wsize(node->src0, node->src1, node);
+                    } else
 #endif
 #if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS)
-                            if (ggml_compute_forward_mul_mat_use_blas(node->src0, node->src1, node)) {
-                                n_tasks = 1; // TODO: this actually is doing nothing
-                                             //       the threads are still spinning
-                                if (node->src0->type != GGML_TYPE_F32) {
-                                    // here we need memory just for single 2D matrix from src0
-                                    cur = GGML_TYPE_SIZE[GGML_TYPE_F32]*(node->src0->ne[0]*node->src0->ne[1]);
-                                }
-                            } else
+                    if (ggml_compute_forward_mul_mat_use_blas(node->src0, node->src1, node)) {
+                        n_tasks = 1; // TODO: this actually is doing nothing
+                                     //       the threads are still spinning
+                        if (node->src0->type != GGML_TYPE_F32) {
+                            // here we need memory just for single 2D matrix from src0
+                            cur = GGML_TYPE_SIZE[GGML_TYPE_F32]*(node->src0->ne[0]*node->src0->ne[1]);
+                        }
+                    } else
 #endif
-                                if (node->src1->type != vec_dot_type) {
-                                    cur = GGML_TYPE_SIZE[vec_dot_type]*ggml_nelements(node->src1)/GGML_BLCK_SIZE[vec_dot_type];
-                                } else {
-                                    cur = 0;
-                                }
+                    if (node->src1->type != vec_dot_type) {
+                        cur = GGML_TYPE_SIZE[vec_dot_type]*ggml_nelements(node->src1)/GGML_BLCK_SIZE[vec_dot_type];
+                    } else {
+                        cur = 0;
+                    }
 
                     work_size = MAX(work_size, cur);
                 } break;

--- a/ggml.h
+++ b/ggml.h
@@ -449,7 +449,7 @@ extern "C" {
         // Size of work buffer, calculated by `ggml_graph_compute_make_plan()`.
         size_t work_size;
         // Work buffer, to be allocated by caller before calling to `ggml_graph_compute()`.
-        void * work_data;
+        uint8_t * work_data;
 
         int n_threads;
 

--- a/ggml.h
+++ b/ggml.h
@@ -65,15 +65,17 @@
 //       ggml_set_f32(a, 3.0f);
 //       ggml_set_f32(b, 4.0f);
 //
-//       const int n_threads = 1;
-//       struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, n_threads);
-//       if (plan.work_size > 0) {
-//           plan.work_data = malloc(plan.work_size);
-//           GGML_ASSERT(plan.work_data);
+//       struct ggml_cplan pf = ggml_graph_compute_make_plan(&gf, n_threads);
+//
+//       if (pf.work_size > 0) {
+//           pf.work_data = malloc(pf.work_size);
+//           GGML_ASSERT(pf.work_data);
 //       }
-//       ggml_graph_compute(&plan, &gf);
-//       if (plan.work_data) {
-//           free(plan.work_data);
+//
+//       ggml_graph_compute(&gf, &pf);
+//
+//       if (pf.work_data) {
+//           free(pf.work_data);
 //       }
 //
 //       printf("f = %f\n", ggml_get_f32_1d(f, 0));

--- a/ggml.h
+++ b/ggml.h
@@ -443,17 +443,15 @@ extern "C" {
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);
 
-    // The default graph compute plan that needs to be prepared for ggml_graph_compute().
-    // Since https://github.com/ggerganov/ggml/issues/287
-    struct ggml_graph_compute_plan {
-        // Size of work buffer, calculated by `ggml_graph_compute_make_plan()`.
-        size_t work_size;
-        // Work buffer, to be allocated by caller before calling to `ggml_graph_compute()`.
-        uint8_t * work_data;
+    // the compute plan that needs to be prepared for ggml_graph_compute()
+    // since https://github.com/ggerganov/ggml/issues/287
+    struct ggml_cplan {
+        size_t    work_size; // size of work buffer, calculated by `ggml_graph_plan()`
+        uint8_t * work_data; // work buffer, to be allocated by caller before calling to `ggml_graph_compute()`
 
         int n_threads;
 
-        // The `n_tasks` of nodes, 1:1 mapping to cgraph nodes.
+        // the `n_tasks` of nodes, 1:1 mapping to cgraph nodes
         int n_tasks[GGML_MAX_NODES];
     };
 
@@ -1313,11 +1311,11 @@ extern "C" {
     GGML_API struct ggml_cgraph ggml_build_forward (struct ggml_tensor * tensor);
     GGML_API struct ggml_cgraph ggml_build_backward(struct ggml_context * ctx, struct ggml_cgraph * gf, bool keep);
 
-    // ggml_graph_compute_make_plan() needs to be called before ggml_graph_compute().
-    // Returns a plan object. When plan.work_size > 0, caller must allocate memory for plan.work_data.
-    GGML_API struct ggml_graph_compute_plan ggml_graph_compute_make_plan(struct ggml_cgraph * cgraph, const int n_threads/*=GGML_DEFAULT_N_THREADS*/);
-    GGML_API void ggml_graph_compute(struct ggml_graph_compute_plan * plan, struct ggml_cgraph * cgraph);
-    GGML_API void ggml_graph_reset  (struct ggml_cgraph * cgraph);
+    // ggml_graph_plan() has to be called before ggml_graph_compute()
+    // when plan.work_size > 0, caller must allocate memory for plan.work_data
+    GGML_API struct ggml_cplan ggml_graph_plan   (struct ggml_cgraph * cgraph, int n_threads /*= GGML_DEFAULT_N_THREADS*/);
+    GGML_API              void ggml_graph_compute(struct ggml_cgraph * cgraph, struct ggml_cplan * cplan);
+    GGML_API              void ggml_graph_reset  (struct ggml_cgraph * cgraph);
 
     GGML_API struct ggml_tensor * ggml_graph_get_tensor(struct ggml_cgraph * cgraph, const char * name);
 

--- a/ggml.h
+++ b/ggml.h
@@ -1306,7 +1306,7 @@ extern "C" {
 
     GGML_API void ggml_set_param(
             struct ggml_context * ctx,
-            struct ggml_tensor * tensor);
+            struct ggml_tensor  * tensor);
 
     GGML_API void ggml_build_forward_expand(struct ggml_cgraph * cgraph, struct ggml_tensor * tensor);
 
@@ -1318,6 +1318,10 @@ extern "C" {
     GGML_API struct ggml_cplan ggml_graph_plan   (struct ggml_cgraph * cgraph, int n_threads /*= GGML_DEFAULT_N_THREADS*/);
     GGML_API              void ggml_graph_compute(struct ggml_cgraph * cgraph, struct ggml_cplan * cplan);
     GGML_API              void ggml_graph_reset  (struct ggml_cgraph * cgraph);
+
+    // same as ggml_graph_compute() but the work data is allocated as a part of the context
+    // note: the drawback of this API is that you must have ensured that the context has enough memory for the work data
+    GGML_API void ggml_graph_compute_with_ctx(struct ggml_context * ctx, struct ggml_cgraph * cgraph, int n_threads);
 
     GGML_API struct ggml_tensor * ggml_graph_get_tensor(struct ggml_cgraph * cgraph, const char * name);
 

--- a/ggml.h
+++ b/ggml.h
@@ -65,18 +65,7 @@
 //       ggml_set_f32(a, 3.0f);
 //       ggml_set_f32(b, 4.0f);
 //
-//       struct ggml_cplan pf = ggml_graph_compute_make_plan(&gf, n_threads);
-//
-//       if (pf.work_size > 0) {
-//           pf.work_data = malloc(pf.work_size);
-//           GGML_ASSERT(pf.work_data);
-//       }
-//
-//       ggml_graph_compute(&gf, &pf);
-//
-//       if (pf.work_data) {
-//           free(pf.work_data);
-//       }
+//       ggml_graph_compute_with_ctx(ctx, &gf, n_threads);
 //
 //       printf("f = %f\n", ggml_get_f32_1d(f, 0));
 //

--- a/ggml.h
+++ b/ggml.h
@@ -66,14 +66,14 @@
 //       ggml_set_f32(b, 4.0f);
 //
 //       const int n_threads = 1;
-//       struct ggml_graph_compute_plan ctx = ggml_graph_compute_make_plan(&gf, n_threads);
-//       if (ctx.work_size > 0) {
-//           ctx.work_data = malloc(ctx.work_size);
-//           GGML_ASSERT(ctx.work_data);
+//       struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, n_threads);
+//       if (plan.work_size > 0) {
+//           plan.work_data = malloc(plan.work_size);
+//           GGML_ASSERT(plan.work_data);
 //       }
-//       ggml_graph_compute(&ctx, &gf);
-//       if (ctx.work_data) {
-//           free(ctx.work_data);
+//       ggml_graph_compute(&plan, &gf);
+//       if (plan.work_data) {
+//           free(plan.work_data);
 //       }
 //
 //       printf("f = %f\n", ggml_get_f32_1d(f, 0));

--- a/ggml.h
+++ b/ggml.h
@@ -448,8 +448,7 @@ extern "C" {
     struct ggml_graph_compute_plan {
         // Size of work buffer, calculated by `ggml_graph_compute_make_plan()`.
         size_t work_size;
-        // Worker buffer.
-        // Expect allocate/free by caller before/after calling to `ggml_graph_compute()`.
+        // Work buffer, to be allocated by caller before calling to `ggml_graph_compute()`.
         void * work_data;
 
         int n_threads;

--- a/llama.cpp
+++ b/llama.cpp
@@ -83,7 +83,7 @@ void llama_nop(struct ggml_tensor * tensor) { // don't offload by default
 // ggml helpers
 //
 
-void ggml_graph_compute_helper(std::vector<uint8_t> & buf, ggml_cgraph * graph, int n_threads) {
+static void ggml_graph_compute_helper(std::vector<uint8_t> & buf, ggml_cgraph * graph, int n_threads) {
     struct ggml_cplan plan = ggml_graph_plan(graph, n_threads);
 
     if (plan.work_size > 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,5 @@ llama_add_test(test-quantize-fns.cpp)
 llama_add_test(test-quantize-perf.cpp)
 llama_add_test(test-sampling.cpp)
 llama_add_test(test-tokenizer-0.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../models/ggml-vocab.bin)
-# llama_add_test(test-grad0.c) # SLOW
+llama_add_test(test-grad0.c) # SLOW
 # llama_add_test(test-opt.c) # SLOW

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,5 @@ llama_add_test(test-quantize-fns.cpp)
 llama_add_test(test-quantize-perf.cpp)
 llama_add_test(test-sampling.cpp)
 llama_add_test(test-tokenizer-0.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../models/ggml-vocab.bin)
-llama_add_test(test-grad0.c) # SLOW
-llama_add_test(test-opt.c) # SLOW
+# llama_add_test(test-grad0.c) # SLOW
+# llama_add_test(test-opt.c) # SLOW

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,5 @@ llama_add_test(test-quantize-fns.cpp)
 llama_add_test(test-quantize-perf.cpp)
 llama_add_test(test-sampling.cpp)
 llama_add_test(test-tokenizer-0.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../models/ggml-vocab.bin)
-# llama_add_test(test-grad0.c) # SLOW
-# llama_add_test(test-opt.c) # SLOW
+llama_add_test(test-grad0.c) # SLOW
+llama_add_test(test-opt.c) # SLOW

--- a/tests/test-grad0.c
+++ b/tests/test-grad0.c
@@ -218,7 +218,6 @@ bool check_gradient(
 
     struct ggml_cgraph gb = ggml_build_backward(ctx0, &gf, false);
 
-    ggml_graph_compute(ctx0, &gf);
     {
         struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&gf, n_threads);
         if (plan.work_size > 0) {

--- a/tests/test-opt.c
+++ b/tests/test-opt.c
@@ -140,7 +140,19 @@ int main(int argc, const char ** argv) {
 
     struct ggml_cgraph ge = ggml_build_forward(e);
     ggml_graph_reset  (&ge);
-    ggml_graph_compute(ctx, &ge);
+
+    {
+        struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&ge, /*n_threads*/ 1);
+        if (plan.work_size > 0) {
+            plan.work_data = malloc(plan.work_size);
+            GGML_ASSERT(plan.work_data);
+        }
+        ggml_graph_compute(&plan, &ge);
+        if (plan.work_data) {
+            free(plan.work_data);
+        }
+    }
+
     const float fe = ggml_get_f32_1d(e, 0);
     printf("%s: e = %.4f\n", __func__, fe);
 
@@ -149,7 +161,19 @@ int main(int argc, const char ** argv) {
     ggml_opt(ctx, opt_params, e);
 
     ggml_graph_reset  (&ge);
-    ggml_graph_compute(ctx, &ge);
+
+    {
+        struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(&ge, /*n_threads*/ 1);
+        if (plan.work_size > 0) {
+            plan.work_data = malloc(plan.work_size);
+            GGML_ASSERT(plan.work_data);
+        }
+        ggml_graph_compute(&plan, &ge);
+        if (plan.work_data) {
+            free(plan.work_data);
+        }
+    }
+
     const float fe_opt = ggml_get_f32_1d(e, 0);
     printf("%s: original  e = %.4f\n", __func__, fe);
     printf("%s: optimized e = %.4f\n", __func__, fe_opt);


### PR DESCRIPTION
Try resolve https://github.com/ggerganov/ggml/issues/287

EDIT: see latest update at the end.

<del>
### Intro

The design is a bit different to the suggested one: named the buffer type as  a generalized one:`ggml_cgraph_context`.

```
struct ggml_cgraph_context {
    size_t work_size;
    void * work_data;
    bool   planned; // true means ready to compute graph nodes.
};
```
I'll explain `planned` later, let's focus on the APIs.

The first parameter `ctx` of `ggml_graph_compute()` is deprecated (pass in NULL is OK).
Removed `wsize` and `work` from `ggml_cgraph`, unlikely break external users because no reason to use them directly.

To avoid break external users, can not simply change the signature of `ggml_graph_compute()`, have to add `ggml_graph_compute_v2()`, the name looks weird but this is the reality :/  Now `ggml_graph_compute()` is a thin wrapper of `ggml_graph_compute_v2().

Extracted codes to new function `ggml_graph_compute_plan()`: set node->`n_tasks`, calculate `work_size`.

### Usage
```
struct ggml_cgraph_context ctx = {0};

// case 1:
ggml_graph_compute_plan(&ctx, cgraph);
if (ctx.work_size > 0) {
    ctx.work_data = malloc(ctx.work_size);
}
ggml_graph_compute_v2(&ctx, cgraph);

// case 2:
ggml_graph_compute_v2(&ctx, cgraph);

// case 3:
ggml_graph_compute_v2(NULL, cgraph);

// case 4:
ggml_graph_compute(ggml_context *ctx, cgraph);

// case 5:
ggml_graph_compute(NULL, cgraph);
```

### Why did I add the field `planned`?

Because:
 * The `ctx` is allowed to be NULL, empty or initialized by `ggml_graph_compute_plan()`.
 * One of the corner cases is: the `work_size` and `work_data` can be default values even if the plan has been called.  So we can not simply determine whether or not call `ggml_graph_compute_plan()` by default values.
 * `ggml_graph_compute_plan()` MUST be called because it  also sets `node->n_tasks`. The `work_size` depends on `n_tasks`.

The `planned` makes plan-compute sequence stateful, not good enough. Any ideas?

</del>

# Update on JUL 3

1. No longer consider backward compatibility, this means the `plan phase` MUST be executed before `compute`. And `gml_graph_compute()` no longer responsible for creating any kind of buffer. @ggerganov
2. Removed `n_tasks` from `ggml_tensor`; removed `n_threads` from `ggml_cgraph`. @slaren
3. the `struct ggml_graph_compute_plan` implies that it should be initialized or created by some procedure. @howard0su

Usage:

```
struct ggml_graph_compute_plan plan = ggml_graph_compute_make_plan(gb, params.n_threads);
if (plan.work_size > 0) {
    plan.work_data = malloc(plan.work_size);
    GGML_ASSERT(plan.work_data);
}
ggml_graph_compute(&plan, gb);
if (plan.work_data) {
    free(plan.work_data);
}
```

I tested `main` and `perplexity`.

# Update JUL 6

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 551ed08</samp>

### Summary
🛠️📚🚀

<!--
1.  🛠️ - This emoji represents the changes that fix bugs, improve performance, or refactor the code.
2.  📚 - This emoji represents the changes that update the documentation, comments, or examples.
3.  🚀 - This emoji represents the changes that add new features, enhance the API, or enable new tests.
-->
This pull request improves the performance and usability of the `ggml_graph_compute` function by introducing a new `ggml_cplan` structure and a helper function `ggml_graph_compute_helper`. It also adds support for specifying the number of command buffers for the Metal context, and updates the examples, tests, and workflows to use the new API and settings.

> _This pull request makes some changes_
> _To `ggml_graph_compute` and friends_
> _It adds a new plan_
> _And some Metal commands_
> _And fixes some warnings and ends_

### Walkthrough
*  Change the `ggml_graph_compute` function to require a `ggml_cplan` argument and add new functions `ggml_graph_plan` and `ggml_graph_compute_with_ctx` to support the new API ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394L1300-R1314))
*  Add a helper function `ggml_graph_compute_helper` to wrap the logic of creating and using a `ggml_cplan` structure and update the example code in `ggml.h` to use the new API ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baR34-R44), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07R23-R33), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267R63-R73), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394L68-R68), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR82-R100))
*  Remove the fields `n_threads`, `n_tasks`, and `work` from the `ggml_cgraph` and `ggml_tensor` structures and add them to the `ggml_cplan` structure ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L1429-R1442), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394L421-L423), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-f0f2d0dc971e0aa60560e7e3bc1d512b4bf914aedf44333f7008c605433cd394L435-R453))
*  Update the `llama_eval_internal` function to use the new API and adjust the number of threads for the BLAS settings ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL1268-R1289), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL1309-R1334), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL1594-R1623), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL1614-R1646))
*  Add a parameter `n_cb` to the `ggml_metal_init` function and a function `ggml_metal_set_n_cb` to control the number of command buffers for the Metal context and update the `ggml_metal_graph_compute` function to use the `n_cb` field instead of the `n_threads` field ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-3cebf7a1bc643557eff27cae1c81d9894615a7f944c271eefcfca861aaa013e1L37-R43), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d189c5117255f368aa89f521bd523afa399ada0bbfb7043b74c65bf4ac2472fdR28-R29), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d189c5117255f368aa89f521bd523afa399ada0bbfb7043b74c65bf4ac2472fdL89-R96), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d189c5117255f368aa89f521bd523afa399ada0bbfb7043b74c65bf4ac2472fdR214-R217), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d189c5117255f368aa89f521bd523afa399ada0bbfb7043b74c65bf4ac2472fdL357-R364))
*  Update the `metal.cpp` example to pass the number of threads to the `ggml_metal_init` function ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-f5177339d387bef8794ff76aa0cdae0aa28b68d63067bfc2ffe82904c096b619L38-R40))
*  Update the `baby-llama.cpp`, `benchmark-matmult.cpp`, and `train-text-from-scratch.cpp` examples to use the new API and remove the assignments of `gf.n_threads` ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baR1583-R1584), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1589), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1598-R1610), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1614-R1626), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1662), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1668-R1679), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-256be3a51fd8a6c1332bbcf2d5dd122810ba137a6184495fc3e42415857f69baL1690-R1706), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L162-R181), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L190), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L202-R213), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L224-R235), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L231-R242), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-6a296d1a1222746faa37384705c8ae3f535428097dbe46295d7ccf8405a6ff07L256-R267), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267R3174), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267R3196-R3197), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L3220-L3222), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L3251-R3260), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L3275-R3284), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L3357), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267L3363-R3371), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-d1491dab0ced83c9f5cd0ea092044b3f8c820d5da6405ccdec17ecebd9638267R3397))
*  Update the `llama.cpp` file to use the new API and pass the number 1 to the `ggml_metal_init` function ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR343-R345), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL761), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL2648-R2674), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efR2831-R2833), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL2969-R3000), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL3123), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL3143-R3171), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL3229), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-150dc86746a90bad4fc2c3334aeb9b5887b3adad3cc1459446717638605348efL3249-R3276))
*  Enable the `test-grad0.c` test and update it to use the new API and ignore the double promotion warning ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dL13-R13), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdR13-R14), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdL52-R54), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdL162-R171), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdL218-R230), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdL239-R251), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-719f57ae1dee9d562185e8fbe8a3c57b4b346c3a09c0fab71af3a7a5bff66cbdL255-R265))
*  Update the `test-opt.c` test to use the new API and ignore the double promotion warning ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-b0455748dd7cc28380469ad1ae439aac0dcb65d0bc8e9712fdcafd6adbda408fR10), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-b0455748dd7cc28380469ad1ae439aac0dcb65d0bc8e9712fdcafd6adbda408fL36-R37), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-b0455748dd7cc28380469ad1ae439aac0dcb65d0bc8e9712fdcafd6adbda408fL117-R118), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-b0455748dd7cc28380469ad1ae439aac0dcb65d0bc8e9712fdcafd6adbda408fL140-R145), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-b0455748dd7cc28380469ad1ae439aac0dcb65d0bc8e9712fdcafd6adbda408fL151-R156))
*  Add a timeout option to the `ctest` command for the GitHub workflow jobs to avoid the tests from hanging or running too long and add a new environment variable `GGML_NLOOP` to control the number of iterations for the benchmark tests ([link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R21), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L67-R69), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L102-R104), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L150-R156), [link](https://github.com/ggerganov/llama.cpp/pull/1999/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L252-R255))

