### PR TITLE
Some more Q4_K and Q5_K speedup on CUDA

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2349,6 +2349,9 @@ static void mul_mat_vec_q4_K_q8_1_cuda(const void * vx, const void * vy, float *
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(1, block_num_y, 1);
     const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
+    // Note: we use QI4_K/2 instead of QI4_K to make the dot product template require 4 groups of quants to be processed per
+    //       kernel call instead of 2. This results in a better perfmance because the cost of computing the k-quant scales
+    //       is better amortized.
     mul_mat_vec_q<QK_K, QI4_K/2, block_q4_K, vec_dot_q4_K_q8_1>
         <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows);
 }
@@ -2358,6 +2361,9 @@ static void mul_mat_vec_q5_K_q8_1_cuda(const void * vx, const void * vy, float *
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(1, block_num_y, 1);
     const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
+    // Note: we use QI5_K/2 instead of QI5_K to make the dot product template require 4 groups of quants to be processed per
+    //       kernel call instead of 2. This results in a better perfmance because the cost of computing the k-quant scales
+    //       is better amortized.
     mul_mat_vec_q<QK_K, QI5_K/2, block_q5_K, vec_dot_q5_K_q8_1>
         <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows);
 }


### PR DESCRIPTION

Quite minor on the modern card (RTX-4080), but fairly significant on the older card that I have available (GTX-1660). For `Q5_K` the same bit fiddling for computing the scales is added as in #2322. For both, we gain somewhat if we do 2 dot products per 32 quants in the dot product kernel. Both changes apply to `LLAMA_CUDA_FORCE_DMMV=OFF`.

* TG-128 in ms/t on on GTX-1660 (6GB VRAM, so no 13B results, for `Q5_K_S` 32 layers fit on the GPU).

| Quants  | Master | PR | Speedup |
|--:|--:|--:|--:|
| Q4_K_S | 29.5 | 25.6 | 15.2% |
| Q5_K_S | 42.8 | 35.5 |  20.6% |  

* TG-128 in ms/t on RTX-4080:

| Quants  | Master | PR | Speedup |
|--:|--:|--:|--:| 
| Q4_K_S - 7B | 8.40 | 8.23 | 2.1% |
| Q5_K_S - 7B | 10.42 | 9.52 |  9.5% |
| Q4_K_S - 13B |  14.64 | 14.38 | 1.8% |
| Q5_K_S - 13B |  17.89 | 16.80 | 6.5% |
