### PR TITLE
CUDA: mul_mat_vec_q tiling, refactor mul mat logic

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -5319,13 +5319,13 @@ static __global__ void mul_mat_vec_q(
     const void * __restrict__ vx, const void * __restrict__ vy, float * __restrict__ dst,
     const int ncols_x, const int nrows_x, const int nrows_y, const int nrows_dst) {
 
-#if __CUDA_ARCH__ < CC_RDNA2
-    constexpr int nwarps              = ncols_y <= 4 ? 4 : 2;
-    constexpr int rows_per_cuda_block = ncols_y == 1 ? 1 : 2;
-#else
+#if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) && (defined(RDNA2) || defined(RDNA3))
     constexpr int nwarps              = 1;
     constexpr int rows_per_cuda_block = 1;
-#endif // __CUDA_ARCH__ < CC_RDNA2
+#else
+    constexpr int nwarps              = ncols_y <= 4 ? 4 : 2;
+    constexpr int rows_per_cuda_block = ncols_y == 1 ? 1 : 2;
+#endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) && !defined(RDNA2) && !defined(RDNA3)
 
     constexpr int blocks_per_iter = vdr * nwarps*WARP_SIZE / qi;
 

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -9932,7 +9932,8 @@ static void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1
             }
         }
     } else {
-        min_compute_capability = g_device_caps[g_main_device].cc;
+        min_compute_capability    = g_device_caps[g_main_device].cc;
+        any_pascal_with_slow_fp16 = g_device_caps[g_main_device].cc == 610;
     }
 
     // check data types and tensor shapes for custom matrix multiplication kernels:

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -6898,7 +6898,7 @@ static void mul_mat_vec_q_cuda(
     const dim3 block_nums(nblocks, 1, 1);
     const dim3 block_dims(WARP_SIZE, nwarps, 1);
 
-    switch(ncols_y) {
+    switch (ncols_y) {
         case 1:
             mul_mat_vec_q<1, qk, qi, block_q_t, vdr, vec_dot>
                 <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols_x, nrows_x, nrows_y, nrows_dst);

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -9967,7 +9967,7 @@ static void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1
 #ifdef CUDA_USE_TENSOR_CORES
     // when tensor cores are available, use them for large batch size
     // ref: https://github.com/ggerganov/llama.cpp/pull/3776
-    use_mul_mat_q     = use_mul_mat_q     && !(fp16_performance_good && src1->ne[1] > MMQ_MAX_BATCH_SIZE);
+    use_mul_mat_q     = use_mul_mat_q     && (!fp16_performance_good || src1->ne[1] <= MMQ_MAX_BATCH_SIZE);
 #endif // CUDA_USE_TENSOR_CORES
 
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)


### PR DESCRIPTION
This PR does the following:

* Refactor `ggml_cuda_mul_mat` and simplify the logic for choosing between different matrix multiplication kernels. This also fixes P100s not being treated as having good FP16 performance.
* Add tiling in src0 rows to `mul_mat_vec_q`. This increases arithmetic intensity and results in higher t/s for batch sizes > 1. This and a reduction in the number of warps for batch sizes 5-8 (to reduce register pressure) mostly fixes the performance regression sometimes seen when increasing batch sizes. I increased the maximum batch size for `mul_mat_vec_q` to 8. There are still some cases where the performance regresses slightly as you increase the batch size if you get unlucky with occupancy but these cases should be rare now.
* Refactor `mul_mat_vec_q` to use as few registers as possible so that there are more for loop unrolling. This increases performance on average but it again is possible to get unlucky with occupancy so there are also some cases where performance is ~1% worse.
* Removed the option to compile a `mul_mat_vec_q` kernel with variable `ncols_y`. With a batch size of 8 the kernel seems to already be hitting its limits and making `ncols_y` purely a template parameter makes it possible to reduce compilation time.

I'm currently too tired to re-run all of the performance tests; I'll post results tomorrow.

Because of the loop unrolling for the new kernels the compilation time has increased. On master the command

```
make clean && time make LLAMA_CUBLAS=1 LLAMA_NO_CCACHE=1 main
```

reports 13.443 s, with this PR it's 18.691 s. It may make sense to add an option like `LLAMA_FAST_COMPILE` that reduces compilation time as much as possible.