### PR TITLE
ci : exempt some labels from being tagged as stale

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          exempt-issue-labels: "refactor,help wanted,good first issue,research"
           days-before-issue-stale: 30
           days-before-issue-close: 14
           stale-issue-label: "stale"


### PR DESCRIPTION
Based on the documentation here: https://github.com/actions/stale/tree/v5/?tab=readme-ov-file#exempt-issue-labels