### PR TITLE
Fix compilation warning that fread return value is not used

### DIFF
--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -127,7 +127,14 @@ static bool load_file_to_bytes(const char* path, unsigned char** bytesOut, long 
         fclose(file);
         return false;
     }
-    fread(buffer, 1, fileSize, file); // Read the file into the buffer
+    errno = 0;
+    size_t ret = fread(buffer, 1, fileSize, file); // Read the file into the buffer
+    if (ferror(file)) {
+        die_fmt("read error: %s", strerror(errno));
+    }
+    if (ret != (size_t) fileSize) {
+        die("unexpectedly reached end of file");
+    }
     fclose(file); // Close the file
 
     *bytesOut = buffer;


### PR DESCRIPTION
Fix the warning that fread return value is not used.

```
./examples/llava/llava.cpp:130:10: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  130 |     fread(buffer, 1, fileSize, file); // Read the file into the buffer
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```