### PR TITLE
missing #include for strcasecmp

### DIFF
--- a/examples/server/httplib.h
+++ b/examples/server/httplib.h
@@ -192,6 +192,11 @@ using socket_t = SOCKET;
 #include <sys/un.h>
 #include <unistd.h>
 
+#if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
+#include <strings.h>
+#endif
+
+
 using socket_t = int;
 #ifndef INVALID_SOCKET
 #define INVALID_SOCKET (-1)


### PR DESCRIPTION
Posix specifications say you need strings.h to use strcasecmp

- it happens to work on most Linux systems without it, but that's basically just a compiler include bug (i think?)
- Cygwin gcc actually requires strings.h, compiling on Cygwin is how I noticed strings.h was missing