### PR TITLE
cuda : print the returned error when CUDA initialization fails

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -294,8 +294,9 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
     ggml_cuda_device_info info = {};
 
-    if (cudaGetDeviceCount(&info.device_count) != cudaSuccess) {
-        fprintf(stderr, "%s: no " GGML_CUDA_NAME " devices found, " GGML_CUDA_NAME " will be disabled\n", __func__);
+    cudaError_t err = cudaGetDeviceCount(&info.device_count);
+    if (err != cudaSuccess) {
+        fprintf(stderr, "%s: failed to initialize " GGML_CUDA_NAME ": %s\n", __func__, cudaGetErrorString(err));
         return info;
     }
 


### PR DESCRIPTION
`cudaGetDeviceCount` may return different errors when it fails during CUDA initialization (`cudaErrorInitializationError`, `cudaErrorInsufficientDriver` or `cudaErrorNoDevice`), and printing this error may help diagnose the issue when the CUDA backend is not working.