### PR TITLE
Escape prompt prefix/suffix along with prompt

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -418,6 +418,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
 
     if (escape_prompt) {
         process_escapes(params.prompt);
+        process_escapes(params.input_prefix);
+        process_escapes(params.input_suffix);
     }
 
     return true;


### PR DESCRIPTION
I've been using some models that are a bit picky about the prompt format during chats. In particular, it seems like some of them prefer a newline after the reverse prompt (e.g., `ASSISTANT:\n`). The existing "main" example does allow parsing newlines and other escape characters in the prompt with `-e`, but not in the prompt prefix or suffix (`--in-prefix` and `--in-suffix`). This pull request adds escaping to those parts as well, allowing for things like this:

```bash
./main -m some-model.bin -f ./prompts/some-prompt.txt -i -e --reverse-prompt 'USER:' --in-prefix ' ' --in-suffix 'ASSISTANT:\n'
```

This inserts "ASSISTANT:" and a newline after the user presses enter, which works a bit better in some of my cases. I haven't needed escape characters in the prompt prefix, but it seems better to parse them anyway for consistency. Possibly there are use cases where it would be needed that I haven't encountered.