### PR TITLE
Fix token_to_piece implementation in Swift

### DIFF
--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -242,6 +242,16 @@ private func token_to_piece(token: llama_token, buffer: inout [CChar]) -> String
             Int32(result.count)
         )
         assert(check == nTokens)
+    } else if nTokens > 8 {
+        result.removeAll()
+        result = [CChar](repeating: 0, count: nTokens)
+        let check = llama_token_to_piece(
+            model,
+            token,
+            &result,
+            Int32(result.count)
+        )
+        assert(check == nTokens)
     } else {
         result.removeLast(result.count - Int(nTokens))
     }

--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -230,28 +230,15 @@ private func token_to_piece(token: llama_token, buffer: inout [CChar]) -> String
     var result = [CChar](repeating: 0, count: 8)
     let nTokens = llama_token_to_piece(model, token, &result, Int32(result.count))
     if nTokens < 0 {
-        if result.count >= -Int(nTokens) {
-            result.removeLast(-Int(nTokens))
-        } else {
-            result.removeAll()
-        }
+        let actualTokensCount = -Int(nTokens)
+        result = .init(repeating: 0, count: actualTokensCount)
         let check = llama_token_to_piece(
             model,
             token,
             &result,
             Int32(result.count)
         )
-        assert(check == nTokens)
-    } else if nTokens > 8 {
-        result.removeAll()
-        result = [CChar](repeating: 0, count: nTokens)
-        let check = llama_token_to_piece(
-            model,
-            token,
-            &result,
-            Int32(result.count)
-        )
-        assert(check == nTokens)
+        assert(check == actualTokensCount)
     } else {
         result.removeLast(result.count - Int(nTokens))
     }
@@ -269,5 +256,4 @@ private func token_to_piece(token: llama_token, buffer: inout [CChar]) -> String
         buffer = []
         return bufferString
     }
-    return nil
 }

--- a/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
+++ b/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
@@ -165,7 +165,18 @@ actor LlamaContext {
         let result = UnsafeMutablePointer<Int8>.allocate(capacity: 8)
         result.initialize(repeating: Int8(0), count: 8)
 
-        let _ = llama_token_to_piece(model, token, result, 8)
+        let nTokens = llama_token_to_piece(model, token, result, 8)
+
+        if nTokens > 8 {
+            result.removeAll()
+            result = [CChar](repeating: 0, count: nTokens)
+            _ = llama_token_to_piece(
+                model,
+                token,
+                &result,
+                Int32(result.count)
+            )
+        }
 
         let resultStr = String(cString: result)
 


### PR DESCRIPTION
Current implementation of `token_to_piece` in Swift examples are working incorrectly, when the target token contains more than 8 characters. As a result, the result produced by Swift sometimes seems wrong. I tried [llama-2-13b.Q4_0.gguf](https://huggingface.co/TheBloke/Llama-2-13B-GGUF/blob/main/llama-2-13b.Q4_0.gguf), and when I give 'programming' as a prompt, Swift cannot decode the word.

To avoid this behavior, I updated Swift scripts in example directory.