### PR TITLE
Fix MacOS Sonoma model quantization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,15 @@ if (LLAMA_LTO)
     endif()
 endif()
 
+# this version of Apple ld64 is buggy
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_EXE_LINKER_FLAGS} -Wl,-v
+    ERROR_VARIABLE output
+)
+if (output MATCHES "dyld-1015\.7")
+    add_compile_definitions(-DBUGGY_APPLE_LINKER)
+endif()
+
 # Architecture specific
 # TODO: probably these flags need to be tweaked on some architectures
 #       feel free to update the Makefile for your architecture and send a pull request or issue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,7 +464,7 @@ execute_process(
     ERROR_VARIABLE output
 )
 if (output MATCHES "dyld-1015\.7")
-    add_compile_definitions(-DBUGGY_APPLE_LINKER)
+    add_compile_definitions(HAVE_BUGGY_APPLE_LINKER)
 endif()
 
 # Architecture specific

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,11 @@ else
 	endif
 endif
 
+# this version of Apple ld64 is buggy
+ifneq '' '$(findstring dyld-1015.7,$(shell $(CC) $(LDFLAGS) -Wl,-v 2>&1))'
+	MK_CPPFLAGS += -DBUGGY_APPLE_LINKER
+endif
+
 # OS specific
 # TODO: support Windows
 ifneq '' '$(filter $(UNAME_S),Linux Darwin FreeBSD NetBSD OpenBSD Haiku)'

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ endif
 
 # this version of Apple ld64 is buggy
 ifneq '' '$(findstring dyld-1015.7,$(shell $(CC) $(LDFLAGS) -Wl,-v 2>&1))'
-	MK_CPPFLAGS += -DBUGGY_APPLE_LINKER
+	MK_CPPFLAGS += -DHAVE_BUGGY_APPLE_LINKER
 endif
 
 # OS specific

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,12 +1273,12 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-+#if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
-+    // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x
-+    for (volatile int i = 1; i < n; ++i) {
-+#else
-     for (int i = 1; i < n; ++i) {
-+#endif
+    #if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
+      // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
+      for (volatile int i = 1; i < n; ++i) {
+    #else
+      for (int i = 1; i < n; ++i) {
+    #endif
         if (x[i] < min) min = x[i];
         if (x[i] > max) max = x[i];
         float w = weights[i];

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,7 +1273,8 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-    for (int i = 1; i < n; ++i) {
+    // Mark i as volatile to prevent the -O3 optimizer from unrolling this loop and breaking MacOS Sonoma quantization
+    for (volatile int i = 1; i < n; ++i) {
         if (x[i] < min) min = x[i];
         if (x[i] > max) max = x[i];
         float w = weights[i];

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,12 +1273,12 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-    #if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
-        // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
-        for (volatile int i = 1; i < n; ++i) {
-    #else
-        for (int i = 1; i < n; ++i) {
-    #endif
+#if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
+    // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
+    for (volatile int i = 1; i < n; ++i) {
+#else
+    for (int i = 1; i < n; ++i) {
+#endif
         if (x[i] < min) min = x[i];
         if (x[i] > max) max = x[i];
         float w = weights[i];

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,8 +1273,12 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-    // Mark i as volatile to prevent the -O3 optimizer from unrolling this loop and breaking MacOS Sonoma quantization
-    for (volatile int i = 1; i < n; ++i) {
++#if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
++    // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x
++    for (volatile int i = 1; i < n; ++i) {
++#else
+     for (int i = 1; i < n; ++i) {
++#endif
         if (x[i] < min) min = x[i];
         if (x[i] > max) max = x[i];
         float w = weights[i];

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,7 +1273,7 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-#ifdef BUGGY_APPLE_LINKER
+#ifdef HAVE_BUGGY_APPLE_LINKER
     // use 'volatile' to prevent unroll and work around a bug in Apple ld64 1015.7
     for (volatile int i = 1; i < n; ++i) {
 #else

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1273,8 +1273,8 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float max = x[0];
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
-#if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
-    // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
+#ifdef BUGGY_APPLE_LINKER
+    // use 'volatile' to prevent unroll and work around a bug in Apple ld64 1015.7
     for (volatile int i = 1; i < n; ++i) {
 #else
     for (int i = 1; i < n; ++i) {

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1274,10 +1274,10 @@ static float make_qkx2_quants(int n, int nmax, const float * restrict x, const f
     float sum_w = weights[0];
     float sum_x = sum_w * x[0];
     #if defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 15
-      // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
-      for (volatile int i = 1; i < n; ++i) {
+        // use 'volatile' to prevent unroll and work around a bug in Apple clang 15.x.x with -O3 flag
+        for (volatile int i = 1; i < n; ++i) {
     #else
-      for (int i = 1; i < n; ++i) {
+        for (int i = 1; i < n; ++i) {
     #endif
         if (x[i] < min) min = x[i];
         if (x[i] > max) max = x[i];


### PR DESCRIPTION
A PR to resolve the Issue: https://github.com/ggerganov/llama.cpp/issues/3983

I'm not sure why unrolling this particular for-loop in the -O3 compiler is causing problems, but by marking the iterator index as volatile to prevent that particular unroll I can now successfully quantize the 70B LLama2 model again on my M1 MBP. 