### PR TITLE
cuda: fix compile error in jetson platform

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -12,9 +12,6 @@
 #include <vector>
 #include <map>
 #include <array>
-#include "ggml-cuda.h"
-#include "ggml.h"
-#include "ggml-backend-impl.h"
 
 #if defined(GGML_USE_HIPBLAS)
 #include <hip/hip_runtime.h>
@@ -117,6 +114,10 @@
 #endif // CUDART_VERSION < 11020
 
 #endif // defined(GGML_USE_HIPBLAS)
+
+#include "ggml-cuda.h"
+#include "ggml.h"
+#include "ggml-backend-impl.h"
 
 #define CUDART_HMAX     11070 // CUDA 11.7, min. ver. for which __hmax and __hmax2 are known to work (may be higher than needed)
 

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -115,6 +115,7 @@
 
 #endif // defined(GGML_USE_HIPBLAS)
 
+// ggml-cuda need half type so keep ggml headers include at last 
 #include "ggml-cuda.h"
 #include "ggml.h"
 #include "ggml-backend-impl.h"

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -115,7 +115,7 @@
 
 #endif // defined(GGML_USE_HIPBLAS)
 
-// ggml-cuda need half type so keep ggml headers include at last 
+// ggml-cuda need half type so keep ggml headers include at last
 #include "ggml-cuda.h"
 #include "ggml.h"
 #include "ggml-backend-impl.h"


### PR DESCRIPTION
this pr fix compile error in jetson platform
related issue: #4922 

the error was introduced by #4766 

#4766  add ```#include "ggml-cuda.h"```
before include ```#include <cuda_fp16.h>```

so the solution is move #include "ggml-cuda.h" after #include <cuda_fp16.h>