### PR TITLE
ggml : extend `enum ggml_log_level` with new `GGML_LOG_LEVEL_DEBUG` value

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -484,7 +484,8 @@ extern "C" {
     enum ggml_log_level {
         GGML_LOG_LEVEL_ERROR = 2,
         GGML_LOG_LEVEL_WARN = 3,
-        GGML_LOG_LEVEL_INFO = 4
+        GGML_LOG_LEVEL_INFO = 4,
+        GGML_LOG_LEVEL_DEBUG = 5
     };
 
     // ggml object


### PR DESCRIPTION
To improve consistency, we need to extend the `enum ggml_log_level` by introducing a new value, `GGML_LOG_LEVEL_DEBUG`, which will enable us to implement `WHISPER_LOG_DEBUG`. 

If this PR is merged, it will subsequently be synchronized to whisper.cpp

See https://github.com/ggerganov/whisper.cpp/pull/1658#discussion_r1434508600