### PR TITLE
gemma : use more bits for the token_embd.weight tensor

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -10499,6 +10499,9 @@ static ggml_type get_k_quant_type(quantize_state_internal & qs, ggml_type new_ty
         else if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS) {
             new_type = GGML_TYPE_Q4_K;
         }
+        else if (arch == LLM_ARCH_GEMMA) {
+            new_type = GGML_TYPE_Q8_0;
+        }
     } else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ1_S) {
         if (name.find("attn_v.weight") != std::string::npos) {
             if (qs.model.hparams.n_gqa() >= 4 || qs.model.hparams.n_expert >= 4) new_type = GGML_TYPE_Q4_K;


### PR DESCRIPTION
Based on some anecdotal runs with Q4 quantizations, it seems that the quality of the generated responses is very sensitive to the type of the `token_embd.weight` tensor:

```
make -j && ./main -m models/gemma-2b/ggml-model-q4_k_m.gguf -p "I believe the meaning of life is" -n 64 -s 3 -ngl 99

...

 I believe the meaning of life is to do what you want, not what others tell you to do. Interehavior that looks like obstinacy is obstinacy in fact Interehavior that looks obstinacy is obstinacy Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Interehavior Intere
```

Quantizing this tensor to `Q8_0` seems like a safe bet. Thought, there might be better strategies