### PR TITLE
Vulkan Apple Silicon compatibility

### DIFF
--- a/ggml-vulkan.cpp
+++ b/ggml-vulkan.cpp
@@ -978,8 +978,14 @@ void ggml_vk_init() {
 #ifdef GGML_VULKAN_VALIDATE
         "VK_EXT_validation_features",
 #endif
+#ifdef __APPLE__
+        "VK_KHR_portability_enumeration",
+#endif
     };
-    vk::InstanceCreateInfo instance_create_info(vk::InstanceCreateFlags(), &app_info, layers, extensions);
+vk::InstanceCreateInfo instance_create_info(vk::InstanceCreateFlags(), &app_info, layers, extensions);
+#ifdef __APPLE__
+    instance_create_info.flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+#endif
 #ifdef GGML_VULKAN_VALIDATE
     const std::vector<vk::ValidationFeatureEnableEXT> features_enable = { vk::ValidationFeatureEnableEXT::eBestPractices };
     vk::ValidationFeaturesEXT validation_features = {

--- a/ggml-vulkan.cpp
+++ b/ggml-vulkan.cpp
@@ -982,7 +982,7 @@ void ggml_vk_init() {
         "VK_KHR_portability_enumeration",
 #endif
     };
-vk::InstanceCreateInfo instance_create_info(vk::InstanceCreateFlags(), &app_info, layers, extensions);
+    vk::InstanceCreateInfo instance_create_info(vk::InstanceCreateFlags(), &app_info, layers, extensions);
 #ifdef __APPLE__
     instance_create_info.flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
 #endif

--- a/ggml.c
+++ b/ggml.c
@@ -270,6 +270,8 @@ inline static void * ggml_calloc(size_t num, size_t size) {
 #include <Accelerate/Accelerate.h>
 #if defined(GGML_USE_CLBLAST) // allow usage of CLBlast alongside Accelerate functions
 #include "ggml-opencl.h"
+#elif defined(GGML_USE_VULKAN) && __APPLE__
+#include "ggml-vulkan.h"
 #endif
 #elif defined(GGML_USE_OPENBLAS)
 #if defined(GGML_BLAS_USE_MKL)


### PR DESCRIPTION
I just apply my https://github.com/ggerganov/llama.cpp/pull/2059#issuecomment-1911808801 suggestion to @0cc4m !

Tested with `mistral-7b-instruct-v0.1.Q4_K_M.gguf` model with Mac M1 Max (RAM: 32Go):

```bash
$ LLAMA_VULKAN=1 make
[...]
$ ./main -m ./models/mistral-7b-instruct-v0.1.Q4_K_M.gguf -n 128 -ngl 1 --repeat_penalty 1.1 --color -i
[...]
llama_print_timings:        load time =     291,56 ms
llama_print_timings:      sample time =       2,61 ms /    22 runs   (    0,12 ms per token,  8422,66 tokens per second)
llama_print_timings: prompt eval time =       0,00 ms /     1 tokens (    0,00 ms per token,      inf tokens per second)
llama_print_timings:        eval time =    1670,33 ms /    23 runs   (   72,62 ms per token,    13,77 tokens per second)
llama_print_timings:       total time =    1934,57 ms /    24 tokens
```

And without vulkan:
```bash
llama_print_timings:        load time =     301.09 ms
llama_print_timings:      sample time =       3.30 ms /    27 runs   (    0.12 ms per token,  8184.30 tokens per second)
llama_print_timings: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_print_timings:        eval time =    1862.61 ms /    28 runs   (   66.52 ms per token,    15.03 tokens per second)
llama_print_timings:       total time =    2857.50 ms /    29 tokens
```