### PR TITLE
add `/v1/completions` endpoint

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2923,7 +2923,7 @@ int main(int argc, char ** argv) {
         res.set_content(data.dump(), "application/json; charset=utf-8");
     });
 
-    svr.Post("/completion", [&ctx_server, &validate_api_key](const httplib::Request & req, httplib::Response & res) {
+    const auto completions = [&ctx_server, &validate_api_key](const httplib::Request & req, httplib::Response & res) {
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         if (!validate_api_key(req, res)) {
             return;
@@ -3001,7 +3001,11 @@ int main(int argc, char ** argv) {
 
             res.set_chunked_content_provider("text/event-stream", chunked_content_provider, on_complete);
         }
-    });
+    };
+
+    svr.Post("/completion", completions);
+    svr.Post("/completions", completions);
+    svr.Post("/v1/completions", completions);
 
     svr.Get("/v1/models", [&params, &model_meta](const httplib::Request & req, httplib::Response & res) {
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3003,7 +3003,7 @@ int main(int argc, char ** argv) {
         }
     };
 
-    svr.Post("/completion", completions);
+    svr.Post("/completion", completions); // legacy
     svr.Post("/completions", completions);
     svr.Post("/v1/completions", completions);
 


### PR DESCRIPTION
resolves #4497

additional proposal:
add `/completions` endpoint to match the naming and mark `/completion` as legacy, then remove in future releases
<img width="489" alt="image" src="https://github.com/ggerganov/llama.cpp/assets/54794500/39d78fdb-d040-4634-afd8-4da6fb984001">
