### PR TITLE
Add ability to evauate multiple choice tasks 

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -203,6 +203,25 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
             params.prompt_cache_all = true;
         } else if (arg == "--prompt-cache-ro") {
             params.prompt_cache_ro = true;
+        } else if (arg == "-bf" || arg == "--binary-file") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            std::ifstream file(argv[i], std::ios::binary);
+            if (!file) {
+                fprintf(stderr, "error: failed to open file '%s'\n", argv[i]);
+                invalid_param = true;
+                break;
+            }
+            // store the external file name in params
+            params.prompt_file = argv[i];
+            file.seekg(0, std::ios::end);
+            size_t size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            params.prompt.resize(size);
+            file.read((char *)params.prompt.data(), size);
+            fprintf(stderr, "Read %zu bytes from binary file %s\n", size, argv[i]);
         } else if (arg == "-f" || arg == "--file") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -689,6 +708,14 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.winogrande_tasks = std::stoi(argv[i]);
+        } else if (arg == "--truthful-qa") {
+            params.truthful_qa = true;
+        } else if (arg == "--truthful-qa-tasks") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.thruthful_qa_tasks = std::stoi(argv[i]);
         } else if (arg == "--ignore-eos") {
             params.ignore_eos = true;
         } else if (arg == "--no-penalize-nl") {
@@ -936,6 +963,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --hellaswag-tasks N   number of tasks to use when computing the HellaSwag score (default: %zu)\n", params.hellaswag_tasks);
     printf("  --winogrande          compute Winogrande score over random tasks from datafile supplied with -f\n");
     printf("  --winogrande-tasks N  number of tasks to use when computing the Winogrande score (default: %zu)\n", params.winogrande_tasks);
+    printf("  --truthful-qa         compute TruthFullQA multiple choice score over random tasks from datafile supplied with -f\n");
+    printf("  --truthful-qa-tasks N number of tasks to use when computing the TruthFullQA score (default: %zu)\n", params.winogrande_tasks);
     printf("  --keep N              number of tokens to keep from the initial prompt (default: %d, -1 = all)\n", params.n_keep);
     printf("  --draft N             number of tokens to draft for speculative decoding (default: %d)\n", params.n_draft);
     printf("  --chunks N            max number of chunks to process (default: %d, -1 = all)\n", params.n_chunks);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -708,14 +708,14 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.winogrande_tasks = std::stoi(argv[i]);
-        } else if (arg == "--truthful-qa") {
-            params.truthful_qa = true;
-        } else if (arg == "--truthful-qa-tasks") {
+        } else if (arg == "--multiple-choice") {
+            params.multiple_choice = true;
+        } else if (arg == "--multiple-choice-tasks") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;
             }
