### PR TITLE
llama : use std::abs in llama_sample_tail_free

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -3908,7 +3908,7 @@ void llama_sample_tail_free(struct llama_context * ctx, llama_token_data_array *
 
     // Calculate absolute value of second derivatives
     for (size_t i = 0; i < second_derivatives.size(); ++i) {
-        second_derivatives[i] = abs(second_derivatives[i]);
+        second_derivatives[i] = std::abs(second_derivatives[i]);
     }
 
     // Normalize the second derivatives


### PR DESCRIPTION
Fixes this clang warning when building without '-march=native':
```
clang++ -I. -I./common -O3 -std=c++11 -fPIC -DNDEBUG -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -pthread -DGGML_USE_K_QUANTS -c llama.cpp -o llama.o
llama.cpp:3911:33: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        second_derivatives[i] = abs(second_derivatives[i]);
                                ^
llama.cpp:3911:33: note: use function 'std::abs' instead
        second_derivatives[i] = abs(second_derivatives[i]);
                                ^~~
                                std::abs
1 warning generated.
```

`abs` will round the input to int, which I don't think was intended here.