### PR TITLE
build : enable link-time optimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,17 @@ jobs:
         id: depends
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gcc-8
+          sudo apt-get install build-essential gcc-8 g++-8
 
       - name: Build
         id: make_build
         run: |
-          CC=gcc-8 make -j $(nproc)
+          CC=gcc-8 CXX=g++-8 make -j $(nproc)
 
       - name: Test
         id: make_test
         run: |
-          CC=gcc-8 make tests -j $(nproc)
+          CC=gcc-8 CXX=g++-8 make tests -j $(nproc)
           make test -j $(nproc)
 
   ubuntu-latest-cmake:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gcc-8 lcov
+          sudo apt-get install build-essential gcc-9 g++-9 lcov
 
       - name: Build
-        run: CC=gcc-8 make -j LLAMA_CODE_COVERAGE=1 tests
+        run: CC=gcc-9 CXX=g++-9 make -j LLAMA_CODE_COVERAGE=1 tests
 
       - name: Run tests
-        run: CC=gcc-8 make test
+        run: CC=gcc-9 CXX=g++-9 make test
 
       - name: Generate coverage report
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,6 +676,8 @@ add_library(ggml OBJECT
             ${GGML_SOURCES_EXTRA} ${GGML_HEADERS_EXTRA}
             )
 
+set_property(TARGET ggml PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+
 target_include_directories(ggml PUBLIC . ${LLAMA_EXTRA_INCLUDES})
 target_compile_features(ggml PUBLIC c_std_11) # don't bump
 target_link_libraries(ggml PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 # general
 option(LLAMA_STATIC                     "llama: static link libraries"                          OFF)
 option(LLAMA_NATIVE                     "llama: enable -march=native flag"                      ON)
-option(LLAMA_LTO                        "llama: enable link time optimization"                  OFF)
+option(LLAMA_LTO                        "llama: enable link time optimization"                  ON)
 
 # debug
 option(LLAMA_ALL_WARNINGS               "llama: enable all compiler warnings"                   ON)
@@ -675,8 +675,6 @@ add_library(ggml OBJECT
             ${GGML_SOURCES_MPI} ${GGML_HEADERS_MPI}
             ${GGML_SOURCES_EXTRA} ${GGML_HEADERS_EXTRA}
             )
-
-set_property(TARGET ggml PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 target_include_directories(ggml PUBLIC . ${LLAMA_EXTRA_INCLUDES})
 target_compile_features(ggml PUBLIC c_std_11) # don't bump

--- a/Makefile
+++ b/Makefile
@@ -120,11 +120,11 @@ MK_CXXFLAGS = -std=c++11 -fPIC
 
 # -Ofast tends to produce faster code, but may not be available for some compilers.
 ifdef LLAMA_FAST
-MK_CFLAGS        += -Ofast -flto
+MK_CFLAGS        += -Ofast -flto=auto
 MK_HOST_CXXFLAGS += -Ofast
 MK_CUDA_CXXFLAGS += -O3
 else
-MK_CFLAGS        += -O3 -flto
+MK_CFLAGS        += -O3 -flto=auto
 MK_CXXFLAGS      += -O3
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,12 @@ MK_CXXFLAGS = -std=c++11 -fPIC
 
 # -Ofast tends to produce faster code, but may not be available for some compilers.
 ifdef LLAMA_FAST
-MK_CFLAGS        += -Ofast
-MK_HOST_CXXFLAGS += -Ofast
-MK_CUDA_CXXFLAGS += -O3
+MK_CFLAGS        += -flto -Ofast
+MK_HOST_CXXFLAGS += -flto -Ofast
+MK_CUDA_CXXFLAGS += -flto -O3
 else
-MK_CFLAGS        += -O3
-MK_CXXFLAGS      += -O3
+MK_CFLAGS        += -flto -O3
+MK_CXXFLAGS      += -flto -O3
 endif
 
 # clock_gettime came in POSIX.1b (1993)

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,12 @@ MK_CXXFLAGS = -std=c++11 -fPIC
 
 # -Ofast tends to produce faster code, but may not be available for some compilers.
 ifdef LLAMA_FAST
-MK_CFLAGS        += -flto -Ofast
-MK_HOST_CXXFLAGS += -flto -Ofast
-MK_CUDA_CXXFLAGS += -flto -O3
+MK_CFLAGS        += -Ofast -flto
+MK_HOST_CXXFLAGS += -Ofast
+MK_CUDA_CXXFLAGS += -O3
 else
-MK_CFLAGS        += -flto -O3
-MK_CXXFLAGS      += -flto -O3
+MK_CFLAGS        += -O3 -flto
+MK_CXXFLAGS      += -O3
 endif
 
 # clock_gettime came in POSIX.1b (1993)


### PR DESCRIPTION
ref #3858 

Try to restore the performance to what it was before the refactoring #3833 
Seems like the `ggml_fp16_to_fp32` and `ggml_fp32_to_fp16` calls slow down the processing significantly. At least with ARM_NEON. Haven't confirmed for x86 architectures