### PR TITLE
cuda : use amd wave sharing intrinsics for warp_reduce functions

### DIFF
--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -384,13 +384,24 @@ static __device__ __forceinline__ float2 warp_reduce_sum_impl_amd(float2 a) {
     return a;
 }
 
-static __device__ __forceinline__ half2 warp_reduce_sum_impl_amd(half2 x) {
-    x += hip_ds_swizzleh2(x, AMD_SWIZZLE_MASK(0x1F, 0, 0x10));
-    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(8), 0xF, 0xF, true);
-    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(4), 0xF, 0xF, true);
-    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(2), 0xF, 0xF, true);
-    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(1), 0xF, 0xF, true);
-    return x;
+static __device__ __forceinline__ half2 warp_reduce_sum_impl_amd(half2 a) {
+    half2 tmp;
+    tmp = hip_ds_swizzleh2(a, AMD_SWIZZLE_MASK(0x1F, 0, 0x10));
+    a.data.x += tmp.data.x;
+    a.data.y += tmp.data.y;
+    tmp = hip_move_dpph2(a, AMD_DPP_ROW_RR(8), 0xF, 0xF, true);
+    a.data.x += tmp.data.x;
+    a.data.y += tmp.data.y;
+    tmp = hip_move_dpph2(a, AMD_DPP_ROW_RR(4), 0xF, 0xF, true);
+    a.data.x += tmp.data.x;
+    a.data.y += tmp.data.y;
+    tmp = hip_move_dpph2(a, AMD_DPP_ROW_RR(2), 0xF, 0xF, true);
+    a.data.x += tmp.data.x;
+    a.data.y += tmp.data.y;
+    tmp = hip_move_dpph2(a, AMD_DPP_ROW_RR(1), 0xF, 0xF, true);
+    a.data.x += tmp.data.x;
+    a.data.y += tmp.data.y;
+    return a;
 }
 
 static __device__ __forceinline__ float warp_reduce_max_impl_amd(float x) {

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -321,6 +321,9 @@ static __device__ __forceinline__ int __dp4a(const int a, const int b, int c) {
 #define AMD_DPP_ROW_RR(x) (0x120+(x)) // 121-12F - row rotate right by 1-15 threads - a row is 16 threads
 #define hip_move_dppf(src, dpp_ctrl, row_mask, bank_mask, bound_ctrl) \
   hip_move_dppf_N<(dpp_ctrl), (row_mask), (bank_mask), (bound_ctrl)>((src))
+#define hip_move_dpph2(src, dpp_ctrl, row_mask, bank_mask, bound_ctrl) \
+  hip_move_dpph2_N<(dpp_ctrl), (row_mask), (bank_mask), (bound_ctrl)>((src))
+#define hip_ds_swizzleh2(src, pattern)  hip_ds_swizzleh2_N<(pattern)>((src))
 
 template <int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl>
 static __device__ __forceinline__ float hip_move_dppf_N(float x) {
@@ -331,6 +334,30 @@ static __device__ __forceinline__ float hip_move_dppf_N(float x) {
     float_b32_t tmp;
     tmp.val = x;
     tmp.b32 = __builtin_amdgcn_mov_dpp(tmp.b32, dpp_ctrl, row_mask, bank_mask, bound_ctrl);
+    return tmp.val;
+}
+
+template <int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl>
+static __device__ __forceinline__ half2 hip_move_dpph2_N(half2 x) {
+    typedef union half2_b32 {
+        half2 val;
+        int   b32;
+    } half2_b32_t;
+    half2_b32_t tmp;
+    tmp.val = x;
+    tmp.b32 = __builtin_amdgcn_mov_dpp(tmp.b32, dpp_ctrl, row_mask, bank_mask, bound_ctrl);
+    return tmp.val;
+}
+
+template <int pattern>
+static __device__ __forceinline__ half2 hip_ds_swizzleh2_N(half2 src) {
+    typedef union half2_b32 {
+        half2 val;
+        int   b32;
+    } half2_b32_t;
+    half2_b32_t tmp;
+    tmp.val = src;
+    tmp.b32 = __builtin_amdgcn_ds_swizzle(tmp.b32, pattern);
     return tmp.val;
 }
 
@@ -355,6 +382,15 @@ static __device__ __forceinline__ float2 warp_reduce_sum_impl_amd(float2 a) {
     a.x += hip_move_dppf(a.x, AMD_DPP_ROW_RR(1), 0xF, 0xF, true);
     a.y += hip_move_dppf(a.y, AMD_DPP_ROW_RR(1), 0xF, 0xF, true);
     return a;
+}
+
+static __device__ __forceinline__ half2 warp_reduce_sum_impl_amd(half2 x) {
+    x += hip_ds_swizzleh2(x, AMD_SWIZZLE_MASK(0x1F, 0, 0x10));
+    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(8), 0xF, 0xF, true);
+    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(4), 0xF, 0xF, true);
+    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(2), 0xF, 0xF, true);
+    x += hip_move_dpph2(x, AMD_DPP_ROW_RR(1), 0xF, 0xF, true);
+    return x;
 }
 
 static __device__ __forceinline__ float warp_reduce_max_impl_amd(float x) {
@@ -428,13 +464,7 @@ static __device__ __forceinline__ half2 warp_reduce_sum(half2 a) {
 #if FP16_AVAILABLE
 
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-#pragma unroll
-    for (int mask = 16; mask > 0; mask >>= 1) {
-        const half2 a_other = __shfl_xor_sync(0xffffffff, a, mask, 32);
-        reinterpret_cast<half&>(a.x) +=  __low2half(a_other);
-        reinterpret_cast<half&>(a.y) += __high2half(a_other);
-    }
-    return a;
+    return warp_reduce_sum_impl_amd(a);
 #else
 #pragma unroll
     for (int mask = 16; mask > 0; mask >>= 1) {


### PR DESCRIPTION
The warp_reduce functions use `__shfl_xor_sync()` which on AMD HIP gets turned into the `ds_bpermute` instruction which requires some setup instructions and uses local data share bandwidth and latency. AMD GPUs also support Data-Parallel Primitive (DPP) instructions which can perform certain forms of sharing within a warp for free or nearly free.

Using the DPP intrinsic in this PR my GPU gets 1% faster token generation times, but oddly 0-1% slower prompt processing times. Maybe it has to do with there being 4 fewer waits on LDS memory each reduction and how the GPU schedules warps, but I really have no idea. Other GPU models might behave differently.

Details on the instructions available for sharing within a warp are on [AMD's website](https://gpuopen.com/learn/amd-gcn-assembly-cross-lane-operations/) and within each [ISA's documentation](https://gpuopen.com/amd-isa-documentation/).
I'd like to note that in the event that a warp_reduce function is called with some threads inactive, that the results will differ between GFX9 GPUs and GFX10+, but I don't think this matters since according to the [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#warp-shuffle-description) performing `__shfl_xor_sync()` with inactive threads is undefined on NVIDIA GPUs anyways.

Here are my llama-bench results:
| GPU        | Model                |   Model Size [GiB] | Test   |   t/s master |   t/s PR |   Speedup |
|:-----------|:---------------------|-------------------:|:-------|-------------:|----------------------:|----------:|
| RX 5700 XT | llama 7B Q4_K_S      |               3.59 | pp512  |       300.78 |                298.79 |      0.99 |
| RX 5700 XT | llama 7B Q4_K_S      |               3.59 | tg128  |        46.63 |                 47.18 |      1.01 |
| RX 5700 XT | llama 7B Q8_0        |               6.67 | pp512  |       345.31 |                341.53 |      0.99 |
| RX 5700 XT | llama 7B Q8_0        |               6.67 | tg128  |        38.99 |                 39.38 |      1.01 |
| RX 5700 XT | mpt 7B Q4_0          |               3.64 | pp512  |       339.65 |                339.53 |      1.00 |
| RX 5700 XT | mpt 7B Q4_0          |               3.64 | tg128  |        63.27 |                 63.90 |      1.01 |
| RX 5700 XT | orion 14B Q3_K_S     |               5.96 | pp512  |        84.05 |                 83.88 |      1.00 |
| RX 5700 XT | orion 14B Q3_K_S     |               5.96 | tg128  |        15.91 |                 16.10 |      1.01 |
| RX 5700 XT | phi2 3B Q8_0         |               2.75 | pp512  |       783.94 |                783.35 |      1.00 |
| RX 5700 XT | phi2 3B Q8_0         |               2.75 | tg128  |        76.15 |                 76.67 |      1.01 |
| RX 5700 XT | starcoder2 7B Q4_K_M |               4.22 | pp512  |       280.40 |                279.28 |      1.00 |
| RX 5700 XT | starcoder2 7B Q4_K_M |               4.22 | tg128  |        39.39 |                 39.67 |      1.01 |

I also tried testing SOFT_MAX and saw between 0-8% speedup except for cases with `[1024,1024,1,1]` or `[1023,1023,1,1]` that had max bias of 8, which were ~5% slower. Again I'm not sure why.