### PR TITLE
ggml : restore abort() in GGML_ASSERT

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -244,11 +244,10 @@
 #define GGML_ASSERT(x) \
     do { \
         if (!(x)) { \
-            fprintf(stderr, "GGML_ASSERT: %s:%d: %s\n", __FILE__, __LINE__, #x); \
-            fflush(stderr); \
             fflush(stdout); \
+            fprintf(stderr, "GGML_ASSERT: %s:%d: %s\n", __FILE__, __LINE__, #x); \
             ggml_print_backtrace(); \
-            exit(1); \
+            abort(); \
         } \
     } while (0)
 


### PR DESCRIPTION
Quoting https://github.com/ggerganov/llama.cpp/pull/3912#issuecomment-1828819247:
> With this change, you no longer get a coredump when you hit a GGML_ASSERT, and you can't even catch the assertion with gdb without e.g. `catch syscall exit_group`:
> 
> ```
> GGML_ASSERT: /home/jared/src/forks/llama.cpp/ggml-cuda.cu:5644: false
> [Detaching after fork from child process 509162]
> stack module disabled
> warning: process 509151 is already traced by process 509126
> ptrace: Operation not permitted.
> No stack.
> The program is not being run.
> [Thread 0x7fffbcfde000 (LWP 509160) exited]
> [Thread 0x7fffc9162000 (LWP 509159) exited]
> [Thread 0x7fffcbbff000 (LWP 509155) exited]
> [Thread 0x7ffff7f36000 (LWP 509151) exited]
> [Thread 0x7fffb4fde000 (LWP 509161) exited]
> [New process 509151]
> [Inferior 1 (process 509151) exited with code 01]
> >>>
> ```

This PR fixes that issue by restoring the abort().

I'm also flushing stdout before printing to stderr for better ordering in console, and removing `fflush(stderr)` because we are printing a newline to stderr and [in standard C](https://en.cppreference.com/w/cpp/io/c/std_streams): "at program startup, the stream [stderr] is not fully buffered," meaning a newline should be sufficient to flush it. By Unix convention, stderr is unbuffered at startup.