### PR TITLE
Fix op params change

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -16278,6 +16278,9 @@ struct ggml_cplan ggml_graph_plan(struct ggml_cgraph * cgraph, int n_threads) {
             case GGML_OP_GET_ROWS:
             case GGML_OP_GET_ROWS_BACK:
             case GGML_OP_DIAG:
+                {
+                    n_tasks = 1;
+                } break;
             case GGML_OP_DIAG_MASK_ZERO:
             case GGML_OP_DIAG_MASK_INF:
             case GGML_OP_SOFT_MAX:


### PR DESCRIPTION
While trying to fix the `n_tasks` for `GGML_OP_DIAG_MASK_ZERO`, I broke the `n_tasks` of other ops.