### PR TITLE
CUDA: fixed redundant value dequantization

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1872,14 +1872,6 @@ static __device__ void convert_f16(const void * vx, const int ib, const int iqs,
     v.y = x[ib + iqs + 1];
 }
 
-static __device__ void convert_f32(const void * vx, const int ib, const int iqs, dfloat2 & v){
-    const float * x = (const float *) vx;
-
-    // automatic half -> float type cast if dfloat == float
-    v.x = x[ib + iqs + 0];
-    v.y = x[ib + iqs + 1];
-}
-
 static __global__ void quantize_q8_1(const float * __restrict__ x, void * __restrict__ vy, const int kx, const int kx_padded) {
     const int ix = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -1983,7 +1975,7 @@ static __global__ void k_get_rows_float(
 
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
 static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __restrict__ y, const int k) {
-    const int i = blockDim.x*blockIdx.x + 2*threadIdx.x;
+    const int i = 2*(blockDim.x*blockIdx.x + threadIdx.x);
 
     if (i >= k) {
         return;
@@ -2000,6 +1992,19 @@ static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __
 
     y[iybs + iqs + 0]        = v.x;
     y[iybs + iqs + y_offset] = v.y;
+}
+
+template <typename src_t, typename dst_t>
+static __global__ void convert_unary(const void * __restrict__ vx, dst_t * __restrict__ y, const int k) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+
+    const src_t * x = (src_t *) vx;
+
+    y[i] = x[i];
 }
 
 // VDR = vec dot ratio, how many contiguous integers each thread processes when the vec dot kernel is called
@@ -5609,7 +5614,7 @@ static void quantize_row_q8_1_cuda(const float * x, void * vy, const int kx, con
 
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
 static void dequantize_block_cuda(const void * __restrict__ vx, dst_t * __restrict__ y, const int k, cudaStream_t stream) {
-    const int num_blocks = (k + CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / CUDA_DEQUANTIZE_BLOCK_SIZE;
+    const int num_blocks = (k + 2*CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / (2*CUDA_DEQUANTIZE_BLOCK_SIZE);
     dequantize_block<qk, qr, dequantize_kernel><<<num_blocks, CUDA_DEQUANTIZE_BLOCK_SIZE, 0, stream>>>(vx, y, k);
 }
 
@@ -5659,6 +5664,12 @@ static void dequantize_row_q6_K_cuda(const void * vx, dst_t * y, const int k, cu
 #endif
 }
 
+template <typename src_t, typename dst_t>
+static void convert_unary_cuda(const void * __restrict__ vx, dst_t * __restrict__ y, const int k, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_DEQUANTIZE_BLOCK_SIZE - 1) / CUDA_DEQUANTIZE_BLOCK_SIZE;
+    convert_unary<src_t><<<num_blocks, CUDA_DEQUANTIZE_BLOCK_SIZE, 0, stream>>>(vx, y, k);
+}
+
 static to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
     switch (type) {
         case GGML_TYPE_Q4_0:
@@ -5682,7 +5693,7 @@ static to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
         case GGML_TYPE_Q6_K:
             return dequantize_row_q6_K_cuda;
         case GGML_TYPE_F32:
-            return dequantize_block_cuda<1, 1, convert_f32>;
+            return convert_unary_cuda<float>;
         default:
             return nullptr;
     }
@@ -5711,7 +5722,7 @@ static to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
         case GGML_TYPE_Q6_K:
             return dequantize_row_q6_K_cuda;
         case GGML_TYPE_F16:
-            return dequantize_block_cuda<1, 1, convert_f16>;
+            return convert_unary_cuda<half>;
         default:
             return nullptr;
     }


### PR DESCRIPTION
While working on https://github.com/ggerganov/llama.cpp/pull/4801 I noticed that the dequantization kernel used for q4_0, q4_1, q5_0, q5_1, and q8_0 have a bug on master. The dequantization kernel dequantizes two values per thread but the total number of threads is equal to the number of values to be dequantized. As a consequence the kernel does redundant work and reads and writes each value twice. This PR fixes this so that each value is only processed once. NVIDIA NSight Systems suggests this makes the dequantization kernel 1.5-1.7 times faster. The overall performance changes as follows:

| Model         | GPU                     | test   |   t/s master |   t/s PR |   Speedup |
|---------------|-------------------------|--------|--------------|----------|-----------|
| llama 7B Q4_0 | NVIDIA GeForce RTX 3090 | pp512  |      3351.16 |  3663.45 |      1.09 |
| llama 7B Q4_0 | NVIDIA GeForce RTX 3090 | tg128  |       133.60 |   133.51 |      1.00 |
| llama 7B Q4_1 | NVIDIA GeForce RTX 3090 | pp512  |      3320.01 |  3617.73 |      1.09 |
| llama 7B Q4_1 | NVIDIA GeForce RTX 3090 | tg128  |       125.82 |   126.06 |      1.00 |
| llama 7B Q5_0 | NVIDIA GeForce RTX 3090 | pp512  |      3184.30 |  3546.27 |      1.11 |
| llama 7B Q5_0 | NVIDIA GeForce RTX 3090 | tg128  |       115.38 |   115.34 |      1.00 |
| llama 7B Q5_1 | NVIDIA GeForce RTX 3090 | pp512  |      3172.27 |  3513.94 |      1.11 |
| llama 7B Q5_1 | NVIDIA GeForce RTX 3090 | tg128  |       110.45 |   110.36 |      1.00 |
| llama 7B Q8_0 | NVIDIA GeForce RTX 3090 | pp512  |      3189.03 |  3482.86 |      1.09 |
| llama 7B Q8_0 | NVIDIA GeForce RTX 3090 | tg128  |        88.25 |    88.10 |      1.00 |