### PR TITLE
Allow exporting a view of the KV cache

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1393,8 +1393,8 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
 //
 
 void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
-    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d\n",
-        view.n_cells, view.n_max_seq, view.used_cells, view.token_count);
+    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, max contiguous cells=%d @ %d\n",
+        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
     llama_kv_cache_view_cell * c_curr = view.cells;
     struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
     for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
@@ -1405,14 +1405,14 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id >= 0) { seq_count++; }
         }
-        putchar(int('0' + (std::min(9, seq_count))));
+        putchar(seq_count == 0 ? '.' : ('0' + (std::min(9, seq_count))));
     }
     printf("\n=== Done dumping\n");
 }
 
 void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
-    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d\n",
-        view.n_cells, view.n_max_seq, view.used_cells, view.token_count);
+    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, max contiguous cells=%d @ %d\n",
+        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
 
     std::unordered_map<llama_seq_id, size_t> seqs;
     llama_kv_cache_view_cell * c_curr = view.cells;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1397,8 +1397,10 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
 
     printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d",
         view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
+
     llama_kv_cache_view_cell * c_curr = view.cells;
     struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
+
     for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
         if (i % row_size == 0) {
             printf("\n%5d: ", i);
@@ -1407,19 +1409,22 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id >= 0) { seq_count++; }
         }
-        putchar(slot_chars[std::min(sizeof(slot_chars) - 1, size_t(seq_count))]);
+        putchar(slot_chars[std::min(sizeof(slot_chars) - 2, size_t(seq_count))]);
     }
+
     printf("\n=== Done dumping\n");
 }
 
 void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
     static const char slot_chars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
     printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d\n",
         view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
 
     std::unordered_map<llama_seq_id, size_t> seqs;
     llama_kv_cache_view_cell * c_curr = view.cells;
     struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
+
     for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id < 0) { continue; }
@@ -1430,6 +1435,7 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
         }
         if (seqs.size() + 1 >= sizeof(slot_chars)) { break; }
     }
+
     printf("=== Sequence legend: ");
     for (const auto & it : seqs) {
         printf("%zu=%d, ", it.second, it.first);
@@ -1452,5 +1458,6 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
         }
         putchar(' ');
     }
+
     printf("\n=== Done dumping\n");
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1396,10 +1396,10 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
     static const char slot_chars[] = ".123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+";
 
     printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d",
-        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
+        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous, view.max_contiguous_idx);
 
     llama_kv_cache_view_cell * c_curr = view.cells;
-    struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
+    llama_seq_id * cs_curr = view.cells_sequences;
 
     for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
         if (i % row_size == 0) {
@@ -1407,7 +1407,7 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
         }
         int seq_count = 0;
         for (int j = 0; j < view.n_max_seq; j++) {
-            if (cs_curr[j].seq_id >= 0) { seq_count++; }
+            if (cs_curr[j] >= 0) { seq_count++; }
         }
         putchar(slot_chars[std::min(sizeof(slot_chars) - 2, size_t(seq_count))]);
     }
@@ -1419,18 +1419,18 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
     static const char slot_chars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
     printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d\n",
-        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
+        view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous, view.max_contiguous_idx);
 
     std::unordered_map<llama_seq_id, size_t> seqs;
     llama_kv_cache_view_cell * c_curr = view.cells;
