### PR TITLE
llama2c : fix segfault and alloc-dealloc-mismatch

### DIFF
--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -596,6 +596,10 @@ void load_vocab(const char *filename, Config *config, struct llama_vocab *vocab)
         // assume llama2.c vocabulary
         printf("Assuming llama2.c vocabulary since %s is not a gguf file\n", filename);
         llama_file file(filename, "rb");
+        if (!file.fp) {
+            fprintf(stderr, "error: %s: %s\n", strerror(errno), filename);
+            exit(1);
+        }
         const int  n_vocab = config->vocab_size;
         /* uint32_t max_token_length =  */ file.read_u32(); // unused
         vocab->id_to_token.resize(n_vocab);

--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -174,18 +174,18 @@ int checkpoint_init_weights(TransformerWeights *w, Config* p, FILE* f, bool shar
 }
 
 void free_weights(TransformerWeights* w) {
-    delete w->token_embedding_table;
-    delete w->rms_att_weight;
-    delete w->rms_ffn_weight;
-    delete w->wq;
-    delete w->wk;
-    delete w->wv;
-    delete w->wo;
-    delete w->w1;
-    delete w->w2;
-    delete w->w3;
-    delete w->rms_final_weight;
-    if (w->wcls) delete w->wcls;
+    delete[] w->token_embedding_table;
+    delete[] w->rms_att_weight;
+    delete[] w->rms_ffn_weight;
+    delete[] w->wq;
+    delete[] w->wk;
+    delete[] w->wv;
+    delete[] w->wo;
+    delete[] w->w1;
+    delete[] w->w2;
+    delete[] w->w3;
+    delete[] w->rms_final_weight;
+    delete[] w->wcls;
 }
 
 void print_sample_weights(TransformerWeights *w){

--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -902,7 +902,7 @@ bool params_parse(int argc, char ** argv, struct train_params * params) {
 }
 
 std::string basename(const std::string &path) {
-    size_t pos = path.find_last_of("/");
+    size_t pos = path.find_last_of("/\\");
     if (pos == std::string::npos) {
         return path;
     }


### PR DESCRIPTION
When the vocab file was not found:
```
$ gdb --args ./convert-llama2c-to-ggml --llama2c-model stories15M.bin
<snip>
Assuming llama2.c vocabulary since models/7B/ggml-model-f16.gguf is not a gguf file

Program received signal SIGSEGV, Segmentation fault.
__GI__IO_fread (buf=0x7fffffffd4f4, size=4, count=1, fp=0x0) at iofread.c:37
37        _IO_acquire_lock (fp);
>>> bt
#0  __GI__IO_fread (buf=0x7fffffffd4f4, size=4, count=1, fp=0x0) at iofread.c:37
#1  0x0000555555561623 in llama_file::read_raw (this=0x7fffffffd5a0, ptr=0x7fffffffd4f4, size=4)
    at examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:500
#2  0x000055555556182f in llama_file::read_u32 (this=0x7fffffffd5a0)
    at examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:511
#3  0x000055555555f5da in load_vocab (filename=0x555555645dd7 "models/7B/ggml-model-f16.gguf", config=0x7fffffffd660, 
    vocab=0x7fffffffd680) at examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:600
#4  0x000055555556105c in main (argc=3, argv=0x7fffffffd988)
    at examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:930
```

When doing exit cleanup:
```
==114607==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x7fb510ed7800
    #0 0x7fb5166e2b8a in operator delete(void*) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:152
    #1 0x55fbe2d76b3c in free_weights(TransformerWeights*) examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:177
    #2 0x55fbe2d71b2a in main examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:960
    #3 0x7fb515e23ccf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #4 0x7fb515e23d89 in __libc_start_main_impl ../csu/libc-start.c:360
    #5 0x55fbe2d73d34 in _start (/home/cebtenzzre/src/forks/llama.cpp/convert-llama2c-to-ggml+0x2dd34) (BuildId: 8dfd479c1bd88031c1afb94dc85b78069e3fcc93)

0x7fb510ed7800 is located 0 bytes inside of 36864000-byte region [0x7fb510ed7800,0x7fb5131ff800)
allocated by thread T0 here:
    #0 0x7fb5166e2182 in operator new[](unsigned long) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x55fbe2d74e82 in malloc_weights(TransformerWeights*, Config*, bool) examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:104
    #2 0x55fbe2d714c4 in main examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp:928
    #3 0x7fb515e23ccf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:152 in operator delete(void*)
```