### PR TITLE
Added '--server' option to ENTRYPOINT in tools.sh for Docker image

### DIFF
--- a/.devops/tools.sh
+++ b/.devops/tools.sh
@@ -26,6 +26,8 @@ elif [[ $arg1 == '--all-in-one' || $arg1 == '-a' ]]; then
             ./quantize "$i" "${i/f16/q4_0}" q4_0
         fi
     done
+elif [[ $arg1 == '--server' || $arg1 == '-s' ]]; then
+    ./server $arg2
 else
     echo "Unknown command: $arg1"
     echo "Available commands: "
@@ -37,4 +39,6 @@ else
     echo "              ex: \"/models/7B/ggml-model-f16.bin\" \"/models/7B/ggml-model-q4_0.bin\" 2"
     echo "  --all-in-one (-a): Execute --convert & --quantize"
     echo "              ex: \"/models/\" 7B"
+    echo "  --server (-s): Run a model on the server"
+    echo "              ex: -m /models/7B/ggml-model-q4_0.bin -c 2048 -ngl 43 -mg 1 --port 8080"
 fi


### PR DESCRIPTION
This pull request adds the '--server' option to the ENTRYPOINT in the [tools.sh](https://github.com/ggerganov/llama.cpp/blob/master/.devops/tools.sh) script for the Docker image. The '--server' option allows running the './server' script within the Docker container.

By adding this option, users can easily start the server functionality by running the Docker image with the '--server' (or '-s') argument. This enhances the usability and flexibility of the Docker image, making it more convenient for users to run the server example.

Please review and merge this pull request.

Thank you!