### PR TITLE
ggml : testing GPU FP precision via quantized CPY

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -291,6 +291,10 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
             options = [MTLCompileOptions new];
             options.preprocessorMacros = @{ @"QK_K" : @(64) };
 #endif
+            // disable fast math
+            // NOTE: this seems to have no effect whatsoever
+            //[options setFastMathEnabled:false];
+
             ctx->library = [ctx->device newLibraryWithSource:src options:options error:&error];
         }
 

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1103,12 +1103,17 @@ void dequantize_row_q4_0(const block_q4_0 * restrict x, float * restrict y, int 
     }
 }
 
+#include <stdio.h>
+
 void dequantize_row_q4_1(const block_q4_1 * restrict x, float * restrict y, int k) {
     static const int qk = QK4_1;
 
     assert(k % qk == 0);
 
     const int nb = k / qk;
+
+    printf("d = %9f\n", GGML_FP16_TO_FP32(x[0].d));
+    printf("m = %9f\n", GGML_FP16_TO_FP32(x[0].m));
 
     for (int i = 0; i < nb; i++) {
         const float d = GGML_FP16_TO_FP32(x[i].d);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -437,11 +437,12 @@ struct test_case {
             double err = nmse(f1.data(), f2.data(), f1.size());
             if (err > ud->max_err) {
                 printf("[%s] NMSE = %f ", ggml_op_desc(t1), err);
-                //for (int i = 0; i < f1.size(); i++) {
-                //    printf("%5d %9.6f %9.6f, diff = %9.6f\n", i, f1[i], f2[i], f1[i] - f2[i]);
-                //}
-                //printf("\n");
-                //exit(1);
+                printf("\n");
+                for (int i = 0; i < f1.size(); i++) {
+                    printf("%5d %9.6f %9.6f, diff = %9.6f\n", i, f1[i], f2[i], f1[i] - f2[i]);
+                }
+                printf("\n");
+                exit(1);
                 ud->ok = false;
             }
             return true;
@@ -1459,8 +1460,14 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
 
     test_cases.emplace_back(new test_dup());
 
-    for (ggml_type type : all_types) {
-       test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, type, {256, 10, 10, 1}));
+    //for (ggml_type type : all_types) {
+    //   test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, type, {256, 10, 10, 1}));
+    //}
+
+    for (ggml_type type : { GGML_TYPE_Q4_1} ) {
+        for (int i = 0; i < 2048; ++i) {
+            test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, type, {32, 1, 1, 1}));
+        }
     }
 
     test_cases.emplace_back(new test_cont());


