### PR TITLE
Stream save llama context data to file instead of allocating entire buffer upfront

### DIFF
--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -67,9 +67,10 @@ int main(int argc, char ** argv) {
 
     // Save state (rng, logits, embedding and kv_cache) to file
     {
-        llama_file file("dump_state.bin", "wb");
-        llama_data_file_context data_ctx(&file);
-        llama_copy_state_data(ctx, &data_ctx); // can also copy to memory buffer
+         FILE *fp_write = fopen("dump_state.bin", "wb");
+        llama_copy_state_data(ctx, state_mem); // could also copy directly to memory mapped file
+        fwrite(state_mem, 1, state_size, fp_write);
+        fclose(fp_write);
     }
 
     // save state (last tokens)

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -66,11 +66,7 @@ int main(int argc, char ** argv) {
     uint8_t * state_mem = new uint8_t[state_size];
 
     // Save state (rng, logits, embedding and kv_cache) to file
-    {
-        llama_file file("dump_state.bin", "wb");
-        llama_data_file_context data_ctx(&file);
-        llama_copy_state_data(ctx, &data_ctx); // can also copy to memory buffer
-    }
+    llama_save_session_file(ctx, "dump_state.bin", tokens.data(), tokens.size());
 
     // save state (last tokens)
     const auto last_n_tokens_data_saved = std::vector<llama_token>(last_n_tokens_data);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "llama.h"
+#include "llama-util.h"
 #include "build-info.h"
 
 #include <vector>
@@ -66,10 +67,9 @@ int main(int argc, char ** argv) {
 
     // Save state (rng, logits, embedding and kv_cache) to file
     {
-        FILE *fp_write = fopen("dump_state.bin", "wb");
-        llama_copy_state_data(ctx, state_mem); // could also copy directly to memory mapped file
-        fwrite(state_mem, 1, state_size, fp_write);
-        fclose(fp_write);
+        llama_file file("dump_state.bin", "wb");
+        llama_data_file_context data_ctx(&file);
+        llama_copy_state_data(ctx, &data_ctx); // can also copy to memory buffer
     }
 
     // save state (last tokens)

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -1,6 +1,5 @@
 #include "common.h"
 #include "llama.h"
-#include "llama-util.h"
 #include "build-info.h"
 
 #include <vector>

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -67,7 +67,7 @@ int main(int argc, char ** argv) {
 
     // Save state (rng, logits, embedding and kv_cache) to file
     {
-         FILE *fp_write = fopen("dump_state.bin", "wb");
+        FILE *fp_write = fopen("dump_state.bin", "wb");
         llama_copy_state_data(ctx, state_mem); // could also copy directly to memory mapped file
         fwrite(state_mem, 1, state_size, fp_write);
         fclose(fp_write);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -66,7 +66,11 @@ int main(int argc, char ** argv) {
     uint8_t * state_mem = new uint8_t[state_size];
 
     // Save state (rng, logits, embedding and kv_cache) to file
-    llama_save_session_file(ctx, "dump_state.bin", tokens.data(), tokens.size());
+    {
+        llama_file file("dump_state.bin", "wb");
+        llama_data_file_context data_ctx(&file);
+        llama_copy_state_data(ctx, &data_ctx); // can also copy to memory buffer
+    }
 
     // save state (last tokens)
     const auto last_n_tokens_data_saved = std::vector<llama_token>(last_n_tokens_data);

--- a/llama-util.h
+++ b/llama-util.h
@@ -149,6 +149,29 @@ struct llama_file {
     }
 };
 
+// llama_context_data
+struct llama_data_context {
+    virtual void write(const void* src, size_t size) = 0;
+    virtual ~llama_data_context() = default;
+};
+
+struct llama_data_buffer_context : llama_data_context {
+    uint8_t* ptr;
+    llama_data_buffer_context(uint8_t* p) : ptr(p) {}
+    void write(const void* src, size_t size) override {
+        memcpy(ptr, src, size);
+        ptr += size;
+    }
+};
+
+struct llama_data_file_context : llama_data_context {
+    llama_file* file;
+    llama_data_file_context(llama_file* f) : file(f) {}
+    void write(const void* src, size_t size) override {
+        file->write_raw(src, size);
+    }
+};
+
 #if defined(_WIN32)
 static std::string llama_format_win_err(DWORD err) {
     LPSTR buf;

--- a/llama-util.h
+++ b/llama-util.h
@@ -151,7 +151,7 @@ struct llama_file {
 
 // llama_context_data
 struct llama_data_context {
-    virtual void write(const void* src, size_t size) = 0;
+    virtual void write(const void * src, size_t size) = 0;
     virtual size_t get_size_written() = 0;
     virtual ~llama_data_context() = default;
 };
@@ -160,9 +160,9 @@ struct llama_data_buffer_context : llama_data_context {
     uint8_t* ptr;
     size_t size_written = 0;
 
-    llama_data_buffer_context(uint8_t* p) : ptr(p) {}
+    llama_data_buffer_context(uint8_t * p) : ptr(p) {}
 
-    void write(const void* src, size_t size) override {
+    void write(const void * src, size_t size) override {
         memcpy(ptr, src, size);
         ptr += size;
         size_written += size;
@@ -177,9 +177,9 @@ struct llama_data_file_context : llama_data_context {
     llama_file* file;
     size_t size_written = 0;
 
-    llama_data_file_context(llama_file* f) : file(f) {}
+    llama_data_file_context(llama_file * f) : file(f) {}
 
-    void write(const void* src, size_t size) override {
+    void write(const void * src, size_t size) override {
         file->write_raw(src, size);
         size_written += size;
     }

--- a/llama-util.h
+++ b/llama-util.h
@@ -152,23 +152,40 @@ struct llama_file {
 // llama_context_data
 struct llama_data_context {
     virtual void write(const void* src, size_t size) = 0;
+    virtual size_t get_size_written() = 0;
     virtual ~llama_data_context() = default;
 };
 
 struct llama_data_buffer_context : llama_data_context {
     uint8_t* ptr;
+    size_t size_written = 0;
+
     llama_data_buffer_context(uint8_t* p) : ptr(p) {}
+
     void write(const void* src, size_t size) override {
         memcpy(ptr, src, size);
         ptr += size;
+        size_written += size;
+    }
+
+    size_t get_size_written() override {
+        return size_written;
     }
 };
 
 struct llama_data_file_context : llama_data_context {
     llama_file* file;
+    size_t size_written = 0;
+
     llama_data_file_context(llama_file* f) : file(f) {}
+
     void write(const void* src, size_t size) override {
         file->write_raw(src, size);
+        size_written += size;
+    }
+
+    size_t get_size_written() override {
+        return size_written;
     }
 };
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -3743,10 +3743,8 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
     return s_total;
 }
 
-// Copies the state to the specified destination address
-size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
-    uint8_t * out = dst;
-
+// copy state data into either a buffer or file depending on the passed in context
+void llama_copy_state_data(struct llama_context * ctx, llama_data_context * data_ctx) {
     // copy rng
     {
         std::stringstream rng_ss;
@@ -3758,8 +3756,8 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
         memset(&rng_buf[0], 0, LLAMA_MAX_RNG_STATE);
         memcpy(&rng_buf[0], rng_ss.str().data(), rng_ss.str().size());
 
-        memcpy(out, &rng_size,   sizeof(rng_size));    out += sizeof(rng_size);
-        memcpy(out, &rng_buf[0], LLAMA_MAX_RNG_STATE); out += LLAMA_MAX_RNG_STATE;
+        data_ctx->write(&rng_size,   sizeof(rng_size));
+        data_ctx->write(&rng_buf[0], LLAMA_MAX_RNG_STATE);
     }
 
     // copy logits
@@ -3767,114 +3765,18 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
         const size_t logits_cap  = ctx->logits.capacity();
         const size_t logits_size = ctx->logits.size();
 
-        memcpy(out, &logits_cap,  sizeof(logits_cap));  out += sizeof(logits_cap);
-        memcpy(out, &logits_size, sizeof(logits_size)); out += sizeof(logits_size);
+        data_ctx->write(&logits_cap,  sizeof(logits_cap));
+        data_ctx->write(&logits_size, sizeof(logits_size));
 
         if (logits_size) {
-            memcpy(out, ctx->logits.data(), logits_size * sizeof(float));
-        }
-
-        out += logits_cap * sizeof(float);
-    }
-
-    // copy embeddings
-    {
-        const size_t embedding_size = ctx->embedding.size();
-
-        memcpy(out, &embedding_size, sizeof(embedding_size)); out += sizeof(embedding_size);
-
-        if (embedding_size) {
-            memcpy(out, ctx->embedding.data(), embedding_size * sizeof(float));
-            out += embedding_size * sizeof(float);
-        }
-    }
-
-    // copy kv cache
-    {
-        const auto & kv_self = ctx->kv_self;
-        const auto & hparams = ctx->model.hparams;
-        const int    n_layer = hparams.n_layer;
-        const int    n_embd  = hparams.n_embd_gqa();
-        const int    n_ctx   = hparams.n_ctx;
-
-        const size_t kv_size = kv_self.buf.size;
-        const int    kv_ntok = llama_get_kv_cache_token_count(ctx);
-
-        memcpy(out, &kv_size, sizeof(kv_size)); out += sizeof(kv_size);
-        memcpy(out, &kv_ntok, sizeof(kv_ntok)); out += sizeof(kv_ntok);
-
-        if (kv_size) {
-            const size_t elt_size = ggml_element_size(kv_self.k);
-
-            ggml_context * cpy_ctx = ggml_init({ 4096, NULL, /* no_alloc */ true });
-            ggml_cgraph gf{};
-
-            ggml_tensor * kout3d = ggml_new_tensor_3d(cpy_ctx, kv_self.k->type, n_embd, kv_ntok, n_layer);
-            kout3d->data = out;
-            out += ggml_nbytes(kout3d);
-
-            ggml_tensor * vout3d = ggml_new_tensor_3d(cpy_ctx, kv_self.v->type, kv_ntok, n_embd, n_layer);
-            vout3d->data = out;
-            out += ggml_nbytes(vout3d);
-
-            ggml_tensor * k3d = ggml_view_3d(cpy_ctx, kv_self.k,
-                n_embd, kv_ntok, n_layer,
-                elt_size*n_embd, elt_size*n_embd*n_ctx, 0);
-
-            ggml_tensor * v3d = ggml_view_3d(cpy_ctx, kv_self.v,
-                kv_ntok, n_embd, n_layer,
-                elt_size*n_ctx, elt_size*n_ctx*n_embd, 0);
-
-            ggml_build_forward_expand(&gf, ggml_cpy(cpy_ctx, k3d, kout3d));
-            ggml_build_forward_expand(&gf, ggml_cpy(cpy_ctx, v3d, vout3d));
-            ggml_graph_compute_helper(ctx->work_buffer, &gf, /*n_threads*/ 1);
-
-            ggml_free(cpy_ctx);
-        }
-    }
-
-    const size_t written  = out - dst;
-    const size_t max_size = llama_get_state_size(ctx);
-
-    LLAMA_ASSERT(written <= max_size);
-
-    return written;
-}
-
-// writes state data directly to file instead of copying it into a buffer
-void llama_write_state_data_to_file(struct llama_context * ctx, llama_file * dst_file) {
-    // copy rng
-    {
-        std::stringstream rng_ss;
-        rng_ss << ctx->rng;
-
-        const size_t rng_size = rng_ss.str().size();
-        char rng_buf[LLAMA_MAX_RNG_STATE];
-
-        memset(&rng_buf[0], 0, LLAMA_MAX_RNG_STATE);
-        memcpy(&rng_buf[0], rng_ss.str().data(), rng_ss.str().size());
-
-        dst_file->write_raw(&rng_size,   sizeof(rng_size));
-        dst_file->write_raw(&rng_buf[0], LLAMA_MAX_RNG_STATE);
-    }
-
-    // copy logits
-    {
-        const size_t logits_cap  = ctx->logits.capacity();
-        const size_t logits_size = ctx->logits.size();
-
-        dst_file->write_raw(&logits_cap,  sizeof(logits_cap));
-        dst_file->write_raw(&logits_size, sizeof(logits_size));
-
-        if (logits_size) {
-            dst_file->write_raw(ctx->logits.data(), logits_size * sizeof(float));
+            data_ctx->write(ctx->logits.data(), logits_size * sizeof(float));
         }
 
         // If there is a gap between the size and the capacity, write padding
         size_t padding_size = (logits_cap - logits_size) * sizeof(float);
         if (padding_size > 0) {
             std::vector<uint8_t> padding(padding_size, 0); // Create a buffer filled with zeros
-            dst_file->write_raw(padding.data(), padding_size);
+            data_ctx->write(padding.data(), padding_size);
         }
     }
 
@@ -3882,10 +3784,10 @@ void llama_write_state_data_to_file(struct llama_context * ctx, llama_file * dst
     {
         const size_t embedding_size = ctx->embedding.size();
 
-        dst_file->write_raw(&embedding_size, sizeof(embedding_size));
+        data_ctx->write(&embedding_size, sizeof(embedding_size));
 
         if (embedding_size) {
-            dst_file->write_raw(ctx->embedding.data(), embedding_size * sizeof(float));
+            data_ctx->write(ctx->embedding.data(), embedding_size * sizeof(float));
         }
     }
 
@@ -3900,8 +3802,8 @@ void llama_write_state_data_to_file(struct llama_context * ctx, llama_file * dst
         const size_t kv_size = kv_self.buf.size;
         const int    kv_ntok = llama_get_kv_cache_token_count(ctx);
 
-        dst_file->write_raw(&kv_size, sizeof(kv_size));
-        dst_file->write_raw(&kv_ntok, sizeof(kv_ntok));
+        data_ctx->write(&kv_size, sizeof(kv_size));
+        data_ctx->write(&kv_ntok, sizeof(kv_ntok));
 
         if (kv_size) {
             const size_t elt_size = ggml_element_size(kv_self.k);
@@ -3933,8 +3835,8 @@ void llama_write_state_data_to_file(struct llama_context * ctx, llama_file * dst
 
             // our data is now in the kout3d_data and vout3d_data buffers
             // write them to file
-            dst_file->write_raw(kout3d_data.data(), kout3d_data.size());
-            dst_file->write_raw(vout3d_data.data(), vout3d_data.size());
+            data_ctx->write(kout3d_data.data(), kout3d_data.size());
+            data_ctx->write(vout3d_data.data(), vout3d_data.size());
         }
     }
 }
@@ -4122,7 +4024,8 @@ bool llama_save_session_file(struct llama_context * ctx, const char * path_sessi
     file.write_raw(tokens, sizeof(llama_token) * n_token_count);
 
     // save the context state using stream saving
-    llama_write_state_data_to_file(ctx, &file);
+    llama_data_file_context data_ctx(&file);
+    llama_copy_state_data(ctx, &data_ctx);
 
     return true;
 }

--- a/llama.cpp
+++ b/llama.cpp
@@ -3841,6 +3841,104 @@ size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
     return written;
 }
 
+// writes state data directly to file instead of copying it into a buffer
+void llama_write_state_data_to_file(struct llama_context * ctx, llama_file * dst_file) {
+    // copy rng
+    {
+        std::stringstream rng_ss;
+        rng_ss << ctx->rng;
+
+        const size_t rng_size = rng_ss.str().size();
+        char rng_buf[LLAMA_MAX_RNG_STATE];
+
+        memset(&rng_buf[0], 0, LLAMA_MAX_RNG_STATE);
+        memcpy(&rng_buf[0], rng_ss.str().data(), rng_ss.str().size());
+
+        dst_file->write_raw(&rng_size,   sizeof(rng_size));
+        dst_file->write_raw(&rng_buf[0], LLAMA_MAX_RNG_STATE);
+    }
+
+    // copy logits
+    {
+        const size_t logits_cap  = ctx->logits.capacity();
+        const size_t logits_size = ctx->logits.size();
+
+        dst_file->write_raw(&logits_cap,  sizeof(logits_cap));
+        dst_file->write_raw(&logits_size, sizeof(logits_size));
+
+        if (logits_size) {
+            dst_file->write_raw(ctx->logits.data(), logits_size * sizeof(float));
+        }
+
+        // If there is a gap between the size and the capacity, write padding
+        size_t padding_size = (logits_cap - logits_size) * sizeof(float);
+        if (padding_size > 0) {
+            std::vector<uint8_t> padding(padding_size, 0); // Create a buffer filled with zeros
+            dst_file->write_raw(padding.data(), padding_size);
+        }
+    }
+
+    // copy embeddings
+    {
+        const size_t embedding_size = ctx->embedding.size();
+
+        dst_file->write_raw(&embedding_size, sizeof(embedding_size));
+
+        if (embedding_size) {
+            dst_file->write_raw(ctx->embedding.data(), embedding_size * sizeof(float));
+        }
+    }
+
+    // copy kv cache
+    {
+        const auto & kv_self = ctx->kv_self;
+        const auto & hparams = ctx->model.hparams;
+        const int    n_layer = hparams.n_layer;
+        const int    n_embd  = hparams.n_embd_gqa();
+        const int    n_ctx   = hparams.n_ctx;
+
+        const size_t kv_size = kv_self.buf.size;
+        const int    kv_ntok = llama_get_kv_cache_token_count(ctx);
+
+        dst_file->write_raw(&kv_size, sizeof(kv_size));
+        dst_file->write_raw(&kv_ntok, sizeof(kv_ntok));
+
+        if (kv_size) {
+            const size_t elt_size = ggml_element_size(kv_self.k);
+
+            ggml_context * cpy_ctx = ggml_init({ 4096, NULL, /* no_alloc */ true });
+            ggml_cgraph gf{};
+
+            ggml_tensor * kout3d = ggml_new_tensor_3d(cpy_ctx, kv_self.k->type, n_embd, kv_ntok, n_layer);
+            std::vector<uint8_t> kout3d_data(ggml_nbytes(kout3d), 0);
+            kout3d->data = kout3d_data.data();
+
+            ggml_tensor * vout3d = ggml_new_tensor_3d(cpy_ctx, kv_self.v->type, kv_ntok, n_embd, n_layer);
+            std::vector<uint8_t> vout3d_data(ggml_nbytes(vout3d), 0);
+            vout3d->data = vout3d_data.data();
+
+            ggml_tensor * k3d = ggml_view_3d(cpy_ctx, kv_self.k,
+                n_embd, kv_ntok, n_layer,
+                elt_size*n_embd, elt_size*n_embd*n_ctx, 0);
+
+            ggml_tensor * v3d = ggml_view_3d(cpy_ctx, kv_self.v,
+                kv_ntok, n_embd, n_layer,
+                elt_size*n_ctx, elt_size*n_ctx*n_embd, 0);
+
+            ggml_build_forward_expand(&gf, ggml_cpy(cpy_ctx, k3d, kout3d));
+            ggml_build_forward_expand(&gf, ggml_cpy(cpy_ctx, v3d, vout3d));
+            ggml_graph_compute_helper(ctx->work_buffer, &gf, /*n_threads*/ 1);
+
+            ggml_free(cpy_ctx);
+
+            // our data is now in the kout3d_data and vout3d_data buffers
+            // write them to file
+            dst_file->write_raw(kout3d_data.data(), kout3d_data.size());
+            dst_file->write_raw(vout3d_data.data(), vout3d_data.size());
+        }
+    }
+}
+
 // Sets the state reading from the specified source address
 size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
     uint8_t * inp = src;
@@ -4023,15 +4121,8 @@ bool llama_save_session_file(struct llama_context * ctx, const char * path_sessi
     file.write_u32((uint32_t) n_token_count);
     file.write_raw(tokens, sizeof(llama_token) * n_token_count);
 
-    // save the context state
-    {
-        const size_t n_state_size_max = llama_get_state_size(ctx);
-
-        std::vector<uint8_t> state_data(n_state_size_max);
-        const size_t n_state_size_cur = llama_copy_state_data(ctx, state_data.data());
-
-        file.write_raw(state_data.data(), n_state_size_cur);
-    }
+    // save the context state using stream saving
+    llama_write_state_data_to_file(ctx, &file);
 
     return true;
 }

--- a/llama.cpp
+++ b/llama.cpp
@@ -3743,6 +3743,14 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
     return s_total;
 }
 
+size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst)
+{
+    llama_data_buffer_context data_ctx(dst);
+    llama_copy_state_data_internal(ctx, &data_ctx);
+
+    return data_ctx.get_size_written();
+}
+
 /** copy state data into either a buffer or file depending on the passed in context
  *
  * file context:
@@ -3756,7 +3764,7 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
  * llama_copy_state_data(ctx, &data_ctx);
  *
 */
-void llama_copy_state_data(struct llama_context * ctx, llama_data_context * data_ctx) {
+void llama_copy_state_data_internal(struct llama_context * ctx, llama_data_context * data_ctx) {
     // copy rng
     {
         std::stringstream rng_ss;
@@ -4037,7 +4045,7 @@ bool llama_save_session_file(struct llama_context * ctx, const char * path_sessi
 
     // save the context state using stream saving
     llama_data_file_context data_ctx(&file);
-    llama_copy_state_data(ctx, &data_ctx);
+    llama_copy_state_data_internal(ctx, &data_ctx);
 
     return true;
 }

--- a/llama.cpp
+++ b/llama.cpp
@@ -3743,14 +3743,6 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
     return s_total;
 }
 
-size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst)
-{
-    llama_data_buffer_context data_ctx(dst);
-    llama_copy_state_data_internal(ctx, &data_ctx);
-
-    return data_ctx.get_size_written();
-}
-
 /** copy state data into either a buffer or file depending on the passed in context
  *
  * file context:
@@ -3859,6 +3851,14 @@ void llama_copy_state_data_internal(struct llama_context * ctx, llama_data_conte
             data_ctx->write(vout3d_data.data(), vout3d_data.size());
         }
     }
+}
+
+size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst)
+{
+    llama_data_buffer_context data_ctx(dst);
+    llama_copy_state_data_internal(ctx, &data_ctx);
+
+    return data_ctx.get_size_written();
 }
 
 // Sets the state reading from the specified source address

--- a/llama.cpp
+++ b/llama.cpp
@@ -3744,17 +3744,17 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
 }
 
 /** copy state data into either a buffer or file depending on the passed in context
- * 
+ *
  * file context:
  * llama_file file("/path", "wb");
  * llama_data_file_context data_ctx(&file);
  * llama_copy_state_data(ctx, &data_ctx);
- * 
+ *
  * buffer context:
  * std::vector<uint8_t> buf(max_size, 0);
  * llama_data_buffer_context data_ctx(&buf.data());
  * llama_copy_state_data(ctx, &data_ctx);
- * 
+ *
 */
 void llama_copy_state_data(struct llama_context * ctx, llama_data_context * data_ctx) {
     // copy rng

--- a/llama.cpp
+++ b/llama.cpp
@@ -3743,7 +3743,19 @@ size_t llama_get_state_size(const struct llama_context * ctx) {
     return s_total;
 }
 
-// copy state data into either a buffer or file depending on the passed in context
+/** copy state data into either a buffer or file depending on the passed in context
+ * 
+ * file context:
+ * llama_file file("/path", "wb");
+ * llama_data_file_context data_ctx(&file);
+ * llama_copy_state_data(ctx, &data_ctx);
+ * 
+ * buffer context:
+ * std::vector<uint8_t> buf(max_size, 0);
+ * llama_data_buffer_context data_ctx(&buf.data());
+ * llama_copy_state_data(ctx, &data_ctx);
+ * 
+*/
 void llama_copy_state_data(struct llama_context * ctx, llama_data_context * data_ctx) {
     // copy rng
     {

--- a/llama.cpp
+++ b/llama.cpp
@@ -3853,8 +3853,7 @@ void llama_copy_state_data_internal(struct llama_context * ctx, llama_data_conte
     }
 }
 
-size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst)
-{
+size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
     llama_data_buffer_context data_ctx(dst);
     llama_copy_state_data_internal(ctx, &data_ctx);
 


### PR DESCRIPTION
It seems when saving context data to file, we are allocating the entire buffer upfront, copying it over, then writing to file.

This seems unnecessary.

I've adjusted the code to write data to file directly without allocating a copy of the context in memory.

Tested to work when saving/loading session prompts.

I believe this is an important update so that llama.cpp can be better used in devices with memory constraints such as consumer mobile phones.