### PR TITLE
Another bucket sort

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8001,71 +8001,56 @@ void llama_sample_top_k(struct llama_context * ctx, llama_token_data_array * can
         auto comp = [](const llama_token_data & a, const llama_token_data & b) {
             return a.logit > b.logit;
         };
-        constexpr int   nbuckets    = 100;
-        constexpr float bucket_low  = -10.0f;
-        constexpr float bucket_high =  10.0f;
+        if (k < 200) {
+            std::partial_sort(candidates->data, candidates->data + k, candidates->data + candidates->size, comp);
+        } else {
+            constexpr int   nbuckets    = 128;
+            constexpr float bucket_low  = -10.0f;
+            constexpr float bucket_high =  10.0f;
+            constexpr float bucket_scale = nbuckets/(bucket_high - bucket_low);
+            constexpr float bucker_inter = -bucket_low * bucket_scale;
 
-        std::vector<llama_token_data> tmp_tokens(candidates->size);
-        std::vector<int> bucket_idx(candidates->size);
-        std::vector<int> histo(nbuckets, 0);
-        std::vector<llama_token_data*> bucket_ptrs;
-        bucket_ptrs.reserve(nbuckets);
+            std::vector<llama_token_data> tmp_tokens(candidates->size);
+            std::vector<int> bucket_idx(candidates->size);
+            std::vector<int> histo(nbuckets, 0);
+            std::vector<llama_token_data*> bucket_ptrs;
+            bucket_ptrs.reserve(nbuckets);
 
-        for (int i = 0; i < (int)candidates->size; ++i) {
-            const float val = candidates->data[i].logit;
-            int ib = nbuckets * (val - bucket_low) / (bucket_high - bucket_low);
-            ib = std::max(0, std::min(nbuckets-1, ib));
-            bucket_idx[i] = ib;
-            ++histo[ib];
-        }
-        auto ptr = tmp_tokens.data();
-        int nhave = 0;
-        int ib = nbuckets - 1;
-        for ( ; ib >= 0; --ib) {
-            nhave += histo[ib];
-            bucket_ptrs.push_back(ptr);
-            if (nhave >= k) break;
-            ptr += histo[ib];
-        }
-        for (int i = 0; i < (int)candidates->size; ++i) {
-            int j = bucket_idx[i];
-            if (j >= ib) {
-                *bucket_ptrs[nbuckets-1-j]++ = candidates->data[i];
+            for (int i = 0; i < (int)candidates->size; ++i) {
+                const float val = candidates->data[i].logit;
+                int ib = int(bucket_scale * val + bucker_inter); //nbuckets * (val - bucket_low) / (bucket_high - bucket_low);
+                ib = std::max(0, std::min(nbuckets-1, ib));
+                bucket_idx[i] = ib;
+                ++histo[ib];
             }
+            auto ptr = tmp_tokens.data();
+            int nhave = 0;
+            int ib = nbuckets - 1;
+            for ( ; ib >= 0; --ib) {
+                nhave += histo[ib];
+                bucket_ptrs.push_back(ptr);
+                if (nhave >= k) break;
+                ptr += histo[ib];
+            }
+            for (int i = 0; i < (int)candidates->size; ++i) {
+                int j = bucket_idx[i];
+                if (j >= ib) {
+                    *bucket_ptrs[nbuckets-1-j]++ = candidates->data[i];
+                }
+            }
+
+            ptr = tmp_tokens.data();
+            int ndone = 0;
+            for (int j = nbuckets-1; j > ib; --j) {
+                std::sort(ptr, ptr + histo[j], comp);
+                ptr += histo[j];
+                ndone += histo[j];
+            }
+            std::partial_sort(ptr, ptr + k - ndone, ptr + histo[ib], comp);
+
+            std::memcpy(candidates->data, tmp_tokens.data(), k*sizeof(llama_token_data));
+
         }
-
-        ptr = tmp_tokens.data();
-        int ndone = 0;
-        for (int j = nbuckets-1; j > ib; --j) {
-            std::sort(ptr, ptr + histo[j], comp);
-            ptr += histo[j];
-            ndone += histo[j];
-        }
-        std::partial_sort(ptr, ptr + k - ndone, ptr + histo[ib], comp);
-
-        std::memcpy(candidates->data, tmp_tokens.data(), k*sizeof(llama_token_data));
-
-        //std::vector<llama_token_data> buckets[nbuckets];
-
-        //for (size_t i = 0; i < candidates->size; ++i) {
-        //    const float val = candidates->data[i].logit;
-        //    int ib = nbuckets * (val - bucket_low) / (bucket_high - bucket_low);
-        //    ib = std::max(ib, 0);
-        //    ib = std::min(ib, nbuckets-1);
-        //    buckets[ib].push_back(candidates->data[i]);
-        //}
-
-        //int nsorted = 0;
-        //for (int ib = nbuckets-1; ib >= 0; --ib) {
-        //    std::sort(buckets[ib].begin(), buckets[ib].end(), comp);
-        //    memcpy(candidates->data + nsorted, buckets[ib].data(), buckets[ib].size()*sizeof(llama_token_data));
-
-        //    nsorted += buckets[ib].size();
-
-        //    if (nsorted >= k) {
-        //        break;
-        //    }
-        //}
         candidates->sorted = true;
     }
     candidates->size = k;

--- a/llama.cpp
+++ b/llama.cpp
@@ -8001,11 +8001,71 @@ void llama_sample_top_k(struct llama_context * ctx, llama_token_data_array * can
         auto comp = [](const llama_token_data & a, const llama_token_data & b) {
             return a.logit > b.logit;
         };
-        if (k == (int) candidates->size) {
-            std::sort(candidates->data, candidates->data + candidates->size, comp);
-        } else {
-            std::partial_sort(candidates->data, candidates->data + k, candidates->data + candidates->size, comp);
+        constexpr int   nbuckets    = 100;
+        constexpr float bucket_low  = -10.0f;
+        constexpr float bucket_high =  10.0f;
+
+        std::vector<llama_token_data> tmp_tokens(candidates->size);
+        std::vector<int> bucket_idx(candidates->size);
+        std::vector<int> histo(nbuckets, 0);
+        std::vector<llama_token_data*> bucket_ptrs;
+        bucket_ptrs.reserve(nbuckets);
+
+        for (int i = 0; i < (int)candidates->size; ++i) {
+            const float val = candidates->data[i].logit;
+            int ib = nbuckets * (val - bucket_low) / (bucket_high - bucket_low);
+            ib = std::max(0, std::min(nbuckets-1, ib));
+            bucket_idx[i] = ib;
+            ++histo[ib];
         }
+        auto ptr = tmp_tokens.data();
+        int nhave = 0;
+        int ib = nbuckets - 1;
+        for ( ; ib >= 0; --ib) {
+            nhave += histo[ib];
+            bucket_ptrs.push_back(ptr);
+            if (nhave >= k) break;
+            ptr += histo[ib];
+        }
+        for (int i = 0; i < (int)candidates->size; ++i) {
+            int j = bucket_idx[i];
+            if (j >= ib) {
+                *bucket_ptrs[nbuckets-1-j]++ = candidates->data[i];
+            }
+        }
+
+        ptr = tmp_tokens.data();
+        int ndone = 0;
+        for (int j = nbuckets-1; j > ib; --j) {
+            std::sort(ptr, ptr + histo[j], comp);
+            ptr += histo[j];
+            ndone += histo[j];
+        }
+        std::partial_sort(ptr, ptr + k - ndone, ptr + histo[ib], comp);
+
+        std::memcpy(candidates->data, tmp_tokens.data(), k*sizeof(llama_token_data));
+
+        //std::vector<llama_token_data> buckets[nbuckets];
+
+        //for (size_t i = 0; i < candidates->size; ++i) {
+        //    const float val = candidates->data[i].logit;
+        //    int ib = nbuckets * (val - bucket_low) / (bucket_high - bucket_low);
+        //    ib = std::max(ib, 0);
+        //    ib = std::min(ib, nbuckets-1);
+        //    buckets[ib].push_back(candidates->data[i]);
+        //}
+
+        //int nsorted = 0;
+        //for (int ib = nbuckets-1; ib >= 0; --ib) {
+        //    std::sort(buckets[ib].begin(), buckets[ib].end(), comp);
+        //    memcpy(candidates->data + nsorted, buckets[ib].data(), buckets[ib].size()*sizeof(llama_token_data));
+
+        //    nsorted += buckets[ib].size();
+
+        //    if (nsorted >= k) {
+        //        break;
+        //    }
+        //}
         candidates->sorted = true;
     }
     candidates->size = k;


### PR DESCRIPTION
We now have 3 PR's related to sorting logits with the goal to speedup top-k sampling:
* PR #5085 - speed up via usage of `std::nth_element` before `std::partial_sort`
* PR #5101, which introduces a bucket sort algorithm
* This PR, which provides a better (faster) implementation of the bucket sort proposed in #5101 

The table shows a comparison between master and these 3 PR's as a function of `top_k`. Tests run on a Ryzen-5975WX + RTX--4080 with Ubuntu 22.04 and GCC 11.4.0.

| --top-k | t/s master | t/s (PR 5085) | t/s PR 5101 | t/s this PR | Speedup this PR |
|---------|------------|-----------------|---------------------|-----------------|---------------------|
|      100 |       7758 |            7758 |   3084 | 7758 | 1.000 |
|      200 |       6796 |            6796 |   3076 | 7121 |  1.048 |
|      500 |       4848 |            4848 |    2905 | 6733 | 1.389 |
|    1000 |       3353 |            3353 |    2872 | 6075 | 1.812 |
|    2000 |       2123 |            2123 |    2592 | 5006 | 2.358 |
|    4000 |       1288 |            2000 |    2246 | 3627 | 2.816 |
|    8000 |         783 |            1438 |    1718 | 2292 | 2.927 |
|   16000 |        508 |             921 |     1143 | 1326 | 2.611 |
|   31780 |        397 |             558 |       675 | 734  | 1.848 |
|   32000 |        559 |             559 |       703 | 773 |  1.384 |