### PR TITLE
Make Q3_K_S be the same as old Q3_K_L for Mixtral-8x7B

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8465,9 +8465,16 @@ static ggml_type get_k_quant_type(quantize_state_internal & qs, ggml_type new_ty
         ++qs.i_feed_forward_w2;
     } else if (name.find("attn_output.weight") != std::string::npos) {
         if (arch != LLM_ARCH_FALCON) {
-            if      (ftype == LLAMA_FTYPE_MOSTLY_Q2_K  ) new_type = GGML_TYPE_Q3_K;
-            else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M) new_type = GGML_TYPE_Q4_K;
-            else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q5_K;
+            if (qs.model.hparams.n_expert == 8) {
+                if (ftype == LLAMA_FTYPE_MOSTLY_Q2_K   || ftype == LLAMA_FTYPE_MOSTLY_Q3_K_S || ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M ||
+                    ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S || ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M) {
+                    new_type = GGML_TYPE_Q5_K;
+                }
+            } else {
+                if      (ftype == LLAMA_FTYPE_MOSTLY_Q2_K  ) new_type = GGML_TYPE_Q3_K;
+                else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M) new_type = GGML_TYPE_Q4_K;
+                else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q5_K;
+            }
         } else {
             if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q4_K;
         }


### PR DESCRIPTION
Before PR #4872 the intended k-quants quantization mix did not work for Mixtral-8x7B (and in general, for any MoE model). But after merging #4872 it was observed that the new `Q3_K_S` is only 128 MiB smaller than the former `Q3_K_L`, and yet it has a significantly higher perplexity (see #4900). `Q3_K_L` before #4872 is basically identical to `Q3_K_S` after #4872, except for the `attn_output` tensor being quantized with `Q5_K` instead of `Q3_K`.

For a MoE model the attention portion of the network is a small fraction of the overall model size. Hence, it makes sense to spend more bits on the attention tensors. This is already being done for `attn_k` and `attn_v` (quantized with `Q8_0`). This PR changes `attn_output` quantization to `Q5_K` for `Q2_K ... Q4_K_M` for Mixtral-8x7B. This makes the new `Q3_K_S` be exactly the same as the old `Q3_K_L`.

Closes #4900 