### PR TITLE
cmake : fix building shared libs for clang (rocm) on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,7 @@ if (LLAMA_ALL_WARNINGS)
 
 endif()
 
-if (MSVC)
+if (WIN32)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 
     if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
Instead of having CMake check `MSVC` before setting `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` when building shared libraries, this PR has it check `WIN32`. This lets the HIP SDK's clang build the shared libraries on Windows and fixes #3144.