### PR TITLE
P-Step Truncation Sampling

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -360,6 +360,12 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             sparams.min_p = std::stof(argv[i]);
+        } else if (arg == "--p-step") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            sparams.p_step = std::stof(argv[i]);
         } else if (arg == "--temp") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -970,6 +976,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --top-k N             top-k sampling (default: %d, 0 = disabled)\n", sparams.top_k);
     printf("  --top-p N             top-p sampling (default: %.1f, 1.0 = disabled)\n", (double)sparams.top_p);
     printf("  --min-p N             min-p sampling (default: %.1f, 0.0 = disabled)\n", (double)sparams.min_p);
+    printf("  --p-step N            p-step sampling (default: %.1f, 0.0 = disabled)\n", (double)sparams.p_step);
     printf("  --tfs N               tail free sampling, parameter z (default: %.1f, 1.0 = disabled)\n", (double)sparams.tfs_z);
     printf("  --typical N           locally typical sampling, parameter p (default: %.1f, 1.0 = disabled)\n", (double)sparams.typical_p);
     printf("  --repeat-last-n N     last n tokens to consider for penalize (default: %d, 0 = disabled, -1 = ctx_size)\n", sparams.penalty_last_n);
@@ -1140,6 +1147,7 @@ std::vector<llama_sampler_type> sampler_types_from_names(const std::vector<std::
         {"top_p",       llama_sampler_type::TOP_P},
         {"typical_p",   llama_sampler_type::TYPICAL_P},
         {"min_p",       llama_sampler_type::MIN_P},
+        {"p_step",      llama_sampler_type::P_STEP},
         {"tfs_z",       llama_sampler_type::TFS_Z},
         {"temperature", llama_sampler_type::TEMPERATURE}
     };
@@ -1153,6 +1161,7 @@ std::vector<llama_sampler_type> sampler_types_from_names(const std::vector<std::
         {"typical-p",   llama_sampler_type::TYPICAL_P},
         {"typical",     llama_sampler_type::TYPICAL_P},
         {"min-p",       llama_sampler_type::MIN_P},
+        {"p-step",      llama_sampler_type::P_STEP},
         {"tfs-z",       llama_sampler_type::TFS_Z},
         {"tfs",         llama_sampler_type::TFS_Z},
         {"temp",        llama_sampler_type::TEMPERATURE}
@@ -1188,6 +1197,7 @@ std::vector<llama_sampler_type> sampler_types_from_chars(const std::string & nam
         {'p', llama_sampler_type::TOP_P},
         {'y', llama_sampler_type::TYPICAL_P},
         {'m', llama_sampler_type::MIN_P},
+        {'s', llama_sampler_type::P_STEP},
         {'f', llama_sampler_type::TFS_Z},
         {'t', llama_sampler_type::TEMPERATURE}
     };
@@ -1210,6 +1220,7 @@ std::string sampler_type_to_name_string(llama_sampler_type sampler_type) {
         case llama_sampler_type::TYPICAL_P:   return "typical_p";
         case llama_sampler_type::TOP_P:       return "top_p";
         case llama_sampler_type::MIN_P:       return "min_p";
+        case llama_sampler_type::P_STEP:      return "p_step";
         case llama_sampler_type::TEMPERATURE: return "temperature";
         default : return "";
     }
@@ -1755,6 +1766,7 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "top_k: %d # default: 40\n", sparams.top_k);
     fprintf(stream, "top_p: %f # default: 0.95\n", sparams.top_p);
     fprintf(stream, "min_p: %f # default: 0.0\n", sparams.min_p);
