### PR TITLE
server : update xxd usage for older versions compatibility

### DIFF
--- a/examples/server/deps.sh
+++ b/examples/server/deps.sh
@@ -13,8 +13,7 @@ FILES=$(ls $PUBLIC)
 
 cd $PUBLIC
 for FILE in $FILES; do
-  func=$(echo $FILE | tr '.' '_')
-  echo "generate $FILE.hpp ($func)"
+  echo "generate $FILE.hpp"
 
   # use simple flag for old version of xxd
   xxd -i $FILE > $DIR/$FILE.hpp

--- a/examples/server/deps.sh
+++ b/examples/server/deps.sh
@@ -11,8 +11,11 @@ echo >> $PUBLIC/index.js # add newline
 
 FILES=$(ls $PUBLIC)
 
+cd $PUBLIC
 for FILE in $FILES; do
   func=$(echo $FILE | tr '.' '_')
   echo "generate $FILE.hpp ($func)"
-  xxd -n $func -i $PUBLIC/$FILE > $DIR/$FILE.hpp
+
+  # use simple flag for old version of xxd
+  xxd -i $FILE > $DIR/$FILE.hpp
 done


### PR DESCRIPTION
Update `xxd` usage in ./deps.sh for older versions of `xxd` compatibility, just generate the binary in `/public` so the func name will be correct. It was part of #2643. (See also https://github.com/ggerganov/llama.cpp/pull/2643#issuecomment-1683041885)

Tested in macOS 13.4 (xxd 2022-01-14) & Ubuntu 22.04 (xxd 2021-10-22, not supported `-n`)