### PR TITLE
gguf-py readme example fixes for keys: general.architecture and general.alignment

### DIFF
--- a/gguf-py/examples/writer.py
+++ b/gguf-py/examples/writer.py
@@ -15,7 +15,6 @@ def writer_example() -> None:
     # Example usage with a file
     gguf_writer = GGUFWriter("example.gguf", "llama")
 
-    gguf_writer.add_architecture()
     gguf_writer.add_block_count(12)
     gguf_writer.add_uint32("answer", 42)  # Write a 32-bit integer
     gguf_writer.add_float32("answer_in_float", 42.0)  # Write a 32-bit float

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -107,7 +107,13 @@ class GGUFReader:
         offs, tensors_fields = self._build_tensors_fields(offs, tensor_count)
         new_align = self.fields.get('general.alignment')
         if new_align is not None:
-            if new_align.types != [GGUFValueType.UINT64]:
+            if (
+                    (
+                        new_align.types != [GGUFValueType.UINT64]
+                    ) and (
+                        new_align.types != [GGUFValueType.UINT32]
+                    )
+            ):
                 raise ValueError('Bad type for general.alignment field')
             self.alignment = new_align.parts[-1][0]
         padding = offs % self.alignment


### PR DESCRIPTION
Hello,

Thanks for this repository and all the help.

I was looking at the ``gguf-py`` examples and hit the errors below. Hopefully the proposed fixes work for the many different architectures out there.

Setup:
- fresh git clone of the repo
- fresh python 3.11 venv
- ``pip install -e .`` inside gguf-py directory

Issues:

1 - **general.architecture** dupe error 

```bash
./scripts/gguf-dump.py ./example.gguf
* Loading: ./example.gguf
Traceback (most recent call last):
  File "/opt/public/llama.cpp/gguf-py/./scripts/gguf-dump.py", line 116, in <module>
    main()
  File "/opt/public/llama.cpp/gguf-py/./scripts/gguf-dump.py", line 108, in main
    reader = GGUFReader(args.model, 'r')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/public/llama.cpp/gguf-py/gguf/gguf_reader.py", line 106, in __init__
    offs = self._build_fields(offs, kv_count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/public/llama.cpp/gguf-py/gguf/gguf_reader.py", line 223, in _build_fields
    self._push_field(ReaderField(
  File "/opt/public/llama.cpp/gguf-py/gguf/gguf_reader.py", line 148, in _push_field
    raise KeyError(f'Duplicate {field.name} already in list at offset {field.offset}')
KeyError: 'Duplicate general.architecture already in list at offset 69'
```

After removing the ``gguf_writer.add_architecture()`` duplicate call inside ``./examples/writer.py`` I got passed that issue:

```bash
rm -f example.gguf
./examples/writer.py
gguf: This GGUF file is for Little Endian only
```

2 - **general.alignment** missing support for UINT32

```bash
./scripts/gguf-dump.py ./example.gguf
* Loading: ./example.gguf
Traceback (most recent call last):
  File "/opt/public/llama.cpp/gguf-py/./scripts/gguf-dump.py", line 116, in <module>
    main()
  File "/opt/public/llama.cpp/gguf-py/./scripts/gguf-dump.py", line 108, in main
    reader = GGUFReader(args.model, 'r')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/public/llama.cpp/gguf-py/gguf/gguf_reader.py", line 111, in __init__
    raise ValueError('Bad type for general.alignment field')
ValueError: Bad type for general.alignment field
```

I added support to gguf-py/gguf/gguf_reader.py for handling UINT32 and UINT64 where ``new_align.types == GGUFValueType.UINT[32|64]`` (hopefully there's not more fixes downstream for this type size like for an offset but let me know). The ``./scripts/gguf-dump.py`` now works for me:

```bash
./scripts/gguf-dump.py ./example.gguf
* Loading: ./example.gguf
* File is LITTLE endian, script is running on a LITTLE endian host.

* Dumping 8 key/value pair(s)
      1: UINT32     |        1 | GGUF.version = 3
      2: UINT64     |        1 | GGUF.tensor_count = 3
      3: UINT64     |        1 | GGUF.kv_count = 5
      4: STRING     |        1 | general.architecture = 'llama'
      5: UINT32     |        1 | llama.block_count = 12
      6: UINT32     |        1 | answer = 42
      7: FLOAT32    |        1 | answer_in_float = 42.0
      8: UINT32     |        1 | general.alignment = 64

* Dumping 3 tensor(s)
      1:         32 |    32,     1,     1,     1 | F32     | tensor1
      2:         64 |    64,     1,     1,     1 | F32     | tensor2
      3:         96 |    96,     1,     1,     1 | F32     | tensor3
```

end to end:

```bash
rm -f ./example.gguf; ./examples/writer.py && ls -lrth ./example.gguf && ./scripts/gguf-dump.py example.gguf && echo $?

gguf: This GGUF file is for Little Endian only
-rw-rw-r-- 1 jay jay 1.1K Nov 13 17:37 ./example.gguf
* Loading: example.gguf
* File is LITTLE endian, script is running on a LITTLE endian host.

* Dumping 8 key/value pair(s)
      1: UINT32     |        1 | GGUF.version = 3
      2: UINT64     |        1 | GGUF.tensor_count = 3
      3: UINT64     |        1 | GGUF.kv_count = 5
      4: STRING     |        1 | general.architecture = 'llama'
      5: UINT32     |        1 | llama.block_count = 12
      6: UINT32     |        1 | answer = 42
      7: FLOAT32    |        1 | answer_in_float = 42.0
      8: UINT32     |        1 | general.alignment = 64

* Dumping 3 tensor(s)
      1:         32 |    32,     1,     1,     1 | F32     | tensor1
      2:         64 |    64,     1,     1,     1 | F32     | tensor2
      3:         96 |    96,     1,     1,     1 | F32     | tensor3
0
```