### PR TITLE
quantize: fix F16/F32 downcast to q6_K

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -11675,7 +11675,7 @@ static ggml_type get_k_quant_type(quantize_state_internal & qs, ggml_type new_ty
                  ftype == LLAMA_FTYPE_MOSTLY_IQ1_S   || ftype == LLAMA_FTYPE_MOSTLY_IQ2_S  || ftype == LLAMA_FTYPE_MOSTLY_IQ2_M) {
             new_type = GGML_TYPE_Q5_K;
         }
-        else if (new_type != GGML_TYPE_Q8_0) {
+        else if (new_type != GGML_TYPE_Q8_0 && new_type != GGML_TYPE_F16 && new_type != GGML_TYPE_F32) {
             new_type = GGML_TYPE_Q6_K;
         }
     } else if (name == "token_embd.weight") {


### PR DESCRIPTION
While converting the official Gemma FP32 GGUF to FP16 with `quantize` I noticed that `token_embd.weight` was being converted to q6_k. This seems to be a simple oversight in the code where the only data type checked against is q8_0 but not f16/f32. This PR adds the missing checks.