### PR TITLE
Using `uint8x16_t` as the return type for `ggml_vqtbl1q_u8`

### DIFF
--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -464,7 +464,7 @@ inline static int8x16_t ggml_vqtbl1q_s8(int8x16_t a, uint8x16_t b) {
 }
 
 // NOTE: not tested
-inline static int8x16_t ggml_vqtbl1q_u8(uint8x16_t a, uint8x16_t b) {
+inline static uint8x16_t ggml_vqtbl1q_u8(uint8x16_t a, uint8x16_t b) {
     int8x16_t res;
 
     res[ 0] = a[b[ 0]];

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -465,7 +465,7 @@ inline static int8x16_t ggml_vqtbl1q_s8(int8x16_t a, uint8x16_t b) {
 
 // NOTE: not tested
 inline static uint8x16_t ggml_vqtbl1q_u8(uint8x16_t a, uint8x16_t b) {
-    int8x16_t res;
+    uint8x16_t res;
 
     res[ 0] = a[b[ 0]];
     res[ 1] = a[b[ 1]];


### PR DESCRIPTION
Address the issues found in both https://github.com/ggerganov/llama.cpp/issues/5748 and whisper.cpp