### PR TITLE
Add ReLU and SQR CUDA ops to fix Persimmon offloading

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -2877,6 +2877,13 @@ static void llm_load_tensors(
                         ggml_backend_type backend_output;
 
                         if (n_gpu_layers > int(n_layer)) {
+#ifdef GGML_USE_CUBLAS
+                            if (n_gpu_layers > int(n_layer + 1)) {
+                                LLAMA_LOG_ERROR("%s: CUDA backend missing Persimmon CUDA ops, can offload at most %ld layers. See: https://github.com/ggerganov/llama.cpp/issues/4038\n",
+                                    __func__, n_layer + 1);
+                                throw std::runtime_error("Persimmon CUDA offload failed");
+                            }
+#endif
                             // norm is not performance relevant on its own but keeping it in VRAM reduces data copying
                             // on Windows however this is detrimental unless everything is on the GPU
 #ifndef _WIN32


### PR DESCRIPTION
See #4038 - Persimmon uses ReLU and SQR but those CUDA ops didn't exist. Looks like they are in Metal already just as a note.

This pull adds those ops. This still isn't enough for full offloading. You can offload `n_layers + 1`. So for the 8B model with 36 layers, `-ngl 37` works but `-ngl 38` does not.

*edit:* ~~The next op it fails on seems to be `CPY`. Is the solution just do add that as well?~~ Actually seems like `CPY` already exists so the problem must be something else like maybe it's not combination of tensor types that can be copied.

```plaintext
#3  0x00005555556bf394 in ggml_cuda_cpy (src0=0x7ffada8a1100, src1=0x7ffada8a1280, dst=0x0) at ggml-cuda.cu:7576
7576        GGML_ASSERT(src1->backend == GGML_BACKEND_GPU);
(gdb) p *src0
$1 = {type = GGML_TYPE_F32, backend = GGML_BACKEND_GPU, buffer = 0x555567196b40, n_dims = 4, ne = {64, 64, 2, 3}, nb = {4, 768, 49152, 256}, op = GGML_OP_PERMUTE, op_params = {0, 3, 
    1, 2, 0 <repeats 12 times>}, is_param = false, grad = 0x0, src = {0x7ffada8a0f80, 0x0, 0x0, 0x0, 0x0, 0x0}, perf_runs = 1, perf_cycles = 0, perf_time_us = 0, 
  view_src = 0x7ffada8a0e00, view_offs = 0, data = 0x7ffab9610160, name = "tmpqkv-0 (permuted)", '\000' <repeats 44 times>, extra = 0x55556b1e3c40, 
  padding = '\000' <repeats 11 times>}
(gdb) p *src1
$2 = {type = GGML_TYPE_F32, backend = GGML_BACKEND_CPU, buffer = 0x555567196b40, n_dims = 4, ne = {64, 64, 2, 3}, nb = {4, 256, 16384, 32768}, op = GGML_OP_CONT, op_params = {
    0 <repeats 16 times>}, is_param = false, grad = 0x0, src = {0x7ffada8a1100, 0x0, 0x0, 0x0, 0x0, 0x0}, perf_runs = 0, perf_cycles = 0, perf_time_us = 0, view_src = 0x0, 
  view_offs = 0, data = 0x7ffab9628160, name = "tmpqkv-0\000(permuted) (cont)", '\000' <repeats 37 times>, extra = 0x0, padding = '\000' <repeats 11 times>}
```

One of the operands is on CPU. I don't know how to fix that though. *edit*: Well, the next issue after that is `CPY` only supports up to 3 dimensions but those tensors are 4D.