### PR TITLE
readme : add FreeChat to UI list

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ as the main playground for developing new features for the [ggml](https://github
 - [oobabooga/text-generation-webui](https://github.com/oobabooga/text-generation-webui)
 - [withcatai/catai](https://github.com/withcatai/catai)
 - [semperai/amica](https://github.com/semperai/amica)
+- [psugihara/FreeChat](https://github.com/psugihara/FreeChat)
 
 ---
 


### PR DESCRIPTION
This adds [FreeChat](https://github.com/psugihara/FreeChat) to the UI section. FreeChat is a native macOS app for using llama.cpp with 1-click install from the mac app store. It works by embedding the server binary and running it as a helper process from a SwiftUI front-end.

Thanks again for this amazing project.