### PR TITLE
[SYCL] increase igpu cluster limit

### DIFF
--- a/ggml-sycl.h
+++ b/ggml-sycl.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-#define GGML_SYCL_MAX_DEVICES       16
+#define GGML_SYCL_MAX_DEVICES       48
 #define GGML_SYCL_NAME "SYCL"
 
 GGML_API void   ggml_init_sycl(void);


### PR DESCRIPTION
The original value of GGML_SYCL_MAX_DEVICES is 16. It can't meet the capability in real test environment.
Because 1 GPU could have 2 device IDs in SYCL: level_zero device and opencl device.
In multiple GPUs case, the max devices will be double.

Extend limit for certain iGPU clusters.
cc @ggerganov @NeoZhangJianyu 
feel free to merge after CI pass