### PR TITLE
llama : save and restore kv cache for single seq id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inference of Meta's [LLaMA](https://arxiv.org/abs/2302.13971) model (and others)
 
 ### Recent API changes
 
+- [2024 Mar 30] State and session file functions reorganized under `llama_state_*` https://github.com/ggerganov/llama.cpp/pull/6341
 - [2024 Mar 26] Logits and embeddings API updated for compactness https://github.com/ggerganov/llama.cpp/pull/6122
 - [2024 Mar 13] Add `llama_synchronize()` + `llama_context_params.n_ubatch` https://github.com/ggerganov/llama.cpp/pull/6017
 - [2024 Mar 8] `llama_kv_cache_seq_rm()` returns a `bool` instead of `void`, and new `llama_n_seq_max()` returns the upper limit of acceptable `seq_id` in batches (relevant when dealing with multiple sequences) https://github.com/ggerganov/llama.cpp/pull/5328

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inference of Meta's [LLaMA](https://arxiv.org/abs/2302.13971) model (and others)
 
 ### Recent API changes
 
-- [2024 Mar 30] State and session file functions reorganized under `llama_state_*` https://github.com/ggerganov/llama.cpp/pull/6341
+- [2024 Apr 4] State and session file functions reorganized under `llama_state_*` https://github.com/ggerganov/llama.cpp/pull/6341
 - [2024 Mar 26] Logits and embeddings API updated for compactness https://github.com/ggerganov/llama.cpp/pull/6122
 - [2024 Mar 13] Add `llama_synchronize()` + `llama_context_params.n_ubatch` https://github.com/ggerganov/llama.cpp/pull/6017
 - [2024 Mar 8] `llama_kv_cache_seq_rm()` returns a `bool` instead of `void`, and new `llama_n_seq_max()` returns the upper limit of acceptable `seq_id` in batches (relevant when dealing with multiple sequences) https://github.com/ggerganov/llama.cpp/pull/5328

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1500,7 +1500,13 @@ std::string gpt_random_prompt(std::mt19937 & rng) {
     GGML_UNREACHABLE();
 }
 
