### PR TITLE
convert.py : Handle null rope scaling value in HF config.json

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -170,7 +170,8 @@ class Params:
         f_norm_eps       = config["rms_norm_eps"]
         f_rope_freq_base = config["rope_theta"] if "rope_theta" in config else None
 
-        if "rope_scaling" in config and config["rope_scaling"].get("type") == "linear":
+        rope_scaling = config.get("rope_scaling")
+        if isinstance(rope_scaling, dict) and rope_scaling.get("type") == "linear":
             f_rope_scale = config["rope_scaling"].get("factor")
         else:
             f_rope_scale = None


### PR DESCRIPTION
@TheBloke noted that config.json can have a `null` value for rope scaling, which was not handled in #2772. My bad! This PR fixes that.

Tested with three possibilities: null rope scaling, rope scaling defined with `"type": "linear", "factor": 4.0`, and no rope scaling defined at all in the JSON object.