### PR TITLE
convert.py: BPE fixes?

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -339,8 +339,7 @@ class BpeVocab:
         actual_ids      = sorted(added_tokens.values())
         if expected_ids != actual_ids:
             expected_end_id = vocab_size + len(actual_ids) - 1
-            if actual_ids[0] != vocab_size or actual_ids[-1] != expected_end_id:
-                raise Exception(f"Expected the {len(actual_ids)} added token ID(s) to be sequential in the range {vocab_size} - {expected_end_id}; got {actual_ids}")
+            raise Exception(f"Expected the {len(actual_ids)} added token ID(s) to be sequential in the range {vocab_size} - {expected_end_id}; got {actual_ids}")
 
         items = sorted(added_tokens.items(), key=lambda text_idx: text_idx[1])
         self.added_tokens_list    = [text for (text, idx) in items]

--- a/convert.py
+++ b/convert.py
@@ -319,15 +319,28 @@ class BpeVocab:
         self.bpe_tokenizer = json.loads(open(str(fname_tokenizer), encoding="utf-8").read())
         added_tokens: dict[str, int]
         if fname_added_tokens is not None:
+            # FIXME: Verify that added tokens here _cannot_ overlap with the main vocab.
             added_tokens = json.load(open(fname_added_tokens, encoding="utf-8"))
         else:
-            added_tokens = {}
+            # Fall back to trying to find the added tokens in tokenizer.json
+            tokenizer_json_file = fname_tokenizer.parent / 'tokenizer.json'
+            if not tokenizer_json_file.is_file():
+                added_tokens = {}
+            else:
+                tokenizer_json = json.load(open(tokenizer_json_file, encoding="utf-8"))
+                added_tokens = dict(
+                    (item['content'], item['id'])
+                    for item in tokenizer_json.get('added_tokens', [])
+                    # Added tokens here can be duplicates of the main vocabulary.
+                    if item['content'] not in self.bpe_tokenizer )
 
         vocab_size: int = len(self.bpe_tokenizer)
         expected_ids    = list(range(vocab_size, vocab_size + len(added_tokens)))
         actual_ids      = sorted(added_tokens.values())
         if expected_ids != actual_ids:
-            raise Exception(f"Expected added token IDs to be sequential and start at {len(added_tokens)}; got {actual_ids}")
+            expected_end_id = vocab_size + len(actual_ids) - 1
+            if actual_ids[0] != vocab_size or actual_ids[-1] != expected_end_id:
+                raise Exception(f"Expected the {len(actual_ids)} added token ID(s) to be sequential in the range {vocab_size} - {expected_end_id}; got {actual_ids}")
 
         items = sorted(added_tokens.items(), key=lambda text_idx: text_idx[1])
         self.added_tokens_list    = [text for (text, idx) in items]
@@ -341,10 +354,22 @@ class BpeVocab:
         from transformers.models.gpt2 import tokenization_gpt2  # type: ignore[import]
         byte_encoder = tokenization_gpt2.bytes_to_unicode()
         byte_decoder = {v: k for k, v in byte_encoder.items()}
+        score = 0.0
         for i, item in enumerate(tokenizer):
             text: bytes = item.encode("utf-8")
-            score: float = -i
-            yield text, score, gguf.TokenType.USER_DEFINED
+            # FIXME: These shouldn't be hardcoded, but it's probably better than the current behavior?
+            if i <= 258 and text.startswith(b'<') and text.endswith(b'>'):
+                if i == 0 and text == b'<unk>':
+                    toktype = gguf.TokenType.UNKNOWN
+                elif i == 1 or i == 2:
+                    toktype = gguf.TokenType.CONTROL
+                elif i >= 3 and text.startswith(b'<0x'):
+                    toktype = gguf.TokenType.BYTE
+                else:
+                    toktype = gguf.TokenType.NORMAL
+            else:
+                toktype = gguf.TokenType.NORMAL
+            yield text, score, toktype
 
     def added_tokens(self) -> Iterable[tuple[bytes, float, gguf.TokenType]]:
         for text in self.added_tokens_list:


### PR DESCRIPTION
Trying to get https://huggingface.co/BAAI/Aquila-7B working but it... doesn't feel very close.

- The main scores were added as int but `added_tokens` adds them as float: this fails in gguf since arrays have to be homogeneous. Adding it as the wrong time might have caused issues too. Fixed that.
- Some models like Aquila have added tokens but no separate `added_tokens.json`. I added some logic to fall back to trying to find the added tokens in `tokenizer.json` if it's available.
- At least in `tokenizer.json` (and the Aquila model I mentioned) the added tokens aren't necessarily unique with the main vocab and have to be filtered out if it's already in the vocab. Maybe `added_tokens.json` doesn't need this logic?
- ***All** tokens were added as `USER_DEFINED`. However the token id to text rendering stuff in `llama.cpp` has no case for `USER_DEFINED` so it would return an empty string 100% of the time. Fixed to add tokens with `NORMAL` type.
- Scores were getting added as negative token id. Scores aren't even used for BPE, right? I changed it to just use `0.0` like the Falcon converter. I don't think it makes a difference what they're set to.
- There's some logic to try to handle models that seem like they use some stuff like `<0xblah>` for bytes same as LLaMA - for example https://huggingface.co/kfkas/Llama-2-ko-7b-Chat

