### PR TITLE
Work around MinGW bug

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1,6 +1,8 @@
 #define _CRT_SECURE_NO_DEPRECATE // Disables ridiculous "unsafe" warnings on Windows
 #define _USE_MATH_DEFINES // For M_PI on MSVC
 
+// Load `stdlib.h` before other headers to work around MinGW bug: <https://sourceforge.net/p/mingw-w64/bugs/192/>.
+#include <stdlib.h>
 #include "ggml-impl.h"
 #include "ggml-quants.h"
 
@@ -14,7 +16,6 @@
 #include <errno.h>
 #include <time.h>
 #include <math.h>
-#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>


### PR DESCRIPTION
Without this patch, compiling llama.cpp with MinGW results in
```
/workspace/srcdir/llama.cpp/ggml.c: In function ‘ggml_init’:
/workspace/srcdir/llama.cpp/ggml.c:193:35: error: implicit declaration of function ‘_aligned_malloc’; did you mean ‘_aligned_realloc’? [-Werror=implicit-function-declaration]
  193 | #define GGML_ALIGNED_MALLOC(size) _aligned_malloc(size, GGML_MEM_ALIGN)
      |                                   ^~~~~~~~~~~~~~~
```
This is an upstream bug: https://sourceforge.net/p/mingw-w64/bugs/192/, this change is to work around it.