### PR TITLE
Fix heap corruption from wmode out-of-bound writes on windows

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -465,7 +465,7 @@ FILE * ggml_fopen(const char * fname, const char * mode) {
     wchar_t * wfname = ggml_mbstowcs(fname);
     if (wfname) {
         // convert mode (ANSI)
-        wchar_t * wmode = GGML_MALLOC(strlen(mode) + 1);
+        wchar_t * wmode = GGML_MALLOC((strlen(mode) + 1) * sizeof(wchar_t));
         wchar_t * wmode_p = wmode;
         do {
             *wmode_p++ = (wchar_t)*mode;


### PR DESCRIPTION
* would throw error on VS2022 on GGML_FREE(wmode)
* wchar_t is usually 2 bytes, but malloc wants bytes
  * therefore `*wmode_p++ = (wchar_t)*mode;` could write off the end of the allocation
* Fixes error possibly introduced by https://github.com/ggerganov/llama.cpp/pull/6248