### PR TITLE
llama: fix crash when tokenize unkown spm vocab token.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -8770,7 +8770,10 @@ static llama_token llama_byte_to_token(const llama_vocab & vocab, uint8_t ch) {
             }
             // Try to fall back to just the byte as a string
             const char buf2[2] = { (char)ch, 0 };
-            return vocab.token_to_id.at(buf2);
+            token = vocab.token_to_id.find(buf2);
+            if (token != vocab.token_to_id.end()) {
+                return (*token).second;
+            }
         }
         case LLAMA_VOCAB_TYPE_WPM:
         case LLAMA_VOCAB_TYPE_BPE: {


### PR DESCRIPTION
this PR fix crash caused by calling unorder_map.at on unkown token.

as offical docs show, If k does not match the key of any element in the container, the function `throws an [out_of_range](https://cplusplus.com/out_of_range) exception.`

[https://cplusplus.com/reference/unordered_map/unordered_map/at/](https://cplusplus.com/reference/unordered_map/unordered_map/at/)
