### PR TITLE
[Falcon] Use stated vocab size

### DIFF
--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -131,7 +131,9 @@ with open(tokenizer_json_file, "r", encoding="utf-8") as f:
 
 print("gguf: get gpt2 tokenizer vocab")
 
-vocab_size = len(tokenizer_json["model"]["vocab"])
+# The number of tokens in tokenizer.json can differ from the expected vocab size.
+# This causes downstream issues with mismatched tensor sizes when running the inference
+vocab_size = hparams["vocab_size"] if "vocab_size" in hparams else len(tokenizer_json["model"]["vocab"])
 
 # ref: https://github.com/cmp-nct/ggllm.cpp/blob/master/falcon_convert.py
 tokenizer = AutoTokenizer.from_pretrained(dir_model)


### PR DESCRIPTION
See e.g https://github.com/ggerganov/llama.cpp/issues/2894 and https://github.com/ggerganov/llama.cpp/issues/2868

In all of these cases, there is a `vocab_size` in `config.json` with the correct size, but `tokenizer.json` has an incorrect amount of tokens compared to the vocab size. Later on, the inference is expecting a tensor with `vocab_size` as one of its dimensions but gets `<actual count of tokens>` instead.  

At least in the case of https://github.com/ggerganov/llama.cpp/issues/2894, there is some configuration for an extra 'pad' token which makes up the difference (we are only missing a single token). However for https://github.com/ggerganov/llama.cpp/issues/2868, the difference is much larger and I wasn't able to figure out where those tokens were supposed to come from. 

In both cases, this fix was able to produce a gguf which doesn't run into that mismatch issue later on. That's because we already have some logic to introduce pad tokens if the ID is not found: https://github.com/ggerganov/llama.cpp/blob/71d6975559acfd6c8407a4ef8275a9979c737765/convert-falcon-hf-to-gguf.py#L155-L157