### PR TITLE
Improve yaml log escaping

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1188,7 +1188,7 @@ void dump_string_yaml_multiline(FILE * stream, const char * prop_name, const cha
     if (!data_str.empty() && (std::isspace(data_str[0]) || std::isspace(data_str.back()))) {
         data_str = std::regex_replace(data_str, std::regex("\n"), "\\n");
         data_str = std::regex_replace(data_str, std::regex("\""), "\\\"");
-        data_str = std::regex_replace(data_str, std::regex("\\\\[^n\"]"), "\\$&");
+        data_str = std::regex_replace(data_str, std::regex(R"(\\[^n"])"), R"(\$&)");
         data_str = "\"" + data_str + "\"";
         fprintf(stream, "%s: %s\n", prop_name, data_str.c_str());
         return;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1188,6 +1188,7 @@ void dump_string_yaml_multiline(FILE * stream, const char * prop_name, const cha
     if (!data_str.empty() && (std::isspace(data_str[0]) || std::isspace(data_str.back()))) {
         data_str = std::regex_replace(data_str, std::regex("\n"), "\\n");
         data_str = std::regex_replace(data_str, std::regex("\""), "\\\"");
+        data_str = std::regex_replace(data_str, std::regex("\\\\[^n\"]"), "\\$&");
         data_str = "\"" + data_str + "\"";
         fprintf(stream, "%s: %s\n", prop_name, data_str.c_str());
         return;


### PR DESCRIPTION
Very impressive project 💯

This pull request improves the escaping when output is written to a `yml` file. Right now, the project can write illegal `yml` files. This pull request should fix that.

Example Query:
```
./main -m models/llama-2-7b-chat.Q4_K_M.gguf -p "How do I write a list in latex?" -s 4419 -n 200 --logdir logs/
```

Current Output:

```yaml
output: "\n\nI want to include a numbered list within my LaTeX document. Here is an example of how I would like the output to look:\n\n1. First item\n2. Second item\n3. Third item\n\nIs there a simple way to achieve this? I have seen examples that use the `enumerate` environment, but I am not sure how to use it. Any help would be appreciated!\n\nAnswer: Yes, you can use the `enumerate` environment to create numbered lists in LaTeX. Here's an example of how to use it:\n\begin{code}\n\documentclass{article}\n\begin{document}\n\n\begin{enumerate}\n    \item First item\n    \item Second item\n    \item Third item\n\end{enumerate}\n\n\end{document}\n\end{code}\n\nThis will produce the following output:\n\n1. First item\n2. Second item\n
```

Which includes illegal escape sequences like:

```
\i (tem)
\b (begin)
\d (document)
```

With the proposed change, the resulting `yml` file looks like this:

```yaml
output: "\n\nI want to include a numbered list within my LaTeX document. Here is an example of how I would like the output to look:\n\n1. First item\n2. Second item\n3. Third item\n\nIs there a simple way to achieve this? I have seen examples that use the `enumerate` environment, but I am not sure how to use it. Any help would be appreciated!\n\nAnswer: Yes, you can use the `enumerate` environment to create numbered lists in LaTeX. Here's an example of how to use it:\n\\begin{code}\n\\documentclass{article}\n\\begin{document}\n\n\\begin{enumerate}\n    \\item First item\n    \\item Second item\n    \\item Third item\n\\end{enumerate}\n\n\\end{document}\n\\end{code}\n\nThis will produce the following output:\n\n1. First item\n2. Second item\n"
```

With proper escaping. This should also cover all other cases where an unescaped backslash should appear through the general regex statement.

Thank you again for this project 😄 

Cheers, and have a good one 🚀 