### PR TITLE
gguf-py: Support 01.AI Yi models

### DIFF
--- a/gguf-py/gguf/gguf.py
+++ b/gguf-py/gguf/gguf.py
@@ -393,6 +393,7 @@ class TensorNameMap:
             "layers.{bid}.attention_norm",                         # llama-pth
             "encoder.layer.{bid}.attention.output.LayerNorm",      # bert
             "language_model.encoder.layers.{bid}.input_layernorm", # persimmon
+            "model.layers.{bid}.ln1",                              # yi
         ),
 
         # Attention norm 2
@@ -464,6 +465,7 @@ class TensorNameMap:
             "layers.{bid}.ffn_norm",                                        # llama-pth
             "encoder.layer.{bid}.output.LayerNorm",                         # bert
             "language_model.encoder.layers.{bid}.post_attention_layernorm", # persimmon
+            "model.layers.{bid}.ln2",                                       # yi
         ),
 
         # Feed-forward up


### PR DESCRIPTION
Tiny change to support Yi model layernorm tensor names. Architecturally, it's the same as LLaMA2. See https://github.com/01-ai/Yi/issues/1

The model has impressively high MMLU results, higher than any 70B models actually. Whether it's valid or translates to real world results, I don't know.

I successfully converted this model: https://huggingface.co/01-ai/Yi-34B (note that there's both Safetensors and PyTorch versions in the same repo, so be careful unless you actually want to download two copies of the model).

Quantized version runs just fine. I didn't test with the 6B but looking at the tensor index it looks the same.

@TheBloke - tagging in case you're interested in trying to convert this one.