### PR TITLE
Metal support for Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "llama",
+    platforms: [.macOS(.v11)],
     products: [
         .library(name: "llama", targets: ["llama"]),
     ],
@@ -11,16 +12,19 @@ let package = Package(
         .target(
             name: "llama",
             path: ".",
-            exclude: ["ggml-metal.metal"],
             sources: [
                 "ggml.c",
                 "llama.cpp",
                 "ggml-alloc.c",
-                "k_quants.c"
+                "k_quants.c",
+                "ggml-metal.m",
             ],
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32"]),
+                .unsafeFlags(["-fno-objc-arc"]),
+                .define("GGML_SWIFT"),
+                .define("GGML_USE_METAL"),
                 .define("GGML_USE_K_QUANTS"),
                 .define("GGML_USE_ACCELERATE")
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,20 @@
 
 import PackageDescription
 
+#if arch(arm) || arch(arm64)
+let exclude: [String] = []
+let additionalSources: [String] = ["ggml-metal.m"]
+let additionalSettings: [CSetting] = [
+    .unsafeFlags(["-fno-objc-arc"]),
+    .define("GGML_SWIFT"),
+    .define("GGML_USE_METAL")
+]
+#else
+let exclude: [String] = ["ggml-metal.metal"]
+let additionalSources: [String] = []
+let additionalSettings: [CSetting] = []
+#endif
+
 let package = Package(
     name: "llama",
     platforms: [.macOS(.v11)],
@@ -12,26 +26,23 @@ let package = Package(
         .target(
             name: "llama",
             path: ".",
+            exclude: exclude,
             sources: [
                 "ggml.c",
                 "llama.cpp",
                 "ggml-alloc.c",
                 "k_quants.c",
-                "ggml-metal.m",
-            ],
+            ] + additionalSources,
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32"]),
-                .unsafeFlags(["-fno-objc-arc"]),
-                .define("GGML_SWIFT"),
-                .define("GGML_USE_METAL"),
                 .define("GGML_USE_K_QUANTS"),
                 .define("GGML_USE_ACCELERATE")
-            ],
+            ] + additionalSettings,
             linkerSettings: [
                 .linkedFramework("Accelerate")
             ]
-        ),
+        )
     ],
     cxxLanguageStandard: .cxx11
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@
 import PackageDescription
 
 #if arch(arm) || arch(arm64)
