### PR TITLE
server: metrics: fix bucket reset on /health, add few more metrics

### DIFF
--- a/examples/server/tests/features/server.feature
+++ b/examples/server/tests/features/server.feature
@@ -29,6 +29,7 @@ Feature: llama.cpp server
     And   a completion request with no api error
     Then  <n_predicted> tokens are predicted matching <re_content>
     And   prometheus metrics are exposed
+    And   metric llamacpp:tokens_predicted is <n_predicted>
 
     Examples: Prompts
       | prompt                           | n_predict | re_content                       | n_predicted |


### PR DESCRIPTION
### Context
Server `/metrics` endpoint share the same task event as `/health`: `TASK_TYPE_METRICS`. It means metrics are reset on both calls.

The `Process-Start-Time-Unix` http response header is not set.

Add total prompt and generation time in order to get the global server throughput for all slots.

Closes #5850