### PR TITLE
[SYCL] Add nvidia and amd backends index

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -977,8 +977,10 @@ namespace dpct
         static int convert_backend_index(std::string & backend) {
             if (backend == "ext_oneapi_level_zero:gpu") return 0;
             if (backend == "opencl:gpu") return 1;
-            if (backend == "opencl:cpu") return 2;
-            if (backend == "opencl:acc") return 3;
+            if (backend == "ext_oneapi_cuda:gpu") return 2;
+            if (backend == "ext_oneapi_hip:gpu") return 3;
+            if (backend == "opencl:cpu") return 4;
+            if (backend == "opencl:acc") return 5;
             printf("convert_backend_index: can't handle backend=%s\n", backend.c_str());
             GGML_ASSERT(false);
         }


### PR DESCRIPTION
This PR adds an associated index for the CUDA and HIP backends. This prevents a runtime failure when trying to target these two vendors. As currently the Nvidia build fails to run in these cases.

Tested on A100 and PVC