### PR TITLE
metal : support MTLGPUFamily < Apple7, formatting, style

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -274,16 +274,18 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         GGML_METAL_ADD_KERNEL(mul_mv_q4_K_f32);
         GGML_METAL_ADD_KERNEL(mul_mv_q5_K_f32);
         GGML_METAL_ADD_KERNEL(mul_mv_q6_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_f32_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_f16_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q4_0_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q8_0_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q4_1_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q2_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q3_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q4_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q5_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mm_q6_K_f32);
+        if ([ctx->device supportsFamily:MTLGPUFamilyApple7]) {
+            GGML_METAL_ADD_KERNEL(mul_mm_f32_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_f16_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q4_0_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q8_0_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q4_1_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q2_K_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q3_K_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q4_K_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q5_K_f32);
+            GGML_METAL_ADD_KERNEL(mul_mm_q6_K_f32);
+        }
         GGML_METAL_ADD_KERNEL(rope_f32);
         GGML_METAL_ADD_KERNEL(rope_f16);
         GGML_METAL_ADD_KERNEL(alibi_f32);
@@ -296,8 +298,22 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
 #undef GGML_METAL_ADD_KERNEL
     }
 
-    GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");
 #if TARGET_OS_OSX
+    // print MTL GPU family:
+    GGML_METAL_LOG_INFO("%s: GPU name:   %s\n", __func__, [[ctx->device name] UTF8String]);
+    GGML_METAL_LOG_INFO("%s: GPU arch:   %s\n", __func__, [[ctx->device architecture].name UTF8String]);
+
+    // determine max supported GPU family
+    // https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
+    // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+    for (int i = MTLGPUFamilyApple9 + 10; i >= MTLGPUFamilyApple1; --i) {
+        if ([ctx->device supportsFamily:i]) {
+            GGML_METAL_LOG_INFO("%s: GPU family: MTLGPUFamilyApple%d (%d)\n", __func__, i - MTLGPUFamilyApple1 + 1, i);
+            break;
+        }
+    }
+
+    GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");
     GGML_METAL_LOG_INFO("%s: recommendedMaxWorkingSetSize  = %8.2f MB\n", __func__, ctx->device.recommendedMaxWorkingSetSize / 1024.0 / 1024.0);
     if (ctx->device.maxTransferRate != 0) {
         GGML_METAL_LOG_INFO("%s: maxTransferRate               = %8.2f MB/s\n", __func__, ctx->device.maxTransferRate / 1024.0 / 1024.0);
@@ -351,16 +367,18 @@ void ggml_metal_free(struct ggml_metal_context * ctx) {
     GGML_METAL_DEL_KERNEL(mul_mv_q4_K_f32);
     GGML_METAL_DEL_KERNEL(mul_mv_q5_K_f32);
     GGML_METAL_DEL_KERNEL(mul_mv_q6_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_f32_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_f16_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q4_0_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q8_0_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q4_1_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q2_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q3_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q4_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q5_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mm_q6_K_f32);
+    if ([ctx->device supportsFamily:MTLGPUFamilyApple7]) {
+        GGML_METAL_DEL_KERNEL(mul_mm_f32_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_f16_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q4_0_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q8_0_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q4_1_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q2_K_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q3_K_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q4_K_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q5_K_f32);
+        GGML_METAL_DEL_KERNEL(mul_mm_q6_K_f32);
+    }
     GGML_METAL_DEL_KERNEL(rope_f32);
     GGML_METAL_DEL_KERNEL(rope_f16);
     GGML_METAL_DEL_KERNEL(alibi_f32);
@@ -986,32 +1004,36 @@ void ggml_metal_graph_compute(
                         } break;
                     case GGML_OP_MUL_MAT:
                         {
-                            // TODO: needs to be updated after PR: https://github.com/ggerganov/ggml/pull/224
-
                             GGML_ASSERT(ne00 == ne10);
-                            // GGML_ASSERT(ne02 == ne12); // Should be checked on individual data types until broadcast is implemented everywhere
-                            uint gqa = ne12/ne02;
                             GGML_ASSERT(ne03 == ne13);
 
+                            const uint gqa = ne12/ne02;
+
                             // find the break-even point where the matrix-matrix kernel becomes more efficient compared
-                            // to the matrix-vector kernel. the numbers below are measured on M2 Ultra
-                            // not sure if this translates across all chips
+                            // to the matrix-vector kernel
                             int ne11_mm_min = 1;
 
-                            switch (src0t) {
-                                case GGML_TYPE_F16:  ne11_mm_min = 2;  break;
-                                case GGML_TYPE_Q8_0: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q2_K: ne11_mm_min = 15; break;
-                                case GGML_TYPE_Q3_K: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q4_0:
-                                case GGML_TYPE_Q4_1: ne11_mm_min = 15; break;
-                                case GGML_TYPE_Q4_K: ne11_mm_min = 11; break;
-                                case GGML_TYPE_Q5_0:                          // not tested yet
-                                case GGML_TYPE_Q5_1: ne11_mm_min = 13; break; // not tested yet
-                                case GGML_TYPE_Q5_K: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q6_K: ne11_mm_min = 7;  break;
-                                default:             ne11_mm_min = 1;  break;
+#if 0
+                            // the numbers below are measured on M2 Ultra for 7B and 13B models
+                            // these numbers do not translate to other devices or model sizes
+                            // TODO: need to find a better approach
+                            if ([ctx->device.name isEqualToString:@"Apple M2 Ultra"]) {
+                                switch (src0t) {
+                                    case GGML_TYPE_F16:  ne11_mm_min = 2;  break;
+                                    case GGML_TYPE_Q8_0: ne11_mm_min = 7;  break;
+                                    case GGML_TYPE_Q2_K: ne11_mm_min = 15; break;
+                                    case GGML_TYPE_Q3_K: ne11_mm_min = 7;  break;
+                                    case GGML_TYPE_Q4_0:
+                                    case GGML_TYPE_Q4_1: ne11_mm_min = 15; break;
+                                    case GGML_TYPE_Q4_K: ne11_mm_min = 11; break;
+                                    case GGML_TYPE_Q5_0:                          // not tested yet
+                                    case GGML_TYPE_Q5_1: ne11_mm_min = 13; break; // not tested yet
+                                    case GGML_TYPE_Q5_K: ne11_mm_min = 7;  break;
+                                    case GGML_TYPE_Q6_K: ne11_mm_min = 7;  break;
+                                    default:             ne11_mm_min = 1;  break;
+                                }
                             }
+#endif
 
                             // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
                             // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -81,18 +81,18 @@ struct ggml_metal_context {
     GGML_METAL_DECL_KERNEL(get_rows_q6_K);
     GGML_METAL_DECL_KERNEL(rms_norm);
     GGML_METAL_DECL_KERNEL(norm);
-    GGML_METAL_DECL_KERNEL(mul_mat_f32_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_f16_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_f16_f32_1row);
-    GGML_METAL_DECL_KERNEL(mul_mat_f16_f32_l4);
-    GGML_METAL_DECL_KERNEL(mul_mat_q4_0_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q4_1_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q8_0_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q2_K_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q3_K_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q4_K_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q5_K_f32);
-    GGML_METAL_DECL_KERNEL(mul_mat_q6_K_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_f32_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_f16_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_f16_f32_1row);
+    GGML_METAL_DECL_KERNEL(mul_mv_f16_f32_l4);
+    GGML_METAL_DECL_KERNEL(mul_mv_q4_0_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q4_1_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q8_0_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q2_K_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q3_K_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q4_K_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q5_K_f32);
+    GGML_METAL_DECL_KERNEL(mul_mv_q6_K_f32);
     GGML_METAL_DECL_KERNEL(mul_mm_f32_f32);
     GGML_METAL_DECL_KERNEL(mul_mm_f16_f32);
     GGML_METAL_DECL_KERNEL(mul_mm_q4_0_f32);
@@ -262,18 +262,18 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         GGML_METAL_ADD_KERNEL(get_rows_q6_K);
         GGML_METAL_ADD_KERNEL(rms_norm);
         GGML_METAL_ADD_KERNEL(norm);
-        GGML_METAL_ADD_KERNEL(mul_mat_f32_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_f16_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_f16_f32_1row);
-        GGML_METAL_ADD_KERNEL(mul_mat_f16_f32_l4);
-        GGML_METAL_ADD_KERNEL(mul_mat_q4_0_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q4_1_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q8_0_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q2_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q3_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q4_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q5_K_f32);
-        GGML_METAL_ADD_KERNEL(mul_mat_q6_K_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_f32_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_f16_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_f16_f32_1row);
+        GGML_METAL_ADD_KERNEL(mul_mv_f16_f32_l4);
+        GGML_METAL_ADD_KERNEL(mul_mv_q4_0_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q4_1_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q8_0_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q2_K_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q3_K_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q4_K_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q5_K_f32);
+        GGML_METAL_ADD_KERNEL(mul_mv_q6_K_f32);
         GGML_METAL_ADD_KERNEL(mul_mm_f32_f32);
         GGML_METAL_ADD_KERNEL(mul_mm_f16_f32);
         GGML_METAL_ADD_KERNEL(mul_mm_q4_0_f32);
@@ -339,18 +339,18 @@ void ggml_metal_free(struct ggml_metal_context * ctx) {
     GGML_METAL_DEL_KERNEL(get_rows_q6_K);
     GGML_METAL_DEL_KERNEL(rms_norm);
     GGML_METAL_DEL_KERNEL(norm);
-    GGML_METAL_DEL_KERNEL(mul_mat_f32_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_f16_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_f16_f32_1row);
-    GGML_METAL_DEL_KERNEL(mul_mat_f16_f32_l4);
-    GGML_METAL_DEL_KERNEL(mul_mat_q4_0_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q4_1_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q8_0_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q2_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q3_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q4_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q5_K_f32);
-    GGML_METAL_DEL_KERNEL(mul_mat_q6_K_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_f32_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_f16_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_f16_f32_1row);
+    GGML_METAL_DEL_KERNEL(mul_mv_f16_f32_l4);
+    GGML_METAL_DEL_KERNEL(mul_mv_q4_0_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q4_1_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q8_0_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q2_K_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q3_K_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q4_K_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q5_K_f32);
+    GGML_METAL_DEL_KERNEL(mul_mv_q6_K_f32);
     GGML_METAL_DEL_KERNEL(mul_mm_f32_f32);
     GGML_METAL_DEL_KERNEL(mul_mm_f16_f32);
     GGML_METAL_DEL_KERNEL(mul_mm_q4_0_f32);
@@ -1059,7 +1059,7 @@ void ggml_metal_graph_compute(
                                 switch (src0t) {
                                     case GGML_TYPE_F32:
                                         {
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_f32_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_f32_f32];
                                             nrows = 4;
                                         } break;
                                     case GGML_TYPE_F16:
@@ -1067,12 +1067,12 @@ void ggml_metal_graph_compute(
                                             nth0 = 32;
                                             nth1 = 1;
                                             if (ne11 * ne12 < 4) {
-                                                [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_1row];
+                                                [encoder setComputePipelineState:ctx->pipeline_mul_mv_f16_f32_1row];
                                             } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
-                                                [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32_l4];
+                                                [encoder setComputePipelineState:ctx->pipeline_mul_mv_f16_f32_l4];
                                                 nrows = ne11;
                                             } else {
-                                                [encoder setComputePipelineState:ctx->pipeline_mul_mat_f16_f32];
+                                                [encoder setComputePipelineState:ctx->pipeline_mul_mv_f16_f32];
                                                 nrows = 4;
                                             }
                                         } break;
@@ -1083,7 +1083,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 8;
                                             nth1 = 8;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q4_0_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q4_0_f32];
                                         } break;
                                     case GGML_TYPE_Q4_1:
                                         {
@@ -1092,7 +1092,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 8;
                                             nth1 = 8;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q4_1_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q4_1_f32];
                                         } break;
                                     case GGML_TYPE_Q8_0:
                                         {
@@ -1101,7 +1101,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 8;
                                             nth1 = 8;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q8_0_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q8_0_f32];
                                         } break;
                                     case GGML_TYPE_Q2_K:
                                         {
@@ -1110,7 +1110,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 2;
                                             nth1 = 32;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q2_K_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q2_K_f32];
                                         } break;
                                     case GGML_TYPE_Q3_K:
                                         {
@@ -1119,7 +1119,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 2;
                                             nth1 = 32;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q3_K_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q3_K_f32];
                                         } break;
                                     case GGML_TYPE_Q4_K:
                                         {
@@ -1128,7 +1128,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 4; //1;
                                             nth1 = 8; //32;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q4_K_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q4_K_f32];
                                         } break;
                                     case GGML_TYPE_Q5_K:
                                         {
@@ -1137,7 +1137,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 2;
                                             nth1 = 32;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q5_K_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q5_K_f32];
                                         } break;
                                     case GGML_TYPE_Q6_K:
                                         {
@@ -1146,7 +1146,7 @@ void ggml_metal_graph_compute(
 
                                             nth0 = 2;
                                             nth1 = 32;
-                                            [encoder setComputePipelineState:ctx->pipeline_mul_mat_q6_K_f32];
+                                            [encoder setComputePipelineState:ctx->pipeline_mul_mv_q6_K_f32];
                                         } break;
                                     default:
                                         {

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -13,8 +13,8 @@ typedef struct {
 
 #define QK4_1 32
 typedef struct {
-    half d;          // delta
-    half m;          // min
+    half d;                 // delta
+    half m;                 // min
     uint8_t qs[QK4_1 / 2];  // nibbles / quants
 } block_q4_1;
 
@@ -2397,7 +2397,7 @@ kernel void kernel_mul_mm(device const  uchar * src0,
         + nb10 * (BLOCK_SIZE_K / THREAD_PER_COL * (tiitg % THREAD_PER_COL)));
 
     for (int loop_k = 0; loop_k < ne00; loop_k += BLOCK_SIZE_K) {
-        //load data and store to threadgroup memory
+        // load data and store to threadgroup memory
         half4x4 temp_a;
         dequantize_func(x, il, temp_a);
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -2417,7 +2417,7 @@ kernel void kernel_mul_mm(device const  uchar * src0,
 
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        //load matrices from threadgroup memory and conduct outer products
+        // load matrices from threadgroup memory and conduct outer products
         threadgroup half  * lsma = (sa + THREAD_MAT_M * SG_MAT_SIZE * (sgitg % 2));
         threadgroup float * lsmb = (sb + THREAD_MAT_N * SG_MAT_SIZE * (sgitg / 2));
 
@@ -2444,25 +2444,25 @@ kernel void kernel_mul_mm(device const  uchar * src0,
     }
 
     if ((r0 + 1) * BLOCK_SIZE_M <= ne0 && (r1 + 1) * BLOCK_SIZE_N <= ne1) {
-        device float *C = dst + (BLOCK_SIZE_M * r0 + 32 * (sgitg &  1)) \
-                              + (BLOCK_SIZE_N * r1 + 16 * (sgitg >> 1)) * ne0 + im*ne1*ne0;
+        device float * C = dst + (BLOCK_SIZE_M * r0 + 32 * (sgitg &  1)) \
+                               + (BLOCK_SIZE_N * r1 + 16 * (sgitg >> 1)) * ne0 + im*ne1*ne0;
         for (int i = 0; i < 8; i++) {
             simdgroup_store(c_res[i], C + 8 * (i%4) + 8 * ne0 * (i/4), ne0);
         }
     } else {
         // block is smaller than 64x32, we should avoid writing data outside of the matrix
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        threadgroup float *temp_str = ((threadgroup float *)shared_memory) \
+        threadgroup float * temp_str = ((threadgroup float *)shared_memory) \
                                       + 32 * (sgitg&1) + (16 * (sgitg>>1)) * BLOCK_SIZE_M;
         for (int i = 0; i < 8; i++) {
             simdgroup_store(c_res[i], temp_str + 8 * (i%4) + 8 * BLOCK_SIZE_M * (i/4), BLOCK_SIZE_M);
         }
 
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        device float *C = dst + BLOCK_SIZE_M * r0 + (BLOCK_SIZE_N * r1) * ne0 + im*ne1*ne0;
-        if (sgitg==0) {
+        device float * C = dst + BLOCK_SIZE_M * r0 + (BLOCK_SIZE_N * r1) * ne0 + im*ne1*ne0;
+        if (sgitg == 0) {
             for (int i = 0; i < n_rows; i++) {
-                for (int j = tiitg; j< n_cols; j += BLOCK_SIZE_N) {
+                for (int j = tiitg; j < n_cols; j += BLOCK_SIZE_N) {
                     *(C + i + j * ne0) = *(temp_str + i + j * BLOCK_SIZE_M);
                 }
             }

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -2332,7 +2332,7 @@ kernel void kernel_get_rows(
 }
 
 #define BLOCK_SIZE_M 64 // 8 simdgroup matrices from matrix A
-#define BLOCK_SIZE_N 32 // 4 simdgroup matrices from matrix A
+#define BLOCK_SIZE_N 32 // 4 simdgroup matrices from matrix B
 #define BLOCK_SIZE_K 32
 #define THREAD_MAT_M 4 // each thread take 4 simdgroup matrices from matrix A
 #define THREAD_MAT_N 2 // each thread take 2 simdgroup matrices from matrix B
@@ -2459,7 +2459,8 @@ kernel void kernel_mul_mm(device const  uchar * src0,
         }
 
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        device float * C = dst + BLOCK_SIZE_M * r0 + (BLOCK_SIZE_N * r1) * ne0 + im*ne1*ne0;
+
+        device float * C = dst + (BLOCK_SIZE_M * r0) + (BLOCK_SIZE_N * r1) * ne0 + im*ne1*ne0;
         if (sgitg == 0) {
             for (int i = 0; i < n_rows; i++) {
                 for (int j = tiitg; j < n_cols; j += BLOCK_SIZE_N) {


### PR DESCRIPTION
#### Edit:

ref #3129

The scope of this PR changed - it is now mostly a formatting change. Improved batched decoding will be investigated in a future PR.

Obsolete info below

---

ref #3479 

In Metal, we have 2 matrix multiplication kernels:

- matrix-matrix
- matrix-vector

Depending on the batch size, one of the 2 kernels is faster.

This PR adds logic for choosing which kernel to use depending on the batch size. The numbers are determined empirically on M2 Ultra. Not sure if these translate to the optimal numbers for other chips, but for sure would not affect the performance tests that we have been doing so far, since we have been testing either batch size of 1 or batch size of 512.

This change improves batched decoding performance for non-F16 types. For F16 there is no difference, although similar analysis should be performed on the CUDA kernels and see where is the break-even point between the 2 kernels

```bash
make -j && ../scripts/run-all-perf.sh llama-13b-v2 "q4_0" "-ngl 1 -t 4 -p 1,2,4,5,6,7,8,9,10,11,12,13,14,15,16,32,64,128,256 -n 128"
```

| model                   |       size | backend    | ngl |    th | test       |    master    t/s |   PR         t/s |   speedup |
| ----------------------- | ---------: | ---------- | --: | ----- | ---------- | ---------------: | ---------------: | --------: |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 1       |    48.31 ± 24.64 |    48.69 ± 24.48 |     1.008 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 2       |     88.30 ± 0.97 |     88.81 ± 0.90 |     1.006 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 4       |     42.94 ± 0.15 |    108.12 ± 0.77 |     2.518 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 5       |     53.43 ± 0.12 |    113.97 ± 0.79 |     2.133 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 6       |     64.03 ± 0.20 |    126.26 ± 0.65 |     1.972 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 7       |     74.53 ± 0.09 |    130.34 ± 0.79 |     1.749 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 8       |     84.85 ± 0.22 |    127.16 ± 0.50 |     1.499 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 9       |     95.41 ± 0.05 |    143.48 ± 0.80 |     1.504 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 10      |    105.56 ± 0.13 |    146.24 ± 0.41 |     1.385 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 11      |    115.74 ± 0.10 |    142.48 ± 0.70 |     1.231 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 12      |    125.90 ± 0.12 |    145.26 ± 0.43 |     1.154 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 13      |    135.86 ± 0.10 |    148.30 ± 0.45 |     1.092 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 14      |    146.83 ± 0.26 |    155.42 ± 0.59 |     1.059 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 15      |    156.65 ± 0.45 |    156.63 ± 0.33 |     1.000 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 16      |    165.56 ± 0.10 |    165.38 ± 0.31 |     0.999 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 32      |    333.24 ± 1.00 |    332.12 ± 0.39 |     0.997 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 64      |    474.08 ± 0.61 |    474.25 ± 0.92 |     1.000 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 128     |    596.25 ± 1.05 |    596.23 ± 1.49 |     1.000 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | pp 256     |    630.68 ± 2.13 |    629.23 ± 1.68 |     0.998 |
| llama 13B Q4_0          |   6.86 GiB | Metal      |   1 |     4 | tg 128     |     58.55 ± 0.23 |     58.82 ± 0.07 |     1.005 |

build: 99ed03a (1343)

```bash
make -j && ../scripts/run-all-perf.sh llama-7b-v2 "q4_0" "-ngl 1 -t 4 -p 1,2,4,5,6,7,8,9,10,11,12,13,14,15,16,32,64,128,256 -n 128"
```

| model                   |       size | backend    | ngl |    th | test       |              t/s |              t/s |   speedup |
| ----------------------- | ---------: | ---------- | --: | ----: | ---------- | ---------------: | ---------------: | --------: |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 1       |    76.45 ± 42.71 |    82.15 ± 41.40 |     1.075 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 2       |    153.05 ± 2.75 |    152.31 ± 3.73 |     0.995 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 4       |     73.90 ± 0.30 |    195.84 ± 3.21 |     2.650 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 5       |     91.90 ± 0.18 |    207.80 ± 1.06 |     2.261 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 6       |    109.99 ± 0.47 |    231.24 ± 2.18 |     2.102 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 7       |    128.03 ± 0.54 |    238.55 ± 2.61 |     1.863 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 8       |    146.67 ± 0.89 |    240.39 ± 0.53 |     1.639 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 9       |    164.05 ± 0.69 |    263.59 ± 1.70 |     1.607 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 10      |    181.87 ± 0.18 |    268.87 ± 2.57 |     1.478 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 11      |    200.08 ± 0.61 |    264.98 ± 2.13 |     1.324 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 12      |    217.81 ± 0.78 |    270.22 ± 1.90 |     1.241 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 13      |    234.61 ± 0.82 |    274.98 ± 0.56 |     1.172 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 14      |    252.92 ± 1.04 |    284.32 ± 2.01 |     1.124 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 15      |    270.12 ± 1.27 |    287.72 ± 0.72 |     1.065 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 16      |    288.98 ± 0.96 |    288.78 ± 1.11 |     0.999 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 32      |    569.31 ± 2.22 |    568.82 ± 2.76 |     0.999 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 64      |    840.19 ± 1.89 |    840.68 ± 0.23 |     1.001 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 128     |   1064.88 ± 2.15 |   1067.44 ± 2.81 |     1.002 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | pp 256     |   1165.27 ± 1.40 |   1166.87 ± 1.66 |     1.001 |
| llama 7B Q4_0           |   3.56 GiB | Metal      |   1 |     4 | tg 128     |     98.42 ± 0.09 |     98.34 ± 0.07 |     0.999 |

### Sample results for `parallel` example

Generating 64 sequences using a system prompt, serving 4 requests in parallel

```bash
# 13B Q8_0, n_parallel = 4
make -j && ./parallel -m ./models/llama-13b-v2/ggml-model-q8_0.gguf -f "prompts/parallel-questions.txt" -n 512 -t 1 -s 3456 -ngl 100 -c 8192 -np 4 -ns 64 -cb
```

- master

```java
main: n_parallel = 4, n_sequences = 64, cont_batching = 1, system tokens = 305
External prompt file: prompts/parallel-questions.txt
Model and path used:  ./models/llama-13b-v2/ggml-model-q8_0.gguf

Total prompt tokens:    895, speed:  9.59 t/s
Total gen tokens:      3437, speed: 36.84 t/s
Total speed (AVG):           speed: 46.43 t/s
Cache misses:             0


llama_print_timings:        load time =     788.18 ms
llama_print_timings:      sample time =    2339.45 ms /  3501 runs   (    0.67 ms per token,  1496.51 tokens per second)
llama_print_timings: prompt eval time =   90551.29 ms /  4635 tokens (   19.54 ms per token,    51.19 tokens per second)
llama_print_timings:        eval time =      55.12 ms /     2 runs   (   27.56 ms per token,    36.29 tokens per second)
llama_print_timings:       total time =   93307.56 ms
```

- PR

```java
main: n_parallel = 4, n_sequences = 64, cont_batching = 1, system tokens = 305
External prompt file: prompts/parallel-questions.txt
Model and path used:  ./models/llama-13b-v2/ggml-model-q8_0.gguf

Total prompt tokens:    895, speed: 13.49 t/s
Total gen tokens:      3497, speed: 52.71 t/s
Total speed (AVG):           speed: 66.20 t/s
Cache misses:             0


llama_print_timings:        load time =     778.88 ms
llama_print_timings:      sample time =    2392.38 ms /  3561 runs   (    0.67 ms per token,  1488.48 tokens per second)
llama_print_timings: prompt eval time =   63470.54 ms /  4693 tokens (   13.52 ms per token,    73.94 tokens per second)
llama_print_timings:        eval time =     111.81 ms /     4 runs   (   27.95 ms per token,    35.77 tokens per second)
llama_print_timings:       total time =   66341.93 ms
```
