### PR TITLE
Fix trying to strip newline from empty prompt and cfg prompt file content

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -170,7 +170,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             // store the external file name in params
             params.prompt_file = argv[i];
             std::copy(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), back_inserter(params.prompt));
-            if (params.prompt.back() == '\n') {
+            if (!params.prompt.empty() && params.prompt.back() == '\n') {
                 params.prompt.pop_back();
             }
         } else if (arg == "-n" || arg == "--n-predict") {
@@ -295,7 +295,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             std::copy(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), back_inserter(params.cfg_negative_prompt));
-            if (params.cfg_negative_prompt.back() == '\n') {
+            if (!params.cfg_negative_prompt.empty() && params.cfg_negative_prompt.back() == '\n') {
                 params.cfg_negative_prompt.pop_back();
             }
         } else if (arg == "--cfg-scale") {


### PR DESCRIPTION
If the prompt or CFG negative prompt file options are set to an empty file, attempting to strip a newline currently causes a memory error. This small fix just makes sure the files aren't empty. I found this out the fun way (don't ask why I set `-f /dev/null`).

Also, GCC's address sanitizer is pretty handy. Maybe there should be a `LLAMA_ADDRESS_SANITIZER` option that just adds `-fsanitize=address -g` to the `CFLAGS` and `CXXFLAGS`. I believe this will work with Clang also. It even seems to work when compiling with optimizations turned on and is way faster than Valgrind.