### PR TITLE
Better CUDA synchronization logic

### DIFF
--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -8,10 +8,6 @@ extern "C" {
 
 #define GGML_CUDA_MAX_DEVICES       16
 
-struct ggml_tensor_extra_gpu {
-    void * data_device[GGML_CUDA_MAX_DEVICES]; // 1 pointer for each device for split tensors
-};
-
 void   ggml_init_cublas(void);
 void   ggml_cuda_set_tensor_split(const float * tensor_split);
 


### PR DESCRIPTION
Currently there are still more calls to `cudaDeviceSynchronize` than would be necessary. This PR improves the synchronization logic to reduce the number of those calls. In multi GPU settings synchronization is instead done via CUDA events. The performance boost turned out to be relatively small but it is measurable:

| GPU            | Model   | Test  | t/s master | t/s PR |
|----------------|---------|-------|------------|--------|
| RTX 3090       | 7b q4_0 | tg128 |      90.81 |  91.33 |
| P40 + GTX 1070 | 7b q4_0 | tg128 |      21.53 |  21.60 |

I also deduplicated the calls to `cudaGetLastError`.