### PR TITLE
build : Check the ROCm installation location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ ifdef LLAMA_HIPBLAS
 
 	ifeq ($(wildcard /opt/rocm),)
 		ROCM_PATH	?= /usr
-		GPU_TARGETS ?= $(shell which amdgpu-arch)
+		GPU_TARGETS ?= $(shell $(shell which amdgpu-arch))
 	else
 		ROCM_PATH	?= /opt/rocm
 		GPU_TARGETS ?= $(shell $(ROCM_PATH)/llvm/bin/amdgpu-arch)

--- a/Makefile
+++ b/Makefile
@@ -439,9 +439,17 @@ ggml-opencl.o: ggml-opencl.cpp ggml-opencl.h
 endif # LLAMA_CLBLAST
 
 ifdef LLAMA_HIPBLAS
-	ROCM_PATH	?= /opt/rocm
-	HIPCC	    ?= $(ROCM_PATH)/bin/hipcc
-	GPU_TARGETS ?= $(shell $(ROCM_PATH)/llvm/bin/amdgpu-arch)
+
+	ifeq ($(wildcard /opt/rocm),)
+		ROCM_PATH	?= /usr
+		HIPCC	    ?= $(ROCM_PATH)/bin/hipcc
+		GPU_TARGETS ?= $(shell $(ROCM_PATH)/bin/amdgpu-arch)
+	else
+		ROCM_PATH	?= /opt/rocm
+		HIPCC	    ?= $(ROCM_PATH)/bin/hipcc
+		GPU_TARGETS ?= $(shell $(ROCM_PATH)/llvm/bin/amdgpu-arch)
+	endif
+	
 	LLAMA_CUDA_DMMV_X       ?= 32
 	LLAMA_CUDA_MMV_Y        ?= 1
 	LLAMA_CUDA_KQUANTS_ITER ?= 2

--- a/Makefile
+++ b/Makefile
@@ -442,14 +442,13 @@ ifdef LLAMA_HIPBLAS
 
 	ifeq ($(wildcard /opt/rocm),)
 		ROCM_PATH	?= /usr
-		HIPCC	    ?= $(ROCM_PATH)/bin/hipcc
-		GPU_TARGETS ?= $(shell $(ROCM_PATH)/bin/amdgpu-arch)
+		GPU_TARGETS ?= $(shell which amdgpu-arch)
 	else
 		ROCM_PATH	?= /opt/rocm
-		HIPCC	    ?= $(ROCM_PATH)/bin/hipcc
 		GPU_TARGETS ?= $(shell $(ROCM_PATH)/llvm/bin/amdgpu-arch)
 	endif
 	
+	HIPCC	    			?= $(ROCM_PATH)/bin/hipcc
 	LLAMA_CUDA_DMMV_X       ?= 32
 	LLAMA_CUDA_MMV_Y        ?= 1
 	LLAMA_CUDA_KQUANTS_ITER ?= 2

--- a/Makefile
+++ b/Makefile
@@ -447,8 +447,7 @@ ifdef LLAMA_HIPBLAS
 		ROCM_PATH	?= /opt/rocm
 		GPU_TARGETS ?= $(shell $(ROCM_PATH)/llvm/bin/amdgpu-arch)
 	endif
-	
-	HIPCC	    			?= $(ROCM_PATH)/bin/hipcc
+	HIPCC                   ?= $(ROCM_PATH)/bin/hipcc
 	LLAMA_CUDA_DMMV_X       ?= 32
 	LLAMA_CUDA_MMV_Y        ?= 1
 	LLAMA_CUDA_KQUANTS_ITER ?= 2


### PR DESCRIPTION
Fedora's ROCm installation does not follow the ROCm standard (/opt/rocm), it is installed directly in the /usr directory.
To build with HIPBLAS on Fedora, the following steps are currently required:
`dnf install fedora-repos-rawhide` (Fedora 39 does not provide the rocblas package);
`dnf install clang-tools-extra` (Package that provides the amdgpu-arch command);
`dnf install rocm-hip-devel hip-devel hipblas-devel rocblas-devel --enablerepo rawhide` (Packages required for compilation)