### PR TITLE
server: add llama2 chat template

### DIFF
--- a/examples/server/oai.hpp
+++ b/examples/server/oai.hpp
@@ -19,8 +19,7 @@ inline static json oaicompat_completion_params_parse(
     const std::string &chat_template)
 {
     json llama_params;
-    bool using_chatml = chat_template == "chatml";
-    std::string formatted_prompt = using_chatml
+    std::string formatted_prompt = chat_template == "chatml"
         ? format_chatml(body["messages"])  // OpenAI 'messages' to chatml (with <|im_start|>,...)
         : format_llama2(body["messages"]); // OpenAI 'messages' to llama2 (with [INST],...)
 

--- a/examples/server/oai.hpp
+++ b/examples/server/oai.hpp
@@ -21,8 +21,8 @@ inline static json oaicompat_completion_params_parse(
     json llama_params;
     bool using_chatml = chat_template == "chatml";
     std::string formatted_prompt = using_chatml
-        ? format_chatml(body["messages"])  // OpenAI 'messages' to chatml
-        : format_mistral(body["messages"]); // OpenAI 'messages' to mistral format
+        ? format_chatml(body["messages"])  // OpenAI 'messages' to chatml (with <|im_start|>,...)
+        : format_llama2(body["messages"]); // OpenAI 'messages' to llama2 (with [INST],...)
 
     llama_params["__oaicompat"] = true;
 

--- a/examples/server/oai.hpp
+++ b/examples/server/oai.hpp
@@ -20,7 +20,7 @@ inline static json oaicompat_completion_params_parse(
 {
     json llama_params;
     bool using_chatml = chat_template == "chatml";
-    std::string formated_prompt = using_chatml
+    std::string formatted_prompt = using_chatml
         ? format_chatml(body["messages"])  // OpenAI 'messages' to chatml
         : format_mistral(body["messages"]); // OpenAI 'messages' to mistral format
 
@@ -35,7 +35,7 @@ inline static json oaicompat_completion_params_parse(
     // https://platform.openai.com/docs/api-reference/chat/create
     llama_sampling_params default_sparams;
     llama_params["model"]             = json_value(body, "model", std::string("unknown"));
-    llama_params["prompt"]            = formated_prompt;
+    llama_params["prompt"]            = formatted_prompt;
     llama_params["cache_prompt"]      = json_value(body, "cache_prompt", false);
     llama_params["temperature"]       = json_value(body, "temperature", 0.0);
     llama_params["top_k"]             = json_value(body, "top_k", default_sparams.top_k);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2300,7 +2300,13 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
                 invalid_param = true;
                 break;
             }
-            sparams.chat_template = argv[i];
+            std::string value(argv[i]);
+            if (value != "chatml" && value != "llama2") {
+                fprintf(stderr, "error: chat template can be \"llama2\" or \"chatml\", but got: %s\n", value.c_str());
+                invalid_param = true;
+                break;
+            }
+            sparams.chat_template = value;
         }
         else if (arg == "--override-kv")
         {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -36,6 +36,7 @@ struct server_params
     std::string hostname = "127.0.0.1";
     std::vector<std::string> api_keys;
     std::string public_path = "examples/server/public";
+    std::string chat_template = "chatml";
     int32_t port = 8080;
     int32_t read_timeout = 600;
     int32_t write_timeout = 600;
@@ -1859,6 +1860,8 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("                            types: int, float, bool. example: --override-kv tokenizer.ggml.add_bos_token=bool:false\n");
     printf("  -gan N, --grp-attn-n N    set the group attention factor to extend context size through self-extend(default: 1=disabled), used together with group attention width `--grp-attn-w`");
     printf("  -gaw N, --grp-attn-w N    set the group attention width to extend context size through self-extend(default: 512), used together with group attention factor `--grp-attn-n`");
+    printf("  --chat-template FORMAT_NAME");
+    printf("                            set chat template, possible valus is: mistral, chatml (default %s)", sparams.chat_template.c_str());
     printf("\n");
 }
 
@@ -2289,6 +2292,15 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
         {
             log_set_target(stdout);
             LOG_INFO("logging to file is disabled.", {});
+        }
+        else if (arg == "--chat-template")
+        {
+            if (++i >= argc)
+            {
+                invalid_param = true;
+                break;
+            }
+            sparams.chat_template = argv[i];
         }
         else if (arg == "--override-kv")
         {
@@ -2743,13 +2755,13 @@ int main(int argc, char **argv)
 
 
     // TODO: add mount point without "/v1" prefix -- how?
-    svr.Post("/v1/chat/completions", [&llama, &validate_api_key](const httplib::Request &req, httplib::Response &res)
+    svr.Post("/v1/chat/completions", [&llama, &validate_api_key, &sparams](const httplib::Request &req, httplib::Response &res)
             {
                 res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
                 if (!validate_api_key(req, res)) {
                     return;
                 }
-                json data = oaicompat_completion_params_parse(json::parse(req.body));
+                json data = oaicompat_completion_params_parse(json::parse(req.body), sparams.chat_template);
 
                 const int task_id = llama.queue_tasks.get_new_id();
                 llama.queue_results.add_waiting_task_id(task_id);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1861,7 +1861,7 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("  -gan N, --grp-attn-n N    set the group attention factor to extend context size through self-extend(default: 1=disabled), used together with group attention width `--grp-attn-w`");
     printf("  -gaw N, --grp-attn-w N    set the group attention width to extend context size through self-extend(default: 512), used together with group attention factor `--grp-attn-n`");
     printf("  --chat-template FORMAT_NAME");
-    printf("                            set chat template, possible valus is: mistral, chatml (default %s)", sparams.chat_template.c_str());
+    printf("                            set chat template, possible valus is: llama2, chatml (default %s)", sparams.chat_template.c_str());
     printf("\n");
 }
 

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -167,7 +167,7 @@ static T json_value(const json &body, const std::string &key, const T &default_v
         : default_value;
 }
 
-inline std::string format_mistral(std::vector<json> messages)
+inline std::string format_llama2(std::vector<json> messages)
 {
     std::ostringstream output;
     bool is_inside_turn = false;
@@ -190,7 +190,7 @@ inline std::string format_mistral(std::vector<json> messages)
         }
     }
 
-    LOG_VERBOSE("format_mistral", {{"text", output.str()}});
+    LOG_VERBOSE("format_llama2", {{"text", output.str()}});
 
     return output.str();
 }

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -167,6 +167,34 @@ static T json_value(const json &body, const std::string &key, const T &default_v
         : default_value;
 }
 
+inline std::string format_mistral(std::vector<json> messages)
+{
+    std::ostringstream output;
+    bool is_inside_turn = false;
+
+    for (auto it = messages.begin(); it != messages.end(); ++it) {
+        if (!is_inside_turn) {
+            output << "<s>[INST] ";
+        }
+        std::string role    = json_value(*it, "role", std::string("user"));
+        std::string content = json_value(*it, "content", std::string(""));
+        if (role == "system") {
+            output << "<<SYS>>\n" << content << "\n<<SYS>>\n\n";
+            is_inside_turn = true;
+        } else if (role == "user") {
+            output << content << " [/INST]";
+            is_inside_turn = true;
+        } else {
+            output << " " << content << " </s>";
+            is_inside_turn = false;
+        }
+    }
+
+    LOG_VERBOSE("format_mistral", {{"text", output.str()}});
+
+    return output.str();
+}
+
 inline std::string format_chatml(std::vector<json> messages)
 {
     std::ostringstream chatml_msgs;
@@ -179,6 +207,8 @@ inline std::string format_chatml(std::vector<json> messages)
     }
 
     chatml_msgs << "<|im_start|>assistant" << '\n';
+
+    LOG_VERBOSE("format_chatml", {{"text", chatml_msgs.str()}});
 
     return chatml_msgs.str();
 }

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -174,7 +174,7 @@ inline std::string format_llama2(std::vector<json> messages)
 
     for (auto it = messages.begin(); it != messages.end(); ++it) {
         if (!is_inside_turn) {
-            output << "<s>[INST] ";
+            output << "[INST] ";
         }
         std::string role    = json_value(*it, "role", std::string("user"));
         std::string content = json_value(*it, "content", std::string(""));


### PR DESCRIPTION
## Motivation

Some of llama2-based models (for example, Mistral) does not use chatml template. As I observed, using the chatml with Mistral **does still work**, but it leads to some weird behaviors and hard to steer (the model does not follow system message).

Mistral uses this kind of chat template:

```
<s>[INST] <<SYS>>
You are a helpful assistant.
<</SYS>>

Who are you? [/INST] I'm a helpful assistant </s>
```

With this PR, I observed that Mistral (and fine-tuned model based on Mistral) response more correct & coherent than using chatml.

Ideally, I want to switch between chatml and mistral format using kv named `tokenizer.chat_template`, but access to kv is hidden inside `llama_model_loader` and I cannot access it modifying a lot of things in llama.cpp. Switching using argument is less ideal, but still works though.