### PR TITLE
Updates Package.swift to use ggml as dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,21 +13,25 @@ let package = Package(
     products: [
         .library(name: "llama", targets: ["llama"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/1-ashraful-islam/ggml.git", .branch("master"))
+    ],
     targets: [
         .target(
             name: "llama",
+            dependencies: ["ggml"],
             path: ".",
             exclude: [],
             sources: [
-                "ggml.c",
+                // "ggml.c",
                 "llama.cpp",
-                "ggml-alloc.c",
-                "ggml-backend.c",
-                "ggml-quants.c",
-                "ggml-metal.m",
+                // "ggml-alloc.c",
+                // "ggml-backend.c",
+                // "ggml-quants.c",
+                // "ggml-metal.m",
             ],
             resources: [
-                .process("ggml-metal.metal")
+                // .process("ggml-metal.metal")
             ],
             publicHeadersPath: "spm-headers",
             cSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "llama", targets: ["llama"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/1-ashraful-islam/ggml.git", .branch("master"))
+        .package(url: "https://github.com/ggerganov/ggml.git", .branch("master"))
     ],
     targets: [
         .target(
@@ -23,15 +23,7 @@ let package = Package(
             path: ".",
             exclude: [],
             sources: [
-                // "ggml.c",
                 "llama.cpp",
-                // "ggml-alloc.c",
-                // "ggml-backend.c",
-                // "ggml-quants.c",
-                // "ggml-metal.m",
-            ],
-            resources: [
-                // .process("ggml-metal.metal")
             ],
             publicHeadersPath: "spm-headers",
             cSettings: [


### PR DESCRIPTION
When adding both whisper.cpp and llama.cpp as package dependency in Xcode - we run into "duplicate declarations of symbols" issue as both of these package uses the same source files for ggml.

Adding a swift package declaration to ggml (ggerganov/ggml/pull/674) and importing it as a dependency to both whisper.cpp and llama.cpp solves the issue.

Once the pull request (ggerganov/ggml/pull/674) is merged, merge this pull requests to llama.cpp that use ggml as dependency.