### PR TITLE
flake.nix: rewrite

### DIFF
--- a/.devops/nix/apps.nix
+++ b/.devops/nix/apps.nix
@@ -1,0 +1,14 @@
+{ package, binaries }:
+
+let
+  default = builtins.elemAt binaries 0;
+  mkApp = name: {
+    ${name} = {
+      type = "app";
+      program = "${package}/bin/${name}";
+    };
+  };
+  result = builtins.foldl' (acc: name: (mkApp name) // acc) { } binaries;
+in
+
+result // { default = result.${default}; }

--- a/.devops/nix/apps.nix
+++ b/.devops/nix/apps.nix
@@ -1,14 +1,22 @@
-{ package, binaries }:
-
-let
-  default = builtins.elemAt binaries 0;
-  mkApp = name: {
-    ${name} = {
-      type = "app";
-      program = "${package}/bin/${name}";
+{
+  perSystem =
+    { config, lib, ... }:
+    {
+      apps =
+        let
+          inherit (config.packages) default;
+          binaries = [
+            "llama"
+            "llama-embedding"
+            "llama-server"
+            "quantize"
+            "train-text-from-scratch"
+          ];
+          mkApp = name: {
+            type = "app";
+            program = "${default}/bin/${name}";
+          };
+        in
+        lib.genAttrs binaries mkApp;
     };
-  };
-  result = builtins.foldl' (acc: name: (mkApp name) // acc) { } binaries;
-in
-
-result // { default = result.${default}; }
+}

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -1,8 +1,13 @@
-{ concatMapAttrs, packages }:
-
-concatMapAttrs
-  (name: package: {
-    ${name} = package.passthru.shell;
-    ${name + "-extra"} = package.passthru.shell-extra;
-  })
-  packages
+{
+  perSystem =
+    { config, lib, ... }:
+    {
+      devShells =
+        lib.concatMapAttrs
+          (name: package: {
+            ${name} = package.passthru.shell;
+            ${name + "-extra"} = package.passthru.shell-extra;
+          })
+          config.packages;
+    };
+}

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -1,0 +1,10 @@
+{ concatMapAttrs, packages }:
+
+concatMapAttrs
+  (name: package: {
+    ${name} = package.passthru.shell.overrideAttrs (prevAttrs: { inputsFrom = [ package ]; });
+    ${name + "-extra"} = package.passthru.shell-extra.overrideAttrs (
+      prevAttrs: { inputsFrom = [ package ]; }
+    );
+  })
+  packages

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -2,9 +2,7 @@
 
 concatMapAttrs
   (name: package: {
-    ${name} = package.passthru.shell.overrideAttrs (prevAttrs: { inputsFrom = [ package ]; });
-    ${name + "-extra"} = package.passthru.shell-extra.overrideAttrs (
-      prevAttrs: { inputsFrom = [ package ]; }
-    );
+    ${name} = package.passthru.shell;
+    ${name + "-extra"} = package.passthru.shell-extra;
   })
   packages

--- a/.devops/nix/jetson-support.nix
+++ b/.devops/nix/jetson-support.nix
@@ -1,0 +1,32 @@
+{ inputs, ... }:
+{
+  perSystem =
+    {
+      config,
+      system,
+      lib,
+      pkgsCuda,
+      ...
+    }:
+    lib.optionalAttrs (system == "aarch64-linux") {
+      packages =
+        let
+          caps.jetson-xavier = "7.2";
+          caps.jetson-orin = "8.7";
+          caps.jetson-nano = "5.3";
+
+          pkgsFor =
+            cap:
+            import inputs.nixpkgs {
+              inherit system;
+              config = {
+                cudaSupport = true;
+                cudaCapabilities = [ cap ];
+                cudaEnableForwardCompat = false;
+                inherit (pkgsCuda.config) allowUnfreePredicate;
+              };
+            };
+        in
+        builtins.mapAttrs (name: cap: ((pkgsFor cap).callPackage ./scope.nix { }).llama-cpp) caps;
+    };
+}

--- a/.devops/nix/nixpkgs-instances.nix
+++ b/.devops/nix/nixpkgs-instances.nix
@@ -1,0 +1,35 @@
+{ inputs, ... }:
+{
+  # The _module.args definitions are passed on to modules as arguments. E.g.
+  # the module `{ pkgs ... }: { /* config */ }` implicitly uses
+  # `_module.args.pkgs` (defined in this case by flake-parts).
+  perSystem =
+    { system, ... }:
+    {
+      _module.args = {
+        pkgsCuda = import inputs.nixpkgs {
+          inherit system;
+          # Ensure dependencies use CUDA consistently (e.g. that openmpi, ucc,
+          # and ucx are built with CUDA support)
+          config.cudaSupport = true;
+          config.allowUnfreePredicate =
+            p:
+            builtins.all
+              (
+                license:
+                license.free
+                || builtins.elem license.shortName [
+                  "CUDA EULA"
+                  "cuDNN EULA"
+                ]
+              )
+              (p.meta.licenses or [ p.meta.license ]);
+        };
+        # Ensure dependencies use ROCm consistently
+        pkgsRocm = import inputs.nixpkgs {
+          inherit system;
+          config.rocmSupport = true;
+        };
+      };
+    };
+}

--- a/.devops/nix/overlay.nix
+++ b/.devops/nix/overlay.nix
@@ -1,17 +1,5 @@
 final: prev:
 
-let
-  inherit (final.stdenv) isAarch64 isDarwin;
-
-  darwinSpecific =
-    if isAarch64 then
-      { inherit (final.darwin.apple_sdk_11_0.frameworks) Accelerate MetalKit; }
-    else
-      { inherit (final.darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo; };
-
-  osSpecific = if isDarwin then darwinSpecific else { };
-in
-
 {
-  llama-cpp = final.callPackage ./package.nix osSpecific;
+  llama-cpp = final.callPackage ./package.nix { };
 }

--- a/.devops/nix/overlay.nix
+++ b/.devops/nix/overlay.nix
@@ -1,0 +1,17 @@
+final: prev:
+
+let
+  inherit (final.stdenv) isAarch64 isDarwin;
+
+  darwinSpecific =
+    if isAarch64 then
+      { inherit (final.darwin.apple_sdk_11_0.frameworks) Accelerate MetalKit; }
+    else
+      { inherit (final.darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo; };
+
+  osSpecific = if isDarwin then darwinSpecific else { };
+in
+
+{
+  llama-cpp = final.callPackage ./package.nix osSpecific;
+}

--- a/.devops/nix/overlay.nix
+++ b/.devops/nix/overlay.nix
@@ -1,5 +1,0 @@
-final: prev:
-
-{
-  llama-cpp = final.callPackage ./package.nix { };
-}

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -77,12 +77,12 @@ let
   # separately
   darwinBuildInputs =
     with darwin.apple_sdk.frameworks;
-    [ Accelerate ]
-    ++ optionals useMetalKit [ MetalKit ]
-    ++ optionals (!useMetalKit) [
+    [
+      Accelerate
       CoreVideo
       CoreGraphics
-    ];
+    ]
+    ++ optionals useMetalKit [ MetalKit ];
 
   cudaBuildInputs = with cudaPackages; [
     cuda_cccl.dev # <nv/target>

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -97,86 +97,88 @@ let
   ];
 in
 
-effectiveStdenv.mkDerivation (finalAttrs: {
-  name = "llama.cpp";
-  src = ../../.;
-  meta = {
-    description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-    mainProgram = "llama";
-  };
-
-  postPatch = ''
-    substituteInPlace ./ggml-metal.m \
-      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
-
-    # TODO: Package up each Python script or service appropriately.
-    # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
-    # we could make those *.py into setuptools' entrypoints
-    substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
-  '';
-
-  nativeBuildInputs = [
-    cmake
-    ninja
-    pkg-config
-    git
-  ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
-
-  buildInputs =
-    [ mpi ]
-    ++ optionals useOpenCL [ clblast ]
-    ++ optionals useCuda cudaBuildInputs
-    ++ optionals useRocm rocmBuildInputs
-    ++ optionals effectiveStdenv.isDarwin darwinBuildInputs;
-
-  cmakeFlags =
-    [
-      (cmakeBool "LLAMA_NATIVE" true)
-      (cmakeBool "LLAMA_BUILD_SERVER" true)
-      (cmakeBool "BUILD_SHARED_LIBS" true)
-      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
-      (cmakeBool "LLAMA_METAL" useMetalKit)
-      (cmakeBool "LLAMA_BLAS" useBlas)
-    ]
-    ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
-    ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
-    ++ optionals useRocm [
-      (cmakeBool "LLAMA_HIPBLAS" true)
-      (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
-      (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
-
-      # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
-      # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
-      # and select the line that matches the current nixpkgs version of rocBLAS.
-      # Should likely use `rocmPackages.clr.gpuTargets`.
-      "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
-    ]
-    ++ optionals useMetalKit [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1") ]
-    ++ optionals useBlas [ (lib.cmakeFeature "LLAMA_BLAS_VENDOR" "OpenBLAS") ];
-
-  # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
-  # if they haven't been added yet.
-  postInstall = ''
-    mv $out/bin/main $out/bin/llama
-    mv $out/bin/server $out/bin/llama-server
-    mkdir -p $out/include
-    cp $src/llama.h $out/include/
-  '';
-
-  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
-  passthru = {
-    shell = mkShell {
-      name = "default${descriptionSuffix}";
-      description = "contains numpy and sentencepiece";
-      buildInputs = [ llama-python ];
-      inputsFrom = [ finalAttrs.finalPackage ];
+effectiveStdenv.mkDerivation (
+  finalAttrs: {
+    name = "llama.cpp";
+    src = ../../.;
+    meta = {
+      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+      mainProgram = "llama";
     };
 
-    shell-extra = mkShell {
-      name = "extra${descriptionSuffix}";
-      description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
-      buildInputs = [ llama-python-extra ];
-      inputsFrom = [ finalAttrs.finalPackage ];
+    postPatch = ''
+      substituteInPlace ./ggml-metal.m \
+        --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+
+      # TODO: Package up each Python script or service appropriately.
+      # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
+      # we could make those *.py into setuptools' entrypoints
+      substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
+    '';
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+      git
+    ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
+
+    buildInputs =
+      [ mpi ]
+      ++ optionals useOpenCL [ clblast ]
+      ++ optionals useCuda cudaBuildInputs
+      ++ optionals useRocm rocmBuildInputs
+      ++ optionals effectiveStdenv.isDarwin darwinBuildInputs;
+
+    cmakeFlags =
+      [
+        (cmakeBool "LLAMA_NATIVE" true)
+        (cmakeBool "LLAMA_BUILD_SERVER" true)
+        (cmakeBool "BUILD_SHARED_LIBS" true)
+        (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+        (cmakeBool "LLAMA_METAL" useMetalKit)
+        (cmakeBool "LLAMA_BLAS" useBlas)
+      ]
+      ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
+      ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
+      ++ optionals useRocm [
+        (cmakeBool "LLAMA_HIPBLAS" true)
+        (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
+        (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
+
+        # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
+        # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
+        # and select the line that matches the current nixpkgs version of rocBLAS.
+        # Should likely use `rocmPackages.clr.gpuTargets`.
+        "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
+      ]
+      ++ optionals useMetalKit [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1") ]
+      ++ optionals useBlas [ (lib.cmakeFeature "LLAMA_BLAS_VENDOR" "OpenBLAS") ];
+
+    # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
+    # if they haven't been added yet.
+    postInstall = ''
+      mv $out/bin/main $out/bin/llama
+      mv $out/bin/server $out/bin/llama-server
+      mkdir -p $out/include
+      cp $src/llama.h $out/include/
+    '';
+
+    # Define the shells here, but don't add in the inputsFrom to avoid recursion.
+    passthru = {
+      shell = mkShell {
+        name = "default${descriptionSuffix}";
+        description = "contains numpy and sentencepiece";
+        buildInputs = [ llama-python ];
+        inputsFrom = [ finalAttrs.finalPackage ];
+      };
+
+      shell-extra = mkShell {
+        name = "extra${descriptionSuffix}";
+        description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
+        buildInputs = [ llama-python-extra ];
+        inputsFrom = [ finalAttrs.finalPackage ];
+      };
     };
-  };
-})
+  }
+)

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -104,6 +104,16 @@ effectiveStdenv.mkDerivation (
     meta = {
       description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
       mainProgram = "llama";
+
+
+      # These people might respond if you ping them in case of Nix-specific
+      # regressions or for reviewing Nix-specific PRs.
+
+      # Note that lib.maintainers is defined in Nixpkgs.
+      maintainers = with lib.maintainers; [
+          philiptaron
+          SomeoneSerge
+      ];
     };
 
     postPatch = ''

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -89,8 +89,15 @@ let
 
   cudaBuildInputs = with cudaPackages; [
     cuda_cccl.dev # <nv/target>
-    cuda_cudart
-    libcublas
+
+    # A temporary hack for reducing the closure size, remove once cudaPackages
+    # have stopped using lndir: https://github.com/NixOS/nixpkgs/issues/271792
+    cuda_cudart.dev
+    cuda_cudart.lib
+    cuda_cudart.static
+    libcublas.dev
+    libcublas.lib
+    libcublas.static
   ];
 
   rocmBuildInputs = with rocmPackages; [

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -24,6 +24,7 @@
   useMetalKit ? stdenv.isAarch64 && stdenv.isDarwin && !useOpenCL,
   useOpenCL ? false,
   useRocm ? config.rocmSupport,
+  llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
 }@inputs:
 
 let
@@ -31,6 +32,7 @@ let
     cmakeBool
     cmakeFeature
     optionals
+    strings
     versionOlder
     ;
 
@@ -39,18 +41,19 @@ let
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if useCuda then cudaPackages.backendStdenv else inputs.stdenv;
 
-  # Give a little description difference between the flavors.
+  suffices =
+    lib.optionals useOpenCL [ "OpenCL" ]
+    ++ lib.optionals useCuda [ "CUDA" ]
+    ++ lib.optionals useRocm [ "ROCm" ]
+    ++ lib.optionals useMetalKit [ "MetalKit" ]
+    ++ lib.optionals useBlas [ "BLAS" ];
+
+  pnameSuffix =
+    strings.optionalString (suffices != [ ])
+      "-${strings.concatMapStringsSep "-" strings.toLower suffices}";
   descriptionSuffix =
-    if useOpenCL then
-      " (OpenCL accelerated)"
-    else if useCuda then
-      " (CUDA accelerated)"
-    else if useRocm then
-      " (ROCm accelerated)"
-    else if useMetalKit then
-      " (MetalKit accelerated)"
-    else
-      "";
+    strings.optionalString (suffices != [ ])
+      ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   # TODO: package the Python in this repository in a Nix-like way.
   # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo
@@ -99,7 +102,9 @@ in
 
 effectiveStdenv.mkDerivation (
   finalAttrs: {
-    name = "llama.cpp";
+    pname = "llama-cpp${pnameSuffix}";
+    version = llamaVersion;
+
     src = ../../.;
 
     postPatch = ''
@@ -171,14 +176,14 @@ effectiveStdenv.mkDerivation (
         ;
 
       shell = mkShell {
-        name = "default${descriptionSuffix}";
+        name = "shell-${finalAttrs.finalPackage.name}";
         description = "contains numpy and sentencepiece";
         buildInputs = [ llama-python ];
         inputsFrom = [ finalAttrs.finalPackage ];
       };
 
       shell-extra = mkShell {
-        name = "extra${descriptionSuffix}";
+        name = "shell-extra-${finalAttrs.finalPackage.name}";
         description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
         buildInputs = [ llama-python-extra ];
         inputsFrom = [ finalAttrs.finalPackage ];

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -91,7 +91,7 @@ let
   ];
 in
 
-effectiveStdenv.mkDerivation {
+effectiveStdenv.mkDerivation (finalAttrs: {
   name = "llama.cpp";
   src = ../../.;
   meta = {
@@ -171,12 +171,14 @@ effectiveStdenv.mkDerivation {
       name = "default${descriptionSuffix}";
       description = "contains numpy and sentencepiece";
       buildInputs = [ llama-python ];
+      inputsFrom = [ finalAttrs.finalPackage ];
     };
 
     shell-extra = mkShell {
       name = "extra${descriptionSuffix}";
       description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
       buildInputs = [ llama-python-extra ];
+      inputsFrom = [ finalAttrs.finalPackage ];
     };
   };
-}
+})

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -150,6 +150,14 @@ effectiveStdenv.mkDerivation (
         (cmakeBool "LLAMA_HIPBLAS" useRocm)
         (cmakeBool "LLAMA_METAL" useMetalKit)
       ]
+      ++ optionals useCuda [
+        (
+          with cudaPackages.flags;
+          cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (
+            builtins.concatStringsSep ";" (map dropDot cudaCapabilities)
+          )
+        )
+      ]
       ++ optionals useRocm [
         (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
         (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -124,12 +124,20 @@ effectiveStdenv.mkDerivation (
       substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
     '';
 
-    nativeBuildInputs = [
-      cmake
-      ninja
-      pkg-config
-      git
-    ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
+    nativeBuildInputs =
+      [
+        cmake
+        ninja
+        pkg-config
+        git
+      ]
+      ++ optionals useCuda [
+        cudaPackages.cuda_nvcc
+
+        # TODO: Replace with autoAddDriverRunpath
+        # once https://github.com/NixOS/nixpkgs/pull/275241 has been merged
+        cudaPackages.autoAddOpenGLRunpathHook
+      ];
 
     buildInputs =
       [ mpi ]

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -112,7 +112,16 @@ effectiveStdenv.mkDerivation (
     pname = "llama-cpp${pnameSuffix}";
     version = llamaVersion;
 
-    src = lib.cleanSource ../../.;
+    src = lib.cleanSourceWith {
+      filter =
+        name: type:
+        !(builtins.any (_: _) [
+          (lib.hasSuffix ".nix" name) # Ignore *.nix files when computing outPaths
+          (name == "README.md") # Ignore *.md changes whe computing outPaths
+          (lib.hasPrefix "." name) # Skip hidden files and directories
+        ]);
+      src = lib.cleanSource ../../.;
+    };
 
     postPatch = ''
       substituteInPlace ./ggml-metal.m \

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -112,7 +112,7 @@ effectiveStdenv.mkDerivation (
     pname = "llama-cpp${pnameSuffix}";
     version = llamaVersion;
 
-    src = ../../.;
+    src = lib.cleanSource ../../.;
 
     postPatch = ''
       substituteInPlace ./ggml-metal.m \

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -137,13 +137,13 @@ effectiveStdenv.mkDerivation (
         (cmakeBool "LLAMA_BUILD_SERVER" true)
         (cmakeBool "BUILD_SHARED_LIBS" true)
         (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
-        (cmakeBool "LLAMA_METAL" useMetalKit)
         (cmakeBool "LLAMA_BLAS" useBlas)
+        (cmakeBool "LLAMA_CLBLAST" useOpenCL)
+        (cmakeBool "LLAMA_CUBLAS" useCuda)
+        (cmakeBool "LLAMA_HIPBLAS" useRocm)
+        (cmakeBool "LLAMA_METAL" useMetalKit)
       ]
-      ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
-      ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
       ++ optionals useRocm [
-        (cmakeBool "LLAMA_HIPBLAS" true)
         (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
         (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
 

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -101,20 +101,6 @@ effectiveStdenv.mkDerivation (
   finalAttrs: {
     name = "llama.cpp";
     src = ../../.;
-    meta = {
-      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-      mainProgram = "llama";
-
-
-      # These people might respond if you ping them in case of Nix-specific
-      # regressions or for reviewing Nix-specific PRs.
-
-      # Note that lib.maintainers is defined in Nixpkgs.
-      maintainers = with lib.maintainers; [
-          philiptaron
-          SomeoneSerge
-      ];
-    };
 
     postPatch = ''
       substituteInPlace ./ggml-metal.m \
@@ -189,6 +175,21 @@ effectiveStdenv.mkDerivation (
         buildInputs = [ llama-python-extra ];
         inputsFrom = [ finalAttrs.finalPackage ];
       };
+    };
+
+    meta = {
+      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+      mainProgram = "llama";
+
+
+      # These people might respond if you ping them in case of Nix-specific
+      # regressions or for reviewing Nix-specific PRs.
+
+      # Note that lib.maintainers is defined in Nixpkgs.
+      maintainers = with lib.maintainers; [
+          philiptaron
+          SomeoneSerge
+      ];
     };
   }
 )

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -1,0 +1,182 @@
+{
+  lib,
+  config,
+  stdenv,
+  mkShell,
+  cmake,
+  ninja,
+  pkg-config,
+  git,
+  python3,
+  mpi,
+  openblas, # TODO: Use the generic `blas` so users could switch betwen alternative implementations
+  cudaPackages,
+  rocmPackages,
+  clblast,
+  Accelerate ? null,
+  MetalKit ? null,
+  CoreVideo ? null,
+  CoreGraphics ? null,
+  useOpenCL ? false,
+  useCuda ? config.cudaSupport,
+  useRocm ? config.rocmSupport,
+}@inputs:
+
+let
+  inherit (lib)
+    cmakeBool
+    cmakeFeature
+    optionals
+    versionOlder
+    ;
+  isDefault = !useOpenCL && !useCuda && !useRocm;
+
+  # It's necessary to consistently use backendStdenv when building with CUDA support,
+  # otherwise we get libstdc++ errors downstream.
+  stdenv = throw "Use effectiveStdenv instead";
+  effectiveStdenv = if useCuda then cudaPackages.backendStdenv else inputs.stdenv;
+
+  # Give a little description difference between the flavors.
+  descriptionSuffix =
+    if useOpenCL then
+      " (OpenCL accelerated)"
+    else if useCuda then
+      " (CUDA accelerated)"
+    else if useRocm then
+      " (ROCm accelerated)"
+    else if (MetalKit != null) then
+      " (MetalKit accelerated)"
+    else
+      "";
+
+  # TODO: package the Python in this repository in a Nix-like way.
+  # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo
+  # is PEP 517-compatible, and ensure the correct .dist-info is generated.
+  # https://peps.python.org/pep-0517/
+  llama-python = python3.withPackages (
+    ps: [
+      ps.numpy
+      ps.sentencepiece
+    ]
+  );
+
+  # TODO(Green-Sky): find a better way to opt-into the heavy ml python runtime
+  llama-python-extra = python3.withPackages (
+    ps: [
+      ps.numpy
+      ps.sentencepiece
+      ps.torchWithoutCuda
+      ps.transformers
+    ]
+  );
+
+  # See ./overlay.nix for where these dependencies are passed in.
+  defaultBuildInputs = builtins.filter (p: p != null) [
+    Accelerate
+    MetalKit
+    CoreVideo
+    CoreGraphics
+  ];
+
+  cudaBuildInputs = with cudaPackages; [
+    cuda_cccl.dev # <nv/target>
+    cuda_cudart
+    libcublas
+  ];
+
+  rocmBuildInputs = with rocmPackages; [
+    clr
+    hipblas
+    rocblas
+  ];
+in
+
+effectiveStdenv.mkDerivation {
+  name = "llama.cpp";
+  src = ../../.;
+  meta = {
+    description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+    mainProgram = "llama";
+  };
+
+  postPatch = ''
+    substituteInPlace ./ggml-metal.m \
+      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+
+    # TODO: Package up each Python script or service appropriately.
+    # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
+    # we could make those *.py into setuptools' entrypoints
+    substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    git
+  ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
+
+  buildInputs =
+    [ mpi ]
+    ++ optionals useOpenCL [ clblast ]
+    ++ optionals useCuda cudaBuildInputs
+    ++ optionals useRocm rocmBuildInputs
+    ++ optionals isDefault defaultBuildInputs;
+
+  cmakeFlags =
+    [
+      (cmakeBool "LLAMA_NATIVE" true)
+      (cmakeBool "LLAMA_BUILD_SERVER" true)
+      (cmakeBool "BUILD_SHARED_LIBS" true)
+      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+    ]
+    ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
+    ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
+    ++ optionals useRocm [
+      (cmakeBool "LLAMA_HIPBLAS" true)
+      (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
+      (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
+
+      # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
+      # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
+      # and select the line that matches the current nixpkgs version of rocBLAS.
+      # Should likely use `rocmPackages.clr.gpuTargets`.
+      "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
+    ]
+    ++ optionals isDefault (
+      if (MetalKit != null) then
+        [
+          "-DCMAKE_C_FLAGS=-D__ARM_FEATURE_DOTPROD=1"
+          "-DLLAMA_METAL=ON"
+        ]
+      else
+        [
+          "-DLLAMA_BLAS=ON"
+          "-DLLAMA_BLAS_VENDOR=OpenBLAS"
+        ]
+    );
+
+  # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
+  # if they haven't been added yet.
+  postInstall = ''
+    mv $out/bin/main $out/bin/llama
+    mv $out/bin/server $out/bin/llama-server
+    mkdir -p $out/include
+    cp $src/llama.h $out/include/
+  '';
+
+  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
+  passthru = {
+    shell = mkShell {
+      name = "default${descriptionSuffix}";
+      description = "contains numpy and sentencepiece";
+      buildInputs = [ llama-python ];
+    };
+
+    shell-extra = mkShell {
+      name = "extra${descriptionSuffix}";
+      description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
+      buildInputs = [ llama-python-extra ];
+    };
+  };
+}

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -1,3 +1,12 @@
-{ lib, newScope }:
+{
+  lib,
+  newScope,
+  llamaVersion ? "0.0.0",
+}:
 
-lib.makeScope newScope (self: { llama-cpp = self.callPackage ./package.nix { }; })
+lib.makeScope newScope (
+  self: {
+    inherit llamaVersion;
+    llama-cpp = self.callPackage ./package.nix { };
+  }
+)

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -1,0 +1,3 @@
+{ lib, newScope }:
+
+lib.makeScope newScope (self: { llama-cpp = self.callPackage ./package.nix { }; })

--- a/.github/workflows/nix-flakestry.yml
+++ b/.github/workflows/nix-flakestry.yml
@@ -1,0 +1,23 @@
+# Make the flake discoverable on https://flakestry.dev
+name: "Publish a flake to flakestry"
+on:
+    push:
+        tags:
+        - "v?[0-9]+.[0-9]+.[0-9]+"
+        - "v?[0-9]+.[0-9]+"
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "The existing tag to publish"
+                type: "string"
+                required: true
+jobs:
+    publish-flake:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: "write"
+            contents: "read"
+        steps:
+            - uses: flakestry/flakestry-publish@main
+              with:
+                version: "${{ inputs.tag || github.ref_name }}"

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1703559957,
@@ -16,8 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1703559957,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1703559957,
+        "narHash": "sha256-x9PUuMEPGUOMB51zNxrDr2QoHbYWlCS2xhFedm9MC5Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "75dd68c36f458c6593c5bbb48abfd3e59bfed380",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
         flake.overlays.default =
           (final: prev: {
             llamaPackages = final.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
+            inherit (final.llamaPackages) llama-cpp;
           });
 
         systems = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,111 +1,79 @@
 {
+  description = "Port of Facebook's LLaMA model in C/C++";
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
+  # For inspection, use `nix flake show github:ggerganov/llama.cpp` or the nix repl:
+  #
+  # ```bash
+  # ❯ nix repl
+  # nix-repl> :lf github:ggerganov/llama.cpp
+  # Added 13 variables.
+  # nix-repl> outputs.apps.x86_64-linux.quantize
+  # { program = "/nix/store/00000000000000000000000000000000-llama.cpp/bin/quantize"; type = "app"; }
+  # ```
   outputs =
-    { self, nixpkgs }:
+    { flake-parts, ... }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; }
 
-    let
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin" # x86_64-darwin isn't tested (and likely isn't relevant)
-        "x86_64-linux"
-      ];
-      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f system);
-    in
+      {
 
-    {
-      # An overlay can be used to have a more granular control over llama-cpp's
-      # dependencies and configuration, than that offered by the `.override`
-      # mechanism. Cf. https://nixos.org/manual/nixpkgs/stable/#chap-overlays.
-      #
-      # E.g. in a flake:
-      # ```
-      # { nixpkgs, llama-cpp, ... }:
-      # let pkgs = import nixpkgs {
-      #     overlays = [ (llama-cpp.overlays.default) ];
-      #     system = "aarch64-linux";
-      #     config.allowUnfree = true;
-      #     config.cudaSupport = true;
-      #     config.cudaCapabilities = [ "7.2" ];
-      #     config.cudaEnableForwardCompat = false;
-      # }; in {
-      #     packages.aarch64-linux.llamaJetsonXavier = pkgs.llamaPackages.llama-cpp;
-      # }
-      # ```
-      #
-      # Cf. https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html?highlight=flake#flake-format
-      overlays.default = (final: prev: { llamaPackages = final.callPackage .devops/nix/scope.nix { }; });
+        imports = [
+          .devops/nix/nixpkgs-instances.nix
+          .devops/nix/apps.nix
+          .devops/nix/devshells.nix
+        ];
 
-      # These use the package definition from `./.devops/nix/package.nix`.
-      # There's one per backend that llama-cpp uses. Add more as needed!
-      packages = eachSystem (
-        system:
-        let
-          # Avoid re-evaluation for the nixpkgs instance,
-          # cf. https://zimbatm.com/notes/1000-instances-of-nixpkgs
-          pkgs = nixpkgs.legacyPackages.${system};
+        # An overlay can be used to have a more granular control over llama-cpp's
+        # dependencies and configuration, than that offered by the `.override`
+        # mechanism. Cf. https://nixos.org/manual/nixpkgs/stable/#chap-overlays.
+        #
+        # E.g. in a flake:
+        # ```
+        # { nixpkgs, llama-cpp, ... }:
+        # let pkgs = import nixpkgs {
+        #     overlays = [ (llama-cpp.overlays.default) ];
+        #     system = "aarch64-linux";
+        #     config.allowUnfree = true;
+        #     config.cudaSupport = true;
+        #     config.cudaCapabilities = [ "7.2" ];
+        #     config.cudaEnableForwardCompat = false;
+        # }; in {
+        #     packages.aarch64-linux.llamaJetsonXavier = pkgs.llamaPackages.llama-cpp;
+        # }
+        # ```
+        #
+        # Cf. https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html?highlight=flake#flake-format
+        flake.overlays.default =
+          (final: prev: { llamaPackages = final.callPackage .devops/nix/scope.nix { }; });
 
-          # Ensure dependencies use CUDA consistently (e.g. that openmpi, ucc,
-          # and ucx are built with CUDA support)
-          pkgsCuda = import nixpkgs {
-            inherit system;
+        systems = [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "x86_64-darwin" # x86_64-darwin isn't tested (and likely isn't relevant)
+          "x86_64-linux"
+        ];
 
-            config.cudaSupport = true;
-            config.allowUnfreePredicate =
-              p:
-              builtins.all
-                (
-                  license:
-                  license.free
-                  || builtins.elem license.shortName [
-                    "CUDA EULA"
-                    "cuDNN EULA"
-                  ]
-                )
-                (p.meta.licenses or [ p.meta.license ]);
+        perSystem =
+          {
+            config,
+            pkgs,
+            pkgsCuda,
+            pkgsRocm,
+            ...
+          }:
+          {
+            # We don't use the overlay here so as to avoid making too many instances of nixpkgs,
+            # cf. https://zimbatm.com/notes/1000-instances-of-nixpkgs
+            packages = {
+              default = (pkgs.callPackage .devops/nix/scope.nix { }).llama-cpp;
+              opencl = config.packages.default.override { useOpenCL = true; };
+              cuda = (pkgsCuda.callPackage .devops/nix/scope.nix { }).llama-cpp;
+              rocm = (pkgsRocm.callPackage .devops/nix/scope.nix { }).llama-cpp;
+            };
           };
-
-          # Ensure dependencies use ROCm consistently
-          pkgsRocm = import nixpkgs {
-            inherit system;
-            config.rocmSupport = true;
-          };
-        in
-        {
-          default = (pkgs.callPackage .devops/nix/scope.nix { }).llama-cpp;
-          opencl = self.packages.${system}.default.override { useOpenCL = true; };
-          cuda = (pkgsCuda.callPackage .devops/nix/scope.nix { }).llama-cpp;
-          rocm = (pkgsRocm.callPackage .devops/nix/scope.nix { }).llama-cpp;
-        }
-      );
-
-      # These use the definition of llama-cpp from `./.devops/nix/package.nix`
-      # and expose various binaries as apps with `nix run .#app-name`.
-      # Note that none of these apps use anything other than the default backend.
-      apps = eachSystem (
-        system:
-        import ./.devops/nix/apps.nix {
-          package = self.packages.${system}.default;
-          binaries = [
-            "llama"
-            "llama-embedding"
-            "llama-server"
-            "quantize"
-            "train-text-from-scratch"
-          ];
-        }
-      );
-
-      # These expose a build environment for either a "default" or an "extra" set of dependencies.
-      devShells = eachSystem (
-        system:
-        import ./.devops/nix/devshells.nix {
-          concatMapAttrs = nixpkgs.lib.concatMapAttrs;
-          packages = self.packages.${system};
-        }
-      );
-    };
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,13 @@
   outputs =
     { self, flake-parts, ... }@inputs:
     let
-      llamaVersion = self.dirtyShortRev or self.shortRev;
+      # We could include the git revisions in the package names but those would
+      # needlessly trigger rebuilds:
+      # llamaVersion = self.dirtyShortRev or self.shortRev;
+
+      # Nix already uses cryptographic hashes for versioning, so we'll just fix
+      # the fake semver for now:
+      llamaVersion = "0.0.0";
     in
     flake-parts.lib.mkFlake { inherit inputs; }
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
         perSystem =
           {
             config,
+            lib,
             pkgs,
             pkgsCuda,
             pkgsRocm,
@@ -81,15 +82,18 @@
           {
             # We don't use the overlay here so as to avoid making too many instances of nixpkgs,
             # cf. https://zimbatm.com/notes/1000-instances-of-nixpkgs
-            packages = {
-              default = (pkgs.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
-              opencl = config.packages.default.override { useOpenCL = true; };
-              cuda = (pkgsCuda.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
-              rocm = (pkgsRocm.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
+            packages =
+              {
+                default = (pkgs.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
+              }
+              // lib.optionalAttrs pkgs.stdenv.isLinux {
+                opencl = config.packages.default.override { useOpenCL = true; };
+                cuda = (pkgsCuda.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
+                rocm = (pkgsRocm.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
 
-              mpi-cpu = config.packages.default.override { useMpi = true; };
-              mpi-cuda = config.packages.default.override { useMpi = true; };
-            };
+                mpi-cpu = config.packages.default.override { useMpi = true; };
+                mpi-cuda = config.packages.default.override { useMpi = true; };
+              };
           };
       };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           .devops/nix/nixpkgs-instances.nix
           .devops/nix/apps.nix
           .devops/nix/devshells.nix
+          .devops/nix/jetson-support.nix
         ];
 
         # An overlay can be used to have a more granular control over llama-cpp's

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,9 @@
               opencl = config.packages.default.override { useOpenCL = true; };
               cuda = (pkgsCuda.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
               rocm = (pkgsRocm.callPackage .devops/nix/scope.nix { inherit llamaVersion; }).llama-cpp;
+
+              mpi-cpu = config.packages.default.override { useMpi = true; };
+              mpi-cuda = config.packages.default.override { useMpi = true; };
             };
           };
       };


### PR DESCRIPTION
@SomeoneSerge and I rewrote `flake.nix` with the changes listed below. The top line from a user perspective is:

* Building CUDA-accelerated packages now works (`nix run github:ggerganov/llama.cpp#cuda`, once this PR is merged) without asking to accept unfree packages.
* There's support for [NVIDIA Jetson](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems).
* When using ROCm and CUDA acceleration, _all_ packages that might are in the dependency graph are built with that acceleration, most importantly openmpi. 
* For platforms like MacOS where the CUDA or ROCm backend isn't supported, it's not listed.
* There are extra dev shells, one per backend.
* For users integrating this flake into a NixOS system, there's an overlay exposing the `llama-cpp` package and `llamaPackages` scope.

## Detailed change log

1. Split into separate files per output, using the pattern established at [flake.parts](https://flake.parts). 
2. Added an overlay, so that this flake can be integrated into others. 
3. In the overlay, added a scope called `llamaPackages` which can contain all the relevant packages.
4. The name in the overlay is `llama-cpp`. The packages `opencl`, `cuda`, and `rocm` are derived from this one, so that they fit into the broader set of Nix packages from [nixpkgs](https://github.com/nixos/nixpkgs).
5. Use [callPackage](https://summer.nixos.org/blog/callpackage-a-tool-for-the-lazy/) rather than `with pkgs;` so that there's dependency injection rather than dependency lookup.
6. Add a description and meta information for each package. The description includes a bit about what's trying to accelerate each one. @SomeoneSerge and I are listed as maintainers, which means we're mildly on the hook if something about this flake breaks.
7. The flake is published to https://flakestry.dev/.
8. The size of the dependency graph (the build and runtime closure) is down about 1.4 GB due to being more precise about dependencies (we now use specific CUDA packages instead of cudatoolkit).
9. We now use the apple_sdk selection logic in nixpkgs instead of rolling our own.
10. Accept the CUDA packages for `nix run` use. When used through the overlay, they still need to be accepted by the greater system, obviously.
11. Updated flake.lock to pull in the latest nixpkgs.
12. Formatted the Nix code with the in-progress [RFC101](https://github.com/nix-rfc-101/rfcs/blob/master/rfcs/0166-nix-formatting.md) formatter. `nix shell github:piegamesde/nixfmt/rfc101-style --command nixfmt flake.nix .devops/nix/*.nix`

I tested this out using [DaringMaid-13B-GGUF](https://huggingface.co/TheBloke/DaringMaid-13B-GGUF) on NixOS x86_64-linux with all the variants, including CUDA, and macOS Sonoma aarch64-darwin. While the flake claims to support macOS x86_64-darwin and aarch64-linux, I don't have a machine to support building and running these variants.

To run it yourself, [install Nix](https://github.com/DeterminateSystems/nix-installer) and run `nix run github:philiptaron/llama.cpp/nix`. Use `nix flake show github:philiptaron/llama.cpp/nix` to see what the flake has in it.