### PR TITLE
Add verbose flag for model loading

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -395,6 +395,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.input_suffix = argv[i];
+        } else if (arg == "--no-verbose") {
+            params.verbose = false;
         } else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             gpt_print_usage(argc, argv, default_params);
@@ -501,6 +503,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  --verbose-prompt      print prompt before generation\n");
     fprintf(stderr, "  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");
     fprintf(stderr, "  --lora-base FNAME     optional model to use as a base for the layers modified by the LoRA adapter\n");
+    fprintf(stderr, "  --no-verbose          do not print model info on startup\n");
     fprintf(stderr, "  -m FNAME, --model FNAME\n");
     fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());
     fprintf(stderr, "\n");
@@ -551,6 +554,7 @@ std::tuple<struct llama_model *, struct llama_context *> llama_init_from_gpt_par
     lparams.use_mlock    = params.use_mlock;
     lparams.logits_all   = params.perplexity;
     lparams.embedding    = params.embedding;
+    lparams.verbose      = params.verbose;
 
     llama_model * model  = llama_load_model_from_file(params.model.c_str(), lparams);
     if (model == NULL) {

--- a/examples/common.h
+++ b/examples/common.h
@@ -78,6 +78,7 @@ struct gpt_params {
     bool mem_test          = false; // compute maximum memory usage
     bool export_cgraph     = false; // export the computation graph
     bool verbose_prompt    = false; // print prompt tokens before generation
+    bool verbose           = true;  // print model info on load
 };
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/llama.h
+++ b/llama.h
@@ -100,6 +100,7 @@ extern "C" {
         bool use_mmap;   // use mmap if possible
         bool use_mlock;  // force system to keep model in RAM
         bool embedding;  // embedding mode only
+        bool verbose;    // show information on stderr on model load. This doesn't affect error messages.
     };
     // model file types
     enum llama_ftype {


### PR DESCRIPTION
Right now, the console is spammed with a lot of information about the model when llama_load_model_from_file is called. This PR adds a verbose flag so that you can optionally disable this.