### PR TITLE
quantize : make output filename optional again

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -100,7 +100,7 @@ int main(int argc, char ** argv) {
         }
     }
 
-    if (argc - arg_idx < 3) {
+    if (argc - arg_idx < 2) {
         usage(argv[0]);
     }
 

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -114,7 +114,7 @@ int main(int argc, char ** argv) {
     std::string ftype_str;
     if (try_parse_ftype(argv[arg_idx], params.ftype, ftype_str)) {
         std::string fpath;
-        const size_t pos = fname_inp.find_last_of('/');
+        const size_t pos = fname_inp.find_last_of("/\\");
         if (pos != std::string::npos) {
             fpath = fname_inp.substr(0, pos + 1);
         }


### PR DESCRIPTION
Commit 5c7b0e79a7555fe5264d2e1f5a274afb0d2bb623 removed the ability to simply call quantize with an input filename and a quantization type, like this:
```
./quantize some_ggml_model.bin Q4_0
```
The output filename _may_ be omitted if you pass a value for nthreads. In other words, the script works as long as you pass at least three arguments, but two of the four are optional.

This was presumably unintentional. Changing the minimum argument count to two makes the behavior of quantize match the usage string:
```
usage: ./quantize [--help] [--allow-requantize] [--leave-output-tensor] model-f32.bin [model-quant.bin] type [nthreads]
```