### PR TITLE
add php api bindings to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Typically finetunes of the base models below are supported as well.
 - Java: [kherud/java-llama.cpp](https://github.com/kherud/java-llama.cpp)
 - Zig: [deins/llama.cpp.zig](https://github.com/Deins/llama.cpp.zig)
 - Flutter/Dart: [netdur/llama_cpp_dart](https://github.com/netdur/llama_cpp_dart)
-- PHP (API bindings and features built on top of llama.cpp): [distantmagic/resonance](https://github.com/distantmagic/resonance)
+- PHP (API bindings and features built on top of llama.cpp): [distantmagic/resonance](https://github.com/distantmagic/resonance) [(more info)](https://github.com/ggerganov/llama.cpp/pull/6326)
 
 **UI:**
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Typically finetunes of the base models below are supported as well.
 - Java: [kherud/java-llama.cpp](https://github.com/kherud/java-llama.cpp)
 - Zig: [deins/llama.cpp.zig](https://github.com/Deins/llama.cpp.zig)
 - Flutter/Dart: [netdur/llama_cpp_dart](https://github.com/netdur/llama_cpp_dart)
+- PHP (API bindings and features built on top of llama.cpp): [distantmagic/resonance](https://github.com/distantmagic/resonance)
 
 **UI:**
 


### PR DESCRIPTION
Hello!

Thank you for this project!

I made an async PHP framework with a lot of features dedicated to llama.cpp . llama.cpp bindings can also be used standalone.

Here are the docs on how to use the basic bindings: https://resonance.distantmagic.com/docs/features/ai/server/llama-cpp/

There are also some features built on top llama.cpp API:
https://resonance.distantmagic.com/docs/features/ai/prompt-subject-responders/

I also wrote some tutorials:
https://resonance.distantmagic.com/tutorials/how-to-create-llm-websocket-chat-with-llama-cpp/
https://resonance.distantmagic.com/tutorials/how-to-serve-llm-completions/

I added the direct link to the bindings in the readme. Is there a chance I can also add links to those tutorials and other resources here somewhere?

Best wishes