### PR TITLE
Convert checks in llama_load_session_file to throw and handle them

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -3336,7 +3336,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
     return nread;
 }
 
-void llama_load_session_file_internal(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
+static void llama_load_session_file_internal(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
     llama_file file(path_session, "rb");
 
     // sanity checks

--- a/llama.cpp
+++ b/llama.cpp
@@ -3336,7 +3336,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
     return nread;
 }
 
-static void llama_load_session_file_internal(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
+static bool llama_load_session_file_internal(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
     llama_file file(path_session, "rb");
 
     // sanity checks
@@ -3345,14 +3345,16 @@ static void llama_load_session_file_internal(struct llama_context * ctx, const c
         const uint32_t version = file.read_u32();
 
         if (magic != LLAMA_SESSION_MAGIC || version != LLAMA_SESSION_VERSION) {
-            throw std::runtime_error(format("%s : unknown (magic, version) for session file: %08x, %08x\n", __func__, magic, version));
+            fprintf(stderr, "%s : unknown (magic, version) for session file: %08x, %08x\n", __func__, magic, version);
+            return false;
         }
 
         llama_hparams session_hparams;
         file.read_raw(&session_hparams, sizeof(llama_hparams));
 
         if (session_hparams != ctx->model.hparams) {
-            throw std::runtime_error(format("%s : model hparams didn't match from session file!\n", __func__));
+            fprintf(stderr, "%s : model hparams didn't match from session file!\n", __func__);
+            return false;
         }
     }
 
@@ -3361,7 +3363,8 @@ static void llama_load_session_file_internal(struct llama_context * ctx, const c
         const uint32_t n_token_count = file.read_u32();
 
         if (n_token_count > n_token_capacity) {
-            throw std::runtime_error(format("%s : token count in session file exceeded capacity! %u > %zu\n", __func__, n_token_count, n_token_capacity));
+            fprintf(stderr, "%s : token count in session file exceeded capacity! %u > %zu\n", __func__, n_token_count, n_token_capacity);
+            return false;
         }
 
         file.read_raw(tokens_out, sizeof(llama_token) * n_token_count);
@@ -3374,7 +3377,8 @@ static void llama_load_session_file_internal(struct llama_context * ctx, const c
         const size_t n_state_size_max = llama_get_state_size(ctx);
 
         if (n_state_size_cur > n_state_size_max) {
-            throw std::runtime_error(format("%s : the state size in session file is too big! max %zu, got %zu\n", __func__, n_state_size_max, n_state_size_cur));
+            fprintf(stderr, "%s : the state size in session file is too big! max %zu, got %zu\n", __func__, n_state_size_max, n_state_size_cur);
+            return false;
         }
 
         std::vector<uint8_t> state_data(n_state_size_max);
@@ -3386,8 +3390,7 @@ static void llama_load_session_file_internal(struct llama_context * ctx, const c
 
 bool llama_load_session_file(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
     try {
-        llama_load_session_file_internal(ctx, path_session, tokens_out, n_token_capacity, n_token_count_out);
-        return true;
+        return llama_load_session_file_internal(ctx, path_session, tokens_out, n_token_capacity, n_token_count_out);
     } catch (const std::exception & err) {
         fprintf(stderr, "error loading session file: %s\n", err.what());
         return false;


### PR DESCRIPTION
This pull request addresses https://github.com/ggerganov/llama.cpp/issues/1716

Similar to `llama_model_load`, there is a `llama_model_load_internal` that throws exceptions for invalid cases, and the API `llama_model_load` handles the exceptions.