### PR TITLE
Strided perplexity

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -418,6 +418,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.antiprompt.push_back(argv[i]);
         } else if (arg == "--perplexity") {
             params.perplexity = true;
+        } else if (arg == "--ppl-stride") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.ppl_stride = std::stoi(argv[i]);
         } else if (arg == "--hellaswag") {
             params.hellaswag = true;
         } else if (arg == "--hellaswag-tasks") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -424,6 +424,12 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.ppl_stride = std::stoi(argv[i]);
+        } else if (arg == "--ppl-output-type") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.ppl_output_type = std::stoi(argv[i]);
         } else if (arg == "--hellaswag") {
             params.hellaswag = true;
         } else if (arg == "--hellaswag-tasks") {

--- a/common/common.h
+++ b/common/common.h
@@ -65,7 +65,9 @@ struct gpt_params {
     std::string lora_base    = "";  // base model path for the lora adapter
 
     int  ppl_stride        = 0;     // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.
-                                    // 
+    int  ppl_output_type   = 0;     // = 0 -> ppl output is as usual, = 1 -> ppl output is num_tokens, ppl, one per line
+                                    //                                       (which is more convenient to use for plotting)
+                                    //
     bool hellaswag         = false; // compute HellaSwag score over random tasks from datafile supplied in prompt
     size_t hellaswag_tasks = 400;   // number of tasks to use when computing the HellaSwag score
 

--- a/common/common.h
+++ b/common/common.h
@@ -64,6 +64,8 @@ struct gpt_params {
     std::string lora_adapter = "";  // lora adapter path
     std::string lora_base    = "";  // base model path for the lora adapter
 
+    int  ppl_stride        = 0;     // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.
+                                    // 
     bool hellaswag         = false; // compute HellaSwag score over random tasks from datafile supplied in prompt
     size_t hellaswag_tasks = 400;   // number of tasks to use when computing the HellaSwag score
 

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -125,7 +125,11 @@ void perplexity_v2(llama_context * ctx, const gpt_params & params) {
             ++count;
         }
         // perplexity is e^(average negative log-likelihood)
-        printf("[%d]%.4lf,", i + 1, std::exp(nll / count));
+        if (params.ppl_output_type == 0) {
+            printf("[%d]%.4lf,", i + 1, std::exp(nll / count));
+        } else {
+            printf("%8d  %.4lf\n", i*params.ppl_stride, std::exp(nll / count));
+        }
         fflush(stdout);
     }
     printf("\n");
@@ -226,7 +230,11 @@ void perplexity(llama_context * ctx, const gpt_params & params) {
             ++count;
         }
         // perplexity is e^(average negative log-likelihood)
-        printf("[%d]%.4lf,", i + 1, std::exp(nll / count));
+        if (params.ppl_output_type == 0) {
+            printf("[%d]%.4lf,", i + 1, std::exp(nll / count));
+        } else {
+            printf("%8d  %.4lf\n", i*params.n_ctx, std::exp(nll / count));
+        }
         fflush(stdout);
     }
     printf("\n");

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -27,7 +27,117 @@ std::vector<float> softmax(const std::vector<float>& logits) {
     return probs;
 }
 
+void perplexity_v2(llama_context * ctx, const gpt_params & params) {
+
+    // Download: https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-raw-v1.zip?ref=salesforce-research
+    // Run `./perplexity -m models/7B/ggml-model-q4_0.bin -f wiki.test.raw`
+    // Output: `perplexity: 13.5106 [114/114]`
+    // BOS tokens will be added for each chunk before eval
+
+    if (params.ppl_stride <= 0) {
+        fprintf(stderr, "%s: stride is %d but must be greater than zero!\n",__func__,params.ppl_stride);
+        return;
+    }
+    auto tokens = ::llama_tokenize(ctx, params.prompt, true);
+
+    const int calc_chunk = params.n_ctx;
+
+    fprintf(stderr, "%s: have %zu tokens. Calculation chunk = %d\n", __func__, tokens.size(), calc_chunk);
+
+    if (int(tokens.size()) <= calc_chunk) {
+        fprintf(stderr, "%s: there are only %zu tokens, this is not enough for a context size of %d and stride %d\n",__func__,
+                tokens.size(), params.n_ctx, params.ppl_stride);
+        return;
+    }
+
+    const int n_chunk_max = (tokens.size() - calc_chunk + params.ppl_stride - 1)  / params.ppl_stride;
+
+    const int n_chunk = params.n_chunks < 0 ? n_chunk_max : std::min(params.n_chunks, n_chunk_max);
+    const int n_vocab = llama_n_vocab(ctx);
+    const int n_batch = params.n_batch;
+
+    int count = 0;
+    double nll = 0.0;
+
+    fprintf(stderr, "%s: calculating perplexity over %d chunks, batch_size=%d\n", __func__, n_chunk, n_batch);
+
+    for (int i = 0; i < n_chunk; ++i) {
+        const int start =     i * params.ppl_stride;
+        const int end   = start + calc_chunk;
+
+        const int num_batches = (calc_chunk + n_batch - 1) / n_batch;
+        //fprintf(stderr, "%s: evaluating %d...%d using %d batches\n", __func__, start, end, num_batches);
+
+        std::vector<float> logits;
+
+        const auto t_start = std::chrono::high_resolution_clock::now();
+
+        for (int j = 0; j < num_batches; ++j) {
+            const int batch_start = start + j * n_batch;
+            const int batch_size  = std::min(end - batch_start, n_batch);
+
+            //fprintf(stderr, "    Batch %d: starts at %d, size is %d, n_past is %d\n",j,batch_start,batch_size,j * n_batch);
+            if (llama_eval(ctx, tokens.data() + batch_start, batch_size, j * n_batch, params.n_threads)) {
+                //fprintf(stderr, "%s : failed to eval\n", __func__);
+                return;
+            }
+
+            // save original token and restore it after eval
+            const auto token_org = tokens[batch_start];
+
+            // add BOS token for the first batch of each chunk
+            if (j == 0) {
+                tokens[batch_start] = llama_token_bos(ctx);
+            }
+
+            const auto batch_logits = llama_get_logits(ctx);
+            logits.insert(logits.end(), batch_logits, batch_logits + batch_size * n_vocab);
+
+            if (j == 0) {
+                tokens[batch_start] = token_org;
+            }
+        }
+
+        const auto t_end = std::chrono::high_resolution_clock::now();
+
+        if (i == 0) {
+            const float t_total = std::chrono::duration<float>(t_end - t_start).count();
+            fprintf(stderr, "%s: %.2f seconds per pass - ETA ", __func__, t_total);
+            int total_seconds = (int)(t_total * n_chunk);
+            if (total_seconds >= 60*60) {
+                fprintf(stderr, "%d hours ", total_seconds / (60*60));
+                total_seconds = total_seconds % (60*60);
+            }
+            fprintf(stderr, "%.2f minutes\n", total_seconds / 60.0);
+        }
+
+        //fprintf(stderr, "%s: using tokens %d...%d\n",__func__,params.n_ctx - params.ppl_stride + start, params.n_ctx + start);
+        for (int j = params.n_ctx - params.ppl_stride - 1; j < params.n_ctx - 1; ++j) {
+
+            // Calculate probability of next token, given the previous ones.
+            const std::vector<float> tok_logits(
+                logits.begin() + (j + 0) * n_vocab,
+                logits.begin() + (j + 1) * n_vocab);
+
+            const float prob = softmax(tok_logits)[tokens[start + j + 1]];
+
+            nll += -std::log(prob);
+            ++count;
+        }
+        // perplexity is e^(average negative log-likelihood)
+        printf("[%d]%.4lf,", i + 1, std::exp(nll / count));
+        fflush(stdout);
+    }
+    printf("\n");
+}
+
 void perplexity(llama_context * ctx, const gpt_params & params) {
+
+    if (params.ppl_stride > 0) {
+        perplexity_v2(ctx, params);
+        return;
+    }
+
     // Download: https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-raw-v1.zip?ref=salesforce-research
     // Run `./perplexity -m models/7B/ggml-model-q4_0.bin -f wiki.test.raw`
     // Output: `perplexity: 13.5106 [114/114]`
@@ -368,6 +478,12 @@ int main(int argc, char ** argv) {
 
     params.perplexity = true;
     params.n_batch = std::min(params.n_batch, params.n_ctx);
+
+    if (params.ppl_stride > 0) {
+        fprintf(stderr, "Will perform strided perplexity calculation -> adjusting context size from %d to %d\n",
+                params.n_ctx, params.n_ctx + params.ppl_stride/2);
+        params.n_ctx += params.ppl_stride/2;
+    }
 
     if (params.n_ctx > 2048) {
         fprintf(stderr, "%s: warning: model might not support context sizes greater than 2048 tokens (%d specified);"


### PR DESCRIPTION
TL;DR: A more accurate implementation of perplexity calculation. Triggered via `./perplexity ... --ppl_stride N`. 

It has been a long-standing mystery why PPL values computed with `llama.cpp` are higher than those coming from the Python universe. For instance, for LLaMA-v1-7B, the `llama.cpp` perplexity for the `fp16` model is `~5.91`, while the value frequently quoted around the Internet is `~5.68`. One prominent hypothesis has been that the difference may be due to differences in the tokenization. But even after merging the GGUF changes and the improvements in the tokenizer, `llama.cpp` perplexities are largely unchanged.

I think this PR resolves the mystery: it is simply a matter of the perplexity computation not being done correctly in `llama.cpp`. The existing implementation evaluates chunks of `n_ctx` (the context size), and then averages the log probabilities in the range `n_ctx/2...n_ctx`.  This is roughly equivalent to a strided perplexity calculation for an effective context length of `3/4 * n_ctx` with a stride of `n_ctx/2`, see e.g. [this HF post](https://huggingface.co/docs/transformers/perplexity). It is "roughly", because this basically skips half of the tokens during evaluation.

An exact, token-by-token perplexity evaluation would be too expensive to be of practical use. There are ~330,000 tokens in Wikitext, each token takes ~8 ms on a high-end GPU, so one needs in the range of ~45 minutes to evaluate (compared to the current ~3.5 minutes for 7B). But even if one wanted to implement that way, this is currently not possible with `ggml` because one can not modify the positional encoding (to be able to do that, one would need to change `ggml` to store embeddings into the KV-cache **before** RoPE has been applied, and then apply RoPE as needed, given the current number of past tokens). Hence, this PR adds a strided implementation as discussed in the HF post. The new implementation is triggered using `--ppl-stride N`, where `N` is some integer. The smaller `N` is, the more accurate the result, and the longer the computation takes (see below for actual usage examples). The implementation then increases the context `n_ctx` supplied by the user by `N/2`, evaluates chunks of `n_ctx + N/2` tokens, adds log probabilities from the `n_ctx - N/2 ... n_ctx + N/2` token range, moves `N` tokens ahead, and repeats until all tokens have been processes.

For now I have kept the original implementation and added a new function `perplexity_v2()` instead of trying to fit in the new logic into the existing implementation. This will make it easier to remove one of the implementations in the future.

If the change of storing un-RoPE'ed embeddings in the KV-cache was made in `ggml`, then one would have a much more efficient implementation. One would first evaluate `n_ctx + N/2` tokens, and then one would keep evaluating `N` tokens at a time with `n_past = n_ctx`. 

The following table gives compute times in seconds (using CUDA on a 4080 GPU) and perplexities obtained with `LLaMA-v1-7B`:

| Stride | Time | PPL |
|---|---|---|
| Master | 195 | 5.9066 |
| 512 | 347 | 5.7668 |
| 256 | 598 | 5.7291 |
| 128 | 1100 | 5.7226 |

We see that the strided approach gives a PPL that is much closer to the Python PPL (although, it looks unlikely it will converge to 5.68, so there must be still differences in the implementation).

The following graph shows PPL as a function of the number of tokens evaluated so far for LLaMA-v2-7B. Based on this, a stride of 128 is likely to be good enough.  
![strided_ppl](https://github.com/ggerganov/llama.cpp/assets/48489457/64a03820-5d53-4f13-80d3-4f14adff3544)

 
 