### PR TITLE
Remove "first token must be BOS" restriction

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1291,12 +1291,6 @@ static bool llama_eval_internal(
 
     LLAMA_ASSERT((!tokens && embd) || (tokens && !embd));
 
-    // enforce that the first token is BOS
-    if (tokens && n_past == 0 && tokens[0] != llama_token_bos()) {
-        fprintf(stderr, "%s: first token must be BOS\n", __func__);
-        return false;
-    }
-
     const int64_t t_start_us = ggml_time_us();
 
     const int N = n_tokens;


### PR DESCRIPTION
Currently, the `llama_eval_internal` function requires the first token in the `tokens` array to be a BOS token (=1).

I believe that this is not necessary, as

1) Intentionally removing the BOS token can make generations more creative. With the BOS token, the prompt is associated to text at the beginning of a new document in the training dataset. Without it, the prompt can be associated to text at any location. 

In other words, the BOS token adds a "beginning of document" bias that can be optionally removed.

2) This is not desirable while evaluating the model perplexity, since in most cases the sequence of ids will be mid-document. 

I originally encountered the "first token must be BOS" error while trying to evaluate llama.cpp using a transformers wrapper that I am working on [here](https://github.com/oobabooga/text-generation-webui/pull/3062). The evaluation fails because the first token in the sequence provided by my code, which is based on [this tutorial](https://huggingface.co/docs/transformers/perplexity#calculating-ppl-with-fixedlength-models), is not BOS.