### PR TITLE
ggml-alloc: Don't try to re-use buffers of external tensors

### DIFF
--- a/ggml-alloc.c
+++ b/ggml-alloc.c
@@ -397,7 +397,7 @@ static void allocate_node(struct ggml_allocr * alloc, struct ggml_tensor * node)
 
                     // if the node's data is external, then we cannot re-use it
                     if ((char *) parent->data < (char *) alloc->data ||
-                        (char *) parent->data > ((char *) alloc->data + alloc->size)) {
+                        (char *) parent->data >= ((char *) alloc->data + alloc->size)) {
                         AT_PRINTF("not reusing parent %s for %s as %p is external\n", parent->name, node->name, parent->data);
                         continue;
                     }

--- a/ggml-alloc.c
+++ b/ggml-alloc.c
@@ -394,6 +394,14 @@ static void allocate_node(struct ggml_allocr * alloc, struct ggml_tensor * node)
                     if (parent == NULL) {
                         break;
                     }
+
+                    // if the node's data is external, then we cannot re-use it
+                    if ((char *) parent->data < (char *) alloc->data ||
+                        (char *) parent->data > ((char *) alloc->data + alloc->size)) {
+                        AT_PRINTF("not reusing parent %s for %s as %p is external\n", parent->name, node->name, parent->data);
+                        continue;
+                    }
+
                     struct hash_node * p_hn = hash_get(ht, parent);
                     if (parent->data != NULL && p_hn->n_children == 1 && p_hn->n_views == 0 && ggml_are_same_layout(node, parent)) {
                         if (ggml_is_view(parent)) {


### PR DESCRIPTION
They might be weights that came from another context, so we have no control over them (and they might be re-used elsewhere so writing to them would be a bad idea).