### PR TITLE
Fix a Typo Which Causes It Unable to Compile with Old Glibc

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2085,7 +2085,7 @@ void ggml_numa_init(enum ggml_numa_strategy numa_flag) {
     getcpu_ret = getcpu(&current_cpu, &g_state.numa.current_node);
 #else
     // old glibc doesn't have a wrapper for this call. Fall back on direct syscall
-    getcpu_ret = syscall(SYS_getcpu,&current_cpu,&g_state.numa.current_node);
+    getcpu_ret = syscall(SYS_get_cpu,&current_cpu,&g_state.numa.current_node);
 #endif
 
     if (g_state.numa.n_nodes < 1 || g_state.numa.total_cpus < 1 || getcpu_ret != 0) {


### PR DESCRIPTION
I encoutered this error when compiling llama.cpp.

```
ggml.c: In function 'ggml_numa_init':
ggml.c:2088:26: error: 'SYS_getcpu' undeclared (first use in this function); did you mean 'SYS_get_cpu'?
 2088 |     getcpu_ret = syscall(SYS_getcpu,&current_cpu,&g_state.numa.current_node);
      |                          ^~~~~~~~~~
      |                          SYS_get_cpu
ggml.c:2088:26: note: each undeclared identifier is reported only once for each function it appears in
```

I followed the comiler suggestions to fix the typo and then successfully compiled it.