### PR TITLE
Fixes for CLBLAST compile support in FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,20 +236,14 @@ endif # LLAMA_CUBLAS
 
 ifdef LLAMA_CLBLAST
 
-	# If FreeBSD system is detected and env GGML_USE_CLBLAST=1 is used, we compile llama.cpp with this support
-	ifeq ($(UNAME_S),FreeBSD)
-		CFLAGS   += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast)
-		CXXFLAGS += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast)
-	else
-		CFLAGS   += -DGGML_USE_CLBLAST
-		CXXFLAGS += -DGGML_USE_CLBLAST
-	endif
+	CFLAGS   += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast OpenCL)
+	CXXFLAGS += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast OpenCL)
 
 	# Mac provides OpenCL as a framework
 	ifeq ($(UNAME_S),Darwin)
 		LDFLAGS += -lclblast -framework OpenCL
 	else
-		LDFLAGS += -lclblast -lOpenCL
+		LDFLAGS += $(shell pkg-config --libs clblast OpenCL)
 	endif
 	OBJS    += ggml-opencl.o
 

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,16 @@ ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
 endif # LLAMA_CUBLAS
 
 ifdef LLAMA_CLBLAST
-	CFLAGS   += -DGGML_USE_CLBLAST
-	CXXFLAGS += -DGGML_USE_CLBLAST
+
+	# If FreeBSD system is detected and env GGML_USE_CLBLAST=1 is used, we compile llama.cpp with this support
+	ifeq ($(UNAME_S),FreeBSD)
+		CFLAGS   += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast)
+		CXXFLAGS += -DGGML_USE_CLBLAST $(shell pkg-config --cflags clblast)
+	else
+		CFLAGS   += -DGGML_USE_CLBLAST
+		CXXFLAGS += -DGGML_USE_CLBLAST
+	endif
+
 	# Mac provides OpenCL as a framework
 	ifeq ($(UNAME_S),Darwin)
 		LDFLAGS += -lclblast -framework OpenCL

--- a/README.md
+++ b/README.md
@@ -242,6 +242,23 @@ In order to build llama.cpp you have three different options.
     zig build -Doptimize=ReleaseFast
     ```
 
+-   Using `gmake` (FreeBSD):
+
+    1. Install and activate [DRM in FreeBSD](https://wiki.freebsd.org/Graphics)
+    2. Add your user to **video** group
+    3. Install compilation dependencies.
+
+        ```bash
+        sudo pkg install gmake automake autoconf pkgconf llvm15 clinfo clover \
+            opencl clblast openblas
+
+            gmake CC=/usr/local/bin/clang15 CXX=/usr/local/bin/clang++15 -j4
+        ```
+
+    **Notes:** With this packages you can build llama.cpp with OPENBLAS and
+    CLBLAST support for use OpenCL GPU acceleration in FreeBSD. Please read
+    the instructions for use and activate this options in this document below.
+
 ### Metal Build
 
 Using Metal allows the computation to be executed on the GPU for Apple devices:


### PR DESCRIPTION
Hi, this PR has two fixes:


1.  New bits in Makefile for add CLBLAST support in FreeBSD.
2. Instructions for compile llama.cpp in FreeBSD using gmake. These instructions have the packages necessary for OpenBLAS and CLBLAST support for llama.cpp. These packages are available and up-to-date from FreeBSD 11 to FreeBSD 13 in almost architectures supported (only aarch64 remain with lagged support). 


All tested in FreeBSD 13.2, local compilation and testing without issues. 