### PR TITLE
Use BLAS to implement ggml_compute_forward_out_prod_f32 for matrix src0, src1 (finetuning speedup ~5x).

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -9611,10 +9611,12 @@ static void ggml_compute_forward_out_prod_f32(
     const int ith = params->ith;
     const int nth = params->nth;
 
+    GGML_ASSERT(ne0  == ne00);
+    GGML_ASSERT(ne1  == ne10);
+    GGML_ASSERT(ne2  == ne02);
     GGML_ASSERT(ne02 == ne12);
-    GGML_ASSERT(ne03 == ne13);
-    GGML_ASSERT(ne2  == ne12);
     GGML_ASSERT(ne3  == ne13);
+    GGML_ASSERT(ne03 == ne13);
 
     // we don't support permuted src0 or src1
     GGML_ASSERT(nb00 == sizeof(float));
@@ -9624,11 +9626,6 @@ static void ggml_compute_forward_out_prod_f32(
     // GGML_ASSERT(nb0 <= nb1);
     // GGML_ASSERT(nb1 <= nb2);
     // GGML_ASSERT(nb2 <= nb3);
-
-    GGML_ASSERT(ne0 == ne00);
-    GGML_ASSERT(ne1 == ne10);
-    GGML_ASSERT(ne2 == ne02);
-    GGML_ASSERT(ne3 == ne03);
 
     // nb01 >= nb00 - src0 is not transposed
     //   compute by src0 rows

--- a/ggml.c
+++ b/ggml.c
@@ -9598,35 +9598,6 @@ static void ggml_compute_forward_mul_mat(
 
 // ggml_compute_forward_out_prod
 
-#if defined(GGML_USE_ACCELERATE)
-    // helper function to determine if it is better to use BLAS or not
-    // based on ggml_compute_forward_mul_mat_use_blas()
-    // However, testing suggested that BLAS was never slower than the existing code
-static bool ggml_compute_forward_out_prod_use_blas(
-        const struct ggml_tensor * src0,
-        const struct ggml_tensor * src1,
-              struct ggml_tensor * dst) {
-
-    UNUSED(dst);
-//    const int64_t ne10 = src1->ne[0];
-//
-//    const int64_t ne0 = dst->ne[0];
-//    const int64_t ne1 = dst->ne[1];
-
-    if (ggml_is_matrix(src0) &&
-        ggml_is_matrix(src1) &&
-        ggml_is_contiguous(src0) &&
-        (ggml_is_contiguous(src1) || ggml_is_transposed(src1))){ //&&
-        //(ne0 >= 32 && ne1 >= 32 && ne10 >= 32)) {
-        return true;
-    }
-//    if (ne0 >= 32 && ne1 >= 32 && ne10 >= 32) {
-//        printf("Cannot use BLAS for large matrix at %s; ne0: %lld, ne1: %lld, ne10:, %lld", dst->name, ne0, ne1, ne10);
-//    }
-    return false;
-}
-#endif
-
 static void ggml_compute_forward_out_prod_f32(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src0,
@@ -9660,25 +9631,31 @@ static void ggml_compute_forward_out_prod_f32(
     //   compute by src0 rows
 
     // TODO: #if defined(GGML_USE_CUBLAS) ggml_cuda_out_prod
-    // TODO: #if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS) || defined(GGML_USE_CLBLAST)
+    // TODO: #if defined(GGML_USE_OPENBLAS) || defined(GGML_USE_CLBLAST)
+
+#if defined(GGML_USE_ACCELERATE)
+    bool use_blas = ggml_is_matrix(src0) &&
+        ggml_is_matrix(src1) &&
+        ggml_is_contiguous(src0) &&
+        (ggml_is_contiguous(src1) || ggml_is_transposed(src1));
+#endif
 
     if (params->type == GGML_TASK_INIT) {
-#if !defined(GGML_USE_ACCELERATE) // gemm beta will do this
-        if (!ggml_compute_forward_out_prod_use_blas(src0, src1, dst)) {
-#endif
-            ggml_vec_set_f32(ne0*ne1*ne2*ne3, dst->data, 0);
-#if !defined(GGML_USE_ACCELERATE)
+#if defined(GGML_USE_ACCELERATE) // gemm beta will zero dst
+        if (use_blas) {
+            return;
         }
 #endif
+        ggml_vec_set_f32(ne0*ne1*ne2*ne3, dst->data, 0);
         return;
     }
 
     if (params->type == GGML_TASK_FINALIZE) {
         return;
     }
-    
+
 #if defined(GGML_USE_ACCELERATE)
-    if (ggml_compute_forward_out_prod_use_blas(src0, src1, dst)) {
+    if (use_blas) {
         if (params->ith != 0) { // All threads other than the first do no work.
             return;
         }
@@ -9696,13 +9673,13 @@ static void ggml_compute_forward_out_prod_f32(
         // However, if ggml_is_transposed(src1) is true, then
         // src1->data already contains a transposed version, so sgemm mustn't
         // transpose it further.
-        
+
         int n = src0->ne[0];
         int k = src0->ne[1];
         int m = src1->ne[0];
-        
+
         int transposeA, lda;
-        
+
         if (!ggml_is_transposed(src1)) {
             transposeA = CblasTrans;
             lda = m;
@@ -9710,13 +9687,13 @@ static void ggml_compute_forward_out_prod_f32(
             transposeA = CblasNoTrans;
             lda = k;
         }
-        
+
         float * a = (float *) ((char *) src1->data);
         float * b = (float *) ((char *) src0->data);
         float * c = (float *) ((char *) dst->data);
-  
+
         cblas_sgemm(CblasRowMajor, transposeA, CblasNoTrans, m, n, k, 1.0, a, lda, b, n, 0.0, c, n);
-        
+
         return;
     }
 #endif

--- a/ggml.c
+++ b/ggml.c
@@ -9631,9 +9631,9 @@ static void ggml_compute_forward_out_prod_f32(
     //   compute by src0 rows
 
     // TODO: #if defined(GGML_USE_CUBLAS) ggml_cuda_out_prod
-    // TODO: #if defined(GGML_USE_OPENBLAS) || defined(GGML_USE_CLBLAST)
+    // TODO: #if defined(GGML_USE_CLBLAST)
 
-#if defined(GGML_USE_ACCELERATE)
+#if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS)
     bool use_blas = ggml_is_matrix(src0) &&
         ggml_is_matrix(src1) &&
         ggml_is_contiguous(src0) &&
@@ -9641,7 +9641,7 @@ static void ggml_compute_forward_out_prod_f32(
 #endif
 
     if (params->type == GGML_TASK_INIT) {
-#if defined(GGML_USE_ACCELERATE) // gemm beta will zero dst
+#if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS) // gemm beta will zero dst
         if (use_blas) {
             return;
         }
@@ -9654,7 +9654,7 @@ static void ggml_compute_forward_out_prod_f32(
         return;
     }
 
-#if defined(GGML_USE_ACCELERATE)
+#if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS)
     if (use_blas) {
         if (params->ith != 0) { // All threads other than the first do no work.
             return;


### PR DESCRIPTION
Profiling a finetuning session suggested >70% of the time was spent in `ggml_compute_forward_out_prod_f32()` (because it's called as part of the backwards pass for `GGML_OP_MUL_MAT`).

This patch uses `cblas_sgemm()` to perform the same calculation. This leads to a substantial speed-up. Testing on a 10-core M1 Max Macbook Pro with the following command:

`finetune --model-base models/mistral-7b-v0.1.Q8_0.gguf --train-data shakespeare.txt --threads 9 --warmup 10 --adam-iter 40 --batch 6 --ctx 64 -s 1699879824`

I get around 43s/iteration with the patch and 3m34s/iteration without it.

At the moment, the patch is guarded by `#if defined(GGML_USE_ACCELERATE)`; I have not yet tested it with OpenBLAS.

All the tests pass for me except `test-quantize-fns` and `test-quantize-perf`, which are failing with the error described in #3983 (but those are also failing for me on master at the moment).