### PR TITLE
CUDA: fixed row rounding for 0 tensor splits

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -7929,12 +7929,16 @@ static void ggml_cuda_op_mul_mat(
 
             if (id != 0) {
                 row_low[id]  = ne01*g_tensor_split[id];
-                row_low[id] -= row_low[id] % rounding;
+                if (row_low[id] < ne01) {
+                    row_low[id] -= row_low[id] % rounding;
+                }
             }
 
             if (id != g_device_count - 1) {
                 row_high[id]  = ne01*g_tensor_split[id + 1];
-                row_high[id] -= row_high[id] % rounding;
+                if (row_high[id] < ne01) {
+                    row_high[id] -= row_high[id] % rounding;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/4229 . @cebtenzzre please check whether it works.

From what I can tell the problem is that the row rounding logic was slightly wrong. It implicitly assumed that all GPUs would get a nonzero slice of the tensor but did not consider that there are models which add a few extra rows for the output tensor. This can then cause the last GPU to receive some rows even if its tensor slice is set to 0.