### PR TITLE
Fixed json strings grammar by blacklisting character control set

### DIFF
--- a/grammars/json.gbnf
+++ b/grammars/json.gbnf
@@ -15,7 +15,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 

--- a/grammars/json_arr.gbnf
+++ b/grammars/json_arr.gbnf
@@ -24,7 +24,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 


### PR DESCRIPTION
This time it works.

At the first try I tried to disable only \n, which made appear quickly \r, and after brutforcing jsons for 30mins It gave me an error on a `0x1B` character.

For curious people, I was using mistral 7b 0.2 instruct.


Initial incomplete fix : #5885