### PR TITLE
Fix try_override for bool_value which always return true ignoring ove…

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1937,7 +1937,7 @@ namespace GGUFMeta {
                 target = override->bool_value;
                 return true;
             }
-            return true;
+            return false;
         }
 
         template<typename OT>


### PR DESCRIPTION
`try_override` used to return true no matter whether `override` is valid or not.