### PR TITLE
Fix CudaMemcpy direction

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -8843,7 +8843,7 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
         const cudaMemcpyKind src1_kind = src1->backend == GGML_BACKEND_CPU ?
             cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice;
         const cudaMemcpyKind dst_kind  =  dst->backend == GGML_BACKEND_CPU ?
-            cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice;
+            cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice;
 
         for (int32_t row_id = 0; row_id < n_as; ++row_id) {
             const struct ggml_tensor * src0_row = dst->src[row_id + 2];


### PR DESCRIPTION
On master Mixtral 8x7B crashes with CUDA error 1 when prompt is long enough and CPU offloading is used. It works with this small change.

```bash
./main -m mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf -ngl 1 -c 16384 -f summary.txt -b 512

CUDA error 1 at ggml-cuda.cu:8892: invalid argument
current device: 0
GGML_ASSERT: ggml-cuda.cu:8892: !"CUDA error"

Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007f8f8eaea42f in __GI___wait4 (pid=983058, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30	../sysdeps/unix/sysv/linux/wait4.c: No such file or directory.
#0  0x00007f8f8eaea42f in __GI___wait4 (pid=983058, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30	in ../sysdeps/unix/sysv/linux/wait4.c

#1  0x000055c8ef06dadb in ggml_print_backtrace ()
#2  0x000055c8ef144a8b in ggml_cuda_mul_mat_id(ggml_tensor const*, ggml_tensor const*, ggml_tensor*) ()
#3  0x000055c8ef14670c in ggml_cuda_compute_forward ()
#4  0x000055c8ef0994ff in ggml_graph_compute_thread ()
#5  0x000055c8ef09d36d in ggml_graph_compute ()
#6  0x000055c8ef15d74e in ggml_backend_cpu_graph_compute ()
#7  0x000055c8ef15e31b in ggml_backend_graph_compute ()
#8  0x000055c8ef0c6e35 in llama_decode_internal(llama_context&, llama_batch) ()
#9  0x000055c8ef0c78d3 in llama_decode ()
#10 0x000055c8ef06173e in main ()
[Inferior 1 (process 982918) detached]
Aborted (core dumped)
```

Should be the same bug as https://github.com/ggerganov/llama.cpp/issues/4563#issuecomment-1867176932