### PR TITLE
quantize : fail fast on write errors

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -6639,6 +6639,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
     }
 
     std::ofstream fout(fname_out, std::ios::binary);
+    fout.exceptions(std::ofstream::failbit); // fail fast on write errors
 
     const size_t meta_size = gguf_get_meta_size(ctx_out);
 


### PR DESCRIPTION
This causes quantize to fail early with an error message if you run out of disk space, instead of appearing to succeed while silently producing a corrupt output file.

```
[ 170/ 543]                 blk.18.ffn_up.weight - [ 6656, 17920,     1,     1], type =    f16, quantizing to q5_0 .. size =   227.50 MB ->    78.20 MB | hist: 0.078 0.062 0.061 0.059 0.059 0.062 0.067 0.070 0.078 0.063 0.060 0.056 0.054 0.055 0.057 0.059 
llama_model_quantize: failed to quantize: basic_ios::clear: iostream error
main: failed to quantize model from 'alpacino-33B.f16.gguf'
```