### PR TITLE
Grammar optimization: eliminate redundant grammar trees (~4x faster grammar sampling)

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -11861,7 +11861,9 @@ static void llama_grammar_advance_stack(
         std::vector<std::vector<const llama_grammar_element *>> & new_stacks) {
 
     if (stack.empty()) {
-        new_stacks.emplace_back(stack);
+        if (std::find(new_stacks.begin(), new_stacks.end(), stack) == new_stacks.end()) {
+            new_stacks.emplace_back(stack);
+        }
         return;
     }
 
@@ -11898,7 +11900,10 @@ static void llama_grammar_advance_stack(
         }
         case LLAMA_GRETYPE_CHAR:
         case LLAMA_GRETYPE_CHAR_NOT:
-            new_stacks.emplace_back(stack);
+            if (std::find(new_stacks.begin(), new_stacks.end(), stack) == new_stacks.end()) {
+                // only add the stack if it's not a duplicate of one we already have
+                new_stacks.emplace_back(stack);
+            }
             break;
         default:
             // end of alternate (LLAMA_GRETYPE_END, LLAMA_GRETYPE_ALT) or middle of char range


### PR DESCRIPTION
# tl;dr

~4x-5x speedup on processing complex grammars.

Previously discussed in https://github.com/ggerganov/llama.cpp/issues/4218#issuecomment-2049728861 

# Motivation:

The grammar stacks have a tendency to explode exponentially in the case of redundant ambiguities (see https://github.com/ggerganov/llama.cpp/issues/4218#issuecomment-2038195981 ). In these cases, the grammar engine winds up duplicating effort by evaluating the feasibility of multiple redundant copies of grammars, even though they are equivalent.


# Fix:

After each token, the grammar engine builds stacks representing the possible directions the parser could go. When building these stacks, this change takes care to not add new grammars to the stack if they are already there. Despite `std::find()` being an O(N) operation, the savings gained from not adding trees of redundant grammars vast outweigh this minor check.

# Results:

## Integration Benchmark
I expanded the grammar integration tests to add some crude timing metrics.

<details> 
<summary>Before:</summary>

```
./tests/test-grammar-integration
Expected error:  parse: error parsing grammar: Undefined rule identifier 'numero'
End of expected error. Test successful.

Timings:
Simple grammar: 18 us
Complex grammar: 939 us
Chained ambiguity: 238687 us
Chained ambiguity (grouped): 45 us
Failure missing root: 5 us
Failure missing reference: 188 us
```
</details>

<details> 
<summary>After:</summary>

```
./tests/test-grammar-integration
Expected error:  parse: error parsing grammar: Undefined rule identifier 'numero'
End of expected error. Test successful.

Timings:
Simple grammar: 38 us
Complex grammar: 1032 us
Chained ambiguity: 71 us
Chained ambiguity (grouped): 19 us
Failure missing root: 4 us
Failure missing reference: 156 us
```
</details>

Note the significant improvement in the chained ambiguity case, which is what this PR was targeting most directly. Most of the other speed differences seem to be hovering around in the noise floor, and don't seem to be consistently faster or slower one way or the other.

## "Full" benchmark

Thanks to @ochafik for teaching me how to use Hyperfine, here are the results of the benchmark cribbed from #6609 for a ~9x speedup vs. master:

<details>
<summary>Hyperfine Results</summary>

```
Benchmark 1: ./main \
        -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf \
        --grammar-file json_numbers.grammar \
        -p "List of 20 integers starting from 0" \
        --seed 12344 (branch = master)
  Time (mean ± σ):     19.028 s ±  0.887 s    [User: 11.001 s, System: 5.890 s]
  Range (min … max):   18.092 s … 20.205 s    5 runs

Benchmark 2: ./main \
        -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf \
        --grammar-file json_numbers.grammar \
        -p "List of 20 integers starting from 0" \
        --seed 12344 (branch = gbnf-optimize-ambiguity2)
  Time (mean ± σ):      2.095 s ±  0.051 s    [User: 0.861 s, System: 0.143 s]
  Range (min … max):    2.058 s …  2.175 s    5 runs

Summary
  ./main \
        -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf \
        --grammar-file json_numbers.grammar \
        -p "List of 20 integers starting from 0" \
        --seed 12344 (branch = gbnf-optimize-ambiguity2) ran
    9.08 ± 0.48 times faster than ./main \
        -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf \
        --grammar-file json_numbers.grammar \
        -p "List of 20 integers starting from 0" \
        --seed 12344 (branch = master)
```
</details>

It's interesting to me that even though this test's grammar seeks to remove redundant ambiguities, this PR still offers enough improvement to be quite significant.