You won't get anywhere without #2889

That's apparently not enough for the Aquila model to do anything except die. Apparently it has no newline token? We just expect it to exist and blindly look it up: https://github.com/ggerganov/llama.cpp/blob/e8422de39e4aa2f7e50574124b060a80607e654a/llama.cpp#L1752-L1757 - so it'll crash there unless you comment out that line.

Another issue with trying to get the Aquila model to do something is the JSON files are _not_ utf-8, they're GBK apparently. On Linux at least you can convert it with something like `iconv -f gbk -t utf8 < vocab.json >vocab.json.tmp` and then rename over the original file. `tokenizer.json` also needs this treatment.

After all that, it _sort_ of works for English text at least. Except it doesn't have ` ` (space) in its vocabulary so tokenizing and all output is goingtobeallruntogethergoodtimes. It can't seem to tokenize Chinese characters at all. I also tried without the GBK to UTF8 conversion and pasting in the wonky GBK stuff from the original files but that didn't seem to work either (but I don't know that it would paste correctly since stuff on my system is set to use UTF8).

As for the other Korean model, one problem is it has no `vocab.json` which `convert.py`'s BPE mode requires but that's pretty easy to extract from `tokenizer.json`. It actually tokenizes properly (I think?) but only produces garbage output whether you speak Korean or English to it:

<details>
<summary>Trying Korean</summary>

```plaintext
main: prompt: '옛날 옛적에 작은 여우가 있었어요'
main: number of tokens in prompt = 14
 45555 -> '옛'
 44939 -> '날'
    35 -> ' '
 45555 -> '옛'
 44824 -> '적'
 31054 -> '에'
    35 -> ' '
 43089 -> '작은'
    35 -> ' '
 31457 -> '여'
 37719 -> '우가'
    35 -> ' '
 44815 -> '있'
 38248 -> '었어요'
main: static prompt based on n_keep: '옛날 옛적에 작은 여우가 있었어요'

sampling: repeat_last_n = 0, repeat_penalty = 1.040000, presence_penalty = 0.000000, frequency_penalty = 0.060000, top_k = 70, tfs_z = 0.950000, top_p = 2.000000, typical_p = 0.250000, temp = 1.200000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
generate: n_ctx = 200, n_batch = 4, n_predict = 500, n_keep = 14


옛날 옛적에 작은 여우가 있었어요는,는의,를가의에ing에가:가>가의에에를가>의가>를의를가는에,의가=가,의,가,가=가,o>t의는,>>r는t>r>o=r,o.w.t.o.o.r.
```

</details>


<details>
<summary>Trying English</summary>

```plaintext
main: prompt: ' Once upon a time, in a dark forest, there lived a little fox'
main: number of tokens in prompt = 32
    35 -> ' '
 26222 -> 'Once'
    35 -> ' '
   786 -> 'up'
   265 -> 'on'
    35 -> ' '
 29874 -> 'a'
    35 -> ' '
  2230 -> 'time'
 29892 -> ','
    35 -> ' '
   262 -> 'in'
    35 -> ' '
 29874 -> 'a'
    35 -> ' '
 26031 -> 'dark'
    35 -> ' '
  1454 -> 'for'
   342 -> 'est'
 29892 -> ','
    35 -> ' '
 12711 -> 'there'
    35 -> ' '
 29880 -> 'l'
  2347 -> 'ived'
    35 -> ' '
 29874 -> 'a'
    35 -> ' '
 29880 -> 'l'
  1992 -> 'ittle'
    35 -> ' '
  8944 -> 'fox'
main: static prompt based on n_keep: ' Once upon a time, in a dark forest, there lived a little fox'

sampling: repeat_last_n = 0, repeat_penalty = 1.040000, presence_penalty = 0.000000, frequency_penalty = 0.060000, top_k = 70, tfs_z = 0.950000, top_p = 2.000000, typical_p = 0.250000, temp = 1.200000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
generate: n_ctx = 200, n_batch = 4, n_predict = 500, n_keep = 32


 Once upon a time, in a dark forest, there lived a little fox은2의은의,는이,은에(,는(32의2(이은3에(022에은(의2은,에32,의은2(은이은2(이은의,32(에3의0(에3은(|,은,에(_에_,322,,은,23(023(은은,,은0에3은
```

</details>

This could be merged but hopefully we can talk about the existing problems and maybe figure out a way to fix more stuff first.