+// Validate if a filename is safe to use
+// To validate a full path, split the path by the OS-specific path separator, and validate each part with this function
 bool validate_file_name(const std::string & filename) {
+    if (!filename.length()) {
+        // Empty filename invalid
+        return false;
+    }
     if (filename.length() > 255) {
         // Limit at common largest possible filename on Linux filesystems
         // to avoid unnecessary further validation
@@ -1546,7 +1552,7 @@ bool validate_file_name(const std::string & filename) {
         }
     }
 
-    // Reject any ".." (this is stricter than checking for ../ combinations)
+    // Reject any ".." (currently stricter than necessary, it should be fine to just check for == ".." instead)
     if (filename.find("..") != std::string::npos) {
         return false;
     }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -16,6 +16,7 @@
 #include <unordered_set>
 #include <vector>
 #include <cinttypes>
+#include <codecvt>
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <sys/types.h>
@@ -27,7 +28,6 @@
 #ifndef NOMINMAX
 #   define NOMINMAX
 #endif
-#include <codecvt>
 #include <locale>
 #include <windows.h>
 #include <fcntl.h>
@@ -1528,6 +1528,7 @@ bool validate_file_name(const std::string & filename) {
     // - Unicode equivalents of illegal characters
     // - UTF-16 surrogate pairs
     // - UTF-8 replacement character
+    // - Byte order mark (BOM)
     // - Illegal characters: / \ : * ? " < > |
     for (char32_t c : filename_utf32) {
         if (c <= 0x1F // Control characters (C0)
@@ -1538,6 +1539,7 @@ bool validate_file_name(const std::string & filename) {
             || c == 0x2216 // Set Minus (backslash equivalent)
             || (c >= 0xD800 && c <= 0xDFFF) // UTF-16 surrogate pairs
             || c == 0xFFFD // Replacement Character (UTF-8)
+            || c == 0xFEFF // Byte Order Mark (BOM)
             || c == '/' || c == '\\' || c == ':' || c == '*' // Illegal characters
             || c == '?' || c == '"' || c == '<' || c == '>' || c == '|') {
             return false;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1552,6 +1552,12 @@ bool validate_file_name(const std::string & filename) {
         }
     }
 
+    // Reject any leading or trailing ' ', or any trailing '.', these are stripped on Windows and will cause a different filename
+    // Unicode and other whitespace is not affected, only 0x20 space
+    if (filename.front() == ' ' || filename.back() == ' ' || filename.back() == '.') {
+        return false;
+    }
+
     // Reject any ".." (currently stricter than necessary, it should be fine to just check for == ".." instead)
     if (filename.find("..") != std::string::npos) {
         return false;

--- a/common/common.h
+++ b/common/common.h
@@ -179,6 +179,8 @@ std::string gpt_random_prompt(std::mt19937 & rng);
 
 void process_escapes(std::string& input);
 
+bool validate_file_name(const std::string & filename);
+
 //
 // String utils
 //

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char ** argv) {
             // The file exists and is not empty
             session_tokens.resize(n_ctx);
             size_t n_token_count_out = 0;
-            if (!llama_load_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(), &n_token_count_out)) {
+            if (!llama_state_load_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(), &n_token_count_out)) {
                 LOG_TEE("%s: error: failed to load session file '%s'\n", __func__, path_session.c_str());
                 return 1;
             }
@@ -693,7 +693,7 @@ int main(int argc, char ** argv) {
             // optionally save the session on first sample (for faster prompt loading next time)
             if (!path_session.empty() && need_to_save_session && !params.prompt_cache_ro) {
                 need_to_save_session = false;
-                llama_save_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
+                llama_state_save_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
 
                 LOG("saved session to %s\n", path_session.c_str());
             }
@@ -935,7 +935,7 @@ int main(int argc, char ** argv) {
 
     if (!path_session.empty() && params.prompt_cache_all && !params.prompt_cache_ro) {
         LOG_TEE("\n%s: saving final output to session file '%s'\n", __func__, path_session.c_str());
-        llama_save_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
+        llama_state_save_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.size());
     }
 
     llama_print_timings(ctx);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -45,8 +45,8 @@ int main(int argc, char ** argv) {
 
     // save state (rng, logits, embedding and kv_cache) to file
     {
-        std::vector<uint8_t> state_mem(llama_get_state_size(ctx));
-        const size_t written = llama_copy_state_data(ctx, state_mem.data());
+        std::vector<uint8_t> state_mem(llama_state_get_size(ctx));
+        const size_t written = llama_state_get_data(ctx, state_mem.data());
 
         FILE *fp_write = fopen("dump_state.bin", "wb");
         fwrite(state_mem.data(), 1, written, fp_write);
@@ -98,13 +98,13 @@ int main(int argc, char ** argv) {
 
     // load state (rng, logits, embedding and kv_cache) from file
     {
-        std::vector<uint8_t> state_mem(llama_get_state_size(ctx2));
+        std::vector<uint8_t> state_mem(llama_state_get_size(ctx2));
 
         FILE * fp_read = fopen("dump_state.bin", "rb");
         const size_t read = fread(state_mem.data(), 1, state_mem.size(), fp_read);
         fclose(fp_read);
 
-        if (read != llama_set_state_data(ctx2, state_mem.data())) {
+        if (read != llama_state_set_data(ctx2, state_mem.data())) {
             fprintf(stderr, "\n%s : failed to read state\n", __func__);
             llama_free(ctx2);
             llama_free_model(model);
@@ -158,13 +158,13 @@ int main(int argc, char ** argv) {
 
     // load state (rng, logits, embedding and kv_cache) from file
     {
-        std::vector<uint8_t> state_mem(llama_get_state_size(ctx3));
+        std::vector<uint8_t> state_mem(llama_state_get_size(ctx3));
 
         FILE * fp_read = fopen("dump_state.bin", "rb");
         const size_t read = fread(state_mem.data(), 1, state_mem.size(), fp_read);
         fclose(fp_read);
 
-        if (read != llama_set_state_data(ctx3, state_mem.data())) {
+        if (read != llama_state_set_data(ctx3, state_mem.data())) {
             fprintf(stderr, "\n%s : failed to read state\n", __func__);
             llama_free(ctx3);
             llama_free_model(model);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -24,6 +24,7 @@ int main(int argc, char ** argv) {
 
     std::string result0;
     std::string result1;
+    std::string result2;
 
     // init
     llama_model * model;
@@ -141,13 +142,101 @@ int main(int argc, char ** argv) {
         n_past += 1;
     }
 
-    printf("\n");
+    printf("\n\n");
 
     llama_free(ctx2);
-    llama_free_model(model);
 
     if (result0 != result1) {
         fprintf(stderr, "\n%s : error : the 2 generations are different\n", __func__);
+        return 1;
+    }
+
+    // make new context
+    auto* ctx3 = llama_new_context_with_model(model, llama_context_params_from_gpt_params(params));
+
+    printf("\nsingle seq run: %s", params.prompt.c_str());
+
+    // load state (rng, logits, embedding and kv_cache) from file
+    {
+        std::vector<uint8_t> state_mem(llama_get_state_size(ctx3));
+
+        FILE * fp_read = fopen("dump_state.bin", "rb");
+        const size_t read = fread(state_mem.data(), 1, state_mem.size(), fp_read);
+        fclose(fp_read);
+
+        if (read != llama_set_state_data(ctx3, state_mem.data())) {
+            fprintf(stderr, "\n%s : failed to read state\n", __func__);
+            llama_free(ctx3);
+            llama_free_model(model);
+            return 1;
+        }
+
+        fprintf(stderr, "%s : deserialized state from %zd out of a maximum of %zd bytes\n", __func__, read, state_mem.size());
+    }
+
+    // restore state (last tokens)
+    n_past = n_past_saved;
+
+    // save seq 0 and load into seq 1
+    {
+        // save kv of seq 0
+        std::vector<uint8_t> seq_store(llama_get_seq_size(ctx3, 0));
+        const size_t ncopy = llama_copy_seq_data(ctx3, seq_store.data(), 0);
+        if (ncopy != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
+            llama_free(ctx3);
+            llama_free_model(model);
+            return 1;
+        }
+        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
+
+        // erase whole kv
+        llama_kv_cache_clear(ctx3);
+        fprintf(stderr, "%s : kv cache cleared\n", __func__);
+
+        // restore kv into seq 1
+        const size_t nset = llama_set_seq_data(ctx3, seq_store.data(), 1);
+        if (nset != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
+            llama_free(ctx3);
+            llama_free_model(model);
+            return 1;
+        }
+        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
+    }
+
+    // third run with seq 1 instead of 0
+    for (auto i = 0; i < params.n_predict; i++) {
+        auto * logits = llama_get_logits(ctx3);
+        auto n_vocab = llama_n_vocab(model);
+        std::vector<llama_token_data> candidates;
+        candidates.reserve(n_vocab);
+        for (llama_token token_id = 0; token_id < n_vocab; token_id++) {
+            candidates.emplace_back(llama_token_data{token_id, logits[token_id], 0.0f});
+        }
+        llama_token_data_array candidates_p = { candidates.data(), candidates.size(), false };
+        auto next_token = llama_sample_token(ctx3, &candidates_p);
+        auto next_token_str = llama_token_to_piece(ctx3, next_token);
+
+        printf("%s", next_token_str.c_str());
+        result2 += next_token_str;
+
+        if (llama_decode(ctx3, llama_batch_get_one(&next_token, 1, n_past, 1))) {
+            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            llama_free(ctx3);
+            llama_free_model(model);
+            return 1;
+        }
+        n_past += 1;
+    }
+
+    printf("\n");
+
+    llama_free(ctx3);
+    llama_free_model(model);
+
+    if (result0 != result2) {
+        fprintf(stderr, "\n%s : error : the seq restore generation is different\n", __func__);
         return 1;
     }
 

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -180,8 +180,8 @@ int main(int argc, char ** argv) {
     // save seq 0 and load into seq 1
     {
         // save kv of seq 0
-        std::vector<uint8_t> seq_store(llama_get_seq_size(ctx3, 0));
-        const size_t ncopy = llama_copy_seq_data(ctx3, seq_store.data(), 0);
+        std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx3, 0));
+        const size_t ncopy = llama_state_seq_get_data(ctx3, seq_store.data(), 0);
         if (ncopy != seq_store.size()) {
             fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
             llama_free(ctx3);
@@ -195,7 +195,7 @@ int main(int argc, char ** argv) {
         fprintf(stderr, "%s : kv cache cleared\n", __func__);
 
         // restore kv into seq 1
-        const size_t nset = llama_set_seq_data(ctx3, seq_store.data(), 1);
+        const size_t nset = llama_state_seq_set_data(ctx3, seq_store.data(), 1);
         if (nset != seq_store.size()) {
             fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
             llama_free(ctx3);

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -59,6 +59,7 @@ see https://github.com/ggerganov/llama.cpp/issues/1437
 - `-n N, --n-predict N`: Set the maximum tokens to predict (default: -1)
 - `--slots-endpoint-disable`: To disable slots state monitoring endpoint. Slots state may contain user data, prompts included.
 - `--metrics`: enable prometheus `/metrics` compatible endpoint (default: disabled)
+- `--slot-save-path PATH`: Specifies the path where the state of slots (the prompt cache) can be stored. If not provided, the slot management endpoints will be disabled.
 - `--chat-template JINJA_TEMPLATE`: Set custom jinja chat template. This parameter accepts a string, not a file name (default: template taken from model's metadata). We only support [some pre-defined templates](https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template)
 - `--log-disable`: Output logs to stdout only, not to `llama.log`. default: enabled.
 - `--log-format FORMAT`: Define the log output to FORMAT: json or text (default: json)
@@ -518,6 +519,57 @@ Available metrics:
 - `llamacpp:kv_cache_tokens`: KV-cache tokens.
 - `llamacpp:requests_processing`: Number of request processing.
 - `llamacpp:requests_deferred`: Number of request deferred.
+
+- **POST** `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
+
+    *Options:*
+
+    `filename`: Name of the file to save the slot's prompt cache. The file will be saved in the directory specified by the `--slot-save-path` server parameter.
+
+### Result JSON
+
+```json
+{
+    "id_slot": 0,
+    "filename": "slot_save_file.bin",
+    "n_saved": 1745,
+    "n_written": 14309796,
+    "timings": {
+        "save_ms": 49.865
+    }
+}
+```
+
+- **POST** `/slots/{id_slot}?action=restore`: Restore the prompt cache of the specified slot from a file.
+
+    *Options:*
+
+    `filename`: Name of the file to restore the slot's prompt cache from. The file should be located in the directory specified by the `--slot-save-path` server parameter.
+
+### Result JSON
+
+```json
+{
+    "id_slot": 0,
+    "filename": "slot_save_file.bin",
+    "n_restored": 1745,
+    "n_read": 14309796,
+    "timings": {
+        "restore_ms": 42.937
+    }
+}
+```
+
+- **POST** `/slots/{id_slot}?action=erase`: Erase the prompt cache of the specified slot.
+
+### Result JSON
+
+```json
+{
+    "id_slot": 0,
+    "n_erased": 1745
+}
+```
 
 ## More examples
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3278,7 +3278,7 @@ int main(int argc, char ** argv) {
     const auto handle_slots_save = [&ctx_server, &res_error, &sparams](const httplib::Request & req, httplib::Response & res, int id_slot) {
         json request_data = json::parse(req.body);
         std::string filename = request_data["filename"];
-        if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos || filename.find("..") != std::string::npos) {
+        if (!validate_file_name(filename)) {
             res_error(res, format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
             return;
         }
@@ -3308,7 +3308,7 @@ int main(int argc, char ** argv) {
     const auto handle_slots_restore = [&ctx_server, &res_error, &sparams](const httplib::Request & req, httplib::Response & res, int id_slot) {
         json request_data = json::parse(req.body);
         std::string filename = request_data["filename"];
-        if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos || filename.find("..") != std::string::npos) {
+        if (!validate_file_name(filename)) {
             res_error(res, format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
             return;
         }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1745,10 +1745,7 @@ struct server_context {
 
                     // Erase token cache
                     const size_t n_erased = slot->cache_tokens.size();
-                    if (!llama_kv_cache_seq_rm(ctx, slot->id + 1, -1, -1)) {
-                        send_error(task, "Failed to erase slot KV cache", ERROR_TYPE_INVALID_REQUEST);
-                        break;
-                    }
+                    llama_kv_cache_seq_rm(ctx, slot->id + 1, -1, -1);
                     slot->cache_tokens.clear();
 
                     server_task_result result;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1693,7 +1693,7 @@ struct server_context {
 
                     size_t nread = llama_set_seq_data(ctx, state_data.data(), slot->id + 1);
                     if (nread == 0) {
-                        send_error(task, "Unable to restore slot, no available space in KV cache", ERROR_TYPE_INVALID_REQUEST);
+                        send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }
                     GGML_ASSERT(nread <= state_data.size());

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3321,7 +3321,7 @@ int main(int argc, char ** argv) {
         json request_data = json::parse(req.body);
         std::string filename = request_data["filename"];
         if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos || filename.find("..") != std::string::npos) {
-            res_error(res, "Invalid filename");
+            res_error(res, format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
             return;
         }
         std::string filepath = sparams.slot_save_path + filename;
@@ -3351,7 +3351,7 @@ int main(int argc, char ** argv) {
         json request_data = json::parse(req.body);
         std::string filename = request_data["filename"];
         if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos || filename.find("..") != std::string::npos) {
-            res_error(res, "Invalid filename");
+            res_error(res, format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
             return;
         }
         std::string filepath = sparams.slot_save_path + filename;
@@ -3393,7 +3393,7 @@ int main(int argc, char ** argv) {
         if (result.error) {
             res_error(res, result.data);
         } else {
-            res.set_content(result.data, "application/json");
+            res.set_content(result.data.dump(), "application/json");
         }
     };
 
@@ -3406,7 +3406,7 @@ int main(int argc, char ** argv) {
         try {
             id_slot = std::stoi(id_slot_str);
         } catch (const std::exception &) {
-            res_error(res, "Invalid slot ID");
+            res_error(res, format_error_response("Invalid slot ID", ERROR_TYPE_INVALID_REQUEST));
             return;
         }
 
@@ -3419,7 +3419,7 @@ int main(int argc, char ** argv) {
         } else if (action == "erase") {
             handle_slots_erase(req, res, id_slot);
         } else {
-            res_error(res, "Invalid action");
+            res_error(res, format_error_response("Invalid action", ERROR_TYPE_INVALID_REQUEST));
         }
     };
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3377,7 +3377,7 @@ int main(int argc, char ** argv) {
         }
     };
 
-    const auto handle_slots_erase = [&ctx_server, &res_error](const httplib::Request & req, httplib::Response & res, int id_slot) {
+    const auto handle_slots_erase = [&ctx_server, &res_error](const httplib::Request & /* req */, httplib::Response & res, int id_slot) {
         server_task task;
         task.type = SERVER_TASK_TYPE_SLOT_ERASE;
         task.data = {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1630,9 +1630,9 @@ struct server_context {
 
                     std::string filename = task.data["filename"];
                     std::string filepath = task.data["filepath"];
-                    size_t state_size = llama_get_seq_size(ctx, slot->id + 1);
+                    size_t state_size = llama_state_seq_get_size(ctx, slot->id + 1);
                     std::vector<uint8_t> state_data(state_size + sizeof(size_t) + token_count * sizeof(llama_token));
-                    size_t nwrite = llama_copy_seq_data(ctx, state_data.data(), slot->id + 1);
+                    size_t nwrite = llama_state_seq_get_data(ctx, state_data.data(), slot->id + 1);
                     GGML_ASSERT(nwrite <= state_size);
 
                     // write the cached token count of the slot->cache_tokens.size()
@@ -1691,7 +1691,7 @@ struct server_context {
                     std::vector<uint8_t> state_data((std::istreambuf_iterator<char>(infile)), std::istreambuf_iterator<char>());
                     infile.close();
 
-                    size_t nread = llama_set_seq_data(ctx, state_data.data(), slot->id + 1);
+                    size_t nread = llama_state_seq_set_data(ctx, state_data.data(), slot->id + 1);
                     if (nread == 0) {
                         send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
                         break;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1689,6 +1689,10 @@ struct server_context {
                     infile.close();
 
                     size_t nread = llama_set_seq_data(ctx, state_data.data(), slot->id + 1);
+                    if (nread == 0) {
+                        send_error(task, "Unable to restore slot, no available space in KV cache", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
                     GGML_ASSERT(nread <= state_data.size());
 
                     // restore cached token values

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1745,7 +1745,10 @@ struct server_context {
 
                     // Erase token cache
                     const size_t n_erased = slot->cache_tokens.size();
-                    llama_kv_cache_seq_rm(ctx, slot->id + 1, -1, -1);
+                    if (!llama_kv_cache_seq_rm(ctx, slot->id + 1, -1, -1)) {
+                        send_error(task, "Failed to erase slot KV cache", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
                     slot->cache_tokens.clear();
 
                     server_task_result result;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3397,7 +3397,7 @@ int main(int argc, char ** argv) {
         }
     };
 
-    const auto handle_slots_action = [&ctx_server, &res_error, &sparams, &handle_slots_save, &handle_slots_restore, &handle_slots_erase](const httplib::Request & req, httplib::Response & res) {
+    const auto handle_slots_action = [&res_error, &handle_slots_save, &handle_slots_restore, &handle_slots_erase](const httplib::Request & req, httplib::Response & res) {
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
 
         std::string id_slot_str = req.path_params.at("id_slot");

--- a/examples/server/tests/features/slotsave.feature
+++ b/examples/server/tests/features/slotsave.feature
@@ -1,0 +1,48 @@
+@llama.cpp
+@server
+Feature: llama.cpp server slot management
+
+  Background: Server startup
+    Given a server listening on localhost:8080
+    And   a model file tinyllamas/stories260K.gguf from HF repo ggml-org/models
+    And   prompt caching is enabled
+    And   2 slots
+    And   . as slot save path
+    And   2048 KV cache size
+    And   42 as server seed
+    And   24 max tokens to predict
+    Then  the server is starting
+    Then  the server is healthy
+
+  Scenario: Save and Restore Slot
+    Given a user prompt "What is the capital of France?"
+    And   using slot id 1
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Lily
+    And   22 prompt tokens are processed
+    When  the slot 1 is saved with filename "slot1.bin"
+    Then  the server responds with status code 200
+    Given a user prompt "What is the capital of Germany?"
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Thank
+    And   7 prompt tokens are processed
+    When  the slot 2 is restored with filename "slot1.bin"
+    Then  the server responds with status code 200
+    Given a user prompt "What is the capital of France?"
+    And   using slot id 2
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Lily
+    And   1 prompt tokens are processed
+
+  Scenario: Erase Slot
+    Given a user prompt "What is the capital of France?"
+    And   using slot id 1
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Lily
+    And   22 prompt tokens are processed
+    When  the slot 1 is erased
+    Then  the server responds with status code 200
+    Given a user prompt "What is the capital of France?"
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Lily
+    And   22 prompt tokens are processed

--- a/examples/server/tests/features/slotsave.feature
+++ b/examples/server/tests/features/slotsave.feature
@@ -26,7 +26,7 @@ Feature: llama.cpp server slot management
     # Since we have cache, this should only process the last tokens
     Given a user prompt "What is the capital of Germany?"
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Thank
+    Then  24 tokens are predicted matching (Thank|special)
     And   7 prompt tokens are processed
     # Loading the original cache into slot 0,
     # we should only be processing 1 prompt token and get the same output
@@ -41,7 +41,7 @@ Feature: llama.cpp server slot management
     Given a user prompt "What is the capital of Germany?"
     And   using slot id 1
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Thank
+    Then  24 tokens are predicted matching (Thank|special)
     And   1 prompt tokens are processed
 
   Scenario: Erase Slot

--- a/examples/server/tests/features/slotsave.feature
+++ b/examples/server/tests/features/slotsave.feature
@@ -1,5 +1,5 @@
 @llama.cpp
-@server
+@slotsave
 Feature: llama.cpp server slot management
 
   Background: Server startup
@@ -15,34 +15,44 @@ Feature: llama.cpp server slot management
     Then  the server is healthy
 
   Scenario: Save and Restore Slot
+    # First prompt in slot 1 should be fully processed
     Given a user prompt "What is the capital of France?"
     And   using slot id 1
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Lily
+    Then  24 tokens are predicted matching (Lily|cake)
     And   22 prompt tokens are processed
     When  the slot 1 is saved with filename "slot1.bin"
     Then  the server responds with status code 200
+    # Since we have cache, this should only process the last tokens
     Given a user prompt "What is the capital of Germany?"
     And   a completion request with no api error
     Then  24 tokens are predicted matching Thank
     And   7 prompt tokens are processed
-    When  the slot 2 is restored with filename "slot1.bin"
+    # Loading the original cache into slot 0,
+    # we should only be processing 1 prompt token and get the same output
+    When  the slot 0 is restored with filename "slot1.bin"
     Then  the server responds with status code 200
     Given a user prompt "What is the capital of France?"
-    And   using slot id 2
+    And   using slot id 0
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Lily
+    Then  24 tokens are predicted matching (Lily|cake)
+    And   1 prompt tokens are processed
+    # For verification that slot 1 was not corrupted during slot 0 load, same thing
+    Given a user prompt "What is the capital of Germany?"
+    And   using slot id 1
+    And   a completion request with no api error
+    Then  24 tokens are predicted matching Thank
     And   1 prompt tokens are processed
 
   Scenario: Erase Slot
     Given a user prompt "What is the capital of France?"
     And   using slot id 1
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Lily
+    Then  24 tokens are predicted matching (Lily|cake)
     And   22 prompt tokens are processed
     When  the slot 1 is erased
     Then  the server responds with status code 200
     Given a user prompt "What is the capital of France?"
     And   a completion request with no api error
-    Then  24 tokens are predicted matching Lily
+    Then  24 tokens are predicted matching (Lily|cake)
     And   22 prompt tokens are processed

--- a/examples/server/tests/features/steps/steps.py
+++ b/examples/server/tests/features/steps/steps.py
@@ -49,6 +49,9 @@ def step_server_config(context, server_fqdn, server_port):
     context.n_predict = None
     context.n_prompts = 0
     context.n_server_predict = None
+    context.slot_save_path = None
+    context.id_slot = None
+    context.cache_prompt = None
     context.n_slots = None
     context.prompt_prefix = None
     context.prompt_suffix = None
@@ -117,6 +120,21 @@ def step_n_slots(context, n_slots):
 @step('{n_predict:d} server max tokens to predict')
 def step_server_n_predict(context, n_predict):
     context.n_server_predict = n_predict
+
+
+@step('{slot_save_path} as slot save path')
+def step_slot_save_path(context, slot_save_path):
+    context.slot_save_path = slot_save_path
+
+
+@step('using slot id {id_slot:d}')
+def step_id_slot(context, id_slot):
+    context.id_slot = id_slot
+
+
+@step('prompt caching is enabled')
+def step_enable_prompt_cache(context):
+    context.cache_prompt = True
 
 
 @step('continuous batching')
@@ -212,6 +230,8 @@ async def step_request_completion(context, api_error):
                                           context.base_url,
                                           debug=context.debug,
                                           n_predict=context.n_predict,
+                                          cache_prompt=context.cache_prompt,
+                                          id_slot=context.id_slot,
                                           seed=await completions_seed(context),
                                           expect_api_error=expect_api_error,
                                           user_api_key=context.user_api_key)
@@ -711,12 +731,48 @@ async def concurrent_requests(context, f_completion, *args, **kwargs):
     await asyncio.sleep(0.1)
 
 
+@step('the slot {slot_id:d} is saved with filename "{filename}"')
+@async_run_until_complete
+async def step_save_slot(context, slot_id, filename):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{context.base_url}/slots/{slot_id}?action=save',
+                                json={"filename": filename},
+                                headers={"Content-Type": "application/json"}) as response:
+            context.response = response
+
+
+@step('the slot {slot_id:d} is restored with filename "{filename}"')
+@async_run_until_complete
+async def step_restore_slot(context, slot_id, filename):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{context.base_url}/slots/{slot_id}?action=restore',
+                                json={"filename": filename},
+                                headers={"Content-Type": "application/json"}) as response:
+            context.response = response
+
+
+@step('the slot {slot_id:d} is erased')
+@async_run_until_complete
+async def step_erase_slot(context, slot_id):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{context.base_url}/slots/{slot_id}?action=erase',
+                                headers={"Content-Type": "application/json"}) as response:
+            context.response = response
+
+
+@step('the server responds with status code {status_code:d}')
+def step_server_responds_with_status_code(context, status_code):
+    assert context.response.status == status_code
+
+
 async def request_completion(prompt,
                              base_url,
                              debug=False,
                              prompt_prefix=None,
                              prompt_suffix=None,
                              n_predict=None,
+                             cache_prompt=False,
+                             id_slot=None,
                              seed=None,
                              expect_api_error=None,
                              user_api_key=None):
@@ -738,6 +794,8 @@ async def request_completion(prompt,
                                     "prompt": prompt,
                                     "input_suffix": prompt_suffix,
                                     "n_predict": n_predict if n_predict is not None else -1,
+                                    "cache_prompt": cache_prompt,
+                                    "id_slot": id_slot,
                                     "seed": seed if seed is not None else 42
                                 },
                                 headers=headers,
@@ -1104,6 +1162,8 @@ def start_server_background(context):
         server_args.extend(['--parallel', context.n_slots])
     if context.n_server_predict:
         server_args.extend(['--n-predict', context.n_server_predict])
+    if context.slot_save_path:
+        server_args.extend(['--slot-save-path', context.slot_save_path])
     if context.server_api_key:
         server_args.extend(['--api-key', context.server_api_key])
     if context.n_ga:

--- a/llama.cpp
+++ b/llama.cpp
@@ -15343,13 +15343,13 @@ size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src,
         memcpy(&v_size_el_ref, inp, sizeof(v_size_el_ref));
         inp += sizeof(v_size_el_ref);
 
-        if (cell_count) {
-            const size_t v_size_el = ggml_type_size(kv_self.v_l[il]->type);
-            if (v_size_el != v_size_el_ref) {
-                llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1);
-                return 0;
-            }
+        const size_t v_size_el = ggml_type_size(kv_self.v_l[il]->type);
+        if (v_size_el != v_size_el_ref) {
+            llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1);
+            return 0;
+        }
 
+        if (cell_count) {
             // For each row in the transposed matrix, read the values for the whole cell range
             for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
                 const size_t dst_offset = (kv_head + j * kv_size) * v_size_el;

--- a/llama.cpp
+++ b/llama.cpp
@@ -15243,9 +15243,7 @@ size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src,
     GGML_ASSERT(!kv_self.recurrent); // not implemented
 
     // Wipe the slot
-    if (!llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1)) {
-        return 0;
-    }
+    llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1);
 
     const uint8_t * inp = src;
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -15196,7 +15196,7 @@ size_t llama_copy_seq_data(struct llama_context * ctx, uint8_t * dst, llama_seq_
         // Write element size
         const size_t v_size_el = ggml_type_size(kv_self.v_l[il]->type);
         data_ctx.write(&v_size_el, sizeof(v_size_el));
-        
+
         // For each row, we get the element values of each cell
         for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
             // Read each range of cells of v_size_el length each into tmp_buf and write out
@@ -15215,7 +15215,7 @@ size_t llama_copy_seq_data(struct llama_context * ctx, uint8_t * dst, llama_seq_
 
 size_t llama_set_seq_data(struct llama_context * ctx, const uint8_t * src, llama_seq_id dest_seq_id) {
     auto & kv_self = ctx->kv_self;
-    
+
     // Wipe the slot
     llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1);
 
@@ -15226,7 +15226,7 @@ size_t llama_set_seq_data(struct llama_context * ctx, const uint8_t * src, llama
     memcpy(&size_t_size, inp, sizeof(size_t_size));
     inp += sizeof(size_t_size);
     GGML_ASSERT(size_t_size == sizeof(size_t));
-    
+
     // Read the cell count
     uint32_t cell_count;
     memcpy(&cell_count, inp, sizeof(cell_count));

--- a/llama.cpp
+++ b/llama.cpp
@@ -15243,7 +15243,9 @@ size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src,
     GGML_ASSERT(!kv_self.recurrent); // not implemented
 
     // Wipe the slot
-    llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1);
+    if (!llama_kv_cache_seq_rm(kv_self, dest_seq_id, -1, -1)) {
+        return 0;
+    }
 
     const uint8_t * inp = src;
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -14568,6 +14568,30 @@ void llama_kv_cache_update(struct llama_context * ctx) {
     llama_kv_cache_update_internal(*ctx);
 }
 
+// deprecated
+size_t llama_get_state_size(const struct llama_context * ctx) {
+    return llama_state_get_size(ctx);
+}
+
+// deprecated
+size_t llama_copy_state_data(struct llama_context * ctx, uint8_t * dst) {
+    return llama_state_get_data(ctx, dst);
+}
+
+// deprecated
+size_t llama_set_state_data(struct llama_context * ctx, const uint8_t * src) {
+    return llama_state_set_data(ctx, src);
+}
+
+// deprecated
+bool llama_load_session_file(struct llama_context * ctx, const char * path_session, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
+    return llama_state_load_file(ctx, path_session, tokens_out, n_token_capacity, n_token_count_out);
+}
+
+// deprecated
+bool llama_save_session_file(struct llama_context * ctx, const char * path_session, const llama_token * tokens, size_t n_token_count) {
+    return llama_state_save_file(ctx, path_session, tokens, n_token_count);
+}
 
 // Returns the *maximum* size of the state
 size_t llama_state_get_size(const struct llama_context * ctx) {

--- a/llama.cpp
+++ b/llama.cpp
@@ -15059,7 +15059,7 @@ bool llama_save_session_file(struct llama_context * ctx, const char * path_sessi
     return true;
 }
 
-size_t llama_get_seq_size(struct llama_context* ctx, llama_seq_id seq_id) {
+size_t llama_state_seq_get_size(struct llama_context* ctx, llama_seq_id seq_id) {
     // save the size of size_t as a uint32_t for safety check
     const size_t size_t_size_size = sizeof(uint32_t);
 
@@ -15109,7 +15109,7 @@ size_t llama_get_seq_size(struct llama_context* ctx, llama_seq_id seq_id) {
     return s_total;
 }
 
-size_t llama_copy_seq_data(struct llama_context * ctx, uint8_t * dst, llama_seq_id seq_id) {
+size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama_seq_id seq_id) {
     llama_data_buffer_context data_ctx(dst);
     const auto& kv_self = ctx->kv_self;
     GGML_ASSERT(!kv_self.recurrent); // not implemented
@@ -15214,7 +15214,7 @@ size_t llama_copy_seq_data(struct llama_context * ctx, uint8_t * dst, llama_seq_
     return data_ctx.get_size_written();
 }
 
-size_t llama_set_seq_data(struct llama_context * ctx, const uint8_t * src, llama_seq_id dest_seq_id) {
+size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src, llama_seq_id dest_seq_id) {
     auto & kv_self = ctx->kv_self;
     GGML_ASSERT(!kv_self.recurrent); // not implemented
 

--- a/llama.cpp
+++ b/llama.cpp
@@ -15094,15 +15094,15 @@ size_t llama_state_seq_get_size(struct llama_context* ctx, llama_seq_id seq_id) 
 
     size_t s_cell_count = 0;
     size_t s_cell_data_size = 0;
-    const auto& kv_self = ctx->kv_self;
-    const auto& hparams = ctx->model.hparams;
+    const auto & kv_self = ctx->kv_self;
+    const auto & hparams = ctx->model.hparams;
 
     const uint32_t n_layer = hparams.n_layer;
     const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa() + hparams.n_embd_k_s();
     const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa() + hparams.n_embd_v_s();
 
     for (uint32_t i = 0; i < kv_self.size; ++i) {
-        const auto& cell = kv_self.cells[i];
+        const auto & cell = kv_self.cells[i];
         if (cell.seq_id.count(seq_id) > 0) {
             ++s_cell_count;
             s_cell_data_size += sizeof(llama_pos);
@@ -15135,7 +15135,7 @@ size_t llama_state_seq_get_size(struct llama_context* ctx, llama_seq_id seq_id) 
 
 size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama_seq_id seq_id) {
     llama_data_buffer_context data_ctx(dst);
-    const auto& kv_self = ctx->kv_self;
+    const auto & kv_self = ctx->kv_self;
     GGML_ASSERT(!kv_self.recurrent); // not implemented
 
     // Save the size of size_t as a uint32_t for safety check
@@ -15150,7 +15150,7 @@ size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama
     {
         uint32_t cell_range_begin = kv_self.size;
         for (uint32_t i = 0; i < kv_self.size; ++i) {
-            const auto& cell = kv_self.cells[i];
+            const auto & cell = kv_self.cells[i];
             if (cell.has_seq_id(seq_id)) {
                 ++cell_count;
                 if (cell_range_begin == kv_self.size) {
@@ -15170,7 +15170,7 @@ size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama
 
         // DEBUG CHECK: Sum of cell counts in ranges should equal the total cell count
         uint32_t cell_count_check = 0;
-        for (const auto& range : cell_ranges) {
+        for (const auto & range : cell_ranges) {
             cell_count_check += range.second - range.first;
         }
         GGML_ASSERT(cell_count == cell_count_check);
@@ -15211,7 +15211,7 @@ size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama
             const size_t range_size = range.second - range.first;
             tmp_buf.resize(range_size * k_size_row);
             ggml_backend_tensor_get(kv_self.k_l[il], tmp_buf.data(), range.first * k_size_row, range_size * k_size_row);
-            data_ctx.write(&tmp_buf[0], tmp_buf.size());
+            data_ctx.write(tmp_buf.data(), tmp_buf.size());
         }
     }
 
@@ -15230,7 +15230,7 @@ size_t llama_state_seq_get_data(struct llama_context * ctx, uint8_t * dst, llama
                 const size_t src_offset = (range.first + j * kv_size) * v_size_el;
                 tmp_buf.resize(range_size * v_size_el);
                 ggml_backend_tensor_get(kv_self.v_l[il], tmp_buf.data(), src_offset, tmp_buf.size());
-                data_ctx.write(&tmp_buf[0], tmp_buf.size());
+                data_ctx.write(tmp_buf.data(), tmp_buf.size());
             }
         }
     }
@@ -15273,7 +15273,7 @@ size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src,
     inp += sizeof(n_embd_v_gqa_ref);
 
     // Sanity check model compatibility
-    const auto& hparams = ctx->model.hparams;
+    const auto & hparams = ctx->model.hparams;
     const uint32_t n_layer = hparams.n_layer;
     const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa() + hparams.n_embd_k_s();
     const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa() + hparams.n_embd_v_s();

--- a/llama.h
+++ b/llama.h
@@ -595,6 +595,8 @@ extern "C" {
     // Returns the maximum size in bytes of the state (rng, logits, embedding
     // and kv_cache) - will often be smaller after compacting tokens
     LLAMA_API size_t llama_state_get_size(const struct llama_context * ctx);
+    LLAMA_API DEPRECATED(size_t llama_get_state_size(const struct llama_context * ctx),
+        "use llama_state_get_size instead");
 
     // Copies the state to the specified destination address.
     // Destination needs to have allocated enough memory.
@@ -602,12 +604,20 @@ extern "C" {
     LLAMA_API size_t llama_state_get_data(
             struct llama_context * ctx,
                          uint8_t * dst);
+    LLAMA_API DEPRECATED(size_t llama_copy_state_data(
+            struct llama_context * ctx,
+                         uint8_t * dst),
+        "use llama_state_get_data instead");
 
     // Set the state reading from the specified address
     // Returns the number of bytes read
     LLAMA_API size_t llama_state_set_data(
             struct llama_context * ctx,
                    const uint8_t * src);
+    LLAMA_API DEPRECATED(size_t llama_set_state_data(
+            struct llama_context * ctx,
+                   const uint8_t * src),
+        "use llama_state_set_data instead");
 
     // Save/load session file
     LLAMA_API bool llama_state_load_file(
@@ -616,12 +626,25 @@ extern "C" {
                      llama_token * tokens_out,
                           size_t   n_token_capacity,
                           size_t * n_token_count_out);
+    LLAMA_API DEPRECATED(bool llama_load_session_file(
+            struct llama_context * ctx,
+                      const char * path_session,
+                     llama_token * tokens_out,
+                          size_t   n_token_capacity,
+                          size_t * n_token_count_out),
+        "use llama_state_load_file instead");
 
     LLAMA_API bool llama_state_save_file(
             struct llama_context * ctx,
                       const char * path_session,
                const llama_token * tokens,
                           size_t   n_token_count);
+    LLAMA_API DEPRECATED(bool llama_save_session_file(
+            struct llama_context * ctx,
+                      const char * path_session,
+               const llama_token * tokens,
+                          size_t   n_token_count),
+        "use llama_state_save_file instead");
 
     LLAMA_API size_t llama_state_seq_get_size(
             struct llama_context * ctx,

--- a/llama.h
+++ b/llama.h
@@ -623,6 +623,20 @@ extern "C" {
                const llama_token * tokens,
                           size_t   n_token_count);
 
+    LLAMA_API size_t llama_get_seq_size(
+            struct llama_context * ctx,
+                    llama_seq_id   seq_id);
+
+    LLAMA_API size_t llama_copy_seq_data(
+            struct llama_context * ctx,
+                         uint8_t * dst,
+                    llama_seq_id   seq_id);
+
+    LLAMA_API size_t llama_set_seq_data(
+            struct llama_context * ctx,
+                   const uint8_t * src,
+                    llama_seq_id   dest_seq_id);
+
     //
     // Decoding
     //

--- a/llama.h
+++ b/llama.h
@@ -523,6 +523,7 @@ extern "C" {
             struct llama_context * ctx);
 
     // Removes all tokens that belong to the specified sequence and have positions in [p0, p1)
+    // Returns false if a partial sequence cannot be removed. Removing a whole sequence never fails
     // seq_id < 0 : match any sequence
     // p0 < 0     : [0,  p1]
     // p1 < 0     : [p0, inf)

--- a/llama.h
+++ b/llama.h
@@ -646,16 +646,18 @@ extern "C" {
                           size_t   n_token_count),
         "use llama_state_save_file instead");
 
+    // Get the exact size needed to copy the KV cache of a single sequence
     LLAMA_API size_t llama_state_seq_get_size(
             struct llama_context * ctx,
                     llama_seq_id   seq_id);
 
+    // Copy the KV cache of a single sequence into the specified buffer
     LLAMA_API size_t llama_state_seq_get_data(
             struct llama_context * ctx,
                          uint8_t * dst,
                     llama_seq_id   seq_id);
 
-    // Copy the sequence data (originally copied with `llama_state_seq_get_data`) into a sequence.
+    // Copy the sequence data (originally copied with `llama_state_seq_get_data`) into the specified sequence
     // Returns:
     //  - Positive: Ok
     //  - Zero: Failed to load

--- a/llama.h
+++ b/llama.h
@@ -632,6 +632,10 @@ extern "C" {
                          uint8_t * dst,
                     llama_seq_id   seq_id);
 
+    // Copy the sequence data (originally copied with `llama_copy_seq_data`) into a sequence.
+    // Returns:
+    //  - Positive: Ok
+    //  - Zero: Failed to load
     LLAMA_API size_t llama_set_seq_data(
             struct llama_context * ctx,
                    const uint8_t * src,

--- a/llama.h
+++ b/llama.h
@@ -594,30 +594,30 @@ extern "C" {
 
     // Returns the maximum size in bytes of the state (rng, logits, embedding
     // and kv_cache) - will often be smaller after compacting tokens
-    LLAMA_API size_t llama_get_state_size(const struct llama_context * ctx);
+    LLAMA_API size_t llama_state_get_size(const struct llama_context * ctx);
 
     // Copies the state to the specified destination address.
     // Destination needs to have allocated enough memory.
     // Returns the number of bytes copied
-    LLAMA_API size_t llama_copy_state_data(
+    LLAMA_API size_t llama_state_get_data(
             struct llama_context * ctx,
                          uint8_t * dst);
 
     // Set the state reading from the specified address
     // Returns the number of bytes read
-    LLAMA_API size_t llama_set_state_data(
+    LLAMA_API size_t llama_state_set_data(
             struct llama_context * ctx,
                    const uint8_t * src);
 
     // Save/load session file
-    LLAMA_API bool llama_load_session_file(
+    LLAMA_API bool llama_state_load_file(
             struct llama_context * ctx,
                       const char * path_session,
                      llama_token * tokens_out,
                           size_t   n_token_capacity,
                           size_t * n_token_count_out);
 
-    LLAMA_API bool llama_save_session_file(
+    LLAMA_API bool llama_state_save_file(
             struct llama_context * ctx,
                       const char * path_session,
                const llama_token * tokens,

--- a/llama.h
+++ b/llama.h
@@ -37,9 +37,13 @@
 
 #define LLAMA_FILE_MAGIC_GGLA 0x67676c61u // 'ggla'
 #define LLAMA_FILE_MAGIC_GGSN 0x6767736eu // 'ggsn'
+#define LLAMA_FILE_MAGIC_GGSQ 0x67677371u // 'ggsq'
 
 #define LLAMA_SESSION_MAGIC   LLAMA_FILE_MAGIC_GGSN
 #define LLAMA_SESSION_VERSION 5
+
+#define LLAMA_STATE_SEQ_MAGIC   LLAMA_FILE_MAGIC_GGSQ
+#define LLAMA_STATE_SEQ_VERSION 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -666,6 +670,21 @@ extern "C" {
             struct llama_context * ctx,
                    const uint8_t * src,
                     llama_seq_id   dest_seq_id);
+
+    LLAMA_API size_t llama_state_seq_save_file(
+            struct llama_context * ctx,
+                      const char * filepath,
+                    llama_seq_id   seq_id,
+               const llama_token * tokens,
+                          size_t   n_token_count);
+
+    LLAMA_API size_t llama_state_seq_load_file(
+            struct llama_context * ctx,
+                      const char * filepath,
+                    llama_seq_id   dest_seq_id,
+                     llama_token * tokens_out,
+                          size_t   n_token_capacity,
+                          size_t * n_token_count_out);
 
     //
     // Decoding

--- a/llama.h
+++ b/llama.h
@@ -623,20 +623,20 @@ extern "C" {
                const llama_token * tokens,
                           size_t   n_token_count);
 
-    LLAMA_API size_t llama_get_seq_size(
+    LLAMA_API size_t llama_state_seq_get_size(
             struct llama_context * ctx,
                     llama_seq_id   seq_id);
 
-    LLAMA_API size_t llama_copy_seq_data(
+    LLAMA_API size_t llama_state_seq_get_data(
             struct llama_context * ctx,
                          uint8_t * dst,
                     llama_seq_id   seq_id);
 
-    // Copy the sequence data (originally copied with `llama_copy_seq_data`) into a sequence.
+    // Copy the sequence data (originally copied with `llama_state_seq_get_data`) into a sequence.
     // Returns:
     //  - Positive: Ok
     //  - Zero: Failed to load
-    LLAMA_API size_t llama_set_seq_data(
+    LLAMA_API size_t llama_state_seq_set_data(
             struct llama_context * ctx,
                    const uint8_t * src,
                     llama_seq_id   dest_seq_id);


### PR DESCRIPTION
See https://github.com/ggerganov/llama.cpp/issues/5843

This adds `llama_get_seq_size`, `llama_copy_seq_data`, and `llama_set_seq_data` functions to save and restore the kv cache of a single sequence id.

On the server this adds `/slot/save` and `/slot/restore` endpoints, which will save the kv cache for the given slot along with the token cache to a file. Also added a `/slot/erase` to just wipe the kv cache for a slot.

Works so far, ~~but still needs test cases, and perhaps a path parameter for the server to enable the functionality restricted within a specified folder~~ *(done)*. Might be missing some special cases that I'm not aware of.