### PR TITLE
Fix f16_sycl cpy call from Arc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,47 @@ jobs:
           cd build
           cmake -DLLAMA_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx ..
           cmake --build . --config Release -j $(nproc)
+  
+  ubuntu-22-cmake-sycl-fp16:
+    runs-on: ubuntu-22.04
+
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: add oneAPI to apt
+        shell: bash
+        run: |
+          cd /tmp
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+
+      - name: install oneAPI dpcpp compiler
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp
+
+      - name: install oneAPI MKL library
+        shell: bash
+        run: |
+          sudo apt install intel-oneapi-mkl-devel
+
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        id: cmake_build
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          mkdir build
+          cd build
+          cmake -DLLAMA_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DLLAMA_SYCL_F16=ON ..
+          cmake --build . --config Release -j $(nproc)
 
   # TODO: build with LLAMA_NO_METAL because test-backend-ops fail on "Apple Paravirtual device" and I don't know
   #       how to debug it.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
           cd build
           cmake -DLLAMA_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx ..
           cmake --build . --config Release -j $(nproc)
-  
+
   ubuntu-22-cmake-sycl-fp16:
     runs-on: ubuntu-22.04
 

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -12185,9 +12185,6 @@ inline void ggml_sycl_op_dequantize_mul_mat_vec(
             src1_dfloat = (sycl::half *)src1->data + src1_padded_row_size;
         } else {
             src1_dfloat = src1_dfloat_a.alloc(ne00);
-            //ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
-            //                      ne00, ne00, 1, sizeof(float), 0, 0, ne00, 1,
-            //                      sizeof(sycl::half), 0, 0, stream);
             ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
                                    ne00, ne00, ne01, ne02, nb00, nb01, nb02,
                                    nb03, ne10, ne11, ne12, nb10, nb11, nb12,

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -12148,26 +12148,8 @@ inline void ggml_sycl_op_dequantize_mul_mat_vec(
     const int64_t src1_ncols, const int64_t src1_padded_row_size,
     const dpct::queue_ptr &stream) {
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
+    GGML_TENSOR_BINARY_OP_LOCALS
 
-
-    const int64_t nb00 = src0->nb[0];
-    const int64_t nb01 = src0->nb[1];
-    const int64_t nb02 = src0->nb[2];
-    const int64_t nb03 = src0->nb[3];
-
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
-    const int64_t ne12 = src1->ne[2];
-
-
-    const int64_t nb10 = src1->nb[0];
-    const int64_t nb11 = src1->nb[1];
-    const int64_t nb12 = src1->nb[2];
-    const int64_t nb13 = src1->nb[3];
-                        
     const int64_t row_diff = row_high - row_low;
 
     // on some GPUs it is faster to convert src1 to half and to use half precision intrinsics
@@ -12186,9 +12168,9 @@ inline void ggml_sycl_op_dequantize_mul_mat_vec(
         } else {
             src1_dfloat = src1_dfloat_a.alloc(ne00);
             ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
-                                   ne00, ne00, ne01, ne02, nb00, nb01, nb02,
-                                   nb03, ne10, ne11, ne12, nb10, nb11, nb12,
-                                   nb13, stream);
+                                  ne00, ne00, ne01, ne02, nb00, nb01, nb02,
+                                  nb03, ne10, ne11, ne12, nb10, nb11, nb12,
+                                  nb13, stream);
         }
     }
 #else

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -12149,6 +12149,25 @@ inline void ggml_sycl_op_dequantize_mul_mat_vec(
     const dpct::queue_ptr &stream) {
 
     const int64_t ne00 = src0->ne[0];
+    const int64_t ne01 = src0->ne[1];
+    const int64_t ne02 = src0->ne[2];
+
+
+    const int64_t nb00 = src0->nb[0];
+    const int64_t nb01 = src0->nb[1];
+    const int64_t nb02 = src0->nb[2];
+    const int64_t nb03 = src0->nb[3];
+
+    const int64_t ne10 = src1->ne[0];
+    const int64_t ne11 = src1->ne[1];
+    const int64_t ne12 = src1->ne[2];
+
+
+    const int64_t nb10 = src1->nb[0];
+    const int64_t nb11 = src1->nb[1];
+    const int64_t nb12 = src1->nb[2];
+    const int64_t nb13 = src1->nb[3];
+                        
     const int64_t row_diff = row_high - row_low;
 
     // on some GPUs it is faster to convert src1 to half and to use half precision intrinsics
@@ -12166,9 +12185,13 @@ inline void ggml_sycl_op_dequantize_mul_mat_vec(
             src1_dfloat = (sycl::half *)src1->data + src1_padded_row_size;
         } else {
             src1_dfloat = src1_dfloat_a.alloc(ne00);
+            //ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
+            //                      ne00, ne00, 1, sizeof(float), 0, 0, ne00, 1,
+            //                      sizeof(sycl::half), 0, 0, stream);
             ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
-                                  ne00, ne00, 1, sizeof(float), 0, 0, ne00, 1,
-                                  sizeof(sycl::half), 0, 0, stream);
+                                   ne00, ne00, ne01, ne02, nb00, nb01, nb02,
+                                   nb03, ne10, ne11, ne12, nb10, nb11, nb12,
+                                   nb13, stream);
         }
     }
 #else


### PR DESCRIPTION
With respect to changes in #5289  , Arc has an issue for FP16 build when trying to query fp16_cpy on sycl . This is caused due to function arg mismatch , as it was calling an older version of the ```ggml_cpy_f32_f16_sycl``` method. 

Error Log:
```
    |                                      ^
llama.cpp/ggml-sycl.cpp:12169:13: error: no matching function for call to 'ggml_cpy_f32_f16_sycl'
12169 |             ggml_cpy_f32_f16_sycl((const char *)src1_ddf_i, (char *)src1_dfloat,
       |             ^~~~~~~~~~~~~~~~~~~~~
llama.cpp/ggml-sycl.cpp:10638:13: note: candidate function not viable: requires 18 arguments, but 14 were provided
10638 | static void ggml_cpy_f32_f16_sycl(const char *cx, char *cdst, const int ne,
       |             ^                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10639 |                                   const int ne00, const int ne01,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10640 |                                   const int ne02, const int nb00,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10641 |                                   const int nb01, const int nb02,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10642 |                                   const int nb03, const int ne10,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10643 |                                   const int ne11, const int ne12,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10644 |                                   const int nb10, const int nb11,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10645 |                                   const int nb12, const int nb13,
       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
10646 |                                   dpct::queue_ptr stream) {
       |                                   ~~~~~~~~~~~~~~~~~~~~~~
103 warnings and 1 error generated.
gmake[2]: *** [CMakeFiles/ggml.dir/build.make:132: CMakeFiles/ggml.dir/ggml-sycl.cpp.o] Error 1
gmake[2]: Leaving directory 'llama.cpp/build'
gmake[1]: *** [CMakeFiles/Makefile2:738: CMakeFiles/ggml.dir/all] Error 2
gmake[1]: Leaving directory 'llama.cpp/build'
gmake: *** [Makefile:146: all] Error 2
```
@airMeng  @AidanBeltonS  @NeoZhangJianyu  @ggerganov  please review . Thanks