### PR TITLE
added lto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,13 @@ else
 	MK_CPPFLAGS += -DNDEBUG
 endif
 
+
+ifdef LLAMA_LTO
+	MK_CFLAGS   += -flto
+	MK_CXXFLAGS += -flto
+endif
+
+
 ifdef LLAMA_SANITIZE_THREAD
 	MK_CFLAGS   += -fsanitize=thread -g
 	MK_CXXFLAGS += -fsanitize=thread -g


### PR DESCRIPTION
Minimum support for link time optimization.

```bash
LLAMA_LTO=1 make
```

Reduces size of main on OSX M2 from 2128 to 1568.

Unblocks PGO+LTO build, and eventually BOLT. 

CC @aaupov
 
