### PR TITLE
[SYCL] Split device code per kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,7 +553,7 @@ if (LLAMA_SYCL)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl -L${MKLROOT}/lib")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl -L${MKLROOT}/lib -fsycl-device-code-split=per_kernel")
 
     set(GGML_HEADERS_SYCL ggml-sycl.h)
     set(GGML_SOURCES_SYCL ggml-sycl.cpp)


### PR DESCRIPTION
This is a simple PR that splits each SYCL kernel into a separate module. This is done to handle devices which do not support certain data types, e.g. fp16 and fp64. 

If the module splitting is not performed, we have all kernels in a single module so when the first kernel is executed, and undergoes the JIT pass all other kernels will. This means fp16 types will under go JIT even if the device does not support it, causing an error in the runtime.