### PR TITLE
Added `enum` to `llama_token_get_type` return type for C compliance

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -348,7 +348,7 @@ extern "C" {
 
     LLAMA_API float llama_token_get_score(const struct llama_context * ctx, llama_token token);
 
-    LLAMA_API llama_token_type llama_token_get_type(const struct llama_context * ctx, llama_token token);
+    LLAMA_API enum llama_token_type llama_token_get_type(const struct llama_context * ctx, llama_token token);
 
     // Special tokens
     LLAMA_API llama_token llama_token_bos(const struct llama_context * ctx);  // beginning-of-sentence


### PR DESCRIPTION
Not sure if a `typedef` would be preferred. I went off current `enum` usage around log levels.

The declaration without the `enum` caused an error for me when trying to create rust bindings.

I am neither a C or C++ dev, I am unsure of the consequences (if any) of this on the cpp side of things.