### PR TITLE
Add flush for printf on example

### DIFF
--- a/examples/train-text-from-scratch/train-text-from-scratch.cpp
+++ b/examples/train-text-from-scratch/train-text-from-scratch.cpp
@@ -1964,6 +1964,7 @@ void opt_callback(void * vdata, float * sched) {
 
     int impr_plot = std::isnan(opt->loss_after) ? 0 : -std::lround(1 + (opt->loss_before - opt->loss_after) * 10.0f);
     printf("%s: iter=%*d, sched=%f loss0=%f loss=%f | improvement: %*d>\n", __func__, 6, opt->iter, *sched, opt->loss_before, opt->loss_after, impr_plot, (int)0);
+    fflush(stdout);
 
     if (data->shuffle_countdown < n_batch) {
         printf("%s: reshuffle samples\n", __func__);


### PR DESCRIPTION
I'm trying to run the training example in a remote machine while dump output to a file.
So that I can exit the ssh terminal.
Without this flush, the printf data will keep in stdout buffer, as a result, file will miss training progress info