### PR TITLE
ci: close inactive issue, increase operations per run

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -19,5 +19,5 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 1000
+          operations-per-run: 10000
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Increase again operations per run as it still stop after few issues.

https://github.com/ggerganov/llama.cpp/actions/runs/8405784895/job/23018946144