### PR TITLE
Suggest setting AMDGPU_TARGETS

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ Building the program with BLAS support may lead to some performance improvements
     ```bash
     mkdir build
     cd build
-    CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ cmake .. -DLLAMA_HIPBLAS=ON
-    cmake --build .
+    CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ cmake .. -DLLAMA_HIPBLAS=ON -DAMDGPU_TARGETS=native
+    cmake --build . --config Release
     ```
 
   The environment variable [`HIP_VISIBLE_DEVICES`](https://rocm.docs.amd.com/en/latest/understand/gpu_isolation.html#hip-visible-devices) can be used to specify which GPU(s) will be used.


### PR DESCRIPTION
Currently, when building llama.cpp with CMake and hipBLAS option, [it will build for gfx900, gfx906, gfx908, gfx90a, gfx1030 if using 5.6.1 or older](https://github.com/ROCm-Developer-Tools/clr/blob/rocm-5.6.1/hipamd/hip-config.cmake.in#L161). And, [build for gfx906 if using ROCm 5.7.0 or 5.7.1](https://github.com/ROCm-Developer-Tools/clr/blob/rocm-5.7.1/hipamd/hip-config-amd.cmake#L69) (it is set to empty, but that will result in it building only for gfx906.

The former raised multiple issues that CMake build wasn't working for RDNA3 cards, and once ROCm 5.7.0 or 5.7.1 is available in popular linux distributions, it will surely raise issues for most AMD cards owner.

[This issue was fixed upstream 3 days ago](https://github.com/ROCm-Developer-Tools/clr/commit/d05d08ddc03293a217e121e734c05c3c7490677f), it will do something similar to this suggestion.

It might be better to implement AMD GPU targets selection in CMakeLists.txt, using devices present in computer by default with an option to set GPU targets for package maintainers.

~~Also, I noticed that in Makefile, the way it select GPU targets probably doesn't work on a computer with multiple GPU that use different ISA.~~