### PR TITLE
ROCm: Fix HIP build by adding missing defines

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -31,6 +31,7 @@
 #define CUDA_R_16F  HIPBLAS_R_16F
 #define CUDA_R_32F  HIPBLAS_R_32F
 #define __shfl_xor_sync(mask, var, laneMask, width) __shfl_xor(var, laneMask, width)
+#define cublasComputeType_t hipblasDatatype_t //deprecated, new hipblasComputeType_t not in 5.6
 #define cublasCreate hipblasCreate
 #define cublasGemmEx hipblasGemmEx
 #define cublasGemmBatchedEx hipblasGemmBatchedEx
@@ -40,6 +41,7 @@
 #define cublasSetStream hipblasSetStream
 #define cublasSgemm hipblasSgemm
 #define cublasStatus_t hipblasStatus_t
+#define cudaDataType_t hipblasDatatype_t //deprecated, new hipblasDatatype not in 5.6
 #define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
 #define cudaDeviceDisablePeerAccess hipDeviceDisablePeerAccess
 #define cudaDeviceEnablePeerAccess hipDeviceEnablePeerAccess


### PR DESCRIPTION
This was a regression of b9e74f9bca5fdf7d0a22ed25e7a9626335fdfa48.

Fixes #4525

This currently uses the deprecated defines on purpose as 5.6 is still widely used and the newer defines are thus not supported there. I added a comment with the newer datatype that should be used after. 

I tested inference on both an older gguf model and a Phi-2 with ROCm 5.6 on gfx1030 and it seemed to work fine.