### PR TITLE
null grammar field after reset

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -39,6 +39,7 @@ void llama_sampling_free(struct llama_sampling_context * ctx) {
 void llama_sampling_reset(llama_sampling_context * ctx) {
     if (ctx->grammar != NULL) {
         llama_grammar_free(ctx->grammar);
+        ctx->grammar = NULL;
     }
 
     if (!ctx->parsed_grammar.rules.empty()) {


### PR DESCRIPTION
I think it's best practice to set the deleted field `grammar` to NULL after freeing memory.

I have a unique scenario where I'm clearing the `ctx->parsed_grammar.rules` manually before calling `sampling_reset`, so I can apply different grammars in the middle of the context. Because the `grammar` field was not set to NULL, subsequent `sample` calls crashes. 