### PR TITLE
Use correct pointer for llama_token_eos (llama.swiftui)

### DIFF
--- a/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
+++ b/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
@@ -161,7 +161,7 @@ actor LlamaContext {
             new_token_id = llama_sample_token_greedy(context, &candidates_p)
         }
 
-        if new_token_id == llama_token_eos(context) || n_cur == n_len {
+        if new_token_id == llama_token_eos(model) || n_cur == n_len {
             print("\n")
             let new_token_str = String(cString: temporary_invalid_cchars + [0])
             temporary_invalid_cchars.removeAll()


### PR DESCRIPTION
This PR fixes an issue regarding EOF token detection in the **llama.swiftui** example.
As seen in the other Swift example, `examples/batched.swift/Sources/main.swift)
/main.swift`, we need to use model pointer obtained through `llama_load_model_from_file` when using `llama_token_eos`.