### PR TITLE
⚾ Throw an error to be caught by upstream callers when `slot unavailable`

### DIFF
--- a/examples/server/public/completion.js
+++ b/examples/server/public/completion.js
@@ -97,6 +97,15 @@ export async function* llama(prompt, params = {}, config = {}) {
           }
           if (result.error) {
             result.error = JSON.parse(result.error);
+            if (result.error.content.includes('slot unavailable')) {
+              // Throw an error to be caught by upstream callers
+              throw new Error('slot unavailable');
+            } else {
+              console.error(`llama.cpp error: ${result.error.content}`);
+            }
+          }
+          if (result.error) {
+            result.error = JSON.parse(result.error);
             console.error(`llama.cpp error: ${result.error.content}`);
           }
         }


### PR DESCRIPTION
This will allow upstream callers to catch "slot unavailable" errors and handle them more appropriately.

An example from some code I use that imports `completion.js`:
```javascript
    try {
        await streamLlamaData(job.data.prompt, res, job);
        responseStreams.delete(requestId);
    } catch (error) {
        console.error('Error streaming data:', error);
        if (error.message.includes('slot unavailable')) {
            await handleSlotUnavailableError(job); // <---------- error successfully caught and retry logic is applied
        }
    }
```