### PR TITLE
Little changes in .gitignore for Poetry users and Makefile for FreeBSD users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ qnt-*.txt
 perf-*.txt
 
 examples/jeopardy/results.txt
+
+pyproject.toml
+poetry.lock
+poetry.toml

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 # Architecture specific
 # TODO: probably these flags need to be tweaked on some architectures
 #       feel free to update the Makefile for your architecture and send a pull request or issue
-ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686))
+ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686 amd64))
 	# Use all CPU extensions that are available:
 	CFLAGS   += -march=native -mtune=native
 	CXXFLAGS += -march=native -mtune=native

--- a/examples/llama2-13b.sh
+++ b/examples/llama2-13b.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Temporary script - will be removed in the future
+#
+
+cd `dirname $0`
+cd ..
+
+./main -m models/available/Llama2/13B/llama-2-13b.ggmlv3.q4_0.bin \
+       --color \
+       --ctx_size 2048 \
+       -n -1 \
+       -ins -b 256 \
+       --top_k 10000 \
+       --temp 0.2 \
+       --repeat_penalty 1.1 \
+       -t 8

--- a/examples/llama2.sh
+++ b/examples/llama2.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Temporary script - will be removed in the future
+#
+
+cd `dirname $0`
+cd ..
+
+./main -m models/available/Llama2/7B/llama-2-7b.ggmlv3.q4_0.bin \
+       --color \
+       --ctx_size 2048 \
+       -n -1 \
+       -ins -b 256 \
+       --top_k 10000 \
+       --temp 0.2 \
+       --repeat_penalty 1.1 \
+       -t 8


### PR DESCRIPTION
Hi! This PR resolve two simple issue for Poetry and FreeBSD users.

First, little change for ignore files for Poetry generated files in their venv process. 

Second, a fix in Makefile for FreeBSD users. In this OS, platform x86_64 isn't recognize, the correct name is amd64. This fix resolve compilation issues (for example: not enabled AVX support in the generated binary) using CFLAGS and CXXFLAGS with -march=native and -mtune=native for default.  Tested in FreeBSD 13.2. 

Finally, add two examples for interactive mode using Llama2 models (thx TheBloke for models)