### PR TITLE
ci : disable Metal for macOS-latest-cmake-x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,9 @@ jobs:
           sysctl -a
           mkdir build
           cd build
-          cmake -DLLAMA_FATAL_WARNINGS=ON -DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_CURL=ON ..
+          # Metal is disabled due to intermittent failures with Github runners not having a GPU:
+          # https://github.com/ggerganov/llama.cpp/actions/runs/8635935781/job/23674807267#step:5:2313
+          cmake -DLLAMA_FATAL_WARNINGS=ON -DLLAMA_METAL=OFF -DLLAMA_CURL=ON ..
           cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test


### PR DESCRIPTION
Sometimes these runners get some sort of virtualized GPU (`Apple Paravirtual device`):

https://github.com/ggerganov/llama.cpp/actions/runs/8612505990/job/23601856885#step:5:2314

And sometimes they don't get the device which is causing the CI to fail:

https://github.com/ggerganov/llama.cpp/actions/runs/8635935781/job/23674807267#step:5:2313

Disabling this for now since Intel Mac + Metal is quite outdated technology anyway. Might find ways to add a node to `ggml-ci` in the future for this configuration