### PR TITLE
flake.nix: add missing meta, including maintainers

### DIFF
--- a/.devops/nix/apps.nix
+++ b/.devops/nix/apps.nix
@@ -1,0 +1,14 @@
+{ package, binaries }:
+
+let
+  default = builtins.elemAt binaries 0;
+  mkApp = name: {
+    ${name} = {
+      type = "app";
+      program = "${package}/bin/${name}";
+    };
+  };
+  result = builtins.foldl' (acc: name: (mkApp name) // acc) { } binaries;
+in
+
+result // { default = result.${default}; }

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -1,0 +1,10 @@
+{ concatMapAttrs, packages }:
+
+concatMapAttrs
+  (name: package: {
+    ${name} = package.passthru.shell.overrideAttrs (prevAttrs: { inputsFrom = [ package ]; });
+    ${name + "-extra"} = package.passthru.shell-extra.overrideAttrs (
+      prevAttrs: { inputsFrom = [ package ]; }
+    );
+  })
+  packages

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -2,9 +2,7 @@
 
 concatMapAttrs
   (name: package: {
-    ${name} = package.passthru.shell.overrideAttrs (prevAttrs: { inputsFrom = [ package ]; });
-    ${name + "-extra"} = package.passthru.shell-extra.overrideAttrs (
-      prevAttrs: { inputsFrom = [ package ]; }
-    );
+    ${name} = package.passthru.shell;
+    ${name + "-extra"} = package.passthru.shell-extra;
   })
   packages

--- a/.devops/nix/overlay.nix
+++ b/.devops/nix/overlay.nix
@@ -1,17 +1,5 @@
 final: prev:
 
