### PR TITLE
Fix convert-llama-ggmlv3-to-gguf.py vocab conversion

### DIFF
--- a/convert-llama-ggmlv3-to-gguf.py
+++ b/convert-llama-ggmlv3-to-gguf.py
@@ -236,8 +236,7 @@ class GGMLToGGUF:
             if len(vbytes) == 0:
                 tt = 3 # Control
             elif tokid >= 3 and tokid <= 258 and len(vbytes) == 1:
-                hv = hex(vbytes[0])[2:].upper()
-                vbytes = bytes(f'<0x{hv}>', encoding = 'UTF-8')
+                vbytes = bytes(f'<0x{vbytes[0]:02X}>', encoding = 'UTF-8')
                 tt = 6 # Byte
             else:
                 vbytes = vbytes.replace(b' ', b'\xe2\x96\x81')


### PR DESCRIPTION
When converting without metadata, the hex values for bytes entries weren't 0 padded to 2 digits. (The llama.cpp changes in #2668 made handling more strict, though my output was always wrong.)

Closes #2697