### PR TITLE
swift : fix build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let platforms: [SupportedPlatform]? = [
     .tvOS(.v14)
 ]
 let exclude: [String] = []
-let additionalSources: [String] = ["ggml-metal.m"]
+let additionalSources: [String] = ["ggml-metal.m", "ggml-metal.metal"]
 let additionalSettings: [CSetting] = [
     .unsafeFlags(["-fno-objc-arc"]),
     .define("GGML_SWIFT"),
@@ -44,8 +44,8 @@ let package = Package(
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32"]),
                 .define("GGML_USE_K_QUANTS"),
-                .define("GGML_USE_ACCELERATE")
-                .define("ACCELERATE_NEW_LAPACK")
+                .define("GGML_USE_ACCELERATE"),
+                .define("ACCELERATE_NEW_LAPACK"),
                 .define("ACCELERATE_LAPACK_ILP64")
             ] + additionalSettings,
             linkerSettings: [


### PR DESCRIPTION
Fix the swift package build, closes #3385.

Two issues:
1. The build issue was caused from #3342
2. multiple resources named 'ggml-metal.metal' in target 'llama'

Tested with `https://github.com/jhen0409/llama.cpp` + branch `fix-swift-xcode15` in a initial Xcode project.