### PR TITLE
Revert LLAMA_NATIVE to OFF in flake.nix

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -159,7 +159,7 @@ effectiveStdenv.mkDerivation (
 
     cmakeFlags =
       [
-        (cmakeBool "LLAMA_NATIVE" true)
+        (cmakeBool "LLAMA_NATIVE" false)
         (cmakeBool "LLAMA_BUILD_SERVER" true)
         (cmakeBool "BUILD_SHARED_LIBS" true)
         (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)


### PR DESCRIPTION
I've noticed that since PR #4605, performance (CPU-only) took a massive dive when using the Nix flake (I went from ~4 tokens/s to <0.5). It seems that the slowdown is caused by `LLAMA_NATIVE=ON`. Reverting to `OFF` (as it was before the PR) restores the expected performance.

This regression was observed on both an i7-1165G7 and a Ryzen 3800X running NixOS.

FWIW, the [llama-cpp package in nixpkgs](https://github.com/NixOS/nixpkgs/blob/49309c0d27b332bfe2f233d6dec3e29001da280a/pkgs/by-name/ll/llama-cpp/package.nix#L86) has `LLAMA_NATIVE=OFF`.

I'm not sure what the implications of turning off `LLAMA_NATIVE` are, maybe @philiptaron and @SomeoneSerge want to chime in.