### PR TITLE
Consistent prefix/suffix coloring

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -694,10 +694,8 @@ int main(int argc, char ** argv) {
                     if (last_output.find(antiprompt, search_start_pos) != std::string::npos) {
                         if (params.interactive) {
                             is_interacting = true;
-                            console::set_display(console::user_input);
                         }
                         is_antiprompt = true;
-                        fflush(stdout);
                         break;
                     }
                 }
@@ -721,8 +719,6 @@ int main(int argc, char ** argv) {
 
                     is_interacting = true;
                     printf("\n");
-                    console::set_display(console::user_input);
-                    fflush(stdout);
                 } else if (params.instruct) {
                     is_interacting = true;
                 }
@@ -746,6 +742,9 @@ int main(int argc, char ** argv) {
                     buffer += params.input_prefix;
                     printf("%s", buffer.c_str());
                 }
+
+                // color user input only
+                console::set_display(console::user_input);
 
                 std::string line;
                 bool another_line = true;

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -667,7 +667,7 @@ int main(int argc, char ** argv) {
             }
             fflush(stdout);
         }
-        // reset color to default if we there is no pending user input
+        // reset color to default if there is no pending user input
         if (input_echo && (int) embd_inp.size() == n_consumed) {
             console::set_display(console::reset);
         }


### PR DESCRIPTION
This PR removes any coloring from the `--in-prefix` text. Previously, all `--in-suffix` texts as well as only the first `--in-prefix` text weren't colored. So, now, strictly the actually typed user input is colored.

Potentially, the `--in-prefix` and `--in-suffix` texts could also be colored yellow like the initial prompt you can take from a file. (Not done by this PR.)