### PR TITLE
CUDA: fix mul_mat_q not used for output tensor

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6291,7 +6291,7 @@ void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_
                 ggml_cuda_op_mul_mat(src0, src1, dst, ggml_cuda_op_dequantize_mul_mat_vec, false);
             }
         } else {
-            if (src1->backend == GGML_BACKEND_GPU && g_mul_mat_q && ggml_is_quantized(src0->type) && min_compute_capability >= MIN_CC_DP4A) {
+            if (g_mul_mat_q && ggml_is_quantized(src0->type) && min_compute_capability >= MIN_CC_DP4A) {
                 ggml_cuda_op_mul_mat(src0, src1, dst, ggml_cuda_op_mul_mat_q, true);
             } else {
                 ggml_cuda_op_mul_mat(src0, src1, dst, ggml_cuda_op_mul_mat_cublas, false);


### PR DESCRIPTION
As pointed out by https://github.com/ggerganov/llama.cpp/pull/3110#issuecomment-1714467191 , the recent PR https://github.com/ggerganov/llama.cpp/pull/3110 has increased VRAM usage. The problem is that at some point I added a condition for using mul_mat_q over cuBLAS for debugging purposes and forgot to remove it again. This PR removes said condition which fixes the increased VRAM usage for the output tensor.