### PR TITLE
disable LLAMA_NATIVE by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 # general
 option(LLAMA_STATIC                     "llama: static link libraries"                          OFF)
-option(LLAMA_NATIVE                     "llama: enable -march=native flag"                      ON)
+option(LLAMA_NATIVE                     "llama: enable -march=native flag"                      OFF)
 option(LLAMA_LTO                        "llama: enable link time optimization"                  OFF)
 
 # debug


### PR DESCRIPTION
`LLAMA_NATIVE` doesn't work on MSVC, and this is causing default builds on Windows to not include AVX anymore, which effectively is a breaking change. This PR disables it by default to restore the previous behavior.