### PR TITLE
llama : minimize size used for state save/load

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9795,12 +9795,8 @@ struct llama_context * llama_new_context_with_model(
                 ggml_type_name(type_v), (float)memory_size_v / (1024.0f * 1024.0f));
         }
 
-        // resized during inference
-        if (params.logits_all) {
-            ctx->logits.reserve(hparams.n_vocab*cparams.n_batch);
-        } else {
-            ctx->logits.reserve(hparams.n_vocab);
-        }
+        // resized during inference, reserve maximum
+        ctx->logits.reserve(hparams.n_vocab*cparams.n_batch);
 
         if (params.embedding){
             ctx->embedding.resize(hparams.n_embd);

--- a/llama.cpp
+++ b/llama.cpp
@@ -9797,7 +9797,7 @@ struct llama_context * llama_new_context_with_model(
 
         // resized during inference
         if (params.logits_all) {
-            ctx->logits.reserve(cparams.n_ctx*hparams.n_vocab);
+            ctx->logits.reserve(hparams.n_vocab*cparams.n_batch);
         } else {
             ctx->logits.reserve(hparams.n_vocab);
         }

--- a/llama.cpp
+++ b/llama.cpp
@@ -10225,7 +10225,7 @@ struct llama_data_file_context : llama_data_context {
 static void llama_copy_state_data_internal(struct llama_context * ctx, llama_data_context * data_ctx) {
     // copy rng
     {
-        std::stringstream rng_ss;
+        std::ostringstream rng_ss;
         rng_ss << ctx->rng;
 
         const size_t rng_size = rng_ss.str().size();
@@ -10361,7 +10361,7 @@ size_t llama_set_state_data(struct llama_context * ctx, uint8_t * src) {
         memcpy(&rng_size,   inp, sizeof(rng_size));    inp += sizeof(rng_size);
         memcpy(&rng_buf[0], inp, LLAMA_MAX_RNG_STATE); inp += LLAMA_MAX_RNG_STATE;
 
-        std::stringstream rng_ss;
+        std::istringstream rng_ss;
         rng_ss.str(std::string(&rng_buf[0], rng_size));
         rng_ss >> ctx->rng;
 

--- a/llama.h
+++ b/llama.h
@@ -43,7 +43,7 @@
 #define LLAMA_FILE_MAGIC_GGSN 0x6767736eu // 'ggsn'
 
 #define LLAMA_SESSION_MAGIC   LLAMA_FILE_MAGIC_GGSN
-#define LLAMA_SESSION_VERSION 3
+#define LLAMA_SESSION_VERSION 4
 
 #if defined(GGML_USE_CUBLAS) || defined(GGML_USE_CLBLAST) || defined(GGML_USE_METAL)
 // Defined when llama.cpp is compiled with support for offloading model layers to GPU.


### PR DESCRIPTION
#### Context

I am playing with creating a chat application for Android on which I would like to save context state on each message written to allow for chat continuation and message regeneration. As such, small state serialization and robust state deserialization are of great interest.

#### Overview

With the new `llama_batch` API state saving and loading is currently broken as the capacity of `llama_context->logits` depends on the largest batch size ever passed to `llama_decode` (see #4430). To fix this issue, this PR suggests reserving the maximum capacity reachable during context initialization.

To reduce the increase in storage required to now serialize all of the logits buffer, save and load functions are changed to only save currently valid logits. The check against capacity is kept, but as an upper bound instead of requiring it to match serialized state. This enables "compacting" the state by passing a batch of one token as the last batch before saving.

As I saw no reason not to, RNG serialization is also changed to only write the required amount of space instead of a full block of `LLAMA_MAX_RNG_STATE`, although the upper limit is kept.

---

As this changes the session file, this is a **breaking** change. I welcome any kind of feedback or request for changes.