### PR TITLE
fix speculative decoding build on windows

### DIFF
--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -226,7 +226,7 @@ int main(int argc, char ** argv) {
 
                     while (active_seqs.size() > 0) {
                         // randomly select a sequence to verify from active sequences
-                        std::uniform_int_distribution<u_int> u_int_dist(0, active_seqs.size() - 1);
+                        std::uniform_int_distribution<unsigned int> u_int_dist(0, active_seqs.size() - 1);
                         int s = *std::next(active_seqs.begin(), u_int_dist(rng));
                         if (i_dft >= (int) drafts[s].tokens.size()) {
                             drafts[s].active = false;


### PR DESCRIPTION
For certain Windows builds, `u_int` is not a typedef and compilation fails. Simplifies to the more standard `unsigned int`