### PR TITLE
kompute : fix fallback to CPU

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -4136,7 +4136,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
         }
 
 #ifdef GGML_USE_KOMPUTE
-        if (ggml_vk_has_device() && params.n_gpu_layers > 0 && (
+        if (params.n_gpu_layers > 0 && (
             !(model.arch == LLM_ARCH_LLAMA || model.arch == LLM_ARCH_FALCON)
             || !(
                 model.ftype == LLAMA_FTYPE_ALL_F32 ||
@@ -4145,8 +4145,8 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                 model.ftype == LLAMA_FTYPE_MOSTLY_Q4_1
             )
         )) {
-            // disable Vulkan due to unsupported model architecture or quantization type
             // TODO(cebtenzzre): propagate this error outside of llama_load_model_from_file
+            LLAMA_LOG_WARN("%s: disabling Kompute due to unsupported model arch or quantization\n", __func__);
             params.n_gpu_layers = 0;
         }
 #endif


### PR DESCRIPTION
I missed this when I changed the way devices were managed by the Kompute backend.

Also add a warning so it's clearer to the user when the Kompute backend isn't being used.

ref: https://github.com/ggerganov/llama.cpp/pull/4456#issuecomment-1915627890