### PR TITLE
scripts : use `/usr/bin/env` in shebang

### DIFF
--- a/scripts/verify-checksum-models.py
+++ b/scripts/verify-checksum-models.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import hashlib


### PR DESCRIPTION
`/usr/bin/env` is more standard and exists on macOS, unlike `/bin/env`.