### PR TITLE
cuda: 1.2x faster dequantization kernel

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -4224,19 +4224,19 @@ static __global__ void dequantize_block_q4_0(const void * __restrict__ vx, float
     const int iqs = i%(QK4_0/4);
 
     const block_q4_0 * x = (const block_q4_0 *) vx;
-    const uchar2 qs = *(uchar2 *)(x[ib].qs + iqs*2);
+    const uchar2 qs = *(const uchar2 *)(x[ib].qs + iqs*2);
     const dfloat d = x[ib].d;
 
     dfloat2 dv0;
     dv0.x = (int)(qs.x & 0xf) - 8;
     dv0.y = (int)(qs.y & 0xf) - 8;
-    float2 v0 = dfloat22float2(dfmul2(dv0, {d, d}));
+    const float2 v0 = dfloat22float2(dfmul2(dv0, {d, d}));
     *(float2 *)(y + ib*QK4_0 + iqs*2) = v0;
 
     dfloat2 dv1;
     dv1.x = (int)(qs.x >> 4) - 8;
     dv1.y = (int)(qs.y >> 4) - 8;
-    float2 v1 = dfloat22float2(dfmul2(dv1, {d, d}));
+    const float2 v1 = dfloat22float2(dfmul2(dv1, {d, d}));
     *(float2 *)(y + ib*QK4_0 + QK4_0/2 + iqs*2) = v1;
 }
 

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -4198,7 +4198,7 @@ static void quantize_row_q8_1_cuda(const float * x, void * vy, const int kx, con
 }
 
 #ifdef GGML_CUDA_F16
-#define make_dfloat2(x, y) make_half2((x), (y))
+#define make_dfloat2(x, y) __halves2half2((x), (y))
 #else
 #define make_dfloat2(x, y) make_float2((x), (y))
 #endif


### PR DESCRIPTION
Optimize cuda dequantization with memory coalescing, achieving 1.2x speed up. For now, I only implement the faster kernel for q4_0. If this PR gets accepted, I'll implement the rest.

I use nvprof to profile kernels on a V100-SXM2 GPU with 900GB/s memory bankwidth.
```sh
nvprof --print-gpu-trace ./main -m ./models/7B/ggml-model-q4_0.gguf -p "Hello" -n 8 -ngl 32 -nommq
```

Before this PR, dequantizing a 11008x4096 q4_0 weight matrix costs 332.10us:
```
...
2.34055s  332.10us         (176128 1 1)       (256 1 1)        16        0B        0B         -           -           -           -  Tesla V100-SXM2         1        13  void dequantize_block<int=32, int=2, __operator_&__(_INTERNAL_3560778b_12_ggml_cuda_cu_2317e5a6::dequantize_q4_0(void const *, int, int, float2&))>(void const *, float*, int) [7307]
2.34088s  238.40us           (1376 1 1)       (128 1 1)        40  3.0000KB        0B         -           -           -           -  Tesla V100-SXM2         1        13  void gemmSN_TN_kernel<float, int=128, int=16, int=2, int=4, int=2, int=2, bool=1, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float>>(cublasGemmSmallNParams<float const , cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, float>) [7311]
...
```

With this PR, the same operation only costs 277.18us (1.2x speed up).
```
...
5.48006s  277.18us          (44032 1 1)       (256 1 1)        16        0B        0B         -           -           -           -  Tesla V100-SXM2         1        13  dequantize_block_q4_0(void const *, float*, int) [7307]
5.48034s  239.17us           (1376 1 1)       (128 1 1)        40  3.0000KB        0B         -           -           -           -  Tesla V100-SXM2         1        13  void gemmSN_TN_kernel<float, int=128, int=16, int=2, int=4, int=2, int=2, bool=1, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float>>(cublasGemmSmallNParams<float const , cublasGemvTensorStridedBatched<float const >, cublasGemvTensorStridedBatched<float const >, float>) [7311]
...
```

The memory bandwidth utilized reached (11008x4096x(0.5+4)B)/277.18us = 682GB/s (76% out of the peak 900GB/s), compared to the previous 569GB/s out of 900GB/s (63% peak).
