### PR TITLE
server: fix passing prompt as tokens

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -856,12 +856,9 @@ struct server_context {
         // get prompt
         {
             const auto & prompt = data.find("prompt");
-            if (prompt == data.end())
-            {
+            if (prompt == data.end()) {
                 slot.prompt = "";
-            }
-            else
-            {
+            } else {
                 slot.prompt = *prompt;
             }
         }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -852,7 +852,19 @@ struct server_context {
         // infill
         slot.params.input_prefix = json_value(data, "input_prefix", default_params.input_prefix);
         slot.params.input_suffix = json_value(data, "input_suffix", default_params.input_suffix);
-        slot.prompt              = json_value(data, "prompt",       std::string(""));
+
+        // get prompt
+        {
+            const auto & prompt = data.find("prompt");
+            if (prompt == data.end())
+            {
+                slot.prompt = "";
+            }
+            else
+            {
+                slot.prompt = *prompt;
+            }
+        }
 
         // penalize user-provided tokens
         {


### PR DESCRIPTION
This PR fixes a crash in `server` that happens if `prompt` is an array of tokens.

**Before:**
```sh
❯ curl -sS --data '{"prompt": [15043,29892,590,1024,338], "n_predict": 4}' http://127.0.0.1:8080/completion | jq .content
curl: (52) Empty reply from server
```

```
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_2::detail::type_error'
  what():  [json.exception.type_error.302] type must be string, but is array
fish: Job 1, './server -m /opt/models/text/ll…' terminated by signal SIGABRT (Abort)
```


**After:**
```sh
❯ curl -sS --data '{"prompt": [15043,29892,590,1024,338], "n_predict": 4}' http://127.0.0.1:8080/completion | jq .content
" John and I have"
```