### PR TITLE
Rename LLAMA_CUBLAS flag to LLAMA_CUDA in fulfilment of the prophecy.

### DIFF
--- a/.devops/llama-cpp-cublas.srpm.spec
+++ b/.devops/llama-cpp-cublas.srpm.spec
@@ -32,7 +32,7 @@ CPU inference for Meta's Lllama2 models using default options.
 %setup -n llama.cpp-master
 
 %build
-make -j LLAMA_CUBLAS=1
+make -j LLAMA_CUDA=1
 
 %install
 mkdir -p %{buildroot}%{_bindir}/


### PR DESCRIPTION
This is being changed in Make.
https://github.com/ggerganov/llama.cpp/pull/6299