### PR TITLE
feat: docker gpu image CI builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,15 @@ jobs:
     strategy:
       matrix:
         config:
-          - { tag: "light", dockerfile: ".devops/main.Dockerfile" }
-          - { tag: "full", dockerfile: ".devops/full.Dockerfile" }
+          - { tag: "light", dockerfile: ".devops/main.Dockerfile", platforms: "linux/amd64,linux/arm64" }
+          - { tag: "full", dockerfile: ".devops/full.Dockerfile", platforms: "linux/amd64,linux/arm64" }
+          # NOTE(canardletter): The CUDA builds on arm64 are very slow, so I
+          #                     have disabled them for now until the reason why
+          #                     is understood.
+          - { tag: "light-cuda", dockerfile: ".devops/main-cuda.Dockerfile", platforms: "linux/amd64" }
+          - { tag: "full-cuda", dockerfile: ".devops/full-cuda.Dockerfile", platforms: "linux/amd64" }
+          - { tag: "light-rocm", dockerfile: ".devops/main-rocm.Dockerfile", platforms: "linux/amd64,linux/arm64" }
+          - { tag: "full-rocm", dockerfile: ".devops/full-rocm.Dockerfile", platforms: "linux/amd64,linux/arm64" }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -51,7 +58,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platforms }}
           tags: "ghcr.io/ggerganov/llama.cpp:${{ matrix.config.tag }}-${{ env.COMMIT_SHA }}"
           file: ${{ matrix.config.dockerfile }}
 
@@ -60,6 +67,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.config.platforms }}
           tags: "ghcr.io/ggerganov/llama.cpp:${{ matrix.config.tag }}"
           file: ${{ matrix.config.dockerfile }}

--- a/README.md
+++ b/README.md
@@ -844,8 +844,17 @@ Place your desired model into the `~/llama.cpp/models/` directory and execute th
 #### Images
 We have two Docker images available for this project:
 
-1. `ghcr.io/ggerganov/llama.cpp:full`: This image includes both the main executable file and the tools to convert LLaMA models into ggml and convert into 4-bit quantization.
-2. `ghcr.io/ggerganov/llama.cpp:light`: This image only includes the main executable file.
+1. `ghcr.io/ggerganov/llama.cpp:full`: This image includes both the main executable file and the tools to convert LLaMA models into ggml and convert into 4-bit quantization. (platforms: `linux/amd64`, `linux/arm64`)
+2. `ghcr.io/ggerganov/llama.cpp:light`: This image only includes the main executable file. (platforms: `linux/amd64`, `linux/arm64`)
+
+Additionally, there the following images, similar to the above:
+
+- `ghcr.io/ggerganov/llama.cpp:full-cuda`: Same as `full` but compiled with CUDA support. (platforms: `linux/amd64`)
+- `ghcr.io/ggerganov/llama.cpp:light-cuda`: Same as `light` but compiled with CUDA support. (platforms: `linux/amd64`)
+- `ghcr.io/ggerganov/llama.cpp:full-rocm`: Same as `full` but compiled with ROCm support. (platforms: `linux/amd64`, `linux/arm64`)
+- `ghcr.io/ggerganov/llama.cpp:light-rocm`: Same as `light` but compiled with ROCm support. (platforms: `linux/amd64`, `linux/arm64`)
+
+The GPU enabled images are not currently tested by CI beyond being built. They are not built with any variation from the ones in the Dockerfiles defined in [.devops/](.devops/) and the Gitlab Action defined in [.github/workflows/docker.yml](.github/workflows/docker.yml). If you need different settings (for example, a different CUDA or ROCm library, you'll need to build the images locally for now).
 
 #### Usage
 


### PR DESCRIPTION
Enables the GPU enabled container images to be built and pushed alongside the CPU containers, and liberates the GPU Container images from local building for casual experimenters. This also generally addresses some of my CI concerns raised in #1461 & #3044

This doesn't validate the GPU enabled binary in the container, just that the declarations in place to build the
container and binary is functional, so it **doesn't need any GPU infrastructure,** and can be run as a Github Action. This generally
normalizes the delivery of GPU containers to match the CPU only ones.

As I'm not the maintainer of the primary repository, nor the owner of the DockerHub repository, I cannot run a full
validation on these as it only runs for `master` on @ggerganov's DockerHub credentials, I have a slightly different
variation of this Action (with `push: false`) that confirms the changes generally. You can view that validation in my repository: [Branch with similar change](https://github.com/ggerganov/llama.cpp/compare/master...canardleteer:llama.cpp:docker-ci), [Action Validation](https://github.com/canardleteer/llama.cpp/actions/runs/6133575378).

**Not Addressed By This Pull Request:**

- Multiple {CUDA,ROCm} Library Version Support
- Tailored GPU Architecture Support
- Pipeline support for validating the binaries in the images work
  - This is true of the current CPU image as well.

**Known Issues:**

- The `linux/arm64` build for CUDA is really slow, but hasn't timed out on me (yet). I don't know why, but I don't find the pipeline delay acceptable so have it disabled for now.


**The value of opening up these builds and pushes:**

1. Making sure the `Dockerfile`s don't go out of date, and changes don't break builds.
2. Containers tagged with a version:
    - Generally can be now be used from any GPU Cloud provider without a consumer having to build & push their own.
        - This is a huge value proposition for project popularity & adoption by GPU Cloud users.
3. Containers tagged with a commit hash / branch name from an MR (not done in this MR):
    - Generally opens doors for much more robust CI infrastructure in/on containers, which I'd love to help with, but don't have time to at the moment (but feel free to loop me into conversations).
    - CAN be made available for testing via GPU enabled k8s clusters via an API trigger.
    - Tests COULD be launched in these GPU enabled containers via an API call before a merge.
        - Depending on how the GPU Cluster Access infrastructure & Grants evolve.
    - CAN reduce the need for VM with "always acquired" GPU infrastructure and/or maintenance of the GPU Docker runtimes, to validate GPU builds.

I don't think I will have time to help set up the third item on this list, but that shouldn't stop us from gaining value from the first 2. Most of the effort is setting up additional infrastructure for a third party (like myself) to validate the process, the code changes are just a matter of finessing the tags and triggers.
