### PR TITLE
InternLM xcomposer2 support (at least on eye level of GPT4V and CogVLM) - help needed

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -203,6 +203,8 @@ class Model:
             return CodeShellModel
         if model_architecture == "OrionForCausalLM":
             return OrionModel
+        if model_architecture == "InternLM2ForCausalLM":
+            return InternLM2Model
         return Model
 
     def _is_model_safetensors(self) -> bool:
@@ -254,6 +256,8 @@ class Model:
             return gguf.MODEL_ARCH.CODESHELL
         if arch == "OrionForCausalLM":
             return gguf.MODEL_ARCH.ORION
+        if arch == "InternLM2ForCausalLM":
+            return gguf.MODEL_ARCH.INTERNLM2
 
         raise NotImplementedError(f'Architecture "{arch}" not supported!')
 
@@ -1343,6 +1347,147 @@ class CodeShellModel(Model):
             if not has_lm_head and name == "transformer.wte.weight":
                 self.gguf_writer.add_tensor("output.weight", data)
                 print(name, f"=> output.weight, shape = {data.shape}, {old_dtype} --> {data.dtype}")
+
+class InternLM2Model(Model):
+    def set_vocab(self):
+        # (TODO): Is there a better way?
+        # Copy from _set_vocab_sentencepiece, The only difference is that we will treat the character
+        # \x00 specially and convert it into an emoji character to prevent it from being mistakenly
+        # recognized as an empty string in C++.
+        from sentencepiece import SentencePieceProcessor
+
+        tokenizer_path = self.dir_model / 'tokenizer.model'
+
+        tokens: list[bytes] = []
+        scores: list[float] = []
+        toktypes: list[int] = []
+
+        if not tokenizer_path.is_file():
+            print(f'Error: Missing {tokenizer_path}', file=sys.stderr)
+            sys.exit(1)
+
+        tokenizer = SentencePieceProcessor(str(tokenizer_path))
+        vocab_size = self.hparams.get('vocab_size', tokenizer.vocab_size())
+
+        for token_id in range(vocab_size):
+            piece = tokenizer.id_to_piece(token_id)
+            text = piece.encode("utf-8")
+            score = tokenizer.get_score(token_id)
+            if text == b"\x00":
+                # (TODO): fixme
+                # Hack here and replace the \x00 characters.
+                print(f"InternLM2 convert token '{text}' to '🐉'!")
+                text = "🐉"
+
+            toktype = SentencePieceTokenTypes.NORMAL
+            if tokenizer.is_unknown(token_id):
+                toktype = SentencePieceTokenTypes.UNKNOWN
+            elif tokenizer.is_control(token_id):
+                toktype = SentencePieceTokenTypes.CONTROL
+            elif tokenizer.is_unused(token_id):
+                toktype = SentencePieceTokenTypes.UNUSED
+            elif tokenizer.is_byte(token_id):
+                toktype = SentencePieceTokenTypes.BYTE
+
+            tokens.append(text)
+            scores.append(score)
+            toktypes.append(toktype)
+
+        added_tokens_file = self.dir_model / 'added_tokens.json'
+        if added_tokens_file.is_file():
+            with open(added_tokens_file, "r", encoding="utf-8") as f:
+                added_tokens_json = json.load(f)
+
+                for key in added_tokens_json:
+                    tokens.append(key.encode("utf-8"))
+                    scores.append(-1000.0)
+                    toktypes.append(SentencePieceTokenTypes.USER_DEFINED)
+
+        self.gguf_writer.add_tokenizer_model("llama")
+        self.gguf_writer.add_token_list(tokens)
+        self.gguf_writer.add_token_scores(scores)
+        self.gguf_writer.add_token_types(toktypes)
+
+        special_vocab = gguf.SpecialVocab(self.dir_model, n_vocab=len(tokens))
+        special_vocab.add_to_gguf(self.gguf_writer)
+
+    def set_gguf_parameters(self):
+        self.gguf_writer.add_name("InternLM2")
+        self.gguf_writer.add_context_length(self.hparams["max_position_embeddings"])
+        self.gguf_writer.add_block_count(self.hparams["num_hidden_layers"])
+        self.gguf_writer.add_embedding_length(self.hparams["hidden_size"])
+        self.gguf_writer.add_feed_forward_length(self.hparams["intermediate_size"])
+        self.gguf_writer.add_rope_freq_base(self.hparams["rope_theta"])
+        self.gguf_writer.add_head_count(self.hparams["num_attention_heads"])
+        self.gguf_writer.add_layer_norm_rms_eps(self.hparams["rms_norm_eps"])
+        self.gguf_writer.add_head_count_kv(self.hparams["num_key_value_heads"])
+
+    def post_write_tensors(self, tensor_map, name, data_torch):
+        old_dtype = data_torch.dtype
+
+        # convert any unsupported data types to float32
+        if data_torch.dtype not in (torch.float16, torch.float32):
+            data_torch = data_torch.to(torch.float32)
+
+        data = data_torch.squeeze().numpy()
+
+        # map tensor names
+        new_name = tensor_map.get_name(name, try_suffixes=(".weight", ".bias"))
+        if new_name is None:
+            print(f"Can not map tensor {name!r}")
+            sys.exit()
+
+        n_dims = len(data.shape)
+        data_dtype = data.dtype
+
+        # if f32 desired, convert any float16 to float32
+        if self.ftype == 0 and data_dtype == np.float16:
+            data = data.astype(np.float32)
+
+        # TODO: Why cant we use these float16 as-is? There should be not reason to store float16 as float32
+        if self.ftype == 1 and data_dtype == np.float16 and n_dims == 1:
+            data = data.astype(np.float32)
+
+        # if f16 desired, convert any float32 2-dim weight tensors to float16
+        if self.ftype == 1 and data_dtype == np.float32 and name.endswith(".weight") and n_dims == 2:
+            data = data.astype(np.float16)
+
+        print(f"{new_name}, n_dims = {n_dims}, {old_dtype} --> {data.dtype}")
+        self.gguf_writer.add_tensor(new_name, data)
+
+    def write_tensors(self):
+        from einops import rearrange
+
+        num_heads = self.hparams.get("num_attention_heads")
+        num_kv_heads = self.hparams.get("num_key_value_heads")
+        hidden_size = self.hparams.get("hidden_size")
+        q_per_kv = num_heads // num_kv_heads
+        head_dim = hidden_size // num_heads
+        num_groups = num_heads // q_per_kv
+
+        block_count = self.hparams["num_hidden_layers"]
+        model_kv = dict(self.get_tensors())
+        tensor_map = gguf.get_tensor_name_map(self.model_arch, block_count)
+        qkv_pattern = r"model\.layers\.(\d+)\.attention\.wqkv"
+        for name, data_torch in model_kv.items():
+            # we don't need these
+            if name.endswith(".rotary_emb.inv_freq"):
+                continue
+            plora_tensor = True if "Plora" in name else False
+            if re.match(qkv_pattern, name) and not plora_tensor:
+                bid = re.findall(qkv_pattern, name)[0]
+                qkv = data_torch
+                qkv = rearrange(qkv.T, " o (g n i)  ->o g n i", g=num_groups, n=q_per_kv+2, i=head_dim)
+                q, k, v = qkv[...,:q_per_kv,:], qkv[...,q_per_kv:q_per_kv+1,:], qkv[...,q_per_kv+1:q_per_kv+2,:]
+                q = rearrange(q, " o g n i ->  o (g n i)").T
+                k = rearrange(k, " o g n i ->  o (g n i)").T
+                v = rearrange(v, " o g n i ->  o (g n i)").T
+                self.post_write_tensors(tensor_map, f"model.layers.{bid}.attention.wq.weight", q)
+                self.post_write_tensors(tensor_map, f"model.layers.{bid}.attention.wk.weight", k)
+                self.post_write_tensors(tensor_map, f"model.layers.{bid}.attention.wv.weight", v)
+            else:
+                self.post_write_tensors(tensor_map, name, data_torch)
+
 
 ###### CONVERSION LOGIC ######
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -102,6 +102,7 @@ class MODEL_ARCH(IntEnum):
     PLAMO     = auto()
     CODESHELL = auto()
     ORION     = auto()
