### PR TITLE
docs: add java-llama.cpp to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ as the main playground for developing new features for the [ggml](https://github
 - Scala 3: [donderom/llm4s](https://github.com/donderom/llm4s)
 - Clojure: [phronmophobic/llama.clj](https://github.com/phronmophobic/llama.clj)
 - React Native: [mybigday/llama.rn](https://github.com/mybigday/llama.rn)
+- Java: [kherud/java-llama.cpp](https://github.com/kherud/java-llama.cpp)
 
 **UI:**
 


### PR DESCRIPTION
Since not much has happened on the Java side so far, I'd like to add my repository. Hopefully as a starting point for further collaboration. It exposes the entire C API and for the major part Java glue code exists, including grammar parsing and sampling.

I decided to implement the binding using JNA. In general, JNI exists as an alternative, but this usually comes with increased deployment effort, which is somewhat against the philosophy of the project. There is also project panama, which looks awesome, but so far is only an early access feature.