### PR TITLE
Print that one line of the syntax help *also* to standard output

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -743,7 +743,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
 #endif // GGML_USE_CUBLAS
 #endif
     printf("  --verbose-prompt      print prompt before generation\n");
-    fprintf(stderr, "  --simple-io           use basic IO for better compatibility in subprocesses and limited consoles\n");
+    printf("  --simple-io           use basic IO for better compatibility in subprocesses and limited consoles\n");
     printf("  --lora FNAME          apply LoRA adapter (implies --no-mmap)\n");
     printf("  --lora-scaled FNAME S apply LoRA adapter with user defined scaling S (implies --no-mmap)\n");
     printf("  --lora-base FNAME     optional model to use as a base for the layers modified by the LoRA adapter\n");


### PR DESCRIPTION
Fixes a small bug introduced 2 months ago:

https://github.com/ggerganov/llama.cpp/commit/3498588e0fb4daf040c4e3c698595cb0bfd345c0#r131123349