### PR TITLE
CUDA: mul_mat_q=true as default for llama_context_params

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -5287,7 +5287,7 @@ struct llama_context_params llama_context_default_params() {
         /*.progress_callback           =*/ nullptr,
         /*.progress_callback_user_data =*/ nullptr,
         /*.low_vram                    =*/ false,
-        /*.mul_mat_q                   =*/ false,
+        /*.mul_mat_q                   =*/ true,
         /*.f16_kv                      =*/ true,
         /*.logits_all                  =*/ false,
         /*.vocab_only                  =*/ false,


### PR DESCRIPTION
As pointed out by https://github.com/ggerganov/llama.cpp/pull/2683#issuecomment-1699262118 , in a previous PR I forgot to change the mul_mat_q default in `llama_context_default_params`. So this PR sets it to true in line with CLI use.