### PR TITLE
llama : fix grammar sometimes generating null char

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -4074,7 +4074,7 @@ void llama_sample_grammar(struct llama_context * ctx, llama_token_data_array * c
             if (!allow_eos) {
                 candidates->data[i].logit = -INFINITY;
             }
-        } else if (text.empty()) {
+        } else if (text.empty() || text[0] == 0) {
             candidates->data[i].logit = -INFINITY;
         } else {
             candidates_decoded.push_back(decode_utf8(text.c_str(), grammar->partial_utf8));


### PR DESCRIPTION
Inference with a grammar was sometimes generating null characters, effectively causing the output to hang. Probably introduced in #2553. It turns out `llama_sample_grammar` wasn't accounting for the `'\0'` token. This patch fixes the issue by rejecting that token unconditionally, treating it the same way as empty tokens.