### PR TITLE
server : fix n_keep always showing as 0 in response

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1247,7 +1247,7 @@ struct server_context {
             {"penalize_nl",               slot.sparams.penalize_nl},
             {"stop",                      slot.params.antiprompt},
             {"n_predict",                 slot.params.n_predict}, // TODO: fix duplicate key n_predict
-            {"n_keep",                    params.n_keep},
+            {"n_keep",                    slot.params.n_keep},
             {"ignore_eos",                ignore_eos},
             {"stream",                    slot.params.stream},
             {"logit_bias",                slot.sparams.logit_bias},


### PR DESCRIPTION
The /completion API of the server always returns n_keep as 0 instead of the passed n_keep parameter. It currently seems to be reporting an n_keep value from a different structure than the one that's actually used in the server code. This fix changes it to report the n_keep value from the slot parameters, in line with the other reported slot parameters.