### PR TITLE
nix: static build

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   lib,
   config,
   stdenv,
@@ -160,6 +161,7 @@ effectiveStdenv.mkDerivation (
         ninja
         pkg-config
         git
+        pkgs.glibc.static
       ]
       ++ optionals useCuda [
         cudaPackages.cuda_nvcc

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -196,7 +196,7 @@ effectiveStdenv.mkDerivation (
         (cmakeBool "LLAMA_METAL" useMetalKit)
         (cmakeBool "LLAMA_MPI" useMpi)
         (cmakeBool "LLAMA_VULKAN" useVulkan)
-        (cmakeBool "LLAMA_STATIC" buildStatic)
+        (cmakeBool "LLAMA_STATIC" enableStatic)
       ]
       ++ optionals useCuda [
         (

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -33,7 +33,7 @@
   llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
 
   # It's necessary to consistently use backendStdenv when building with CUDA support,
-  # otherwise we get libstdc++ errors downstream.1
+  # otherwise we get libstdc++ errors downstream.
   effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic
 }@inputs:

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -187,7 +187,7 @@ effectiveStdenv.mkDerivation (
       [
         (cmakeBool "LLAMA_NATIVE" false)
         (cmakeBool "LLAMA_BUILD_SERVER" true)
-        (cmakeBool "BUILD_SHARED_LIBS" (!buildStatic))
+        (cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
         (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
         (cmakeBool "LLAMA_BLAS" useBlas)
         (cmakeBool "LLAMA_CLBLAST" useOpenCL)

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -183,7 +183,7 @@ effectiveStdenv.mkDerivation (
       [
         (cmakeBool "LLAMA_NATIVE" false)
         (cmakeBool "LLAMA_BUILD_SERVER" true)
-        (cmakeBool "BUILD_SHARED_LIBS" true)
+        (cmakeBool "BUILD_SHARED_LIBS" false)
         (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
         (cmakeBool "LLAMA_BLAS" useBlas)
         (cmakeBool "LLAMA_CLBLAST" useOpenCL)
@@ -192,6 +192,7 @@ effectiveStdenv.mkDerivation (
         (cmakeBool "LLAMA_METAL" useMetalKit)
         (cmakeBool "LLAMA_MPI" useMpi)
         (cmakeBool "LLAMA_VULKAN" useVulkan)
+        (cmakeBool "LLAMA_STATIC" true)
       ]
       ++ optionals useCuda [
         (

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -31,7 +31,8 @@
   useRocm ? config.rocmSupport,
   useVulkan ? false,
   llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
-  buildStatic ? false,
+  effectiveStdenv = if useCuda then cudaPackages.backendStdenv else stdenv,
+  enableStatic ? effectiveStdenv.hostPlatform.isStatic
 }@inputs:
 
 let

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -171,7 +171,7 @@ effectiveStdenv.mkDerivation (
         # once https://github.com/NixOS/nixpkgs/pull/275241 has been merged
         cudaPackages.autoAddOpenGLRunpathHook
       ]
-      ++ optionals buildStatic [
+      ++ optionals (effectiveStdenv.hostPlatform.isGnu && enableStatic) [
         glibc.static
       ];
 

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -186,7 +186,7 @@ effectiveStdenv.mkDerivation (
       [
         (cmakeBool "LLAMA_NATIVE" false)
         (cmakeBool "LLAMA_BUILD_SERVER" true)
-        (cmakeBool "BUILD_SHARED_LIBS" !buildStatic)
+        (cmakeBool "BUILD_SHARED_LIBS" (!buildStatic))
         (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
         (cmakeBool "LLAMA_BLAS" useBlas)
         (cmakeBool "LLAMA_CLBLAST" useOpenCL)

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -31,6 +31,9 @@
   useRocm ? config.rocmSupport,
   useVulkan ? false,
   llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
+
+  # It's necessary to consistently use backendStdenv when building with CUDA support,
+  # otherwise we get libstdc++ errors downstream.1
   effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic
 }@inputs:
@@ -43,11 +46,8 @@ let
     strings
     versionOlder
     ;
-
-  # It's necessary to consistently use backendStdenv when building with CUDA support,
-  # otherwise we get libstdc++ errors downstream.
+    
   stdenv = throw "Use effectiveStdenv instead";
-  effectiveStdenv = if useCuda then cudaPackages.backendStdenv else inputs.stdenv;
 
   suffices =
     lib.optionals useBlas [ "BLAS" ]

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -31,7 +31,7 @@
   useRocm ? config.rocmSupport,
   useVulkan ? false,
   llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
-  effectiveStdenv = if useCuda then cudaPackages.backendStdenv else stdenv,
+  effectiveStdenv ? if useCuda then cudaPackages.backendStdenv else stdenv,
   enableStatic ? effectiveStdenv.hostPlatform.isStatic
 }@inputs:
 


### PR DESCRIPTION
Exposes existing cmake static build process through the nix build system if the `buildStatic` parameter is true.

The output of this build process is an archive file instead of a completely static shared object, so linking still needs to be done by any program that wishes to use this as a dependency.