### PR DESCRIPTION
Wanted to find out why the Metal `test-backend-ops` is failing from [time to time](https://github.com/ggml-org/ci/tree/results/llama.cpp/a2/0f3c7465d6d1b33767757c2760643b799a81bf/ggml-100-m1). This PR applies just the `GGML_OP_CPY` operation with `F32` src -> `Q4_1` dst. I.e. it performs quantization.

Running this long enough will eventually generate an error:

```bash
make -j tests && while ./tests/test-backend-ops -o CPY -b Metal ; do date ; done
```

```py
# example (scroll down)

  CPY(type_src=f32,type_dst=q4_1,ne=[32,1,1,1]): ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.03 MiB, (    1.66 / 147456.00)
d =  0.127808
m = -0.954590
d =  0.127808
m = -0.954590
OK
  CPY(type_src=f32,type_dst=q4_1,ne=[32,1,1,1]): ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.03 MiB, (    1.66 / 147456.00)
d =  0.126709
m = -0.922852
d =  0.126709
m = -0.922852
OK
  CPY(type_src=f32,type_dst=q4_1,ne=[32,1,1,1]): ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.03 MiB, (    1.66 / 147456.00)
d =  0.115479
m = -0.740723
d =  0.115479
m = -0.740723
OK
  CPY(type_src=f32,type_dst=q4_1,ne=[32,1,1,1]): ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.03 MiB, (    1.66 / 147456.00)
d =  0.119568                             # <------ GPU result (notice d is different here)
m = -0.834961
d =  0.119507                             # <------ CPU result (reference)
m = -0.834961
[CPY] NMSE = 0.000001 
    0 -0.834961 -0.834961, diff =  0.000000
    1 -0.834961 -0.834961, diff =  0.000000
    2 -0.476257 -0.476440, diff =  0.000183
    3  0.599854  0.599121, diff =  0.000732
    4  0.002014  0.001587, diff =  0.000427
    5  0.958557  0.957642, diff =  0.000916
    6 -0.117554 -0.117920, diff =  0.000366
    7  0.002014  0.001587, diff =  0.000427
    8  0.719421  0.718628, diff =  0.000793
    9  0.241150  0.240601, diff =  0.000549
   10  0.121582  0.121094, diff =  0.000488
   11  0.599854  0.599121, diff =  0.000732
   12  0.121582  0.121094, diff =  0.000488
   13  0.241150  0.240601, diff =  0.000549
   14  0.121582  0.121094, diff =  0.000488
   15  0.719421  0.718628, diff =  0.000793
   16 -0.356689 -0.356934, diff =  0.000244
   17  0.002014  0.001587, diff =  0.000427
   18  0.121582  0.121094, diff =  0.000488
   19  0.002014  0.001587, diff =  0.000427
   20  0.360718  0.360107, diff =  0.000610
   21 -0.117554 -0.117920, diff =  0.000366
   22  0.241150  0.240601, diff =  0.000549
   23  0.838989  0.838135, diff =  0.000854
   24  0.599854  0.599121, diff =  0.000732
   25 -0.476257 -0.476440, diff =  0.000183
   26 -0.117554 -0.117920, diff =  0.000366
   27  0.241150  0.240601, diff =  0.000549
   28 -0.595825 -0.595947, diff =  0.000122
   29  0.002014  0.001587, diff =  0.000427
   30  0.719421  0.718628, diff =  0.000793
   31 -0.237122 -0.237427, diff =  0.000305
```

It looks like the floating-point operation for computing `d` can produce different results between the CPU and the GPU:

```c
const float d  = (max - min) / ((1 << 4) - 1);
```

Not sure how to fix this - ideas?


---

While looking into this issue, I found that CUDA can also fail the CPY test sometimes.
On `master`, run this and it will eventually fail, though I haven't investigated what is the source of the error in this case:

```bash
LLAMA_CUBLAS=1 make -j tests && while ./tests/test-backend-ops -o CPY -b CUDA0 ; do date ; done
```

```py
Backend 2/2 (CUDA0)
ggml_init_cublas: GGML_CUDA_FORCE_MMQ:   no
ggml_init_cublas: CUDA_USE_TENSOR_CORES: yes
ggml_init_cublas: found 1 CUDA devices:
  Device 0: NVIDIA GeForce RTX 2060 SUPER, compute capability 7.5, VMM: yes
  Backend name: CUDA
  CPY(type_src=f32,type_dst=f32,ne=[256,10,10,1]): OK
  CPY(type_src=f32,type_dst=f16,ne=[256,10,10,1]): OK
  CPY(type_src=f32,type_dst=q4_0,ne=[256,10,10,1]): OK
  CPY(type_src=f32,type_dst=q4_1,ne=[256,10,10,1]): [CPY] NMSE = 0.000004 FAIL
  CPY(type_src=f32,type_dst=q5_0,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q5_1,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q8_0,ne=[256,10,10,1]): OK
  CPY(type_src=f32,type_dst=q2_K,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q3_K,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q4_K,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q5_K,ne=[256,10,10,1]): not supported [CUDA] 
  CPY(type_src=f32,type_dst=q6_K,ne=[256,10,10,1]): not supported [CUDA] 
  876/877 tests passed
  Backend CUDA: FAIL

1/2 backends passed
FAIL
```

Sometimes it can take a while. Reproed on RTX 2060 and V100