### PR TITLE
readme: add -DAMDGPU_TARGETS to linux cmake invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Building the program with BLAS support may lead to some performance improvements
     ```bash
     mkdir build
     cd build
-    CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ cmake .. -DLLAMA_HIPBLAS=ON
+    CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ cmake .. -DAMDGPU_TARGETS=gfx1100 -DLLAMA_HIPBLAS=ON
     cmake --build .
     ```
   - Using `CMake` for Windows (using x64 Native Tools Command Prompt for VS):


### PR DESCRIPTION
Honestly, there's probably a nonzero chance this should've been filed as an issue, but I've already found a fix, so here it is. If I don't add ithe parameter, I get the following cryptic error when trying to load any model (I'm using a 6700XT, which is gfx1031, with HSA_OVERRIDE_GFX_VERSION=10.3.0, on commit 948ff13):
```
CUDA error 98 at /source/llama.cpp/ggml-cuda.cu:7788: invalid device function
current device: 0
GGML_ASSERT: /source/llama.cpp/ggml-cuda.cu:7788: !"CUDA error"
ptrace: Operation not permitted.
No stack.
The program is not being run.
[1]    212127 IOT instruction (core dumped)  ./bin/main -m /mnt4/models/mistral-7b-v0.1.Q5_K_M.gguf -ngl 33 -c 4096 -p
```
When I properly set `-DAMDGPU_TARGETS`, all works fine (removed build dir between every attempt). My cmake invocation matches the one in the readme exactly. 

This does not appear to be needed for Makefile builds, as that uses `hipcc` which appears to call `rocm_agent_enumerator` to autodetect what GPUs the system has (seems to be unfazed by `HSA_OVERRIDE_GFX_VERSION` so maybe it might need to be overridden in some case? idk) the system has if the `HCC_AMDGPU_TARGET` env var isn't set, or `--offload-arch` isn't passed to it.