### PR TITLE
server : fix OpenAI API `stop` field to be optional

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2410,9 +2410,7 @@ json oaicompat_completion_params_parse(
     }
 
     // Handle 'stop' field
-    if (body["stop"].is_null()) {
-        llama_params["stop"] = json::array({});
-    } else if (body["stop"].is_string()) {
+    if (body.contains("stop") && body["stop"].is_string()) {
         llama_params["stop"] = json::array({body["stop"].get<std::string>()});
     } else {
         llama_params["stop"] = json_value(body, "stop", json::array());


### PR DESCRIPTION
As requested from https://github.com/Mozilla-Ocho/llamafile/pull/36#pullrequestreview-1760945115 to fix upstream

https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop

(cherry picked from commit Mozilla-Ocho/llamafile@e8c92bcb84ae3bcbf0d617b7ee6a5413bcbd58af)