### PR TITLE
server: rename legacy --ctx-size to --kv-size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ llm_load_print_meta: vocab type     = SPM
 llm_load_print_meta: n_vocab        = 32000
 llm_load_print_meta: n_merges       = 0
 llm_load_print_meta: n_ctx_train    = 4096
-llm_load_print_meta: n_ctx          = 512
+llm_load_print_meta: kv_size        = 512
 llm_load_print_meta: n_embd         = 5120
 llm_load_print_meta: n_head         = 40
 llm_load_print_meta: n_head_kv      = 40
@@ -214,7 +214,7 @@ llama_new_context_with_model: compute buffer total size =   75.41 MB
 
 system_info: n_threads = 16 / 24 | AVX = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 |
 sampling: repeat_last_n = 64, repeat_penalty = 1.100000, presence_penalty = 0.000000, frequency_penalty = 0.000000, top_k = 40, tfs_z = 1.000000, top_p = 0.950000, typical_p = 1.000000, temp = 0.800000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
-generate: n_ctx = 512, n_batch = 512, n_predict = 400, n_keep = 0
+generate: kv_size = 512, n_batch = 512, n_predict = 400, n_keep = 0
 
 
  Building a website can be done in 10 simple steps:

--- a/common/common.h
+++ b/common/common.h
@@ -50,7 +50,7 @@ struct gpt_params {
     int32_t n_threads_batch       = -1;    // number of threads to use for batch processing (-1 = use n_threads)
     int32_t n_threads_batch_draft = -1;
     int32_t n_predict             = -1;    // new tokens to predict
-    int32_t n_ctx                 = 512;   // context size
+    int32_t kv_size               = 512;   // KV Cache size
     int32_t n_batch               = 512;   // batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_keep                = 0;     // number of tokens to keep from initial prompt
     int32_t n_draft               = 8;     // number of tokens to draft during speculative decoding

--- a/examples/Miku.sh
+++ b/examples/Miku.sh
@@ -7,11 +7,11 @@ USER_NAME="${USER_NAME:-Anon}"
 
 # Uncomment and adjust to the number of CPU cores you want to use.
 #N_THREAD="${N_THREAD:-4}"
-CTX_SIZE="${CTX_SIZE:-4096}"
+KV_SIZE="${KV_SIZE:-4096}"
 N_PREDICTS="${N_PREDICTS:-4096}"
 
 GEN_OPTIONS=(--batch_size 1024
---ctx_size "$CTX_SIZE"
+--kv_size "$KV_SIZE"
 --keep -1
 --repeat_last_n 256
 --repeat_penalty 1.17647

--- a/examples/alpaca.sh
+++ b/examples/alpaca.sh
@@ -10,7 +10,7 @@ cd ..
 ./main -m ./models/alpaca.13b.ggmlv3.q8_0.bin \
        --color \
        -f ./prompts/alpaca.txt \
-       --ctx_size 2048 \
+       --kv_size 2048 \
        -n -1 \
        -ins -b 256 \
        --top_k 10000 \

--- a/examples/batched-bench/batched-bench.cpp
+++ b/examples/batched-bench/batched-bench.cpp
@@ -104,7 +104,7 @@ int main(int argc, char ** argv) {
     llama_context_params ctx_params = llama_context_default_params();
 
     ctx_params.seed      = 1234;
-    ctx_params.n_ctx     = n_kv_max;
+    ctx_params.kv_size   = n_kv_max;
     ctx_params.n_batch   = 512;
     ctx_params.mul_mat_q = mmq;
 

--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -38,7 +38,7 @@ let n_kv_req = UInt32(tokens.count) + UInt32((n_len - Int(tokens.count)) * n_par
 
 var context_params = llama_context_default_params()
 context_params.seed = 1234
-context_params.n_ctx = n_kv_req
+context_params.kv_size = n_kv_req
 context_params.n_batch = UInt32(max(n_len, n_parallel))
 context_params.n_threads = 8
 context_params.n_threads_batch = 8
@@ -53,12 +53,12 @@ defer {
     llama_free(context)
 }
 
-let n_ctx = llama_n_ctx(context)
+let kv_size = llama_kv_size(context)
 
-print("\nn_len = \(n_len), n_ctx = \(n_ctx), n_batch = \(context_params.n_batch), n_parallel = \(n_parallel), n_kv_req = \(n_kv_req)\n")
+print("\nn_len = \(n_len), kv_size = \(kv_size), n_batch = \(context_params.n_batch), n_parallel = \(n_parallel), n_kv_req = \(n_kv_req)\n")
 
-if n_kv_req > n_ctx {
-    print("error: n_kv_req (%d) > n_ctx, the required KV cache size is not big enough\n", n_kv_req)
+if n_kv_req > kv_size {
+    print("error: n_kv_req (%d) > kv_size, the required KV cache size is not big enough\n", n_kv_req)
     exit(1)
 }
 

--- a/examples/batched/README.md
+++ b/examples/batched/README.md
@@ -7,7 +7,7 @@ The example demonstrates batched generation from a given prompt
 
 ...
 
-main: n_len = 32, n_ctx = 2048, n_parallel = 4, n_kv_req = 113
+main: n_len = 32, kv_size = 2048, n_parallel = 4, n_kv_req = 113
 
  Hello my name is
 

--- a/examples/batched/batched.cpp
+++ b/examples/batched/batched.cpp
@@ -78,7 +78,7 @@ int main(int argc, char ** argv) {
     llama_context_params ctx_params = llama_context_default_params();
 
     ctx_params.seed  = 1234;
-    ctx_params.n_ctx = n_kv_req;
+    ctx_params.kv_size = n_kv_req;
     ctx_params.n_batch = std::max(n_len, n_parallel);
     ctx_params.n_threads       = params.n_threads;
     ctx_params.n_threads_batch = params.n_threads_batch == -1 ? params.n_threads : params.n_threads_batch;
@@ -90,14 +90,14 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    const int n_ctx    = llama_n_ctx(ctx);
+    const int kv_size    = llama_kv_size(ctx);
 
-    LOG_TEE("\n%s: n_len = %d, n_ctx = %d, n_batch = %u, n_parallel = %d, n_kv_req = %d\n", __func__, n_len, n_ctx, ctx_params.n_batch, n_parallel, n_kv_req);
+    LOG_TEE("\n%s: n_len = %d, kv_size = %d, n_batch = %u, n_parallel = %d, n_kv_req = %d\n", __func__, n_len, kv_size, ctx_params.n_batch, n_parallel, n_kv_req);
 
     // make sure the KV cache is big enough to hold all the prompt and generated tokens
-    if (n_kv_req > n_ctx) {
-        LOG_TEE("%s: error: n_kv_req (%d) > n_ctx, the required KV cache size is not big enough\n", __func__,  n_kv_req);
-        LOG_TEE("%s:        either reduce n_parallel or increase n_ctx\n", __func__);
+    if (n_kv_req > kv_size) {
+        LOG_TEE("%s: error: n_kv_req (%d) > kv_size, the required KV cache size is not big enough\n", __func__,  n_kv_req);
+        LOG_TEE("%s:        either reduce n_parallel or increase kv_size\n", __func__);
         return 1;
     }
 

--- a/examples/beam-search/beam-search.cpp
+++ b/examples/beam-search/beam-search.cpp
@@ -139,8 +139,8 @@ int main(int argc, char ** argv)
 
     std::vector<llama_token> tokens_list = llama_tokenize(ctx, params.prompt, true);
 
-    const size_t max_context_size     = llama_n_ctx( ctx );
-    const size_t max_tokens_list_size = max_context_size - 4 ;
+    const size_t max_kv_size          = llama_kv_size(ctx);
+    const size_t max_tokens_list_size = max_kv_size - 4 ;
 
     if (tokens_list.size() > max_tokens_list_size)
     {

--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -129,16 +129,16 @@ int main(int argc, char ** argv)  {
     const ggml_type qtype = GGML_TYPE_Q4_1;
 
     size_t kv_size = 0;
-    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey);
-    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey);
-    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizez);
-    kv_size += ggml_row_size(qtype, sizex * sizey);
-    kv_size += ggml_row_size(qtype, sizex * sizey);
-    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey); // BLAS
-    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey); // BLAS
-    kv_size += 1024 * 1024 * 16;
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex*sizez);
+    kv_size += ggml_row_size(qtype, sizex*sizey);
+    kv_size += ggml_row_size(qtype, sizex*sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey); // BLAS
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey); // BLAS
+    kv_size += 1024*1024*16;
 
-    printf("Allocating Memory of size %zi bytes, %zi MB\n", kv_size, (kv_size / 1024 / 1024));
+    printf("Allocating Memory of size %zi bytes, %zi MB\n", kv_size, (kv_size/1024/1024));
 
     struct ggml_init_params params = {
         /*.mem_size   =*/ kv_size,

--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -128,20 +128,20 @@ int main(int argc, char ** argv)  {
     // TODO: perform the bench for all types or for a user specified type
     const ggml_type qtype = GGML_TYPE_Q4_1;
 
-    size_t ctx_size = 0;
-    ctx_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey);
-    ctx_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey);
-    ctx_size += ggml_row_size(GGML_TYPE_F32, sizex*sizez);
-    ctx_size += ggml_row_size(qtype,         sizex*sizey);
-    ctx_size += ggml_row_size(qtype,         sizex*sizey);
-    ctx_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey); // BLAS
-    ctx_size += ggml_row_size(GGML_TYPE_F32, sizex*sizey); // BLAS
-    ctx_size += 1024*1024*16;
+    size_t kv_size = 0;
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizez);
+    kv_size += ggml_row_size(qtype, sizex * sizey);
+    kv_size += ggml_row_size(qtype, sizex * sizey);
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey); // BLAS
+    kv_size += ggml_row_size(GGML_TYPE_F32, sizex * sizey); // BLAS
+    kv_size += 1024 * 1024 * 16;
 
