### PR TITLE
server: tests: scheduled slow tests step only on Release or on demand

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -3,6 +3,11 @@ name: Server
 
 on:
   workflow_dispatch: # allows manual triggering
+    inputs:
+      slow_tests:
+        description: 'Run slow tests'
+        required: true
+        type: boolean
   push:
     branches:
       - master
@@ -11,7 +16,7 @@ on:
     types: [opened, synchronize, reopened]
     paths: ['.github/workflows/server.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/tests/**.*']
   schedule:
-    -  cron: '00 0 * * *'
+    -  cron: '0 0 * * *'
 
 jobs:
   server:
@@ -80,7 +85,7 @@ jobs:
 
       - name: Slow tests
         id: server_integration_tests_slow
-        if: github.event.schedule != ''
+        if: ${{ github.event.schedule != '' && matrix.build_type == 'Release' || github.event.inputs.slow_tests == 'true' }}
         run: |
           cd examples/server/tests
           PORT=8888 ./tests.sh --stop --no-skipped --no-capture --tags slow


### PR DESCRIPTION
### Context

Current CI Server workflow master scheduled step will [fail](https://github.com/phymbert/llama.cpp/actions/runs/8125346582/job/22207851847).

It might be useful to ensure slow tests are still working nightly, especially the context self extend with passkey as it is not tested somewhere else.

Workflow CI job Server will trigger slow tests (20min) only on `Release` build type.


Working pipeline: [here](https://github.com/phymbert/llama.cpp/actions/runs/8125429370/job/22208032942)