### PR TITLE
Add CFLAGS when compiling ggml-cuda.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ else
 	NVCCFLAGS += -DK_QUANTS_PER_ITERATION=2
 endif
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
-	$(NVCC) $(NVCCFLAGS) $(CXXFLAGS) -Wno-pedantic -c $< -o $@
+	$(NVCC) $(NVCCFLAGS) $(CXXFLAGS) $(CFLAGS) -Wno-pedantic -c $< -o $@
 endif # LLAMA_CUBLAS
 
 ifdef LLAMA_CLBLAST


### PR DESCRIPTION
`make LLAMA_CUBLAS=1` can not be compiled successfully without CFLAGS