### PR TITLE
Address undeclared identifiers by adding conditional compilation

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -735,19 +735,37 @@ struct llama_mmap {
         }
 
         if (prefetch > 0) {
+            #ifdef __USE_XOPEN2K
             // Advise the kernel to preload the mapped memory
             if (posix_madvise(addr, std::min(file->size, prefetch), POSIX_MADV_WILLNEED)) {
                 fprintf(stderr, "warning: posix_madvise(.., POSIX_MADV_WILLNEED) failed: %s\n",
                         strerror(errno));
             }
+            #else
+            // Advise the kernel to preload the mapped memory
+            if (madvise(addr, std::min(file->size, prefetch), MADV_WILLNEED)) {
+                fprintf(stderr, "warning: madvise(.., MADV_WILLNEED) failed: %s\n",
+                        strerror(errno));
+            }
+            #endif
+
         }
         if (numa) {
+            #ifdef __USE_XOPEN2K
             // advise the kernel not to use readahead
             // (because the next page might not belong on the same node)
             if (posix_madvise(addr, file->size, POSIX_MADV_RANDOM)) {
                 fprintf(stderr, "warning: posix_madvise(.., POSIX_MADV_RANDOM) failed: %s\n",
                         strerror(errno));
             }
+            #else
+            // advise the kernel not to use readahead
+            // (because the next page might not belong on the same node)
+            if (madvise(addr, file->size, MADV_RANDOM)) {
+                fprintf(stderr, "warning: madvise(.., MADV_RANDOM) failed: %s\n",
+                        strerror(errno));
+            }
+            #endif
         }
     }
 


### PR DESCRIPTION
This fixes an issue i encountered when compiling my app maid (https://github.com/danemadsen/maid) for android. 
For some reason the __USE_XOPEN2K flag is not defined when compiling for android so POSIX_MADV_WILLNEED and POSIX_MADV_RANDOM throw undefined errors. 

below is the error message i received:
```
flutter build apk --debug


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:buildCMakeDebug[arm64-v8a]'.
> Build command failed.
  Error while executing process /home/dane_madsen/Android/Sdk/cmake/3.18.1/bin/ninja with arguments {-C /home/dane_madsen/maid/android/app/.cxx/Debug/221c6fv2/arm64-v8a butler ggml_shared llama}
  ninja: Entering directory `/home/dane_madsen/maid/android/app/.cxx/Debug/221c6fv2/arm64-v8a'
  [1/3] Building CXX object llama.cpp/CMakeFiles/llama.dir/llama.cpp.o
  FAILED: llama.cpp/CMakeFiles/llama.dir/llama.cpp.o 
  /home/dane_madsen/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --gcc-toolchain=/home/dane_madsen/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64 --sysroot=/home/dane_madsen/Android/Sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DGGML_USE_K_QUANTS -DLLAMA_BUILD -DLLAMA_SHARED -D_XOPEN_SOURCE=600 -Dllama_EXPORTS -I/home/dane_madsen/maid/src/llama.cpp/. -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -fno-limit-debug-info  -fPIC -Wmissing-declarations -Wmissing-noreturn -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wunreachable-code-break -Wunreachable-code-return -Wmissing-prototypes -Wextra-semi -pthread -std=gnu++11 -MD -MT llama.cpp/CMakeFiles/llama.dir/llama.cpp.o -MF llama.cpp/CMakeFiles/llama.dir/llama.cpp.o.d -o llama.cpp/CMakeFiles/llama.dir/llama.cpp.o -c /home/dane_madsen/maid/src/llama.cpp/llama.cpp
  /home/dane_madsen/maid/src/llama.cpp/llama.cpp:739:17: error: use of undeclared identifier 'posix_madvise'
              if (posix_madvise(addr, std::min(file->size, prefetch), MADV_WILLNEED)) {
                  ^
  /home/dane_madsen/maid/src/llama.cpp/llama.cpp:747:17: error: use of undeclared identifier 'posix_madvise'
              if (posix_madvise(addr, file->size, MADV_RANDOM)) {
                  ^
  2 errors generated.
  ninja: build stopped: subcommand failed.



* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4s
Running Gradle task 'assembleDebug'...                              4.6s
Gradle task assembleDebug failed with exit code 1
```