### PR TITLE
build: use std::make_tuple() for compatibility with older GCC versions

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -361,7 +361,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 invalid_param = true;
                 break;
             }
-            params.lora_adapter.push_back({argv[i], 1.0f});
+            params.lora_adapter.push_back(std::make_tuple(argv[i], 1.0f));
             params.use_mmap = false;
         } else if (arg == "--lora-scaled") {
             if (++i >= argc) {
@@ -373,7 +373,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 invalid_param = true;
                 break;
             }
-            params.lora_adapter.push_back({lora_adapter, std::stof(argv[i])});
+            params.lora_adapter.push_back(std::make_tuple(lora_adapter, std::stof(argv[i])));
             params.use_mmap = false;
         } else if (arg == "--lora-base") {
             if (++i >= argc) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1015,7 +1015,7 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
                 invalid_param = true;
                 break;
             }
-            params.lora_adapter.push_back({argv[i], 1.0f});
+            params.lora_adapter.push_back(std::make_tuple(argv[i], 1.0f));
             params.use_mmap = false;
         }
         else if (arg == "--lora-scaled")
@@ -1031,7 +1031,7 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
                 invalid_param = true;
                 break;
             }
-            params.lora_adapter.push_back({lora_adapter, std::stof(argv[i])});
+            params.lora_adapter.push_back(std::make_tuple(lora_adapter, std::stof(argv[i])));
             params.use_mmap = false;
         }
         else if (arg == "--lora-base")


### PR DESCRIPTION
Older versions of GCC, such as GCC 5.x, do not support the following syntax for constructing tuples, so the user will get the following error:

```c
params.lora_adapter.push_back({std::string(argv[i]), 1.0f});
```

```
common/common.cpp:364:58: error: converting to ‘std::vector<std::tuple<std::__cxx11::basic_string<char, std::char_traits, std::allocator >, float> >::value_type {aka std::tuple<std::__cxx11::basic_string<char, std::char_traits, std::allocator >, float>}’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = char*&; _U2 = float; = void; _T1 = std::__cxx11::basic_string; _T2 = float]’ params.lora_adapter.push_back({argv[i], 1.0f});
```

This commit will use classical way to construct tuples to make it compatible with old GCCs.