### PR TITLE
nix: add cc to devShell LD_LIBRARY_PATH

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -213,10 +213,16 @@ effectiveStdenv.mkDerivation (
         ;
 
       shell = mkShell {
+        NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [
+          effectiveStdenv.cc.cc
+        ];
         name = "shell-${finalAttrs.finalPackage.name}";
         description = "contains numpy and sentencepiece";
         buildInputs = [ llama-python ];
         inputsFrom = [ finalAttrs.finalPackage ];
+        shellHook = ''
+          export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH
+        '';
       };
 
       shell-extra = mkShell {

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -213,15 +213,12 @@ effectiveStdenv.mkDerivation (
         ;
 
       shell = mkShell {
-        NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [
-          effectiveStdenv.cc.cc
-        ];
         name = "shell-${finalAttrs.finalPackage.name}";
         description = "contains numpy and sentencepiece";
         buildInputs = [ llama-python ];
         inputsFrom = [ finalAttrs.finalPackage ];
         shellHook = ''
-          export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH
+          addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib effectiveStdenv.cc.cc}/lib"
         '';
       };
 


### PR DESCRIPTION
this fixes the error I encountered when trying to run the convert.py script in a venv:

```
$ nix develop

[...]$ source .venv/bin/activate
(.venv)
[...]$ pip3 install -r requirements.txt
<... clipped ...>
[...]$ python3 ./convert.py
Traceback (most recent call last):
  File "/home/mhueschen/projects-reference/llama.cpp/./convert.py", line 40, in <module>
    from sentencepiece import SentencePieceProcessor
  File "/home/mhueschen/projects-reference/llama.cpp/.venv/lib/python3.11/site-packages/sentencepiece/__init__.py", line 13, in <module>
    from . import _sentencepiece
ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory
```

however, I am not sure this is the cleanest way to address this linker issue...