### PR TITLE
speculative: add --n-gpu-layers-draft option

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -375,6 +375,17 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             fprintf(stderr, "warning: not compiled with GPU offload support, --n-gpu-layers option will be ignored\n");
             fprintf(stderr, "warning: see main README.md for information on enabling GPU BLAS support\n");
 #endif
+        } else if (arg == "--gpu-layers-draft" || arg == "-ngld" || arg == "--n-gpu-layers-draft") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+#ifdef LLAMA_SUPPORTS_GPU_OFFLOAD
+            params.n_gpu_layers_draft = std::stoi(argv[i]);
+#else
+            fprintf(stderr, "warning: not compiled with GPU offload support, --n-gpu-layers-draft option will be ignored\n");
+            fprintf(stderr, "warning: see main README.md for information on enabling GPU BLAS support\n");
+#endif
         } else if (arg == "--main-gpu" || arg == "-mg") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -664,6 +675,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
 #ifdef LLAMA_SUPPORTS_GPU_OFFLOAD
     printf("  -ngl N, --n-gpu-layers N\n");
     printf("                        number of layers to store in VRAM\n");
+    printf("  -ngld N, --n-gpu-layers-draft N\n");
+    printf("                        number of layers to store in VRAM for the draft model\n");
     printf("  -ts SPLIT --tensor-split SPLIT\n");
     printf("                        how to split tensors across multiple GPUs, comma-separated list of proportions, e.g. 3,1\n");
     printf("  -mg i, --main-gpu i   the GPU to use for scratch and small tensors\n");

