### PR TITLE
Simple chat templates

### DIFF
--- a/examples/server/public/chat_templates.js
+++ b/examples/server/public/chat_templates.js
@@ -1,0 +1,16 @@
+export const chat_templates = {
+        "Alpaca" : {
+            "template" : "{{prompt}}\n### Instruction:\n{{history}}\n### Response:\n{{char}}:",
+            "historyTemplate" : "{{name}}: {{message}}"
+        },
+
+        "Vicuna" : {
+            "template" : "{{prompt}}\n\n{{history}}\n{{char}}:",
+            "historyTemplate" : "{{name}}: {{message}}"
+        },
+        
+        "ChatML" : {
+            "template" : "<|im_start|>system\n{{prompt}}<|im_end|>\n{{history}}<|im_start|>{{char}}\n",
+            "historyTemplate" : "<|im_start|>{{name}}\n{{message}}<|im_end|>\n"
+        }
+};

--- a/examples/server/public/index.html
+++ b/examples/server/public/index.html
@@ -203,6 +203,9 @@
 
     import { llama } from '/completion.js';
     import { SchemaConverter } from '/json-schema-to-grammar.mjs';
+    
+    import { chat_templates } from '/chat_templates.js';
+    
     let selected_image = false;
     var slot_id = -1;
 
@@ -710,6 +713,28 @@
         </fieldset>
         `
       );
+     
+    const PromptTemplateOptions = () => {
+        var templatenames = Object.keys(chat_templates);
+        templatenames.sort();
+        var optionlist = templatenames.map(name => html`<option value="${name}">${name}</option>`);
+        return optionlist;
+     };
+
+    const updatePromptTemplate = (el) => {
+      // Get the selected template name
+      var templatename = el.target.value;
+      // console.log(templatename);
+      if (templatename != "") {
+         // set the template parameters
+        session.value.template = chat_templates[templatename]["template"];
+         session.value.historyTemplate = chat_templates[templatename]["historyTemplate"];
+
+         // this line is required to trigger the setting of the textareas
+        session.value = { ...session.value, image_selected: '' };
+      }
+    }
+
 
       const ChatConfigForm = () => (
         html`
@@ -730,12 +755,17 @@
           <fieldset>
             <div>
               <label for="template">Prompt template</label>
+              <select id="templateSelect" onchange=${updatePromptTemplate} >
+                <option value="">- Select a chat template -</option>
+                 ${PromptTemplateOptions()}
+               </select>
+
               <textarea id="template" name="template" value="${session.value.template}" rows=4 oninput=${updateSession}/>
             </div>
 
             <div>
               <label for="template">Chat history template</label>
-              <textarea id="template" name="historyTemplate" value="${session.value.historyTemplate}" rows=1 oninput=${updateSession}/>
+              <textarea id="historyTemplate" name="historyTemplate" value="${session.value.historyTemplate}" rows=1 oninput=${updateSession}/>
             </div>
             ${GrammarControl()}
           </fieldset>


### PR DESCRIPTION
Here is a simplistic extension to the current server example UI to select predefined chat templates from a pulldown menu. Until #4216 is resolved, it is helpful for testing models which expect ChatML. 