### PR TITLE
ggml-cuda : explicitly use cmath for log2

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1,11 +1,12 @@
 #include <algorithm>
+#include <assert.h>
+#include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdint.h>
 #include <stdio.h>
-#include <atomic>
-#include <assert.h>
 
 #if defined(GGML_USE_HIPBLAS)
 #include <hip/hip_runtime.h>
@@ -6237,7 +6238,7 @@ inline void ggml_cuda_op_alibi(
     GGML_ASSERT(ne01 + n_past == ne00);
     GGML_ASSERT(n_head == ne02);
 
-    const int n_heads_log2_floor = 1 << (int) floor(log2(n_head));
+    const int n_heads_log2_floor = 1 << (int) std::floor(std::log2(n_head));
 
     const float m0 = powf(2.0f, -(max_bias) / n_heads_log2_floor);
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_heads_log2_floor);


### PR DESCRIPTION
Should fix compilation issues when building with some versions of the standard library, as reported in #3398