### PR TITLE
convert : fix another python 3.8 issue

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -530,7 +530,7 @@ class LazyTensor:
             raise ValueError(f'Cannot validate conversion from {self.data_type} to {data_type}.')
 
 
-LazyModel = dict[str, LazyTensor]
+LazyModel: TypeAlias = 'dict[str, LazyTensor]'
 
 
 @dataclass


### PR DESCRIPTION
I missed a compatibility issue while implementing the PEP 585 syntax changes in #2916.