### PR TITLE
make : do not add linker flags when compiling static llava lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,7 +618,7 @@ llama-bench: examples/llama-bench/llama-bench.cpp ggml.o llama.o $(COMMON_DEPS) 
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
 libllava.a: examples/llava/llava.cpp examples/llava/llava.h examples/llava/clip.cpp examples/llava/clip.h common/stb_image.h common/base64.hpp ggml.o llama.o $(COMMON_DEPS) $(OBJS)
-	$(CXX) $(CXXFLAGS) -static -fPIC -c $< -o $@ $(LDFLAGS) -Wno-cast-qual
+	$(CXX) $(CXXFLAGS) -static -fPIC -c $< -o $@ -Wno-cast-qual
 
 llava-cli: examples/llava/llava-cli.cpp examples/llava/clip.h examples/llava/clip.cpp examples/llava/llava.h examples/llava/llava.cpp ggml.o llama.o $(COMMON_DEPS) $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) -Wno-cast-qual


### PR DESCRIPTION
Fixes build warnings on macOS:

```bash
c++ -I. -Icommon -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -DNDEBUG -DGGML_USE_ACCELERATE -DACCELERATE_NEW_LAPACK -DACCELERATE_LAPACK_ILP64 -DGGML_USE_METAL  -std=c++11 -fPIC -O3 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wmissing-declarations -Wmissing-noreturn -pthread  -Wunreachable-code-break -Wunreachable-code-return -Wmissing-prototypes -Wextra-semi  -static -fPIC -c examples/llava/llava.cpp -o libllava.a -framework Accelerate -framework Foundation -framework Metal -framework MetalKit  -Wno-cast-qual
clang: warning: -framework Accelerate: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -framework Foundation: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -framework Metal: 'linker' input unused [-Wunused-command-line-argument]
clang: warning: -framework MetalKit: 'linker' input unused [-Wunused-command-line-argument]
```