### PR TITLE
swift : improvements and fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             resources: resources,
             publicHeadersPath: "spm-headers",
             cSettings: [
-                .unsafeFlags(["-Wno-shorten-64-to-32"]),
+                .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
                 .define("GGML_USE_K_QUANTS"),
                 .define("GGML_USE_ACCELERATE")
                 // NOTE: NEW_LAPACK will required iOS version 16.4+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
                 "ggml.c",
                 "llama.cpp",
                 "ggml-alloc.c",
+                "ggml-backend.c",
                 "k_quants.c",
             ] + additionalSources,
             resources: resources,

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
 #if arch(arm) || arch(arm64)
 let platforms: [SupportedPlatform]? = [
-    .macOS(.v11),
+    .macOS(.v12),
     .iOS(.v14),
     .watchOS(.v4),
     .tvOS(.v14)


### PR DESCRIPTION
Some small improvements and fixes:

- We currently used [int64_t](https://developer.apple.com/documentation/metal/mtldatatype/long) in Metal, so we should use macOS 12 as minimum requirement (macOS v12 platform is defined in `swift-tools-version:5.5`)
- Add -O3 -DNDEBUG unsafe flags as we already did in the makefile (context: comments in #3527)
- Add missing ggml-backend.c source for fix build, but I'll remove it in this PR if #3562 get merged first