### PR TITLE
llama-bench : use random tokens to improve accuracy with mixtral

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <cstdlib>
 #include <iterator>
 #include <map>
 #include <numeric>
@@ -1123,15 +1124,19 @@ struct sql_printer : public printer {
 static void test_prompt(llama_context * ctx, int n_prompt, int n_past, int n_batch, int n_threads) {
     llama_set_n_threads(ctx, n_threads, n_threads);
 
-    //std::vector<llama_token> tokens(n_prompt, llama_token_bos(llama_get_model(ctx)));
-    //llama_decode(ctx, llama_batch_get_one(tokens.data(), n_prompt, n_past, 0));
-    //GGML_UNUSED(n_batch);
+    const llama_model * model = llama_get_model(ctx);
+    const int32_t n_vocab = llama_n_vocab(model);
 
-    std::vector<llama_token> tokens(n_batch, llama_token_bos(llama_get_model(ctx)));
+    std::vector<llama_token> tokens(n_batch);
+
     int n_processed = 0;
 
     while (n_processed < n_prompt) {
         int n_tokens = std::min(n_prompt - n_processed, n_batch);
+        tokens[0] = n_processed == 0 && llama_add_bos_token(model) ? llama_token_bos(model) : std::rand() % n_vocab;
+        for (int i = 1; i < n_tokens; i++) {
+            tokens[i] = std::rand() % n_vocab;
+        }
         llama_decode(ctx, llama_batch_get_one(tokens.data(), n_tokens, n_past + n_processed, 0));
         n_processed += n_tokens;
     }
@@ -1142,11 +1147,15 @@ static void test_prompt(llama_context * ctx, int n_prompt, int n_past, int n_bat
 static void test_gen(llama_context * ctx, int n_gen, int n_past, int n_threads) {
     llama_set_n_threads(ctx, n_threads, n_threads);
 
-    llama_token token = llama_token_bos(llama_get_model(ctx));
+    const llama_model * model = llama_get_model(ctx);
+    const int32_t n_vocab = llama_n_vocab(model);
+
+    llama_token token = llama_add_bos_token(model) ? llama_token_bos(model) : std::rand() % n_vocab;
 
     for (int i = 0; i < n_gen; i++) {
         llama_decode(ctx, llama_batch_get_one(&token, 1, n_past + i, 0));
         llama_synchronize(ctx);
+        token = std::rand() % n_vocab;
     }
 }
 


### PR DESCRIPTION
`llama-bench` currently does not produce accurate results with mixtral because it uses the same token for the entire prompt (bos). This results in the same experts being chosen repeatedly, which is not what happens during real usage. With this change `llama-bench` uses random tokens instead.

Current `llama-bench` results in `master`:
  Device 0: NVIDIA GeForce RTX 3090 Ti, compute capability 8.6, VMM: yes
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 | pp 512     |    189.62 ± 0.97 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 | pp 1024    |    182.17 ± 0.54 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  99 | pp 512     |    613.36 ± 0.81 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  99 | pp 1024    |    607.84 ± 0.48 |

build: 4755afd1 (2431)

Using `main` with a large representative prompt (extracted from the frankenstein book text) produces these values instead:

With `-ngl 0`:
```
llama_print_timings: prompt eval time =    8695.65 ms /   512 tokens (   16.98 ms per token,    58.88 tokens per second)
llama_print_timings: prompt eval time =   17340.24 ms /  1024 tokens (   16.93 ms per token,    59.05 tokens per second)
```

With `-ngl 99`:
```
llama_print_timings: prompt eval time =    1411.63 ms /   512 tokens (    2.76 ms per token,   362.70 tokens per second)
llama_print_timings: prompt eval time =    2811.67 ms /  1024 tokens (    2.75 ms per token,   364.20 tokens per second)
```

`llama-bench` after this PR:

  Device 0: NVIDIA GeForce RTX 3090 Ti, compute capability 8.6, VMM: yes
| model                          |       size |     params | backend    | ngl | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------- | ---------------: |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 | pp 512     |     61.87 ± 0.26 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 | pp 1024    |     61.56 ± 0.11 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  99 | pp 512     |    378.69 ± 0.87 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  99 | pp 1024    |    377.54 ± 1.76 |

The small difference is probably due to the warmup run performed by `llama-bench`.

Why is this important: a future change will cause all experts to be copied to VRAM during prompt processing regardless of if they are actually used, while currently only the experts used are copied. This change is important to understand the performance impact of doing that.