### PR TITLE
Importance matrix support for legacy quants

### DIFF
--- a/ggml-quants.h
+++ b/ggml-quants.h
@@ -253,3 +253,7 @@ size_t quantize_q3_K   (const float * src, void * dst, int nrows, int n_per_row,
 size_t quantize_q4_K   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
 size_t quantize_q5_K   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
 size_t quantize_q6_K   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
+size_t quantize_q4_0   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
+size_t quantize_q4_1   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
+size_t quantize_q5_0   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);
+size_t quantize_q5_1   (const float * src, void * dst, int nrows, int n_per_row, int64_t * hist, const float * imatrix);

--- a/ggml.c
+++ b/ggml.c
@@ -18674,26 +18674,38 @@ size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, i
         case GGML_TYPE_Q4_0:
             {
                 GGML_ASSERT(start % QK4_0 == 0);
-                block_q4_0 * block = (block_q4_0*)dst + start / QK4_0;
-                result = ggml_quantize_q4_0(src + start, block, n, n, hist);
+                GGML_ASSERT(start % n_per_row == 0);
+                size_t start_row = start / n_per_row;
+                size_t row_size = ggml_row_size(type, n_per_row);
+                result = quantize_q4_0(src + start, (char *)dst + start_row * row_size, nrows, n_per_row, hist, imatrix);
+                GGML_ASSERT(result == row_size * nrows);
             } break;
         case GGML_TYPE_Q4_1:
             {
                 GGML_ASSERT(start % QK4_1 == 0);
-                block_q4_1 * block = (block_q4_1*)dst + start / QK4_1;
-                result = ggml_quantize_q4_1(src + start, block, n, n, hist);
+                GGML_ASSERT(start % n_per_row == 0);
+                size_t start_row = start / n_per_row;
+                size_t row_size = ggml_row_size(type, n_per_row);
+                result = quantize_q4_1(src + start, (char *)dst + start_row * row_size, nrows, n_per_row, hist, imatrix);
+                GGML_ASSERT(result == row_size * nrows);
             } break;
         case GGML_TYPE_Q5_0:
             {
                 GGML_ASSERT(start % QK5_0 == 0);
-                block_q5_0 * block = (block_q5_0*)dst + start / QK5_0;
-                result = ggml_quantize_q5_0(src + start, block, n, n, hist);
+                GGML_ASSERT(start % n_per_row == 0);
+                size_t start_row = start / n_per_row;
+                size_t row_size = ggml_row_size(type, n_per_row);
+                result = quantize_q5_0(src + start, (char *)dst + start_row * row_size, nrows, n_per_row, hist, imatrix);
+                GGML_ASSERT(result == row_size * nrows);
             } break;
         case GGML_TYPE_Q5_1:
             {
                 GGML_ASSERT(start % QK5_1 == 0);
-                block_q5_1 * block = (block_q5_1*)dst + start / QK5_1;
-                result = ggml_quantize_q5_1(src + start, block, n, n, hist);
+                GGML_ASSERT(start % n_per_row == 0);
+                size_t start_row = start / n_per_row;
+                size_t row_size = ggml_row_size(type, n_per_row);
+                result = quantize_q5_1(src + start, (char *)dst + start_row * row_size, nrows, n_per_row, hist, imatrix);
+                GGML_ASSERT(result == row_size * nrows);
             } break;
         case GGML_TYPE_Q8_0:
             {


### PR DESCRIPTION
TL;DR See title and PR #4861, #4930 for more details.

Opinions on adding importance matrix support for legacy quants were divided (see #4932), but given @ggerganov's comment there I decided to go ahead and prepare this PR.

I observe quite significant improvement in perplexity for all models I have tested. In addition, `Q4_1` and `Q5_1` no longer have the erratic behavior of having a higher perplexity than `Q4_0/Q5_0` for some models despite using more bits.

The following tables give a few representative perplexity examples. The `QError` columns are defined as `PPL(Q)/PPL(fp16)-1`. Perplexity is for a context of 512 tokens.

### Q4_0

| Model | PPL(Master) | PPL (PR) | QError (Master) | QError (PR) | QError ratio PR/Master |
| ---: | ---: | ---: | ---: | ---: | ---: |
|LLaMA-v1-7B | 6.1162 | 6.0276 | 3.55% | 2.05% | 0.577 |
|LLaMA-v2-7B | 5.9635 | 5.9107 | 2.86% | 1.95% | 0.682 |
|Mistral-7B       | 5.8189 | 5.7993 | 2.22% | 1.88% | 0.847 |
|LLaMA-v1-13B| 5.3639 | 5.3104 | 2.07% | 1.05% | 0.507 |
|LLaMA-v2-13B| 5.1994 | 5.1875 | 1.95% | 1.71% | 0.877 |

### Q4_1

| Model | PPL(Master) | PPL (PR) | QError (Master) | QError (PR) | QError ratio PR/Master |
| ---: | ---: | ---: | ---: | ---: | ---: |
|LLaMA-v1-7B | 6.0653 | 5.9725 | 2.69% | 1.12% | 0.416 |
|LLaMA-v2-7B | 6.0008 | 5.8605 | 3.50% | 1.08% | 0.309 |
|Mistral-7B       | 5.8244 | 5.7458 | 2.32% | 0.94% | 0.405 |
|LLaMA-v1-13B| 5.3416 | 5.2997 | 1.65% | 0.85% | 0.515 |
|LLaMA-v2-13B| 5.2151 | 5.1635 | 2.25% | 1.24% | 0.551 |

### Q5_0

| Model | PPL(Master) | PPL (PR) | QError (Master) | QError (PR) | QError ratio PR/Master |
| ---: | ---: | ---: | ---: | ---: | ---: |
|LLaMA-v1-7B | 5.9803 | 5.9298 | 1.25% | 0.39% | 0.312 |
|LLaMA-v2-7B | 5.8282 | 5.8138 | 0.53% | 0.28% | 0.528 |
|Mistral-7B       | 5.7180 | 5.7113 | 0.45% | 0.33% | 0.733 |
|LLaMA-v1-13B| 5.2844 | 5.2648 | 0.56% | 0.18% | 0.321 |
|LLaMA-v2-13B| 5.1412 | 5.1368 | 0.81% | 0.72% | 0.889 |

### Q5_1

| Model | PPL(Master) | PPL (PR) | QError (Master) | QError (PR) | QError ratio PR/Master |
| ---: | ---: | ---: | ---: | ---: | ---: |
|LLaMA-v1-7B | 5.9418 | 5.9116 | 0.60% | 0.08% | 0.134 |
|LLaMA-v2-7B | 5.8468 | 5.8104| 0.85% | 0.22% | 0.259 |
|Mistral-7B       | 5.7128 | 5.7057 | 0.36% | 0.23% | 0.639 |
|LLaMA-v1-13B| 5.2682 | 5.2634 | 0.25% | 0.16% | 0.640 |
|LLaMA-v2-13B| 5.1448 | 5.1340 | 0.88% | 0.66% | 0.750 |

