### PR TITLE
Add single-client multi-prompt support

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1345,7 +1345,7 @@ struct llama_server_context
         // when a completion task's prompt array is not a singleton, we split it into multiple requests
         if (task.data.at("prompt").size() > 1)
         {
-            auto id = request_multiprompt_task(task);
+            auto id = split_multiprompt_task(task);
             return id;
         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1548,7 +1548,7 @@ struct llama_server_context
             if (queue_iterator->subtasks_remaining.empty())
             {
                 // all subtasks done == multitask is done
-                task_result aggregate_result{};
+                task_result aggregate_result;
                 aggregate_result.id = queue_iterator->id;
                 aggregate_result.stop = true;
                 aggregate_result.error = false;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1553,7 +1553,7 @@ struct llama_server_context
                 aggregate_result.error = false;
 
                 // collect json results into one json result
-                std::vector<json> result_jsons{};
+                std::vector<json> result_jsons;
                 for (auto& subres : queue_iterator->results)
                 {
                     result_jsons.push_back(subres.result_json);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1346,8 +1346,7 @@ struct llama_server_context
         if (task.data.at("prompt").size() > 1)
         {
             lock.unlock(); // entering new func scope
-            auto id = split_multiprompt_task(task);
-            return id;
+            return split_multiprompt_task(task);
         }
 
         // otherwise, it's a single-prompt task, we actually queue it

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <mutex>
 #include <chrono>
-#include <unordered_set>
 
 #ifndef SERVER_VERBOSE
 #define SERVER_VERBOSE 1
@@ -169,7 +168,7 @@ struct task_result {
 
 struct task_multi {
     int id;
-    std::unordered_set<int> subtasks_remaining{};
+    std::set<int> subtasks_remaining{};
     std::vector<task_result> results{};
 };
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -169,8 +169,8 @@ struct task_result {
 
 struct task_multi {
     int id;
-    std::unordered_set<int> subtasks_remaining{};
-    std::vector<task_result> results{};
+    std::unordered_set<int> subtasks_remaining;
+    std::vector<task_result> results;
 };
 
 // TODO: can become bool if we can't find use of more states


### PR DESCRIPTION
Added multiprompt support as requested by issue #3478.

For a multiprompt request from a single client, the resulting json result is a json containing an array `results` of regular json results as specified by the [spec](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints).

The server **must support slot parallelism** for this to work properly. If there aren't enough available slots, currently one of the sub-prompts will fail and you'll get an error in the json results.

Example multiprompt:
```
 curl --request POST --url http://localhost:8080/completion --header "Content-Type: application/json" --data '{"prompt": ["<s>[INST] What is the capital of the US? [/INST]", "<s>[INST] What is the capital of France? [/INST]"], "n_predict": 2048}'
 ```

Output
```
["results",[{"content":" The capital city of France is Paris.","generation_settings":{"frequency_penalty":0.0,"grammar":"","ignore_eos":false,"logit_bias":[],"min_p":0.05000000074505806,"mirostat":0,"mirostat_eta":0.10000000149011612,"mirostat_tau":5.0,"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","n_ctx":1618,"n_keep":0,"n_predict":2048,"n_probs":0,"penalize_nl":true,"presence_penalty":0.0,"repeat_last_n":64,"repeat_penalty":1.100000023841858,"seed":4294967295,"stop":[],"stream":false,"temp":0.800000011920929,"tfs_z":1.0,"top_k":40,"top_p":0.949999988079071,"typical_p":1.0},"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","prompt":"<s>[INST] What is the capital of France? [/INST]","slot_id":1,"stop":true,"stopped_eos":true,"stopped_limit":false,"stopped_word":false,"stopping_word":"","timings":{"predicted_ms":16244.23,"predicted_n":8,"predicted_per_second":0.4924825615002989,"predicted_per_token_ms":2030.52875,"prompt_ms":34897.573,"prompt_n":16,"prompt_per_second":0.4584846057919272,"prompt_per_token_ms":2181.0983125},"tokens_cached":24,"tokens_evaluated":16,"tokens_predicted":8,"truncated":false},{"content":" The capital city of France is Paris.","generation_settings":{"frequency_penalty":0.0,"grammar":"","ignore_eos":false,"logit_bias":[],"min_p":0.05000000074505806,"mirostat":0,"mirostat_eta":0.10000000149011612,"mirostat_tau":5.0,"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","n_ctx":1618,"n_keep":0,"n_predict":2048,"n_probs":0,"penalize_nl":true,"presence_penalty":0.0,"repeat_last_n":64,"repeat_penalty":1.100000023841858,"seed":4294967295,"stop":[],"stream":false,"temp":0.800000011920929,"tfs_z":1.0,"top_k":40,"top_p":0.949999988079071,"typical_p":1.0},"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","prompt":"<s>[INST] What is the capital of France? [/INST]","slot_id":1,"stop":true,"stopped_eos":true,"stopped_limit":false,"stopped_word":false,"stopping_word":"","timings":{"predicted_ms":16244.23,"predicted_n":8,"predicted_per_second":0.4924825615002989,"predicted_per_token_ms":2030.52875,"prompt_ms":34897.573,"prompt_n":16,"prompt_per_second":0.4584846057919272,"prompt_per_token_ms":2181.0983125},"tokens_cached":24,"tokens_evaluated":16,"tokens_predicted":8,"truncated":false},{"content":" The capital of the United States is Washington, D.C.","generation_settings":{"frequency_penalty":0.0,"grammar":"","ignore_eos":false,"logit_bias":[],"min_p":0.05000000074505806,"mirostat":0,"mirostat_eta":0.10000000149011612,"mirostat_tau":5.0,"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","n_ctx":1618,"n_keep":0,"n_predict":2048,"n_probs":0,"penalize_nl":true,"presence_penalty":0.0,"repeat_last_n":64,"repeat_penalty":1.100000023841858,"seed":4294967295,"stop":[],"stream":false,"temp":0.800000011920929,"tfs_z":1.0,"top_k":40,"top_p":0.949999988079071,"typical_p":1.0},"model":"mistral-7b-instruct-v0.1.Q4_0.gguf","prompt":"<s>[INST] What is the capital of the US? [/INST]","slot_id":0,"stop":true,"stopped_eos":true,"stopped_limit":false,"stopped_word":false,"stopping_word":"","timings":{"predicted_ms":22387.163,"predicted_n":13,"predicted_per_second":0.5806899248466632,"predicted_per_token_ms":1722.0894615384616,"prompt_ms":34891.824,"prompt_n":17,"prompt_per_second":0.4872201579372864,"prompt_per_token_ms":2052.460235294118},"tokens_cached":30,"tokens_evaluated":17,"tokens_predicted":13,"truncated":false}]]
```
Obviously, there's duplicate data being sent, but it works. Perhaps a future optimization. I did not want to do too much for my first contribution 😄 
