### PR TITLE
Add C grammar

### DIFF
--- a/grammars/c.gbnf
+++ b/grammars/c.gbnf
@@ -1,0 +1,42 @@
+root ::= (declaration)*
+
+declaration ::= dataType identifier "(" parameter? ")" "{" statement* "}"
+
+dataType  ::= "int" ws | "float" ws | "char" ws
+identifier ::= [a-zA-Z_] [a-zA-Z_0-9]*
+
+parameter ::= dataType identifier
+
+statement ::=
+    ( dataType identifier ws "=" ws expression ";" ) |
+    ( identifier ws "=" ws expression ";" ) |
+    ( identifier ws "(" argList? ")" ";" ) |
+    ( "return" ws expression ";" ) |
+    ( "while" "(" condition ")" "{" statement* "}" ) |
+    ( "for" "(" forInit ";" ws condition ";" ws forUpdate ")" "{" statement* "}" ) |
+    ( "if" "(" condition ")" "{" statement* "}" ("else" "{" statement* "}")? ) |
+    ( singleLineComment ) |
+    ( multiLineComment )
+
+forInit ::= dataType identifier ws "=" ws expression | identifier ws "=" ws expression
+forUpdate ::= identifier ws "=" ws expression
+
+condition ::= expression relationOperator expression
+relationOperator ::= ("<=" | "<" | "==" | "!=" | ">=" | ">")
+
+expression ::= term (("+" | "-") term)*
+term ::= factor(("*" | "/") factor)*
+
+factor ::= identifier | number | unaryTerm | funcCall | parenExpression
+unaryTerm ::= "-" factor
+funcCall ::= identifier "(" argList? ")"
+parenExpression ::= "(" ws expression ws ")"
+
+argList ::= expression ("," ws expression)*
+
+number ::= [0-9]+
+
+singleLineComment ::= "//" [^\n]* "\n"
+multiLineComment ::= "/*" ( [^*] | ("*" [^/]) )* "*/"
+
+ws ::= ([ \t\n]+)


### PR DESCRIPTION
Based on the work in #1773.

Some thoughts:

- When developing the grammar, sometimes it segfaults unexpectedly, I later found it it's probably due to left-recursion. Should we perform some normalization on the grammar to reduce this?
- Base model still has a tendency to hallucinate even with the grammar direction, sometimes in variable names. Very strange.
- How does this interact with finetuned models? I also tried this extension with WizardLM but haven't run anything concrete.
- Sometimes the model generates large sequences of whitespace with my grammar. Is it something with the rules or can certain productions be penalized?

<details>
<summary>Generating a function to square a number</summary>

