### PR TITLE
Use Q4_K for attn_v for Q2_K_S when n_gqa >= 4

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8477,7 +8477,12 @@ static ggml_type get_k_quant_type(quantize_state_internal & qs, ggml_type new_ty
         }
         else if (name == "token_embd.weight") new_type = GGML_TYPE_Q2_K;
     } else if (name.find("attn_v.weight") != std::string::npos) {
-        if      (ftype == LLAMA_FTYPE_MOSTLY_Q2_K) new_type = GGML_TYPE_Q3_K;
+        if      (ftype == LLAMA_FTYPE_MOSTLY_Q2_K) {
+            new_type = qs.model.hparams.n_gqa() >= 4 ? GGML_TYPE_Q4_K : GGML_TYPE_Q3_K;
+        }
+        else if (ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S && qs.model.hparams.n_gqa() >= 4) {
+            new_type = GGML_TYPE_Q4_K;
+        }
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M) {
             new_type = qs.i_attention_wv < 2 ? GGML_TYPE_Q5_K : GGML_TYPE_Q4_K;
         }


### PR DESCRIPTION
I have missed this tweak when adding `Q2_K_S`.

With this change, model size for Mistral-7B increases by only ~30 MB (0.03 bpw) while
* Perplexity for a context of 512 on `wiki.test.raw` goes down from `6.9259` to `6.7116`
* 10-shot HellaSwag score after 2000 tasks increases by `0.95 +/- 0.42`. 