### PR TITLE
Server: fix server hangs on empty prompt

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1336,6 +1336,10 @@ struct llama_server_context
                 split_multiprompt_task(task_id, task);
             }
         } else {
+            // an empty prompt can make slot become buggy
+            if (task.data.contains("prompt") && task.data["prompt"].is_string() && task.data["prompt"].get<std::string>().empty()) {
+                task.data["prompt"] = " "; // add a space so that we have one token
+            }
             queue_tasks.post(task);
         }
     }


### PR DESCRIPTION
This is a proposal to fix #5724 and #5246

It's buggy when we run a slot with no tokens to evaluate, since some parts of code implicitly expect `n_tokens` to be `> 0`

This PR fixes issue when using:
- `/v1/embeddings` with `"input": ""`
- `/embedding` with `"content": ""`
- `/completion` with `"prompt": ""`