### PR TITLE
gguf-py : fail fast on nonsensical special token IDs

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -109,8 +109,10 @@ class SpecialVocab:
         return True
 
     def _set_special_token(self, typ: str, tid: Any) -> None:
-        if not isinstance(tid, int) or tid < 0:
+        if not isinstance(tid, int):
             return
+        if tid < 0:
+            raise ValueError(f'invalid value for special token type {typ}: {tid}')
         if self.n_vocab is None or tid < self.n_vocab:
             if typ in self.special_token_ids:
                 return


### PR DESCRIPTION
Reject the special token ID of '-1' early so the user doesn't get as far as converting, quantizing, and running the models only to discover that the token IDs are completely messed up.

ref https://github.com/ggerganov/llama.cpp/issues/2981#issuecomment-1758638450