### PR TITLE
Fix "usage" message in convert-to-gguf python scripts

### DIFF
--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -48,7 +48,7 @@ def count_model_parts(dir_model: str) -> int:
 
 
 if len(sys.argv) < 3:
-    print("Usage: convert-h5-to-ggml.py dir-model ftype\n")
+    print(f"Usage: python {sys.argv[0]} dir-model ftype\n")
     print("  ftype == 0 -> float32")
     print("  ftype == 1 -> float16")
     sys.exit(1)

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -50,7 +50,7 @@ def count_model_parts(dir_model: str) -> int:
 
 
 if len(sys.argv) < 3:
-    print("Usage: convert-h5-to-ggml.py dir-model ftype\n")
+    print(f"Usage: python {sys.argv[0]} dir-model ftype\n")
     print("  ftype == 0 -> float32")
     print("  ftype == 1 -> float16")
     sys.exit(1)

--- a/convert-llama-7b-pth-to-gguf.py
+++ b/convert-llama-7b-pth-to-gguf.py
@@ -32,7 +32,7 @@ def count_model_parts(dir_model: str) -> int:
 
 
 if len(sys.argv) < 3:
-    print("Usage: convert-h5-to-ggml.py dir-model ftype\n")
+    print(f"Usage: python {sys.argv[0]} dir-model ftype\n")
     print("  ftype == 0 -> float32")
     print("  ftype == 1 -> float16")
 

--- a/convert-llama-hf-to-gguf.py
+++ b/convert-llama-hf-to-gguf.py
@@ -44,7 +44,7 @@ def count_model_parts(dir_model: str) -> int:
 
 
 if len(sys.argv) < 3:
-    print("Usage: convert-h5-to-ggml.py dir-model ftype\n")
+    print(f"Usage: python {sys.argv[0]} dir-model ftype\n")
     print("  ftype == 0 -> float32")
     print("  ftype == 1 -> float16")
 


### PR DESCRIPTION
Most converter scripts had the following usage-message :

`"Usage: convert-h5-to-ggml.py dir-model ftype\n"`.
Replaced it with
f "Usage: python {sys.argv[0]}
as it already is for example in `convert-lora-to-ggml.py` 
