### PR TITLE
[falcon] Fix Falcon for rw-1b model

### DIFF
--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -148,7 +148,7 @@ if Path(dir_model + "/tokenizer.json").is_file():
 
     print("gguf: get gpt2 tokenizer vocab")
 
-    vocab_size = len(tokenizer_json["model"]["vocab"])
+    vocab_size = hparams["vocab_size"]
 
     # ref: https://github.com/cmp-nct/ggllm.cpp/blob/master/falcon_convert.py
     tokenizer = AutoTokenizer.from_pretrained(dir_model)

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -94,22 +94,22 @@ gguf_writer = gguf.GGUFWriter(fname_out, gguf.MODEL_ARCH_NAMES[ARCH])
 print("gguf: get model metadata")
 
 if "n_layer" in hparams:
-  block_count = hparams["n_layer"]
+    block_count = hparams["n_layer"]
 elif "num_hidden_layers" in hparams:
-  block_count = hparams["num_hidden_layers"]
+    block_count = hparams["num_hidden_layers"]
 else:
-  print("No block count found")
+    print("No block count found")
 
-  sys.exit()
+    sys.exit()
 
 if "n_head" in hparams:
-  n_head = hparams["n_head"]
+    n_head = hparams["n_head"]
 elif "num_attention_heads" in hparams:
-  n_head = hparams["num_attention_heads"]
+    n_head = hparams["num_attention_heads"]
 else:
-  print("No head count found")
+    print("No head count found")
 
-  sys.exit()
+    sys.exit()
 
 n_head_kv = hparams["n_head_kv"] if "n_head_kv" in hparams else 1
 

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -206,6 +206,7 @@ tensor_map = gguf.get_tensor_name_map(ARCH,block_count)
 
 # params for qkv transform
 head_dim = hparams["hidden_size"] // n_head
+parallel_attn = hparams["parallel_attn"]
 
 # tensor info
 print("gguf: get tensor metadata")
@@ -240,7 +241,7 @@ for part_name in part_names:
         # in contiguous fashion.
         # ref: https://github.com/jploski/ggml/blob/falcon40b/examples/falcon/convert-hf-to-ggml.py
 
