### PR TITLE
common: llama_load_model_from_url using --model-url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         id: depends
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gcc-8
+          sudo apt-get install build-essential gcc-8 libcurl4-openssl-dev
 
       - name: Build
         id: make_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           make test -j $(nproc)
 
   ubuntu-focal-make-curl:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Clone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         id: make_build
         env:
             LLAMA_FATAL_WARNINGS: 1
-            LLAMA_USE_CURL: 1
+            LLAMA_CURL: 1
         run: |
           CC=gcc-8 make -j $(nproc)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,17 +39,36 @@ jobs:
         id: make_build
         env:
             LLAMA_FATAL_WARNINGS: 1
-            LLAMA_CURL: 1
         run: |
           CC=gcc-8 make -j $(nproc)
 
       - name: Test
         id: make_test
-        env:
-          LLAMA_CURL: 1
         run: |
           CC=gcc-8 make tests -j $(nproc)
           make test -j $(nproc)
+
+  ubuntu-focal-make-curl:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Dependencies
+        id: depends
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential gcc-8 libcurl4-openssl-dev
+
+      - name: Build
+        id: make_build
+        env:
+          LLAMA_FATAL_WARNINGS: 1
+          LLAMA_CURL: 1
+        run: |
+          CC=gcc-8 make -j $(nproc)
 
   ubuntu-latest-cmake:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         id: make_build
         env:
             LLAMA_FATAL_WARNINGS: 1
+            LLAMA_USE_CURL: 1
         run: |
           CC=gcc-8 make -j $(nproc)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         id: depends
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gcc-8 libcurl4-openssl-dev
+          sudo apt-get install build-essential gcc-8
 
       - name: Build
         id: make_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Test
         id: make_test
+        env:
+          LLAMA_CURL: 1
         run: |
           CC=gcc-8 make tests -j $(nproc)
           make test -j $(nproc)

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -68,6 +68,7 @@ jobs:
           cmake .. \
               -DLLAMA_NATIVE=OFF \
               -DLLAMA_BUILD_SERVER=ON \
+              -DLLAMA_CURL=ON \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON ;
           cmake --build . --config ${{ matrix.build_type }} -j $(nproc) --target server
@@ -126,7 +127,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="$env:RUNNER_TEMP/libcurl/lib" -DCURL_INCLUDE_DIR="$env:RUNNER_TEMP/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON
+          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="$env:RUNNER_TEMP/libcurl/lib/libcurl.dll.a" -DCURL_INCLUDE_DIR="$env:RUNNER_TEMP/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup
@@ -136,6 +136,7 @@ jobs:
         if: ${{ !matrix.disabled_on_pr || !github.event.pull_request }}
         run: |
           cd examples/server/tests
+          $env:PATH += ";$env:RUNNER_TEMP/libcurl/bin"
           behave.exe --summary --stop --no-capture --exclude 'issues|wrong_usages|passkey' --tags llama.cpp
 
       - name: Slow tests
@@ -143,4 +144,5 @@ jobs:
         if: ${{ (github.event.schedule || github.event.inputs.slow_tests == 'true') && matrix.build_type == 'Release' }}
         run: |
           cd examples/server/tests
+          $env:PATH += ";$env:RUNNER_TEMP/libcurl/bin"
           behave.exe --stop --no-skipped --no-capture --tags slow

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -103,31 +103,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download libCURL
+      - name: libCURL
         id: get_libcurl
         env:
-          CURL_TAG: 8_6_0
-          CURL_VERSION: 8.6.0
+          CURL_VERSION: 8.6.0_6
         run: |
-          curl.exe -o $env:RUNNER_TEMP/libcurl.tar.gz -L "https://github.com/curl/curl/releases/download/curl-${env:CURL_TAG}/curl-${env:CURL_VERSION}.tar.gz"
+          curl.exe -o $env:RUNNER_TEMP/curl.zip -L "https://curl.se/windows/dl-${env:CURL_VERSION}/curl-${env:CURL_VERSION}-win64-mingw.zip"
           mkdir $env:RUNNER_TEMP/libcurl
-          tar.exe -xvf $env:RUNNER_TEMP/libcurl.tar.gz --strip-components=1 -C $env:RUNNER_TEMP/libcurl
-
-      - name: Build libcurl
-        id: build_libcurl
-        run: |
-          cd $env:RUNNER_TEMP/libcurl
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
-          cmake --build . --config Release
+          tar.exe -xvf $env:RUNNER_TEMP/curl.zip --strip-components=1 -C $env:RUNNER_TEMP/libcurl
 
       - name: Build
         id: cmake_build
         run: |
           mkdir build
           cd build
-          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="$env:RUNNER_TEMP/libcurl/lib" -DCURL_INCLUDE_DIR="$env:RUNNER_TEMP/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -135,8 +135,8 @@ jobs:
         id: server_integration_tests
         if: ${{ !matrix.disabled_on_pr || !github.event.pull_request }}
         run: |
+          cp $env:RUNNER_TEMP/libcurl/bin/libcurl-x64.dll ./build/bin/Release/libcurl.dll
           cd examples/server/tests
-          $env:PATH += ";$env:RUNNER_TEMP/libcurl/bin"
           behave.exe --summary --stop --no-capture --exclude 'issues|wrong_usages|passkey' --tags llama.cpp
 
       - name: Slow tests
@@ -144,5 +144,4 @@ jobs:
         if: ${{ (github.event.schedule || github.event.inputs.slow_tests == 'true') && matrix.build_type == 'Release' }}
         run: |
           cd examples/server/tests
-          $env:PATH += ";$env:RUNNER_TEMP/libcurl/bin"
           behave.exe --stop --no-skipped --no-capture --tags slow

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -102,6 +102,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download libCURL
+        id: get_libcurl
+        env:
+          CURL_VERSION: 8.6.0
+        run: |
+          curl.exe -o $env:RUNNER_TEMP/libcurl.tar.gz -L "https://github.com/curl/curl/releases/download/v${env:CURL_VERSION}/curl-v${env:CURL_VERSION}.tar.gz"
+          mkdir $env:RUNNER_TEMP/libcurl
+          tar.exe -xvf $env:RUNNER_TEMP/libcurl.tar.gz --strip-components=1 -C $env:RUNNER_TEMP/libcurl
+
+      - name: Install libcurl
+        id: install_libcurl
+        run: |
+          cd $env:RUNNER_TEMP/libcurl
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release ;
+          cmake --build . --config Release
+          make install          
+
       - name: Build
         id: cmake_build
         run: |

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -131,11 +131,15 @@ jobs:
         run: |
           pip install -r examples/server/tests/requirements.txt
 
