### PR TITLE
Fixed mmap prefetch for GPU offloading

### DIFF
--- a/llama-util.h
+++ b/llama-util.h
@@ -219,7 +219,7 @@ struct llama_mmap {
         // prefetch/readahead impairs performance on NUMA systems
         if (numa) { prefetch = 0; }
 #ifdef __linux__
-        if (prefetch) { flags |= MAP_POPULATE; }
+        if (prefetch >= file->size) { flags |= MAP_POPULATE; }
 #endif
         addr = mmap(NULL, file->size, PROT_READ, flags, fd, 0);
         if (addr == MAP_FAILED) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -747,12 +747,12 @@ struct llama_model_loader {
 
     void load_all_data(llama_progress_callback progress_callback, void *  progress_callback_user_data, llama_mlock * lmlock) {
         size_t data_size = 0;
-        size_t prefetch_size = 0;
+        size_t prefetch_size = file_loader->file.size;
         size_t lock_size = 0;
         for (const llama_load_tensor & lt : tensors_map.tensors) {
             data_size += lt.size;
-            if (lt.ggml_tensor->backend == GGML_BACKEND_CPU) {
-                prefetch_size += lt.size;
+            if (lt.ggml_tensor->backend != GGML_BACKEND_CPU) {
+                prefetch_size -= lt.size;
             }
         }
 


### PR DESCRIPTION
I've noticed that currently when loading models to VRAM (with mmap) the entire model first gets loaded into RAM and then the model get loaded from RAM to VRAM. This is not how I intended it since this will very likely cause problems when running models with a total size larger than RAM. Instead the loading should be lazy so the model file only needs to be iterated over once (ideally with the CPU tensors being mlocked). Looking through the code I've noticed that when the prefetch size is > 0 the `MAP_POPULATE` flag gets set unconditionally; this flag eagerly loads the entire file into memory and it seems I forgot to adjust the logic when I changed `prefetch` from `bool` to `size_t`. This PR fixes the logic to only eagerly load the file if the requested prefetch is at least as big as the file size.