### PR TITLE
Fix OpenAI server sampling w.r.t. penalty.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2461,7 +2461,7 @@ json oaicompat_completion_params_parse(
     llama_params["mirostat_eta"]      = json_value(body, "mirostat_eta", default_sparams.mirostat_eta);
     llama_params["penalize_nl"]       = json_value(body, "penalize_nl", default_sparams.penalize_nl);
     llama_params["typical_p"]         = json_value(body, "typical_p", default_sparams.typical_p);
-    llama_params["repeat_last_n"]     = json_value(body, "repeat_last_n", 0);
+    llama_params["repeat_last_n"]     = json_value(body, "repeat_last_n", default_sparams.penalty_last_n);
     llama_params["ignore_eos"]        = json_value(body, "ignore_eos", false);
     llama_params["tfs_z"]             = json_value(body, "tfs_z", default_sparams.tfs_z);
 


### PR DESCRIPTION
Nearly the same with #4668

The default value of `repeat_last_n` was set to zero, so when I use OpenAI python package to send requests, I found the penalty not working in the generation. And that is because the param `repeat_last_n` does not exist in OpenAI API's default params, the user must add a `extra_body` which contains `repeat_last_n` > 0 to have an expected behaviour same as openai does.