### PR TITLE
Missing tokenizer.model error during gguf conversion

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -324,7 +324,7 @@ class Model(ABC):
 
         if not tokenizer_path.is_file():
             print(f'Error: Missing {tokenizer_path}', file=sys.stderr)
-            sys.exit(1)
+            raise FileNotFoundError(f"File not found: {tokenizer_path}")
 
         tokenizer = SentencePieceProcessor(str(tokenizer_path))
         vocab_size = self.hparams.get('vocab_size', tokenizer.vocab_size())

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -323,7 +323,6 @@ class Model(ABC):
         toktypes: list[int] = []
 
         if not tokenizer_path.is_file():
-            print(f'Error: Missing {tokenizer_path}', file=sys.stderr)
             raise FileNotFoundError(f"File not found: {tokenizer_path}")
 
         tokenizer = SentencePieceProcessor(str(tokenizer_path))


### PR DESCRIPTION
As mentioned in [issue#6419](https://github.com/ggerganov/llama.cpp/issues/6419#issue-2217760252)

Added the line for raising the error such that the flow continues.