### PR TITLE
server: feature Add Admin key parameter for slots/health/metrics

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -43,8 +43,9 @@ see https://github.com/ggerganov/llama.cpp/issues/1437
 - `--host`: Set the hostname or ip address to listen. Default `127.0.0.1`.
 - `--port`: Set the port to listen. Default: `8080`.
 - `--path`: path from which to serve static files (default examples/server/public)
-- `--api-key`: Set an api key for request authorization. By default the server responds to every request. With an api key set, the requests must have the Authorization header set with the api key as Bearer token. May be used multiple times to enable multiple valid keys.
+- `--api-key`: Set an api key for request authorization. By default the server responds to every request. With an api key set, the requests to `/completion`, `/infill` and `/chat/completions` must have the Authorization header set with the api key as Bearer token. May be used multiple times to enable multiple valid keys.
 - `--api-key-file`: path to file containing api keys delimited by new lines. If set, requests must include one of the keys for access. May be used in conjunction with `--api-key`'s.
+- `--admin-key`: Set an admin key for request authorization. With an admin key set, requests to `/metrics` and `/slots` must have the Authorization header set with the api key as Bearer token. Additionally, `/health` will not show slots without the key. May be used multiple times to enable multiple valid keys.
 - `--embedding`: Enable embedding extraction, Default: disabled.
 - `-np N`, `--parallel N`: Set the number of slots for process requests (default: 1)
 - `-cb`, `--cont-batching`: enable continuous batching (a.k.a dynamic batching) (default: disabled)

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2800,8 +2800,8 @@ int main(int argc, char **argv)
             }
         }
 
-	// Check for API key in the params
-	auto auth_param = req.get_param_value("key");
+        // Check for API key in the params
+        auto auth_param = req.get_param_value("key");
         if (std::find(keys.begin(), keys.end(), auth_param) != keys.end()) {
             return true; // API key is valid
         }


### PR DESCRIPTION
The API key solely protects the completion/infill endpoints. Adding an admin key that protects the slots/metrics endpoints is important when these endpoints are turned on. Without this, anyone can hit the slots endpoint and snoop on the prompts that other users are submitting.

This is quick, mostly replicating the api_key feature. It shifts to a generalized `validate_key` function that takes in a vector of strings to check against. The new validation function checks the headers, but then also the query params for a key (named `key` in all cases).