### PR TITLE
server : fix 'terminated by signal SIGSEGV' error when suffix is empty

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -349,7 +349,7 @@ struct llama_server_context
         auto prefix_tokens = tokenize(params.input_prefix, false);
         auto suffix_tokens = tokenize(params.input_suffix, false);
         const int space_token = 29871;
-        if (suff_rm_leading_spc  && suffix_tokens[0] == space_token) {
+        if (suff_rm_leading_spc  && !suffix_tokens.empty() && suffix_tokens[0] == space_token) {
             suffix_tokens.erase(suffix_tokens.begin());
         }
         prefix_tokens.insert(prefix_tokens.begin(), llama_token_prefix(ctx));


### PR DESCRIPTION
Access to the first element of `suffix_tokens` is incorrect when `suffix_tokens` is an empty vector. This PR fixes this issue by checking if `suffix_tokens` is empty. 