### PR TITLE
Fix: GBNF missing "root" node crashing server

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -17,6 +17,13 @@ struct llama_sampling_context * llama_sampling_init(const struct llama_sampling_
             return nullptr;
         }
 
+        // Ensure that there is a "root" node.
+        if (result->parsed_grammar.symbol_ids.find("root") == result->parsed_grammar.symbol_ids.end()) {
+            fprintf(stderr, "%s: grammar does not contain a 'root' symbol\n", __func__);
+            delete result;
+            return nullptr;
+        }
+
         std::vector<const llama_grammar_element *> grammar_rules(result->parsed_grammar.c_rules());
 
         result->grammar = llama_grammar_init(


### PR DESCRIPTION
Resolves #3878 by ensuring the existence of a "root" symbol before returning a valid grammar.

NOTE: There are two possible locations to put this fix -- the alternate location is to put it in `sampling.cpp->llama_sampling_init()`, which is the only place where the "root" node is named as required. That fix would [look like this](https://github.com/HanClinto/llama.cpp/commit/23e3f17935759c9119ad8094b1314f2c1a298853).

@ggerganov Do you have preference on the two versions of this fix? I think this main difference is -- philosophically -- do we want all grammars to require a "root" node (if so, then put it in grammar-parser), or if it's possible to have a grammar without a "root" node (that's technically a syntactically correct grammar, but it's missing our expected entry point), then we should put the fix in sampling.cpp.