### PR TITLE
metal: somewhat faster f16 x f32 matrix multiply kernel

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -840,7 +840,7 @@ void ggml_metal_graph_compute(
                                 switch (src0t) {
                                     case GGML_TYPE_F16:
                                         {
-                                            nth0 = 64;
+                                            nth0 = 32;
                                             nth1 = 1;
                                             [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32];
                                         } break;


### PR DESCRIPTION
Simply via better accumulation of thread results. The larger the context (prompt), the more improvement we see in pp timing. 

7B `Q4_0` on 30-core M2 Max.

| model                          | backend    | test       |    t/s (Master)  |    ts (PR)       |  Speedup |
| ------------------------------ | ---------- | ---------- | ---------------: | ---------------: | -------: |
| LLaMA 7B mostly Q4_0           | Metal      | pp 32      |    370.26 ± 1.59 |    374.78 ± 0.95 |    1.2%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 64      |    425.70 ± 0.62 |    433.17 ± 0.46 |    1.8%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 128     |    406.00 ± 0.62 |    419.64 ± 0.76 |    3.4%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 256     |    350.71 ± 0.15 |    373.11 ± 0.23 |    6.4%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 512     |    264.21 ± 0.42 |    290.76 ± 0.29 |   10.0%  |

Update:

If we also change the number of thread groups from 64 to 32, it gets even better:

| model                          | backend    | test       |    t/s (Master)  |    ts (PR)       |  Speedup |
| ------------------------------ | ---------- | ---------- | ---------------: | ---------------: | -------: |
| LLaMA 7B mostly Q4_0           | Metal      | pp 32      |    370.26 ± 1.59 |    376.74 ± 2.03 |    +1.7%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 64      |    425.70 ± 0.62 |    442.49 ± 0.98 |    +3.9%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 128     |    406.00 ± 0.62 |    437.34 ± 0.66 |   +7.7%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 256     |    350.71 ± 0.15 |    400.49 ± 0.50 |    +14.2%  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 512     |    264.21 ± 0.42 |   323.87 ± 0.10  |   +22.6%  |

It does give a small benefit for TG too. E.g., for TG-128 I get  `61.28 +/- 0.16` vs `59.98 ± 0.10` on master.