```
nix-shell-env ❯ ./main -ngl 1 -m ./models/llama-30b.ggmlv3.q3_K_S.bin --color -p $'// Function to square a number\n\n' --grammar-file grammars/c.gbnf
main: build = 895 (84e09a7)
main: seed  = 1690172920
llama.cpp: loading model from ./models/llama-30b.ggmlv3.q3_K_S.bin
llama_model_load_internal: format     = ggjt v3 (latest)
llama_model_load_internal: n_vocab    = 32000
llama_model_load_internal: n_ctx      = 512
llama_model_load_internal: n_embd     = 6656
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 52
llama_model_load_internal: n_head_kv  = 52
llama_model_load_internal: n_layer    = 60
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: n_gqa      = 1
llama_model_load_internal: n_ff       = 17920
llama_model_load_internal: freq_base  = 10000.0
llama_model_load_internal: freq_scale = 1
llama_model_load_internal: ftype      = 11 (mostly Q3_K - Small)
llama_model_load_internal: model size = 30B
llama_model_load_internal: ggml ctx size =    0.16 MB
llama_model_load_internal: mem required  = 13820.68 MB (+  780.00 MB per state)
llama_new_context_with_model: kv self size  =  780.00 MB
ggml_metal_init: allocating
ggml_metal_init: using MPS
ggml_metal_init: loading '/Users/siraben/Git/llama.cpp/ggml-metal.metal'
ggml_metal_init: loaded kernel_add                            0x12670d740
ggml_metal_init: loaded kernel_add_row                        0x12670dac0
ggml_metal_init: loaded kernel_mul                            0x12670de40
ggml_metal_init: loaded kernel_mul_row                        0x12670e2d0
ggml_metal_init: loaded kernel_scale                          0x12670e650
ggml_metal_init: loaded kernel_silu                           0x12670e9d0
ggml_metal_init: loaded kernel_relu                           0x12670ed50
ggml_metal_init: loaded kernel_gelu                           0x12670f0d0
ggml_metal_init: loaded kernel_soft_max                       0x12670f5e0
ggml_metal_init: loaded kernel_diag_mask_inf                  0x12670faa0
ggml_metal_init: loaded kernel_get_rows_f16                   0x12670ff80
ggml_metal_init: loaded kernel_get_rows_q4_0                  0x126710460
ggml_metal_init: loaded kernel_get_rows_q4_1                  0x126710940
ggml_metal_init: loaded kernel_get_rows_q2_K                  0x126710e20
ggml_metal_init: loaded kernel_get_rows_q3_K                  0x126711300
ggml_metal_init: loaded kernel_get_rows_q4_K                  0x1267117e0
ggml_metal_init: loaded kernel_get_rows_q5_K                  0x126711cc0
ggml_metal_init: loaded kernel_get_rows_q6_K                  0x1267121a0
ggml_metal_init: loaded kernel_rms_norm                       0x1267126c0
ggml_metal_init: loaded kernel_norm                           0x126712bd0
ggml_metal_init: loaded kernel_mul_mat_f16_f32                0x126713290
ggml_metal_init: loaded kernel_mul_mat_q4_0_f32               0x1267137b0
ggml_metal_init: loaded kernel_mul_mat_q4_1_f32               0x126713cd0
ggml_metal_init: loaded kernel_mul_mat_q2_K_f32               0x126714370
ggml_metal_init: loaded kernel_mul_mat_q3_K_f32               0x126714890
ggml_metal_init: loaded kernel_mul_mat_q4_K_f32               0x126714db0
ggml_metal_init: loaded kernel_mul_mat_q5_K_f32               0x1267152b0
ggml_metal_init: loaded kernel_mul_mat_q6_K_f32               0x126715c10
ggml_metal_init: loaded kernel_rope                           0x126715f90
ggml_metal_init: loaded kernel_alibi_f32                      0x1267166b0
ggml_metal_init: loaded kernel_cpy_f32_f16                    0x126716da0
ggml_metal_init: loaded kernel_cpy_f32_f32                    0x126717490
ggml_metal_init: loaded kernel_cpy_f16_f16                    0x126717b80
ggml_metal_init: recommendedMaxWorkingSetSize = 21845.34 MB
ggml_metal_init: hasUnifiedMemory             = true
ggml_metal_init: maxTransferRate              = built-in GPU
llama_new_context_with_model: max tensor size =    87.28 MB
ggml_metal_add_buffer: allocated 'data            ' buffer, size = 13332.97 MB, (13333.42 / 21845.34)
ggml_metal_add_buffer: allocated 'eval            ' buffer, size =    16.00 MB, (13349.42 / 21845.34)
ggml_metal_add_buffer: allocated 'kv              ' buffer, size =   782.00 MB, (14131.42 / 21845.34)
ggml_metal_add_buffer: allocated 'scr0            ' buffer, size =   216.00 MB, (14347.42 / 21845.34)
ggml_metal_add_buffer: allocated 'scr1            ' buffer, size =   256.00 MB, (14603.42 / 21845.34)

system_info: n_threads = 8 / 10 | AVX = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 | 
sampling: repeat_last_n = 64, repeat_penalty = 1.100000, presence_penalty = 0.000000, frequency_penalty = 0.000000, top_k = 40, tfs_z = 1.000000, top_p = 0.950000, typical_p = 1.000000, temp = 0.800000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
generate: n_ctx = 512, n_batch = 512, n_predict = -1, n_keep = 0


main: grammar:
root ::= root_3 
root_1 ::= declaration 
declaration ::= dataType identifier [(] declaration_7 [)] [{] declaration_9 [}] 
root_3 ::= root_1 root_3 | 
dataType ::= [i] [n] [t] ws | [f] [l] [o] [a] [t] ws | [c] [h] [a] [r] ws 
identifier ::= [a-zA-Z_] identifier_11 
parameter ::= dataType identifier 
declaration_7 ::= parameter | 
statement ::= statement_12 | statement_14 | statement_15 | statement_18 | statement_19 | statement_22 | statement_26 | statement_31 | statement_33 
declaration_9 ::= statement declaration_9 | 
ws ::= ws_56 
identifier_11 ::= [a-zA-Z_0-9] identifier_11 | 
statement_12 ::= dataType identifier ws [=] ws expression [;] 
expression ::= expression_37 | expression_42 
statement_14 ::= identifier ws [=] ws expression [;] 
statement_15 ::= identifier ws [(] statement_17 [)] [;] 
argList ::= expression argList_49 
statement_17 ::= argList | 
statement_18 ::= [r] [e] [t] [u] [r] [n] ws expression [;] 
statement_19 ::= [w] [h] [i] [l] [e] [(] condition [)] [{] statement_21 [}] 
condition ::= expression relationOperator expression 
statement_21 ::= statement statement_21 | 
statement_22 ::= [f] [o] [r] [(] forInit [;] ws condition [;] ws forUpdate [)] [{] statement_25 [}] 
forInit ::= dataType identifier ws [=] ws expression | identifier ws [=] ws expression 
forUpdate ::= identifier ws [=] ws expression 
statement_25 ::= statement statement_25 | 
statement_26 ::= [i] [f] [(] condition [)] [{] statement_27 [}] statement_30 
statement_27 ::= statement statement_27 | 
statement_28 ::= [e] [l] [s] [e] [{] statement_29 [}] 
statement_29 ::= statement statement_29 | 
statement_30 ::= statement_28 | 
statement_31 ::= singleLineComment 
singleLineComment ::= [/] [/] singleLineComment_52 [<U+000A>] 
statement_33 ::= multiLineComment 
multiLineComment ::= [/] [*] multiLineComment_55 [*] [/] 
relationOperator ::= relationOperator_36 
relationOperator_36 ::= [<] [=] | [<] | [=] [=] | [!] [=] | [>] [=] | [>] 
expression_37 ::= term expression_41 
term ::= identifier | number | unaryTerm | funcCall | parenExpression 
expression_39 ::= operator term 
operator ::= operator_50 
expression_41 ::= expression_39 expression_41 | 
expression_42 ::= [(] ws expression ws [)] 
number ::= number_51 
unaryTerm ::= [-] term 
funcCall ::= identifier [(] funcCall_47 [)] 
parenExpression ::= [(] ws expression ws [)] 
funcCall_47 ::= argList | 
argList_48 ::= [,] ws expression 
argList_49 ::= argList_48 argList_49 | 
operator_50 ::= [+] | [-] | [*] | [/] 
number_51 ::= [0-9] number_51 | [0-9] 
singleLineComment_52 ::= [^<U+000A>] singleLineComment_52 | 
multiLineComment_53 ::= [^*] | multiLineComment_54 
multiLineComment_54 ::= [*] [^/] 
multiLineComment_55 ::= multiLineComment_53 multiLineComment_55 | 
ws_56 ::= ws_57 
ws_57 ::= [ <U+0009><U+000A>] ws_57 | [ <U+0009><U+000A>] 

 // Function to square a number

int squareNumber(int x){return x*x;} [end of text]

llama_print_timings:        load time =   653.95 ms
llama_print_timings:      sample time =    73.12 ms /    14 runs   (    5.22 ms per token,   191.47 tokens per second)
llama_print_timings: prompt eval time =  3384.85 ms /     9 tokens (  376.09 ms per token,     2.66 tokens per second)
llama_print_timings:        eval time =  2663.51 ms /    13 runs   (  204.89 ms per token,     4.88 tokens per second)
llama_print_timings:       total time =  6132.45 ms
ggml_metal_free: deallocating

```
</details>

