### PR TITLE
Fix incorrect prompt tokenization in speculative example

### DIFF
--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -94,9 +94,13 @@ int main(int argc, char ** argv) {
         }
     }
 
-    // tokenize the prompt
+
+    // Tokenize the prompt
+    const bool add_bos = llama_vocab_type(llama_get_model(ctx_tgt)) == LLAMA_VOCAB_TYPE_SPM;
+    LOG("add_bos: %d\n", add_bos);
+
     std::vector<llama_token> inp;
-    inp = ::llama_tokenize(ctx_tgt, params.prompt, true);
+    inp = ::llama_tokenize(ctx_tgt, params.prompt, add_bos, true);
 
     const int max_context_size     = llama_n_ctx(ctx_tgt);
     const int max_tokens_list_size = max_context_size - 4;

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -96,11 +96,20 @@ int main(int argc, char ** argv) {
 
 
     // Tokenize the prompt
-    const bool add_bos = llama_should_add_bos_token(model_tgt);
-    LOG("add_bos: %d\n", add_bos);
+    const bool add_bos_tgt = llama_should_add_bos_token(model_tgt);
+    LOG("add_bos tgt: %d\n", add_bos_tgt);
+
+    const bool add_bos_dft = llama_should_add_bos_token(model_dft);
+    LOG("add_bos dft: %d\n", add_bos_dft);
+
+    if (add_bos_tgt != add_bos_dft) {
+        fprintf(stderr, "%s: error: draft model add_bos must match target model to use speculation but ", __func__);
+        fprintf(stderr, "add_bos_dft = %d while add_bos_tgt = %d\n", add_bos_dft, add_bos_tgt);
+        return 1;
+    }
 
     std::vector<llama_token> inp;
-    inp = ::llama_tokenize(ctx_tgt, params.prompt, add_bos, true);
+    inp = ::llama_tokenize(ctx_tgt, params.prompt, add_bos_tgt, true);
 
     const int max_context_size     = llama_n_ctx(ctx_tgt);
     const int max_tokens_list_size = max_context_size - 4;

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -96,7 +96,7 @@ int main(int argc, char ** argv) {
 
 
     // Tokenize the prompt
-    const bool add_bos = llama_vocab_type(llama_get_model(ctx_tgt)) == LLAMA_VOCAB_TYPE_SPM;
+    const bool add_bos = llama_should_add_bos_token(model_tgt);
     LOG("add_bos: %d\n", add_bos);
 
     std::vector<llama_token> inp;


### PR DESCRIPTION
This PR fixes a discrepancy between how the speculative example and the main example tokenize the input prompt. The speculative example did not check for the `add_bos` requirement nor did it allow special tokens in the prompt, while the main did. This PR simply copies the main implementation to the speculative example.

Testing with `dolphin-2.1-70b`, the speculative example now generates coherent text instead of going off the rails.