### PR TITLE
Remove intel mkl from flake.nix due to missing files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,16 +186,7 @@ if (LLAMA_BLAS)
                 pkg_check_modules(DepBLAS REQUIRED flexiblas_api)
             elseif (${LLAMA_BLAS_VENDOR} MATCHES "Intel")
                 # all Intel* libraries share the same include path
-                pkg_check_modules(DepBLAS mkl-sdl)
-                if (NOT DepBLAS)
-                    if (BUILD_SHARED_LIBS)
-                        set(LINK_METHOD dynamic)
-                    else()
-                        set(LINK_METHOD static)
-                    endif()
-                    string(REGEX REPLACE ".*_" "" DATA_TYPE_MODEL ${LLAMA_BLAS_VENDOR})
-                    pkg_check_modules(DepBLAS REQUIRED mkl-${LINK_METHOD}-${DATA_TYPE_MODEL}-iomp)
-                endif()
+                pkg_check_modules(DepBLAS REQUIRED mkl-sdl)
             elseif (${LLAMA_BLAS_VENDOR} MATCHES "NVHPC")
                 # this doesn't provide pkg-config
                 # suggest to assign BLAS_INCLUDE_DIRS on your own

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Building the program with BLAS support may lead to some performance improvements
   ```bash
   mkdir build
   cd build
-  cmake .. -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=Intel10_lp64 -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
+  cmake .. -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=Intel10_64lp -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
   cmake --build . --config Release
   ```
 


### PR DESCRIPTION
NixOS's mkl misses some libraries like mkl-sdl.pc. See #2261
Currently NixOS doesn't have intel C compiler (icx, icpx). See https://discourse.nixos.org/t/packaging-intel-math-kernel-libraries-mkl/975
So remove it from flake.nix

Some minor changes:

- Change pkgs.python310 to pkgs.python3 to keep latest
- Add pkgconfig to devShells.default
- Remove installPhase because we have `cmake --install` from #2256

Now build it for NixOS on x86_64-linux will use openBlas:

```shell
$ nix build --impure
$ tree result/
 result
├──  bin
│  ├──  baby-llama
│  ├──  benchmark
│  ├──  convert-lora-to-ggml.py
│  ├──  convert.py
│  ├──  embd-input-test
│  ├──  embedding
│  ├──  llama
│  ├──  llama-server
│  ├──  perplexity
│  ├──  quantize
│  ├──  quantize-stats
│  ├──  save-load-state
│  ├──  simple
│  ├──  test-grad0
│  ├──  test-quantize-fns
│  ├──  test-quantize-perf
│  ├──  test-sampling
│  ├──  test-tokenizer-0
│  └──  train-text-from-scratch
└──  lib
   ├──  libembdinput.so
   ├──  libggml_shared.so
   └──  libllama.so
$ ldd result/bin/llama | rg openblas
7:      libopenblas.so.0 => /nix/store/0cz1gdz17hk9myawjpycscm4dnhy7b3l-openblas-0.3.21/lib/libopenblas.so.0 (0x00007f2ea7860000)
```

I have tested it can work for NixOS on x86_64-linux.
