### PR TITLE
Logging generations with SQLite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OPT = -O3
 endif
 CFLAGS   = -I.              $(OPT) -std=c11   -fPIC
 CXXFLAGS = -I. -I./examples $(OPT) -std=c++11 -fPIC
-LDFLAGS  =
+LDFLAGS  = -lsqlite3
 
 ifdef LLAMA_DEBUG
 	CFLAGS   += -O0 -g

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+for ngl in {0..35}
+do
+    ./main --model models/nvme/llama-7b-ggml-q4_0.bin --seed 1337 --ignore-eos --n-predict 128 --ctx-size 2048 --threads 8 -ngl $ngl -mmq
+done

--- a/llama.cpp
+++ b/llama.cpp
@@ -4243,6 +4243,15 @@ void llama_print_timings(struct llama_context * ctx) {
     fprintf(stderr, "%s:       total time = %8.2f ms\n", __func__, (timings.t_end_ms - timings.t_start_ms));
 }
 
+void llama_sqlite_append_timings(struct llama_context * ctx, std::ostringstream & sql_insert_values) {
+    sql_insert_values << ctx->t_sample_us << ",";
+    sql_insert_values << ctx->t_eval_us   << ",";
+    sql_insert_values << ctx->t_p_eval_us << ",";
+    sql_insert_values << ctx->n_sample    << ",";
+    sql_insert_values << ctx->n_eval      << ",";
+    sql_insert_values << ctx->n_p_eval    << ");";
+}
+
 void llama_reset_timings(struct llama_context * ctx) {
     ctx->t_start_us = ggml_time_us();
     ctx->t_sample_us = ctx->n_sample = 0;

--- a/llama.h
+++ b/llama.h
@@ -8,6 +8,7 @@
 #else
 #define LLAMA_MAX_DEVICES 1
 #endif // GGML_USE_CUBLAS
+#include <sstream>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -446,6 +447,7 @@ extern "C" {
     // Performance information
     LLAMA_API struct llama_timings llama_get_timings(struct llama_context * ctx);
     LLAMA_API void llama_print_timings(struct llama_context * ctx);
+    LLAMA_API void llama_sqlite_append_timings(struct llama_context * ctx, std::ostringstream & sql_insert_values);
     LLAMA_API void llama_reset_timings(struct llama_context * ctx);
 
     // Print system information

--- a/plot_ts_per_ngl.py
+++ b/plot_ts_per_ngl.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sqlite3
+import matplotlib.pyplot as plt
+
+con = sqlite3.connect("llama.sqlite")
+cur = con.cursor()
+
+ts = []
+
+for ngl in range(0, 36):
+    res = cur.execute(f"SELECT t_eval_us,n_eval FROM llama_runs WHERE n_gpu_layers={ngl};")
+    t_eval_us, n_eval = res.fetchone()
+    ts.append(n_eval * 1000000/t_eval_us)
+
+plt.plot(ts)
+plt.xlim(0, 35)
+plt.ylim(0, 130)
+plt.title("7b q4_0, 3700X, 3200 MHz dual-channel RAM, RTX 3090")
+plt.xlabel("-ngl")
+plt.ylabel("Generated t/s")
+plt.savefig("benchmark.png", dpi=240)
+plt.show()

--- a/plot_ts_per_ngl.py
+++ b/plot_ts_per_ngl.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python3
 
 import sqlite3
+import numpy as np
 import matplotlib.pyplot as plt
 
 con = sqlite3.connect("llama.sqlite")
 cur = con.cursor()
 
-ts = []
+res = cur.execute("SELECT n_gpu_layers, 1000000.0*n_eval/t_eval_us FROM llama_runs ORDER BY n_gpu_layers;")
+ts = np.array(res.fetchall())
 
-for ngl in range(0, 36):
-    res = cur.execute(f"SELECT t_eval_us,n_eval FROM llama_runs WHERE n_gpu_layers={ngl};")
-    t_eval_us, n_eval = res.fetchone()
-    ts.append(n_eval * 1000000/t_eval_us)
-
-plt.plot(ts)
+plt.plot(ts[:, 0], ts[:, 1])
 plt.xlim(0, 35)
 plt.ylim(0, 130)
 plt.title("7b q4_0, 3700X, 3200 MHz dual-channel RAM, RTX 3090")


### PR DESCRIPTION
I run a lot of benchmarks to test my implementations but the process of manually running the program and copying the results from console is kind of tedious. So I want to implement a way to automate benchmarking and transforming the data into a human-readable format. This PR aims to do that: I added a very simple prototype for logging generations to a SQLite database as well as two example scripts that let you run a benchmark and plot the results. Something like this should be the output after running `benchmark.sh` and `plot_ts_per_ngl.py`:

![benchmark](https://github.com/ggerganov/llama.cpp/assets/18492268/7c7bf762-bce1-45a3-8849-357adc624153)

I am willing to do a proper implementation for this but in order to avoid wasted effort please let me know:

1. Is SQLite even desired? It would be my preferred way of logging results but something like JSON or YAML would also be an option.
2. At what level should logging be integrated? It would be possible to bake it directly into ggml but my intuition is that this is not desirable and instead should be at the level of llama.cpp.
3. How should compilation be handled? SQLite is public domain software so we could simply add a copy to the repository and I think this would be the easiest solution (currently you need to have it installed on your system).