### PR TITLE
Add a `/health` endpoint to the `server`

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2798,7 +2798,9 @@ int main(int argc, char **argv)
                                 {"total_threads", std::thread::hardware_concurrency()},
                                 {"system_info", llama_print_system_info()},
                             });
-    
+
+    httplib::Server svr;
+
     ServerState server_state = LOADING_MODEL;
     // load the model
     if (!llama.load_model(params))
@@ -2810,7 +2812,6 @@ int main(int argc, char **argv)
     llama.initialize();
     server_state = READY;
 
-    httplib::Server svr;
 
     // Middleware for API key validation
     auto validate_api_key = [&sparams](const httplib::Request &req, httplib::Response &res) -> bool {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2901,18 +2901,6 @@ int main(int argc, char **argv)
                 return 0;
             });
 
-    // GG: if I put the main loop inside a thread, it crashes on the first request when build in Debug!?
-    //     "Bus error: 10" - this is on macOS, it does not crash on Linux
-    //std::thread t2([&]()
-    {
-        bool running = true;
-        while (running)
-        {
-            running = llama.update_slots();
-        }
-    }
-    //);
-
 
     // load the model
     if (!llama.load_model(params))
@@ -3276,6 +3264,18 @@ int main(int argc, char **argv)
                 task_result result = llama.next_result(task_id);
                 return res.set_content(result.result_json.dump(), "application/json; charset=utf-8");
             });
+
+    // GG: if I put the main loop inside a thread, it crashes on the first request when build in Debug!?
+    //     "Bus error: 10" - this is on macOS, it does not crash on Linux
+    //std::thread t2([&]()
+    {
+        bool running = true;
+        while (running)
+        {
+            running = llama.update_slots();
+        }
+    }
+    //);
 
     t.join();
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2956,7 +2956,7 @@ int main(int argc, char **argv)
                 res.set_content(R"({"status": "ok"})", "application/json");
                 res.status = 200; // HTTP OK
                 break;
-            case LOADING:
+            case LOADING_MODEL:
                 res.set_content(R"({"status": "loading model"})", "application/json");
                 res.status = 503; // HTTP Service Unavailable
                 break;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2938,7 +2938,13 @@ int main(int argc, char **argv)
             });
 
 
-
+    svr.Get("/health", [&](const httplib::Request&, httplib::Response& res) {
+        // Perform necessary internal status checks here
+        // For demonstration purposes, we'll simply return a status of 'ok'
+        res.set_content(R"({"status": "ok"})", "application/json");
+        res.status = 200; // HTTP OK
+    });
+    
     svr.Get("/v1/models", [&params](const httplib::Request&, httplib::Response& res)
             {
                 std::time_t t = std::time(0);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2799,11 +2799,11 @@ int main(int argc, char **argv)
                                 {"system_info", llama_print_system_info()},
                             });
     
-    server_state = LOADING_MODEL;
+    ServerState server_state = LOADING_MODEL;
     // load the model
     if (!llama.load_model(params))
     {
-        server_state = ERRPR;
+        server_state = ERROR;
         return 1;
     }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2801,6 +2801,8 @@ int main(int argc, char **argv)
 
     httplib::Server svr;
 
+    ServerState server_state = LOADING_MODEL;
+
     svr.set_default_headers({{"Server", "llama.cpp"},
                              {"Access-Control-Allow-Origin", "*"},
                              {"Access-Control-Allow-Headers", "content-type"}});
@@ -2823,7 +2825,6 @@ int main(int argc, char **argv)
     });
 
 
-    ServerState server_state = LOADING_MODEL;
     // load the model
     if (!llama.load_model(params))
     {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2939,8 +2939,8 @@ int main(int argc, char **argv)
 
 
     svr.Get("/health", [&](const httplib::Request&, httplib::Response& res) {
-        // Perform necessary internal status checks here
-        // For demonstration purposes, we'll simply return a status of 'ok'
+        // in real-world applications, it's common to first query the /health endpoint of the server to make sure it's running
+        // it will return "ok" only after the model is successfully loaded by the server.
         res.set_content(R"({"status": "ok"})", "application/json");
         res.status = 200; // HTTP OK
     });


### PR DESCRIPTION
This PR adds a `/health` endpoint to the `server` example. It works as follows:

- While the model is being loaded, querying `/health` returns `"{"status": "loading model"}`.
- After the model is successfully loaded, querying `/health` returns `{"status": "ok"}`.
- If any errors occurs, `/health` returns `{"status": "error"}`.

I re-ordered the code about the two threads of the server so that the server starts first, but only `/health` is available. In the other thread, the model is being loaded. If the model successfully loads, the rest of the endpoints (`/completion/`, etc.) become available as well.

## Why add a `/health` endpoint?

Because loading large models (especially with `--no-mmap` flag) takes a long time. The server should not accept completions/embedding/etc. requests during this time. The user can query `/health` to make sure the model is fully loaded before they send their requests.

## Example

While the model is being loaded:

```
curl --request GET --url http://127.0.0.1:8080/health
>> {"status": "loading model"}
```

After model is fully loaded:

```
curl --request GET --url http://127.0.0.1:8080/health
>> {"status": "ok"}
```