### PR TITLE
Fix a typo in examples/server/README.md

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -163,7 +163,7 @@ node .
 
     `content`: Set the text to tokenize.
 
-    Note that the special `BOS` token is not added in fron of the text and also a space character is not inserted automatically as it is for `/completion`.
+    Note that the special `BOS` token is not added in front of the text and also a space character is not inserted automatically as it is for `/completion`.
 
 -   **POST** `/embedding`: Generate embedding of a given text just as [the embedding example](../embedding) does.
 


### PR DESCRIPTION
fron-> front