### PR TITLE
Update convert-hf-to-gguf.py

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -8,10 +8,11 @@ import json
 import os
 import re
 import sys
+import transformers
 from enum import IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ContextManager, Iterator, Sequence, cast
-
+from transformers import GemmaModel
 import numpy as np
 import torch
 


### PR DESCRIPTION
@ggerganov @cebtenzzre 

The merge i opened to add the import statements at the top of convert-hf-to-gguf.py were necessary for merged models using Gemma, The "GemmaforCasualLM is not supported" Error occurred when these import statements are not there, when trying to convert Merged Gemma model (using mergekit) to gguf using the convert-hf-to-gguf.py. So please reconsider merging the pr. I am reopening it because the fix is necessary, and the error does occur when converting merged models that have been merged through mergekit. You can try merging two gemma models yourself and then converting them to gguf and see the error for yourself. 
