### PR TITLE
Use n_embd_gqa instead of n_embd to handle llama-2 70B

### DIFF
--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -26,6 +26,7 @@ int main(int argc, char ** argv) {
     auto lparams = llama_context_default_params();
 
     lparams.n_ctx     = params.n_ctx;
+    lparams.n_gqa     = params.n_gqa;
     lparams.seed      = params.seed;
     lparams.f16_kv    = params.memory_f16;
     lparams.use_mmap  = params.use_mmap;

--- a/llama.cpp
+++ b/llama.cpp
@@ -3663,7 +3663,7 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
         const auto & kv_self = ctx->kv_self;
         const auto & hparams = ctx->model.hparams;
         const int    n_layer = hparams.n_layer;
-        const int    n_embd  = hparams.n_embd;
+        const int    n_embd  = hparams.n_embd_gqa();
         const int    n_ctx   = hparams.n_ctx;
 
         const size_t kv_size = kv_self.buf.size;
@@ -3766,7 +3766,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
         const auto & kv_self = ctx->kv_self;
         const auto & hparams = ctx->model.hparams;
         const int    n_layer = hparams.n_layer;
-        const int    n_embd  = hparams.n_embd;
+        const int    n_embd  = hparams.n_embd_gqa();
         const int    n_ctx   = hparams.n_ctx;
 
         size_t kv_size;


### PR DESCRIPTION
This PR fixes https://github.com/ggerganov/llama.cpp/issues/2350. Verified with 2 approaches:

### Approach 1

Run `make state-load-sate` then run `./save-load-state --model /home/randxie/weights/llama-2-70b-chat.ggmlv3.q4_K_M.bin --gqa 8`.

### Approach 2

Run the reproducing steps in the above issue, and verify no more Segmentation fault.

The model weight is downloaded from https://huggingface.co/TheBloke/Llama-2-70B-Chat-GGML/blob/main/llama-2-70b-chat.ggmlv3.q4_K_M.bin