### PR TITLE
FlashAttention CUDA fixes

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -9973,7 +9973,7 @@ static int llama_decode_internal(
                 // a heuristic, to avoid attending the full cache if it is not yet utilized
                 // after enough generations, the benefit from this heuristic disappears
                 // if we start defragmenting the cache, the benefit from this will be more important
-                kv_self.n = std::min(kv_self.size, std::max(128u, GGML_PAD(llama_kv_cache_cell_max(kv_self), 128)));
+                kv_self.n = std::min(kv_self.size, std::max(256u, GGML_PAD(llama_kv_cache_cell_max(kv_self), 256)));
                 //kv_self.n = llama_kv_cache_cell_max(kv_self);
             }
         }
@@ -13909,7 +13909,7 @@ struct llama_context * llama_new_context_with_model(
     cparams.rope_freq_scale  = params.rope_freq_scale == 0.0f ? hparams.rope_freq_scale_train : params.rope_freq_scale;
 
     // this is necessary due to kv_self.n being padded later during inference
-    cparams.n_ctx = GGML_PAD(cparams.n_ctx, 32);
+    cparams.n_ctx = GGML_PAD(cparams.n_ctx, 256);
 
     // with causal attention, the batch size is limited by the context size
     cparams.n_batch          = hparams.causal_attn ? std::min(cparams.n_ctx, params.n_batch) : params.n_batch;


### PR DESCRIPTION
Fixup for https://github.com/ggerganov/llama.cpp/pull/6374 . There were 2 bugs:

1. I forgot to adjust the padding of the KV cache to 256; long-term it would probably make sense to use a define for this.
2. I initialized the max. KQ values with `-INFINITY`. My expectation was that `-INFINITY - some value` would again be `-INFINITY`. Instead it was NaN. I'm now instead using a very small but finite value to initialize the max. KQ values.