### PR TITLE
Use correct type of pooling for embedding models

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1652,7 +1652,7 @@ class BertModel(Model):
         self.gguf_writer.add_causal_attention(False)
 
         # get pooling path
-        with open(self.dir_model / "modules.json", "r", encoding="utf-8") as f:
+        with open(self.dir_model / "modules.json", encoding="utf-8") as f:
             modules = json.load(f)
         pooling_path = None
         for mod in modules:
@@ -1663,15 +1663,14 @@ class BertModel(Model):
         # get pooling type
         pooling_type = gguf.PoolingType.NONE
         if pooling_path is not None:
-            with open(self.dir_model / pooling_path / "config.json", "r", encoding="utf-8") as f:
+            with open(self.dir_model / pooling_path / "config.json", encoding="utf-8") as f:
                 pooling = json.load(f)
             if pooling["pooling_mode_mean_tokens"]:
                 pooling_type = gguf.PoolingType.MEAN
             elif pooling["pooling_mode_cls_token"]:
                 pooling_type = gguf.PoolingType.CLS
             else:
-                print("Only MEAN and CLS pooling types supported")
-                sys.exit(1)
+                raise NotImplementedError("Only MEAN and CLS pooling types supported")
 
         self.gguf_writer.add_pooling_type(pooling_type.value)
 

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1650,7 +1650,30 @@ class BertModel(Model):
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
         self.gguf_writer.add_causal_attention(False)
-        self.gguf_writer.add_pooling_layer(True)
+
+        # get pooling path
+        with open(self.dir_model / "modules.json", "r", encoding="utf-8") as f:
+            modules = json.load(f)
+        pooling_path = None
+        for mod in modules:
+            if mod["type"] == "sentence_transformers.models.Pooling":
+                pooling_path = mod["path"]
+                break
+
+        # get pooling type
+        pooling_type = gguf.PoolingType.NONE
+        if pooling_path is not None:
+            with open(self.dir_model / pooling_path / "config.json", "r", encoding="utf-8") as f:
+                pooling = json.load(f)
+            if pooling["pooling_mode_mean_tokens"]:
+                pooling_type = gguf.PoolingType.MEAN
+            elif pooling["pooling_mode_cls_token"]:
+                pooling_type = gguf.PoolingType.CLS
+            else:
+                print("Only MEAN and CLS pooling types supported")
+                sys.exit(1)
+
+        self.gguf_writer.add_pooling_type(pooling_type.value)
 
     def set_vocab(self):
         path = self.dir_model

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -559,7 +559,7 @@ class RopeScalingType(Enum):
     YARN   = 'yarn'
 
 
-class PoolingType(Enum):
+class PoolingType(IntEnum):
     NONE = 0
     MEAN = 1
     CLS  = 2

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -40,7 +40,7 @@ class Keys:
         TENSOR_DATA_LAYOUT    = "{arch}.tensor_data_layout"
         EXPERT_COUNT          = "{arch}.expert_count"
         EXPERT_USED_COUNT     = "{arch}.expert_used_count"
-        POOLING_LAYER         = "{arch}.pooling_layer"
+        POOLING_TYPE          = "{arch}.pooling_type"
 
     class Attention:
         HEAD_COUNT        = "{arch}.attention.head_count"
@@ -557,6 +557,12 @@ class RopeScalingType(Enum):
     NONE   = 'none'
     LINEAR = 'linear'
     YARN   = 'yarn'
+
+
+class PoolingType(Enum):
+    NONE = 0
+    MEAN = 1
+    CLS  = 2
 
 
 class GGMLQuantizationType(IntEnum):

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -19,6 +19,7 @@ from .constants import (
     GGUFValueType,
     Keys,
     RopeScalingType,
+    PoolingType,
     TokenType,
 )
 

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -360,8 +360,8 @@ class GGUFWriter:
     def add_causal_attention(self, value: bool) -> None:
         self.add_bool(Keys.Attention.CAUSAL.format(arch=self.arch), value)
 
-    def add_pooling_layer(self, value: bool) -> None:
-        self.add_bool(Keys.LLM.POOLING_LAYER.format(arch=self.arch), value)
+    def add_pooling_type(self, value: PoolingType) -> None:
+        self.add_uint32(Keys.LLM.POOLING_TYPE.format(arch=self.arch), value)
 
     def add_rope_dimension_count(self, count: int) -> None:
         self.add_uint32(Keys.Rope.DIMENSION_COUNT.format(arch=self.arch), count)

--- a/llama.h
+++ b/llama.h
@@ -112,6 +112,12 @@ extern "C" {
         LLAMA_ROPE_SCALING_MAX_VALUE   = LLAMA_ROPE_SCALING_YARN,
     };
 
+    enum llama_pooling_type {
+        LLAMA_POOLING_NONE = 0,
+        LLAMA_POOLING_MEAN = 1,
+        LLAMA_POOLING_CLS  = 2,
+    };
+
     enum llama_split_mode {
         LLAMA_SPLIT_NONE    = 0, // single GPU
         LLAMA_SPLIT_LAYER   = 1, // split layers and KV across GPUs


### PR DESCRIPTION
We had previously been doing sum pooling to approximate mean pooling in all cases. This changes to:

* On conversion, read pooling configuration (MEAN, CLS, NONE)
* Actually do MEAN pooling by precomputing sequence lengths
* Use `ggml_get_rows` to speed up CLS pooling (just first token)

Testing with a couple of different types of models, numbers look very close to SentenceTransformers. Remaining differentials are due to the various tokenization issues discussed.