### PR TITLE
Fix input embedding example unsigned int seed

### DIFF
--- a/examples/embd-input/embd-input-lib.cpp
+++ b/examples/embd-input/embd-input-lib.cpp
@@ -29,7 +29,7 @@ struct MyModel* create_mymodel(int argc, char ** argv) {
 
     fprintf(stderr, "%s: build = %d (%s)\n", __func__, BUILD_NUMBER, BUILD_COMMIT);
 
-    if (params.seed < 0) {
+    if (params.seed == LLAMA_DEFAULT_SEED) {
         params.seed = time(NULL);
     }
     fprintf(stderr, "%s: seed  = %d\n", __func__, params.seed);


### PR DESCRIPTION
I noticed that the [examples/embd-input](https://github.com/ggerganov/llama.cpp/tree/master/examples/embd-input) example did not follow the new `LLAMA_DEFAULT_SEED` convention needed to properly handle the new unsigned int format used for random seeds. This simple PR fixes that.