### PR TITLE
ggml : fix null backend dereference

### DIFF
--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -703,7 +703,7 @@ ggml_backend_t ggml_backend_cpu_init(void) {
 }
 
 bool ggml_backend_is_cpu(ggml_backend_t backend) {
-    return backend->iface.get_name == ggml_backend_cpu_name;
+    return backend && backend->iface.get_name == ggml_backend_cpu_name;
 }
 
 void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads) {

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -10140,7 +10140,7 @@ ggml_backend_t ggml_backend_cuda_init(int device) {
 }
 
 bool ggml_backend_is_cuda(ggml_backend_t backend) {
-    return backend->iface.get_name == ggml_backend_cuda_name;
+    return backend && backend->iface.get_name == ggml_backend_cuda_name;
 }
 
 int ggml_backend_cuda_get_device_count() {

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -2749,7 +2749,7 @@ ggml_backend_t ggml_backend_metal_init(void) {
 }
 
 bool ggml_backend_is_metal(ggml_backend_t backend) {
-    return backend->iface.get_name == ggml_backend_metal_name;
+    return backend && backend->iface.get_name == ggml_backend_metal_name;
 }
 
 void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {


### PR DESCRIPTION
With Metal and `-ngl 0`, `ggml_backend_is_metal()` triggers segfault:

```bash
make -j && ./main -m ./models/llama-7b-v2/ggml-model-q8_0.gguf -p "I believe the meaning of life is" -ngl 0
```

Applied same change to `ggml_backend_is_cuda()` and `ggml_backend_is_cpu()` for consistency
