### PR TITLE
Server: clean up OAI params parsing function

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -360,7 +360,7 @@ Notice that each `probs` is an array of length `n_probs`.
 - `default_generation_settings` - the default generation settings for the `/completion` endpoint, has the same fields as the `generation_settings` response object from the `/completion` endpoint.
 - `total_slots` - the total number of slots for process requests (defined by `--parallel` option)
 
-- **POST** `/v1/chat/completions`: OpenAI-compatible Chat Completions API. Given a ChatML-formatted json description in `messages`, it returns the predicted completion. Both synchronous and streaming mode are supported, so scripted and interactive applications work fine. While no strong claims of compatibility with OpenAI API spec is being made, in our experience it suffices to support many apps. Only ChatML-tuned models, such as Dolphin, OpenOrca, OpenHermes, OpenChat-3.5, etc can be used with this endpoint.
+- **POST** `/v1/chat/completions`: OpenAI-compatible Chat Completions API. Given a ChatML-formatted json description in `messages`, it returns the predicted completion. Both synchronous and streaming mode are supported, so scripted and interactive applications work fine. While no strong claims of compatibility with OpenAI API spec is being made, in our experience it suffices to support many apps. Only model with [supported chat template](https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template) can be used optimally with this endpoint. By default, ChatML template will be used.
 
     *Options:*
 

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -393,6 +393,7 @@ static json oaicompat_completion_params_parse(
     }
 
     // Handle "logprobs" field
+    // TODO: The response format of this option is not yet OAI-compatible, but seems like no one really using it; We may need to fix it in the future
     if (body.contains("logprobs")) {
         llama_params["n_probs"] = json_value(body, "top_logprobs", 20);
     } else if (body.contains("top_logprobs")) {

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -376,10 +376,10 @@ static json oaicompat_completion_params_parse(
     // Handle "response_format" field
     if (body.contains("response_format")) {
         json response_format      = json_value(body, "response_format", json::object());
-        std::string response_type = json_value(response_format, "type", std::string("unknown"));
+        std::string response_type = json_value(response_format, "type", std::string());
         if (response_type == "json_object") {
             llama_params["json_schema"] = json_value(response_format, "schema", json::object());
-        } else {
+        } else if (!response_type.empty()) {
             throw std::runtime_error("response_format type not supported: " + response_type);
         }
     }

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -371,7 +371,7 @@ static json oaicompat_completion_params_parse(
         llama_params["stop"] = json_value(body, "stop", json::array());
     }
     // Some chat templates don't use EOS token to stop generation
-    // We must add their end sequences among stop words
+    // We must add their end sequences to list of stop words
     llama_params["stop"].push_back("<|im_end|>"); // chatml
     llama_params["stop"].push_back("<end_of_turn>"); // gemma
 


### PR DESCRIPTION
## Motivation

This PR aims to resolve 2 issues:
1. `oaicompat_completion_params_parse` and `launch_slot_with_task` have some duplicated logic
2. For now, we're not having a good separation between "params come from OAI" and "params come from llama.cpp"

## Proposal

1. `oaicompat_completion_params_parse` should only take care of params that are specified in OAI's documentation. The other params , for example `mirostat`, `tfs_z`,... should be leave as-is and forwarded to `launch_slot_with_task`
2. We explicitly throw errors for non-supported OAI fields: `"tools", "tool_choice"`

This PR also add partially support for `logprobs` since we already had this underlay logic, but the param is not implement in OAI logic