### PR TITLE
ggml_metal_init: Show all Metal device instances in the system

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -117,9 +117,9 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
     metal_printf("%s: allocating\n", __func__);
 
     // Show all the Metal device instances in the system
-    NSArray *devices = MTLCopyAllDevices();
+    NSArray * devices = MTLCopyAllDevices();
     id <MTLDevice> device;
-    NSString *s;
+    NSString * s;
     for (device in devices) {
         s = [device name];
         metal_printf("%s: found device: %s\n", __func__, [s UTF8String]);
@@ -134,7 +134,6 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
     struct ggml_metal_context * ctx = malloc(sizeof(struct ggml_metal_context));
     ctx->device = device;
     ctx->n_cb   = MIN(n_cb, GGML_METAL_MAX_BUFFERS);
-    ctx->device = MTLCreateSystemDefaultDevice();
     ctx->queue  = [ctx->device newCommandQueue];
     ctx->n_buffers = 0;
     ctx->concur_list_len = 0;

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -116,8 +116,23 @@ static NSString * const msl_library_source = @"see metal.metal";
 struct ggml_metal_context * ggml_metal_init(int n_cb) {
     metal_printf("%s: allocating\n", __func__);
 
-    struct ggml_metal_context * ctx = malloc(sizeof(struct ggml_metal_context));
+    // Show all the Metal device instances in the system
+    NSArray *devices = MTLCopyAllDevices();
+    id <MTLDevice> device;
+    NSString *s;
+    for (device in devices) {
+        s = [device name];
+        metal_printf("%s: found device: %s\n", __func__, [s UTF8String]);
+    }
 
+    // Pick and show default Metal device
+    device = MTLCreateSystemDefaultDevice();
+    s = [device name];
+    metal_printf("%s: picking default device: %s\n", __func__, [s UTF8String]);
+
+    // Configure context
+    struct ggml_metal_context * ctx = malloc(sizeof(struct ggml_metal_context));
+    ctx->device = device;
     ctx->n_cb   = MIN(n_cb, GGML_METAL_MAX_BUFFERS);
     ctx->device = MTLCreateSystemDefaultDevice();
     ctx->queue  = [ctx->device newCommandQueue];


### PR DESCRIPTION
As e.g. mentioned in #2407 some Macs have several Metal-capable devices. List them in `ggml_metal_init()` and show which one was picked.

Example output from my MacBook Pro, 16-inch (2019):
```
ggml_metal_init: found device: AMD Radeon Pro 5500M
ggml_metal_init: found device: Intel(R) UHD Graphics 630
ggml_metal_init: picking default device: AMD Radeon Pro 5500M
```

This PR introduces no functional change.