### PR TITLE
Assume tied weights if lm_head/output weights is missing.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -3855,7 +3855,13 @@ static bool llm_load_tensors(
                     {
                         model.output_norm = ml.create_tensor(ctx_output,       tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
                         if (model.arch != LLM_ARCH_MINICPM){
-                            model.output = ml.create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab});
+                            model.output = ml.create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT, "weight"), {n_embd, n_vocab}, false);
+                            // if output is NULL, init from the input tok embed
+                            if (model.output == NULL) {
+                                model.output = ml.create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
+                                ml.n_created--; // artificial tensor
+                                ml.size_data += ggml_nbytes(model.output);
+                            }
                         }
                     }
 


### PR DESCRIPTION
This supports model configurations with "tie_word_embeddings", by using the embd_tokens weights if output/lm_head weights are missing (as they will be when weights are tied).

With this change, a tied model like the following can be converted to gguf.
https://huggingface.co/BEE-spoke-data/smol_llama-81M-tied