### PR TITLE
llama-bench : add model sizes

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -718,6 +718,13 @@ struct markdown_printer : public printer {
         if (field == "t/s") {
             return 15;
         }
+        if (field == "size" || field == "params") {
+            return 8;
+        }
+        if (field == "n_gpu_layers") {
+            return 3;
+        }
+
         int width = std::max((int)field.length(), 10);
 
         if (test::get_field_type(field) == test::STRING) {
@@ -726,11 +733,27 @@ struct markdown_printer : public printer {
         return width;
     }
 
+    static std::string get_field_display_name(const std::string & field) {
+        if (field == "n_gpu_layers") {
+            return "ngl";
+        }
+        if (field == "n_threads") {
+            return "threads";
+        }
+        if (field == "mul_mat_q") {
+            return "mmq";
+        }
+        if (field == "tensor_split") {
+            return "ts";
+        }
+        return field;
+    }
+
     void print_header(const cmd_params & params) override {
         // select fields to print
         fields.push_back("model");
-        fields.push_back("model_size");
-        fields.push_back("model_n_params");
+        fields.push_back("size");
+        fields.push_back("params");
         fields.push_back("backend");
         bool is_cpu_backend = test::get_backend() == "CPU" || test::get_backend() == "BLAS";
         if (!is_cpu_backend) {
@@ -762,7 +785,7 @@ struct markdown_printer : public printer {
 
         fprintf(fout, "|");
         for (const auto & field : fields) {
-            fprintf(fout, " %*s |", get_field_width(field), field.c_str());
+            fprintf(fout, " %*s |", get_field_width(field), get_field_display_name(field).c_str());
         }
         fprintf(fout, "\n");
         fprintf(fout, "|");
@@ -782,10 +805,10 @@ struct markdown_printer : public printer {
             char buf[128];
             if (field == "model") {
                 value = t.model_type;
-            } else if (field == "model_size") {
-                snprintf(buf, sizeof(buf), "%.2f GiB", t.model_size / 1024.0 / 1024.0 / 1024.0);
+            } else if (field == "size") {
+                snprintf(buf, sizeof(buf), "%.2f GB", t.model_size / 1024.0 / 1024.0 / 1024.0);
                 value = buf;
-            } else if (field == "model_n_params") {
+            } else if (field == "params") {
                 if (t.model_n_params < 1000*1000*1000) {
                     snprintf(buf, sizeof(buf), "%.2f M", t.model_n_params / 1e6);
                 } else {

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -806,7 +806,11 @@ struct markdown_printer : public printer {
             if (field == "model") {
                 value = t.model_type;
             } else if (field == "size") {
-                snprintf(buf, sizeof(buf), "%.2f GB", t.model_size / 1024.0 / 1024.0 / 1024.0);
+                if (t.model_size < 1024*1024*1024) {
+                    snprintf(buf, sizeof(buf), "%.2f MiB", t.model_size / 1024.0 / 1024.0);
+                } else {
+                    snprintf(buf, sizeof(buf), "%.2f GiB", t.model_size / 1024.0 / 1024.0 / 1024.0);
+                }
                 value = buf;
             } else if (field == "params") {
                 if (t.model_n_params < 1000*1000*1000) {

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -716,10 +716,10 @@ struct markdown_printer : public printer {
             return -30;
         }
         if (field == "t/s") {
-            return 15;
+            return 16;
         }
         if (field == "size" || field == "params") {
-            return 8;
+            return 10;
         }
         if (field == "n_gpu_layers") {
             return 3;

--- a/llama.cpp
+++ b/llama.cpp
@@ -5277,11 +5277,27 @@ int llama_model_n_embd(const struct llama_model * model) {
     return model->hparams.n_embd;
 }
 
-int llama_model_type(const struct llama_model * model, char * buf, size_t buf_size) {
+int llama_model_desc(const struct llama_model * model, char * buf, size_t buf_size) {
     return snprintf(buf, buf_size, "%s %s %s",
             model->name.c_str(),
             llama_model_type_name(model->type),
             llama_model_ftype_name(model->ftype).c_str());
+}
+
+uint64_t llama_model_size(const struct llama_model * model) {
+    uint64_t size = 0;
+    for (const auto & it : model->tensors_by_name) {
+        size += ggml_nbytes(it.second);
+    }
+    return size;
+}
+
+uint64_t llama_model_n_params(const struct llama_model * model) {
+    uint64_t nparams = 0;
+    for (const auto & it : model->tensors_by_name) {
+        nparams += ggml_nelements(it.second);
+    }
+    return nparams;
 }
 
 int llama_model_quantize(

--- a/llama.h
+++ b/llama.h
@@ -254,7 +254,11 @@ extern "C" {
     LLAMA_API int llama_model_n_embd (const struct llama_model * model);
 
     // Get a string describing the model type
-    LLAMA_API int llama_model_type(const struct llama_model * model, char * buf, size_t buf_size);
+    LLAMA_API int llama_model_desc(const struct llama_model * model, char * buf, size_t buf_size);
+    // Returns the total size of all the tensors in the model in bytes
+    LLAMA_API uint64_t llama_model_size(const struct llama_model * model);
+    // Returns the total number of parameters in the model
+    LLAMA_API uint64_t llama_model_n_params(const struct llama_model * model);
 
     // Returns 0 on success
     LLAMA_API int llama_model_quantize(


### PR DESCRIPTION
Renames `llama_model_type` API to `llama_model_desc`, adds `llama_model_size` and `llama_model_n_params` APIs to llama.cpp.

Currently, the sizes are always shown in the markdown output. I am ok with that, but if it adds too much clutter, I could make them optional.

Example output with markdown:

  Device 0: NVIDIA GeForce RTX 3090 Ti, compute capability 8.6
| model                          | model_size | model_n_params | backend    | n_gpu_layers | test       |             t/s |
| ------------------------------ | ---------: | -------------: | ---------- | -----------: | ---------- | --------------: |
| LLaMA 7B mostly Q4_0           |   3.56 GiB |         6.74 B | CUDA       |           99 | pp 512     | 2235.89 ± 34.61 |
| LLaMA 13B mostly Q4_0          |   6.86 GiB |        13.02 B | CUDA       |           99 | pp 512     | 1326.61 ± 100.20 |
| LLaMA 30B mostly Q4_0          |  17.09 GiB |        32.53 B | CUDA       |           99 | pp 512     |   619.07 ± 2.03 |

build: d0f77b1 (1055)

