### PR TITLE
scripts: Use local gguf package when running from repo

### DIFF
--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -15,8 +15,9 @@ import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
-if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+# Use local gguf module if available.
+if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 
 

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -16,7 +16,7 @@ import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
 # Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
     sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -15,9 +15,8 @@ import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
-# Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
+if 'NO_LOCAL_GGUF' not in os.environ:
+    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py' / 'gguf'))
 import gguf
 
 

--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -11,10 +11,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import gguf
 import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
+
+if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
+    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+import gguf
 
 
 def bytes_to_unicode():

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -16,6 +16,10 @@ import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
+if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
+    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+import gguf
+
 # ref: https://github.com/openai/gpt-2/blob/master/src/encoder.py
 
 

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import gguf
 import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -16,7 +16,7 @@ import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
 # Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
     sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -15,8 +15,9 @@ import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
-if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+# Use local gguf module if available.
+if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 
 # ref: https://github.com/openai/gpt-2/blob/master/src/encoder.py

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -15,9 +15,8 @@ import numpy as np
 import torch
 from transformers import AutoTokenizer  # type: ignore[import]
 
-# Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
+if 'NO_LOCAL_GGUF' not in os.environ:
+    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py' / 'gguf'))
 import gguf
 
 # ref: https://github.com/openai/gpt-2/blob/master/src/encoder.py

--- a/convert-llama-ggmlv3-to-gguf.py
+++ b/convert-llama-ggmlv3-to-gguf.py
@@ -10,8 +10,9 @@ from pathlib import Path
 import numpy as np
 
 import os
-if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+# Use local gguf module if available.
+if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 
 # Note: Does not support GGML_QKK_64

--- a/convert-llama-ggmlv3-to-gguf.py
+++ b/convert-llama-ggmlv3-to-gguf.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import os
 # Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
     sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 

--- a/convert-llama-ggmlv3-to-gguf.py
+++ b/convert-llama-ggmlv3-to-gguf.py
@@ -10,9 +10,8 @@ from pathlib import Path
 import numpy as np
 
 import os
-# Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
+if 'NO_LOCAL_GGUF' not in os.environ:
+    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py' / 'gguf'))
 import gguf
 
 # Note: Does not support GGML_QKK_64

--- a/convert-llama-ggmlv3-to-gguf.py
+++ b/convert-llama-ggmlv3-to-gguf.py
@@ -7,8 +7,12 @@ import struct
 import sys
 from pathlib import Path
 
-import gguf
 import numpy as np
+
+import os
+if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
+    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+import gguf
 
 # Note: Does not support GGML_QKK_64
 QK_K = 256

--- a/convert.py
+++ b/convert.py
@@ -29,9 +29,8 @@ import numpy as np
 from sentencepiece import SentencePieceProcessor  # type: ignore[import]
 
 import os
-# Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
+if 'NO_LOCAL_GGUF' not in os.environ:
+    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py' / 'gguf'))
 import gguf
 
 if TYPE_CHECKING:

--- a/convert.py
+++ b/convert.py
@@ -30,7 +30,7 @@ from sentencepiece import SentencePieceProcessor  # type: ignore[import]
 
 import os
 # Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py').is_file():
     sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 

--- a/convert.py
+++ b/convert.py
@@ -29,8 +29,9 @@ import numpy as np
 from sentencepiece import SentencePieceProcessor  # type: ignore[import]
 
 import os
-if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+# Use local gguf module if available.
+if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf', '__init__.py')).is_file():
+    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('gguf-py', 'gguf')))
 import gguf
 
 if TYPE_CHECKING:

--- a/convert.py
+++ b/convert.py
@@ -25,9 +25,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Generator, Iterable, Literal, Sequence, TypeVar
 
-import gguf
 import numpy as np
 from sentencepiece import SentencePieceProcessor  # type: ignore[import]
+
+import os
+if os.environ.get('NO_LOCAL_GGUF') is None and Path('gguf-py', 'gguf', '__init__.py').is_file():
+    sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+import gguf
 
 if TYPE_CHECKING:
     from typing import TypeAlias

--- a/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
+++ b/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
@@ -9,7 +9,7 @@ import numpy as np
 from pathlib import Path
 
 # Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf', '__init__.py')).is_file():
+if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf', '__init__.py').is_file():
     sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf')))
 import gguf
 

--- a/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
+++ b/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
@@ -8,9 +8,8 @@ import sys
 import numpy as np
 from pathlib import Path
 
-# Use local gguf module if available.
-if 'NO_LOCAL_GGUF' not in os.environ and Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf', '__init__.py').is_file():
-    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf')))
+if 'NO_LOCAL_GGUF' not in os.environ:
+    sys.path.insert(1, str(Path(__file__).parent / '..' / '..' / 'gguf-py' / 'gguf'))
 import gguf
 
 # gguf constants

--- a/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
+++ b/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
@@ -8,11 +8,9 @@ import sys
 import numpy as np
 from pathlib import Path
 
-if os.environ.get('NO_LOCAL_GGUF') is None:
-    if Path('gguf-py', 'gguf', '__init__.py').is_file():
-        sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
-    elif Path('..', '..', 'gguf-py', 'gguf', '__init__.py').is_file():
-        sys.path.insert(1, str(Path('..', '..', 'gguf-py', 'gguf').absolute()))
+# Use local gguf module if available.
+if 'NO_LOCAL_GGUF' not in os.environ and (Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf', '__init__.py')).is_file():
+    sys.path.insert(1, str(Path(__file__).parent.absolute().joinpath('..', '..', 'gguf-py', 'gguf')))
 import gguf
 
 # gguf constants

--- a/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
+++ b/examples/train-text-from-scratch/convert-train-checkpoint-to-gguf.py
@@ -2,12 +2,18 @@
 # train-text-from-scratch checkpoint --> gguf conversion
 
 import argparse
-import gguf
 import os
 import struct
 import sys
 import numpy as np
 from pathlib import Path
+
+if os.environ.get('NO_LOCAL_GGUF') is None:
+    if Path('gguf-py', 'gguf', '__init__.py').is_file():
+        sys.path.insert(1, str(Path('gguf-py', 'gguf').absolute()))
+    elif Path('..', '..', 'gguf-py', 'gguf', '__init__.py').is_file():
+        sys.path.insert(1, str(Path('..', '..', 'gguf-py', 'gguf').absolute()))
+import gguf
 
 # gguf constants
 LLM_KV_OPTIMIZER_TYPE = "optimizer.type"


### PR DESCRIPTION
You can get the default behavior by setting the `NO_LOCAL_GGUF` environment variable.

Personally I find the new behavior of ignoring the in-repo version of GGUF kind of unintuitive. This simple pull just adds the local `gguf` to `sys.path` if it exists and `NO_LOCAL_GGUF` is unset. That way one can use the `gguf` version that's in sync with the scripts without having to worry about setting up environments or manually syncing.

I didn't apply this to the convert-llama scripts because of #2906