### PR TITLE
ggml alloc: Fix for null dereference on alloc failure

### DIFF
--- a/ggml-alloc.c
+++ b/ggml-alloc.c
@@ -788,12 +788,10 @@ static bool alloc_tensor_range(struct ggml_context * ctx,
 #ifndef NDEBUG
         fprintf(stderr, "%s: failed to allocate %s buffer of size %zu\n", __func__, ggml_backend_buft_name(buft), size);
 #endif
-        if (buffers && *buffers) {
-            for (size_t i = 0; i < *n_buffers; i++) {
-                ggml_backend_buffer_free(*buffers[i]);
-            }
-            free(buffers);
+        for (size_t i = 0; i < *n_buffers; i++) {
+            ggml_backend_buffer_free(*buffers[i]);
         }
+        free(*buffers);
         return false;
     }
 
@@ -845,12 +843,10 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
                     __func__, t->name,
                     ggml_backend_buft_name(buft),
                     this_size, max_size);
-            if(buffers && *buffers) {
-                for (size_t i = 0; i < n_buffers; i++) {
-                    ggml_backend_buffer_free(buffers[i]);
-                }
-                free(buffers);
+            for (size_t i = 0; i < n_buffers; i++) {
+                ggml_backend_buffer_free(buffers[i]);
             }
+            free(*buffers);
             return NULL;
         }
 
@@ -887,7 +883,7 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
     } else {
         buffer = ggml_backend_multi_buffer_alloc_buffer(buffers, n_buffers);
     }
-    free(buffers);
+    free(*buffers);
     return buffer;
 }
 

--- a/ggml-alloc.c
+++ b/ggml-alloc.c
@@ -788,10 +788,12 @@ static bool alloc_tensor_range(struct ggml_context * ctx,
 #ifndef NDEBUG
         fprintf(stderr, "%s: failed to allocate %s buffer of size %zu\n", __func__, ggml_backend_buft_name(buft), size);
 #endif
-        for (size_t i = 0; i < *n_buffers; i++) {
-            ggml_backend_buffer_free(*buffers[i]);
+        if (buffers && *buffers) {
+            for (size_t i = 0; i < *n_buffers; i++) {
+                ggml_backend_buffer_free(*buffers[i]);
+            }
+            free(buffers);
         }
-        free(buffers);
         return false;
     }
 
@@ -843,10 +845,12 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
                     __func__, t->name,
                     ggml_backend_buft_name(buft),
                     this_size, max_size);
-            for (size_t i = 0; i < n_buffers; i++) {
-                ggml_backend_buffer_free(buffers[i]);
+            if(buffers && *buffers) {
+                for (size_t i = 0; i < n_buffers; i++) {
+                    ggml_backend_buffer_free(buffers[i]);
+                }
+                free(buffers);
             }
-            free(buffers);
             return NULL;
         }
 

--- a/ggml-alloc.c
+++ b/ggml-alloc.c
@@ -846,7 +846,7 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
             for (size_t i = 0; i < n_buffers; i++) {
                 ggml_backend_buffer_free(buffers[i]);
             }
-            free(*buffers);
+            free(buffers);
             return NULL;
         }
 
@@ -883,7 +883,7 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
     } else {
         buffer = ggml_backend_multi_buffer_alloc_buffer(buffers, n_buffers);
     }
-    free(*buffers);
+    free(buffers);
     return buffer;
 }
 


### PR DESCRIPTION
If `alloc_tensor_range` is called and either/or:
- The `buffers` argument is NULL
- The `ggml_tallocr_new_from_buffer` call inside this function fails to allocate

The code will end up trying to free a NULL `buffers` pointer which, at least on macOS, causes a crash (or worse, corruption)

This PR adds checks for `buffers` being NULL, or for some reason `buffers` points to NULL. This change will allow the llama context init to fail (as expected, since there was not enough memory in this path) rather than crash / corrupt state.

(Note: This breakage will happen in release builds. In debug builds the Metal framework will throw an exception during the allocation if there is not enough memory, so the code will not reach this point, but in release builds it will keep going and break)

Picture of the call stack in case it helps:

<img width="1149" alt="Screenshot 2024-01-29 at 21 16 43" src="https://github.com/ggerganov/llama.cpp/assets/521581/d318c42c-f170-46be-ad88-f1523d31ed72">

To reproduce: Load a model that is much bigger than the system memory and allocate all the layers to the GPU on an Apple Silicon Mac.