### PR TITLE
fix deepseek bug in stream mode

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -985,6 +985,16 @@ struct llama_server_context
                 slot.multibyte_pending = 0;
             }
         }
+        else if (token_str.size() == 2)
+        {
+            const char c0 = token_str[0];
+            const char c1 = token_str[1];
+            if (((c0 & 0xF0) == 0xE0) && ((c1 & 0xC0) == 0x80))
+            {
+                slot.multibyte_pending = 1;
+                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
+            }
+        }
 
         if (slot.multibyte_pending == 0)
         {


### PR DESCRIPTION
[deepseek](https://huggingface.co/deepseek-ai/deepseek-coder-33b-instruct) model may direct return `token_str.size() -> 2` after `llama_token_to_piece`

it will skip `multibyte_pending`


```python
    bool process_token(completion_token_output &result, llama_client_slot &slot) {
        // remember which tokens were sampled - used for repetition penalties during sampling
        const std::string token_str = llama_token_to_piece(ctx, result.tok);
        slot.sampled = result.tok;

        // search stop word and delete it
        slot.generated_text += token_str;
        slot.has_next_token = true;

        if (slot.multibyte_pending > 0)
        {
            slot.multibyte_pending -= token_str.size();
        }
        else if (token_str.size() == 1) // MAY SKIP THIS BECAUSE token_str.size() == 2
        {
            const char c = token_str[0];
            // 2-byte characters: 110xxxxx 10xxxxxx
            if ((c & 0xE0) == 0xC0)
            {
                slot.multibyte_pending = 1;
                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
            }
            else if ((c & 0xF0) == 0xE0)
            {
                slot.multibyte_pending = 2;
                // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
            }
            else if ((c & 0xF8) == 0xF0)
            {
                slot.multibyte_pending = 3;
            }
            else
            {
                slot.multibyte_pending = 0;
            }
        }
        else if (token_str.size() == 2)  // PATCH HERE
        {
            const char c0 = token_str[0];
            const char c1 = token_str[1];
            if (((c0 & 0xF0) == 0xE0) && ((c1 & 0xC0) == 0x80))
            {
                slot.multibyte_pending = 1;
                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
            }
        }
```

before patch:

```python
{'content': '当然', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '，', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '这是', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '一个', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '用', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': 'Python', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '实现', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '的', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '快速', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '排', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '序', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '�', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '�', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '数', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '�', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '�', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '\n```', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': 'python', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': ' ', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'generation_settings': {'frequency_penalty': 0.0, 'grammar': '', 'ignore_eos': False, 'logit_bias': [], 'min_p': 0.05000000074505806, 'mirostat': 0, 'mirostat_eta': 0.10000000149011612, 'mirostat_tau': 5.0, 'model': '../deepseek-coder-1.3b-instruct.Q4_K_M.gguf', 'n_ctx': 512, 'n_keep': 0, 'n_predict': 20, 'n_probs': 0, 'penalize_nl': True, 'presence_penalty': 0.0, 'repeat_last_n': 64, 'repeat_penalty': 1.100000023841858, 'seed': 4294967295, 'stop': ['</s>', '\n###'], 'stream': True, 'temp': 0.699999988079071, 'tfs_z': 1.0, 'top_k': 1, 'top_p': 0.949999988079071, 'typical_p': 1.0}, 'model': '../deepseek-coder-1.3b-instruct.Q4_K_M.gguf', 'prompt': '### INSTRUCTION:\n用python写一个快速排序函数，写详细点的中文注释\n### Response:\n', 'slot_id': 0, 'stop': True, 'stopped_eos': False, 'stopped_limit': True, 'stopped_word': False, 'stopping_word': '', 'timings': {'predicted_ms': 370.632, 'predicted_n': 20, 'predicted_per_second': 53.96188132703059, 'predicted_per_token_ms': 18.5316, 'prompt_ms': 204.254, 'prompt_n': 30, 'prompt_per_second': 146.87594857383453, 'prompt_per_token_ms': 6.808466666666666}, 'tokens_cached': 50, 'tokens_evaluated': 30, 'tokens_predicted': 20, 'truncated': False}
```

after patch

```python
{'content': '当然', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '，', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '这是', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '一个', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '用', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': 'Python', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '实现', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '的', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '快速', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '排', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '序', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '函', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '数', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '：', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '\n```', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': 'python', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': ' ', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'multimodal': False, 'slot_id': 0, 'stop': False}
{'content': '', 'generation_settings': {'frequency_penalty': 0.0, 'grammar': '', 'ignore_eos': False, 'logit_bias': [], 'min_p': 0.05000000074505806, 'mirostat': 0, 'mirostat_eta': 0.10000000149011612, 'mirostat_tau': 5.0, 'model': '../deepseek-coder-1.3b-instruct.Q4_K_M.gguf', 'n_ctx': 512, 'n_keep': 0, 'n_predict': 20, 'n_probs': 0, 'penalize_nl': True, 'presence_penalty': 0.0, 'repeat_last_n': 64, 'repeat_penalty': 1.100000023841858, 'seed': 4294967295, 'stop': ['</s>', '\n###'], 'stream': True, 'temp': 0.699999988079071, 'tfs_z': 1.0, 'top_k': 1, 'top_p': 0.949999988079071, 'typical_p': 1.0}, 'model': '../deepseek-coder-1.3b-instruct.Q4_K_M.gguf', 'prompt': '### INSTRUCTION:\n用python写一个快速排序函数，写详细点的中文注释\n### Response:\n', 'slot_id': 0, 'stop': True, 'stopped_eos': False, 'stopped_limit': True, 'stopped_word': False, 'stopping_word': '', 'timings': {'predicted_ms': 365.661, 'predicted_n': 20, 'predicted_per_second': 54.69546930080047, 'predicted_per_token_ms': 18.28305, 'prompt_ms': 203.587, 'prompt_n': 30, 'prompt_per_second': 147.35714952329965, 'prompt_per_token_ms': 6.786233333333333}, 'tokens_cached': 50, 'tokens_evaluated': 30, 'tokens_predicted': 20, 'truncated': False}
```
