### PR TITLE
cmake: add explicit metal version options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,15 +254,14 @@ if (LLAMA_METAL)
         endif()
 
         # Append macOS metal versioning flags
-        if(LLAMA_METAL_MACOSX_VERSION_MIN)
+        if (LLAMA_METAL_MACOSX_VERSION_MIN)
             message(STATUS "Adding -mmacosx-version-min=${LLAMA_METAL_MACOSX_VERSION_MIN} flag to metal compilation")
             list(APPEND XC_FLAGS -mmacosx-version-min=${LLAMA_METAL_MACOSX_VERSION_MIN})
         endif()
-        if(LLAMA_METAL_STD)
+        if (LLAMA_METAL_STD)
             message(STATUS "Adding -std=${LLAMA_METAL_STD} flag to metal compilation")
             list(APPEND XC_FLAGS -std=${LLAMA_METAL_STD})
         endif()
-
 
         add_custom_command(
             OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/default.metallib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,9 @@ option(LLAMA_METAL                           "llama: use Metal"                 
 option(LLAMA_METAL_NDEBUG                    "llama: disable Metal debugging"                   OFF)
 option(LLAMA_METAL_SHADER_DEBUG              "llama: compile Metal with -fno-fast-math"         OFF)
 option(LLAMA_METAL_EMBED_LIBRARY             "llama: embed Metal library"                       OFF)
+set(LLAMA_METAL_MACOSX_VERSION_MIN "" CACHE STRING
+                                             "llama: metal minimum macOS version")
+set(LLAMA_METAL_STD "" CACHE STRING          "llama: metal standard version (-std flag)")
 option(LLAMA_KOMPUTE                         "llama: use Kompute"                               OFF)
 option(LLAMA_MPI                             "llama: use MPI"                                   OFF)
 option(LLAMA_QKK_64                          "llama: use super-block size of 64 for k-quants"   OFF)
@@ -249,6 +252,17 @@ if (LLAMA_METAL)
         else()
             set(XC_FLAGS -O3)
         endif()
+
+        # Append macOS metal versioning flags
+        if(LLAMA_METAL_MACOSX_VERSION_MIN)
+            message(STATUS "Adding -mmacosx-version-min=${LLAMA_METAL_MACOSX_VERSION_MIN} flag to metal compilation")
+            list(APPEND XC_FLAGS -mmacosx-version-min=${LLAMA_METAL_MACOSX_VERSION_MIN})
+        endif()
+        if(LLAMA_METAL_STD)
+            message(STATUS "Adding -std=${LLAMA_METAL_STD} flag to metal compilation")
+            list(APPEND XC_FLAGS -std=${LLAMA_METAL_STD})
+        endif()
+
 
         add_custom_command(
             OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/default.metallib


### PR DESCRIPTION
Currently, if you want to build `llama.cpp` binaries with metal enabled, you can only compile the metal libraries to be compatible with the minimum mac os version and metal shading language standard associated with your current machines SDK. This is the default behavior of of the `xcrun metal` command.

This presents a problem if you ever want to build llama.cpp from a newer machine (say a Mac running macOS 14.x with default metal shading language 3.1), and have it be able to run on an older machine (say a Mac running macOS 13.x with default metal shading language 3.0).

With the current state of `llama.cpp`, trying to perform the exact build above from macOS 14.x and running on macOS 13.x results in the following error during model load:
```
ggml_metal_init: error: load pipeline error: Error Domain=AGXMetal13_3 Code=3 "Function kernel_add is using language version 3.1 which is incompatible with this OS." UserInfo={NSLocalizedDescription=Function kernel_add is using language version 3.1 which is incompatible with this OS.}
```

By providing the new CMake options `LLAMA_METAL_MACOSX_VERSION_MIN` and `LLAMA_METAL_STD`, you can now explicitly set the macOS min version and metal shading library standard that your build will support:
```
cmake -DLLAMA_METAL_MACOSX_VERSION_MIN="13.6" -DLLAMA_METAL_STD="metal3.0" ..
```
and you will be notified in the output of that cmake command:
```
~/Workspace/forks/llama.cpp/build git:[mattjcly/explicit-metal-version-options]
cmake -DLLAMA_METAL_MACOSX_VERSION_MIN="13.6" -DLLAMA_METAL_STD="metal3.0" ..
-- Accelerate framework found
-- Metal framework found
-- Adding -mmacosx-version-min=13.6 flag to metal compilation
-- Adding -std=metal3.0 flag to metal compilation
-- Warning: ccache not found - consider installing it for faster compilation or disable this warning with LLAMA_CCACHE=OFF
-- CMAKE_SYSTEM_PROCESSOR: arm64
-- ARM detected
-- Configuring done (0.1s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/matt/Workspace/forks/llama.cpp/build
```

Doing this allows for both macOS 13.x and macOS 14.x to run llama.cpp binaries built from macOS 14.x without metal incompatibility errors.

The default behavior of builds without those options set will remain the same (since default value of these variables is `""`, and therefore will be ignored in the logic to add the flags to `XC_FLAGS`).