### PR TITLE
MPT : clone wte to output at load time

### DIFF
--- a/convert-mpt-hf-to-gguf.py
+++ b/convert-mpt-hf-to-gguf.py
@@ -197,11 +197,6 @@ for part_name in part_names:
 
         gguf_writer.add_tensor(new_name, data)
 
-        # note: MPT output is tied to (same as) wte in original model;
-        # for easier implementation in llama.cpp it's duplicated in GGUF, though :/
-        if new_name == "token_embd.weight":
-            gguf_writer.add_tensor("output.weight", data)
-
 print("gguf: write header")
 gguf_writer.write_header_to_file()
 print("gguf: write metadata")

--- a/ggml.c
+++ b/ggml.c
@@ -21167,10 +21167,11 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
         // the ggml_tensor structs to the appropriate locations in the binary blob
 
         // compute the exact size needed for the new ggml_context
+        int n_tensors = ctx->header.n_tensors + params.extra_tensors;
         const size_t mem_size =
             params.no_alloc ?
-            (ctx->header.n_tensors    )*ggml_tensor_overhead() :
-            (ctx->header.n_tensors + 1)*ggml_tensor_overhead() + ctx->size;
+            (n_tensors    )*ggml_tensor_overhead() :
+            (n_tensors + 1)*ggml_tensor_overhead() + ctx->size;
 
         struct ggml_init_params pdata = {
             .mem_size   = mem_size,
@@ -21452,6 +21453,10 @@ int gguf_find_tensor(const struct gguf_context * ctx, const char * name) {
 
 size_t gguf_get_tensor_offset(const struct gguf_context * ctx, int i) {
     return ctx->infos[i].offset;
+}
+
+void gguf_set_tensor_offset(const struct gguf_context * ctx, int i, size_t offset) {
+    ctx->infos[i].offset = offset;
 }
 
 char * gguf_get_tensor_name(const struct gguf_context * ctx, int i) {

--- a/ggml.h
+++ b/ggml.h
@@ -1964,6 +1964,7 @@ extern "C" {
 
         // if not NULL, create a ggml_context and allocate the tensor data in it
         struct ggml_context ** ctx;
+        int extra_tensors;
     };
 
     GGML_API struct gguf_context * gguf_init_empty(void);
@@ -2006,6 +2007,7 @@ extern "C" {
     GGML_API int    gguf_get_n_tensors    (const struct gguf_context * ctx);
     GGML_API int    gguf_find_tensor      (const struct gguf_context * ctx, const char * name);
     GGML_API size_t gguf_get_tensor_offset(const struct gguf_context * ctx, int i);
+    GGML_API void   gguf_set_tensor_offset(const struct gguf_context * ctx, int i, size_t offset);
     GGML_API char * gguf_get_tensor_name  (const struct gguf_context * ctx, int i);
 
     // overrides existing values or adds a new one

--- a/llama.cpp
+++ b/llama.cpp
@@ -5532,7 +5532,7 @@ static struct ggml_cgraph * llm_build_mpt(
                 wsize * n_embd_head,
                 wsize * n_embd_head * (n_head + 2 * n_head_kv),
                 wsize * n_embd_head * (n_head +     n_head_kv));
-            offload_func_kq(Kcur);
+            offload_func_v(tmpv);
 
             ggml_set_name(Qcur, "Qcur");
             ggml_set_name(Kcur, "Kcur");


### PR DESCRIPTION
This change removes the need to duplicate the token_embd.weight tensor on disk. Instead, it is cloned as output.weight at load time.

The tensor is not cloned while quantizing because quantize does not call llm_load_tensors.