### PR TITLE
ci: server: verify deps are coherent with the commit

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -11,12 +11,12 @@ on:
   push:
     branches:
       - master
-    paths: ['.github/workflows/server.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/tests/**.*']
-  pull_request:
+    paths: ['.github/workflows/server.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/**.*']
+  pull_request_target:
     types: [opened, synchronize, reopened]
-    paths: ['.github/workflows/server.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/tests/**.*']
+    paths: ['.github/workflows/server.yml', '**/CMakeLists.txt', '**/Makefile', '**/*.h', '**/*.hpp', '**/*.c', '**/*.cpp', '**/*.cu', '**/*.swift', '**/*.m', 'examples/server/**.*']
   schedule:
-    -  cron: '0 0 * * *'
+    -  cron: '2 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,24 +44,43 @@ jobs:
       options: --cpus 4
 
     steps:
-      - name: Clone
-        id: checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       - name: Dependencies
         id: depends
         run: |
           apt-get update
           apt-get -y install \
             build-essential \
+            xxd \
             git \
             cmake \
             python3-pip \
+            curl \
             wget \
             language-pack-en \
             libcurl4-openssl-dev
+
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Verify server deps
+        id: verify_server_deps
+        run: |
+          git config --global --add safe.directory $(realpath .)
+          cd examples/server
+          git ls-files --others --modified
+          git status
+          ./deps.sh
+          git status
+          not_ignored_files="$(git ls-files --others --modified)"
+          echo "Modified files: ${not_ignored_files}"
+          if [ -n "${not_ignored_files}" ]; then
+            echo "Repository is dirty or server deps are not built as expected"
+            echo "${not_ignored_files}"
+            exit 1
+          fi
 
       - name: Build
         id: cmake_build

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -4,6 +4,10 @@ name: Server
 on:
   workflow_dispatch: # allows manual triggering
     inputs:
+      sha:
+        description: 'Commit SHA1 to build'
+        required: false
+        type: string
       slow_tests:
         description: 'Run slow tests'
         required: true
@@ -64,6 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
 
       - name: Verify server deps
         id: verify_server_deps


### PR DESCRIPTION
#### Context

It can be difficult to assess if the server dependencies are built correctly, as the files are obsucated, example:

- #6325

#### Changes

- Run in the `server` CI workflow the `deps.sh` and verify the git index is not dirty.
- Do not allow to change the `server` CI workflow from a fork  branch
- Change the schedule trigger to a time where github runners should be less busy
- include any files modified in the server as trigger

#### Tests
- If a `js` file is modified without updating the equivalent `hpp`: https://github.com/phymbert/llama.cpp/pull/2 https://github.com/phymbert/llama.cpp/actions/runs/8504681958/job/23291956170
- if a `js` file or an `hpp` is modified but they are not coherent: https://github.com/phymbert/llama.cpp/pull/3 https://github.com/phymbert/llama.cpp/actions/runs/8504643113/job/23291868220
- passing test: https://github.com/phymbert/llama.cpp/pull/4  https://github.com/phymbert/llama.cpp/actions/runs/8504705788/job/23292025618