### PR TITLE
main: add --prompt-cache-clobber option

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -137,6 +137,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.prompt_cache_all = true;
         } else if (arg == "--prompt-cache-ro") {
             params.prompt_cache_ro = true;
+        } else if (arg == "--prompt-cache-clobber") {
+            params.prompt_cache_clobber = true;
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -537,6 +539,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stdout, "  --prompt-cache-all    if specified, saves user input and generations to cache as well.\n");
     fprintf(stdout, "                        not supported with --interactive or other interactive options\n");
     fprintf(stdout, "  --prompt-cache-ro     if specified, uses the prompt cache but does not update it.\n");
+    fprintf(stdout, "  --prompt-cache-clobber\n");
+    fprintf(stdout, "                        if error on loading prompt cache, treat as new file\n");
     fprintf(stdout, "  --random-prompt       start with a randomized prompt.\n");
     fprintf(stdout, "  --in-prefix-bos       prefix BOS to user inputs, preceding the `--in-prefix` string\n");
     fprintf(stdout, "  --in-prefix STRING    string to prefix user inputs with (default: empty)\n");

--- a/examples/common.h
+++ b/examples/common.h
@@ -68,14 +68,15 @@ struct gpt_params {
     bool hellaswag         = false; // compute HellaSwag score over random tasks from datafile supplied in prompt
     size_t hellaswag_tasks = 400;   // number of tasks to use when computing the HellaSwag score
 
-    bool low_vram          = false; // if true, reduce VRAM usage at the cost of performance
-    bool mul_mat_q         = false; // if true, use experimental mul_mat_q kernels
-    bool memory_f16        = true;  // use f16 instead of f32 for memory kv
-    bool random_prompt     = false; // do not randomize prompt if none provided
-    bool use_color         = false; // use color to distinguish generations and inputs
-    bool interactive       = false; // interactive mode
-    bool prompt_cache_all  = false; // save user input and generations to prompt cache
-    bool prompt_cache_ro   = false; // open the prompt cache read-only and do not update it
+    bool low_vram             = false; // if true, reduce VRAM usage at the cost of performance
+    bool mul_mat_q            = false; // if true, use experimental mul_mat_q kernels
+    bool memory_f16           = true;  // use f16 instead of f32 for memory kv
+    bool random_prompt        = false; // do not randomize prompt if none provided
+    bool use_color            = false; // use color to distinguish generations and inputs
+    bool interactive          = false; // interactive mode
+    bool prompt_cache_all     = false; // save user input and generations to prompt cache
+    bool prompt_cache_ro      = false; // open the prompt cache read-only and do not update it
+    bool prompt_cache_clobber = false; // if error on loading prompt cache, treat as new file
 
     bool embedding         = false; // get only sentence embedding
     bool interactive_first = false; // wait for user input immediately


### PR DESCRIPTION
This makes it so that you don't need to manually delete the prompt cache if you're switching models but using the same prompt cache (e.g. in a script).

Apologies if the lambda is weird. I am new to c++, and this seemed like the best way to get the control flow necessary while keeping the code close together.