### PR TITLE
CUDA: fix __builtin_assume for CUDA < 11.2

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -51,7 +51,14 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
             exit(1);                                                                    \
         }                                                                               \
     } while (0)
-#endif // CUDART_VERSION >= 11
+#endif // CUDART_VERSION >= 12000
+
+// define nop for old CUDA versions to fix compilation issues
+#if CUDART_VERSION < 11020
+__device__ void __builtin_assume(bool exp) {
+    (void) exp;
+}
+#endif // CUDART_VERSION < 11020
 
 #ifdef GGML_CUDA_F16
 typedef half dfloat; // dequantize float


### PR DESCRIPTION
Reportedly there are compilation issues on old CUDA versions due to `__builtin_assume`, see https://github.com/ggerganov/llama.cpp/pull/2458#issuecomment-1680200084 . This PR attempts to fix the issue by defining a dummy implementation for old CUDA versions. I don't have old CUDA versions installed on any of my old machines, so I did **not** test that the dummy implementation actually fixes the compilation issues (but the code seemed to work correctly with CUDA 12 when using the dummy implementation). @whoreson please confirm that this fixes the compilation issue for you.