### PR TITLE
adding train-text-from-scratch to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,10 @@
           type = "app";
           program = "${self.packages.${system}.default}/bin/quantize";
         };
+        apps.train-text-from-scratch = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/train-text-from-scratch";
+        };
         apps.default = self.apps.${system}.llama;
         devShells.default = pkgs.mkShell {
           buildInputs = [ llama-python ];


### PR DESCRIPTION
Just added the example train-text-from-scratch to the flake.nix file so it can be tested as well.