### PR TITLE
server : avoid antiprompt in probabilities of final response

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1377,7 +1377,13 @@ int main(int argc, char **argv)
                 }
             }
 
-            const json data = format_final_response(llama, llama.generated_text, llama.generated_token_probs);
+            auto probs = llama.generated_token_probs;
+            if (llama.params.n_probs > 0 && llama.stopped_word) {
+                const std::vector<llama_token> stop_word_toks = llama_tokenize(llama.ctx, llama.stopping_word, false);
+                probs = std::vector<completion_token_output>(llama.generated_token_probs.begin(), llama.generated_token_probs.end() - stop_word_toks.size());
+            }
+
+            const json data = format_final_response(llama, llama.generated_text, probs);
 
             llama_print_timings(llama.ctx);
 
@@ -1454,7 +1460,11 @@ int main(int argc, char **argv)
 
                     if (!llama.has_next_token) {
                         // Generation is done, send extra information.
-                        const json data = format_final_response(llama, "", llama.generated_token_probs);
+                        const json data = format_final_response(
+                            llama,
+                            "",
+                            std::vector<completion_token_output>(llama.generated_token_probs.begin(), llama.generated_token_probs.begin() + sent_token_probs_index)
+                        );
 
                         const std::string str =
                             "data: " +


### PR DESCRIPTION
This fix the probabilities of stopping_word are included in the final response of `/completion`.

To test response without stream mode:

```bash
curl --url http://localhost:8080/completion --header "Content-Type: application/json" \
  --data '{ "n_probs": 1, "prompt": "Hello my name is", "stop": ["I"] }' | json_pp
```

With stream mode (see the last event):

```bash
curl -N --url http://localhost:8080/completion --header "Content-Type: application/json" \
  --data '{ "stream": true, "n_probs": 1, "prompt": "Hello my name is", "stop": ["I"] }'
```

Or see the console output in the web UI.