### PR TITLE
[grammar] Revert the replacement of llama_token_to_piece with id_to_token

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -7503,7 +7503,7 @@ void llama_sample_grammar(struct llama_context * ctx, llama_token_data_array * c
 
     for (size_t i = 0; i < candidates->size; ++i) {
         const llama_token id    = candidates->data[i].id;
-        const std::string & piece = ctx->model.vocab.id_to_token[id].text;
+        const std::string piece = llama_token_to_piece(ctx, id);
         if (id == eos) {
             if (!allow_eos) {
                 candidates->data[i].logit = -INFINITY;
@@ -7715,7 +7715,7 @@ void llama_grammar_accept_token(struct llama_context * ctx, struct llama_grammar
         GGML_ASSERT(false);
     }
 
-    const std::string & piece = ctx->model.vocab.id_to_token[token].text;
+    const std::string piece = llama_token_to_piece(ctx, token);
 
     // Note terminating 0 in decoded string
     const auto   decoded     = decode_utf8(piece, grammar->partial_utf8);


### PR DESCRIPTION
The commit 5f6e0c0dff1e7a89331e6b25eca9a9fd71324069 introduced an optimization which replaced `llama_token_to_piece` with `model.vocab.id_to_token[id].text`. This causes problem with models, like CodeLlama, that use the SentencePiece tokenizer because they require `llama_unescape_whitespace` to unescape whitespace.

Reverting the changes in `llama_sample_grammar` and `llama_grammar_accept_token` fixed the issue.

See https://github.com/ggerganov/llama.cpp/issues/4376
