### PR TITLE
eval-callback: use ggml_op_desc to pretty print unary operator name

### DIFF
--- a/examples/eval-callback/eval-callback.cpp
+++ b/examples/eval-callback/eval-callback.cpp
@@ -93,7 +93,7 @@ static bool ggml_debug(struct ggml_tensor * t, bool ask, void * user_data) {
     }
 
     printf("%s: %24s = (%s) %10s(%s{%s}, %s}) = {%s}\n", __func__,
-           t->name, ggml_type_name(t->type), ggml_op_name(t->op),
+           t->name, ggml_type_name(t->type), ggml_op_desc(t),
            src0->name, ggml_ne_string(src0).c_str(),
            src1 ? src1_str : "",
            ggml_ne_string(t).c_str());


### PR DESCRIPTION
### Context

Unary operator name was not printed. 

Suggested by @slaren here: https://github.com/ggerganov/llama.cpp/pull/6576#discussion_r1561649072

Before:
```
ggml_debug:           ffn_moe_silu-0 = (f32)      UNARY(ffn_moe_gate-0{10752, 3, 1, 1}, }) = {10752, 3, 1, 1}
                                     [
                                      [
                                       [  0.0065,   4.0065,   8.0065, ...],
                                       [43008.0078, 43012.0078, 43016.0078, ...],
                                       [86016.0078, 86020.0078, 86024.0078, ...],
                                      ],
                                     ]
                                     sum = 387108.062500
```

After:
```
ggml_debug:           ffn_moe_silu-0 = (f32)       SILU(ffn_moe_gate-0{10752, 3, 1, 1}, }) = {10752, 3, 1, 1}
                                     [
                                      [
                                       [  0.0065,   4.0065,   8.0065, ...],
                                       [43008.0078, 43012.0078, 43016.0078, ...],
                                       [86016.0078, 86020.0078, 86024.0078, ...],
                                      ],
                                     ]
                                     sum = 387108.062500
```