### PR TITLE
speculative: support `--color`

### DIFF
--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -203,8 +203,8 @@ int main(int argc, char ** argv) {
 
             const std::string token_str = llama_token_to_piece(ctx_tgt, id);
 
-            printf("%s", token_str.c_str());
-            fflush(stdout);
+            if (!params.use_color)
+                printf("%s", token_str.c_str());
 
             if (id == llama_token_eos(model_tgt)) {
                 has_eos = true;
@@ -236,10 +236,17 @@ int main(int argc, char ** argv) {
                     ++n_past_tgt;
                     ++n_past_dft;
                     ++i_dft;
-
+                    if (params.use_color) {
+                        // Color token according to its origin sequence
+                        printf("\u001b[%dm%s\u001b[37m", (36 - s_keep % 6), token_str.c_str());
+                        fflush(stdout);
+                    }
                     continue;
                 }
             }
+            if (params.use_color)
+                printf("%s", token_str.c_str());
+            fflush(stdout);
 
             LOG("the sampled target token (%d, '%s') did not match, or we ran out of drafted tokens\n", id, token_str.c_str());
 

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -203,8 +203,9 @@ int main(int argc, char ** argv) {
 
             const std::string token_str = llama_token_to_piece(ctx_tgt, id);
 
-            if (!params.use_color)
+            if (!params.use_color) {
                 printf("%s", token_str.c_str());
+            }
 
             if (id == llama_token_eos(model_tgt)) {
                 has_eos = true;
@@ -244,8 +245,9 @@ int main(int argc, char ** argv) {
                     continue;
                 }
             }
-            if (params.use_color)
+            if (params.use_color) {
                 printf("%s", token_str.c_str());
+            }
             fflush(stdout);
 
             LOG("the sampled target token (%d, '%s') did not match, or we ran out of drafted tokens\n", id, token_str.c_str());


### PR DESCRIPTION
This small PR uses terminal colors to distinguish drafted tokens to those generated by the target model. Different draft sequences have different terminal colors associated with them.

Example using this command;
`.\bin\speculative.exe -m .\models\code\deepseek-coder-6.7b-instruct.Q4_0.gguf -md .\models\code\deepseek-coder-1.3b-instruct.Q8_0.gguf -n 4 -c 4096 -n 128 -p "#The transformer architecture\n\n##Abstract" -e -s 1 --draft 32 -pa
 0.67 --temp 0.1 -np 4 -ps 0.2 --color`
 
 On the main branch, the output looks like that:
![main branc: no colorsh](https://github.com/ggerganov/llama.cpp/assets/28208228/573b2cce-9ae5-4320-935d-7a6ab1846991)

 Wheras with this PR, it looks like that:
![this PR: some colors](https://github.com/ggerganov/llama.cpp/assets/28208228/bf3ed960-5aeb-4218-8031-76b64dda05bb)