+    fprintf(stream, "p_step: %f # default: 0.0\n", sparams.p_step);
     fprintf(stream, "typical_p: %f # default: 1.0\n", sparams.typical_p);
     fprintf(stream, "verbose_prompt: %s # default: false\n", params.verbose_prompt ? "true" : "false");
     fprintf(stream, "display_prompt: %s # default: true\n", params.display_prompt ? "true" : "false");

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -91,10 +91,10 @@ std::string llama_sampling_print(const llama_sampling_params & params) {
 
     snprintf(result, sizeof(result),
             "\trepeat_last_n = %d, repeat_penalty = %.3f, frequency_penalty = %.3f, presence_penalty = %.3f\n"
-            "\ttop_k = %d, tfs_z = %.3f, top_p = %.3f, min_p = %.3f, typical_p = %.3f, temp = %.3f\n"
+            "\ttop_k = %d, tfs_z = %.3f, top_p = %.3f, min_p = %.3f, p_step = %.3f, typical_p = %.3f, temp = %.3f\n"
             "\tmirostat = %d, mirostat_lr = %.3f, mirostat_ent = %.3f",
             params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present,
-            params.top_k, params.tfs_z, params.top_p, params.min_p, params.typical_p, params.temp,
+            params.top_k, params.tfs_z, params.top_p, params.min_p, params.p_step, params.typical_p, params.temp,
             params.mirostat, params.mirostat_eta, params.mirostat_tau);
 
     return std::string(result);
@@ -128,6 +128,7 @@ static void sampler_queue(
     const int32_t       top_k             = params.top_k;
     const float         top_p             = params.top_p;
     const float         min_p             = params.min_p;
+    const float         p_step            = params.p_step;
     const float         tfs_z             = params.tfs_z;
     const float         typical_p         = params.typical_p;
     const std::vector<llama_sampler_type> & samplers_sequence = params.samplers_sequence;
@@ -139,6 +140,7 @@ static void sampler_queue(
             case llama_sampler_type::TYPICAL_P: llama_sample_typical  (ctx_main, &cur_p, typical_p, min_keep); break;
             case llama_sampler_type::TOP_P    : llama_sample_top_p    (ctx_main, &cur_p, top_p,     min_keep); break;
             case llama_sampler_type::MIN_P    : llama_sample_min_p    (ctx_main, &cur_p, min_p,     min_keep); break;
+            case llama_sampler_type::P_STEP   : llama_sample_p_step   (ctx_main, &cur_p, p_step,    min_keep); break;
             case llama_sampler_type::TEMPERATURE:
                 if (dynatemp_range > 0) {
                     float dynatemp_min = std::max(0.0f, temp - dynatemp_range);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -13,6 +13,7 @@ enum class llama_sampler_type : char {
     TOP_K       = 'k',
     TOP_P       = 'p',
     MIN_P       = 'm',
+    P_STEP      = 's',
     TFS_Z       = 'f',
     TYPICAL_P   = 'y',
     TEMPERATURE = 't'
@@ -26,6 +27,7 @@ typedef struct llama_sampling_params {
     int32_t     top_k                 = 40;       // <= 0 to use vocab size
     float       top_p                 = 0.95f;    // 1.0 = disabled
     float       min_p                 = 0.05f;    // 0.0 = disabled
+    float       p_step                = 0.00f;    // 0.0 = disabled
     float       tfs_z                 = 1.00f;    // 1.0 = disabled
     float       typical_p             = 1.00f;    // 1.0 = disabled
     float       temp                  = 0.80f;    // <= 0.0 to sample greedily, 0.0 to not output probabilities
@@ -46,6 +48,7 @@ typedef struct llama_sampling_params {
         llama_sampler_type::TYPICAL_P,
         llama_sampler_type::TOP_P,
         llama_sampler_type::MIN_P,
+        llama_sampler_type::P_STEP,
         llama_sampler_type::TEMPERATURE
     };
 

--- a/llama.h
+++ b/llama.h
@@ -799,6 +799,13 @@ extern "C" {
                            float   p,
                           size_t   min_keep);
 
+    /// @details P-Step sampling as described in [THIS PR]
+    LLAMA_API void llama_sample_p_step(
+            struct llama_context * ctx,
+          llama_token_data_array * candidates,
+                           float   step,
+                          size_t   min_keep);
+
     /// @details Tail Free Sampling described in https://www.trentonbricken.com/Tail-Free-Sampling/.
     LLAMA_API void llama_sample_tail_free(
             struct llama_context * ctx,


### PR DESCRIPTION
This PR introduces a new truncation sampler called **P-Step**. The sampler discards all tokens after the first "step" in the probability distribution, that is, the first position where the following tokens are substantially less probable than the preceding ones.

![p_step](https://github.com/ggerganov/llama.cpp/assets/2702526/bff3dd6a-ab86-40bb-8a3b-815e66c02118)

The step is defined by the probability of a token being less than `p_step` times the probability of the preceding, more likely token. That is, the first occurrence of `p[i+1] < p_step * p[i]` leads to all tokens after `i` being discarded.

I claim that this strategy can offer advantages over existing truncation samplers, namely:

* **Top-K**, because it adapts to the specific probability distribution.
* **Top-P**, because it doesn't discard tokens just because an arbitrary summation threshold is reached.
* **Min-P**, because Min-P can discard tokens that are almost exactly as probable as other tokens it retains, if the threshold implied by `min_p * (p of most probable token)` happens to fall between them.

(This isn't to say that P-Step obsoletes those samplers; in fact, it works great in combination with them.)

By construction, P-Step truncation has an attractive theoretical property that no other currently implemented sampler provides: **Any retained token is at least `1/p_step` times more probable than any discarded token.** In other words, P-Step splits tokens into two sets with a pairwise classification criterion that is independent of any global properties of the distribution.

P-Step will follow slowly decreasing distributions for long distances. I therefore recommend pairing P-Step with one of the other truncation samplers when using a `p_step` value of less than 0.5. To get a feeling for how the sampler behaves in practice, try the following parameters:

* `p_step = 0.5` with all other samplers disabled. This gives high coherence within semantic units of the text, and high creativity at the start of new units where the distribution tends to be smooth.
* `p_step = 0.3` plus `min_p = 0.02`. In my tests, this gives improved coherence compared to the Min-P sampler alone, while maintaining the same level of creativity.

Philosophically, P-Step is the complement of Tail Free Sampling: While TFS cuts off the "tail" of the distribution, that is, the part where probabilities *stop* getting worse, P-Step cuts off everything except the "head" by identifying where probabilities *start* to get worse (of course, the exact behavior depends on the chosen parameter values in both cases). P-Step is much simpler than TFS and can be applied by hand when inspecting token distributions. It is therefore easy to find a suitable `p_step` value for the desired truncation outcome.

As stated previously, this isn't really my field, so if someone had this idea before me, please let me know.

/cc @kalomaze @oobabooga Maybe you find this interesting.
