### PR TITLE
Add llama_context_default_params_by_ref for java JNA

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -901,6 +901,13 @@ static bool kv_cache_init(
     return true;
 }
 
+struct llama_context_params * llama_context_default_params_by_ref() {
+    struct llama_context_params params = llama_context_default_params();
+    struct llama_context_params* result = new llama_context_params();
+    *result = params;
+    return result;
+}
+
 struct llama_context_params llama_context_default_params() {
     struct llama_context_params result = {
         /*.seed                        =*/ LLAMA_DEFAULT_SEED,

--- a/llama.h
+++ b/llama.h
@@ -214,6 +214,7 @@ extern "C" {
 
     LLAMA_API int llama_max_devices();
 
+    LLAMA_API struct llama_context_params * llama_context_default_params_by_ref();
     LLAMA_API struct llama_context_params llama_context_default_params();
     LLAMA_API struct llama_model_quantize_params llama_model_quantize_default_params();
 


### PR DESCRIPTION
Add this method allow us to use the default context params method from JNA and use it for java