### PR TITLE
Free Cublas GPU memory

### DIFF
--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -17,6 +17,9 @@ extern "C" {
 
 #define GGML_CUDA_MAX_DEVICES       16
 
+// Release CUDA resources
+GGML_API GGML_CALL void   ggml_free_cublas(void);
+
 // Always success. To check if CUDA is actually loaded, use `ggml_cublas_loaded`.
 GGML_API GGML_CALL void   ggml_init_cublas(void);
 


### PR DESCRIPTION
I have corrected the PR https://github.com/ggerganov/llama.cpp/pull/5576 which causes crash and streamlined the code. Unfortunately, this does not free all occupied GPU memory yet (only 15% of it). We still need to find some objects which are not freed after releasing GPU memory.