### PR TITLE
convert.py : fix llama/llama2 conversion due to vocab_size=-1

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -267,7 +267,7 @@ class Params:
             n_ctx = 2048
 
         return Params(
-            n_vocab          = config.get("vocab_size", model["tok_embeddings.weight"].shape[0]),
+            n_vocab          = model["tok_embeddings.weight"].shape[0],
             n_embd           = config["dim"],
             n_layer          = config["n_layers"],
             n_ctx            = n_ctx,


### PR DESCRIPTION
`convert.py` has been broken for a while because it cannot handle `vocab_size: -1` in llama and llama2 `params.json`. Changed to always take the `n_vocab` from the shape of `tok_embeddings`.