### PR TITLE
llama : correctly report GGUFv3 format

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1578,12 +1578,14 @@ static void llama_kv_cache_seq_shift(
 enum llama_fver {
     GGUF_FILE_VERSION_V1 = 1,
     GGUF_FILE_VERSION_V2 = 2,
+    GGUF_FILE_VERSION_V3 = 3,
 };
 
 static const char * llama_file_version_name(llama_fver version) {
     switch (version) {
         case GGUF_FILE_VERSION_V1: return "GGUF V1 (support until nov 2023)";
-        case GGUF_FILE_VERSION_V2: return "GGUF V2 (latest)";
+        case GGUF_FILE_VERSION_V2: return "GGUF V2";
+        case GGUF_FILE_VERSION_V3: return "GGUF V3 (latest)";
     }
 
     return "unknown";


### PR DESCRIPTION
Follow-up to #3552.

Before:
```
llm_load_print_meta: format           = unknown
```
After:
```
llm_load_print_meta: format           = GGUFv3 (latest)
```

Will GGUFv2 be deprecated like GGUFv1 was?

**edit:** I guess it doesn't matter since for little-endian it's just a version bump AFAIK.