### PR TITLE
Fix incorrect format strings and uninitialized variables.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1095,6 +1095,7 @@ struct llama_server_context
         std::lock_guard<std::mutex> lock(mutex_results);
         task_result res;
         res.id = id;
+        res.stop = false;
         res.error = true;
         res.result_json = { { "content", error } };
         queue_results.push_back(res);
@@ -1255,6 +1256,7 @@ struct llama_server_context
         std::lock_guard<std::mutex> lock(mutex_tasks);
         task_server task;
         task.id = id_gen++;
+        task.target_id = 0;
         task.data = data;
         task.infill_mode = infill;
         task.embedding_mode = embedding;

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -8057,7 +8057,7 @@ bool ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_
     if (tensor->op == GGML_OP_MUL_MAT) {
         if (tensor->src[0]->ne[3] != tensor->src[1]->ne[3]) {
 #ifndef NDEBUG
-            fprintf(stderr, "%s: cannot compute %s: src0->ne[3] = %ld, src1->ne[3] = %ld - fallback to CPU\n", __func__, tensor->name, tensor->src[0]->ne[3], tensor->src[1]->ne[3]);
+            fprintf(stderr, "%s: cannot compute %s: src0->ne[3] = " PRId64 ", src1->ne[3] = " PRId64 " - fallback to CPU\n", __func__, tensor->name, tensor->src[0]->ne[3], tensor->src[1]->ne[3]);
 #endif
             return false;
         }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <limits>

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -8057,7 +8057,7 @@ bool ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_
     if (tensor->op == GGML_OP_MUL_MAT) {
         if (tensor->src[0]->ne[3] != tensor->src[1]->ne[3]) {
 #ifndef NDEBUG
-            fprintf(stderr, "%s: cannot compute %s: src0->ne[3] = %d, src1->ne[3] = %d - fallback to CPU\n", __func__, tensor->name, tensor->src[0]->ne[3], tensor->src[1]->ne[3]);
+            fprintf(stderr, "%s: cannot compute %s: src0->ne[3] = %ld, src1->ne[3] = %ld - fallback to CPU\n", __func__, tensor->name, tensor->src[0]->ne[3], tensor->src[1]->ne[3]);
 #endif
             return false;
         }

--- a/ggml.c
+++ b/ggml.c
@@ -1586,7 +1586,7 @@ inline static void ggml_vec_argmax_f32(const int n, int * s, const float * x) {
 // data types
 //
 
-static const char * GGML_OP_NAME[GGML_OP_COUNT + 2] = {
+static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "NONE",
 
     "DUP",
@@ -1664,8 +1664,6 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT + 2] = {
 
     "CROSS_ENTROPY_LOSS",
     "CROSS_ENTROPY_LOSS_BACK",
-    "",
-    "",
 };
 
 static_assert(GGML_OP_COUNT == 68, "GGML_OP_COUNT != 68");

--- a/ggml.c
+++ b/ggml.c
@@ -1586,7 +1586,7 @@ inline static void ggml_vec_argmax_f32(const int n, int * s, const float * x) {
 // data types
 //
 
-static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
+static const char * GGML_OP_NAME[GGML_OP_COUNT + 2] = {
     "NONE",
 
     "DUP",
@@ -1664,6 +1664,8 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
 
     "CROSS_ENTROPY_LOSS",
     "CROSS_ENTROPY_LOSS_BACK",
+    "",
+    "",
 };
 
 static_assert(GGML_OP_COUNT == 68, "GGML_OP_COUNT != 68");


### PR DESCRIPTION
This PR fixes a few incorrect types of format strings and uninitialized variables on gcc 11.4.

The code base is now without warnings on gcc 11.4 with -Wall