### PR TITLE
Add llama_chat_apply_template()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -862,3 +862,7 @@ tests/test-model-load-cancel: tests/test-model-load-cancel.cpp ggml.o llama.o te
 tests/test-autorelease: tests/test-autorelease.cpp ggml.o llama.o tests/get-model.cpp $(COMMON_DEPS) $(OBJS)
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
+
+tests/test-chat-template: tests/test-chat-template.cpp ggml.o llama.o $(COMMON_DEPS) $(OBJS)
+	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
+	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)

--- a/llama.cpp
+++ b/llama.cpp
@@ -12522,6 +12522,14 @@ int32_t llama_chat_apply_template_internal(std::string &dest, std::string chat_t
             }
         }
         // llama2 templates seem to not care about "add_generation_prompt"
+    } else if (chat_template.find("<|user|>") != std::string::npos) {
+        // zephyr template
+        for (auto message : conversation) {
+            ss << "<|" << message->role << "|>" << "\n" << message->content << "<|endoftext|>\n";
+        }
+        if (add_ass) {
+            ss << "<|assistant|>\n";
+        }
     } else {
         // template not supported
         return -1;

--- a/llama.cpp
+++ b/llama.cpp
@@ -12542,14 +12542,14 @@ LLAMA_API int32_t llama_chat_apply_template(
     if (custom_template == nullptr) {
         GGML_ASSERT(model != nullptr);
         // load template from model
-        current_template.resize(2048); // longest known template is about 1200 bytes
+        std::vector<char> model_template(2048, 0); // longest known template is about 1200 bytes
         std::string template_key = "tokenizer.chat_template";
-        int32_t res = llama_model_meta_val_str(model, template_key.c_str(), &(*current_template.begin()), current_template.size());
+        int32_t res = llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), current_template.size());
         if (res < 0) {
             // worst case: there is no information about template, we will use chatml by default
             current_template = "<|im_start|>"; // see llama_chat_apply_template_internal
         } else {
-            current_template.resize(res);
+            current_template = std::string(model_template.data(), model_template.size());
         }
     }
     // format the conversation to string

