### PR TITLE
Fix line breaking error in build-info.sh

### DIFF
--- a/scripts/build-info.sh
+++ b/scripts/build-info.sh
@@ -16,7 +16,8 @@ fi
 echo "#ifndef BUILD_INFO_H"
 echo "#define BUILD_INFO_H"
 echo ""
-echo "#define BUILD_NUMBER $BUILD_NUMBER"
+echo "#define BUILD_NUMBER $BUILD_NUMBER" | tr -d '\n'
+echo ""
 echo "#define BUILD_COMMIT \"$BUILD_COMMIT\"" | tr -d '\n'
 echo ""
 echo "#endif // BUILD_INFO_H"

--- a/scripts/build-info.sh
+++ b/scripts/build-info.sh
@@ -17,6 +17,6 @@ echo "#ifndef BUILD_INFO_H"
 echo "#define BUILD_INFO_H"
 echo ""
 echo "#define BUILD_NUMBER $BUILD_NUMBER"
-echo "#define BUILD_COMMIT \"$BUILD_COMMIT\""
+echo "#define BUILD_COMMIT \"$BUILD_COMMIT\"" | tr -d '\n'
 echo ""
 echo "#endif // BUILD_INFO_H"


### PR DESCRIPTION
Interestingly I realized that in certain machines (mine Windows + WSL2 + Ubuntu 22.10), the `build-info.h` generated through the build process could have line break issues. The below was generated: 

```
#ifndef BUILD_INFO_H
#define BUILD_INFO_H
#define BUILD_NUMBER 880


#define BUILD_COMMIT "b9b7d94

"
#endif // BUILD_INFO_H
```

It seems that somehow two extra line breaks were added. This change will solve the issue, while not breaking things for other platforms. 