### PR TITLE
Control vectors in server

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2650,12 +2650,7 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
 
     // calculate size of ctx needed for tensors, ensure tensors are f32, and find max layer
     {
-        struct ggml_init_params meta_params = {
-            /* .mem_size   = */ ggml_tensor_overhead() * 128 + ggml_graph_overhead(),
-            /* .mem_buffer = */ nullptr,
-            /* .no_alloc   = */ true,
-        };
-        ggml_context * meta_ctx = ggml_init(meta_params);
+        ggml_context * meta_ctx = nullptr;
         struct gguf_init_params meta_gguf_params = {
             /* .no_alloc = */ true,
             /* .ctx      = */ &meta_ctx,
@@ -2720,13 +2715,7 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
     }
 
     // load and scale tensors into final control vector context
-    struct ggml_init_params ggml_params = {
-        /* .mem_size   = */ ggml_tensor_overhead() * n_tensors + n_bytes,
-        /* .mem_buffer = */ nullptr,
-        /* .no_alloc   = */ false,
-    };
-    struct ggml_context * ctx = ggml_init(ggml_params);
-
+    struct ggml_context * ctx = nullptr;
     struct gguf_init_params params = {
         /*.no_alloc = */ false,
         /*.ctx      = */ &ctx,

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2673,8 +2673,8 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
                     uint32_t layer = std::stoi(name.substr(dotpos + 1));
                     if (layer == 0) {
                         fprintf(stderr, "%s: direction tensor invalid in %s\n", __func__, load_info.fname.c_str());
-                        ggml_free(meta_ctx);
                         gguf_free(meta_ctx_gguf);
+                        ggml_free(meta_ctx);
                         return result;
                     }
                     if (layer > max_direction_layer) {
@@ -2682,8 +2682,8 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
                     }
                 } catch (...) {
                     fprintf(stderr, "%s: direction tensor invalid in %s\n", __func__, load_info.fname.c_str());
-                    ggml_free(meta_ctx);
                     gguf_free(meta_ctx_gguf);
+                    ggml_free(meta_ctx);
                     return result;
                 }
             }
@@ -2691,22 +2691,22 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
             struct ggml_tensor * tensor_meta = ggml_get_tensor(meta_ctx, name.c_str());
             if (tensor_meta->type != GGML_TYPE_F32 || ggml_n_dims(tensor_meta) != 1) {
                 fprintf(stderr, "%s: direction tensor invalid in %s\n", __func__, load_info.fname.c_str());
-                ggml_free(meta_ctx);
                 gguf_free(meta_ctx_gguf);
+                ggml_free(meta_ctx);
                 return result;
             }
             if (result.n_embd == -1) {
                 result.n_embd = ggml_nelements(tensor_meta);
             } else if (ggml_nelements(tensor_meta) != result.n_embd) {
                 fprintf(stderr, "%s: direction tensor sizes mismatched in %s\n", __func__, load_info.fname.c_str());
-                ggml_free(meta_ctx);
                 gguf_free(meta_ctx_gguf);
+                ggml_free(meta_ctx);
                 return result;
             }
             n_bytes += ggml_nbytes(tensor_meta);
         }
-        ggml_free(meta_ctx);
         gguf_free(meta_ctx_gguf);
+        ggml_free(meta_ctx);
     }
 
     if (n_tensors == 0) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2640,6 +2640,8 @@ float llama_embd_similarity_cos(const float * embd1, const float * embd2, int n)
 //
 
 static llama_control_vector_data llama_control_vector_load_one(const llama_control_vector_load_info & load_info) {
+    auto start = ggml_time_ms();
+    printf("control vector load_one...\n");
     int32_t n_tensors;
 
     size_t n_bytes = 0;
@@ -2684,7 +2686,6 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
                     fprintf(stderr, "%s: direction tensor invalid in %s\n", __func__, load_info.fname.c_str());
                     gguf_free(meta_ctx_gguf);
                     ggml_free(meta_ctx);
-                    return result;
                 }
             }
 
