### PR TITLE
gguf-py: Add support for loading merges.txt

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.4.5"
+version = "0.4.6"
 description = "Write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
I added support in `gguf.py` for loading `merges.txt` when loading merges is enabled and merges aren't found in `tokenizer.json`. It will also print out a warning when loading merges is turned on but there no merges are found (to hopefully avoid accidentally creating a model that can't be loaded).

I also added a `--padvocab` option to `convert.py` which will just create `<dummy00001>` etc tokens when the model expects more vocab entries than exist in the vocab metadata.

Some other minor cleanups. (I don't know about the line splitting format but some of the lines were getting absurdly long.) Also fixed a small bug where the endianness option wasn't honored when creating vocab only GGUF files.

*edit: Confirmed to fix CausalLM models.* Tested on https://huggingface.co/CausalLM/EarlyFailures14B/tree/main creating a vocab-only model, which presumably should be the same as the real CausalLM models.

```plaintext
gguf: WARNING: merges.txt: Line 109171: Entry malformed, ignoring
Padding vocab with 213 token(s) - <dummy00001> through <dummy00213>
This gguf file is for Little Endian only
gguf: Adding 109170 merge(s).
gguf: Setting special token type bos to 151643
gguf: Setting special token type eos to 151643
gguf: Setting special token type pad to 151643
```

Tried loading:

```plaintext
llm_load_vocab: mismatch in special tokens definition ( 421/152064 vs 213/152064 ).
llm_load_print_meta: format           = unknown
llm_load_print_meta: arch             = llama
llm_load_print_meta: vocab type       = BPE
llm_load_print_meta: n_vocab          = 152064
llm_load_print_meta: n_merges         = 109170
```

I don't know how much of an issue the special tokens mismatch is. I can't see if it's the same in the master version or not since the model can't be loaded.

Closes #3732.