### PR TITLE
llama : fix Baichuan2 13B

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -5903,7 +5903,7 @@ struct llm_build_context {
         inpL = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
 
         // inp_pos - contains the positions
-        struct ggml_tensor * inp_pos = build_inp_pos();
+        struct ggml_tensor * inp_pos = model.type == MODEL_7B ? build_inp_pos() : nullptr;
 
         // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
         struct ggml_tensor * KQ_mask = build_inp_KQ_mask();
@@ -5952,7 +5952,6 @@ struct llm_build_context {
                 }
                 cb(Qcur, "Qcur", il);
                 cb(Kcur, "Kcur", il);
-
 
                 cur = llm_build_kv(ctx0, model, hparams, kv_self, gf,
                         model.layers[il].wo, NULL,


### PR DESCRIPTION
Baichuan2-13B creates an input that is never used in the graph, so it is never allocated.

Fixes #6091