### PR TITLE
cmake : increase minimum version for add_link_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12) # Don't bump this version for no reason
+cmake_minimum_required(VERSION 3.13)  # for add_link_options
 project("llama.cpp" C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
CMake 3.12 cannot build this project due to the use of add_link_options.

ref: https://github.com/ggerganov/llama.cpp/pull/3419#discussion_r1342183357