### PR TITLE
Add missing c file to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             name: "llama",
             path: ".",
             exclude: ["ggml-metal.metal"],
-            sources: ["ggml.c", "llama.cpp"],
+            sources: ["ggml.c", "llama.cpp", "ggml-alloc.c"],
             publicHeadersPath: "spm-headers",
             cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32"]), .define("GGML_USE_ACCELERATE")],
             linkerSettings: [


### PR DESCRIPTION
The latest master can't import llama in Xcode properly. It fails with linker errors and can't resolve functions:

```
Undefined symbol: _ggml_allocr_alloc

Undefined symbol: _ggml_allocr_alloc_graph

Undefined symbol: _ggml_allocr_free

Undefined symbol: _ggml_allocr_is_measure

Undefined symbol: _ggml_allocr_new

Undefined symbol: _ggml_allocr_new_measure

Undefined symbol: _ggml_allocr_reset
```

This can be solved by adding the `ggml-alloc.c` to the Package.swift