### PR TITLE
[draft] metal: running Metal tests on macOS 13 arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
   #       how to debug it.
   #       ref: https://github.com/ggerganov/llama.cpp/actions/runs/7131777249/job/19420981052#step:5:1124
   macOS-latest-make:
-    runs-on: macos-latest
+    runs-on: macos-13-arm64
 
     steps:
       - name: Clone
@@ -163,20 +163,20 @@ jobs:
       - name: Build
         id: make_build
         run: |
-          LLAMA_NO_METAL=1 make -j $(sysctl -n hw.logicalcpu)
+          make -j $(sysctl -n hw.logicalcpu)
 
       - name: Test
         id: make_test
         run: |
-          LLAMA_NO_METAL=1 make tests -j $(sysctl -n hw.logicalcpu)
-          LLAMA_NO_METAL=1 make test  -j $(sysctl -n hw.logicalcpu)
+          make tests -j $(sysctl -n hw.logicalcpu)
+          make test  -j $(sysctl -n hw.logicalcpu)
 
   # TODO: build with LLAMA_METAL=OFF because test-backend-ops fail on "Apple Paravirtual device" and I don't know
   #       how to debug it.
   #       ref: https://github.com/ggerganov/llama.cpp/actions/runs/7132125951/job/19422043567?pr=4359#step:5:6584
   #       would be great if we fix these
   macOS-latest-cmake:
-    runs-on: macos-latest
+    runs-on: macos-13-arm64
 
     steps:
       - name: Clone
@@ -195,7 +195,7 @@ jobs:
           sysctl -a
           mkdir build
           cd build
-          cmake -DLLAMA_METAL=OFF ..
+          cmake ..
           cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,3 +900,4 @@ if (LLAMA_BUILD_EXAMPLES)
     add_subdirectory(examples)
     add_subdirectory(pocs)
 endif()
+


### PR DESCRIPTION
PR to test CI. There is a chance that jobs won't fail on arm64 where Virtualization.framework better supports Metal.