### PR TITLE
ggml : include stdlib.h before intrin.h

### DIFF
--- a/ggml-impl.h
+++ b/ggml-impl.h
@@ -5,6 +5,7 @@
 // GGML internal header
 
 #include <assert.h>
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h> // memcpy

--- a/ggml-impl.h
+++ b/ggml-impl.h
@@ -5,7 +5,7 @@
 // GGML internal header
 
 #include <assert.h>
-#include <stdlib.h>
+#include <stdlib.h> // load `stdlib.h` before other headers to work around MinGW bug: https://sourceforge.net/p/mingw-w64/bugs/192/
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h> // memcpy


### PR DESCRIPTION
fix #4707 