### PR TITLE
Fix for LLAMA_WIN_VER default value, fixes #5158

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if (NOT MSVC)
 endif()
 
 if (WIN32)
-    option(LLAMA_WIN_VER                     "llama: Windows Version"                           0x602)
+    set(LLAMA_WIN_VER "0x602" CACHE STRING "llama: Windows Version")
 endif()
 
 # 3rd party libs


### PR DESCRIPTION
Fix for #5158 

Updated CMakeLists.txt to set the default value for `LLAMA_WIN_VER` with `set()` instead of `option()` (which is specifically for booleans).

I encountered the issue when I updated [my Java JNI project](https://github.com/crimsonmagick/jllama) to tag b2050, and [my MinGW build broke](https://github.com/crimsonmagick/jllama/actions/runs/7764646615/job/21178345971#step:4:828).

Confirmed the bug with this diagnostic in CMakeLists.txt:

```
if (WIN32)
    option(LLAMA_WIN_VER                     "llama: Windows Version"                           0x602)
    message(WARNING "LLAMA_WIN_VER set to: ${LLAMA_WIN_VER}")
endif()
```

Which resulted in:

![5158-default-message-before](https://github.com/ggerganov/llama.cpp/assets/10789485/fea8f1ab-316d-4a62-92e8-e4344a82e2cb)

So, unless `LLAMA_WIN_VER` is supplied by a user def, this value defaults to `OFF` instead of the intended `0x602`. Since I wasn't specifying the def, the MinGW build failed.

The [`option()`](https://cmake.org/cmake/help/v3.28/command/option.html#option) command is for boolean values, and it looks like cmake defaults to `OFF` if it can't parse the parameter.

Switching from `option()` to `set()` fixed the issue:

![5158-default-message-after](https://github.com/ggerganov/llama.cpp/assets/10789485/0354ae55-b7a3-4cc1-b720-cb771bf5f48c)

I also confirmed that specifying `LLAMA_WIN_VER` still works after my update by passing `-DLLAMA_WIN_VER=0x400`:

![5158-definition-message-after](https://github.com/ggerganov/llama.cpp/assets/10789485/093e6663-3897-484b-bd1e-d0170405a2ca)

