### PR TITLE
metal: minor q4 optimization and reduce code size

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -792,7 +792,7 @@ void ggml_metal_graph_compute(
 
                             const float eps = 1e-6f;
 
-                            const int nth = 256;
+                            const int nth = 512;
 
                             [encoder setComputePipelineState:ctx->pipeline_rms_norm];
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
@@ -800,7 +800,7 @@ void ggml_metal_graph_compute(
                             [encoder setBytes:&ne00 length:sizeof( int64_t) atIndex:2];
                             [encoder setBytes:&nb01 length:sizeof(uint64_t) atIndex:3];
                             [encoder setBytes:&eps  length:sizeof(   float) atIndex:4];
-                            [encoder setThreadgroupMemoryLength:nth*sizeof(float) atIndex:0];
+                            [encoder setThreadgroupMemoryLength:nth/32*sizeof(float) atIndex:0];
 
                             const int64_t nrows = ggml_nrows(src0);
 

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -339,26 +339,33 @@ kernel void kernel_rms_norm(
         threadgroup float  * sum [[threadgroup(0)]],
         uint tgpig[[threadgroup_position_in_grid]],
         uint tpitg[[thread_position_in_threadgroup]],
+        uint sgitg[[simdgroup_index_in_threadgroup]],
+        uint tiisg[[thread_index_in_simdgroup]],
         uint   ntg[[threads_per_threadgroup]]) {
-    device const float * x = (device const float *) ((device const char *) src0 + tgpig*nb01);
+    device const float4 * x = (device const float4 *) ((device const char *) src0 + tgpig*nb01);
+    device const float * x_scalar = (device const float *) x;
+    float4 sumf=0;
+    float all_sum=0;
 
     // parallel sum
-    sum[tpitg] = 0.0f;
-    for (int i00 = tpitg; i00 < ne00; i00 += ntg) {
-        sum[tpitg] += x[i00] * x[i00];
+    for (int i00 = tpitg; i00 < ne00/4; i00 += ntg) {
+        sumf += x[i00] * x[i00];
+    }
+    all_sum = sumf[0] + sumf[1] + sumf[2] + sumf[3];
+    all_sum = simd_sum(all_sum);
+    if (tiisg == 0) {
+        sum[sgitg] = all_sum;
     }
 
-    // reduce
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint i = ntg/2; i > 0; i /= 2) {
-        if (tpitg < i) {
-            sum[tpitg] += sum[tpitg + i];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
+    // broadcast, simd group number is ntg / 32
+    for (int i = ntg / 32 / 2; i > 0; i /= 2) {
+       if (tpitg < i) {
+           sum[tpitg] += sum[tpitg + i];
+       }
     }
-
-    // broadcast
     if (tpitg == 0) {
+        for (int i = 4 * (ne00 / 4); i < ne00; i++) {sum[0] += x_scalar[i];}
         sum[0] /= ne00;
     }
 
@@ -367,9 +374,13 @@ kernel void kernel_rms_norm(
     const float mean  = sum[0];
     const float scale = 1.0f/sqrt(mean + eps);
 
-    device float * y = dst + tgpig*ne00;
-    for (int i00 = tpitg; i00 < ne00; i00 += ntg) {
+    device float4 * y = (device float4 *) (dst + tgpig*ne00);
+    device float * y_scalar = (device float *) y;
+    for (int i00 = tpitg; i00 < ne00/4; i00 += ntg) {
         y[i00] = x[i00] * scale;
+    }
+    if (tpitg == 0) {
+        for (int i00 = 4 * (ne00 / 4); i00 < ne00; i00++) {y_scalar[i00] = x_scalar[i00] * scale;}
     }
 }
 


### PR DESCRIPTION
The first commit uses uint16_t instead of uint8_t in q4_0 and q4_1 kernels. Apple GPUs don't like 8-bit types, and for any operation on a 8-bit number the GPU will first copy it to an empty register and then do the calculation. This brings ~3% improvement for 33B model on M1 Max.<br>
 After this commit, we can achieve 340-350 GB/s memory read speed on M1 Max for 33B model, if we only run the q4_0-f32 MAT_MUL kernel and skip all other operations. This is very close to the reported hardware limit.
<img width="795" alt="Screenshot 2023-07-17 at 01 18 29" src="https://github.com/ggerganov/llama.cpp/assets/61452103/211fd36e-8509-43cb-9c16-ef485a2bc86f">
<br>(Only run matrix vector multiplications and skip all other operations.)

#
The second commit updates the RMS_NORM kernel by minimizing the use of threadgroup memory barrier, brings ~2% improvement for 33B model on M1 Max.

The third commit uses template to reduce code size. q5_0 and q5_1 support can be added quite efficiently using the new template. The new template also improve the behavior when `nb` is not divisible by 32. (thanks to discussion with @ikawrakow !)

Overall speed up (M1 Max, Updated as `f3f2e8e`):
||master| this PR|Speed up|
|---|---|---|---|
|33B q4_0  256 tokens| 82.1 ms/tok | 72.5 ms/tok| ~13%
|7B q4_0  256 tokens| 21.1 ms/tok | 19.6 ms/tok| ~7.6%

`./main -m model -n 256 -c 512 -s 123 -p "I believe the meaning of life is" -ngl 1 --no-mmap -t 8`