### PR TITLE
main : Fix some missing lines in main.log

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -101,9 +101,9 @@ static void sigint_handler(int signo) {
 #endif
 
 static void llama_log_callback_logTee(ggml_log_level level, const char * text, void * user_data) {
-	(void) level;
-	(void) user_data;
-	LOG_TEE("%s", text);
+    (void) level;
+    (void) user_data;
+    LOG_TEE("%s", text);
 }
 
 int main(int argc, char ** argv) {
@@ -119,7 +119,7 @@ int main(int argc, char ** argv) {
     log_set_target(log_filename_generator("main", "log"));
     LOG_TEE("Log start\n");
     log_dump_cmdline(argc, argv);
-	llama_log_set(llama_log_callback_logTee, nullptr);
+    llama_log_set(llama_log_callback_logTee, nullptr);
 #endif // LOG_DISABLE_LOGS
 
     // TODO: Dump params ?

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -100,6 +100,12 @@ static void sigint_handler(int signo) {
 }
 #endif
 
+static void llama_log_callback_logTee(ggml_log_level level, const char * text, void * user_data) {
+	(void) level;
+	(void) user_data;
+	LOG_TEE("%s", text);
+}
+
 int main(int argc, char ** argv) {
     gpt_params params;
     g_params = &params;
@@ -113,6 +119,7 @@ int main(int argc, char ** argv) {
     log_set_target(log_filename_generator("main", "log"));
     LOG_TEE("Log start\n");
     log_dump_cmdline(argc, argv);
+	llama_log_set(llama_log_callback_logTee, nullptr);
 #endif // LOG_DISABLE_LOGS
 
     // TODO: Dump params ?


### PR DESCRIPTION
This fixes the issue of some log output appearing on stderr but not appearing in main.log.

A limited change because I don't yet understand the difference between the two logging systems.
LOG_TEE intended to fully replace the other eventually? Can llama_log_callback_default call LOG_TEE already, or is more work needed?