### PR TITLE
Input Temperature & Output Temperature

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -187,13 +187,16 @@ llama_token llama_sampling_sample(
         } else {
             // temperature sampling
             size_t min_keep = std::max(1, params.n_probs);
+            float output_temp = 1.0; // WIP, this should be defined separately as its own parameter.
 
+            llama_sample_temp     (ctx_main, &cur_p, temp); // "Initial temp", this is how it's traditionally implemented
             llama_sample_top_k    (ctx_main, &cur_p, top_k,     min_keep);
             llama_sample_tail_free(ctx_main, &cur_p, tfs_z,     min_keep);
             llama_sample_typical  (ctx_main, &cur_p, typical_p, min_keep);
             llama_sample_top_p    (ctx_main, &cur_p, top_p,     min_keep);
             llama_sample_min_p    (ctx_main, &cur_p, min_p,     min_keep);
-            llama_sample_temp     (ctx_main, &cur_p, temp);
+            llama_sample_temp     (ctx_main, &cur_p, temp_last); // "Output temp", this is how llama.cpp chose to implement it
+
 
             id = llama_sample_token(ctx_main, &cur_p);
 


### PR DESCRIPTION
The expected implementation of Temperature (as it is used in OpenAI's models and also inference backends) is to modify the original distribution so that truncation samplers such as Top P or Top K aren't _strictly_ necessary, but the current implementation as it is in llama.cpp behaves differently.

This can be confusing because truncation fundamentally changes the model's scores in a way that is very similar to lower temperature, except it _explicitly cuts out bad choices_ to do this rather than scaling the model's confidence. This is not _objectively_ a flawed approach; the llama.cpp style temperature allows you to apply some randomization after selecting your limited set of 'good' candidates. But the problem is, we want to **have interpretability in what the model is doing in response to sampler changes** so that there's an easy and understood way to control the model output.

Basically, the current trend across FOSS LLM inference backends is layering different samplers (and in the case of Temperature, the order of operations) haphazardly without carefully considering how they interact: this causes a very skewed and sometimes unnatural representation of what the model is actually predicting in response to different settings across different backends.

I want to propose a new standard that is interpretable and helps distinguish between the Temperature implementation variants:

- An **Input Temperature** which is ran before any other sampler and changes the original distribution before any changes are made, this is the 'classic' style which llama.cpp never implemented.
- An **Output Temperature** which will come last after all the truncation samplers (such as Top K, Top P, etc) have been ran, in which the end goal is to increase the diversity of choices made by making all token probabilities closer together.

This would give users freedom because:
- You can apply temperature _after_ the model has selected a set of high quality candidates (post-truncation samplers) to 'randomize' in a way that won't invite any 'low quality' token choices, but instead works as a way to make the model avoid overly predictable outputs while staying in the safe range.
- You can apply temperature _before_ the model has selected its list of candidates to change the scale at which the model's scores are 'graded' in the first place to help trim out the outliers.

In addition to this, Top P & Top K samplers are skewing the model in ways that are also unnatural as I've documented in the past. After a lot of research on sampler solutions, I think it makes sense to try to phase out their use (with the exception of Top K for debugging / deterministic tests) and to avoid using them as defaults instead of Min P, which seems to be universally preferred by now. 

Min P 0.1 seems to do well across most models, and only allows for tokens at least 1/10th as probable as the highest ranking choice, but it's a bit more deterministic. I'd say 0.05 is a solid all arounder default option assuming 1.0 temp for the "Input Temperature" unless we want to make the defaults more 'safe'.