### PR TITLE
Link to cublas dynamically on Windows even with LLAMA_STATIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,12 @@ if (LLAMA_CUBLAS)
         add_compile_definitions(GGML_CUDA_PEER_MAX_BATCH_SIZE=${LLAMA_CUDA_PEER_MAX_BATCH_SIZE})
 
         if (LLAMA_STATIC)
-            set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static)
+            if (WIN32)
+                # As of 12.3.1 CUDA Tookit for Windows does not offer a static cublas library
+                set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart_static CUDA::cublas CUDA::cublasLt)
+            else ()
+                set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static)
+            endif()
         else()
             set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart CUDA::cublas CUDA::cublasLt)
         endif()


### PR DESCRIPTION
CUDA Toolkit for Windows does not have a static cublas library.
This makes LLAMA_STATIC "as static as possible".

The benefit is that the result executable would not depend on the dynamic CRT (e.g: `api-ms-win-crt-runtime-l1-1-0.dll` and friends) and becomes easier to redistribute.

With this, my executable only depends on:

* cublas64_12.dll: Dynamic cublas library
* kernel32.dll: As with every windows executable.