### PR TITLE
llama : add llm_build helper functions

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -4856,12 +4856,13 @@ struct llm_offload_trie {
 static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map = {
   //{ "inp_tokens",                 OFFLOAD_FUNC_NR  }, // TODO: missing K-quants get_rows kernel
   //{ "inp_embd",                   OFFLOAD_FUNC_NR  }, // TODO: missing K-quants get_rows kernel
-    { "inp_pos",                    OFFLOAD_FUNC_NR  },
     { "pos_embd",                   OFFLOAD_FUNC_NR  },
 
-    { "KQ_mask",                    OFFLOAD_FUNC_NR  },
-    { "K_shift",                    OFFLOAD_FUNC_NR  },
-    { "K_shifted",                  OFFLOAD_FUNC_NR  },
+    { "inp_pos",                    OFFLOAD_FUNC_KQ  }, // this is often used for KQ ops (e.g. rope)
+    { "KQ_scale",                   OFFLOAD_FUNC_KQ  },
+    { "KQ_mask",                    OFFLOAD_FUNC_KQ  },
+    { "K_shift",                    OFFLOAD_FUNC_KQ  },
+    { "K_shifted",                  OFFLOAD_FUNC_KQ  },
 
     { "inp_norm",                   OFFLOAD_FUNC_NR  },
     { "inp_norm_w",                 OFFLOAD_FUNC_NR  },

--- a/llama.cpp
+++ b/llama.cpp
@@ -4970,10 +4970,10 @@ static struct ggml_cgraph * llama_build_graph(
         // allocate input tensors and set input data
         //
 
-        if (batch.token && !alloc_inp_tokens && strcmp(name, "inp_tokens") == 0) {
+        if (!alloc_inp_tokens && strcmp(name, "inp_tokens") == 0) {
             ggml_allocr_alloc(lctx.alloc, cur);
 
-            if (!ggml_allocr_is_measure(lctx.alloc)) {
+            if (!ggml_allocr_is_measure(lctx.alloc) && batch.token) {
                 const int64_t n_tokens = cur->ne[0];
 
                 memcpy(cur->data, batch.token, n_tokens*ggml_element_size(cur));
@@ -4982,10 +4982,10 @@ static struct ggml_cgraph * llama_build_graph(
             alloc_inp_tokens = true;
         }
 
-        if (batch.embd && !alloc_inp_embd && strcmp(name, "inp_embd") == 0) {
+        if (!alloc_inp_embd && strcmp(name, "inp_embd") == 0) {
             ggml_allocr_alloc(lctx.alloc, cur);
 
-            if (!ggml_allocr_is_measure(lctx.alloc)) {
+            if (!ggml_allocr_is_measure(lctx.alloc) && batch.embd) {
                 const int64_t n_embd   = cur->ne[0];
                 const int64_t n_tokens = cur->ne[1];
 
@@ -4995,10 +4995,10 @@ static struct ggml_cgraph * llama_build_graph(
             alloc_inp_embd = true;
         }
 
-        if (batch.pos && !alloc_inp_pos && strcmp(name, "inp_pos") == 0) {
+        if (!alloc_inp_pos && strcmp(name, "inp_pos") == 0) {
             ggml_allocr_alloc(lctx.alloc, cur);
 
-            if (!ggml_allocr_is_measure(lctx.alloc)) {
+            if (!ggml_allocr_is_measure(lctx.alloc) && batch.pos) {
                 const int64_t n_tokens = cur->ne[0];
 
                 int32_t * data = (int32_t *) cur->data;

--- a/llama.cpp
+++ b/llama.cpp
@@ -3135,7 +3135,7 @@ static void llm_build_k_shift(
         case LLM_ROPE:      rope_type = 0; break;
         case LLM_ROPE_NEOX: rope_type = 2; break;
         case LLM_ROPE_GLM:  rope_type = 4; break;
-    };
+    }
 
     for (int il = 0; il < n_layer; ++il) {
         struct ggml_tensor * tmp =
@@ -3207,7 +3207,8 @@ static struct ggml_tensor * llm_build_norm(
     switch (type) {
         case LLM_NORM:     cur = ggml_norm    (ctx, cur, eps); break;
         case LLM_NORM_RMS: cur = ggml_rms_norm(ctx, cur, eps); break;
-    };
+    }
+
     if (mw || mb) {
         cb(cur, "norm", il);
     }
@@ -3265,23 +3266,18 @@ static struct ggml_tensor * llm_build_ffn(
                 {
                     cur = ggml_mul_mat(ctx, gate, tmp);
                     cb(cur, "ffn_gate", il);
-
-                    if (gate_b) {
-                        cur = ggml_add(ctx, cur, gate_b);
-                        cb(cur, "ffn_gate_b", il);
-                    }
                 } break;
             case LLM_FFN_PAR:
                 {
                     cur = ggml_mul_mat(ctx, gate, cur);
                     cb(cur, "ffn_gate", il);
-
-                    if (gate_b) {
-                        cur = ggml_add(ctx, cur, gate_b);
-                        cb(cur, "ffn_gate_b", il);
-                    }
                 } break;
-        };
+        }
+
+        if (gate_b) {
+            cur = ggml_add(ctx, cur, gate_b);
+            cb(cur, "ffn_gate_b", il);
+        }
     } else {
         cur = tmp;
     }
@@ -3310,7 +3306,7 @@ static struct ggml_tensor * llm_build_ffn(
                 cur = ggml_sqr(ctx, cur);
                 cb(cur, "ffn_sqr(relu)", il);
             } break;
-    };
+    }
 
     if (type_gate == LLM_FFN_PAR) {
         cur = ggml_mul(ctx, cur, tmp);
@@ -4098,6 +4094,7 @@ static struct ggml_cgraph * llm_build_persimmon(
     const bool do_rope_shift  = worst_case || kv_self.has_shift;
 
     auto & buf_compute = lctx.buf_compute;
+
     struct ggml_init_params params = {
         /*.mem_size   =*/ buf_compute.size,
         /*.mem_buffer =*/ buf_compute.data,

--- a/llama.cpp
+++ b/llama.cpp
@@ -3503,8 +3503,7 @@ static struct ggml_cgraph * llm_build_llama(
 
         // norm
         cur = llm_build_norm(ctx0, inpL,
-                model.layers[il].attn_norm,
-                NULL,
+                model.layers[il].attn_norm, NULL,
                 LLM_NORM_RMS, norm_rms_eps, cb, il);
         cb(cur, "attn_norm", il);
 
@@ -3540,8 +3539,7 @@ static struct ggml_cgraph * llm_build_llama(
         // feed-forward network
         {
             cur = llm_build_norm(ctx0, inpFF,
-                    model.layers[il].ffn_norm,
-                    NULL,
+                    model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
 
@@ -3563,8 +3561,7 @@ static struct ggml_cgraph * llm_build_llama(
     cur = inpL;
 
     cur = llm_build_norm(ctx0, cur,
-            model.output_norm,
-            NULL,
+            model.output_norm, NULL,
             LLM_NORM_RMS, norm_rms_eps, cb, -1);
     cb(cur, "result_norm", -1);
 
@@ -3661,8 +3658,7 @@ static struct ggml_cgraph * llm_build_baichaun(
         struct ggml_tensor * inpSA = inpL;
 
         cur = llm_build_norm(ctx0, inpL,
-                model.layers[il].attn_norm,
-                NULL,
+                model.layers[il].attn_norm, NULL,
                 LLM_NORM_RMS, norm_rms_eps, cb, il);
         cb(cur, "attn_norm", il);
 
@@ -3709,8 +3705,7 @@ static struct ggml_cgraph * llm_build_baichaun(
         // feed-forward network
         {
             cur = llm_build_norm(ctx0, inpFF,
-                    model.layers[il].ffn_norm,
-                    NULL,
+                    model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
 
@@ -3732,8 +3727,7 @@ static struct ggml_cgraph * llm_build_baichaun(
     cur = inpL;
 
     cur = llm_build_norm(ctx0, cur,
-            model.output_norm,
-            NULL,
+            model.output_norm, NULL,
             LLM_NORM_RMS, norm_rms_eps, cb, -1);
     cb(cur, "result_norm", -1);
 
@@ -4394,8 +4388,7 @@ static struct ggml_cgraph * llm_build_refact(
         struct ggml_tensor * inpSA = inpL;
 
         cur = llm_build_norm(ctx0, inpL,
-                model.layers[il].attn_norm,
-                NULL,
+                model.layers[il].attn_norm, NULL,
                 LLM_NORM_RMS, norm_rms_eps, cb, il);
         cb(cur, "attn_norm", il);
 
@@ -4430,8 +4423,7 @@ static struct ggml_cgraph * llm_build_refact(
         // feed-forward network
         {
             cur = llm_build_norm(ctx0, inpFF,
-                    model.layers[il].ffn_norm,
-                    NULL,
+                    model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
 
@@ -4453,8 +4445,7 @@ static struct ggml_cgraph * llm_build_refact(
     cur = inpL;
 
     cur = llm_build_norm(ctx0, cur,
-            model.output_norm,
-            NULL,
+            model.output_norm, NULL,
             LLM_NORM_RMS, norm_rms_eps, cb, -1);
     cb(cur, "result_norm", -1);
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -5235,7 +5235,6 @@ static struct ggml_cgraph * llama_build_graph(
 
         LLAMA_LOG_INFO("%s: non-view tensors processed: %d/%d\n", __func__, n_non_view, n_non_view_total);
 
-#ifdef LLAMA_OFFLOAD_DEBUG
         if (n_non_view != n_non_view_total) {
             LLAMA_LOG_WARN("%s: ****************************************************************\n", __func__);
             LLAMA_LOG_WARN("%s: not all non-view tensors have been processed with a callback\n",     __func__);
@@ -5244,7 +5243,6 @@ static struct ggml_cgraph * llama_build_graph(
             LLAMA_LOG_WARN("%s: ref: https://github.com/ggerganov/llama.cpp/pull/3837\n",            __func__);
             LLAMA_LOG_WARN("%s: ****************************************************************\n", __func__);
         }
-#endif
     }
 
     return result;

--- a/llama.cpp
+++ b/llama.cpp
@@ -3533,12 +3533,12 @@ static struct ggml_cgraph * llm_build_llama(
             cb(cur, "kqv_out", il);
         }
 
-        struct ggml_tensor * inpFF = ggml_add(ctx0, cur, inpSA);
-        cb(inpFF, "inpFF", il);
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
 
         // feed-forward network
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
@@ -3551,8 +3551,8 @@ static struct ggml_cgraph * llm_build_llama(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         // input for next layer
         inpL = cur;
@@ -3699,12 +3699,12 @@ static struct ggml_cgraph * llm_build_baichaun(
             cb(cur, "kqv_out", il);
         }
 
-        struct ggml_tensor * inpFF = ggml_add(ctx0, cur, inpSA);
-        cb(inpFF, "inpFF", il);
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
 
         // feed-forward network
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
@@ -3717,8 +3717,8 @@ static struct ggml_cgraph * llm_build_baichaun(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         // input for next layer
         inpL = cur;
@@ -3875,7 +3875,7 @@ static struct ggml_cgraph * llm_build_falcon(
             cb(cur, "kqv_out", il);
         }
 
-        struct ggml_tensor * attn_out = cur;
+        struct ggml_tensor * ffn_inp = cur;
 
         // feed forward
         {
@@ -3887,11 +3887,11 @@ static struct ggml_cgraph * llm_build_falcon(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, attn_out);
-        cb(cur, "inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_inpFF_ffn_out", il);
+        cb(cur, "l_out", il);
 
         // input for next layer
         inpL = cur;
@@ -4026,15 +4026,13 @@ static struct ggml_cgraph * llm_build_starcoder(
             cb(cur, "kqv_out", il);
         }
 
-        // Add the input
-        cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_kqv_out", il);
-
-        struct ggml_tensor * inpFF = cur;
+        // add the input
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpL);
+        cb(ffn_inp, "ffn_inp", il);
 
         // FF
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm,
                     model.layers[il].ffn_norm_b,
                     LLM_NORM, norm_eps, cb, il);
@@ -4048,8 +4046,8 @@ static struct ggml_cgraph * llm_build_starcoder(
             cb(cur, "ffn_out", il);
         }
 
-        inpL = ggml_add(ctx0, cur, inpFF);
-        cb(inpL, "inpL_inpFF_ffn_out", il);
+        inpL = ggml_add(ctx0, cur, ffn_inp);
+        cb(inpL, "l_out", il);
     }
 
     cur = llm_build_norm(ctx0, inpL,
@@ -4279,12 +4277,12 @@ static struct ggml_cgraph * llm_build_persimmon(
             cb(cur, "kqv_out", il);
         }
 
-        struct ggml_tensor * inpFF = ggml_add(ctx0, residual, cur);
-        cb(inpFF, "inpFF", il);
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, residual, cur);
+        cb(ffn_inp, "ffn_inp", il);
 
         // feed-forward network
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm,
                     model.layers[il].ffn_norm_b,
                     LLM_NORM, norm_eps, cb, il);
@@ -4298,8 +4296,8 @@ static struct ggml_cgraph * llm_build_persimmon(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         inpL = cur;
     }
@@ -4418,12 +4416,12 @@ static struct ggml_cgraph * llm_build_refact(
             cb(cur, "kqv_out", il);
         }
 
-        struct ggml_tensor * inpFF = ggml_add(ctx0, cur, inpSA);
-        cb(inpFF, "inpFF", il);
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
 
         // feed-forward network
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm, NULL,
                     LLM_NORM_RMS, norm_rms_eps, cb, il);
             cb(cur, "ffn_norm", il);
@@ -4436,8 +4434,8 @@ static struct ggml_cgraph * llm_build_refact(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         // input for next layer
         inpL = cur;
@@ -4569,14 +4567,12 @@ static struct ggml_cgraph * llm_build_bloom(
         }
 
         // Add the input
-        cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_kqv_out", il);
-
-        struct ggml_tensor * inpFF = cur;
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpL);
+        cb(ffn_inp, "ffn_inp", il);
 
         // FF
         {
-            cur = llm_build_norm(ctx0, inpFF,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm,
                     model.layers[il].ffn_norm_b,
                     LLM_NORM, norm_eps, cb, il);
@@ -4590,8 +4586,8 @@ static struct ggml_cgraph * llm_build_bloom(
             cb(cur, "ffn_out", il);
         }
 
-        inpL = ggml_add(ctx0, cur, inpFF);
-        cb(inpL, "inpFF_ffn_out", il);
+        inpL = ggml_add(ctx0, cur, ffn_inp);
+        cb(inpL, "l_out", il);
     }
 
     cur = llm_build_norm(ctx0, inpL,
@@ -4717,14 +4713,12 @@ static struct ggml_cgraph * llm_build_mpt(
         }
 
         // Add the input
-        cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_kqv_out", il);
-
-        struct ggml_tensor * attn_out = cur;
+        struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpL);
+        cb(ffn_inp, "ffn_inp", il);
 
         // feed forward
         {
-            cur = llm_build_norm(ctx0, attn_out,
+            cur = llm_build_norm(ctx0, ffn_inp,
                     model.layers[il].ffn_norm,
                     NULL,
                     LLM_NORM, norm_eps, cb, il);
@@ -4738,8 +4732,8 @@ static struct ggml_cgraph * llm_build_mpt(
             cb(cur, "ffn_out", il);
         }
 
-        cur = ggml_add(ctx0, cur, attn_out);
-        cb(cur, "inpL_inpFF_ffn_out", il);
+        cur = ggml_add(ctx0, cur, ffn_inp);
+        cb(cur, "l_out", il);
 
         // input for next layer
         inpL = cur;
@@ -4907,9 +4901,7 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "kqv_wo",                     OFFLOAD_FUNC_V   },
     { "kqv_out",                    OFFLOAD_FUNC_V   },
 
-    { "inpL_kqv_out",               OFFLOAD_FUNC     },
-    { "inpFF",                      OFFLOAD_FUNC     },
-
+    { "ffn_inp",                    OFFLOAD_FUNC     },
     { "ffn_norm",                   OFFLOAD_FUNC     },
 
     { "ffn_up",                     OFFLOAD_FUNC     },
@@ -4926,8 +4918,7 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "ffn_relu",                   OFFLOAD_FUNC     },
     { "ffn_sqr(relu)",              OFFLOAD_FUNC     },
 
-    { "inpFF_ffn_out",              OFFLOAD_FUNC     },
-    { "inpL_inpFF_ffn_out",         OFFLOAD_FUNC     },
+    { "l_out",                      OFFLOAD_FUNC     },
 
     { "result_norm",                OFFLOAD_FUNC_EMB },
     { "result_output",              OFFLOAD_FUNC_OUT },
@@ -4960,6 +4951,7 @@ static struct ggml_cgraph * llama_build_graph(
     int n_non_view = 0; // number of non-view tensors that have been processed by the callback
 
     // this callback allows us to apply custom logic to each tensor (e.g. ggml-alloc, offloading, etc.)
+    // TODO: will be removed with backend v2
     llm_build_cb cb = [&](struct ggml_tensor * cur, const char * name, int il) {
         if (il >= 0) {
             ggml_format_name(cur, "%s-%d", name, il);
@@ -4970,6 +4962,7 @@ static struct ggml_cgraph * llama_build_graph(
         //
         // allocate input tensors and set input data
         //
+        // TODO: will be removed with backend v2
 
         if (!alloc_inp_tokens && strcmp(name, "inp_tokens") == 0) {
             ggml_allocr_alloc(lctx.alloc, cur);

--- a/llama.cpp
+++ b/llama.cpp
@@ -3548,11 +3548,11 @@ static struct ggml_cgraph * llm_build_llama(
                     model.layers[il].ffn_gate, NULL,
                     model.layers[il].ffn_down, NULL,
                     LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_+_result_w2", il);
+        cb(cur, "inpFF_ffn_out", il);
 
         // input for next layer
         inpL = cur;
@@ -3714,11 +3714,11 @@ static struct ggml_cgraph * llm_build_baichaun(
                     model.layers[il].ffn_gate, NULL,
                     model.layers[il].ffn_down, NULL,
                     LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_+_result_w2", il);
+        cb(cur, "inpFF_ffn_out", il);
 
         // input for next layer
         inpL = cur;
@@ -3884,14 +3884,14 @@ static struct ggml_cgraph * llm_build_falcon(
                     NULL,                      NULL,
                     model.layers[il].ffn_down, NULL,
                     LLM_FFN_GELU, LLM_FFN_SEQ, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, attn_out);
-        cb(cur, "inpFF_+_result_w2", il);
+        cb(cur, "inpFF_ffn_out", il);
 
         cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_+_inpFF_+_result_w2", il);
+        cb(cur, "inpL_inpFF_ffn_out", il);
 
         // input for next layer
         inpL = cur;
@@ -3988,6 +3988,7 @@ static struct ggml_cgraph * llm_build_starcoder(
     cb(KQ_mask, "KQ_mask", -1);
 
     pos = ggml_get_rows(ctx0, model.pos_embeddings, inp_pos);
+    cb(pos, "pos_embd", -1);
 
     inpL = ggml_add(ctx0, embd, pos);
     cb(inpL, "inpL", -1);
@@ -4027,7 +4028,7 @@ static struct ggml_cgraph * llm_build_starcoder(
 
         // Add the input
         cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_+_result_wo", il);
+        cb(cur, "inpL_kqv_out", il);
 
         struct ggml_tensor * inpFF = cur;
 
@@ -4044,11 +4045,11 @@ static struct ggml_cgraph * llm_build_starcoder(
                     NULL,                      NULL,
                     model.layers[il].ffn_down, model.layers[il].ffn_down_b,
                     LLM_FFN_GELU, LLM_FFN_SEQ, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         inpL = ggml_add(ctx0, cur, inpFF);
-
+        cb(inpL, "inpL_inpFF_ffn_out", il);
     }
 
     cur = llm_build_norm(ctx0, inpL,
@@ -4294,11 +4295,11 @@ static struct ggml_cgraph * llm_build_persimmon(
                     NULL,                      NULL,
                     model.layers[il].ffn_down, model.layers[il].ffn_down_b,
                     LLM_FFN_RELU_SQR, LLM_FFN_SEQ, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_+_result_w2", il);
+        cb(cur, "inpFF_ffn_out", il);
 
         inpL = cur;
     }
@@ -4432,11 +4433,11 @@ static struct ggml_cgraph * llm_build_refact(
                     model.layers[il].ffn_gate, NULL,
                     model.layers[il].ffn_down, NULL,
                     LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, inpFF);
-        cb(cur, "inpFF_+_result_w2", il);
+        cb(cur, "inpFF_ffn_out", il);
 
         // input for next layer
         inpL = cur;
@@ -4569,7 +4570,7 @@ static struct ggml_cgraph * llm_build_bloom(
 
         // Add the input
         cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_+_result_wo", il);
+        cb(cur, "inpL_kqv_out", il);
 
         struct ggml_tensor * inpFF = cur;
 
@@ -4586,11 +4587,11 @@ static struct ggml_cgraph * llm_build_bloom(
                     NULL,                      NULL,
                     model.layers[il].ffn_down, model.layers[il].ffn_down_b,
                     LLM_FFN_GELU, LLM_FFN_SEQ, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         inpL = ggml_add(ctx0, cur, inpFF);
-        cb(inpL, "inpFF_+_result_w2", il);
+        cb(inpL, "inpFF_ffn_out", il);
     }
 
     cur = llm_build_norm(ctx0, inpL,
@@ -4717,7 +4718,7 @@ static struct ggml_cgraph * llm_build_mpt(
 
         // Add the input
         cur = ggml_add(ctx0, cur, inpL);
-        cb(cur, "inpL_+_result_wo", il);
+        cb(cur, "inpL_kqv_out", il);
 
         struct ggml_tensor * attn_out = cur;
 
@@ -4734,11 +4735,11 @@ static struct ggml_cgraph * llm_build_mpt(
                     NULL,                      NULL,
                     model.layers[il].ffn_down, NULL,
                     LLM_FFN_GELU, LLM_FFN_SEQ, cb, il);
-            cb(cur, "ffn_result", il);
+            cb(cur, "ffn_out", il);
         }
 
         cur = ggml_add(ctx0, cur, attn_out);
-        cb(cur, "inpL_+_inpFF_+_result_w2", il);
+        cb(cur, "inpL_inpFF_ffn_out", il);
 
         // input for next layer
         inpL = cur;
@@ -4777,6 +4778,7 @@ enum llm_offload_func_e {
     OFFLOAD_FUNC_OUT,
 };
 
+// TODO: will be removed with backend v2
 struct llm_offload_trie {
     struct node {
         ~node() {
@@ -4850,10 +4852,12 @@ struct llm_offload_trie {
     node * root = nullptr;
 };
 
+// TODO: will be removed with backend v2
 static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map = {
   //{ "inp_tokens",                 OFFLOAD_FUNC_NR  }, // TODO: missing K-quants get_rows kernel
   //{ "inp_embd",                   OFFLOAD_FUNC_NR  }, // TODO: missing K-quants get_rows kernel
     { "inp_pos",                    OFFLOAD_FUNC_NR  },
+    { "pos_embd",                   OFFLOAD_FUNC_NR  },
 
     { "KQ_mask",                    OFFLOAD_FUNC_NR  },
     { "K_shift",                    OFFLOAD_FUNC_NR  },
@@ -4902,7 +4906,7 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "kqv_wo",                     OFFLOAD_FUNC_V   },
     { "kqv_out",                    OFFLOAD_FUNC_V   },
 
-    { "inpL_+_result_wo",           OFFLOAD_FUNC     },
+    { "inpL_kqv_out",               OFFLOAD_FUNC     },
     { "inpFF",                      OFFLOAD_FUNC     },
 
     { "ffn_norm",                   OFFLOAD_FUNC     },
@@ -4914,15 +4918,15 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "ffn_gate_par",               OFFLOAD_FUNC     },
     { "ffn_down",                   OFFLOAD_FUNC     },
     { "ffn_down_b",                 OFFLOAD_FUNC     },
-    { "ffn_result",                 OFFLOAD_FUNC     },
+    { "ffn_out",                    OFFLOAD_FUNC     },
 
     { "ffn_silu",                   OFFLOAD_FUNC     },
     { "ffn_gelu",                   OFFLOAD_FUNC     },
     { "ffn_relu",                   OFFLOAD_FUNC     },
     { "ffn_sqr(relu)",              OFFLOAD_FUNC     },
 
-    { "inpFF_+_result_w2",          OFFLOAD_FUNC     },
-    { "inpL_+_inpFF_+_result_w2",   OFFLOAD_FUNC     },
+    { "inpFF_ffn_out",              OFFLOAD_FUNC     },
+    { "inpL_inpFF_ffn_out",         OFFLOAD_FUNC     },
 
     { "result_norm",                OFFLOAD_FUNC_EMB },
     { "result_output",              OFFLOAD_FUNC_OUT },
@@ -4945,6 +4949,14 @@ static struct ggml_cgraph * llama_build_graph(
     bool alloc_inp_KQ_scale = false;
     bool alloc_inp_KQ_mask  = false;
     bool alloc_inp_K_shift  = false;
+
+#ifdef GGML_USE_CUBLAS
+    const bool do_offload = true;
+#else
+    const bool do_offload = true; // TODO: set to false after finishing refactoring
+#endif
+
+    int n_non_view = 0; // number of non-view tensors that have been processed by the callback
 
     // this callback allows us to apply custom logic to each tensor (e.g. ggml-alloc, offloading, etc.)
     llm_build_cb cb = [&](struct ggml_tensor * cur, const char * name, int il) {
@@ -5053,23 +5065,23 @@ static struct ggml_cgraph * llama_build_graph(
             alloc_inp_K_shift = true;
         }
 
-        //
-        // offload layers
-        //
-        // TODO: this code will be obsoleted with backend v2
-
-#ifdef GGML_USE_CUBLAS
-        const bool do_offload = true;
-#else
-        const bool do_offload = true; // TODO: set to false after finishing refactoring
-#endif
-
-        if (!do_offload) {
+        // view tensors are not processed further
+        if (cur->view_src != nullptr) {
             return;
         }
 
-        // view tensors are not offloaded
-        if (cur->view_src != nullptr) {
+        if (cur->op != GGML_OP_NONE) {
+            n_non_view++;
+        }
+
+        //
+        // offload layers
+        //
+        // TODO: will be removed with backend v2
+
+//#define LLAMA_OFFLOAD_DEBUG
+
+        if (!do_offload) {
             return;
         }
 
@@ -5103,11 +5115,13 @@ static struct ggml_cgraph * llama_build_graph(
         llm_offload_func_e func_e = k_offload_func_trie.find(name);
 
         if (func_e == OFFLOAD_FUNC_NOP) {
+#ifdef LLAMA_OFFLOAD_DEBUG
             // if a tensor hasn't been offloaded, we warn the user
             if (worst_case) {
                 LLAMA_LOG_WARN("%s: %32s: not offloaded (ref: %s)\n", __func__,
                         cur->name, "https://github.com/ggerganov/llama.cpp/pull/3837");
             }
+#endif
 
             return;
         }
@@ -5170,9 +5184,11 @@ static struct ggml_cgraph * llama_build_graph(
         // apply offload function to the tensor
         func(cur);
 
+#ifdef LLAMA_OFFLOAD_DEBUG
         if (worst_case) {
             LLAMA_LOG_INFO("%s: %32s: %s\n", __func__, cur->name, k_offload_func_name.at(func_e).c_str());
         }
+#endif
     };
 
     struct ggml_cgraph * result = NULL;
@@ -5212,6 +5228,29 @@ static struct ggml_cgraph * llama_build_graph(
             } break;
         default:
             GGML_ASSERT(false);
+    }
+
+    if (worst_case) {
+        int n_non_view_total = 0;
+
+        for (int i = 0; i < result->n_nodes; ++i) {
+            if (result->nodes[i]->view_src == nullptr) {
+                n_non_view_total++;
+            }
+        }
+
+        LLAMA_LOG_INFO("%s: non-view tensors processed: %d/%d\n", __func__, n_non_view, n_non_view_total);
+
+#ifdef LLAMA_OFFLOAD_DEBUG
+        if (n_non_view != n_non_view_total) {
+            LLAMA_LOG_WARN("%s: ****************************************************************\n", __func__);
+            LLAMA_LOG_WARN("%s: not all non-view tensors have been processed with a callback\n",     __func__);
+            LLAMA_LOG_WARN("%s: this can indicate an inefficiency in the graph implementation\n",    __func__);
+            LLAMA_LOG_WARN("%s: build with LLAMA_OFFLOAD_DEBUG for more info\n",                     __func__);
+            LLAMA_LOG_WARN("%s: ref: https://github.com/ggerganov/llama.cpp/pull/3837\n",            __func__);
+            LLAMA_LOG_WARN("%s: ****************************************************************\n", __func__);
+        }
+#endif
     }
 
     return result;

--- a/llama.cpp
+++ b/llama.cpp
@@ -5213,12 +5213,9 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "tmpk",                       OFFLOAD_FUNC_KQ  },
     { "tmpq",                       OFFLOAD_FUNC_KQ  },
     { "tmpv",                       OFFLOAD_FUNC_V   },
-    { "tmpkqv",                     OFFLOAD_FUNC_KQ  }, // ??
     { "Kcur",                       OFFLOAD_FUNC_KQ  },
     { "Qcur",                       OFFLOAD_FUNC_KQ  },
     { "Vcur",                       OFFLOAD_FUNC_V   },
-    { "Vcur_0",                     OFFLOAD_FUNC_V   },
-    { "Vcur_1",                     OFFLOAD_FUNC_V   },
 
     { "krot",                       OFFLOAD_FUNC_KQ  },
     { "qrot",                       OFFLOAD_FUNC_KQ  },
@@ -5226,9 +5223,6 @@ static const std::unordered_map<const char *, llm_offload_func_e> k_offload_map 
     { "qpass",                      OFFLOAD_FUNC_KQ  },
     { "krotated",                   OFFLOAD_FUNC_KQ  },
     { "qrotated",                   OFFLOAD_FUNC_KQ  },
-
-    { "k",                          OFFLOAD_FUNC_KQ  },
-    { "v",                          OFFLOAD_FUNC_V   },
 
     { "Q",                          OFFLOAD_FUNC_KQ  },
     { "K",                          OFFLOAD_FUNC_KQ  },

--- a/llama.cpp
+++ b/llama.cpp
@@ -3253,8 +3253,8 @@ static void llm_build_k_shift(
 
     const auto & hparams = model.hparams;
 
-    const int64_t n_head      = hparams.n_head;
     const int64_t n_layer     = hparams.n_layer;
+    const int64_t n_head_kv   = hparams.n_head_kv;
     const int64_t n_embd_gqa  = hparams.n_embd_gqa();
     const int64_t n_embd_head = hparams.n_embd_head();
 
@@ -3281,7 +3281,7 @@ static void llm_build_k_shift(
             // we rotate only the first n_rot dimensions
             ggml_rope_custom_inplace(ctx,
                     ggml_view_3d(ctx, kv_self.k,
-                        n_rot, n_head, n_ctx,
+                        n_rot, n_head_kv, n_ctx,
                         ggml_element_size(kv_self.k)*n_embd_head,
                         ggml_element_size(kv_self.k)*n_embd_gqa,
                         ggml_element_size(kv_self.k)*n_embd_gqa*n_ctx*il),


### PR DESCRIPTION
### Code reuse via functions

Factored some common code into separate functions:

- [x] `llm_build_inp_embd()`
- [x] `llm_build_norm()`
- [x] `llm_build_ffn()`
- [x] `llm_build_k_shift()`
- [x] `llm_build_kv_store()`
- [x] `llm_build_qkv()`

### Tensor offloading improvements

*All this stuff is temporary as we will soon integrate a new backend implementation that should automatically take care of tensor offloading, so these changes can be seen as a preparation step for migrating to the new interface.*

Added sanity checks for offloading. Look for the following messages in the output:

```bash
llama_new_context_with_model: kv self size  =    2.75 MB
llama_build_graph: non-view tensors processed: 510/510                              <--- this is good
llama_new_context_with_model: compute buffer total size = 22.75 MB
```

```bash
llama_new_context_with_model: kv self size  =  256,00 MB
llama_build_graph: non-view tensors processed: 708/740                              <--- this is bad
llama_build_graph: ****************************************************************
llama_build_graph: not all non-view tensors have been processed with a callback
llama_build_graph: this can indicate an inefficiency in the graph implementation
llama_build_graph: build with LLAMA_OFFLOAD_DEBUG for more info
llama_build_graph: ref: https://github.com/ggerganov/llama.cpp/pull/3837
llama_build_graph: ****************************************************************
llama_new_context_with_model: compute buffer total size = 76,66 MB
```

The latter indicates that some of the tensors in the graph have not been processed with the callback function. This can lead to inefficiencies during inference and can be debugged by enabling `LLAMA_OFFLOAD_DEBUG`:

https://github.com/ggerganov/llama.cpp/blob/fc5a26aadea54e2bcf6dd384e1ca0c846575bc0c/llama.cpp#L5075-L5077

### Some observations

- Persimmon's Q, K, V implementation is very cumbersome. There is high probability that something is not right there
- ALiBi models might not work well with the K-shift (also on `master`):
```bash
# MPT-7B, small context of 256 to trigger shift more often, starts generating junk after first shift
make -j main && ./main -m ./models/mpt-7b/ggml-model-q4_0.gguf -p "I believe the meaning of life is" --ignore-eos -c 256 -n 512 -t 8 -ngl 999 -s 1
```