### PR TITLE
cmake: fix clang build when CUDA is enabled (#4208)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,13 +399,17 @@ endif()
 
 if (LLAMA_ALL_WARNINGS)
     if (NOT MSVC)
+        # warning_flags is common to C and C++ but not CUDA
         set(warning_flags -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function)
         set(c_flags -Wshadow -Wstrict-prototypes -Wpointer-arith -Wmissing-prototypes -Werror=implicit-int -Werror=implicit-function-declaration)
-        set(cxx_flags -Wmissing-declarations -Wmissing-noreturn)
-        set(host_cxx_flags "")
+        # host_cxx_flags gets passed to nvcc after '-Xcompiler', i.e., it then gets sent to gcc (which is the default
+        # preprocessor for nvcc, even when clang would be used .c/.cpp files)
+        set(host_cxx_flags -Wmissing-declarations -Wmissing-noreturn)
 
         if (CMAKE_C_COMPILER_ID MATCHES "Clang")
-            set(warning_flags ${warning_flags} -Wunreachable-code-break -Wunreachable-code-return)
+            set(c_flags ${c_flags} -Wunreachable-code-break -Wunreachable-code-return)
+            # cxx_flags are used for C++ files but not for CUDA
+            set(cxx_flags -Wunreachable-code-break -Wunreachable-code-return)
             set(host_cxx_flags ${host_cxx_flags} -Wmissing-prototypes -Wextra-semi)
 
             if (
@@ -440,7 +444,7 @@ endif()
 if (NOT MSVC)
     set(cuda_flags -Wno-pedantic)
 endif()
-set(cuda_flags ${cxx_flags} -use_fast_math ${cuda_flags})
+set(cuda_flags -use_fast_math ${cuda_flags})
 
 list(JOIN host_cxx_flags " " cuda_host_flags)  # pass host compiler flags as a single argument
 if (NOT cuda_host_flags STREQUAL "")


### PR DESCRIPTION
Don't use the cxx_flags for .cu files so that -Wunreachable-code-break and -Wunreachable-code-return would not be sent to GCC which doesn't understand them.
By default, nvcc uses gcc as the preprocessor even when Clang is used for .c/.cpp.

This should fix the CUDA build with clang 14 (when gcc is used with nvcc). With more complex configuration, it probably would be possible to use clang itself (instead of nvcc) to compile CUDA code or use clang as the preprocessor for nvcc. But these are probably to be quite rare use cases. It seems that Clang 16 would require even more changes.