### PR TITLE
update path to match default folder name for 7B model in readme

### DIFF
--- a/examples/chat.sh
+++ b/examples/chat.sh
@@ -11,6 +11,6 @@ cd ..
 #
 #   "--keep 48" is based on the contents of prompts/chat-with-bob.txt
 #
-./main -m ./models/llama-7b/ggml-model-q4_0.gguf -c 512 -b 1024 -n 256 --keep 48 \
+./main -m ./models/7B/ggml-model-q4_0.gguf -c 512 -b 1024 -n 256 --keep 48 \
     --repeat_penalty 1.0 --color -i \
     -r "User:" -f prompts/chat-with-bob.txt


### PR DESCRIPTION
Following the steps in the readme, noticed the readme puts the 7B weights in models/7B and examples/chat.sh looks for them in models/llama-7b.   This PR updates chat.sh to look for the weights in models/7B