### PR TITLE
ci: bench: fix Resource not accessible by integration on PR event

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,7 +25,7 @@ on:
     branches:
       - master
     paths: ['.github/workflows/bench.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/bench/**.*']
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths: ['.github/workflows/bench.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/bench/**.*']
   schedule:
@@ -143,7 +143,6 @@ jobs:
 
       - name: Commit status
         uses: Sibz/github-status-action@v1
-        continue-on-error: true # If not authorized on external repo
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
### Context

Facing `Resource not accessible by integration` on [Benchmark](https://github.com/ggerganov/llama.cpp/actions/workflows/bench.yml) workflow on PR created from forks, example:
- https://github.com/ggerganov/llama.cpp/actions/runs/8478465820/job/23230834051

This is expected according to the github [documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), the `GITHUB_TOKEN` has `read` permission on PR from fork.


### Change

Switch trigger event from `pull_request` to `pull_request_target`.

Explained on github [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target):
> For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission

As we need write permission for commit status and and PR comment.
