### PR TITLE
llama : minor fixed return int value

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -10867,7 +10867,7 @@ static int llama_apply_lora_from_file_internal(
                     {
                         LLAMA_LOG_ERROR("%s: invalid tensor data type '%d'\n",
                                 __func__, ftype);
-                        return false;
+                        return 1;
                     }
         }
 


### PR DESCRIPTION
@ggerganov,
I noticed problem thanks to warnings compiler, who reported that an attempt was being made to cast `bool` to `int`. But here, most likely, something else was meant, above there is a code with exactly same error and it returns an int with value `1`, which means an incorrectly executed function, function returned `false` when cast to `bool`, it will be `0`, which breaks logic if this function is called in conditional body-block.

https://github.com/ggerganov/llama.cpp/blob/6dcc02d2444c779c18d49c364c5d5c5728b6b484/llama.cpp#L10882-L10898

