### PR TITLE
Support special tokens as reverse/anti prompt.

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -511,6 +511,14 @@ int main(int argc, char ** argv) {
     std::vector<llama_token> embd;
     std::vector<llama_token> embd_guidance;
 
+    // tokenized antiprompts
+    std::vector<std::vector<llama_token>> antiprompt_ids;
+
+    antiprompt_ids.reserve(params.antiprompt.size());
+    for (const std::string & antiprompt : params.antiprompt) {
+        antiprompt_ids.emplace_back(::llama_tokenize(ctx, antiprompt, false, true));
+    }
+
     struct llama_sampling_context * ctx_sampling = llama_sampling_init(sparams);
 
     while ((n_remain != 0 && !is_antiprompt) || params.interactive) {
@@ -766,14 +774,6 @@ int main(int argc, char ** argv) {
                         }
                         is_antiprompt = true;
                         break;
-                    }
-                }
-
-                // tokenize reverse/antiprompt special tokens only once using static
-                static std::vector<std::vector<llama_token>> antiprompt_ids;
-                if (antiprompt_ids.empty()) {
-                    for (std::string& antiprompt : params.antiprompt) {
-                        antiprompt_ids.push_back(::llama_tokenize(ctx, antiprompt, false, true));
                     }
                 }
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -760,7 +760,8 @@ int main(int argc, char ** argv) {
                         ? last_output.length() - static_cast<size_t>(antiprompt.length() + extra_padding)
                         : 0;
 
-                    if (last_output.find(antiprompt, search_start_pos) != std::string::npos) {
+                    auto tmp = ::llama_tokenize(ctx, antiprompt, false, true);
+                    if (last_output.find(antiprompt, search_start_pos) != std::string::npos || (tmp.size() == 1 && llama_sampling_last(ctx_sampling) == tmp[0])) {
                         if (params.interactive) {
                             is_interacting = true;
                         }


### PR DESCRIPTION
Special tokens do not match doing a string search, so they need to be matched tokenized.

EDIT: This is needed for using the zephyr models.