### PR TITLE
output normalize embedding in '/v1/embeddings'

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1852,3 +1852,19 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
 
     printf("\n=== Done dumping\n");
 }
+
+void llama_embd_normalize(const float * inp, float * out, int n) {
+    float norm = 0;
+    for (int i = 0; i < n; i++) {
+        norm += inp[i] * inp[i];
+    }
+    norm = sqrt(norm);
+    if (norm == 0) {
+        return;
+    }
+    norm = 1.0 / norm;
+    for (int i = 0; i < n; i++) {
+        out[i] = inp[i] * norm;
+    }
+}
+

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1854,15 +1854,14 @@ void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size) {
 }
 
 void llama_embd_normalize(const float * inp, float * out, int n) {
-    float norm = 0;
+    double sum = 0.0;
     for (int i = 0; i < n; i++) {
-        norm += inp[i] * inp[i];
+        sum += inp[i] * inp[i];
     }
-    norm = sqrt(norm);
-    if (norm == 0) {
-        return;
-    }
-    norm = 1.0 / norm;
+    sum = sqrt(sum);
+
+    const float norm = sum > 0.0 ? 1.0f / sum : 0.0f;
+
     for (int i = 0; i < n; i++) {
         out[i] = inp[i] * norm;
     }

--- a/common/common.h
+++ b/common/common.h
@@ -260,3 +260,10 @@ void dump_kv_cache_view(const llama_kv_cache_view & view, int row_size = 80);
 
 // Dump the KV cache view showing individual sequences in each cell (long output).
 void dump_kv_cache_view_seqs(const llama_kv_cache_view & view, int row_size = 40);
+
+//
+// Embedding utils
+//
+
+void llama_embd_normalize(const float * inp, float * out, int n);
+

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -23,17 +23,6 @@ static void batch_add_seq(llama_batch & batch, const std::vector<int32_t> & toke
     }
 }
 
-static void normalize(const float * vec, float * out, int n) {
-    float norm = 0;
-    for (int i = 0; i < n; i++) {
-        norm += vec[i] * vec[i];
-    }
-    norm = sqrt(norm);
-    for (int i = 0; i < n; i++) {
-        out[i] = vec[i] / norm;
-    }
-}
-
 static void batch_decode(llama_context * ctx, llama_batch & batch, float * output, int n_seq, int n_embd) {
     // clear previous kv_cache values (irrelevant for embeddings)
     llama_kv_cache_clear(ctx);
@@ -44,7 +33,6 @@ static void batch_decode(llama_context * ctx, llama_batch & batch, float * outpu
         fprintf(stderr, "%s : failed to decode\n", __func__);
     }
 
-    // normalize on copy
     for (int i = 0; i < batch.n_tokens; i++) {
         if (!batch.logits[i]) {
             continue;
@@ -61,7 +49,7 @@ static void batch_decode(llama_context * ctx, llama_batch & batch, float * outpu
         }
 
         float * out = output + batch.seq_id[i][0] * n_embd;
-        normalize(embd, out, n_embd);
+        llama_embd_normalize(embd, out, n_embd);
     }
 }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2651,6 +2651,17 @@ inline void signal_handler(int signal) {
     shutdown_handler(signal);
 }
 
+static void normalize(std::vector<float>& vec) {
+    float norm = 0;
+    for (float val : vec) {
+        norm += val * val;
+    }
+    norm = sqrt(norm);
+    for (float& val : vec) {
+        val /= norm;
+    }
+}
+
 int main(int argc, char ** argv) {
 #if SERVER_VERBOSE != 1
     log_disable();
@@ -3345,6 +3356,13 @@ int main(int argc, char ** argv) {
             // get the result
             server_task_result result = ctx_server.queue_results.recv(id_task);
             ctx_server.queue_results.remove_waiting_task_id(id_task);
+
+            // normalize the embedding
+            std::vector<float> embedding = json_value(result.data, "embedding", json::array());
+            normalize(embedding);
+            result.data["embedding"] = embedding;
+
+            // append to the responses
             responses.push_back(result.data);
         }
 


### PR DESCRIPTION
## Description
Configure server.cpp to output normalized embeddings with the endpoint set to "v1/embeddings".
This PR is related with issue #5954 

## Test Method
I use below code to check normalized results.
```
def check_normalize(embedding):
    s = 0
    for i in embedding:
        s += i * i
    print(f"sum: {s}")


response = client.embeddings.create(input = input_texts, model="test")

print(response)

check_normalize(response.data[0].embedding)
```

### Before
```
CreateEmbeddingResponse(data=[Embedding(embedding=[0.779549777507782, -1.7770930528640747, -0.5943143963813782, ... ,], index=0, object='embedding')], model='test', object='list', usage=Usage(prompt_tokens=0, total_tokens=0))

sum: 85301.80714120051
```

### After
```
CreateEmbeddingResponse(data=[Embedding(embedding=[0.0026690999511629343, -0.006084587424993515, -0.0020348725374788046, ..., ], index=0, object='embedding')], model='test', object='list', usage=Usage(prompt_tokens=0, total_tokens=0))

sum: 1.0000004424428977
```