### PR TITLE
Add common utilities to Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,18 @@ let package = Package(
                 "ggml.c",
                 "llama.cpp",
                 "ggml-alloc.c",
-                "k_quants.c"
+                "k_quants.c",
+                "common/common.cpp",
+                "common/console.cpp",
+                "common/grammar-parser.cpp",
             ],
             publicHeadersPath: "spm-headers",
             cSettings: [
+                .headerSearchPath("common"),
                 .unsafeFlags(["-Wno-shorten-64-to-32"]),
                 .define("GGML_USE_K_QUANTS"),
-                .define("GGML_USE_ACCELERATE")
+                .define("GGML_USE_ACCELERATE"),
+                .define("LLAMA_USE_SWIFT")
             ],
             linkerSettings: [
                 .linkedFramework("Accelerate")

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
+#ifndef LLAMA_USE_SWIFT
 #include "build-info.h"
+#endif
 #include "llama.h"
 
 #include <algorithm>
@@ -971,8 +973,10 @@ std::string get_sortable_timestamp() {
 
 void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const llama_context * lctx,
                                const std::string & timestamp, const std::vector<int> & prompt_tokens, const char * model_desc) {
+#ifndef LLAMA_USE_SWIFT
     fprintf(stream, "build_commit: %s\n", BUILD_COMMIT);
     fprintf(stream, "build_number: %d\n", BUILD_NUMBER);
+#endif
     fprintf(stream, "cpu_has_arm_fma: %s\n", ggml_cpu_has_arm_fma() ? "true" : "false");
     fprintf(stream, "cpu_has_avx: %s\n", ggml_cpu_has_avx() ? "true" : "false");
     fprintf(stream, "cpu_has_avx2: %s\n", ggml_cpu_has_avx2() ? "true" : "false");

--- a/spm-headers/common.h
+++ b/spm-headers/common.h
@@ -1,0 +1,1 @@
+../common/common.h

--- a/spm-headers/log.h
+++ b/spm-headers/log.h
@@ -1,0 +1,1 @@
+../common/log.h


### PR DESCRIPTION
Hopefully this is a welcome contribution. I'm working on using LLaMA in Swift, but it would be convenient to access some of the common utilities like the gpt_params and helper functions.

I got this to work on my machine:

```
llama_new_context_with_model: kv self size  =  256.00 MB
llama_new_context_with_model: compute buffer total size =   71.97 MB
Tokens: [1, 15043, 29892, 3186, 29991]
[ '': 1, ' Hello': 15043, ',': 29892, ' world': 3186, '!': 29991 ]
llama_new_context_with_model: kv self size  =  256.00 MB
llama_new_context_with_model: compute buffer total size =   71.97 MB
! I’m so excited to share my first post with you all! I’ve been wanting to start a blog for a while now,
```

loaded up a quantized gguf model https://huggingface.co/TheBloke/Yarn-Llama-2-7B-64K-GGUF.
the extra flag is because I didn't want to add a dependency on the build-info.h, and i'm not an expert on the spm-headers and stuff, but adding the common.h & log.h to spm-headers wouldn't compile otherwise. the `.headerSearchPath("common")` appears to be needed to get rid of a warning: `umbrella header for module 'llama' does not include header 'common.h'`

and alternative solution could be to move some of the common functions & gpt_params into the llama.h but not sure how you feel about that