<details>
<summary>Fibonacci</summary>

```
nix-shell-env ❯ ./main -ngl 1 -m ./models/llama-30b.ggmlv3.q3_K_S.bin --color -p $'Fibonacci in C:\n\n' --grammar-file grammars/c.gbnf
main: build = 895 (84e09a7)
main: seed  = 1690175698
llama.cpp: loading model from ./models/llama-30b.ggmlv3.q3_K_S.bin
llama_model_load_internal: format     = ggjt v3 (latest)
llama_model_load_internal: n_vocab    = 32000
llama_model_load_internal: n_ctx      = 512
llama_model_load_internal: n_embd     = 6656
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 52
llama_model_load_internal: n_head_kv  = 52
llama_model_load_internal: n_layer    = 60
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: n_gqa      = 1
llama_model_load_internal: n_ff       = 17920
llama_model_load_internal: freq_base  = 10000.0
llama_model_load_internal: freq_scale = 1
llama_model_load_internal: ftype      = 11 (mostly Q3_K - Small)
llama_model_load_internal: model size = 30B
llama_model_load_internal: ggml ctx size =    0.16 MB
llama_model_load_internal: mem required  = 13820.68 MB (+  780.00 MB per state)
llama_new_context_with_model: kv self size  =  780.00 MB
ggml_metal_init: allocating
ggml_metal_init: using MPS
ggml_metal_init: loading '/Users/siraben/Git/llama.cpp/ggml-metal.metal'
ggml_metal_init: loaded kernel_add                            0x1320091e0
ggml_metal_init: loaded kernel_add_row                        0x132009440
ggml_metal_init: loaded kernel_mul                            0x1320097c0
ggml_metal_init: loaded kernel_mul_row                        0x132009c50
ggml_metal_init: loaded kernel_scale                          0x132009fd0
ggml_metal_init: loaded kernel_silu                           0x13200a350
ggml_metal_init: loaded kernel_relu                           0x13200a6d0
ggml_metal_init: loaded kernel_gelu                           0x13200aa50
ggml_metal_init: loaded kernel_soft_max                       0x13200af60
ggml_metal_init: loaded kernel_diag_mask_inf                  0x13200b420
ggml_metal_init: loaded kernel_get_rows_f16                   0x13200b900
ggml_metal_init: loaded kernel_get_rows_q4_0                  0x13200bde0
ggml_metal_init: loaded kernel_get_rows_q4_1                  0x13200c2c0
ggml_metal_init: loaded kernel_get_rows_q2_K                  0x110e04cb0
ggml_metal_init: loaded kernel_get_rows_q3_K                  0x110e05190
ggml_metal_init: loaded kernel_get_rows_q4_K                  0x110e05670
ggml_metal_init: loaded kernel_get_rows_q5_K                  0x110e05b50
ggml_metal_init: loaded kernel_get_rows_q6_K                  0x110e06030
ggml_metal_init: loaded kernel_rms_norm                       0x110e06550
ggml_metal_init: loaded kernel_norm                           0x110e06a60
ggml_metal_init: loaded kernel_mul_mat_f16_f32                0x110e07120
ggml_metal_init: loaded kernel_mul_mat_q4_0_f32               0x110e07640
ggml_metal_init: loaded kernel_mul_mat_q4_1_f32               0x110e07b60
ggml_metal_init: loaded kernel_mul_mat_q2_K_f32               0x110e08200
ggml_metal_init: loaded kernel_mul_mat_q3_K_f32               0x110e08720
ggml_metal_init: loaded kernel_mul_mat_q4_K_f32               0x110e08c40
ggml_metal_init: loaded kernel_mul_mat_q5_K_f32               0x110e09140
ggml_metal_init: loaded kernel_mul_mat_q6_K_f32               0x110e09aa0
ggml_metal_init: loaded kernel_rope                           0x110e09e20
ggml_metal_init: loaded kernel_alibi_f32                      0x110e0a540
ggml_metal_init: loaded kernel_cpy_f32_f16                    0x110e0ac30
ggml_metal_init: loaded kernel_cpy_f32_f32                    0x110e0b320
ggml_metal_init: loaded kernel_cpy_f16_f16                    0x110e0ba10
ggml_metal_init: recommendedMaxWorkingSetSize = 21845.34 MB
ggml_metal_init: hasUnifiedMemory             = true
ggml_metal_init: maxTransferRate              = built-in GPU
llama_new_context_with_model: max tensor size =    87.28 MB
ggml_metal_add_buffer: allocated 'data            ' buffer, size = 13332.97 MB, (13333.42 / 21845.34)
ggml_metal_add_buffer: allocated 'eval            ' buffer, size =    16.00 MB, (13349.42 / 21845.34)
ggml_metal_add_buffer: allocated 'kv              ' buffer, size =   782.00 MB, (14131.42 / 21845.34)
ggml_metal_add_buffer: allocated 'scr0            ' buffer, size =   216.00 MB, (14347.42 / 21845.34)
ggml_metal_add_buffer: allocated 'scr1            ' buffer, size =   256.00 MB, (14603.42 / 21845.34)

system_info: n_threads = 8 / 10 | AVX = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 | 
sampling: repeat_last_n = 64, repeat_penalty = 1.100000, presence_penalty = 0.000000, frequency_penalty = 0.000000, top_k = 40, tfs_z = 1.000000, top_p = 0.950000, typical_p = 1.000000, temp = 0.800000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
generate: n_ctx = 512, n_batch = 512, n_predict = -1, n_keep = 0


main: grammar:
root ::= root_3 
root_1 ::= declaration 
declaration ::= dataType identifier [(] declaration_7 [)] [{] declaration_9 [}] 
root_3 ::= root_1 root_3 | 
dataType ::= [i] [n] [t] ws | [f] [l] [o] [a] [t] ws | [c] [h] [a] [r] ws 
identifier ::= [a-zA-Z_] identifier_11 
parameter ::= dataType identifier 
declaration_7 ::= parameter | 
statement ::= statement_12 | statement_14 | statement_15 | statement_18 | statement_19 | statement_22 | statement_26 | statement_31 | statement_33 
declaration_9 ::= statement declaration_9 | 
ws ::= ws_57 
identifier_11 ::= [a-zA-Z_0-9] identifier_11 | 
statement_12 ::= dataType identifier ws [=] ws expression [;] 
expression ::= term expression_40 
statement_14 ::= identifier ws [=] ws expression [;] 
statement_15 ::= identifier ws [(] statement_17 [)] [;] 
argList ::= expression argList_51 
statement_17 ::= argList | 
statement_18 ::= [r] [e] [t] [u] [r] [n] ws expression [;] 
statement_19 ::= [w] [h] [i] [l] [e] [(] condition [)] [{] statement_21 [}] 
condition ::= expression relationOperator expression 
statement_21 ::= statement statement_21 | 
statement_22 ::= [f] [o] [r] [(] forInit [;] ws condition [;] ws forUpdate [)] [{] statement_25 [}] 
forInit ::= dataType identifier ws [=] ws expression | identifier ws [=] ws expression 
forUpdate ::= identifier ws [=] ws expression 
statement_25 ::= statement statement_25 | 
statement_26 ::= [i] [f] [(] condition [)] [{] statement_27 [}] statement_30 
statement_27 ::= statement statement_27 | 
statement_28 ::= [e] [l] [s] [e] [{] statement_29 [}] 
statement_29 ::= statement statement_29 | 
statement_30 ::= statement_28 | 
statement_31 ::= singleLineComment 
singleLineComment ::= [/] [/] singleLineComment_53 [<U+000A>] 
statement_33 ::= multiLineComment 
multiLineComment ::= [/] [*] multiLineComment_56 [*] [/] 
relationOperator ::= relationOperator_36 
relationOperator_36 ::= [<] [=] | [<] | [=] [=] | [!] [=] | [>] [=] | [>] 
term ::= factor term_44 
expression_38 ::= expression_39 term 
expression_39 ::= [+] | [-] 
expression_40 ::= expression_38 expression_40 | 
factor ::= identifier | number | unaryTerm | funcCall | parenExpression 
term_42 ::= term_43 factor 
term_43 ::= [*] | [/] 
term_44 ::= term_42 term_44 | 
number ::= number_52 
unaryTerm ::= [-] factor 
funcCall ::= identifier [(] funcCall_49 [)] 
parenExpression ::= [(] ws expression ws [)] 
funcCall_49 ::= argList | 
argList_50 ::= [,] ws expression 
argList_51 ::= argList_50 argList_51 | 
number_52 ::= [0-9] number_52 | [0-9] 
singleLineComment_53 ::= [^<U+000A>] singleLineComment_53 | 
multiLineComment_54 ::= [^*] | multiLineComment_55 
multiLineComment_55 ::= [*] [^/] 
multiLineComment_56 ::= multiLineComment_54 multiLineComment_56 | 
ws_57 ::= ws_58 
ws_58 ::= [ <U+0009><U+000A>] ws_58 | [ <U+0009><U+000A>] 

 Fibonacci in C:

char F(int n){int nFibonacci = 0;if(n<2){return 1;}else{return F(n-2)+F(n-1);}} [end of text]

llama_print_timings:        load time = 23430.51 ms
llama_print_timings:      sample time =   279.79 ms /    48 runs   (    5.83 ms per token,   171.55 tokens per second)
llama_print_timings: prompt eval time =  6594.15 ms /    10 tokens (  659.42 ms per token,     1.52 tokens per second)
llama_print_timings:        eval time =  9306.79 ms /    47 runs   (  198.02 ms per token,     5.05 tokens per second)
llama_print_timings:       total time = 16222.58 ms
ggml_metal_free: deallocating
```
</details>