### PR TITLE
CUDA: Removed obsolete cmake CUDA arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,11 +280,10 @@ if (LLAMA_CUBLAS)
         # 52 == lowest CUDA 12 standard
         # 60 == f16 CUDA intrinsics
         # 61 == integer CUDA intrinsics
-        # 70 == compute capability at which unrolling a loop in mul_mat_q kernels is faster
         if (LLAMA_CUDA_F16 OR LLAMA_CUDA_DMMV_F16)
-            set(CMAKE_CUDA_ARCHITECTURES "60;61;70") # needed for f16 CUDA intrinsics
+            set(CMAKE_CUDA_ARCHITECTURES "60;61") # needed for f16 CUDA intrinsics
         else()
-            set(CMAKE_CUDA_ARCHITECTURES "52;61;70") # lowest CUDA 12 standard + lowest for integer intrinsics
+            set(CMAKE_CUDA_ARCHITECTURES "52;61") # lowest CUDA 12 standard + lowest for integer intrinsics
         endif()
     endif()
     message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")


### PR DESCRIPTION
In https://github.com/ggerganov/llama.cpp/pull/2546# I removed a check against `__CUDA_ARCH__ >= 700` to determine whether a particular loop should be unrolled. However, I forgot to remove the corresponding compute capability from cmake. This PR removes said obsoleted CUDA architecture from cmake which should reduce compilation times and binary size.