### PR TITLE
server: add cURL support to `server.Dockerfile`

### DIFF
--- a/.devops/server.Dockerfile
+++ b/.devops/server.Dockerfile
@@ -3,15 +3,20 @@ ARG UBUNTU_VERSION=22.04
 FROM ubuntu:$UBUNTU_VERSION as build
 
 RUN apt-get update && \
-    apt-get install -y build-essential git
+    apt-get install -y build-essential git libcurl4-openssl-dev
 
 WORKDIR /app
 
 COPY . .
 
+ENV LLAMA_CURL=1
+
 RUN make
 
 FROM ubuntu:$UBUNTU_VERSION as runtime
+
+RUN apt-get update && \
+    apt-get install -y libcurl4-openssl-dev
 
 COPY --from=build /app/server /server
 


### PR DESCRIPTION
Adding cURL to support `--hf-repo` and `--hf-file` params when running through Docker. Only added to the main `server.Dockerfile` image for now, but happy to add to other images as well, if needed.

Resolves #6291 