### PR TITLE
Fix regression of model loading performance when using mlock.

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -572,6 +572,7 @@ struct llama_context_params llama_context_params_from_gpt_params(const gpt_param
     lparams.use_mlock    = params.use_mlock;
     lparams.logits_all   = params.perplexity;
     lparams.embedding    = params.embedding;
+    lparams.has_lora     = !params.lora_adapter.empty();
 
     return lparams;
 }

--- a/llama-util.h
+++ b/llama-util.h
@@ -172,16 +172,16 @@ struct llama_mmap {
 #ifdef _POSIX_MAPPED_FILES
     static constexpr bool SUPPORTED = true;
 
-    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1 /* -1 = max value */, bool numa = false) {
+    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1 /* -1 = max value */, bool numa = false, bool lora = false) {
         size = file->size;
         int fd = fileno(file->fp);
-        int flags = MAP_PRIVATE;
+        int flags = (lora) ? MAP_PRIVATE : MAP_SHARED;
         // prefetch/readahead impairs performance on NUMA systems
         if (numa) { prefetch = 0; }
 #ifdef __linux__
         if (prefetch) { flags |= MAP_POPULATE; }
 #endif
-        addr = mmap(NULL, file->size, PROT_READ | PROT_WRITE, flags, fd, 0);
+        addr = mmap(NULL, file->size, (lora) ? PROT_READ | PROT_WRITE : PROT_READ, flags, fd, 0);
         if (addr == MAP_FAILED) {
             throw std::runtime_error(format("mmap failed: %s", strerror(errno)));
         }

--- a/llama-util.h
+++ b/llama-util.h
@@ -172,16 +172,16 @@ struct llama_mmap {
 #ifdef _POSIX_MAPPED_FILES
     static constexpr bool SUPPORTED = true;
 
-    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1 /* -1 = max value */, bool numa = false, bool lora = false) {
+    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1 /* -1 = max value */, bool numa = false, bool has_lora = false) {
         size = file->size;
         int fd = fileno(file->fp);
-        int flags = (lora) ? MAP_PRIVATE : MAP_SHARED;
+        int flags = (has_lora) ? MAP_PRIVATE : MAP_SHARED;
         // prefetch/readahead impairs performance on NUMA systems
         if (numa) { prefetch = 0; }
 #ifdef __linux__
         if (prefetch) { flags |= MAP_POPULATE; }
 #endif
-        addr = mmap(NULL, file->size, (lora) ? PROT_READ | PROT_WRITE : PROT_READ, flags, fd, 0);
+        addr = mmap(NULL, file->size, (has_lora) ? PROT_READ | PROT_WRITE : PROT_READ, flags, fd, 0);
         if (addr == MAP_FAILED) {
             throw std::runtime_error(format("mmap failed: %s", strerror(errno)));
         }

--- a/llama.cpp
+++ b/llama.cpp
@@ -2927,7 +2927,7 @@ int llama_apply_lora_from_file_internal(const struct llama_model & model, const 
 
         // maybe this should in llama_model_loader
         if (model_loader->use_mmap) {
-            model_loader->mapping.reset(new llama_mmap(&model_loader->file_loader->file, /* prefetch */ 0, ggml_is_numa(), true));
+            model_loader->mapping.reset(new llama_mmap(&model_loader->file_loader->file, /* prefetch */ 0, ggml_is_numa(), model_loader->has_lora));
         }
     }
 

--- a/llama.h
+++ b/llama.h
@@ -102,6 +102,7 @@ extern "C" {
         bool use_mmap;   // use mmap if possible
         bool use_mlock;  // force system to keep model in RAM
         bool embedding;  // embedding mode only
+        bool has_lora;   // model has LoRA layers
     };
     // model file types
     enum llama_ftype {

--- a/llama.h
+++ b/llama.h
@@ -102,7 +102,7 @@ extern "C" {
         bool use_mmap;   // use mmap if possible
         bool use_mlock;  // force system to keep model in RAM
         bool embedding;  // embedding mode only
-        bool has_lora;   // model has LoRA layers
+        bool has_lora;   // a LoRA is being used
     };
     // model file types
     enum llama_ftype {


### PR DESCRIPTION
Performance of subsequent runs when using mlock suffered a large regression from 2347463201a9f4159ae95b737e1544dd300569c8. 

It appears that changing the mmap flag from MAP_SHARED to MAP_PRIVATE causes the model to be loaded into memory fresh each time. This PR changes llama_mmap to take a new parameter called has_lora which if true calls mmap with `MAP_PRIVATE` and  `PROT_READ | PROT_WRITE`  otherwise uses `MAP_SHARED` and `PROT_READ`.

Caveats: 

- I've only tested this on mac OS
- I haven't tested extensively actually using a LoRa
- Maybe use_mmap/use_mlock/has_lora should be combined into an enum.
- There is probably a better name for the parameter than `has_lora`.