### PR TITLE
fix zig build readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ In order to build llama.cpp you have three different options.
 - Using `Zig`:
 
     ```bash
-    zig build -Drelease-fast
+    zig build -Doptimize=ReleaseFast
     ```
 
 ### Metal Build


### PR DESCRIPTION
```bash
./zig-macos-aarch64-0.11.0-dev.3952+82a9d5d78/zig build build -Drelease-fast  
error: Invalid option: -Drelease-fast
```

Needs to be 

```bash
zig build -Doptimize=ReleaseFast
```