+let platforms: [SupportedPlatform]? = [
+    .macOS(.v11),
+    .iOS(.v11),
+    .watchOS(.v4),
+    .tvOS(.v11)
+]
 let exclude: [String] = []
 let additionalSources: [String] = ["ggml-metal.m"]
 let additionalSettings: [CSetting] = [
@@ -11,6 +17,7 @@ let additionalSettings: [CSetting] = [
     .define("GGML_USE_METAL")
 ]
 #else
+let platforms: [SupportedPlatform]? = nil
 let exclude: [String] = ["ggml-metal.metal"]
 let additionalSources: [String] = []
 let additionalSettings: [CSetting] = []
@@ -18,7 +25,7 @@ let additionalSettings: [CSetting] = []
 
 let package = Package(
     name: "llama",
-    platforms: [.macOS(.v11)],
+    platforms: platforms,
     products: [
         .library(name: "llama", targets: ["llama"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,9 @@ import PackageDescription
 #if arch(arm) || arch(arm64)
 let platforms: [SupportedPlatform]? = [
     .macOS(.v11),
-    .iOS(.v11),
+    .iOS(.v14),
     .watchOS(.v4),
-    .tvOS(.v11)
+    .tvOS(.v14)
 ]
 let exclude: [String] = []
 let additionalSources: [String] = ["ggml-metal.m"]

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -150,9 +150,10 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         NSString * llamaBundlePath = [bundle pathForResource:@"llama_llama" ofType:@"bundle"];
         NSBundle * llamaBundle = [NSBundle bundleWithPath:llamaBundlePath];
         NSString * libPath = [llamaBundle pathForResource:@"default" ofType:@"metallib"];
+        NSURL * libURL = [NSURL fileURLWithPath:libPath];
 
         // Load the metallib file into a Metal library
-        ctx->library = [ctx->device newLibraryWithFile:libPath error:&error];
+        ctx->library = [ctx->device newLibraryWithURL:libURL error:&error];
 
         if (error) {
             metal_printf("%s: error: %s\n", __func__, [[error description] UTF8String]);

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -141,9 +141,6 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
 
     ctx->d_queue = dispatch_queue_create("llama.cpp", DISPATCH_QUEUE_CONCURRENT);
 
-    MTLCompileOptions* options = [MTLCompileOptions new];
-    options.preprocessorMacros = @{ @"QK_K" : @(64) };
-
 #ifdef GGML_SWIFT
     // load the default.metallib file
     {
@@ -181,6 +178,8 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         }
 
 #ifdef GGML_QKK_64
+        MTLCompileOptions* options = [MTLCompileOptions new];
+        options.preprocessorMacros = @{ @"QK_K" : @(64) };
         ctx->library = [ctx->device newLibraryWithSource:src options:options error:&error];
 #else
         ctx->library = [ctx->device newLibraryWithSource:src options:nil error:&error];


### PR DESCRIPTION
I have a working demo of using Metal w/ a Swift Mac app with these changes. Hopefully, this is a welcome contribution!

```
llama_model_loader: loaded meta data with 19 key-value pairs and 363 tensors from /Users/jeffhara/.cache/lm-studio/models/TheBloke/MythoMax-L2-Kimiko-v2-13B-GGUF/mythomax-l2-kimiko-v2-13b.Q4_K_M.gguf (version GGUF V2 (latest))
llama_model_loader: - tensor    0:                token_embd.weight q4_K     [  5120, 32000,     1,     1 ]
...B (+  400.00 MB per state)
...................................................................................................
llama_new_context_with_model: kv self size  =  400.00 MB
ggml_metal_init: allocating
2023-09-07 22:35:08.973604-0700 TestTypeaheadAI[60657:1063549] Metal GPU Frame Capture Enabled
2023-09-07 22:35:08.973931-0700 TestTypeaheadAI[60657:1063549] Metal API Validation Enabled
ggml_metal_init: found device: Apple M1 Pro
ggml_metal_init: picking default device: Apple M1 Pro
ggml_metal_init: loaded kernel_add                         0x600000fd0370 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_add_row                     0x600000fd0500 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_mul                         0x600000fd0690 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_mul_row                     0x600000fd0820 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_scale                       0x600000fd44b0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_silu                        0x600000fd4640 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_relu                        0x600000fd47d0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_gelu                        0x600000fee7b0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_soft_max                    0x600000fee940 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_diag_mask_inf               0x600000feead0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_f16                0x600000feec60 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q4_0               0x600000feedf0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q4_1               0x600000feef80 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q8_0               0x600000fd09b0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q2_K               0x600000fd0b40 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q3_K               0x600000fd0cd0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q4_K               0x600000fd0e60 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q5_K               0x600000fd0ff0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_get_rows_q6_K               0x600000fd1180 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_rms_norm                    0x600000fd1310 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_norm                        0x600000fd14a0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_f16_f32             0x600000fd1630 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q4_0_f32            0x600000fd17c0 | th_max =  896 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q4_1_f32            0x600000fd1950 | th_max =  896 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q8_0_f32            0x600000fd1ae0 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q2_K_f32            0x600000fd1c70 | th_max =  640 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q3_K_f32            0x600000fd1e00 | th_max =  704 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q4_K_f32            0x600000fd1f90 | th_max =  576 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q5_K_f32            0x600000fd2120 | th_max =  576 | th_width =   32
ggml_metal_init: loaded kernel_mul_mat_q6_K_f32            0x600000fd22b0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_f16_f32              0x600000fd2440 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q4_0_f32             0x600000fd25d0 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q8_0_f32             0x600000fd2760 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q4_1_f32             0x600000fd28f0 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q2_K_f32             0x600000fd2a80 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q3_K_f32             0x600000fd2c10 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q4_K_f32             0x600000fd2da0 | th_max =  768 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q5_K_f32             0x600000fd2f30 | th_max =  704 | th_width =   32
ggml_metal_init: loaded kernel_mul_mm_q6_K_f32             0x600000fd30c0 | th_max =  704 | th_width =   32
ggml_metal_init: loaded kernel_rope                        0x600000fd3250 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_alibi_f32                   0x600000fd33e0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_cpy_f32_f16                 0x600000fd3610 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_cpy_f32_f32                 0x600000fd37a0 | th_max = 1024 | th_width =   32
ggml_metal_init: loaded kernel_cpy_f16_f16                 0x600000fd3930 | th_max = 1024 | th_width =   32
ggml_metal_init: recommendedMaxWorkingSetSize  = 10922.67 MB
ggml_metal_init: hasUnifiedMemory              = true
ggml_metal_init: maxTransferRate               = built-in GPU
llama_new_context_with_model: compute buffer total size =   91.47 MB
llama_new_context_with_model: max tensor size =   128.17 MB
ggml_metal_add_buffer: allocated 'data            ' buffer, size =  7501.56 MB, ( 7502.12 / 10922.67)
ggml_metal_add_buffer: allocated 'eval            ' buffer, size =     1.48 MB, ( 7503.61 / 10922.67)
ggml_metal_add_buffer: allocated 'kv              ' buffer, size =   402.00 MB, ( 7905.61 / 10922.67)
ggml_metal_add_buffer: allocated 'alloc           ' buffer, size =    90.02 MB, ( 7995.62 / 10922.67)


 what is the capital of japan
The capital of Japan is Tokyo. [end of text]
0
ggml_metal_free: deallocating
```
