### PR TITLE
llama: add an api to get max devices at runtime.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -875,6 +875,10 @@ struct llama_model_quantize_params llama_model_quantize_default_params() {
     return result;
 }
 
+int llama_max_devices() {
+    return LLAMA_MAX_DEVICES;
+}
+
 bool llama_mmap_supported() {
     return llama_mmap::SUPPORTED;
 }

--- a/llama.h
+++ b/llama.h
@@ -153,6 +153,8 @@ extern "C" {
         int32_t n_eval;
     };
 
+    LLAMA_API int llama_max_devices();
+
     LLAMA_API struct llama_context_params llama_context_default_params();
     LLAMA_API struct llama_model_quantize_params llama_model_quantize_default_params();
 


### PR DESCRIPTION
When using `llama.cpp` as a native library for other languages, the package of native library and main package may be separated. Thus it makes the size of `llama_context_params` unknown. Could you please consider adding an API to get the `LLAMA_MAX_DEVICES` at runtime?