### PR TITLE
CUDA : Make the error message easier to understand

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6825,7 +6825,7 @@ static void ggml_cuda_op_get_rows(
             break;
         default:
             // TODO: k-quants
-            fprintf(stderr, "ERROR: Unsupported CUDA Data Type:%s\n", ggml_type_name(src0->type));
+            fprintf(stderr, "%s: unsupported type: %s\n", __func__, ggml_type_name(src0->type));
             GGML_ASSERT(false);
             break;
     }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6825,7 +6825,7 @@ static void ggml_cuda_op_get_rows(
             break;
         default:
             // TODO: k-quants
-            GGML_ASSERT(false);
+            GGML_ASSERT(false && "Unsupported CUDA Quantization Mode");
             break;
     }
 }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6825,7 +6825,8 @@ static void ggml_cuda_op_get_rows(
             break;
         default:
             // TODO: k-quants
-            GGML_ASSERT(false && "Unsupported CUDA Quantization Mode");
+            fprintf(stderr, "ERROR: Unsupported CUDA Data Type:%s\n", ggml_type_name(src0->type));
+            GGML_ASSERT(false);
             break;
     }
 }


### PR DESCRIPTION
Although this issue mainly occurs in whisper.cpp, the development of `ggml` primarily take place in llama.cpp. If this PR is merged, it will subsequently be synchronized to whisper.cpp

**Before:**
```
GGML_ASSERT: C:\Users\qianp\Downloads\whisper.cpp-master\ggml-cuda.cu:6828: false
```

**After:**
```
ERROR: Unsupported CUDA Data Type:q2_K
GGML_ASSERT: C:\Users\qianp\Downloads\whisper.cpp-master\ggml-cuda.cu:6829: false
```