### PR TITLE
CUDA: faster dequantize kernels for Q4_0 and Q4_1

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1105,6 +1105,61 @@ static __device__ __forceinline__ void dequantize_q8_0(const void * vx, const in
 #endif // GGML_CUDA_F16
 }
 
+template<typename dst_t>
+static __global__ void dequantize_block_q4_0(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb32) {
+
+    const int i = blockIdx.x;
+
+    // assume 32 threads
+    const int tid = threadIdx.x;
+    const int il  = tid/8;
+    const int ir  = tid%8;
+    const int ib = 8*i + ir;
+    if (ib >= nb32) {
+        return;
+    }
+
+    dst_t * y = yy + 256*i + 32*ir + 4*il;
+
+    const block_q4_0 * x = (const block_q4_0 *)vx + ib;
+    const float d = __half2float(x->d);
+    const float dm = -8*d;
+
+    const uint8_t * q = x->qs + 4*il;
+
+    for (int l = 0; l < 4; ++l) {
+        y[l+ 0] = d * (q[l] & 0xF) + dm;
+        y[l+16] = d * (q[l] >>  4) + dm;
+    }
+}
+
+template<typename dst_t>
+static __global__ void dequantize_block_q4_1(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb32) {
+
+    const int i = blockIdx.x;
+
+    // assume 32 threads
+    const int tid = threadIdx.x;
+    const int il  = tid/8;
+    const int ir  = tid%8;
+    const int ib = 8*i + ir;
+    if (ib >= nb32) {
+        return;
+    }
+
+    dst_t * y = yy + 256*i + 32*ir + 4*il;
+
+    const block_q4_1 * x = (const block_q4_1 *)vx + ib;
+    const float2 d = __half22float2(x->dm);
+
+    const uint8_t * q = x->qs + 4*il;
+
+    for (int l = 0; l < 4; ++l) {
+        y[l+ 0] = d.x * (q[l] & 0xF) + d.y;
+        y[l+16] = d.x * (q[l] >>  4) + d.y;
+    }
+}
+
 //================================== k-quants
 
 template<typename dst_t>
@@ -6254,6 +6309,20 @@ static void dequantize_row_q3_K_cuda(const void * vx, dst_t * y, const int k, cu
 }
 
 template<typename dst_t>
+static void dequantize_q4_0_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q4_0<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+
+template<typename dst_t>
+static void dequantize_q4_1_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q4_1<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+
+template<typename dst_t>
 static void dequantize_row_q4_K_cuda(const void * vx, dst_t * y, const int k, cudaStream_t stream) {
     const int nb = k / QK_K;
     dequantize_block_q4_K<<<nb, 32, 0, stream>>>(vx, y);
@@ -6301,9 +6370,9 @@ static to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
     int id;
     switch (type) {
         case GGML_TYPE_Q4_0:
-            return dequantize_block_cuda<QK4_0, QR4_0, dequantize_q4_0>;
+            return dequantize_q4_0_cuda;
         case GGML_TYPE_Q4_1:
-            return dequantize_block_cuda<QK4_1, QR4_1, dequantize_q4_1>;
+            return dequantize_q4_1_cuda;
         case GGML_TYPE_Q5_0:
             return dequantize_block_cuda<QK5_0, QR5_0, dequantize_q5_0>;
         case GGML_TYPE_Q5_1:
@@ -6338,9 +6407,9 @@ static to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
 static to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
     switch (type) {
         case GGML_TYPE_Q4_0:
-            return dequantize_block_cuda<QK4_0, QR4_0, dequantize_q4_0>;
+            return dequantize_q4_0_cuda;
         case GGML_TYPE_Q4_1:
-            return dequantize_block_cuda<QK4_1, QR4_1, dequantize_q4_1>;
+            return dequantize_q4_1_cuda;
         case GGML_TYPE_Q5_0:
             return dequantize_block_cuda<QK5_0, QR5_0, dequantize_q5_0>;
         case GGML_TYPE_Q5_1:


### PR DESCRIPTION
On my GPU (RTX-4080) prompt processing (PP) is faster for `Q4_K` than it is for `Q4_0` and `Q4_1`. This is unexpected as `Q4_K` de-quantization has more to do than `Q4_0`. So, I went ahead and implemented the same approach as is used for `Q4_K` also for `Q4_0`. I get the following results for `Q4_0` (`Q4_1` is very similar):

| model                          |       size |     params | backend    | test       |      t/s (Master)|        t/s (PR)  |  ratio |
| ------------------------------ | ---------: | ---------: | ---------- | ---------- | ---------------: | ---------------: | -----: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 64      |   1503.23 ± 0.97 |   1603.60 ± 1.47 | 1.066  |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 128     |   2575.35 ± 0.78 |   2729.26 ± 1.86 | 1.060  |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 256     |   4236.93 ± 1.05 |   4489.80 ± 1.93 | 1.060  |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 512     |   5643.46 ± 3.20 |   5934.50 ± 1.79 | 1.052  |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 1024    |   5186.04 ± 4.66 |   5460.50 ± 5.18 | 1.053  |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | pp 2048    |   4561.84 ± 3.12 |   4740.26 ± 3.55 | 1.039  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 64      |  3737.06 ± 73.80 | 4169.26 ± 138.48 | 1.116  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 128     |  6153.63 ± 13.18 |  6818.39 ± 13.93 | 1.108  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 256     |  8901.27 ± 16.68 |  9418.51 ± 13.08 | 1.058  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 512     | 10823.46 ± 10.70 |  11140.56 ± 9.31 | 1.029  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 1024    |   9499.67 ± 9.30 |  9775.45 ± 16.06 | 1.029  |
| phi2 3B Q4_0                   |   1.49 GiB |     2.78 B | CUDA       | pp 2048    |   7910.42 ± 9.57 |   8074.38 ± 8.51 | 1.021  |

If this change is considered acceptable, I can add similar kernels for `Q5_0` and `Q5_1`.

We see benefit is increasing with decreasing batch size, so it would be interesting to see results below 64 tokens, but I did not want to go and change the current small-batch approach (which uses the MMQ kernels).