### PR TITLE
Fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,8 @@ ls ./models
 python3 -m pip install -r requirements.txt
 
 # convert the 7B model to ggml FP16 format
-python3 convert.py models/7B/
+# Use --ctx 4096 for LLaMA v2
+python3 convert.py models/7B/ --ctx 2048
 
   # [Optional] for models using BPE tokenizers
   python convert.py models/7B/ --vocabtype bpe

--- a/README.md
+++ b/README.md
@@ -504,7 +504,8 @@ Building the program with BLAS support may lead to some performance improvements
 ```bash
 # obtain the original LLaMA model weights and place them in ./models
 ls ./models
-65B 30B 13B 7B tokenizer_checklist.chk tokenizer.model
+65B 30B 13B 7B tokenizer.model
+
   # [Optional] for models using BPE tokenizers
   ls ./models
   65B 30B 13B 7B vocab.json


### PR DESCRIPTION
Fixing up the docs a bit:
- As far as I can tell, `tokenizer_checklist.chk` is not a file you get from downloading the weights and it doesn't seem to be needed for anything (zero references to `tokenizer_checklist` nor any `.chk` files in any of the code)
- The `convert` command is missing a mandatory `ctx` param. Easy enough to figure out when you run it without, but still need a moment to double check you're doing everything correctly. 