### PR TITLE
tests: conditional python & node json schema tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,9 @@ jobs:
 
   ubuntu-focal-make:
     runs-on: ubuntu-20.04
+    env:
+      LLAMA_NODE_AVAILABLE: true
+      LLAMA_PYTHON_AVAILABLE: true
 
     steps:
       - name: Clone
@@ -146,6 +149,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install build-essential gcc-8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Build
         id: make_build

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -804,7 +804,7 @@ int main() {
         }
     });
 
-    if (std::system("python --version") == 0) {
+    if (getenv("LLAMA_PYTHON_AVAILABLE") || (std::system("python --version") == 0)) {
         test_all("Python", [](const TestCase & tc) {
             write("test-json-schema-input.tmp", tc.schema);
             tc.verify_status(std::system(
@@ -815,7 +815,7 @@ int main() {
         fprintf(stderr, "\033[33mWARNING: Python not found, skipping Python JSON schema -> grammar tests.\n\033[0m");
     }
 
-    if (std::system("node --version") == 0) {
+    if (getenv("LLAMA_NODE_AVAILABLE") || (std::system("node --version") == 0)) {
         test_all("JavaScript", [](const TestCase & tc) {
             write("test-json-schema-input.tmp", tc.schema);
             tc.verify_status(std::system(

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -812,7 +812,7 @@ int main() {
             tc.verify(read("test-grammar-output.tmp"));
         });
     } else {
-        fprintf(stderr, "#\n# WARNING: Python not found, skipping Python JSON schema -> grammar tests!\n#\n");
+        fprintf(stderr, "\033[33mWARNING: Python not found, skipping Python JSON schema -> grammar tests.\n\033[0m");
     }
 
     if (std::system("node --version") == 0) {
@@ -823,7 +823,7 @@ int main() {
             tc.verify(read("test-grammar-output.tmp"));
         });
     } else {
-        fprintf(stderr, "#\n# WARNING: Node not found, skipping JavaScript JSON schema -> grammar tests!\n#\n");
+        fprintf(stderr, "\033[33mWARNING: Node not found, skipping JavaScript JSON schema -> grammar tests.\n\033[0m");
     }
 
     test_all("Check Expectations Validity", [](const TestCase & tc) {

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -803,18 +803,28 @@ int main() {
             tc.verify_status(FAILURE);
         }
     });
-    //test_all("Python", [](const TestCase & tc) {
-    //    write("test-json-schema-input.tmp", tc.schema);
-    //    tc.verify_status(std::system(
-    //        "python ./examples/json-schema-to-grammar.py test-json-schema-input.tmp > test-grammar-output.tmp") == 0 ? SUCCESS : FAILURE);
-    //    tc.verify(read("test-grammar-output.tmp"));
-    //});
-    //test_all("JavaScript", [](const TestCase & tc) {
-    //    write("test-json-schema-input.tmp", tc.schema);
-    //    tc.verify_status(std::system(
-    //        "node ./tests/run-json-schema-to-grammar.mjs test-json-schema-input.tmp > test-grammar-output.tmp") == 0 ? SUCCESS : FAILURE);
-    //    tc.verify(read("test-grammar-output.tmp"));
-    //});
+
+    if (std::system("python --version") == 0) {
+        test_all("Python", [](const TestCase & tc) {
+            write("test-json-schema-input.tmp", tc.schema);
+            tc.verify_status(std::system(
+                "python ./examples/json-schema-to-grammar.py test-json-schema-input.tmp > test-grammar-output.tmp") == 0 ? SUCCESS : FAILURE);
+            tc.verify(read("test-grammar-output.tmp"));
+        });
+    } else {
+        fprintf(stderr, "#\n# WARNING: Python not found, skipping Python JSON schema -> grammar tests!\n#\n");
+    }
+
+    if (std::system("node --version") == 0) {
+        test_all("JavaScript", [](const TestCase & tc) {
+            write("test-json-schema-input.tmp", tc.schema);
+            tc.verify_status(std::system(
+                "node ./tests/run-json-schema-to-grammar.mjs test-json-schema-input.tmp > test-grammar-output.tmp") == 0 ? SUCCESS : FAILURE);
+            tc.verify(read("test-grammar-output.tmp"));
+        });
+    } else {
+        fprintf(stderr, "#\n# WARNING: Node not found, skipping JavaScript JSON schema -> grammar tests!\n#\n");
+    }
 
     test_all("Check Expectations Validity", [](const TestCase & tc) {
         if (tc.expected_status == SUCCESS) {

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -794,6 +794,9 @@ static void test_all(const std::string & lang, std::function<void(const TestCase
 }
 
 int main() {
+    fprintf(stderr, "LLAMA_NODE_AVAILABLE = %s\n", getenv("LLAMA_NODE_AVAILABLE") ? "true" : "false");
+    fprintf(stderr, "LLAMA_PYTHON_AVAILABLE = %s\n", getenv("LLAMA_PYTHON_AVAILABLE") ? "true" : "false");
+
     test_all("C++", [](const TestCase & tc) {
         try {
             tc.verify(json_schema_to_grammar(nlohmann::json::parse(tc.schema)));


### PR DESCRIPTION
Runs these tests either when python/node is detected (as suggested by @cebtenzzre) or when `LLAMA_PYTHON_AVAILABLE` / `LLAMA_NODE_AVAILABLE` env var is set (which is done - w/ extra node & python setup - in one test env, `ubuntu-focal-make`, to guarantee those tests are run *somewhere*).

(tests introduced in https://github.com/ggerganov/llama.cpp/pull/5978 / disabled in https://github.com/ggerganov/llama.cpp/pull/6198 as node/python aren't always there)

