### PR TITLE
StableLM 1.6B models revert back to GPT2Tokenizer

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -78,7 +78,6 @@ let
     ps: [
       ps.numpy
       ps.sentencepiece
-      ps.tiktoken
       ps.torchWithoutCuda
       ps.transformers
     ]

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1059,11 +1059,7 @@ class PersimmonModel(Model):
 
 class StableLMModel(Model):
     def set_vocab(self):
-        if (self.dir_model / "tokenizer.json").is_file():
-            self._set_vocab_gpt2()
-        else:
-            # StableLM 2 1.6B uses a vocab in a similar format to Qwen's vocab
-            self._set_vocab_qwen()
+        self._set_vocab_gpt2()
 
     def set_gguf_parameters(self):
         hparams = self.hparams


### PR DESCRIPTION
## Type of Change

- Stability.ai converted their 1.6B models tokenizers back to GPT2Tokenizer instead of tiktoken tokenizer:
   -> https://huggingface.co/stabilityai/stablelm-2-zephyr-1_6b/commit/c89d7d19e9781974793a7e9b0fe55bcabcf8abc5
   -> https://huggingface.co/stabilityai/stablelm-2-1_6b/commit/a7a1fb8a8318c8012dea6a23b65f1dfc58dc3033

- This PR eliminates some useless code and dependencies that were added bcs of the tiktoken tokenizer.


## Description

- Same as above

## Expected Behavior & Potential Risk

- N/A

## How has this PR been tested?

- N/A


## Dependency Change?

- N/A