### PR TITLE
server: --n-predict option document and ensure the completion request does not exceed it

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -39,6 +39,7 @@ see https://github.com/ggerganov/llama.cpp/issues/1437
 - `--mmproj MMPROJ_FILE`: Path to a multimodal projector file for LLaVA.
 - `--grp-attn-n`: Set the group attention factor to extend context size through self-extend(default: 1=disabled), used together with group attention width `--grp-attn-w`
 - `--grp-attn-w`: Set the group attention width to extend context size through self-extend(default: 512), used together with group attention factor `--grp-attn-n`
+- `-n, --n-predict`: Set the maximum tokens to predict (default: -1)
 
 ## Build
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1926,14 +1926,14 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("  --mmproj MMPROJ_FILE      path to a multimodal projector file for LLaVA.\n");
     printf("  --log-disable             disables logging to a file.\n");
     printf("\n");
+    printf("  -n, --n-predict           maximum tokens to predict (default: %d)\n", params.n_predict);
     printf("  --override-kv KEY=TYPE:VALUE\n");
     printf("                            advanced option to override model metadata by key. may be specified multiple times.\n");
     printf("                            types: int, float, bool. example: --override-kv tokenizer.ggml.add_bos_token=bool:false\n");
     printf("  -gan N, --grp-attn-n N    set the group attention factor to extend context size through self-extend(default: 1=disabled), used together with group attention width `--grp-attn-w`");
     printf("  -gaw N, --grp-attn-w N    set the group attention width to extend context size through self-extend(default: 512), used together with group attention factor `--grp-attn-n`");
     printf("  --chat-template FORMAT_NAME");
-    printf("                            set chat template, possible values is: llama2, chatml (default %s)", sparams.chat_template.c_str());
-    printf("  -n, --n-predict           maximum tokens to predict (default: %d)\n", params.n_predict);
+    printf("                            set chat template, possible value is: llama2, chatml (default %s)", sparams.chat_template.c_str());
     printf("\n");
 }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1920,7 +1920,8 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("  -gan N, --grp-attn-n N    set the group attention factor to extend context size through self-extend(default: 1=disabled), used together with group attention width `--grp-attn-w`");
     printf("  -gaw N, --grp-attn-w N    set the group attention width to extend context size through self-extend(default: 512), used together with group attention factor `--grp-attn-n`");
     printf("  --chat-template FORMAT_NAME");
-    printf("                            set chat template, possible valus is: llama2, chatml (default %s)", sparams.chat_template.c_str());
+    printf("                            set chat template, possible values is: llama2, chatml (default %s)", sparams.chat_template.c_str());
+    printf("  -n, --n-predict           maximum tokens to predict (default: %d)\n", params.n_predict);
     printf("\n");
 }
 


### PR DESCRIPTION
**Context**
server `--n-predict` option is supported but not documented. When endpoints `completion` or the oai compatible one are called with ` n_predict`  or `max_tokens` , global configuration is not checked and completion tokens can exceed `--n-predict` server option.

It may help people to ensure request will never infinite loop for example in #3969.

**Proposed changes**
1. Document the `--n-predict` option in `README.md` and in the server print usage.
2. Min the slot ` n_predict` param by the server params ` n_predict` or the user input data.

**Open question**

- [ ] @ggerganov  Should the server reject the completion requests with `400`  when `--n-predict` > 0 && `data['n_predict']` > `--n-predict` or it can be done later on