### PR TITLE
Support bcast add & dup & cont op on MPS backend

### DIFF
--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -67,6 +67,17 @@ kernel void kernel_add(
     dst[tpig] = src0[tpig] + src1[tpig];
 }
 
+// assumption: src1 is a row
+// broadcast src1 into src0
+kernel void kernel_add_row(
+        device const float * src0,
+        device const float * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        uint tpig[[thread_position_in_grid]]) {
+    dst[tpig] = src0[tpig] + src1[tpig % ne00];
+}
+
 kernel void kernel_mul(
         device const float * src0,
         device const float * src1,


### PR DESCRIPTION
These ops are for [chatglm.cpp](https://github.com/li-plus/chatglm.cpp) MPS implementation. Implement here first and then upstream to [ggml](https://github.com/ggerganov/ggml).