### PR TITLE
embedding: adjust `n_ubatch` value, print error on insufficient `n_batch` value

### DIFF
--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv) {
     }
 
     params.embedding = true;
-    // For BERT models, batch size must be equal to ubatch size
+    // For non-causal models, batch size must be equal to ubatch size
     params.n_ubatch = params.n_batch;
 
     print_build_info();

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -61,6 +61,8 @@ int main(int argc, char ** argv) {
     }
 
     params.embedding = true;
+    // For BERT models, batch size must be equal to ubatch size
+    params.n_ubatch = params.n_batch;
 
     print_build_info();
 
@@ -114,7 +116,9 @@ int main(int argc, char ** argv) {
     for (const auto & prompt : prompts) {
         auto inp = ::llama_tokenize(ctx, prompt, true, false);
         if (inp.size() > n_batch) {
-            inp.resize(n_batch);
+            fprintf(stderr, "%s: error: number of tokens in input line (%lld) exceeds batch size (%lld), increase batch size and re-run\n",
+                    __func__, (long long int) inp.size(), (long long int) n_batch);
+            return 1;
         }
         inputs.push_back(inp);
     }

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -116,8 +116,8 @@ int main(int argc, char ** argv) {
     for (const auto & prompt : prompts) {
         auto inp = ::llama_tokenize(ctx, prompt, true, false);
         if (inp.size() > n_batch) {
-            fprintf(stderr, "%s: error: number of tokens in input line (%lld) exceeds batch size (%lld), increase batch size and re-run\n",
-                    __func__, (long long int) inp.size(), (long long int) n_batch);
+            fprintf(stderr, "%s: error: number of tokens in input line (%ld) exceeds batch size (%ld), increase batch size and re-run\n",
+                    __func__, inp.size(), n_batch);
             return 1;
         }
         inputs.push_back(inp);

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -116,8 +116,8 @@ int main(int argc, char ** argv) {
     for (const auto & prompt : prompts) {
         auto inp = ::llama_tokenize(ctx, prompt, true, false);
         if (inp.size() > n_batch) {
-            fprintf(stderr, "%s: error: number of tokens in input line (%ld) exceeds batch size (%ld), increase batch size and re-run\n",
-                    __func__, inp.size(), n_batch);
+            fprintf(stderr, "%s: error: number of tokens in input line (%lld) exceeds batch size (%lld), increase batch size and re-run\n",
+                    __func__, (long long int) inp.size(), (long long int) n_batch);
             return 1;
         }
         inputs.push_back(inp);


### PR DESCRIPTION
updates to the `embedding` example based on discussion from #6193 
- assign `n_batch` value to `u_batch`
- output error on insufficient batch size