@@ -2751,10 +2752,14 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
     gguf_free(ctx_gguf);
     ggml_free(ctx);
 
+    auto end = ggml_time_ms();
+    printf("control vector load_one took %ums\n", end - start);
     return result;
 }
 
 llama_control_vector_data llama_control_vector_load(const std::vector<llama_control_vector_load_info> & load_infos) {
+    auto start = ggml_time_ms();
+    printf("control vector load...\n");
     llama_control_vector_data result = { -1, {} };
 
     for (const auto & info : load_infos) {
@@ -2764,7 +2769,7 @@ llama_control_vector_data llama_control_vector_load(const std::vector<llama_cont
             return result;
         }
         if (result.n_embd != -1 && (result.n_embd != cur.n_embd || result.data.size() != cur.data.size())) {
-            fprintf(stderr, "%s: control vector in %s does not match previous vector dimensions\n", __func__, info.fname.c_str());
+            printf("%s: control vector in %s does not match previous vector dimensions\n", __func__, info.fname.c_str());
             return result;
         }
 
@@ -2778,8 +2783,10 @@ llama_control_vector_data llama_control_vector_load(const std::vector<llama_cont
     }
 
     if (result.n_embd == -1) {
-        fprintf(stderr, "%s: no vectors passed\n", __func__);
+        printf("%s: no vectors passed\n", __func__);
     }
 
+    auto end = ggml_time_ms();
+    printf("control vector load time: %ums\n", end-start);
     return result;
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2748,6 +2748,9 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
         }
     }
 
+    gguf_free(ctx_gguf);
+    ggml_free(ctx);
+
     return result;
 }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2216,6 +2216,12 @@ static void server_print_usage(const char * argv0, const gpt_params & params, co
     printf("                            set an alias for the model, will be added as `model` field in completion response\n");
     printf("  --lora FNAME              apply LoRA adapter (implies --no-mmap)\n");
     printf("  --lora-base FNAME         optional model to use as a base for the layers modified by the LoRA adapter\n");
+    printf("  --control-vector FNAME\n");
+    printf("                        add a control vector\n");
+    printf("  --control-vector-scaled FNAME S\n");
+    printf("                        add a control vector with user defined scaling S\n");
+    printf("  --control-vector-layer-range START END\n");
+    printf("                        layer range to apply the control vector(s) to, start and end inclusive\n");
     printf("  --host                    ip address to listen (default  (default: %s)\n", sparams.hostname.c_str());
     printf("  --port PORT               port to listen (default  (default: %d)\n", sparams.port);
     printf("  --path PUBLIC_PATH        path from which to serve static files (default: disabled)\n");

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -624,6 +624,7 @@ struct server_response {
         }
     }
 };
