### PR TITLE
A step ahead supporting NousResearch/Nous-Hermes-2-Vision

### DIFF
--- a/examples/llava/convert-image-encoder-to-gguf.py
+++ b/examples/llava/convert-image-encoder-to-gguf.py
@@ -83,10 +83,9 @@ ap.add_argument("--clip_model_is_vision", action="store_true", required=False,
 ap.add_argument("--clip_model_is_openclip", action="store_true", required=False,
                 help="The clip model is from openclip (for ViT-SO400M type))")
 ap.add_argument("--llava-projector", help="Path to llava.projector file. If specified, save an image encoder for LLaVA models.")
-ap.add_argument("--image-mean", nargs=3, type=float, required=False, help="Override image mean values")
-ap.add_argument("--image-std", nargs=3, type=float, required=False, help="Override image std values")
 ap.add_argument("-o", "--output-dir", help="Directory to save GGUF files. Default is the original model directory", default=None)
 # Example --image_mean 0.48145466 0.4578275 0.40821073 --image_std 0.26862954 0.26130258 0.27577711
+# Example --image_mean 0.5 0.5 0.5 --image_std 0.5 0.5 0.5
 default_image_mean = [0.48145466, 0.4578275, 0.40821073]
 default_image_std = [0.26862954, 0.26130258, 0.27577711]
 ap.add_argument('--image_mean', type=float, nargs='+', help='Mean of the images for normalization (overrides processor) ', default=None)

--- a/examples/llava/convert-image-encoder-to-gguf.py
+++ b/examples/llava/convert-image-encoder-to-gguf.py
@@ -105,7 +105,7 @@ if args.use_f32:
 # output in the same directory as the model if output_dir is None
 dir_model = args.model_dir
 
-if args.clip_model_is_vision or not os.path.exists(dir_model + "/vocab.json") or clip_model_is_openclip:
+if args.clip_model_is_vision or not os.path.exists(dir_model + "/vocab.json") or args.clip_model_is_openclip:
     vocab = None
     tokens = None
 else:

--- a/examples/llava/convert-image-encoder-to-gguf.py
+++ b/examples/llava/convert-image-encoder-to-gguf.py
@@ -92,7 +92,7 @@ default_image_std = [0.26862954, 0.26130258, 0.27577711]
 ap.add_argument('--image_mean', type=float, nargs='+', help='Mean of the images for normalization (overrides processor) ', default=None)
 ap.add_argument('--image_std', type=float, nargs='+', help='Standard deviation of the images for normalization (overrides processor)', default=None)
 
-# with proper 
+# with proper
 args = ap.parse_args()
 
 

--- a/examples/llava/convert-image-encoder-to-gguf.py
+++ b/examples/llava/convert-image-encoder-to-gguf.py
@@ -80,6 +80,8 @@ ap.add_argument("--vision-only", action="store_true", required=False,
                 help="Save a vision-only model. It can't be used to encode texts")
 ap.add_argument("--clip_model_is_vision", action="store_true", required=False,
                 help="The clip model is a pure vision model (ShareGPT4V vision extract for example)")
+ap.add_argument("--clip_model_is_openclip", action="store_true", required=False,
+                help="The clip model is from openclip (for ViT-SO400M type))")
 ap.add_argument("--llava-projector", help="Path to llava.projector file. If specified, save an image encoder for LLaVA models.")
 ap.add_argument("--image-mean", nargs=3, type=float, required=False, help="Override image mean values")
 ap.add_argument("--image-std", nargs=3, type=float, required=False, help="Override image std values")
@@ -90,7 +92,7 @@ default_image_std = [0.26862954, 0.26130258, 0.27577711]
 ap.add_argument('--image_mean', type=float, nargs='+', help='Mean of the images for normalization (overrides processor) ', default=None)
 ap.add_argument('--image_std', type=float, nargs='+', help='Standard deviation of the images for normalization (overrides processor)', default=None)
 
-# with proper
+# with proper 
 args = ap.parse_args()
 
 
@@ -104,7 +106,7 @@ if args.use_f32:
 # output in the same directory as the model if output_dir is None
 dir_model = args.model_dir
 
-if args.clip_model_is_vision:
+if args.clip_model_is_vision or not os.path.exists(dir_model + "/vocab.json") or clip_model_is_openclip:
     vocab = None
     tokens = None
 else:
@@ -132,7 +134,7 @@ ftype = 1
 if args.use_f32:
     ftype = 0
 
-if args.clip_model_is_vision:
+if args.clip_model_is_vision or args.clip_model_is_openclip:
     model = CLIPVisionModel.from_pretrained(dir_model)
     processor = None
 else:


### PR DESCRIPTION
The new Nous-Hermes-2 is a function calling vision model, based on llava but uses a much smaller ViT kernel than usual.
I've not tested it's performance yet, for ggml we'll need to adapt the clip encoding, I think it uses another activation function, maybe more differences.
The new vision tower is this one: https://huggingface.co/timm/ViT-SO400M-14-SigLIP-384

This change removed the old img-mean parameter as they were not used in the code.
I believe 0.5/0.5/0.5 are the right normalization parameters (needs to be verified) I based that on `https://huggingface.co/timm/ViT-SO400M-14-SigLIP-384/blob/main/open_clip_config.json`

In addition I added --clip_model_is_openclip which basically just skips the tokenization and processor when used.

Usage:
`py .\examples\llava\convert-image-encoder-to-gguf.py -m Q:\models\llava\ViT-SO400M-14-SigLIP-384-hf\ --llava-projector Q:\models\llava\Nous-Hermes-2-Vision\llava.projector  --output-dir Q:\models\llava\Nous-Hermes-2-Vision\ --clip_model_is_openclip --image_mean 0.5 0.5 0.5 --image_std 0.5 0.5 0.5`

This produces the vision model as before, so tests are possible.

One padding token was needed, I used the padvocab variant of convert.py:
`py .\convert.py Q:\models\llava\Nous-Hermes-2-Vision\ --padvocab`


Now it was able to run through, the produced language model works as expected but the vision part needs the mentioned update to be compatible, I've not digged into that part. 
Maybe @FSSRepo knows ?

P.S. I'm not sure how good the new model is, though the function calling support looks nice