+    INTERNLM2  = auto()
 
 
 class MODEL_TENSOR(IntEnum):
@@ -132,6 +133,21 @@ class MODEL_TENSOR(IntEnum):
     ATTN_Q_NORM     = auto()
     ATTN_K_NORM     = auto()
 
+    ATTN_QKV_LORA_A = auto()
+    ATTN_QKV_LORA_B = auto()
+    ATTN_OUT_LORA_A = auto()
+    ATTN_OUT_LORA_B = auto()
+    FFN_UP_LORA_A   = auto()
+    FFN_UP_LORA_B   = auto()
+    FFN_GATE_LORA_A = auto()
+    FFN_GATE_LORA_B = auto()
+    FFN_DOWN_LORA_A = auto()
+    FFN_DOWN_LORA_B = auto()
+
+
+
+
+
 
 MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.LLAMA:          "llama",
@@ -153,6 +169,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.PLAMO:          "plamo",
     MODEL_ARCH.CODESHELL:      "codeshell",
     MODEL_ARCH.ORION:          "orion",
+    MODEL_ARCH.INTERNLM2:      "internlm2",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
@@ -182,6 +199,18 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.FFN_GATE_EXP:    "blk.{bid}.ffn_gate.{xid}",
     MODEL_TENSOR.FFN_DOWN_EXP:    "blk.{bid}.ffn_down.{xid}",
     MODEL_TENSOR.FFN_UP_EXP:      "blk.{bid}.ffn_up.{xid}",
