### PR TITLE
Fix for CI macOS-latest-cmake-arm64

### DIFF
--- a/examples/eval-callback/CMakeLists.txt
+++ b/examples/eval-callback/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)
 
 set(TEST_TARGET test-eval-callback)
-add_test(NAME ${TEST_TARGET} COMMAND eval-callback --hf-repo ggml-org/models --hf-file tinyllamas/stories260K.gguf --model stories260K.gguf --prompt hello --seed 42)
+add_test(NAME ${TEST_TARGET} COMMAND eval-callback --hf-repo ggml-org/models --hf-file tinyllamas/stories260K.gguf --model stories260K.gguf --prompt hello --seed 42 -ngl 0)
 set_property(TEST ${TEST_TARGET} PROPERTY LABELS eval-callback curl)


### PR DESCRIPTION
As suggested by @slaren ( https://github.com/ggerganov/llama.cpp/pull/6576#issuecomment-2050509372 ), disabling Metal for test invocation of eval-callback to fix CI build on macOS-latest-cmake-arm64

Example failure:
https://github.com/ggerganov/llama.cpp/actions/runs/8651988935/job/23723903645#step:5:4773