### PR TITLE
ggml : mul mat tweaks

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -10537,6 +10537,12 @@ static void ggml_compute_forward_mul_mat(
 
     //printf("ir010 = %6lld, ir011 = %6lld, ir110 = %6lld, ir111 = %6lld\n", ir010, ir011, ir110, ir111);
 
+    // threads with no work simply yield (not sure if it helps)
+    if (ir010 >= ir011 || ir110 >= ir111) {
+        sched_yield();
+        return;
+    }
+
     assert(ne12 % ne02 == 0);
     assert(ne13 % ne03 == 0);
 


### PR DESCRIPTION
ref: https://github.com/ggerganov/ggml/issues/293

See if #2355 can be resolved and also make sure we broadcast correctly across dims 2 and 3

Also, did a first try for block tiled matrix multiplication which seems to improve slightly the performance.

Currently, my tests on x86 show that OpenBLAS does not offer any advantage compared to non-BLAS both for prompt processing and text generation.

Looking for reports where this is not the case. Make sure to use thread count equal to the number of performance cores on your system.

TODO:

- [ ] add broadcast support for CPU BLAS path (https://github.com/ggerganov/ggml/issues/412#issuecomment-1650300845)
- [ ] add broadcast support in Metal