--- a/common/common.h
+++ b/common/common.h
@@ -35,6 +35,7 @@ struct gpt_params {
     int32_t n_draft                         = 16;   // number of tokens to draft during speculative decoding
     int32_t n_chunks                        = -1;   // max number of chunks to process (-1 = unlimited)
     int32_t n_gpu_layers                    = -1;   // number of layers to store in VRAM (-1 - use default)
+    int32_t n_gpu_layers_draft              = -1;   // number of layers to store in VRAM for the draft model (-1 - use default)
     int32_t main_gpu                        = 0;    // the GPU that is used for scratch and small tensors
     float   tensor_split[LLAMA_MAX_DEVICES] = {0};  // how split tensors should be distributed across GPUs
     int32_t n_probs                         = 0;    // if greater than 0, output the probabilities of top n_probs tokens.

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -46,6 +46,7 @@ int main(int argc, char ** argv) {
 
     // load the draft model
     params.model = params.model_draft;
+    params.n_gpu_layers = params.n_gpu_layers_draft;
     std::tie(model_dft, ctx_dft) = llama_init_from_gpt_params(params);
 
     // tokenize the prompt


### PR DESCRIPTION
This PR adds an option to the speculative example to specify number of layers to offload to GPU for the draft model.
May help people to play with speculative with larger models and without a lot of VRAM.


Some test runs with ROCm on RX 6850M XT (12GB):

```shell
## CPU, only codellama-34b.Q8_0.gguf
759,34s user 1,08s system 395% cpu 3:12,19 total
## CPU+GPU only codellama-34b.Q8_0.gguf (with 16/51 layers offloaded)
549,70s user 1,07s system 391% cpu 2:20,71 total
## CPU, speculative codellama-34b.Q8_0.gguf with codellama-7b.Q4_K_M.gguf as draft
594,54s user 1,39s system 392% cpu 2:31,80 total
## CPU+GPU, speculative codellama-34b.Q8_0.gguf (16/51 offloaded) with codellama-7b.Q4_K_M.gguf (0/35 offloaded) as draft
465,69s user 1,40s system 387% cpu 2:00,60 total
## CPU+GPU, speculative codellama-34b.Q8_0.gguf (0/51 offloaded) with codellama-7b.Q4_K_M.gguf (35/35 offloaded) as draft
522,74s user 1,39s system 390% cpu 2:14,21 total
## CPU+GPU, speculative codellama-34b.Q8_0.gguf (7/51 offloaded) with codellama-7b.Q4_K_M.gguf (35/35 offloaded) as draft
462,27s user 1,38s system 387% cpu 1:59,54 total



## CPU, only codellama-34b.Q8_0.gguf

./build/bin/main \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 \
-ngl 0

...

llama_print_timings:        load time =  1386,57 ms
llama_print_timings:      sample time =    94,60 ms /   256 runs   (    0,37 ms per token,  2706,13 tokens per second)
llama_print_timings: prompt eval time =  6737,07 ms /    25 tokens (  269,48 ms per token,     3,71 tokens per second)
llama_print_timings:        eval time = 182709,83 ms /   255 runs   (  716,51 ms per token,     1,40 tokens per second)
llama_print_timings:       total time = 189669,78 ms
Log end

759,34s user 1,08s system 395% cpu 3:12,19 total



## CPU+GPU only codellama-34b.Q8_0.gguf (with 16/51 layers offloaded)

./build/bin/main \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 \
-ngl 16

...

llama_print_timings:        load time =  2595,30 ms
llama_print_timings:      sample time =    95,45 ms /   256 runs   (    0,37 ms per token,  2681,92 tokens per second)
llama_print_timings: prompt eval time =  4795,47 ms /    25 tokens (  191,82 ms per token,     5,21 tokens per second)
llama_print_timings:        eval time = 131956,09 ms /   255 runs   (  517,47 ms per token,     1,93 tokens per second)
llama_print_timings:       total time = 136967,01 ms
Log end

549,70s user 1,07s system 391% cpu 2:20,71 total



## CPU, speculative codellama-34b.Q8_0.gguf with codellama-7b.Q4_K_M.gguf as draft

./build/bin/speculative \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-md ../models/codellama/codellama-7b.Q4_K_M.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 --draft 16 \
-ngl 0 -ngld 0

...

encoded   25 tokens in    8.518 seconds, speed:    2.935 t/s
decoded  258 tokens in  140.315 seconds, speed:    1.839 t/s

n_draft   = 16
n_predict = 258
n_drafted = 311
n_accept  = 213
accept    = 68.489%

draft:

llama_print_timings:        load time =   388.96 ms
llama_print_timings:      sample time =   620.51 ms /     1 runs   (  620.51 ms per token,     1.61 tokens per second)
llama_print_timings: prompt eval time =  1266.42 ms /    25 tokens (   50.66 ms per token,    19.74 tokens per second)
llama_print_timings:        eval time = 31189.23 ms /   345 runs   (   90.40 ms per token,    11.06 tokens per second)
llama_print_timings:       total time = 148833.25 ms

target:

llama_print_timings:        load time =  1381.40 ms
llama_print_timings:      sample time =    97.55 ms /   258 runs   (    0.38 ms per token,  2644.72 tokens per second)
llama_print_timings: prompt eval time = 109174.09 ms /   371 tokens (  294.27 ms per token,     3.40 tokens per second)
llama_print_timings:        eval time =  6444.34 ms /     9 runs   (  716.04 ms per token,     1.40 tokens per second)
llama_print_timings:       total time = 149227.66 ms

594,54s user 1,39s system 392% cpu 2:31,80 total



## CPU+GPU, speculative codellama-34b.Q8_0.gguf (16/51 offloaded) with codellama-7b.Q4_K_M.gguf (0/35 offloaded) as draft

./build/bin/speculative \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-md ../models/codellama/codellama-7b.Q4_K_M.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 --draft 16 \
-ngl 16 -ngld 0

...

encoded   25 tokens in    6.325 seconds, speed:    3.952 t/s
decoded  258 tokens in  110.069 seconds, speed:    2.344 t/s

n_draft   = 16
n_predict = 258
n_drafted = 311
n_accept  = 213
accept    = 68.489%

draft:

llama_print_timings:        load time =   390.08 ms
llama_print_timings:      sample time =   625.54 ms /     1 runs   (  625.54 ms per token,     1.60 tokens per second)
llama_print_timings: prompt eval time =  1268.08 ms /    25 tokens (   50.72 ms per token,    19.71 tokens per second)
llama_print_timings:        eval time = 31142.22 ms /   345 runs   (   90.27 ms per token,    11.08 tokens per second)
llama_print_timings:       total time = 116394.27 ms

target:

llama_print_timings:        load time =  2602.36 ms
llama_print_timings:      sample time =    98.55 ms /   258 runs   (    0.38 ms per token,  2618.04 tokens per second)
llama_print_timings: prompt eval time = 78556.04 ms /   371 tokens (  211.74 ms per token,     4.72 tokens per second)
llama_print_timings:        eval time =  4653.90 ms /     9 runs   (  517.10 ms per token,     1.93 tokens per second)
llama_print_timings:       total time = 116789.71 ms

465,69s user 1,40s system 387% cpu 2:00,60 total



## CPU+GPU, speculative codellama-34b.Q8_0.gguf (0/51 offloaded) with codellama-7b.Q4_K_M.gguf (35/35 offloaded) as draft

./build/bin/speculative \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-md ../models/codellama/codellama-7b.Q4_K_M.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 --draft 16 \
-ngl 0 -ngld 35

...

encoded   25 tokens in    7.430 seconds, speed:    3.365 t/s
decoded  258 tokens in  123.224 seconds, speed:    2.094 t/s

n_draft   = 16
n_predict = 258
n_drafted = 334
n_accept  = 213
accept    = 63.772%

draft:

llama_print_timings:        load time =   988.47 ms
llama_print_timings:      sample time =   660.38 ms /     1 runs   (  660.38 ms per token,     1.51 tokens per second)
llama_print_timings: prompt eval time =   269.49 ms /    25 tokens (   10.78 ms per token,    92.77 tokens per second)
llama_print_timings:        eval time =  7218.84 ms /   367 runs   (   19.67 ms per token,    50.84 tokens per second)
llama_print_timings:       total time = 130654.42 ms

target:

llama_print_timings:        load time =  1377.21 ms
llama_print_timings:      sample time =    97.19 ms /   258 runs   (    0.38 ms per token,  2654.48 tokens per second)
llama_print_timings: prompt eval time = 115224.91 ms /   393 tokens (  293.19 ms per token,     3.41 tokens per second)
llama_print_timings:        eval time =  7148.35 ms /    10 runs   (  714.84 ms per token,     1.40 tokens per second)
llama_print_timings:       total time = 131649.47 ms

522,74s user 1,39s system 390% cpu 2:14,21 total



## CPU+GPU, speculative codellama-34b.Q8_0.gguf (7/51 offloaded) with codellama-7b.Q4_K_M.gguf (35/35 offloaded) as draft

./build/bin/speculative \
-m ../models/codellama/codellama-34b.Q8_0.gguf \
-md ../models/codellama/codellama-7b.Q4_K_M.gguf \
-p "// Quick-sort implementation in C (4 spaces indentation + detailed comments) and sample usage:\n\n#include" \
-e -t 4 -n 256 -c 4096 -s 8 --top_k 1 --temp 0.1 --top-p 0.95 --draft 16 \
-ngl 7 -ngld 35

...

encoded   25 tokens in    6.520 seconds, speed:    3.834 t/s
decoded  258 tokens in  108.936 seconds, speed:    2.368 t/s

n_draft   = 16
n_predict = 258
n_drafted = 334
n_accept  = 213
accept    = 63.772%

draft:

llama_print_timings:        load time =   989.95 ms
llama_print_timings:      sample time =   659.58 ms /     1 runs   (  659.58 ms per token,     1.52 tokens per second)
llama_print_timings: prompt eval time =   256.32 ms /    25 tokens (   10.25 ms per token,    97.53 tokens per second)
llama_print_timings:        eval time =  7149.95 ms /   367 runs   (   19.48 ms per token,    51.33 tokens per second)
llama_print_timings:       total time = 115455.20 ms

target:

llama_print_timings:        load time =  1898.06 ms
llama_print_timings:      sample time =    97.65 ms /   258 runs   (    0.38 ms per token,  2642.01 tokens per second)
llama_print_timings: prompt eval time = 100969.41 ms /   393 tokens (  256.92 ms per token,     3.89 tokens per second)
llama_print_timings:        eval time =  6287.35 ms /    10 runs   (  628.74 ms per token,     1.59 tokens per second)
llama_print_timings:       total time = 116450.65 ms

462,27s user 1,38s system 387% cpu 1:59,54 total

```

I've found it unexpected that acceptance rate went from 68.489% with draft on CPU to 63.772% with draft on GPU (tried bunch of different seeds, acceptance with draft on GPU stays at 63.772%).