### PR TITLE
metal: more PP speedup for Falcon

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -838,8 +838,6 @@ void ggml_metal_graph_compute(
                     case GGML_OP_DIAG_MASK_INF:
                         {
                             const int n_past = ((int32_t *)(dst->op_params))[0];
-                            const int64_t n00x01 = ne00*ne01;
-                            assert((n00x01*ne02)%8 == 0);
 
                             if (ne00%8 == 0) {
                                 [encoder setComputePipelineState:ctx->pipeline_diag_mask_inf_8];
@@ -848,8 +846,8 @@ void ggml_metal_graph_compute(
                             }
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
-                            [encoder setBytes:&ne00    length:sizeof(ne00) atIndex:2];
-                            [encoder setBytes:&n00x01  length:sizeof(n00x01) atIndex:3];
+                            [encoder setBytes:&ne00   length:sizeof(ne00) atIndex:2];
+                            [encoder setBytes:&ne01   length:sizeof(ne01) atIndex:3];
                             [encoder setBytes:&n_past length:sizeof(int)  atIndex:4];
 
                             if (ne00%8 == 0) {

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -909,11 +909,6 @@ void ggml_metal_graph_compute(
                                 switch (src0t) {
                                     case GGML_TYPE_F16:
                                         {
-                                            //[encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32];
-                                            //nth0 = 32;
-                                            //nth1 = 1;
-                                            //if (ne11 * ne12 < 4) {
-                                            //    [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_1row];
                                             if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
                                                 [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_l4];
                                                 nx = ne01;
@@ -1044,12 +1039,6 @@ void ggml_metal_graph_compute(
                                 else if (src0t == GGML_TYPE_Q6_K) {
                                     [encoder dispatchThreadgroups:MTLSizeMake((ne01 + 1)/2, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 } else {
-                                    ////printf("f16xf32: %d x %d x %d,  %d x %d x %d -> %d\n",(int)ne00,(int)ne01,(int)ne02,
-                                    ////        (int)ne10,(int)ne11,(int)ne12,nrows);
-                                    //int64_t ny = (ne11 + nrows - 1)/nrows;
-                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
-                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne10*ne11*ne12, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
-                                    //int n = ne01 >= 32 ? 32 : ne01 >= 16 ? 16 : ne01 >= 8 ? 8 : ne01 >= 4 ? 4 : ne01 >= 2 ? 2 : 1;
                                     [encoder dispatchThreadgroups:MTLSizeMake(nx, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, 1, 1)];
                                 }
                             }

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -838,6 +838,8 @@ void ggml_metal_graph_compute(
                     case GGML_OP_DIAG_MASK_INF:
                         {
                             const int n_past = ((int32_t *)(dst->op_params))[0];
+                            const int64_t n00x01 = ne00*ne01;
+                            assert((n00x01*ne02)%8 == 0);
 
                             if (ne00%8 == 0) {
                                 [encoder setComputePipelineState:ctx->pipeline_diag_mask_inf_8];
@@ -846,8 +848,8 @@ void ggml_metal_graph_compute(
                             }
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
-                            [encoder setBytes:&ne00   length:sizeof(ne00) atIndex:2];
-                            [encoder setBytes:&ne01   length:sizeof(ne01) atIndex:3];
+                            [encoder setBytes:&ne00    length:sizeof(ne00) atIndex:2];
+                            [encoder setBytes:&n00x01  length:sizeof(n00x01) atIndex:3];
                             [encoder setBytes:&n_past length:sizeof(int)  atIndex:4];
 
                             if (ne00%8 == 0) {

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -294,6 +294,7 @@ void ggml_metal_free(struct ggml_metal_context * ctx) {
     GGML_METAL_DEL_KERNEL(soft_max);
     GGML_METAL_DEL_KERNEL(soft_max_4);
     GGML_METAL_DEL_KERNEL(diag_mask_inf_8);
+    GGML_METAL_DEL_KERNEL(diag_mask_inf);
     GGML_METAL_DEL_KERNEL(get_rows_f16);
     GGML_METAL_DEL_KERNEL(get_rows_q4_0);
     GGML_METAL_DEL_KERNEL(get_rows_q4_1);

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -902,22 +902,28 @@ void ggml_metal_graph_compute(
                             } else {
                                 int nth0 = 32;
                                 int nth1 = 1;
-                                int nrows = 1;
+                                //int nrows = 1;
+                                int nx = 1, ny = 1;
 
                                 // use custom matrix x vector kernel
                                 switch (src0t) {
                                     case GGML_TYPE_F16:
                                         {
-                                            nth0 = 32;
-                                            nth1 = 1;
-                                            if (ne11 * ne12 < 4) {
-                                                [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_1row];
-                                            } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
+                                            //[encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32];
+                                            //nth0 = 32;
+                                            //nth1 = 1;
+                                            //if (ne11 * ne12 < 4) {
+                                            //    [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_1row];
+                                            if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
                                                 [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_l4];
-                                                nrows = ne11;
+                                                nx = ne01;
+                                                ny = 1;
+                                                nth0 = 32;
                                             } else {
                                                 [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32];
-                                                nrows = 4;
+                                                nth0 = ne01 >= 32 ? 32 : ne01 >= 16 ? 16 : ne01 >= 8 ? 8 : ne01 >= 4 ? 4 : ne01 >= 2 ? 2 : 1;
+                                                nx = (ne01 + nth0 - 1)/nth0;
+                                                ny = ne11;
                                             }
                                         } break;
                                     case GGML_TYPE_Q4_0:
@@ -1038,8 +1044,13 @@ void ggml_metal_graph_compute(
                                 else if (src0t == GGML_TYPE_Q6_K) {
                                     [encoder dispatchThreadgroups:MTLSizeMake((ne01 + 1)/2, ne11, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
                                 } else {
-                                    int64_t ny = (ne11 + nrows - 1)/nrows;
-                                    [encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
+                                    ////printf("f16xf32: %d x %d x %d,  %d x %d x %d -> %d\n",(int)ne00,(int)ne01,(int)ne02,
+                                    ////        (int)ne10,(int)ne11,(int)ne12,nrows);
+                                    //int64_t ny = (ne11 + nrows - 1)/nrows;
+                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne01, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, nth1, 1)];
+                                    //[encoder dispatchThreadgroups:MTLSizeMake(ne10*ne11*ne12, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+                                    //int n = ne01 >= 32 ? 32 : ne01 >= 16 ? 16 : ne01 >= 8 ? 8 : ne01 >= 4 ? 4 : ne01 >= 2 ? 2 : 1;
+                                    [encoder dispatchThreadgroups:MTLSizeMake(nx, ny, ne12) threadsPerThreadgroup:MTLSizeMake(nth0, 1, 1)];
                                 }
                             }
                         } break;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -183,21 +183,19 @@ kernel void kernel_soft_max_4(
 }
 
 kernel void kernel_diag_mask_inf(
-        device const float * src0,
-        device       float * dst,
+        device const float4 * src0,
+        device       float4 * dst,
         constant   int64_t & ne00,
-        constant   int64_t & ne01,
+        constant   int64_t & n00x01,
         constant       int & n_past,
         uint3 tpig[[thread_position_in_grid]]) {
-    const int64_t i02 = tpig[2];
-    const int64_t i01 = tpig[1];
-    const int64_t i00 = tpig[0];
+    const int64_t i = 2*tpig[0];
 
     if (i00 > n_past + i01) {
         dst[i02*ne01*ne00 + i01*ne00 + i00] = -INFINITY;
     } else {
         dst[i02*ne01*ne00 + i01*ne00 + i00] = src0[i02*ne01*ne00 + i01*ne00 + i00];
-     }
+    }
 }
 
 kernel void kernel_diag_mask_inf_8(
@@ -216,6 +214,13 @@ kernel void kernel_diag_mask_inf_8(
     const int64_t i02 = i4/(ne00*ne01); i4 -= i02*ne00*ne01;
     const int64_t i01 = i4/(ne00);      i4 -= i01*ne00;
     const int64_t i00 = i4;
+    dst[i+0] = src0[i+0];
+    dst[i+1] = src0[i+1];
+    int64_t i4 = 4*i;
+    const int64_t i02 = i4/n00x01;
+    i4 -= i02*n00x01;
+    const int64_t i01 = i4/ne00;
+    const int64_t i00 = i4 - i01*ne00;
     for (int k = 3; k >= 0; --k) {
         if (i00 + 4 + k <= n_past + i01) {
             break;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -682,6 +682,7 @@ kernel void kernel_mul_mat_f16_f32_l4(
     device const half4 * x4 = (device const half4 *) (src0 + r0*nb01 + im/(ne12/ne02)*nb02);
 
     for (int r1 = 0; r1 < nrows; ++r1) {
+
         device const float4 * y4 = (device const float4 *) (src1 + r1*nb11 + im*nb12);
 
         float sumf = 0;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -216,41 +216,6 @@ kernel void kernel_diag_mask_inf_8(
     const int64_t i02 = i4/(ne00*ne01); i4 -= i02*ne00*ne01;
     const int64_t i01 = i4/(ne00);      i4 -= i01*ne00;
     const int64_t i00 = i4;
-    dst[i+0] = src0[i+0];
-    dst[i+1] = src0[i+1];
-    int64_t i4 = 4*i;
-    const int64_t i02 = i4/n00x01;
-    i4 -= i02*n00x01;
-    const int64_t i01 = i4/ne00;
-    const int64_t i00 = i4 - i01*ne00;
-    for (int k = 3; k >= 0; --k) {
-        if (i00 + 4 + k <= n_past + i01) {
-            break;
-        }
-        dst[i+1][k] = -INFINITY;
-        if (i00 + k > n_past + i01) {
-            dst[i][k] = -INFINITY;
-        }
-    }
-}
-
-kernel void kernel_diag_mask_inf_8(
-        device const float4 * src0,
-        device       float4 * dst,
-        constant    int64_t & ne00,
-        constant    int64_t & ne01,
-        constant        int & n_past,
-        uint3 tpig[[thread_position_in_grid]]) {
-
-    const int64_t i = 2*tpig[0];
-
-    dst[i+0] = src0[i+0];
-    dst[i+1] = src0[i+1];
-    int64_t i4 = 4*i;
-    const int64_t i02 = i4/(ne00*ne01);
-    i4 -= i02*ne00*ne01;
-    const int64_t i01 = i4/ne00;
-    const int64_t i00 = i4 - i01*ne00;
     for (int k = 3; k >= 0; --k) {
         if (i00 + 4 + k <= n_past + i01) {
             break;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -234,6 +234,34 @@ kernel void kernel_diag_mask_inf_8(
     }
 }
 
+kernel void kernel_diag_mask_inf_8(
+        device const float4 * src0,
+        device       float4 * dst,
+        constant    int64_t & ne00,
+        constant    int64_t & ne01,
+        constant        int & n_past,
+        uint3 tpig[[thread_position_in_grid]]) {
+
+    const int64_t i = 2*tpig[0];
+
+    dst[i+0] = src0[i+0];
+    dst[i+1] = src0[i+1];
+    int64_t i4 = 4*i;
+    const int64_t i02 = i4/(ne00*ne01);
+    i4 -= i02*ne00*ne01;
+    const int64_t i01 = i4/ne00;
+    const int64_t i00 = i4 - i01*ne00;
+    for (int k = 3; k >= 0; --k) {
+        if (i00 + 4 + k <= n_past + i01) {
+            break;
+        }
+        dst[i+1][k] = -INFINITY;
+        if (i00 + k > n_past + i01) {
+            dst[i][k] = -INFINITY;
+        }
+    }
+}
+
 kernel void kernel_norm(
         device const  void * src0,
         device       float * dst,

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -183,13 +183,15 @@ kernel void kernel_soft_max_4(
 }
 
 kernel void kernel_diag_mask_inf(
-        device const float4 * src0,
-        device       float4 * dst,
+        device const float * src0,
+        device       float * dst,
         constant   int64_t & ne00,
-        constant   int64_t & n00x01,
+        constant   int64_t & ne01,
         constant       int & n_past,
         uint3 tpig[[thread_position_in_grid]]) {
-    const int64_t i = 2*tpig[0];
+    const int64_t i02 = tpig[2];
+    const int64_t i01 = tpig[1];
+    const int64_t i00 = tpig[0];
 
     if (i00 > n_past + i01) {
         dst[i02*ne01*ne00 + i01*ne00 + i00] = -INFINITY;


### PR DESCRIPTION
TL;DR: For PP on metal, a significant fraction of the time is spent in the `K * Q` matrix multiplication. The PR is an attempt to speed up this matrix multiplication. The result is mostly useful for the Falcon model where we see a ~12% increase in performance.

If I turn the `f16 x f32` matrix multiplication operation into a no-op, I see a 51% increase in PP performance for Falcon-7B and 17% gain for LLaMA-7B on metal. This explains most of the PP performance gap between between Falcon and LLaMA. Most of the time spent in `f16 x f32` matrix multiplications is due to the `K * Q` matrix multiplication. On metal, the kernel utilized for most other matrix multiplications cannot be used because the `K` and `Q` tensors are not contiguous. Hence, a poor-men's matrix multiplication kernel is invoked, which becomes a bottleneck as the context/batch size increases. This PR adds a slightly better version, which I think is still very far from optimal. The effect is a ~12% speedup for Falcon-7B PP, along with some very minor gains for TG.

30-core M2 Max:

| model                          | backend    | test       |    /s (Master)   |      t/s (PR)    |  Speedup |
| ------------------------------ | ---------- | ---------- | ---------------: | ---------------: | -------: |
| Falcon 7B mostly F16           | Metal      | pp 512     |    380.18 ± 0.13 |    426.83 ± 0.26 |   1.123  |
| LLaMA 7B mostly F16            | Metal      | pp 512     |    539.46 ± 0.31 |    539.61 ± 0.37 |   1.000  |
| LLaMA 7B mostly Q8_0           | Metal      | pp 512     |    486.91 ± 0.18 |    486.83 ± 0.44 |   1.000  |
| LLaMA 7B mostly Q4_0           | Metal      | pp 512     |    495.91 ± 0.38 |    495.82 ± 0.17 |   1.000  |
| LLaMA 7B mostly Q4_1           | Metal      | pp 512     |    494.31 ± 0.26 |    494.52 ± 0.55 |   1.000  |
| LLaMA 7B mostly Q6_K           | Metal      | pp 512     |    413.82 ± 0.39 |    414.16 ± 0.23 |   1.001  |
| LLaMA 7B mostly Q5_K - Small   | Metal      | pp 512     |    413.35 ± 0.27 |    413.58 ± 0.12 |   1.000  |
| LLaMA 7B mostly Q4_K - Small   | Metal      | pp 512     |    438.64 ± 0.23 |    438.39 ± 0.18 |   1.000  |
| LLaMA 7B mostly Q3_K - Small   | Metal      | pp 512     |    417.91 ± 0.25 |    417.79 ± 0.25 |   1.000  |
| Falcon 7B mostly F16           | Metal      | tg 128     |     23.33 ± 0.04 |     23.51 ± 0.05 |   1.008  |
| LLaMA 7B mostly F16            | Metal      | tg 128     |     24.26 ± 0.04 |     24.24 ± 0.07 |   1.000  |
| LLaMA 7B mostly Q8_0           | Metal      | tg 128     |     40.16 ± 0.27 |     40.35 ± 0.25 |   1.005  |
| LLaMA 7B mostly Q4_0           | Metal      | tg 128     |     62.53 ± 0.06 |     63.34 ± 0.04 |   1.013  |
| LLaMA 7B mostly Q4_1           | Metal      | tg 128     |     58.88 ± 0.78 |     58.62 ± 0.02 |   0.996  |
| LLaMA 7B mostly Q6_K           | Metal      | tg 128     |     42.93 ± 0.48 |     43.21 ± 0.46 |   1.006  |
| LLaMA 7B mostly Q5_K - Small   | Metal      | tg 128     |     44.67 ± 0.03 |     45.79 ± 0.03 |   1.025  |
| LLaMA 7B mostly Q4_K - Small   | Metal      | tg 128     |     57.31 ± 0.44 |     57.86 ± 0.04 |   1.010  |
| LLaMA 7B mostly Q3_K - Small   | Metal      | tg 128     |     53.42 ± 0.24 |     53.77 ± 0.17 |   1.007  |

    