### PR TITLE
Removes segfault when parsing grammar with missing symbols. Adds friendly error message.

### DIFF
--- a/common/grammar-parser.cpp
+++ b/common/grammar-parser.cpp
@@ -278,6 +278,22 @@ namespace grammar_parser {
             while (*pos) {
                 pos = parse_rule(state, pos);
             }
+            // Validate the state to ensure that all rules are defined
+            for (const auto & rule : state.rules) {
+                for (const auto & elem : rule) {
+                    if (elem.type == LLAMA_GRETYPE_RULE_REF) {
+                        // Ensure that the rule at that location exists
+                        if (elem.value >= state.rules.size() || state.rules[elem.value].empty()) {
+                            // Get the name of the rule that is missing
+                            for (const auto & kv : state.symbol_ids) {
+                                if (kv.second == elem.value) {
+                                    throw std::runtime_error("Undefined rule identifier '" + kv.first + "'");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             return state;
         } catch (const std::exception & err) {
             fprintf(stderr, "%s: error parsing grammar: %s\n", __func__, err.what());


### PR DESCRIPTION
This adds a friendly error message to help debug GBNF parsing errors. When developing a new grammar recently, I didn't realize that I had some typos in my identifier names, and it caused me some amount of headache until I figured it out.

This addition will raise an exception when parsing grammars that have undefined symbols.

Example: Create "chess_bad.gbnf" and comment out the definition of `nonpawn`.

Then run it with your favorite model:

Before:

```
./main -m models/mistral-7b-v0.1.Q4_K_M.gguf --grammar-file grammars/chess_bad.gbnf -p 'The following chess match is a rousing game of blitz played at the 2002 Ohio Valley Regional Championship: '
Log start
main: build = 2366 (c2101a2e)
main: built with Apple clang version 15.0.0 (clang-1500.1.0.2.5) for arm64-apple-darwin23.2.0
<SNIP>
sampling order:
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature
generate: n_ctx = 512, n_batch = 512, n_predict = -1, n_keep = 1


[1]    64973 segmentation fault  ./main -m models/mistral-7b-v0.1.Q4_K_M.gguf --grammar-file  -p
```

After this fix:
```
./main -m models/mistral-7b-v0.1.Q4_K_M.gguf --grammar-file grammars/chess_bad.gbnf -p 'The following chess match is a rousing game of blitz played at the 2002 Ohio Valley Regional Championship: '
Log start
main: build = 2367 (92ee6311)
main: built with Apple clang version 15.0.0 (clang-1500.1.0.2.5) for arm64-apple-darwin23.2.0
<SNIP>
sampling order:
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature
generate: n_ctx = 512, n_batch = 512, n_predict = -1, n_keep = 1


libc++abi: terminating due to uncaught exception of type std::runtime_error: Undefined rule identifier 'nonpawn'
[1]    68828 abort      ./main -m models/mistral-7b-v0.1.Q4_K_M.gguf --grammar-file  -p
```

It's not much, but in my case it telling me the name of the missing identifier was invaluable, and hopefully this can be of help to others!

This also nicely removes crashing due to segfault, which may be of help to things like #4066 or #3878.