### PR TITLE
examples : do not assume BOS when shifting context

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1440,8 +1440,6 @@ struct llama_server_context
         task.target_id = -1;
         queue_tasks.post(task);
 
-        int32_t n_keep = slot.params.n_keep + add_bos_token;
-
         for (llama_client_slot &slot : slots)
         {
             if (slot.ga_n == 1)
@@ -1449,6 +1447,7 @@ struct llama_server_context
                 if (slot.is_processing() && system_tokens.size() + slot.cache_tokens.size() >= (size_t) slot.n_ctx)
                 {
                     // Shift context
+                    const int n_keep    = slot.params.n_keep + add_bos_token;
                     const int n_left    = system_tokens.size() + slot.n_past - n_keep;
                     const int n_discard = n_left / 2;
 


### PR DESCRIPTION
Am I understanding this code right?

All references to n_keep were effectively +1, and the only reason I can think that would be is for the BOS token. But some models do not use a BOS token, e.g. Falcon, and this is reflected by the value of `add_bos` (from llama_should_add_bos_token).

So I think these changes make the behavior more consistent between models - either way, I think add_bos should have an effect here, unless we are ever prompting e.g. Llama without BOS because of a context shift (which AFAICT we aren't).