### PR TITLE
CUDA: tighter VRAM scratch size for 65b/70b

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -149,7 +149,7 @@ static const std::map<e_model, size_t> & MEM_REQ_EVAL()
 }
 
 // amount of VRAM needed per batch size to hold temporary results
-// the values for 3b and 65b are not derived from testing but instead chosen conservatively
+// the values for 3b are not derived from testing but instead chosen conservatively
 static const std::map<e_model, size_t> & VRAM_REQ_SCRATCH_BASE()
 {
     static std::map<e_model, size_t> k_sizes = {
@@ -157,14 +157,14 @@ static const std::map<e_model, size_t> & VRAM_REQ_SCRATCH_BASE()
         { MODEL_7B,   512ull * kB },
         { MODEL_13B,  640ull * kB },
         { MODEL_30B,  768ull * kB },
-        { MODEL_65B, 1536ull * kB },
-        { MODEL_70B, 1536ull * kB }, // TODO (likely can be reduced)
+        { MODEL_65B, 1280ull * kB },
+        { MODEL_70B, 1280ull * kB },
     };
     return k_sizes;
 }
 
 // amount of VRAM needed per batch size and context to hold temporary results
-// the values for 3b and 65b are not derived from testing but instead chosen conservatively
+// the values for 3b are not derived from testing but instead chosen conservatively
 static const std::map<e_model, size_t> & VRAM_REQ_SCRATCH_PER_CONTEXT()
 {
     static std::map<e_model, size_t> k_sizes = {
@@ -172,8 +172,8 @@ static const std::map<e_model, size_t> & VRAM_REQ_SCRATCH_PER_CONTEXT()
         { MODEL_7B,  128ull },
         { MODEL_13B, 160ull },
         { MODEL_30B, 208ull },
-        { MODEL_65B, 416ull },
-        { MODEL_70B, 416ull }, // TODO (likely can be reduced)
+        { MODEL_65B, 256ull },
+        { MODEL_70B, 256ull },
     };
     return k_sizes;
 }


### PR DESCRIPTION
This PR is a followup to https://github.com/ggerganov/llama.cpp/pull/2056 . At the time I did not have enough VRAM to properly measure the minimum required VRAM scratch sizes for 65b (and 70b was not yet published). This PR tightens VRAM scratch sizes based on testing. The specific methodology is that I hard-coded VRAM scratch sizes with a granularity of 1 MiB and determined the minimum VRAM scratch size at which perplexity calculations are not being affected. I then added a ~25% margin on top of the minimum. These are the test results that the new numbers are based on:

| Model    | Context size | Min. VRAM scratch size [MiB] | Delta [MiB] |
|----------|--------------|------------------------------|-------------|
| 65b q2_k |          512 |                          272 |           - |
| 65b q2_k |         1024 |                          342 |          70 |
| 65b q2_k |         1536 |                          486 |         144 |
| 65b q2_k |         2048 |                          636 |         150 |
| 65b q2_k |         2560 |                          700 |          64 |
| 65b q2_k |         3072 |                          764 |          64 |
| 65b q2_k |         3584 |                          828 |          64 |
| 65b q2_k |         4096 |                          892 |          64 |

| Model      | Context size | Min. VRAM scratch size [MiB] | Delta [MiB] |
|------------|--------------|------------------------------|-------------|
| 70b q4_k_m |          512 |                          324 |           - |
| 70b q4_k_m |         1024 |                          336 |          12 |
| 70b q4_k_m |         1536 |                          402 |          66 |
| 70b q4_k_m |         2048 |                          576 |         174 |
| 70b q4_k_m |         2560 |                          724 |         148 |
| 70b q4_k_m |         3072 |                          788 |          64 |
| 70b q4_k_m |         3584 |                          852 |          64 |
| 70b q4_k_m |         4096 |                          916 |          64 |

When I tested with smaller models the min. required VRAM scratch at some point always started increasing linearly with scratch size (measured up to 8192 context). Because the results are so close I just used the same scratch size for both 65b and 70b.