### PR TITLE
[SYCL] conext add name

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -15091,7 +15091,7 @@ ggml_backend_t ggml_backend_sycl_init(int device) {
 
     ggml_backend_sycl_context * ctx = new ggml_backend_sycl_context {
         /* .device = */ device,
-	/* .name   = */ std::to_string(device),
+	/* .name   = */ GGML_SYCL_NAME + std::to_string(device),
     };
 
     ggml_backend_t sycl_backend = new ggml_backend {

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -14642,7 +14642,8 @@ GGML_CALL static const char * ggml_backend_sycl_buffer_type_name(ggml_backend_bu
 static ggml_backend_buffer_t
 ggml_backend_sycl_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft,
                                            size_t size) try {
-    int device = (int) (intptr_t) buft->context;
+    ggml_backend_sycl_buffer_type_context * buft_ctx = (ggml_backend_sycl_buffer_type_context *)buft->context;
+    int device = (int) buft_ctx->device;
 
     ggml_sycl_set_device(device);
     int device_index = get_device_index_by_id(device);
@@ -14720,7 +14721,7 @@ ggml_backend_buffer_type_t ggml_backend_sycl_buffer_type(int device) {
         for (int i = 0; i < GGML_SYCL_MAX_DEVICES; i++) {
             ggml_backend_sycl_buffer_types[i] = {
                 /* .iface    = */ ggml_backend_sycl_buffer_type_interface,
-                /* .context  = */ (ggml_backend_buffer_type_context_t) (intptr_t) i,
+                /* .context  = */ new ggml_backend_sycl_buffer_type_context{i, GGML_SYCL_NAME + std::to_string(i)},
             };
         }
         ggml_backend_sycl_buffer_type_initialized = true;
@@ -14782,10 +14783,6 @@ ggml_backend_buffer_type_t ggml_backend_sycl_host_buffer_type() {
 
 // backend
 
-struct ggml_backend_context_sycl {
-    int device;
-};
-
 static const char * ggml_backend_sycl_name(ggml_backend_t backend) {
     return GGML_SYCL_NAME;
 
@@ -14793,14 +14790,14 @@ static const char * ggml_backend_sycl_name(ggml_backend_t backend) {
 }
 
 static void ggml_backend_sycl_free(ggml_backend_t backend) {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     delete sycl_ctx;
     delete backend;
 }
 
 static ggml_backend_buffer_type_t ggml_backend_sycl_get_default_buffer_type(ggml_backend_t backend) {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     return ggml_backend_sycl_buffer_type(sycl_ctx->device);
 }
@@ -14809,7 +14806,7 @@ static void ggml_backend_sycl_set_tensor_async(ggml_backend_t backend,
                                                ggml_tensor *tensor,
                                                const void *data, size_t offset,
                                                size_t size) try {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     GGML_ASSERT(tensor->buffer->buft == ggml_backend_sycl_buffer_type(sycl_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -14827,7 +14824,7 @@ static void ggml_backend_sycl_get_tensor_async(ggml_backend_t backend,
                                                const ggml_tensor *tensor,
                                                void *data, size_t offset,
                                                size_t size) try {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     GGML_ASSERT(tensor->buffer->buft == ggml_backend_sycl_buffer_type(sycl_ctx->device) && "unsupported buffer type");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -14842,7 +14839,7 @@ catch (sycl::exception const &exc) {
 }
 
 static void ggml_backend_sycl_synchronize(ggml_backend_t backend) try {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     SYCL_CHECK(CHECK_TRY_ERROR(g_syclStreams[sycl_ctx->device][0]->wait()));
 
@@ -14878,7 +14875,7 @@ static void ggml_backend_sycl_graph_plan_compute(ggml_backend_t backend, ggml_ba
 }
 
 static bool ggml_backend_sycl_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
-    ggml_backend_context_sycl * sycl_ctx = (ggml_backend_context_sycl *)backend->context;
+    ggml_backend_sycl_context * sycl_ctx = (ggml_backend_sycl_context *)backend->context;
 
     ggml_sycl_set_main_device(sycl_ctx->device);
 
@@ -15092,8 +15089,9 @@ ggml_backend_t ggml_backend_sycl_init(int device) {
     // not strictly necessary, but it may reduce the overhead of the first graph_compute
     ggml_sycl_set_main_device(device);
 
-    ggml_backend_context_sycl * ctx = new ggml_backend_context_sycl {
-        /* .device = */ device
+    ggml_backend_sycl_context * ctx = new ggml_backend_sycl_context {
+        /* .device = */ device,
+	/* .name   = */ std::to_string(device),
     };
 
     ggml_backend_t sycl_backend = new ggml_backend {

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -15091,7 +15091,7 @@ ggml_backend_t ggml_backend_sycl_init(int device) {
 
     ggml_backend_sycl_context * ctx = new ggml_backend_sycl_context {
         /* .device = */ device,
-	/* .name   = */ GGML_SYCL_NAME + std::to_string(device),
+        /* .name   = */ GGML_SYCL_NAME + std::to_string(device),
     };
 
     ggml_backend_t sycl_backend = new ggml_backend {


### PR DESCRIPTION
This might also resolve https://github.com/ggerganov/llama.cpp/issues/5469


```shell
gta@DUT109DG2MRB:~/llama.cpp/build$ cmake .. -DLLAMA_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DLLAMA_SYCL_F16=ON -G Ninja 2>&1 | tee build.log
```
<details>
  <summary>build.log</summary>


```shell
[1/16] Building CXX object common/CMakeFiles/build_info.dir/build-info.cpp.o
[2/16] Building C object CMakeFiles/ggml.dir/ggml-backend.c.o
[3/16] Building C object CMakeFiles/ggml.dir/ggml-alloc.c.o
[4/16] Building CXX object common/CMakeFiles/common.dir/console.cpp.o
[5/16] Building CXX object common/CMakeFiles/common.dir/grammar-parser.cpp.o
[6/16] Building CXX object common/CMakeFiles/common.dir/sampling.cpp.o
/home/gta/llama.cpp/common/sampling.cpp:282:63: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  282 |         bool is_valid = single_token_data_array.data[0].logit != -INFINITY;
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
1 warning generated.
/home/gta/llama.cpp/common/sampling.cpp:282:63: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  282 |         bool is_valid = single_token_data_array.data[0].logit != -INFINITY;
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
1 warning generated.
[7/16] Building CXX object common/CMakeFiles/common.dir/train.cpp.o
/home/gta/llama.cpp/common/train.cpp:1445:13: warning: explicit comparison with NaN in fast floating point mode [-Wtautological-constant-compare]
 1445 |         if (std::isnan(opt->loss_before) || std::isnan(opt->loss_after)) impr_plot = 0;
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gta/llama.cpp/common/train.cpp:1445:45: warning: explicit comparison with NaN in fast floating point mode [-Wtautological-constant-compare]
 1445 |         if (std::isnan(opt->loss_before) || std::isnan(opt->loss_after)) impr_plot = 0;
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
/home/gta/llama.cpp/common/train.cpp:1445:13: warning: explicit comparison with NaN in fast floating point mode [-Wtautological-constant-compare]
 1445 |         if (std::isnan(opt->loss_before) || std::isnan(opt->loss_after)) impr_plot = 0;
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gta/llama.cpp/common/train.cpp:1445:45: warning: explicit comparison with NaN in fast floating point mode [-Wtautological-constant-compare]
 1445 |         if (std::isnan(opt->loss_before) || std::isnan(opt->loss_after)) impr_plot = 0;
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
[8/16] Building CXX object examples/main/CMakeFiles/main.dir/main.cpp.o
[9/16] Building C object CMakeFiles/ggml.dir/ggml-quants.c.o
[10/16] Building CXX object common/CMakeFiles/common.dir/common.cpp.o
/home/gta/llama.cpp/common/common.cpp:1671:98: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 1671 |     const bool ignore_eos = logit_bias_eos != sparams.logit_bias.end() && logit_bias_eos->second == -INFINITY;
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
1 warning generated.
/home/gta/llama.cpp/common/common.cpp:1671:98: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 1671 |     const bool ignore_eos = logit_bias_eos != sparams.logit_bias.end() && logit_bias_eos->second == -INFINITY;
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
1 warning generated.
[11/16] Building C object CMakeFiles/ggml.dir/ggml.c.o
/home/gta/llama.cpp/ggml.c:11627:23: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 11627 |             if (wp[i] == -INFINITY) {
       |                 ~~~~~ ^  ~~~~~~~~~
/home/gta/llama.cpp/ggml.c:13420:42: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 13420 |                         } else if (SS[j] == -INFINITY) {
       |                                    ~~~~~ ^  ~~~~~~~~~
/home/gta/llama.cpp/ggml.c:13625:35: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 13625 |                         if (SS[j] == -INFINITY) {
       |                             ~~~~~ ^  ~~~~~~~~~
/home/gta/llama.cpp/ggml.c:14073:50: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 14073 |                                 } else if (SR[j] == -INFINITY) {
       |                                            ~~~~~ ^  ~~~~~~~~~
/home/gta/llama.cpp/ggml.c:14833:27: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 14833 |                 if (s0[i] == -INFINITY) {
       |                     ~~~~~ ^  ~~~~~~~~~
/home/gta/llama.cpp/ggml.c:14947:27: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
 14947 |                 if (s0[i] == -INFINITY) {
       |                     ~~~~~ ^  ~~~~~~~~~
6 warnings generated.
[12/16] Building CXX object CMakeFiles/llama.dir/llama.cpp.o
/home/gta/llama.cpp/llama.cpp:4828:9: warning: TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL [-W#pragma-messages]
 4828 | #pragma message("TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL")
      |         ^
/home/gta/llama.cpp/llama.cpp:4829:9: warning:       Falling back to ggml_alibi(). Will become an error in Mar 2024 [-W#pragma-messages]
 4829 | #pragma message("      Falling back to ggml_alibi(). Will become an error in Mar 2024")
      |         ^
/home/gta/llama.cpp/llama.cpp:4830:9: warning: ref:  https://github.com/ggerganov/llama.cpp/pull/5488 [-W#pragma-messages]
 4830 | #pragma message("ref:  https://github.com/ggerganov/llama.cpp/pull/5488")
      |         ^
3 warnings generated.
/home/gta/llama.cpp/llama.cpp:153:9: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  153 |     if (std::isinf(a) || std::isinf(b)) {
      |         ^~~~~~~~~~~~~
/home/gta/llama.cpp/llama.cpp:153:26: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  153 |     if (std::isinf(a) || std::isinf(b)) {
      |                          ^~~~~~~~~~~~~
/home/gta/llama.cpp/llama.cpp:4828:9: warning: TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL [-W#pragma-messages]
 4828 | #pragma message("TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL")
      |         ^
/home/gta/llama.cpp/llama.cpp:4829:9: warning:       Falling back to ggml_alibi(). Will become an error in Mar 2024 [-W#pragma-messages]
 4829 | #pragma message("      Falling back to ggml_alibi(). Will become an error in Mar 2024")
      |         ^
/home/gta/llama.cpp/llama.cpp:4830:9: warning: ref:  https://github.com/ggerganov/llama.cpp/pull/5488 [-W#pragma-messages]
 4830 | #pragma message("ref:  https://github.com/ggerganov/llama.cpp/pull/5488")
      |         ^
/home/gta/llama.cpp/llama.cpp:4835:14: warning: 'ggml_alibi' is deprecated: use ggml_soft_max_ext instead (will be removed in Mar 2024) [-Wdeprecated-declarations]
 4835 |         kq = ggml_alibi(ctx, kq, /*n_past*/ 0, n_head, hparams.f_max_alibi_bias);
      |              ^
/home/gta/llama.cpp/ggml.h:1500:5: note: 'ggml_alibi' has been explicitly marked deprecated here
 1500 |     GGML_DEPRECATED(GGML_API struct ggml_tensor * ggml_alibi(
      |     ^
/home/gta/llama.cpp/ggml.h:202:61: note: expanded from macro 'GGML_DEPRECATED'
  202 | #    define GGML_DEPRECATED(func, hint) func __attribute__((deprecated(hint)))
      |                                                             ^
6 warnings generated.
/home/gta/llama.cpp/llama.cpp:153:9: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  153 |     if (std::isinf(a) || std::isinf(b)) {
      |         ^~~~~~~~~~~~~
/home/gta/llama.cpp/llama.cpp:153:26: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
  153 |     if (std::isinf(a) || std::isinf(b)) {
      |                          ^~~~~~~~~~~~~
/home/gta/llama.cpp/llama.cpp:4828:9: warning: TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL [-W#pragma-messages]
 4828 | #pragma message("TODO: ALiBi support in ggml_soft_max_ext is not implemented for Vulkan, Kompute, and SYCL")
      |         ^
/home/gta/llama.cpp/llama.cpp:4829:9: warning:       Falling back to ggml_alibi(). Will become an error in Mar 2024 [-W#pragma-messages]
 4829 | #pragma message("      Falling back to ggml_alibi(). Will become an error in Mar 2024")
      |         ^
/home/gta/llama.cpp/llama.cpp:4830:9: warning: ref:  https://github.com/ggerganov/llama.cpp/pull/5488 [-W#pragma-messages]
 4830 | #pragma message("ref:  https://github.com/ggerganov/llama.cpp/pull/5488")
      |         ^
/home/gta/llama.cpp/llama.cpp:4835:14: warning: 'ggml_alibi' is deprecated: use ggml_soft_max_ext instead (will be removed in Mar 2024) [-Wdeprecated-declarations]
 4835 |         kq = ggml_alibi(ctx, kq, /*n_past*/ 0, n_head, hparams.f_max_alibi_bias);
      |              ^
/home/gta/llama.cpp/ggml.h:1500:5: note: 'ggml_alibi' has been explicitly marked deprecated here
 1500 |     GGML_DEPRECATED(GGML_API struct ggml_tensor * ggml_alibi(
      |     ^
/home/gta/llama.cpp/ggml.h:202:61: note: expanded from macro 'GGML_DEPRECATED'
  202 | #    define GGML_DEPRECATED(func, hint) func __attribute__((deprecated(hint)))
      |                                                             ^
6 warnings generated.
[13/16] Building CXX object CMakeFiles/ggml.dir/ggml-sycl.cpp.o
/home/gta/llama.cpp/ggml-sycl.cpp:1123:55: warning: cast from 'const void *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
 1123 |                 auto it = m_map.upper_bound((byte_t *)ptr);
      |                                                       ^
/home/gta/llama.cpp/ggml-sycl.cpp:3659:31: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3659 |     if (item_ct1.get_group(0) < ne02) { // src0
      |         ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:3701:31: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3701 |         item_ct1.get_group(0) < ne02) {
      |         ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:3700:46: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3700 |     if (nidx < ne00 && item_ct1.get_group(1) < ne01 &&
      |                        ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:8627:59: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8627 |                                             s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                                           ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8648:54: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8648 |                                        s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                      ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8673:43: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8673 |                             s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                           ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8698:60: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8698 |                                              s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                            ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8763:63: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8763 |                                                 s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8784:58: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8784 |                                            s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                          ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9292:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9292 |                             tile_x_qs_q4_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9293:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9293 |                             tile_x_d_q4_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9294:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9294 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9295:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9295 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9327:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9327 |                             tile_x_qs_q4_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9328:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9328 |                             tile_x_d_q4_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9329:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9329 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9330:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9330 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9407:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9407 |                             tile_x_qs_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9408:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9408 |                             tile_x_dm_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9409:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9409 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9410:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9410 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9442:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9442 |                             tile_x_qs_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9443:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9443 |                             tile_x_dm_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9444:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9444 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9445:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9445 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9522:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9522 |                             tile_x_ql_q5_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9523:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9523 |                             tile_x_d_q5_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9524:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9524 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9525:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9525 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9557:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9557 |                             tile_x_ql_q5_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9558:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9558 |                             tile_x_d_q5_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9559:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9559 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9560:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9560 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9637:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9637 |                             tile_x_ql_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9638:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9638 |                             tile_x_dm_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9639:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9639 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9640:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9640 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9672:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9672 |                             tile_x_ql_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9673:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9673 |                             tile_x_dm_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9674:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9674 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9675:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9675 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9752:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9752 |                             tile_x_qs_q8_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9753:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9753 |                             tile_x_d_q8_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9754:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9754 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9755:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9755 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9787:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9787 |                             tile_x_qs_q8_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9788:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9788 |                             tile_x_d_q8_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9789:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9789 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9790:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9790 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9869:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9869 |                             tile_x_ql_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9870:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9870 |                             tile_x_dm_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9871:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9871 |                             tile_x_sc_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9872:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9872 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9873:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9873 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9907:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9907 |                             tile_x_ql_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9908:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9908 |                             tile_x_dm_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9909:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9909 |                             tile_x_sc_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9910:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9910 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9911:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9911 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9994:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9994 |                             tile_x_ql_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9995:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9995 |                             tile_x_dm_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9996:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9996 |                             tile_x_qh_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9997:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9997 |                             tile_x_sc_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9998:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9998 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9999:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9999 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10035:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10035 |                             tile_x_ql_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10036:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10036 |                             tile_x_dm_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10037:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10037 |                             tile_x_qh_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10038:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10038 |                             tile_x_sc_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10039:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10039 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10040:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10040 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10120:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10120 |                             tile_x_ql_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10121:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10121 |                             tile_x_dm_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10122:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10122 |                             tile_x_sc_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10123:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10123 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10124:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10124 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10158:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10158 |                             tile_x_ql_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10159:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10159 |                             tile_x_dm_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10160:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10160 |                             tile_x_sc_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10161:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10161 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10162:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10162 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10241:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10241 |                             tile_x_ql_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10242:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10242 |                             tile_x_dm_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10243:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10243 |                             tile_x_sc_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10244:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10244 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10245:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10245 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10279:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10279 |                             tile_x_ql_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10280:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10280 |                             tile_x_dm_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10281:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10281 |                             tile_x_sc_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10282:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10282 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10283:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10283 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10362:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10362 |                             tile_x_ql_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10363:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10363 |                             tile_x_dm_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10364:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10364 |                             tile_x_sc_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10365:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10365 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10366:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10366 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10400:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10400 |                             tile_x_ql_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10401:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10401 |                             tile_x_dm_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10402:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10402 |                             tile_x_sc_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10403:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10403 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10404:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10404 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10896:42: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10896 |                              buf_acc_ct1.get_pointer());
       |                                          ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
103 warnings generated.
/home/gta/llama.cpp/ggml-sycl.cpp:1123:55: warning: cast from 'const void *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
 1123 |                 auto it = m_map.upper_bound((byte_t *)ptr);
      |                                                       ^
/home/gta/llama.cpp/ggml-sycl.cpp:2916:120: warning: function 'ggml_sycl_error' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
 2916 | static void ggml_sycl_error(const char * stmt, const char * func, const char * file, const int line, const char * msg) {
      |                                                                                                                        ^
/home/gta/llama.cpp/ggml-sycl.cpp:3659:31: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3659 |     if (item_ct1.get_group(0) < ne02) { // src0
      |         ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:3701:31: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3701 |         item_ct1.get_group(0) < ne02) {
      |         ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:3700:46: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'const int' [-Wsign-compare]
 3700 |     if (nidx < ne00 && item_ct1.get_group(1) < ne01 &&
      |                        ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/home/gta/llama.cpp/ggml-sycl.cpp:8627:59: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8627 |                                             s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                                           ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8648:54: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8648 |                                        s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                      ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8673:43: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8673 |                             s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                           ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8698:60: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8698 |                                              s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                            ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8763:63: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8763 |                                                 s_sum_acc_ct1.get_pointer(), WARP_SIZE);
      |                                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:8784:58: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 8784 |                                            s_sum_acc_ct1.get_pointer(), work_group_size);
      |                                                          ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9292:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9292 |                             tile_x_qs_q4_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9293:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9293 |                             tile_x_d_q4_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9294:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9294 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9295:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9295 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9327:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9327 |                             tile_x_qs_q4_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9328:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9328 |                             tile_x_d_q4_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9329:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9329 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9330:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9330 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9407:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9407 |                             tile_x_qs_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9408:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9408 |                             tile_x_dm_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9409:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9409 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9410:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9410 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9442:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9442 |                             tile_x_qs_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9443:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9443 |                             tile_x_dm_q4_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9444:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9444 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9445:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9445 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9522:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9522 |                             tile_x_ql_q5_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9523:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9523 |                             tile_x_d_q5_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9524:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9524 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9525:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9525 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9557:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9557 |                             tile_x_ql_q5_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9558:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9558 |                             tile_x_d_q5_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9559:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9559 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9560:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9560 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9637:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9637 |                             tile_x_ql_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9638:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9638 |                             tile_x_dm_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9639:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9639 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9640:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9640 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9672:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9672 |                             tile_x_ql_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9673:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9673 |                             tile_x_dm_q5_1_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9674:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9674 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9675:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9675 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9752:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9752 |                             tile_x_qs_q8_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9753:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9753 |                             tile_x_d_q8_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9754:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9754 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9755:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9755 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9787:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9787 |                             tile_x_qs_q8_0_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9788:51: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9788 |                             tile_x_d_q8_0_acc_ct1.get_pointer(),
      |                                                   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9789:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9789 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9790:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9790 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9869:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9869 |                             tile_x_ql_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9870:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9870 |                             tile_x_dm_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9871:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9871 |                             tile_x_sc_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9872:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9872 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9873:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9873 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9907:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9907 |                             tile_x_ql_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9908:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9908 |                             tile_x_dm_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9909:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9909 |                             tile_x_sc_q2_K_acc_ct1.get_pointer(),
      |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9910:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9910 |                             tile_y_qs_acc_ct1.get_pointer(),
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9911:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 9911 |                             tile_y_ds_acc_ct1.get_pointer());
      |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9994:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9994 |                             tile_x_ql_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9995:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9995 |                             tile_x_dm_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9996:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9996 |                             tile_x_qh_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9997:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9997 |                             tile_x_sc_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9998:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9998 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:9999:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
  9999 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10035:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10035 |                             tile_x_ql_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10036:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10036 |                             tile_x_dm_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10037:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10037 |                             tile_x_qh_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10038:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10038 |                             tile_x_sc_q3_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10039:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10039 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10040:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10040 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10120:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10120 |                             tile_x_ql_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10121:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10121 |                             tile_x_dm_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10122:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10122 |                             tile_x_sc_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10123:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10123 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10124:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10124 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10158:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10158 |                             tile_x_ql_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10159:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10159 |                             tile_x_dm_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10160:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10160 |                             tile_x_sc_q4_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10161:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10161 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10162:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10162 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10241:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10241 |                             tile_x_ql_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10242:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10242 |                             tile_x_dm_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10243:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10243 |                             tile_x_sc_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10244:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10244 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10245:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10245 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10279:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10279 |                             tile_x_ql_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10280:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10280 |                             tile_x_dm_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10281:52: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10281 |                             tile_x_sc_q5_K_acc_ct1.get_pointer(),
       |                                                    ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10282:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10282 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10283:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10283 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10362:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10362 |                             tile_x_ql_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10363:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10363 |                             tile_x_dm_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10364:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10364 |                             tile_x_sc_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10365:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10365 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10366:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10366 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10400:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10400 |                             tile_x_ql_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10401:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10401 |                             tile_x_dm_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10402:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10402 |                             tile_x_sc_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10403:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10403 |                             tile_y_qs_acc_ct1.get_pointer(),
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10404:47: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10404 |                             tile_y_ds_acc_ct1.get_pointer());
       |                                               ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:10896:42: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr() [-Wdeprecated-declarations]
 10896 |                              buf_acc_ct1.get_pointer());
       |                                          ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/accessor.hpp:3182:3: note: 'get_pointer' has been explicitly marked deprecated here
 3182 |   __SYCL2020_DEPRECATED(
      |   ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:53:40: note: expanded from macro '__SYCL2020_DEPRECATED'
   53 | #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
      |                                        ^
/opt/intel/oneapi/compiler/2024.1/bin/compiler/../../include/sycl/detail/defines_elementary.hpp:44:38: note: expanded from macro '__SYCL_DEPRECATED'
   44 | #define __SYCL_DEPRECATED(message) [[deprecated(message)]]
      |                                      ^
/home/gta/llama.cpp/ggml-sycl.cpp:14863:103: warning: function 'ggml_backend_sycl_graph_plan_free' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
 14863 | static void ggml_backend_sycl_graph_plan_free(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
       |                                                                                                       ^
/home/gta/llama.cpp/ggml-sycl.cpp:14870:106: warning: function 'ggml_backend_sycl_graph_plan_compute' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
 14870 | static void ggml_backend_sycl_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
       |                                                                                                          ^
106 warnings generated.
[14/16] Linking CXX static library libllama.a
[15/16] Linking CXX static library common/libcommon.a
[16/16] Linking CXX executable bin/main
```

</details>


```shell
gta@DUT109DG2MRB:~/llama.cpp/build$ GGML_SYCL_DEVICE=0 ./bin/main -m ~/llama-2-7b.Q4_K_S.gguf -p "Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun" -n 128 -e -ngl 33 --no-mmap
Log start
main: build = 2221 (df43b275)
main: built with Intel(R) oneAPI DPC++/C++ Compiler 2024.1.0 (2024.1.0.20240117) for x86_64-unknown-linux-gnu
main: seed  = 1708497265
GGML_SYCL_DEBUG=0
ggml_init_sycl: GGML_SYCL_F16:   yes
ggml_init_sycl: SYCL_USE_XMX: yes
found 4 SYCL devices:
  Device 0: Intel(R) Arc(TM) A730M Graphics,    compute capability 1.3,
        max compute_units 384,  max work group size 1024,       max sub group size 32,  global mem size 12160962560
  Device 1: Intel(R) FPGA Emulation Device,     compute capability 1.2,
        max compute_units 6,    max work group size 67108864,   max sub group size 64,  global mem size 16498610176
  Device 2: Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz,   compute capability 3.0,
        max compute_units 6,    max work group size 8192,       max sub group size 64,  global mem size 16498610176
  Device 3: Intel(R) Arc(TM) A730M Graphics,    compute capability 3.0,
        max compute_units 384,  max work group size 1024,       max sub group size 32,  global mem size 12160962560
Using device 0 (Intel(R) Arc(TM) A730M Graphics) as main device
llama_model_loader: loaded meta data with 19 key-value pairs and 291 tensors from /home/gta/llama-2-7b.Q4_K_S.gguf (version GGUF V2)
llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
llama_model_loader: - kv   0:                       general.architecture str              = llama
llama_model_loader: - kv   1:                               general.name str              = LLaMA v2
llama_model_loader: - kv   2:                       llama.context_length u32              = 4096
llama_model_loader: - kv   3:                     llama.embedding_length u32              = 4096
llama_model_loader: - kv   4:                          llama.block_count u32              = 32
llama_model_loader: - kv   5:                  llama.feed_forward_length u32              = 11008
llama_model_loader: - kv   6:                 llama.rope.dimension_count u32              = 128
llama_model_loader: - kv   7:                 llama.attention.head_count u32              = 32
llama_model_loader: - kv   8:              llama.attention.head_count_kv u32              = 32
llama_model_loader: - kv   9:     llama.attention.layer_norm_rms_epsilon f32              = 0.000010
llama_model_loader: - kv  10:                          general.file_type u32              = 14
llama_model_loader: - kv  11:                       tokenizer.ggml.model str              = llama
llama_model_loader: - kv  12:                      tokenizer.ggml.tokens arr[str,32000]   = ["<unk>", "<s>", "</s>", "<0x00>", "<...
llama_model_loader: - kv  13:                      tokenizer.ggml.scores arr[f32,32000]   = [0.000000, 0.000000, 0.000000, 0.0000...
llama_model_loader: - kv  14:                  tokenizer.ggml.token_type arr[i32,32000]   = [2, 3, 3, 6, 6, 6, 6, 6, 6, 6, 6, 6, ...
llama_model_loader: - kv  15:                tokenizer.ggml.bos_token_id u32              = 1
llama_model_loader: - kv  16:                tokenizer.ggml.eos_token_id u32              = 2
llama_model_loader: - kv  17:            tokenizer.ggml.unknown_token_id u32              = 0
llama_model_loader: - kv  18:               general.quantization_version u32              = 2
llama_model_loader: - type  f32:   65 tensors
llama_model_loader: - type q4_K:  217 tensors
llama_model_loader: - type q5_K:    8 tensors
llama_model_loader: - type q6_K:    1 tensors
llm_load_vocab: special tokens definition check successful ( 259/32000 ).
llm_load_print_meta: format           = GGUF V2
llm_load_print_meta: arch             = llama
llm_load_print_meta: vocab type       = SPM
llm_load_print_meta: n_vocab          = 32000
llm_load_print_meta: n_merges         = 0
llm_load_print_meta: n_ctx_train      = 4096
llm_load_print_meta: n_embd           = 4096
llm_load_print_meta: n_head           = 32
llm_load_print_meta: n_head_kv        = 32
llm_load_print_meta: n_layer          = 32
llm_load_print_meta: n_rot            = 128
llm_load_print_meta: n_embd_head_k    = 128
llm_load_print_meta: n_embd_head_v    = 128
llm_load_print_meta: n_gqa            = 1
llm_load_print_meta: n_embd_k_gqa     = 4096
llm_load_print_meta: n_embd_v_gqa     = 4096
llm_load_print_meta: f_norm_eps       = 0.0e+00
llm_load_print_meta: f_norm_rms_eps   = 1.0e-05
llm_load_print_meta: f_clamp_kqv      = 0.0e+00
llm_load_print_meta: f_max_alibi_bias = 0.0e+00
llm_load_print_meta: n_ff             = 11008
llm_load_print_meta: n_expert         = 0
llm_load_print_meta: n_expert_used    = 0
llm_load_print_meta: rope scaling     = linear
llm_load_print_meta: freq_base_train  = 10000.0
llm_load_print_meta: freq_scale_train = 1
llm_load_print_meta: n_yarn_orig_ctx  = 4096
llm_load_print_meta: rope_finetuned   = unknown
llm_load_print_meta: model type       = 7B
llm_load_print_meta: model ftype      = Q4_K - Small
llm_load_print_meta: model params     = 6.74 B
llm_load_print_meta: model size       = 3.59 GiB (4.58 BPW) 
llm_load_print_meta: general.name     = LLaMA v2
llm_load_print_meta: BOS token        = 1 '<s>'
llm_load_print_meta: EOS token        = 2 '</s>'
llm_load_print_meta: UNK token        = 0 '<unk>'
llm_load_print_meta: LF token         = 13 '<0x0A>'
llm_load_tensors: ggml ctx size =    0.22 MiB
llm_load_tensors: offloading 32 repeating layers to GPU
llm_load_tensors: offloading non-repeating layers to GPU
llm_load_tensors: offloaded 33/33 layers to GPU
llm_load_tensors:            buffer size =  3607.06 MiB
llm_load_tensors:        CPU buffer size =    70.31 MiB
.................................................................................................
llama_new_context_with_model: n_ctx      = 512
llama_new_context_with_model: freq_base  = 10000.0
llama_new_context_with_model: freq_scale = 1
llama_kv_cache_init:            KV buffer size =   256.00 MiB
llama_new_context_with_model: KV self size  =  256.00 MiB, K (f16):  128.00 MiB, V (f16):  128.00 MiB
llama_new_context_with_model:        CPU input buffer size   =    10.01 MiB
llama_new_context_with_model:      SYCL0 compute buffer size =    70.50 MiB
llama_new_context_with_model:  SYCL_Host compute buffer size =     8.00 MiB
llama_new_context_with_model: graph splits (measure): 3

system_info: n_threads = 3 / 6 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | SSSE3 = 1 | VSX = 0 | MATMUL_INT8 = 0 | 
sampling: 
        repeat_last_n = 64, repeat_penalty = 1.100, frequency_penalty = 0.000, presence_penalty = 0.000
        top_k = 40, tfs_z = 1.000, top_p = 0.950, min_p = 0.050, typical_p = 1.000, temp = 0.800
        mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000
sampling order: 
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature 
generate: n_ctx = 512, n_batch = 512, n_predict = 128, n_keep = 0


 Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.
One day, the girl grew up into a woman. She was still very fond of having adventures, and she loved traveling around the world. But now the adventure could be anywhere; it wasn’t necessarily only about travelling abroad. And it certainly didn’t necessarily need to be just one single adventure either.
In 2019 I quit my job in a corporate environment. It was a major shift for me, because I was very much used to the security of having a fixed salary and permanent employment. So when it came to deciding what I wanted to do next,
llama_print_timings:        load time =    7180.94 ms
llama_print_timings:      sample time =      22.74 ms /   128 runs   (    0.18 ms per token,  5628.85 tokens per second)
llama_print_timings: prompt eval time =     768.74 ms /    33 tokens (   23.30 ms per token,    42.93 tokens per second)
llama_print_timings:        eval time =    7635.43 ms /   127 runs   (   60.12 ms per token,    16.63 tokens per second)
llama_print_timings:       total time =    8454.79 ms /   160 tokens
Log end
```