### PR TITLE
llava : fix tokenization to not add bos after system prompt

### DIFF
--- a/examples/llava/llava-utils.h
+++ b/examples/llava/llava-utils.h
@@ -49,9 +49,9 @@ inline bool eval_id(struct llama_context * ctx_llama, int id, int * n_past) {
     return eval_tokens(ctx_llama, tokens, 1, n_past);
 }
 
-inline bool eval_string(struct llama_context * ctx_llama, const char* str, int n_batch, int * n_past){
+inline bool eval_string(struct llama_context * ctx_llama, const char* str, int n_batch, int * n_past, bool add_bos){
     std::string              str2     = str;
-    std::vector<llama_token> embd_inp = ::llama_tokenize(ctx_llama, str2, true);
+    std::vector<llama_token> embd_inp = ::llama_tokenize(ctx_llama, str2, add_bos);
     eval_tokens(ctx_llama, embd_inp, n_batch, n_past);
     return true;
 }

--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -106,7 +106,8 @@ int main(int argc, char ** argv) {
     }
 
     // make sure that the correct mmproj was used, i.e., compare apples to apples
-    int n_llama_embd = llama_n_embd(llama_get_model(ctx_llama));
+    const int n_llama_embd = llama_n_embd(llama_get_model(ctx_llama));
+
     if (n_img_embd != n_llama_embd) {
         printf("%s: embedding dim of the multimodal projector (%d) is not equal to that of LLaMA (%d). Make sure that you use the correct mmproj file.\n", __func__, n_img_embd, n_llama_embd);
 
@@ -125,14 +126,14 @@ int main(int argc, char ** argv) {
 
     const int max_tgt_len = params.n_predict < 0 ? 256 : params.n_predict;
 
-    // GG: are we sure that the should be a trailing whitespace at the end of this string?
-    eval_string(ctx_llama, "A chat between a curious human and an artificial intelligence assistant.  The assistant gives helpful, detailed, and polite answers to the human's questions.\nUSER: ", params.n_batch, &n_past);
+    eval_string(ctx_llama, "A chat between a curious human and an artificial intelligence assistant.  The assistant gives helpful, detailed, and polite answers to the human's questions.\nUSER:", params.n_batch, &n_past, true);
     eval_image_embd(ctx_llama, image_embd, n_img_pos, params.n_batch, &n_past);
-    eval_string(ctx_llama, params.prompt.c_str(), params.n_batch, &n_past);
-    eval_string(ctx_llama, "\nASSISTANT:",        params.n_batch, &n_past);
+    eval_string(ctx_llama, (params.prompt + "\nASSISTANT:").c_str(), params.n_batch, &n_past, false);
 
     // generate the response
 
+    printf("\n");
+    printf("prompt: '%s'\n", params.prompt.c_str());
     printf("\n");
 
     for (int i = 0; i < max_tgt_len; i++) {

--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -97,6 +97,7 @@ int main(int argc, char ** argv) {
     ctx_params.n_ctx           = params.n_ctx < 2048 ? 2048 : params.n_ctx; // we need a longer context size to process image embeddings
     ctx_params.n_threads       = params.n_threads;
     ctx_params.n_threads_batch = params.n_threads_batch == -1 ? params.n_threads : params.n_threads_batch;
+    ctx_params.seed            = params.seed;
 
     llama_context * ctx_llama = llama_new_context_with_model(model, ctx_params);
 


### PR DESCRIPTION
We had a bug in adding a BOS token unconditionally on every `eval_string` call:

https://github.com/ggerganov/llama.cpp/blob/11bff290458f12f020b588792707f76ec658a27a/examples/llava/llava-utils.h#L52-L57

https://github.com/ggerganov/llama.cpp/blob/11bff290458f12f020b588792707f76ec658a27a/examples/llava/llava.cpp#L128-L132

This PR fixes that by adding BOS only for the system prompt:

https://github.com/ggerganov/llama.cpp/blob/e0fb74c6ee343f7a4e4a1ca349004c7bb2db99f0/examples/llava/llava.cpp#L129-L131

Some anecdotal testing shows that the performance with the 13B model is now much better:

<img src="https://github.com/ggerganov/llama.cpp/assets/6631389/f051e177-c7a1-49a1-a0c5-a0f0cad87b3a" width="250">

```bash
./llava -m ./models/llava-13b-v1.5/ggml-model-q4_k.gguf --mmproj ./models/llava-13b-v1.5/mmproj-model-f16.gguf --image ~/Downloads/274487006-f051e177-c7a1-49a1-a0c5-a0f0cad87b3a.jpg --temp 0.0 -p 'Please read the text in this image and return the information in the following JSON format (note xxx is placeholder, if the information is not available in the image, put "N/A" instead).\n{"class": xxx, "DLN": xxx, "DOB": xxx, "Name": xxx, "Address": xxx, "EXP": xxx, "ISS": xxx, "SEX": xxx, "HGT": xxx, "WGT": xxx, "EYES": xxx, "HAIR": xxx, "DONOR": xxx}' -e

# master

 {
"class": "California driver's license",
"DLN": "CA DL 123456789",
"DOB": "01/01/1990",
"Name": "John Doe",
"Address": "123 Main St, Anytown, CA 12345",
"EXP": "01/31/2024",
"ISS": "California Department of Motor Vehicles",
"SEX": "Male",
"HGT": "6'2\"",
"WGT": "190 lbs",
"EYES": "Brown",
"HAIR": "Brown",
"DONOR": "No"
}

# PR

{"class": "California", "DLN": "1123456789", "DOB": "08/23/1971", "Name": "Ima Cardholder", "Address": "1234 N Main Street, Anytown, CA 92678", "EXP": "08/23/2014", "ISS": "California", "SEX": "F", "HGT": "5' 3"", "WGT": "123 lbs", "EYES": "Brown", "HAIR": "Black", "DONOR": "Sex F"
```