### PR TITLE
[bug] kv_self.size is being set to buffer size during load state

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -7276,7 +7276,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
         }
 
         ctx->kv_self.head = kv_ntok;
-        ctx->kv_self.size = kv_size;
+        ctx->kv_self.size = n_ctx;
     }
 
     const size_t nread    = inp - src;


### PR DESCRIPTION
It seems `llama_context.kv_self.size` is initialised to be equal to `context size`, but when loading from a session file, it's being set to the `buffer size`. This should fix it.