### PR TITLE
Track and free temporary ggml_tensor_extra_gpu struct 

### DIFF
--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -30,6 +30,8 @@ void   ggml_cuda_set_main_device(int main_device);
 void   ggml_cuda_set_scratch_size(size_t scratch_size);
 void   ggml_cuda_free_scratch(void);
 bool   ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor);
+void   ggml_cuda_begin_eval(void);
+void   ggml_cuda_end_eval(void);
 
 #ifdef  __cplusplus
 }

--- a/llama.cpp
+++ b/llama.cpp
@@ -1379,6 +1379,8 @@ static bool llama_eval_internal(
     offload_func_t offload_func_v  = llama_nop;
 
 #ifdef GGML_USE_CUBLAS
+    ggml_cuda_begin_eval();
+
     if (n_gpu_layers > n_layer) {
         offload_func_nr = ggml_cuda_assign_buffers;
     }
@@ -1719,6 +1721,10 @@ static bool llama_eval_internal(
             ggml_used_mem(ctx0)/1024.0/1024.0,
             lctx.get_buf_max_mem(0)/1024.0/1024.0,
             lctx.get_buf_max_mem(1)/1024.0/1024.0);
+#endif
+
+#ifdef GGML_USE_CUBLAS
+    ggml_cuda_end_eval();
 #endif
 
     ggml_free(ctx0);


### PR DESCRIPTION
Fix #2145.

Temporary allocations during eval are tracked and freed at the end.
I decided to go with the implicit context idea here: https://github.com/ggerganov/llama.cpp/pull/2146#issuecomment-1630641137 since the code change is minimal.

Pooling could be added if needed and freed in `llama_backend_free`.

Tested on my machine with `--ignore-eos` to keep generation running and RAM usage does not increase anymore.