### PR TITLE
examples : support minLength and maxLength in JSON schema grammar converter

### DIFF
--- a/examples/json-schema-to-grammar.py
+++ b/examples/json-schema-to-grammar.py
@@ -93,6 +93,7 @@ class SchemaConverter:
             if min_items > 0:
                first_item = f"({item_rule_name})"
                successive_items = list_item_operator * (min_items - 1)
+               min_items -= 1
             else:
                first_item = f"({item_rule_name})?"
             max_items = schema.get("maxItems")

--- a/examples/json-schema-to-grammar.py
+++ b/examples/json-schema-to-grammar.py
@@ -87,7 +87,20 @@ class SchemaConverter:
         elif schema_type == 'array' and 'items' in schema:
             # TODO `prefixItems` keyword
             item_rule_name = self.visit(schema['items'], f'{name}{"-" if name else ""}item')
-            rule = f'"[" space ({item_rule_name} ("," space {item_rule_name})*)? "]" space'
+            list_item_operator = f'("," space {item_rule_name})'
+            successive_items = ""
+            min_items = schema.get("minItems", 0)
+            if min_items > 0:
+               first_item = f"({item_rule_name})"
+               successive_items = list_item_operator * (min_items - 1)
+            else:
+               first_item = f"({item_rule_name})?"
+            max_items = schema.get("maxItems")
+            if max_items is not None and max_items > min_items:
+                successive_items += (list_item_operator + "?") * (max_items - min_items - 1)
+            else:
+                successive_items += list_item_operator + "*"
+            rule = f'"[" space {first_item} {successive_items} "]" space'
             return self._add_rule(rule_name, rule)
 
         else:


### PR DESCRIPTION
Changes the JSON schema to BNF grammar converter to restrict the length of output arrays to `minItems` and `maxItems` if specified in the JSON schema.

## Example
```
echo '{"type": "object", "properties": {"tags": {"type": "array", "items": {"type": "string"}, "minItems": 2, "maxItems": 5}}}' > length.json
./main -m $MODEL_FILE --grammar "$( python examples/json-schema-to-grammar.py length.json )"
```
Output:
```
{"tags":["php","laravel"]}  [end of text]
```