### PR TITLE
Handle cases where git index is not found in .git directory

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Build info header
 #
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git/index")
     set(GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
 
     # Is git submodule

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Build info header
 #
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git/index")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
     set(GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
 
     # Is git submodule
@@ -19,7 +19,12 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git/index")
         endif()
     endif()
 
-    set(GIT_INDEX "${GIT_DIR}/index")
+    if(EXISTS "${GIT_DIR}/index")
+        set(GIT_INDEX "${GIT_DIR}/index")
+    else()
+        message(WARNING "Git index not found in git repository.")
+        set(GIT_INDEX "")
+    endif()
 else()
     message(WARNING "Git repository not found; to enable automatic generation of build info, make sure Git is installed and the project is a Git repository.")
     set(GIT_INDEX "")


### PR DESCRIPTION
I know Ive tried to merge this in the past and it got denied in favor of handling sub modules explicitly but please reconsider.

This fixes #3902

The issue is not common and in most cases the code to handle sub modules that  has already been added should work but in my case it doesn't work for an unknowable reason.

In the case of maid this error occurs because flutter is trying to build llama.cpp through a simlink to a package added as a submodule which itself includes a submodule (llama.cpp). Somewhere along the line the .git/index gets lost but the .git directory remains so ```if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")``` succeeds but because .git/index doesn't exist an error occurs.

So my simple fix is to just check that the .git/index exists instead of the .git directory. Which in my mind makes more sense as the crux of what that block of code is doing requires that .git/index exists not that the .git directory exists.