-    printf("Allocating Memory of size %zi bytes, %zi MB\n",ctx_size, (ctx_size/1024/1024));
+    printf("Allocating Memory of size %zi bytes, %zi MB\n", kv_size, (kv_size / 1024 / 1024));
 
     struct ggml_init_params params = {
-        /*.mem_size   =*/ ctx_size,
+        /*.mem_size   =*/ kv_size,
         /*.mem_buffer =*/ NULL,
         /* no_alloc   =*/ 0
     };

--- a/examples/chat-13B.bat
+++ b/examples/chat-13B.bat
@@ -15,7 +15,7 @@ rem Adjust to the number of CPU cores you want to use.
 rem if not defined N_THREAD set "N_THREAD=8"
 rem Number of tokens to predict (made it larger than default because we want a long interaction)
 if not defined N_PREDICTS set "N_PREDICTS=2048"
-if not defined GEN_OPTIONS set "GEN_OPTIONS=--ctx_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647"
+if not defined GEN_OPTIONS set "GEN_OPTIONS=--kv_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647"
 
 rem Default main script paths
 set "DEFAULT_MAIN_SCRIPT_PATHS=main.exe build\bin\main.exe"

--- a/examples/chat-13B.sh
+++ b/examples/chat-13B.sh
@@ -15,8 +15,8 @@ N_THREAD="${N_THREAD:-8}"
 N_PREDICTS="${N_PREDICTS:-2048}"
 
 # Note: you can also override the generation options by specifying them on the command line:
-# For example, override the context size by doing: ./chatLLaMa --ctx_size 1024
-GEN_OPTIONS="${GEN_OPTIONS:---ctx_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647}"
+# For example, override the context size by doing: ./chatLLaMa --kv_size 1024
+GEN_OPTIONS="${GEN_OPTIONS:---kv_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647}"
 
 DATE_TIME=$(date +%H:%M)
 DATE_YEAR=$(date +%Y)

