### PR TITLE
Tag release with build number instead of short hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,9 +297,9 @@ jobs:
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "::set-output name=name::$BUILD_NUMBER"
+            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $$ GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -350,9 +350,9 @@ jobs:
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "::set-output name=name::$BUILD_NUMBER"
+            echo "name=$BUILD_NUMBER" > $GITHUB_OUTPUT
           else
-            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" > $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -412,9 +412,9 @@ jobs:
       - windows-latest-cmake-cublas
 
     steps:
-      - name: Download artifacts
-        id: download-artifact
-        uses: actions/download-artifact@v3
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v1
 
       - name: Determine tag name
         id: tag
@@ -422,10 +422,14 @@ jobs:
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "::set-output name=name::$BUILD_NUMBER"
+            echo "name=$BUILD_NUMBER" > $GITHUB_OUTPUT
           else
-            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" > $GITHUB_OUTPUT
           fi
+
+      - name: Download artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v3
 
       - name: Create release
         id: create_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
             echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $$ GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -350,9 +350,9 @@ jobs:
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER" > $GITHUB_OUTPUT
+            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" > $GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -422,9 +422,9 @@ jobs:
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER" > $GITHUB_OUTPUT
+            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" > $GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
           fi
 
       - name: Download artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
             echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            SAFE_NAME=$(echo "${{ env.BRANCH_NAME }}" | tr '/' '-')
             echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 
@@ -355,7 +355,7 @@ jobs:
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
             echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            SAFE_NAME=$(echo "${{ env.BRANCH_NAME }}" | tr '/' '-')
             echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 
@@ -429,7 +429,7 @@ jobs:
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
             echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            SAFE_NAME=$(echo "${{ env.BRANCH_NAME }}" | tr '/' '-')
             echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,9 +298,10 @@ jobs:
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -352,9 +353,10 @@ jobs:
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -425,9 +427,10 @@ jobs:
           BUILD_NUMBER="$(git rev-list --count HEAD)"
           SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            echo "name=b${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
+            SAFE_NAME=${{ env.BRANCH_NAME//\//- }}  # Replace slashes with dashes
+            echo "name=${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}" >> $GITHUB_OUTPUT
           fi
 
       - name: Download artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,24 +291,30 @@ jobs:
           cd build
           ctest -C Release --verbose --timeout 900
 
-      - name: Get commit hash
-        id: commit
-        if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
-        uses: pr-mpt/actions-commit-hash@v2
+      - name: Determine tag name
+        id: tag
+        shell: bash
+        run: |
+          BUILD_NUMBER="$(git rev-list --count HEAD)"
+          if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
+            echo "::set-output name=name::$BUILD_NUMBER"
+          else
+            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+          fi
 
       - name: Pack artifacts
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
           Copy-Item LICENSE .\build\bin\Release\llama.cpp.txt
-          7z a llama-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-win-${{ matrix.build }}-x64.zip .\build\bin\Release\*
+          7z a llama-${{ steps.tag.outputs.name }}-bin-win-${{ matrix.build }}-x64.zip .\build\bin\Release\*
 
       - name: Upload artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           path: |
-            llama-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-win-${{ matrix.build }}-x64.zip
+            llama-${{ steps.tag.outputs.name }}-bin-win-${{ matrix.build }}-x64.zip
 
   windows-latest-cmake-cublas:
     runs-on: windows-latest
@@ -338,23 +344,29 @@ jobs:
           cmake .. -DLLAMA_BUILD_SERVER=ON -DLLAMA_CUBLAS=ON
           cmake --build . --config Release
 
-      - name: Get commit hash
-        id: commit
-        if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
-        uses: pr-mpt/actions-commit-hash@v2
+      - name: Determine tag name
+        id: tag
+        shell: bash
+        run: |
+          BUILD_NUMBER="$(git rev-list --count HEAD)"
+          if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
+            echo "::set-output name=name::$BUILD_NUMBER"
+          else
+            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+          fi
 
       - name: Pack artifacts
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
-          7z a llama-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-win-${{ matrix.build }}-cu${{ matrix.cuda }}-x64.zip .\build\bin\Release\*
+          7z a llama-${{ steps.tag.outputs.name }}-bin-win-${{ matrix.build }}-cu${{ matrix.cuda }}-x64.zip .\build\bin\Release\*
 
       - name: Upload artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           path: |
-            llama-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-win-${{ matrix.build }}-cu${{ matrix.cuda }}-x64.zip
+            llama-${{ steps.tag.outputs.name }}-bin-win-${{ matrix.build }}-cu${{ matrix.cuda }}-x64.zip
 
       - name: Copy and pack Cuda runtime
         if: ${{ matrix.cuda == '12.1.0' }}
@@ -404,9 +416,16 @@ jobs:
         id: download-artifact
         uses: actions/download-artifact@v3
 
-      - name: Get commit hash
-        id: commit
-        uses: pr-mpt/actions-commit-hash@v2
+      - name: Determine tag name
+        id: tag
+        shell: bash
+        run: |
+          BUILD_NUMBER="$(git rev-list --count HEAD)"
+          if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
+            echo "::set-output name=name::$BUILD_NUMBER"
+          else
+            echo "::set-output name=name::${{ env.BRANCH_NAME }}-$BUILD_NUMBER"
+          fi
 
       - name: Create release
         id: create_release
@@ -414,7 +433,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}
+          tag_name: ${{ steps.tag.outputs.name }}
 
       - name: Upload release
         id: upload_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,10 +296,11 @@ jobs:
         shell: bash
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -349,10 +350,11 @@ jobs:
         shell: bash
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           fi
 
       - name: Pack artifacts
@@ -421,10 +423,11 @@ jobs:
         shell: bash
         run: |
           BUILD_NUMBER="$(git rev-list --count HEAD)"
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
           if [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
-            echo "name=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           else
-            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER" >> $GITHUB_OUTPUT
+            echo "name=${{ env.BRANCH_NAME }}-$BUILD_NUMBER-$SHORT_HASH" >> $GITHUB_OUTPUT
           fi
 
       - name: Download artifacts


### PR DESCRIPTION
Better versioning for the releases has been requested multiple times in the past. In issue #2292, I had suggested [using the build number](https://github.com/ggerganov/llama.cpp/issues/2292#issuecomment-1645448668) (instead of the date as originally suggested) and got a thumbs up from ggerganov. That said, it was a month ago, so I hope this is still an acceptable solution.

I tested this on my fork ([it took a couple tries](https://github.com/DannyDaemonic/llama.cpp/actions/workflows/build.yml)) but it seems to work now.

The only change we might want to make is to put something in front of the build number for the release tag. (The release files still start with "llama".) I checked other repos and a lot of them just put their version number (`0.8.3-beta` or `1.0.2`) but if just `1032` feels strange, we could instead use something like `build-1032` and it would still be sortable and easy to tell which was newer just by looking:
```diff
-          tag_name: ${{ steps.tag.outputs.name }}
+          tag_name: build-${{ steps.tag.outputs.name }}
```