+      - name: Copy Libcurl
+        id: prepare_libcurl
+        run: |
+          cp $env:RUNNER_TEMP/libcurl/bin/libcurl-x64.dll ./build/bin/Release/libcurl-x64.dll
+
       - name: Tests
         id: server_integration_tests
         if: ${{ !matrix.disabled_on_pr || !github.event.pull_request }}
         run: |
-          cp $env:RUNNER_TEMP/libcurl/bin/libcurl-x64.dll ./build/bin/Release/libcurl.dll
           cd examples/server/tests
           behave.exe --summary --stop --no-capture --exclude 'issues|wrong_usages|passkey' --tags llama.cpp
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -57,7 +57,8 @@ jobs:
             cmake \
             python3-pip \
             wget \
-            language-pack-en
+            language-pack-en \
+            libcurl4-openssl-dev
 
       - name: Build
         id: cmake_build

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -105,28 +105,28 @@ jobs:
       - name: Download libCURL
         id: get_libcurl
         env:
+          CURL_TAG: 8_6_0
           CURL_VERSION: 8.6.0
         run: |
-          curl.exe -o $env:RUNNER_TEMP/libcurl.tar.gz -L "https://github.com/curl/curl/releases/download/v${env:CURL_VERSION}/curl-v${env:CURL_VERSION}.tar.gz"
+          curl.exe -o $env:RUNNER_TEMP/libcurl.tar.gz -L "https://github.com/curl/curl/releases/download/curl-${env:CURL_TAG}/curl-${env:CURL_VERSION}.tar.gz"
           mkdir $env:RUNNER_TEMP/libcurl
           tar.exe -xvf $env:RUNNER_TEMP/libcurl.tar.gz --strip-components=1 -C $env:RUNNER_TEMP/libcurl
 
-      - name: Install libcurl
-        id: install_libcurl
+      - name: Build libcurl
+        id: build_libcurl
         run: |
           cd $env:RUNNER_TEMP/libcurl
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release ;
+          cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
-          make install          
 
       - name: Build
         id: cmake_build
         run: |
           mkdir build
           cd build
-          cmake ..  -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release ;
+          cmake .. -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="${env:RUNNER_TEMP}/libcurl/lib/Release/libcurl_imp.lib" -DCURL_INCLUDE_DIR="${env:RUNNER_TEMP}/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="$env:RUNNER_TEMP/libcurl/lib/libcurl.dll.a" -DCURL_INCLUDE_DIR="$env:RUNNER_TEMP/libcurl/include" -DLLAMA_BUILD_SERVER=ON -DLLAMA_NATIVE=OFF -DBUILD_SHARED_LIBS=ON
+          cmake .. -DLLAMA_CURL=ON -DCURL_LIBRARY="$env:RUNNER_TEMP/libcurl/lib/libcurl.dll.a" -DCURL_INCLUDE_DIR="$env:RUNNER_TEMP/libcurl/include"
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target server
 
       - name: Python setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ option(LLAMA_CUDA_F16                        "llama: use 16 bit floats for some 
 set(LLAMA_CUDA_KQUANTS_ITER "2" CACHE STRING "llama: iters./thread per block for Q2_K/Q6_K")
 set(LLAMA_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING
                                              "llama: max. batch size for using peer access")
+option(LLAMA_CURL                            "llama: use libcurl to download model from an URL" OFF)
 option(LLAMA_HIPBLAS                         "llama: use hipBLAS"                               OFF)
 option(LLAMA_HIP_UMA                         "llama: use HIP unified memory architecture"       OFF)
 option(LLAMA_CLBLAST                         "llama: use CLBlast"                               OFF)

--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,7 @@ include scripts/get-flags.mk
 CUDA_CXXFLAGS := $(BASE_CXXFLAGS) $(GF_CXXFLAGS) -Wno-pedantic
 endif
 
-ifdef LLAMA_USE_CURL
+ifdef LLAMA_CURL
 override CXXFLAGS := $(CXXFLAGS) -DLLAMA_USE_CURL
 override LDFLAGS  := $(LDFLAGS) -lcurl
 endif

--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,11 @@ include scripts/get-flags.mk
 CUDA_CXXFLAGS := $(BASE_CXXFLAGS) $(GF_CXXFLAGS) -Wno-pedantic
 endif
 
+ifdef LLAMA_USE_CURL
+override CXXFLAGS := $(CXXFLAGS) -DLLAMA_USE_CURL
+override LDFLAGS  := $(LDFLAGS) -lcurl
+endif
+
 #
 # Print build information
 #

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -47,14 +47,14 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
-# Check for OpenSSL
-find_package(OpenSSL QUIET)
-if (OPENSSL_FOUND)
-    add_definitions(-DHAVE_OPENSSL)
-    include_directories(${OPENSSL_INCLUDE_DIR})
-    link_libraries(${OPENSSL_LIBRARIES})
+# Check for curl
+find_package(CURL QUIET)
+if (CURL_FOUND)
+    add_definitions(-DHAVE_CURL)
+    include_directories(${CURL_INCLUDE_DIRS})
+    link_libraries(${CURL_LIBRARIES})
 else()
-    message(WARNING "OpenSSL not found. Building without model download support.")
+    message(INFO "libcurl not found. Building without model download support.")
 endif ()
 
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -54,7 +54,7 @@ if (CURL_FOUND)
     include_directories(${CURL_INCLUDE_DIRS})
     link_libraries(${CURL_LIBRARIES})
 else()
-    message(INFO "libcurl not found. Building without model download support.")
+    message(INFO " libcurl not found. Building without model download support.")
 endif ()
 
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -68,14 +68,17 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
+set(LLAMA_COMMON_EXTRA_LIBS build_info)
+
 # Use curl to download model url
 if (LLAMA_CURL)
-    find_package(CURL)
+    find_package(CURL REQUIRED)
     add_definitions(-DLLAMA_USE_CURL)
     include_directories(${CURL_INCLUDE_DIRS})
-    target_link_libraries(${TARGET} PRIVATE curl)
+    find_library(CURL_LIBRARY curl REQUIRED)
+    set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${CURL_LIBRARY})
 endif ()
 
 target_include_directories(${TARGET} PUBLIC .)
 target_compile_features(${TARGET} PUBLIC cxx_std_11)
