### PR TITLE
docker : ignore Git files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 *.o
 *.a
 .cache/
+.git/
+.github/
+.gitignore
 .vs/
 .vscode/
 .DS_Store


### PR DESCRIPTION
Git files (including history) should not need to be copied into the Docker container.