+
+    MODEL_TENSOR.ATTN_QKV_LORA_A : "blk.{bid}.attn_qkv_lora_a",
+    MODEL_TENSOR.ATTN_QKV_LORA_B : "blk.{bid}.attn_qkv_lora_b",
+    MODEL_TENSOR.ATTN_OUT_LORA_A : "blk.{bid}.attn_out_lora_a",
+    MODEL_TENSOR.ATTN_OUT_LORA_B : "blk.{bid}.attn_out_lora_b",
+    MODEL_TENSOR.FFN_UP_LORA_A   : "blk.{bid}.ffn_up_lora_a",
+    MODEL_TENSOR.FFN_UP_LORA_B   : "blk.{bid}.ffn_up_lora_b",
+    MODEL_TENSOR.FFN_GATE_LORA_A : "blk.{bid}.ffn_gate_lora_a",
+    MODEL_TENSOR.FFN_GATE_LORA_B : "blk.{bid}.ffn_gate_lora_b",
+    MODEL_TENSOR.FFN_DOWN_LORA_A : "blk.{bid}.ffn_down_lora_a",
+    MODEL_TENSOR.FFN_DOWN_LORA_B : "blk.{bid}.ffn_down_lora_b",
+
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -445,6 +474,32 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE,
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
+    ],
+    MODEL_ARCH.INTERNLM2: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.ATTN_ROT_EMBD,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_GATE,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
+
+        MODEL_TENSOR.ATTN_QKV_LORA_A,
+        MODEL_TENSOR.ATTN_QKV_LORA_B,
+        MODEL_TENSOR.ATTN_OUT_LORA_A,
+        MODEL_TENSOR.ATTN_OUT_LORA_B,
+        MODEL_TENSOR.FFN_UP_LORA_A,
+        MODEL_TENSOR.FFN_UP_LORA_B,
+        MODEL_TENSOR.FFN_GATE_LORA_A,
+        MODEL_TENSOR.FFN_GATE_LORA_B,
+        MODEL_TENSOR.FFN_DOWN_LORA_A,
+        MODEL_TENSOR.FFN_DOWN_LORA_B,
     ],
     # TODO
 }

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -19,6 +19,7 @@ class TensorNameMap:
             "language_model.embedding.word_embeddings",  # persimmon
             "wte",                                       # gpt2
             "transformer.embd.wte",                      # phi2
+            "model.tok_embeddings",                      # internlm2
         ),
 
         # Token type embeddings
@@ -42,7 +43,7 @@ class TensorNameMap:
         MODEL_TENSOR.OUTPUT: (
             "embed_out",                 # gptneox
             "lm_head",                   # gpt2 mpt falcon llama-hf baichuan qwen
-            "output",                    # llama-pth bloom
+            "output",                    # llama-pth bloom internlm2
             "word_embeddings_for_head",  # persimmon
             "lm_head.linear",            # phi2
         ),
