### PR TITLE
server : allow to specify custom prompt for penalty calculation

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -193,12 +193,14 @@ llama_token llama_sampling_sample(
     }
 
     // apply penalties
-    if (!prev.empty()) {
+    const auto& penalty_tokens = params.use_penalty_prompt_tokens ? params.penalty_prompt_tokens : prev;
+    const int penalty_tokens_used_size = std::min((int)penalty_tokens.size(), penalty_last_n);
+    if (penalty_tokens_used_size) {
         const float nl_logit = logits[llama_token_nl(llama_get_model(ctx_main))];
 
         llama_sample_repetition_penalties(ctx_main, &cur_p,
-                prev.data() + prev.size() - penalty_last_n,
-                penalty_last_n, penalty_repeat, penalty_freq, penalty_present);
+                penalty_tokens.data() + penalty_tokens.size() - penalty_tokens_used_size,
+                penalty_tokens_used_size, penalty_repeat, penalty_freq, penalty_present);
 
         if (!penalize_nl) {
             for (size_t idx = 0; idx < cur_p.size; idx++) {

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -36,6 +36,9 @@ typedef struct llama_sampling_params {
     float       cfg_scale     = 1.f; // how strong is guidance
 
     std::unordered_map<llama_token, float> logit_bias; // logit bias for specific tokens
+
+    std::vector<llama_token> penalty_prompt_tokens;
+    bool                     use_penalty_prompt_tokens = false;
 } llama_sampling_params;
 
 // general sampler context

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -148,6 +148,8 @@ node index.js
 
     `frequency_penalty`: Repeat alpha frequency penalty (default: 0.0, 0.0 = disabled);
 
+    `penalty_prompt`: This will replace the `prompt` for the purpose of the penalty evaluation. Can be either `null`, a string or an array of numbers representing tokens (default: `null` = use the original `prompt`).
+
     `mirostat`: Enable Mirostat sampling, controlling perplexity during text generation (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0).
 
     `mirostat_tau`: Set the Mirostat target entropy, parameter tau (default: 5.0).


### PR DESCRIPTION
## What does it do?

This PR allows to specify a custom prompt for the purpose of calculating the penalties (repetition, frequency, presence).

It adds a new parameter `penalty_prompt` to the `server`'s API. This param can be set either as a string or a token array. It can also be `null` (default), which will mean that the original `prompt` will be used for the penalties (the current behavior).


## What does it solve?

Consider the following prompt which represents a chat:
```
Bob: Hello!
Alice: Hi, Bob! How are you?
Bob:
```
If the repetition penalty is applied to this prompt, then it means that Bob has a lesser chance to say "Alice", because this word is already in the prompt. However, such logic does not make any sense from a chat perspective. Bob never said "Alice", why he now suddenly has less chances to say it? These `Bob:` and `Alice:` prefixes are essentially just a metadata and not a part of the actual conversation. That's why these prefixes should not be used to affect what the chat participants are going to say.

This problem also happens the other way around: let's assume there are 5 people in the chat, and `Bob` is mentioned constantly. After applying the frequency penalty, the AI will less likely to decide to start a new line with `Bob:`, though it also does not make any sense in this context.

The new `penalty_prompt` can be set as the following:
```
Hello!
Hi, Bob! How are you?
```
to only penalize words in the actual conversation. Or even like this:
```
Hello!
```
to only restrict the repetition within a single chat participant's dialog lines (Bob, in this case).

Also, we have `penalize_nl` param. But why do newlines get a special treatment? What if I want to not penalize some other tokens, like punctuation, for example? The `penalize_nl`-approach does not scale well in this case.

Basically, the `penalty_prompt` allows any arbitrary customization of the penalty tokens.

Coincidentally, this PR also fixes the bug that was introduced by https://github.com/ggerganov/llama.cpp/pull/3696. That PR removed this line:
```cpp
const int last_n_repeat = std::min(std::min((int)prev.size(), repeat_last_n), n_ctx);
```
And now the `server` crashes when you specify `penalty_last_n` bigger than the context size. This PR fixes it, though not intentionally.


## How does it work?

You pass `penalty_prompt` as a string or a token array to the `server` via API. If it's a string, it gets parsed into tokens. After that it gets passed into the sampler instead of the original prompt. Then each time the token is generated, it gets added to the penalty prompt. The `penalty_last_n` is still in effect.

Nothing in this PR affects the sampling algorithm itself (i.e. `llama_sample_repetition_penalties`). And I think it will be compatible with all the future penalty samplers. Also, this change is backwards-compatible. If you don't set the `penalty_prompt` param, everything will work as it previously worked.


## Comments/Quirks

* This was done only for the `server`. Not sure if it makes sense for `main`. And, frankly, I'm only interested in the `server`, so maybe someone else can add it to the `main` if they want.

* I didn't write any tests. I'm a little bit confused where these tests should be (in what exact file) or what exactly should I test, since this PR does not change any sampling algorithms, but just passes different arguments to them. If the tests are required, can someone point me in the right direction?

* The new `penalty_prompt` only replaces the initial `prompt` at the beginning. After that, the new tokens will be appended to it (just like in case of the original `prompt`), and there's no control over it. So, even if you remove some words from the `penalty_prompt`, they can still appear in the generated text and will be used for the penalty calculation. With that in mind, the `penalize_nl` param can be somewhat useful, because it can affect the new tokens. Also, because of this, this PR is not quite the solution for https://github.com/ggerganov/llama.cpp/issues/3675.

* The `penalty_prompt` param can be a string, an array or `null`. And an empty string is not the same as `null`. Empty string means no text will be used for the penalty (initially, but the new generated tokens will be added to the `penalty_prompt` of course), and `null` means that the original `prompt` should be used. Otherwise it would be impossible to instruct the server that no initial prompt is needed for the penalty when specifying `penalty_prompt` as a string.

* I also had to mess up some formatting in the `get_formated_generation` [sic], because I tried to only introduce minimal changes to not cause a lot of git conflicts.
