### PR TITLE
logging: Fix creating empty file even when disabled

### DIFF
--- a/common/log.h
+++ b/common/log.h
@@ -346,6 +346,7 @@ inline FILE *log_handler1_impl(bool change = false, LogTriState disable = LogTri
         // Log is disabled
         return nullptr;
     }
+
     if (_initialized)
     {
         // with fallback in case something went wrong

--- a/common/log.h
+++ b/common/log.h
@@ -341,14 +341,13 @@ inline FILE *log_handler1_impl(bool change = false, LogTriState disable = LogTri
         }
     }
 
+    if (_disabled)
+    {
+        // Log is disabled
+        return nullptr;
+    }
     if (_initialized)
     {
-        if (_disabled)
-        {
-            // Log is disabled
-            return nullptr;
-        }
-
         // with fallback in case something went wrong
         return logfile ? logfile : stderr;
     }


### PR DESCRIPTION
Logging doesn't seem to fully respect being set to disabled: it'll still create the logfile, just not write anything to it. So, for example, if you pass `--log-disable` to `main` you'll still end up with a bunch of empty logfiles.

This seems like the obvious fix and as far as I can see doesn't break stuff with logging enabled or disabled but my understanding of the log system here is very rudimentary.

Going to mark this as a bug since even if my approach to fixing it is wrong, surely creating a bunch of log files when logging is disabled can't be intended behavior.