### PR TITLE
make : remove unnecessary dependency on build-info.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,10 +547,10 @@ OBJS += ggml-alloc.o ggml-backend.o
 llama.o: llama.cpp ggml.h ggml-alloc.h ggml-backend.h ggml-cuda.h ggml-metal.h llama.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-COMMON_H_DEPS = common/common.h common/sampling.h build-info.h common/log.h
-COMMON_DEPS   = $(COMMON_H_DEPS) common.o sampling.o grammar-parser.o
+COMMON_H_DEPS = common/common.h common/sampling.h common/log.h
+COMMON_DEPS   = common.o sampling.o grammar-parser.o
 
-common.o: common/common.cpp $(COMMON_H_DEPS)
+common.o: common/common.cpp build-info.h $(COMMON_H_DEPS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 sampling.o: common/sampling.cpp $(COMMON_H_DEPS)


### PR DESCRIPTION
This makes incremental builds quicker, as less objects will need to rebuilt when the git index changes.

Also remove COMMON_H_DEPS from COMMON_DEPS, as this is already implied by common.o's dependency on COMMON_H_DEPS.