### PR TITLE
Server: Use multi-task for embeddings endpoint

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3390,10 +3390,7 @@ int main(int argc, char ** argv) {
         {
             const int id_task = ctx_server.queue_tasks.get_new_id();
             ctx_server.queue_results.add_waiting_task_id(id_task);
-            ctx_server.request_completion(id_task, -1, {
-                {"prompt", prompt},
-                {"n_predict", 0},
-            }, false, true);
+            ctx_server.request_completion(id_task, -1, {{"prompt", prompt}}, false, true);
 
             // get the result
             server_task_result result = ctx_server.queue_results.recv(id_task);

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -529,6 +529,16 @@ static std::vector<json> format_partial_response_oaicompat(json result, const st
 }
 
 static json format_embeddings_response_oaicompat(const json & request, const json & embeddings) {
+    json data = json::array();
+    int i = 0;
+    for (auto & elem : embeddings) {
+        data.push_back(json{
+            {"embedding", json_value(elem, "embedding", json::array())},
+            {"index",     i++},
+            {"object",    "embedding"}
+        });
+    }
+
     json res = json {
         {"model", json_value(request, "model", std::string(DEFAULT_OAICOMPAT_MODEL))},
         {"object", "list"},
@@ -536,7 +546,7 @@ static json format_embeddings_response_oaicompat(const json & request, const jso
             {"prompt_tokens", 0},
             {"total_tokens", 0}
         }},
-        {"data", embeddings}
+        {"data", data}
     };
 
     return res;


### PR DESCRIPTION
As discussed in https://github.com/ggerganov/llama.cpp/pull/5939#pullrequestreview-1924944420 , using multi-task for multi prompts in embeddings endpoint is preferable.

I also make the code less verbose for this function. There're maybe other ways to make the code even shorter, but I prefer stay this way to keep it readable (also easy to understand what the code does). But suggestions are welcome for this.

The next task for me will be to see if we can reuse part of code inside `handle_completions` for `handle_chat_completions` to prevent code duplication.