### PR TITLE
llama : expose model's rope_freq_scale in the API

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -6895,6 +6895,10 @@ int llama_n_embd(const struct llama_model * model) {
     return model->hparams.n_embd;
 }
 
+float llama_rope_freq_scale_train(const struct llama_model * model) {
+    return model->hparams.rope_freq_scale_train;
+}
+
 int llama_model_desc(const struct llama_model * model, char * buf, size_t buf_size) {
     return snprintf(buf, buf_size, "%s %s %s",
             llama_model_arch_name(model->arch).c_str(),

--- a/llama.h
+++ b/llama.h
@@ -282,6 +282,9 @@ extern "C" {
     LLAMA_API int llama_n_ctx_train(const struct llama_model * model);
     LLAMA_API int llama_n_embd     (const struct llama_model * model);
 
+    // Get the model's RoPE frequency scaling factor
+    LLAMA_API float llama_rope_freq_scale_train(const struct llama_model * model);
+
     // Get a string describing the model type
     LLAMA_API int llama_model_desc(const struct llama_model * model, char * buf, size_t buf_size);
 


### PR DESCRIPTION
I think this is necessary for automatic implementations of https://github.com/ggerganov/llama.cpp/tree/master/examples/main#extended-context-size when the model's RoPE scaling factor isn't 1.0. (We want to further scale it rather than overwriting the value, right?)