### PR TITLE
cuda : disable host register by default

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -11646,7 +11646,7 @@ GGML_CALL void ggml_backend_cuda_get_device_memory(int device, size_t * free, si
 }
 
 GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size) {
-    if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
+    if (getenv("GGML_CUDA_REGISTER_HOST") == nullptr) {
         return false;
     }
 
@@ -11663,6 +11663,10 @@ GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size
 }
 
 GGML_CALL void ggml_backend_cuda_unregister_host_buffer(void * buffer) {
+    if (getenv("GGML_CUDA_REGISTER_HOST") == nullptr) {
+        return;
+    }
+
     cudaError_t err = cudaHostUnregister(buffer);
     if (err != cudaSuccess) {
         // clear the error


### PR DESCRIPTION
Disables pinning the model when using mmap, since it can cause instability on some systems. Host pinned memory can still be used enabled by setting the environment variable `GGML_CUDA_REGISTER_HOST`, or with `--no-mmap`.

Fixes #6149