-    struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
+    llama_seq_id * cs_curr = view.cells_sequences;
 
     for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
         for (int j = 0; j < view.n_max_seq; j++) {
-            if (cs_curr[j].seq_id < 0) { continue; }
-            if (seqs.find(cs_curr[j].seq_id) == seqs.end()) {
+            if (cs_curr[j] < 0) { continue; }
+            if (seqs.find(cs_curr[j]) == seqs.end()) {
                 if (seqs.size() + 1 >= sizeof(slot_chars)) { break; }
-                seqs[cs_curr[j].seq_id] = seqs.size();
+                seqs[cs_curr[j]] = seqs.size();
             }
         }
         if (seqs.size() + 1 >= sizeof(slot_chars)) { break; }
@@ -1449,8 +1449,8 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
             printf("\n%5d: ", i);
         }
         for (int j = 0; j < view.n_max_seq; j++) {
-            if (cs_curr[j].seq_id >= 0) {
-                const auto & it = seqs.find(cs_curr[j].seq_id);
+            if (cs_curr[j] >= 0) {
+                const auto & it = seqs.find(cs_curr[j]);
                 putchar(it != seqs.end() ? int(slot_chars[it->second]) : '+');
             } else {
                 putchar('.');

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1386,3 +1386,25 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "typical_p: %f # default: 1.0\n", sparams.typical_p);
     fprintf(stream, "verbose_prompt: %s # default: false\n", params.verbose_prompt ? "true" : "false");
 }
+
+//
+// KV cache utils
+//
+
+void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
+    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d\n",
+        view.n_cells, view.n_max_seq, view.used_cells, view.token_count);
+    llama_kv_cache_view_cell * c_curr = view.cells;
+    struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
+    for (int i = 0; i < view.n_cells; i++, c_curr++, cs_curr += view.n_max_seq) {
+        if (i % row_size == 0) {
+            printf("\n%5d: ", i);
+        }
+        int seq_count = 0;
+        for (int j = 0; j < view.n_max_seq; j++) {
+            if (cs_curr[j].seq_id >= 0) { seq_count++; }
+        }
+        putchar(int('0' + (std::min(9, seq_count))));
+    }
+    printf("\n=== Done dumping\n");
+}

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1393,7 +1393,9 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
 //
 
 void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
-    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, max contiguous cells=%d @ %d\n",
+    static const char slot_chars[] = ".123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+";
+
+    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d",
         view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
     llama_kv_cache_view_cell * c_curr = view.cells;
     struct llama_kv_cache_view_cell_sequence * cs_curr = view.cells_sequences;
@@ -1405,13 +1407,14 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id >= 0) { seq_count++; }
         }
-        putchar(seq_count == 0 ? '.' : ('0' + (std::min(9, seq_count))));
+        putchar(slot_chars[std::min(sizeof(slot_chars) - 1, size_t(seq_count))]);
     }
     printf("\n=== Done dumping\n");
 }
 
 void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
-    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, max contiguous cells=%d @ %d\n",
+    static const char slot_chars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    printf("=== Dumping KV cache. total cells %d, max sequences per cell %d, populated cells %d, total tokens in cache %d, largest empty slot=%d @ %d\n",
         view.n_cells, view.n_max_seq, view.used_cells, view.token_count, view.max_contiguous_cells, view.max_contiguous_cells_idx);
 
     std::unordered_map<llama_seq_id, size_t> seqs;
@@ -1421,16 +1424,17 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id < 0) { continue; }
             if (seqs.find(cs_curr[j].seq_id) == seqs.end()) {
+                if (seqs.size() + 1 >= sizeof(slot_chars)) { break; }
                 seqs[cs_curr[j].seq_id] = seqs.size();
-                if (seqs.size() >= 10) { break; }
             }
         }
-        if (seqs.size() >= 10) { break; }
+        if (seqs.size() + 1 >= sizeof(slot_chars)) { break; }
     }
     printf("=== Sequence legend: ");
     for (const auto & it : seqs) {
         printf("%zu=%d, ", it.second, it.first);
     }
+    printf("'+'=other sequence ids");
 
     c_curr = view.cells;
     cs_curr = view.cells_sequences;
@@ -1441,7 +1445,7 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
         for (int j = 0; j < view.n_max_seq; j++) {
             if (cs_curr[j].seq_id >= 0) {
                 const auto & it = seqs.find(cs_curr[j].seq_id);
-                putchar(it != seqs.end() ? int('0' + it->second) : '+');
+                putchar(it != seqs.end() ? int(slot_chars[it->second]) : '+');
             } else {
                 putchar('.');
             }

--- a/common/common.h
+++ b/common/common.h
@@ -218,3 +218,9 @@ std::string get_sortable_timestamp();
 void dump_non_result_info_yaml(
     FILE * stream, const gpt_params & params, const llama_context * lctx,
     const std::string & timestamp, const std::vector<int> & prompt_tokens, const char * model_desc);
+
+//
+// KV cache utils
+//
+
+void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size = 80);

--- a/common/common.h
+++ b/common/common.h
@@ -223,5 +223,8 @@ void dump_non_result_info_yaml(
 // KV cache utils
 //
 
+// Dump the KV cache view with the number of sequences per cell.
 void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size = 80);
-void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size = 80);
+
+// Dump the KV cache view showing individual sequences in each cell (long output).
+void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size = 40);

