### PR TITLE
Metal: PP speedup

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -818,17 +818,15 @@ void ggml_metal_graph_compute(
                     case GGML_OP_DIAG_MASK_INF:
                         {
                             const int n_past = ((int32_t *)(dst->op_params))[0];
-                            const int64_t n00x01 = ne00*ne01;
-                            assert((n00x01*ne02)%8 == 0);
 
                             [encoder setComputePipelineState:ctx->pipeline_diag_mask_inf];
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
-                            [encoder setBytes:&ne00    length:sizeof(ne00) atIndex:2];
-                            [encoder setBytes:&n00x01  length:sizeof(n00x01) atIndex:3];
+                            [encoder setBytes:&ne00   length:sizeof(ne00) atIndex:2];
+                            [encoder setBytes:&ne01   length:sizeof(ne01) atIndex:3];
                             [encoder setBytes:&n_past length:sizeof(int)  atIndex:4];
 
-                            [encoder dispatchThreadgroups:MTLSizeMake(n00x01*ne02/8, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+                            [encoder dispatchThreadgroups:MTLSizeMake(ne00, ne01, ne02) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
                         } break;
                     case GGML_OP_MUL_MAT:
                         {

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -63,6 +63,7 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(relu);
     GGML_METAL_DECL_KERNEL(gelu);
     GGML_METAL_DECL_KERNEL(soft_max);
+    GGML_METAL_DECL_KERNEL(soft_max_4);
     GGML_METAL_DECL_KERNEL(diag_mask_inf);
     GGML_METAL_DECL_KERNEL(get_rows_f16);
     GGML_METAL_DECL_KERNEL(get_rows_q4_0);
@@ -207,6 +208,7 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         GGML_METAL_ADD_KERNEL(relu);
         GGML_METAL_ADD_KERNEL(gelu);
         GGML_METAL_ADD_KERNEL(soft_max);
+        GGML_METAL_ADD_KERNEL(soft_max_4);
         GGML_METAL_ADD_KERNEL(diag_mask_inf);
         GGML_METAL_ADD_KERNEL(get_rows_f16);
         GGML_METAL_ADD_KERNEL(get_rows_q4_0);
@@ -273,6 +275,7 @@ void ggml_metal_free(struct ggml_metal_context * ctx) {
     GGML_METAL_DEL_KERNEL(relu);
     GGML_METAL_DEL_KERNEL(gelu);
     GGML_METAL_DEL_KERNEL(soft_max);
+    GGML_METAL_DEL_KERNEL(soft_max_4);
     GGML_METAL_DEL_KERNEL(diag_mask_inf);
     GGML_METAL_DEL_KERNEL(get_rows_f16);
     GGML_METAL_DEL_KERNEL(get_rows_q4_0);
@@ -796,7 +799,11 @@ void ggml_metal_graph_compute(
                         {
                             const int nth = 32;
 
-                            [encoder setComputePipelineState:ctx->pipeline_soft_max];
+                            if (ne00%4 == 0) {
+                                [encoder setComputePipelineState:ctx->pipeline_soft_max_4];
+                            } else {
+                                [encoder setComputePipelineState:ctx->pipeline_soft_max];
+                            }
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
                             [encoder setBytes:&ne00 length:sizeof(ne00) atIndex:2];

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -815,15 +815,17 @@ void ggml_metal_graph_compute(
                     case GGML_OP_DIAG_MASK_INF:
                         {
                             const int n_past = ((int32_t *)(dst->op_params))[0];
+                            const int64_t n00x01 = ne00*ne01;
+                            assert((n00x01*ne02)%8 == 0);
 
                             [encoder setComputePipelineState:ctx->pipeline_diag_mask_inf];
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
-                            [encoder setBytes:&ne00   length:sizeof(ne00) atIndex:2];
-                            [encoder setBytes:&ne01   length:sizeof(ne01) atIndex:3];
+                            [encoder setBytes:&ne00    length:sizeof(ne00) atIndex:2];
+                            [encoder setBytes:&n00x01  length:sizeof(n00x01) atIndex:3];
                             [encoder setBytes:&n_past length:sizeof(int)  atIndex:4];
 
-                            [encoder dispatchThreadgroups:MTLSizeMake(ne00, ne01, ne02) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+                            [encoder dispatchThreadgroups:MTLSizeMake(n00x01*ne02/8, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
                         } break;
                     case GGML_OP_MUL_MAT:
                         {

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -750,7 +750,7 @@ void ggml_metal_graph_compute(
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
                             [encoder setBytes:&scale length:sizeof(scale) atIndex:2];
 
-                            const int64_t n = ggml_nelements(dst);
+                            const int64_t n = ggml_nelements(dst)/4;
 
                             [encoder dispatchThreadgroups:MTLSizeMake(n, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
                         } break;

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -762,7 +762,7 @@ void ggml_metal_graph_compute(
                                     [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                                     [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
 
-                                    const int64_t n = ggml_nelements(dst);
+                                    const int64_t n = ggml_nelements(dst)/4;
 
                                     [encoder dispatchThreadgroups:MTLSizeMake(n, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
                                 } break;
@@ -782,7 +782,7 @@ void ggml_metal_graph_compute(
                                     [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                                     [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
 
-                                    const int64_t n = ggml_nelements(dst);
+                                    const int64_t n = ggml_nelements(dst)/4;
 
                                     [encoder dispatchThreadgroups:MTLSizeMake(n, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
                                 } break;
@@ -802,7 +802,6 @@ void ggml_metal_graph_compute(
                             [encoder setBytes:&ne00 length:sizeof(ne00) atIndex:2];
                             [encoder setBytes:&ne01 length:sizeof(ne01) atIndex:3];
                             [encoder setBytes:&ne02 length:sizeof(ne02) atIndex:4];
-                            [encoder setThreadgroupMemoryLength:nth*sizeof(float) atIndex:0];
 
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne02, ne03) threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
                         } break;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -200,6 +200,34 @@ kernel void kernel_diag_mask_inf(
      }
 }
 
+kernel void kernel_diag_mask_inf_8(
+        device const float4 * src0,
+        device       float4 * dst,
+        constant    int64_t & ne00,
+        constant    int64_t & ne01,
+        constant        int & n_past,
+        uint3 tpig[[thread_position_in_grid]]) {
+
+    const int64_t i = 2*tpig[0];
+
+    dst[i+0] = src0[i+0];
+    dst[i+1] = src0[i+1];
+    int64_t i4 = 4*i;
+    const int64_t i02 = i4/(ne00*ne01);
+    i4 -= i02*ne00*ne01;
+    const int64_t i01 = i4/ne00;
+    const int64_t i00 = i4 - i01*ne00;
+    for (int k = 3; k >= 0; --k) {
+        if (i00 + 4 + k <= n_past + i01) {
+            break;
+        }
+        dst[i+1][k] = -INFINITY;
+        if (i00 + k > n_past + i01) {
+            dst[i][k] = -INFINITY;
+        }
+    }
+}
+
 kernel void kernel_norm(
         device const  void * src0,
         device       float * dst,

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -63,8 +63,8 @@ kernel void kernel_mul_row(
 }
 
 kernel void kernel_scale(
-        device const float * src0,
-        device       float * dst,
+        device const float4 * src0,
+        device       float4 * dst,
         constant     float & scale,
         uint tpig[[thread_position_in_grid]]) {
     dst[tpig] = src0[tpig] * scale;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -141,6 +141,47 @@ kernel void kernel_soft_max(
     }
 }
 
+kernel void kernel_soft_max_4(
+        device const float * src0,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant   int64_t & ne01,
+        constant   int64_t & ne02,
+        uint3 tgpig[[threadgroup_position_in_grid]],
+        uint3 tpitg[[thread_position_in_threadgroup]],
+        uint3   ntg[[threads_per_threadgroup]]) {
+    const int64_t i03 = tgpig[2];
+    const int64_t i02 = tgpig[1];
+    const int64_t i01 = tgpig[0];
+
+    device const float4 * psrc4 = (device const float4 *)(src0 + i03*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00);
+    device       float4 * pdst4 = (device       float4 *)(dst  + i03*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00);
+
+    // parallel max
+    float4 lmax4 = psrc4[tpitg[0]];
+    for (int i00 = tpitg[0] + ntg[0]; i00 < ne00/4; i00 += ntg[0]) {
+        lmax4 = fmax(lmax4, psrc4[i00]);
+    }
+    float lmax = MAX(MAX(lmax4[0], lmax4[1]), MAX(lmax4[2], lmax4[3]));
+
+    const float max = simd_max(lmax);
+
+    // parallel sum
+    float4 lsum4 = 0.0f;
+    for (int i00 = tpitg[0]; i00 < ne00/4; i00 += ntg[0]) {
+        const float4 exp_psrc4 = exp(psrc4[i00] - max);
+        lsum4 += exp_psrc4;
+        pdst4[i00] = exp_psrc4;
+    }
+    float lsum = lsum4[0] + lsum4[1] + lsum4[2] + lsum4[3];
+
+    const float sum = simd_sum(lsum);
+
+    for (int i00 = tpitg[0]; i00 < ne00/4; i00 += ntg[0]) {
+        pdst4[i00] /= sum;
+    }
+}
+
 kernel void kernel_diag_mask_inf(
         device const float * src0,
         device       float * dst,

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -213,10 +213,9 @@ kernel void kernel_diag_mask_inf_8(
     dst[i+0] = src0[i+0];
     dst[i+1] = src0[i+1];
     int64_t i4 = 4*i;
-    const int64_t i02 = i4/(ne00*ne01);
-    i4 -= i02*ne00*ne01;
-    const int64_t i01 = i4/ne00;
-    const int64_t i00 = i4 - i01*ne00;
+    const int64_t i02 = i4/(ne00*ne01); i4 -= i02*ne00*ne01;
+    const int64_t i01 = i4/(ne00);      i4 -= i01*ne00;
+    const int64_t i00 = i4;
     for (int k = 3; k >= 0; --k) {
         if (i00 + 4 + k <= n_past + i01) {
             break;
@@ -678,7 +677,6 @@ kernel void kernel_mul_mat_f16_f32_l4(
     device const half4 * x4 = (device const half4 *) (src0 + r0*nb01 + im/(ne12/ne02)*nb02);
 
     for (int r1 = 0; r1 < nrows; ++r1) {
-
         device const float4 * y4 = (device const float4 *) (src1 + r1*nb11 + im*nb12);
 
         float sumf = 0;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -183,30 +183,21 @@ kernel void kernel_soft_max_4(
 }
 
 kernel void kernel_diag_mask_inf(
-        device const float4 * src0,
-        device       float4 * dst,
+        device const float * src0,
+        device       float * dst,
         constant   int64_t & ne00,
-        constant   int64_t & n00x01,
+        constant   int64_t & ne01,
         constant       int & n_past,
         uint3 tpig[[thread_position_in_grid]]) {
-    const int64_t i = 2*tpig[0];
+    const int64_t i02 = tpig[2];
+    const int64_t i01 = tpig[1];
+    const int64_t i00 = tpig[0];
 
-    dst[i+0] = src0[i+0];
-    dst[i+1] = src0[i+1];
-    int64_t i4 = 4*i;
-    const int64_t i02 = i4/n00x01;
-    i4 -= i02*n00x01;
-    const int64_t i01 = i4/ne00;
-    const int64_t i00 = i4 - i01*ne00;
-    for (int k = 3; k >= 0; --k) {
-        if (i00 + 4 + k <= n_past + i01) {
-            break;
-        }
-        dst[i+1][k] = -INFINITY;
-        if (i00 + k > n_past + i01) {
-            dst[i][k] = -INFINITY;
-        }
-    }
+    if (i00 > n_past + i01) {
+        dst[i02*ne01*ne00 + i01*ne00 + i00] = -INFINITY;
+    } else {
+        dst[i02*ne01*ne00 + i01*ne00 + i00] = src0[i02*ne01*ne00 + i01*ne00 + i00];
+     }
 }
 
 kernel void kernel_norm(


### PR DESCRIPTION
Speedup is achieved via
* Faster `soft_max`, `diag_mask_inf`, `scale`, `silu`, `gelu`
* A new kernel for `f16 x f32` matrix multiplications that can not be done via the usual matrix multiplication kernel because the tensors are not contiguous. This mostly affects the `K x Q` matrix multiplication, the importance of which grows with increasing context / batch size. 
* Tuning of the k_quants dequantization kernels. The effect is most strong for `Q5_K` and `Q6_K`. 

The table gives results on a 30-core M2 Max. TG performance is mostly unaffected, but there are some very minor gains here and there. For PP the lion share of the speedup comes from the new `f16 x f32` matrix multiplication kernel, which somehow does not benefit as much the Falcon model, so this is something left to look Into.

| model                          | backend    | test       |     t/s (Master) |       t/s (PR)   |  Speedup |
| ------------------------------ | ---------- | ---------- | ---------------: | ---------------: | -------: |
| Falcon 7B mostly F16           | Metal      | pp 512     |    365.11 ± 0.06 |    380.18 ± 0.13 |   1.041  |
| LLaMA 7B mostly F16            | Metal      | pp 512     |    489.73 ± 0.32 |    539.46 ± 0.31 |   1.102  |
| LLaMA 7B mostly Q8_0           | Metal      | pp 512     |    445.27 ± 0.13 |    486.91 ± 0.18 |   1.094  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 512     |    445.65 ± 0.30 |    495.91 ± 0.38 |   1.113  |
| LLaMA 7B mostly Q4_1           | Metal      | pp 512     |    448.26 ± 0.11 |    494.31 ± 0.26 |   1.103  |
| LLaMA 7B mostly Q6_K           | Metal      | pp 512     |    367.58 ± 0.15 |    413.82 ± 0.39 |   1.126  |
| LLaMA 7B mostly Q5_K - Small   | Metal      | pp 512     |    366.29 ± 0.14 |    413.35 ± 0.27 |   1.128  |
| LLaMA 7B mostly Q4_K - Small   | Metal      | pp 512     |    399.22 ± 0.28 |    438.64 ± 0.23 |   1.099  |
| LLaMA 7B mostly Q3_K - Small   | Metal      | pp 512     |    379.32 ± 0.18 |    417.91 ± 0.25 |   1.102  |
| Falcon 7B mostly F16           | Metal      | tg 128     |     23.34 ± 0.05 |     23.33 ± 0.04 |   1.000  |
| LLaMA 7B mostly F16            | Metal      | tg 128     |     24.25 ± 0.10 |     24.26 ± 0.04 |   1.000  |
| LLaMA 7B mostly Q8_0           | Metal      | tg 128     |     40.09 ± 0.34 |     40.16 ± 0.27 |   1.000  |
| LLaMA 7B mostly Q4_0           | Metal      | tg 128     |     62.23 ± 0.88 |     62.53 ± 0.06 |   1.005  |
| LLaMA 7B mostly Q4_1           | Metal      | tg 128     |     57.93 ± 0.49 |     58.88 ± 0.78 |   1.016  |
| LLaMA 7B mostly Q6_K           | Metal      | tg 128     |     42.68 ± 0.54 |     42.93 ± 0.48 |   1.006  |
| LLaMA 7B mostly Q5_K - Small   | Metal      | tg 128     |     43.90 ± 0.65 |     44.67 ± 0.03 |   1.017  |
| LLaMA 7B mostly Q4_K - Small   | Metal      | tg 128     |     56.42 ± 0.98 |     57.31 ± 0.44 |   1.016  |
| LLaMA 7B mostly Q3_K - Small   | Metal      | tg 128     |     45.67 ± 0.57 |     46.19 ± 0.50 |   1.011  |
  