### PR TITLE
gguf : track writer state, free unneeded tensors, cleanup

### DIFF
--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -863,7 +863,11 @@ class GGUFWriter:
         self.write_padding(self.fout, self.fout.tell())
 
         if self.temp_file is None:
-            for tensor in self.tensors:
+            while True:
+                try:
+                    tensor = self.tensors.pop(0)
+                except IndexError:
+                    break
                 tensor.tofile(self.fout)
                 self.write_padding(self.fout, tensor.nbytes)
             return

--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -806,6 +806,9 @@ class GGUFWriter:
         return ((x + n - 1) // n) * n
 
     def add_tensor_info(self, name: str, tensor_shape: Sequence[int], tensor_dtype: np.dtype[np.float16] | np.dtype[np.float32], tensor_nbytes: int, raw_dtype: GGMLQuantizationType | None = None):
+        if self.state is not WriterState.EMPTY:
+            raise ValueError(f'Expected output file to be empty, got {self.state}')
+
         assert raw_dtype is not None or tensor_dtype in (np.float32, np.float16), "Only F32 and F16 tensors are supported for now"
 
         encoded_name = name.encode("utf8")

--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -696,7 +696,6 @@ class GGUFWriter:
         self.fout.write(struct.pack(f"{self.pack_prefix}Q", self.ti_data_count))
         self.fout.write(struct.pack(f"{self.pack_prefix}Q", self.kv_data_count))
         self.flush()
-        #print("tensors " + str(self.ti_data_count) + " kv " + str(self.kv_data_count))
         self.state = WriterState.HEADER
 
     def write_kv_data_to_file(self):

--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.4.5"
+version = "0.4.6"
 description = "Write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
The idea of checking for incorrect use of GGUFWriter was described here: https://github.com/ggerganov/llama.cpp/pull/3838#discussion_r1375364901

The methods of GGUFWriter are designed to be called in a specific order. This PR makes sure this order is respected, otherwise it will raise an exception. Previously, incorrect use would silently fail in most cases, leaving the user wondering why they got a file with the correct size that fails to load.

Also, when use_temp_file is False, we should remove tensors from the list as soon as we are done with them in order to free the associated memory sooner. This can reduce unnecessary swapping when converting large models with scripts that set that parameter, such as convert-llama-ggml-to-gguf.py.