### PR TITLE
Makefile: add test and update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
         run: |
           CC=gcc-8 make
 
+      - name: Test
+        id: make_test
+        run: |
+          CC=gcc-8 make tests
+          make test
+
   ubuntu-latest-cmake:
     runs-on: ubuntu-latest
 
@@ -156,6 +162,12 @@ jobs:
         id: make_build
         run: |
           make
+
+      - name: Test
+        id: make_test
+        run: |
+          CC=gcc-8 make tests
+          make test
 
   macOS-latest-cmake:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Test
         id: make_test
         run: |
-          CC=gcc-8 make tests
+          make tests
           make test
 
   macOS-latest-cmake:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	@for test_target in $(TEST_TARGETS); do \
 		if [ "$$test_target" = "tests/test-tokenizer-0-llama" ]; then \
 			./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
-		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; \
+		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; then \
 			continue; \
 		elif [ "$$test_target" = "tests/test-tokenizer-1" ]; then \
 			continue; \

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,9 @@ test:
 	@for test_target in $(TEST_TARGETS); do \
 		if [ "$$test_target" = "tests/test-tokenizer-0-llama" ]; then \
 			./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
-		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; then \
-			# ./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
+		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; \
 			continue; \
 		elif [ "$$test_target" = "tests/test-tokenizer-1" ]; then \
-			# ./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
 			continue; \
 		else \
 			./$$test_target; \

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ test:
 	@echo "Running tests..."
 	@for test_target in $(TEST_TARGETS); do \
 		if [ "$$test_target" = "tests/test-tokenizer-0-llama" ]; then \
-			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
-			continue; \
+			./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
 		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; then \
 			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
 			continue; \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,26 @@ TEST_TARGETS = tests/test-llama-grammar tests/test-grammar-parser tests/test-dou
 
 default: $(BUILD_TARGETS)
 
+test:
+	@echo "Running tests..."
+	@for test_target in $(TEST_TARGETS); do \
+		if [ "$$test_target" = "tests/test-tokenizer-0-llama" ]; then \
+			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			continue; \
+		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; then \
+			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			continue; \
+		elif [ "$$test_target" = "tests/test-tokenizer-1" ]; then \
+			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			continue; \
+		else \
+			./$$test_target; \
+		fi; \
+	done
+	@echo "All tests have been run."
+
+all: $(BUILD_TARGETS) $(TEST_TARGETS)
+
 ifndef UNAME_S
 UNAME_S := $(shell uname -s)
 endif

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ test:
 	@echo "Running tests..."
 	@for test_target in $(TEST_TARGETS); do \
 		if [ "$$test_target" = "tests/test-tokenizer-0-llama" ]; then \
-			./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
 		elif [ "$$test_target" = "tests/test-tokenizer-0-falcon" ]; then \
-			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			# ./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
 			continue; \
 		elif [ "$$test_target" = "tests/test-tokenizer-1" ]; then \
-			# ./$$test_target $(CURDIR)/../models/ggml-vocab-llama.gguf; \
+			# ./$$test_target $(CURDIR)/models/ggml-vocab-llama.gguf; \
 			continue; \
 		else \
 			./$$test_target; \


### PR DESCRIPTION
Followup https://github.com/ggerganov/llama.cpp/pull/2855

This PR add the ability to run `make test` similar to `ctest` in cmake and update the CI to run the tests.

- `test-tokenizer-0-falcon`, `test-tokenizer-1` are currently skipped until we have the vocab files
- add `all` to build the default targets and test targets