### PR TITLE
swift : disable ACCELERATE_NEW_LAPACK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,9 +44,12 @@ let package = Package(
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32"]),
                 .define("GGML_USE_K_QUANTS"),
-                .define("GGML_USE_ACCELERATE"),
-                .define("ACCELERATE_NEW_LAPACK"),
-                .define("ACCELERATE_LAPACK_ILP64")
+                .define("GGML_USE_ACCELERATE")
+                // NOTE: NEW_LAPACK will required iOS version 16.4+
+                // We should consider add this in the future when we drop support for iOS 14
+                // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
+                // .define("ACCELERATE_NEW_LAPACK"),
+                // .define("ACCELERATE_LAPACK_ILP64")
             ] + additionalSettings,
             linkerSettings: [
                 .linkedFramework("Accelerate")


### PR DESCRIPTION
ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc

These new APIs appear to be only compatible with iOS 16.4+, and it seems to cause problems like #3438. I think we should not use it for the time being, so I just comment it and add notes.