### PR TITLE
Windows XP: support MinGW 8.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)  # for add_link_options
+cmake_minimum_required(VERSION 3.14)  # for add_link_options and implicit target directories.
 project("llama.cpp" C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -74,6 +74,10 @@ option(LLAMA_FMA                             "llama: enable FMA"                
 # in MSVC F16C is implied with AVX2/AVX512
 if (NOT MSVC)
     option(LLAMA_F16C                        "llama: enable F16C"                               ${INS_ENB})
+endif()
+
+if (WIN32)
+    option(LLAMA_WIN_VER                     "llama: Windows Version"                           0x602)
 endif()
 
 # 3rd party libs
@@ -686,7 +690,7 @@ endif()
 
 if (MINGW)
     # Target Windows 8 for PrefetchVirtualMemory
-    add_compile_definitions(_WIN32_WINNT=0x602)
+    add_compile_definitions(_WIN32_WINNT=${LLAMA_WIN_VER})
 endif()
 
 #

--- a/llama.cpp
+++ b/llama.cpp
@@ -987,6 +987,7 @@ struct llama_mmap {
         }
 
         if (prefetch > 0) {
+#if _WIN32_WINNT >= 0x602
             // PrefetchVirtualMemory is only present on Windows 8 and above, so we dynamically load it
             BOOL (WINAPI *pPrefetchVirtualMemory) (HANDLE, ULONG_PTR, PWIN32_MEMORY_RANGE_ENTRY, ULONG);
             HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
@@ -1004,6 +1005,9 @@ struct llama_mmap {
                             llama_format_win_err(GetLastError()).c_str());
                 }
             }
+#else
+            throw std::runtime_error("PrefetchVirtualMemory unavailable");
+#endif
         }
     }
 


### PR DESCRIPTION
I am trying to get LLAMA to work on Windows XP, faced quite a few issues with MinGW 8.1.0, decided to add a patch that fixes it.

Updated Summary of issues addressed:

- Bump to CMake 3.14, due to unavailability of `add_link_options` and `target_link_libraries` and implicit destinations.
- Windows 8 code is left unguarded and won't compile unless a WINVER/_WIN32_WINNT guard is set. This patch fixes it. 

Again, this PR is the bare minimum needed to build and run this completely on XP. More functionality will follow in subsequent PRs.

Screenshot: StarCoder 1B is working with mmap disabled:

![Screenshot-Working-LLAMA-StarCoder-1B](https://github.com/ggerganov/llama.cpp/assets/195178/106f0365-b681-481a-aa81-30ebf2cbb6b8)
![Screenshot-Working-LLAMA-StarCoder-1B-V2](https://github.com/ggerganov/llama.cpp/assets/195178/580b2b8f-45ff-43c3-b399-51f6cc5c6298)

Roughly speed is like < 10 tokens/minute measured by looking between those screenshots.