### PR TITLE
add support for k quantization for swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,18 @@ let package = Package(
             name: "llama",
             path: ".",
             exclude: ["ggml-metal.metal"],
-            sources: ["ggml.c", "llama.cpp"],
+            sources: [
+                "ggml.c",
+                "llama.cpp",
+                "ggml-alloc.c",
+                "k_quants.c"
+            ],
             publicHeadersPath: "spm-headers",
-            cSettings: [.unsafeFlags(["-Wno-shorten-64-to-32"]), .define("GGML_USE_ACCELERATE")],
+            cSettings: [
+                .unsafeFlags(["-Wno-shorten-64-to-32"]),
+                .define("GGML_USE_K_QUANTS"),
+                .define("GGML_USE_ACCELERATE")
+            ],
             linkerSettings: [
                 .linkedFramework("Accelerate")
             ]


### PR DESCRIPTION
Ran into some problems trying to run https://huggingface.co/TheBloke/Yarn-Llama-2-7B-64K-GGUF/blob/main/yarn-llama-2-7b-64k.Q5_K_M.gguf in Swift.

Needed to add GGML_USE_K_QUANTS flag to Package.swift. Otherwise it thinks the QK_K value is 0. Maybe a better way to solve this, I'm not a pro at Swift, but this works.