### PR TITLE
Fix issue related to Windows console mode persistence

### DIFF
--- a/examples/console.cpp
+++ b/examples/console.cpp
@@ -80,8 +80,10 @@ namespace console {
             // Set console input codepage to UTF16
             _setmode(_fileno(stdin), _O_WTEXT);
 
-            if (!simple_io) {
-                // Turn off ICANON (ENABLE_LINE_INPUT) and ECHO (ENABLE_ECHO_INPUT)
+            // Set ICANON (ENABLE_LINE_INPUT) and ECHO (ENABLE_ECHO_INPUT)
+            if (simple_io) {
+                dwMode |= ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT;
+            } else {
                 dwMode &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
             }
             if (!SetConsoleMode(hConIn, dwMode)) {


### PR DESCRIPTION
A small fix to the simple-io code. In Windows 11 PowerShell the console modes seem to persist between programs. This wasn't the case with the old command prompt. The fix is just to always set the console mode, even if we're just using simple io.