### PR TITLE
ggml : use SYS_get_cpu if SYS_getcpu is not defined

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2154,7 +2154,10 @@ void ggml_numa_init(enum ggml_numa_strategy numa_flag) {
     getcpu_ret = getcpu(&current_cpu, &g_state.numa.current_node);
 #else
     // old glibc doesn't have a wrapper for this call. Fall back on direct syscall
-    getcpu_ret = syscall(SYS_getcpu,&current_cpu,&g_state.numa.current_node);
+#   if !defined(SYS_getcpu) && defined(SYS_get_cpu)
+#       define SYS_getcpu SYS_get_cpu // some older glibc versions use this name
+#   endif
+    getcpu_ret = syscall(SYS_getcpu, &current_cpu, &g_state.numa.current_node);
 #endif
 
     if (g_state.numa.n_nodes < 1 || g_state.numa.total_cpus < 1 || getcpu_ret != 0) {


### PR DESCRIPTION
Alternative to ggerganov/whisper.cpp#1897. Choosing this venue because I have collaborator permissions here, and that PR has gone nowhere in two weeks.

This is apparently needed on some older versions of glibc.

Fixes #5694
Fixes ggerganov/whisper.cpp#1894