### PR TITLE
Add a warning when quantize IQ3_XXS without imatrix

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -287,9 +287,9 @@ int main(int argc, char ** argv) {
         }
     }
 
-    if ((params.ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || params.ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || params.ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S) && imatrix_data.empty()) {
+    if ((params.ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || params.ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || params.ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S || params.ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS) && imatrix_data.empty()) {
         fprintf(stderr, "\n===============================================================================================\n");
-        fprintf(stderr, "Please do not use IQ2_XXS, IQ2_XS or Q2_K_S quantization without an importance matrix\n");
+        fprintf(stderr, "Please do not use IQ2_XXS, IQ2_XS, Q2_K_S or IQ3_XXS quantization without an importance matrix\n");
         fprintf(stderr, "===============================================================================================\n\n\n");
         return 1;
     }


### PR DESCRIPTION
I believe we forgot to add `IQ3_XXS` to warning list when quantized without an importance matrix, as `IQ3_XXS` performs extremely bad without an imatrix.

| Llama-2-7B@IQ3_XXS | PPL                  |
| ------------------ | -------------------- |
| w/o imatrix        | 107.1787 +/- 2.65072 |
| w/ imatrix         | 5.5101 +/- 0.09247   |

*Note: The imatrix was calculated using the first 100 chunks of wiki.train.raw*

