### PR TITLE
ggml : fix soft max out-of-bounds access

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -15629,7 +15629,6 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
             } break;
         case GGML_OP_DIAG_MASK_ZERO:
         case GGML_OP_DIAG_MASK_INF:
-        case GGML_OP_SOFT_MAX:
         case GGML_OP_SOFT_MAX_BACK:
         case GGML_OP_ROPE:
         case GGML_OP_ROPE_BACK:
@@ -15644,6 +15643,10 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
         case GGML_OP_CLAMP:
             {
                 n_tasks = 1; //TODO
+            } break;
+        case GGML_OP_SOFT_MAX:
+            {
+                n_tasks = MIN(MIN(4, n_threads), ggml_nrows(node->src[0]));
             } break;
         case GGML_OP_CONV_TRANSPOSE_1D:
             {


### PR DESCRIPTION
close #4296

This bug was introduced in #4256 

There was a mismatch between `n_tasks` for `GGML_OP_SOFT_MAX` returned by `ggml_get_n_tasks()` and `ggml_graph_plan()`.