### PR TITLE
gguf-py : bump version to 0.8.0

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.7.0"
+version = "0.8.0"
 description = "Read and write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
Bumping the gguf-py version as requested in https://github.com/ggerganov/llama.cpp/pull/6045#issuecomment-1997789514.