### PR TITLE
POC: combined scale + diagonal mask infinity + soft max op

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4001,7 +4001,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "CROSS_ENTROPY_LOSS_BACK",
 };
 
-static_assert(GGML_OP_COUNT == 68, "GGML_OP_COUNT != 68");
+static_assert(GGML_OP_COUNT == 69, "GGML_OP_COUNT != 69");
 
 static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "none",
@@ -4083,7 +4083,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "cross_entropy_loss_back(x,y)",
 };
 
-static_assert(GGML_OP_COUNT == 68, "GGML_OP_COUNT != 68");
+static_assert(GGML_OP_COUNT == 69, "GGML_OP_COUNT != 69");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
@@ -6950,6 +6950,32 @@ struct ggml_tensor * ggml_soft_max_back_inplace(
         struct ggml_tensor  * a,
         struct ggml_tensor  * b) {
     return ggml_soft_max_back_impl(ctx, a, b, true);
+}
+
+struct ggml_tensor * ggml_scale_diag_mask_inf_softmax_inplace(
+        struct ggml_context * ctx,
+        float                 scale,
+        int                   n_past,
+        struct ggml_tensor  * a) {
+    //bool is_node = false;
+
+    //if (a->grad) {
+    //    is_node = true;
+    //}
+
+    struct ggml_tensor * result = ggml_view_tensor(ctx, a);
+
+    int32_t params[2];
+    memcpy(&params[0], &scale, sizeof(scale));
+    params[1] = n_past;
+    ggml_set_op_params(result, params, sizeof(params));
+
+    result->op   = GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX;
+    //result->grad = is_node ? ggml_dup_tensor(ctx, result) : NULL;
+    result->grad = NULL;
+    result->src[0] = a;
+
+    return result;
 }
 
 // ggml_rope
@@ -15993,6 +16019,11 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 // nop
             } break;
+        case GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX:
+            {
+                fprintf(stderr, "GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX not implemented\n");
+                GGML_ASSERT(false);
+            } break;
         case GGML_OP_COUNT:
             {
                 GGML_ASSERT(false);
@@ -16861,6 +16892,11 @@ static void ggml_compute_backward(struct ggml_context * ctx, struct ggml_tensor 
             {
                 // nop
             } break;
+        case GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX:
+            {
+                fprintf(stderr, "GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX not implemented\n");
+                GGML_ASSERT(false);
+            } break;
         case GGML_OP_COUNT:
             {
                 GGML_ASSERT(false);
@@ -17697,6 +17733,11 @@ struct ggml_cplan ggml_graph_plan(struct ggml_cgraph * cgraph, int n_threads) {
             case GGML_OP_NONE:
                 {
                     n_tasks = 1;
+                } break;
+            case GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX:
+                {
+                    fprintf(stderr, "GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX not implemented\n");
+                    GGML_ASSERT(false);
                 } break;
             case GGML_OP_COUNT:
                 {

--- a/ggml.h
+++ b/ggml.h
@@ -415,6 +415,8 @@ extern "C" {
         GGML_OP_CROSS_ENTROPY_LOSS,
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
 
+        GGML_OP_SCALE_DIAG_MASK_INF_SOFTMAX,
+
         GGML_OP_COUNT,
     };
 
@@ -1208,6 +1210,12 @@ extern "C" {
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             struct ggml_tensor  * b);
+
+    GGML_API struct ggml_tensor * ggml_scale_diag_mask_inf_softmax_inplace(
+            struct ggml_context * ctx,
+            float                 scale,
+            int                   n_past,
+            struct ggml_tensor  * a);
 
     // rotary position embedding
     // if mode & 1 == 1, skip n_past elements


### PR DESCRIPTION
TL;DR: This PR is a POC that combines scale + diagonal mask infinity + soft max, used on `K * Q` in the attention part of the network, to raise the question if we want to get involved with fusing operations.

It is a POC, so for now just a simple Metal implementation (i.e., none of the optimizations to these operations in #3084 are used). Despite this, fusing these 3 operations leads to a small, but measurable performance gain (see table). If the consensus is that this is a worthwhile thing to do, I can add implementation for the other backends, and would see if it is possible to optimize the kernel(s) for the combined scale + diagonal mask infinity + soft max operation.

| model                          | backend    | test       |     t/s (Master) |        t/s (PR)  |  Speedup  |
| ------------------------------ | ---------- | ---------- | ---------------: | ---------------: | --------: |
| Falcon 7B mostly F16           | Metal      | pp 512     |    379.71 ± 0.23 |    386.22 ± 0.43 |  1.017    |   
| LLaMA 7B mostly F16            | Metal      | pp 512     |    539.25 ± 0.30 |    543.57 ± 0.35 |  1.008    |   
| LLaMA 7B mostly Q4_0           | Metal      | pp 512     |    495.43 ± 0.59 |    499.20 ± 0.35 |  1.008    |   
| Falcon 7B mostly F16           | Metal      | tg 128     |     23.26 ± 0.01 |     23.48 ± 0.05 |  1.009    |   
| LLaMA 7B mostly F16            | Metal      | tg 128     |     24.14 ± 0.04 |     24.34 ± 0.10 |  1.008    |   
| LLaMA 7B mostly Q4_0           | Metal      | tg 128     |     62.82 ± 0.01 |     63.91 ± 0.04 |  1.017    |   