### PR TITLE
convert.py: fix failure caused by missing abstract methods

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -465,6 +465,13 @@ class GGMLQuantizedTensor(Tensor):
     def permute(self, n_head: int, n_kv_head: Optional[int] = None) -> 'GGMLQuantizedTensor':
         return GGMLQuantizedTensor(permute(self.ndarray, n_head, n_kv_head), self.shape, self.data_type)
 
+    def permute_part(self, n_part: int, n_head: int) -> 'UnquantizedTensor':
+        r = self.ndarray.shape[0] // 3
+        return UnquantizedTensor(permute(self.ndarray[r * n_part : r * n_part + r, ...], n_head))
+
+    def part(self, n_part: int) -> 'UnquantizedTensor':
+        r = self.ndarray.shape[0] // 3
+        return UnquantizedTensor(self.ndarray[r * n_part : r * n_part + r, ...])
 
 GGMLCompatibleTensor = Union[UnquantizedTensor, GGMLQuantizedTensor]
 


### PR DESCRIPTION
`convert.py` fails to run when converting `gpt4all-lora-quantized.bin`.

In the class `Tensor`, `permute_part()` and `part()` are declared `@abstractmethod`, but they are not defined in the sub-class `GGMLQuantizedTensor`. As a result, `convert.py` aborts with a message `TypeError: Can't instantiate abstract class GGMLQuantizedTensor with abstract methods part, permute_part`. My environment is Python 3.10.7 on Ubuntu 22.10 on WSL2.

I added the implementations of `permute_part()` and `part()` in `GGMLQuantizedTensor`, and the conversion works fine now. 

