### PR TITLE
convert : restore Falcon vocab padding

### DIFF
--- a/convert-bloom-hf-to-gguf.py
+++ b/convert-bloom-hf-to-gguf.py
@@ -102,7 +102,6 @@ gguf_writer.add_file_type(ftype)
 print("gguf: get tokenizer metadata")
 
 tokens: list[bytearray] = []
-scores: list[float] = []
 toktypes: list[int] = []
 
 # gpt2 tokenizer

--- a/convert-gptneox-hf-to-gguf.py
+++ b/convert-gptneox-hf-to-gguf.py
@@ -107,7 +107,6 @@ gguf_writer.add_layer_norm_eps(hparams["layer_norm_eps"])
 print("gguf: get tokenizer metadata")
 
 tokens: list[bytearray] = []
-scores: list[float] = []
 toktypes: list[int] = []
 
 # gpt2 tokenizer

--- a/convert-mpt-hf-to-gguf.py
+++ b/convert-mpt-hf-to-gguf.py
@@ -110,7 +110,6 @@ gguf_writer.add_max_alibi_bias(hparams["attn_config"]["alibi_bias_max"])
 print("gguf: get tokenizer metadata")
 
 tokens: list[bytearray] = []
-scores: list[float] = []
 toktypes: list[int] = []
 
 # gpt2 tokenizer

--- a/convert-refact-hf-to-gguf.py
+++ b/convert-refact-hf-to-gguf.py
@@ -123,7 +123,6 @@ gguf_writer.add_file_type(ftype)
 print("gguf: get tokenizer metadata")
 
 tokens: list[bytearray] = []
-scores: list[float] = []
 toktypes: list[int] = []
 
 # gpt2 tokenizer

--- a/convert-starcoder-hf-to-gguf.py
+++ b/convert-starcoder-hf-to-gguf.py
@@ -95,7 +95,6 @@ gguf_writer.add_file_type(ftype)
 print("gguf: get tokenizer metadata")
 
 tokens: list[bytearray] = []
-scores: list[float] = []
 toktypes: list[int] = []
 
 # gpt2 tokenizer


### PR DESCRIPTION
This restores the vocab padding in the Falcon conversion script that was removed in #3252.
It also adds the BPE token type checks that are seen in the other conversion scripts after #3746.

originally noticed in https://github.com/ggerganov/llama.cpp/pull/3252#discussion_r1341997142
problem reported in https://github.com/ggerganov/llama.cpp/pull/3680#issuecomment-1779278610

#3838 would fix this as a side-effect, but I don't know how long that will be in draft status or if it will even be merged.