### PR TITLE
Fix ggml_tensor_extra_gpu memory leak

### DIFF
--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -1,12 +1,21 @@
 #pragma once
 
+#define GGML_CUDA_MAX_DEVICES       16
+
+#include <cuda_runtime.h>
+
+struct ggml_tensor_extra_gpu {
+    void * data_device[GGML_CUDA_MAX_DEVICES]; // 1 pointer for each device for split tensors
+    cudaEvent_t events[GGML_CUDA_MAX_DEVICES]; // events for synchronizing multiple GPUs
+};
+
 #include "ggml.h"
 
 #ifdef  __cplusplus
 extern "C" {
 #endif
 
-#define GGML_CUDA_MAX_DEVICES       16
+
 
 void   ggml_init_cublas(void);
 void   ggml_cuda_set_tensor_split(const float * tensor_split);

--- a/ggml.c
+++ b/ggml.c
@@ -4588,8 +4588,6 @@ struct ggml_tensor * ggml_new_tensor_impl(
         /*.perf_time_us =*/ 0,
         /*.data         =*/ (data == NULL && !ctx->no_alloc) ? (void *)(result + 1) : data,
         /*.name         =*/ { 0 },
-        /*.extra        =*/ NULL,
-        /*.padding      =*/ { 0 },
     };
 
     // TODO: this should not be needed as long as we don't rely on aligned SIMD loads

--- a/ggml.h
+++ b/ggml.h
@@ -235,6 +235,10 @@
     const type prefix##3 = (pointer)->array[3]; \
     GGML_UNUSED(prefix##3);
 
+#ifdef GGML_USE_CUBLAS
+#include "ggml-cuda.h"
+#endif
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -427,9 +431,9 @@ extern "C" {
 
         char name[GGML_MAX_NAME];
 
-        void * extra; // extra things e.g. for ggml-cuda.cu
-
-        char padding[8];
+#ifdef GGML_USE_CUBLAS
+        char extra[sizeof(struct ggml_tensor_extra_gpu)]; // extra things e.g. for ggml-cuda.cu
+#endif
     };
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);


### PR DESCRIPTION
Fixes  #2145. Allocate the `extra` member of `ggml_tensor` statically