### PR TITLE
llama.h: add missing struct keyword for C compat in callback type

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -496,7 +496,7 @@ extern "C" {
     // Type of pointer to the beam_search_callback function.
     // void* callback_data is any custom data passed to llama_beam_search, that is subsequently
     // passed back to beam_search_callback. This avoids having to use global variables in the callback.
-    typedef void (*llama_beam_search_callback_fn_t)(void * callback_data, llama_beams_state);
+    typedef void (*llama_beam_search_callback_fn_t)(void * callback_data, struct llama_beams_state);
 
     /// @details Deterministically returns entire sentence constructed by a beam search.
     /// @param ctx Pointer to the llama_context.


### PR DESCRIPTION
Fixes C compatibility (Tested with gcc 11.3.0 on linux)