### PR TITLE
Fix trailing whitespaces

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8585,7 +8585,7 @@ void llama_sample_top_k(struct llama_context * ctx, llama_token_data_array * can
     // }
 
     const int64_t t_start_sample_us = ggml_time_us();
-    
+
     if (k <= 0) {
         k = candidates->size;
     }


### PR DESCRIPTION
It seems the Github editor does not fix trailing whitespaces so https://github.com/ggerganov/llama.cpp/pull/5388 has added some to `llama.cpp`. This PR removes them again.