### PR TITLE
[SYCL] Fix non-intel device selection

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -3451,7 +3451,7 @@ class sycl_gpu_mgr {
                 dpct::device_info prop;
                 dpct::get_device_info(prop, device);
                 if (max_compute_units == prop.get_max_compute_units() &&
-                    prop.get_major_version() == 1) {
+                    can_support_multi_gpu(device)) {
                     gpus.push_back(id);
                     devices.push_back(device);
                     work_group_size = prop.get_max_work_group_size();
@@ -3483,6 +3483,15 @@ class sycl_gpu_mgr {
             }
             assert(false);
             return -1;
+        }
+
+        bool can_support_multi_gpu(const sycl::device &dev) {
+            sycl::backend dev_backend = dev.get_backend();
+            if (dev_backend == sycl::backend::ext_oneapi_level_zero ||
+                dev_backend == sycl::backend::ext_oneapi_cuda ||
+                dev_backend == sycl::backend::ext_oneapi_hip)
+                return true;
+            return false;
         }
 };
 

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -3451,7 +3451,7 @@ class sycl_gpu_mgr {
                 dpct::device_info prop;
                 dpct::get_device_info(prop, device);
                 if (max_compute_units == prop.get_max_compute_units() &&
-                    can_support_multi_gpu(device)) {
+                    is_ext_oneapi_device(device)) {
                     gpus.push_back(id);
                     devices.push_back(device);
                     work_group_size = prop.get_max_work_group_size();

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -3485,7 +3485,7 @@ class sycl_gpu_mgr {
             return -1;
         }
 
-        bool can_support_multi_gpu(const sycl::device &dev) {
+        bool is_ext_oneapi_device(const sycl::device &dev) {
             sycl::backend dev_backend = dev.get_backend();
             if (dev_backend == sycl::backend::ext_oneapi_level_zero ||
                 dev_backend == sycl::backend::ext_oneapi_cuda ||


### PR DESCRIPTION
This PR fixes the SYCL backend for non intel devices.
It replaces the major version query with a backend check for the device. This is more standard and robust SYCL as the version name changes its meaning based on the target vendor.

Solution to: #6026 