### PR TITLE
metal: Removing unnecessary nil check

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -2236,10 +2236,7 @@ static bool ggml_metal_graph_compute(
 #endif
         }
 
-        if (encoder != nil) {
-            [encoder endEncoding];
-            encoder = nil;
-        }
+        [encoder endEncoding];
 
         [command_buffer commit];
     });


### PR DESCRIPTION
Tiny cleanup - no need to check for `nil` here. Was originally in https://github.com/ggerganov/llama.cpp/pull/4924 but got lost in a subsequent merge (my bad!)