### PR TITLE
grammars: 1.5x faster inference w/ complex grammars (vector reserves / reuses)

### DIFF
--- a/examples/gbnf-validator/gbnf-validator.cpp
+++ b/examples/gbnf-validator/gbnf-validator.cpp
@@ -17,7 +17,7 @@ static bool llama_sample_grammar_string(struct llama_grammar * grammar, const st
     size_t pos = 0;
     for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
         auto prev_stacks = grammar->stacks;
-        grammar->stacks = llama_grammar_accept(grammar->rules, grammar->stacks, *it);
+        llama_grammar_accept(grammar->rules, prev_stacks, *it, grammar->stacks);
         if (grammar->stacks.empty()) {
             error_pos = pos;
             error_msg = "Unexpected character '" + unicode_cpt_to_utf8(*it) + "'";

--- a/llama.cpp
+++ b/llama.cpp
@@ -12776,7 +12776,7 @@ void llama_grammar_accept_token(struct llama_context * ctx, struct llama_grammar
     std::vector<std::vector<const llama_grammar_element *>> tmp_new_stacks;
     for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
         llama_grammar_accept(grammar->rules, grammar->stacks, *it, tmp_new_stacks);
-        tmp_new_stacks.swap(grammar->stacks);
+        grammar->stacks = tmp_new_stacks;
     }
     grammar->partial_utf8 = decoded.second;
     GGML_ASSERT(!grammar->stacks.empty());

--- a/llama.cpp
+++ b/llama.cpp
@@ -11912,12 +11912,13 @@ static void llama_grammar_advance_stack(
 // be positioned at a character range (see `llama_grammar_advance_stack`), and
 // produces the N possible stacks if the given char is accepted at those
 // positions
-std::vector<std::vector<const llama_grammar_element *>> llama_grammar_accept(
+void llama_grammar_accept(
         const std::vector<std::vector<llama_grammar_element>>         & rules,
         const std::vector<std::vector<const llama_grammar_element *>> & stacks,
-        const uint32_t                                                  chr) {
+        const uint32_t                                                  chr,
+        std::vector<std::vector<const llama_grammar_element *>>       & new_stacks) {
 
-    std::vector<std::vector<const llama_grammar_element *>> new_stacks;
+    new_stacks.clear();
 
     for (const auto & stack : stacks) {
         if (stack.empty()) {
@@ -11936,8 +11937,6 @@ std::vector<std::vector<const llama_grammar_element *>> llama_grammar_accept(
             llama_grammar_advance_stack(rules, new_stack, new_stacks);
         }
     }
-
-    return new_stacks;
 }
 
 static std::vector<llama_grammar_candidate> llama_grammar_reject_candidates(
@@ -12774,8 +12773,10 @@ void llama_grammar_accept_token(struct llama_context * ctx, struct llama_grammar
     // Note terminating 0 in decoded string
     const auto   decoded     = decode_utf8(piece, grammar->partial_utf8);
     const auto & code_points = decoded.first;
+    std::vector<std::vector<const llama_grammar_element *>> tmp_new_stacks;
     for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
-        grammar->stacks = llama_grammar_accept(grammar->rules, grammar->stacks, *it);
+        llama_grammar_accept(grammar->rules, grammar->stacks, *it, tmp_new_stacks);
+        tmp_new_stacks.swap(grammar->stacks);
     }
     grammar->partial_utf8 = decoded.second;
     GGML_ASSERT(!grammar->stacks.empty());

--- a/llama.cpp
+++ b/llama.cpp
@@ -11951,6 +11951,7 @@ static std::vector<llama_grammar_candidate> llama_grammar_reject_candidates_for_
         const std::vector<llama_grammar_candidate>            & candidates) {
 
     std::vector<llama_grammar_candidate> rejects;
+    rejects.reserve(candidates.size());
 
     if (stack.empty()) {
         for (const auto & tok : candidates) {
@@ -11964,6 +11965,8 @@ static std::vector<llama_grammar_candidate> llama_grammar_reject_candidates_for_
     const llama_grammar_element * stack_pos = stack.back();
 
     std::vector<llama_grammar_candidate> next_candidates;
+    next_candidates.reserve(candidates.size());
+
     for (const auto & tok : candidates) {
         if (*tok.code_points == 0) {
             // reached end of full codepoints in token, reject iff it ended in a partial sequence

--- a/llama.h
+++ b/llama.h
@@ -1097,10 +1097,11 @@ const std::vector<std::pair<std::string, struct ggml_tensor *>> & llama_internal
     struct llama_context * ctx
 );
 
-std::vector<std::vector<const llama_grammar_element *>> llama_grammar_accept(
+void llama_grammar_accept(
         const std::vector<std::vector<llama_grammar_element>>         & rules,
         const std::vector<std::vector<const llama_grammar_element *>> & stacks,
-        const uint32_t                                                  chr);
+        const uint32_t                                                  chr,
+        std::vector<std::vector<const llama_grammar_element *>>       & new_stacks);
 
 std::pair<std::vector<uint32_t>, llama_partial_utf8> decode_utf8(
         const std::string & src,

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -38,7 +38,7 @@ number ::= [0-9]+)""";
 
     for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
         auto prev_stacks = grammar->stacks;
-        grammar->stacks = llama_grammar_accept(grammar->rules, grammar->stacks, *it);
+        llama_grammar_accept(grammar->rules, prev_stacks, *it, grammar->stacks);
         assert(!grammar->stacks.empty());
     }
 
@@ -138,7 +138,7 @@ ws ::= [ \t\n\r]?)""";
         for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
             ++pos;
             auto prev_stacks = grammar->stacks;
-            grammar->stacks = llama_grammar_accept(grammar->rules, grammar->stacks, *it);
+            llama_grammar_accept(grammar->rules, prev_stacks, *it, grammar->stacks);
 
             // Expect that each code point will not cause the grammar to fail
             if (grammar->stacks.empty()) {
@@ -173,7 +173,7 @@ ws ::= [ \t\n\r]?)""";
 
         for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
             auto prev_stacks = grammar->stacks;
-            grammar->stacks = llama_grammar_accept(grammar->rules, grammar->stacks, *it);
+            llama_grammar_accept(grammar->rules, prev_stacks, *it, grammar->stacks);
             if (grammar->stacks.empty()) {
                 parse_failed = true;
                 break;


### PR DESCRIPTION
See discussion in https://github.com/ggerganov/llama.cpp/issues/4218#issuecomment-2049604659

Here's simple code to repro 1.6x faster inference speedup (on Metal) w/ a nested repetition-heavy grammar from https://github.com/ggerganov/llama.cpp/pull/6555 (for JSON schema `{"items": {"type": "number"}, "maxItems": 100}`):

```bash
git clone https://github.com/ochafik/llama.cpp --branch grammar-speedup3 llama.cpp-grammar && \
    cd llama.cpp-grammar && \
    git pull && \
    mkdir -p models/7B

echo '
    decimal-part ::= [0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9])?)?)?)?)?)?)?)?)?)?)?)?)?)?)?
    integral-part ::= [0-9] | [1-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9] ([0-9])?)?)?)?)?)?)?)?)?)?)?)?)?)?)?
    number ::= ("-"? integral-part) ("." decimal-part)? ([eE] [-+]? integral-part)? space
    root ::= "[" space number "," space number "," space number "," space number "," space number "," space number "," space number "," space number "," space number "," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number ("," space number)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)? "]" space
    space ::= " "?
' > json_numbers.grammar

hyperfine \
    --warmup 1 --runs 5 \
    -L branch grammar-speedup3,master \
    --setup 'git checkout {branch} && make clean && make -j LLAMA_CURL=1 main' \
    './main \
        -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf \
        --grammar-file json_numbers.grammar \
        -p "List of 20 integers starting from 0" \
        --seed 12344'
```

<details>
<summary>Show results</summary>

```
Benchmark 1: ./main -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf --grammar-file json_numbers.grammar -p "List of 20 integers starting from 0" --seed 12344 (branch = grammar-speedup3)
  Time (mean ± σ):      8.405 s ±  0.234 s    [User: 6.806 s, System: 0.412 s]
  Range (min … max):    8.179 s …  8.750 s    5 runs
 
Benchmark 2: ./main -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf --grammar-file json_numbers.grammar -p "List of 20 integers starting from 0" --seed 12344 (branch = master)
  Time (mean ± σ):     13.386 s ±  0.109 s    [User: 9.596 s, System: 2.552 s]
  Range (min … max):   13.253 s … 13.520 s    5 runs
 
Summary
  ./main -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf --grammar-file json_numbers.grammar -p "List of 20 integers starting from 0" --seed 12344 (branch = grammar-speedup3) ran
    1.59 ± 0.05 times faster than ./main -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf --grammar-file json_numbers.grammar -p "List of 20 integers starting from 0" --seed 12344 (branch = master)
```

</details>

cc/ @HanClinto 