### PR TITLE
llama : sanity checks for access to logits

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -5617,6 +5617,8 @@ static int llama_decode_internal(
         auto & logits_valid = lctx.logits_valid;
         logits_valid.clear();
         logits_valid.resize(n_tokens);
+
+        logits_out.clear();
 #endif
 
         if (batch.logits) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -5616,7 +5616,7 @@ static int llama_decode_internal(
 #ifndef NDEBUG
         auto & logits_valid = lctx.logits_valid;
         logits_valid.clear();
-        logits_valid.resize(n_vocab);
+        logits_valid.resize(n_tokens);
 #endif
 
         if (batch.logits) {


### PR DESCRIPTION
This change attempts to validate logit access in debug mode. No effect on release builds.

This change is incomplete:
- We can't actually validate access via llama_get_logits (which is the problem I actually had when transitioning to the new batch API - I wasn't using llama_get_logits_ith), because it has two meanings. Most people use the undocumented meaning: 1D array of logits for the final token.
- Since we can't identify which meaning the programmer intends when they call llama_get_logits, could we deprecate it and provide a replacement that has never and will never return a 1D array, e.g. "llama_get_logits_all"? This would avoid a footgun when developers transition to the new batch API, making it clear to them via compiler warnings (we should actually use `__attribute__((deprecated))`) that they need to use llama_get_logits_ith.
- I'm assuming we don't intend to keep llama_eval and llama_batch_get_one forever, so those should be properly deprecated as well so people don't use them in new code.

cc @ggerganov