### PR TITLE
Added magic for file types

### DIFF
--- a/grammars/magic
+++ b/grammars/magic
@@ -1,0 +1,7 @@
+# Magic local data for file(1) command.
+# Append this to your /etc/magic file.
+# Insert here your local magic data. Format is described in magic(5).
+0	string	tjgg	GGML/GGJT LLM model
+>0x4	lelong	<255	version=%d
+0	string	GGUF	GGUF LLM model
+>0x4	lelong	<255	version=%d


### PR DESCRIPTION
Add this to your /etc/magic file to enable the `file` command.
```
jboero@xps ~/Downloads> file *llama*
codellama-7b.Q8_0.gguf:     GGUF LLM model version=1
llama-2-7b.ggmlv3.q8_0.bin: GGML/GGJT LLM model version=3
llama-cpp.srpm.spec:        ASCII text
```