### PR TITLE
server : fix typo in model name

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2515,7 +2515,7 @@ json oaicompat_completion_params_parse(
     //
     // https://platform.openai.com/docs/api-reference/chat/create
     llama_sampling_params default_sparams;
-    llama_params["model"]             = json_value(body, "model", std::string("uknown"));
+    llama_params["model"]             = json_value(body, "model", std::string("unknown"));
     llama_params["prompt"]            = format_chatml(body["messages"]); // OpenAI 'messages' to llama.cpp 'prompt'
     llama_params["cache_prompt"]      = json_value(body, "cache_prompt", false);
     llama_params["temperature"]       = json_value(body, "temperature", 0.0);


### PR DESCRIPTION
- Previously the model name was returned as "uknown" which is a misspelling of "unknown".
- This PR updates the spelling.
- I was unsure if this is really something that should be done as it's possibly a breaking change if people are depending on the old spelling, but I thought I'd propose it anyway and then this PR could be closed if it's considered too much of a breaking change.