### PR TITLE
add safetensors support to convert-lora-to-ggml.py

### DIFF
--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -59,7 +59,14 @@ if __name__ == '__main__':
     input_model = os.path.join(sys.argv[1], "adapter_model.bin")
     output_path = os.path.join(sys.argv[1], "ggml-adapter-model.bin")
 
-    model = torch.load(input_model, map_location="cpu")
+    if os.path.exists(input_model):
+        model = torch.load(input_model, map_location="cpu")
+    else:
+        input_model = os.path.join(sys.argv[1], "adapter_model.safetensors")
+        # lazy import load_file only if lora is in safetensors format.
+        from safetensors.torch import load_file
+        model = load_file(input_model, device="cpu")
+    
     arch_name = sys.argv[2] if len(sys.argv) == 3 else "llama"
 
     if arch_name not in gguf.MODEL_ARCH_NAMES.values():

--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         # lazy import load_file only if lora is in safetensors format.
         from safetensors.torch import load_file
         model = load_file(input_model, device="cpu")
-    
+
     arch_name = sys.argv[2] if len(sys.argv) == 3 else "llama"
 
     if arch_name not in gguf.MODEL_ARCH_NAMES.values():


### PR DESCRIPTION
Huggingface will save trained Lora in Safetensors format by default, Safetensors format can be easily loaded with `safetensors.torch.load_file(path)`.