### PR TITLE
build(nix): Package gguf-py

### DIFF
--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -2,8 +2,13 @@
   perSystem =
     { config, lib, ... }:
     {
-      devShells = lib.concatMapAttrs (name: package: {
-        ${name} = package.passthru.shell;
-      }) config.packages;
+      devShells = lib.pipe (config.packages) [
+        (lib.concatMapAttrs
+        (name: package: {
+          ${name} = package.passthru.shell or null;
+        }))
+        (lib.filterAttrs (name: value: value != null))
+      ];
     };
 }
+

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -4,7 +4,6 @@
     {
       devShells = lib.concatMapAttrs (name: package: {
         ${name} = package.passthru.shell;
-        ${name + "-extra"} = package.passthru.shell-extra;
       }) config.packages;
     };
 }

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -2,12 +2,9 @@
   perSystem =
     { config, lib, ... }:
     {
-      devShells =
-        lib.concatMapAttrs
-          (name: package: {
-            ${name} = package.passthru.shell;
-            ${name + "-extra"} = package.passthru.shell-extra;
-          })
-          config.packages;
+      devShells = lib.concatMapAttrs (name: package: {
+        ${name} = package.passthru.shell;
+        ${name + "-extra"} = package.passthru.shell-extra;
+      }) config.packages;
     };
 }

--- a/.devops/nix/devshells.nix
+++ b/.devops/nix/devshells.nix
@@ -35,6 +35,10 @@
                       package
                       scripts
                     ];
+                    # Extra packages that *may* be used by some scripts
+                    packages = [
+                        pkgs.python3Packages.tiktoken
+                    ];
                     shellHook = ''
                       echo "Entering ${name} devShell"
                       addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib stdenv.cc.cc}/lib"

--- a/.devops/nix/nixpkgs-instances.nix
+++ b/.devops/nix/nixpkgs-instances.nix
@@ -26,16 +26,14 @@
           config.cudaSupport = true;
           config.allowUnfreePredicate =
             p:
