### PR TITLE
gguf-py: Support identity operation in TensorNameMap

### DIFF
--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -311,6 +311,7 @@ class TensorNameMap:
             tensor_name = tensor_names.get(tensor)
             if tensor_name is None:
                 continue
+            mapping[tensor_name] = (tensor, tensor_name)
             for key in keys:
                 mapping[key] = (tensor, tensor_name)
         for bid in range(n_blocks):
@@ -319,11 +320,12 @@ class TensorNameMap:
                 if tensor_name is None:
                     continue
                 tensor_name = tensor_name.format(bid = bid)
+                mapping[tensor_name] = (tensor, tensor_name)
                 for key in keys:
                     key = key.format(bid = bid)
                     mapping[key] = (tensor, tensor_name)
 
-    def get_type_and_name(self, key: str, try_suffixes: Sequence[str]) -> tuple[MODEL_TENSOR, str] | None:
+    def get_type_and_name(self, key: str, try_suffixes: Sequence[str] = ()) -> tuple[MODEL_TENSOR, str] | None:
         result = self.mapping.get(key)
         if result is not None:
             return result
@@ -334,13 +336,13 @@ class TensorNameMap:
                     return (result[0], result[1] + suffix)
         return None
 
-    def get_name(self, key: str, try_suffixes: Sequence[str]) -> str | None:
+    def get_name(self, key: str, try_suffixes: Sequence[str] = ()) -> str | None:
         result = self.get_type_and_name(key, try_suffixes = try_suffixes)
         if result is None:
             return None
         return result[1]
 
-    def get_type(self, key: str, try_suffixes: Sequence[str]) -> MODEL_TENSOR | None:
+    def get_type(self, key: str, try_suffixes: Sequence[str] = ()) -> MODEL_TENSOR | None:
         result = self.get_type_and_name(key, try_suffixes = try_suffixes)
         if result is None:
             return None

--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.3.2"
+version = "0.3.3"
 description = "Write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
*edit*: Just to make it a bit more clear what this is trying to do: `TensorNameMap` is used to map the assorted naming conventions for types of tensors in various models to GGUF convention. A HuggingFace LLaMA model might call the attention norm tensor `model.layers.1.input_layernorm`, the `.pth` version might call it something different and so on. In GGUF it's called `blk.1.attn_norm`. 

However, currently `TensorNameMap` only maps the non-GGUF names to the GGUF name. If you already have the GGUF name and try to map, it'll fail. This pull just adds an entry for the GGUF-style name to the list so trying to map a name that's already correct is a no-op.

Before:
```plaintext
>>> nm = gguf.TensorNameMap(gguf.MODEL_ARCH.LLAMA, 2)
>>> nm['transformer.wte']
'token_embd'
>>> nm[nm['transformer.wte']]
Traceback (most recent call last):
  File "/blah/llama.cpp/gguf-py/gguf/gguf.py", line 351, in __getitem__
    return self.mapping[key][1]
           ~~~~~~~~~~~~^^^^^
KeyError: 'token_embd'
```

After:

```plaintext
>>> nm = gguf.TensorNameMap(gguf.MODEL_ARCH.LLAMA, 2)
>>> nm['transformer.wte']
'token_embd'
>>> nm[nm[nm[nm['transformer.wte']]]]
'token_embd'
>>> nm[nm[nm[nm['transformer.h.1.ln_1']]]]
'blk.1.attn_norm'
```

This also fixes an issue where you had to specify `try_suffixes` to `TensorNameMap.get_name` and friends. It just sets the default value for the keyword param to an empty sequence (I meant to do this originally but apparently I messed it up).