### PR TITLE
gpu: concurrently dispatch operations

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -364,7 +364,7 @@ void ggml_metal_graph_compute(
     size_t offs_src1 = 0;
     size_t offs_dst  = 0;
 
-    id<MTLComputeCommandEncoder> encoder = nil;
+    id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
 
     for (int i = 0; i < gf->n_nodes; ++i) {
         metal_printf("%s: encoding node %3d, op = %8s\n", __func__, i, ggml_op_name(gf->nodes[i]->op));
@@ -434,10 +434,14 @@ void ggml_metal_graph_compute(
                 {
                     // noop
                 } break;
+            case GGML_OP_BARRIER:
+                {
+                    [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers | MTLBarrierScopeRenderTargets | MTLBarrierScopeTextures];
+                } break;
             case GGML_OP_ADD:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     [encoder setComputePipelineState:ctx->pipeline_add];
@@ -452,7 +456,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_MUL:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     if (ggml_nelements(src1) == ne10) {
@@ -473,7 +477,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_SCALE:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const float scale = *(const float *) src1->data;
@@ -490,7 +494,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_SILU:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     [encoder setComputePipelineState:ctx->pipeline_silu];
@@ -504,7 +508,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_RELU:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     [encoder setComputePipelineState:ctx->pipeline_relu];
@@ -518,7 +522,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_GELU:
             {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     [encoder setComputePipelineState:ctx->pipeline_gelu];
@@ -532,7 +536,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_SOFT_MAX:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const int nth = 32;
@@ -550,7 +554,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_DIAG_MASK_INF:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const int n_past = ((int32_t *)(src1->data))[0];
@@ -613,7 +617,7 @@ void ggml_metal_graph_compute(
                         }
                     } else {
                         if (encoder == nil) {
-                            encoder = [command_buffer computeCommandEncoder];
+                            encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                         }
 
                         int nth0 = 32;
@@ -740,7 +744,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_GET_ROWS:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     switch (src0->type) {
@@ -769,7 +773,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_RMS_NORM:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const float eps = 1e-6f;
@@ -791,7 +795,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_NORM:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const float eps = 1e-5f;
@@ -813,7 +817,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_ALIBI:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     GGML_ASSERT((src0t == GGML_TYPE_F32));
@@ -855,7 +859,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_ROPE:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const int n_dims = ((int32_t *) src1->data)[1];
@@ -898,7 +902,7 @@ void ggml_metal_graph_compute(
             case GGML_OP_CPY:
                 {
                     if (encoder == nil) {
-                        encoder = [command_buffer computeCommandEncoder];
+                        encoder = [command_buffer computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
                     }
 
                     const int nth = 32;

--- a/ggml.h
+++ b/ggml.h
@@ -388,7 +388,7 @@ extern "C" {
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
 
         GGML_OP_BARRIER, // Any operation between two barriers can be issued concurrently.
-        
+
         GGML_OP_COUNT,
     };
 
@@ -1367,7 +1367,7 @@ extern "C" {
 
     //sort all nodes in a graph to find operations that can be issued concurrently, insert memory barrier if necessary
     GGML_API void ggml_graph_find_concurrency(struct ggml_context * ctx, struct ggml_cgraph * cgraph);
-    
+
     // print info and performance information for the graph
     GGML_API void ggml_graph_print(const struct ggml_cgraph * cgraph);
 

--- a/ggml.h
+++ b/ggml.h
@@ -194,7 +194,7 @@
 #define GGML_QNT_VERSION_FACTOR 1000 // do not change this
 
 #define GGML_MAX_DIMS          4
-#define GGML_MAX_NODES         4096
+#define GGML_MAX_NODES         8192
 #define GGML_MAX_PARAMS        256
 #define GGML_MAX_CONTEXTS      64
 #define GGML_MAX_SRC           6
@@ -387,6 +387,8 @@ extern "C" {
         GGML_OP_CROSS_ENTROPY_LOSS,
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
 
+        GGML_OP_BARRIER, // Any operation between two barriers can be issued concurrently.
+        
         GGML_OP_COUNT,
     };
 
@@ -1363,6 +1365,9 @@ extern "C" {
     GGML_API void               ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname);
     GGML_API struct ggml_cgraph ggml_graph_import(const char * fname, struct ggml_context ** ctx_data, struct ggml_context ** ctx_eval);
 
+    //sort all nodes in a graph to find operations that can be issued concurrently, insert memory barrier if necessary
+    GGML_API void ggml_graph_find_concurrency(struct ggml_context * ctx, struct ggml_cgraph * cgraph);
+    
     // print info and performance information for the graph
     GGML_API void ggml_graph_print(const struct ggml_cgraph * cgraph);
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -1662,6 +1662,7 @@ static bool llama_eval_internal(
 
 #ifdef GGML_USE_METAL
     if (lctx.ctx_metal && N == 1) {
+        ggml_graph_find_concurrency(ctx0,&gf);
         ggml_metal_set_n_cb     (lctx.ctx_metal, n_threads);
         ggml_metal_graph_compute(lctx.ctx_metal, &gf);
         ggml_metal_get_tensor   (lctx.ctx_metal, cur);


### PR DESCRIPTION
This is an early attempt to maximize throughput for all GPU backends. For now Metal backend  run operations in a graph in a serial manner. That is, for an element-wise or a reduce operation that only needs a few hundreds threads, the GPU will only use a few hundreds threads, even if modern GPUs can run tens of thousands of threads at the same time. (cuda backend may also have this problem, I am not sure)

The commit resolve this by providing a `ggml_graph_find_concurrency` function to find if some
operations can be issued simultaneously by GPU. Before sending a graph to the GPU backend we can call the new function
to find concurrency in the graph. This will sort all the nodes and insert memory barrier nodes (nodes with `op=GGML_OP_BARRIER`) if necessary. One can simply dismiss the barrier nodes and issue operations sequentially, or try to concurrently issue all the operations between two barriers. 

Taking the graph from #915 for example
![](https://user-images.githubusercontent.com/1991296/228443093-b1baf1d8-97ce-439d-9ced-8b3ac6cab5f0.png)
Operation `#4, #7 and #18` have no dependency, and can run concurrently.
The `ggml_graph_find_concurrency` function reordered the graph, put them together and inserted memory barrier before and after them.
<img width="400" src="https://github.com/ggerganov/llama.cpp/assets/61452103/8582e33b-6be7-4aec-81a9-a6518dbbc211">

 On master branch, The net time for inference a 33B model is ~69.6 ms/tok on my M1 Max.
<img width="200" src="https://github.com/ggerganov/llama.cpp/assets/61452103/9f56fa06-d5a1-4aec-bbf4-11c8f7d0b14c">
 On This PR, The net time for inference a 33B model is ~65.5 ms/tok on my M1 Max.
<img width="200" src="https://github.com/ggerganov/llama.cpp/assets/61452103/ccd9a08a-a5ae-4566-9d67-35b95c457d5d">

However, for now we create the graph, find concurrency and encode the command every time for a single token (at least for Metal). The gain is pretty much killed by this, leading to a poor ~0.3 ms/tok speed up. So, @ggerganov @slaren , is it possible that we can have some mechanisms to tell the GPU if the graph is unchanged from last time in our new backend interface. By this way, we can save the time for encoding the command to GPU, and also the time for finding concurrency.



