### PR TITLE
byte_decoder -> byte_encoder

### DIFF
--- a/convert-falcon-hf-to-gguf.py
+++ b/convert-falcon-hf-to-gguf.py
@@ -154,7 +154,7 @@ for i in range(vocab_size):
             text = bytearray()
             for c in reverse_vocab[i]:
                 if ord(c) < 256:  # single byte character
-                    text.append(byte_decoder[ord(c)])
+                    text.append(byte_encoder[ord(c)])
                 else:  # multibyte special token character
                     text.extend(c.encode('utf-8'))
     else:

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -149,7 +149,7 @@ for i in range(vocab_size):
             text = bytearray()
             for c in reverse_vocab[i]:
                 if ord(c) < 256:  # single byte character
-                    text.append(byte_decoder[ord(c)])
+                    text.append(byte_encoder[ord(c)])
                 else:  # multibyte special token character
                     text.extend(c.encode('utf-8'))
     else:


### PR DESCRIPTION
byte_encoder is mapping 0-255 -> unicode chr
byte_decoder is mapping unicode chr -> 0-255
ord returns the int of unicode chr, so it should use byte_encoder

@ggerganov take a look~