### PR TITLE
Guard against all weights in a super-block being zero

### DIFF
--- a/k_quants.c
+++ b/k_quants.c
@@ -83,7 +83,7 @@ static float make_qx_quants(int n, int nmax, const float * restrict x, int8_t * 
         float ax = fabsf(x[i]);
         if (ax > amax) { amax = ax; max = x[i]; }
     }
-    if (!amax) { // all zero
+    if (amax < 1e-30f) { // all zero
         for (int i = 0; i < n; ++i) {
             L[i] = 0;
         }

--- a/k_quants.c
+++ b/k_quants.c
@@ -1086,6 +1086,12 @@ void quantize_row_q6_K_reference(const float * restrict x, block_q6_K * restrict
 
         }
 
+        if (!max_abs_scale) {
+            memset(&y[i], 0, sizeof(block_q6_K));
+            y[i].d = ggml_fp32_to_fp16(0.f);
+            continue;
+        }
+
         float iscale = -128.f/max_scale;
         y[i].d = ggml_fp32_to_fp16(1/iscale);
         for (int ib = 0; ib < QK_K/16; ++ib) {


### PR DESCRIPTION
@Cebtenzzre 

Does this resolve the problem in #2982.

In order to get the assertion observed in #2982 all weights in a block of 256 must be zero. I see that I have a guard against this for all k_quants except `Q6_K` 