### PR TITLE
New quantization method for Q4_K and Q5_K

### DIFF
--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1332,11 +1332,11 @@ static void quantize_q_k_1(const float * x, int bits, int scale_bits, int block_
         }
     }
 
-    float scales[QK_K/block_size];
-    float mins[QK_K/block_size];
+    float scales[QK_K];
+    float mins[QK_K];
 
     for (int j = 0; j < QK_K/block_size; j++) {
-        uint8_t q[block_size];
+        uint8_t q[QK_K];
         // First find least squares solution for min and scale for each block.
         quantize_1(&x[block_size*j], block_size, bits, q, &mins[j], &scales[j]);
         // Flip the sign because quantize_1 assumes that min is added, but min
@@ -1411,7 +1411,7 @@ static void quantize_q_k_1(const float * x, int bits, int scale_bits, int block_
         }
 
         float q_fit[QK_K];
-        float q_m[QK_K/block_size];
+        float q_m[QK_K];
 
         // Quantize elements and populate arrays needed for least squares fit.
         for (int j = 0; j < QK_K/block_size; ++j) {

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1336,7 +1336,7 @@ static void quantize_q_k_1(const float * x, int bits, int scale_bits, int block_
     float mins[QK_K/block_size];
 
     for (int j = 0; j < QK_K/block_size; j++) {
-        uint8_t q[QK_K/block_size];
+        uint8_t q[block_size];
         // First find least squares solution for min and scale for each block.
         quantize_1(&x[block_size*j], block_size, bits, q, &mins[j], &scales[j]);
         // Flip the sign because quantize_1 assumes that min is added, but min

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1754,8 +1754,6 @@ void quantize_row_q3_K_reference(const float * restrict x, block_q3_K * restrict
         }
 #endif
 
-        y[i].d = GGML_FP32_TO_FP16(lstsq_q_0(q_fit, x, QK_K));
-
         memset(y[i].hmask, 0, QK_K/8);
         // We put the high-bit for the 1st 8 quants into bit 0, the next 8 into bit 1, etc.
         int m = 0;
@@ -2231,8 +2229,6 @@ void quantize_row_q6_K_reference(const float * restrict x, block_q6_K * restrict
                 q_fit[16*j + ii] = l * y[i].scales[j];
             }
         }
-
-        y[i].d = GGML_FP32_TO_FP16(lstsq_q_0(q_fit, x, QK_K));
 
         uint8_t * restrict ql = y[i].ql;
         uint8_t * restrict qh = y[i].qh;

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -433,16 +433,19 @@ static void lstsq_q_1(const uint8_t * restrict q, const float * restrict x, int 
     float xq = 0.0f;
     float minx = x[0];
     float maxx = x[0];
+    float q1 = 0.0f;
     for (int i = 0; i < qk; i++) {
         float qf = q[i];
-        qs += qf;
-        qs2 += qf*qf;
-        xs += x[i];
-        xq += x[i]*qf;
+        float w = fabsf(x[i]);
+        q1 += w;
+        qs += w*qf;
+        qs2 += w*qf*qf;
+        xs += w*x[i];
+        xq += w*x[i]*qf;
         if (x[i] < minx) minx = x[i];
         if (x[i] > maxx) maxx = x[i];
     }
-    float denom = qs*qs - qs2*qk;
+    float denom = qs*qs - qs2*q1;
     if (minx == maxx) {
         *min = x[0];
         *d = 0.0f;
@@ -451,7 +454,7 @@ static void lstsq_q_1(const uint8_t * restrict q, const float * restrict x, int 
         *d = 0.0f;
     } else {
         *min = (qs*xq - qs2*xs) / denom;
-        *d = (qs*xs - qk*xq) / denom;
+        *d = (qs*xs - q1*xq) / denom;
     }
 }
 
@@ -491,11 +494,12 @@ static void lstsq_q_k(const float * restrict q, const float * restrict x, const 
     float sx = 0.0f;
     float qx = 0.0f;
     for (int i = 0; i < QK_K; i++) {
-        s2 += s[i/bs]*s[i/bs];
-        qs += q[i]*s[i/bs];
-        q2 += q[i]*q[i];
-        sx += s[i/bs]*x[i];
-        qx += q[i]*x[i];
+        float w = fabsf(x[i]);
+        s2 += w*s[i/bs]*s[i/bs];
+        qs += w*q[i]*s[i/bs];
+        q2 += w*q[i]*q[i];
+        sx += w*s[i/bs]*x[i];
+        qx += w*q[i]*x[i];
     }
     float denom = qs*qs - q2*s2;
     if (s2 == 0.0f && q2 != 0.0f) {

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -1892,6 +1892,35 @@ redo_pos4:
             uint8_t lm = nearest_int(inv_min*mins[j]);
             ls = MIN(63, ls);
             lm = MIN(63, lm);
+            float rms = 0.0f;
+            float rms2 = 0.0f;
+            float rms3 = 0.0f;
+            uint8_t lm2 = MIN(63, MAX(0, lm - 1));
+            uint8_t lm3 = MIN(63, MAX(0, lm + 1));
+            const float d1 = max_scale / 63.0f;
+            const float dmin1 = max_min / 63.0f;
+            for (int ii = 0; ii < 32; ii++) {
+                const float d = d1 * ls;
+                const float dm1 = dmin1 * lm;
+                const float dm2 = dmin1 * lm2;
+                const float dm3 = dmin1 * lm3;
+                if (!d) continue;
+                int l1 = nearest_int((x[32*j + ii] + dm1)/d);
+                l1 = MAX(0, MIN(15, l1));
+                int l2 = nearest_int((x[32*j + ii] + dm2)/d);
+                l2 = MAX(0, MIN(15, l2));
+                int l3 = nearest_int((x[32*j + ii] + dm3)/d);
+                l3 = MAX(0, MIN(15, l3));
+                rms += ((d*l1 - dm1) - x[32*j + ii]) * ((d*l1 - dm1) - x[32*j + ii]);
+                rms2 += ((d*l2 - dm2) - x[32*j + ii]) * ((d*l2 - dm2) - x[32*j + ii]);
+                rms3 += ((d*l3 - dm3) - x[32*j + ii]) * ((d*l3 - dm3) - x[32*j + ii]);
+            }
+            if (rms2 < rms && rms2 < rms3) {
+                lm = lm2;
+            }
+            if (rms3 < rms && rms3 < rms2) {
+                lm = lm3;
+            }
             if (lm != 0) all_zero_lm = 0;
             if (j < 4) {
                 y[i].scales[j] = ls;


### PR DESCRIPTION
Quantization performance is usually evaluated using perplexity. Perplexity measures how sure the model is of its token choices, in other words how sharp the output logit distribution is. It makes sense for evaluating unquantized models because there isn't really any one true output for the output tokens. However, when measuring how much quantization affects the output there is a correct output, the unquantized model's output with the same inputs, and it makes sense to compare how closely aligned the output logits are to the unquantized model. KL divergence is very natural choice for measuring how close two distributions are.

This PR changes the quantization for Q4_K and Q5_K formats, commit history also includes changes for some other formats too but testing all of them was too much work. Quantization format is unchanged and the generated weights are backwards compatible. It's not very big change and especially if perplexity is used to compare models the changes are within the error margin. KL divergence measurement is better and outside the error margins with all tested models. RMS error is also slightly decreased.

<details><summary>RMS errors</summary>

```
RMS error (master)
phi-2:
q4_K : rmse 0.00226361, maxerr 0.52862549, 95pct<0.0042, median<0.0016
q5_K : rmse 0.00115071, maxerr 0.28332520, 95pct<0.0022, median<0.0010

Llama-2 7B:
q4_K : rmse 0.00137495, maxerr 0.11077881, 95pct<0.0026, median<0.0010
q5_K : rmse 0.00069610, maxerr 0.05142975, 95pct<0.0014, median<0.0006

Mixtral 8x7B:
q4_K : rmse 0.00082300, maxerr 0.44823837, 95pct<0.0016, median<0.0008
q5_K : rmse 0.00041677, maxerr 0.20952225, 95pct<0.0008, median<0.0004

RMS error (PR)
phi-2:
q4_K : rmse 0.00220827, maxerr 0.54077148, 95pct<0.0042, median<0.0016
q5_K : rmse 0.00109032, maxerr 0.33684158, 95pct<0.0020, median<0.0008

Llama-2 7B:
q4_K : rmse 0.00134057, maxerr 0.31831360, 95pct<0.0026, median<0.0010
q5_K : rmse 0.00065857, maxerr 0.11894464, 95pct<0.0014, median<0.0006

Mixtral 8x7B:
q4_K : rmse 0.00079569, maxerr 0.44116211, 95pct<0.0016, median<0.0006
q5_K : rmse 0.00039095, maxerr 0.19310760, 95pct<0.0008, median<0.0004
```
</details>

KL divergence is calculated with [this script](https://gist.github.com/Ttl/0d51f739dc59254b4b2183e259c97d82). Reference logits are calculated with fp16 model on `wiki.test.raw`. Mixtral 8x7B uses only about 15% of the file because running fp16 model is way too slow on my computer, other models are evaluated on full file. KL divergence error margin is 99% confidence interval. Perplexity is also calculated on `wiki.test.raw` using the full file. Last column is the fraction of how often the token with highest value agreed on quantized and fp16 models and it gives more easily interpretable measure on how the quantization actually affects the generated tokens.

| Model | Quantization | Perplexity | KL divergence to fp16 model | Top-1 token agreement to fp16 model |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| phi-2 | (master) Q4_K_S | 11.0052 ± 0.07823 | 0.0430889 ± 0.000276 | 0.8895 ± 0.001508 |
| phi-2 | (PR) Q4_K_S | 11.0145 ± 0.07824 | 0.0385425 ± 0.000245 | 0.8951 ± 0.001472 |
| Llama-2 7B | (master) Q4_K_S | 5.8852 ± 0.03279 | 0.0246132 ± 0.000419 | 0.9269 ± 0.001156 |
| Llama-2 7B | (PR) Q4_K_S | 5.8930 ± 0.03290 | 0.0226238 ± 0.000415 | 0.929 ± 0.00114 |
| Mixtral-8x7B | (master) Q4_K_S | 4.5136 ± 0.02424 | 0.035074 ± 0.000992 | 0.9191 ± 0.003105 |
| Mixtral-8x7B | (PR) Q4_K_S | 4.5159 ± 0.02435 | 0.0323496 ± 0.000888 | 0.9208 ± 0.003075 |

Model | Quantization | Perplexity | KL divergence to fp16 model | Top-1 token agreement to fp16 model
| ------------- | ------------- | ------------- | ------------- | ------------- |
phi-2 | (master) Q5_K_S | 10.8949 ± 0.07747 | 0.0225299 ± 0.000143 | 0.9193 ± 0.00131
phi-2 | (PR) Q5_K_S | 10.8883 ± 0.07739 | 0.0210207 ± 0.000130 | 0.9215 ± 0.001294
Llama-2 7B | (master) Q5_K_S | 5.8204 ± 0.03250 | 0.0104636 ± 0.000210 | 0.9507 ± 0.0009612
Llama-2 7B | (PR) Q5_K_S | 5.8160 ± 0.03252 | 0.00894639 ± 0.000129 | 0.9518 ± 0.0009511
Mixtral-8x7B | (master) Q5_K_S | 4.4399 ± 0.02378 | 0.0131443 ± 0.000651 | 0.9501 ± 0.00248
Mixtral-8x7B | (PR) Q5_K_S | 4.4440 ± 0.02379 | 0.0125088 ± 0.000457 | 0.9497 ± 0.002488

The script also outputs other statistics such as 90%, 95% and 99% quantile KL divergence and how often fp16 top token is in quantized model top5 and top10. I didn't try to fill all of them in the table but this PR also improves those for example LLama-2 7B Q4_K_S:

<details><summary>Llama-2 7B stats</summary>

```
Model: llama-2-7b-q4_k_s.gguf
Size: 3.59 GiB, (BPW 4.58)
Tokens: 336345
KL-divergence:
mean: 0.0246132, [0.0241945 - 0.025032]
q90: 0.04327, [0.04299 - 0.04354]
q95: 0.06774, [0.06709 - 0.06839]
q99: 0.2054, [0.1996 - 0.2112]
max: 6.866
Reference top token in eval top-n probability:
ref_top1: 0.9269 ± 0.001156
ref_top5: 0.9965 ± 0.0002622
ref_top10: 0.997556 ± 0.0002193
Eval top token in reference top-n probability:
eval_top5: 0.9982 ± 0.0001866
eval_top10: 0.99904 ± 0.0001376

Model: llama-2-7b-q4_k_pr.gguf
Size: 3.59 GiB, (BPW 4.58)
Tokens: 336345
KL-divergence:
mean: 0.0226238, [0.0222092 - 0.0230385]
q90: 0.04112, [0.04085 - 0.04139]
q95: 0.06352, [0.06297 - 0.06408]
q99: 0.1809, [0.1767 - 0.1853]
max: 8.778
Reference top token in eval top-n probability:
ref_top1: 0.929 ± 0.00114
ref_top5: 0.999 ± 0.0001432
ref_top10: 0.999762 ± 6.849e-05
Eval top token in reference top-n probability:
eval_top5: 0.9988 ± 0.0001559
eval_top10: 0.999611 ± 8.764e-05
```
</details>

For example `Eval top token in reference top-10 probability` increased from 0.99904 to 0.999611, which means that with 336345 total tokens the amount of tokens where top-1 quantized model token was outside of top-10 tokens of fp16 model decreased from 323 to 131 in the test set.

Here's two plots with also some other quantization formats for easier visualization:

![phi2_kl](https://github.com/ggerganov/llama.cpp/assets/544240/98b22be0-efe3-442f-add0-644234b68e61)
![llama2_kl](https://github.com/ggerganov/llama.cpp/assets/544240/f4958ae1-0e36-4c1f-8ea5-cb2156af8f30)

I don't think this approach is optimal even when considering only the current activation unaware quantization. Even if just using RMS error as the target the quantization of Q_K formats is mixed integer least squares problem which is NP-hard, but I didn't want to spend too much time on it and wanted to first get some feedback if this makes sense.
