### PR TITLE
add MobileVLM 1.7B/3B to the supported models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ as the main playground for developing new features for the [ggml](https://github
 - [x] [Bakllava](https://huggingface.co/models?search=SkunkworksAI/Bakllava)
 - [x] [Obsidian](https://huggingface.co/NousResearch/Obsidian-3B-V0.5)
 - [x] [ShareGPT4V](https://huggingface.co/models?search=Lin-Chen/ShareGPT4V)
+- [x] [MobileVLM 1.7B/3B models](https://huggingface.co/models?search=mobileVLM)
 
 
 **Bindings:**


### PR DESCRIPTION
`llama.cpp` has supported `MobileVLM` multimodal models in #4954. But we forgot to update the supported model list. In order to let more people know and use it, we want to add the `MobileVLM` link to the multimodal models list.