### PR TITLE
Add protobuf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.24.4
 sentencepiece==0.1.98
 transformers>=4.34.0
 gguf>=0.1.0
+protobuf>=4.21.0


### PR DESCRIPTION
Issue:  https://github.com/ggerganov/llama.cpp/pull/3633#issuecomment-1855404348
https://github.com/ggml-org/ci/blob/results/llama.cpp/87/3637afc7924f435ac44c067630a28e82eefa7b/ggml-3-arm64-cpu/stdall

After merge https://github.com/ggerganov/llama.cpp/pull/3633, ggml CI is now failing with the protobuf import error.
So i add a protobuf dependency.