### PR TITLE
ggml-metal: round up to 16 to fix setThreadgroupMemoryLength assertion

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1017,7 +1017,7 @@ void ggml_metal_graph_compute(
                             [encoder setBytes:&ne00 length:sizeof(ne00) atIndex:2];
                             [encoder setBytes:&ne01 length:sizeof(ne01) atIndex:3];
                             [encoder setBytes:&ne02 length:sizeof(ne02) atIndex:4];
-                            [encoder setThreadgroupMemoryLength:nth/32*sizeof(float) atIndex:0];
+                            [encoder setThreadgroupMemoryLength:MAX(16, nth/32*sizeof(float)) atIndex:0];
 
                             [encoder dispatchThreadgroups:MTLSizeMake(ne01*ne02*ne03, 1, 1) threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
                         } break;
@@ -1348,7 +1348,7 @@ void ggml_metal_graph_compute(
                             [encoder setBytes:&ne00    length:sizeof( int64_t) atIndex:2];
                             [encoder setBytes:&nb01    length:sizeof(uint64_t) atIndex:3];
                             [encoder setBytes:&eps     length:sizeof(   float) atIndex:4];
-                            [encoder setThreadgroupMemoryLength:nth*sizeof(float) atIndex:0];
+                            [encoder setThreadgroupMemoryLength:MAX(16, nth*sizeof(float)) atIndex:0];
 
                             const int64_t nrows = ggml_nrows(src0);
 


### PR DESCRIPTION
Without this fix, when running inside Xcode, MTLDebugComputeCommandEncoder throws the following assertion: 

```-[MTLDebugComputeCommandEncoder setThreadgroupMemoryLength:atIndex:]:817: failed assertion `length(4) must be a multiple of 16 bytes.'```

Logging shows me it’s getting passed 4 on line 1020. This fix just makes sure that we round up to 16 if we’re under.

Here’s the relevant doc that discusses setThreadgroupMemoryLength being a multiple of 16: https://developer.apple.com/documentation/metal/mtlcomputecommandencoder/1443142-setthreadgroupmemorylength