### PR TITLE
Update how to run in README.md of examples/batched.swift

### DIFF
--- a/examples/batched.swift/README.md
+++ b/examples/batched.swift/README.md
@@ -1,4 +1,4 @@
 This is a swift clone of `examples/batched`.
 
 $ `make`
-$ `./swift MODEL_PATH [PROMPT] [PARALLEL]`
+$ `./batched_swift MODEL_PATH [PROMPT] [PARALLEL]`


### PR DESCRIPTION
The description of how batched.swift is executed was incorrect. So I fixed the description based on the Makefile.