### PR TITLE
Fix broken build for LLAMA_METAL

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1825,7 +1825,6 @@ static bool llama_eval_internal(
         //}
         ggml_metal_set_n_cb     (lctx.ctx_metal, n_threads);
         ggml_metal_graph_compute(lctx.ctx_metal, gf);
-        ggml_metal_get_tensor   (lctx.ctx_metal, cur);
     } else {
         // IMPORTANT:
         // Since we don't have efficient Matrix x Matrix Metal multiplication yet, we fallback to vanilla


### PR DESCRIPTION
a113689 broke the build with:

```
llama.cpp:1828:50: error: use of undeclared identifier 'cur'
        ggml_metal_get_tensor   (lctx.ctx_metal, cur);
```

This commit removes the stray line to repair the build.