### PR TITLE
llama : move #includes out of _GNU_SOURCE conditional

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1,9 +1,6 @@
 // Defines fileno on msys:
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
-#include <cstddef>
-#include <cstdint>
-#include <cstdio>
 #endif
 
 #include "llama.h"
@@ -62,6 +59,9 @@
 #include <cinttypes>
 #include <climits>
 #include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <ctime>
 #include <fstream>


### PR DESCRIPTION
Commit c150e1b0c3090f9f98452e2abf845d12b5bb8aed put some \#includes inside of an existing _GNU_SOURCE preprocessor conditional for no clear reason. This was presumably unintentional, so I moved them to where the rest of the standard includes are.