### PR TITLE
build : enable libstdc++ assertions for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 include(CheckCXXCompilerFlag)
 
+# enable libstdc++ assertions for debug builds
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>)
+endif()
+
 if (NOT MSVC)
     if (LLAMA_SANITIZE_THREAD)
         add_compile_options(-fsanitize=thread)

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ ifdef LLAMA_DEBUG
 	MK_CFLAGS   += -O0 -g
 	MK_CXXFLAGS += -O0 -g
 	MK_LDFLAGS  += -g
+
+	ifeq ($(UNAME_S),Linux)
+		MK_CXXFLAGS += -Wp,-D_GLIBCXX_ASSERTIONS
+	endif
 else
 	MK_CPPFLAGS += -DNDEBUG
 endif


### PR DESCRIPTION
Arch Linux enables `-D_GLIBCXX_ASSERTIONS` by default. I don't see any reason not to enable them for at least debug builds. They are good at detecting abuse of STL containers.

See https://github.com/nomic-ai/gpt4all/issues/1696 for an example of a downstream fork of llama.cpp triggering one of these assertions.

Arch Linux also builds with `-D_FORTIFY_SOURCE=2` by default (which helps with libc stuff like memcpy), but that requires building with optimizations, so I'm not sure where that would fit in.