### PR TITLE
Build llama.cpp on Intel with nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,12 @@
               CoreGraphics
               CoreVideo
             ]
+          else if isDarwin then
+            with pkgs.darwin.apple_sdk.frameworks; [
+              Accelerate
+              CoreGraphics
+              CoreVideo
+            ]
           else
             with pkgs; [ openblas ]
         );
@@ -80,8 +86,13 @@
           type = "app";
           program = "${self.packages.${system}.default}/bin/llama";
         };
+        apps.quantize = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/quantize";
+        };
         apps.default = self.apps.${system}.llama;
         devShells.default = pkgs.mkShell {
+          buildInputs = [ llama-python ];
           packages = nativeBuildInputs ++ osSpecific;
         };
       });


### PR DESCRIPTION
Thank you for this great project!

Problem
-------
`nix build` on a laptop with Intel CPU fails due to missing `Accelerate.h`.

Changes
-------
- When building for Intel use the same SDK frameworks as for ARM
- Add `quantize` app to the output of nix flake
- Extend nix devShell with llama-python so we can use `convert.py` script

Testing
-------
Testing the steps with nix:
1. `nix build`
2. Get the model
3. `nix develop` to get into the dev shell
4. and then convert it`python convert.py models/llama-2-7b.ggmlv3.q4_0.bin`
5. `nix run llama.cpp#quantize -- open_llama_7b/ggml-model-f16.gguf ./models/ggml-model-q4_0.bin 2`
6. `nix run llama.cpp#llama -- -m models/ggml-model-q4_0.bin -p "What is nix?" -n 400 --temp 0.8 -e -t 8`