### PR TITLE
Fix ROCm link 404 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Building the program with BLAS support may lead to some performance improvements
 
   This provides BLAS acceleration on HIP-supported AMD GPUs.
   Make sure to have ROCm installed.
-  You can download it from your Linux distro's package manager or from here: [ROCm Quick Start (Linux)](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html).
+  You can download it from your Linux distro's package manager or from here: [ROCm Quick Start (Linux)](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/tutorial/quick-start.html#rocm-install-quick).
 
   - Using `make`:
     ```bash


### PR DESCRIPTION
Current [link](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html) gives 404 
<img width="1752" alt="image" src="https://github.com/ggerganov/llama.cpp/assets/967132/abbfb2ae-8d7d-474d-a1bb-26e93df89e8e">

The new link seems to be https://rocm.docs.amd.com/projects/install-on-linux/en/latest/tutorial/quick-start.html#rocm-install-quick as per AMD docs.