### PR TITLE
KL-divergence

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -672,6 +672,12 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
             if (params.logdir.back() != DIRECTORY_SEPARATOR) {
                 params.logdir += DIRECTORY_SEPARATOR;
             }
+        } else if (arg == "--save-all-logits") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.logits_file = argv[i];
         } else if (arg == "--perplexity" || arg == "--all-logits") {
             params.logits_all = true;
         } else if (arg == "--ppl-stride") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -672,7 +672,7 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
             if (params.logdir.back() != DIRECTORY_SEPARATOR) {
                 params.logdir += DIRECTORY_SEPARATOR;
             }
-        } else if (arg == "--save-all-logits") {
+        } else if (arg == "--save-all-logits" || arg == "--kl-divergence-base") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;
@@ -722,6 +722,8 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.multiple_choice_tasks = std::stoi(argv[i]);
+        } else if (arg == "--kl-divergence") {
+            params.kl_divergence = true;
         } else if (arg == "--ignore-eos") {
             params.ignore_eos = true;
         } else if (arg == "--no-penalize-nl") {
@@ -973,6 +975,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --winogrande-tasks N  number of tasks to use when computing the Winogrande score (default: %zu)\n", params.winogrande_tasks);
     printf("  --multiple-choice     compute multiple choice score over random tasks from datafile supplied with -f\n");
     printf("  --multiple-choice-tasks N number of tasks to use when computing the multiple choice score (default: %zu)\n", params.winogrande_tasks);
+    printf("  --kl-divergence       computes KL-divergence to logits provided via --kl-divergence-base");
     printf("  --keep N              number of tokens to keep from the initial prompt (default: %d, -1 = all)\n", params.n_keep);
     printf("  --draft N             number of tokens to draft for speculative decoding (default: %d)\n", params.n_draft);
     printf("  --chunks N            max number of chunks to process (default: %d, -1 = all)\n", params.n_chunks);

--- a/common/common.h
+++ b/common/common.h
@@ -91,6 +91,7 @@ struct gpt_params {
     std::string input_suffix      = "";  // string to suffix user inputs with
     std::vector<std::string> antiprompt; // string upon seeing which more user input is prompted
     std::string logdir            = "";  // directory in which to save YAML log files
+    std::string logits_file       = "";  // file for saving *all* logits
 
     std::vector<llama_model_kv_override> kv_overrides;
 

--- a/common/common.h
+++ b/common/common.h
@@ -112,6 +112,8 @@ struct gpt_params {
     bool   multiple_choice = false; // compute TruthfulQA score over random tasks from datafile supplied in prompt
     size_t multiple_choice_tasks = 0;     // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
 
+    bool   kl_divergence   = false; // compute KL-divergence
+
     bool mul_mat_q         = true;  // if true, use mul_mat_q kernels instead of cuBLAS
     bool random_prompt     = false; // do not randomize prompt if none provided
     bool use_color         = false; // use color to distinguish generations and inputs


### PR DESCRIPTION
There have been several discussions about the potential value of being able to compute KL-divergence as another quantization accuracy test.

There is the [Python script](https://gist.github.com/Ttl/0d51f739dc59254b4b2183e259c97d82) that @Ttl provided in PR #4739. But for those who prefer C/C++, this PR adds the ability to perform KL-divergence calculations natively in `llama.cpp`.

**Usage**

First get all logits of the `fp16` model via
```
./perplexity -m <fp16_model> -f wiki.test.raw --kl-divergence-base <file_name> [other GPT parameters]
```
Be warned: the file can become quite large (about 10 GB  for `wiki.test.raw` and context of 512) as all `n_vocab` logits are stored in the file for each evaluated token.

Then run a calculation using the base logits obtained in step 1 for a quantized model (or any model that has the same vocabulary):
```
./perplexity -m <quantized_model> --kl-divergence-base <file_name> --kl-divergence [other GPT parameters]
```
Note: you don't need to provide the test dataset via `-f` again as tokens are taken from the data stored in `<file_name>` (and if you do provide it, it will be simply ignored. In this way it is assured that the base model logits and the quantized model logits are based on the exact same set of tokens).

If everything goes well, you will see output such as
```
system_info: n_threads = 1 / 64 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | SSSE3 = 1 | VSX = 0 | 
kl_divergence: 0.10 seconds per pass - ETA 1.05 minutes

chunk        PPL          ln(PPL(Q)/PPL(base))          KL-Divergence
   1        4.1138       0.02821 ±    0.01121       0.02080 ±    0.00302
   2        4.6038       0.02404 ±    0.00845       0.02413 ±    0.00268
   3        5.4438       0.02745 ±    0.00773       0.02251 ±    0.00191
   4        6.1767       0.02966 ±    0.00680       0.02109 ±    0.00147
   5        6.1787       0.02765 ±    0.00599       0.02052 ±    0.00125
   6        6.2272       0.02690 ±    0.00534       0.02007 ±    0.00106
   7        6.4234       0.02448 ±    0.00491       0.01964 ±    0.00094
   8        6.5653       0.02621 ±    0.00469       0.01984 ±    0.00085
   9        6.7273       0.02760 ±    0.00441       0.01954 ±    0.00077
  10        7.0274       0.02565 ±    0.00422       0.02056 ±    0.00088
  11        7.2842       0.02377 ±    0.00401       0.02034 ±    0.00080
  12        7.2599       0.02171 ±    0.00385       0.02042 ±    0.00078
  13        7.2981       0.02437 ±    0.00372       0.02160 ±    0.00093
  14        7.3247       0.02374 ±    0.00357       0.02124 ±    0.00087
  15        7.2000       0.02592 ±    0.00347       0.02172 ±    0.00084
  16        7.0290       0.02587 ±    0.00335       0.02185 ±    0.00080
...
 636        5.8173       0.02201 ±    0.00058       0.02315 ±    0.00020
 637        5.8190       0.02200 ±    0.00058       0.02316 ±    0.00020
 638        5.8234       0.02200 ±    0.00058       0.02317 ±    0.00020
 639        5.8272       0.02204 ±    0.00058       0.02317 ±    0.00020
 640        5.8335       0.02206 ±    0.00058       0.02318 ±    0.00020
 641        5.8241       0.02210 ±    0.00058       0.02319 ±    0.00020
 642        5.8189       0.02220 ±    0.00058       0.02320 ±    0.00020


llama_print_timings:        load time =     706.57 ms
llama_print_timings:      sample time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time =   62265.21 ms / 328704 tokens (    0.19 ms per token,  5279.10 tokens per second)
llama_print_timings:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings:       total time =   66075.96 ms / 328705 tokens

```
I.e., you get the PPL of the quantized model along with KL-divergence and the logarithm of the ratio of the quantized model PPL to the base model PPL. The statistical uncertainty on the KL-divergence and `ln(PPL(Q)/PPL(Base))` is much lower compared to the uncertainty of PPL itself.
