### PR TITLE
passkey : add "self-extend"-like context extension

### DIFF
--- a/examples/passkey/passkey.cpp
+++ b/examples/passkey/passkey.cpp
@@ -125,7 +125,7 @@ int main(int argc, char ** argv) {
     const int n_batch     = ctx_params.n_batch;
     const int n_batch_grp = ctx_params.n_batch/n_grp;
 
-    LOG_TEE("\n%s: n_len = %d, n_ctx = %d, n_kv_req = %d\n", __func__, n_len, n_ctx, n_kv_req);
+    LOG_TEE("\n%s: n_len = %d, n_ctx = %d, n_kv_req = %d, n_grp = %d, n_batch = %d\n", __func__, n_len, n_ctx, n_kv_req, n_grp, n_batch);
 
     // print the prompt token-by-token
 
@@ -141,6 +141,7 @@ int main(int argc, char ** argv) {
     // fill the KV cache
     for (int i = 0; i < n_ctx; i += n_batch) {
         if (i > 0 && n_grp > 1) {
+            // if SelfExtend is enabled, we compress the position from the last batch by a factor of n_grp
             const int ib = i/n_batch - 1;
             const int bd = n_batch_grp*(n_grp - 1);
 

--- a/examples/passkey/passkey.cpp
+++ b/examples/passkey/passkey.cpp
@@ -10,7 +10,7 @@ int main(int argc, char ** argv) {
     gpt_params params;
 
     if (argc == 1 || argv[1][0] == '-') {
-        printf("usage: %s MODEL_PATH N_JUNK I_POS SEED\n" , argv[0]);
+        printf("usage: %s MODEL_PATH N_JUNK N_GRP I_POS SEED\n" , argv[0]);
         return 1 ;
     }
 
@@ -18,6 +18,7 @@ int main(int argc, char ** argv) {
 
     int n_junk = 250; // number of times to repeat the junk text
     int n_keep = 32;  // number of tokens in the prompt prefix
+    int n_grp  = 1;   // if more than 1 - perform LongLM SelfExtend
     int i_pos  = -1;  // position of the passkey in the junk text
 
     if (argc >= 2) {
@@ -29,11 +30,15 @@ int main(int argc, char ** argv) {
     }
 
     if (argc >= 4) {
-        i_pos = std::stoi(argv[3]);
+        n_grp = std::stoi(argv[3]);
     }
 
     if (argc >= 5) {
-        seed = std::stoi(argv[4]);
+        i_pos = std::stoi(argv[4]);
+    }
+
+    if (argc >= 6) {
+        seed = std::stoi(argv[5]);
     }
 
     if (seed == -1) {
@@ -86,10 +91,12 @@ int main(int argc, char ** argv) {
     llama_context_params ctx_params = llama_context_default_params();
 
     ctx_params.seed    = seed;
-    ctx_params.n_ctx   = llama_n_ctx_train(model) + n_keep;
+    ctx_params.n_ctx   = llama_n_ctx_train(model)*n_grp + n_keep;
     ctx_params.n_batch = 512;
     ctx_params.n_threads       = params.n_threads;
     ctx_params.n_threads_batch = params.n_threads_batch == -1 ? params.n_threads : params.n_threads_batch;
+
+    GGML_ASSERT(ctx_params.n_batch % n_grp == 0 && "n_batch must be divisible by n_grp");
 
     llama_context * ctx = llama_new_context_with_model(model, ctx_params);
 
@@ -113,9 +120,10 @@ int main(int argc, char ** argv) {
     // total length of the sequences including the prompt
     const int n_len = n_tokens_all + n_predict;
 
-    const int n_ctx    = llama_n_ctx(ctx) - n_keep;
-    const int n_kv_req = llama_n_ctx(ctx);
-    const int n_batch  = ctx_params.n_batch;
+    const int n_ctx       = llama_n_ctx(ctx) - n_keep;
+    const int n_kv_req    = llama_n_ctx(ctx);
+    const int n_batch     = ctx_params.n_batch;
+    const int n_batch_grp = ctx_params.n_batch/n_grp;
 
     LOG_TEE("\n%s: n_len = %d, n_ctx = %d, n_kv_req = %d\n", __func__, n_len, n_ctx, n_kv_req);
 
@@ -132,6 +140,16 @@ int main(int argc, char ** argv) {
 
     // fill the KV cache
     for (int i = 0; i < n_ctx; i += n_batch) {
+        if (i > 0 && n_grp > 1) {
+            const int ib = i/n_batch - 1;
+            const int bd = n_batch_grp*(n_grp - 1);
+
+            llama_kv_cache_seq_shift(ctx, 0, n_past - n_batch,         n_past,         ib*bd);
+            llama_kv_cache_seq_div  (ctx, 0, n_past - n_batch + ib*bd, n_past + ib*bd, n_grp);
+
+            n_past -= bd;
+        }
+
         llama_batch_clear(batch);
 
         for (int j = 0; j < n_batch && i + j < n_tokens_all; j++) {

--- a/llama.h
+++ b/llama.h
@@ -484,6 +484,13 @@ extern "C" {
                        llama_pos   p1,
                        llama_pos   delta);
 
+    LLAMA_API void llama_kv_cache_seq_div(
+            struct llama_context * ctx,
+                    llama_seq_id   seq_id,
+                       llama_pos   p0,
+                       llama_pos   p1,
+                             int   d);
+
     //
     // State / sessions
     //


### PR DESCRIPTION
ref: https://github.com/ggerganov/llama.cpp/discussions/4785

Inspired by the Self-Extend method: https://arxiv.org/pdf/2401.01325.pdf
I could be wrong, but this implementation should be pretty much equivalent to the proposed method.

The passkey test does work with context extension of up to x4 (LLaMA 7B v2 with ctx of 16384):

```bash
# use G = 4 (second argument), batch = 512 (default, corresponds to W from the paper)
# put the pass key near the beginning of a ~15k prompt (10/600)
# 600 - number of times to repeat the junk text
# 4   - the group factor G from the paper
# 10  - insert the pass key after 10 times of junk text

make -j && ./bin/passkey ../models/llama-7b-v2/ggml-model-f16.gguf 600 4 10
```

```bash
...

# scroll down for results

main: n_len = 14483, n_ctx = 16384, n_kv_req = 16416

prefix tokens: 32
prompt tokens: 14467
main: processed: [     0,    512)
main: processed: [   512,   1024)
main: processed: [  1024,   1536)
main: processed: [  1536,   2048)
main: processed: [  2048,   2560)
main: processed: [  2560,   3072)
main: processed: [  3072,   3584)
main: processed: [  3584,   4096)
main: processed: [  4096,   4608)
main: processed: [  4608,   5120)
main: processed: [  5120,   5632)
main: processed: [  5632,   6144)
main: processed: [  6144,   6656)
main: processed: [  6656,   7168)
main: processed: [  7168,   7680)
main: processed: [  7680,   8192)
main: processed: [  8192,   8704)
main: processed: [  8704,   9216)
main: processed: [  9216,   9728)
main: processed: [  9728,  10240)
main: processed: [ 10240,  10752)
main: processed: [ 10752,  11264)
main: processed: [ 11264,  11776)
main: processed: [ 11776,  12288)
main: processed: [ 12288,  12800)
main: processed: [ 12800,  13312)
main: processed: [ 13312,  13824)
main: processed: [ 13824,  14336)
main: processed: [ 14336,  14467)

main: passkey = 37590, inserted at position 10 / 600 (token pos: ~241)

 What is the pass key? The pass key is 37590. Remember it. 37590

main: decoded 16 tokens in 0.77 s, speed: 20.73 t/s

llama_print_timings:        load time =    1752.33 ms
llama_print_timings:      sample time =       0.36 ms /    17 runs   (    0.02 ms per token, 46831.96 tokens per second)
llama_print_timings: prompt eval time =   16257.26 ms / 14467 tokens (    1.12 ms per token,   889.88 tokens per second)
llama_print_timings:        eval time =     769.77 ms /    16 runs   (   48.11 ms per token,    20.79 tokens per second)
llama_print_timings:       total time =   17782.21 ms
```

Still a lot to be investigated here and high-probability of a mistake, so be careful in the analysis.

Note that this implementation does not use any kind of RoPE scaling and no context shifting.
If the prompt exceeds the extended context, the implementation will fallback to the old method of context shifting which was demonstrated in #3856 that it is not able to pass this test when the size of the prompt exceeds the training context.

### Step-by-step explanation for `G=4, W=512`

- Process batch 0 with 512 tokens and positions `[0, 512)`
- Update KV cache positions: `[0, 512) -> [0, 128)`
- Process batch 1 with 512 tokens and positions `[128, 640)`
- Update KV cache positions: `[128, 640] -> [128, 256]`
- ...
- Process batch K with 512 tokens and positions `[W/G*K, W/G*K + W)`
- Update KV cache positions: `[W/G*K, W/G*K + W] -> ([W/G*K, W/G*K + W) + K*W/G)/G = [W/G*K, W/G*K + W/G]`
- ...

The KV cache update is performed via RoPE shift based on the position delta.
This way, every new batch attends it's own tokens with the standard attention of sequential positions, while it also attends to the old cached tokens with "compressed" positions by a factor of `G`