### PR TITLE
Fix ROCM build by relaxing constness

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -7369,9 +7369,9 @@ static void ggml_cuda_mul_mat_mat_batched_cublas(const ggml_tensor * src0, const
         CUBLAS_CHECK(
         cublasGemmBatchedEx(g_cublas_handles[id], CUBLAS_OP_T, CUBLAS_OP_N,
                 ne01, ne11, ne10,
-                &alpha_f16, (const void * const *) (ptrs_as + 0*ne23), CUDA_R_16F, nb01/sizeof(half),
-                            (const void * const *) (ptrs_as + 1*ne23), CUDA_R_16F, nb11/sizeof(float),
-                &beta_f16,  (      void **       ) (ptrs_as + 2*ne23), CUDA_R_16F, ne01,
+                &alpha_f16, (const void **) (ptrs_as + 0*ne23), CUDA_R_16F, nb01/sizeof(half),
+                            (const void **) (ptrs_as + 1*ne23), CUDA_R_16F, nb11/sizeof(float),
+                &beta_f16,  (      void **) (ptrs_as + 2*ne23), CUDA_R_16F, ne01,
                 ne23,
                 CUBLAS_COMPUTE_16F,
                 CUBLAS_GEMM_DEFAULT_TENSOR_OP));


### PR DESCRIPTION
This change seems necessary to build with ROCM, at least on my system.

```plaintext
ggml-cuda.cu:7370:9: error: no matching function for call to 'hipblasGemmBatchedEx'
        cublasGemmBatchedEx(g_cublas_handles[id], CUBLAS_OP_T, CUBLAS_OP_N,
        ^~~~~~~~~~~~~~~~~~~
ggml-cuda.cu:32:29: note: expanded from macro 'cublasGemmBatchedEx'
#define cublasGemmBatchedEx hipblasGemmBatchedEx
                            ^~~~~~~~~~~~~~~~~~~~
ggml-cuda.cu:209:32: note: expanded from macro 'CUBLAS_CHECK'
        cublasStatus_t err_ = (err);                                                    \
                               ^~~
/opt/rocm/include/hipblas/hipblas.h:18459:32: note: candidate function not viable: 11th argument ('const void *const *') would lose const qualifier
HIPBLAS_EXPORT hipblasStatus_t hipblasGemmBatchedEx(hipblasHandle_t    handle,
```

Similar to a previous change that got "accepted"...