### PR TITLE
CI: make the brew update temporarily optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Dependencies
         id: depends
+        continue-on-error: true
         run: |
           brew update
 
@@ -129,6 +130,7 @@ jobs:
 
       - name: Dependencies
         id: depends
+        continue-on-error: true
         run: |
           brew update
 


### PR DESCRIPTION
until they decide to fix the brew installation in the macos runners. see the open issues. eg https://github.com/actions/runner-images/pull/7710

---

![image](https://github.com/ggerganov/llama.cpp/assets/2938071/b169bbfd-4e29-4c2a-ab45-390d3d7906cb)
https://github.com/Green-Sky/llama.cpp/actions/runs/5449352741/jobs/9913483492#step:3:7