@@ -51,7 +52,7 @@ class TensorNameMap:
         MODEL_TENSOR.OUTPUT_NORM: (
             "gpt_neox.final_layer_norm",               # gptneox
             "transformer.ln_f",                        # gpt2 gpt-j falcon
-            "model.norm",                              # llama-hf baichuan
+            "model.norm",                              # llama-hf baichuan internlm2
             "norm",                                    # llama-pth
             "embeddings.LayerNorm",                    # bert
             "transformer.norm_f",                      # mpt
@@ -84,6 +85,7 @@ class TensorNameMap:
             "h.{bid}.ln_1",                                         # gpt2
             "transformer.h.{bid}.ln",                               # phi2
             "model.layers.layers.{bid}.norm",                       # plamo
+            "model.layers.{bid}.attention_norm",                    # internlm2
         ),
 
         # Attention norm 2
@@ -111,6 +113,7 @@ class TensorNameMap:
             "encoder.layer.{bid}.attention.self.query",    # bert
             "transformer.h.{bid}.attn.q_proj",             # gpt-j
             "model.layers.layers.{bid}.self_attn.q_proj",  # plamo
+            "model.layers.{bid}.attention.wq"             # internlm2
         ),
 
         # Attention key
@@ -120,6 +123,7 @@ class TensorNameMap:
             "encoder.layer.{bid}.attention.self.key",      # bert
             "transformer.h.{bid}.attn.k_proj",             # gpt-j
             "model.layers.layers.{bid}.self_attn.k_proj",  # plamo
+            "model.layers.{bid}.attention.wk"             # internlm2
         ),
 
         # Attention value
@@ -129,6 +133,13 @@ class TensorNameMap:
             "encoder.layer.{bid}.attention.self.value",    # bert
             "transformer.h.{bid}.attn.v_proj",             # gpt-j
             "model.layers.layers.{bid}.self_attn.v_proj",  # plamo
+            "model.layers.{bid}.attention.wv"             # internlm2
+        ),
+        MODEL_TENSOR.ATTN_QKV_LORA_A: (
+            "model.layers.{bid}.attention.wqkv.Plora_A",                 # internlm2
+        ),
+        MODEL_TENSOR.ATTN_QKV_LORA_B: (
+            "model.layers.{bid}.attention.wqkv.Plora_B",                 # internlm2
         ),
 
         # Attention output
@@ -147,6 +158,13 @@ class TensorNameMap:
             "h.{bid}.attn.c_proj",                                       # gpt2
             "transformer.h.{bid}.mixer.out_proj",                        # phi2
             "model.layers.layers.{bid}.self_attn.o_proj",                # plamo
+            "model.layers.{bid}.attention.wo",                           # internlm2
+        ),
+        MODEL_TENSOR.ATTN_OUT_LORA_A: (
+            "model.layers.{bid}.attention.wo.Plora_A",                 # internlm2
+        ),
+        MODEL_TENSOR.ATTN_OUT_LORA_B: (
+            "model.layers.{bid}.attention.wo.Plora_B",                 # internlm2
         ),
 
         # Rotary embeddings
@@ -169,6 +187,7 @@ class TensorNameMap:
             "language_model.encoder.layers.{bid}.post_attention_layernorm",  # persimmon
             "model.layers.{bid}.ln2",                                        # yi
             "h.{bid}.ln_2",                                                  # gpt2
