### PR TITLE
server: allow to override threads server pool with --threads-http

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -18,6 +18,7 @@ The project is under active development, and we are [looking for feedback and co
 
 - `--threads N`, `-t N`: Set the number of threads to use during generation.
 - `-tb N, --threads-batch N`: Set the number of threads to use during batch and prompt processing. If not specified, the number of threads will be set to the number of threads used for generation.
+- `--threads-http N`: number of threads in the http server pool to process requests (default: `std::thread::hardware_concurrency()`)
 - `-m FNAME`, `--model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.gguf`).
 - `-a ALIAS`, `--alias ALIAS`: Set an alias for the model. The alias will be returned in API responses.
 - `-c N`, `--ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference. The size may differ in other models, for example, baichuan models were build with a context of 4096.

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -44,6 +44,7 @@ struct server_params
     int32_t write_timeout = 600;
     bool slots_endpoint = true;
     bool metrics_endpoint = false;
+    int n_threads_http = -1;
 };
 
 bool server_verbose = false;
@@ -2065,6 +2066,7 @@ static void server_print_usage(const char *argv0, const gpt_params &params,
     printf("  -v, --verbose             verbose output (default: %s)\n", server_verbose ? "enabled" : "disabled");
     printf("  -t N, --threads N         number of threads to use during computation (default: %d)\n", params.n_threads);
     printf("  -tb N, --threads-batch N  number of threads to use during batch and prompt processing (default: same as --threads)\n");
+    printf("  --threads-http N          number of threads in the http server pool to process requests (default: hardware concurrency)\n");
     printf("  -c N, --ctx-size N        size of the prompt context (default: %d)\n", params.n_ctx);
     printf("  --rope-scaling {none,linear,yarn}\n");
     printf("                            RoPE frequency scaling method, defaults to linear unless specified by the model\n");
@@ -2350,6 +2352,15 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
                 break;
             }
             params.n_threads_batch = std::stoi(argv[i]);
+        }
+        else if (arg == "--threads-http")
+        {
+            if (++i >= argc)
+            {
+                invalid_param = true;
+                break;
+            }
+            sparams.n_threads_http = std::stoi(argv[i]);
         }
         else if (arg == "-b" || arg == "--batch-size")
         {
@@ -3508,6 +3519,11 @@ int main(int argc, char **argv)
         }
     }*/
     //);
+
+    if (sparams.n_threads_http > 0) {
+        log_data["n_threads_http"] =  std::to_string(sparams.n_threads_http);
+        svr.new_task_queue = [&sparams] { return new httplib::ThreadPool(sparams.n_threads_http); };
+    }
 
     LOG_INFO("HTTP server listening", log_data);
     // run the HTTP server in a thread - see comment below


### PR DESCRIPTION
### Motivation

The default [httplib threads pool](https://github.com/yhirose/cpp-httplib/tree/master?tab=readme-ov-file#default-thread-pool-support) is set to `std::thread::hardware_concurrency()`
which is NOT always adapted for completions.
As far, completions tasks can be deferred, http server threads pool
can quickly be full by reaching the number of available host cpu cores
while actually continuous batching can accept more requests on the GPU device.

This fix allows the user to choose the balanced number of threads in the http server pool.

### Changes
Introduce `--threads-http N` to override the default configuration.