-let
-  inherit (final.stdenv) isAarch64 isDarwin;
-
-  darwinSpecific =
-    if isAarch64 then
-      { inherit (final.darwin.apple_sdk_11_0.frameworks) Accelerate MetalKit; }
-    else
-      { inherit (final.darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo; };
-
-  osSpecific = if isDarwin then darwinSpecific else { };
-in
-
 {
-  llama-cpp = final.callPackage ./package.nix osSpecific;
+  llama-cpp = final.callPackage ./package.nix { };
 }

--- a/.devops/nix/overlay.nix
+++ b/.devops/nix/overlay.nix
@@ -1,0 +1,17 @@
+final: prev:
+
+let
+  inherit (final.stdenv) isAarch64 isDarwin;
+
+  darwinSpecific =
+    if isAarch64 then
+      { inherit (final.darwin.apple_sdk_11_0.frameworks) Accelerate MetalKit; }
+    else
+      { inherit (final.darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo; };
+
+  osSpecific = if isDarwin then darwinSpecific else { };
+in
+
+{
+  llama-cpp = final.callPackage ./package.nix osSpecific;
+}

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -9,7 +9,7 @@
   git,
   python3,
   mpi,
-  openblas, # This could be `blas` to enable easy swapping out with `lapack`
+  openblas, # TODO: Use the generic `blas` so users could switch betwen alternative implementations
   cudaPackages,
   rocmPackages,
   clblast,
@@ -158,13 +158,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
   # if they haven't been added yet.
-  #
-  # For example:
-  #
-  #  1. Avoid GLOBs
-  #  2. Add whatever COMPONENTs are missing
-  #  3. Fix whatever issues remain with override-ability.
-  #
   postInstall = ''
     mv $out/bin/main $out/bin/llama
     mv $out/bin/server $out/bin/llama-server

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -77,12 +77,12 @@ let
   # separately
   darwinBuildInputs =
     with darwin.apple_sdk.frameworks;
-    [ Accelerate ]
-    ++ optionals useMetalKit [ MetalKit ]
-    ++ optionals (!useMetalKit) [
+    [
+      Accelerate
       CoreVideo
       CoreGraphics
-    ];
+    ]
+    ++ optionals useMetalKit [ MetalKit ];
 
   cudaBuildInputs = with cudaPackages; [
     cuda_cccl.dev # <nv/target>

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -91,7 +91,7 @@ let
   ];
 in
 
-effectiveStdenv.mkDerivation {
+effectiveStdenv.mkDerivation (finalAttrs: {
   name = "llama.cpp";
   src = ../../.;
   meta = {
@@ -178,12 +178,14 @@ effectiveStdenv.mkDerivation {
       name = "default${descriptionSuffix}";
       description = "contains numpy and sentencepiece";
       buildInputs = [ llama-python ];
+      inputsFrom = [ finalAttrs.finalPackage ];
     };
 
     shell-extra = mkShell {
       name = "extra${descriptionSuffix}";
       description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
       buildInputs = [ llama-python-extra ];
+      inputsFrom = [ finalAttrs.finalPackage ];
     };
   };
-}
+})

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -1,0 +1,189 @@
+{
+  lib,
+  config,
+  stdenv,
+  mkShell,
+  cmake,
+  ninja,
+  pkg-config,
+  git,
+  python3,
+  mpi,
+  openblas, # This could be `blas` to enable easy swapping out with `lapack`
+  cudaPackages,
+  rocmPackages,
+  clblast,
+  Accelerate ? null,
+  MetalKit ? null,
+  CoreVideo ? null,
+  CoreGraphics ? null,
+  useOpenCL ? false,
+  useCuda ? config.cudaSupport,
+  useRocm ? config.rocmSupport,
+}@inputs:
+
+let
+  inherit (lib)
+    cmakeBool
+    cmakeFeature
+    optionals
+    versionOlder
+    ;
+  isDefault = !useOpenCL && !useCuda && !useRocm;
+
+  # It's necessary to consistently use backendStdenv when building with CUDA support,
+  # otherwise we get libstdc++ errors downstream.
+  stdenv = throw "Use effectiveStdenv instead";
+  effectiveStdenv = if useCuda then cudaPackages.backendStdenv else inputs.stdenv;
+
+  # Give a little description difference between the flavors.
+  descriptionSuffix =
+    if useOpenCL then
+      " (OpenCL accelerated)"
+    else if useCuda then
+      " (CUDA accelerated)"
+    else if useRocm then
+      " (ROCm accelerated)"
+    else if (MetalKit != null) then
+      " (MetalKit accelerated)"
+    else
+      "";
+
+  # TODO: package the Python in this repository in a Nix-like way.
+  # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo
+  # is PEP 517-compatible, and ensure the correct .dist-info is generated.
+  # https://peps.python.org/pep-0517/
+  llama-python = python3.withPackages (
+    ps: [
+      ps.numpy
+      ps.sentencepiece
+    ]
+  );
+
+  # TODO(Green-Sky): find a better way to opt-into the heavy ml python runtime
+  llama-python-extra = python3.withPackages (
+    ps: [
+      ps.numpy
+      ps.sentencepiece
+      ps.torchWithoutCuda
+      ps.transformers
+    ]
+  );
+
+  # See ./overlay.nix for where these dependencies are passed in.
+  defaultBuildInputs = builtins.filter (p: p != null) [
+    Accelerate
+    MetalKit
+    CoreVideo
+    CoreGraphics
+  ];
+
+  cudaBuildInputs = with cudaPackages; [
+    cuda_cccl.dev # <nv/target>
+    cuda_cudart
+    libcublas
+  ];
+
+  rocmBuildInputs = with rocmPackages; [
+    clr
+    hipblas
+    rocblas
+  ];
+in
+
+effectiveStdenv.mkDerivation {
+  name = "llama.cpp";
+  src = ../../.;
+  meta = {
+    description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+    mainProgram = "llama";
+  };
+
+  postPatch = ''
+    substituteInPlace ./ggml-metal.m \
+      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+
+    # TODO: Package up each Python script or service appropriately.
+    # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
+    # we could make those *.py into setuptools' entrypoints
+    substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    git
+  ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
+
+  buildInputs =
+    [ mpi ]
+    ++ optionals useOpenCL [ clblast ]
+    ++ optionals useCuda cudaBuildInputs
+    ++ optionals useRocm rocmBuildInputs
+    ++ optionals isDefault defaultBuildInputs;
+
+  cmakeFlags =
+    [
+      (cmakeBool "LLAMA_NATIVE" true)
+      (cmakeBool "LLAMA_BUILD_SERVER" true)
+      (cmakeBool "BUILD_SHARED_LIBS" true)
+      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+    ]
+    ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
+    ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
+    ++ optionals useRocm [
+      (cmakeBool "LLAMA_HIPBLAS" true)
+      (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
+      (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
+
+      # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
+      # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
+      # and select the line that matches the current nixpkgs version of rocBLAS.
+      # Should likely use `rocmPackages.clr.gpuTargets`.
+      "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
+    ]
+    ++ optionals isDefault (
+      if (MetalKit != null) then
+        [
+          "-DCMAKE_C_FLAGS=-D__ARM_FEATURE_DOTPROD=1"
+          "-DLLAMA_METAL=ON"
+        ]
+      else
+        [
+          "-DLLAMA_BLAS=ON"
+          "-DLLAMA_BLAS_VENDOR=OpenBLAS"
+        ]
+    );
+
+  # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
+  # if they haven't been added yet.
+  #
+  # For example:
+  #
+  #  1. Avoid GLOBs
+  #  2. Add whatever COMPONENTs are missing
+  #  3. Fix whatever issues remain with override-ability.
+  #
+  postInstall = ''
+    mv $out/bin/main $out/bin/llama
+    mv $out/bin/server $out/bin/llama-server
+    mkdir -p $out/include
+    cp $src/llama.h $out/include/
+  '';
+
+  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
+  passthru = {
+    shell = mkShell {
+      name = "default${descriptionSuffix}";
+      description = "contains numpy and sentencepiece";
+      buildInputs = [ llama-python ];
+    };
+
+    shell-extra = mkShell {
+      name = "extra${descriptionSuffix}";
+      description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
+      buildInputs = [ llama-python-extra ];
+    };
+  };
+}

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -97,86 +97,88 @@ let
   ];
 in
 
-effectiveStdenv.mkDerivation (finalAttrs: {
-  name = "llama.cpp";
-  src = ../../.;
-  meta = {
-    description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-    mainProgram = "llama";
-  };
-
-  postPatch = ''
-    substituteInPlace ./ggml-metal.m \
-      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
-
-    # TODO: Package up each Python script or service appropriately.
-    # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
-    # we could make those *.py into setuptools' entrypoints
-    substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
-  '';
-
-  nativeBuildInputs = [
-    cmake
-    ninja
-    pkg-config
-    git
-  ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
-
-  buildInputs =
-    [ mpi ]
-    ++ optionals useOpenCL [ clblast ]
-    ++ optionals useCuda cudaBuildInputs
-    ++ optionals useRocm rocmBuildInputs
-    ++ optionals effectiveStdenv.isDarwin darwinBuildInputs;
-
-  cmakeFlags =
-    [
-      (cmakeBool "LLAMA_NATIVE" true)
-      (cmakeBool "LLAMA_BUILD_SERVER" true)
-      (cmakeBool "BUILD_SHARED_LIBS" true)
-      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
-      (cmakeBool "LLAMA_METAL" useMetalKit)
-      (cmakeBool "LLAMA_BLAS" useBlas)
-    ]
-    ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
-    ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
-    ++ optionals useRocm [
-      (cmakeBool "LLAMA_HIPBLAS" true)
-      (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
-      (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
-
-      # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
-      # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
-      # and select the line that matches the current nixpkgs version of rocBLAS.
-      # Should likely use `rocmPackages.clr.gpuTargets`.
-      "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
-    ]
-    ++ optionals useMetalKit [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1") ]
-    ++ optionals useBlas [ (lib.cmakeFeature "LLAMA_BLAS_VENDOR" "OpenBLAS") ];
-
-  # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
-  # if they haven't been added yet.
-  postInstall = ''
-    mv $out/bin/main $out/bin/llama
-    mv $out/bin/server $out/bin/llama-server
-    mkdir -p $out/include
-    cp $src/llama.h $out/include/
-  '';
-
-  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
-  passthru = {
-    shell = mkShell {
-      name = "default${descriptionSuffix}";
-      description = "contains numpy and sentencepiece";
-      buildInputs = [ llama-python ];
-      inputsFrom = [ finalAttrs.finalPackage ];
+effectiveStdenv.mkDerivation (
+  finalAttrs: {
+    name = "llama.cpp";
+    src = ../../.;
+    meta = {
+      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+      mainProgram = "llama";
     };
 
-    shell-extra = mkShell {
-      name = "extra${descriptionSuffix}";
-      description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
-      buildInputs = [ llama-python-extra ];
-      inputsFrom = [ finalAttrs.finalPackage ];
+    postPatch = ''
+      substituteInPlace ./ggml-metal.m \
+        --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+
+      # TODO: Package up each Python script or service appropriately.
+      # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,
+      # we could make those *.py into setuptools' entrypoints
+      substituteInPlace ./*.py --replace "/usr/bin/env python" "${llama-python}/bin/python"
+    '';
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+      git
+    ] ++ optionals useCuda [ cudaPackages.cuda_nvcc ];
+
+    buildInputs =
+      [ mpi ]
+      ++ optionals useOpenCL [ clblast ]
+      ++ optionals useCuda cudaBuildInputs
+      ++ optionals useRocm rocmBuildInputs
+      ++ optionals effectiveStdenv.isDarwin darwinBuildInputs;
+
+    cmakeFlags =
+      [
+        (cmakeBool "LLAMA_NATIVE" true)
+        (cmakeBool "LLAMA_BUILD_SERVER" true)
+        (cmakeBool "BUILD_SHARED_LIBS" true)
+        (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+        (cmakeBool "LLAMA_METAL" useMetalKit)
+        (cmakeBool "LLAMA_BLAS" useBlas)
+      ]
+      ++ optionals useOpenCL [ (cmakeBool "LLAMA_CLBLAST" true) ]
+      ++ optionals useCuda [ (cmakeBool "LLAMA_CUBLAS" true) ]
+      ++ optionals useRocm [
+        (cmakeBool "LLAMA_HIPBLAS" true)
+        (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
+        (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
+
+        # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
+        # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
+        # and select the line that matches the current nixpkgs version of rocBLAS.
+        # Should likely use `rocmPackages.clr.gpuTargets`.
+        "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
+      ]
+      ++ optionals useMetalKit [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1") ]
+      ++ optionals useBlas [ (lib.cmakeFeature "LLAMA_BLAS_VENDOR" "OpenBLAS") ];
+
+    # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
+    # if they haven't been added yet.
+    postInstall = ''
+      mv $out/bin/main $out/bin/llama
+      mv $out/bin/server $out/bin/llama-server
+      mkdir -p $out/include
+      cp $src/llama.h $out/include/
+    '';
+
+    # Define the shells here, but don't add in the inputsFrom to avoid recursion.
+    passthru = {
+      shell = mkShell {
+        name = "default${descriptionSuffix}";
+        description = "contains numpy and sentencepiece";
+        buildInputs = [ llama-python ];
+        inputsFrom = [ finalAttrs.finalPackage ];
+      };
+
+      shell-extra = mkShell {
+        name = "extra${descriptionSuffix}";
+        description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
+        buildInputs = [ llama-python-extra ];
+        inputsFrom = [ finalAttrs.finalPackage ];
+      };
     };
-  };
-})
+  }
+)

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -104,6 +104,16 @@ effectiveStdenv.mkDerivation (
     meta = {
       description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
       mainProgram = "llama";
+
+
+      # These people might respond if you ping them in case of Nix-specific
+      # regressions or for reviewing Nix-specific PRs.
+
+      # Note that lib.maintainers is defined in Nixpkgs.
+      maintainers = with lib.maintainers; [
+          philiptaron
+          SomeoneSerge
+      ];
     };
 
     postPatch = ''

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -178,18 +178,24 @@ effectiveStdenv.mkDerivation (
     };
 
     meta = {
+      broken = (useCuda && effectiveStdenv.isDarwin) || (useMetalKit && !effectiveStdenv.isDarwin);
       description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-      mainProgram = "llama";
+      homepage = "https://github.com/ggerganov/llama.cpp/";
+      license = lib.licenses.mit;
 
+      # Accommodates `nix run` and `lib.getExe`
+      mainProgram = "llama";
 
       # These people might respond if you ping them in case of Nix-specific
       # regressions or for reviewing Nix-specific PRs.
 
       # Note that lib.maintainers is defined in Nixpkgs.
       maintainers = with lib.maintainers; [
-          philiptaron
-          SomeoneSerge
+        philiptaron
+        SomeoneSerge
       ];
+
+      platforms = lib.platforms.unix;
     };
   }
 )

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -186,10 +186,16 @@ effectiveStdenv.mkDerivation (
       # Accommodates `nix run` and `lib.getExe`
       mainProgram = "llama";
 
-      # These people might respond if you ping them in case of Nix-specific
-      # regressions or for reviewing Nix-specific PRs.
+      # These people might respond, on the best effort basis, if you ping them
+      # in case of Nix-specific regressions or for reviewing Nix-specific PRs.
+      # Consider adding yourself to this list if you want to ensure this flake
+      # stays maintained and you're willing to invest your time. Do not add
+      # other people without their consent. Consider removing people after
+      # they've been unreachable for long periods of time.
 
-      # Note that lib.maintainers is defined in Nixpkgs.
+      # Note that lib.maintainers is defined in Nixpkgs, but you may just add
+      # an attrset following the same format as in
+      # https://github.com/NixOS/nixpkgs/blob/f36a80e54da29775c78d7eff0e628c2b4e34d1d7/maintainers/maintainer-list.nix
       maintainers = with lib.maintainers; [
         philiptaron
         SomeoneSerge

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -178,7 +178,15 @@ effectiveStdenv.mkDerivation (
     };
 
     meta = {
-      broken = (useCuda && effectiveStdenv.isDarwin) || (useMetalKit && !effectiveStdenv.isDarwin);
+      # Configurations we don't want even the CI to evaluate. Results in the
+      # "unsupported platform" messages. This is mostly a no-op, because
+      # cudaPackages would've refused to evaluate anyway.
+      badPlatforms = optionals (useCuda || useOpenCL) lib.platforms.darwin;
+
+      # Configurations that are known to result in build failures. Can be
+      # overridden by importing Nixpkgs with `allowBroken = true`.
+      broken = (useMetalKit && !effectiveStdenv.isDarwin);
+
       description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
       homepage = "https://github.com/ggerganov/llama.cpp/";
       license = lib.licenses.mit;
@@ -201,7 +209,8 @@ effectiveStdenv.mkDerivation (
         SomeoneSerge
       ];
 
-      platforms = lib.platforms.unix;
+      # Extend `badPlatforms` instead
+      platforms = lib.platforms.all;
     };
   }
 )

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -162,6 +162,14 @@ effectiveStdenv.mkDerivation (
 
     # Define the shells here, but don't add in the inputsFrom to avoid recursion.
     passthru = {
+      inherit
+        useBlas
+        useCuda
+        useMetalKit
+        useOpenCL
+        useRocm
+        ;
+
       shell = mkShell {
         name = "default${descriptionSuffix}";
         description = "contains numpy and sentencepiece";

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -101,20 +101,6 @@ effectiveStdenv.mkDerivation (
   finalAttrs: {
     name = "llama.cpp";
     src = ../../.;
-    meta = {
-      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-      mainProgram = "llama";
-
-
-      # These people might respond if you ping them in case of Nix-specific
-      # regressions or for reviewing Nix-specific PRs.
-
-      # Note that lib.maintainers is defined in Nixpkgs.
-      maintainers = with lib.maintainers; [
-          philiptaron
-          SomeoneSerge
-      ];
-    };
 
     postPatch = ''
       substituteInPlace ./ggml-metal.m \
@@ -189,6 +175,21 @@ effectiveStdenv.mkDerivation (
         buildInputs = [ llama-python-extra ];
         inputsFrom = [ finalAttrs.finalPackage ];
       };
+    };
+
+    meta = {
+      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+      mainProgram = "llama";
+
+
+      # These people might respond if you ping them in case of Nix-specific
+      # regressions or for reviewing Nix-specific PRs.
+
+      # Note that lib.maintainers is defined in Nixpkgs.
+      maintainers = with lib.maintainers; [
+          philiptaron
+          SomeoneSerge
+      ];
     };
   }
 )

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },


### PR DESCRIPTION
Also a follow-up to https://github.com/ggerganov/llama.cpp/pull/4605, this time reworking the [`meta`](https://nixos.org/manual/nixpkgs/unstable/#chap-meta) attributes.

Notably, this PR populates the `meta.maintainers` with contacts of the people that may be asked for a review of nix-related changes. Cf. comments in the code