--- a/llama.h
+++ b/llama.h
@@ -706,12 +706,12 @@ extern "C" {
 
     /// Apply chat template and maybe tokenize it. Inspired by hf apply_chat_template() on python.
     /// Both "model" and "custom_template" are optional, but at least one is required. "custom_template" has higher precedence than "model"
-    /// NOTE: This function only support some know jinja templates. It is not a jinja parser.
+    /// NOTE: This function only support some known jinja templates. It is not a jinja parser.
     /// @param custom_template A Jinja template to use for this conversion. If this is nullptr, the model’s default chat template will be used instead.
     /// @param msg Pointer to a list of multiple llama_chat_message
     /// @param add_ass Whether to end the prompt with the token(s) that indicate the start of an assistant message.
-    /// @return If "tokenize" is set to false, the "buf" must be a string (returned value will be the string length).
-    ///         Otherwise, "buf" must be a list of tokens (returned value will be the number of tokens).
+    /// @param buf A buffer to hold the output formatted prompt. The recommended alloc size is 2 * (total number of characters of all messages)
+    /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
     LLAMA_API int32_t llama_chat_apply_template(
               const struct llama_model * model,
                             const char * custom_template,

--- a/llama.h
+++ b/llama.h
@@ -706,6 +706,7 @@ extern "C" {
 
     /// Apply chat template and maybe tokenize it. Inspired by hf apply_chat_template() on python.
     /// Both "model" and "custom_template" are optional, but at least one is required. "custom_template" has higher precedence than "model"
+    /// NOTE: This function only support some know jinja templates. It is not a jinja parser.
     /// @param custom_template A Jinja template to use for this conversion. If this is nullptr, the model’s default chat template will be used instead.
     /// @param msg Pointer to a list of multiple llama_chat_message
     /// @param add_ass Whether to end the prompt with the token(s) that indicate the start of an assistant message.

--- a/llama.h
+++ b/llama.h
@@ -704,18 +704,20 @@ extern "C" {
                                   char * buf,
                                int32_t   length);
 
-    /// Apply chat template and maybe tokenize it. Inspired by hf apply_chat_template() on python.
+    /// Apply chat template. Inspired by hf apply_chat_template() on python.
     /// Both "model" and "custom_template" are optional, but at least one is required. "custom_template" has higher precedence than "model"
     /// NOTE: This function only support some known jinja templates. It is not a jinja parser.
-    /// @param custom_template A Jinja template to use for this conversion. If this is nullptr, the model’s default chat template will be used instead.
-    /// @param msg Pointer to a list of multiple llama_chat_message
+    /// @param custom_template A Jinja template to use for this chat. If this is nullptr, the model’s default chat template will be used instead.
+    /// @param chat Pointer to a list of multiple llama_chat_message
+    /// @param n_msg Number of llama_chat_message in this chat
     /// @param add_ass Whether to end the prompt with the token(s) that indicate the start of an assistant message.
     /// @param buf A buffer to hold the output formatted prompt. The recommended alloc size is 2 * (total number of characters of all messages)
+    /// @param length The size of the allocated buffer
     /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
     LLAMA_API int32_t llama_chat_apply_template(
               const struct llama_model * model,
                             const char * custom_template,
-       const struct llama_chat_message * msg,
+       const struct llama_chat_message * chat,
                                 size_t   n_msg,
                                   bool   add_ass,
                                   char * buf,

--- a/llama.h
+++ b/llama.h
@@ -707,7 +707,7 @@ extern "C" {
     /// Apply chat template. Inspired by hf apply_chat_template() on python.
     /// Both "model" and "custom_template" are optional, but at least one is required. "custom_template" has higher precedence than "model"
     /// NOTE: This function only support some known jinja templates. It is not a jinja parser.
-    /// @param custom_template A Jinja template to use for this chat. If this is nullptr, the model’s default chat template will be used instead.
+    /// @param tmpl A Jinja template to use for this chat. If this is nullptr, the model’s default chat template will be used instead.
     /// @param chat Pointer to a list of multiple llama_chat_message
     /// @param n_msg Number of llama_chat_message in this chat
     /// @param add_ass Whether to end the prompt with the token(s) that indicate the start of an assistant message.
@@ -716,7 +716,7 @@ extern "C" {
     /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
     LLAMA_API int32_t llama_chat_apply_template(
               const struct llama_model * model,
-                            const char * custom_template,
+                            const char * tmpl,
        const struct llama_chat_message * chat,
                                 size_t   n_msg,
                                   bool   add_ass,

--- a/llama.h
+++ b/llama.h
@@ -304,6 +304,12 @@ extern "C" {
         int32_t n_eval;
     };
 
+    // used in chat template
+    typedef struct llama_chat_message {
+        const char * role;
+        const char * content;
+    } llama_chat_message;
+
     // Helpers for getting default parameters
     LLAMA_API struct llama_model_params llama_model_default_params(void);
     LLAMA_API struct llama_context_params llama_context_default_params(void);
@@ -695,6 +701,22 @@ extern "C" {
     LLAMA_API int32_t llama_token_to_piece(
               const struct llama_model * model,
                            llama_token   token,
+                                  char * buf,
+                               int32_t   length);
+
+    /// Apply chat template and maybe tokenize it. Inspired by hf apply_chat_template() on python.
+    /// Both "model" and "custom_template" are optional, but at least one is required. "custom_template" has higher precedence than "model"
+    /// @param custom_template A Jinja template to use for this conversion. If this is nullptr, the model’s default chat template will be used instead.
+    /// @param msg Pointer to a list of multiple llama_chat_message
+    /// @param add_ass Whether to end the prompt with the token(s) that indicate the start of an assistant message.
+    /// @return If "tokenize" is set to false, the "buf" must be a string (returned value will be the string length).
+    ///         Otherwise, "buf" must be a list of tokens (returned value will be the number of tokens).
+    LLAMA_API int32_t llama_chat_apply_template(
+              const struct llama_model * model,
+                            const char * custom_template,
+       const struct llama_chat_message * msg,
+                                size_t   n_msg,
+                                  bool   add_ass,
                                   char * buf,
                                int32_t   length);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ endfunction()
 llama_build_and_test_executable(test-quantize-fns.cpp)
 llama_build_and_test_executable(test-quantize-perf.cpp)
 llama_build_and_test_executable(test-sampling.cpp)
+llama_build_and_test_executable(test-chat-template.cpp)
 
 llama_build_executable(test-tokenizer-0-llama.cpp)
 llama_test_executable (test-tokenizer-0-llama test-tokenizer-0-llama.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../models/ggml-vocab-llama.gguf)

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sstream>
+
+#undef NDEBUG
+#include <cassert>
+
+#include "llama.h"
+
+int main(void) {
+    llama_chat_message conversation[] = {
+        {"system", "You are a helpful assistant"},
+        {"user", "Hello"},
+        {"assistant", "Hi there"},
+        {"user", "Who are you"},
+        {"assistant", "   I am an assistant   "},
+        {"user", "Another question"},
+    };
+    size_t message_count = 6;
+    std::vector<const llama_chat_message *> conversation_vec;
+    conversation_vec.resize(message_count);
+    for (size_t i = 0; i < message_count; i++) {
+        conversation_vec[i] = &conversation[i];
+    }
+    std::vector<std::string> templates = {
+        // teknium/OpenHermes-2.5-Mistral-7B
+        "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>' + '\\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\\n' }}{% endif %}",
+        // mistralai/Mistral-7B-Instruct-v0.2
+        "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token}}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}",
+        // TheBloke/FusionNet_34Bx2_MoE-AWQ
+        "{%- for idx in range(0, messages|length) -%}\\n{%- if messages[idx]['role'] == 'user' -%}\\n{%- if idx > 1 -%}\\n{{- bos_token + '[INST] ' + messages[idx]['content'] + ' [/INST]' -}}\\n{%- else -%}\\n{{- messages[idx]['content'] + ' [/INST]' -}}\\n{%- endif -%}\\n{% elif messages[idx]['role'] == 'system' %}\\n{{- '[INST] <<SYS>>\\\\n' + messages[idx]['content'] + '\\\\n<</SYS>>\\\\n\\\\n' -}}\\n{%- elif messages[idx]['role'] == 'assistant' -%}\\n{{- ' '  + messages[idx]['content'] + ' ' + eos_token -}}\\n{% endif %}\\n{% endfor %}",
+        // bofenghuang/vigogne-2-70b-chat
+        "{{ bos_token }}{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% elif true == true and not '<<SYS>>' in messages[0]['content'] %}{% set loop_messages = messages %}{% set system_message = 'Vous êtes Vigogne, un assistant IA créé par Zaion Lab. Vous suivez extrêmement bien les instructions. Aidez autant que vous le pouvez.' %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\\\\n' + system_message + '\\\\n<</SYS>>\\\\n\\\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'system' %}{{ '<<SYS>>\\\\n' + content.strip() + '\\\\n<</SYS>>\\\\n\\\\n' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' ' + eos_token }}{% endif %}{% endfor %}",
+    };
+    std::vector<std::string> expected_substr = {
+        "<|im_start|>assistant\n   I am an assistant   <|im_end|>\n<|im_start|>user\nAnother question<|im_end|>\n<|im_start|>assistant",
+        "[/INST]Hi there</s>[INST] Who are you [/INST]   I am an assistant   </s>[INST] Another question [/INST]",
+        "</s><s>[INST] Who are you [/INST]    I am an assistant    </s><s>[INST] Another question [/INST]",
+        "[/INST] Hi there </s>[INST] Who are you [/INST] I am an assistant </s>[INST] Another question [/INST]",
+    };
+    std::string formatted_chat;
+    int32_t res;
+
+    // test invalid chat template
+    res = llama_chat_apply_template(nullptr, "INVALID TEMPLATE", conversation, message_count, true, &(*formatted_chat.begin()), formatted_chat.size());
+    assert(res < 0);
+
+    for (size_t i = 0; i < templates.size(); i++) {
+        std::string custom_template = templates[i];
+        std::string substr = expected_substr[i];
+        formatted_chat.resize(1024);
+        res = llama_chat_apply_template(
+            nullptr,
+            custom_template.c_str(),
+            conversation,
+            message_count,
+            true,
+            &(*formatted_chat.begin()),
+            formatted_chat.size()
+        );
+        formatted_chat.resize(res);
+        std::cout << formatted_chat << "\n-------------------------\n";
+        // expect the "formatted_chat" to contain pre-defined strings
+        assert(formatted_chat.find(substr) != std::string::npos);
+    }
+    return 0;
+}

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -34,11 +34,11 @@ int main(void) {
         "</s><s>[INST] Who are you [/INST]    I am an assistant    </s><s>[INST] Another question [/INST]",
         "[/INST] Hi there </s>[INST] Who are you [/INST] I am an assistant </s>[INST] Another question [/INST]",
     };
-    std::string formatted_chat;
+    std::vector<char> formatted_chat(1024);
     int32_t res;
 
     // test invalid chat template
-    res = llama_chat_apply_template(nullptr, "INVALID TEMPLATE", conversation, message_count, true, &(*formatted_chat.begin()), formatted_chat.size());
+    res = llama_chat_apply_template(nullptr, "INVALID TEMPLATE", conversation, message_count, true, formatted_chat.data(), formatted_chat.size());
     assert(res < 0);
 
     for (size_t i = 0; i < templates.size(); i++) {
@@ -51,13 +51,14 @@ int main(void) {
             conversation,
             message_count,
             true,
-            &(*formatted_chat.begin()),
+            formatted_chat.data(),
             formatted_chat.size()
         );
         formatted_chat.resize(res);
-        std::cout << formatted_chat << "\n-------------------------\n";
+        std::string output(formatted_chat.data(), formatted_chat.size());
+        std::cout << output << "\n-------------------------\n";
         // expect the "formatted_chat" to contain pre-defined strings
-        assert(formatted_chat.find(substr) != std::string::npos);
+        assert(output.find(substr) != std::string::npos);
     }
     return 0;
 }

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -18,11 +18,6 @@ int main(void) {
         {"user", "Another question"},
     };
     size_t message_count = 6;
-    std::vector<const llama_chat_message *> conversation_vec;
-    conversation_vec.resize(message_count);
-    for (size_t i = 0; i < message_count; i++) {
-        conversation_vec[i] = &conversation[i];
-    }
     std::vector<std::string> templates = {
         // teknium/OpenHermes-2.5-Mistral-7B
         "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>' + '\\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\\n' }}{% endif %}",


### PR DESCRIPTION
Closes #5527

Since most gguf models already have chat template saved in its metadata, developers can use `llama_chat_apply_template` function to format the chat:

```cpp
llama_chat_message conversation[] = {
    {"system", "You are a helpful assistant"},
    {"user", "Hello"},
    {"assistant", "Hi there"},
    {"user", "Who are you"},
    {"assistant", "   I am an assistant   "},
    {"user", "Another question"},
};
size_t message_count = 6;

// ideally, size of buffer should be 2 * (total number of characters of all messages)
std::vector<char> formatted_chat(1024);
res = llama_chat_apply_template(
    model, // by default, template is taken from model metadata
    nullptr, // alternatively, you can supply your own template as string
    conversation,
    message_count,
    true, // add a trailing "assistant" prompt, only use on chatml for now
    formatted_chat.data(),
    formatted_chat.size()
);
formatted_chat.resize(res);

std::cout << std::string(formatted_chat.data(), formatted_chat.size());
```

Result (chatml for example):

```
<|im_start|>system
You are a helpful assistant<|im_end|>
<|im_start|>user
Hello<|im_end|>
<|im_start|>assistant
Hi there<|im_end|>
<|im_start|>user
Who are you<|im_end|>
<|im_start|>assistant
   I am an assistant   <|im_end|>
<|im_start|>user
Another question<|im_end|>
<|im_start|>assistant
```

CC @ggerganov and @cebtenzzre for review