### PR TITLE
Fix bug in server.cpp for grammar.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2413,7 +2413,7 @@ json oaicompat_completion_params_parse(
     llama_params["ignore_eos"]        = json_value(body, "ignore_eos", false);
     llama_params["tfs_z"]             = json_value(body, "tfs_z", 0.0);
 
-    if (llama_params.count("grammar") != 0) {
+    if (body.count("grammar") != 0) {
         llama_params["grammar"] = json_value(body, "grammar", json::object());
     }
 


### PR DESCRIPTION
- Fix bug in identifying the grammar.
- Looks like it's wrong and checking the `llama_params` which is what we are generating. 
- Instead we should fix if the grammar is present in the incoming `body`.

cc : @ggerganov 