### PR TITLE
sampling_temperature_fix

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -322,7 +322,7 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             sparams.temp = std::stof(argv[i]);
-            sparams.temp = std::max(sparams.temp, 0.0f);
+            // sparams.temp = std::max(sparams.temp, 0.0f);
         } else if (arg == "--tfs") {
             if (++i >= argc) {
                 invalid_param = true;


### PR DESCRIPTION
llama.cpp has 3 default sampling modes:
1) greedy sampling with probabilities (temp < 0)
2) greedy without (temp == 0)
3) complex sampling (mirostat, min_p, top_k, etc) (temp > 0)

I'm not sure if greedy sampling 1 vs 2 makes much of a difference but the code in sampling.cpp is not going to work if we restrict it to 0.0f - so either we should not limit it to 0.0f minimal or we should remove the first option from the sampling code as it can never be reached.
``` sampling.cpp:
if (temp < 0.0) {
        // greedy sampling, with probs
        llama_sample_softmax(ctx_main, &cur_p);
        id = cur_p.data[0].id;
    } 
``` 