### PR TITLE
server: allow to get default generation settings for completion

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -264,7 +264,21 @@ Notice that each `probs` is an array of length `n_probs`.
 
     It also accepts all the options of `/completion` except `stream` and `prompt`.
 
-- **GET** `/props`: Return the required assistant name and anti-prompt to generate the prompt in case you have specified a system prompt for all slots.
+- **GET** `/props`: Return current server settings.
+
+### Result JSON
+
+```json
+{
+  "assistant_name": "",
+  "user_name": "",
+  "default_generation_settings": { ... }
+}
+```
+
+- `assistant_name` - the required assistant name to generate the prompt in case you have specified a system prompt for all slots.
+- `user_name` - the required anti-prompt to generate the prompt in case you have specified a system prompt for all slots.
+- `default_generation_settings` - the default generation settings for the `/completion` endpoint, has the same fields as the `generation_settings` response object from the `/completion` endpoint.
 
 - **POST** `/v1/chat/completions`: OpenAI-compatible Chat Completions API. Given a ChatML-formatted json description in `messages`, it returns the predicted completion. Both synchronous and streaming mode are supported, so scripted and interactive applications work fine. While no strong claims of compatibility with OpenAI API spec is being made, in our experience it suffices to support many apps. Only ChatML-tuned models, such as Dolphin, OpenOrca, OpenHermes, OpenChat-3.5, etc can be used with this endpoint. Compared to `api_like_OAI.py` this API implementation does not require a wrapper to be served.
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -334,6 +334,7 @@ struct llama_server_context
 
     // slots / clients
     std::vector<llama_client_slot> slots;
+    json default_generation_settings_for_props;
 
     llama_server_queue queue_tasks;
     llama_server_response queue_results;
@@ -429,6 +430,9 @@ struct llama_server_context
 
             slots.push_back(slot);
         }
+
+        default_generation_settings_for_props = get_formated_generation(slots.front());
+        default_generation_settings_for_props["seed"] = -1;
 
         batch = llama_batch_init(n_ctx, 0, params.n_parallel);
 
@@ -2614,7 +2618,8 @@ int main(int argc, char **argv)
                 res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
                 json data = {
                     { "user_name",      llama.name_user.c_str() },
-                    { "assistant_name", llama.name_assistant.c_str() }
+                    { "assistant_name", llama.name_assistant.c_str() },
+                    { "default_generation_settings", llama.default_generation_settings_for_props }
                 };
                 res.set_content(data.dump(), "application/json; charset=utf-8");
             });


### PR DESCRIPTION
## What does it do?

The PR adds a new field into the `/props` response - `default_generation_settings`. This object contains the default server params that will be used to generate the response. Its contents are exactly the same as in the `generation_settings` object from the `/completion` endpoint.


## What does it solve?

This PR mainly addresses one of my points in https://github.com/ggerganov/llama.cpp/issues/4216#issuecomment-1921901533

> 6. There should be a way to get some common server params, like the context size, without doing a `/completion` request. Since an API client can't set the context size, it needs to get it from the server. Yes, the context size is returned from the `/completion` endpoint, but there should be a way to get it before sending the first inference request, because the API client might need to use the context size to process the input or something else. I think some common "static" server params like `n_ctx` and `model` can be returned from the `/props`.

Now API clients can get the context size without any trickery. Before that I used `{"n_predict": 0}` request, but recently it stopped working (https://github.com/ggerganov/llama.cpp/issues/5246) and it was a hack anyway.

Also, this PR will allow API clients to get the default inference params before doing any inference. For example, if the API client decides to populate its GUI with these default values.


## Implementation

1. For the new `default_generation_settings` object, I take the first slot available. Here the code assumes that all slots have identical default params. Not sure if this is true or not.

2. The JSON is stored right after creating the slot. We can't get info from the slot itself after that, because it will/may be polluted by API params that user already sent to the server.

3. This line is kind of awkward:
    ```cpp
    default_generation_settings_for_props["seed"] = -1;
    ```
    But i'm not sure how to do it "properly".


## Example

The resulting `/props` response example:
```json
{
  "assistant_name": "",
  "default_generation_settings": {
    "frequency_penalty": 0,
    "grammar": "",
    "ignore_eos": false,
    "logit_bias": [],
    "min_p": 0.05000000074505806,
    "mirostat": 0,
    "mirostat_eta": 0.10000000149011612,
    "mirostat_tau": 5,
    "model": "/opt/models/text/llama-2-13b-chat.Q4_K_M.gguf",
    "n_ctx": 2048,
    "n_keep": 0,
    "n_predict": -1,
    "n_probs": 0,
    "penalize_nl": true,
    "penalty_prompt_tokens": [],
    "presence_penalty": 0,
    "repeat_last_n": 64,
    "repeat_penalty": 1.100000023841858,
    "seed": -1,
    "stop": [],
    "stream": true,
    "temperature": 0.800000011920929,
    "tfs_z": 1,
    "top_k": 40,
    "top_p": 0.949999988079071,
    "typical_p": 1,
    "use_penalty_prompt_tokens": false
  },
  "user_name": ""
}
```
