### PR TITLE
Performance: Placing Metal encoder debug group behind a define

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1067,7 +1067,9 @@ bool ggml_metal_graph_compute(
                     GGML_ASSERT(!"unsupported op");
                 }
 
+#ifndef GGML_METAL_NDEBUG
                 [encoder pushDebugGroup:[NSString stringWithCString:ggml_op_desc(dst) encoding:NSUTF8StringEncoding]];
+#endif
 
                 const int64_t  ne00 = src0 ? src0->ne[0] : 0;
                 const int64_t  ne01 = src0 ? src0->ne[1] : 0;
@@ -2426,7 +2428,9 @@ bool ggml_metal_graph_compute(
                         }
                 }
 
+#ifndef GGML_METAL_NDEBUG
                 [encoder popDebugGroup];
+#endif
             }
 
             if (encoder != nil) {


### PR DESCRIPTION
Bearing the granularity and frequency of the task being performed in this tight loop, this debug group code performs quite a bit of relatively heavy lifting - it allocates a string on the heap, populates it by examining and parsing another buffer for UTF8 and recreates it, as well as whatever complexity comes from `ggml_op_desc`, via two ObjC dynamic dispatches.

While clearly this is extremely useful for development, it may be introducing a bit of a load on non-debug situations? This PR suggests putting it behind a `define`. `GGML_METAL_NDEBUG` seemed to me the most obvious choice, but others could make sense too.