### PR TITLE
Fix flag name in help message `--logits-all` to `--all-logits`

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1015,7 +1015,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --ignore-eos          ignore end of stream token and continue generating (implies --logit-bias 2-inf)\n");
     printf("  --no-penalize-nl      do not penalize newline token\n");
     printf("  --temp N              temperature (default: %.1f)\n", (double)sparams.temp);
-    printf("  --logits-all          return logits for all tokens in the batch (default: disabled)\n");
+    printf("  --all-logits          return logits for all tokens in the batch (default: disabled)\n");
     printf("  --hellaswag           compute HellaSwag score over random tasks from datafile supplied with -f\n");
     printf("  --hellaswag-tasks N   number of tasks to use when computing the HellaSwag score (default: %zu)\n", params.hellaswag_tasks);
     printf("  --winogrande          compute Winogrande score over random tasks from datafile supplied with -f\n");


### PR DESCRIPTION
Currently `./main -h` describes `--logits-all` is for returning logits for all tokens in the batch, but it yields an error `
error: unknown argument: --logits-all`.

The option is actually the typo of `--all-logits`. I fixed the help message to follow the implementation.