### PR TITLE
backend : offload large batches to GPU

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -114,10 +114,10 @@ static std::string get_cpu_info() {
 static std::string get_gpu_info() {
     std::string id;
 #ifdef GGML_USE_CUBLAS
-    int count = ggml_cuda_get_device_count();
+    int count = ggml_backend_cuda_get_device_count();
     for (int i = 0; i < count; i++) {
         char buf[128];
-        ggml_cuda_get_device_description(i, buf, sizeof(buf));
+        ggml_backend_cuda_get_device_description(i, buf, sizeof(buf));
         id += buf;
         if (i < count - 1) {
             id += "/";

--- a/ggml-backend-impl.h
+++ b/ggml-backend-impl.h
@@ -103,6 +103,11 @@ extern "C" {
         // check if the backend supports an operation
         bool (*GGML_CALL supports_op)(ggml_backend_t backend, const struct ggml_tensor * op);
 
+        // check if the backend want to run an operation, even if the weights are allocated in a CPU buffer
+        // these should be expensive operations with large batch sizes that may benefit from running on this backend
+        // even if the weight has to be copied from the CPU temporarily
+        bool (*GGML_CALL offload_op)(ggml_backend_t backend, const struct ggml_tensor * op);
+
         // (optional) event synchronization
         ggml_backend_event_t (*GGML_CALL event_new)         (ggml_backend_t backend);
         void                 (*GGML_CALL event_free)        (ggml_backend_event_t event);

--- a/ggml-backend-impl.h
+++ b/ggml-backend-impl.h
@@ -103,7 +103,7 @@ extern "C" {
         // check if the backend supports an operation
         bool (*GGML_CALL supports_op)(ggml_backend_t backend, const struct ggml_tensor * op);
 
-        // check if the backend want to run an operation, even if the weights are allocated in a CPU buffer
+        // check if the backend wants to run an operation, even if the weights are allocated in a CPU buffer
         // these should be expensive operations with large batch sizes that may benefit from running on this backend
         // even if the weight has to be copied from the CPU temporarily
         bool (*GGML_CALL offload_op)(ggml_backend_t backend, const struct ggml_tensor * op);

--- a/ggml-backend.h
+++ b/ggml-backend.h
@@ -70,11 +70,11 @@ extern "C" {
     GGML_API ggml_backend_graph_plan_t ggml_backend_graph_plan_create(ggml_backend_t backend, struct ggml_cgraph * cgraph);
     GGML_API void                      ggml_backend_graph_plan_free  (ggml_backend_t backend, ggml_backend_graph_plan_t plan);
 
-    GGML_API enum ggml_status ggml_backend_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan);
-    GGML_API enum ggml_status ggml_backend_graph_compute     (ggml_backend_t backend, struct ggml_cgraph * cgraph);
-
-    GGML_API bool ggml_backend_graph_compute_async(ggml_backend_t backend, struct ggml_cgraph * cgraph);
+    GGML_API enum ggml_status ggml_backend_graph_plan_compute (ggml_backend_t backend, ggml_backend_graph_plan_t plan);
+    GGML_API enum ggml_status ggml_backend_graph_compute      (ggml_backend_t backend, struct ggml_cgraph * cgraph);
+    GGML_API enum ggml_status ggml_backend_graph_compute_async(ggml_backend_t backend, struct ggml_cgraph * cgraph);
     GGML_API bool ggml_backend_supports_op(ggml_backend_t backend, const struct ggml_tensor * op);
+    GGML_API bool ggml_backend_offload_op(ggml_backend_t backend, const struct ggml_tensor * op);
 
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst);

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -7791,10 +7791,6 @@ struct cuda_pool_alloc {
 
 static bool g_cublas_loaded = false;
 
-static bool ggml_cublas_loaded(void) {
-    return g_cublas_loaded;
-}
-
 static void ggml_init_cublas() {
     static bool initialized = false;
 
@@ -11381,7 +11377,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
 GGML_CALL static bool ggml_backend_cuda_offload_op(ggml_backend_t backend, const ggml_tensor * op) {
     const int min_batch_size = 32;
 
-    return op->ne[1] > min_batch_size && op->op != GGML_OP_GET_ROWS;
+    return op->ne[1] >= min_batch_size && op->op != GGML_OP_GET_ROWS;
 
     UNUSED(backend);
 }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -7890,7 +7890,7 @@ GGML_CALL void * ggml_cuda_host_malloc(size_t size) {
     if (err != cudaSuccess) {
         // clear the error
         cudaGetLastError();
-        fprintf(stderr, "WARNING: failed to allocate %.2f MB of pinned memory: %s\n",
+        fprintf(stderr, "%s: warning: failed to allocate %.2f MiB of pinned memory: %s\n", __func__,
             size/1024.0/1024.0, cudaGetErrorString(err));
         return nullptr;
     }
@@ -9036,21 +9036,13 @@ static void ggml_cuda_op_soft_max(
 
     // positions tensor
     float * src2_dd = nullptr;
-    cuda_pool_alloc<float> src2_f;
 
     ggml_tensor * src2 = dst->src[2];
     const bool use_src2 = src2 != nullptr;
 
     if (use_src2) {
-        const bool src2_on_device = src2->backend == GGML_BACKEND_TYPE_GPU;
-
-        if (src2_on_device) {
-            ggml_tensor_extra_gpu * src2_extra = (ggml_tensor_extra_gpu *) src2->extra;
-            src2_dd = (float *) src2_extra->data_device[g_main_device];
-        } else {
-            src2_dd = src2_f.alloc(ggml_nelements(src2));
-            CUDA_CHECK(ggml_cuda_cpy_tensor_2d(src2_dd, src2, 0, 0, 0, 1, main_stream));
-        }
+        ggml_tensor_extra_gpu * src2_extra = (ggml_tensor_extra_gpu *) src2->extra;
+        src2_dd = (float *) src2_extra->data_device[g_main_device];
     }
 
     soft_max_f32_cuda(src0_dd, src1 ? src1_dd : nullptr, src2_dd, dst_dd, ne00, nrows_x, nrows_y, scale, max_bias, main_stream);
@@ -9107,55 +9099,24 @@ static void ggml_cuda_op_flatten(const ggml_tensor * src0, const ggml_tensor * s
     ggml_tensor_extra_gpu * src1_extra = use_src1 ? (ggml_tensor_extra_gpu *) src1->extra : nullptr;
     ggml_tensor_extra_gpu * dst_extra  =            (ggml_tensor_extra_gpu *)  dst->extra;
 
-    const bool src0_on_device =             src0->backend == GGML_BACKEND_TYPE_GPU || src0->backend == GGML_BACKEND_TYPE_GPU_SPLIT;
-    const bool src1_on_device = use_src1 && src1->backend == GGML_BACKEND_TYPE_GPU;
-    const bool  dst_on_device =              dst->backend == GGML_BACKEND_TYPE_GPU;
-
     // dd = data device
     float * src0_ddf = nullptr;
     float * src1_ddf = nullptr;
     float *  dst_ddf = nullptr;
 
-    cuda_pool_alloc<float> src0_f;
-    cuda_pool_alloc<float> src1_f;
-    cuda_pool_alloc<float>  dst_f;
-
     ggml_cuda_set_device(g_main_device);
     cudaStream_t main_stream = g_cudaStreams[g_main_device][0];
 
-    if (src0_on_device) {
-        src0_ddf = (float *) src0_extra->data_device[g_main_device];
-    } else {
-        src0_ddf = src0_f.alloc(ggml_nelements(src0));
-        CUDA_CHECK(ggml_cuda_cpy_tensor_2d(src0_ddf, src0, 0, 0, 0, nrows0, main_stream));
-    }
+    src0_ddf = (float *) src0_extra->data_device[g_main_device];
 
     if (use_src1) {
-        if (src1_on_device) {
-            src1_ddf = (float *) src1_extra->data_device[g_main_device];
-        } else {
-            src1_ddf = src1_f.alloc(ggml_nelements(src1));
-            CUDA_CHECK(ggml_cuda_cpy_tensor_2d(src1_ddf, src1, 0, 0, 0, nrows1, main_stream));
-        }
+        src1_ddf = (float *) src1_extra->data_device[g_main_device];
     }
-    if (dst_on_device) {
-        dst_ddf = (float *) dst_extra->data_device[g_main_device];
-    } else {
-        dst_ddf = dst_f.alloc(ggml_nelements(dst));
-    }
+    dst_ddf = (float *) dst_extra->data_device[g_main_device];
 
     // do the computation
     op(src0, src1, dst, src0_ddf, src1_ddf, dst_ddf, main_stream);
     CUDA_CHECK(cudaGetLastError());
-
-    // copy dst to host if necessary
-    if (!dst_on_device) {
-        CUDA_CHECK(cudaMemcpyAsync(dst->data, dst_ddf, ggml_nbytes(dst), cudaMemcpyDeviceToHost, main_stream));
-    }
-
-    if (dst->backend == GGML_BACKEND_TYPE_CPU) {
-        CUDA_CHECK(cudaDeviceSynchronize());
-    }
 }
 
 static void ggml_cuda_set_peer_access(const int n_tokens) {
@@ -9251,7 +9212,6 @@ static void ggml_cuda_op_mul_mat(
     ggml_tensor_extra_gpu * src1_extra = (ggml_tensor_extra_gpu *) src1->extra;
     ggml_tensor_extra_gpu *  dst_extra = (ggml_tensor_extra_gpu *)  dst->extra;
 
-    const bool src0_on_device = src0->backend == GGML_BACKEND_TYPE_GPU || src0->backend == GGML_BACKEND_TYPE_GPU_SPLIT;
     const bool src0_is_contiguous = ggml_is_contiguous(src0);
     const bool src1_is_contiguous = ggml_is_contiguous(src1);
 
@@ -9328,7 +9288,7 @@ static void ggml_cuda_op_mul_mat(
         ggml_cuda_set_device(id);
         cudaStream_t stream = g_cudaStreams[id][0];
 
-        if (src0_on_device && src0_is_contiguous) {
+        if (src0_is_contiguous) {
             dev[id].src0_dd = (char *) src0_extra->data_device[id];
         } else {
             dev[id].src0_dd = dev[id].src0_dd_alloc.alloc(ggml_nbytes(src0));
@@ -9418,19 +9378,19 @@ static void ggml_cuda_op_mul_mat(
                                                             src1_ncols*ne10*sizeof(float), stream));
                         }
                     }
-                } else if (src1->backend == GGML_BACKEND_TYPE_CPU || (src1_on_device && !src1_is_contiguous)) {
+                } else if (src1_on_device && !src1_is_contiguous) {
                     CUDA_CHECK(ggml_cuda_cpy_tensor_2d(
                                 src1_ddf_i, src1, i03, i02, src1_col_0, src1_col_0+src1_ncols, stream));
                 } else {
                     GGML_ASSERT(false);
                 }
 
-                if (convert_src1_to_q8_1 && (src1->backend == GGML_BACKEND_TYPE_CPU || !src1_is_contiguous)) {
+                if (convert_src1_to_q8_1 && !src1_is_contiguous) {
                     quantize_row_q8_1_cuda(src1_ddf_i, src1_ddq_i, ne10, src1_ncols, src1_padded_col_size, stream);
                     CUDA_CHECK(cudaGetLastError());
                 }
 
-                if (src1_col_0 == 0 && (!src0_on_device || !src0_is_contiguous) && i02 % i02_divisor == 0) {
+                if (src1_col_0 == 0 && !src0_is_contiguous && i02 % i02_divisor == 0) {
                     CUDA_CHECK(ggml_cuda_cpy_tensor_2d(src0_dd_i, src0, i03, i02/i02_divisor, dev[id].row_low, dev[id].row_high, stream));
                 }
 
@@ -9441,17 +9401,7 @@ static void ggml_cuda_op_mul_mat(
 
                 // copy dst to host or other device if necessary
                 if (!dst_on_device) {
-                    void * dst_off_device;
-                    cudaMemcpyKind kind;
-                    if (dst->backend == GGML_BACKEND_TYPE_CPU) {
-                        dst_off_device = dst->data;
-                        kind = cudaMemcpyDeviceToHost;
-                    } else if (dst->backend == GGML_BACKEND_TYPE_GPU) {
-                        dst_off_device = dst_extra->data_device[g_main_device];
-                        kind = cudaMemcpyDeviceToDevice;
-                    } else {
-                        GGML_ASSERT(false);
-                    }
+                    void * dst_off_device = dst_extra->data_device[g_main_device];
                     if (split) {
                         // src0 = weight matrix is saved as a transposed matrix for better memory layout.
                         // dst is NOT transposed.
@@ -9462,28 +9412,26 @@ static void ggml_cuda_op_mul_mat(
                         GGML_ASSERT(dst->nb[1] == ne0*sizeof(float));
                         dhf_dst_i += src1_col_0*ne0 + dev[id].row_low;
 #if !defined(GGML_USE_HIPBLAS)
-                        if (kind == cudaMemcpyDeviceToDevice) {
-                            // cudaMemcpy2DAsync may fail with copies between vmm pools of different devices
-                            cudaMemcpy3DPeerParms p = {};
-                            p.dstDevice = g_main_device;
-                            p.dstPtr = make_cudaPitchedPtr(dhf_dst_i, ne0*sizeof(float), row_diff, src1_ncols);
-                            p.srcDevice = id;
-                            p.srcPtr = make_cudaPitchedPtr(dst_dd_i, row_diff*sizeof(float), row_diff, src1_ncols);
-                            p.extent = make_cudaExtent(row_diff*sizeof(float), src1_ncols, 1);
-                            CUDA_CHECK(cudaMemcpy3DPeerAsync(&p, stream));
-                        } else
+                        // cudaMemcpy2DAsync may fail with copies between vmm pools of different devices
+                        cudaMemcpy3DPeerParms p = {};
+                        p.dstDevice = g_main_device;
+                        p.dstPtr = make_cudaPitchedPtr(dhf_dst_i, ne0*sizeof(float), row_diff, src1_ncols);
+                        p.srcDevice = id;
+                        p.srcPtr = make_cudaPitchedPtr(dst_dd_i, row_diff*sizeof(float), row_diff, src1_ncols);
+                        p.extent = make_cudaExtent(row_diff*sizeof(float), src1_ncols, 1);
+                        CUDA_CHECK(cudaMemcpy3DPeerAsync(&p, stream));
+#else
+                        // HIP does not support cudaMemcpy3DPeerAsync or vmm pools
+                        CUDA_CHECK(cudaMemcpy2DAsync(dhf_dst_i, ne0*sizeof(float),
+                                                        dst_dd_i, row_diff*sizeof(float),
+                                                        row_diff*sizeof(float), src1_ncols,
+                                                        cudaMemcpyDeviceToDevice, stream));
 #endif
-                        {
-                            CUDA_CHECK(cudaMemcpy2DAsync(dhf_dst_i, ne0*sizeof(float),
-                                                            dst_dd_i, row_diff*sizeof(float),
-                                                            row_diff*sizeof(float), src1_ncols,
-                                                            kind, stream));
-                        }
                     } else {
                         float * dhf_dst_i = (float *) ((char *) dst_off_device + i02*nb2 + i03*nb3);
                         GGML_ASSERT(dst->nb[1] == ne0*sizeof(float));
                         dhf_dst_i += src1_col_0*ne0;
-                        CUDA_CHECK(cudaMemcpyAsync(dhf_dst_i, dst_dd_i, src1_ncols*ne0*sizeof(float), kind, stream));
+                        CUDA_CHECK(cudaMemcpyAsync(dhf_dst_i, dst_dd_i, src1_ncols*ne0*sizeof(float), cudaMemcpyDeviceToDevice, stream));
                     }
                 }
 
@@ -9509,11 +9457,6 @@ static void ggml_cuda_op_mul_mat(
                 CUDA_CHECK(cudaStreamWaitEvent(g_cudaStreams[g_main_device][0], src0_extra->events[id][is], 0));
             }
         }
-    }
-
-    if (dst->backend == GGML_BACKEND_TYPE_CPU) {
-        ggml_cuda_set_device(g_main_device);
-        CUDA_CHECK(cudaDeviceSynchronize());
     }
 }
 
@@ -9599,36 +9542,19 @@ static void ggml_cuda_pad(const ggml_tensor * src0, const ggml_tensor * src1, gg
 static void ggml_cuda_arange(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     ggml_tensor_extra_gpu * dst_extra = (ggml_tensor_extra_gpu *)  dst->extra;
 
-    const bool dst_on_device = dst->backend == GGML_BACKEND_TYPE_GPU;
-
     // dd = data device
     float * src0_ddf = nullptr;
     float * src1_ddf = nullptr;
     float *  dst_ddf = nullptr;
 
-    cuda_pool_alloc<float>  dst_f;
-
     ggml_cuda_set_device(g_main_device);
     cudaStream_t main_stream = g_cudaStreams[g_main_device][0];
 
-    if (dst_on_device) {
-        dst_ddf = (float *) dst_extra->data_device[g_main_device];
-    } else {
-        dst_ddf = dst_f.alloc(ggml_nelements(dst));
-    }
+    dst_ddf = (float *) dst_extra->data_device[g_main_device];
 
     // do the computation
     ggml_cuda_op_arange(src0, src1, dst, src0_ddf, src1_ddf, dst_ddf, main_stream);
     CUDA_CHECK(cudaGetLastError());
-
-    // copy dst to host if necessary
-    if (!dst_on_device) {
-        CUDA_CHECK(cudaMemcpyAsync(dst->data, dst_ddf, ggml_nbytes(dst), cudaMemcpyDeviceToHost, main_stream));
-    }
-
-    if (dst->backend == GGML_BACKEND_TYPE_CPU) {
-        CUDA_CHECK(cudaDeviceSynchronize());
-    }
 }
 
 static void ggml_cuda_timestep_embedding(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
@@ -9891,11 +9817,6 @@ static void ggml_cuda_mul_mat_batched_cublas(const ggml_tensor * src0, const ggm
 }
 
 static void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    const bool all_on_device =
-        (src0->backend == GGML_BACKEND_TYPE_GPU || src0->backend == GGML_BACKEND_TYPE_GPU_SPLIT) &&
-        (src1->backend == GGML_BACKEND_TYPE_GPU) &&
-        ( dst->backend == GGML_BACKEND_TYPE_GPU);
-
     const bool split = src0->backend == GGML_BACKEND_TYPE_GPU_SPLIT;
 
     int64_t min_compute_capability = INT_MAX;
@@ -9972,13 +9893,13 @@ static void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1
     //printf("src0 is contiguous %d, transposed %d, type = %s, name = %s\n", ggml_is_contiguous(src0), ggml_is_transposed(src0), ggml_type_name(src0->type), src0->name);
     //printf("src1 is contiguous %d, transposed %d, type = %s, name = %s\n", ggml_is_contiguous(src1), ggml_is_transposed(src1), ggml_type_name(src1->type), src1->name);
 
-    if (!split && all_on_device && !fp16_performance_good && src0->type == GGML_TYPE_F16 && ggml_is_permuted(src0) && ggml_is_permuted(src1) && src1->ne[1] == 1) {
+    if (!split && !fp16_performance_good && src0->type == GGML_TYPE_F16 && ggml_is_permuted(src0) && ggml_is_permuted(src1) && src1->ne[1] == 1) {
         // KQ single-batch
         ggml_cuda_mul_mat_vec_p021(src0, src1, dst);
-    } else if (!split && all_on_device && !fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && src1->ne[1] == 1) {
+    } else if (!split && !fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && src1->ne[1] == 1) {
         // KQV single-batch
         ggml_cuda_mul_mat_vec_nc(src0, src1, dst);
-    } else if (!split && all_on_device && fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
+    } else if (!split && fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
         // KQ + KQV multi-batch
         ggml_cuda_mul_mat_batched_cublas(src0, src1, dst);
     } else if (use_dequantize_mul_mat_vec) {
@@ -10178,6 +10099,7 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
     ggml_cuda_mul_mat_id_cublas(dst);
     // TODO: mmq/mmv support
 #endif
+    cudaStream_t stream = g_cudaStreams[g_main_device][0];
 
     const size_t nb11 = src1->nb[1];
     const size_t nb1  =  dst->nb[1];
@@ -10187,16 +10109,9 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
     const int32_t n_as = ((int32_t *) dst->op_params)[1];
 
     std::vector<char> ids_host(ggml_nbytes(ids));
-
-    cudaStream_t stream = g_cudaStreams[g_main_device][0];
-
-    if (ids->backend == GGML_BACKEND_TYPE_GPU) {
-        const char * ids_dev = (const char *)((const ggml_tensor_extra_gpu *)ids->extra)->data_device[g_main_device];
-        CUDA_CHECK(cudaMemcpyAsync(ids_host.data(), ids_dev, ggml_nbytes(ids), cudaMemcpyDeviceToHost, stream));
-        CUDA_CHECK(cudaStreamSynchronize(stream));
-    } else {
-        memcpy(ids_host.data(), ids->data, ggml_nbytes(ids));
-    }
+    const char * ids_dev = (const char *)((const ggml_tensor_extra_gpu *)ids->extra)->data_device[g_main_device];
+    CUDA_CHECK(cudaMemcpyAsync(ids_host.data(), ids_dev, ggml_nbytes(ids), cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     const ggml_tensor_extra_gpu * src1_extra = (const ggml_tensor_extra_gpu *) src1->extra;
     const ggml_tensor_extra_gpu * dst_extra = (const ggml_tensor_extra_gpu *) dst->extra;
@@ -10213,20 +10128,11 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
     src1_row.extra = &src1_row_extra;
     dst_row.extra = &dst_row_extra;
 
-    char * src1_original = src1->backend == GGML_BACKEND_TYPE_CPU ?
-        (char *) src1->data : (char *) src1_extra->data_device[g_main_device];
-    char * dst_original  =  dst->backend == GGML_BACKEND_TYPE_CPU ?
-        (char *)  dst->data : (char *)  dst_extra->data_device[g_main_device];
+    char * src1_original = (char *) src1_extra->data_device[g_main_device];
+    char * dst_original  = (char *)  dst_extra->data_device[g_main_device];
 
     if (src1->ne[1] == 1) {
-        GGML_ASSERT(src1->backend == GGML_BACKEND_TYPE_GPU);
-        GGML_ASSERT(dst->backend  == GGML_BACKEND_TYPE_GPU);
-
         for (int64_t i01 = 0; i01 < ids->ne[1]; i01++) {
-            //int32_t row_id;
-            //CUDA_CHECK(cudaMemcpyAsync(&row_id, ids_dev + i01*ids->nb[1] + id*ids->nb[0], sizeof(int32_t), cudaMemcpyDeviceToHost, g_cudaStreams[g_main_device][0]));
-            //CUDA_CHECK(cudaStreamSynchronize(g_cudaStreams[g_main_device][0]));
-
             const int32_t row_id = *(const int32_t *) (ids_host.data() + i01*ids->nb[1] + id*ids->nb[0]);
 
             GGML_ASSERT(row_id >= 0 && row_id < n_as);
@@ -10248,11 +10154,6 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
         src1_row_extra.data_device[g_main_device] = src1_contiguous.get();
         dst_row_extra.data_device[g_main_device]  =  dst_contiguous.get();
 
-        const cudaMemcpyKind src1_kind = src1->backend == GGML_BACKEND_TYPE_CPU ?
-            cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice;
-        const cudaMemcpyKind dst_kind  =  dst->backend == GGML_BACKEND_TYPE_CPU ?
-            cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice;
-
         for (int32_t row_id = 0; row_id < n_as; ++row_id) {
             const struct ggml_tensor * src0_row = dst->src[row_id + 2];
 
@@ -10267,7 +10168,7 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
                 GGML_ASSERT(row_id >= 0 && row_id < n_as);
 
                 CUDA_CHECK(cudaMemcpyAsync(src1_contiguous.get() + num_src1_rows*nb11, src1_original + i01*nb11,
-                                        nb11, src1_kind, stream));
+                                        nb11, cudaMemcpyDeviceToDevice, stream));
                 num_src1_rows++;
             }
 
@@ -10299,14 +10200,10 @@ static void ggml_cuda_mul_mat_id(const ggml_tensor * src0, const ggml_tensor * s
                 GGML_ASSERT(row_id >= 0 && row_id < n_as);
 
                 CUDA_CHECK(cudaMemcpyAsync(dst_original + i01*nb1, dst_contiguous.get() + num_src1_rows*nb1,
-                                        nb1, dst_kind, stream));
+                                        nb1, cudaMemcpyDeviceToDevice, stream));
                 num_src1_rows++;
             }
         }
-    }
-
-    if (dst->backend == GGML_BACKEND_TYPE_CPU) {
-        CUDA_CHECK(cudaStreamSynchronize(stream));
     }
 }
 
@@ -10735,8 +10632,13 @@ GGML_CALL static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t
         size_t original_size = ggml_nbytes(tensor);
         size_t padded_size = ggml_backend_buft_get_alloc_size(buffer->buft, tensor);
 
+        //printf("%s: data: %p, original: %lu, padded: %lu, diff: %lu\n", tensor->name, tensor->data, original_size, padded_size, padded_size - original_size);
+        //printf("buffer range: %p - %p\n", ctx->dev_ptr, (char *)ctx->dev_ptr + buffer->size);
+
         if (padded_size > original_size && tensor->view_src == nullptr) {
-            CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
+            //CUDA_CHECK(cudaDeviceSynchronize());
+            //printf("cudaMemset(%p, %d, %ld)\n", (char *)tensor->data + original_size, 0, padded_size - original_size);
+            //CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
         }
     }
 }
@@ -11509,6 +11411,18 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
     UNUSED(backend);
 }
 
+GGML_CALL static bool ggml_backend_cuda_offload_op(ggml_backend_t backend, const ggml_tensor * op) {
+    const ggml_tensor * dst = op;
+
+    const int min_batch_size = 32;
+
+    if (dst->ne[1] > min_batch_size && dst->op != GGML_OP_GET_ROWS) {
+        return true;
+    }
+
+    return false;
+}
+
 static ggml_backend_event_t ggml_backend_cuda_event_new(ggml_backend_t backend) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
 
@@ -11571,6 +11485,7 @@ static ggml_backend_i ggml_backend_cuda_interface = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_cuda_graph_compute,
     /* .supports_op             = */ ggml_backend_cuda_supports_op,
+    /* .offload_op              = */ ggml_backend_cuda_offload_op,
     /* .event_new               = */ ggml_backend_cuda_event_new,
     /* .event_free              = */ ggml_backend_cuda_event_free,
     /* .event_record            = */ ggml_backend_cuda_event_record,
@@ -11625,6 +11540,31 @@ GGML_CALL void ggml_backend_cuda_get_device_memory(int device, size_t * free, si
     ggml_cuda_set_device(device);
 
     CUDA_CHECK(cudaMemGetInfo(free, total));
+}
+
+GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size) {
+    if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
+        return false;
+    }
+
+    cudaError_t err = cudaHostRegister(buffer, size, cudaHostRegisterPortable | cudaHostRegisterReadOnly);
+    if (err != cudaSuccess) {
+        // clear the error
+        cudaGetLastError();
+
+        fprintf(stderr, "%s: warning: failed to register %.2f MiB of pinned memory: %s\n", __func__,
+                size/1024.0/1024.0, cudaGetErrorString(err));
+        return false;
+    }
+    return true;
+}
+
+GGML_CALL void ggml_backend_cuda_unregister_host_buffer(void * buffer) {
+    cudaError_t err = cudaHostUnregister(buffer);
+    if (err != cudaSuccess) {
+        // clear the error
+        cudaGetLastError();
+    }
 }
 
 // backend registry

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -10618,6 +10618,7 @@ GGML_CALL static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t
         size_t padded_size = ggml_backend_buft_get_alloc_size(buffer->buft, tensor);
 
         if (padded_size > original_size && tensor->view_src == nullptr) {
+            ggml_cuda_set_device(ctx->device);
             CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
         }
     }

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -82,6 +82,10 @@
 #define cudaGetDeviceProperties hipGetDeviceProperties
 #define cudaGetErrorString hipGetErrorString
 #define cudaGetLastError hipGetLastError
+#define cudaHostRegister hipHostRegister
+#define cudaHostRegisterPortable hipHostRegisterPortable
+#define cudaHostRegisterReadOnly hipHostRegisterReadOnly
+#define cudaHostUnregister hipHostUnregister
 #define cudaLaunchHostFunc hipLaunchHostFunc
 #ifdef GGML_HIP_UMA
 #define cudaMalloc hipMallocManaged

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -9286,8 +9286,8 @@ static void ggml_cuda_op_mul_mat(
 
         used_devices++;
 
-        const bool src1_on_device = src1->backend == GGML_BACKEND_TYPE_GPU && id == g_main_device;
-        const bool  dst_on_device =  dst->backend == GGML_BACKEND_TYPE_GPU && id == g_main_device;
+        const bool src1_on_device = id == g_main_device; // TODO: check from buffer
+        const bool  dst_on_device = id == g_main_device;
 
         ggml_cuda_set_device(id);
         cudaStream_t stream = g_cudaStreams[id][0];
@@ -9338,8 +9338,8 @@ static void ggml_cuda_op_mul_mat(
                 continue;
             }
 
-            const bool src1_on_device = src1->backend == GGML_BACKEND_TYPE_GPU && id == g_main_device;
-            const bool  dst_on_device =  dst->backend == GGML_BACKEND_TYPE_GPU && id == g_main_device;
+            const bool src1_on_device = id == g_main_device; // TODO: check from buffer
+            const bool  dst_on_device = id == g_main_device;
             const int64_t row_diff = dev[id].row_high - dev[id].row_low;
 
             ggml_cuda_set_device(id);
@@ -9364,12 +9364,12 @@ static void ggml_cuda_op_mul_mat(
 
                 // the main device memory buffer can be on VRAM scratch, with space for all partial results
                 // in that case an offset on dst_ddf_i is needed
-                if (dst->backend == GGML_BACKEND_TYPE_GPU && id == g_main_device) {
+                if (id == g_main_device) {
                     dst_dd_i += dev[id].row_low; // offset is 0 if no tensor split
                 }
 
                 // copy src0, src1 to device if necessary
-                if (src1->backend == GGML_BACKEND_TYPE_GPU && src1_is_contiguous) {
+                if (src1_is_contiguous) {
                     if (id != g_main_device) {
                         if (convert_src1_to_q8_1) {
                             char * src1_ddq_i_source = dev[g_main_device].src1_ddq + src1_ddq_i_offset;
@@ -10351,17 +10351,8 @@ GGML_CALL static void ggml_cuda_set_main_device(const int main_device) {
     }
 }
 
-GGML_CALL bool ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor) {
+GGML_CALL bool ggml_cuda_compute_forward(struct ggml_tensor * tensor) {
     if (!g_cublas_loaded) return false;
-
-    ggml_cuda_func_t func;
-    const bool any_on_device = tensor->backend == GGML_BACKEND_TYPE_GPU
-        || (tensor->src[0] != nullptr && (tensor->src[0]->backend == GGML_BACKEND_TYPE_GPU || tensor->src[0]->backend == GGML_BACKEND_TYPE_GPU_SPLIT))
-        || (tensor->src[1] != nullptr && tensor->src[1]->backend == GGML_BACKEND_TYPE_GPU);
-
-    if (!any_on_device && tensor->op != GGML_OP_MUL_MAT && tensor->op != GGML_OP_MUL_MAT_ID) {
-        return false;
-    }
 
     if (tensor->op == GGML_OP_MUL_MAT) {
         if (tensor->src[0]->ne[3] != tensor->src[1]->ne[3]) {
@@ -10371,6 +10362,8 @@ GGML_CALL bool ggml_cuda_compute_forward(struct ggml_compute_params * params, st
             return false;
         }
     }
+
+    ggml_cuda_func_t func;
 
     switch (tensor->op) {
         case GGML_OP_REPEAT:
@@ -10449,15 +10442,9 @@ GGML_CALL bool ggml_cuda_compute_forward(struct ggml_compute_params * params, st
             func = ggml_cuda_rms_norm;
             break;
         case GGML_OP_MUL_MAT:
-            if (!any_on_device && !ggml_cuda_can_mul_mat(tensor->src[0], tensor->src[1], tensor)) {
-                return false;
-            }
             func = ggml_cuda_mul_mat;
             break;
         case GGML_OP_MUL_MAT_ID:
-            if (!any_on_device && !ggml_cuda_can_mul_mat(tensor->src[2], tensor->src[1], tensor)) {
-                return false;
-            }
             func = ggml_cuda_mul_mat_id;
             break;
         case GGML_OP_SCALE:
@@ -10514,12 +10501,6 @@ GGML_CALL bool ggml_cuda_compute_forward(struct ggml_compute_params * params, st
         ggml_cuda_set_peer_access(tensor->src[1]->ne[1]);
     }
 
-    if (params->ith != 0) {
-        return true;
-    }
-    if (params->type == GGML_TASK_TYPE_INIT || params->type == GGML_TASK_TYPE_FINALIZE) {
-        return true;
-    }
     func(tensor->src[0], tensor->src[1], tensor);
     return true;
 }
@@ -10636,13 +10617,8 @@ GGML_CALL static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t
         size_t original_size = ggml_nbytes(tensor);
         size_t padded_size = ggml_backend_buft_get_alloc_size(buffer->buft, tensor);
 
-        //printf("%s: data: %p, original: %lu, padded: %lu, diff: %lu\n", tensor->name, tensor->data, original_size, padded_size, padded_size - original_size);
-        //printf("buffer range: %p - %p\n", ctx->dev_ptr, (char *)ctx->dev_ptr + buffer->size);
-
         if (padded_size > original_size && tensor->view_src == nullptr) {
-            //CUDA_CHECK(cudaDeviceSynchronize());
-            //printf("cudaMemset(%p, %d, %ld)\n", (char *)tensor->data + original_size, 0, padded_size - original_size);
-            //CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
+            CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
         }
     }
 }
@@ -11254,9 +11230,6 @@ GGML_CALL static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t
 
     ggml_cuda_set_main_device(cuda_ctx->device);
 
-    ggml_compute_params params = {};
-    params.type = GGML_TASK_TYPE_COMPUTE;
-    params.ith = 0;
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
 
@@ -11278,7 +11251,7 @@ GGML_CALL static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t
         }
 #endif
 
-        bool ok = ggml_cuda_compute_forward(&params, node);
+        bool ok = ggml_cuda_compute_forward(node);
         if (!ok) {
             fprintf(stderr, "%s: error: op not supported %s (%s)\n", __func__, node->name, ggml_op_name(node->op));
         }

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -17,18 +17,17 @@ extern "C" {
 
 #define GGML_CUDA_MAX_DEVICES       16
 
-// TODO: remove this
-GGML_API GGML_CALL int    ggml_cuda_get_device_count(void);
-GGML_API GGML_CALL void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
-
 // backend API
 GGML_API GGML_CALL ggml_backend_t ggml_backend_cuda_init(int device);
 
 GGML_API GGML_CALL bool ggml_backend_is_cuda(ggml_backend_t backend);
 
+// device buffer
 GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);
+
 // split tensor buffer that splits matrices by rows across multiple devices
 GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_split_buffer_type(const float * tensor_split);
+
 // pinned host buffer for use with the CPU backend for faster copies between CPU and GPU
 GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type(void);
 

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -17,18 +17,7 @@ extern "C" {
 
 #define GGML_CUDA_MAX_DEVICES       16
 
-// Always success. To check if CUDA is actually loaded, use `ggml_cublas_loaded`.
-GGML_API GGML_CALL void   ggml_init_cublas(void);
-
-// Returns `true` if there are available CUDA devices and cublas loads successfully; otherwise, it returns `false`.
-GGML_API GGML_CALL bool   ggml_cublas_loaded(void);
-
-GGML_API GGML_CALL void * ggml_cuda_host_malloc(size_t size);
-GGML_API GGML_CALL void   ggml_cuda_host_free(void * ptr);
-
-GGML_API GGML_CALL bool   ggml_cuda_can_mul_mat(const struct ggml_tensor * src0, const struct ggml_tensor * src1, struct ggml_tensor * dst);
-GGML_API GGML_CALL bool   ggml_cuda_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor);
-
+// TODO: remove this
 GGML_API GGML_CALL int    ggml_cuda_get_device_count(void);
 GGML_API GGML_CALL void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
 
@@ -46,6 +35,9 @@ GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type
 GGML_API GGML_CALL int  ggml_backend_cuda_get_device_count(void);
 GGML_API GGML_CALL void ggml_backend_cuda_get_device_description(int device, char * description, size_t description_size);
 GGML_API GGML_CALL void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * total);
+
+GGML_API GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size);
+GGML_API GGML_CALL void ggml_backend_cuda_unregister_host_buffer(void * buffer);
 
 #ifdef  __cplusplus
 }

--- a/ggml-kompute.cpp
+++ b/ggml-kompute.cpp
@@ -1951,6 +1951,7 @@ static struct ggml_backend_i kompute_backend_i = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_kompute_graph_compute,
     /* .supports_op             = */ ggml_backend_kompute_supports_op,
+    /* .offload_op              = */ NULL,
     /* .event_new               = */ NULL,
     /* .event_free              = */ NULL,
     /* .event_record            = */ NULL,

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -2837,6 +2837,7 @@ static struct ggml_backend_i ggml_backend_metal_i = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_metal_graph_compute,
     /* .supports_op             = */ ggml_backend_metal_supports_op,
+    /* .offload_op              = */ NULL,
     /* .event_new               = */ NULL,
     /* .event_free              = */ NULL,
     /* .event_record            = */ NULL,

--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -17390,6 +17390,7 @@ static ggml_backend_i ggml_backend_sycl_interface = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_sycl_graph_compute,
     /* .supports_op             = */ ggml_backend_sycl_supports_op,
+    /* .offload_op              = */ NULL,
     /* .event_new               = */ NULL,
     /* .event_free              = */ NULL,
     /* .event_record            = */ NULL,

--- a/ggml-vulkan.cpp
+++ b/ggml-vulkan.cpp
@@ -5693,6 +5693,7 @@ static ggml_backend_i ggml_backend_vk_interface = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_vk_graph_compute,
     /* .supports_op             = */ ggml_backend_vk_supports_op,
+    /* .offload_op              = */ NULL,
     /* .event_new               = */ NULL,
     /* .event_free              = */ NULL,
     /* .event_record            = */ NULL,

--- a/ggml.c
+++ b/ggml.c
@@ -282,8 +282,6 @@ inline static void * ggml_calloc(size_t num, size_t size) {
 #else
 #include <cblas.h>
 #endif
-#elif defined(GGML_USE_CUBLAS)
-#include "ggml-cuda.h"
 #elif defined(GGML_USE_CLBLAST)
 #include "ggml-opencl.h"
 #elif defined(GGML_USE_VULKAN)
@@ -2545,9 +2543,7 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
             GGML_PRINT_DEBUG("%s: g_state initialized in %f ms\n", __func__, (t_end - t_start)/1000.0f);
         }
 
-#if defined(GGML_USE_CUBLAS)
-        ggml_init_cublas();
-#elif defined(GGML_USE_CLBLAST)
+#if defined(GGML_USE_CLBLAST)
         ggml_cl_init();
 #elif defined(GGML_USE_VULKAN)
         ggml_vk_init_cpu_assist();
@@ -11010,7 +11006,6 @@ static void ggml_compute_forward_out_prod_f32(
     // nb01 >= nb00 - src0 is not transposed
     //   compute by src0 rows
 
-    // TODO: #if defined(GGML_USE_CUBLAS) ggml_cuda_out_prod
     // TODO: #if defined(GGML_USE_CLBLAST)
 
 #if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS)
@@ -11210,7 +11205,6 @@ static void ggml_compute_forward_out_prod_q_f32(
     // nb01 >= nb00 - src0 is not transposed
     //   compute by src0 rows
 
-    // TODO: #if defined(GGML_USE_CUBLAS) ggml_cuda_out_prod
     // TODO: #if defined(GGML_USE_ACCELERATE) || defined(GGML_USE_OPENBLAS) || defined(GGML_USE_CLBLAST)
 
     if (params->type == GGML_TASK_TYPE_INIT) {
@@ -15956,14 +15950,7 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
         return;
     }
 
-#ifdef GGML_USE_CUBLAS
-    bool skip_cpu = ggml_cuda_compute_forward(params, tensor);
-    if (skip_cpu) {
-        return;
-    }
-    GGML_ASSERT(tensor->src[0] == NULL || tensor->src[0]->backend == GGML_BACKEND_TYPE_CPU);
-    GGML_ASSERT(tensor->src[1] == NULL || tensor->src[1]->backend == GGML_BACKEND_TYPE_CPU);
-#elif defined(GGML_USE_VULKAN)
+#if defined(GGML_USE_VULKAN)
     const bool skip_cpu = ggml_vk_compute_forward_cpu_assist(params, tensor);
 #ifdef GGML_VULKAN_CHECK_RESULTS
     if (skip_cpu) {
@@ -15975,7 +15962,7 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
     }
     GGML_ASSERT(tensor->src[0] == NULL || tensor->src[0]->backend == GGML_BACKEND_TYPE_CPU);
     GGML_ASSERT(tensor->src[1] == NULL || tensor->src[1]->backend == GGML_BACKEND_TYPE_CPU);
-#endif // GGML_USE_CUBLAS
+#endif // GGML_USE_VULKAN
 
 #ifdef GGML_USE_SYCL
     bool skip_cpu = ggml_sycl_compute_forward(params, tensor);

--- a/llama.cpp
+++ b/llama.cpp
@@ -8612,16 +8612,18 @@ static struct ggml_cgraph * llama_build_graph(
         }
 
         // norm may be automatically assigned to the backend of the previous layer, increasing data transfer between backends
-        // to fix this, we assign the norm layer manually to the backend of its layer
-        // FIXME: interferes with auto offloading of large batches
-        //if (il != -1 && strcmp(name, "norm") == 0) {
-        //    for (auto * backend : lctx.backends) {
-        //        if (ggml_backend_buft_supports_backend(lctx.model.buft_layer[il].buft, backend)) {
-        //            ggml_backend_sched_set_tensor_backend(lctx.sched, cur, backend);
-        //            break;
-        //        }
-        //    }
-        //}
+        // FIXME: fix in ggml_backend_sched
+        const bool full_offload = lctx.model.n_gpu_layers > (int)lctx.model.hparams.n_layer;
+        if (batch.n_tokens <= 32 || full_offload) {
+            if (il != -1 && strcmp(name, "norm") == 0) {
+                for (auto * backend : lctx.backends) {
+                    if (ggml_backend_buft_supports_backend(lctx.model.buft_layer[il].buft, backend)) {
+                        ggml_backend_sched_set_tensor_backend(lctx.sched, cur, backend);
+                        break;
+                    }
+                }
+            }
+        }
     };
 
     struct ggml_cgraph * result = NULL;
@@ -13119,27 +13121,25 @@ struct llama_context * llama_new_context_with_model(
             ctx->backends.push_back(ctx->backend_metal);
         }
 #elif defined(GGML_USE_CUBLAS)
-        if (model->n_gpu_layers >= 0) { // TODO: make auto-offload configurable
+        if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_ROW) {
             // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_ROW, only the main GPU backend is used
-            if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_ROW) {
-                ggml_backend_t backend = ggml_backend_cuda_init(model->main_gpu);
+            ggml_backend_t backend = ggml_backend_cuda_init(model->main_gpu);
+            if (backend == nullptr) {
+                LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, model->main_gpu);
+                llama_free(ctx);
+                return nullptr;
+            }
+            ctx->backends.push_back(backend);
+        } else {
+            // LLAMA_SPLIT_MODE_LAYER requires a backend for each GPU
+            for (int device = 0; device < ggml_backend_cuda_get_device_count(); ++device) {
+                ggml_backend_t backend = ggml_backend_cuda_init(device);
                 if (backend == nullptr) {
-                    LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, model->main_gpu);
+                    LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, device);
                     llama_free(ctx);
                     return nullptr;
                 }
                 ctx->backends.push_back(backend);
-            } else {
-                // LLAMA_SPLIT_MODE_LAYER requires a backend for each GPU
-                for (int device = 0; device < ggml_backend_cuda_get_device_count(); ++device) {
-                    ggml_backend_t backend = ggml_backend_cuda_init(device);
-                    if (backend == nullptr) {
-                        LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, device);
-                        llama_free(ctx);
-                        return nullptr;
-                    }
-                    ctx->backends.push_back(backend);
-                }
             }
         }
 #elif defined(GGML_USE_VULKAN)
@@ -13297,14 +13297,17 @@ struct llama_context * llama_new_context_with_model(
                 ggml_backend_t backend = ctx->backends[i];
                 ggml_backend_buffer_type_t buft = backend_buft[i];
                 size_t size = ggml_backend_sched_get_buffer_size(ctx->sched, backend);
-                LLAMA_LOG_INFO("%s: %10s compute buffer size = %8.2f MiB\n", __func__,
-                        ggml_backend_buft_name(buft),
-                        size / 1024.0 / 1024.0);
+                if (size > 1) {
+                    LLAMA_LOG_INFO("%s: %10s compute buffer size = %8.2f MiB\n", __func__,
+                            ggml_backend_buft_name(buft),
+                            size / 1024.0 / 1024.0);
+                }
             }
 
             // note: the number of splits during measure is higher than during inference due to the kv shift
             int n_splits = ggml_backend_sched_get_n_splits(ctx->sched);
-            LLAMA_LOG_INFO("%s: graph splits: %d\n", __func__, n_splits);
+            LLAMA_LOG_INFO("%s: graph nodes  = %d\n", __func__, gf->n_nodes);
+            LLAMA_LOG_INFO("%s: graph splits = %d\n", __func__, n_splits);
         }
     }
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -8614,7 +8614,7 @@ static struct ggml_cgraph * llama_build_graph(
         // norm may be automatically assigned to the backend of the previous layer, increasing data transfer between backends
         // FIXME: fix in ggml_backend_sched
         const bool full_offload = lctx.model.n_gpu_layers > (int)lctx.model.hparams.n_layer;
-        if (batch.n_tokens <= 32 || full_offload) {
+        if (batch.n_tokens < 32 || full_offload) {
             if (il != -1 && strcmp(name, "norm") == 0) {
                 for (auto * backend : lctx.backends) {
                     if (ggml_backend_buft_supports_backend(lctx.model.buft_layer[il].buft, backend)) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -5039,7 +5039,11 @@ static bool llm_load_tensors(
             ml.get_mapping_range(&first, &last, ctx);
             buf = ggml_backend_cpu_buffer_from_ptr((char *) ml.mapping->addr + first, last - first);
 #ifdef GGML_USE_CUBLAS
-            ggml_backend_cuda_register_host_buffer((char *) ml.mapping->addr + first, last - first);
+            if (n_layer >= n_gpu_layers) {
+                ggml_backend_cuda_register_host_buffer(
+                        ggml_backend_buffer_get_base(buf),
+                        ggml_backend_buffer_get_size(buf));
+            }
 #endif
         }
 #ifdef GGML_USE_METAL


### PR DESCRIPTION
Moves the logic of auto-offloading to the GPU when processing large batches to `ggml_backend_sched`. Currently only CUDA and Vulkan support this, this will allow any backend to support this feature. 

Instead of offloading only the matrix multiplications, the entire computation of the batch is offloaded. This reduces the amount of data that needs to be transferred between the GPU and CPU and improves performance significantly.

The weights are now copied to VRAM in the compute buffer, instead of the private CUDA pool buffer. As a result, the size of the compute buffers will increase significantly when offloading a model partially. However, the total VRAM usage should stay same, or slightly lower.

Backends that wish to support this feature need to implement the `offload_op` function. Only the CUDA backend implements it at this point.

Additionally, the CUDA backend will now attempt to register as a host pinned buffer the memory of the models, even when using mmap. Previously, host buffers were only supported with mmap disabled. This further increases the performance of automatic offloading. The usage of host pinned memory can be disabled by defining the `GGML_CUDA_NO_PINNED` environment variable.

RTX 3090 Ti, CUDA under WSL:
![bench-7b-pp1024](https://github.com/ggerganov/llama.cpp/assets/2141330/fe11f96d-93f6-4abe-b750-e716c8950e63)

![bench-mixtral-pp1024](https://github.com/ggerganov/llama.cpp/assets/2141330/402131a1-1f9d-4165-bcad-8f7ad8df5a83)

<details>
<summary>Raw data</summary>

| model                          |       size |     params | backend    | ngl |    n_batch |   n_ubatch |       mmap | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------: | ---------: | ---------: | ---------- | ---------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   0 |       1024 |       1024 |          0 | pp 1024    |    388.15 ± 1.24 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   0 |       1024 |       1024 |          1 | pp 1024    |    348.58 ± 2.46 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   1 |       1024 |       1024 |          0 | pp 1024    |    397.95 ± 1.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   1 |       1024 |       1024 |          1 | pp 1024    |    359.64 ± 1.94 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   2 |       1024 |       1024 |          0 | pp 1024    |    409.85 ± 2.36 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   2 |       1024 |       1024 |          1 | pp 1024    |    370.63 ± 3.55 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   3 |       1024 |       1024 |          0 | pp 1024    |    422.51 ± 2.51 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   3 |       1024 |       1024 |          1 | pp 1024    |    380.48 ± 1.25 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   4 |       1024 |       1024 |          0 | pp 1024    |    433.78 ± 1.37 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   4 |       1024 |       1024 |          1 | pp 1024    |    392.48 ± 2.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   5 |       1024 |       1024 |          0 | pp 1024    |    447.87 ± 1.24 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   5 |       1024 |       1024 |          1 | pp 1024    |    404.52 ± 2.98 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   6 |       1024 |       1024 |          0 | pp 1024    |    463.28 ± 1.98 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   6 |       1024 |       1024 |          1 | pp 1024    |    418.75 ± 2.95 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   7 |       1024 |       1024 |          0 | pp 1024    |    478.75 ± 1.40 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   7 |       1024 |       1024 |          1 | pp 1024    |    430.76 ± 2.00 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   8 |       1024 |       1024 |          0 | pp 1024    |    495.91 ± 1.76 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   8 |       1024 |       1024 |          1 | pp 1024    |    447.96 ± 3.44 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   9 |       1024 |       1024 |          0 | pp 1024    |    515.97 ± 1.26 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   9 |       1024 |       1024 |          1 | pp 1024    |    469.55 ± 2.47 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  10 |       1024 |       1024 |          0 | pp 1024    |    535.50 ± 2.02 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  10 |       1024 |       1024 |          1 | pp 1024    |    485.98 ± 3.47 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  11 |       1024 |       1024 |          0 | pp 1024    |    555.22 ± 3.80 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  11 |       1024 |       1024 |          1 | pp 1024    |    504.74 ± 3.24 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  12 |       1024 |       1024 |          0 | pp 1024    |    581.50 ± 3.47 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  12 |       1024 |       1024 |          1 | pp 1024    |    529.37 ± 1.10 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  13 |       1024 |       1024 |          0 | pp 1024    |    605.49 ± 3.89 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  13 |       1024 |       1024 |          1 | pp 1024    |    550.70 ± 1.20 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  14 |       1024 |       1024 |          0 | pp 1024    |    636.00 ± 3.93 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  14 |       1024 |       1024 |          1 | pp 1024    |    574.79 ± 1.91 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  15 |       1024 |       1024 |          0 | pp 1024    |    669.54 ± 2.16 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  15 |       1024 |       1024 |          1 | pp 1024    |    611.74 ± 3.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  16 |       1024 |       1024 |          0 | pp 1024    |    696.63 ± 5.25 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  16 |       1024 |       1024 |          1 | pp 1024    |    638.12 ± 2.97 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  17 |       1024 |       1024 |          0 | pp 1024    |    739.56 ± 3.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  17 |       1024 |       1024 |          1 | pp 1024    |    678.63 ± 3.30 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  18 |       1024 |       1024 |          0 | pp 1024    |    784.66 ± 2.44 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  18 |       1024 |       1024 |          1 | pp 1024    |    713.97 ± 2.73 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  19 |       1024 |       1024 |          0 | pp 1024    |    828.81 ± 3.28 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  19 |       1024 |       1024 |          1 | pp 1024    |    759.73 ± 3.57 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  20 |       1024 |       1024 |          0 | pp 1024    |    884.96 ± 4.69 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  20 |       1024 |       1024 |          1 | pp 1024    |    806.80 ± 6.71 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  21 |       1024 |       1024 |          0 | pp 1024    |    948.70 ± 5.85 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  21 |       1024 |       1024 |          1 | pp 1024    |    860.19 ± 5.59 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  22 |       1024 |       1024 |          0 | pp 1024    |   1019.88 ± 3.62 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  22 |       1024 |       1024 |          1 | pp 1024    |    933.79 ± 4.86 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  23 |       1024 |       1024 |          0 | pp 1024    |   1101.54 ± 4.91 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  23 |       1024 |       1024 |          1 | pp 1024    |   1007.86 ± 4.38 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  24 |       1024 |       1024 |          0 | pp 1024    |   1194.18 ± 3.30 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  24 |       1024 |       1024 |          1 | pp 1024    |  1095.93 ± 15.66 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  25 |       1024 |       1024 |          0 | pp 1024    |   1311.94 ± 8.63 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  25 |       1024 |       1024 |          1 | pp 1024    |  1207.60 ± 10.30 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  26 |       1024 |       1024 |          0 | pp 1024    |  1442.92 ± 14.07 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  26 |       1024 |       1024 |          1 | pp 1024    |  1346.63 ± 15.93 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  27 |       1024 |       1024 |          0 | pp 1024    |  1615.53 ± 15.01 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  27 |       1024 |       1024 |          1 | pp 1024    |   1490.20 ± 9.59 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  28 |       1024 |       1024 |          0 | pp 1024    |  1818.64 ± 30.18 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  28 |       1024 |       1024 |          1 | pp 1024    |  1710.29 ± 17.53 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  29 |       1024 |       1024 |          0 | pp 1024    |  2144.10 ± 21.59 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  29 |       1024 |       1024 |          1 | pp 1024    |  1993.06 ± 27.68 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  30 |       1024 |       1024 |          0 | pp 1024    |  2546.11 ± 19.09 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  30 |       1024 |       1024 |          1 | pp 1024    |  2371.35 ± 35.65 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  31 |       1024 |       1024 |          0 | pp 1024    | 2885.51 ± 115.14 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  31 |       1024 |       1024 |          1 | pp 1024    | 2863.88 ± 132.35 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  32 |       1024 |       1024 |          0 | pp 1024    | 3732.88 ± 206.19 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  32 |       1024 |       1024 |          1 | pp 1024    | 3694.50 ± 119.51 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  33 |       1024 |       1024 |          0 | pp 1024    |   4685.48 ± 5.83 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  33 |       1024 |       1024 |          1 | pp 1024    |  4653.46 ± 45.50 |

build: 4755afd1 (2431)

| model                          |       size |     params | backend    | ngl |    n_batch |   n_ubatch | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------: | ---------: | ---------- | ---------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   0 |       1024 |       1024 | pp 1024    |  1178.01 ± 52.80 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   1 |       1024 |       1024 | pp 1024    |  1221.25 ± 20.50 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   2 |       1024 |       1024 | pp 1024    |  1251.01 ± 30.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   3 |       1024 |       1024 | pp 1024    |  1294.10 ± 15.29 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   4 |       1024 |       1024 | pp 1024    |  1299.26 ± 36.69 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   5 |       1024 |       1024 | pp 1024    |  1313.64 ± 53.28 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   6 |       1024 |       1024 | pp 1024    |  1371.72 ± 48.12 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   7 |       1024 |       1024 | pp 1024    |  1404.57 ± 38.03 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   8 |       1024 |       1024 | pp 1024    |  1467.46 ± 42.10 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |   9 |       1024 |       1024 | pp 1024    |  1512.92 ± 44.17 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  10 |       1024 |       1024 | pp 1024    |  1561.79 ± 32.51 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  11 |       1024 |       1024 | pp 1024    |  1546.95 ± 33.21 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  12 |       1024 |       1024 | pp 1024    |  1638.92 ± 38.17 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  13 |       1024 |       1024 | pp 1024    |  1689.80 ± 66.00 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  14 |       1024 |       1024 | pp 1024    |  1770.98 ± 30.59 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  15 |       1024 |       1024 | pp 1024    |  1721.52 ± 79.84 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  16 |       1024 |       1024 | pp 1024    |  1806.18 ± 95.38 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  17 |       1024 |       1024 | pp 1024    |  1924.98 ± 55.63 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  18 |       1024 |       1024 | pp 1024    |  1969.87 ± 81.24 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  19 |       1024 |       1024 | pp 1024    |  2023.63 ± 63.53 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  20 |       1024 |       1024 | pp 1024    | 2105.42 ± 160.57 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  21 |       1024 |       1024 | pp 1024    | 2224.15 ± 130.01 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  22 |       1024 |       1024 | pp 1024    |  2274.62 ± 54.49 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  23 |       1024 |       1024 | pp 1024    |  2402.49 ± 98.09 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  24 |       1024 |       1024 | pp 1024    |  2598.08 ± 99.31 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  25 |       1024 |       1024 | pp 1024    |  2758.21 ± 67.71 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  26 |       1024 |       1024 | pp 1024    | 2788.94 ± 168.04 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  27 |       1024 |       1024 | pp 1024    |  3061.96 ± 81.72 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  28 |       1024 |       1024 | pp 1024    |  3219.39 ± 97.09 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  29 |       1024 |       1024 | pp 1024    |  3455.13 ± 77.40 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  30 |       1024 |       1024 | pp 1024    |  3603.32 ± 77.86 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  31 |       1024 |       1024 | pp 1024    | 3886.03 ± 106.86 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  32 |       1024 |       1024 | pp 1024    |   4449.24 ± 4.91 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  33 |       1024 |       1024 | pp 1024    |   4622.98 ± 8.33 |

build: 7664a45b (2441)

| model                          |       size |     params | backend    | ngl |    n_batch |   n_ubatch |       mmap | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------: | ---------: | ---------: | ---------- | ---------------: |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 |       1024 |       1024 |          0 | pp 1024    |    134.99 ± 0.17 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 |       1024 |       1024 |          1 | pp 1024    |     94.98 ± 0.96 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   1 |       1024 |       1024 |          0 | pp 1024    |    137.99 ± 0.18 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   1 |       1024 |       1024 |          1 | pp 1024    |     94.75 ± 6.26 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   2 |       1024 |       1024 |          0 | pp 1024    |    140.96 ± 0.19 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   2 |       1024 |       1024 |          1 | pp 1024    |     99.24 ± 0.99 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   3 |       1024 |       1024 |          0 | pp 1024    |    144.41 ± 0.32 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   3 |       1024 |       1024 |          1 | pp 1024    |    101.79 ± 0.87 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   4 |       1024 |       1024 |          0 | pp 1024    |    147.93 ± 0.42 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   4 |       1024 |       1024 |          1 | pp 1024    |    104.54 ± 1.73 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   5 |       1024 |       1024 |          0 | pp 1024    |    151.50 ± 0.25 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   5 |       1024 |       1024 |          1 | pp 1024    |    108.43 ± 0.68 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   6 |       1024 |       1024 |          0 | pp 1024    |    155.25 ± 0.41 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   6 |       1024 |       1024 |          1 | pp 1024    |    111.04 ± 0.83 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   7 |       1024 |       1024 |          0 | pp 1024    |    159.65 ± 0.39 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   7 |       1024 |       1024 |          1 | pp 1024    |    114.14 ± 1.36 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   8 |       1024 |       1024 |          0 | pp 1024    |    164.27 ± 0.42 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   8 |       1024 |       1024 |          1 | pp 1024    |    118.19 ± 0.47 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   9 |       1024 |       1024 |          0 | pp 1024    |    168.53 ± 0.30 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   9 |       1024 |       1024 |          1 | pp 1024    |    121.97 ± 0.78 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  10 |       1024 |       1024 |          0 | pp 1024    |    173.33 ± 0.66 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  10 |       1024 |       1024 |          1 | pp 1024    |    126.47 ± 0.79 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  11 |       1024 |       1024 |          0 | pp 1024    |    178.72 ± 0.26 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  11 |       1024 |       1024 |          1 | pp 1024    |    132.09 ± 1.04 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  12 |       1024 |       1024 |          0 | pp 1024    |    184.57 ± 0.45 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  12 |       1024 |       1024 |          1 | pp 1024    |    135.79 ± 1.24 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  13 |       1024 |       1024 |          0 | pp 1024    |    190.21 ± 0.58 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  13 |       1024 |       1024 |          1 | pp 1024    |    141.10 ± 1.34 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  14 |       1024 |       1024 |          0 | pp 1024    |    196.32 ± 0.35 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  14 |       1024 |       1024 |          1 | pp 1024    |    147.36 ± 1.18 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  15 |       1024 |       1024 |          0 | pp 1024    |    203.56 ± 0.48 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  15 |       1024 |       1024 |          1 | pp 1024    |    152.44 ± 0.84 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  16 |       1024 |       1024 |          0 | pp 1024    |    209.75 ± 0.60 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  16 |       1024 |       1024 |          1 | pp 1024    |    157.82 ± 1.16 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  17 |       1024 |       1024 |          0 | pp 1024    |    217.25 ± 0.71 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  17 |       1024 |       1024 |          1 | pp 1024    |    165.75 ± 0.76 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  18 |       1024 |       1024 |          0 | pp 1024    |    225.32 ± 0.77 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  18 |       1024 |       1024 |          1 | pp 1024    |    171.47 ± 1.00 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  19 |       1024 |       1024 |          0 | pp 1024    |    233.52 ± 0.36 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  19 |       1024 |       1024 |          1 | pp 1024    |    179.67 ± 1.13 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  20 |       1024 |       1024 |          0 | pp 1024    |    243.01 ± 0.55 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  20 |       1024 |       1024 |          1 | pp 1024    |    189.02 ± 1.60 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  21 |       1024 |       1024 |          0 | pp 1024    |    253.07 ± 0.47 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  21 |       1024 |       1024 |          1 | pp 1024    |    198.75 ± 1.02 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  22 |       1024 |       1024 |          0 | pp 1024    |    263.99 ± 0.49 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  22 |       1024 |       1024 |          1 | pp 1024    |    210.41 ± 0.96 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  23 |       1024 |       1024 |          0 | pp 1024    |    276.09 ± 0.38 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  23 |       1024 |       1024 |          1 | pp 1024    |    221.90 ± 0.81 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  24 |       1024 |       1024 |          0 | pp 1024    |    288.64 ± 0.34 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  24 |       1024 |       1024 |          1 | pp 1024    |    234.89 ± 0.71 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  25 |       1024 |       1024 |          0 | pp 1024    |    303.30 ± 0.45 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  25 |       1024 |       1024 |          1 | pp 1024    |    251.23 ± 0.95 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  26 |       1024 |       1024 |          0 | pp 1024    |    318.69 ± 0.62 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  26 |       1024 |       1024 |          1 | pp 1024    |    267.34 ± 1.26 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  27 |       1024 |       1024 |          0 | pp 1024    |    336.82 ± 1.00 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  27 |       1024 |       1024 |          1 | pp 1024    |    290.10 ± 0.65 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  28 |       1024 |       1024 |          0 | pp 1024    |    357.83 ± 0.52 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  28 |       1024 |       1024 |          1 | pp 1024    |    313.36 ± 1.26 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  29 |       1024 |       1024 |          0 | pp 1024    |    379.97 ± 0.58 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  29 |       1024 |       1024 |          1 | pp 1024    |    342.14 ± 1.99 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  30 |       1024 |       1024 |          0 | pp 1024    |    405.32 ± 0.72 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  30 |       1024 |       1024 |          1 | pp 1024    |    375.44 ± 2.22 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  31 |       1024 |       1024 |          0 | pp 1024    |    435.00 ± 1.21 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  31 |       1024 |       1024 |          1 | pp 1024    |    416.74 ± 1.62 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  32 |       1024 |       1024 |          0 | pp 1024    |    468.47 ± 1.59 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  32 |       1024 |       1024 |          1 | pp 1024    |    466.26 ± 1.79 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  33 |       1024 |       1024 |          0 | pp 1024    |    475.30 ± 0.69 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  33 |       1024 |       1024 |          1 | pp 1024    |    476.06 ± 0.96 |

build: 46acb367 (2437)

| model                          |       size |     params | backend    | ngl |    n_batch |   n_ubatch | test       |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ---------: | ---------: | ---------- | ---------------: |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   0 |       1024 |       1024 | pp 1024    |    241.84 ± 2.76 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   1 |       1024 |       1024 | pp 1024    |    235.62 ± 4.85 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   2 |       1024 |       1024 | pp 1024    |    247.34 ± 3.94 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   3 |       1024 |       1024 | pp 1024    |    249.00 ± 2.90 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   4 |       1024 |       1024 | pp 1024    |    256.21 ± 2.90 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   5 |       1024 |       1024 | pp 1024    |    256.75 ± 5.63 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   6 |       1024 |       1024 | pp 1024    |    256.88 ± 5.62 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   7 |       1024 |       1024 | pp 1024    |    258.29 ± 7.07 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   8 |       1024 |       1024 | pp 1024    |    267.07 ± 1.51 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |   9 |       1024 |       1024 | pp 1024    |    265.86 ± 4.53 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  10 |       1024 |       1024 | pp 1024    |    275.18 ± 0.92 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  11 |       1024 |       1024 | pp 1024    |    278.09 ± 1.90 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  12 |       1024 |       1024 | pp 1024    |    282.25 ± 8.06 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  13 |       1024 |       1024 | pp 1024    |    293.48 ± 8.02 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  14 |       1024 |       1024 | pp 1024    |    295.53 ± 3.59 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  15 |       1024 |       1024 | pp 1024    |    312.34 ± 5.02 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  16 |       1024 |       1024 | pp 1024    |    316.29 ± 6.70 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  17 |       1024 |       1024 | pp 1024    |   319.90 ± 10.61 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  18 |       1024 |       1024 | pp 1024    |    326.59 ± 4.95 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  19 |       1024 |       1024 | pp 1024    |    332.98 ± 4.75 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  20 |       1024 |       1024 | pp 1024    |    344.74 ± 8.89 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  21 |       1024 |       1024 | pp 1024    |    352.98 ± 3.65 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  22 |       1024 |       1024 | pp 1024    |    357.80 ± 5.44 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  23 |       1024 |       1024 | pp 1024    |    368.76 ± 5.73 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  24 |       1024 |       1024 | pp 1024    |    374.94 ± 3.11 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  25 |       1024 |       1024 | pp 1024    |    388.92 ± 6.49 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  26 |       1024 |       1024 | pp 1024    |    401.82 ± 4.66 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  27 |       1024 |       1024 | pp 1024    |    408.44 ± 6.74 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  28 |       1024 |       1024 | pp 1024    |    422.58 ± 4.10 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  29 |       1024 |       1024 | pp 1024    |    435.36 ± 2.60 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  30 |       1024 |       1024 | pp 1024    |    435.46 ± 8.18 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  31 |       1024 |       1024 | pp 1024    |    461.35 ± 1.81 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  32 |       1024 |       1024 | pp 1024    |    476.20 ± 1.11 |
| llama 7B Q3_K - Large          |  19.03 GiB |    46.70 B | CUDA       |  33 |       1024 |       1024 | pp 1024    |    478.29 ± 0.65 |

build: 7664a45b (2441)

</details>


<details>
<summary>70B Q4_0</summary>

|   GPU layers | Model          | Test   |   t/s master |   t/s sl/sched-auto-offload |   Speedup |
|-------------:|:---------------|:-------|-------------:|----------------------------:|----------:|
|            0 | llama 70B Q4_0 | pp512  |        47.42 |                       75.89 |      1.60 |
|            0 | llama 70B Q4_0 | pp1024 |        58.25 |                      133.77 |      2.30 |
|           10 | llama 70B Q4_0 | pp512  |        53.49 |                       86.37 |      1.61 |
|           10 | llama 70B Q4_0 | pp1024 |        65.27 |                      154.15 |      2.36 |
|           20 | llama 70B Q4_0 | pp512  |        58.38 |                       95.88 |      1.64 |
|           20 | llama 70B Q4_0 | pp1024 |        73.33 |                      167.48 |      2.28 |
|           30 | llama 70B Q4_0 | pp512  |        70.39 |                      148.83 |      2.11 |
|           30 | llama 70B Q4_0 | pp1024 |        84.76 |                      240.11 |      2.83 |
|           40 | llama 70B Q4_0 | pp512  |        85.17 |                      178.25 |      2.09 |
|           40 | llama 70B Q4_0 | pp1024 |       102.42 |                      280.74 |      2.74 |

</details>