### PR TITLE
Additional KL-divergence statistics

### DIFF
--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -1758,14 +1758,24 @@ static void kl_divergence(llama_context * ctx, const gpt_params & params) {
     auto kld_median = kld_values.size()%2 == 0 ? 0.5f*(kld_values[kld_values.size()/2] + kld_values[kld_values.size()/2-1])
                                                : kld_values[kld_values.size()/2];
     printf("Median : %10.6f\n", kld_median);
-    printf("Minimum: %10.6f\n", kld_values.front());
+
+    auto percentile = [&kld_values] (float fraction) {
+        if (fraction <= 0) return kld_values.front();
+        if (fraction >= 1) return kld_values.back();
+        float p = fraction*(kld_values.size() - 1);
+        size_t ip = size_t(p); p -= ip;
+        return (1 - p)*kld_values[ip] + p*kld_values[std::min(ip+1, kld_values.size()-1)];
+    };
+
     printf("Maximum: %10.6f\n", kld_values.back());
-    const int n_1percent = nearest_int(0.01f*kld_values.size());
-    printf("KLD_01 : %10.6f\n", kld_values[n_1percent]);
-    printf("KLD_99 : %10.6f\n", kld_values[kld_values.size()-1-n_1percent]);
-    const int n_5percent = nearest_int(0.05f*kld_values.size());
-    printf("KLD_05 : %10.6f\n", kld_values[n_5percent]);
-    printf("KLD_95 : %10.6f\n", kld_values[kld_values.size()-1-n_5percent]);
+    printf("KLD_99 : %10.6f\n", percentile(0.99f));
+    printf("KLD_95 : %10.6f\n", percentile(0.95f));
+    printf("KLD_90 : %10.6f\n", percentile(0.90f));
+
+    printf("Minimum: %10.6f\n", kld_values.front());
+    printf("KLD_01 : %10.6f\n", percentile(0.01f));
+    printf("KLD_05 : %10.6f\n", percentile(0.05f));
+    printf("KLD_10 : %10.6f\n", percentile(0.10f));
 
 }
 


### PR DESCRIPTION
I have added:
* Probability for quantized model predicting the same top token as the base model
* KL-divergence median
* KL-divergence min/max
* KL-divergence 1%, 5%, 95%, 99%

I'll keep it as a draft PR for a bit.
Please express your wishes for additional things one may want to know.

Here is an example of what you currently get:
```
chunk        PPL          ln(PPL(Q)/PPL(base))          KL-Divergence           Same top
   1        3.9734      -0.00651 ±    0.01162       0.01145 ±    0.00153    0.96078 ± 0.01218
   2        4.5052       0.00239 ±    0.00794       0.01388 ±    0.00164    0.95686 ± 0.00901
   3        5.3057       0.00175 ±    0.00625       0.01315 ±    0.00118    0.95163 ± 0.00776
   4        6.0247       0.00473 ±    0.00524       0.01236 ±    0.00092    0.95196 ± 0.00670
...
 638        5.7483       0.00903 ±    0.00039       0.01062 ±    0.00006    0.95254 ± 0.00053
 639        5.7520       0.00904 ±    0.00039       0.01062 ±    0.00006    0.95252 ± 0.00053
 640        5.7581       0.00905 ±    0.00039       0.01062 ±    0.00006    0.95254 ± 0.00053
 641        5.7486       0.00904 ±    0.00039       0.01062 ±    0.00006    0.95259 ± 0.00053
 642        5.7427       0.00901 ±    0.00039       0.01062 ±    0.00006    0.95261 ± 0.00053

===== KL-divergence statistics
Average:   0.010623 ±   0.000065
Median :   0.005517
Minimum:  -0.000008
Maximum:   2.462638
KLD_01 :   0.000007
KLD_99 :   0.088446
KLD_05 :   0.000046
KLD_95 :   0.034547

llama_print_timings:        load time =     699.00 ms
llama_print_timings:      sample time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time =   62910.38 ms / 328704 tokens (    0.19 ms per token,  5224.96 tokens per second)
llama_print_timings:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings:       total time =   66734.41 ms / 328705 tokens
```