### PR TITLE
ggml-cuda: Fix HIP build by adding define for __trap

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -80,6 +80,7 @@
 #define cudaStreamWaitEvent(stream, event, flags) hipStreamWaitEvent(stream, event, flags)
 #define cudaStream_t hipStream_t
 #define cudaSuccess hipSuccess
+#define __trap abort
 #else
 #include <cuda_runtime.h>
 #include <cublas_v2.h>


### PR DESCRIPTION
Regression of 139882392258671ffe5acdfcadc0bc08572d6eef (PR: #4556) HIP doesn't have trap, only abort. No idea if this is the right define, hipify didn't have anything and just said unsupported and I only found this by digging through old issues in the HIP repository where it was referenced together with cuda's trap.

Because of the __trap you currently can't compile for HIP. Not tested since unsure how to even trigger.