### PR TITLE
CUDA: use 1 thread if model is fully offloaded

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -3777,6 +3777,15 @@ static bool llama_eval_internal(
         n_threads = std::min(4, n_threads);
     }
 
+    // If all tensors can be run on the GPU then using more than 1 thread is detrimental.
+    const bool full_offload_supported = model.arch == LLM_ARCH_LLAMA ||
+        model.arch == LLM_ARCH_BAICHUAN ||
+        model.arch == LLM_ARCH_FALCON;
+    const bool fully_offloaded = model.n_gpu_layers >= (int) hparams.n_layer + 3;
+    if (ggml_cpu_has_cublas() && full_offload_supported && fully_offloaded) {
+        n_threads = 1;
+    }
+
     struct ggml_tensor * res        = gf->nodes[gf->n_nodes - 1];
     struct ggml_tensor * embeddings = gf->nodes[gf->n_nodes - 2];
 


### PR DESCRIPTION
Currently when using the maximum possible number of GPU layers with CUDA there is no benefit from > 1 thread. In fact, using more than 1 thread is detrimental due to increased overhead. This PR changes the logic for the default number of threads in such a way that (unless the user manually overrides it) only a single thread is used if all layers are offloaded.

I also changed the logic for `llama-bench` to be the same as `main`: -1 is interpreted as the number of logical cores.