### PR TITLE
console: fix getwchar failing when LC_ALL undefined

### DIFF
--- a/common/console.cpp
+++ b/common/console.cpp
@@ -111,7 +111,16 @@ namespace console {
             }
         }
 
-        setlocale(LC_ALL, "");
+        auto locale = setlocale(LC_ALL, "");
+        auto lang = getenv("LANG");
+        
+        if (locale == nullptr) {
+            if (lang != nullptr) {
+                setlocale(LC_ALL, lang);
+            } else{
+                setlocale(LC_ALL, "C.UTF-8");
+            }
+        }
 #endif
     }
 

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <termios.h>
+#include <string.h>
 #endif
 
 #define ANSI_COLOR_RED     "\x1b[31m"
@@ -115,7 +116,7 @@ namespace console {
         auto lang = getenv("LANG");
 
         if (locale == nullptr) {
-            if (lang != nullptr) {
+            if (lang != nullptr && strcmp(lang, "C") && strcasestr(lang, "utf-8")) {
                 setlocale(LC_ALL, lang);
             } else{
                 setlocale(LC_ALL, "C.UTF-8");

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -113,7 +113,7 @@ namespace console {
 
         auto locale = setlocale(LC_ALL, "");
         auto lang = getenv("LANG");
-        
+
         if (locale == nullptr) {
             if (lang != nullptr) {
                 setlocale(LC_ALL, lang);

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -114,9 +114,9 @@ namespace console {
 
         auto locale = setlocale(LC_ALL, "");
 
-        if (locale == nullptr || !strcmp(locale, "C") || strcasestr(locale, "utf-8") == nullptr) {
+        if (locale == nullptr || strcasestr(locale, "utf-8") == nullptr) {
             auto lang = getenv("LANG");
-            if (lang != nullptr && strcmp(lang, "C") && strcasestr(lang, "utf-8") != nullptr) {
+            if (lang != nullptr && strcasestr(lang, "utf-8") != nullptr) {
                 setlocale(LC_ALL, lang);
             } else {
                 setlocale(LC_ALL, "C.UTF-8");

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -113,10 +113,10 @@ namespace console {
         }
 
         auto locale = setlocale(LC_ALL, "");
-        auto lang = getenv("LANG");
 
-        if (locale == nullptr) {
-            if (lang != nullptr && strcmp(lang, "C") && strcasestr(lang, "utf-8")) {
+        if (locale == nullptr || !strcmp(locale, "C") || strcasestr(locale, "utf-8") == nullptr) {
+            auto lang = getenv("LANG");
+            if (lang != nullptr && strcmp(lang, "C") && strcasestr(lang, "utf-8") != nullptr) {
                 setlocale(LC_ALL, lang);
             } else{
                 setlocale(LC_ALL, "C.UTF-8");

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -118,7 +118,7 @@ namespace console {
             auto lang = getenv("LANG");
             if (lang != nullptr && strcmp(lang, "C") && strcasestr(lang, "utf-8") != nullptr) {
                 setlocale(LC_ALL, lang);
-            } else{
+            } else {
                 setlocale(LC_ALL, "C.UTF-8");
             }
         }

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -53,6 +53,7 @@ namespace console {
     static termios   initial_state;
 #endif
 
+#if !defined(_WIN32)
     static bool locale_isvalid( const char * l )
     {
         return !(l == nullptr || l[0] == '\0' || (strcasestr(l, "utf-8") == nullptr && strcasestr(l, "utf8") == nullptr));
@@ -65,6 +66,7 @@ namespace console {
 
         return !strcmp( l, locale );
     }
+#endif
 
     //
     // Init and cleanup


### PR DESCRIPTION
Fixes #3638

It appears some Linux distributions can have `LC_ALL` undefined and `LANG` is used instead, which causes `getwchar()` to fail unicode conversion, but more importantly, this "poisons" the `stdin` (`/dev/tty`) causing any subsequent `getwchar` to return `WEOF` indefinitely.

This PR, addresses this issue, by adding a fallback which sets locale from `LANG`, and if that too is undefined, sets locale to `C.UTF-8` which ensures IO in unicode compatible mode.

![image](https://github.com/ggerganov/llama.cpp/assets/15910535/596f7cc7-98fa-4685-b62d-c645d81a18aa)


