### PR TITLE
metal : fix kernel_norm

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -773,7 +773,7 @@ std::tuple<struct llama_model *, struct llama_context *> llama_init_from_gpt_par
         LOG("warming up the model with an empty run\n");
 
         const std::vector<llama_token> tmp = { llama_token_bos(lctx), llama_token_eos(lctx), };
-        llama_eval(lctx, tmp.data(), tmp.size(), 0, params.n_threads);
+        llama_eval(lctx, tmp.data(), std::min(tmp.size(), (size_t) params.n_batch), 0, params.n_threads);
         llama_reset_timings(lctx);
     }
 

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -995,12 +995,8 @@ void ggml_metal_graph_compute(
                                 else if (src0t == GGML_TYPE_Q6_K) {
                                     [encoder dispatchThreadgroups:MTLSizeMake((ne01 + 1)/2, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 } else {
-                                    [encoder setThreadgroupMemoryLength:nth0*sizeof(float) atIndex:0];
-                                    [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-
-                                    // TODO: this breaks for Q4_0 - understand why and fix it
-                                    //int64_t ny = (ne11 + 3)/4;
-                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
+                                    int64_t ny = (ne11 + 3)/4;
+                                    [encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 }
                             }
                         } break;

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -995,8 +995,12 @@ void ggml_metal_graph_compute(
                                 else if (src0t == GGML_TYPE_Q6_K) {
                                     [encoder dispatchThreadgroups:MTLSizeMake((ne01 + 1)/2, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 } else {
-                                    int64_t ny = (ne11 + 3)/4;
-                                    [encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
+                                    [encoder setThreadgroupMemoryLength:nth0*sizeof(float) atIndex:0];
+                                    [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
+
+                                    // TODO: this breaks for Q4_0 - understand why and fix it
+                                    //int64_t ny = (ne11 + 3)/4;
+                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 }
                             }
                         } break;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -111,7 +111,7 @@ kernel void kernel_soft_max(
         uint3 tgpig[[threadgroup_position_in_grid]],
         uint3 tpitg[[thread_position_in_threadgroup]],
         uint3   ntg[[threads_per_threadgroup]]) {
-        const int64_t i03 = tgpig[2];
+    const int64_t i03 = tgpig[2];
     const int64_t i02 = tgpig[1];
     const int64_t i01 = tgpig[0];
 

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -235,6 +235,12 @@ kernel void kernel_norm(
 
     // VARIANCE
     // parallel sum
+    //
+    // WARNING: combining this loop with the one above will give you wrong results for nth == 256
+    //          I have no idea why, so for now I am keeping them separate. But this behavior is very concerning.
+    //          Tested with:
+    //          ./perplexity -m ./falcon-7b/ggml-model-q4_0.gguf -f wiki.test.raw -ngl 1 -t 4
+    //
     sum[tpitg] = 0.0f;
     for (int i00 = tpitg; i00 < ne00; i00 += ntg) {
         sum[tpitg] += y[i00] * y[i00];


### PR DESCRIPTION
## Edit

After looking at the solution in https://github.com/ggerganov/llama.cpp/pull/3060/ I now understand where is my mistake. There is a missing barrier after computing `mean`. 

Ignore everything below

---

The `norm` kernel used by Falcon was broken in https://github.com/ggerganov/llama.cpp/pull/2959

After fixing it, there still remains a very strange behaviour with it, that I have explained in the comments in the kernel. Basically, when the 2 loops for computing the mean and the variance are combined into one, the inference breaks for threadgroup size of 256 for that kernel. If I tune down the threadgroup size to 128 or 32 threads, it works again.

I spent about an hour looking into this and I have no idea what is going on.
The only possible hint is maybe we are somehow exceeding some threadgroup memory limit and Metal fails silently?

![image](https://github.com/ggerganov/llama.cpp/assets/1991296/ade012c3-0244-4c2e-a9f4-c72c12faec61)

![image](https://github.com/ggerganov/llama.cpp/assets/1991296/f5831feb-1e81-4150-aeb5-8958ba5aa5cd)

Seems unlikely, but I have no other guess. If someone else can also look into this would be great and please let me know if you can confirm these observations:

First run the following command and note down the first few ppl numbers:

```bash
./bin/perplexity -m ../models/falcon-7b/ggml-model-q4_0.gguf -f ../build/wikitext-2-raw/wiki.test.raw -ngl 1 -t 4

[1]5.1857,[2]6.3693,[3]6.6081,[4]7.5008,[5]7.5353,[6]7.4923,[7]7.6464,[8]7.8036,[9]8.1274,[10]8.2545
```

Now apply this patch and repeat:

```diff
--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -229,20 +229,9 @@ kernel void kernel_norm(
 
     // recenter
     device float * y = dst + tgpig*ne00;
-    for (int i00 = tpitg; i00 < ne00; i00 += ntg) {
-        y[i00] = x[i00] - mean;
-    }
-
-    // VARIANCE
-    // parallel sum
-    //
-    // WARNING: combining this loop with the one above will give you wrong results for nth == 256
-    //          I have no idea why, so for now I am keeping them separate. But this behavior is very concerning.
-    //          Tested with:
-    //          ./perplexity -m ./falcon-7b/ggml-model-q4_0.gguf -f wiki.test.raw -ngl 1 -t 4
-    //
     sum[tpitg] = 0.0f;
     for (int i00 = tpitg; i00 < ne00; i00 += ntg) {
+        y[i00] = x[i00] - mean;
         sum[tpitg] += y[i00] * y[i00];
     }
 
```

```bash
./bin/perplexity -m ../models/falcon-7b/ggml-model-q4_0.gguf -f ../build/wikitext-2-raw/wiki.test.raw -ngl 1 -t 4

[1]5.2692,[2]6.4269,[3]6.6902,[4]7.5840,[5]7.6415,[6]7.6029,[7]7.7632,[8]7.9142,[9]8.2509,[10]8.3694
[1]5.2684,[2]6.4327,[3]6.6964,[4]7.5955,[5]7.6512,[6]7.6121,[7]7.7719,[8]7.9235,[9]8.2577,[10]8.3772
```

The numbers are not the same and are different each run.

Try to change the thraedgroup size to 32 and observe that the numbers are back to normal (within numerical variation of course):

```diff
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1050,7 +1050,7 @@ void ggml_metal_graph_compute(
                             float eps;
                             memcpy(&eps, dst->op_params, sizeof(float));
 
-                            const int nth = 256;
+                            const int nth = 32;
 
                             [encoder setComputePipelineState:ctx->pipeline_norm];
                             [encoder setBuffer:id_src0 offse
```

```bash
./bin/perplexity -m ../models/falcon-7b/ggml-model-q4_0.gguf -f ../build/wikitext-2-raw/wiki.test.raw -ngl 1 -t 4

[1]5.1853,[2]6.3691,[3]6.6080,[4]7.5007,[5]7.5353,[6]7.4923,[7]7.6464,[8]7.8036,[9]8.1274,[10]8.2545
```