### PR TITLE
llama.cpp: fix typo in source file llama.cpp

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -15203,7 +15203,7 @@ const char * llama_print_system_info(void) {
     s += "SSE3 = "        + std::to_string(ggml_cpu_has_sse3())        + " | ";
     s += "SSSE3 = "       + std::to_string(ggml_cpu_has_ssse3())       + " | ";
     s += "VSX = "         + std::to_string(ggml_cpu_has_vsx())         + " | ";
-    s += "MATMUL_INT8 = " + std::to_string(ggml_cpu_has_matmul_int8()) + " | ";
+    s += "MATMUL_INT8 = " + std::to_string(ggml_cpu_has_matmul_int8())        ;
 
     return s.c_str();
 }


### PR DESCRIPTION
I'm not sure if there is a typo in the source file llama.cpp? If not, this PR should be closed accordingly.

before modification:

![1578215371](https://github.com/ggerganov/llama.cpp/assets/6889919/0f6c755b-e76b-4f49-84a5-0ac91ce2fe9d)

after modification:

![2141632995](https://github.com/ggerganov/llama.cpp/assets/6889919/771f34a5-c873-4d75-bf7a-6718ce4603aa)
