### PR TITLE
Fix n_ctx issue for Baichuan & Baichuan2 13B model

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -229,6 +229,8 @@ class Params:
             n_ctx = config["max_sequence_length"]
         elif "max_position_embeddings" in config:
             n_ctx = config["max_position_embeddings"]
+        elif "model_max_length" in config:
+            n_ctx = config["model_max_length"]
         else:
             raise Exception("failed to guess 'n_ctx'. This model is unknown or unsupported.\n"
                             "Suggestion: provide 'config.json' of the model in the same directory containing model files.")


### PR DESCRIPTION
When converting baichuan or baichuan2 13B model to gguf format, a `n_ctx` issue will occur.

```
mint@Z800:/workspace/llama.cpp$ python3 convert.py --outfile models/baichuan-13b-chat-f16.gguf /huggingface.co/baichuan-inc/Baichuan-13B-Chat/
Loading model file /huggingface.co/baichuan-inc/Baichuan-13B-Chat/pytorch_model-00001-of-00003.bin
Loading model file /huggingface.co/baichuan-inc/Baichuan-13B-Chat/pytorch_model-00001-of-00003.bin
Loading model file /huggingface.co/baichuan-inc/Baichuan-13B-Chat/pytorch_model-00002-of-00003.bin
Loading model file /huggingface.co/baichuan-inc/Baichuan-13B-Chat/pytorch_model-00003-of-00003.bin
Traceback (most recent call last):
  File "/workspace/llama.cpp/convert.py", line 1228, in <module>
    main()
  File "/workspace/llama.cpp/convert.py", line 1172, in main
    params = Params.load(model_plus)
  File "/workspace/llama.cpp/convert.py", line 287, in load
    params = Params.loadHFTransformerJson(model_plus.model, hf_config_path)
  File "/workspace/llama.cpp/convert.py", line 233, in loadHFTransformerJson
    raise Exception("failed to guess 'n_ctx'. This model is unknown or unsupported.\n"
Exception: failed to guess 'n_ctx'. This model is unknown or unsupported.
Suggestion: provide 'config.json' of the model in the same directory containing model files.
```

The root cause is the code in convert.py below cannot guess baichuan & baichuan2 13B's context length.

```
        if "max_sequence_length" in config:
            n_ctx = config["max_sequence_length"]
        elif "max_position_embeddings" in config:
            n_ctx = config["max_position_embeddings"]
        else:
            raise Exception("failed to guess 'n_ctx'. This model is unknown or unsupported.\n"
                            "Suggestion: provide 'config.json' of the model in the same directory containing model files.")

```

baichuan & baichuan2 13B models use `model_max_length` for n_ctx.

https://huggingface.co/baichuan-inc/Baichuan-13B-Base/blob/main/config.json#L17
https://huggingface.co/baichuan-inc/Baichuan-13B-Chat/blob/main/config.json#L17
https://huggingface.co/baichuan-inc/Baichuan2-13B-Base/blob/main/config.json#L18
https://huggingface.co/baichuan-inc/Baichuan2-13B-Chat/blob/main/config.json#L18

I think it would be better if the official adds `max_position_embeddings` to the model config.json.
But we can also make llama.cpp more compatible with it


