### PR TITLE
split: allow --split-max-size option

### DIFF
--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -226,13 +226,10 @@ struct split_strategy {
         size_t curr_tensors_size = 0; // current size by counting only tensors size (without metadata)
         for (int i = 0; i < n_tensors; ++i) {
             struct ggml_tensor * t = ggml_get_tensor(ctx_meta, gguf_get_tensor_name(ctx_gguf, i));
-            // calculate the "imaginary" size including this tensor
+            // calculate the "imaginary" size = the current size + next tensor size
             size_t n_bytes = GGML_PAD(ggml_nbytes(t), GGUF_DEFAULT_ALIGNMENT);
             size_t next_tensors_size = curr_tensors_size + n_bytes;
-            size_t next_metadata_size = gguf_get_meta_size(ctx_out)
-                + GGUF_DEFAULT_ALIGNMENT
-                + sizeof(struct ggml_tensor *); // not sure if we're missing something
-            if (should_split(i, next_tensors_size + next_metadata_size)) {
+            if (should_split(i, next_tensors_size)) {
                 new_ctx_out();
                 curr_tensors_size = n_bytes;
             } else {

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -62,12 +62,12 @@ static size_t split_str_to_n_bytes(std::string str) {
         sscanf(str.c_str(), "%d", &n);
         n_bytes = n * 1024 * 1024 * 1024; // gigabytes
     } else {
-        throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got " + str.back());
+        throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
     }
     return n_bytes;
 }
 
-static bool split_params_parse_ex(int argc, const char ** argv, split_params & params) {
+static void split_params_parse_ex(int argc, const char ** argv, split_params & params) {
     std::string arg;
     const std::string arg_prefix = "--";
     bool invalid_param = false;
@@ -138,24 +138,17 @@ static bool split_params_parse_ex(int argc, const char ** argv, split_params & p
     }
 
     if (argc - arg_idx < 2) {
-        printf("%s: bad arguments\n", argv[0]);
-        split_print_usage(argv[0]);
-        return false;
+        throw std::invalid_argument("error: bad arguments");
     }
 
     params.input = argv[arg_idx++];
     params.output = argv[arg_idx++];
-
-    return true;
 }
 
 static bool split_params_parse(int argc, const char ** argv, split_params & params) {
     bool result = true;
     try {
-        if (!split_params_parse_ex(argc, argv, params)) {
-            split_print_usage(argv[0]);
-            exit(EXIT_FAILURE);
-        }
+        split_params_parse_ex(argc, argv, params);
     }
     catch (const std::invalid_argument & ex) {
         fprintf(stderr, "%s\n", ex.what());
@@ -501,10 +494,6 @@ static void gguf_merge(const split_params & split_params) {
 }
 
 int main(int argc, const char ** argv) {
-    if (argc < 3) {
-        split_print_usage(argv[0]);
-    }
-
     split_params params;
     split_params_parse(argc, argv, params);
 

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -66,6 +66,9 @@ static size_t split_str_to_n_bytes(std::string str) {
     } else {
         throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
     }
+    if (n <= 0) {
+        throw std::invalid_argument("error: size must be a negative value");
+    }
     return n_bytes;
 }
 
@@ -200,6 +203,10 @@ struct split_strategy {
         auto new_ctx_out = [&]() {
             i_split++;
             if (ctx_out != NULL) {
+                if (gguf_get_n_tensors(ctx_out) == 0) {
+                    fprintf(stderr, "error: one of splits have 0 tensors. Maybe size or tensors limit is too small\n");
+                    exit(EXIT_FAILURE);
+                }
                 ctx_outs.push_back(ctx_out);
             }
             ctx_out = gguf_init_empty();

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -67,7 +67,7 @@ static size_t split_str_to_n_bytes(std::string str) {
         throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
     }
     if (n <= 0) {
-        throw std::invalid_argument("error: size must be a negative value");
+        throw std::invalid_argument("error: size must be a positive value");
     }
     return n_bytes;
 }


### PR DESCRIPTION
Closes #6259

I ended up re-write the `split_strategy` class. How it works now:
1. In the constructor, it produces all the `ctx_out` that is used by the output file (one `ctx_out` per one split). These `ctx_out` are saved into a `std::vector<struct gguf_context *> ctx_outs`. This step only produce a split "plan", not the actual file.
2. `split_strategy.print_info()` can be used to print out the "plan" and details for each split (n_tensors, size)
3. Finally, when you're happy with the split "plan", call `split_strategy.write()` to actually write out to output files