### PR TITLE
ci: add g++-10 and gcc-10 to the main-cuda

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -11,8 +11,12 @@ FROM ${BASE_CUDA_DEV_CONTAINER} as build
 # Unless otherwise specified, we make a fat build.
 ARG CUDA_DOCKER_ARCH=all
 
+# Install gcc-10 and g++-10 to work around and issue CUDA 11.7.1 and gcc-11
 RUN apt-get update && \
-    apt-get install -y build-essential python3 python3-pip git
+    apt-get install -y build-essential python3 python3-pip git g++-10  gcc-10
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
 
 COPY requirements.txt   requirements.txt
 COPY requirements       requirements

--- a/.devops/main-cuda.Dockerfile
+++ b/.devops/main-cuda.Dockerfile
@@ -11,8 +11,12 @@ FROM ${BASE_CUDA_DEV_CONTAINER} as build
 # Unless otherwise specified, we make a fat build.
 ARG CUDA_DOCKER_ARCH=all
 
+# Install gcc-10 and g++-10 to work around and issue CUDA 11.7.1 and gcc-11
 RUN apt-get update && \
-    apt-get install -y build-essential git
+    apt-get install -y build-essential git g++-10  gcc-10
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+
 
 WORKDIR /app
 

--- a/.devops/server-cuda.Dockerfile
+++ b/.devops/server-cuda.Dockerfile
@@ -11,8 +11,13 @@ FROM ${BASE_CUDA_DEV_CONTAINER} as build
 # Unless otherwise specified, we make a fat build.
 ARG CUDA_DOCKER_ARCH=all
 
+# Install gcc-10 and g++-10 to work around and issue CUDA 11.7.1 and gcc-11
 RUN apt-get update && \
     apt-get install -y build-essential git
+    apt-get install -y build-essential git g++-10  gcc-10
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
 
 WORKDIR /app
 


### PR DESCRIPTION
This commit contains an attempt to work around an issue with CUDA 11.7.1 and gcc-11.

The motivation for this change is that currently the following compilation error occurs when building the main-cuda image:
```console
219.4 ggml-cuda.cu(675): warning #177-D: function "warp_reduce_max(half2)" was declared but never referenced
219.4
243.1 /usr/include/c++/11/type_traits:79:52: error: redefinition of 'constexpr const _Tp std::integral_constant<_Tp, __v>::value'
243.1    79 |   template<typename _Tp, _Tp __v>
243.1       |                                                    ^
243.1 /usr/include/c++/11/type_traits:67:29: note: 'constexpr const _Tp value' previously declared here
243.1    67 |       static constexpr _Tp                  value = __v;
243.1       |                             ^~~~~
243.9 make: *** [Makefile:447: ggml-cuda.o] Error 1
```
Downgrading to gcc-10 and g++-10 seems to work around the issue. I'm not sure about the root cause of the issue, but will try to investigate further and see what proper fix might be.