### PR TITLE
Early return for zero size calls to get_tensor.

### DIFF
--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -213,6 +213,10 @@ void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_ten
 }
 
 GGML_CALL void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    if (!size) {
+        return;
+    }
+
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
@@ -223,6 +227,10 @@ GGML_CALL void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void *
 }
 
 GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    if (!size) {
+        return;
+    }
+
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");

--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -213,29 +213,29 @@ void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_ten
 }
 
 GGML_CALL void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    if (!size) {
-        return;
-    }
-
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(buf != NULL && "tensor buffer not set");
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
 
-    tensor->buffer->iface.set_tensor(buf, tensor, data, offset, size);
-}
-
-GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     if (!size) {
         return;
     }
 
+    tensor->buffer->iface.set_tensor(buf, tensor, data, offset, size);
+}
+
+GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(tensor->buffer != NULL && "tensor buffer not set");
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+
+    if (!size) {
+        return;
+    }
 
     tensor->buffer->iface.get_tensor(buf, tensor, data, offset, size);
 }

--- a/ggml-kompute.cpp
+++ b/ggml-kompute.cpp
@@ -1805,8 +1805,9 @@ static void * ggml_backend_kompute_buffer_get_base(ggml_backend_buffer_t buffer)
 static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
 
-    if (!size)
+    if (!size) {
         return;
+    }
 
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);

--- a/ggml-kompute.cpp
+++ b/ggml-kompute.cpp
@@ -1805,6 +1805,9 @@ static void * ggml_backend_kompute_buffer_get_base(ggml_backend_buffer_t buffer)
 static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
 
+    if (!size)
+        return;
+
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);
 
@@ -1815,6 +1818,9 @@ static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer,
 
 static void ggml_backend_kompute_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
+
+    if (!size)
+        return;
 
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);

--- a/ggml-kompute.cpp
+++ b/ggml-kompute.cpp
@@ -1819,9 +1819,9 @@ static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer,
 static void ggml_backend_kompute_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
 
-    if (!size)
+    if (!size) {
         return;
-
+    }
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);
 

--- a/ggml-kompute.cpp
+++ b/ggml-kompute.cpp
@@ -1805,10 +1805,6 @@ static void * ggml_backend_kompute_buffer_get_base(ggml_backend_buffer_t buffer)
 static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
 
-    if (!size) {
-        return;
-    }
-
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);
 
@@ -1820,9 +1816,6 @@ static void ggml_backend_kompute_buffer_set_tensor(ggml_backend_buffer_t buffer,
 static void ggml_backend_kompute_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     GGML_UNUSED(buffer);
 
-    if (!size) {
-        return;
-    }
     const auto res = ggml_vk_get_tensor(tensor);
     GGML_ASSERT(res);
 


### PR DESCRIPTION
The llama_copy_state_data_internal function can sometimes call ggml_backend_tensor_get with a null size when the kv cache is empty. This guards against unnecessarily syncing from device to host in such a case.