### PR TITLE
flake.nix : include llama.h in nix output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,8 @@
         postInstall = ''
           mv $out/bin/main $out/bin/llama
           mv $out/bin/server $out/bin/llama-server
+          mkdir $out/include
+          cp ${src}/llama.h $out/include/
         '';
         cmakeFlags = [ "-DLLAMA_BUILD_SERVER=ON" "-DLLAMA_MPI=ON" "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
       in


### PR DESCRIPTION
Yup. Does what it says on the tin.

I just added a `cp` to `postInstall`.

This lets me include llama.cpp in other programs built with nix :tada: 