### PR TITLE
Fixed Windows MSVC Compilation

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -887,10 +887,6 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                 sep += 4;
                 kvo.tag = LLAMA_KV_OVERRIDE_TYPE_INT;
                 kvo.int_value = std::atol(sep);
-            } else if (strncmp(sep, "float:", 6) == 0) {
-                sep += 6;
-                kvo.tag = LLAMA_KV_OVERRIDE_TYPE_FLOAT;
-                kvo.float_value = std::atof(sep);
             } else if (strncmp(sep, "bool:", 5) == 0) {
                 sep += 5;
                 kvo.tag = LLAMA_KV_OVERRIDE_TYPE_BOOL;
@@ -903,6 +899,10 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
                     invalid_param = true;
                     break;
                 }
+            } else if (strncmp(sep, "float:", 6) == 0) {
+                sep += 6;
+                kvo.tag = LLAMA_KV_OVERRIDE_TYPE_FLOAT;
+                kvo.float_value = std::atof(sep);
             } else {
                 fprintf(stderr, "error: Invalid type for KV override: %s\n", argv[i]);
                 invalid_param = true;


### PR DESCRIPTION
Quick and ugly fix.

MSVC only allows for a certain number of nested if's.

Since else-if's count as nested, moving the affected branch up one else-if position is enough for compilation.

Not very sustainable moving forward though, so some refactoring would probably be good.

fixes #6093 