-            params.thruthful_qa_tasks = std::stoi(argv[i]);
+            params.multiple_choice_tasks = std::stoi(argv[i]);
         } else if (arg == "--ignore-eos") {
             params.ignore_eos = true;
         } else if (arg == "--no-penalize-nl") {
@@ -915,6 +915,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --in-suffix STRING    string to suffix after user inputs with (default: empty)\n");
     printf("  -f FNAME, --file FNAME\n");
     printf("                        prompt file to start generation.\n");
+    printf("  -bf FNAME, --binary-file FNAME\n");
+    printf("                        binary file containing multiple choice tasks.\n");
     printf("  -n N, --n-predict N   number of tokens to predict (default: %d, -1 = infinity, -2 = until context filled)\n", params.n_predict);
     printf("  -c N, --ctx-size N    size of the prompt context (default: %d, 0 = loaded from model)\n", params.n_ctx);
     printf("  -b N, --batch-size N  batch size for prompt processing (default: %d)\n", params.n_batch);
@@ -963,8 +965,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --hellaswag-tasks N   number of tasks to use when computing the HellaSwag score (default: %zu)\n", params.hellaswag_tasks);
     printf("  --winogrande          compute Winogrande score over random tasks from datafile supplied with -f\n");
     printf("  --winogrande-tasks N  number of tasks to use when computing the Winogrande score (default: %zu)\n", params.winogrande_tasks);
-    printf("  --truthful-qa         compute TruthFullQA multiple choice score over random tasks from datafile supplied with -f\n");
-    printf("  --truthful-qa-tasks N number of tasks to use when computing the TruthFullQA score (default: %zu)\n", params.winogrande_tasks);
+    printf("  --multiple-choice     compute multiple choice score over random tasks from datafile supplied with -f\n");
+    printf("  --multiple-choice-tasks N number of tasks to use when computing the multiple choice score (default: %zu)\n", params.winogrande_tasks);
     printf("  --keep N              number of tokens to keep from the initial prompt (default: %d, -1 = all)\n", params.n_keep);
     printf("  --draft N             number of tokens to draft for speculative decoding (default: %d)\n", params.n_draft);
     printf("  --chunks N            max number of chunks to process (default: %d, -1 = all)\n", params.n_chunks);

--- a/common/common.h
+++ b/common/common.h
@@ -108,8 +108,8 @@ struct gpt_params {
     bool   winogrande      = false; // compute Winogrande score over random tasks from datafile supplied in prompt
     size_t winogrande_tasks= 0;     // number of tasks to use when computing the Winogrande score. If 0, all tasks will be computed
 
-    bool   truthful_qa     = false; // compute TruthfulQA score over random tasks from datafile supplied in prompt
-    size_t thruthful_qa_tasks = 0;     // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
+    bool   multiple_choice = false; // compute TruthfulQA score over random tasks from datafile supplied in prompt
+    size_t multiple_choice_tasks = 0;     // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
 
     bool mul_mat_q         = true;  // if true, use mul_mat_q kernels instead of cuBLAS
     bool random_prompt     = false; // do not randomize prompt if none provided

--- a/common/common.h
+++ b/common/common.h
@@ -108,6 +108,9 @@ struct gpt_params {
     bool   winogrande      = false; // compute Winogrande score over random tasks from datafile supplied in prompt
     size_t winogrande_tasks= 0;     // number of tasks to use when computing the Winogrande score. If 0, all tasks will be computed
 
+    bool   truthful_qa     = false; // compute TruthfulQA score over random tasks from datafile supplied in prompt
+    size_t thruthful_qa_tasks = 0;     // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
+
     bool mul_mat_q         = true;  // if true, use mul_mat_q kernels instead of cuBLAS
     bool random_prompt     = false; // do not randomize prompt if none provided
     bool use_color         = false; // use color to distinguish generations and inputs

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -1119,6 +1119,7 @@ static void truthful_qa_score(llama_context * ctx, const gpt_params & params) {
         printf("%s: selecting %zu random tasks from %u tasks available\n", __func__, params.thruthful_qa_tasks, n_task);
         std::mt19937 rng(1);
         std::vector<int> aux(n_task);
+        for (uint32_t i = 0; i < n_task; ++i) aux[i] = i;
         float scale = 1.f/(1.f + (float)std::mt19937::max());
         tasks.resize(params.thruthful_qa_tasks);
         for (auto& task : tasks) {
@@ -1310,26 +1311,11 @@ static void truthful_qa_score(llama_context * ctx, const gpt_params & params) {
             for (int s = 0; s < int(cur_task.seq_tokens.size()); ++s) {
                 size_t count = 1;
                 float  log_prob  = std::log(first_probs[cur_task.seq_tokens[s][cur_task.common_prefix]]);
-                //printf("    <%s> : %g\n", cur_task.mc1.answers[s].c_str(), log_prob);
-                //for (size_t j = cur_task.common_prefix; j < cur_task.seq_tokens[s].size() - 1; j++) {
-                //    printf("        %zu  %g\n", ir, eval_results[ir]);
-                //    ++count;
-                //    log_prob += eval_results[ir++];
-                //}
-                //size_t count = 0;
-                //float  log_prob = 0;
-                //printf("    <%s>\n", cur_task.mc1.answers[s].c_str());
-                //float  log_prob  = std::log(first_probs[cur_task.seq_tokens[s][cur_task.common_prefix]]);
-                //printf("    <%s> : %g\n", cur_task.mc1.answers[s].c_str(), log_prob);
                 for (size_t j = cur_task.common_prefix; j < cur_task.seq_tokens[s].size() - 1; j++) {
                     //printf("        %zu  %g\n", ir, eval_results[ir]);
                     ++count;
                     log_prob += eval_results[ir++];
                 }
-                //if (!count) {
-                //    ++count;
-                //    log_prob += std::log(first_probs[cur_task.seq_tokens[s][cur_task.common_prefix]]);
-                //}
                 cur_task.log_probs[s] = log_prob / count;
                 //printf("        Final: %g\n", log_prob / count);
                 //printf("    <%s> : %g\n", cur_task.mc1.answers[s].c_str(), log_prob/count);


### PR DESCRIPTION
### Summary

This PR adds the ability to run multiple-choice-single-correct-answer type of LLM benchmarks with the `perplexity` tool.

### Details 

Commonly used LLM benchmarks of this type are
* ARC
* HellaSwag
* MMLU
* Truthful QA

Although the HellaSwag test asks for continuing a given context with one of 4 possible endings, it is basically the same as finding the highest probability answer (as per LLM predicted logits) to a multiple-choice question. Hence, it can be done with the exact same evaluation approach as ARC, MMLU, and Truthful QA (and the `multiple_choice_score()` function added by the PR achieves the exact same HellSwag score as the existing implementation in `hellaswag_score()`).

I have posted validation datasets for all of the above benchmarks in [this Huggingface repository](https://huggingface.co/datasets/ikawrakow/validation-datasets-for-llama.cpp). A very simple binary format is used for these datasets and in the implementation in this PR. 

The results I'm getting with this implementation are not quite the same as we find on the [Huggingface Open LLM Leaderboard](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) (HFLB), see table below. This can be due to several reasons:
* The validation datasets being different from the test datasets being used by HFLB
* The evaluation technique implemented here not being quite the same as in the [Eleuther AI Language Model Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness) utilized by HFLB
* The way I'm combining the question with the possible answers not being the best
* These are 0-shot evaluations, while HFLB tends to contain few-shot results (and few-shot is typically better than 0-shot)

Nevertheless, I think that it is useful to add this capability in the present from to `llama.cpp` to allow experimentation. Perhaps this will lead to better approaches and scores matching better HFLB.

The following table summarizes results for Mistral-7B-Instruct-v0.2. The full `fp16` model is used, and the calculations are run on an RTX-4080 GPU.

| Benchmark | Score | HFLB score | Tasks | Time in seconds |
| ---: | ---: | ---: | ---: | ---: | 
| ARC-Easy | 64.56  ± 2.01 | - | 570 | 4.5 |
| ARC-Challenge | 50.17  ± 2.90 | - | 299 | 2.9 |
| ARC-Mix | 59.61  ± 1.66 |  63.14 | 869 | 7.4 |
| HellaSwag | 84.42 ± 0.36 | 84.88 | 10042 | 301 |
| MMLU-test | 42.01 ± 0.42 | 60.78 | 13943 | 269 |
| Truthful QA | 55.20  ± 1.74 | 68.26 | 817 | 9.7 |

Note: I'm assuming that ARC on HFLB is an even mix of ARC-Easy and ARC-Challenge.

In this implementation, the prompts passed for evaluation for ARC, MMLU and TruthfulQA are in the form
```
Question: "question_body" Answer: answer_body
```
and the probability for each answer is computed from the tokens in `answer_body`. I did experiment with several variations, but the above gave the highest score. Somewhat surprisingly, I did not get a higher score for Mistral-7B-Instruct-v0.2 using
```
[INST]  question_body [/INST] answer_body
```
Given this, and the fact that the former is LLM/tuning agnostic, I have prepared the datasets in this form. Obviously one can change to having the bare question/answers stored in the dataset, and add question prefix/suffix via command line arguments.  

### Usage

```
./perplexity -m <some_model> -bf <some_data_file> --multiple-choice [--multiple-choice-tasks N] [other GPT parameters]
```

Without the `--multiple-choice-tasks` argument, or with `N = 0`, or `N >= number of tasks`, all tasks `<some_data_file>`  will be run consecutively, else a random sample of `N` tasks will be selected.  

~~It woks, but the scores I'm getting are much lower compared to HFLB leader board:~~
* ~~29.1% vs 42.2% on HFLB for Mistral-7B~~
* ~~55.2% vs 68.3% on HFLB for Mistral-7B-Instruct-v0.2~~

~~I know the implementation is correct because the same function that is used to evaluate the TruthfulQA score can be also used for HellaSwag if one converts the HellaSwag dataset to the binary format I use for TruthfulQA, and I get the exact same HellaSwag score as in the existing HellSwag implementation.~~

~~The implementation uses the same batched implementation as it is now used for HellaSwag and Winogrande, and needs just 9 seconds to process the 817 validation dataset tasks.~~

~~I'm combining the question and each answer as `Question: "question goes here" Answer: answer goes here`. I guess, this is not the best way, but I didn't find a variation that works better (produces higher scores), but it definitely works better than just concatenating the question with each multiple choice answer.~~

~~Why binary format for this test? Because, unlike HellSwag's line-oriented text data, the format can handle multiple choice questions with arbitrary number of answers along with a single correct answer or multiple correct answers, without adding a massive dependency on a Parquet (format used on Huggingface) or JSON parsing libraries to `llama.cpp`.~~