### PR TITLE
Add flag for gpu layers in finetune.cpp

### DIFF
--- a/examples/finetune/finetune.cpp
+++ b/examples/finetune/finetune.cpp
@@ -1288,6 +1288,7 @@ static void train_print_usage(int argc, char ** argv, const struct train_params 
     fprintf(stderr, "  --model-base FNAME         model path from which to load base model (default '%s')\n", params->fn_model_base);
     fprintf(stderr, "  --lora-out FNAME           path to save llama lora (default '%s')\n", params->fn_lora_out);
     fprintf(stderr, "  --only-write-lora          only save llama lora, don't do any training.  use this if you only want to convert a checkpoint to a lora adapter.\n");
+    fprintf(stderr, "  --n-gpu-layers N           Number of model layers to offload to GPU (default 0).\n");
     fprintf(stderr, "  --norm-rms-eps F           RMS-Norm epsilon value (default %f)\n", params->f_norm_rms_eps);
     fprintf(stderr, "  --rope-freq-base F         Frequency base for ROPE (default %f)\n", params->rope_freq_base);
     fprintf(stderr, "  --rope-freq-scale F        Frequency scale for ROPE (default %f)\n", params->rope_freq_scale);


### PR DESCRIPTION
To reflect fix of [3458](https://github.com/ggerganov/llama.cpp/issues/3458) from [3762](https://github.com/ggerganov/llama.cpp/pull/3762)

Summary:
added --n-gpu-layers flag to finetune.cpp for clarity on finetune --help (based on the same flag in commons/train.cpp)