### PR TITLE
server: fix prompt caching for repeated prompts

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1592,10 +1592,6 @@ struct llama_server_context
                         LOG_TEE("slot %d : in cache: %i tokens | to process: %i tokens\n", slot.id, slot.n_past, slot.num_prompt_tokens_processed);
                     }
 
-                    LOG_TEE("slot %d : kv cache rm - [%d, end)\n", slot.id, (int) system_tokens.size() + slot.n_past);
-
-                    llama_kv_cache_seq_rm(ctx, slot.id, system_tokens.size() + slot.n_past, -1);
-
                     slot.cache_tokens = prompt_tokens;
 
                     if (slot.n_past == slot.num_prompt_tokens && slot.n_past > 0)
@@ -1608,6 +1604,10 @@ struct llama_server_context
                             slot.n_past_se--;
                         }
                     }
+
+                    LOG_TEE("slot %d : kv cache rm - [%d, end)\n", slot.id, (int) system_tokens.size() + slot.n_past);
+
+                    llama_kv_cache_seq_rm(ctx, slot.id, system_tokens.size() + slot.n_past, -1);
 
                     LOG_VERBOSE("prompt ingested", {
                                                     {"n_past",  slot.n_past},


### PR DESCRIPTION
Fix non-deterministic prompt caching for repeated prompts (#4902).

All this PR does is move the conditional that checks if there are no new prompt tokens from after to before the kv cache is trimmed. This fixes the issue in my testing (repeating `curl localhost:3731/completion -s -X POST -H 'Content-type: application/json' --data '{"prompt":"What a beautiful","n_probs":1,"n_predict":1,"cache_prompt":true}'`).