### PR TITLE
Server: allow requests larger than 8K

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -10,7 +10,8 @@
 // crash the server in debug mode, otherwise send an http 500 error
 #define CPPHTTPLIB_NO_EXCEPTIONS 1
 #endif
-
+// increase max payload length to allow use of larger context size
+#define CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH 1048576
 #include "httplib.h"
 #include "json.hpp"
 


### PR DESCRIPTION
Currently `server` responds with `HTTP 413: Payload too large` for completion requests larger than 8K. This PR sets the max request length to 1M, which allows use of larger context sizes.