### PR TITLE
Use already defined default seed to avoid compiler error C2397

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -43,7 +43,7 @@ extern char const *LLAMA_BUILD_TARGET;
 int32_t get_num_physical_cores();
 
 struct gpt_params {
-    uint32_t seed                 = -1;    // RNG seed
+    uint32_t seed                 = LLAMA_DEFAULT_SEED; // RNG seed
 
     int32_t n_threads             = get_num_physical_cores();
     int32_t n_threads_draft       = -1;


### PR DESCRIPTION
Getting error [C2397](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2397?view=msvc-170) on Windows using llama.cpp as static library and this PR fixes the issue.
```
common.h(46,38): error C2397: conversion from 'int' to 'uint32_t' requires a narrowing conversion
```
