### PR TITLE
llama : change yarn_ext_factor placeholder to -1

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -7982,7 +7982,7 @@ struct llama_context_params llama_context_default_params() {
         /*.rope_scaling_type           =*/ LLAMA_ROPE_SCALING_UNSPECIFIED,
         /*.rope_freq_base              =*/ 0.0f,
         /*.rope_freq_scale             =*/ 0.0f,
-        /*.yarn_ext_factor             =*/ NAN,
+        /*.yarn_ext_factor             =*/ -1.0f,
         /*.yarn_attn_factor            =*/ 1.0f,
         /*.yarn_beta_fast              =*/ 32.0f,
         /*.yarn_beta_slow              =*/ 1.0f,
@@ -8125,7 +8125,7 @@ struct llama_context * llama_new_context_with_model(
         cparams.rope_freq_scale = 1.0f; // never scale if scaling type is none
     }
 
-    if (std::isnan(cparams.yarn_ext_factor)) { // NaN indicates 'not set'
+    if (cparams.yarn_ext_factor < 0.0f) { // negative indicates 'not set'
         cparams.yarn_ext_factor = rope_scaling_type == LLAMA_ROPE_SCALING_YARN ? 1.0f : 0.0f;
     }
 


### PR DESCRIPTION
I have been unable to reproduce any strange results from this code on gcc 12.3.0 or clang 16.0.6 - cparams.yarn_ext_factor is always correctly set to 0.0f for me.

However, with some compilers and system configurations and the `-Ofast` compiler option, the default of NaN apparently does not work. I was thinking that a good placeholder should be impossible to confuse for a valid value, but apparently the result of std::isnan cannot be relied upon.

ref: https://github.com/ggerganov/llama.cpp/pull/2268#issuecomment-1791651250