### PR TITLE
CUDA: enable option for F16 with LLAMA_HIPBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,10 @@ if (LLAMA_HIPBLAS)
         set_source_files_properties(ggml-cuda.cu PROPERTIES LANGUAGE CXX)
         target_link_libraries(ggml-rocm PRIVATE hip::device PUBLIC hip::host roc::rocblas roc::hipblas)
 
+        if (LLAMA_CUDA_F16)
+            add_compile_definitions(GGML_CUDA_F16)
+        endif()
+
         if (LLAMA_STATIC)
             message(FATAL_ERROR "Static linking not supported for HIP/ROCm")
         endif()

--- a/Makefile
+++ b/Makefile
@@ -412,6 +412,9 @@ ifdef LLAMA_HIPBLAS
 ifdef LLAMA_CUDA_FORCE_DMMV
 	HIPFLAGS 	+= -DGGML_CUDA_FORCE_DMMV
 endif # LLAMA_CUDA_FORCE_DMMV
+ifdef LLAMA_CUDA_F16
+	HIPFLAGS	+= -DGGML_CUDA_F16
+endif # LLAMA_CUDA_F16
 	OBJS        += ggml-cuda.o
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
 	$(HIPCC) $(CXXFLAGS) $(HIPFLAGS) -x hip -c -o $@ $<


### PR DESCRIPTION
With `-DLLAMA_CUDA_F16=ON`

  Device 0: AMD Radeon RX 7900 XTX, compute capability 11.0
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| LLaMA v2 7B mostly Q4_0        |   3.56 GiB |     6.74 B | ROCm       |  99 | pp 512     |  1668.06 ± 22.24 |
| LLaMA v2 7B mostly Q4_0        |   3.56 GiB |     6.74 B | ROCm       |  99 | tg 128     |    116.04 ± 0.18 |

Without `-DLLAMA_CUDA_F16=ON`

  Device 0: AMD Radeon RX 7900 XTX, compute capability 11.0
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| LLaMA v2 7B mostly Q4_0        |   3.56 GiB |     6.74 B | ROCm       |  99 | pp 512     |  1653.26 ± 19.46 |
| LLaMA v2 7B mostly Q4_0        |   3.56 GiB |     6.74 B | ROCm       |  99 | tg 128     |    115.49 ± 1.08 |