### PR TITLE
llama : fix non-quantization of expert gating tensors

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -11213,7 +11213,8 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         quantize &= !params->only_copy;
 
         // do not quantize expert gating tensors
-        quantize &= name != LLM_TN(model.arch)(LLM_TENSOR_FFN_GATE_INP, "weight");
+        // NOTE: can't use LLM_TN here because the layer number is not known
+        quantize &= name.find("ffn_gate_inp.weight") == std::string::npos;
 
         // do not quantize positional embeddings and token types (BERT)
         quantize &= name != LLM_TN(model.arch)(LLM_TENSOR_POS_EMBD,    "weight");


### PR DESCRIPTION
This reverts a single line from #5475 and adds a comment.

Using `LLM_TN` here to get the tensor name can't work, because the layer number is not known, so the string compared to the actual tensor name contains `%d` instead of a layer number, so it never matches, and expert gating tensors are quantized anyway.

I've added a comment so that it won't happen again by accident.

I've noticed this when refactoring some [Mamba-related code](https://github.com/compilade/llama.cpp/blob/919d79f60590923ee85563348157c345443e7266/llama.cpp#L11689-L11691) (in #5328) preventing some tensors to be quantized to use `LLM_TN` (since not using hard-coded strings seemed cleaner), and it didn't work anymore, while checking for the suffix (as was done before for the expert gating tensors) works.

I've tested this with the [smallest MoE model I could find](https://huggingface.co/jtatman/TinyMistral-248m-v2.5-4x-Moe), and it works (i.e. the `ffn_gate_inp.weight` tensors are not quantized, while on `master`, they are even though they should not).