### PR TITLE
CUDA: fixed peer access toggle synchronization

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -8,6 +8,7 @@
 #include <limits>
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <vector>
 
 
@@ -7999,6 +8000,9 @@ static void ggml_cuda_set_peer_access(const int n_tokens) {
             }
         }
     }
+
+    usleep(100000); // 0.1 s
+
 #endif // NDEBUG
 
     peer_access_enabled = enable_peer_access;


### PR DESCRIPTION
While investigating https://github.com/ggerganov/llama.cpp/pull/4594 I noticed that sometimes the data transfer between GPUs would throw an error but only for specific model sizes and combinations of input parameters. I noticed that the error can be fixed by disabling peer access.

The specific commands that are causing the error in my case:

```
export model_name=llama_2-13b && export quantization=q4_0
./perplexity --n-gpu-layers 99 --model models/opt/${model_name}-${quantization}.gguf --file wikitext-2-raw/wiki.test.raw --mlock --chunks 10
```

What I think is happening: when peer access is enabled or disabled the change is not instant nor does the CPU code wait for the change to take effect. If the change takes effect during a data transfer this causes an error. Adding `usleep(100000)` to wait 0.1 seconds after changing peer access fixes the error.  Adding `cudaDeviceSynchronize` does **not**. In my specific case peer access gets first enabled for the warmup eval with a batch size of 2 and then disabled again for the perplexity eval with a batch size of 512.

Feedback or ideas for better solutions would be very welcome.