### PR TITLE
Fix integer `abs()` warning

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1947,7 +1947,7 @@ void llama_sample_tail_free(struct llama_context * ctx, llama_token_data_array *
 
     // Calculate absolute value of second derivatives
     for (size_t i = 0; i < second_derivatives.size(); ++i) {
-        second_derivatives[i] = abs(second_derivatives[i]);
+        second_derivatives[i] = fabsf(second_derivatives[i]);
     }
 
     // Normalize the second derivatives


### PR DESCRIPTION
Values in the second derivative array are being truncated

```
llama.cpp:1950:33: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        second_derivatives[i] = abs(second_derivatives[i]);
                                ^
llama.cpp:1950:33: note: use function 'std::abs' instead
        second_derivatives[i] = abs(second_derivatives[i]);
                                ^~~
                                std::abs
llama.cpp:1950:33: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
1 warning generated.
```