### PR TITLE
nix: make `xcrun` visible in Nix sandbox for precompiling Metal shaders

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -156,6 +156,8 @@ effectiveStdenv.mkDerivation (
     postPatch = ''
       substituteInPlace ./ggml-metal.m \
         --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+      substituteInPlace ./ggml-metal.m \
+        --replace '[bundle pathForResource:@"default" ofType:@"metallib"];' "@\"$out/bin/default.metallib\";"
 
       # TODO: Package up each Python script or service appropriately.
       # If we were to migrate to buildPythonPackage and prepare the `pyproject.toml`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1260,6 +1260,12 @@ if (LLAMA_METAL)
             GROUP_READ
             WORLD_READ
         DESTINATION ${CMAKE_INSTALL_BINDIR})
+    if (NOT LLAMA_METAL_EMBED_LIBRARY)
+        install(
+            FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/default.metallib
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif()
 endif()
 
 #


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/6117

Adds `/usr/bin/` to $PATH prior to running Cmake when building with Nix. No change to building normally/ without Nix. 