### PR TITLE
server : stop gracefully on SIGTERM

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3566,6 +3566,7 @@ int main(int argc, char ** argv) {
     sigemptyset (&sigint_action.sa_mask);
     sigint_action.sa_flags = 0;
     sigaction(SIGINT, &sigint_action, NULL);
+    sigaction(SIGTERM, &sigint_action, NULL);
 #elif defined (_WIN32)
     auto console_ctrl_handler = +[](DWORD ctrl_type) -> BOOL {
         return (ctrl_type == CTRL_C_EVENT) ? (signal_handler(SIGINT), true) : false;


### PR DESCRIPTION
As of b2548 the server does not explicitly handle `SIGTERM`, thus the default behavior of terminating the process applies. This will not cause any problem normally, but since terminated processes have a abnormal (!= 0) exit code, and `SIGTERM` is the default stop signal for `kill` and `docker stop`/`podman stop`, not explicitly handling `SIGTERM` may mess with service health checks. For example, when running the server Docker image as a systemd service (via [podman-generate-systemd](https://docs.podman.io/en/latest/markdown/podman-generate-systemd.1.html)), errors will always occur when stopping the service.

This PR reuses the handler for `SIGINT`, enabling the server to stop gracefully on `SIGTERM`.