### PR TITLE
[SYCL] Update unsupported quantization types

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -12010,7 +12010,10 @@ inline void ggml_sycl_op_mul_mat_vec_q(
     GGML_ASSERT(!(src0->type == GGML_TYPE_IQ2_XXS ||
                   src0->type == GGML_TYPE_IQ2_XS ||
                   src0->type == GGML_TYPE_IQ3_XXS ||
-                  src0->type == GGML_TYPE_IQ1_S));
+                  src0->type == GGML_TYPE_IQ1_S ||
+                  src0->type == GGML_TYPE_IQ2_S ||
+                  src0->type == GGML_TYPE_IQ3_S ||
+                  src0->type == GGML_TYPE_IQ4_NL));
 
     switch (src0->type) {
         case GGML_TYPE_Q4_0:
@@ -15049,6 +15052,15 @@ static bool ggml_backend_sycl_supports_op(ggml_backend_t backend, const ggml_ten
                 }
 
                 if (a->type == GGML_TYPE_IQ1_S) {
+                    return false;
+                }
+                if (a->type == GGML_TYPE_IQ2_S) {
+                    return false;
+                }
+                if (a->type == GGML_TYPE_IQ3_S) {
+                    return false;
+                }
+                if (a->type == GGML_TYPE_IQ4_NL) {
                     return false;
                 }
                 if (a->type == GGML_TYPE_IQ3_XXS) {


### PR DESCRIPTION
This PR updates the unsupported list of quantization types as the necessary implementations have not yet been added to the SYCL backend. This PR skips failing tests in backend-ops.