### PR TITLE
ci : switch cudatoolkit install on windows to networked

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,6 +406,7 @@ jobs:
         id: cuda-toolkit
         with:
           cuda: ${{ matrix.cuda }}
+          method: 'network'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
 
       - name: Build


### PR DESCRIPTION
as proposed in #3232 , this switches to the networked installer that should reduce the traffic. In my testing it reduces the time from 15-20min down to ~10min.
Even if it does not reduce the time by much, it reduces the cache size significantly.

run: https://github.com/Green-Sky/llama.cpp/actions/runs/6215910973/job/16869261559