### PR TITLE
flake : allow $out/include to already exist

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
         postInstall = ''
           mv $out/bin/main $out/bin/llama
           mv $out/bin/server $out/bin/llama-server
-          mkdir $out/include
+          mkdir -p $out/include
           cp ${src}/llama.h $out/include/
         '';
         cmakeFlags = [ "-DLLAMA_BUILD_SERVER=ON" "-DLLAMA_MPI=ON" "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_SKIP_BUILD_RPATH=ON" ];


### PR DESCRIPTION
Following #3159 , nix builds were failing for me because of the `include` directory already existing. I'm not sure in exactly which circumstances it will already exist, but anyway it seems harmless to not fail the build when that happens.