### PR TITLE
Include IQ2_XXS and IQ2_XS in test-quantize-fns

### DIFF
--- a/tests/test-quantize-fns.cpp
+++ b/tests/test-quantize-fns.cpp
@@ -138,11 +138,6 @@ int main(int argc, char * argv[]) {
 
         const ggml_type ei = (ggml_type)i;
 
-        if (ei == GGML_TYPE_IQ2_XXS || ei == GGML_TYPE_IQ2_XS) {
-            printf("Skip %s due to missing quantization functionality\n", ggml_type_name(ei));
-            continue;
-        }
-
         printf("Testing %s\n", ggml_type_name((ggml_type) i));
         ggml_quantize_init(ei);
 


### PR DESCRIPTION
They were excluded due to the missing quantize functionality when these quantization types were first added.