### PR TITLE
swift : exclude ggml-metal.metal from the package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             name: "llama",
             dependencies: ["ggml"],
             path: ".",
-            exclude: [],
+            exclude: ["ggml-metal.metal"],
             sources: [
                 "llama.cpp",
             ],


### PR DESCRIPTION
`ggml-metal.metal` comes from the `ggml` package. If not excluded, it causes duplicate resource errors