### PR TITLE
ggml : fix -Warray-bounds warning with gcc

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -15689,13 +15689,14 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
             {
                 n_tasks = 1;
             } break;
-        case GGML_OP_COUNT:
-            {
-                GGML_ASSERT(false);
-            } break;
         default:
             {
-                printf("%s: op %s not implemented\n", __func__, ggml_op_name(node->op));
+                fprintf(stderr, "%s: op not implemented: ", __func__);
+                if (node->op < GGML_OP_COUNT) {
+                    fprintf(stderr, "%s\n", ggml_op_name(node->op));
+                } else {
+                    fprintf(stderr, "%d\n", node->op);
+                }
                 GGML_ASSERT(false);
             } break;
     }


### PR DESCRIPTION
Fixes this warning:
```
/home/jared/src/forks/llama.cpp/ggml.c: In function ‘ggml_get_n_tasks’:
/home/jared/src/forks/llama.cpp/ggml.c:2019:24: warning: array subscript 69 is above array bounds of ‘const char *[68]’ [-Warray-bounds]
 2019 |     return GGML_OP_NAME[op];
      |            ~~~~~~~~~~~~^~~~
/home/jared/src/forks/llama.cpp/ggml.c:1589:21: note: while referencing ‘GGML_OP_NAME’
 1589 | static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
      |                     ^~~~~~~~~~~~
```

ref #4133