### PR TITLE
lookup: use hashmaps, select most frequent tokens, abort draft early if no good candidates

### DIFF
--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -7,6 +7,22 @@
 #include <cstdio>
 #include <string>
 #include <vector>
+#include <unordered_map>
+
+// Data structures to map n-grams to empirical token probabilities:
+typedef std::unordered_map<llama_token, int>            token_hashmap; // token -> number of times token has been seen
+typedef std::unordered_map<uint64_t, token_hashmap> all_token_hashmap; // n-gram -> empirical distribution of following tokens
+// n-grams are encoded as 64 bit integers with each of the 4 16 bit sections representing a token id.
+// This way no custom hashing function for the n-grams is needed.
+
+// Min/max n-gram size to search for in prompt:
+constexpr int   ngram_min =  1;
+constexpr int   ngram_max =  4;
+static_assert(ngram_max <= sizeof(uint64_t)/2, "A 64 bit integer can only hold information for 4 16 bit tokens.");
+
+// If sample size or percentage in context are below these thresholds the draft is aborted early:
+constexpr float draft_min_sample_size[ngram_max] = { 2,  2,  1,  1};
+constexpr float     draft_min_percent[ngram_max] = {66, 50, 50, 50};
 
 int main(int argc, char ** argv){
     gpt_params params;
@@ -16,9 +32,6 @@ int main(int argc, char ** argv){
     }
 
     // max/min n-grams size to search for in prompt
-    const int ngram_max = 4;
-    const int ngram_min = 1;
-
     // length of the candidate / draft sequence, if match is found
     const int n_draft = params.n_draft;
 
@@ -38,6 +51,7 @@ int main(int argc, char ** argv){
 
     // load the model
     std::tie(model, ctx) = llama_init_from_gpt_params(params);
+    GGML_ASSERT(llama_n_vocab(model) < (1 << 16));
 
     // tokenize the prompt
     const bool add_bos = llama_should_add_bos_token(model);
@@ -45,6 +59,55 @@ int main(int argc, char ** argv){
 
     std::vector<llama_token> inp;
     inp = ::llama_tokenize(ctx, params.prompt, add_bos, true);
+
+    auto update_hashmaps = [](all_token_hashmap * atcs, const llama_token * inp_data, const int inp_size, const int nnew) -> void {
+        // atcs = all_token_counts: the hashmaps to modify.
+        // inp_data: the token sequence on which the hashmaps are based.
+        // inp_size: the current size of inp_data.
+        // nnew: how many new tokens have been appended to inp_data since the last call to this function.
+        //
+        // In order to get correct results inp_data can ONLY BE APPENDED TO.
+        // Changes in the middle need a complete rebuild.
+        for (int ngram_size = ngram_min; ngram_size <= ngram_max; ++ngram_size) {
+            all_token_hashmap * atc = atcs + ngram_size - ngram_min;
+
+            const int i_start = std::max(inp_size - nnew, ngram_size);
+            for (int i = i_start; i < inp_size; ++i) {
+                const int ngram_start = i - ngram_size;
+                uint64_t ngram = inp_data[ngram_start];
+                for (int j = ngram_start; j < ngram_start + ngram_size; ++j) {
+                    const uint64_t ngram_part = inp_data[j];
+                    ngram <<= 16;
+                    ngram |= ngram_part;
+                }
+                const llama_token token = inp_data[i];
+
+                all_token_hashmap::iterator token_counts_it = atc->find(ngram);
+                if (token_counts_it == atc->end()) {
+                    token_hashmap token_counts;
+                    token_counts.emplace(token, 1);
+                    atc->emplace(ngram, token_counts);
+                } else {
+                    token_hashmap::iterator tc_it = token_counts_it->second.find(token);
+                    if (tc_it == token_counts_it->second.end()) {
+                        token_counts_it->second.emplace(token, 1);
+                    } else {
+                        tc_it->second++;
+                    }
+                }
+            }
+        }
+    };
+
+    all_token_hashmap all_token_counts[ngram_max-ngram_min+1];
+    int64_t t_draft_us = 0;
+
+    {
+        // Fill up hashmaps with tokens from user input:
+        const int64_t t_start_draft_us = ggml_time_us();
+        update_hashmaps(all_token_counts, inp.data(), inp.size(), inp.size());
+        t_draft_us += ggml_time_us() - t_start_draft_us;
+    }
 
     const int max_context_size     = llama_n_ctx(ctx);
     const int max_tokens_list_size = max_context_size - 4;
@@ -74,8 +137,6 @@ int main(int argc, char ** argv){
     int n_predict = 0;
     int n_drafted = 0;
     int n_accept  = 0;
-
-    int64_t t_draft_us = 0;
 
     int n_past = inp.size();
 
@@ -128,6 +189,12 @@ int main(int argc, char ** argv){
                 ++n_past;
                 ++i_dft;
                 inp.push_back(id);
+                {
+                    // Update hashmaps with the newly accepted token:
+                    const int64_t t_start_draft_us = ggml_time_us();
+                    update_hashmaps(all_token_counts, inp.data(), inp.size(), 1);
+                    t_draft_us += ggml_time_us() - t_start_draft_us;
+                }
 
                 if (params.use_color) {
                     // color accepted draft token
@@ -148,6 +215,12 @@ int main(int argc, char ** argv){
             draft.clear();
             draft.push_back(id);
             inp.push_back(id);
+            {
+                // Update hashmaps with the newly accepted token:
+                const int64_t t_start_draft_us = ggml_time_us();
+                update_hashmaps(all_token_counts, inp.data(), inp.size(), 1);
+                t_draft_us += ggml_time_us() - t_start_draft_us;
+            }
             break;
         }
 
@@ -162,44 +235,85 @@ int main(int argc, char ** argv){
         llama_batch_clear(batch_tgt);
         llama_batch_add(batch_tgt, draft[0], n_past, { 0 }, true);
 
-        // generate n_pred tokens through prompt lookup
-        auto prompt_lookup = [&]() -> void {
-            const int inp_size = inp.size();
-            for (int ngram_size = ngram_max ; ngram_size > ngram_min; --ngram_size){
-                const llama_token * ngram = &inp[inp_size - ngram_size];
-
-                for (int i = 0; i <= (int) inp_size - (ngram_size * 2); ++i) {
-                    bool match = true;
-                    for (int j = 0; j < ngram_size; ++j) {
-                        if (inp[i + j] != ngram[j]) {
-                            match = false;
-                            break;
-                        }
-                    }
-
-                    if (match) {
-                        const int startIdx = i + ngram_size;
-                        const int endIdx = startIdx + n_draft;
-                        if (endIdx < inp_size) {
-                            for (int j = startIdx; j < endIdx; ++j) {
-                                LOG(" - draft candidate %d: %d\n", j, inp[j]);
-                                draft.push_back(inp[j]);
-                                llama_batch_add(batch_tgt, inp[j], n_past + (j - startIdx) + 1, { 0 }, true);
-                                ++n_drafted;
-                            }
-                            return;
-                        }
-                    }
-                }
-            }
-            return;
+        auto get_token = [](const std::vector<llama_token> inp, const std::vector<llama_token> draft, const size_t i) -> llama_token {
+            // Helper function to get a token from the combined, speculative sequence of inp and draft.
+            return i < inp.size() ? inp[i] : draft[1 + i - inp.size()];
         };
 
+        auto prompt_lookup = [&]() -> void {
+            // Generate up to n_draft additional tokens through prompt lookup.
+            // The draft is aborted early if there is no suitable token candidate to continue the draft.
+            // At the beginning of this function the draft already contains a single token sampled from the model.
+            const int inp_size = inp.size();
+
+            while ((int) draft.size()-1 < n_draft) {
+                bool draft_success = false;
+                for (int ngram_size = ngram_max; ngram_size >= ngram_min; --ngram_size) {
+                    if (ngram_size > inp_size) {
+                        continue;
+                    }
+
+                    all_token_hashmap & atc = all_token_counts[ngram_size - ngram_min];
+
+                    const int ngram_start = inp_size-ngram_size + draft.size()-1;
+                    uint64_t ngram = get_token(inp, draft, ngram_start);
+                    for (int j = ngram_start; j < ngram_start + ngram_size; ++j) {
+                        const uint64_t ngram_part = get_token(inp, draft, j);
+                        ngram <<= 16;
+                        ngram |= ngram_part;
+                    }
+
+                    all_token_hashmap::iterator token_counts_it = atc.find(ngram);
+                    if (token_counts_it == atc.end()) {
+                        continue;
+                    }
+                    const token_hashmap token_counts = token_counts_it->second;
+
+                    int max_count = 0;
+                    int sum_count = 0;
+                    llama_token max_token = -1;
+
+                    for (std::pair<llama_token, int> tc : token_counts) {
+                        const llama_token token = tc.first;
+                        const llama_token count = tc.second;
+
+                        if (count > max_count) {
+                            max_token = token;
+                            max_count = count;
+                        }
+                        sum_count += count;
+                    }
+                    // Skip this candidate if the sample size is too low:
+                    if (sum_count < draft_min_sample_size[ngram_size-1]) {
+                        continue;
+                    }
+                    // skip this candidate if the empirically most likely token following this token is not likely enough:
+                    if (100*max_count < draft_min_percent[ngram_size-1]*sum_count) {
+                        continue;
+                    }
+
+                    LOG(" - draft candidate: token=%d count=%d\n", max_token, max_count);
+                    llama_batch_add(batch_tgt, max_token, n_past + draft.size(), { 0 }, true);
+                    draft.push_back(max_token);
+                    draft_success = true;
+                    break;
+                }
+
+                if (!draft_success) {
+                    break;
+                }
+            }
+        };
+
+        // Draft already contains a single token sampled from the model:
+        GGML_ASSERT(draft.size() == 1);
+        GGML_ASSERT(draft[0] == inp.back());
         const int64_t t_start_draft_us = ggml_time_us();
 
         prompt_lookup();
 
         t_draft_us += ggml_time_us() - t_start_draft_us;
+        n_drafted += draft.size() - 1;
 
         llama_decode(ctx, batch_tgt);
         ++n_past;


### PR DESCRIPTION
While I was working on https://github.com/ggerganov/llama.cpp/pull/5398 I took a look at the conventional lookup example and noticed that it has some issues. This PR attempts to fix those. The changes are:

* On master the lookup example always selects the first occurrence of an n-gram and then fills up the draft with the exact sequence of tokens following that n-gram. With this PR the example instead builds up the draft one token at a time, each time selecting the token that has most frequently followed the previous few tokens.
* There are thresholds for sample size and empirical probability that the most likely token must meet in order to be drafted. If the token does not meet these thresholds it is not drafted and the draft is aborted early. This is done because the scaling of t/s with batch size is not perfect and unlikely tokens will on average just slow the generation down.
* The interpretation of the value for `ngram_min` is fixed. On master with `ngram_min = 1` the minimal n-gram size is actually 2, with this PR it is 1. However, on master drafts based on the occurrence of only a single token are mostly useless anyways because their acceptance rate is very low. But the filters added with this PR greatly increase the acceptance rate of those drafts that pass the filters.
* Hashmaps are used as the data structure to hold the information regarding the number of times that specific tokens have followed specific n-grams. The inner hashmap maps tokens to the number of times that these tokens have followed an n-gram. The outer hashmap then maps n-grams to these empirical distributions. The hashmaps can be built incrementally as new tokens are sampled. The time required to update the hashmaps with a single token is constant. The time required to find the most likely token is asymptotically proportional to the number of tokens fed to the hashmap but will in practice be almost constant because for a given n-gram only a small fraction of tokens will actually appear as a continuation. This data structure is not strictly needed as of right now but it will be very useful for further lookup sampling projects.

I commands like this for testing:

```
export model_name=miqu-70b && export quantization=q5_k_m
export nd=3
./lookup --model models/opt/${model_name}-${quantization}.gguf -ngl 99 --ctx-size 4096 --split-mode row --n-predict 1024 --seed 1337 --temp 0 --ignore-eos --draft $nd --color --prompt "[INST] Write a love story about two stars that tragically ends in a type Ia supernova. Use a lot of emotional and dramatic language. [/INST]"
``` 

The prompt is intentionally chosen in an adversarial way: it contains few token sequences that can be copied verbatim to the generation. The model is Miqu q5_K_M run on 3 P40s. I get these results:

| --n-draft        |     0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |
|------------------|-------|---------|---------|---------|---------|---------|---------|---------|
| n_drafted master |     0 |     202 |     346 |     492 |     668 |     820 |     978 |    1127 |
| n_drafted PR     |     0 |     164 |     238 |     330 |     434 |     529 |     625 |     725 |
| n_accept master  |     0 |     104 |     134 |     143 |     139 |     142 |     143 |     145 |
| n_accept PR      |     0 |      98 |     119 |     126 |     127 |     130 |     131 |     131 |
| accept % master  |     - | 51.485% | 38.728% | 29.065% | 20.808% | 17.317% | 14.622% | 12.866% |
| accept % PR      |     - | 59.756% | 50.000% | 38.182% | 29.263% | 24.575% | 20.960% | 18.069% |
| t/s master       | 8.905 |   8.662 |   8.802 |   8.692 |   7.913 |   7.718 |   7.511 |   7.342 |
| t/s PR           | 8.896 |   8.814 |   9.047 |   8.994 |   8.456 |   8.345 |   8.194 |   8.044 |

Note: the batch size for lookup decoding is `--draft + 1` which is why the table only goes up to 7. With this PR ~90-95% as many tokens as on master get correctly drafted but with ~30-40% fewer incorrectly drafted tokens. As a consequence the total t/s increases. But because P40s have low compute relative to more modern GPUs they scale comparatively poorly with batch sizes > 1. So for this hardware and no prompt that already contains a lot of usable token sequences there is only a very small speedup, if any. I currently don't have a suitable instruct model on hand to test t/s on my RTX 3090 and non-instruct models (with these settings) tend to repeat themselves a lot which is good for lookup decoding but bad in terms of output quality.

After this PR I intend to implement lookup decoding not just based on the current context but also based on general text statistics and previous user generations. I think the best results will be achieved with a hierarchical system: first look for suitable tokens in the current user session, then in the previous user session, then in a more general text corpus like wikitext. The tradeoff is between sample size and relevance to the current generation. You could potentially use the higher sample size statistics to select among multiple candidates with more relevance to the current generation. For this the hashmap data structure will be very useful because it only stores those n-gram -> token mappings that are actually observed and as such needs very little memory: with a prototype the hashmap based on ~500 MiB of wikitext was only ~1 MiB in size.

When it comes to the implementation considerations laid out in https://github.com/ggerganov/llama.cpp/discussions/4235 ,  the only issue that should arise with the implementation  in this PR is that setting a fixed size for the n-gram cache would skew the statistics used for creating the draft. But I think the caches will be small enough that this will not be necessary in the first place.