### PR TITLE
allowed getting n_batch from llama_context in c api

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9536,7 +9536,7 @@ int llama_n_ctx(const struct llama_context * ctx) {
     return ctx->cparams.n_ctx;
 }
 
-int llama_n_batch(const struct llama_context * ctx) {
+uint32_t llama_n_batch(const struct llama_context * ctx) {
     return ctx->cparams.n_batch;
 }
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -9536,6 +9536,10 @@ int llama_n_ctx(const struct llama_context * ctx) {
     return ctx->cparams.n_ctx;
 }
 
+int llama_n_batch(const struct llama_context * ctx) {
+    return ctx->cparams.n_batch;
+}
+
 enum llama_vocab_type llama_vocab_type(const struct llama_model * model) {
     return model->vocab.type;
 }

--- a/llama.cpp
+++ b/llama.cpp
@@ -9532,7 +9532,7 @@ const llama_model * llama_get_model(const struct llama_context * ctx) {
     return &ctx->model;
 }
 
-int llama_n_ctx(const struct llama_context * ctx) {
+uint32_t llama_n_ctx(const struct llama_context * ctx) {
     return ctx->cparams.n_ctx;
 }
 

--- a/llama.h
+++ b/llama.h
@@ -315,6 +315,7 @@ extern "C" {
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 
     LLAMA_API int llama_n_ctx      (const struct llama_context * ctx);
+    LLAMA_API int llama_n_batch    (const struct llama_context * ctx);
 
     LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_model * model);
 

--- a/llama.h
+++ b/llama.h
@@ -315,7 +315,7 @@ extern "C" {
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 
     LLAMA_API int llama_n_ctx      (const struct llama_context * ctx);
-    LLAMA_API int llama_n_batch    (const struct llama_context * ctx);
+    LLAMA_API uint32_t llama_n_batch    (const struct llama_context * ctx);
 
     LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_model * model);
 

--- a/llama.h
+++ b/llama.h
@@ -314,6 +314,7 @@ extern "C" {
 
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 
+    // TODO: become more consistent with returned int types across the API
     LLAMA_API uint32_t llama_n_ctx      (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_batch    (const struct llama_context * ctx);
 

--- a/llama.h
+++ b/llama.h
@@ -314,7 +314,7 @@ extern "C" {
 
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 
-    LLAMA_API int llama_n_ctx      (const struct llama_context * ctx);
+    LLAMA_API uint32_t llama_n_ctx      (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_batch    (const struct llama_context * ctx);
 
     LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_model * model);


### PR DESCRIPTION
In order to correctly implement prompt processing where `n_prompt_tokens > n_batch` I have to chop up the prompt in to slices smaller than `n_batch`. Thus I need access to `n_batch`.

Added:
```c
LLAMA_API int llama_n_batch(const struct llama_context * ctx);
```

I could go without this API and pass around `n_batch` from `llama_context_params` throughout my code, but as a similar `n_ctx` function already exists, this felt like a fair addition.