### PR TITLE
Fix: Context state-setting assert fails when `ctx->logits_all` is `false`

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9594,7 +9594,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
         memcpy(&logits_cap,  inp, sizeof(logits_cap));  inp += sizeof(logits_cap);
         memcpy(&logits_size, inp, sizeof(logits_size)); inp += sizeof(logits_size);
 
-        GGML_ASSERT(ctx->logits.capacity() == logits_cap);
+        GGML_ASSERT((!ctx->logits_all) || (ctx->logits.capacity() == logits_cap));
 
         if (logits_size) {
             ctx->logits.resize(logits_size);


### PR DESCRIPTION
If a model context is running with the `logits_all` parameter set to false, then saving and restoring its state via any code path that passes through `llama_set_state_data` will trap at the `GGML_ASSERT` that is tweaked here, because `ctx->logits` will not have been sized to the relevant size at the time (from what I understand, that happens in the lines below).

This PR adds this possibility in the assert logic so that it doesn't trap (however I do hope I have understood what is happening in that code and haven't just "cured a symptom" instead. Happy to close the PR if that's the case :)