### PR TITLE
add Vulkan to Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,7 @@
 
                 mpi-cpu = config.packages.default.override { useMpi = true; };
                 mpi-cuda = config.packages.default.override { useMpi = true; };
+                vulkan = config.packages.default.override { useVulkan = true; };
               }
               // lib.optionalAttrs (system == "x86_64-linux") {
                 rocm = config.legacyPackages.llamaPackagesRocm.llama-cpp;


### PR DESCRIPTION
This adds support for the Vulkan backend from https://github.com/ggerganov/llama.cpp/pull/2059 to the Nix flake.

~I've marked this as a draft only because its based on that PR, which has not landed - otherwise it's ready for review.~

I have marked macOS as broken for this backend based on https://github.com/ggerganov/llama.cpp/pull/2059#issuecomment-1911808801, but I might change that if I get the moltenVK changes proposed by @rbourgeat's working in Nix.