### PR TITLE
added `struct` to llama_dump_timing_info_yaml's `llama_context`

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -521,7 +521,7 @@ extern "C" {
     // If this is not called, or NULL is supplied, everything is output on stderr.
     LLAMA_API void llama_log_set(llama_log_callback log_callback, void * user_data);
 
-    LLAMA_API void llama_dump_timing_info_yaml(FILE * stream, const llama_context * ctx);
+    LLAMA_API void llama_dump_timing_info_yaml(FILE * stream, const struct llama_context * ctx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
fixes C compat.

excited for #2848 :)