### PR TITLE
ifndef guards for LLAMA_LOG macros

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -101,9 +101,17 @@ LLAMA_ATTRIBUTE_FORMAT(2, 3)
 static void llama_log_internal        (ggml_log_level level, const char* format, ...);
 static void llama_log_callback_default(ggml_log_level level, const char * text, void * user_data);
 
+#ifndef LLAMA_LOG_INFO 
 #define LLAMA_LOG_INFO(...)  llama_log_internal(GGML_LOG_LEVEL_INFO , __VA_ARGS__)
+#endif
+
+#ifndef LLAMA_LOG_DEBUG
 #define LLAMA_LOG_WARN(...)  llama_log_internal(GGML_LOG_LEVEL_WARN , __VA_ARGS__)
+#endif
+
+#ifndef LLAMA_LOG_DEBUG
 #define LLAMA_LOG_ERROR(...) llama_log_internal(GGML_LOG_LEVEL_ERROR, __VA_ARGS__)
+#endif
 
 //
 // helpers


### PR DESCRIPTION
This allows the user to redirect the LOG outputs to another function should they choose. I'm wanting to use this in my own application in the near future so it would be helpful if it was included.