### PR TITLE
Fix assert when free invalid cuda pointer

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2553,6 +2553,7 @@ void ggml_cuda_assign_buffers_impl(struct ggml_tensor * tensor, bool scratch) {
 
     tensor->backend = GGML_BACKEND_GPU;
     struct ggml_tensor_extra_gpu * extra = new ggml_tensor_extra_gpu;
+    memset(extra, 0, sizeof(*extra));
 
     const bool inplace = (tensor->src0 != nullptr && tensor->src0->data == tensor->data) ||
         tensor->op == GGML_OP_VIEW;


### PR DESCRIPTION
Fix assert:
CUDA error 1 at C:\GPT\llama.cpp\ggml-cuda.cu:2536: invalid argument
By dump the related tensor, I noitced extra contains uninitialized values. Fix it by properly initialize the extra structure.
cache_k[10] 0->000000181A400000 1->CDCDCDCDCDCDCDCD     
