### PR TITLE
convert : fix TypeError on GPT-2 vocab.json

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -334,9 +334,9 @@ class Params:
 class BpeVocab:
     def __init__(self, fname_tokenizer: Path, fname_added_tokens: Path | None) -> None:
         self.bpe_tokenizer = json.loads(open(str(fname_tokenizer), encoding="utf-8").read())
-        try:
+        if isinstance(self.bpe_tokenizer.get('model'), dict):
             self.vocab = self.bpe_tokenizer["model"]["vocab"]
-        except (KeyError, TypeError):
+        else:
             self.vocab = self.bpe_tokenizer
         added_tokens: dict[str, int]
         if fname_added_tokens is not None:

--- a/convert.py
+++ b/convert.py
@@ -336,7 +336,7 @@ class BpeVocab:
         self.bpe_tokenizer = json.loads(open(str(fname_tokenizer), encoding="utf-8").read())
         try:
             self.vocab = self.bpe_tokenizer["model"]["vocab"]
-        except KeyError:
+        except (KeyError, TypeError):
             self.vocab = self.bpe_tokenizer
         added_tokens: dict[str, int]
         if fname_added_tokens is not None:


### PR DESCRIPTION
```
  File "/llama.cpp/convert.py", line 1474, in <module>
    main()
  File "/llama.cpp/convert.py", line 1442, in main
    vocab, special_vocab = vocab_factory.load_vocab(args.vocab_type, model_parent_path)
  File "/llama.cpp/convert.py", line 1324, in load_vocab
    vocab = BpeVocab(
  File "/llama.cpp/convert.py", line 338, in __init__
    self.vocab = self.bpe_tokenizer["model"]["vocab"]
TypeError: 'int' object is not subscriptable
```
The error that occurred is `TypeError`, so I add one more exception type.  
https://github.com/ggerganov/llama.cpp/pull/5194