### PR TITLE
format license text, restore apache license by  legal suggestion

### DIFF
--- a/examples/sycl/ls-sycl-device.cpp
+++ b/examples/sycl/ls-sycl-device.cpp
@@ -1,7 +1,9 @@
-/*MIT license
-  Copyright (C) 2024 Intel Corporation
-  SPDX-License-Identifier: MIT
-*/
+//
+//  MIT license
+//  Copyright (C) 2024 Intel Corporation
+//  SPDX-License-Identifier: MIT
+//
+
 
 #include "ggml-sycl.h"
 

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -1,7 +1,14 @@
-/*MIT license
-  Copyright (C) 2024 Intel Corporation
-  SPDX-License-Identifier: MIT
-*/
+//
+// MIT license
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: MIT
+//
+
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
 
 #include <algorithm>
 #include <assert.h>

--- a/ggml-sycl.h
+++ b/ggml-sycl.h
@@ -1,7 +1,8 @@
-/*MIT license
-  Copyright (C) 2024 Intel Corporation
-  SPDX-License-Identifier: MIT
-*/
+//
+//  MIT license
+//  Copyright (C) 2024 Intel Corporation
+//  SPDX-License-Identifier: MIT
+//
 
 #pragma once
 


### PR DESCRIPTION
According to legal suggestion, the source file used other open-source project code, should keep the license info.
In ggm-sycl.cpp, we copy part of code from oneapi-src/SYCLomatic (Apache 2.0 +TPP).

Restore the license info will reduce the legal risk.
