### PR TITLE
Add a `/detokenize` endpoint to the example server

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -167,6 +167,12 @@ node .
 
     Note that the special `BOS` token is not added in front of the text and also a space character is not inserted automatically as it is for `/completion`.
 
+-   **POST** `/detokenize`: Convert tokens to text.
+
+    *Options:*
+
+    `tokens`: Set the tokens to detokenize.
+
 -   **POST** `/embedding`: Generate embedding of a given text just as [the embedding example](../embedding) does.
 
     *Options:*

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1104,6 +1104,12 @@ static json format_tokenizer_response(const std::vector<llama_token> &tokens)
         {"tokens", tokens}};
 }
 
+static json format_detokenized_response(std::string content)
+{
+    return json{
+        {"content", content}};
+}
+
 template <typename T>
 static T json_value(const json &body, const std::string &key, const T &default_value)
 {
@@ -1499,6 +1505,21 @@ int main(int argc, char **argv)
             tokens = llama.tokenize(body["content"], false);
         }
         const json data = format_tokenizer_response(tokens);
+        return res.set_content(data.dump(), "application/json"); });
+    
+    svr.Post("/detokenize", [&llama](const Request &req, Response &res)
+             {
+        auto lock = llama.lock();
+
+        const json body = json::parse(req.body);
+        std::string content;
+        if (body.count("tokens") != 0)
+        {
+            const std::vector<llama_token> tokens = body["tokens"];
+            content = tokens_to_str(llama.ctx, tokens.cbegin(), tokens.cend());
+        }
+
+        const json data = format_detokenized_response(content);
         return res.set_content(data.dump(), "application/json"); });
 
     svr.Post("/embedding", [&llama](const Request &req, Response &res)

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1506,7 +1506,7 @@ int main(int argc, char **argv)
         }
         const json data = format_tokenizer_response(tokens);
         return res.set_content(data.dump(), "application/json"); });
-    
+
     svr.Post("/detokenize", [&llama](const Request &req, Response &res)
              {
         auto lock = llama.lock();


### PR DESCRIPTION
Expose the ability to convert tokens to strings in the example server.

```
$ curl -X 'POST' \
 -d '{"content":"hello world"}' -H 'Content-Type: application/json' \
 'http://127.0.0.1:8080/tokenize'
{"tokens":[29871,22172,3186]}%                          

$ curl -X 'POST' \
 -d '{"tokens":[29871,22172,3186]}' -H 'Content-Type: application/json' \
 'http://127.0.0.1:8080/detokenize'
{"content":"  hello world"}% 
```

resolves #2801 