-target_link_libraries(${TARGET} PRIVATE build_info PUBLIC llama)
+target_link_libraries(${TARGET} PRIVATE ${LLAMA_COMMON_EXTRA_LIBS} PUBLIC llama)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 # Check for curl
 find_package(CURL QUIET)
 if (CURL_FOUND)
-    add_definitions(-DHAVE_CURL)
+    add_definitions(-DLLAMA_USE_CURL)
     include_directories(${CURL_INCLUDE_DIRS})
     link_libraries(${CURL_LIBRARIES})
 else()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -47,14 +47,13 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
+
 # Check for curl
-find_package(CURL QUIET)
-if (CURL_FOUND)
+if (LLAMA_CURL)
+    find_package(CURL)
     add_definitions(-DLLAMA_USE_CURL)
     include_directories(${CURL_INCLUDE_DIRS})
     link_libraries(${CURL_LIBRARIES})
-else()
-    message(INFO " libcurl not found. Building without model download support.")
 endif ()
 
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -47,6 +47,16 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
+# Check for OpenSSL
+find_package(OpenSSL QUIET)
+if (OPENSSL_FOUND)
+    add_definitions(-DHAVE_OPENSSL)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    link_libraries(${OPENSSL_LIBRARIES})
+else()
+    message(WARNING "OpenSSL not found. Building without model download support.")
+endif ()
+
 
 set(TARGET common)
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -48,15 +48,6 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 
-# Check for curl
-if (LLAMA_CURL)
-    find_package(CURL)
-    add_definitions(-DLLAMA_USE_CURL)
-    include_directories(${CURL_INCLUDE_DIRS})
-    link_libraries(${CURL_LIBRARIES})
-endif ()
-
-
 set(TARGET common)
 
 add_library(${TARGET} STATIC
@@ -80,3 +71,11 @@ endif()
 target_include_directories(${TARGET} PUBLIC .)
 target_compile_features(${TARGET} PUBLIC cxx_std_11)
 target_link_libraries(${TARGET} PRIVATE build_info PUBLIC llama)
+
+# Use curl to download model url
+if (LLAMA_CURL)
+    find_package(CURL)
+    add_definitions(-DLLAMA_USE_CURL)
+    target_include_directories(${TARGET} ${CURL_INCLUDE_DIRS})
+    target_link_libraries(${TARGET} PRIVATE curl)
+endif ()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -68,14 +68,14 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
-target_include_directories(${TARGET} PUBLIC .)
-target_compile_features(${TARGET} PUBLIC cxx_std_11)
-target_link_libraries(${TARGET} PRIVATE build_info PUBLIC llama)
-
 # Use curl to download model url
 if (LLAMA_CURL)
     find_package(CURL)
     add_definitions(-DLLAMA_USE_CURL)
-    target_include_directories(${TARGET} ${CURL_INCLUDE_DIRS})
+    include_directories(${CURL_INCLUDE_DIRS})
     target_link_libraries(${TARGET} PRIVATE curl)
 endif ()
+
+target_include_directories(${TARGET} PUBLIC .)
+target_compile_features(${TARGET} PUBLIC cxx_std_11)
+target_link_libraries(${TARGET} PRIVATE build_info PUBLIC llama)

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -57,7 +57,6 @@
 #ifdef __linux__
 #include <linux/limits.h>
 #elif defined(_WIN32)
-#include <windows.h>
 #define PATH_MAX MAX_PATH
 #else
 #include <sys/syslimits.h>

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1640,7 +1640,7 @@ void llama_batch_add(
 
 #ifdef LLAMA_USE_CURL
 
-struct llama_model *llama_load_model_from_url(const char *model_url, const char *path_model,
+struct llama_model * llama_load_model_from_url(const char * model_url, const char * path_model,
                                               struct llama_model_params params) {
     // Basic validation of the model_url
     if (!model_url || strlen(model_url) == 0) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1681,17 +1681,23 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     if (file_exists) {
         auto * f_etag = fopen(etag_path, "r");
         if (f_etag) {
-            fgets(etag, sizeof(etag), f_etag);
+            if (!fgets(etag, sizeof(etag), f_etag)) {
+                fprintf(stderr, "%s: unable to read file %s\n", __func__, etag_path);
+            } else {
+                fprintf(stderr, "%s: previous model file found %s: %s\n", __func__, etag_path, etag);
+            }
             fclose(f_etag);
-            fprintf(stderr, "%s: previous model .etag file found %s: %s\n", __func__, path_model, etag);
         }
 
         auto * f_last_modified = fopen(last_modified_path, "r");
         if (f_last_modified) {
-            fgets(last_modified, sizeof(last_modified), f_last_modified);
+            if (!fgets(last_modified, sizeof(last_modified), f_last_modified)) {
+                fprintf(stderr, "%s: unable to read file %s\n", __func__, last_modified_path);
+            } else {
+                fprintf(stderr, "%s: previous model file found %s: %s\n", __func__, last_modified_path,
+                        last_modified);
+            }
             fclose(f_last_modified);
-            fprintf(stderr, "%s: previous model .lastModified file found %s: %s\n", __func__, last_modified_path,
-                    last_modified);
         }
     }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1750,6 +1750,14 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     if (!file_exists || strcmp(etag, headers.etag) != 0 || strcmp(last_modified, headers.last_modified) != 0) {
         char path_model_temporary[LLAMA_CURL_MAX_PATH_LENGTH] = {0};
         snprintf(path_model_temporary, sizeof(path_model_temporary), "%s.downloadInProgress", path_model);
+        if (file_exists) {
+            fprintf(stderr, "%s: deleting previous downloaded model file: %s\n", __func__, path_model);
+            if (remove(path_model) != 0) {
+                curl_easy_cleanup(curl);
+                fprintf(stderr, "%s: unable to delete file: %s\n", __func__, path_model);
+                return NULL;
+            }
+        }
 
         // Set the output file
         auto * outfile = fopen(path_model_temporary, "wb");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1785,7 +1785,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
 
         // Write the new lastModified to the .etag file
         if (strlen(headers.last_modified) > 0) {
-            auto *last_modified_file = fopen(last_modified_path, "w");
+            auto * last_modified_file = fopen(last_modified_path, "w");
             if (last_modified_file) {
                 fputs(headers.last_modified, last_modified_file);
                 fclose(last_modified_file);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1711,7 +1711,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
                 strncpy(headers->etag, buffer + strlen(etag_prefix), n_items - strlen(etag_prefix) - 2); // Remove LRLF
             }
 
-            const char *last_modified_prefix = "last-modified: ";
+            const char * last_modified_prefix = "last-modified: ";
             if (strncmp(buffer, last_modified_prefix, strlen(last_modified_prefix)) == 0) {
                 strncpy(headers->last_modified, buffer + strlen(last_modified_prefix),
                         n_items - strlen(last_modified_prefix) - 2); // Remove LRLF

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1785,7 +1785,7 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
             if (etag_file) {
                 fputs(headers.etag, etag_file);
                 fclose(etag_file);
-                fprintf(stderr, "%s: model etag saved %s:%s\n", __func__, etag_path, headers.etag);
+                fprintf(stderr, "%s: model etag saved %s: %s\n", __func__, etag_path, headers.etag);
             }
         }
 
@@ -1795,7 +1795,7 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
             if (last_modified_file) {
                 fputs(headers.last_modified, last_modified_file);
                 fclose(last_modified_file);
-                fprintf(stderr, "%s: model last modified saved %s:%s\n", __func__, last_modified_path,
+                fprintf(stderr, "%s: model last modified saved %s: %s\n", __func__, last_modified_path,
                         headers.last_modified);
             }
         }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1803,7 +1803,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
 
 #else
 
-struct llama_model *llama_load_model_from_url(const char * /*model_url*/, const char * /*path_model*/,
+struct llama_model * llama_load_model_from_url(const char * /*model_url*/, const char * /*path_model*/,
                                               struct llama_model_params /*params*/) {
     fprintf(stderr, "%s: llama.cpp built without curl support, downloading from an url not supported.\n", __func__);
     return nullptr;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1735,7 +1735,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
     // If only the ETag or the Last-Modified header are different, trigger a new download
     if (strcmp(etag, headers.etag) != 0 || strcmp(last_modified, headers.last_modified) != 0) {
         // Set the output file
-        auto *outfile = fopen(path_model, "wb");
+        auto * outfile = fopen(path_model, "wb");
         if (!outfile) {
             curl_easy_cleanup(curl);
             curl_global_cleanup();

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -16,7 +16,7 @@
 #include <unordered_set>
 #include <vector>
 #include <cinttypes>
-#ifdef HAVE_CURL
+#ifdef LLAMA_USE_CURL
 #include <curl/curl.h>
 #endif
 
@@ -1387,7 +1387,7 @@ void llama_batch_add(
     batch.n_tokens++;
 }
 
-#ifdef HAVE_CURL
+#ifdef LLAMA_USE_CURL
 struct llama_model * llama_load_model_from_url(const char * model_url, const char * path_model,
                                                          struct llama_model_params     params) {
     // Initialize libcurl

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1775,7 +1775,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
 
         // Write the new ETag to the .etag file
         if (strlen(headers.etag) > 0) {
-            auto *etag_file = fopen(etag_path, "w");
+            auto * etag_file = fopen(etag_path, "w");
             if (etag_file) {
                 fputs(headers.etag, etag_file);
                 fclose(etag_file);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1706,7 +1706,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
         auto header_callback = [](char *buffer, size_t /*size*/, size_t n_items, void *userdata) -> size_t {
             llama_load_model_from_url_headers *headers = (llama_load_model_from_url_headers *) userdata;
 
-            const char *etag_prefix = "etag: ";
+            const char * etag_prefix = "etag: ";
             if (strncmp(buffer, etag_prefix, strlen(etag_prefix)) == 0) {
                 strncpy(headers->etag, buffer + strlen(etag_prefix), n_items - strlen(etag_prefix) - 2); // Remove LRLF
             }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1667,16 +1667,14 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     struct stat buffer;
     auto file_exists = (stat(path_model, &buffer) == 0);
 
-    // If the file exists, check for ${model_path}.etag or ${model_path}.lastModified files
+    // If the file exists, check for ${path_model}.etag or ${path_model}.lastModified files
     char etag[LLAMA_CURL_MAX_HEADER_LENGTH] = {0};
     char etag_path[LLAMA_CURL_MAX_PATH_LENGTH] = {0};
-    strncpy(etag_path, path_model, LLAMA_CURL_MAX_PATH_LENGTH - 6); // 6 is the length of ".etag\0"
-    strncat(etag_path, ".etag", 6);
+    snprintf(etag_path, sizeof(etag_path), "%s.etag", path_model);
 
     char last_modified[LLAMA_CURL_MAX_HEADER_LENGTH] = {0};
     char last_modified_path[LLAMA_CURL_MAX_PATH_LENGTH] = {0};
-    strncpy(last_modified_path, path_model, LLAMA_CURL_MAX_PATH_LENGTH - 15); // 15 is the length of ".lastModified\0"
-    strncat(last_modified_path, ".lastModified", 15);
+    snprintf(last_modified_path, sizeof(last_modified_path), "%s.lastModified", path_model);
 
     if (file_exists) {
         auto * f_etag = fopen(etag_path, "r");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1660,6 +1660,11 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     // Set the URL, allow to follow http redirection
     curl_easy_setopt(curl, CURLOPT_URL, model_url);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+#if defined(_WIN32)
+    // CURLSSLOPT_NATIVE_CA tells libcurl to use standard certificate store of
+    //   operating system. Currently implemented under MS-Windows.
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+#endif
 
     // Check if the file already exists locally
     struct stat model_file_info;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1686,7 +1686,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
             fprintf(stderr, "%s: previous model .etag file found %s: %s\n", __func__, path_model, etag);
         }
 
-        auto *f_last_modified = fopen(last_modified_path, "r");
+        auto * f_last_modified = fopen(last_modified_path, "r");
         if (f_last_modified) {
             fgets(last_modified, sizeof(last_modified), f_last_modified);
             fclose(f_last_modified);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -16,9 +16,6 @@
 #include <unordered_set>
 #include <vector>
 #include <cinttypes>
-#ifdef LLAMA_USE_CURL
-#include <curl/curl.h>
-#endif
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <sys/types.h>
@@ -40,6 +37,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
+#if defined(LLAMA_USE_CURL)
+#include <curl/curl.h>
+#endif
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
@@ -53,7 +53,7 @@
 #define GGML_USE_CUBLAS_SYCL_VULKAN
 #endif
 
-#ifdef LLAMA_USE_CURL
+#if defined(LLAMA_USE_CURL)
 #ifdef __linux__
 #include <linux/limits.h>
 #elif defined(_WIN32)

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1758,7 +1758,7 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
 
         typedef size_t(*CURLOPT_WRITEFUNCTION_PTR)(void * data, size_t size, size_t nmemb, void * fd);
         auto write_callback = [](void * data, size_t size, size_t nmemb, void * fd) -> size_t {
-            return fwrite(data, size, nmemb, (FILE *)fd);;
+            return fwrite(data, size, nmemb, (FILE *)fd);
         };
         curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, static_cast<CURLOPT_WRITEFUNCTION_PTR>(write_callback));

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1394,7 +1394,6 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     curl_global_init(CURL_GLOBAL_DEFAULT);
     auto curl = curl_easy_init();
 
-
     if (!curl) {
         curl_global_cleanup();
         fprintf(stderr, "%s: error initializing lib curl\n", __func__);
@@ -1445,11 +1444,13 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
     return llama_load_model_from_file(path_model, params);
 }
 #else
-struct llama_model * llama_load_model_from_url(const char *, const char *,
-                                               struct llama_model_params) {
-    fprintf(stderr, "%s: llama.cpp built without SSL support, downloading from url not supported.\n", __func__);
+
+struct llama_model *llama_load_model_from_url(const char * /*model_url*/, const char * /*path_model*/,
+                                              struct llama_model_params /*params*/) {
+    fprintf(stderr, "%s: llama.cpp built without curl support, downloading from an url not supported.\n", __func__);
     return nullptr;
 }
+
 #endif
 
 std::tuple<struct llama_model *, struct llama_context *> llama_init_from_gpt_params(gpt_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1710,13 +1710,13 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
 
             const char * etag_prefix = "etag: ";
             if (strncmp(buffer, etag_prefix, strlen(etag_prefix)) == 0) {
-                strncpy(headers->etag, buffer + strlen(etag_prefix), n_items - strlen(etag_prefix) - 2); // Remove LRLF
+                strncpy(headers->etag, buffer + strlen(etag_prefix), n_items - strlen(etag_prefix) - 2); // Remove CRLF
             }
 
             const char * last_modified_prefix = "last-modified: ";
             if (strncmp(buffer, last_modified_prefix, strlen(last_modified_prefix)) == 0) {
                 strncpy(headers->last_modified, buffer + strlen(last_modified_prefix),
-                        n_items - strlen(last_modified_prefix) - 2); // Remove LRLF
+                        n_items - strlen(last_modified_prefix) - 2); // Remove CRLF
             }
             return n_items;
         };

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1390,7 +1390,7 @@ void llama_batch_add(
 #ifdef LLAMA_USE_CURL
 struct llama_model * llama_load_model_from_url(const char * model_url, const char * path_model,
                                                          struct llama_model_params     params) {
-    // Initialize libcurl
+    // Initialize libcurl globally
     curl_global_init(CURL_GLOBAL_DEFAULT);
     auto curl = curl_easy_init();
 
@@ -1400,7 +1400,7 @@ struct llama_model * llama_load_model_from_url(const char * model_url, const cha
         return nullptr;
     }
 
-    // Set the URL
+    // Set the URL, allow to follow http redirection and display download progress
     curl_easy_setopt(curl, CURLOPT_URL, model_url);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1703,7 +1703,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
     llama_load_model_from_url_headers headers;
     {
         typedef size_t(*CURLOPT_HEADERFUNCTION_PTR)(char *, size_t, size_t, void *);
-        auto header_callback = [](char *buffer, size_t /*size*/, size_t n_items, void *userdata) -> size_t {
+        auto header_callback = [](char * buffer, size_t /*size*/, size_t n_items, void * userdata) -> size_t {
             llama_load_model_from_url_headers *headers = (llama_load_model_from_url_headers *) userdata;
 
             const char * etag_prefix = "etag: ";

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1679,7 +1679,7 @@ struct llama_model *llama_load_model_from_url(const char *model_url, const char 
     strncat(last_modified_path, ".lastModified", 15);
 
     if (file_exists) {
-        auto *f_etag = fopen(etag_path, "r");
+        auto * f_etag = fopen(etag_path, "r");
         if (f_etag) {
             fgets(etag, sizeof(etag), f_etag);
             fclose(f_etag);

--- a/common/common.h
+++ b/common/common.h
@@ -95,7 +95,7 @@ struct gpt_params {
     struct llama_sampling_params sparams;
 
     std::string model             = "models/7B/ggml-model-f16.gguf"; // model path
-    std::string model_url         = ""; // model path
+    std::string model_url         = ""; // model url to download
     std::string model_draft       = "";                              // draft model for speculative decoding
     std::string model_alias       = "unknown"; // model alias
     std::string prompt            = "";

--- a/common/common.h
+++ b/common/common.h
@@ -17,6 +17,12 @@
 #include <unordered_map>
 #include <tuple>
 
+#ifdef HAVE_OPENSSL
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#endif
+
 #ifdef _WIN32
 #define DIRECTORY_SEPARATOR '\\'
 #else
@@ -89,6 +95,7 @@ struct gpt_params {
     struct llama_sampling_params sparams;
 
     std::string model             = "models/7B/ggml-model-f16.gguf"; // model path
+    std::string model_url         = ""; // model path
     std::string model_draft       = "";                              // draft model for speculative decoding
     std::string model_alias       = "unknown"; // model alias
     std::string prompt            = "";
@@ -190,6 +197,9 @@ std::tuple<struct llama_model *, struct llama_context *> llama_init_from_gpt_par
 
 struct llama_model_params   llama_model_params_from_gpt_params  (const gpt_params & params);
 struct llama_context_params llama_context_params_from_gpt_params(const gpt_params & params);
+
+struct llama_model * llama_load_model_from_url(const char * model_url, const char * path_model,
+                                                         struct llama_model_params     params);
 
 // Batch utils
 

--- a/common/common.h
+++ b/common/common.h
@@ -17,12 +17,6 @@
 #include <unordered_map>
 #include <tuple>
 
-#ifdef HAVE_OPENSSL
-#include <openssl/ssl.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#endif
-
 #ifdef _WIN32
 #define DIRECTORY_SEPARATOR '\\'
 #else

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -67,6 +67,7 @@ main.exe -m models\7B\ggml-model.bin --ignore-eos -n -1 --random-prompt
 In this section, we cover the most commonly used options for running the `main` program with the LLaMA models:
 
 -   `-m FNAME, --model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.bin`).
+-   `-mu MODEL_URL --model MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
 -   `-i, --interactive`: Run the program in interactive mode, allowing you to provide input directly and receive real-time responses.
 -   `-ins, --instruct`: Run the program in instruction mode, which is particularly useful when working with Alpaca models.
 -   `-n N, --n-predict N`: Set the number of tokens to predict when generating text. Adjusting this value can influence the length of the generated text.

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -67,7 +67,7 @@ main.exe -m models\7B\ggml-model.bin --ignore-eos -n -1 --random-prompt
 In this section, we cover the most commonly used options for running the `main` program with the LLaMA models:
 
 -   `-m FNAME, --model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.bin`).
--   `-mu MODEL_URL --model MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
+-   `-mu MODEL_URL --model-url MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
 -   `-i, --interactive`: Run the program in interactive mode, allowing you to provide input directly and receive real-time responses.
 -   `-ins, --instruct`: Run the program in instruction mode, which is particularly useful when working with Alpaca models.
 -   `-n N, --n-predict N`: Set the number of tokens to predict when generating text. Adjusting this value can influence the length of the generated text.

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -20,7 +20,7 @@ The project is under active development, and we are [looking for feedback and co
 - `-tb N, --threads-batch N`: Set the number of threads to use during batch and prompt processing. If not specified, the number of threads will be set to the number of threads used for generation.
 - `--threads-http N`: number of threads in the http server pool to process requests (default: `max(std::thread::hardware_concurrency() - 1, --parallel N + 2)`)
 - `-m FNAME`, `--model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.gguf`).
-- `-mu MODEL_URL --model MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
+- `-mu MODEL_URL --model-url MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
 - `-a ALIAS`, `--alias ALIAS`: Set an alias for the model. The alias will be returned in API responses.
 - `-c N`, `--ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference. The size may differ in other models, for example, baichuan models were build with a context of 4096.
 - `-ngl N`, `--n-gpu-layers N`: When compiled with appropriate support (currently CLBlast or cuBLAS), this option allows offloading some layers to the GPU for computation. Generally results in increased performance.

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -20,6 +20,7 @@ The project is under active development, and we are [looking for feedback and co
 - `-tb N, --threads-batch N`: Set the number of threads to use during batch and prompt processing. If not specified, the number of threads will be set to the number of threads used for generation.
 - `--threads-http N`: number of threads in the http server pool to process requests (default: `max(std::thread::hardware_concurrency() - 1, --parallel N + 2)`)
 - `-m FNAME`, `--model FNAME`: Specify the path to the LLaMA model file (e.g., `models/7B/ggml-model.gguf`).
+- `-mu MODEL_URL --model MODEL_URL`: Specify a remote http url to download the file (e.g https://huggingface.co/ggml-org/models/resolve/main/phi-2/ggml-model-q4_0.gguf).
 - `-a ALIAS`, `--alias ALIAS`: Set an alias for the model. The alias will be returned in API responses.
 - `-c N`, `--ctx-size N`: Set the size of the prompt context. The default is 512, but LLaMA models were built with a context of 2048, which will provide better results for longer input/inference. The size may differ in other models, for example, baichuan models were build with a context of 4096.
 - `-ngl N`, `--n-gpu-layers N`: When compiled with appropriate support (currently CLBlast or cuBLAS), this option allows offloading some layers to the GPU for computation. Generally results in increased performance.

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2195,6 +2195,8 @@ static void server_print_usage(const char * argv0, const gpt_params & params, co
     }
     printf("  -m FNAME, --model FNAME\n");
     printf("                            model path (default: %s)\n", params.model.c_str());
+    printf("  -u MODEL_URL, --url MODEL_URL\n");
+    printf("                            model url (default: %s)\n", params.model_url.c_str());
     printf("  -a ALIAS, --alias ALIAS\n");
     printf("                            set an alias for the model, will be added as `model` field in completion response\n");
     printf("  --lora FNAME              apply LoRA adapter (implies --no-mmap)\n");
@@ -2317,6 +2319,12 @@ static void server_params_parse(int argc, char ** argv, server_params & sparams,
                 break;
             }
             params.model = argv[i];
+        } else if (arg == "-u" || arg == "--model-url") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            params.model_url = argv[i];
         } else if (arg == "-a" || arg == "--alias") {
             if (++i >= argc) {
                 invalid_param = true;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2195,8 +2195,8 @@ static void server_print_usage(const char * argv0, const gpt_params & params, co
     }
     printf("  -m FNAME, --model FNAME\n");
     printf("                            model path (default: %s)\n", params.model.c_str());
-    printf("  -u MODEL_URL, --url MODEL_URL\n");
-    printf("                            model url (default: %s)\n", params.model_url.c_str());
+    printf("  -mu MODEL_URL, --model-url MODEL_URL\n");
+    printf("                            model download url (default: %s)\n", params.model_url.c_str());
     printf("  -a ALIAS, --alias ALIAS\n");
     printf("                            set an alias for the model, will be added as `model` field in completion response\n");
     printf("  --lora FNAME              apply LoRA adapter (implies --no-mmap)\n");
@@ -2319,7 +2319,7 @@ static void server_params_parse(int argc, char ** argv, server_params & sparams,
                 break;
             }
             params.model = argv[i];
-        } else if (arg == "-u" || arg == "--model-url") {
+        } else if (arg == "-mu" || arg == "--model-url") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;

--- a/examples/server/tests/README.md
+++ b/examples/server/tests/README.md
@@ -57,7 +57,7 @@ Feature or Scenario must be annotated with `@llama.cpp` to be included in the de
 To run a scenario annotated with `@bug`, start:
 
 ```shell
-DEBUG=ON ./tests.sh --no-skipped --tags bug
+DEBUG=ON ./tests.sh --no-skipped --tags bug --stop
 ```
 
 After changing logic in `steps.py`, ensure that `@bug` and `@wrong_usage` scenario are updated.

--- a/examples/server/tests/features/embeddings.feature
+++ b/examples/server/tests/features/embeddings.feature
@@ -4,7 +4,8 @@ Feature: llama.cpp server
 
   Background: Server startup
     Given a server listening on localhost:8080
-    And   a model file bert-bge-small/ggml-model-f16.gguf from HF repo ggml-org/models
+    And   a model url https://huggingface.co/ggml-org/models/resolve/main/bert-bge-small/ggml-model-f16.gguf
+    And   a model file /tmp/ggml-model-f16.gguf
     And   a model alias bert-bge-small
     And   42 as server seed
     And   2 slots

--- a/examples/server/tests/features/embeddings.feature
+++ b/examples/server/tests/features/embeddings.feature
@@ -5,7 +5,7 @@ Feature: llama.cpp server
   Background: Server startup
     Given a server listening on localhost:8080
     And   a model url https://huggingface.co/ggml-org/models/resolve/main/bert-bge-small/ggml-model-f16.gguf
-    And   a model file /tmp/ggml-model-f16.gguf
+    And   a model file ggml-model-f16.gguf
     And   a model alias bert-bge-small
     And   42 as server seed
     And   2 slots

--- a/examples/server/tests/features/environment.py
+++ b/examples/server/tests/features/environment.py
@@ -109,10 +109,10 @@ def print_server_logs(context):
     out, err = context.server_process.communicate()
     if out:
         print("Server stdout:\n")
-        print(out.decode("utf-8"))
+        print(out.decode('utf-8'))
         print("\n")
     if err:
         print("Server stderr:\n")
-        print(err.decode("utf-8"))
+        print(err.decode('utf-8'))
         print("\n")
 

--- a/examples/server/tests/features/environment.py
+++ b/examples/server/tests/features/environment.py
@@ -33,6 +33,16 @@ def after_scenario(context, scenario):
             print("\x1b[33;101mERROR: Server stopped listening\x1b[0m\n")
 
     if not pid_exists(context.server_process.pid):
+        print("Trying to find server logs:")
+        out, err = context.server_process.communicate()
+        if out:
+            print("Server stdout:\n")
+            print(out)
+            print("\n")
+        if err:
+            print("Server stderr:\n")
+            print(err)
+            print("\n")
         assert False, f"Server not running pid={context.server_process.pid} ..."
 
     server_graceful_shutdown(context)

--- a/examples/server/tests/features/environment.py
+++ b/examples/server/tests/features/environment.py
@@ -1,10 +1,12 @@
-import errno
 import os
-import socket
-import subprocess
-import time
-from contextlib import closing
 import signal
+import socket
+import sys
+import time
+import traceback
+from contextlib import closing
+
+import psutil
 
 
 def before_scenario(context, scenario):
@@ -20,37 +22,40 @@ def before_scenario(context, scenario):
 
 
 def after_scenario(context, scenario):
-    if context.server_process is None:
-        return
-    if scenario.status == "failed":
-        if 'GITHUB_ACTIONS' in os.environ:
-            print(f"\x1b[33;101mSCENARIO FAILED: {scenario.name} server logs:\x1b[0m\n\n")
-            if os.path.isfile('llama.log'):
-                with closing(open('llama.log', 'r')) as f:
-                    for line in f:
-                        print(line)
-        if not is_server_listening(context.server_fqdn, context.server_port):
-            print("\x1b[33;101mERROR: Server stopped listening\x1b[0m\n")
+    try:
+        if 'server_process' not in context or context.server_process is None:
+            return
+        if scenario.status == "failed":
+            if 'GITHUB_ACTIONS' in os.environ:
+                print(f"\x1b[33;101mSCENARIO FAILED: {scenario.name} server logs:\x1b[0m\n\n")
+                if os.path.isfile('llama.log'):
+                    with closing(open('llama.log', 'r')) as f:
+                        for line in f:
+                            print(line)
+            if not is_server_listening(context.server_fqdn, context.server_port):
+                print("\x1b[33;101mERROR: Server stopped listening\x1b[0m\n")
 
-    if not pid_exists(context.server_process.pid):
-        print_server_logs(context)
-        assert False, f"Server not running pid={context.server_process.pid} ..."
+        if not pid_exists(context.server_process.pid):
+            assert False, f"Server not running pid={context.server_process.pid} ..."
 
-    server_graceful_shutdown(context)
+        server_graceful_shutdown(context)
 
-    # Wait few for socket to free up
-    time.sleep(0.05)
+        # Wait few for socket to free up
+        time.sleep(0.05)
 
-    attempts = 0
-    while pid_exists(context.server_process.pid) or is_server_listening(context.server_fqdn, context.server_port):
-        server_kill(context)
-        time.sleep(0.1)
-        attempts += 1
-        if attempts > 5:
-            server_kill_hard(context)
-
-    if scenario.status == "failed" or context.debug:
-        print_server_logs(context)
+        attempts = 0
+        while pid_exists(context.server_process.pid) or is_server_listening(context.server_fqdn, context.server_port):
+            server_kill(context)
+            time.sleep(0.1)
+            attempts += 1
+            if attempts > 5:
+                server_kill_hard(context)
+    except:
+        exc = sys.exception()
+        print("error in after scenario: \n")
+        print(exc)
+        print("*** print_tb: \n")
+        traceback.print_tb(exc.__traceback__, file=sys.stdout)
 
 
 def server_graceful_shutdown(context):
@@ -71,11 +76,11 @@ def server_kill_hard(context):
     path = context.server_path
 
     print(f"Server dangling exits, hard killing force {pid}={path}...\n")
-    if os.name == 'nt':
-        process = subprocess.check_output(['taskkill', '/F', '/pid', str(pid)]).decode()
-        print(process)
-    else:
-        os.kill(-pid, signal.SIGKILL)
+    try:
+        psutil.Process(pid).kill()
+    except psutil.NoSuchProcess:
+        return False
+    return True
 
 
 def is_server_listening(server_fqdn, server_port):
@@ -88,31 +93,9 @@ def is_server_listening(server_fqdn, server_port):
 
 
 def pid_exists(pid):
-    """Check whether pid exists in the current process table."""
-    if pid < 0:
+    try:
+        psutil.Process(pid)
+    except psutil.NoSuchProcess:
         return False
-    if os.name == 'nt':
-        output = subprocess.check_output(['TASKLIST', '/FI', f'pid eq {pid}']).decode()
-        print(output)
-        return "No tasks are running" not in output
-    else:
-        try:
-            os.kill(pid, 0)
-        except OSError as e:
-            return e.errno == errno.EPERM
-        else:
-            return True
-
-
-def print_server_logs(context):
-    print("Trying to find server logs:")
-    out, err = context.server_process.communicate()
-    if out:
-        print("Server stdout:\n")
-        print(out.decode('utf-8'))
-        print("\n")
-    if err:
-        print("Server stderr:\n")
-        print(err.decode('utf-8'))
-        print("\n")
+    return True
 

--- a/examples/server/tests/features/environment.py
+++ b/examples/server/tests/features/environment.py
@@ -33,16 +33,7 @@ def after_scenario(context, scenario):
             print("\x1b[33;101mERROR: Server stopped listening\x1b[0m\n")
 
     if not pid_exists(context.server_process.pid):
-        print("Trying to find server logs:")
-        out, err = context.server_process.communicate()
-        if out:
-            print("Server stdout:\n")
-            print(out)
-            print("\n")
-        if err:
-            print("Server stderr:\n")
-            print(err)
-            print("\n")
+        print_server_logs(context)
         assert False, f"Server not running pid={context.server_process.pid} ..."
 
     server_graceful_shutdown(context)
@@ -57,6 +48,9 @@ def after_scenario(context, scenario):
         attempts += 1
         if attempts > 5:
             server_kill_hard(context)
+
+    if scenario.status == "failed" or context.debug:
+        print_server_logs(context)
 
 
 def server_graceful_shutdown(context):
@@ -108,3 +102,17 @@ def pid_exists(pid):
             return e.errno == errno.EPERM
         else:
             return True
+
+
+def print_server_logs(context):
+    print("Trying to find server logs:")
+    out, err = context.server_process.communicate()
+    if out:
+        print("Server stdout:\n")
+        print(out.decode("utf-8"))
+        print("\n")
+    if err:
+        print("Server stderr:\n")
+        print(err.decode("utf-8"))
+        print("\n")
+

--- a/examples/server/tests/features/server.feature
+++ b/examples/server/tests/features/server.feature
@@ -4,7 +4,8 @@ Feature: llama.cpp server
 
   Background: Server startup
     Given a server listening on localhost:8080
-    And   a model file tinyllamas/stories260K.gguf from HF repo ggml-org/models
+    And   a model url https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf
+    And   a model file stories260K.gguf
     And   a model alias tinyllama-2
     And   42 as server seed
       # KV Cache corresponds to the total amount of tokens

--- a/examples/server/tests/features/steps/steps.py
+++ b/examples/server/tests/features/steps/steps.py
@@ -1094,6 +1094,8 @@ def start_server_background(context):
 
     pkwargs = {
         'creationflags': flags,
+        'stderr': subprocess.PIPE,
+        'stdout': subprocess.PIPE
     }
     context.server_process = subprocess.Popen(
         [str(arg) for arg in [context.server_path, *server_args]],

--- a/examples/server/tests/features/steps/steps.py
+++ b/examples/server/tests/features/steps/steps.py
@@ -32,6 +32,8 @@ def step_server_config(context, server_fqdn, server_port):
     context.base_url = f'http://{context.server_fqdn}:{context.server_port}'
 
     context.model_alias = None
+    context.model_file = None
+    context.model_url = None
     context.n_batch = None
     context.n_ubatch = None
     context.n_ctx = None
@@ -63,6 +65,16 @@ def step_download_hf_model(context, hf_file, hf_repo):
     context.model_file = hf_hub_download(repo_id=hf_repo, filename=hf_file)
     if context.debug:
         print(f"model file: {context.model_file}\n")
+
+
+@step('a model file {model_file}')
+def step_model_file(context, model_file):
+    context.model_file = model_file
+
+
+@step('a model url {model_url}')
+def step_model_url(context, model_url):
+    context.model_url = model_url
 
 
 @step('a model alias {model_alias}')
@@ -1038,8 +1050,11 @@ def start_server_background(context):
     server_args = [
         '--host', server_listen_addr,
         '--port', context.server_port,
-        '--model', context.model_file
     ]
+    if context.model_file:
+        server_args.extend(['--model', context.model_file])
+    if context.model_url:
+        server_args.extend(['--model-url', context.model_url])
     if context.n_batch:
         server_args.extend(['--batch-size', context.n_batch])
     if context.n_ubatch:

--- a/examples/server/tests/features/steps/steps.py
+++ b/examples/server/tests/features/steps/steps.py
@@ -153,7 +153,8 @@ def step_start_server(context):
 async def step_wait_for_the_server_to_be_started(context, expecting_status):
     match expecting_status:
         case 'healthy':
-            await wait_for_health_status(context, context.base_url, 200, 'ok')
+            await wait_for_health_status(context, context.base_url, 200, 'ok',
+                                         timeout=30)
 
         case 'ready' | 'idle':
             await wait_for_health_status(context, context.base_url, 200, 'ok',

--- a/examples/server/tests/requirements.txt
+++ b/examples/server/tests/requirements.txt
@@ -3,4 +3,5 @@ behave~=1.2.6
 huggingface_hub~=0.20.3
 numpy~=1.24.4
 openai~=0.25.0
+psutil~=5.9.8
 prometheus-client~=0.20.0


### PR DESCRIPTION
### Motivation

Since GGUF is officially supported on [huggingface](https://huggingface.co/docs/hub/gguf) it can be useful to start the cli directly from a http url.

We considered this at some point #4735, but it opens a lot of security concerns due to the core library having to execute commands.
So we settled with #5501 which should be good enough for most cases, but when there is no `shell` available it cannot work (example [docker distroless container](https://github.com/GoogleContainerTools/distroless)).

### Changes
- `llama_load_model_from_url` to first download the file if it does not exist locally or the remote is newer, then call `llama_load_model_from_file` in `common`
- introduce `--model-url` which will trigger the download to `--model` in `llama_init_from_gpt_params`
- enable this feature if `-DLLAMA_CURL=ON` in cmake and make toolchains
- server tests using this parameter in `embeddings.feature`

### Attention points
- The `common` will be dynamic linked to [libcurl](https://curl.se/libcurl/).
- It can later be moved to `llama` API if there is positive feedback from the community.
- it saved `${model_path}.etag` or `${model_path}.lastModified` files along with the `model_path`
- It's not possible to pass a custom CA, system CAs are always used in this first implementation on both posix and windows platform

### Task
- [x] download is triggered only if the file has changed based on `etag` and `last-modified` http headers
- [x] CI build is [passing](https://github.com/phymbert/llama.cpp/actions/runs/8317225840)
- [x] Server CI build is [passing](https://github.com/phymbert/llama.cpp/actions/runs/8317213944)

### References
- #4735
- #5501
- Closes #6085
