### PR TITLE
embeddings compatibility for OpenAI [examples/server]

### DIFF
--- a/examples/server/oai.hpp
+++ b/examples/server/oai.hpp
@@ -206,3 +206,18 @@ inline static std::vector<json> format_partial_response_oaicompat(const task_res
 
     return std::vector<json>({ret});
 }
+
+inline static json format_embeddings_response_oaicompat(const json &request, const json &embeddings)
+{
+    json res =
+        json{
+            {"model", json_value(request, "model", std::string(DEFAULT_OAICOMPAT_MODEL))},
+            {"object", "list"},
+            {"usage",
+                json{{"prompt_tokens", 0},
+                     {"total_tokens", 0}}},
+            {"data", embeddings}
+        };
+    return res;
+}
+


### PR DESCRIPTION
Add router for serve `/v1/embeddings`

1.  `input` as string

```shell
curl http://127.0.0.1:8080/v1/embeddings \
    -H 'Content-Type: application/json' \
    -d '{
        "input": "hello",
        "model":"GPT-4",
        "encoding_format": "float"
    }'
```
`response`
```json
{
    "data": [
        {
            "embedding": [
                -3.697190046310425,
                ...
                -4.443967342376709
            ],
            "index": 0,
            "object": "embedding"
        }
    ],
    "model": "GPT-4",
    "object": "list",
    "usage": {
        "prompt_tokens": 0,
        "total_tokens": 0
    }
}
```

2. `input` as string array

```shell
curl http://127.0.0.1:8080/v1/embeddings \
--header 'Content-Type: application/json' \
--data '{
        "input": ["hello","world"],
        "model":"GPT-4",
        "encoding_format": "float"
}'
```

`response`

```json
{
    "data": [
        {
            "embedding": [
                -3.697190046310425,
                ...
                -4.443967342376709
            ],
            "index": 0,
            "object": "embedding"
        },
        {
            "embedding": [
                -0.35142484307289124,
                ...
                -4.626900672912598
            ],
            "index": 1,
            "object": "embedding"
        }
    ],
    "model": "GPT-4",
    "object": "list",
    "usage": {
        "prompt_tokens": 0,
        "total_tokens": 0
    }
}
``` 