### PR TITLE
main.swift: fix EOS checking

### DIFF
--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -153,7 +153,7 @@ while n_cur <= n_len {
         // const llama_token new_token_id = llama_sample_token_greedy(ctx, &candidates_p);
 
         // is it an end of stream? -> mark the stream as finished
-        if new_token_id == llama_token_eos(context) || n_cur == n_len {
+        if new_token_id == llama_token_eos(model) || n_cur == n_len {
             i_batch[i] = -1
             // print("")
             if n_parallel > 1 {


### PR DESCRIPTION
`llama_token_eos(const struct llama_model *)` is currently getting `struct llama_context *` type variable `context` as a parameter. It should be replaced with `model` which is a `struct llama_model *` type variable.

This mistake occurred because both are considered `OpaquePointer` in swift.