### PR TITLE
build: add requirements file for convert-hf-to-gguf.py

### DIFF
--- a/requirements-hf-to-gguf.txt
+++ b/requirements-hf-to-gguf.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+torch==2.1.1
+transformers==4.35.2


### PR DESCRIPTION
This commit adds a requirements file for the `convert-hf-to-gguf.py`
script, and also add the `torch` and `transformers` packages to it.


The motivation for this is that currently running `convert-hf-to-gguf.py` will produce the following error:
```console
$ python3 -m venv venv
$ source venv/bin/activate
(venv) $ pip install -r requirements.txt
Collecting numpy==1.24.4
Collecting sentencepiece==0.1.98
Collecting gguf>=0.1.0
Installing collected packages: sentencepiece, numpy, gguf
Successfully installed gguf-0.5.1 numpy-1.24.4 sentencepiece-0.1.98

(venv) $ python convert-hf-to-gguf.py --help
Traceback (most recent call last):
  File "llama.cpp/convert-hf-to-gguf.py", line 16, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```
With this commit, and using `requirements-hf-to-gguf.txt` instead of
requirements.txt, the script can be run and shows the help output.