### PR TITLE
to allow loading of karpathy/tinyllamas pt weights, assume model weights in 'model' value if exists

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -690,6 +690,7 @@ def lazy_load_torch_file(outer_fp: IO[bytes], path: Path) -> ModelPlus:
                               data_base_path=pickle_paths[0][:-4],
                               zip_file=zf)
     model = unpickler.load()
+    if 'model' in model: model = model['model']
     as_dict = dict(model.items())
     return ModelPlus(model=as_dict, paths=[path], format='torch', vocab=None)
 


### PR DESCRIPTION
Use 'model' value in model weight file if it exists.
This allows tinyllama weights (as .pt) to be used as-is from:

https://huggingface.co/karpathy/tinyllamas

I know that there is  convert-llama2c-to-ggml that allows the llama2c bin files to be used, but the .pt files can be used directly.

can be used with:
mkdir -p tiny
wget -P tiny/ https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.pt
( cd tiny ; echo '{"dim": 288, "multiple_of": 32, "n_layers": 6, "n_heads": 6, "n_kv_heads": 6, "vocab_size": 32000,"norm_eps":1e-05 }' > params.json )
wget -P tiny/ https://github.com/karpathy/llama2.c/raw/master/tokenizer.model

./convert.py --outfile tiny15M.gguf  tiny