### PR TITLE
Turning verify-checksum-models.py into executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Please verify the [sha256 checksums](SHA256SUMS) of all downloaded model files t
 
 ```bash
 # run the verification script
-python3 .\scripts\verify-checksum-models.py
+./scripts/verify-checksum-models.py
 ```
 
 - On linux or macOS it is also possible to run the following commands to verify if you have all possible latest files in your self-installed `./models` subdirectory:

--- a/scripts/verify-checksum-models.py
+++ b/scripts/verify-checksum-models.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import os
 import hashlib
 


### PR DESCRIPTION
The verify-checksum-models.py is a simple script with no extra 3rd party dependencies.
It can be safely executed as a standalone utility and invoked directly from CLI.

The shebang is set so that it will look for default python binary in the environment, including virtual.
