### PR TITLE
Fix typical sampling.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -7027,6 +7027,7 @@ void llama_sample_typical(struct llama_context * ctx, llama_token_data_array * c
     // Replace the data in candidates with the new_candidates data
     std::copy(new_candidates.begin(), new_candidates.end(), candidates->data);
     candidates->size = new_candidates.size();
+    candidates->sorted = false;
 
     if (ctx) {
         ctx->t_sample_us += ggml_time_us() - t_start_sample_us;


### PR DESCRIPTION
Typical sampling was broken because after copying new_candidates into candidates, the "sorted" bool is left at "true" as set by running the softmax function earlier, but the new data is not sorted according to probability. Patch to set "sorted" to false.

Test: Generating with temp=0.0001 (approx. argmax)  should generate the same sequence at typical>=1.0 and typical=0.9999 (approx. disabled, but enters the typical sampling codepath).