### PR TITLE
cuda : fix RoPE after #2268

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -4539,7 +4539,7 @@ static __global__ void rope(
     const int i2 = row/p_delta_rows;
 
     const int p = has_pos ? pos[i2] : 0;
-    const float theta_base = p*powf(freq_base, -col/ncols);
+    const float theta_base = p*powf(freq_base, -float(col)/ncols);
 
     float cos_theta, sin_theta;
     rope_yarn(theta_base, freq_scale, corr_dims, col, ext_factor, attn_factor, &cos_theta, &sin_theta);
@@ -4566,8 +4566,8 @@ static __global__ void rope_neox(
     const int i = row*ncols + col/2;
     const int i2 = row/p_delta_rows;
 
-    // simplified from `(row * ncols + col) * (-1 / ncols)`
-    const float cur_rot = -col/ncols - row;
+    // simplified from `(ib * ncols + col) * (-1 / ncols)`, where ib is assumed to be zero
+    const float cur_rot = -float(col)/ncols;
 
     const int p = has_pos ? pos[i2] : 0;
     const float theta_base = p*powf(freq_base, cur_rot);


### PR DESCRIPTION
Follow-up to #2268

ref: https://github.com/ggerganov/llama.cpp/pull/2268#issuecomment-1789979657

I had meant to test this change, but I had evidently forgotten the `-ngl` parameter. Then CI passed and I thought I was in the clear to merge. Oops.

Integer division semantics had slipped my mind because I've been writing too much python. And apparently `row` does *not* mean what I thought it did in this kernel. I don't think figuring out the details of `ne00 != n_dims` is worth the trouble if we don't have a model to actually test with, and I think the comment makes it sufficiently clear what is going on.