--- a/common/common.h
+++ b/common/common.h
@@ -224,3 +224,4 @@ void dump_non_result_info_yaml(
 //
 
 void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size = 80);
+void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size = 80);

--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -172,6 +172,8 @@ int main(int argc, char ** argv) {
     int32_t n_total_gen    = 0;
     int32_t n_cache_miss   = 0;
 
+    struct llama_kv_cache_view kvc_view = llama_kv_cache_view_init(ctx, n_seq);
+
     const auto t_main_start = ggml_time_us();
 
     LOG_TEE("%s: Simulating parallel requests from clients:\n", __func__);
@@ -201,6 +203,9 @@ int main(int argc, char ** argv) {
     LOG_TEE("Processing requests ...\n\n");
 
     while (true) {
+        llama_kv_cache_view_update(ctx, &kvc_view);
+        dump_kv_cache_view(kvc_view);
+
         llama_batch_clear(batch);
 
         // decode any currently ongoing sequences

--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -172,7 +172,7 @@ int main(int argc, char ** argv) {
     int32_t n_total_gen    = 0;
     int32_t n_cache_miss   = 0;
 
-    struct llama_kv_cache_view kvc_view = llama_kv_cache_view_init(ctx, n_seq);
+    struct llama_kv_cache_view kvc_view = llama_kv_cache_view_init(ctx, n_clients);
 
     const auto t_main_start = ggml_time_us();
 
@@ -204,7 +204,7 @@ int main(int argc, char ** argv) {
 
     while (true) {
         llama_kv_cache_view_update(ctx, &kvc_view);
-        dump_kv_cache_view(kvc_view);
+        dump_kv_cache_view_seqs(kvc_view, 40);
 
         llama_batch_clear(batch);
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -8805,6 +8805,73 @@ int llama_model_apply_lora_from_file(const struct llama_model * model, const cha
     }
 }
 
+struct llama_kv_cache_view llama_kv_cache_view_init(const struct llama_context * ctx, int32_t n_max_seq) {
+    struct llama_kv_cache_view result = {
+        /*.n_cells*/         0,
+        /*.n_max_seq*/       n_max_seq,
+        /*.token_count*/     0,
+        /*.used_cells*/      llama_get_kv_cache_used_cells(ctx),
+        /*.cells*/           nullptr,
+        /*.cells_sequences*/ nullptr,
+    };
+    return result;
+}
+
+void llama_kv_cache_view_free(struct llama_kv_cache_view * view) {
+    if (view->cells != nullptr) {
+        free(view->cells);
+        view->cells = nullptr;
+    }
+    if (view->cells_sequences != nullptr) {
+        free(view->cells_sequences);
+        view->cells_sequences = nullptr;
+    }
+}
+
+void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_kv_cache_view * view) {
+    if (uint32_t(view->n_cells) < ctx->kv_self.size || view->cells == nullptr) {
+        view->n_cells = int32_t(ctx->kv_self.size);
+        void * p = realloc(view->cells, sizeof(struct llama_kv_cache_view_cell) * view->n_cells);
+        GGML_ASSERT(p != nullptr && "Failed to alloc kv_cache_view cells");
+        view->cells = (struct llama_kv_cache_view_cell *)p;
+        p = realloc(view->cells_sequences, sizeof(struct llama_kv_cache_view_cell_sequence) * view->n_max_seq * view->n_cells);
+        GGML_ASSERT(p != nullptr && "Failed to alloc kv_cache_view cells sequences");
+        view->cells_sequences = (struct llama_kv_cache_view_cell_sequence *)p;
+    }
+
+    const std::vector<llama_kv_cell> & kv_cells = ctx->kv_self.cells;
+    llama_kv_cache_view_cell * c_curr = view->cells;
+    struct llama_kv_cache_view_cell_sequence * cs_curr = view->cells_sequences;
+    int32_t used_cells = 0;
+    int32_t token_count = 0;
+
+    for (uint32_t i = 0; i < ctx->kv_self.size; i++, c_curr++, cs_curr += view->n_max_seq) {
+        token_count += ctx->kv_self.cells[i].seq_id.size();
+        c_curr->pos = kv_cells[i].pos + kv_cells[i].delta;
+
+        int seq_idx = 0;
+        for (const llama_seq_id it : kv_cells[i].seq_id) {
+            if (seq_idx >= view->n_max_seq) {
+                break;
+            }
+            cs_curr[seq_idx].seq_id = it;
+            seq_idx++;
+        }
+        if (seq_idx != 0) {
+            used_cells++;
+        }
+        for (; seq_idx < view->n_max_seq; seq_idx++) {
+            cs_curr[seq_idx].seq_id = -1;
+        }
+    }
+    view->token_count = token_count;
+    view->used_cells = used_cells;
+    if (uint32_t(used_cells) != ctx->kv_self.used) {
+        LLAMA_LOG_ERROR("%s: used cells mismatch. kv_cache says %d but we calculated %d\n",
+            __func__, ctx->kv_self.used, used_cells);
+    }
+}
+
 int llama_get_kv_cache_token_count(const struct llama_context * ctx) {
     int result = 0;
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -8807,12 +8807,14 @@ int llama_model_apply_lora_from_file(const struct llama_model * model, const cha
 
 struct llama_kv_cache_view llama_kv_cache_view_init(const struct llama_context * ctx, int32_t n_max_seq) {
     struct llama_kv_cache_view result = {
-        /*.n_cells*/         0,
-        /*.n_max_seq*/       n_max_seq,
-        /*.token_count*/     0,
-        /*.used_cells*/      llama_get_kv_cache_used_cells(ctx),
-        /*.cells*/           nullptr,
-        /*.cells_sequences*/ nullptr,
+        /*.n_cells*/           0,
+        /*.n_max_seq*/         n_max_seq,
+        /*.token_count*/       0,
+        /*.used_cells*/        llama_get_kv_cache_used_cells(ctx),
+        /*max_contiguous*/     0,
+        /*max_contiguous_idx*/ -1,
+        /*.cells*/             nullptr,
+        /*.cells_sequences*/   nullptr,
     };
     return result;
 }
@@ -8844,10 +8846,24 @@ void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_k
     struct llama_kv_cache_view_cell_sequence * cs_curr = view->cells_sequences;
     int32_t used_cells = 0;
     int32_t token_count = 0;
+    int32_t curr_contig_idx = -1;
+    uint32_t max_contig = 0;
+    int32_t max_contig_idx = -1;
 
-    for (uint32_t i = 0; i < ctx->kv_self.size; i++, c_curr++, cs_curr += view->n_max_seq) {
-        token_count += ctx->kv_self.cells[i].seq_id.size();
+    for (int32_t i = 0; i < int32_t(ctx->kv_self.size); i++, c_curr++, cs_curr += view->n_max_seq) {
+        const size_t curr_size = kv_cells[i].seq_id.size();
+        token_count += curr_size;
         c_curr->pos = kv_cells[i].pos + kv_cells[i].delta;
+
+        if (curr_size > 0) {
+            if (curr_contig_idx >= 0 && uint32_t(i - curr_contig_idx) > max_contig) {
+                max_contig_idx = i;
+                max_contig = i - curr_contig_idx;
+            }
+            curr_contig_idx = -1;
+        } else if (curr_contig_idx < 0) {
+            curr_contig_idx = i;
+        }
 
         int seq_idx = 0;
         for (const llama_seq_id it : kv_cells[i].seq_id) {
@@ -8864,6 +8880,12 @@ void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_k
             cs_curr[seq_idx].seq_id = -1;
         }
     }
+    if (curr_contig_idx >= 0 && kv_cells.size() - curr_contig_idx > max_contig) {
+        max_contig_idx = curr_contig_idx;
+        max_contig = kv_cells.size() - curr_contig_idx;
+    }
+    view->max_contiguous_cells = max_contig;
+    view->max_contiguous_cells_idx = max_contig_idx;
     view->token_count = token_count;
     view->used_cells = used_cells;
     if (uint32_t(used_cells) != ctx->kv_self.used) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -8857,8 +8857,8 @@ void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_k
 
         if (curr_size > 0) {
             if (curr_contig_idx >= 0 && uint32_t(i - curr_contig_idx) > max_contig) {
-                max_contig_idx = i;
                 max_contig = i - curr_contig_idx;
+                max_contig_idx = curr_contig_idx;
             }
             curr_contig_idx = -1;
         } else if (curr_contig_idx < 0) {

--- a/llama.h
+++ b/llama.h
@@ -366,6 +366,7 @@ extern "C" {
     };
 
     struct llama_kv_cache_view_cell_sequence {
+        // Would like to have token_id here as well.
         llama_seq_id seq_id;
     };
 
@@ -374,7 +375,9 @@ extern "C" {
         int32_t n_max_seq;
         int32_t token_count;
         int32_t used_cells;
-        struct llama_kv_cache_view_cell *cells;
+        int32_t max_contiguous_cells;
+        int32_t max_contiguous_cells_idx;
+        struct llama_kv_cache_view_cell * cells;
         struct llama_kv_cache_view_cell_sequence * cells_sequences;
     };
 

--- a/llama.h
+++ b/llama.h
@@ -361,30 +361,52 @@ extern "C" {
     // KV cache
     //
 
+    // Information associated with an individual cell in the KV cache view.
     struct llama_kv_cache_view_cell {
+        // The position for this cell. Takes KV cache shifts into account.
+        // May be negative if the cell is not populated.
         llama_pos pos;
     };
 
-    struct llama_kv_cache_view_cell_sequence {
-        // Would like to have token_id here as well.
-        llama_seq_id seq_id;
-    };
-
+    // An updateable view of the KV cache.
     struct llama_kv_cache_view {
+        // Number of KV cache cells. This will be the same as the context size.
         int32_t n_cells;
+
+        // Maximum number of sequences that can exist in a cell. It's not an error
+        // if there are more sequences in a cell than this value, however they will
+        // not be visible in the view cells_sequences.
         int32_t n_max_seq;
+
+        // Number of tokens in the cache. For example, if there are two populated
+        // cells, the first with 1 sequence id in it and the second with 2 sequence
+        // ids then you'll have 3 tokens.
         int32_t token_count;
+
+        // Number of populated cache cells.
         int32_t used_cells;
-        int32_t max_contiguous_cells;
-        int32_t max_contiguous_cells_idx;
+
+        // Maximum contiguous empty slots in the cache.
+        int32_t max_contiguous;
+
+        // Index to the start of the max_contiguous slot range. Can be negative
+        // when cache is full.
+        int32_t max_contiguous_idx;
+
+        // Information for an individual cell.
         struct llama_kv_cache_view_cell * cells;
-        struct llama_kv_cache_view_cell_sequence * cells_sequences;
+
+        // The sequences for each cell. There will be n_max_seq items per cell.
+        llama_seq_id * cells_sequences;
     };
 
+    // Create an empty KV cache view.
     LLAMA_API struct llama_kv_cache_view llama_kv_cache_view_init(const struct llama_context * ctx, int32_t n_max_seq);
 
+    // Free a KV cache view.
     LLAMA_API void llama_kv_cache_view_free(struct llama_kv_cache_view * view);
 
+    // Update the KV cache view structure with the current state of the KV cache.
     LLAMA_API void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_kv_cache_view * view);
 
     // Returns the number of tokens in the KV cache (slow, use only for debug)

--- a/llama.h
+++ b/llama.h
@@ -361,6 +361,29 @@ extern "C" {
     // KV cache
     //
 
+    struct llama_kv_cache_view_cell {
+        llama_pos pos;
+    };
+
+    struct llama_kv_cache_view_cell_sequence {
+        llama_seq_id seq_id;
+    };
+
+    struct llama_kv_cache_view {
+        int32_t n_cells;
+        int32_t n_max_seq;
+        int32_t token_count;
+        int32_t used_cells;
+        struct llama_kv_cache_view_cell *cells;
+        struct llama_kv_cache_view_cell_sequence * cells_sequences;
+    };
+
+    LLAMA_API struct llama_kv_cache_view llama_kv_cache_view_init(const struct llama_context * ctx, int32_t n_max_seq);
+
+    LLAMA_API void llama_kv_cache_view_free(struct llama_kv_cache_view * view);
+
+    LLAMA_API void llama_kv_cache_view_update(const struct llama_context * ctx, struct llama_kv_cache_view * view);
+
     // Returns the number of tokens in the KV cache (slow, use only for debug)
     // If a KV cell has multiple sequences assigned to it, it will be counted multiple times
     LLAMA_API int llama_get_kv_cache_token_count(const struct llama_context * ctx);


### PR DESCRIPTION
For example, dumping with `dump_kv_cache_view` looks like this after running `parallel -np 3 -cb -ns 50 -c 700` for a while:

```plaintext
=== Dumping KV cache. total cells 760, max sequences per cell 4, populated cells 552, total tokens in cache 1431, max contiguous cells=7 @ 702

    0: 44444444444444444444444444444444444444444444444444444444444444444444444444444444
   80: 44444444444444444444444444444444444444444444444444444444444444444444444444444444
  160: 44444444444444444444444444444444444444444444444444444444444444444444444444444444
  240: 444444444444444444444444444444444444444444444444444441...1...1..1..11..11..11111
  320: 111111111.1..1..111111111111.1...1...1...1...1.1.1...1..111111.1.1...11..1.1.1..
  400: 1..1.1..1..1.1..1..1.1..1..111111...1...1...1...1...1...1...1...1...1...1...1...
  480: 1...1...1...1...1...1..1..11..11..11..11..11..11..11..11..11..11..11..11..11..11
  560: ..11..11..11.11.111.111.11.1..11..11..11..11..11..11..11.111111111111111.111.111
  640: .111.111.111.111.111.111.111.111.111.11111111111111...1.......111111111111111111
  720: 1111111111111111111111111...1...1...1...
=== Done dumping
```

The numbers represent the number of sequences each cell is populated with.

*edit*: Also added a way to dump the sequences in each cell:

```plaintext
=== Dumping KV cache. total cells 760, max sequences per cell 4, populated cells 570, total tokens in cache 1449, max contiguous cells=5 @ 402
=== Sequence legend: 3=3, 2=2, 1=1, 0=0, 
    0: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
   40: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
   80: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
  120: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
  160: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
  200: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
  240: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 
  280: 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0123 0... 1... .... .... 0... 0... 1... 0... 1... 2... 3... 0... 1... 2... .... .... .... 0... 1... 0... 1... 2... .... .... .... 0... 1... 
  320: 0... 2... .... .... 0... 1... 0... 1... .... .... 2... .... 0... 0... 1... .... 0... 2... .... .... 0... 0... 1... .... .... 0... 1... 2... .... .... .... 0... 1... 0... 2... .... .... 0... 0... 1... 
  360: .... 2... .... 0... 1... 0... 1... 2... 3... .... .... 0... 1... 0... 1... .... 0... 2... 0... 1... 2... 3... .... 0... .... .... .... 0... 1... 0... 1... 2... 3... 0... 1... 2... 3... .... .... .... 
  400: .... .... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... 0... .... .... .... .... 0... .... .... .... 0... 0... 1... 2... 3... 3... 3... 3... 3... 3... 3... 3... 3... 3... 3... 
  440: 3... 0... 1... 2... 3... 0... 1... 2... 3... 0... 1... 2... 3... 0... 1... 2... .... 0... .... .... .... 0... 1... 2... 0... 1... 2... 3... 0... 1... 2... 3... .... .... 0... 0... 1... 2... 3... 0... 
  480: 1... 2... 3... 0... 1... 2... 3... .... .... 0... 0... 1... 2... 3... .... .... .... 0... 0... 1... 2... 3... 0... 1... 2... 3... 0... 1... 2... 3... .... 0... 0... 1... 2... 3... .... .... .... 0... 
  520: 0... 1... 2... 3... .... 0... .... .... .... 0... 1... 2... .... .... 0... 1... 2... .... .... 0... .... .... .... 0... .... .... .... 0... 0... 1... 2... 3... .... 0... .... .... .... 0... 1... 2... 
  560: .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... 0... 1... 2... 3... 0... .... .... .... 0... .... .... .... 0... 
  600: .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... 0... 1... .... .... 0... 1... .... .... 0... 1... .... .... .... 0... 
  640: .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... 1... .... 2... 2... 2... 2... 2... 2... 
  680: 2... 2... 2... 2... 2... 2... 0... 1... 2... .... 0... 1... 2... .... 0... 1... 2... .... 0... 1... 2... .... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... 
  720: .... 0... .... .... .... 0... .... .... .... 0... .... .... .... 0... .... .... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 1... 0... 1... .... .... 0... 1... .... .... .... 
=== Done dumping
```

*edit*: I added tracking for maximum contiguous empty KV cells and the start position. "max contiguous cells=5 @ 402" - 5 empty cells, starting at index `402`