### PR TITLE
Fix CUDA diag_mask_inf tests with LLAMA_FAST

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -10928,7 +10928,7 @@ static void ggml_compute_forward_diag_mask_inf(
     switch (src0->type) {
         case GGML_TYPE_F32:
             {
-                ggml_compute_forward_diag_mask_f32(params, src0, dst, -INFINITY);
+                ggml_compute_forward_diag_mask_f32(params, src0, dst, -FLT_MAX);
             } break;
         default:
             {


### PR DESCRIPTION
When I run the CUDA backend tests for `diag_mask_inf` with `LLAMA_FAST` they fail on my system on master:

```
> ./tests/test-backend-ops -o DIAG_MASK_INF
Testing 2 backends

Backend 1/2 (CPU)
  Backend name: CPU
ggml_init_cublas: GGML_CUDA_FORCE_MMQ:   no
ggml_init_cublas: CUDA_USE_TENSOR_CORES: yes
ggml_init_cublas: found 1 CUDA devices:
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes
  DIAG_MASK_INF(type=f32,ne=[10,10,1,1],n_past=5): OK
  DIAG_MASK_INF(type=f32,ne=[10,10,10,1],n_past=5): OK
  DIAG_MASK_INF(type=f32,ne=[10,10,10,10],n_past=5): OK
  877/877 tests passed
  Backend CPU: OK

Backend 2/2 (CUDA0)
  Backend name: CUDA
  DIAG_MASK_INF(type=f32,ne=[10,10,1,1],n_past=5): [DIAG_MASK_INF] inf mismatch: -340282346638528859811704183484516925440.000000 -inf FAIL
  DIAG_MASK_INF(type=f32,ne=[10,10,10,1],n_past=5): [DIAG_MASK_INF] inf mismatch: -340282346638528859811704183484516925440.000000 -inf FAIL
  DIAG_MASK_INF(type=f32,ne=[10,10,10,10],n_past=5): [DIAG_MASK_INF] inf mismatch: -340282346638528859811704183484516925440.000000 -inf FAIL
  874/877 tests passed
  Backend CUDA: FAIL

1/2 backends passed
FAIL
```

 The issue seems to be that the CUDA code instead of explicitly setting the values to `-INFINITY` subtracts `FLT_MAX` masked by the position in the matrix. This PR changes the `ggml.c` code in a way that *could* be used to fix the failing tests by simply setting the values to `-FLT_MAX` instead of `-INFINITY` on the CPU. Numerically this should be equivalent in almost all situations but I'm not sure if this is the best solution; you could also just skip the tests when compiled with `LLAMA_FAST`.