### PR TITLE
Small (and unreliable) AVX2 ggml_vec_dot_q4_K_q8_K improvement - remove instruction dependency

### DIFF
--- a/k_quants.c
+++ b/k_quants.c
@@ -2694,13 +2694,13 @@ void ggml_vec_dot_q4_K_q8_K(const int n, float * restrict s, const void * restri
             const __m256i q8l = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
             __m256i p16l = _mm256_maddubs_epi16(q4l, q8l);
             p16l = _mm256_madd_epi16(scale_l, p16l);
-            sumi = _mm256_add_epi32(sumi, p16l);
 
             const __m256i q8h = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
             __m256i p16h = _mm256_maddubs_epi16(q4h, q8h);
             p16h = _mm256_madd_epi16(scale_h, p16h);
-            sumi = _mm256_add_epi32(sumi, p16h);
+            const __m256i sumj = _mm256_add_epi32(p16l, p16h);
 
+            sumi = _mm256_add_epi32(sumi, sumj);
         }
 
         __m256 vd = _mm256_set1_ps(d);


### PR DESCRIPTION
Hi,
This is my first MR. Any help is appreciated.

The change reduces instruction dependency.

E.g. with llama-2-13b-chat.ggmlv3.q4_K_S.bin:
```
bin\RelWithDebInfo\main.exe -m d:\projects\ai\models\llama-2-13b-chat.ggmlv3.q4_K_S.bin -t 24 -n 128 -c 4096 --color -p "[INST] <<SYS>>You are a helpful assistant<</SYS>>Write a short poem on GPUs and memory bandwidth[/INST]"  

[...]
llama_print_timings:        load time =  2295.29 ms
llama_print_timings:      sample time =    15.70 ms /   128 runs   (    0.12 ms per token,  8154.42 tokens per second)
llama_print_timings: prompt eval time =  1298.96 ms /    33 tokens (   39.36 ms per token,    25.40 tokens per second)
llama_print_timings:        eval time = 17234.00 ms /   127 runs   (  135.70 ms per token,     7.37 tokens per second)
llama_print_timings:       total time = 18587.70 ms
```
vs before:
```
llama_print_timings:        load time =  1128.65 ms
llama_print_timings:      sample time =    15.84 ms /   128 runs   (    0.12 ms per token,  8083.36 tokens per second)
llama_print_timings: prompt eval time =  1334.17 ms /    33 tokens (   40.43 ms per token,    24.73 tokens per second)
llama_print_timings:        eval time = 19414.74 ms /   127 runs   (  152.87 ms per token,     6.54 tokens per second)
```

Measured on an 13900K with -t24

_Edit:_
While I observe an improvement of 5-10% with -t 24 on MSVC and models of ~34B params and more, @slaren and @ikawrakow could not reproduce it.
Most benchmarks showed differences within measurement error.