### PR TITLE
Update llava-cli.cpp to support comma-delimited image lists

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -768,7 +768,11 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
             invalid_param = true;
             return true;
         }
-        params.image = argv[i];
+        if (params.image != "") {
+            params.image += ",";
+        }
+        params.image += argv[i];
+        params.image = std::regex_replace(params.image,std::regex(" --image "), ",");
         return true;
     }
     if (arg == "-i" || arg == "--interactive") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -768,11 +768,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
             invalid_param = true;
             return true;
         }
-        if (params.image != "") {
-            params.image += ",";
-        }
-        params.image += argv[i];
-        params.image = std::regex_replace(params.image,std::regex(" --image "), ",");
+        params.image.emplace_back(argv[i]);
         return true;
     }
     if (arg == "-i" || arg == "--interactive") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1395,7 +1395,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  -ps N, --p-split N    speculative decoding split probability (default: %.1f)\n", (double)params.p_split);
     printf("  -cb, --cont-batching  enable continuous batching (a.k.a dynamic batching) (default: disabled)\n");
     printf("  --mmproj MMPROJ_FILE  path to a multimodal projector file for LLaVA. see examples/llava/README.md\n");
-    printf("  --image IMAGE_FILE    path to an image file. use with multimodal models\n");
+    printf("  --image IMAGE_FILE    path to an image file. use with multimodal models. Specify multiple times for batching\n");
     if (llama_supports_mlock()) {
         printf("  --mlock               force system to keep model in RAM rather than swapping or compressing\n");
     }

--- a/common/common.h
+++ b/common/common.h
@@ -161,8 +161,8 @@ struct gpt_params {
     std::string cache_type_v = "f16"; // KV cache data type for the V
 
     // multimodal models (see examples/llava)
-    std::string mmproj = ""; // path to multimodal projector
-    std::string image  = ""; // path to an image file
+    std::string mmproj = "";        // path to multimodal projector
+    std::vector<std::string> image; // path to image file(s)
 };
 
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params);

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -132,9 +132,9 @@ static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_para
         }
         params->prompt = remove_image_from_prompt(prompt);
     } else {
-        embed = llava_image_embed_make_with_filename(ctx_llava->ctx_clip, params->n_threads, image.c_str());
+        embed = llava_image_embed_make_with_filename(ctx_llava->ctx_clip, params->n_threads, fname.c_str());
         if (!embed) {
-            fprintf(stderr, "%s: is %s really an image file?\n", __func__, image.c_str());
+            fprintf(stderr, "%s: is %s really an image file?\n", __func__, fname.c_str());
             return NULL;
         }
     }
@@ -285,7 +285,7 @@ int main(int argc, char ** argv) {
 
         auto ctx_llava = llava_init_context(&params, model);
 
-        auto image_embed = load_image(ctx_llava, &params, &image);
+        auto image_embed = load_image(ctx_llava, &params, image);
         if (!image_embed) {
             std::cerr << "error: failed to load image " << image << ". Terminating\n\n";
             return 1;

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -112,7 +112,7 @@ struct llava_context {
 };
 
 static void show_additional_info(int /*argc*/, char ** argv) {
-    fprintf(stderr, "\n example usage: %s -m <llava-v1.5-7b/ggml-model-q5_k.gguf> --mmproj <llava-v1.5-7b/mmproj-model-f16.gguf> --image <path/to/an/image.jpg> [--temp 0.1] [-p \"describe the image in detail.\"]\n", argv[0]);
+    fprintf(stderr, "\n example usage: %s -m <llava-v1.5-7b/ggml-model-q5_k.gguf> --mmproj <llava-v1.5-7b/mmproj-model-f16.gguf> --image <path/to/an/image.jpg> --image <path/to/another/image.jpg> [--temp 0.1] [-p \"describe the image in detail.\"]\n", argv[0]);
     fprintf(stderr, "  note: a lower temperature value like 0.1 is recommended for better quality.\n");
 }
 
@@ -281,7 +281,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    for (auto & image : image) {
+    for (auto & image : params.image) {
 
         auto ctx_llava = llava_init_context(&params, model);
 

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -211,7 +211,7 @@ static void process_prompt(struct llava_context * ctx_llava, struct llava_image_
 static struct llama_model * llava_init(gpt_params * params) {
     llama_backend_init();
     llama_numa_init(params->numa);
-    
+
     llama_model_params model_params = llama_model_params_from_gpt_params(*params);
     llama_model * model = llama_load_model_from_file(params->model.c_str(), model_params);
     if (model == NULL) {
@@ -219,15 +219,15 @@ static struct llama_model * llava_init(gpt_params * params) {
         return NULL;
     }
     return model;
-}       
-            
+}
+
 static struct llava_context * llava_init_context(gpt_params * params, llama_model * model) {
     const char * clip_path = params->mmproj.c_str();
 
     auto prompt = params->prompt;
     if (prompt.empty()) {
         prompt = "describe the image in detail.";
-    }   
+    }
 
     auto ctx_clip = clip_model_load(clip_path, /*verbosity=*/ 1);
 

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -116,7 +116,7 @@ static void show_additional_info(int /*argc*/, char ** argv) {
     fprintf(stderr, "  note: a lower temperature value like 0.1 is recommended for better quality.\n");
 }
 
-static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_params * params, std::string * image) {
+static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_params * params, const std::string & fname) {
 
     // load and preprocess the image
     llava_image_embed * embed = NULL;

--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -116,7 +116,7 @@ static void show_additional_info(int /*argc*/, char ** argv) {
     fprintf(stderr, "  note: a lower temperature value like 0.1 is recommended for better quality.\n");
 }
 
-static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_params * params) {
+static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_params * params, std::string * image) {
 
     // load and preprocess the image
     llava_image_embed * embed = NULL;
@@ -132,9 +132,9 @@ static struct llava_image_embed * load_image(llava_context * ctx_llava, gpt_para
         }
         params->prompt = remove_image_from_prompt(prompt);
     } else {
-        embed = llava_image_embed_make_with_filename(ctx_llava->ctx_clip, params->n_threads, params->image.c_str());
+        embed = llava_image_embed_make_with_filename(ctx_llava->ctx_clip, params->n_threads, image.c_str());
         if (!embed) {
-            fprintf(stderr, "%s: is %s really an image file?\n", __func__, params->image.c_str());
+            fprintf(stderr, "%s: is %s really an image file?\n", __func__, image.c_str());
             return NULL;
         }
     }
@@ -281,24 +281,13 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    std::stringstream ss(params.image);
-    std::vector<std::string> imagestack;
-
-    while( ss.good() )
-    {
-        std::string substr;
-        getline( ss, substr, ',' );
-        imagestack.push_back( substr );
-    }
-
-    for (auto & image : imagestack) {
+    for (auto & image : image) {
 
         auto ctx_llava = llava_init_context(&params, model);
-        params.image=image;
 
-        auto image_embed = load_image(ctx_llava, &params);
+        auto image_embed = load_image(ctx_llava, &params, &image);
         if (!image_embed) {
-            std::cerr << "error: failed to load image " << params.image << ". Terminating\n\n";
+            std::cerr << "error: failed to load image " << image << ". Terminating\n\n";
             return 1;
         }
 


### PR DESCRIPTION
Add the ability to specify a comma-delimited list of images to llava-cli for batch-processing of multiple images without needing to reload the model file.

If this overall approach is acceptable, we can clean up variable names, help text, etc