### PR TITLE
supporting more diverse tokenizers

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1924,7 +1924,7 @@ struct llama_tokenizer {
             if (token == vocab_.token_to_id.end()) {
                 // output any symbols that did not form tokens as bytes.
                 for (int j = 0; j < (int) symbol.n; ++j) {
-                    llama_vocab::id token_id = static_cast<uint8_t>(symbol.text[j]) + 3;
+                    llama_vocab::id token_id = vocab_.token_to_id.at(std::string(1, symbol.text[j]));
                     output.push_back(token_id);
                 }
             } else {

--- a/llama.cpp
+++ b/llama.cpp
@@ -1924,6 +1924,8 @@ struct llama_tokenizer {
             if (token == vocab_.token_to_id.end()) {
                 // output any symbols that did not form tokens as bytes.
                 for (int j = 0; j < (int) symbol.n; ++j) {
+                    // NOTE: old version, before #2420 - not sure what are the implications of this
+                    //llama_vocab::id token_id = static_cast<uint8_t>(symbol.text[j]) + 3;
                     llama_vocab::id token_id = vocab_.token_to_id.at(std::string(1, symbol.text[j]));
                     output.push_back(token_id);
                 }


### PR DESCRIPTION
Hi, thanks for this awesome work.

I am currently trying to perform inference on different LLM (e.g., [xgen](https://github.com/salesforce/xgen) and [Aquila](https://github.com/FlagAI-Open/FlagAI)) using this project.

I always encounter issues with generating Chinese text smoothly. 
By adopting the flag `--verbose-prompt`, I found that the Chinese words are always being tokenized into wrong token IDs.
After digging into the root cause, I found the reason is that the Chinese characters, which are composed of multiple bytes, are always tokenized incorrectly by this part.
```c++
llama_vocab::id token_id = static_cast<uint8_t>(symbol.text[j]) + 3;
```
This code can work for the llama series of models primarily because the llama's tokenizer follows the char 
coding order and three special tokens are placed at the beginning:
```
'<unk>': 0,
'<s>': 1,
'</s>': 2,
'<0x00>': 3,
'<0x01>': 4,
'<0x02>': 5,
'<0x03>': 6,
...
```

Unfortunately, not all open-source pre-trained models adopt llama's tokenizer such as xgen and Aquila mentioned above.
Therefore, for more flexible support for more diverse pre-trained model tokenizers. I believe we should use the vocabulary generated by `convert.py` appropriately in this case.

For example, the xgen's tokenizer map looks like:
```
b'!': 0,
b'"': 1,
b'#': 2,
b'$': 3,
b'%': 4,
b'&': 5,
b"'": 6,
b'(': 7,
...
```

Although this PR only modifies one line of code, it brings significant benefits for supporting more models with UTF-8 characters. Just like #2228, enabling only BPE in convert.py is not sufficient to successfully infer Chinese words without this modification.

Big thanks for this amazing work again!