### PR TITLE
use _wfopen instead of fopen on Windows

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -3,6 +3,7 @@
 
 #include "ggml-impl.h"
 #include "ggml-quants.h"
+#include "ggml.h"
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <malloc.h> // using malloc.h with MSC/MINGW
@@ -433,6 +434,57 @@ int64_t ggml_cycles_per_ms(void) {
 #define ggml_perf_cycles()        0
 #define ggml_perf_cycles_per_ms() 0
 #endif
+
+//
+// cross-platform UTF-8 file paths
+//
+
+#ifdef _WIN32
+static wchar_t * ggml_mbstowcs(const char * mbs) {
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, mbs, -1, NULL, 0);
+    if (!wlen) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    wchar_t * wbuf = GGML_MALLOC(wlen * sizeof(wchar_t));
+    wlen = MultiByteToWideChar(CP_UTF8, 0, mbs, -1, wbuf, wlen);
+    if (!wlen) {
+        GGML_FREE(wbuf);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    return wbuf;
+}
+#endif
+
+FILE * ggml_fopen(const char * fname, const char * mode) {
+#ifdef _WIN32
+    FILE * file = NULL;
+
+    // convert fname (UTF-8)
+    wchar_t * wfname = ggml_mbstowcs(fname);
+    if (wfname) {
+        // convert mode (ANSI)
+        wchar_t * wmode = GGML_MALLOC(strlen(mode) + 1);
+        wchar_t * wmode_p = wmode;
+        do {
+            *wmode_p++ = (wchar_t)*mode;
+        } while (*mode++);
+
+        // open file
+        file = _wfopen(wfname, wmode);
+
+        GGML_FREE(wfname);
+        GGML_FREE(wmode);
+    }
+
+    return file;
+#else
+    return fopen(fname, mode);
+#endif
+}
 
 //
 // cache line
@@ -18743,7 +18795,7 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
 
     // write binary data
     {
-        FILE * fout = fopen(fname, "wb");
+        FILE * fout = ggml_fopen(fname, "wb");
 
         if (!fout) {
             fprintf(stderr, "%s: failed to open %s\n", __func__, fname);
@@ -18881,7 +18933,7 @@ struct ggml_cgraph * ggml_graph_import(const char * fname, struct ggml_context *
 
     // read file into data
     {
-        FILE * fin = fopen(fname, "rb");
+        FILE * fin = ggml_fopen(fname, "rb");
         if (!fin) {
             fprintf(stderr, "%s: failed to open %s\n", __func__, fname);
             return result;
@@ -19217,7 +19269,7 @@ static void ggml_graph_dump_dot_leaf_edge(FILE * fp, struct ggml_tensor * node, 
 void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph * gf, const char * filename) {
     char color[16];
 
-    FILE * fp = fopen(filename, "w");
+    FILE * fp = ggml_fopen(filename, "w");
     GGML_ASSERT(fp);
 
     fprintf(fp, "digraph G {\n");
@@ -20535,7 +20587,7 @@ struct gguf_context * gguf_init_empty(void) {
 }
 
 struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params) {
-    FILE * file = fopen(fname, "rb");
+    FILE * file = ggml_fopen(fname, "rb");
     if (!file) {
         return NULL;
     }
@@ -21490,7 +21542,7 @@ static void gguf_write_to_buf(const struct gguf_context * ctx, struct gguf_buf *
 }
 
 void gguf_write_to_file(const struct gguf_context * ctx, const char * fname, bool only_meta) {
-    FILE * file = fopen(fname, "wb");
+    FILE * file = ggml_fopen(fname, "wb");
     if (!file) {
         GGML_ASSERT(false && "failed to open file for writing");
     }

--- a/ggml.c
+++ b/ggml.c
@@ -43,6 +43,10 @@
 
 #if defined(_WIN32)
 
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+    #define NOMINMAX
+#endif
 #include <windows.h>
 
 typedef volatile LONG atomic_int;

--- a/ggml.h
+++ b/ggml.h
@@ -214,9 +214,10 @@
 #    define GGML_ATTRIBUTE_FORMAT(...) __attribute__((format(printf, __VA_ARGS__)))
 #endif
 
-#include <stdint.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
 
 #define GGML_FILE_MAGIC   0x67676d6c // "ggml"
 #define GGML_FILE_VERSION 1
@@ -707,6 +708,9 @@ extern "C" {
     GGML_API int64_t ggml_cycles_per_ms(void);
 
     GGML_API void    ggml_print_backtrace(void);
+
+    // accepts a UTF-8 path, even on Windows
+    GGML_API FILE *  ggml_fopen(const char * fname, const char * mode);
 
     GGML_API void    ggml_numa_init(enum ggml_numa_strategy numa); // call once for better performance on NUMA systems
     GGML_API bool    ggml_is_numa(void); // true if init detected that system has >1 NUMA node

--- a/llama.cpp
+++ b/llama.cpp
@@ -3971,7 +3971,7 @@ static void llm_load_vocab(
     } else if (vocab.type == LLAMA_VOCAB_TYPE_WPM) {
         vocab.linefeed_id = vocab.special_pad_id;
     } else {
-        const std::vector<int> ids = llama_tokenize_internal(vocab, "\u010A", false);
+        const std::vector<int> ids = llama_tokenize_internal(vocab, "\xC4\x8A", false); // U+010A
         GGML_ASSERT(!ids.empty() && "model vocab missing newline token");
         vocab.linefeed_id = ids[0];
     }

--- a/llama.cpp
+++ b/llama.cpp
@@ -1041,7 +1041,7 @@ struct llama_file {
     size_t size;
 
     llama_file(const char * fname, const char * mode) {
-        fp = std::fopen(fname, mode);
+        fp = ggml_fopen(fname, mode);
         if (fp == NULL) {
             throw std::runtime_error(format("failed to open %s: %s", fname, strerror(errno)));
         }


### PR DESCRIPTION
This PR uses \_wfopen() instead of fopen() on Windows, to make it more convenient for downstream projects to use llama.cpp with UTF-8 paths.

(This doesn't fix llama_model_quantize, which uses std::ofstream, but AFAIK there is no way to open a std::ofstream with a wchar_t path on MinGW, and this should only really be used by the `quantize` example anyway.)

Supersedes #5927

Tested with llama-cpp-python. Without this change:
```
>>> from llama_cpp import Llama
>>> path = b'\xF0\x9F\x98\x8A'.decode()  # '😊'
>>> llm = Llama(model_path=path, verbose=True)
llama_model_load: error loading model: failed to open 😊: No such file or directory
llama_load_model_from_file: failed to load model
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\msys64\home\Jared\llama-cpp-python\llama_cpp\llama.py", line 314, in __init__
    self._model = _LlamaModel(
                  ^^^^^^^^^^^^
  File "C:\msys64\home\Jared\llama-cpp-python\llama_cpp\_internals.py", line 55, in __init__
    raise ValueError(f"Failed to load model from file: {path_model}")
ValueError: Failed to load model from file: 😊
```

With this change, the model loads successfully.

---

See the Wikipedia page [Unicode in Microsoft Windows](https://en.wikipedia.org/wiki/Unicode_in_Microsoft_Windows) for historical context that explains why Unicode is such a headache on Windows.

On recent versions of Windows, one can set the "ANSI" code page used by the \*A functions[^1] to UTF-8 for the current process using [setlocale()](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170&viewFallbackFrom=vs-2019#utf-8-support), for an executable or DLL using [a manifest](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page), or [system-wide](https://superuser.com/questions/269818/change-default-code-page-of-windows-console-to-utf-8). However, for llama.cpp to be a portable and easy-to-use library, it shouldn't rely on this internally.

The approach used in this PR will work regardless of the above. The standard C wcstombs() depends on the process locale as set by setlocale(), but since this translation is only necessary on Windows, this PR directly uses MultiByteToWideChar with CP\_UTF8.

NOTE: When the system code page is not UTF-8, the examples and tests will still fail on Unicode paths. The simplest fix for this that will also work on MinGW is for all of them to call setlocale(), and to use wmain or GetCommandLineW to get argv in UTF-8. If there is interest, this can be implemented in a future PR.

[^1]: There is also the "OEM" code page used by console functions such as ReadConsoleA/WriteConsoleA - this is what `chcp` changes