### PR TITLE
[BUG fix]Building BUG： Fix a building error on windows+ROCm5.7+Cmake

### DIFF
--- a/common/ngram-cache.cpp
+++ b/common/ngram-cache.cpp
@@ -184,7 +184,6 @@ void llama_ngram_cache_draft(
             break;
         }
 
-        // LOG(" - draft candidate: token=%d\n", drafted_token);
         draft.push_back(drafted_token);
     }
 }

--- a/common/ngram-cache.cpp
+++ b/common/ngram-cache.cpp
@@ -1,5 +1,4 @@
 #include "ngram-cache.h"
-#include "log.h"
 
 #include <fstream>
 
@@ -39,7 +38,6 @@ void llama_ngram_cache_update(llama_ngram_cache & ngram_cache, int ngram_min, in
                 const int64_t eta_min  = eta_ms / (60*1000);
                 const int64_t eta_s    = (eta_ms - 60*1000*eta_min) / 1000;
 
-                fprintf(stderr, "%s: %" PRId64 "/%" PRId64 " done, ETA: %02" PRId64 ":%02" PRId64 "\n", __func__, n_done, n_todo, eta_min, eta_s);
             }
         }
     }
@@ -186,7 +184,7 @@ void llama_ngram_cache_draft(
             break;
         }
 
-        LOG(" - draft candidate: token=%d\n", drafted_token);
+        // LOG(" - draft candidate: token=%d\n", drafted_token);
         draft.push_back(drafted_token);
     }
 }


### PR DESCRIPTION
# [bugfix] building error with Windows+ROCm5.7+Cmake

## Bug Description:

environment: Windows11 ROCm5.7 with (AMD 7800XT)
1. function LOG defined in common/log.h  used in ngram-cache.cpp possibly cause the building error on Windows Platform
        
        Building CXX object common/CMakeFiles/common.dir/ngram-cache.cpp.obj
        FAILED: common/CMakeFiles/common.dir/ngram-cache.cpp.obj
        llama/llama.cpp/common/./log.h:469:5: error: expected ')'

2. function fprintf used in common/ngram-cache.cpp may cause the same error

function LOG performed well in other obj, but the error raised when building ngram-cache.cpp.obj. Since the function fprintf raise the same error, so I guess that it was caused by ngram-cache related content.
I think removing these logs is a reasonable choice when the exact cause is unknown.
## Solve Method:
    remove the including of log.h in ngram-cache.cpp
    remove the function call LOG in ngram-cache.cpp
    remove the function call fprintf in ngram-cache.cpp

## Changes to be committed:
    modified:   common/ngram-cache.cpp

