### PR TITLE
flake: Restore default package's buildInputs #3261

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,8 @@
       in
       {
         packages.default = pkgs.stdenv.mkDerivation {
-          inherit name src meta postPatch nativeBuildInputs buildInputs postInstall;
+          inherit name src meta postPatch nativeBuildInputs postInstall;
+          buildInputs = osSpecific;
           cmakeFlags = cmakeFlags
             ++ (if isAarch64 && isDarwin then [
             "-DCMAKE_C_FLAGS=-D__ARM_FEATURE_DOTPROD=1"


### PR DESCRIPTION
When added support for ROCM to flake(#2808), modified buildInputs, so the dependencies defined in osSpecific that are required for darwin support were not available.
Simply changed the value of buildInputs to osSpecific.