### PR TITLE
CUDA: use min compute capability of GPUs actually used

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -5347,7 +5347,8 @@ void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_
         } else {
             int min_compute_capability = INT_MAX;
             for (int id = 0; id < g_device_count; ++id) {
-                if (min_compute_capability > g_compute_capabilities[id]) {
+                if (min_compute_capability > g_compute_capabilities[id]
+                        && g_tensor_split[id] < (id + 1 < g_device_count ? g_tensor_split[id + 1] : 1.0f)) {
                     min_compute_capability = g_compute_capabilities[id];
                 }
             }


### PR DESCRIPTION
These are my currently installed GPUs:
```
ggml_init_cublas: found 2 CUDA devices:
  Device 0: Tesla P40, compute capability 6.1
  Device 1: NVIDIA GeForce GTX 970, compute capability 5.2
```
I found that if I disabled my GTX 970 using `--tensor-split 1,0`, I still couldn't use the full compute capability of my Telsa P40. With this change, I am able to benefit from the --mul-mat-q option without physically removing the GTX 970 from my PC, which my displays are connected to.