--- a/examples/chat-vicuna.sh
+++ b/examples/chat-vicuna.sh
@@ -15,8 +15,8 @@ N_THREAD="${N_THREAD:-8}"
 N_PREDICTS="${N_PREDICTS:-2048}"
 
 # Note: you can also override the generation options by specifying them on the command line:
-# For example, override the context size by doing: ./chatLLaMa --ctx_size 1024
-GEN_OPTIONS="${GEN_OPTIONS:---ctx_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647}"
+# For example, override the context size by doing: ./chatLLaMa --kv_size 1024
+GEN_OPTIONS="${GEN_OPTIONS:---kv_size 2048 --temp 0.7 --top_k 40 --top_p 0.5 --repeat_last_n 256 --batch_size 1024 --repeat_penalty 1.17647}"
 
 DATE_TIME=$(date +%H:%M)
 DATE_YEAR=$(date +%Y)

--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -226,7 +226,7 @@ struct llama_vocab {
 
 struct my_llama_hparams {
     uint32_t n_vocab = 32000;
-    uint32_t n_ctx   = 512;   // this is provided as user input?
+    uint32_t kv_size   = 512;   // this is provided as user input?
     uint32_t n_embd  = 4096;
     uint32_t n_ff    = 11008;
     uint32_t n_mult  = 4;
@@ -326,7 +326,7 @@ struct train_params {
 
 static void print_params(struct my_llama_hparams * params) {
     printf("%s: n_vocab: %u\n", __func__, params->n_vocab);
-    printf("%s: n_ctx:   %u\n", __func__, params->n_ctx);
+    printf("%s: kv_size: %u\n", __func__, params->kv_size);
     printf("%s: n_embd:  %u\n", __func__, params->n_embd);
     printf("%s: n_mult:  %u\n", __func__, params->n_mult);
     printf("%s: n_head:  %u\n", __func__, params->n_head);
@@ -732,7 +732,7 @@ static void save_as_llama_model(
     gguf_set_val_u32(ctx, KV_TOKENIZER_SEP_ID, -1);
     gguf_set_val_u32(ctx, KV_TOKENIZER_PAD_ID, -1);
 
-    gguf_set_val_u32(ctx, KV_CONTEXT_LENGTH, model->hparams.n_ctx);
+    gguf_set_val_u32(ctx, KV_CONTEXT_LENGTH, model->hparams.kv_size);
     gguf_set_val_u32(ctx, KV_EMBEDDING_LENGTH, model->hparams.n_embd);
     gguf_set_val_u32(ctx, KV_FEED_FORWARD_LENGTH, model->hparams.n_ff);
     gguf_set_val_u32(ctx, KV_ATTENTION_HEAD_COUNT, model->hparams.n_head);
@@ -937,7 +937,7 @@ int main(int argc, char ** argv) {
 
     struct my_llama_model model;
     model.hparams.n_vocab = config.vocab_size; //llama_n_vocab(lctx);
-    model.hparams.n_ctx   = params.n_ctx;
+    model.hparams.kv_size = params.n_ctx;
     model.hparams.n_embd  = config.dim; //params.n_embd;
     model.hparams.n_ff    = config.hidden_dim;
     model.hparams.n_mult  = 32;//params.n_mult;

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -88,11 +88,11 @@ int main(int argc, char ** argv) {
     }
 
     const int n_ctx_train = llama_n_ctx_train(model);
-    const int n_ctx = llama_n_ctx(ctx);
+    const int kv_size = llama_kv_size(ctx);
 
-    if (n_ctx > n_ctx_train) {
+    if (kv_size > n_ctx_train) {
         fprintf(stderr, "%s: warning: model was trained on only %d context tokens (%d specified)\n",
-                __func__, n_ctx_train, n_ctx);
+                __func__, n_ctx_train, kv_size);
     }
 
     // print system information
@@ -106,7 +106,7 @@ int main(int argc, char ** argv) {
 
     // max batch size
     const uint64_t n_batch = params.n_batch;
-    GGML_ASSERT(params.n_batch == params.n_ctx);
+    GGML_ASSERT(params.n_batch == params.kv_size);
 
     // tokenize the prompts and trim
     std::vector<std::vector<int32_t>> inputs;

--- a/examples/gpt4all.sh
+++ b/examples/gpt4all.sh
@@ -10,6 +10,6 @@ cd ..
 ./main --color --instruct --threads 4 \
        --model ./models/gpt4all-7B/gpt4all-lora-quantized.bin \
        --file ./prompts/alpaca.txt \
-       --batch_size 8 --ctx_size 2048 -n -1 \
+       --batch_size 8 --kv_size 2048 -n -1 \
        --repeat_last_n 64 --repeat_penalty 1.3 \
        --n_predict 128 --temp 0.1 --top_k 40 --top_p 0.95

--- a/examples/infill/README.md
+++ b/examples/infill/README.md
@@ -14,7 +14,8 @@ In this section, we cover the most commonly used options for running the `infill
 -   `-m FNAME, --model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.bin`).
 -   `-i, --interactive`: Run the program in interactive mode, allowing you to provide input directly and receive real-time responses.
 -   `-n N, --n-predict N`: Set the number of tokens to predict when generating text. Adjusting this value can influence the length of the generated text.
--   `-c N, --ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference.
+-   `-c N`, `--ctx-size N`: Deprecated, use `--kv-size` instead.
+-   `-kv N`, `--kv-size N`: Specify the total size of the KV cache for the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference.
 
 ## Input Prompts
 

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -514,7 +514,7 @@ struct cmd_params_instance {
     llama_context_params to_llama_cparams() const {
         llama_context_params cparams = llama_context_default_params();
 
-        cparams.n_ctx = n_prompt + n_gen;
+        cparams.kv_size = n_prompt + n_gen;
         cparams.n_batch = n_batch;
         cparams.type_k = type_k;
         cparams.type_v = type_v;

--- a/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
+++ b/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
@@ -68,8 +68,8 @@ actor LlamaContext {
         print("Using \(n_threads) threads")
 
         var ctx_params = llama_context_default_params()
-        ctx_params.seed  = 1234
-        ctx_params.n_ctx = 2048
+        ctx_params.seed    = 1234
+        ctx_params.kv_size = 2048
         ctx_params.n_threads       = UInt32(n_threads)
         ctx_params.n_threads_batch = UInt32(n_threads)
 
@@ -112,13 +112,13 @@ actor LlamaContext {
         tokens_list = tokenize(text: text, add_bos: true)
         temporary_invalid_cchars = []
 
-        let n_ctx = llama_n_ctx(context)
+        let kv_size = llama_kv_size(context)
         let n_kv_req = tokens_list.count + (Int(n_len) - tokens_list.count)
 
-        print("\n n_len = \(n_len), n_ctx = \(n_ctx), n_kv_req = \(n_kv_req)")
+        print("\n n_len = \(n_len), kv_size = \(kv_size), n_kv_req = \(n_kv_req)")
 
-        if n_kv_req > n_ctx {
-            print("error: n_kv_req > n_ctx, the required KV cache size is not big enough")
+        if n_kv_req > kv_size {
+            print("error: n_kv_req > kv_size, the required KV cache size is not big enough")
         }
 
         for id in tokens_list {

--- a/examples/llama2-13b.sh
+++ b/examples/llama2-13b.sh
@@ -9,7 +9,7 @@ cd ..
 
 ./main -m models/available/Llama2/13B/llama-2-13b.ggmlv3.q4_0.bin \
        --color \
-       --ctx_size 2048 \
+       --kv_size 2048 \
        -n -1 \
        -ins -b 256 \
        --top_k 10000 \

--- a/examples/llama2.sh
+++ b/examples/llama2.sh
@@ -9,7 +9,7 @@ cd ..
 
 ./main -m models/available/Llama2/7B/llama-2-7b.ggmlv3.q4_0.bin \
        --color \
-       --ctx_size 2048 \
+       --kv_size 2048 \
        -n -1 \
        -ins -b 256 \
        --top_k 10000 \

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -230,7 +230,7 @@ static struct llava_context * llava_init(gpt_params * params) {
     }
 
     llama_context_params ctx_params = llama_context_params_from_gpt_params(*params);
-    ctx_params.n_ctx           = params->n_ctx < 2048 ? 2048 : params->n_ctx; // we need a longer context size to process image embeddings
+    ctx_params.kv_size              = params->kv_size < 2048 ? 2048 : params->kv_size; // we need a longer context size to process image embeddings
 
     llama_context * ctx_llama = llama_new_context_with_model(model, ctx_params);
 

--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -103,15 +103,15 @@ static bool clip_llava_handle_patches(clip_ctx * ctx_clip, std::vector<float *> 
     const size_t num_images = num_patches_width * num_patches_height + 1;
 
     // TODO: size calculation is not calculated - it's only tens of MB
-    size_t ctx_size = 0;
+    size_t kv_size = 0;
 
     {
-        ctx_size += clip_embd_nbytes(ctx_clip) * num_images * 8; // image_features
-        ctx_size += 1024*1024 * ggml_type_size(GGML_TYPE_F32);
+        kv_size += clip_embd_nbytes(ctx_clip) * num_images * 8; // image_features
+        kv_size += 1024*1024 * ggml_type_size(GGML_TYPE_F32);
     }
 
     struct ggml_init_params params {
-        /*.mem_size   =*/ ctx_size,
+        /*.mem_size   =*/ kv_size,
         /*.mem_buffer =*/ NULL,
         /*.no_alloc   =*/ false, // NOTE: this should be false when using the legacy API
     };

--- a/examples/lookahead/lookahead.cpp
+++ b/examples/lookahead/lookahead.cpp
@@ -73,8 +73,8 @@ int main(int argc, char ** argv) {
     inp = ::llama_tokenize(ctx, params.prompt, add_bos, true);
     all = inp;
 
-    const int max_context_size     = llama_n_ctx(ctx);
-    const int max_tokens_list_size = max_context_size - 4;
+    const int max_kv_size          = llama_kv_size(ctx);
+    const int max_tokens_list_size = max_kv_size - 4;
 
     if ((int) inp.size() > max_tokens_list_size) {
         fprintf(stderr, "%s: error: prompt too long (%d tokens, max %d)\n", __func__, (int) inp.size(), max_tokens_list_size);
@@ -117,7 +117,7 @@ int main(int argc, char ** argv) {
     // seq_id == 0           : the current input token
     // seq_id [1, W]         : tokens from the past N - 1 Jacobi iterations
     // seq_id [W + 1, W + G] : verification n-grams
-    llama_batch batch = llama_batch_init(params.n_ctx, 0, W + G + 1);
+    llama_batch batch = llama_batch_init(params.kv_size, 0, W + G + 1);
 
     // target model sampling context
     struct llama_sampling_context * ctx_sampling = llama_sampling_init(params.sparams);

--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -47,8 +47,8 @@ int main(int argc, char ** argv){
     std::vector<llama_token> inp;
     inp = ::llama_tokenize(ctx, params.prompt, add_bos, true);
 
-    const int max_context_size     = llama_n_ctx(ctx);
-    const int max_tokens_list_size = max_context_size - 4;
+    const int max_kv_size          = llama_kv_size(ctx);
+    const int max_tokens_list_size = max_kv_size - 4;
 
     if ((int) inp.size() > max_tokens_list_size) {
         fprintf(stderr, "%s: error: prompt too long (%d tokens, max %d)\n", __func__, (int) inp.size(), max_tokens_list_size);
@@ -86,7 +86,7 @@ int main(int argc, char ** argv){
 
     std::vector<llama_token> draft;
 
-    llama_batch batch_tgt = llama_batch_init(params.n_ctx, 0, 1);
+    llama_batch batch_tgt = llama_batch_init(params.kv_size, 0, 1);
 
     // debug
     struct llama_kv_cache_view kvc_view = llama_kv_cache_view_init(ctx, 1);

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -70,7 +70,8 @@ In this section, we cover the most commonly used options for running the `main` 
 -   `-i, --interactive`: Run the program in interactive mode, allowing you to provide input directly and receive real-time responses.
 -   `-ins, --instruct`: Run the program in instruction mode, which is particularly useful when working with Alpaca models.
 -   `-n N, --n-predict N`: Set the number of tokens to predict when generating text. Adjusting this value can influence the length of the generated text.
--   `-c N, --ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference.
+-   `-c N`, `--ctx-size N`: Deprecated, use `--kv-size` instead.
+-   `-kv N`, `--kv-size N`: Set the size of the KV cache for the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference.
 
 ## Input Prompts
 
@@ -134,15 +135,15 @@ By understanding and utilizing these interaction options, you can create engagin
 
 During text generation, LLaMA models have a limited context size, which means they can only consider a certain number of tokens from the input and generated text. When the context fills up, the model resets internally, potentially losing some information from the beginning of the conversation or instructions. Context management options help maintain continuity and coherence in these situations.
 
-### Context Size
+### KV Context Size
 
-The `--ctx-size` option allows you to set the size of the prompt context used by the LLaMA models during text generation. A larger context size helps the model to better comprehend and generate responses for longer input or conversations.
+The `--kv-size` option allows you to set the size of the prompt context used by the LLaMA models during text generation. A larger context size helps the model to better comprehend and generate responses for longer input or conversations.
 
--   `-c N, --ctx-size N`: Set the size of the prompt context (default: 512). The LLaMA models were built with a context of 2048, which will yield the best results on longer input/inference. However, increasing the context size beyond 2048 may lead to unpredictable results.
+-   `-c N, --kv-size N`: Set the size of the prompt context (default: 512). The LLaMA models were built with a context of 2048, which will yield the best results on longer input/inference. However, increasing the context size beyond 2048 may lead to unpredictable results.
 
 ### Extended Context Size
 
-Some fine-tuned models have extended the context length by scaling RoPE. For example, if the original pre-trained model have a context length (max sequence length) of 4096 (4k) and the fine-tuned model have 32k. That is a scaling factor of 8, and should work by setting the above `--ctx-size` to 32768 (32k) and `--rope-scale` to 8.
+Some fine-tuned models have extended the context length by scaling RoPE. For example, if the original pre-trained model have a context length (max sequence length) of 4096 (4k) and the fine-tuned model have 32k. That is a scaling factor of 8, and should work by setting the above `--kv-size` to 32768 (32k) and `--rope-scale` to 8.
 
 -   `--rope-scale N`: Where N is the linear scaling factor used by the fine-tuned model.
 
@@ -152,7 +153,7 @@ The `--keep` option allows users to retain the original prompt when the model ru
 
 -   `--keep N`: Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 0 (meaning no tokens are kept). Use `-1` to retain all tokens from the initial prompt.
 
-By utilizing context management options like `--ctx-size` and `--keep`, you can maintain a more coherent and consistent interaction with the LLaMA models, ensuring that the generated text remains relevant to the original prompt or conversation.
+By utilizing context management options like `--kv-size` and `--keep`, you can maintain a more coherent and consistent interaction with the LLaMA models, ensuring that the generated text remains relevant to the original prompt or conversation.
 
 ## Generation Flags
 
@@ -181,12 +182,12 @@ Example usage: `--temp 0.5`
 ### Repeat Penalty
 
 -   `--repeat-penalty N`: Control the repetition of token sequences in the generated text (default: 1.1).
--   `--repeat-last-n N`: Last n tokens to consider for penalizing repetition (default: 64, 0 = disabled, -1 = ctx-size).
+-   `--repeat-last-n N`: Last n tokens to consider for penalizing repetition (default: 64, 0 = disabled, -1 = kv-size).
 -   `--no-penalize-nl`: Disable penalization for newline tokens when applying the repeat penalty.
 
 The `repeat-penalty` option helps prevent the model from generating repetitive or monotonous text. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient. The default value is 1.1.
 
-The `repeat-last-n` option controls the number of tokens in the history to consider for penalizing repetition. A larger value will look further back in the generated text to prevent repetitions, while a smaller value will only consider recent tokens. A value of 0 disables the penalty, and a value of -1 sets the number of tokens considered equal to the context size (`ctx-size`).
+The `repeat-last-n` option controls the number of tokens in the history to consider for penalizing repetition. A larger value will look further back in the generated text to prevent repetitions, while a smaller value will only consider recent tokens. A value of 0 disables the penalty, and a value of -1 sets the number of tokens considered equal to the context size (`kv-size`).
 
 Use the `--no-penalize-nl` option to disable newline penalization when applying the repeat penalty. This option is particularly useful for generating chat conversations, dialogues, code, poetry, or any text where newline tokens play a significant role in structure and formatting. Disabling newline penalization helps maintain the natural flow and intended formatting in these specific use cases.
 

--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -152,7 +152,7 @@ int main(int argc, char ** argv) {
     fprintf(stderr, "\n\n");
     fflush(stderr);
 
-    const int n_ctx = llama_n_ctx(ctx);
+    const int kv_size = llama_kv_size(ctx);
 
     std::vector<client> clients(n_clients);
     for (size_t i = 0; i < clients.size(); ++i) {
@@ -169,7 +169,7 @@ int main(int argc, char ** argv) {
 
     // the max batch size is as large as the context to handle cases where we get very long input prompt from multiple
     // users. regardless of the size, the main loop will chunk the batch into a maximum of params.n_batch tokens at a time
-    llama_batch batch = llama_batch_init(n_ctx, 0, 1);
+    llama_batch batch = llama_batch_init(kv_size, 0, 1);
 
     int32_t n_total_prompt = 0;
     int32_t n_total_gen    = 0;

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -319,7 +319,7 @@ int main(int argc, char ** argv) {
         }
 
         auto cparams = llama_context_default_params();
-        cparams.n_ctx      = 256;
+        cparams.kv_size    = 256;
         cparams.seed       = 1;
 
         ctx = llama_new_context_with_model(model, cparams);

--- a/examples/server-llama2-13B.sh
+++ b/examples/server-llama2-13B.sh
@@ -12,7 +12,7 @@ PROMPT_TEMPLATE=${PROMPT_TEMPLATE:-./prompts/chat-system.txt}
 N_THREAD="${N_THREAD:-12}"
 
 # Note: you can also override the generation options by specifying them on the command line:
-GEN_OPTIONS="${GEN_OPTIONS:---ctx_size 4096 --batch-size 1024}"
+GEN_OPTIONS="${GEN_OPTIONS:---kv_size 4096 --batch-size 1024}"
 
 
 # shellcheck disable=SC2086 # Intended splitting of GEN_OPTIONS

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -8,6 +8,7 @@ Command line options:
 - `-tb N, --threads-batch N`: Set the number of threads to use during batch and prompt processing. If not specified, the number of threads will be set to the number of threads used for generation.
 - `-m FNAME`, `--model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.gguf`).
 - `-a ALIAS`, `--alias ALIAS`: Set an alias for the model. The alias will be returned in API responses.
+- `-c N`, `--ctx-size N`: Deprecated, use `--kv-size` instead.
 - `-kv N`, `--kv-size N`: Specify the total size of the KV cache. This corresponds to the total amount of tokens that can be stored across all independent sequences / slots. `llama.cpp` implements a "unified" cache strategy, the KV cache size is actually shared across all sequences. It's allowed to have sequences with more than `T` tokens as long as the sum of all tokens does not exceed `P*T`. The default is 512.
 - `-ngl N`, `--n-gpu-layers N`: When compiled with appropriate support (currently CLBlast or cuBLAS), this option allows offloading some layers to the GPU for computation. Generally results in increased performance.
 - `-mg i, --main-gpu i`: When using multiple GPUs this option controls which GPU is used for small tensors for which the overhead of splitting the computation across all GPUs is not worthwhile. The GPU in question will use slightly more VRAM to store a scratch buffer for temporary results. By default GPU 0 is used. Requires cuBLAS.

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -8,7 +8,7 @@ Command line options:
 - `-tb N, --threads-batch N`: Set the number of threads to use during batch and prompt processing. If not specified, the number of threads will be set to the number of threads used for generation.
 - `-m FNAME`, `--model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.gguf`).
 - `-a ALIAS`, `--alias ALIAS`: Set an alias for the model. The alias will be returned in API responses.
-- `-c N`, `--ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference. The size may differ in other models, for example, baichuan models were build with a context of 4096.
+- `-kv N`, `--kv-size N`: Specify the total size of the KV cache. This corresponds to the total amount of tokens that can be stored across all independent sequences / slots. `llama.cpp` implements a "unified" cache strategy, the KV cache size is actually shared across all sequences. It's allowed to have sequences with more than `T` tokens as long as the sum of all tokens does not exceed `P*T`. The default is 512.
 - `-ngl N`, `--n-gpu-layers N`: When compiled with appropriate support (currently CLBlast or cuBLAS), this option allows offloading some layers to the GPU for computation. Generally results in increased performance.
 - `-mg i, --main-gpu i`: When using multiple GPUs this option controls which GPU is used for small tensors for which the overhead of splitting the computation across all GPUs is not worthwhile. The GPU in question will use slightly more VRAM to store a scratch buffer for temporary results. By default GPU 0 is used. Requires cuBLAS.
 - `-ts SPLIT, --tensor-split SPLIT`: When using multiple GPUs this option controls how large tensors should be split across all GPUs. `SPLIT` is a comma-separated list of non-negative values that assigns the proportion of data that each GPU should get in order. For example, "3,2" will assign 60% of the data to GPU 0 and 40% to GPU 1. By default the data is split in proportion to VRAM but this may not be optimal for performance. Requires cuBLAS.
@@ -33,7 +33,7 @@ see https://github.com/ggerganov/llama.cpp/issues/1437
 - `--api-key`: Set an api key for request authorization. By default the server responds to every request. With an api key set, the requests must have the Authorization header set with the api key as Bearer token. May be used multiple times to enable multiple valid keys.
 - `--api-key-file`: path to file containing api keys delimited by new lines. If set, requests must include one of the keys for access. May be used in conjunction with `--api-key`'s.
 - `--embedding`: Enable embedding extraction, Default: disabled.
-- `-np N`, `--parallel N`: Set the number of slots for process requests (default: 1)
+- `-np N`, `--parallel N`: Set the number of slots / sequences for process requests (default: 1). Each sequence can have a maximum of `T` tokens, use together with `--kv-size`.
 - `-cb`, `--cont-batching`: enable continuous batching (a.k.a dynamic batching) (default: disabled)
 - `-spf FNAME`, `--system-prompt-file FNAME` Set a file to load "a system prompt (initial prompt of all slots), this is useful for chat applications. [See more](#change-system-prompt-on-runtime)
 - `--mmproj MMPROJ_FILE`: Path to a multimodal projector file for LLaVA.

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -174,7 +174,7 @@ node index.js
 
     `repeat_penalty`: Control the repetition of token sequences in the generated text (default: 1.1).
 
-    `repeat_last_n`: Last n tokens to consider for penalizing repetition (default: 64, 0 = disabled, -1 = ctx-size).
+    `repeat_last_n`: Last n tokens to consider for penalizing repetition (default: 64, 0 = disabled, -1 = kv-size).
 
     `penalize_nl`: Penalize newline tokens when applying the repeat penalty (default: true).
 
@@ -237,7 +237,7 @@ Notice that each `probs` is an array of length `n_probs`.
 
 - `content`: Completion result as a string (excluding `stopping_word` if any). In case of streaming mode, will contain the next token as a string.
 - `stop`: Boolean for use with `stream` to check whether the generation has stopped (Note: This is not related to stopping words array `stop` from input options)
-- `generation_settings`: The provided options above excluding `prompt` but including `n_ctx`, `model`
+- `generation_settings`: The provided options above excluding `prompt` but including `kv_size`, `model`
 - `model`: The path to the model loaded with `-m`
 - `prompt`: The provided `prompt`
 - `stopped_eos`: Indicating whether the completion has stopped because it encountered the EOS token
@@ -247,7 +247,7 @@ Notice that each `probs` is an array of length `n_probs`.
 - `timings`: Hash of timing information about the completion such as the number of tokens `predicted_per_second`
 - `tokens_cached`: Number of tokens from the prompt which could be re-used from previous completion (`n_past`)
 - `tokens_evaluated`: Number of tokens evaluated in total from the prompt
-- `truncated`: Boolean indicating if the context size was exceeded during generation, i.e. the number of tokens provided in the prompt (`tokens_evaluated`) plus tokens generated (`tokens predicted`) exceeded the context size (`n_ctx`)
+- `truncated`: Boolean indicating if the context size was exceeded during generation, i.e. the number of tokens provided in the prompt (`tokens_evaluated`) plus tokens generated (`tokens predicted`) exceeded the KV size (`kv_size`)
 
 - **POST** `/tokenize`: Tokenize a given text.
 
@@ -402,7 +402,7 @@ Notice that each `probs` is an array of length `n_probs`.
         "mirostat_eta": 0.10000000149011612,
         "mirostat_tau": 5.0,
         "model": "llama-2-7b-32k-instruct.Q2_K.gguf",
-        "n_ctx": 2048,
+        "kv_size": 2048,
         "n_keep": 0,
         "n_predict": 100000,
         "n_probs": 0,

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1871,7 +1871,7 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("  -v, --verbose             verbose output (default: %s)\n", server_verbose ? "enabled" : "disabled");
     printf("  -t N, --threads N         number of threads to use during computation (default: %d)\n", params.n_threads);
     printf("  -tb N, --threads-batch N  number of threads to use during batch and prompt processing (default: same as --threads)\n");
-    printf("  -c N, --ctx-size N        size of the prompt context (default: %d)\n", params.n_ctx);
+    printf("  -kv N, --kv-size N        Specify the total size of the KV cache (default: %d)\n", params.n_ctx);
     printf("  --rope-scaling {none,linear,yarn}\n");
     printf("                            RoPE frequency scaling method, defaults to linear unless specified by the model\n");
     printf("  --rope-freq-base N        RoPE base frequency (default: loaded from model)\n");
@@ -2042,6 +2042,17 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
             exit(0);
         }
         else if (arg == "-c" || arg == "--ctx-size" || arg == "--ctx_size")
+        {
+            if (++i >= argc)
+            {
+                invalid_param = true;
+                break;
+            }
+            params.n_ctx = std::stoi(argv[i]);
+            LOG_WARNING("-c,--ctx-size,--ctx_size option is deprecated, use --kv-size instead",
+                        {{"--ctx_size", params.n_ctx}});
+        }
+        else if (arg == "-kv" || arg == "--kv-size" || arg == "--kv_size")
         {
             if (++i >= argc)
             {

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -7,7 +7,7 @@ The purpose of this example is to demonstrate a minimal usage of llama.cpp for g
 
 ...
 
-main: n_len = 32, n_ctx = 2048, n_parallel = 1, n_kv_req = 32
+main: n_len = 32, kv_size = 2048, n_parallel = 1, n_kv_req = 32
 
  Hello my name is Shawn and I'm a 20 year old male from the United States. I'm a 20 year old
 

--- a/examples/simple/simple.cpp
+++ b/examples/simple/simple.cpp
@@ -52,7 +52,7 @@ int main(int argc, char ** argv) {
     llama_context_params ctx_params = llama_context_default_params();
 
     ctx_params.seed  = 1234;
-    ctx_params.n_ctx = 2048;
+    ctx_params.kv_size = 2048;
     ctx_params.n_threads = params.n_threads;
     ctx_params.n_threads_batch = params.n_threads_batch == -1 ? params.n_threads : params.n_threads_batch;
 
@@ -68,15 +68,15 @@ int main(int argc, char ** argv) {
     std::vector<llama_token> tokens_list;
     tokens_list = ::llama_tokenize(ctx, params.prompt, true);
 
-    const int n_ctx    = llama_n_ctx(ctx);
+    const int kv_size  = llama_kv_size(ctx);
     const int n_kv_req = tokens_list.size() + (n_len - tokens_list.size());
 
-    LOG_TEE("\n%s: n_len = %d, n_ctx = %d, n_kv_req = %d\n", __func__, n_len, n_ctx, n_kv_req);
+    LOG_TEE("\n%s: n_len = %d, kv_size = %d, n_kv_req = %d\n", __func__, n_len, kv_size, n_kv_req);
 
     // make sure the KV cache is big enough to hold all the prompt and generated tokens
-    if (n_kv_req > n_ctx) {
-        LOG_TEE("%s: error: n_kv_req > n_ctx, the required KV cache size is not big enough\n", __func__);
-        LOG_TEE("%s:        either reduce n_len or increase n_ctx\n", __func__);
+    if (n_kv_req > kv_size) {
+        LOG_TEE("%s: error: n_kv_req > kv_size, the required KV cache size is not big enough\n", __func__);
+        LOG_TEE("%s:        either reduce n_len or increase kv_size\n", __func__);
         return 1;
     }
 

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -116,7 +116,7 @@ int main(int argc, char ** argv) {
     std::vector<llama_token> inp;
     inp = ::llama_tokenize(ctx_tgt, params.prompt, add_bos_tgt, true);
 
-    const int max_context_size     = llama_n_ctx(ctx_tgt);
+    const int max_context_size     = llama_kv_size(ctx_tgt);
     const int max_tokens_list_size = max_context_size - 4;
 
     if ((int) inp.size() > max_tokens_list_size) {
@@ -172,8 +172,8 @@ int main(int argc, char ** argv) {
         drafts[s].ctx_sampling = llama_sampling_init(params.sparams);
     }
 
-    llama_batch batch_dft = llama_batch_init(params.n_ctx, 0, 1);
-    llama_batch batch_tgt = llama_batch_init(params.n_ctx, 0, n_seq_dft);
+    llama_batch batch_dft = llama_batch_init(params.kv_size, 0, 1);
+    llama_batch batch_tgt = llama_batch_init(params.kv_size, 0, n_seq_dft);
 
     const auto t_dec_start = ggml_time_us();
 

--- a/llama.h
+++ b/llama.h
@@ -217,7 +217,7 @@ extern "C" {
 
     struct llama_context_params {
         uint32_t seed;              // RNG seed, -1 for random
-        uint32_t n_ctx;             // text context, 0 = from model
+        uint32_t kv_size;           // KV Cache size
         uint32_t n_batch;           // prompt processing maximum batch size
         uint32_t n_threads;         // number of threads to use for generation
         uint32_t n_threads_batch;   // number of threads to use for batch processing
@@ -347,7 +347,7 @@ extern "C" {
 
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 
-    LLAMA_API uint32_t llama_n_ctx      (const struct llama_context * ctx);
+    LLAMA_API uint32_t llama_kv_size    (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_batch    (const struct llama_context * ctx);
 
     LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_model * model);

--- a/scripts/run-with-preset.py
+++ b/scripts/run-with-preset.py
@@ -8,7 +8,7 @@ import sys
 import yaml
 
 CLI_ARGS_MAIN_PERPLEXITY = [
-    "batch-size", "cfg-negative-prompt", "cfg-scale", "chunks", "color", "ctx-size", "escape",
+    "batch-size", "cfg-negative-prompt", "cfg-scale", "chunks", "color", "kv-size", "escape",
     "export", "file", "frequency-penalty", "grammar", "grammar-file", "hellaswag",
     "hellaswag-tasks", "ignore-eos", "in-prefix", "in-prefix-bos", "in-suffix", "instruct",
     "interactive", "interactive-first", "keep", "logdir", "logit-bias", "lora", "lora-base",
@@ -27,7 +27,7 @@ CLI_ARGS_LLAMA_BENCH = [
 ]
 
 CLI_ARGS_SERVER = [
-    "alias", "batch-size", "ctx-size", "embedding", "host", "memory-f32", "lora", "lora-base",
+    "alias", "batch-size", "kv-size", "embedding", "host", "memory-f32", "lora", "lora-base",
     "low-vram", "main-gpu", "mlock", "model", "n-gpu-layers", "n-probs", "no-mmap", "no-mul-mat-q",
     "numa", "path", "port", "rope-freq-base", "timeout", "rope-freq-scale", "tensor-split",
     "threads", "verbose"

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1121,21 +1121,21 @@ struct test_rope : public test_case {
     const std::array<int64_t, 4> ne;
     int n_dims;
     int mode;
-    int n_ctx;
+    int kv_size;
 
     std::string vars() override {
-        return VARS_TO_STR5(type, ne, n_dims, mode, n_ctx);
+        return VARS_TO_STR5(type, ne, n_dims, mode, kv_size);
     }
 
     test_rope(ggml_type type = GGML_TYPE_F32,
             std::array<int64_t, 4> ne = {10, 10, 10, 1},
             int n_dims = 10, int mode = 0, int n_ctx = 512)
-        : type(type), ne(ne), n_dims(n_dims), mode(mode), n_ctx(n_ctx) {}
+        : type(type), ne(ne), n_dims(n_dims), mode(mode), kv_size(n_ctx) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne.data());
         ggml_tensor * pos = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, ne[2]);
-        ggml_tensor * out = ggml_rope(ctx, a, pos, n_dims, mode, n_ctx);
+        ggml_tensor * out = ggml_rope(ctx, a, pos, n_dims, mode, kv_size);
         return out;
     }
 
@@ -1145,7 +1145,7 @@ struct test_rope : public test_case {
                 // pos
                 std::vector<int> data(ne[2]);
                 for (int i = 0; i < ne[2]; i++) {
-                    data[i] = rand() % n_ctx;
+                    data[i] = rand() % kv_size;
                 }
                 ggml_backend_tensor_set(t, data.data(), 0, ne[2] * sizeof(int));
             } else {
@@ -1545,7 +1545,7 @@ struct llama_hparams {
     int32_t n_tokens;
 
     // llm_build_context
-    static constexpr int32_t n_kv    = 32; // size of KV cache to consider (n_kv <= n_ctx
+    static constexpr int32_t n_kv    = 32; // size of KV cache to consider (n_kv <= kv_size
     static constexpr int32_t kv_head = 1;  // index of where we store new KV data in the cache
 
     uint32_t n_embd_gqa() const { // dimension of key embeddings across all k-v heads


### PR DESCRIPTION
**Context**
`--ctx-size` is a legacy name before introduction of parallelism slots and creates confusion (see discussion #4130).

**Proposed changes**
Introduce `--kv-size` option and deprecate `--ctx-size` one.

@ggerganov Thanks for the amazing job you are doing here, hope this small contribution will help.