### PR TITLE
clip.cpp offbyone 

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -259,11 +259,11 @@ static ggml_cgraph * clip_image_build_graph(const clip_ctx * ctx, const clip_ima
     ggml_allocr_alloc(ctx->compute_alloc, inp_raw);
 
     if (!ggml_allocr_is_measure(ctx->compute_alloc)) {
-        float * data = (float *)malloc(ggml_nbytes(inp_raw));
+        const int nx = imgs->data[0].nx; // all images have the same size (336 in llava-1.5 with the OA clip patch 14)
+        const int ny = imgs->data[0].ny;
+        float * data = (float *)malloc(batch_size * 3 * ny * nx * sizeof(float));
 
         for (size_t i = 0; i < imgs->size; i++) {
-            const int nx = imgs->data[i].nx;
-            const int ny = imgs->data[i].ny;
             GGML_ASSERT(nx == image_size && ny == image_size);
 
             const int n = nx * ny;
@@ -306,7 +306,7 @@ static ggml_cgraph * clip_image_build_graph(const clip_ctx * ctx, const clip_ima
     struct ggml_tensor * positions = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, num_positions);
     ggml_allocr_alloc(ctx->compute_alloc, positions);
     if (!ggml_allocr_is_measure(ctx->compute_alloc)) {
-        int* positions_data = (int*)malloc(ggml_nbytes(positions));
+        int* positions_data = (int*)malloc(num_positions * sizeof(int));
         for (int i = 0; i < num_positions; i++) {
             positions_data[i] = i;
         }
@@ -412,7 +412,7 @@ static ggml_cgraph * clip_image_build_graph(const clip_ctx * ctx, const clip_ima
         struct ggml_tensor * patches = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, num_patches);
         ggml_allocr_alloc(ctx->compute_alloc, patches);
         if (!ggml_allocr_is_measure(ctx->compute_alloc)) {
-            int* patches_data = (int*)malloc(ggml_nbytes(patches));
+            int* patches_data = (int*)malloc(num_patches * sizeof(int));
             for (int i = 0; i < num_patches; i++) {
                 patches_data[i] = i + 1;
             }

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -413,7 +413,7 @@ static ggml_cgraph * clip_image_build_graph(const clip_ctx * ctx, const clip_ima
         ggml_allocr_alloc(ctx->compute_alloc, patches);
         if (!ggml_allocr_is_measure(ctx->compute_alloc)) {
             int* patches_data = (int*)malloc(ggml_nbytes(patches));
-            for (int i = 0; i < num_positions; i++) {
+            for (int i = 0; i < num_patches; i++) {
                 patches_data[i] = i + 1;
             }
             ggml_backend_tensor_set(patches, patches_data, 0, ggml_nbytes(patches));


### PR DESCRIPTION
It's past 6:00 AM so I might be missing something obvious

Changes:
1) The off-by-one is fixed (num_patches instead of num_positions)
num_positions is 1 larger than num_patches, it likely was a copy/paste error
2) I've changed the memory allocations to use the actual internal memory units we write instead of ggml_nbytes(tensor)
That's cleaner

This is not solving the segmentation fault sadly, my heap is still being corrupted but it's probably one less thing that does it.
