### PR TITLE
Changed assignment clobbering LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ OPT = -O3
 endif
 CFLAGS   = -I.            $(OPT) -std=c11   -fPIC
 CXXFLAGS = -I. -I./common $(OPT) -std=c++11 -fPIC
-LDFLAGS  =
+
+# Changed to += to not wipe out LDFLAGS from the build pipeline.
+LDFLAGS  +=
 
 ifdef LLAMA_DEBUG
 	CFLAGS   += -O0 -g


### PR DESCRIPTION
Assigning LDFLAGS directly wipes out any flags specified by the build pipeline. Is this OK?

This way it's much easier to do things like static builds. May consider the same for CFLAGS, etc others also.

`LDFLAGS="-static" make -j`