### PR TITLE
Fix for lint error complaining of bare except during CI builds.

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -513,7 +513,8 @@ class MPTModel(Model):
     def set_vocab(self):
         try:
             self._set_vocab_gpt2()
-        except:
+        except Exception:
+            # Fallback for SEA-LION model
             self._set_vocab_sentencepiece()
             self.gguf_writer.add_add_bos_token(False)
             self.gguf_writer.add_pad_token_id(3)


### PR DESCRIPTION
As [discussed here](https://github.com/ggerganov/llama.cpp/pull/6448#discussion_r1550873303), adding small qualification to `except` clause to fix the CI linter [breaking on build](https://github.com/ggerganov/llama.cpp/actions/runs/8548590554/job/23422539688?pr=6467#step:4:43), complaining of `./convert-hf-to-gguf.py:516:9: E722 do not use bare 'except'`

While it would be better to use a more specific class other than `Exception` to fall back for SEA-LION support, this may be good enough...?