### PR TITLE
llama.cpp: Fix wrong vsnprintf call in MS compiler

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -6257,10 +6257,6 @@ void llama_log_set(llama_log_callback log_callback, void * user_data) {
     g_state.log_callback_user_data = user_data;
 }
 
-#if defined(_MSC_VER) && !defined(vsnprintf)
-#define vsnprintf _vsnprintf
-#endif
-
 static void llama_log_internal_v(llama_log_level level, const char * format, va_list args) {
     va_list args_copy;
     va_copy(args_copy, args);


### PR DESCRIPTION
I made a mistake in the logging output implementation. When compiled with Visual Studio, _vsnprintf was used instead of vsnprintf. _vsnprintf returns -1 when the buffer is too small, but the code expects the needed size.
This PR fixed that. I now tested vsnprintf on Windows and it seems to work in all cornercases as expected.

In the original implementation, I copied the define from an older codebase. That codebase needed to support older VS versions, which don't have access to vsnprintf. llama.cpp requires at least VS2019, so that is not an issue here.