+            "model.layers.{bid}.ffn_norm",                                   # internlm2
         ),
 
         MODEL_TENSOR.FFN_GATE_INP: (
@@ -194,6 +213,13 @@ class TensorNameMap:
             "transformer.h.{bid}.mlp.fc1",                            # phi2
             "model.layers.{bid}.mlp.fc1",                             # phi2
             "model.layers.layers.{bid}.mlp.up_proj",                  # plamo
+            "model.layers.{bid}.feed_forward.w3",                     # internlm2
+        ),
+        MODEL_TENSOR.FFN_UP_LORA_A: (
+            "model.layers.{bid}.feed_forward.w3.Plora_A",                 # internlm2
+        ),
+        MODEL_TENSOR.FFN_UP_LORA_B: (
+            "model.layers.{bid}.feed_forward.w3.Plora_B",                 # internlm2
         ),
 
         MODEL_TENSOR.FFN_UP_EXP: (
@@ -212,6 +238,13 @@ class TensorNameMap:
             "layers.{bid}.feed_forward.w1",               # llama-pth
             "transformer.h.{bid}.mlp.w2",                 # qwen
             "model.layers.layers.{bid}.mlp.gate_proj",    # plamo
+            "model.layers.{bid}.feed_forward.w1",         # internlm2
+        ),
+        MODEL_TENSOR.FFN_GATE_LORA_A: (
+            "model.layers.{bid}.feed_forward.w1.Plora_A",                 # internlm2
+        ),
+        MODEL_TENSOR.FFN_GATE_LORA_B: (
+            "model.layers.{bid}.feed_forward.w1.Plora_B",                 # internlm2
         ),
 
         MODEL_TENSOR.FFN_GATE_EXP: (
@@ -236,6 +269,13 @@ class TensorNameMap:
             "transformer.h.{bid}.mlp.fc2",                            # phi2
             "model.layers.{bid}.mlp.fc2",                             # phi2
             "model.layers.layers.{bid}.mlp.down_proj",                # plamo
+            "model.layers.{bid}.feed_forward.w2",                     # internlm2
+        ),
+        MODEL_TENSOR.FFN_DOWN_LORA_A: (
+            "model.layers.{bid}.feed_forward.w2.Plora_A",                 # internlm2
+        ),
+        MODEL_TENSOR.FFN_DOWN_LORA_B: (
+            "model.layers.{bid}.feed_forward.w2.Plora_B",                 # internlm2
         ),
 
         MODEL_TENSOR.FFN_DOWN_EXP: (

--- a/llama.cpp
+++ b/llama.cpp
@@ -3082,7 +3082,7 @@ static void llm_load_hparams(
 }
 
 // TODO: This should probably be in llama.h
-static std::vector<llama_vocab::id> llama_tokenize_internal(const llama_vocab & vocab, std::string raw_text, bool bos, bool special = false);
+static std::vector<llama_vocab::id> llama_tokenize_internal(const llama_vocab & vocab, std::string raw_text, bool bos, bool special = false, bool add_space_prefix = true);
 static llama_token llama_byte_to_token(const llama_vocab & vocab, uint8_t ch);
 
 static void llm_load_vocab(


### PR DESCRIPTION
xcomposer2 is like gpt4v/cogVLM - just 5 times faster and smaller 
**This is like llava-1.5 in terms of simplicity (plus a few sequential tensors to multiply) but GPT4V in quality.**

Aside of the stunning visual performance, their use of lora looks interesting to me.
I wonder if a similar lora approach could be used on Mixtral - to cut the total mixtral size down to 1+ experts while giving full 8+ expert inference. Instead of precompiling 8 expert weights, one foundation could be used + 8 sets of conditional lora.

**Difference of xcomposer2 vs llava:**
1) the mm_proj weights are renamed to vision_proj - mlp2x_gelu
2) the same clip model is used but at resolution 490x490
3) The visual embeddings are handled by a dynamic lora (wo,w123,wqkv) which seems to be applied as a first step conditionally.
This results in the features of a full visual-expert but without the need to model it, it's still the 7B LLM that is used

The performance is quite stunning. It was able to solve the license demo (OCR) with no flaws (superior to GPT4V in that test)
I also asked it about the 3 cats, flawless as well.


I've uploaded the converted xcomposer-7B Q3K LLM and a Q5K mmproj/clip model here: https://huggingface.co/cmp-nct/xcomposer2_gguf_for_llama.cpp_development
These are converted by the changes here, so they contain the conditional tensors as they are created at the moment.
I'm doubtful if the qkv partial-lora tensor is good in that form, it likely needs a transform to be used.
My pytorch/python skills are minimal sadly

**Status:**
 - loading of all lora tensors in correct shape [done - the plora from pytorch are all taken without change and integrated into the model]
  - make clip conversion possible [done - projection was tiny and is differnt named]
 - make llm inference possible [works for text]

 **Todo:**
 - dynamic shape for lora tensors [] (right now the plora tensors are just hardcoded in the llama loader)
 - add image token mask []
 - add conditional "lora" on tensors during inference (wo,w123 and wqkv)
 One of the devs that are more experienced with pytorch->ggml conversions could get the plora multiplications into the architecture much faster than me
 
 **Reference:**
https://huggingface.co/internlm/internlm-xcomposer2-vl-7b/blob/main/build_mlp.py
https://huggingface.co/internlm/internlm-xcomposer2-vl-7b/blob/main/modeling_internlm2.py
 