### PR TITLE
Disabled per-tensor info prints on model load

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -2083,7 +2083,7 @@ struct llama_model_loader {
                     type_max   = meta->type;
                 }
 
-                LLAMA_LOG_INFO("%s: - tensor %4d: %32s %-8s [ %s ]\n", __func__, i, name, ggml_type_name(meta->type), llama_format_tensor_shape(meta).c_str());
+                // LLAMA_LOG_INFO("%s: - tensor %4d: %32s %-8s [ %s ]\n", __func__, i, name, ggml_type_name(meta->type), llama_format_tensor_shape(meta).c_str());
             }
 
             switch (type_max) {


### PR DESCRIPTION
Currently llama.cpp prints the name, type, and shape of every single tensor upon model load. I find this very annoying because it can spam your console with ~1000 lines of text per debug run. Quite frankly I believe that the value of this information is not enough to justify the inconvenience. This PR simply removes the print in question. This is a very unsophisticated solution but I'm not familiar with the logging code and don't know how I would make it so that the prints only appear in the log file but not on console.