### PR TITLE
Add Scala 3 bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ as the main playground for developing new features for the [ggml](https://github
 - Node.js: [hlhr202/llama-node](https://github.com/hlhr202/llama-node)
 - Ruby: [yoshoku/llama_cpp.rb](https://github.com/yoshoku/llama_cpp.rb)
 - C#/.NET: [SciSharp/LLamaSharp](https://github.com/SciSharp/LLamaSharp)
+- Scala 3: [donderom/llm4s](https://github.com/donderom/llm4s)
 
 **UI:**
 


### PR DESCRIPTION
I suggest to add bindings for Scala 3.

It supports the latest API (with model and context separation) and implements idiomatic high-level API.