### PR TITLE
Add Winogrande evaluation

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -681,6 +681,14 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.hellaswag_tasks = std::stoi(argv[i]);
+        } else if (arg == "--winogrande") {
+            params.winogrande = true;
+        } else if (arg == "--winogrande-tasks") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.winogrande_tasks = std::stoi(argv[i]);
         } else if (arg == "--ignore-eos") {
             params.ignore_eos = true;
         } else if (arg == "--no-penalize-nl") {
@@ -926,6 +934,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --logits-all          return logits for all tokens in the batch (default: disabled)\n");
     printf("  --hellaswag           compute HellaSwag score over random tasks from datafile supplied with -f\n");
     printf("  --hellaswag-tasks N   number of tasks to use when computing the HellaSwag score (default: %zu)\n", params.hellaswag_tasks);
+    printf("  --winogrande          compute Winogrande score over random tasks from datafile supplied with -f\n");
+    printf("  --winogrande-tasks N  number of tasks to use when computing the Winogrande score (default: %zu)\n", params.winogrande_tasks);
     printf("  --keep N              number of tokens to keep from the initial prompt (default: %d, -1 = all)\n", params.n_keep);
     printf("  --draft N             number of tokens to draft for speculative decoding (default: %d)\n", params.n_draft);
     printf("  --chunks N            max number of chunks to process (default: %d, -1 = all)\n", params.n_chunks);

--- a/common/common.h
+++ b/common/common.h
@@ -105,6 +105,9 @@ struct gpt_params {
     bool   hellaswag       = false; // compute HellaSwag score over random tasks from datafile supplied in prompt
     size_t hellaswag_tasks = 400;   // number of tasks to use when computing the HellaSwag score
 
+    bool   winogrande      = false; // compute Winogrande score over random tasks from datafile supplied in prompt
+    size_t winogrande_tasks= 0;     // number of tasks to use when computing the Winogrande score. If 0, all tasks will be computed
+
     bool mul_mat_q         = true;  // if true, use mul_mat_q kernels instead of cuBLAS
     bool random_prompt     = false; // do not randomize prompt if none provided
     bool use_color         = false; // use color to distinguish generations and inputs

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -746,6 +746,15 @@ static std::vector<winogrande_entry> load_winogrande_from_csv(const std::string&
     return result;
 }
 
+/*
+ * Evaluates the Winogrande score.
+ * Uses a CSV containing task index, dentence, choice 1, choice 2, answer (1 or 2)
+ * You can get one such dataset from e.g. https://huggingface.co/datasets/ikawrakow/winogrande-eval-for-llama.cpp
+ * As an example, the 1st row in the above dataset is
+ *
+ *    0,Sarah was a much better surgeon than Maria so _ always got the easier cases.,Sarah,Maria,2
+ *
+ */
 static void winogrande_score(llama_context * ctx, const gpt_params & params) {
 
     constexpr int k_min_trailing_ctx = 3;


### PR DESCRIPTION
It is not the most efficient implementation, but a) I wanted to have something that looks like to be working 1st, and b) evaluation time is not that long (70 seconds for the 1267 tasks of the Winogrande evaluation dataset for Mistral-7B using CUDA on RTX-4080), so performance improvements are not as important as they would be for HellaSwag.

I'm not quite getting the scores reported on the HF Leader board (HFLB). For the Winogrande evaluation dataset (see https://huggingface.co/datasets/ikawrakow/winogrande-eval-for-llama.cpp), which contains 1267 tasks, I get `73.56` vs `78.37` reported on HFLB for Mistral-7B. Statistical uncertainty (1-sigma) is `1.24`, so there is a tiny chance that this could be simply statistics. On the other hand, we do get lower HellaSwag scores compared to HFLB as well, so this is kind of expected.   

Interestingly enough, the Winogrande score varies quite a bit, depending on what parts of the context are included when computing the average  log-likelihood, so perhaps I haven't found the right magic subset of tokens that maximizes the score.

Usage:
```
./perplexity -m model -f winogrande-debiased-eval.csv --winogrande [--winogrande-tasks N] [other params]
```
If `--winogrande-tasks` is omitted, all tasks in the dataset will be evaluated.

**Update:**
I ran Winogrande on the extra large Winogrande training dataset (40397 tasks) with Mistral-7B. I get  `83.79 +/- 0.18`, which is significantly higher than the HFLB value. Getting a higher value is expected, as this is training data and models have most likely been trained on this dataset, but it still gives confidence that the implementation is correct.   