### PR TITLE
server: test: disable debug release type sanitizer, simplify trigger

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,17 +25,14 @@ jobs:
     strategy:
       matrix:
         sanitizer: [ADDRESS, THREAD, UNDEFINED]
-        build_type: [Debug, Release]
+        build_type: [Debug]
         include:
           - build_type: Release
             sanitizer: ""
-        exclude:
-          - build_type: Release
-            sanitizer: ADDRESS
-          - build_type: Release
+          - build_type: Debug
             sanitizer: THREAD
-          - build_type: Release
-            sanitizer: UNDEFINED
+            disabled_on_pr: true
+      fail-fast: false # While -DLLAMA_SANITIZE_THREAD=ON is broken
 
     container:
       image: ubuntu:latest
@@ -81,13 +78,14 @@ jobs:
 
       - name: Tests
         id: server_integration_tests
+        if: ${{ !matrix.disabled_on_pr || !github.event.pull_request }}
         run: |
           cd examples/server/tests
           PORT=8888 ./tests.sh
 
       - name: Slow tests
         id: server_integration_tests_slow
-        if: ${{ github.event.schedule != '' && matrix.build_type == 'Release' || github.event.inputs.slow_tests == 'true' }}
+        if: ${{ (github.event.schedule || github.event.inputs.slow_tests == 'true') && matrix.build_type == 'Release' }}
         run: |
           cd examples/server/tests
           PORT=8888 ./tests.sh --stop --no-skipped --no-capture --tags slow
@@ -124,13 +122,14 @@ jobs:
 
       - name: Tests
         id: server_integration_tests
+        if: ${{ !matrix.disabled_on_pr || !github.event.pull_request }}
         run: |
           cd examples/server/tests
           behave.exe --summary --stop --no-capture --exclude 'issues|wrong_usages|passkey' --tags llama.cpp
 
       - name: Slow tests
         id: server_integration_tests_slow
-        if: ${{ github.event.schedule != '' || github.event.inputs.slow_tests == 'true' }}
+        if: ${{ (github.event.schedule || github.event.inputs.slow_tests == 'true') && matrix.build_type == 'Release' }}
         run: |
           cd examples/server/tests
           behave.exe --stop --no-skipped --no-capture --tags slow


### PR DESCRIPTION
### Motivation

- Server tests with cmake release type Debug are [extremely slow](https://github.com/ggerganov/llama.cpp/actions/runs/8269324134/job/22624344106) with Thread sanitizer, blocking the CI on each pull request action.
- Recently, GitHub free CI runners are extremly slow, server startup time increased.
- `-fsanitize=*` are [broken](https://github.com/ggerganov/llama.cpp/actions/runs/8269534207):
```shell
AddressSanitizer:DEADLYSIGNAL
... or ...
FATAL: ThreadSanitizer: unexpected memory mapping 0x571167ebd000-0x571167ecd000
```

### Changes

- Disable the `-fsanitize=thread` with `-DCMAKE_BUILD_TYPE=Debug`  matrix entry for pull request.
- Simplify matrix and step conditions.
- Do not fail fast in order to ensure at least `Release` is still passing.
- Increase max attempts in health check and server startup.

#### References

- https://github.com/ggerganov/llama.cpp/pull/6001#issuecomment-1994082440