### PR TITLE
[docs] Fix typo in OpenMP env var

### DIFF
--- a/docs/BLIS.md
+++ b/docs/BLIS.md
@@ -49,7 +49,7 @@ According to the BLIS documentation, we could set the following
 environment variables to modify the behavior of openmp:
 
 ```bash
-export GOMP_GPU_AFFINITY="0-19"
+export GOMP_CPU_AFFINITY="0-19"
 export BLIS_NUM_THREADS=14
 ```
 


### PR DESCRIPTION
Just replaced `GOMP_GPU_AFFINITY` with `GOMP_CPU_AFFINITY`, as stated at https://github.com/flame/blis/blob/master/docs/Multithreading.md#specifying-thread-to-core-affinity.