### PR TITLE
Clarifying error message

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -964,7 +964,7 @@ def load_vocab(path: Path, vocabtype: Optional[str]) -> Union[BpeVocab, Sentence
             path = path3
         else:
             raise FileNotFoundError(
-                f"Could not find tokenizer.model in {path} or its parent; "
+                f"Could not find {vocab_file} in {path} or its parent; "
                 "if it's in another directory, pass the directory as --vocab-dir")
 
     print(f"Loading vocab file '{path}', type '{vocabtype}'")


### PR DESCRIPTION
When I passed in `--vocabtype bpe` to `convert.py`, the error message started with "Could not find tokenizer.model", which at first glance is a bit misleading, because the file it was looking for is actually "vocab.json".

This PR just clarifies the error message by printing the actual name of the missing `vocab_file`.