### PR TITLE
Perplexity: Compute scores correlated to HellaSwag

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -387,6 +387,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.antiprompt.push_back(argv[i]);
         } else if (arg == "--perplexity") {
             params.perplexity = true;
+        } else if (arg == "--perplexity-lines") {
+            params.perplexity_lines = true;
         } else if (arg == "--ignore-eos") {
             params.logit_bias[llama_token_eos()] = -INFINITY;
         } else if (arg == "--no-penalize-nl") {
@@ -512,7 +514,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "                        not recommended: doubles context memory required and no measurable increase in quality\n");
     fprintf(stderr, "  --temp N              temperature (default: %.1f)\n", (double)params.temp);
     fprintf(stderr, "  -b N, --batch-size N  batch size for prompt processing (default: %d)\n", params.n_batch);
-    fprintf(stderr, "  --perplexity          compute perplexity over the prompt\n");
+    fprintf(stderr, "  --perplexity          compute perplexity over each ctx window of the prompt\n");
+    fprintf(stderr, "  --perplexity-lines    compute perplexity over each line of the prompt\n");
     fprintf(stderr, "  --keep                number of tokens to keep from the initial prompt (default: %d, -1 = all)\n", params.n_keep);
     fprintf(stderr, "  --chunks N            max number of chunks to process (default: %d, -1 = all)\n", params.n_chunks);
     if (llama_mlock_supported()) {

--- a/examples/common.h
+++ b/examples/common.h
@@ -82,6 +82,7 @@ struct gpt_params {
     bool instruct          = false; // instruction mode (used for Alpaca models)
     bool penalize_nl       = true;  // consider newlines as a repeatable token
     bool perplexity        = false; // compute perplexity over the prompt
+    bool perplexity_lines  = false; // compute perplexity over each line of the prompt
     bool use_mmap          = true;  // use mmap for faster loads
     bool use_mlock         = false; // use mlock to keep model in memory
     bool mem_test          = false; // compute maximum memory usage

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -180,7 +180,7 @@ void perplexity_lines(llama_context * ctx, const gpt_params & params) {
             nllline += -std::log(prob);
             ++countline;
         }
-        
+
         nll += nllline;
         counttotal += countline;
 

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <ctime>
+#include <sstream>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
@@ -124,17 +125,11 @@ void perplexity_lines(llama_context * ctx, const gpt_params & params) {
     // Calculates perplexity over each line of the prompt
 
     std::vector<std::string> prompt_lines;
+    std::istringstream strstream(params.prompt);
+    std::string line;
 
-    size_t pos=0;
-    while( pos < params.prompt.size() ) {
-        std::string line;
-        while( true ) {
-            if( params.prompt[pos] == '\n' || pos == params.prompt.size() )
-                break;
-            line += params.prompt[pos++];
-        }
-        pos++;
-        prompt_lines.push_back( line );
+    while (std::getline(strstream,line,'\n')) {
+        prompt_lines.push_back(line);
     }
 
     const int n_vocab = llama_n_vocab(ctx);
@@ -245,7 +240,7 @@ int main(int argc, char ** argv) {
                 params.n_threads, std::thread::hardware_concurrency(), llama_print_system_info());
     }
 
-    if( params.perplexity_lines ) {
+    if (params.perplexity_lines) {
         perplexity_lines(ctx, params);
     } else {
         perplexity(ctx, params);

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -180,9 +180,9 @@ void perplexity_lines(llama_context * ctx, const gpt_params & params) {
             nllline += -std::log(prob);
             ++countline;
         }
-
-		nll += nllline;
-		counttotal += countline;
+        
+        nll += nllline;
+        counttotal += countline;
 
         // perplexity is e^(average negative log-likelihood)
         printf("%lu\t%.8lf\t%.8lf\n", i + 1, std::exp(nllline/countline), std::exp(nll / counttotal) );
@@ -245,7 +245,7 @@ int main(int argc, char ** argv) {
     } else {
         perplexity(ctx, params);
     }
-    
+
     llama_print_timings(ctx);
     llama_free(ctx);
     llama_free_model(model);


### PR DESCRIPTION
This PR adds a `--perplexity-lines` parameter to the perplexity tool. In this mode the perplexity is calculated over each line of the prompt instead of over each ctx window.
___
HellaSwag scores is a great way to measure how much of the English language the model understands.

Make two runs on a model, one prompted with a file containing "correct" sentences (one per line) and another run with a file containing "wrong" sentences. The measured perplexity from both files can be used to compute a score that is linearly correlated to the HellaSwag score.

`ppl_correct` = Cumulative perplexity on each line of hellaswag_val_correct.txt, lower values are better.
`ppl_wrong` = Cumulative perplexity on each line of hellaswag_val_wrong.txt, higher values are better.

The formula `(ppl_wrong - ppl_correct) / ppl_correct` correlates linearly with HellaSwag scores on [Open LLM Leaderboard](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard).

Test files: [klosax/ppl_hellaswag](https://github.com/klosax/ppl_hellaswag).

Open LLaMA 3B

200 lines | ppl_wrong | ppl_correct | formula x 100
-- | -- | -- | --
F16 | 24.6445 | 16.0094 | 53.937455
Q8_0 | 24.6335 | 16.0000 | 53.959752
Q5_1 | 24.9139 | 16.2154 | 53.643474
Q4_0 | 25.4092 | 16.4574 | 54.393903

400 lines | ppl_wrong | ppl_correct | formula x 100
-- | -- | -- | --
F16 | 23.7929 | 16.3507 | 45.515894
Q8_0 | 23.7787 | 16.3446 | 45.483392
Q5_1 | 24.0065 | 16.5328 | 45.205637
Q4_0 | 24.4787 | 16.8715 | 45.088413
