### PR TITLE
Default for RMS epsilon

### DIFF
--- a/examples/baby-llama/baby-llama.cpp
+++ b/examples/baby-llama/baby-llama.cpp
@@ -8,7 +8,11 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
-static const float rms_norm_eps = 1e-6f;
+#ifdef LLAMA_DEFAULT_RMS_EPS
+static const float rms_norm_eps = LLAMA_DEFAULT_RMS_EPS;
+#else
+static const float rms_norm_eps = 5e-6f;
+#endif
 
 float frand() {
     return (float)rand()/(float)RAND_MAX;

--- a/examples/common.h
+++ b/examples/common.h
@@ -34,7 +34,7 @@ struct gpt_params {
     int32_t main_gpu                        = 0;    // the GPU that is used for scratch and small tensors
     float   tensor_split[LLAMA_MAX_DEVICES] = {0};  // how split tensors should be distributed across GPUs
     int32_t n_probs                         = 0;    // if greater than 0, output the probabilities of top n_probs tokens.
-    float   rms_norm_eps                    = 1e-6; // rms norm epsilon
+    float   rms_norm_eps                    = LLAMA_DEFAULT_RMS_EPS; // rms norm epsilon
     float   rope_freq_base                  = 10000.0f; // RoPE base frequency
     float   rope_freq_scale                 = 1.0f;     // RoPE frequency scaling factor
 

--- a/examples/train-text-from-scratch/train-text-from-scratch.cpp
+++ b/examples/train-text-from-scratch/train-text-from-scratch.cpp
@@ -16,7 +16,7 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
-static const float rms_norm_eps = 1e-6f;
+static const float rms_norm_eps = LLAMA_DEFAULT_RMS_EPS;
 
 struct random_normal_distribution {
     std::mt19937 gen;

--- a/llama.cpp
+++ b/llama.cpp
@@ -186,7 +186,7 @@ struct llama_hparams {
     // LLaMAv2
     // TODO: load from model data hparams
     float f_ffn_mult = 1.0f;
-    float f_rms_norm_eps = 1e-6f;
+    float f_rms_norm_eps = LLAMA_DEFAULT_RMS_EPS;
 
     float rope_freq_base  = 10000.0f;
     float rope_freq_scale = 1.0f;
@@ -870,7 +870,7 @@ struct llama_context_params llama_context_default_params() {
         /*.n_ctx                       =*/ 512,
         /*.n_batch                     =*/ 512,
         /*.n_gqa                       =*/ 1,
-        /*.rms_norm_eps                =*/ 1e-6f,
+        /*.rms_norm_eps                =*/ LLAMA_DEFAULT_RMS_EPS,
         /*.gpu_layers                  =*/ 0,
         /*.main_gpu                    =*/ 0,
         /*.tensor_split                =*/ nullptr,

--- a/llama.h
+++ b/llama.h
@@ -53,6 +53,10 @@
 #define LLAMA_SUPPORTS_GPU_OFFLOAD
 #endif
 
+#ifndef LLAMA_DEFAULT_RMS_EPS
+#define LLAMA_DEFAULT_RMS_EPS 5e-6f
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
PR #2374 made the `epsilon` used the `rms_norm` operation to be a parameter with a default value of `1e-6` that can be changed via a command line option. This is to account for the fact that in LLaMA-1 `epsilon = 1e-6` was used during training, while LLaMA-2 was trained with `epsilon = 1e-5`.  Using `epsilon = 1e-6` for LLaMA-2 results in significantly lower perplexity scores (see #2373, #2352, and the graphs below), so being able to change RMS `epsilon` via the command line is great. Until one has to run many perplexity calculations, as I'm currently doing in an attempt to improve the `Q4_K` performance for LLaMA-2. In this process I'm making a change to the `Q4_K` quantization, then running perplexity for LLaMA-1 and LLaMA-2, frequently forgetting to modify the `epsilon` from the last run, and hence wasting a lot of time waiting for the calculation to finish to only then realize that I have used the wrong `epsilon`.

So, I decided to see if there is an `epsilon` that works equally well for both LLaMA models. Turns out `epsilon = 5e-6` is this magic value. If anything, `epsilon = 5e-6` slightly improves perplexity scores for LLaMA-2. For LLaMA-1, perplexity scores are the same as with `epsilon = 1e-6` within 1.5 X maximum training context (so, up to and including 3072 tokens), and are only very slightly higher for context lengths of 4096 and beyond. This can be seen in the graphs below.

Given this finding, this PR adds a macro `LLAMA_DEFAULT_RMS_EPS`, set to `5e-6f`. All `rms_norm` default values are set via this macro, which can be changed at build time (`make clean &&  LLAMA_DEFAULT_RMS_EPS=YourPreferredChoice make`) instead of being hard-coded to `1e-6`. One can of course still change `epsilon` via the command line.

![ppl_vs_ctx_7B](https://github.com/ggerganov/llama.cpp/assets/48489457/6f1c5ce6-a339-4cd5-b797-f6ebcea00299)

![ppl_vs_ctx_13B](https://github.com/ggerganov/llama.cpp/assets/48489457/1603f849-bda0-4db2-97b1-fe7f47a5b699)

Figures show perplexity as a function of context size for the 7B and 13B LLaMA models. The black line+circles represent LLaMA-1 results with `epsilon = 1e-6`. The orange squares depict LLaMA-1 with `epislon = 5e-6` (proposed default value for both models). Red line+circles are for LLaMA-2 with `epsilon = 1e-6`. They were computed before we had realized the `rms_norm epsilon` issue and are included in the graph to illustrate the magnitude of the perplexity loss due to using the wrong `epsilon` value. The blue line/circles show LLaMA-2 results for `epsilon = 1e-5`, and the magenta are for LLaMA-2 with `epsilon = 5e-6`. The calculations beyond the maximum training context were run with base RoPE frequency selected to minimize the perplexity score.  

