### PR TITLE
make: add error message for bad CUDA version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -569,6 +569,14 @@ $(info I CC:        $(shell $(CC)   --version | head -n 1))
 $(info I CXX:       $(shell $(CXX)  --version | head -n 1))
 ifdef LLAMA_CUBLAS
 $(info I NVCC:      $(shell $(NVCC) --version | tail -n 1))
+CUDA_VERSION := $(shell nvcc --version | grep -oP 'release (\K[0-9]+\.[0-9])')
+ifeq ($(shell echo "$(CUDA_VERSION) < 11.7" | bc),1)
+ifndef CUDA_DOCKER_ARCH
+ifndef CUDA_POWER_ARCH
+$(error I ERROR: For CUDA versions < 11.7 a target CUDA architecture must be explicitly provided via CUDA_DOCKER_ARCH)
+endif # CUDA_POWER_ARCH
+endif # CUDA_DOCKER_ARCH
+endif # eq ($(shell echo "$(CUDA_VERSION) < 11.7" | bc),1)
 endif # LLAMA_CUBLAS
 $(info )
 

--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ $(info I CXX:       $(shell $(CXX)  --version | head -n 1))
 ifdef LLAMA_CUBLAS
 $(info I NVCC:      $(shell $(NVCC) --version | tail -n 1))
 CUDA_VERSION := $(shell nvcc --version | grep -oP 'release (\K[0-9]+\.[0-9])')
-ifeq ($(shell echo "$(CUDA_VERSION) < 11.7" | bc),1)
+ifeq ($(shell awk -v "v=$(CUDA_VERSION)" 'BEGIN { print (v < 11.7) }'),1)
 ifndef CUDA_DOCKER_ARCH
 ifndef CUDA_POWER_ARCH
 $(error I ERROR: For CUDA versions < 11.7 a target CUDA architecture must be explicitly provided via CUDA_DOCKER_ARCH)


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/5294 in the sense that there is an error message to tell the user what the problem is. The root problem is that for old CUDA versions `-arch=native` is not supported. However, compiling for multiple compute capabilities like with cmake also has drawbacks: the compilation time would increase and nvcc does not seem to natively support compiling for multiple specific CUDA architectures in parallel. So you would instead have to compile multiple .cubin files and then link them together. And since this is only an issue for old CUDA versions I think it's fine to just add an error message that tells users how to fix it.

Currently the error message tells the user to set `CUDA_DOCKER ARCH`. The people with the problem were indeed using Docker but in principle you could have this exact same problem with bare metal. Should we rename the argument to something like `CUDA_ARCH`?