### PR TITLE
Server: various fixes for the prompt field in /completion

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1159,13 +1159,30 @@ struct llama_server_context
         task.multitask_id = multitask_id;
 
         // when a completion task's prompt array is not a singleton, we split it into multiple requests
-        if (task.data.count("prompt") && task.data.at("prompt").size() > 1)
-        {
-            split_multiprompt_task(task_id, task);
-        }
-
         // otherwise, it's a single-prompt task, we actually queue it
-        queue_tasks.post(task);
+        // if there's numbers in the prompt array it will be treated as an array of tokens
+        if (task.data.count("prompt") != 0 && task.data.at("prompt").size() > 1) {
+            bool numbers = false;
+            for (const auto& e : task.data.at("prompt")) {
+                if (e.is_number()) {
+                    numbers = true;
+                    break;
+                }
+            }
+
+            // NOTE: split_multiprompt_task() does not handle a mix of strings and numbers,
+            // it will completely stall the server. I don't know where the bug for this is.
+            //
+            // if there are numbers, it needs to be treated like a single prompt,
+            // queue_tasks handles a mix of strings and numbers just fine.
+            if (numbers) {
+                queue_tasks.post(task);
+            } else {
+                split_multiprompt_task(task_id, task);
+            }
+        } else {
+            queue_tasks.post(task);
+        }
     }
 
     // for multiple images processing
@@ -1247,7 +1264,10 @@ struct llama_server_context
     void split_multiprompt_task(int multitask_id, task_server& multiprompt_task)
     {
         int prompt_count = multiprompt_task.data.at("prompt").size();
-        assert(prompt_count > 1);
+        if (prompt_count <= 1) {
+            send_error(multiprompt_task, "error while handling multiple prompts");
+            return;
+        }
 
         // generate all the ID for subtask
         std::vector<int> subtask_ids(prompt_count);


### PR DESCRIPTION
The two main problems were:
-  `split_multiprompt_task()` was completely stalling server slots if the prompt array had any numbers/tokens in it, the git commit calls this a deadlock but that's probably wrong.
- prompts with an array were being treated as separate prompts, regardless if they had numbers in.

Either of these issues prevent tokens from being used in the prompt array.

Commit [48c857a](https://github.com/ggerganov/llama.cpp/commit/48c857aa10aea73210a4a72da3f1a6f99269e75d) also introduced a bug by removing the `return` before `split_multiprompt_task()` which caused an unused and unnecessary single prompt generation of all combined elements in the prompt array.

Finally, an unnecessary assert was removed. This assert wouldn't abort unless `#include <cassert>` was included, but that seems unnecessary. Was changed to `send_error()` instead. The code should never be hit, but if it is the resulting page will be 404 (as per [the following code](https://github.com/ggerganov/llama.cpp/blob/a305dba8ff642e57f538f42010868fe0bc5262a1/examples/server/server.cpp#L2635)).

Tested the following prompts with `curl -w "\n" --request POST --url http://localhost:8080/completion -d '{"n_predict":24}'`:
```
"prompt":"hello"
"prompt":["hello"]
"prompt":["hello", "hi"]
"prompt":["complete",272,2296,12271,28747,6312,28709]
"prompt":[4160, "the following sentence: hello"]
"prompt":[4160,272,2296,12271,28747,6312,28709]
```

Not tested: /infill with no prompt. cf. https://github.com/ggerganov/llama.cpp/issues/4027 - it's segfaulting for me even with no changes. I don't think these changes will reintroduce that bug.