### PR TITLE
add support of baichuan-7b

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ as the main playground for developing new features for the [ggml](https://github
 - [X] [OpenBuddy 🐶 (Multilingual)](https://github.com/OpenBuddy/OpenBuddy)
 - [X] [Pygmalion 7B / Metharme 7B](#using-pygmalion-7b--metharme-7b)
 - [X] [WizardLM](https://github.com/nlpxucan/WizardLM)
+- [X] [Baichuan-7B](https://huggingface.co/baichuan-inc/baichuan-7B)
 
 **Bindings:**
 


### PR DESCRIPTION
This PR adds support of [baichuan-7b](https://huggingface.co/baichuan-inc/baichuan-7B) model.

> baichuan-7B is an open-source large-scale pre-trained model developed by Baichuan Intelligent  Technology. Based on the Transformer architecture, it is a model with 7 billion parameters trained on approximately 1.2 trillion tokens. It supports both Chinese and English, with a context window length of 4096. It achieves the best performance of its size on standard Chinese and English authoritative benchmarks (C-EVAL/MMLU).

This model doubles the vocabulary (64k) of LLaMa, which seems interesting.