### PR TITLE
Correctly set `support_simdgroup_reduction` and `support_simdgroup_mm` on iOS

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -330,7 +330,6 @@ static struct ggml_metal_context * ggml_metal_init(int n_cb) {
         }
     }
 
-#if TARGET_OS_OSX
     // print MTL GPU family:
     GGML_METAL_LOG_INFO("%s: GPU name:   %s\n", __func__, [[ctx->device name] UTF8String]);
 
@@ -366,7 +365,7 @@ static struct ggml_metal_context * ggml_metal_init(int n_cb) {
     ctx->support_simdgroup_reduction |= [ctx->device supportsFamily:MTLGPUFamilyMetal3];
 
     ctx->support_simdgroup_mm = [ctx->device supportsFamily:MTLGPUFamilyApple7];
-
+#if TARGET_OS_OSX
     GGML_METAL_LOG_INFO("%s: simdgroup reduction support   = %s\n",       __func__, ctx->support_simdgroup_reduction ? "true" : "false");
     GGML_METAL_LOG_INFO("%s: simdgroup matrix mul. support = %s\n",       __func__, ctx->support_simdgroup_mm ? "true" : "false");
     GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -365,10 +365,11 @@ static struct ggml_metal_context * ggml_metal_init(int n_cb) {
     ctx->support_simdgroup_reduction |= [ctx->device supportsFamily:MTLGPUFamilyMetal3];
 
     ctx->support_simdgroup_mm = [ctx->device supportsFamily:MTLGPUFamilyApple7];
-#if TARGET_OS_OSX
+
     GGML_METAL_LOG_INFO("%s: simdgroup reduction support   = %s\n",       __func__, ctx->support_simdgroup_reduction ? "true" : "false");
     GGML_METAL_LOG_INFO("%s: simdgroup matrix mul. support = %s\n",       __func__, ctx->support_simdgroup_mm ? "true" : "false");
     GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");
+#if TARGET_OS_OSX
     GGML_METAL_LOG_INFO("%s: recommendedMaxWorkingSetSize  = %8.2f MB\n", __func__, ctx->device.recommendedMaxWorkingSetSize / 1e6);
     if (ctx->device.maxTransferRate != 0) {
         GGML_METAL_LOG_INFO("%s: maxTransferRate               = %8.2f MB/s\n", __func__, ctx->device.maxTransferRate / 1e6);


### PR DESCRIPTION
These two new flags for Metal kernels where introduced in https://github.com/ggerganov/llama.cpp/pull/4794.

However, currently they are only set `#if TARGET_OS_OSX`, meaning that llama.cpp running on iPhone/iPad fails in `ggml_metal_supports_op` function, even though simd operations are supported on mobile devices as well as long as they are `MTLGPUFamilyMetal3`/`MTLGPUFamilyApple7`. See [Metal features set table](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf).

The fix is very straightforward, I just move `#if TARGET_OS_OSX` a couple of lines down, so ggml_metal_supports_op is initialized on other platforms as well. Let's also include some additional logging, because it doesn't have anything macOS specific.