### PR TITLE
Fix .gitignore for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.so
 *.gguf
 *.bin
+*.exe
+*.dll
 .DS_Store
 .build/
 .cache/
@@ -81,4 +83,3 @@ tests/test-quantize-fns
 tests/test-quantize-perf
 tests/test-sampling
 tests/test-tokenizer-0
-


### PR DESCRIPTION
After following the instructions for building on Windows, I was left with a bunch of .exe files and .dll's as untracked changes in the repo. Updating the .gitignore to ignore these