### PR TITLE
fixing tiny resource leak when reading /proc/cpuinfo on Linux

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -96,6 +96,9 @@ static std::string get_cpu_info() {
                 }
             }
         }
+        if (0 != fclose(f)) {
+            fprintf(stderr, "could not close reader of /proc/cpuinfo\n");
+        }
     }
 #endif
     // TODO: other platforms


### PR DESCRIPTION
Hi there,

this PR fixes a tiny possible resource leak when reading /proc/cpuinfo on Linux. It is more for good measure, no functional changes.

Cheers,
tpltnt