+
 struct server_context {
     llama_model * model = nullptr;
     llama_context * ctx = nullptr;
@@ -3607,4 +3608,3 @@ int main(int argc, char ** argv) {
 
     return 0;
 }
-

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2218,9 +2218,9 @@ static void server_print_usage(const char * argv0, const gpt_params & params, co
     printf("  --lora FNAME              apply LoRA adapter (implies --no-mmap)\n");
     printf("  --lora-base FNAME         optional model to use as a base for the layers modified by the LoRA adapter\n");
     printf("  --control-vector FNAME\n");
-    printf("                        add a control vector\n");
+    printf("                            add a control vector\n");
     printf("  --control-vector-scaled FNAME S\n");
-    printf("                        add a control vector with user defined scaling S\n");
+    printf("                            add a control vector with user defined scaling S\n");
     printf("  --control-vector-layer-range START END\n");
     printf("                        layer range to apply the control vector(s) to, start and end inclusive\n");
     printf("  --host                    ip address to listen (default  (default: %s)\n", sparams.hostname.c_str());

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -120,6 +120,8 @@ struct server_params {
 
     std::vector<std::string> api_keys;
 
+    std::vector<llama_control_vector_load_option> control_vector_load_options;
+
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     std::string ssl_key_file = "";
     std::string ssl_cert_file = "";
@@ -2735,6 +2737,25 @@ static void server_params_parse(int argc, char ** argv, server_params & sparams,
             }
             params.control_vector_layer_end = std::stoi(argv[i]);
             break;
+        } else if (arg == "--control-vector-option") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            char *name = argv[i];
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            size_t slen = strlen(argv[i]);
+            bool is_dir = slen < 5 || strncmp(argv[i] + slen - 5, ".gguf", 5) != 0;
+
+            // Append path separator for dirs
+            std::string fname = argv[i];
+            if (is_dir && argv[i][slen - 1] != '/')
+                fname += '/';
+            sparams.control_vector_load_options.push_back({ argv[i-1], fname, is_dir });
+            break;
         } else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             server_print_usage(argv[0], default_params, default_sparams);
@@ -3183,6 +3204,16 @@ int main(int argc, char ** argv) {
         res.status = 200; // HTTP OK
     };
 
+    const auto handle_control_vector_options = [&sparams](const httplib::Request & req, httplib::Response & res) {
+      res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
+      json options = json::array();
+
+      for (const auto & opt : sparams.control_vector_load_options) {
+          options.push_back(opt.name);
+      }
+      res.set_content(options.dump(), "application/json; charset=utf-8");
+    };
+
     const auto handle_get_control_vectors = [&ctx_server](const httplib::Request & req, httplib::Response & res) {
       res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
       json vectors = json::array();
@@ -3201,23 +3232,62 @@ int main(int argc, char ** argv) {
       res.set_content(data.dump(), "application/json; charset=utf-8");
     };
 
-    const auto handle_set_control_vectors = [&ctx_server, &res_error, &handle_get_control_vectors](const httplib::Request & req, httplib::Response & res) {
+    const auto handle_set_control_vectors = [&ctx_server, &sparams, &res_error, &handle_get_control_vectors](const httplib::Request & req, httplib::Response & res) {
         json data = json::parse(req.body);
+
+        // vector parameters passed by user
         std::vector<llama_control_vector_load_info> vec_params;
+        // names translated to real file names
+        std::vector<llama_control_vector_load_info> real_vec_params;
 
         if (data.contains("vectors") && data["vectors"].is_array()) {
             for (const auto &item : data["vectors"]) {
-                auto v = item.get<llama_control_vector_load_info>();
-                std::cout << "Add vector: " << v.fname << " " << v.strength << "\n";
+                llama_control_vector_load_info v = item.get<llama_control_vector_load_info>();
+                std::string real_fname = "";
+                std::cout << "Check vec " << v.fname << "\n";
+                // check for path traversal attempt
+                if (v.fname.length() > 0 && v.fname[0] != '/' && v.fname[0] != '\\') {
+                    if (v.fname.find("../") == -1 && v.fname.find("..\\") == -1 &&
+                        v.fname.find("/..") == -1 && v.fname.find("\\..") == -1) {
+
+                        // check if vector name matches allowed names
+                        for (auto opt : sparams.control_vector_load_options) {
+                            std::cout << "check option " << opt.name << " : " << opt.fname << " : " << opt.is_dir << "\n";
+                            if (!opt.is_dir && opt.name == v.fname) {
+                                std::cout << "file exact match\n";
+                                real_fname = opt.fname;
+                                break;
+                            }
+                            if (opt.is_dir && v.fname.rfind(opt.name, 0) == 0) {
+                                std::cout << "file exact match\n";
+                                // opt.fname already includes '/' (or '\') while opt.name doesn't
+                                real_fname = opt.fname + v.fname.substr(opt.name.length() + 1);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (real_fname.length() == 0) {
+                    res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
+                    res_error(res, format_error_response("Control vector not allowed", ERROR_TYPE_SERVER));
+                    return;
+                }
+
+                std::cout << "Add vector: " << v.fname << " -> " << real_fname << " " << v.strength << "\n";
+                llama_control_vector_load_info real_info = { v.strength, real_fname };
                 vec_params.push_back(v);
+                real_vec_params.push_back(real_info);
             }
         } else {
-            std::cerr << "No vectors passed\n";
+            std::cerr << "No vectors array passed\n";
             res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
-            res_error(res, format_error_response("No vectors passed", ERROR_TYPE_SERVER));
+            res_error(res, format_error_response("No vectors array passed. If you want reset to 0, send an empty array.", ERROR_TYPE_SERVER));
             return;
         }
-        const auto cvec = llama_control_vector_load(vec_params);
+
+        const auto cvec = llama_control_vector_load(real_vec_params);
+
         if (cvec.n_embd == -1) {
             std::cerr << "Could not load control vector\n";
             res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
@@ -3231,6 +3301,7 @@ int main(int argc, char ** argv) {
         if (ctx_server.params.control_vector_layer_end   <= 0){
             ctx_server.params.control_vector_layer_end   = llama_n_layer(ctx_server.model);
         }
+
         int err = llama_control_vector_apply(ctx_server.ctx,
                                              cvec.data.data(),
                                              cvec.data.size(),
@@ -3243,7 +3314,9 @@ int main(int argc, char ** argv) {
             res_error(res, format_error_response("Could not apply control vector", ERROR_TYPE_SERVER));
             return;
         }
+
         ctx_server.params.control_vectors.clear();
+
         for (auto v : vec_params) {
           std::cout << "set vector param: " << v.fname << " " << v.strength << "\n";
           ctx_server.params.control_vectors.push_back(v);
@@ -3599,24 +3672,25 @@ int main(int argc, char ** argv) {
         json_schema_to_grammar_mjs, json_schema_to_grammar_mjs_len, "text/javascript; charset=utf-8"));
 
     // register API routes
-    svr->Get ("/health",              handle_health);
-    svr->Get ("/slots",               handle_slots);
-    svr->Get ("/metrics",             handle_metrics);
-    svr->Get ("/props",               handle_props);
-    svr->Get ("/v1/models",           handle_models);
-    svr->Get ("/control-vectors",     handle_get_control_vectors);
-    svr->Post("/control-vectors",     handle_set_control_vectors);
-    svr->Post("/completion",          handle_completions); // legacy
-    svr->Post("/completions",         handle_completions);
-    svr->Post("/v1/completions",      handle_completions);
-    svr->Post("/chat/completions",    handle_chat_completions);
-    svr->Post("/v1/chat/completions", handle_chat_completions);
-    svr->Post("/infill",              handle_infill);
-    svr->Post("/embedding",           handle_embeddings); // legacy
-    svr->Post("/embeddings",          handle_embeddings);
-    svr->Post("/v1/embeddings",       handle_embeddings);
-    svr->Post("/tokenize",            handle_tokenize);
-    svr->Post("/detokenize",          handle_detokenize);
+    svr->Get ("/health",                  handle_health);
+    svr->Get ("/slots",                   handle_slots);
+    svr->Get ("/metrics",                 handle_metrics);
+    svr->Get ("/props",                   handle_props);
+    svr->Get ("/v1/models",               handle_models);
+    svr->Get ("/control-vectors",         handle_get_control_vectors);
+    svr->Get ("/control-vector-options",  handle_control_vector_options);
+    svr->Post("/control-vectors",         handle_set_control_vectors);
+    svr->Post("/completion",              handle_completions); // legacy
+    svr->Post("/completions",             handle_completions);
+    svr->Post("/v1/completions",          handle_completions);
+    svr->Post("/chat/completions",        handle_chat_completions);
+    svr->Post("/v1/chat/completions",     handle_chat_completions);
+    svr->Post("/infill",                  handle_infill);
+    svr->Post("/embedding",               handle_embeddings); // legacy
+    svr->Post("/embeddings",              handle_embeddings);
+    svr->Post("/v1/embeddings",           handle_embeddings);
+    svr->Post("/tokenize",                handle_tokenize);
+    svr->Post("/detokenize",              handle_detokenize);
 
     //
     // Start the server

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3184,6 +3184,7 @@ int main(int argc, char ** argv) {
     };
 
     const auto handle_get_control_vectors = [&ctx_server](const httplib::Request & req, httplib::Response & res) {
+      res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
       json vectors = json::array();
 
       for (const auto & vec : ctx_server.params.control_vectors) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3176,84 +3176,6 @@ int main(int argc, char ** argv) {
         res.status = 200; // HTTP OK
     };
 
-    const auto handle_get_control_vectors = [&ctx_server](const httplib::Request & req, httplib::Response & res) {
-      json vectors = json::array();
-
-      for (const auto & vec : ctx_server.params.control_vectors) {
-          vectors.push_back(json {
-              { "fname", vec.fname },
-              { "strength", vec.strength }
-          });
-      }
-      json data = {
-          { "vectors", vectors },
-          { "layer_start", ctx_server.params.control_vector_layer_start },
-          { "layer_end", ctx_server.params.control_vector_layer_end }
-      };
-      res.set_content(data.dump(), "application/json; charset=utf-8");
-    };
-
-    const auto handle_set_control_vectors = [&ctx_server, &res_error, &handle_get_control_vectors](const httplib::Request & req, httplib::Response & res) {
-        res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
-
-        json data = json::parse(req.body);
-        std::vector<llama_control_vector_load_info> vec_params;
-
-        if (data.contains("vectors") && data["vectors"].is_array()) {
-            for (const auto &item : data["vectors"]) {
-                auto v = item.get<llama_control_vector_load_info>();
-                std::cout << "Add vector: " << v.fname << " " << v.strength << "\n";
-                vec_params.push_back(v);
-            }
-        } else {
-            std::cerr << "No vectors passed\n";
-            res_error(res, format_error_response("No vectors passed", ERROR_TYPE_SERVER));
-            return;
-        }
-        const auto cvec = llama_control_vector_load(vec_params);
-        if (cvec.n_embd == -1) {
-            std::cerr << "Could not load control vector\n";
-            res_error(res, format_error_response("Could not load control vector", ERROR_TYPE_SERVER));
-            return;
-        }
-
-        if (ctx_server.params.control_vector_layer_start <= 0) {
-            ctx_server.params.control_vector_layer_start = 1;
-        }
-        if (ctx_server.params.control_vector_layer_end   <= 0){
-            ctx_server.params.control_vector_layer_end   = llama_n_layer(ctx_server.model);
-        }
-        int err = llama_control_vector_apply(ctx_server.ctx,
-                                             cvec.data.data(),
-                                             cvec.data.size(),
-                                             cvec.n_embd,
-                                             ctx_server.params.control_vector_layer_start,
-                                             ctx_server.params.control_vector_layer_end);
-        if (err) {
-            std::cerr << "Could not apply control vector\n";
-            res_error(res, format_error_response("Could not apply control vector", ERROR_TYPE_SERVER));
-            return;
-        }
-        ctx_server.params.control_vectors.clear();
-        for (auto v : vec_params) {
-          //std::cout << "set vector param: " << v.fname << " " << v.strength << "\n";
-          ctx_server.params.control_vectors.push_back(v);
-        }
-
-        /*std::cerr << "Maybe we need to do this initiation ritual before it werks?\n"; // No, it's still all garbled bullshit.
-
-        std::vector<llama_token> tmp = { llama_token_bos(ctx_server.model), llama_token_eos(ctx_server.model), };
-        std::cerr << "decode, bro\n";
-        llama_decode(ctx_server.ctx, llama_batch_get_one(tmp.data(), std::min(tmp.size(), (size_t) ctx_server.params.n_batch), 0, 0));
-        std::cerr << "clear that fucking cache\n";
-        llama_kv_cache_clear(ctx_server.ctx);
-        std::cerr << "symcr0nice or what\n";
-        llama_synchronize(ctx_server.ctx);
-        std::cerr << "time will tell\n";
-        llama_reset_timings(ctx_server.ctx);*/
-        handle_get_control_vectors(req, res);
-    };
-
     const auto handle_props = [&ctx_server](const httplib::Request & req, httplib::Response & res) {
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         json data = {
@@ -3603,10 +3525,8 @@ int main(int argc, char ** argv) {
     svr->Get ("/health",              handle_health);
     svr->Get ("/slots",               handle_slots);
     svr->Get ("/metrics",             handle_metrics);
-    svr->Get ("/control-vectors",     handle_get_control_vectors);
     svr->Get ("/props",               handle_props);
     svr->Get ("/v1/models",           handle_models);
-    svr->Post("/control-vectors",     handle_set_control_vectors);
     svr->Post("/completion",          handle_completions); // legacy
     svr->Post("/completions",         handle_completions);
     svr->Post("/v1/completions",      handle_completions);
@@ -3681,3 +3601,4 @@ int main(int argc, char ** argv) {
 
     return 0;
 }
+

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3202,8 +3202,6 @@ int main(int argc, char ** argv) {
     };
 
     const auto handle_set_control_vectors = [&ctx_server, &res_error, &handle_get_control_vectors](const httplib::Request & req, httplib::Response & res) {
-        res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
-
         json data = json::parse(req.body);
         std::vector<llama_control_vector_load_info> vec_params;
 
@@ -3215,12 +3213,14 @@ int main(int argc, char ** argv) {
             }
         } else {
             std::cerr << "No vectors passed\n";
+            res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
             res_error(res, format_error_response("No vectors passed", ERROR_TYPE_SERVER));
             return;
         }
         const auto cvec = llama_control_vector_load(vec_params);
         if (cvec.n_embd == -1) {
             std::cerr << "Could not load control vector\n";
+            res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
             res_error(res, format_error_response("Could not load control vector", ERROR_TYPE_SERVER));
             return;
         }
@@ -3239,6 +3239,7 @@ int main(int argc, char ** argv) {
                                              ctx_server.params.control_vector_layer_end);
         if (err) {
             std::cerr << "Could not apply control vector\n";
+            res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
             res_error(res, format_error_response("Could not apply control vector", ERROR_TYPE_SERVER));
             return;
         }

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -616,7 +616,7 @@ static json format_error_response(const std::string & message, const enum error_
     };
 }
 
-void from_json(const json& j, llama_control_vector_load_info& l) {
+static void from_json(const json& j, llama_control_vector_load_info& l) {
   j.at("strength").get_to(l.strength);
   j.at("fname").get_to(l.fname);
 }

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -615,8 +615,3 @@ static json format_error_response(const std::string & message, const enum error_
         {"type", type_str},
     };
 }
-
-void from_json(const json& j, llama_control_vector_load_info& l) {
-  j.at("strength").get_to(l.strength);
-  j.at("fname").get_to(l.fname);
-}

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -617,6 +617,12 @@ static json format_error_response(const std::string & message, const enum error_
 }
 
 static void from_json(const json& j, llama_control_vector_load_info& l) {
-  j.at("strength").get_to(l.strength);
-  j.at("fname").get_to(l.fname);
+    j.at("strength").get_to(l.strength);
+    j.at("fname").get_to(l.fname);
 }
+
+struct llama_control_vector_load_option {
+    std::string name;
+    std::string fname;
+    bool is_dir;
+};

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -615,3 +615,8 @@ static json format_error_response(const std::string & message, const enum error_
         {"type", type_str},
     };
 }
+
+void from_json(const json& j, llama_control_vector_load_info& l) {
+  j.at("strength").get_to(l.strength);
+  j.at("fname").get_to(l.fname);
+}

--- a/llama.cpp
+++ b/llama.cpp
@@ -1950,6 +1950,7 @@ struct llama_control_vector {
     }
 
     ~llama_control_vector() {
+        LLAMA_LOG_ERROR("Kill the control vector\n");
         for (struct ggml_context * ctx : ctxs) {
             ggml_free(ctx);
         }
@@ -13994,9 +13995,9 @@ int32_t llama_model_apply_lora_from_file(const struct llama_model * model, const
 }
 
 static bool llama_control_vector_init(struct llama_control_vector & cvec, const llama_model & model) {
-    GGML_ASSERT(cvec.tensors.empty());
-    GGML_ASSERT(cvec.ctxs.empty());
-    GGML_ASSERT(cvec.bufs.empty());
+    cvec.tensors.clear();
+    cvec.ctxs.clear();
+    cvec.bufs.clear();
 
     // count layer buffer types
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;
@@ -14062,10 +14063,9 @@ int32_t llama_control_vector_apply(struct llama_context * lctx, const float * da
         return 1;
     }
 
-    if (cvec.tensors.empty()) {
-        if (!llama_control_vector_init(cvec, model)) {
-            return 1;
-        }
+    if (!llama_control_vector_init(cvec, model)) {
+        LLAMA_LOG_ERROR("%s: FUCKING  BITCH\n", __func__);
+        return 1;
     }
 
     cvec.layer_start = il_start;

--- a/llama.cpp
+++ b/llama.cpp
@@ -1950,7 +1950,6 @@ struct llama_control_vector {
     }
 
     ~llama_control_vector() {
-        LLAMA_LOG_ERROR("Kill the control vector\n");
         for (struct ggml_context * ctx : ctxs) {
             ggml_free(ctx);
         }
@@ -13995,9 +13994,9 @@ int32_t llama_model_apply_lora_from_file(const struct llama_model * model, const
 }
 
 static bool llama_control_vector_init(struct llama_control_vector & cvec, const llama_model & model) {
-    cvec.tensors.clear();
-    cvec.ctxs.clear();
-    cvec.bufs.clear();
+    GGML_ASSERT(cvec.tensors.empty());
+    GGML_ASSERT(cvec.ctxs.empty());
+    GGML_ASSERT(cvec.bufs.empty());
 
     // count layer buffer types
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;
@@ -14063,9 +14062,10 @@ int32_t llama_control_vector_apply(struct llama_context * lctx, const float * da
         return 1;
     }
 
-    if (!llama_control_vector_init(cvec, model)) {
-        LLAMA_LOG_ERROR("%s: FUCKING  BITCH\n", __func__);
-        return 1;
+    if (cvec.tensors.empty()) {
+        if (!llama_control_vector_init(cvec, model)) {
+            return 1;
+        }
     }
 
     cvec.layer_start = il_start;


### PR DESCRIPTION
This PR implements options for loading control-vectors in server.cpp same as it already exists in main.cpp on start-up (only adding cli options here for what was already implemented), as well as hot-swapping control vectors at runtime in server.cpp.

The PR also includes a fix for a memory allocation/freeing bug in `llama_load_control_vector`. Credit for that goes to anon@example.com for his contributions of commits 181879f9424e81be4f56f5b34b9616d49caacb3b, 9914014e1756fe7c2e7b9896d9e67474f6380bb4, and d0304f76566ab82637f4c8906eeec010f005ba9c.

### New CLI options
In addition to the same CLI options that exist for main.cpp there are these additional options for server.cpp to specify named file or directory options from which control vectors can be loaded at runtime:
1) option for specific gguf file:
```--control-vector-option name /path/to/vector.gguf```
2) option for specific directory:
```--control-vector-option name path/to/dir```
```--control-vector-option name path/to/dir/```

The server will decide based on the specified path string whether it is interpreted as a vector file or a directory. A slash will be automatically added to the name of a directory option.


### New endpoints for the server
1) ```GET /control-vector-options``` will return a json array of strings.
So e.g. ```--control-vector-option vectors path/to/dir --control-vector-option victor path/to/some/vector.gguf``` will result in the listed options: ```["vectors/", "victor"]```, meaning that the user would only be allowed to load ```vectors/anything/goes/here``` (except path traversal) or ```victor```.
2) `GET /control-vectors` will return the currently applied control vector combination and layer range parameters (the latter can only be specified on load for now, or will default to full range) like so:
```
{
  "vectors": [
    {
      "fname": "vectors/olga",
      "strength":2.0
    },
    {
      "fname": "vectors/some/levels/deeper/oleg",
      "strength":-3.0
    },
    {
      "fname": "victor",
      "strength": 1.0
    }
  ],
  "layer_start": 1,
  "layer_end": 80
}
```

3) `POST /control-vectors` accepts an array of vector parameters in the same format, which will replace the currently applied control vector:
```
{
  "vectors": [
    {
      "fname": "miqu/happy"
      "strength": 3.1415
    },
    {
      "fname": "miqu/high-on-cocaine.gguf"
      "strength": -2
    },
  ]
}
```
Note that the .gguf here is optional for vectors inside allowed directories. It will be added to the file name to be loaded if not included. The assumption is that all control vector files end in `.gguf`.
Path traversal is guarded against to the extent I am aware of.







## The original message below here is outdated and just left for historical context:

> 
> I want to add control vector support to the server example. However, I know quite little about C++, and something isn't quite right yet that I can't wrap my head around. So I will need some handholding here.
> 
> #### What is implemented: command line parameters just like for main
> ```
> --control-vector <fname>
> --control-vector-scaled <fname> <strength>
> --control-vector-layer-range <n_start> <n_end>
> ```
> This loads the specified control vectors during the initial model load, and it works.
> 
> #### What doesn't work and I don't understand why: applying new vectors later
> It would be nice if one could switch out control vectors at runtime.
> So I added http endpoints for that:
> `GET /control-vectors` will return the currently applied control vector source and layer range parameters like so:
> ```
> {
>   "vectors": [
>     {
>       "fname": "vectors/miqu/happy.gguf","strength":2.0
>     },
>     {
>       "fname": "vectors/miqu/Sentient.gguf",
>       "strength": 0.0
>     }
>   ],
>   "layer_start": 1,
>   "layer_end": 80
> }
> ```
> `POST /control-vectors` accepts an array of vector parameters in the same format, which should replace the currently applied control vector:
> ```
> {
>   "vectors": [
>     {
>       "fname": "path/to/vector.gguf"
>       "strength": 3.1415
>     },
>     {
>       "fname": "path/to/another_vector.gguf"
>       "strength": -2
>     },
>   ]
> }
> ```
> and will then return the same output as the GET route.
> This does not work. The output becomes incoherent. And after a while I get a segmentation fault.
> I tried to take the range parameters from the existing gpt_params. But for some reason that is always (-1, -1), so I just use the full layer range (same as is done in `llama_init_from_gpt_params` - I don't know why that function doesn't save the layer range as it is supposed to).
> 
> **Edit:** About the gpt_params, the reason was that I used the wrong "params". There's a "params" variable in main, and then the server struct saves a copy of that. One should probably use that copy then.
> And about the incoherent behaviour: It seems when calling `llama_control_vector_init` on every new vector load again, it does work, and the new control vector shows its behaviour. But one has to remove assert guards for that, and surely there's a reason for those. And it segfaults much faster when I do that.
> 
> So I'm removing my clumsy attempt at that live vector swap functionality again. But I hope someone might be able to figure out how to do that, because that would be really nice to have.