Before applying this patch:
```
$ python3 convert.py models/gpt4all-7B/gpt4all-lora-quantized.bin
Loading model file models/gpt4all-7B/gpt4all-lora-quantized.bin
vocabtype: spm
Loading vocab file models/tokenizer.model
params: n_vocab:32001 n_embd:4096 n_mult:256 n_head:32 n_layer:32
Writing vocab...
Traceback (most recent call last):
  File "/home/tabata/src/llama.cpp/convert.py", line 1319, in <module>
    main()
  File "/home/tabata/src/llama.cpp/convert.py", line 1314, in main
    OutputFile.write_all(outfile, params, output_type, model, vocab)
  File "/home/tabata/src/llama.cpp/convert.py", line 1108, in write_all
    for i, ((name, lazy_tensor), ndarray) in enumerate(zip(model.items(), ndarrays)):
  File "/home/tabata/src/llama.cpp/convert.py", line 1031, in bounded_parallel_map
    result = futures.pop(0).result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/tabata/src/llama.cpp/convert.py", line 1105, in do_item
    return lazy_tensor.load().to_ggml().ndarray
  File "/home/tabata/src/llama.cpp/convert.py", line 614, in load
    ret = self._load()
  File "/home/tabata/src/llama.cpp/convert.py", line 622, in load
    return self.load().astype(data_type)
  File "/home/tabata/src/llama.cpp/convert.py", line 614, in load
    ret = self._load()
  File "/home/tabata/src/llama.cpp/convert.py", line 985, in load
    return GGMLQuantizedTensor(ndarray, shape, data_type)
TypeError: Can't instantiate abstract class GGMLQuantizedTensor with abstract methods part, permute_part
```
After applying this patch:
```
$ python3 convert.py models/gpt4all-7B/gpt4all-lora-quantized.bin
Loading model file models/gpt4all-7B/gpt4all-lora-quantized.bin
vocabtype: spm
Loading vocab file models/tokenizer.model
params: n_vocab:32001 n_embd:4096 n_mult:256 n_head:32 n_layer:32
Writing vocab...
[  1/291] Writing tensor tok_embeddings.weight                  | size  32001 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  2/291] Writing tensor norm.weight                            | size   4096           | type UnquantizedDataType(name='F32')
[  3/291] Writing tensor output.weight                          | size  32001 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  4/291] Writing tensor layers.0.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  5/291] Writing tensor layers.0.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  6/291] Writing tensor layers.0.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  7/291] Writing tensor layers.0.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[  8/291] Writing tensor layers.0.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[  9/291] Writing tensor layers.0.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 10/291] Writing tensor layers.0.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 11/291] Writing tensor layers.0.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 12/291] Writing tensor layers.0.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 13/291] Writing tensor layers.1.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 14/291] Writing tensor layers.1.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 15/291] Writing tensor layers.1.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 16/291] Writing tensor layers.1.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 17/291] Writing tensor layers.1.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 18/291] Writing tensor layers.1.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 19/291] Writing tensor layers.1.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 20/291] Writing tensor layers.1.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 21/291] Writing tensor layers.1.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 22/291] Writing tensor layers.2.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 23/291] Writing tensor layers.2.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 24/291] Writing tensor layers.2.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 25/291] Writing tensor layers.2.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 26/291] Writing tensor layers.2.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 27/291] Writing tensor layers.2.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 28/291] Writing tensor layers.2.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 29/291] Writing tensor layers.2.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 30/291] Writing tensor layers.2.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 31/291] Writing tensor layers.3.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 32/291] Writing tensor layers.3.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 33/291] Writing tensor layers.3.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 34/291] Writing tensor layers.3.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 35/291] Writing tensor layers.3.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 36/291] Writing tensor layers.3.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 37/291] Writing tensor layers.3.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 38/291] Writing tensor layers.3.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 39/291] Writing tensor layers.3.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 40/291] Writing tensor layers.4.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 41/291] Writing tensor layers.4.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 42/291] Writing tensor layers.4.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 43/291] Writing tensor layers.4.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 44/291] Writing tensor layers.4.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 45/291] Writing tensor layers.4.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 46/291] Writing tensor layers.4.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 47/291] Writing tensor layers.4.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 48/291] Writing tensor layers.4.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 49/291] Writing tensor layers.5.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 50/291] Writing tensor layers.5.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 51/291] Writing tensor layers.5.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 52/291] Writing tensor layers.5.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 53/291] Writing tensor layers.5.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 54/291] Writing tensor layers.5.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 55/291] Writing tensor layers.5.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 56/291] Writing tensor layers.5.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 57/291] Writing tensor layers.5.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 58/291] Writing tensor layers.6.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 59/291] Writing tensor layers.6.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 60/291] Writing tensor layers.6.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 61/291] Writing tensor layers.6.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 62/291] Writing tensor layers.6.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 63/291] Writing tensor layers.6.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 64/291] Writing tensor layers.6.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 65/291] Writing tensor layers.6.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 66/291] Writing tensor layers.6.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 67/291] Writing tensor layers.7.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 68/291] Writing tensor layers.7.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 69/291] Writing tensor layers.7.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 70/291] Writing tensor layers.7.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 71/291] Writing tensor layers.7.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 72/291] Writing tensor layers.7.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 73/291] Writing tensor layers.7.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 74/291] Writing tensor layers.7.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 75/291] Writing tensor layers.7.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 76/291] Writing tensor layers.8.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 77/291] Writing tensor layers.8.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 78/291] Writing tensor layers.8.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 79/291] Writing tensor layers.8.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 80/291] Writing tensor layers.8.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 81/291] Writing tensor layers.8.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 82/291] Writing tensor layers.8.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 83/291] Writing tensor layers.8.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 84/291] Writing tensor layers.8.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 85/291] Writing tensor layers.9.attention.wq.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 86/291] Writing tensor layers.9.attention.wk.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 87/291] Writing tensor layers.9.attention.wv.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 88/291] Writing tensor layers.9.attention.wo.weight           | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 89/291] Writing tensor layers.9.attention_norm.weight         | size   4096           | type UnquantizedDataType(name='F32')
[ 90/291] Writing tensor layers.9.feed_forward.w1.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 91/291] Writing tensor layers.9.feed_forward.w2.weight        | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 92/291] Writing tensor layers.9.feed_forward.w3.weight        | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 93/291] Writing tensor layers.9.ffn_norm.weight               | size   4096           | type UnquantizedDataType(name='F32')
[ 94/291] Writing tensor layers.10.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 95/291] Writing tensor layers.10.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 96/291] Writing tensor layers.10.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 97/291] Writing tensor layers.10.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[ 98/291] Writing tensor layers.10.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[ 99/291] Writing tensor layers.10.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[100/291] Writing tensor layers.10.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[101/291] Writing tensor layers.10.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[102/291] Writing tensor layers.10.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[103/291] Writing tensor layers.11.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[104/291] Writing tensor layers.11.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[105/291] Writing tensor layers.11.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[106/291] Writing tensor layers.11.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[107/291] Writing tensor layers.11.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[108/291] Writing tensor layers.11.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[109/291] Writing tensor layers.11.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[110/291] Writing tensor layers.11.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[111/291] Writing tensor layers.11.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[112/291] Writing tensor layers.12.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[113/291] Writing tensor layers.12.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[114/291] Writing tensor layers.12.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[115/291] Writing tensor layers.12.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[116/291] Writing tensor layers.12.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[117/291] Writing tensor layers.12.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[118/291] Writing tensor layers.12.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[119/291] Writing tensor layers.12.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[120/291] Writing tensor layers.12.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[121/291] Writing tensor layers.13.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[122/291] Writing tensor layers.13.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[123/291] Writing tensor layers.13.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[124/291] Writing tensor layers.13.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[125/291] Writing tensor layers.13.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[126/291] Writing tensor layers.13.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[127/291] Writing tensor layers.13.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[128/291] Writing tensor layers.13.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[129/291] Writing tensor layers.13.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[130/291] Writing tensor layers.14.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[131/291] Writing tensor layers.14.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[132/291] Writing tensor layers.14.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[133/291] Writing tensor layers.14.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[134/291] Writing tensor layers.14.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[135/291] Writing tensor layers.14.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[136/291] Writing tensor layers.14.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[137/291] Writing tensor layers.14.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[138/291] Writing tensor layers.14.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[139/291] Writing tensor layers.15.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[140/291] Writing tensor layers.15.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[141/291] Writing tensor layers.15.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[142/291] Writing tensor layers.15.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[143/291] Writing tensor layers.15.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[144/291] Writing tensor layers.15.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[145/291] Writing tensor layers.15.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[146/291] Writing tensor layers.15.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[147/291] Writing tensor layers.15.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[148/291] Writing tensor layers.16.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[149/291] Writing tensor layers.16.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[150/291] Writing tensor layers.16.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[151/291] Writing tensor layers.16.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[152/291] Writing tensor layers.16.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[153/291] Writing tensor layers.16.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[154/291] Writing tensor layers.16.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[155/291] Writing tensor layers.16.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[156/291] Writing tensor layers.16.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[157/291] Writing tensor layers.17.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[158/291] Writing tensor layers.17.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[159/291] Writing tensor layers.17.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[160/291] Writing tensor layers.17.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[161/291] Writing tensor layers.17.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[162/291] Writing tensor layers.17.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[163/291] Writing tensor layers.17.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[164/291] Writing tensor layers.17.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[165/291] Writing tensor layers.17.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[166/291] Writing tensor layers.18.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[167/291] Writing tensor layers.18.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[168/291] Writing tensor layers.18.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[169/291] Writing tensor layers.18.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[170/291] Writing tensor layers.18.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[171/291] Writing tensor layers.18.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[172/291] Writing tensor layers.18.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[173/291] Writing tensor layers.18.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[174/291] Writing tensor layers.18.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[175/291] Writing tensor layers.19.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[176/291] Writing tensor layers.19.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[177/291] Writing tensor layers.19.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[178/291] Writing tensor layers.19.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[179/291] Writing tensor layers.19.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[180/291] Writing tensor layers.19.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[181/291] Writing tensor layers.19.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[182/291] Writing tensor layers.19.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[183/291] Writing tensor layers.19.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[184/291] Writing tensor layers.20.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[185/291] Writing tensor layers.20.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[186/291] Writing tensor layers.20.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[187/291] Writing tensor layers.20.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[188/291] Writing tensor layers.20.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[189/291] Writing tensor layers.20.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[190/291] Writing tensor layers.20.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[191/291] Writing tensor layers.20.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[192/291] Writing tensor layers.20.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[193/291] Writing tensor layers.21.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[194/291] Writing tensor layers.21.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[195/291] Writing tensor layers.21.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[196/291] Writing tensor layers.21.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[197/291] Writing tensor layers.21.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[198/291] Writing tensor layers.21.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[199/291] Writing tensor layers.21.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[200/291] Writing tensor layers.21.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[201/291] Writing tensor layers.21.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[202/291] Writing tensor layers.22.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[203/291] Writing tensor layers.22.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[204/291] Writing tensor layers.22.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[205/291] Writing tensor layers.22.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[206/291] Writing tensor layers.22.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[207/291] Writing tensor layers.22.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[208/291] Writing tensor layers.22.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[209/291] Writing tensor layers.22.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[210/291] Writing tensor layers.22.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[211/291] Writing tensor layers.23.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[212/291] Writing tensor layers.23.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[213/291] Writing tensor layers.23.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[214/291] Writing tensor layers.23.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[215/291] Writing tensor layers.23.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[216/291] Writing tensor layers.23.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[217/291] Writing tensor layers.23.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[218/291] Writing tensor layers.23.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[219/291] Writing tensor layers.23.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[220/291] Writing tensor layers.24.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[221/291] Writing tensor layers.24.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[222/291] Writing tensor layers.24.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[223/291] Writing tensor layers.24.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[224/291] Writing tensor layers.24.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[225/291] Writing tensor layers.24.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[226/291] Writing tensor layers.24.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[227/291] Writing tensor layers.24.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[228/291] Writing tensor layers.24.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[229/291] Writing tensor layers.25.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[230/291] Writing tensor layers.25.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[231/291] Writing tensor layers.25.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[232/291] Writing tensor layers.25.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[233/291] Writing tensor layers.25.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[234/291] Writing tensor layers.25.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[235/291] Writing tensor layers.25.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[236/291] Writing tensor layers.25.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[237/291] Writing tensor layers.25.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[238/291] Writing tensor layers.26.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[239/291] Writing tensor layers.26.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[240/291] Writing tensor layers.26.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[241/291] Writing tensor layers.26.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[242/291] Writing tensor layers.26.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[243/291] Writing tensor layers.26.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[244/291] Writing tensor layers.26.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[245/291] Writing tensor layers.26.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[246/291] Writing tensor layers.26.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[247/291] Writing tensor layers.27.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[248/291] Writing tensor layers.27.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[249/291] Writing tensor layers.27.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[250/291] Writing tensor layers.27.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[251/291] Writing tensor layers.27.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[252/291] Writing tensor layers.27.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[253/291] Writing tensor layers.27.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[254/291] Writing tensor layers.27.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[255/291] Writing tensor layers.27.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[256/291] Writing tensor layers.28.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[257/291] Writing tensor layers.28.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[258/291] Writing tensor layers.28.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[259/291] Writing tensor layers.28.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[260/291] Writing tensor layers.28.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[261/291] Writing tensor layers.28.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[262/291] Writing tensor layers.28.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[263/291] Writing tensor layers.28.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[264/291] Writing tensor layers.28.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[265/291] Writing tensor layers.29.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[266/291] Writing tensor layers.29.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[267/291] Writing tensor layers.29.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[268/291] Writing tensor layers.29.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[269/291] Writing tensor layers.29.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[270/291] Writing tensor layers.29.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[271/291] Writing tensor layers.29.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[272/291] Writing tensor layers.29.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[273/291] Writing tensor layers.29.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[274/291] Writing tensor layers.30.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[275/291] Writing tensor layers.30.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[276/291] Writing tensor layers.30.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[277/291] Writing tensor layers.30.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[278/291] Writing tensor layers.30.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[279/291] Writing tensor layers.30.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[280/291] Writing tensor layers.30.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[281/291] Writing tensor layers.30.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[282/291] Writing tensor layers.30.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
[283/291] Writing tensor layers.31.attention.wq.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[284/291] Writing tensor layers.31.attention.wk.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[285/291] Writing tensor layers.31.attention.wv.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[286/291] Writing tensor layers.31.attention.wo.weight          | size   4096 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[287/291] Writing tensor layers.31.attention_norm.weight        | size   4096           | type UnquantizedDataType(name='F32')
[288/291] Writing tensor layers.31.feed_forward.w1.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[289/291] Writing tensor layers.31.feed_forward.w2.weight       | size   4096 x  11008  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[290/291] Writing tensor layers.31.feed_forward.w3.weight       | size  11008 x   4096  | type QuantizedDataType(groupsize=32, have_addends=False, have_g_idx=False)
[291/291] Writing tensor layers.31.ffn_norm.weight              | size   4096           | type UnquantizedDataType(name='F32')
Wrote models/gpt4all-7B/ggml-model-q4_0.bin
```
I followed @wtarreau 's advice and rewrote my PR message. I'm very grateful to him for helping me grow. Thank you for your hard work, maintainers and contributors!