### PR TITLE
initial import of hpx support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ option(LLAMA_CLBLAST                         "llama: use CLBlast"               
 option(LLAMA_METAL                           "llama: use Metal"                                 ${LLAMA_METAL_DEFAULT})
 option(LLAMA_METAL_NDEBUG                    "llama: disable Metal debugging"                   OFF)
 option(LLAMA_MPI                             "llama: use MPI"                                   OFF)
+option(LLAMA_HPX                             "llama: use HPX"                                   OFF)
 option(LLAMA_QKK_64                          "llama: use super-block size of 64 for k-quants"   OFF)
 
 option(LLAMA_BUILD_TESTS                     "llama: build tests"    ${LLAMA_STANDALONE})
@@ -320,6 +321,10 @@ if (LLAMA_CUBLAS)
     endif()
 endif()
 
+if(LLAMA_MPI AND LLAMA_HPX)
+    message(FATAL "MPI and HPX are not currently compatible together")
+endif()
+
 if (LLAMA_MPI)
     cmake_minimum_required(VERSION 3.10)
     find_package(MPI)
@@ -341,6 +346,17 @@ if (LLAMA_MPI)
         endif()
     else()
         message(WARNING "MPI not found")
+    endif()
+endif()
+
+if (LLAMA_HPX)
+    cmake_minimum_required(VERSION 3.10)
+    find_package (HPX)
+    if (HPX_FOUND)
+        add_compile_definitions(GGML_USE_HPX)
+        set(LLAMA_EXTRA_INCLUDES ${LLAMA_EXTRA_INCLUDES} ${HPX_CXXFLAGS})
+    else()
+        message(FATAL "HPX not found")
     endif()
 endif()
 
@@ -727,7 +743,11 @@ add_library(ggml OBJECT
 
 target_include_directories(ggml PUBLIC . ${LLAMA_EXTRA_INCLUDES})
 target_compile_features(ggml PUBLIC c_std_11) # don't bump
-target_link_libraries(ggml PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
+if(LLAMA_HPX AND HPX_FOUND)
+   target_link_libraries(ggml PUBLIC HPX::hpx ${LLAMA_EXTRA_LIBS})
+else()
+   target_link_libraries(ggml PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
+endif()
 if (GGML_USE_CPU_HBM)
     target_link_libraries(ggml PUBLIC memkind)
 endif()
@@ -749,6 +769,12 @@ add_library(llama
 
 target_include_directories(llama PUBLIC .)
 target_compile_features(llama PUBLIC cxx_std_11) # don't bump
+
+if(LLAMA_HPX AND HPX_FOUND)
+   target_link_libraries(llama PUBLIC HPX::hpx ${LLAMA_EXTRA_LIBS})
+   target_compile_options (llama PRIVATE ${HPX_CXXFLAGS})
+endif()
+
 target_link_libraries(llama PRIVATE
     ggml
     ${LLAMA_EXTRA_LIBS}

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,11 @@ endif
 # keep standard at C11 and C++11
 MK_CPPFLAGS = -I. -Icommon
 MK_CFLAGS   = -std=c11   -fPIC
+ifdef LLAMA_HPX
+MK_CXXFLAGS = -std=c++17 -fPIC
+else
 MK_CXXFLAGS = -std=c++11 -fPIC
+endif
 
 # -Ofast tends to produce faster code, but may not be available for some compilers.
 ifdef LLAMA_FAST
@@ -344,6 +348,46 @@ ifdef LLAMA_MPI
 	MK_CXXFLAGS += -Wno-cast-qual
 	OBJS        += ggml-mpi.o
 endif # LLAMA_MPI
+
+ifdef LLAMA_HPX
+ 	ifndef HWLOC_FOUND
+                HWLOC_PKG:=hwloc
+ 		HWLOC_REQPKG:=$(shell pkg-config --exists $(HWLOC_PKG) && echo '$(HWLOC_PKG)')
+ 		ifneq ($(HWLOC_REQPKG),)
+ 			HWLOC_FOUND:=1
+ 			HWLOC_CXXFLAGS:=$(shell pkg-config --cflags $(HWLOC_PKG))
+ 			HWLOC_LDFLAGS:=$(shell pkg-config --libs $(HWLOC_PKG))
+ 			warn := $(warning hwloc found)
+ 		else
+ 			$(warning 'hwloc' not found)
+ 		endif
+ 	endif
+
+ 	ifndef HWLOC_FOUND
+ 		$(error hwloc not found)
+ 	endif
+
+ 	ifndef HPX_FOUND
+                HPX_PKG:=hpx_component
+ 		HPX_REQPKG:=$(shell pkg-config --exists $(HPX_PKG) && echo '$(HPX_PKG)')
+ 		ifneq ($(HPX_REQPKG),)
+ 			HPX_FOUND:=1
+ 			HPX_CXXFLAGS:=$(shell pkg-config --cflags hpx_component)
+ 			HPX_LDFLAGS:=$(shell pkg-config --libs hpx_component)
+ 			warn := $(warning HPX found)
+ 		else
+ 			$(warning 'HPX' not found)
+ 		endif
+ 	endif
+
+ 	ifndef HPX_FOUND
+ 		$(error HPX not found)
+ 	endif
+
+ 	MK_CPPFLAGS += -DGGML_USE_HPX $(HWLOC_CXXFLAGS) $(HPX_CXXFLAGS)
+ 	MK_CXXFLAGS += -Wno-cast-qual $(HWLOC_CXXFLAGS) $(HPX_CXXFLAGS)
+ 	MK_LDFLAGS  += -Wno-cast-qual $(HWLOC_LDFLAGS) $(HPX_LDFLAGS)
+ endif # LLAMA_HPX
 
 ifdef LLAMA_OPENBLAS
 	MK_CPPFLAGS += -DGGML_USE_OPENBLAS $(shell pkg-config --cflags-only-I openblas)

--- a/README.md
+++ b/README.md
@@ -335,6 +335,24 @@ Finally, you're ready to run a computation using `mpirun`:
 mpirun -hostfile hostfile -n 3 ./main -m ./models/7B/ggml-model-q4_0.gguf -n 128
 ```
 
+### HPX Build
+
+This build has a dependency on the [HPX](https://github.com/STEllAR-GROUP/hpx) asynchronous many task runtime system. Users are encouraged to compile HPX with tcmalloc. HPX provides a user-land thread implementation and a work-stealing thread management implementation. Both features reduce the number of system calls required of the application which can improve performance. HPX emphasizes 'futurization' of applications; users are encouraged to craft dataflow dependency graphs using futures and HPX's implementation of `std::async`. HPX achieves best performance on large workloads. The BLIS BLAS library has support for HPX. The HPX support provided by this build will improve the performance of the BLIS HPX backend when applied to llama.cpp.
+
+  - Using `make`:
+    - On Linux:
+      ```bash
+      make LLAMA_HPX=1
+      ```
+
+  - Using `CMake` on Linux:
+      ```bash
+      mkdir build
+      cd build
+      CXX=<C++ compiler used to build HPX> cmake -DHPX_DIR=<PATH_TO_HPX_CMAKE> -DLLAMA_HPX=1 ..
+      make
+      ```
+
 ### BLAS Build
 
 Building the program with BLAS support may lead to some performance improvements in prompt processing using batch sizes higher than 32 (the default is 512). Support with CPU-only BLAS implementations doesn't affect the normal generation performance. We may see generation performance improvements with GPU-involved BLAS implementations, e.g. cuBLAS, hipBLAS and CLBlast. There are currently several different BLAS implementations available for build and use:

--- a/llama.cpp
+++ b/llama.cpp
@@ -8936,12 +8936,17 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
                    return hpx::make_ready_future<void>();
                 };
 
-                hpx::future<void> this_fut = computefn(0, counters[0], thread_local_hist, local_sizes);
                 for (int it = 1; it < nthread_use - 1; ++it) {
                     futures.push_back(hpx::run_as_hpx_thread(computefn, it, counters[it], thread_local_hist, local_sizes));
                 }
+
+                hpx::future<void> this_fut =
+                    computefn(0, counters[0], thread_local_hist, local_sizes);
+
                 hpx::wait_all(futures);
+
                 this_fut.wait();
+
                 for(auto & local_hist : thread_local_hist) {
                     for(auto j = 0; j < int(local_hist.size()); ++j) {
                         hist_cur[j] += local_hist[j];


### PR DESCRIPTION
This PR provides llama.cpp support for [HPX](https://github.com/STEllAR-GROUP/hpx) as per issue #4614 . The implementation provides cmake scripts to detect HPX, makefile support, updates to the README.md, and the HPX support implementation in C++. The implementation is modeled after the existing `std::thread` use in llama.cpp.