-        if "query_key_value" in name:
+        if "query_key_value" in name and parallel_attn:
             qkv = data.view(n_head_kv, n_head // n_head_kv + 2, head_dim, head_dim * n_head)
             q = qkv[:, :-2 ].reshape(n_head * head_dim, head_dim * n_head)
             k = qkv[:, [-2]].reshape(n_head_kv * head_dim, head_dim * n_head)

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -80,7 +80,7 @@ print("gguf: loading model "+last_dir)
 with open(dir_model + "/config.json", "r", encoding="utf-8") as f:
     hparams = json.load(f)
 
-if hparams["architectures"][0] != "RWForCausalLM":
+if hparams["architectures"][0] not in ("RWForCausalLM", "FalconForCausalLM"):
     print("Model architecture not supported: " + hparams["architectures"][0])
 
     sys.exit()
@@ -93,7 +93,25 @@ gguf_writer = gguf.GGUFWriter(fname_out, gguf.MODEL_ARCH_NAMES[ARCH])
 
 print("gguf: get model metadata")
 
-block_count = hparams["n_layer"]
+if "n_layer" in hparams:
+  block_count = hparams["n_layer"]
+elif "num_hidden_layers" in hparams:
+  block_count = hparams["num_hidden_layers"]
+else:
+  print("No block count found")
+
+  sys.exit()
+
+if "n_head" in hparams:
+  n_head = hparams["n_head"]
+elif "num_attention_heads" in hparams:
+  n_head = hparams["num_attention_heads"]
+else:
+  print("No head count found")
+
+  sys.exit()
+
+n_head_kv = hparams["n_head_kv"] if "n_head_kv" in hparams else 1
 
 gguf_writer.add_name("Falcon")
 gguf_writer.add_context_length(2048) # not in config.json
@@ -101,11 +119,8 @@ gguf_writer.add_tensor_data_layout("jploski") # qkv tensor transform
 gguf_writer.add_embedding_length(hparams["hidden_size"])
 gguf_writer.add_feed_forward_length(4 * hparams["hidden_size"])
 gguf_writer.add_block_count(block_count)
-gguf_writer.add_head_count(hparams["n_head"])
-if "n_head_kv" in hparams:
-    gguf_writer.add_head_count_kv(hparams["n_head_kv"])
-else:
-    gguf_writer.add_head_count_kv(1)
+gguf_writer.add_head_count(n_head)
+gguf_writer.add_head_count_kv(n_head_kv)
 gguf_writer.add_layer_norm_eps(hparams["layer_norm_epsilon"])
 gguf_writer.add_file_type(ftype)
 
@@ -190,9 +205,6 @@ if "pad_token_id" in hparams and hparams["pad_token_id"] != None:
 tensor_map = gguf.get_tensor_name_map(ARCH,block_count)
 
 # params for qkv transform
-n_head    = hparams["n_head"]
-n_head_kv = hparams["n_head_kv"] if "n_head_kv" in hparams else 1
-
 head_dim = hparams["hidden_size"] // n_head
 
 # tensor info

--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -144,6 +144,7 @@ MODEL_TENSOR_NAMES = {
         MODEL_TENSOR.ATTN_NORM_2: "blk.{bid}.attn_norm_2",
         MODEL_TENSOR.ATTN_QKV:    "blk.{bid}.attn_qkv",
         MODEL_TENSOR.ATTN_OUT:    "blk.{bid}.attn_output",
+        MODEL_TENSOR.FFN_NORM:    "blk.{bid}.ffn_norm",
         MODEL_TENSOR.FFN_DOWN:    "blk.{bid}.ffn_down",
         MODEL_TENSOR.FFN_UP:      "blk.{bid}.ffn_up",
     },
@@ -291,6 +292,7 @@ def get_tensor_name_map(arch: MODEL_ARCH, n_blocks: int) -> dict:
         tensor_map["transformer.blocks."+str(i)+".norm_2"]                = mapped_to  # mpt
         tensor_map["model.layers."+str(i)+".post_attention_layernorm"]    = mapped_to  # llama-hf
         tensor_map["layers."+str(i)+".ffn_norm"]                          = mapped_to  # llama-pth
+        tensor_map["transformer.h."+str(i)+".post_attention_layernorm"]   = mapped_to  # falcon-rw
 
         # Feed-forward up
         mapped_to = MODEL_TENSOR_NAMES[arch].get(MODEL_TENSOR.FFN_UP, None)

--- a/llama.cpp
+++ b/llama.cpp
@@ -830,6 +830,7 @@ static llama_state g_state;
 // available llama models
 enum e_model {
     MODEL_UNKNOWN,
+    MODEL_1B,
     MODEL_3B,
     MODEL_7B,
     MODEL_13B,
@@ -1524,6 +1525,7 @@ std::string llama_model_ftype_name(enum llama_ftype ftype) {
 
 static const char * llama_model_type_name(e_model type) {
     switch (type) {
+        case MODEL_1B:  return "1B";
         case MODEL_3B:  return "3B";
         case MODEL_7B:  return "7B";
         case MODEL_13B: return "13B";
@@ -1626,6 +1628,7 @@ static void llm_load_hparams(
                 GGUF_GET_KEY(ctx, hparams.f_norm_eps, gguf_get_val_f32, GGUF_TYPE_FLOAT32, true, kv(LLM_KV_ATTENTION_LAYERNORM_EPS));
 
                 switch (hparams.n_layer) {
+                    case 24: model.type = e_model::MODEL_1B; break;
                     case 32: model.type = e_model::MODEL_7B; break;
                     case 60: model.type = e_model::MODEL_40B; break;
                     default: model.type = e_model::MODEL_UNKNOWN;


### PR DESCRIPTION
See https://github.com/ggerganov/llama.cpp/issues/2868

- [x] Reconciling some differences in `config.json`:
![image](https://github.com/ggerganov/llama.cpp/assets/142945436/9ffeaabb-b293-4922-abdd-751b805ecdf7)
- [x] Skipping QKV reshaping when parallel attention is off
- [x] Fixing vocab size issues (`config.json` vocab size does not match contents of `tokenizer.json` - going with the stated size and padding with the missing tokens)
- [x] Updating tensor map. This model seems to have an `ffm-norm` layer.
- [x] Add 1b model type  
- [x] Figure out `error loading model: create_tensor: tensor 'blk.0.attn_qkv.weight' has wrong shape; expected  2048,  2176, got  2048,  6144` 
- [ ] TODO: Incorporate FFM norm this into the graph (added to the graph, but not using it)
- [ ] TODO: Properly incorporate bias (attention_qkv, ffdown, ffup) - added to the graph but not yet using it
- [ ] TODO: figure out alibi stuff