### PR TITLE
fix(convert-hf-to-gguf): requires einops for InternLM2ForCausalLM models

### DIFF
--- a/requirements/requirements-convert-hf-to-gguf.txt
+++ b/requirements/requirements-convert-hf-to-gguf.txt
@@ -1,2 +1,3 @@
 -r ./requirements-convert.txt
 torch~=2.1.1
+einops~=0.7.0


### PR DESCRIPTION
small fix for container images, which will currently fail with:
```
Traceback (most recent call last):
  File "/app/convert-hf-to-gguf.py", line 1934, in <module>
gguf: This GGUF file is for Little Endian only
Set model parameters
Set model tokenizer
InternLM2 convert token 'b'\x00'' to '🐉'!
gguf: Setting special token type bos to 1
gguf: Setting special token type eos to 2
gguf: Setting special token type pad to 2
gguf: Setting chat_template to {{ bos_token }}{% for message in messages %}{{'<|im_start|>' + message['role'] + '
' + message['content'] + '<|im_end|>' + '
'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant
' }}{% endif %}
Exporting model to '/workspace/input/ggml-model-f16.gguf'
    main()
  File "/app/convert-hf-to-gguf.py", line 1928, in main
    model_instance.write()
  File "/app/convert-hf-to-gguf.py", line 152, in write
    self.write_tensors()
  File "/app/convert-hf-to-gguf.py", line 1612, in write_tensors
    from einops import rearrange
ModuleNotFoundError: No module named 'einops'
Traceback (most recent call last):
  File "/app/convert.py", line 1483, in <module>
```

used 0.7.0 cause it's the current release.