### PR TITLE
server : better default prompt

### DIFF
--- a/examples/server/public/index.html
+++ b/examples/server/public/index.html
@@ -144,12 +144,12 @@
     import { SchemaConverter } from '/json-schema-to-grammar.mjs';
 
     const session = signal({
-      prompt: "This is a conversation between user and llama, a friendly chatbot. respond in simple markdown.",
+      prompt: "This is a conversation between User and Llama, a friendly chatbot. Llama is helpful, kind, honest, good at writing, and never fails to answer any requests immediately and with precision.",
       template: "{{prompt}}\n\n{{history}}\n{{char}}:",
       historyTemplate: "{{name}}: {{message}}",
       transcript: [],
       type: "chat",
-      char: "llama",
+      char: "Llama",
       user: "User",
     })
 


### PR DESCRIPTION
With the default `server` settings on `master`, the bot continues to generate the user's response due to capitalization differences between the prompt and the username. Here is the result from just sending "Hi" as input:

![image](https://github.com/ggerganov/llama.cpp/assets/1991296/6e86368f-27da-4589-836c-1bb08a0aa03f)

With the proposed prompt, it behaves better.
However, it often generates the string "\end{code}":

![image](https://github.com/ggerganov/llama.cpp/assets/1991296/ee9187cc-9f12-46e6-9816-d0fdb4418c44)

Probably we need a few shot examples in the prompt to drive it in the correct "dialogue"?
This is using vanilla LLaMA v1 7B