-            builtins.all
-              (
-                license:
-                license.free
-                || builtins.elem license.shortName [
-                  "CUDA EULA"
-                  "cuDNN EULA"
-                ]
-              )
-              (p.meta.licenses or [ p.meta.license ]);
+            builtins.all (
+              license:
+              license.free
+              || builtins.elem license.shortName [
+                "CUDA EULA"
+                "cuDNN EULA"
+              ]
+            ) (p.meta.licenses or [ p.meta.license ]);
         };
         # Ensure dependencies use ROCm consistently
         pkgsRocm = import inputs.nixpkgs {

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -14,7 +14,11 @@ buildPythonPackage {
   version = llamaVersion;
   pyproject = true;
   nativeBuildInputs = [ poetry-core ];
-  propagatedBuildInputs = [ numpy tqdm sentencepiece ];
+  propagatedBuildInputs = [
+    numpy
+    tqdm
+    sentencepiece
+  ];
   src = lib.cleanSource ../../gguf-py;
   pythonImportsCheck = [
     "numpy"

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -8,7 +8,7 @@
   poetry-core,
   buildPythonPackage,
   pytestCheckHook,
-}@inputs:
+}:
 
 buildPythonPackage {
   pname = "gguf";

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -4,6 +4,7 @@
   numpy,
   poetry-core,
   buildPythonPackage,
+  pytestCheckHook,
 }@inputs:
 
 buildPythonPackage {
@@ -13,7 +14,12 @@ buildPythonPackage {
   nativeBuildInputs = [ poetry-core ];
   propagatedBuildInputs = [ numpy ];
   src = lib.cleanSource ../../gguf-py;
-  doCheck = false;
+  pythonImportsCheck = [
+    "numpy"
+    "gguf"
+  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  doCheck = true;
   meta = with lib; {
     description = "Python package for writing binary files in the GGUF format";
     license = licenses.mit;

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -2,6 +2,8 @@
   lib,
   llamaVersion,
   numpy,
+  tqdm,
+  sentencepiece,
   poetry-core,
   buildPythonPackage,
   pytestCheckHook,
@@ -12,7 +14,7 @@ buildPythonPackage {
   version = llamaVersion;
   pyproject = true;
   nativeBuildInputs = [ poetry-core ];
-  propagatedBuildInputs = [ numpy ];
+  propagatedBuildInputs = [ numpy tqdm sentencepiece ];
   src = lib.cleanSource ../../gguf-py;
   pythonImportsCheck = [
     "numpy"

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -1,15 +1,17 @@
 {
   lib,
   llamaVersion,
-  python3,
+  numpy,
+  poetry-core,
+  buildPythonPackage,
 }@inputs:
 
-python3.pkgs.buildPythonPackage rec {
+buildPythonPackage {
   pname = "gguf";
   version = llamaVersion;
   pyproject = true;
-  nativeBuildInputs = with python3.pkgs; [ poetry-core ];
-  propagatedBuildInputs = with python3.pkgs; [ numpy ];
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [ numpy ];
   src = lib.cleanSource ../../gguf-py;
   doCheck = false;
   meta = with lib; {

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  llamaVersion,
+  python3,
+}@inputs:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "gguf";
+  version = llamaVersion;
+  pyproject = true;
+  nativeBuildInputs = with python3.pkgs; [ poetry-core ];
+  propagatedBuildInputs = with python3.pkgs; [ numpy ];
+  src = lib.cleanSource ../../gguf-py;
+  doCheck = false;
+  meta = with lib; {
+    description = "Python package for writing binary files in the GGUF format";
+    license = licenses.mit;
+    maintainers = [ maintainers.ditsuke ];
+  };
+}

--- a/.devops/nix/package-gguf-py.nix
+++ b/.devops/nix/package-gguf-py.nix
@@ -4,6 +4,7 @@
   numpy,
   tqdm,
   sentencepiece,
+  pyyaml,
   poetry-core,
   buildPythonPackage,
   pytestCheckHook,
@@ -18,6 +19,7 @@ buildPythonPackage {
     numpy
     tqdm
     sentencepiece
+    pyyaml
   ];
   src = lib.cleanSource ../../gguf-py;
   pythonImportsCheck = [

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -215,25 +215,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cp $src/include/llama.h $out/include/
   '';
 
-  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
-  passthru = {
-    inherit
-      useBlas
-      useCuda
-      useMetalKit
-      useMpi
-      useRocm
-      useVulkan
-      ;
-
-    shell = mkShell {
-      name = "shell-${finalAttrs.finalPackage.name}";
-      description = "contains numpy and sentencepiece";
-      nativeBuildInputs = [ cmake ];
-      inputsFrom = [ finalAttrs.finalPackage ];
-    };
-  };
-
   meta = {
     # Configurations we don't want even the CI to evaluate. Results in the
     # "unsupported platform" messages. This is mostly a no-op, because

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -70,6 +70,24 @@ let
   ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
+  
+  gguf-py = python3.pkgs.buildPythonPackage rec {
+    pname = "gguf";
+    version = "0.0.0";
+    pyproject = true;
+    nativeBuildInputs = with python3.pkgs; [ poetry-core ];
+    # buildInputs = [
+    #   python3.pkgs.poetry-core
+    # ];
+    propagatedBuildInputs = with python3.pkgs; [ numpy ];
+    src = lib.cleanSource ../../gguf-py;
+    doCheck = false;
+    meta = with lib; {
+      description = "Python package for writing binary files in the GGU format";
+      license = licenses.mit;
+      maintainers = [ maintainers.philiptaron ];
+    };
+  };
 
   # TODO: package the Python in this repository in a Nix-like way.
   # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo
@@ -81,6 +99,7 @@ let
   llama-python = python3.withPackages (ps: [
     ps.numpy
     ps.sentencepiece
+    gguf-py
   ]);
 
   # TODO(Green-Sky): find a better way to opt-into the heavy ml python runtime

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -73,7 +73,6 @@ let
   ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
-  mapToPythonPackages = ps: packages: map (package: ps.${package}) packages;
 
   xcrunHost = runCommand "xcrunHost" { } ''
     mkdir -p $out/bin
@@ -121,14 +120,13 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     filter =
       name: type:
       let
-        noneOf = builtins.all (x: !x);
-        baseName = baseNameOf name;
+        any = builtins.any (x: x);
+        baseName = builtins.baseNameOf name;
       in
-      noneOf [
-        (lib.hasSuffix ".nix" name) # Ignore *.nix files when computing outPaths
-        (lib.hasSuffix ".md" name) # Ignore *.md changes whe computing outPaths
-        (lib.hasPrefix "." baseName) # Skip hidden files and directories
-        (baseName == "flake.lock")
+      any [
+        (lib.hasSuffix ".py" name)
+        (baseName == "README.md")
+        (baseName == "pyproject.toml")
       ];
     src = lib.cleanSource ../../.;
   };

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -30,7 +30,8 @@
     && blas.meta.available,
   useCuda ? config.cudaSupport,
   useMetalKit ? stdenv.isAarch64 && stdenv.isDarwin,
-  useMpi ? false, # Increases the runtime closure size by ~700M
+  # Increases the runtime closure size by ~700M
+  useMpi ? false,
   useRocm ? config.rocmSupport,
   enableCurl ? true,
   useVulkan ? false,
@@ -41,6 +42,7 @@
   effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic,
   precompileMetalShaders ? false,
+  gguf-py,
 }@inputs:
 
 let
@@ -70,24 +72,6 @@ let
   ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
-  
-  gguf-py = python3.pkgs.buildPythonPackage rec {
-    pname = "gguf";
-    version = "0.0.0";
-    pyproject = true;
-    nativeBuildInputs = with python3.pkgs; [ poetry-core ];
-    # buildInputs = [
-    #   python3.pkgs.poetry-core
-    # ];
-    propagatedBuildInputs = with python3.pkgs; [ numpy ];
-    src = lib.cleanSource ../../gguf-py;
-    doCheck = false;
-    meta = with lib; {
-      description = "Python package for writing binary files in the GGU format";
-      license = licenses.mit;
-      maintainers = [ maintainers.philiptaron ];
-    };
-  };
 
   # TODO: package the Python in this repository in a Nix-like way.
   # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -72,6 +72,7 @@ let
   ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
+  mapToPythonPackages = ps: packages: map (package: ps.${package}) packages;
 
   # TODO: package the Python in this repository in a Nix-like way.
   # It'd be nice to migrate to buildPythonPackage, as well as ensure this repo
@@ -266,7 +267,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     shell = mkShell {
       name = "shell-${finalAttrs.finalPackage.name}";
       description = "contains numpy and sentencepiece";
-      buildInputs = [ llama-python ];
+      buildInputs = [
+        python3.withPackages
+        (ps: mapToPythonPackages ps llama-python-base-deps)
+      ];
       inputsFrom = [ finalAttrs.finalPackage ];
       shellHook = ''
         addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib effectiveStdenv.cc.cc}/lib"
@@ -276,7 +280,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     shell-extra = mkShell {
       name = "shell-extra-${finalAttrs.finalPackage.name}";
       description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
-      buildInputs = [ llama-python-extra ];
+      buildInputs = [
+        python3.withPackages
+        (ps: mapToPythonPackages ps llama-python-full-deps)
+      ];
       inputsFrom = [ finalAttrs.finalPackage ];
     };
   };

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -230,9 +230,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     shell = mkShell {
       name = "shell-${finalAttrs.finalPackage.name}";
       description = "contains numpy and sentencepiece";
-      buildInputs = [
+      nativeBuildInputs = [
         cmake
-        gcc
       ];
       inputsFrom = [ finalAttrs.finalPackage ];
     };

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -20,12 +20,14 @@
   vulkan-loader,
   curl,
   shaderc,
-  useBlas ? builtins.all (x: !x) [
-    useCuda
-    useMetalKit
-    useRocm
-    useVulkan
-  ] && blas.meta.available,
+  useBlas ?
+    builtins.all (x: !x) [
+      useCuda
+      useMetalKit
+      useRocm
+      useVulkan
+    ]
+    && blas.meta.available,
   useCuda ? config.cudaSupport,
   useMetalKit ? stdenv.isAarch64 && stdenv.isDarwin,
   useMpi ? false, # Increases the runtime closure size by ~700M
@@ -38,7 +40,7 @@
   # otherwise we get libstdc++ errors downstream.
   effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic,
-  precompileMetalShaders ? false
+  precompileMetalShaders ? false,
 }@inputs:
 
 let
@@ -63,9 +65,9 @@ let
   pnameSuffix =
     strings.optionalString (suffices != [ ])
       "-${strings.concatMapStringsSep "-" strings.toLower suffices}";
-  descriptionSuffix =
-    strings.optionalString (suffices != [ ])
-      ", accelerated with ${strings.concatStringsSep ", " suffices}";
+  descriptionSuffix = strings.optionalString (
+    suffices != [ ]
+  ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
 
   executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
 
@@ -76,41 +78,37 @@ let
   #
   # TODO: Package up each Python script or service appropriately, by making
   # them into "entrypoints"
-  llama-python = python3.withPackages (
-    ps: [
-      ps.numpy
-      ps.sentencepiece
-    ]
-  );
+  llama-python = python3.withPackages (ps: [
+    ps.numpy
+    ps.sentencepiece
+  ]);
 
   # TODO(Green-Sky): find a better way to opt-into the heavy ml python runtime
-  llama-python-extra = python3.withPackages (
-    ps: [
-      ps.numpy
-      ps.sentencepiece
-      ps.tiktoken
-      ps.torchWithoutCuda
-      ps.transformers
+  llama-python-extra = python3.withPackages (ps: [
+    ps.numpy
+    ps.sentencepiece
+    ps.tiktoken
+    ps.torchWithoutCuda
+    ps.transformers
 
-      # server bench
-      ps.matplotlib
+    # server bench
+    ps.matplotlib
 
-      # server tests
-      ps.openai
-      ps.behave
-      ps.prometheus-client
+    # server tests
+    ps.openai
+    ps.behave
+    ps.prometheus-client
 
-      # for examples/pydantic-models-to-grammar-examples.py
-      ps.docstring-parser
-      ps.pydantic
+    # for examples/pydantic-models-to-grammar-examples.py
+    ps.docstring-parser
+    ps.pydantic
 
-      # for scripts/compare-llama-bench.py
-      ps.gitpython
-      ps.tabulate
-    ]
-  );
+    # for scripts/compare-llama-bench.py
+    ps.gitpython
+    ps.tabulate
+  ]);
 
-  xcrunHost = runCommand "xcrunHost" {} ''
+  xcrunHost = runCommand "xcrunHost" { } ''
     mkdir -p $out/bin
     ln -s /usr/bin/xcrun $out/bin
   '';
@@ -145,178 +143,174 @@ let
   ];
 in
 
-effectiveStdenv.mkDerivation (
-  finalAttrs: {
-    pname = "llama-cpp${pnameSuffix}";
-    version = llamaVersion;
+effectiveStdenv.mkDerivation (finalAttrs: {
+  pname = "llama-cpp${pnameSuffix}";
+  version = llamaVersion;
 
-    # Note: none of the files discarded here are visible in the sandbox or
-    # affect the output hash. This also means they can be modified without
-    # triggering a rebuild.
-    src = lib.cleanSourceWith {
-      filter =
-        name: type:
-        let
-          noneOf = builtins.all (x: !x);
-          baseName = baseNameOf name;
-        in
-        noneOf [
-          (lib.hasSuffix ".nix" name) # Ignore *.nix files when computing outPaths
-          (lib.hasSuffix ".md" name) # Ignore *.md changes whe computing outPaths
-          (lib.hasPrefix "." baseName) # Skip hidden files and directories
-          (baseName == "flake.lock")
-        ];
-      src = lib.cleanSource ../../.;
-    };
-
-    postPatch = ''
-      substituteInPlace ./ggml/src/ggml-metal.m \
-        --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
-      substituteInPlace ./ggml/src/ggml-metal.m \
-        --replace '[bundle pathForResource:@"default" ofType:@"metallib"];' "@\"$out/bin/default.metallib\";"
-    '';
-
-    # With PR#6015 https://github.com/ggerganov/llama.cpp/pull/6015,
-    # `default.metallib` may be compiled with Metal compiler from XCode
-    # and we need to escape sandbox on MacOS to access Metal compiler.
-    # `xcrun` is used find the path of the Metal compiler, which is varible
-    # and not on $PATH
-    # see https://github.com/ggerganov/llama.cpp/pull/6118 for discussion
-    __noChroot = effectiveStdenv.isDarwin && useMetalKit && precompileMetalShaders;
-
-    nativeBuildInputs =
-      [
-        cmake
-        ninja
-        pkg-config
-        git
-      ]
-      ++ optionals useCuda [
-        cudaPackages.cuda_nvcc
-        autoAddDriverRunpath
-      ]
-      ++ optionals (effectiveStdenv.hostPlatform.isGnu && enableStatic) [
-        glibc.static
-      ] ++ optionals (effectiveStdenv.isDarwin && useMetalKit && precompileMetalShaders) [
-        xcrunHost
+  # Note: none of the files discarded here are visible in the sandbox or
+  # affect the output hash. This also means they can be modified without
+  # triggering a rebuild.
+  src = lib.cleanSourceWith {
+    filter =
+      name: type:
+      let
+        noneOf = builtins.all (x: !x);
+        baseName = baseNameOf name;
+      in
+      noneOf [
+        (lib.hasSuffix ".nix" name) # Ignore *.nix files when computing outPaths
+        (lib.hasSuffix ".md" name) # Ignore *.md changes whe computing outPaths
+        (lib.hasPrefix "." baseName) # Skip hidden files and directories
+        (baseName == "flake.lock")
       ];
+    src = lib.cleanSource ../../.;
+  };
 
-    buildInputs =
-      optionals effectiveStdenv.isDarwin darwinBuildInputs
-      ++ optionals useCuda cudaBuildInputs
-      ++ optionals useMpi [ mpi ]
-      ++ optionals useRocm rocmBuildInputs
-      ++ optionals useBlas [ blas ]
-      ++ optionals useVulkan vulkanBuildInputs
-      ++ optionals enableCurl [ curl ];
+  postPatch = ''
+    substituteInPlace ./ggml/src/ggml-metal.m \
+      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+    substituteInPlace ./ggml/src/ggml-metal.m \
+      --replace '[bundle pathForResource:@"default" ofType:@"metallib"];' "@\"$out/bin/default.metallib\";"
+  '';
 
-    cmakeFlags =
-      [
-        (cmakeBool "LLAMA_BUILD_SERVER" true)
-        (cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
-        (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
-        (cmakeBool "LLAMA_CURL" enableCurl)
-        (cmakeBool "GGML_NATIVE" false)
-        (cmakeBool "GGML_BLAS" useBlas)
-        (cmakeBool "GGML_CUDA" useCuda)
-        (cmakeBool "GGML_HIPBLAS" useRocm)
-        (cmakeBool "GGML_METAL" useMetalKit)
-        (cmakeBool "GGML_VULKAN" useVulkan)
-        (cmakeBool "GGML_STATIC" enableStatic)
-      ]
-      ++ optionals useCuda [
-        (
-          with cudaPackages.flags;
-          cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (
-            builtins.concatStringsSep ";" (map dropDot cudaCapabilities)
-          )
+  # With PR#6015 https://github.com/ggerganov/llama.cpp/pull/6015,
+  # `default.metallib` may be compiled with Metal compiler from XCode
+  # and we need to escape sandbox on MacOS to access Metal compiler.
+  # `xcrun` is used find the path of the Metal compiler, which is varible
+  # and not on $PATH
+  # see https://github.com/ggerganov/llama.cpp/pull/6118 for discussion
+  __noChroot = effectiveStdenv.isDarwin && useMetalKit && precompileMetalShaders;
+
+  nativeBuildInputs =
+    [
+      cmake
+      ninja
+      pkg-config
+      git
+    ]
+    ++ optionals useCuda [
+      cudaPackages.cuda_nvcc
+
+      autoAddDriverRunpath
+    ]
+    ++ optionals (effectiveStdenv.hostPlatform.isGnu && enableStatic) [ glibc.static ]
+    ++ optionals (effectiveStdenv.isDarwin && useMetalKit && precompileMetalShaders) [ xcrunHost ];
+
+  buildInputs =
+    optionals effectiveStdenv.isDarwin darwinBuildInputs
+    ++ optionals useCuda cudaBuildInputs
+    ++ optionals useMpi [ mpi ]
+    ++ optionals useRocm rocmBuildInputs
+    ++ optionals useBlas [ blas ]
+    ++ optionals useVulkan vulkanBuildInputs
+    ++ optionals enableCurl [ curl ];
+
+  cmakeFlags =
+    [
+      (cmakeBool "LLAMA_BUILD_SERVER" true)
+      (cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
+      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+      (cmakeBool "LLAMA_CURL" enableCurl)
+      (cmakeBool "GGML_NATIVE" false)
+      (cmakeBool "GGML_BLAS" useBlas)
+      (cmakeBool "GGML_CUDA" useCuda)
+      (cmakeBool "GGML_HIPBLAS" useRocm)
+      (cmakeBool "GGML_METAL" useMetalKit)
+      (cmakeBool "GGML_VULKAN" useVulkan)
+      (cmakeBool "GGML_STATIC" enableStatic)
+    ]
+    ++ optionals useCuda [
+      (
+        with cudaPackages.flags;
+        cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (
+          builtins.concatStringsSep ";" (map dropDot cudaCapabilities)
         )
-      ]
-      ++ optionals useRocm [
-        (cmakeFeature "CMAKE_HIP_COMPILER" "${rocmPackages.llvm.clang}/bin/clang")
-        (cmakeFeature "CMAKE_HIP_ARCHITECTURES" (builtins.concatStringsSep ";" rocmPackages.clr.gpuTargets))
-      ]
-      ++ optionals useMetalKit [
-        (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1")
-        (cmakeBool "GGML_METAL_EMBED_LIBRARY" (!precompileMetalShaders))
-      ];
+      )
+    ]
+    ++ optionals useRocm [
+      (cmakeFeature "CMAKE_HIP_COMPILER" "${rocmPackages.llvm.clang}/bin/clang")
+      (cmakeFeature "CMAKE_HIP_ARCHITECTURES" (builtins.concatStringsSep ";" rocmPackages.clr.gpuTargets))
+    ]
+    ++ optionals useMetalKit [
+      (lib.cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1")
+      (cmakeBool "GGML_METAL_EMBED_LIBRARY" (!precompileMetalShaders))
+    ];
 
-    # Environment variables needed for ROCm
-    env = optionals useRocm {
-      ROCM_PATH = "${rocmPackages.clr}";
-      HIP_DEVICE_LIB_PATH = "${rocmPackages.rocm-device-libs}/amdgcn/bitcode";
+  # Environment variables needed for ROCm
+  env = optionals useRocm {
+    ROCM_PATH = "${rocmPackages.clr}";
+    HIP_DEVICE_LIB_PATH = "${rocmPackages.rocm-device-libs}/amdgcn/bitcode";
+  };
+
+  # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
+  # if they haven't been added yet.
+  postInstall = ''
+    mkdir -p $out/include
+    cp $src/include/llama.h $out/include/
+  '';
+
+  # Define the shells here, but don't add in the inputsFrom to avoid recursion.
+  passthru = {
+    inherit
+      useBlas
+      useCuda
+      useMetalKit
+      useMpi
+      useRocm
+      useVulkan
+      ;
+
+    shell = mkShell {
+      name = "shell-${finalAttrs.finalPackage.name}";
+      description = "contains numpy and sentencepiece";
+      buildInputs = [ llama-python ];
+      inputsFrom = [ finalAttrs.finalPackage ];
+      shellHook = ''
+        addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib effectiveStdenv.cc.cc}/lib"
+      '';
     };
 
-    # TODO(SomeoneSerge): It's better to add proper install targets at the CMake level,
-    # if they haven't been added yet.
-    postInstall = ''
-      mkdir -p $out/include
-      cp $src/include/llama.h $out/include/
-    '';
-
-    # Define the shells here, but don't add in the inputsFrom to avoid recursion.
-    passthru = {
-      inherit
-        useBlas
-        useCuda
-        useMetalKit
-        useMpi
-        useRocm
-        useVulkan
-        ;
-
-      shell = mkShell {
-        name = "shell-${finalAttrs.finalPackage.name}";
-        description = "contains numpy and sentencepiece";
-        buildInputs = [ llama-python ];
-        inputsFrom = [ finalAttrs.finalPackage ];
-        shellHook = ''
-          addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib effectiveStdenv.cc.cc}/lib"
-        '';
-      };
-
-      shell-extra = mkShell {
-        name = "shell-extra-${finalAttrs.finalPackage.name}";
-        description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
-        buildInputs = [ llama-python-extra ];
-        inputsFrom = [ finalAttrs.finalPackage ];
-      };
+    shell-extra = mkShell {
+      name = "shell-extra-${finalAttrs.finalPackage.name}";
+      description = "contains numpy, sentencepiece, torchWithoutCuda, and transformers";
+      buildInputs = [ llama-python-extra ];
+      inputsFrom = [ finalAttrs.finalPackage ];
     };
+  };
 
-    meta = {
-      # Configurations we don't want even the CI to evaluate. Results in the
-      # "unsupported platform" messages. This is mostly a no-op, because
-      # cudaPackages would've refused to evaluate anyway.
-      badPlatforms = optionals useCuda lib.platforms.darwin;
+  meta = {
+    # Configurations we don't want even the CI to evaluate. Results in the
+    # "unsupported platform" messages. This is mostly a no-op, because
+    # cudaPackages would've refused to evaluate anyway.
+    badPlatforms = optionals useCuda lib.platforms.darwin;
 
-      # Configurations that are known to result in build failures. Can be
-      # overridden by importing Nixpkgs with `allowBroken = true`.
-      broken = (useMetalKit && !effectiveStdenv.isDarwin);
+    # Configurations that are known to result in build failures. Can be
+    # overridden by importing Nixpkgs with `allowBroken = true`.
+    broken = (useMetalKit && !effectiveStdenv.isDarwin);
 
-      description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
-      homepage = "https://github.com/ggerganov/llama.cpp/";
-      license = lib.licenses.mit;
+    description = "Inference of LLaMA model in pure C/C++${descriptionSuffix}";
+    homepage = "https://github.com/ggerganov/llama.cpp/";
+    license = lib.licenses.mit;
 
-      # Accommodates `nix run` and `lib.getExe`
-      mainProgram = "llama-cli";
+    # Accommodates `nix run` and `lib.getExe`
+    mainProgram = "llama-cli";
 
-      # These people might respond, on the best effort basis, if you ping them
-      # in case of Nix-specific regressions or for reviewing Nix-specific PRs.
-      # Consider adding yourself to this list if you want to ensure this flake
-      # stays maintained and you're willing to invest your time. Do not add
-      # other people without their consent. Consider removing people after
-      # they've been unreachable for long periods of time.
+    # These people might respond, on the best effort basis, if you ping them
+    # in case of Nix-specific regressions or for reviewing Nix-specific PRs.
+    # Consider adding yourself to this list if you want to ensure this flake
+    # stays maintained and you're willing to invest your time. Do not add
+    # other people without their consent. Consider removing people after
+    # they've been unreachable for long periods of time.
 
-      # Note that lib.maintainers is defined in Nixpkgs, but you may just add
-      # an attrset following the same format as in
-      # https://github.com/NixOS/nixpkgs/blob/f36a80e54da29775c78d7eff0e628c2b4e34d1d7/maintainers/maintainer-list.nix
-      maintainers = with lib.maintainers; [
-        philiptaron
-        SomeoneSerge
-      ];
+    # Note that lib.maintainers is defined in Nixpkgs, but you may just add
+    # an attrset following the same format as in
+    # https://github.com/NixOS/nixpkgs/blob/f36a80e54da29775c78d7eff0e628c2b4e34d1d7/maintainers/maintainer-list.nix
+    maintainers = with lib.maintainers; [
+      philiptaron
+      SomeoneSerge
+    ];
 
-      # Extend `badPlatforms` instead
-      platforms = lib.platforms.all;
-    };
-  }
-)
+    # Extend `badPlatforms` instead
+    platforms = lib.platforms.all;
+  };
+})

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -120,13 +120,14 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     filter =
       name: type:
       let
-        any = builtins.any (x: x);
-        baseName = builtins.baseNameOf name;
+        noneOf = builtins.all (x: !x);
+        baseName = baseNameOf name;
       in
-      any [
-        (lib.hasSuffix ".py" name)
-        (baseName == "README.md")
-        (baseName == "pyproject.toml")
+      noneOf [
+        (lib.hasSuffix ".nix" name) # Ignore *.nix files when computing outPaths
+        (lib.hasSuffix ".md" name) # Ignore *.md changes whe computing outPaths
+        (lib.hasPrefix "." baseName) # Skip hidden files and directories
+        (baseName == "flake.lock")
       ];
     src = lib.cleanSource ../../.;
   };

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -3,14 +3,11 @@
   glibc,
   config,
   stdenv,
-  mkShell,
   runCommand,
   cmake,
-  gcc,
   ninja,
   pkg-config,
   git,
-  python3,
   mpi,
   blas,
   cudaPackages,
@@ -43,8 +40,7 @@
   effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic,
   precompileMetalShaders ? false,
-  gguf-py,
-}@inputs:
+}:
 
 let
   inherit (lib)
@@ -52,7 +48,6 @@ let
     cmakeFeature
     optionals
     strings
-    versionOlder
     ;
 
   stdenv = throw "Use effectiveStdenv instead";
@@ -71,8 +66,6 @@ let
   descriptionSuffix = strings.optionalString (
     suffices != [ ]
   ) ", accelerated with ${strings.concatStringsSep ", " suffices}";
-
-  executableSuffix = effectiveStdenv.hostPlatform.extensions.executable;
 
   xcrunHost = runCommand "xcrunHost" { } ''
     mkdir -p $out/bin

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -230,9 +230,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     shell = mkShell {
       name = "shell-${finalAttrs.finalPackage.name}";
       description = "contains numpy and sentencepiece";
-      nativeBuildInputs = [
-        cmake
-      ];
+      nativeBuildInputs = [ cmake ];
       inputsFrom = [ finalAttrs.finalPackage ];
     };
   };

--- a/.devops/nix/python-scripts.nix
+++ b/.devops/nix/python-scripts.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  poetry-core,
+  breakpointHook,
+  mkShell,
+  python3Packages,
+  gguf-py,
+}@inputs:
+
+let
+  llama-python-deps = with python3Packages; [
+    numpy
+    sentencepiece
+    transformers
+    protobuf
+    torchWithoutCuda
+    gguf-py
+  ];
+in
+
+buildPythonPackage ({
+  pname = "llama-scripts";
+  src = ../../.;
+  version = "0.0.0";
+  pyproject = true;
+  nativeBuildInputs = [ poetry-core ];
+  projectDir = ../../.;
+  propagatedBuildInputs = llama-python-deps;
+
+  passthru = {
+    shell = mkShell {
+      name = "shell-python-scripts";
+      description = "contains numpy and sentencepiece";
+      buildInputs = llama-python-deps;
+      shellHook = ''
+        addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib stdenv.cc.cc}/lib"
+      '';
+    };
+  };
+})

--- a/.devops/nix/python-scripts.nix
+++ b/.devops/nix/python-scripts.nix
@@ -17,6 +17,7 @@ let
     protobuf
     torchWithoutCuda
     gguf-py
+    tqdm
   ];
 in
 

--- a/.devops/nix/python-scripts.nix
+++ b/.devops/nix/python-scripts.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   poetry-core,
-  breakpointHook,
   mkShell,
   python3Packages,
   gguf-py,
@@ -18,6 +17,25 @@ let
     torchWithoutCuda
     gguf-py
     tqdm
+
+    # for scripts/compare-llama-bench.py
+    gitpython
+    tabulate
+
+    # for examples/pydantic-models-to-grammar-examples.py
+    docstring-parser
+    pydantic
+
+  ];
+
+  llama-python-test-deps = with python3Packages; [
+    # Server bench
+    matplotlib
+
+    # server tests
+    openai
+    behave
+    prometheus-client
   ];
 in
 
@@ -43,16 +61,6 @@ buildPythonPackage ({
     src = lib.cleanSource ../../.;
   };
   nativeBuildInputs = [ poetry-core ];
+  nativeCheckInputs = llama-python-test-deps;
   dependencies = llama-python-deps;
-
-  passthru = {
-    shell = mkShell {
-      name = "shell-python-scripts";
-      description = "contains numpy and sentencepiece";
-      buildInputs = llama-python-deps;
-      shellHook = ''
-        addToSearchPath "LD_LIBRARY_PATH" "${lib.getLib stdenv.cc.cc}/lib"
-      '';
-    };
-  };
 })

--- a/.devops/nix/python-scripts.nix
+++ b/.devops/nix/python-scripts.nix
@@ -23,12 +23,27 @@ in
 
 buildPythonPackage ({
   pname = "llama-scripts";
-  src = ../../.;
   version = "0.0.0";
   pyproject = true;
+
+  # NOTE: The files filtered out here are not visible in the build sandbox, neither
+  # do they affect the output hash. They can be modified without triggering a rebuild.
+  src = lib.cleanSourceWith {
+    filter =
+      name: type:
+      let
+        any = builtins.any (x: x);
+        baseName = builtins.baseNameOf name;
+      in
+      any [
+        (lib.hasSuffix ".py" name)
+        (baseName == "README.md")
+        (baseName == "pyproject.toml")
+      ];
+    src = lib.cleanSource ../../.;
+  };
   nativeBuildInputs = [ poetry-core ];
-  projectDir = ../../.;
-  propagatedBuildInputs = llama-python-deps;
+  dependencies = llama-python-deps;
 
   passthru = {
     shell = mkShell {

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -11,6 +11,7 @@ let
   numpy = pythonPackages.numpy;
   tqdm = pythonPackages.tqdm;
   sentencepiece = pythonPackages.sentencepiece;
+  pyyaml = pythonPackages.pyyaml;
   poetry-core = pythonPackages.poetry-core;
   pytestCheckHook = pythonPackages.pytestCheckHook;
 in
@@ -28,6 +29,7 @@ lib.makeScope newScope (self: {
       tqdm
       sentencepiece
       poetry-core
+      pyyaml
       pytestCheckHook
       ;
   };

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -28,6 +28,7 @@ lib.makeScope newScope (self: {
       pytestCheckHook
       ;
   };
+  python-scripts = self.callPackage ./python-scripts.nix { inherit buildPythonPackage poetry-core; };
   llama-cpp = self.callPackage ./package.nix { };
   docker = self.callPackage ./docker.nix { };
   docker-min = self.callPackage ./docker.nix { interactive = false; };

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -21,7 +21,6 @@ in
 
 lib.makeScope newScope (self: {
   inherit llamaVersion;
-  pp = python3.pkgs;
   gguf-py = self.callPackage ./package-gguf-py.nix {
     inherit
       buildPythonPackage

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -9,6 +9,8 @@ let
   pythonPackages = python3.pkgs;
   buildPythonPackage = pythonPackages.buildPythonPackage;
   numpy = pythonPackages.numpy;
+  tqdm = pythonPackages.tqdm;
+  sentencepiece = pythonPackages.sentencepiece;
   poetry-core = pythonPackages.poetry-core;
   pytestCheckHook = pythonPackages.pytestCheckHook;
 in
@@ -24,6 +26,8 @@ lib.makeScope newScope (self: {
     inherit
       buildPythonPackage
       numpy
+      tqdm
+      sentencepiece
       poetry-core
       pytestCheckHook
       ;

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -10,6 +10,7 @@ let
   buildPythonPackage = pythonPackages.buildPythonPackage;
   numpy = pythonPackages.numpy;
   poetry-core = pythonPackages.poetry-core;
+  pytestCheckHook = pythonPackages.pytestCheckHook;
 in
 
 # We're using `makeScope` instead of just writing out an attrset
@@ -19,7 +20,14 @@ in
 lib.makeScope newScope (self: {
   inherit llamaVersion;
   pp = python3.pkgs;
-  gguf-py = self.callPackage ./package-gguf-py.nix { inherit buildPythonPackage numpy poetry-core; };
+  gguf-py = self.callPackage ./package-gguf-py.nix {
+    inherit
+      buildPythonPackage
+      numpy
+      poetry-core
+      pytestCheckHook
+      ;
+  };
   llama-cpp = self.callPackage ./package.nix { };
   docker = self.callPackage ./docker.nix { };
   docker-min = self.callPackage ./docker.nix { interactive = false; };

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -1,8 +1,16 @@
 {
   lib,
   newScope,
+  python3,
   llamaVersion ? "0.0.0",
 }:
+
+let
+  pythonPackages = python3.pkgs;
+  buildPythonPackage = pythonPackages.buildPythonPackage;
+  numpy = pythonPackages.numpy;
+  poetry-core = pythonPackages.poetry-core;
+in
 
 # We're using `makeScope` instead of just writing out an attrset
 # because it allows users to apply overlays later using `overrideScope'`.
@@ -10,7 +18,8 @@
 
 lib.makeScope newScope (self: {
   inherit llamaVersion;
-  gguf-py = self.callPackage ./package-gguf-py.nix { };
+  pp = python3.pkgs;
+  gguf-py = self.callPackage ./package-gguf-py.nix { inherit buildPythonPackage numpy poetry-core; };
   llama-cpp = self.callPackage ./package.nix { };
   docker = self.callPackage ./docker.nix { };
   docker-min = self.callPackage ./docker.nix { interactive = false; };

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -8,12 +8,10 @@
 # because it allows users to apply overlays later using `overrideScope'`.
 # Cf. https://noogle.dev/f/lib/makeScope
 
-lib.makeScope newScope (
-  self: {
-    inherit llamaVersion;
-    llama-cpp = self.callPackage ./package.nix { };
-    docker = self.callPackage ./docker.nix { };
-    docker-min = self.callPackage ./docker.nix { interactive = false; };
-    sif = self.callPackage ./sif.nix { };
-  }
-)
+lib.makeScope newScope (self: {
+  inherit llamaVersion;
+  llama-cpp = self.callPackage ./package.nix { };
+  docker = self.callPackage ./docker.nix { };
+  docker-min = self.callPackage ./docker.nix { interactive = false; };
+  sif = self.callPackage ./sif.nix { };
+})

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -10,6 +10,7 @@
 
 lib.makeScope newScope (self: {
   inherit llamaVersion;
+  gguf-py = self.callPackage ./package-gguf-py.nix { };
   llama-cpp = self.callPackage ./package.nix { };
   docker = self.callPackage ./docker.nix { };
   docker-min = self.callPackage ./docker.nix { interactive = false; };

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
                 default = config.legacyPackages.llamaPackages.llama-cpp;
                 vulkan = config.packages.default.override { useVulkan = true; };
                 windows = config.legacyPackages.llamaPackagesWindows.llama-cpp;
+                python-scripts = config.legacyPackages.llamaPackages.python-scripts;
               }
               // lib.optionalAttrs pkgs.stdenv.isLinux {
                 cuda = config.legacyPackages.llamaPackagesCuda.llama-cpp;

--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,9 @@
             # the same path you would with an overlay.
             legacyPackages = {
               llamaPackages = pkgs.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
-              llamaPackagesWindows = pkgs.pkgsCross.mingwW64.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
+              llamaPackagesWindows = pkgs.pkgsCross.mingwW64.callPackage .devops/nix/scope.nix {
+                inherit llamaVersion;
+              };
               llamaPackagesCuda = pkgsCuda.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
               llamaPackagesRocm = pkgsRocm.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
             };

--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -23,6 +23,7 @@ python = ">=3.8"
 numpy = ">=1.17"
 tqdm = ">=4.27"
 pyyaml = ">=5.1"
+sentencepiece = ">=0.1.98,<=0.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9"
 numpy = "^1.25.0"
-sentencepiece = ">=0.1.98,<0.2.0"
+sentencepiece = ">=0.1.98,<=0.2.0"
 transformers = ">=4.35.2,<5.0.0"
 protobuf = ">=4.21.0,<5.0.0"
 gguf = { path = "./gguf-py" }


### PR DESCRIPTION
## What and why
Currently, the Nix build does not ship with the `gguf-py` lib, rendering scripts like `convert-hf-to-gguf` unusable.

This is an attempt to package `gguf-py` with `buildPythonPackage`. Very barebones at the moment and needs some work to exclude the Nix built `gguf` from the devShells, and some thought into other things like packaging the heavier python dependencies (we don't want them to be included by default, but we need a way to opt-in).


CC: @SomeoneSerge