### PR TITLE
ci: bench fix concurrency for workflow trigger dispatch with sha1

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
     -  cron: '04 2 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
#### Context

It is possible to submit the bench workflow for a special commit sha, but it cancels the current running as it is the same branch.

I need to trigger master benchmark on some previous commits to have the same format of commit status added previously.
In the idea of starting to see commit per commit performances changes