### PR TITLE
CUDA: fix scratch buffers being allocated on non-main device

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6970,6 +6970,7 @@ void ggml_cuda_assign_scratch_offset(struct ggml_tensor * tensor, size_t offset)
         return;
     }
     if (g_scratch_buffer == nullptr) {
+        ggml_cuda_set_device(g_main_device);
         CUDA_CHECK(cudaMalloc(&g_scratch_buffer, g_scratch_size));
     }
 


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/3163 .

The issue from what I can tell is that `ggml_cuda_assign_scratch_offset` does not set the device to the main device before allocating memory. As a consequence it is possible that the scratch buffers end up on other devices which then later causes an error. This PR simply adds a call to `ggml_cuda_set_device` before any of the other CUDA calls.