### PR TITLE
llama : make quantize example up to 2.7x faster

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -4639,8 +4639,14 @@ void llama_beam_search(llama_context * ctx,
 // quantization
 //
 
+template <typename T>
+struct no_init {
+    T value;
+    no_init() { /* do nothing */ }
+};
+
 static void llama_convert_tensor_internal(
-    struct ggml_tensor * tensor, std::vector<float> & output, std::vector<std::thread> & workers,
+    struct ggml_tensor * tensor, std::vector<no_init<float>> & output, std::vector<std::thread> & workers,
     const size_t nelements, const int nthread
 ) {
     if (output.size() < nelements) {
@@ -4895,9 +4901,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
 
     int idx = 0;
 
-    std::vector<uint8_t> read_data;
-    std::vector<uint8_t> work;
-    std::vector<float> f32_conv_buf;
+    std::vector<no_init<uint8_t>> read_data;
+    std::vector<no_init<uint8_t>> work;
+    std::vector<no_init<float>> f32_conv_buf;
 
     // populate the original tensors so we get an initial meta data
     for (int i = 0; i < ml->n_tensors; ++i) {


### PR DESCRIPTION
Tested on both ramfs and NVMe-backed btrfs. My CPU is a 6-core, 12-thread Ryzen 5 3600.

(These numbers are out of date due to some changes being removed, see the discussion. The final speedup for this PR is about 2.7x at best.)

| model | format | cache | master       | PR          | speedup |
| ----: | - | ----- | -----------: | ----------: | ------- |
| 7B    |Q4_0| ramfs | 19054.03 ms  | 5176.92 ms  | 3.68    |
| 33B   |Q4_0| cold  | 127157.88 ms | 44832.70 ms | 2.84    |
| 33B   |Q4_0| warm  | 126347.77 ms | 44401.31 ms | 2.85    |