### PR TITLE
Fix server crash running multimodal models with add_bos_token = false (e.g. Obsidian)

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1835,7 +1835,7 @@ struct llama_server_context
 
                     slot.cache_tokens = prompt_tokens;
 
-                    if (slot.n_past == slot.num_prompt_tokens)
+                    if (slot.n_past == slot.num_prompt_tokens && slot.n_past > 0)
                     {
                         // we have to evaluate at least 1 token to generate logits.
                         LOG_TEE("slot %d : we have to evaluate at least 1 token to generate logits\n", slot.id);


### PR DESCRIPTION
There seems to be a subtle bug in server.cpp when using a multimodal model where add_bos_token is false, such as Obsidian 3B Q6. The usual prompt tokenizing code isn't used in this case which means that no meaningful tokens are added to prompt_tokens and slot.num_prompt_tokens is set to the length after tokenizing nothing. In models where no BOS token is added, this means slot.num_prompt_tokens is zero which causes the check for slot.n_past == slot.num_prompt_tokens further down to trigger and decrement slot.n_past to -1. This causes various code later on to access before the start of arrays, leading to crashes or other weird misbehaviour. Only decrementing slot.n_past when it's greater than zero seems to fix this and is hopefully safe. 

I think this is likely the root cause of bug #4789 