### PR TITLE
Server: when no slot is available, defer the task instead of returning "slot unavailable"

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1569,7 +1569,6 @@ struct llama_server_context
                     llama_client_slot *slot = get_slot(json_value(task.data, "slot_id", -1));
                     if (slot == nullptr)
                     {
-                        LOG_TEE("slot unavailable\n");
                         // if no slot is available, we defer this task for processing later
                         deferred_tasks.push_back(task);
                         break;


### PR DESCRIPTION
## Motivation

Assuming that there is only one slot in server mode, when trying to send 2 requests at the same time, one request will fail with "slot unavailable" error. This behavior sometimes breaks OpenAI compatibility.

This PR defer the task until one of the slots is available.

On the bright side, request will no longer fail. But on the down side, one request now need to wait for the other one to finish.