### PR TITLE
Resolve ggml_backend_sched_eval_callback visibility (#5029)

### DIFF
--- a/ggml-backend.h
+++ b/ggml-backend.h
@@ -154,7 +154,7 @@ extern "C" {
     // when ask == false, the scheduler is passing the node tensor to the user for observation
     // if the user returns false, the scheduler will cancel the graph compute
     //
-    typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * user_data);
+    GGML_API typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * user_data);
 
     // Initialize a backend scheduler
     GGML_API ggml_backend_sched_t  ggml_backend_sched_new(ggml_backend_t * backends, ggml_backend_buffer_type_t * bufts, int n_backends, size_t graph_size);


### PR DESCRIPTION
Addresses #5029 introduced in #4935

I believe this is necessary as this typedef is exposed in `llama_context_params` struct.