### PR TITLE
server: fix core dump when input prompt larger than prompt context 

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1560,6 +1560,13 @@ struct llama_server_context
                     if (!slot.params.cache_prompt)
                     {
                         llama_sampling_reset(slot.ctx_sampling);
+                        // if input prompt is too big, truncate it
+                        if (slot.num_prompt_tokens >= slot.n_ctx)
+                        {
+                            slot.num_prompt_tokens = slot.n_ctx - 1;
+                            prompt_tokens = std::vector<llama_token>(prompt_tokens.end() - slot.num_prompt_tokens, prompt_tokens.end());
+                            slot.truncated = true;
+                        }
 
                         slot.n_past = 0;
                         slot.num_prompt_tokens_processed = slot.num_prompt_tokens;


### PR DESCRIPTION
Fix the core dump bug caused by 
* when input prompt larger than prompt context (variable `n_ctx` )
* and not hit `slot.params.cache_prompt` code branch.

root cause location:
```c++
                    if (!slot.params.cache_prompt) // root cause: the prompt too long and not truncated
                    {
                        llama_sampling_reset(slot.ctx_sampling);

                        slot.n_past = 0;
                        slot.num_prompt_tokens_processed = slot.num_prompt_tokens;
                    }
                    else ...
```

my gdb debug log:

```python
Core was generated by `bin/server -ngl 32 -m /home/do/ssd/modelhub/Wizard-GGUF/wizardcoder-python-34b-'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055aae060f588 in llama_batch_add (batch=..., id=1053, pos=101, seq_ids=..., logits=false) at /home/do/ssd/local/llama.cpp/common/common.cpp:937
937	        batch.seq_id[batch.n_tokens][i] = seq_ids[i];
[Current thread is 1 (Thread 0x7f25417db000 (LWP 30525))]

(gdb) bt

#0  0x000055aae060f588 in llama_batch_add (batch=..., id=1053, pos=101, seq_ids=std::vector of length 1, capacity 1 = {...}, logits=false)
    at /home/do/ssd/local/llama.cpp/common/common.cpp:937
#1  0x000055aae05202f2 in llama_server_context::update_slots (this=0x7ffc89d270f0) at /home/do/ssd/local/llama.cpp/examples/server/server.cpp:1635
#2  0x000055aae04f55c2 in main (argc=9, argv=0x7ffc89d27708) at /home/do/ssd/local/llama.cpp/examples/server/server.cpp:2571
(gdb) f 0
#0  0x000055aae060f588 in llama_batch_add (batch=..., id=1053, pos=101, seq_ids=std::vector of length 1, capacity 1 = {...}, logits=false)
    at /home/do/ssd/local/llama.cpp/common/common.cpp:937
937	        batch.seq_id[batch.n_tokens][i] = seq_ids[i];

(gdb) l 937
932	                               bool   logits) {
933	    batch.token   [batch.n_tokens] = id;
934	    batch.pos     [batch.n_tokens] = pos,
935	    batch.n_seq_id[batch.n_tokens] = seq_ids.size();
936	    for (size_t i = 0; i < seq_ids.size(); ++i) {
937	        batch.seq_id[batch.n_tokens][i] = seq_ids[i];
938	    }
939	    batch.logits  [batch.n_tokens] = logits;
940	
941	    batch.n_tokens++;

(gdb) p batch.n_tokens
$1 = 101

(gdb) f 1
#1  0x000055aae05202f2 in llama_server_context::update_slots (this=0x7ffc89d270f0) at /home/do/ssd/local/llama.cpp/examples/server/server.cpp:1635
1635	                       llama_batch_add(batch, prefix_tokens[slot.n_past], system_tokens.size() + slot.n_past, { slot.id }, false);

(gdb) p n_ctx
$2 = 100
(gdb) 

```