### PR TITLE
cuda : speed-up by using CUBLAS_COMPUTE_32F instead of CUBLAS_COMPUTE_16F

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -4077,6 +4077,12 @@ struct ggml_tensor * ggml_mul_mat(
     const int64_t ne[4] = { a->ne[1], b->ne[1], b->ne[2], b->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
+    // TMP: force f32 precision
+    {
+        const int32_t prec_i32 = GGML_PREC_F32;
+        ggml_set_op_params_i32(result, 0, prec_i32);
+    }
+
     result->op   = GGML_OP_MUL_MAT;
     result->grad = is_node ? ggml_dup_tensor(ctx, result) : NULL;
     result->src[0] = a;


### PR DESCRIPTION
Curious observation - using `CUBLAS_COMPUTE_32F` is faster than `CUBLAS_COMPUTE_16F`. Tested on V100 and A6000 

Seems to improve both TG, PP and Batched decoding speed and we avoid allocating and copying the F16 `dst` data.

Edit: It leads to improvements on some NVIDIA cards, but not all. For example on 3090 the performance is degraded when using `CUBLAS_COMPUTE_32F`. Also AMD cards can suffer too.

Leaving this PR as a demonstration that people can try for their specific case to see if it helps

---

- V100 tests

```bash
LLAMA_CUBLAS=1 make -j batched batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-f16.gguf 4608 1 99 1 512 128 1,2,3,4,5,6,7,8,16,32

### master

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.174 |  2949.89 |    2.569 |    49.83 |    2.742 |   233.39 |
|   512 |    128 |    2 |    768 |    0.164 |  3120.24 |    3.021 |    84.73 |    3.185 |   241.10 |
|   512 |    128 |    3 |    896 |    0.159 |  3212.35 |    3.089 |   124.30 |    3.249 |   275.81 |
|   512 |    128 |    4 |   1024 |    0.160 |  3206.65 |    3.141 |   163.02 |    3.300 |   310.26 |
|   512 |    128 |    5 |   1152 |    0.160 |  3198.24 |    3.233 |   197.98 |    3.393 |   339.55 |
|   512 |    128 |    6 |   1280 |    0.162 |  3163.07 |    3.345 |   229.62 |    3.507 |   365.03 |
|   512 |    128 |    7 |   1408 |    0.160 |  3203.58 |    3.437 |   260.67 |    3.597 |   391.42 |
|   512 |    128 |    8 |   1536 |    0.170 |  3020.19 |    3.470 |   295.10 |    3.640 |   422.03 |
|   512 |    128 |   16 |   2560 |    0.161 |  3181.31 |    4.346 |   471.25 |    4.507 |   568.03 |
|   512 |    128 |   32 |   4608 |    0.161 |  3186.16 |    5.147 |   795.78 |    5.308 |   868.14 |

### PR

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1


|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.165 |  3107.66 |    2.500 |    51.20 |    2.665 |   240.18 |
|   512 |    128 |    2 |    768 |    0.149 |  3437.12 |    3.037 |    84.30 |    3.186 |   241.07 |
|   512 |    128 |    3 |    896 |    0.149 |  3435.30 |    3.111 |   123.44 |    3.260 |   274.85 |
|   512 |    128 |    4 |   1024 |    0.149 |  3434.40 |    3.128 |   163.66 |    3.277 |   312.44 |
|   512 |    128 |    5 |   1152 |    0.149 |  3435.00 |    3.205 |   199.71 |    3.354 |   343.51 |
|   512 |    128 |    6 |   1280 |    0.156 |  3291.33 |    3.192 |   240.61 |    3.347 |   382.38 |
|   512 |    128 |    7 |   1408 |    0.149 |  3431.13 |    3.311 |   270.64 |    3.460 |   406.95 |
|   512 |    128 |    8 |   1536 |    0.154 |  3325.30 |    3.367 |   304.09 |    3.521 |   436.19 |
|   512 |    128 |   16 |   2560 |    0.158 |  3244.86 |    3.587 |   570.94 |    3.745 |   683.61 |
|   512 |    128 |   32 |   4608 |    0.150 |  3403.44 |    4.949 |   827.70 |    5.099 |   903.69 |


LLAMA_CUBLAS=1 make -j batched batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-q4_k.gguf 4608 1 99 1 512 128 1,2,3,4,5,6,7,8,16,32

### master

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.225 |  2274.96 |    1.410 |    90.79 |    1.635 |   391.47 |
|   512 |    128 |    2 |    768 |    0.216 |  2374.49 |    2.300 |   111.31 |    2.516 |   305.30 |
|   512 |    128 |    3 |    896 |    0.214 |  2392.08 |    2.375 |   161.70 |    2.589 |   346.10 |
|   512 |    128 |    4 |   1024 |    0.212 |  2420.06 |    2.407 |   212.73 |    2.618 |   391.09 |
|   512 |    128 |    5 |   1152 |    0.214 |  2396.26 |    3.082 |   207.67 |    3.296 |   349.57 |
|   512 |    128 |    6 |   1280 |    0.212 |  2412.97 |    3.115 |   246.58 |    3.327 |   384.75 |
|   512 |    128 |    7 |   1408 |    0.212 |  2415.08 |    3.210 |   279.15 |    3.422 |   411.49 |
|   512 |    128 |    8 |   1536 |    0.212 |  2412.95 |    3.256 |   314.46 |    3.469 |   442.84 |
|   512 |    128 |   16 |   2560 |    0.215 |  2379.14 |    5.760 |   355.57 |    5.975 |   428.45 |
|   512 |    128 |   32 |   4608 |    0.214 |  2392.13 |   10.047 |   407.68 |   10.261 |   449.07 |

### PR

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.217 |  2364.08 |    1.326 |    96.52 |    1.543 |   414.84 |
|   512 |    128 |    2 |    768 |    0.203 |  2526.71 |    2.281 |   112.24 |    2.483 |   309.24 |
|   512 |    128 |    3 |    896 |    0.202 |  2538.35 |    2.366 |   162.30 |    2.568 |   348.94 |
|   512 |    128 |    4 |   1024 |    0.202 |  2540.78 |    2.386 |   214.62 |    2.587 |   395.81 |
|   512 |    128 |    5 |   1152 |    0.202 |  2539.73 |    3.037 |   210.71 |    3.239 |   355.67 |
|   512 |    128 |    6 |   1280 |    0.201 |  2541.99 |    3.075 |   249.78 |    3.276 |   390.71 |
|   512 |    128 |    7 |   1408 |    0.202 |  2539.76 |    3.173 |   282.39 |    3.375 |   417.24 |
|   512 |    128 |    8 |   1536 |    0.202 |  2529.92 |    3.196 |   320.35 |    3.399 |   451.92 |
|   512 |    128 |   16 |   2560 |    0.205 |  2502.50 |    5.201 |   393.75 |    5.406 |   473.57 |
|   512 |    128 |   32 |   4608 |    0.211 |  2427.09 |    9.887 |   414.30 |   10.098 |   456.35 |



LLAMA_CUBLAS=1 make -j batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-f16.gguf 4096 1 99 1 512,3200 128,128,800 1

### master

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.173 |  2955.73 |    2.570 |    49.81 |    2.743 |   233.32 |
|   512 |    128 |    1 |    640 |    0.163 |  3138.45 |    2.554 |    50.12 |    2.717 |   235.54 |
|   512 |    800 |    1 |   1312 |    0.162 |  3166.96 |   16.552 |    48.33 |   16.714 |    78.50 |
|  3200 |    128 |    1 |   3328 |    1.397 |  2290.24 |    3.208 |    39.89 |    4.606 |   722.58 |
|  3200 |    128 |    1 |   3328 |    1.404 |  2278.80 |    3.206 |    39.93 |    4.610 |   721.92 |
|  3200 |    800 |    1 |   4000 |    1.399 |  2286.73 |   20.490 |    39.04 |   21.889 |   182.74 |

### PR

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.163 |  3134.09 |    2.483 |    51.54 |    2.647 |   241.81 |
|   512 |    128 |    1 |    640 |    0.149 |  3442.34 |    2.453 |    52.19 |    2.601 |   246.02 |
|   512 |    800 |    1 |   1312 |    0.149 |  3435.07 |   15.608 |    51.26 |   15.757 |    83.26 |
|  3200 |    128 |    1 |   3328 |    1.283 |  2494.81 |    2.754 |    46.47 |    4.037 |   824.40 |
|  3200 |    128 |    1 |   3328 |    1.278 |  2502.93 |    2.758 |    46.42 |    4.036 |   824.56 |
|  3200 |    800 |    1 |   4000 |    1.283 |  2494.49 |   17.413 |    45.94 |   18.695 |   213.96 |


LLAMA_CUBLAS=1 make -j batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-q4_k.gguf 4096 1 99 1 512,3200 128,128,800 1

### master

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.225 |  2272.56 |    1.392 |    91.97 |    1.617 |   395.77 |
|   512 |    128 |    1 |    640 |    0.212 |  2419.60 |    1.382 |    92.60 |    1.594 |   401.54 |
|   512 |    800 |    1 |   1312 |    0.211 |  2424.63 |    9.203 |    86.93 |    9.414 |   139.37 |
|  3200 |    128 |    1 |   3328 |    1.760 |  1818.62 |    2.031 |    63.03 |    3.790 |   878.00 |
|  3200 |    128 |    1 |   3328 |    1.765 |  1813.22 |    2.033 |    62.95 |    3.798 |   876.18 |
|  3200 |    800 |    1 |   4000 |    1.764 |  1813.91 |   13.143 |    60.87 |   14.907 |   268.33 |

### PR

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.216 |  2372.26 |    1.331 |    96.14 |    1.547 |   413.66 |
|   512 |    128 |    1 |    640 |    0.201 |  2551.45 |    1.288 |    99.39 |    1.489 |   429.94 |
|   512 |    800 |    1 |   1312 |    0.201 |  2552.14 |    8.284 |    96.57 |    8.485 |   154.63 |
|  3200 |    128 |    1 |   3328 |    1.651 |  1937.73 |    1.583 |    80.87 |    3.234 |  1029.03 |
|  3200 |    128 |    1 |   3328 |    1.658 |  1929.82 |    1.586 |    80.71 |    3.244 |  1025.86 |
|  3200 |    800 |    1 |   4000 |    1.648 |  1941.65 |   10.096 |    79.24 |   11.744 |   340.59 |
```

```bash
llama-bench
```

  Device 0: Tesla V100-PCIE-16GB, compute capability 7.0
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | pp 512     |  3359.77 ± 73.09 |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | tg 128     |     52.61 ± 0.02 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | pp 512     |  2525.13 ± 41.08 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | tg 128     |    101.71 ± 0.33 |

build: c8d6a1f (1431) (master)

  Device 0: Tesla V100-PCIE-16GB, compute capability 7.0
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | pp 512     |  3648.52 ± 55.04 |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | tg 128     |     53.53 ± 0.16 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | pp 512     |  2668.02 ± 33.54 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | tg 128     |    105.22 ± 0.76 |

build: 3b9ea65 (1432) (PR)

---

  Device 0: NVIDIA RTX A6000, compute capability 8.6
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | pp 512     | 4098.15 ± 105.84 |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | tg 128     |     44.84 ± 0.20 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | pp 512     |  3450.93 ± 72.39 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | tg 128     |    105.11 ± 0.57 |

build: c8d6a1f (1431)

  Device 0: NVIDIA RTX A6000, compute capability 8.6
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | pp 512     |  4306.38 ± 43.09 |
| llama 7B mostly F16            |  12.55 GiB |     6.74 B | CUDA       |  99 | tg 128     |     45.20 ± 0.09 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | pp 512     | 3473.03 ± 118.79 |
| llama 7B mostly Q4_K - Medium  |   3.80 GiB |     6.74 B | CUDA       |  99 | tg 128     |    106.17 ± 0.97 |

build: 3b9ea65 (1432)

---

  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 13B mostly Q4_K - Medium |   7.33 GiB |    13.02 B | CUDA       |  99 | pp 512     |  2241.65 ± 20.20 |
| llama 13B mostly Q4_K - Medium |   7.33 GiB |    13.02 B | CUDA       |  99 | tg 128     |     67.65 ± 0.23 |

build: c8d6a1f (1431)

  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 13B mostly Q4_K - Medium |   7.33 GiB |    13.02 B | CUDA       |  99 | pp 512     |   1760.98 ± 5.52 |
| llama 13B mostly Q4_K - Medium |   7.33 GiB |    13.02 B | CUDA       |  99 | tg 128     |     70.63 ± 0.34 |

build: 3b9ea65 (1432)

---

Latest benches after `GGML_PREC_F32` addition:

- V100 tests

```bash
LLAMA_CUBLAS=1 make -j batched batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-f16.gguf 4608 1 99 1 512 128 1,2,3,4,5,6,7,8,16,32

### PR

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1, n_threads = 3, n_threads_batch = 3

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.167 |  3071.75 |    2.503 |    51.14 |    2.670 |   239.72 |
|   512 |    128 |    2 |    768 |    0.149 |  3430.51 |    3.029 |    84.53 |    3.178 |   241.67 |
|   512 |    128 |    3 |    896 |    0.149 |  3429.80 |    3.087 |   124.39 |    3.236 |   276.86 |
|   512 |    128 |    4 |   1024 |    0.149 |  3432.35 |    3.111 |   164.55 |    3.261 |   314.05 |
|   512 |    128 |    5 |   1152 |    0.149 |  3435.34 |    3.176 |   201.49 |    3.325 |   346.43 |
|   512 |    128 |    6 |   1280 |    0.149 |  3430.67 |    3.221 |   238.46 |    3.370 |   379.84 |
|   512 |    128 |    7 |   1408 |    0.149 |  3436.45 |    3.299 |   271.56 |    3.448 |   408.30 |
|   512 |    128 |    8 |   1536 |    0.150 |  3423.31 |    3.349 |   305.79 |    3.498 |   439.08 |
|   512 |    128 |   16 |   2560 |    0.150 |  3418.48 |    3.584 |   571.38 |    3.734 |   685.57 |
|   512 |    128 |   32 |   4608 |    0.151 |  3396.19 |    4.495 |   911.33 |    4.645 |   991.97 |

LLAMA_CUBLAS=1 make -j batched batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-q4_k.gguf 4608 1 99 1 512 128 1,2,3,4,5,6,7,8,16,32

### PR

main: n_kv_max = 4608, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1, n_threads = 3, n_threads_batch = 3

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.227 |  2253.90 |    1.324 |    96.65 |    1.552 |   412.50 |
|   512 |    128 |    2 |    768 |    0.201 |  2546.87 |    2.273 |   112.63 |    2.474 |   310.44 |
|   512 |    128 |    3 |    896 |    0.201 |  2545.44 |    2.323 |   165.29 |    2.524 |   354.95 |
|   512 |    128 |    4 |   1024 |    0.201 |  2542.89 |    2.378 |   215.28 |    2.580 |   396.95 |
|   512 |    128 |    5 |   1152 |    0.201 |  2543.87 |    3.002 |   213.19 |    3.203 |   359.62 |
|   512 |    128 |    6 |   1280 |    0.201 |  2542.08 |    3.056 |   251.34 |    3.257 |   393.00 |
|   512 |    128 |    7 |   1408 |    0.201 |  2543.49 |    3.120 |   287.19 |    3.321 |   423.94 |
|   512 |    128 |    8 |   1536 |    0.202 |  2538.86 |    3.174 |   322.58 |    3.376 |   454.96 |
|   512 |    128 |   16 |   2560 |    0.202 |  2532.77 |    5.130 |   399.19 |    5.333 |   480.07 |
|   512 |    128 |   32 |   4608 |    0.203 |  2520.90 |    9.382 |   436.57 |    9.585 |   480.73 |


LLAMA_CUBLAS=1 make -j batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-f16.gguf 4096 1 99 1 512,3200 128,128,800 1

### PR

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1, n_threads = 3, n_threads_batch = 3

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.166 |  3080.77 |    2.502 |    51.16 |    2.668 |   239.89 |
|   512 |    128 |    1 |    640 |    0.149 |  3440.05 |    2.496 |    51.28 |    2.645 |   241.96 |
|   512 |    800 |    1 |   1312 |    0.149 |  3444.80 |   15.706 |    50.94 |   15.854 |    82.75 |
|  3200 |    128 |    1 |   3328 |    1.154 |  2773.27 |    2.743 |    46.66 |    3.897 |   853.96 |
|  3200 |    128 |    1 |   3328 |    1.092 |  2930.01 |    2.737 |    46.76 |    3.830 |   869.03 |
|  3200 |    800 |    1 |   4000 |    1.093 |  2928.98 |   17.208 |    46.49 |   18.301 |   218.57 |

LLAMA_CUBLAS=1 make -j batched-bench && ./batched-bench ./models/openllama-7b-v2/ggml-model-q4_k.gguf 4096 1 99 1 512,3200 128,128,800 1

### PR

main: n_kv_max = 4096, is_pp_shared = 1, n_gpu_layers = 99, mmq = 1, n_threads = 3, n_threads_batch = 3

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.219 |  2340.69 |    1.323 |    96.78 |    1.541 |   415.23 |
|   512 |    128 |    1 |    640 |    0.200 |  2554.71 |    1.310 |    97.69 |    1.511 |   423.66 |
|   512 |    800 |    1 |   1312 |    0.202 |  2539.87 |    8.343 |    95.89 |    8.545 |   153.55 |
|  3200 |    128 |    1 |   3328 |    1.515 |  2112.70 |    1.564 |    81.83 |    3.079 |  1080.94 |
|  3200 |    128 |    1 |   3328 |    1.470 |  2177.61 |    1.542 |    83.02 |    3.011 |  1105.17 |
|  3200 |    800 |    1 |   4000 |    1.457 |  2197.03 |    9.854 |    81.19 |   11.310 |   353.66 |
```

```bash
LLAMA_CUBLAS=1 make -j llama-bench && ./llama-bench -m ./models/openllama-7b-v2/ggml-model-f16.gguf -m ./models/openllama-7b-v2/ggml-model-q4_k.gguf -ngl 99
```

  Device 0: Tesla V100-PCIE-16GB, compute capability 7.0
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B F16                   |  12.55 GiB |     6.74 B | CUDA       |  99 | pp 512     | 3722.34 ± 127.35 |
| llama 7B F16                   |  12.55 GiB |     6.74 B | CUDA       |  99 | tg 128     |     52.80 ± 0.24 |
| llama 7B Q4_K - Medium         |   3.80 GiB |     6.74 B | CUDA       |  99 | pp 512     |  2713.46 ± 37.55 |
| llama 7B Q4_K - Medium         |   3.80 GiB |     6.74 B | CUDA       |  99 | tg 128     |    101.10 ± 0.99 |

build: a40f611 (1662)




