### PR TITLE
flake.nix: adds runHook preInstall/postInstall to installPhase so hooks function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
             "-DLLAMA_METAL=ON"
           ]);
           installPhase = ''
+            runHook preInstall
+
             mkdir -p $out/bin
             mv bin/* $out/bin/
             mv $out/bin/main $out/bin/llama
@@ -51,6 +53,8 @@
             echo "#!${llama-python}/bin/python" > $out/bin/convert.py
             cat ${./convert.py} >> $out/bin/convert.py
             chmod +x $out/bin/convert.py
+
+            runHook postInstall
           '';
           meta.mainProgram = "llama";
         };


### PR DESCRIPTION
Per https://nixos.org/manual/nixpkgs/stable/#sec-stdenv-phases:

> When overriding a phase, for example installPhase, it is important to start with runHook preInstall and end it with runHook postInstall, otherwise preInstall and postInstall will not be run. Even if you don’t use them directly, it is good practice to do so anyways for downstream users who would want to add a postInstall by overriding your derivation.

To give an explicit example to motivate this better I hope, this lets me add my own installPhase overrides to llama.cpp when using it as an input in another flake:

```nix
llama-cpp-with-includes =
  llama-cpp.packages.${system}.default.overrideAttrs (oldAttrs: {
    postInstall = (oldAttrs.postInstall or "") + ''
      mkdir -p $out/lib
      mkdir -p $out/include
      cp *.a $out/lib/
      cp $src/*.h $out/include/
    '';
  });
```

This should hopefully allow for more customization for nix users with fewer PRs, and I _think_ this may obviate the need for https://github.com/ggerganov/llama.cpp/pull/1811 as well?