### PR TITLE
false alarm of error check in `ggml_new_tensor_impl()` 

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2456,8 +2456,6 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         data_size *= ne[i];
     }
 
-    GGML_ASSERT(view_src == NULL || data_size + view_offs <= ggml_nbytes(view_src));
-
     void * data = view_src != NULL ? view_src->data : NULL;
     if (data != NULL) {
         data = (char *) data + view_offs;


### PR DESCRIPTION
When the checking the condition `data_size + view_offs <= ggml_nbytes(view_src)`, `nb[]` is not considered. So the assertion is triggered when, for example, broadcasting a vector into a matrix:

```c
// bias is a vector
// output is a matrix
ggml_tensor *bcast_bias = ggml_view_2d(ctx, bias, output->ne[0], output->ne[1], 0, 0);
```

Maybe this error checking can be removed?