### PR TITLE
llama : pad KV cache size

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1083,7 +1083,7 @@ void ggml_metal_graph_compute(
 
                             // find the break-even point where the matrix-matrix kernel becomes more efficient compared
                             // to the matrix-vector kernel
-                            int ne11_mm_min = 1;
+                            int ne11_mm_min = src0t == GGML_TYPE_F16 ? 1 : 16;
 
 #if 0
                             // the numbers below are measured on M2 Ultra for 7B and 13B models

--- a/llama.cpp
+++ b/llama.cpp
@@ -5744,8 +5744,7 @@ static int llama_decode_internal(
     // a heuristic, to avoid attending the full cache if it is not yet utilized
     // after enough generations, the benefit from this heuristic disappears
     // if we start defragmenting the cache, the benefit from this will be more important
-    //kv_self.n = std::max(32, GGML_PAD(llama_kv_cache_cell_max(kv_self), 32));   // TODO: this might be better for CUDA?
-    kv_self.n = std::min((int32_t) cparams.n_ctx, std::max(32, llama_kv_cache_cell_max(kv_self)));
+    kv_self.n = std::min((int32_t) cparams.n_ctx, std::max(32, GGML_PAD(llama_kv_cache_cell_max(kv_self), 32)));
 
     //printf("kv_self.n = %5d, kv_self.used = %5d, kv_self.head = %5d\n", kv_self.n, kv_self.used, kv_self.head);
 


### PR DESCRIPTION
Should result in slight TG speedup

ggml_init_cublas: GGML_CUDA_FORCE_MMQ:   no
ggml_init_cublas: CUDA_USE_TENSOR_CORES: yes
ggml_init_cublas: found 1 CUDA devices:
  Device 0: Tesla V100-PCIE-16GB, compute capability 7.0
| model                   |       size | backend    | ngl | test       |              t/s |              t/s |      speedup     |
| ----------------------- | ---------: | ---------- | --: | ---------- | ---------------: | ---------------: | ---------------: |
| llama 7B F16            |  12.55 GiB | CUDA       |  99 | pp 512     |  3457.68 ± 89.53 | 3444.83 ± 126.66 | 1.000 |
| llama 7B F16            |  12.55 GiB | CUDA       |  99 | tg 128     |     53.01 ± 0.05 |     53.14 ± 0.07 | 1.002 |
| llama 7B F16            |  12.55 GiB | CUDA       |  99 | tg 256     |     52.56 ± 0.03 |     52.84 ± 0.07 | 1.005 |
| llama 7B F16            |  12.55 GiB | CUDA       |  99 | tg 512     |     51.83 ± 0.06 |     52.43 ± 0.06 | 1.012 |
| llama 7B Q8_0           |   6.67 GiB | CUDA       |  99 | pp 512     |  2513.48 ± 31.58 |  2516.75 ± 34.50 | 1.000 |
| llama 7B Q8_0           |   6.67 GiB | CUDA       |  99 | tg 128     |     78.91 ± 0.15 |     79.25 ± 0.23 | 1.004 |
| llama 7B Q8_0           |   6.67 GiB | CUDA       |  99 | tg 256     |     78.16 ± 0.22 |     78.91 ± 0.08 | 1.010 |
| llama 7B Q8_0           |   6.67 GiB | CUDA       |  99 | tg 512     |     76.54 ± 0.14 |     77.83 ± 0.16 | 1.017 |
| llama 7B Q4_0           |   3.56 GiB | CUDA       |  99 | pp 512     |  2720.43 ± 34.16 |  2716.96 ± 32.91 | 1.000 |
| llama 7B Q4_0           |   3.56 GiB | CUDA       |  99 | tg 128     |    115.78 ± 0.34 |    116.34 ± 0.95 | 1.005 |
| llama 7B Q4_0           |   3.56 GiB | CUDA       |  99 | tg 256     |    114.17 ± 0.37 |    115.70 ± 0.31 | 1.013 |
| llama 7B Q4_0           |   3.56 GiB | CUDA       |  99 | tg 512     |    111.05 ± 0.27 |    113.79 ± 0.23 | 1.025 |

build: 75ba5ba (1594)

---

Also, try to improve the batched decoding performance for quantum models on Apple Silicon.

```bash
make -j batched-bench && ./batched-bench ./models/llama-7b-v2/ggml-model-q8_0.gguf 10880 1 99 0 128,2048 128 1,2,4,8
```

`master`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.122 |  1049.89 |    1.899 |    67.39 |    2.021 |   126.65 |
|   128 |    128 |    2 |    384 |    0.120 |  1062.68 |    7.212 |    35.50 |    7.332 |    52.37 |
|   128 |    128 |    4 |    640 |    0.120 |  1067.81 |    7.207 |    71.04 |    7.327 |    87.35 |
|   128 |    128 |    8 |   1152 |    0.120 |  1065.87 |    7.380 |   138.75 |    7.500 |   153.59 |
|  2048 |    128 |    1 |   2176 |    1.665 |  1229.84 |    2.293 |    55.82 |    3.958 |   549.71 |
|  2048 |    128 |    2 |   2304 |    1.659 |  1234.55 |    7.568 |    33.83 |    9.227 |   249.72 |
|  2048 |    128 |    4 |   2560 |    1.658 |  1235.25 |    7.791 |    65.72 |    9.449 |   270.93 |
|  2048 |    128 |    8 |   3072 |    1.659 |  1234.77 |    8.187 |   125.08 |    9.845 |   312.03 |

`PR`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.120 |  1062.85 |    1.898 |    67.42 |    2.019 |   126.81 |
|   128 |    128 |    2 |    384 |    0.121 |  1060.96 |    2.614 |    97.92 |    2.735 |   140.40 |
|   128 |    128 |    4 |    640 |    0.120 |  1069.25 |    3.983 |   128.54 |    4.103 |   155.98 |
|   128 |    128 |    8 |   1152 |    0.120 |  1066.80 |    6.810 |   150.37 |    6.930 |   166.24 |
|  2048 |    128 |    1 |   2176 |    1.665 |  1229.74 |    2.290 |    55.89 |    3.956 |   550.11 |
|  2048 |    128 |    2 |   2304 |    1.662 |  1232.19 |    3.085 |    82.98 |    4.747 |   485.35 |
|  2048 |    128 |    4 |   2560 |    1.658 |  1235.08 |    4.462 |   114.74 |    6.120 |   418.27 |
|  2048 |    128 |    8 |   3072 |    1.657 |  1235.68 |    7.299 |   140.29 |    8.956 |   343.00 |

```bash
make -j batched-bench && ./batched-bench ./models/llama-7b-v2/ggml-model-q4_0.gguf 10880 1 99 0 128,2048 128 1,2,4,8
```

`master`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.121 |  1060.20 |    1.335 |    95.90 |    1.455 |   175.89 |
|   128 |    128 |    2 |    384 |    0.120 |  1065.36 |    7.042 |    36.35 |    7.162 |    53.62 |
|   128 |    128 |    4 |    640 |    0.118 |  1083.25 |    7.062 |    72.50 |    7.180 |    89.13 |
|   128 |    128 |    8 |   1152 |    0.118 |  1080.54 |    7.322 |   139.85 |    7.441 |   154.83 |
|  2048 |    128 |    1 |   2176 |    1.675 |  1222.93 |    1.730 |    73.99 |    3.405 |   639.12 |
|  2048 |    128 |    2 |   2304 |    1.674 |  1223.57 |    7.451 |    34.36 |    9.124 |   252.51 |
|  2048 |    128 |    4 |   2560 |    1.670 |  1225.99 |    7.656 |    66.88 |    9.326 |   274.50 |
|  2048 |    128 |    8 |   3072 |    1.670 |  1226.32 |    8.036 |   127.43 |    9.706 |   316.50 |

`PR`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.121 |  1055.03 |    1.342 |    95.37 |    1.463 |   174.93 |
|   128 |    128 |    2 |    384 |    0.121 |  1060.52 |    1.846 |   138.67 |    1.967 |   195.24 |
|   128 |    128 |    4 |    640 |    0.119 |  1075.47 |    2.680 |   191.02 |    2.799 |   228.62 |
|   128 |    128 |    8 |   1152 |    0.120 |  1068.20 |    4.398 |   232.85 |    4.518 |   255.01 |
|  2048 |    128 |    1 |   2176 |    1.680 |  1218.71 |    1.735 |    73.77 |    3.416 |   637.06 |
|  2048 |    128 |    2 |   2304 |    1.676 |  1221.80 |    2.315 |   110.60 |    3.991 |   577.30 |
|  2048 |    128 |    4 |   2560 |    1.674 |  1223.71 |    3.159 |   162.08 |    4.832 |   529.75 |
|  2048 |    128 |    8 |   3072 |    1.672 |  1224.88 |    4.921 |   208.07 |    6.593 |   465.92 |

```bash
make -j batched-bench && ./batched-bench ./models/codellama-34b/ggml-model-q8_0.gguf 10880 1 99 0 128,2048 128 1,2,4,8
```
`master`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.532 |   240.41 |    7.370 |    17.37 |    7.902 |    32.40 |
|   128 |    128 |    2 |    384 |    0.532 |   240.57 |   24.895 |    10.28 |   25.428 |    15.10 |
|   128 |    128 |    4 |    640 |    0.532 |   240.65 |   25.136 |    20.37 |   25.668 |    24.93 |
|   128 |    128 |    8 |   1152 |    0.532 |   240.71 |   25.648 |    39.93 |   26.180 |    44.00 |
|  2048 |    128 |    1 |   2176 |    7.400 |   276.77 |    8.464 |    15.12 |   15.863 |   137.17 |
|  2048 |    128 |    2 |   2304 |    7.393 |   277.01 |   25.747 |     9.94 |   33.141 |    69.52 |
|  2048 |    128 |    4 |   2560 |    7.391 |   277.09 |   26.215 |    19.53 |   33.606 |    76.18 |
|  2048 |    128 |    8 |   3072 |    7.392 |   277.07 |   27.027 |    37.89 |   34.419 |    89.25 |

`PR`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.532 |   240.63 |    7.371 |    17.36 |    7.903 |    32.39 |
|   128 |    128 |    2 |    384 |    0.532 |   240.73 |   13.211 |    19.38 |   13.743 |    27.94 |
|   128 |    128 |    4 |    640 |    0.531 |   240.95 |   24.350 |    21.03 |   24.881 |    25.72 |
|   128 |    128 |    8 |   1152 |    0.530 |   241.30 |   46.880 |    21.84 |   47.410 |    24.30 |
|  2048 |    128 |    1 |   2176 |    7.398 |   276.82 |    8.457 |    15.14 |   15.855 |   137.24 |
|  2048 |    128 |    2 |   2304 |    7.397 |   276.86 |   14.142 |    18.10 |   21.539 |   106.97 |
|  2048 |    128 |    4 |   2560 |    7.392 |   277.06 |   25.311 |    20.23 |   32.703 |    78.28 |
|  2048 |    128 |    8 |   3072 |    7.392 |   277.05 |   47.932 |    21.36 |   55.325 |    55.53 |

```bash
make -j batched-bench && ./batched-bench ./models/codellama-34b/ggml-model-q4_0.gguf 10880 1 99 0 128,2048 128 1,2,4,8
```

`master
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.530 |   241.28 |    4.454 |    28.74 |    4.984 |    51.36 |
|   128 |    128 |    2 |    384 |    0.530 |   241.32 |   23.865 |    10.73 |   24.396 |    15.74 |
|   128 |    128 |    4 |    640 |    0.531 |   241.21 |   24.083 |    21.26 |   24.614 |    26.00 |
|   128 |    128 |    8 |   1152 |    0.530 |   241.60 |   24.660 |    41.53 |   25.190 |    45.73 |
|  2048 |    128 |    1 |   2176 |    7.475 |   274.00 |    5.536 |    23.12 |   13.010 |   167.26 |
|  2048 |    128 |    2 |   2304 |    7.466 |   274.32 |   24.595 |    10.41 |   32.061 |    71.86 |
|  2048 |    128 |    4 |   2560 |    7.465 |   274.34 |   25.176 |    20.34 |   32.641 |    78.43 |
|  2048 |    128 |    8 |   3072 |    7.464 |   274.37 |   26.181 |    39.11 |   33.645 |    91.31 |

`PR`
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.531 |   240.92 |    4.473 |    28.62 |    5.004 |    51.16 |
|   128 |    128 |    2 |    384 |    0.529 |   241.79 |    7.421 |    34.50 |    7.951 |    48.30 |
|   128 |    128 |    4 |    640 |    0.530 |   241.66 |   13.086 |    39.13 |   13.616 |    47.00 |
|   128 |    128 |    8 |   1152 |    0.530 |   241.64 |   24.512 |    41.78 |   25.041 |    46.00 |
|  2048 |    128 |    1 |   2176 |    7.471 |   274.11 |    5.564 |    23.00 |   13.036 |   166.93 |
|  2048 |    128 |    2 |   2304 |    7.473 |   274.07 |    8.379 |    30.55 |   15.851 |   145.35 |
|  2048 |    128 |    4 |   2560 |    7.464 |   274.40 |   14.202 |    36.05 |   21.666 |   118.16 |
|  2048 |    128 |    8 |   3072 |    7.472 |   274.10 |   25.890 |    39.55 |   33.362 |    92.08 |
