### PR TITLE
Small sampling optimizations

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8030,7 +8030,7 @@ void llama_sample_top_p(struct llama_context * ctx, llama_token_data_array * can
 }
 
 void llama_sample_min_p(struct llama_context * ctx, llama_token_data_array * candidates, float p, size_t min_keep) {
-    if (p <= 0.0f || !candidates->size) {
+    if (p <= 0.0f) {
         return;
     }
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -8005,9 +8005,9 @@ void llama_sample_top_p(struct llama_context * ctx, llama_token_data_array * can
         return;
     }
 
-    llama_sample_softmax(ctx, candidates);
-
     const int64_t t_start_sample_us = ggml_time_us();
+
+    llama_sample_softmax(ctx, candidates);
 
     // Compute the cumulative probabilities
     float cum_sum = 0.0f;
@@ -8036,10 +8036,10 @@ void llama_sample_min_p(struct llama_context * ctx, llama_token_data_array * can
     if (p <= 0.0f) {
         return;
     }
+    
+    const int64_t t_start_sample_us = ggml_time_us();
 
     llama_sample_softmax(ctx, candidates);
-
-    const int64_t t_start_sample_us = ggml_time_us();
 
     float scale = candidates->data[0].p; // scale by max prob
     size_t i = 1; // first token always matches
@@ -8063,8 +8063,9 @@ void llama_sample_tail_free(struct llama_context * ctx, llama_token_data_array *
         return;
     }
 
-    llama_sample_softmax(nullptr, candidates);
     const int64_t t_start_sample_us = ggml_time_us();
+
+    llama_sample_softmax(nullptr, candidates);
 
     // Compute the first and second derivatives
     std::vector<float> first_derivatives(candidates->size - 1);
@@ -8124,10 +8125,10 @@ void llama_sample_typical(struct llama_context * ctx, llama_token_data_array * c
         return;
     }
 
+    const int64_t t_start_sample_us = ggml_time_us();
+
     // Compute the softmax of logits and calculate entropy
     llama_sample_softmax(nullptr, candidates);
-
-    const int64_t t_start_sample_us = ggml_time_us();
 
     float entropy = 0.0f;
     for (size_t i = 0; i < candidates->size; ++i) {


### PR DESCRIPTION
I pointed out in https://github.com/ggerganov/llama.cpp/discussions/5073 that there seems to be some not completely insignificant overhead with current sampling operations:

<img width="700" alt="image" src="https://github.com/ggerganov/llama.cpp/assets/66376113/a1291ae7-2ea5-47f0-9398-4dfe40ee32fa">

With the change I made in this PR, I managed to reduce 15ms per token (for sampling over the whole initial vocabulary) to 11ms per token:

`llama_print_timings:      sample time =   11927.89 ms /  1024 runs   (   11.65 ms per token,    85.85 tokens per second)`

Efficient top k sorting is probably next.