### PR TITLE
llama : restore prefix space in llama tokenizer

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -6283,7 +6283,7 @@ static std::vector<llama_vocab::id> llama_tokenize_internal(const llama_vocab & 
                         //  by modifying llm_tokenizer_x to operate with string offsets like pre-tokenizer
                         //  and passing 'add space prefix' as bool argument
                         //
-                        auto raw_text = (special ? "" : " ") + fragment.raw_text.substr(fragment.offset, fragment.length);
+                        auto raw_text = " " + fragment.raw_text.substr(fragment.offset, fragment.length);
 
 #ifdef PRETOKENIZERDEBUG
                         fprintf(stderr,"TT: (%ld %ld %ld) '%s'\n", raw_text.length(), fragment.offset, fragment.length, raw_text.c_str());

--- a/llama.cpp
+++ b/llama.cpp
@@ -6283,7 +6283,10 @@ static std::vector<llama_vocab::id> llama_tokenize_internal(const llama_vocab & 
                         //  by modifying llm_tokenizer_x to operate with string offsets like pre-tokenizer
                         //  and passing 'add space prefix' as bool argument
                         //
-                        auto raw_text = " " + fragment.raw_text.substr(fragment.offset, fragment.length);
+                        auto raw_text = fragment.raw_text.substr(fragment.offset, fragment.length);
+                        if (&fragment == &fragment_buffer.front()) {
+                            raw_text = " " + raw_text; // prefix with space if the first token is not special
+                        }
 
 #ifdef PRETOKENIZERDEBUG
                         fprintf(stderr,"TT: (%ld %ld %ld) '%s'\n", raw_text.length(), fragment.offset, fragment.length, raw_text.c_str());


### PR DESCRIPTION
I noticed a regression in models that do not use special tokens caused by #3538 ([ref](https://github.com/ggerganov/llama.cpp/pull/3538#issuecomment-1810894765)):
> Command: `build/bin/main -t 16 -m /tmp/dolphin-llama2-7b.Q4_0.new.gguf -n 2048 --ignore-eos -p 'The quick brown fox' --seed 1699464025`
> 
> Before this PR (with a leading space, GitHub doesn't show it):
> > The quick brown fox jumps over the lazy dog is a well-known English nursery rhyme or children's song.➖
> >
> > This nursery rhyme has been popular since 1847, when it was first published in the Monthly Magazine of London. Since then, it has undergone various changes and adaptations, but its essence remains the same. The rhyme tells the story of a quick brown fox who jumps over the lazy dog to avoid being caught for stealing some cheese.
> 
> After this PR (no leading space):
> > The quick brown fox jumps over the wall (the last line of the poem) and is on the other side.nahmáo Often used as a verb, němäo is a term derived from the Sanskrit word nirvana, meaning "spirit" or "consciousness." The concept of the spirit or consciousness can be found in many cultures and religions throughout history. In Buddhism, for instance, the term "nirvana" refers to the state of perfect spiritual awakening that is the goal of practice. Similarly, in Christianity, the Holy Spirit is considered a divine spirit that guides and supports believers.

It's just a random LLaMA-2 model that I use for testing, but its output quality is clearly reduced significantly by this change. I believe this applies to all other llama models that do not use special tokens to frame the prompt.

This is surprising behavior for downstream users - basic instruction-tuned (e.g. Vicuna, Alpaca) or writing-tuned models should just work, and I don't think anyone is adding the space that is currently necessary to match HF transformers. As mentioned [here](https://github.com/ggerganov/llama.cpp/pull/3538#issuecomment-1811370579), there is some nuance in what transformers does that makes their tokenizer cooperate with both prompt formats, but I don't fully understand their implementation yet.

(Whether it really makes sense for HF transformers to put a leading space before the first `### Instruction:` or `USER:` in the context of a multi-turn chat is another question, but that's how these models are being trained - it's done regardless of 'legacy' being True or False. AFAIK, there are models trained on Alpaca-style prompts that haven't seen multi-turn chats, and won't recognize `### Instruction:` without the leading space.)

To be consistent, we should also honor add_prefix_space in the GPT2-style BPE tokenizer (cc @goerch). It appears to be true for Falcon and false for MPT. Right now, it seems that we don't store that in the GGUF at all.