### PR TITLE
Don't allow grammar json array to output unescaped new line in string

### DIFF
--- a/grammars/json.gbnf
+++ b/grammars/json.gbnf
@@ -15,7 +15,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\n] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 

--- a/grammars/json_arr.gbnf
+++ b/grammars/json_arr.gbnf
@@ -24,7 +24,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\n] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 


### PR DESCRIPTION
I had this issue where the generated json was this (with a another grammar file)


```json
{"entities": [

{"type": "Geo-Political Entity", "name": "Paris 2024"},
{"type": "Location", "name": "Paris"}],
"relations": [{"type_from": "G',
eographic Feature", "name_from": "Paris", "type_to": "Event", "name_to": "Paris 2024", "relation_type": "occurs_in"}]}
```


For the grammar builder I came up with this solution

```
string ::= "\"" (char | escapeSequence)* "\""
char ::= [^"\\]
escapeSequence ::= "\\\"" | "\\\\" | "\\n" | "\\r" | "\\t" | "\\b" | "\\f" | "\\'"
```