### PR TITLE
Json integration into console commands

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -115,9 +115,9 @@ void process_escapes(std::string& input) {
     input.resize(output_idx);
 }
 
-nlohmann::json get_json(std::string& file_name) noexcept {
+nlohmann::json get_json(const char* file_name) noexcept {
     try {
-        printf("Opening a json file %s\n", file_name.c_str());
+        printf("Opening a json file %s\n", file_name);
         std::ifstream jstream(file_name);
         return nlohmann::json::parse(jstream);
     }
@@ -136,8 +136,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
     // only the second argument to reduce reading attempts (plus drag'n'drop)
     if (argc > 1) {
         // console arguments should override json values, so json processing goes first
-        std::string json_name = argv[1];
-        nlohmann::json file_config = get_json(json_name);
+        nlohmann::json file_config = get_json(argv[1]);
         pos = 2; // avoid putting file name into arguments
         if (!file_config.empty()) {
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "llama.h"
+#include "json-util.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -113,85 +114,6 @@ void process_escapes(std::string& input) {
     }
 
     input.resize(output_idx);
-}
-
-nlohmann::json get_json(const char* file_name) noexcept {
-    try {
-        printf("Opening a json file %s\n", file_name);
-        std::ifstream jstream(file_name);
-        return nlohmann::json::parse(jstream);
-    }
-    catch (const std::exception& ex) {
-        fprintf(stderr, "%s\n", ex.what());
-    }
-
-    return {};
-}
-
-// standalone parsing attempt
-std::vector<std::string> args_parse_json_only_string(char* file_name) {
-    std::vector<std::string> arguments_w_json;
-    nlohmann::json file_config = get_json(file_name);
-    if (!file_config.empty()) { // ensures no unnecessary work
-        arguments_w_json.push_back(file_name);
-
-        for (auto& p : file_config.items()) {
-            // only use strings, numbers and booleans for switches
-            if (p.value().is_string() || p.value().is_number() || p.value().is_boolean()) {
-                arguments_w_json.push_back(p.key());
-
-                if (!p.value().is_boolean()) {
-                    std::string param_value;
-                    if (p.value().is_string()) {
-                        param_value = p.value().get<std::string>();
-                    } else if (p.value().is_number()) {
-                        param_value = std::to_string(p.value().get<float>()); // works for int values too
-                    }
-                    arguments_w_json.push_back(param_value);
-                }
-            }
-        }
-    }
-
-    return arguments_w_json;
-}
-
-// this variant seems safer, we can clear args after processing
-bool gpt_params_parse_json(char* file_name, gpt_params & params) {
-    bool result = true;
-    std::vector<std::string> arguments = args_parse_json_only_string(file_name);
-
-    if (!arguments.empty()) { // ensures no unnecessary work
-        int    argc_json = arguments.size();
-        char** args_json = new char*[arguments.size()];
-        for(size_t i = 0; i < arguments.size(); i++) {
-            args_json[i] = new char[arguments[i].size() + 1];
-            strcpy(args_json[i], arguments[i].c_str());
-        }
-
-        try {
-            if (!gpt_params_parse_ex(argc_json, args_json, params)) {
-                gpt_print_usage(argc_json, args_json, gpt_params());
-                exit(0);
-            }
-            for (size_t i = 0; i < arguments.size(); i++) {
-                delete [] args_json[i];
-            }
-            delete [] args_json;
-        }
-        catch (const std::invalid_argument & ex) {
-            fprintf(stderr, "%s\n", ex.what());
-            gpt_print_usage(argc_json, args_json, gpt_params());
-            exit(1);
-        }
-    } else {
-        // let's also print help, pointing at a faulty file name/parameter
-        char** args = new char* {file_name};
-        gpt_print_usage(1, args, gpt_params());
-        exit(1);
-    }
-
-    return result;
 }
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
@@ -836,8 +758,14 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
         // End of Parse args for logging parameters
 #endif // LOG_DISABLE_LOGS
         } else {
-            if (!gpt_params_parse_json(argv[i], params)) { // attempt to read as a file
-                invalid_param = true;
+            args_struct args_obj(argv[i]);
+
+            if (args_obj.argc > 0) {
+                int    argc_json = args_obj.argc;
+                char** args_json = args_obj.argv;
+
+                return gpt_params_parse(argc_json, args_json, params);
+            } else {
                 throw std::invalid_argument("error: unknown argument: " + arg);
             }
         }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -146,9 +146,9 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                     char* key = new char[p.key().length() + 1];
                     strcpy(key, p.key().c_str());
                     arguments_w_json.push_back(key);
-                    std::string param_value;
 
                     if (!p.value().is_boolean()) {
+                        std::string param_value;
                         if (p.value().is_string()) {
                             param_value = p.value().get<std::string>();
                         } else if (p.value().is_number()) {
@@ -181,6 +181,10 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         fprintf(stderr, "%s\n", ex.what());
         gpt_print_usage(argc_json, argv_json, gpt_params());
         exit(1);
+    }
+    // clearing pointers
+    for (auto c : arguments_w_json) {
+        delete [] c;
     }
 
     return result;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -128,63 +128,147 @@ nlohmann::json get_json(const char* file_name) noexcept {
     return {};
 }
 
-bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
-    bool result = true;
+std::vector<char*> args_parse_json_only(char* file_name) {
     std::vector<char*> arguments_w_json;
-    arguments_w_json.push_back(argv[0]);
-    int pos = 1;
-    // only the second argument to reduce reading attempts (plus drag'n'drop)
-    if (argc > 1) {
-        // console arguments should override json values, so json processing goes first
-        nlohmann::json file_config = get_json(argv[1]);
-        pos = 2; // avoid putting file name into arguments
-        if (!file_config.empty()) {
+    nlohmann::json file_config = get_json(file_name);
+    if (!file_config.empty()) { // ensures no unnecessary work
+        arguments_w_json.push_back(file_name);
 
-            for (auto& p : file_config.items()) {
-                // only use strings, numbers and booleans for switches
-                if (p.value().is_string() || p.value().is_number() || p.value().is_boolean()) {
-                    char* key = new char[p.key().length() + 1];
-                    strcpy(key, p.key().c_str());
-                    arguments_w_json.push_back(key);
+        for (auto& p : file_config.items()) {
+            // only use strings, numbers and booleans for switches
+            if (p.value().is_string() || p.value().is_number() || p.value().is_boolean()) {
+                char* key = new char[p.key().length() + 1];
+                strcpy(key, p.key().c_str());
+                arguments_w_json.push_back(key);
 
-                    if (!p.value().is_boolean()) {
-                        std::string param_value;
-                        if (p.value().is_string()) {
-                            param_value = p.value().get<std::string>();
-                        } else if (p.value().is_number()) {
-                            param_value = std::to_string(p.value().get<float>()); // nlohmann::json can't just get numbers as strings, float works fine for int values
-                        }
-
-                        char* val = new char[param_value.length() + 1];
-                        strcpy(val, param_value.c_str());
-                        arguments_w_json.push_back(val);
+                if (!p.value().is_boolean()) {
+                    std::string param_value;
+                    if (p.value().is_string()) {
+                        param_value = p.value().get<std::string>();
+                    } else if (p.value().is_number()) {
+                        param_value = std::to_string(p.value().get<float>()); // nlohmann::json can't just get numbers as strings, float works fine for int values
                     }
+                    char* val = new char[param_value.length() + 1];
+                    strcpy(val, param_value.c_str());
+                    arguments_w_json.push_back(val);
                 }
             }
         }
+    }
+    
+    return arguments_w_json;
+}
 
-        for (int i = pos; i < argc; i++) {
-            arguments_w_json.push_back(argv[i]);
+std::vector<std::string> args_parse_json_only_string(char* file_name) {
+    std::vector<std::string> arguments_w_json;
+    nlohmann::json file_config = get_json(file_name);
+    if (!file_config.empty()) { // ensures no unnecessary work
+        arguments_w_json.push_back(file_name);
+
+        for (auto& p : file_config.items()) {
+            // only use strings, numbers and booleans for switches
+            if (p.value().is_string() || p.value().is_number() || p.value().is_boolean()) {
+                arguments_w_json.push_back(p.key());
+
+                if (!p.value().is_boolean()) {
+                    std::string param_value;
+                    if (p.value().is_string()) {
+                        param_value = p.value().get<std::string>();
+                    } else if (p.value().is_number()) {
+                        param_value = std::to_string(p.value().get<float>()); // nlohmann::json can't just get numbers as strings, float works fine for int values
+                    }
+                    arguments_w_json.push_back(param_value);
+                }
+            }
         }
     }
+    
+    return arguments_w_json;
+}
 
-    int argc_json    = arguments_w_json.size();
-    char** argv_json = &arguments_w_json[0];
+// standalone parsing attempt
+bool gpt_params_parse_json(char* file_name, gpt_params & params) {
+    bool result = true;
+    //std::vector<const char*> arguments = args_parse_json_only(file_name);
+    std::vector<std::string> arguments = args_parse_json_only_string(file_name);
+
+    if (!arguments.empty()) { // ensures no unnecessary work
+        int    argc_json = arguments.size();
+        //char** args_json = const_cast<char **>(&arguments[0]);
+        char** args_json = new char*[arguments.size()];
+        for(size_t i = 0; i < arguments.size(); i++) {
+            args_json[i] = new char[arguments[i].size() + 1];
+            strcpy(args_json[i], arguments[i].c_str());
+        }
+        
+        try {
+            if (!gpt_params_parse_ex(argc_json, args_json, params)) {
+                gpt_print_usage(argc_json, args_json, gpt_params());
+                exit(0);
+            }
+            for (size_t i = 0; i < arguments.size(); i++) {
+                delete [] args_json[i];
+            }
+            delete [] args_json;
+        }
+        catch (const std::invalid_argument & ex) {
+            fprintf(stderr, "%s\n", ex.what());
+            gpt_print_usage(argc_json, args_json, gpt_params());
+            exit(1);
+        }
+    } else {
+        // let's also print help, pointing at a faulty file name/parameter
+        char** args = new char* {file_name};
+        gpt_print_usage(1, args, gpt_params());
+        exit(1);
+    }
+
+    return result;
+}
+
+// still deciding which one is worse, both leak
+bool gpt_params_parse_json0(char* file_name, gpt_params & params) {
+    bool result = true;
+    std::vector<char*> arguments = args_parse_json_only(file_name);
+
+    if (!arguments.empty()) { // ensures no unnecessary work
+        int    argc_json = arguments.size();
+        char** args_json = &arguments[0];
+        
+        try {
+            if (!gpt_params_parse_ex(argc_json, args_json, params)) {
+                gpt_print_usage(argc_json, args_json, gpt_params());
+                exit(0);
+            }
+        }
+        catch (const std::invalid_argument & ex) {
+            fprintf(stderr, "%s\n", ex.what());
+            gpt_print_usage(argc_json, args_json, gpt_params());
+            exit(1);
+        }
+    } else {
+        // let's also print help, pointing at a faulty file name/parameter
+        char** args = new char* {file_name};
+        gpt_print_usage(1, args, gpt_params());
+        exit(1);
+    }
+
+    return result;
+}
+
+bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
+    bool result = true;
 
     try {
-        if (!gpt_params_parse_ex(argc_json, argv_json, params)) {
-            gpt_print_usage(argc_json, argv_json, gpt_params());
+        if (!gpt_params_parse_ex(argc, argv, params)) {
+            gpt_print_usage(argc, argv, gpt_params());
             exit(0);
         }
     }
     catch (const std::invalid_argument & ex) {
         fprintf(stderr, "%s\n", ex.what());
-        gpt_print_usage(argc_json, argv_json, gpt_params());
+        gpt_print_usage(argc, argv, gpt_params());
         exit(1);
-    }
-    // clearing pointers
-    for (auto c : arguments_w_json) {
-        delete [] c;
     }
 
     return result;
@@ -814,7 +898,10 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
         // End of Parse args for logging parameters
 #endif // LOG_DISABLE_LOGS
         } else {
-            throw std::invalid_argument("error: unknown argument: " + arg);
+            if (!gpt_params_parse_json0(argv[i], params)) { // attempt to read as a file
+                invalid_param = true;
+                throw std::invalid_argument("error: unknown argument: " + arg);
+            }
         }
     }
     if (invalid_param) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -115,25 +115,17 @@ void process_escapes(std::string& input) {
     input.resize(output_idx);
 }
 
-nlohmann::json get_json(std::string file_name) {
-    nlohmann::json config;
-    std::fstream   jstream(file_name);
-    if (jstream.is_open()) {
-        try {
-            config = nlohmann::json::parse(jstream);
-            jstream.close();
-            printf("Opened a json file %s\n", file_name.c_str());
-        }
-        catch (nlohmann::json::parse_error& ex) {
-            jstream.close();
-            fprintf(stderr, "%s\n", ex.what());
-            return config;
-        }
-    } else {
-        printf("%s not found!\n", file_name.c_str());
+nlohmann::json get_json(std::string& file_name) noexcept {
+    try {
+        printf("Opening a json file %s\n", file_name.c_str());
+        std::ifstream jstream(file_name);
+        return nlohmann::json::parse(jstream);
+    }
+    catch (const std::exception& ex) {
+        fprintf(stderr, "%s\n", ex.what());
     }
 
-    return config;
+    return {};
 }
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
@@ -145,7 +137,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
     if (argc > 1) {
         // console arguments should override json values, so json processing goes first
         std::string json_name = argv[1];
-        nlohmann::json file_config = get_json(argv[1]);
+        nlohmann::json file_config = get_json(json_name);
         pos = 2; // avoid putting file name into arguments
         if (!file_config.empty()) {
 

--- a/common/common.h
+++ b/common/common.h
@@ -6,8 +6,6 @@
 
 #include "sampling.h"
 
-#include "examples/server/json.hpp"
-
 #define LOG_NO_FILE_LINE_FUNCTION
 #include "log.h"
 
@@ -135,12 +133,6 @@ struct gpt_params {
     std::string mmproj = ""; // path to multimodal projector
     std::string image  = ""; // path to an image file
 };
-
-nlohmann::json get_json(const char* file_name) noexcept;
-
-std::vector<std::string> args_parse_json_only_string(char* file_name);
-
-bool gpt_params_parse_json(char* file_name, gpt_params & params);
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 

--- a/common/common.h
+++ b/common/common.h
@@ -138,13 +138,9 @@ struct gpt_params {
 
 nlohmann::json get_json(const char* file_name) noexcept;
 
-std::vector<char*> args_parse_json_only(char* file_name);
-
 std::vector<std::string> args_parse_json_only_string(char* file_name);
 
 bool gpt_params_parse_json(char* file_name, gpt_params & params);
-
-bool gpt_params_parse_json0(char* file_name, gpt_params & params);
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 

--- a/common/common.h
+++ b/common/common.h
@@ -138,6 +138,14 @@ struct gpt_params {
 
 nlohmann::json get_json(const char* file_name) noexcept;
 
+std::vector<char*> args_parse_json_only(char* file_name);
+
+std::vector<std::string> args_parse_json_only_string(char* file_name);
+
+bool gpt_params_parse_json(char* file_name, gpt_params & params);
+
+bool gpt_params_parse_json0(char* file_name, gpt_params & params);
+
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);

--- a/common/common.h
+++ b/common/common.h
@@ -133,7 +133,7 @@ struct gpt_params {
     std::string image = ""; // path to an image file
 };
 
-nlohmann::json get_json(std::string file_name);
+nlohmann::json get_json(std::string& file_name) noexcept;
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 

--- a/common/common.h
+++ b/common/common.h
@@ -6,6 +6,8 @@
 
 #include "sampling.h"
 
+#include "examples/server/json.hpp"
+
 #define LOG_NO_FILE_LINE_FUNCTION
 #include "log.h"
 
@@ -130,6 +132,8 @@ struct gpt_params {
     std::string mmproj = ""; // path to multimodal projector
     std::string image = ""; // path to an image file
 };
+
+nlohmann::json get_json(std::string file_name);
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 

--- a/common/common.h
+++ b/common/common.h
@@ -133,7 +133,7 @@ struct gpt_params {
     std::string image = ""; // path to an image file
 };
 
-nlohmann::json get_json(std::string& file_name) noexcept;
+nlohmann::json get_json(const char* file_name) noexcept;
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);
 

--- a/common/json-util.hpp
+++ b/common/json-util.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include "examples/server/json.hpp"
+
+static nlohmann::json get_json(const char* file_name) noexcept {
+    try {
+        printf("Opening a json file %s\n", file_name);
+        std::ifstream jstream(file_name);
+        return nlohmann::json::parse(jstream);
+    }
+    catch (const std::exception& ex) {
+        fprintf(stderr, "%s\n", ex.what());
+    }
+
+    return {};
+}
+
+struct args_struct {
+    size_t argc;
+    char** argv;
+    size_t elements_count     = 0;
+    size_t index              = 0;
+
+    std::vector<char>   arg_chars = {};
+    std::vector<size_t> arg_idxs  = {};
+    std::vector<char*>  arg_ptrs  = {};
+
+    args_struct() = default;
+
+    args_struct(char* file_name) {
+        createParams(file_name);
+    }
+
+    ~args_struct() = default;
+
+    void reset() noexcept {
+        elements_count = 0;
+        index = 0;
+
+        arg_chars.clear();
+        arg_idxs.clear();
+
+        reset_args();
+    }
+
+    void reset_args() noexcept {
+        arg_ptrs.clear();
+        argc = 0;
+        argv = nullptr;
+    }
+
+    void add(const std::string& data) {
+        // resetting previous args
+        reset_args();
+
+        arg_idxs.emplace_back(index);
+        for(const auto& character : data) {
+            arg_chars.emplace_back(character);
+            ++index;
+        }
+
+        arg_chars.emplace_back('\0');
+        ++index;
+        ++elements_count;
+    }
+
+    void get_args() {
+        reset_args();
+        if(elements_count) {
+            arg_ptrs.reserve(elements_count);
+
+            for(const auto& index : arg_idxs) {
+                arg_ptrs.emplace_back(&arg_chars[index]);
+            }
+        } else {
+            arg_ptrs.emplace_back(nullptr);
+        }
+
+        argc = elements_count;
+        argv = &arg_ptrs[0];
+    }
+
+    void createParams(char* file_name) {
+        reset(); // starting over
+        nlohmann::json file_config = get_json(file_name);
+        if (!file_config.empty()) { // ensures no unnecessary work
+            add(file_name);
+            for (auto& p : file_config.items()) {
+                // only use strings, numbers and booleans for switches
+                if (p.value().is_string() || p.value().is_number() || p.value().is_boolean()) {
+                    add(p.key());
+
+                    if (!p.value().is_boolean()) {
+                        std::string param_value;
+                        if (p.value().is_string()) {
+                            param_value = p.value().get<std::string>();
+                        } else if (p.value().is_number()) {
+                            param_value = std::to_string(p.value().get<float>()); // works for int values too
+                        }
+                        add(param_value);
+                    }
+                }
+            }
+            get_args();
+        }
+    }
+};

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2319,9 +2319,11 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
         }
         else
         {
-            fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
-            server_print_usage(argv[0], default_params, default_sparams);
-            exit(1);
+            if (!gpt_params_parse_json(argv[i], params)) { // attempt to read as a file
+                fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
+                server_print_usage(argv[0], default_params, default_sparams);
+                exit(1);
+            }
         }
     }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "llama.h"
 #include "grammar-parser.h"
+#include "json-util.hpp"
 
 #include "../llava/clip.h"
 
@@ -2319,7 +2320,14 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
         }
         else
         {
-            if (!gpt_params_parse_json(argv[i], params)) { // attempt to read as a file
+            args_struct args_obj(argv[i]);
+
+            if (args_obj.argc > 0) {
+                int    argc_json = args_obj.argc;
+                char** args_json = args_obj.argv;
+
+                return server_params_parse(argc_json, args_json, sparams, params, llama);
+            } else {
                 fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
                 server_print_usage(argv[0], default_params, default_sparams);
                 exit(1);


### PR DESCRIPTION
This PR integrates .json files processing into console commands, allowing to read _console parameters_ from json files. Since nlohmann's json is already used by the server example, no extra libraries are added.

The idea of this particular implementation is to read console parameters from a file and then parse the usual way. Also, drag'n'drop should work.

While it's not the most straightforward way (you can just read parameters from .json into gpt_params, for example, like I do in my chat program), this approach doesn't require maintenance in future. There are already quite a lot of console parameters in `common`, recent commits have added even more (like overriding GGUF metadata and custom samplers order), and there are more to come in ongoing PRs. As such, I think it makes sense to integrate this feature in a more flexible way.

Since many example programs use their own versions of console commands parsing, I've rewritten this PR to be more universal in integrating it. However, this leads to application-specific .json files: for example, `server` doesn't accept sampling parameters that can be passed to `main`, and vice versa.