### PR TITLE
Add flake app to run openai proxy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,15 @@
           type = "app";
           program = "${self.packages.${system}.default}/bin/llama-server";
         };
+        apps.llama-server-openai-proxy = {
+          type = "app";
+          program = "${
+            (let pythonWithPkgs = pkgs.python3.withPackages (ps: with ps; [ flask requests ]);
+             in pkgs.writeShellScriptBin "run-openai-proxy" ''
+                  ${pythonWithPkgs}/bin/python3 ${self}/examples/server/api_like_OAI.py
+             '')
+          }/bin/run-openai-proxy";
+        };
         apps.llama-embedding = {
           type = "app";
           program = "${self.packages.${system}.default}/bin/embedding";


### PR DESCRIPTION
Works with:

nix run .#llama-server-openai-proxy

If merged, then you can run both the server and proxy via two commands:

nix run github:ggerganov/llama.cpp#llama-server
nix run github:ggerganov/llama.cpp#llama-server-openai-proxy

Note: This is likely not ideal or the best way to do this, but it works and can hopefully spark useful discussion  to get this feature into the llama.cpp flake :smiley: 