### PR TITLE
allow empty --prompt-cache file

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -237,21 +237,15 @@ int main(int argc, char ** argv) {
 
     if (!path_session.empty()) {
         LOG_TEE("%s: attempting to load saved session from '%s'\n", __func__, path_session.c_str());
-        if (!file_exists(path_session))
-        {
+        if (!file_exists(path_session)) {
             LOG_TEE("%s: session file does not exist, will create.\n", __func__);
-        }
-        else if (file_size(path_session) == 0)
-        {
+        } else if (file_size(path_session) == 0) {
             LOG_TEE("%s: The session file is empty. A new session will be initialized.\n", __func__);
-        }
-        else
-        {
+        } else {
             // The file exists and is not empty
             session_tokens.resize(n_ctx);
             size_t n_token_count_out = 0;
-            if (!llama_load_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(), &n_token_count_out))
-            {
+            if (!llama_load_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(), &n_token_count_out)) {
                 LOG_TEE("%s: error: failed to load session file '%s'\n", __func__, path_session.c_str());
                 return 1;
             }


### PR DESCRIPTION
This allows the use of mkstemp(), std::tmpfile(), Python's tempfile.NamedTemporaryFile(), and similar create-empty-file API's for the user.

I switched from the C fopen API to the C++ filesystem api to get around the fact that, to the best of my knowledge, C has no portable way to get the file size above LONG_MAX, with std::ftell() returning long? fallback to std::ifstream for c++  < 17 (the project is currently targeting C++11 it seems - file_exists() and file_size() can be removed when we upgrade to c++ >= 17)