### PR TITLE
docs : mark code as Bash

### DIFF
--- a/docs/BLIS.md
+++ b/docs/BLIS.md
@@ -48,7 +48,7 @@ make -j
 According to the BLIS documentation, we could set the following
 environment variables to modify the behavior of openmp:
 
-```
+```bash
 export GOMP_GPU_AFFINITY="0-19"
 export BLIS_NUM_THREADS=14
 ```


### PR DESCRIPTION
The `export` statements are Bash.