### PR TITLE
CUDA: fixed LLAMA_FAST compilation option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ ifdef LLAMA_CUDA_CCBIN
 	NVCCFLAGS += -ccbin $(LLAMA_CUDA_CCBIN)
 endif
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
-	$(NVCC) $(NVCCFLAGS) $(CXXFLAGS) -Wno-pedantic -c $< -o $@
+	$(NVCC) $(NVCCFLAGS) $(subst -Ofast,-O3,$(CXXFLAGS)) -Wno-pedantic -c $< -o $@
 endif # LLAMA_CUBLAS
 
 ifdef LLAMA_CLBLAST


### PR DESCRIPTION
The `LLAMA_FAST` compilation option which replaces `-O3` with `-Ofast` currently does not work in combination with CUDA because nvcc does not have that compilation option. This PR makes it so that `-O3` is always used for nvcc and `-Ofast` otherwise.