### PR TITLE
Add missed dependencies in examples/main-cmake-pkg/CMakeLists.txt

### DIFF
--- a/examples/main-cmake-pkg/CMakeLists.txt
+++ b/examples/main-cmake-pkg/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(common OBJECT
     ${_common_path}/console.cpp
     ${_common_path}/grammar-parser.h
     ${_common_path}/grammar-parser.cpp
+    ${_common_path}/sampling.h
+    ${_common_path}/sampling.cpp
     )
 
 # WARNING: because build-info.h is auto-generated, it will only


### PR DESCRIPTION
Added missed source sampling.cpp when building examples/main-cmake-pkg.