### PR TITLE
ggml: support CUDA's half type for aarch64(#1455)

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -255,9 +255,11 @@
 extern "C" {
 #endif
 
-#ifdef __ARM_NEON
+#if defined(__ARM_NEON) && !defined(GGML_CUDA_F16)
     // we use the built-in 16-bit float type
     typedef __fp16 ggml_fp16_t;
+#elif defined(GGML_CUDA_F16)
+    typedef half ggml_fp16_t;
 #else
     typedef uint16_t ggml_fp16_t;
 #endif

--- a/ggml.h
+++ b/ggml.h
@@ -255,11 +255,10 @@
 extern "C" {
 #endif
 
-#if defined(__ARM_NEON) && !defined(GGML_CUDA_F16)
-    // we use the built-in 16-bit float type
-    typedef __fp16 ggml_fp16_t;
-#elif defined(GGML_CUDA_F16)
+#if defined(__ARM_NEON) && defined(__CUDACC__)
     typedef half ggml_fp16_t;
+#elif defined(__ARM_NEON)
+    typedef __fp16 ggml_fp16_t;
 #else
     typedef uint16_t ggml_fp16_t;
 #endif


### PR DESCRIPTION
this PR addresses an issue specific to the aarch64 architecture. 
When using nvcc, ARM NEON's `__fp16` was not recognized. To remedy this, we've introduced a macro that defines half (from CUDA) as `ggml_fp16_t` instead of using  `__fp16`. Notably, both types represent the `FP16` format.

Related issue:
#1455 
#2004 