### PR TITLE
llama : improve batched CPU perf with BLAS

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -9373,7 +9373,7 @@ static bool ggml_compute_forward_mul_mat_use_blas(
     // TODO: find the optimal values for these
     if (ggml_is_contiguous(src0) &&
         ggml_is_contiguous(src1) &&
-        src0->type == GGML_TYPE_F32 &&
+      //src0->type == GGML_TYPE_F32 &&
         src1->type == GGML_TYPE_F32 &&
         (ne0 >= 32 && ne1 >= 32 && ne10 >= 32)) {
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -5433,7 +5433,7 @@ static int llama_decode_internal(
 
     GGML_ASSERT(n_tokens <= n_batch);
 
-    int n_threads = n_tokens < 32 ? cparams.n_threads : cparams.n_threads_batch;
+    int n_threads = n_tokens == 1 ? cparams.n_threads : cparams.n_threads_batch;
     GGML_ASSERT((!batch.token && batch.embd) || (batch.token && !batch.embd)); // NOLINT
 
     const int64_t t_start_us = ggml_time_us();


### PR DESCRIPTION
We [accidentally disabled BLAS](https://github.com/ggerganov/ggml/commit/ba779f117ecc20f605df6f75dc7d92fb114bf17e#diff-b4a500ab2765c31526c5541f3e51e21e46990b87d9774cac6f3089db315bdc5bR9367) when `src0->type != F32`

Also remove redundant check for full offload support