### PR TITLE
Fix out of bounds memory clobber in GGML_OP_ROPE

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -17151,7 +17151,7 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
             case GGML_OP_SOFT_MAX:
             case GGML_OP_ROPE:
                 {
-                    cur = ggml_type_size(GGML_TYPE_F32) * node->ne[0] * n_tasks;
+                    cur = ggml_type_size(GGML_TYPE_F32) * (node->ne[0] + CACHE_LINE_SIZE_F32) * n_tasks;
                 } break;
             case GGML_OP_CONV_TRANSPOSE_1D:
                 {


### PR DESCRIPTION
This change fixes a memory bug when the rope op is operating on its work data.

Speaking of which, could we have a build flag that disables ggml-alloc.c for cpu workloads? I ask because the custom memory allocator makes it difficult to use address sanitizer and thread sanitizer. I need those tools in order to be able to spot memory bugs like this one. Ideally llama.cpp would just call `malloc()` when creating temporary buffers and `tensor->data` allocations. I like malloc() because the more liberally you use it, the faster scientific computing code goes, since it helps the compiler prove there's no aliases.