## BUG Detail LOG
```
[1/57] Building CXX object common/CMakeFiles/common.dir/ngram-cache.cpp.obj
FAILED: common/CMakeFiles/common.dir/ngram-cache.cpp.obj 
ccache C:\PROGRA~1\AMD\ROCm\5.7\bin\CLANG_~1.EXE -DGGML_CUDA_DMMV_X=32 -DGGML_CUDA_MMV_Y=1 -DGGML_SCHED_MAX_COPIES=4 -DGGML_USE_CUBLAS -DGGML_USE_HIPBLAS -DK_QUANTS_PER_ITERATION=2 -D_CRT_SECURE_NO_WARNINGS -D_XOPEN_SOURCE=600 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -IC:/Users/41104/llama/llama.cpp/common/. -IC:/Users/41104/llama/llama.cpp/. -isystem "C:/Program Files/AMD/ROCm/5.7/include" -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -std=gnu++14 -Wmissing-declarations -Wmissing-noreturn -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wunreachable-code-break -Wunreachable-code-return -Wmissing-prototypes -Wextra-semi -march=native -MD -MT common/CMakeFiles/common.dir/ngram-cache.cpp.obj -MF common\CMakeFiles\common.dir\ngram-cache.cpp.obj.d -o common/CMakeFiles/common.dir/ngram-cache.cpp.obj -c C:/Users/41104/llama/llama.cpp/common/ngram-cache.cpp
In file included from C:/Users/41104/llama/llama.cpp/common/ngram-cache.cpp:2:
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:467:5: error: expected ')'
    LOG("01 Hello World to nobody, because logs are disabled!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:467:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:50: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                 ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:469:5: error: expected ')'
    LOG("02 Hello World to default output, which is \"%s\" ( Yaaay, arguments! )!\n", LOG_STRINGIZE(LOG_TARGET));
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:469:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:56: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                       ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:470:5: error: expected ')'
    LOG_TEE("03 Hello World to **both** default output and " LOG_TEE_TARGET_STRING "!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:470:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:472:5: error: expected ')'
    LOG("04 Hello World to stderr!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:472:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:56: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                       ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:473:5: error: expected ')'
    LOG_TEE("05 Hello World TEE with double printing to stderr prevented!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:473:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:475:5: error: expected ')'
    LOG("06 Hello World to default log file!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:475:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:477:5: error: expected ')'
    LOG("07 Hello World to stdout!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:477:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:479:5: error: expected ')'
    LOG("08 Hello World to default log file again!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:479:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:481:5: error: expected ')'
    LOG("09 Hello World _1_ into the void!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:481:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:483:5: error: expected ')'
    LOG("10 Hello World back from the void ( you should not see _1_ in the log or the output )!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:483:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:486:5: error: expected ')'
    LOG("11 Hello World _2_ to nobody, new target was selected but logs are still disabled!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:486:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:488:5: error: expected ')'
    LOG("12 Hello World this time in a new file ( you should not see _2_ in the log or the output )?\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:488:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:490:5: error: expected ')'
    LOG("13 Hello World this time in yet new file?\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:490:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:492:5: error: expected ')'
    LOG("14 Hello World in log with generated filename!\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:492:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:56: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                       ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:494:5: error: expected ')'
    LOG_TEE("15 Hello msvc TEE without arguments\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:494:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:58: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:495:5: error: expected ')'
    LOG_TEE("16 Hello msvc TEE with (%d)(%s) arguments\n", 1, "test");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:495:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:314:31: note: expanded from macro 'LOG_TEE'
    #define LOG_TEE(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "")
                              ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:323:58: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:496:5: error: expected ')'
    LOG_TEELN("17 Hello msvc TEELN without arguments\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:323:33: note: expanded from macro 'LOG_TEELN'
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:496:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:323:33: note: expanded from macro 'LOG_TEELN'
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:323:60: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                                           ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:284:126: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TEE_TARGET, LOG_TEE_TIMESTAMP_FMT LOG_TEE_FLF_FMT str "%s" LOG_TEE_TIMESTAMP_VAL LOG_TEE_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                                             ^
C:/Users/41104/llama/llama.cpp/common/./log.h:497:5: error: expected ')'
    LOG_TEELN("18 Hello msvc TEELN with (%d)(%s) arguments\n", 1, "test");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:323:33: note: expanded from macro 'LOG_TEELN'
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:102: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:497:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:323:33: note: expanded from macro 'LOG_TEELN'
    #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", ##__VA_ARGS__, "\n")
                                ^
C:/Users/41104/llama/llama.cpp/common/./log.h:279:20: note: expanded from macro 'LOG_TEE_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__);                     \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:48: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                               ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                         ^
C:/Users/41104/llama/llama.cpp/common/./log.h:498:5: error: expected ')'
    LOG("19 Hello msvc LOG without arguments\n");
    ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:102: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                                                                                                     ^
C:/Users/41104/llama/llama.cpp/common/./log.h:498:5: note: to match this '('
C:/Users/41104/llama/llama.cpp/common/./log.h:300:27: note: expanded from macro 'LOG'
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                          ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:20: note: expanded from macro 'LOG_IMPL'
            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \
                   ^
C:/Users/41104/llama/llama.cpp/common/./log.h:300:50: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]
    #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
                                                 ^
C:/Users/41104/llama/llama.cpp/common/./log.h:251:106: warning: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Wgnu-zero-variadic-macro-arguments]

            fprintf(LOG_TARGET, LOG_TIMESTAMP_FMT LOG_FLF_FMT str "%s" LOG_TIMESTAMP_VAL LOG_FLF_VAL "", ##__VA_ARGS__); \

                                                                                                         ^

fatal error: too many errors emitted, stopping now [-ferror-limit=]

46 warnings and 20 errors generated.

ninja: build stopped: subcommand failed.

```
## BUG Detail LOG2 (  fprintf will cause the same error)
```
[1/57] Building CXX object common/CMakeFiles/common.dir/ngram-cache.cpp.obj
FAILED: common/CMakeFiles/common.dir/ngram-cache.cpp.obj 
ccache C:\PROGRA~1\AMD\ROCm\5.7\bin\CLANG_~1.EXE -DGGML_CUDA_DMMV_X=32 -DGGML_CUDA_MMV_Y=1 -DGGML_SCHED_MAX_COPIES=4 -DGGML_USE_CUBLAS -DGGML_USE_HIPBLAS -DK_QUANTS_PER_ITERATION=2 -D_CRT_SECURE_NO_WARNINGS -D_XOPEN_SOURCE=600 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -IC:/Users/41104/llama/llama.cpp/common/. -IC:/Users/41104/llama/llama.cpp/. -isystem "C:/Program Files/AMD/ROCm/5.7/include" -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -std=gnu++14 -Wmissing-declarations -Wmissing-noreturn -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wunreachable-code-break -Wunreachable-code-return -Wmissing-prototypes -Wextra-semi -march=native -MD -MT common/CMakeFiles/common.dir/ngram-cache.cpp.obj -MF common\CMakeFiles\common.dir\ngram-cache.cpp.obj.d -o common/CMakeFiles/common.dir/ngram-cache.cpp.obj -c C:/Users/41104/llama/llama.cpp/common/ngram-cache.cpp
C:/Users/41104/llama/llama.cpp/common/ngram-cache.cpp:42:41: error: expected ')'
                fprintf(stderr, "%s: %" PRId64 "/%" PRId64 " done, ETA: %02" PRId64 ":%02" PRId64 "\n", __func__, n_done, n_todo, eta_min, eta_s);
                                        ^
C:/Users/41104/llama/llama.cpp/common/ngram-cache.cpp:42:24: note: to match this '('
                fprintf(stderr, "%s: %" PRId64 "/%" PRId64 " done, ETA: %02" PRId64 ":%02" PRId64 "\n", __func__, n_done, n_todo, eta_min, eta_s);
                       ^

1 error generated.

ninja: build stopped: subcommand failed.
```