### PR TITLE
common : min_keep should not be set by server n_probs

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -249,7 +249,7 @@ static llama_token llama_sampling_sample_impl(
             id = llama_sample_token_mirostat_v2(ctx_main, &cur_p, mirostat_tau, mirostat_eta, &ctx_sampling->mirostat_mu);
         } else {
             // temperature sampling
-            size_t min_keep = std::max(1, params.n_probs);
+            size_t min_keep = 1;
 
             sampler_queue(ctx_main, params, cur_p, min_keep);
 


### PR DESCRIPTION
Previously `min_keep` was being set to `n_probs`, which was then impacting sampler results.

I do not believe this was the intended use of the parameter. An easy experiment to see this in action is to run server and test with `min_p=1` and `n_probs=10` vs `min_p=1` and `n_probs=0` over multiple generations.

Previously the samplers would return at least 10 probable tokens, even if the min_p sampler would have removed all of them.

This should maybe be made as a new parameter, as being able to specify a minimum number of possible tokens is still an interesting feature.

Let me know if you need more -- I know this is sparse, but it's a minimal change with not much to explain.