### PR TITLE
convert : fix byte tokens for --vocab-type hfft

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -509,11 +509,13 @@ class HfVocab:
 
             # Convert token text to bytes
             token_text = reverse_vocab[token_id].encode("utf-8")
+            if re.fullmatch(br"<0x[0-9A-Fa-f]{2}>", token_text):
+                toktype = gguf.TokenType.BYTE
+            else:
+                toktype = self.get_token_type(token_id, self.special_ids)
 
             # Yield token text, score, and type
-            yield token_text, self.get_token_score(token_id), self.get_token_type(
-                token_id, self.special_ids  # Reuse already stored special IDs
-            )
+            yield token_text, self.get_token_score(token_id), toktype
 
     def get_token_type(self, token_id: int, special_ids: set[int]) -> gguf.TokenType:
         # Determine token type based on whether it's a special token


### PR DESCRIPTION
This is inspired by 9f297f81adb93fdfefbd6496ff50cdfe070bc775, which got lost during the refactoring in 6efb8eb30e7025b168f3fda3ff83b9b386428ad6.

Fixes #5064.