### PR TITLE
server: allow to specify tokens as strings in logit_bias

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -185,7 +185,7 @@ node index.js
 
     `ignore_eos`: Ignore end of stream token and continue generating (default: false).
 
-    `logit_bias`: Modify the likelihood of a token appearing in the generated text completion. For example, use `"logit_bias": [[15043,1.0]]` to increase the likelihood of the token 'Hello', or `"logit_bias": [[15043,-1.0]]` to decrease its likelihood. Setting the value to false, `"logit_bias": [[15043,false]]` ensures that the token `Hello` is never produced (default: []).
+    `logit_bias`: Modify the likelihood of a token appearing in the generated text completion. For example, use `"logit_bias": [[15043,1.0]]` to increase the likelihood of the token 'Hello', or `"logit_bias": [[15043,-1.0]]` to decrease its likelihood. Setting the value to false, `"logit_bias": [[15043,false]]` ensures that the token `Hello` is never produced. The tokens can also be represented as strings, e.g. `[["Hello, World!",-0.5]]` will reduce the likelihood of all the individual tokens that represent the string `Hello, World!`, just like the `presence_penalty` does. (default: []).
 
     `n_probs`: If greater than 0, the response also contains the probabilities of top N tokens for each generated token (default: 0)
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -641,7 +641,7 @@ struct llama_server_context
                         continue;
                     }
 
-                    if(el[0].is_number_integer())
+                    if (el[0].is_number_integer())
                     {
                         llama_token tok = el[0].get<llama_token>();
                         if (tok >= 0 && tok < n_vocab)
@@ -652,7 +652,7 @@ struct llama_server_context
                     else if (el[0].is_string())
                     {
                         auto toks = llama_tokenize(model, el[0].get<std::string>(), false);
-                        for(auto tok : toks)
+                        for (auto tok : toks)
                         {
                             slot->sparams.logit_bias[tok] = bias;
                         }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -625,18 +625,36 @@ struct llama_server_context
             const int n_vocab = llama_n_vocab(model);
             for (const auto &el : *logit_bias)
             {
-                if (el.is_array() && el.size() == 2 && el[0].is_number_integer())
+                if (el.is_array() && el.size() == 2)
                 {
-                    llama_token tok = el[0].get<llama_token>();
-                    if (tok >= 0 && tok < n_vocab)
+                    float bias;
+                    if (el[1].is_number())
                     {
-                        if (el[1].is_number())
+                        bias = el[1].get<float>();
+                    }
+                    else if (el[1].is_boolean() && !el[1].get<bool>())
+                    {
+                        bias = -INFINITY;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    if(el[0].is_number_integer())
+                    {
+                        llama_token tok = el[0].get<llama_token>();
+                        if (tok >= 0 && tok < n_vocab)
                         {
-                            slot->sparams.logit_bias[tok] = el[1].get<float>();
+                            slot->sparams.logit_bias[tok] = bias;
                         }
-                        else if (el[1].is_boolean() && !el[1].get<bool>())
+                    }
+                    else if (el[0].is_string())
+                    {
+                        auto toks = llama_tokenize(model, el[0].get<std::string>(), false);
+                        for(auto tok : toks)
                         {
-                            slot->sparams.logit_bias[tok] = -INFINITY;
+                            slot->sparams.logit_bias[tok] = bias;
                         }
                     }
                 }


### PR DESCRIPTION
Currently, the `logit_bias` param in the `server` accepts token IDs as input. But first these token IDs need to be retrieved from somewhere. It is possible to pass a string to `/tokenize` and then use the result. However, it's pretty cumbersome since it requires to code for a completely different endpoint and makes an additional network call.

This PR allows to pass the initial string to the `logit_bias` param. This string will then be converted to tokens and the specified bias will be applied to all these tokens.