### PR TITLE
Fix ffn_down quantization mix for MoE models

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8473,7 +8473,12 @@ static ggml_type get_k_quant_type(quantize_state_internal & qs, ggml_type new_ty
             // for getting the current layer as I initially thought, and we need to resort to parsing the
             // tensor name.
             n_layer = qs.n_feed_forward_w2 / n_expert;
-            sscanf(name.c_str(), "blk.%d.ffn_down", &i_layer);
+            if (sscanf(name.c_str(), "blk.%d.ffn_down", &i_layer) != 1) {
+                throw std::runtime_error(format("Failed to determine layer for tensor %s", name.c_str()));
+            }
+            if (i_layer < 0 || i_layer >= n_layer) {
+                throw std::runtime_error(format("Bad layer %d for tensor %s. Must be in [0, %d)", i_layer, name.c_str(), n_layer));
+            }
         }
         if      (ftype == LLAMA_FTYPE_MOSTLY_Q2_K) new_type = GGML_TYPE_Q3_K;
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S) {


### PR DESCRIPTION
In #4872 I did not consider the part where every third tensor is quantized with more bits. For MoE this leads to `ffn_down` "expert" tensors of the same layer being quantized with different number of bits, which is not considered as a possibility in the inference implementation (it is assumed all experts use the same quantization). Hence, for `QX_K_M` this leads to garbage output even though the perplexity is fine. Thanks to @shinomakoi who noticed the problem.