### PR TITLE
Use Unicode Escape Sequence to replace encoded characters

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -955,10 +955,10 @@ struct llama_vocab {
     id linefeed_id = 13;
 
     int find_bpe_rank(std::string token_left, std::string token_right) const {
-        replace_all(token_left,  " ",  "Ġ");
-        replace_all(token_left,  "\n", "Ċ");
-        replace_all(token_right, " ",  "Ġ");
-        replace_all(token_right, "\n", "Ċ");
+        replace_all(token_left,  " ",  "\u0120");
+        replace_all(token_left,  "\n", "\u010A");
+        replace_all(token_right, " ",  "\u0120");
+        replace_all(token_right, "\n", "\u010A");
 
         auto it = bpe_ranks.find(std::make_pair(token_left, token_right));
         if (it == bpe_ranks.end()) {


### PR DESCRIPTION
Using special characters within source files can break compiling on some computers with different regions and language settings. I have a ja-JP Windows 11 setup, and trying to compile the current master branch fails on `find_bpe_rank` due to the special characters recently introduced. Note that using a compiled build is fine; only compiling itself fails.

Using Unicode escape sequences should allow the code to be compiled on all setups without changing your computer's settings or switching regions. Trying out my changes and it seems like everything processes as it should, but hopefully others with more C++ experience know if I screwed something else up here.

e. Searching through the other repos, [similar techniques](https://github.com/ggerganov/ggml/blob/1a5d5f331de1d3c7ace40d86fe2373021a42f9ce/examples/common.cpp#L223-L225) have been done before, so I'm feeling more confident now in this.