### PR TITLE
Allow compiling on Cygwin g++

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -1044,7 +1044,7 @@ struct llama_mlock {
         }
     }
 
-#ifdef _POSIX_MEMLOCK_RANGE
+#if defined(_POSIX_MEMLOCK_RANGE) && defined(RLIMIT_MEMLOCK)
     static constexpr bool SUPPORTED = true;
 
     static size_t lock_granularity() {


### PR DESCRIPTION
This patch allows compiling on Cygwin.

Cygwin has partial support for RLIMIT, for example RLIMIT_STACK is supported, but RLIMIT_MEMLOCK is not :( (see https://cygwin.com/git/?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/resource.cc;hb=HEAD for details)