### PR TITLE
Fix unnecessarily retained pointer to rules parameter in llama_grammar_init

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -10538,7 +10538,7 @@ struct llama_grammar * llama_grammar_init(
 
     // loop over alternates of start rule to build initial stacks
     std::vector<std::vector<const llama_grammar_element *>> stacks;
-    pos = rules[start_rule_index];
+    pos = vec_rules[start_rule_index].data();
     do {
         std::vector<const llama_grammar_element *> stack;
         if (!llama_grammar_is_end_of_sequence(pos)) {


### PR DESCRIPTION
`llama_grammar_init` unnecessarily retains a pointer from the `rules` array even though it has been copied, making it necessary to keep `rules` alive after the call has returned (or segfault in my case...).

This fix simply uses a pointer to the copy instead.