### PR TITLE
install ggml-meta.metal if LLAMA_METAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,16 @@ install(
         WORLD_READ
         WORLD_EXECUTE
     DESTINATION ${CMAKE_INSTALL_BINDIR})
+if (LLAMA_METAL)
+    install(
+        FILES ggml-metal.metal
+        PERMISSIONS
+            OWNER_READ
+            OWNER_WRITE
+            GROUP_READ
+            WORLD_READ
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 #
 # programs, examples and tests


### PR DESCRIPTION
Currently if cmake is used with LLAMA_METAL on macOS, `make install` would not copy `ggml-metal.metal` to the `$PREDFIX/bin` directory. This PR fixes that.