### PR TITLE
convert : fix F32 ftype not being saved

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -266,7 +266,7 @@ class Params:
         f_rope_freq_base = config["rope_theta"] if "rope_theta" in config else None
 
         # hack to determine LLaMA v1 vs v2 vs CodeLlama
-        if f_rope_freq_base and f_rope_freq_base == 1000000:
+        if f_rope_freq_base == 1000000:
             # CodeLlama
             n_ctx = 16384
         elif config["norm_eps"] == 1e-05:
@@ -841,9 +841,9 @@ class OutputFile:
         name = "LLaMA"
 
         # TODO: better logic to determine model name
-        if (params.n_ctx == 4096):
+        if params.n_ctx == 4096:
             name = "LLaMA v2"
-        elif params.path_model:
+        elif params.path_model is not None:
             name = str(params.path_model.parent).split('/')[-1]
 
         self.gguf.add_name                (name)
@@ -856,10 +856,10 @@ class OutputFile:
         self.gguf.add_head_count_kv       (params.n_head_kv)
         self.gguf.add_layer_norm_rms_eps  (params.f_norm_eps)
 
-        if params.f_rope_freq_base:
+        if params.f_rope_freq_base is not None:
             self.gguf.add_rope_freq_base(params.f_rope_freq_base)
 
-        if params.f_rope_scale:
+        if params.f_rope_scale is not None:
             self.gguf.add_rope_scale_linear(params.f_rope_scale)
 
         if params.ftype is not None:

--- a/convert.py
+++ b/convert.py
@@ -862,7 +862,7 @@ class OutputFile:
         if params.f_rope_scale:
             self.gguf.add_rope_scale_linear(params.f_rope_scale)
 
-        if params.ftype:
+        if params.ftype is not None:
             self.gguf.add_file_type(params.ftype)
 
     def add_meta_vocab(self, vocab: Vocab) -> None:


### PR DESCRIPTION
params.ftype is falsy if it is GGMLFileType.AllF32. Use `is not None` instead of implicit boolean conversion.

before:
```
$ ./convert.py openlm-research_open_llama_3b --outfile openllama-3b.f32.gguf --outtype f32
$ ./main -m openllama-3b.f32.gguf
<snip>
llm_load_print_meta: model ftype    = all F32 (guessed)
```

after:
```
$ ./convert.py openlm-research_open_llama_3b --outfile openllama-3b.f32.gguf --outtype f32
$ ./main -m openllama-3b.f32.gguf
<snip>
llm_load_print_meta: model ftype    = all F32
```