### PR TITLE
llama : fix not enough space in buffer with Qwen

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -4440,9 +4440,9 @@ static struct ggml_tensor * llm_build_kv(
 
     // these nodes are added to the graph together so that they are not reordered
     // by doing so, the number of splits in the graph is reduced
+    ggml_build_forward_expand(graph, q_cur);
     ggml_build_forward_expand(graph, k_cur);
     ggml_build_forward_expand(graph, v_cur);
-    ggml_build_forward_expand(graph, q_cur);
 
     llm_build_kv_store(ctx, hparams, kv, graph, k_cur, v_cur, n_ctx, n_tokens, kv_head, cb, il);
 


### PR DESCRIPTION
Fixes #5082

This was caused by a minor reordering of the nodes, which caused the measured compute buffer size to not be accurate. Changing the order of the nodes fixes the issue for all the models I could test. On that note, it would be very useful to have a directory with links to gguf files of all the base models supported by llama.cpp.

Ultimately, I think that the current approach for ggml-alloc is always going to be susceptible to these issues, because small changes in the sizes of a tensor can cause the following tensors to be allocated in a different block than during measure, causing different types of fragmentation that leads to out of memory errors.

In the long term, a more robust solution is needed, such as always assigning the same offset within the buffer to the tensors, regardless of their size, then it would always work as long as the tensors are never larger than during measure. This should also make ggml-alloc faster during inference since we could skip the whole allocation process and simply reuse the same allocations obtained during measure, and maybe could allow for a more exhaustive search for a more optimal way to allocate tensor during measure, since it would only happen during initialization.