### PR TITLE
Round away from zero instead of towards nearest whole integer for quantization

### DIFF
--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -500,8 +500,9 @@ void quantize_row_q4_0_reference(const float * restrict x, block_q4_0 * restrict
             const float x0 = x[i*qk + 0    + j]*id;
             const float x1 = x[i*qk + qk/2 + j]*id;
 
-            const uint8_t xi0 = MIN(15, (int8_t)(x0 + 8.5f));
-            const uint8_t xi1 = MIN(15, (int8_t)(x1 + 8.5f));
+            // Experimental change that rounds away from absolute zero instead of 
+            const uint8_t xi0 = MIN(15, (int8_t)(x0 + (x0 >= 0 ? 8.0f : 9.0f)));
+            const uint8_t xi1 = MIN(15, (int8_t)(x1 + (x1 >= 0 ? 8.0f : 9.0f)));
 
             y[i].qs[j]  = xi0;
             y[i].qs[j] |= xi1 << 4;


### PR DESCRIPTION
@ikawrakow I was inspired by your recent quantization work to look into something of potential interest: the rounding method used during quantization.

It occurred to me that rounding values to absolute zero (the typical Bankers rounding, where 0.5 gets rounded up to 1.0, and below 0.5 is rounded down to zero) is probably suboptimal for lower bit quants.

![image](https://github.com/ggerganov/llama.cpp/assets/66376113/abb88c15-131e-4562-abbb-48965614ba79)

After making this chart, I realized, maybe multiplying a large value by absolute zero is very different (mathematically speaking) from multiplying a large value by near zero or a small negative value; the butterfly effect of having a value that was originally a small weight completely canceled out instead of just being a small positive or negative weight could be a lot more drastic than expected.

E.g., 12,000 x 0.05 = 600, not 0, and 12,000 x -0.05 = -600.

In addition to this, rounding away in the current implementation should in theory result in negative values having slightly more weight than positive ones, even if they are equivalent outside of the sign, which could also be a problem for lower bit rates. For example:

Number | Nearest Whole Integer | Away from Zero
--- | --- | ---
2.5 | 3 | 3
-2.5 | -2 | -3
0.25 | 0 | 1
-0.25 | 0 | -1

It would seem that, if my implementation of rounding away from zero was done properly (not entirely sure about this, please scrutinize!), my intuition was correct.

Top 3 tokens for the next token in the Navy Seal Copypasta after "I am trained in", fp16 Mistral 7b
```
Token 1: 98.245804%
Token 2: 0.377182%
Token 3: 0.122453%
```

Top 3 tokens for q4_0, with the round away from zero change:
```
Token 1: 99.239830%
Token 2: 0.411957%
Token 3: 0.141261%
```

q4_0 without the change:
```
Token 1: 97.540352%
Token 2: 0.531796%
Token 3: 0.086804%
```

The top token is the **only** valid outcome in the tested scenario (a base model being able to complete a known, infamous piece of internet text).

This is not a good substitute for perplexity (or KL divergence) evaluation over a bigger set of text, & the sample set of one token is obviously not enough. The logic here could also be completely wrong and this is coincidental. I wanted to put up a PR since I know very little about quantization logic in the first place and would like feedback, as my other attempts resulted in garbled text generations before this, and it being coherent isn't necessarily proof of it working as intended.

The PR currently modifies the reference implementation for q4_0, which is of course, not ready to merge.

If anyone would like to subjectively test this modified rounding technique, they will need to quantize via q4_0.