### PR TITLE
CUDA: faster FlashAttention for batch sizes > 1

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -141,6 +141,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
         info.devices[id].smpb = prop.sharedMemPerBlock;
+        info.devices[id].nsm  = prop.multiProcessorCount;
     }
 
     for (int id = 0; id < info.device_count; ++id) {

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -390,6 +390,11 @@ static __device__ __forceinline__ int __dp4a(const int a, const int b, int c) {
 }
 #endif // defined(GGML_USE_HIPBLAS)
 
+#define FP16_AVAILABLE     defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) ? \
+    defined(RDNA1) || defined(RDNA2) || defined(RDNA3) : __CUDA_ARCH__ >= CC_PASCAL
+#define FP16_MMA_AVAILABLE defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) ? \
+                                        defined(RDNA3) : __CUDA_ARCH__ >= CC_VOLTA
+
 // TODO: move to ggml-common.h
 static const __device__ int8_t kvalues_iq4nl[16] = {-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113};
 
@@ -403,6 +408,7 @@ struct ggml_cuda_device_info {
 
     struct cuda_device_info {
         int     cc;                 // compute capability
+        int     nsm;                // number of streaming multiprocessors
         size_t  smpb;               // max. shared memory per block
         bool    vmm;                // virtual memory support
         size_t  vmm_granularity;    // granularity of virtual memory

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -306,6 +306,13 @@ static __device__ __forceinline__ half2 warp_reduce_max(half2 x) {
 #endif // !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) && __CUDA_ARCH__ >= CC_PASCAL && CUDART_VERSION >= CUDART_HMAX
 }
 
+#if CUDART_VERSION < 12000
+static __device__ __forceinline__ uint __hgt2_mask(const half2 a, const half2 b) {
+    const uint mask_low  = 0x0000FFFF * ( __low2half(a) >  __low2half(b));
+    const uint mask_high = 0xFFFF0000 * (__high2half(a) > __high2half(b));
+    return mask_low | mask_high;
+}
+#endif // CUDART_VERSION < 12000
 
 #if defined(GGML_USE_HIPBLAS)
 #define __CUDA_ARCH__ 1300


### PR DESCRIPTION
This PR does the following:

* Generalize the code for running multiple FlashAttention blocks in parallel to work for batch sizes > 1. This helps with performance for small batch sizes and small numbers of attention heads.
* Extend the CUDA device info to also include the number of streaming multiprocessors.
* Refactor the FlashAttention host code. Instead of macros it now uses templates. Instead of fixed values for `parallel_blocks` the value is chosen based on the number of streaming multiprocessors; as long as the increased number of blocks still finishes in a single wave it's basically always worthwhile to do.
* Add two new macros `FP16_AVAILABLE` and `FP16_MMA_AVAILABLE` that can be used to determine the available of general FP16 intrinsics and FP16 tensor cores **in device code**.

Performance relative to current FlashAttention kernels:

<details>

| GPU        | Model           |     Batch size | Test     |     t/s gg/flash-attn |     t/s jg/flash-attn-20 |     Speedup |
| :--------- | :-------------- | -------------: | :------- | --------------------: | -----------------------: | ----------: |
| RTX 4090   | gemma 2B F16    |              1 | pp4096   |                156.93 |                   157.16 |        1.00 |
| RTX 4090   | gemma 2B F16    |              2 | pp4096   |                245.72 |                   275.30 |        1.12 |
| RTX 4090   | gemma 2B F16    |              4 | pp4096   |                501.66 |                   562.81 |        1.12 |
| RTX 4090   | gemma 2B F16    |              8 | pp4096   |                994.84 |                  1111.80 |        1.12 |
| RTX 4090   | gemma 2B F16    |             16 | pp4096   |               1963.72 |                  2180.48 |        1.11 |
| RTX 4090   | gemma 2B F16    |             32 | pp4096   |               3763.81 |                  4252.16 |        1.13 |
| RTX 4090   | gemma 2B F16    |             64 | pp4096   |               6609.81 |                  7601.76 |        1.15 |
| RTX 4090   | gemma 2B F16    |            128 | pp4096   |              12166.87 |                 13375.50 |        1.10 |
| RTX 4090   | gemma 2B F16    |            256 | pp4096   |              20393.39 |                 20825.66 |        1.02 |
| RTX 4090   | gemma 2B F16    |            512 | pp4096   |              28404.84 |                 28339.54 |        1.00 |
| RTX 4090   | gemma 2B F16    |           1024 | pp4096   |              29462.16 |                 29472.00 |        1.00 |
| RTX 4090   | gemma 2B F16    |           2048 | pp4096   |              30085.55 |                 30055.65 |        1.00 |
| RTX 4090   | gemma 2B F16    |           4096 | pp4096   |              30343.08 |                 30317.35 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |              1 | pp4096   |                146.68 |                   146.38 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |              2 | pp4096   |                276.31 |                   279.32 |        1.01 |
| RTX 4090   | llama 7B Q4_0   |              4 | pp4096   |                547.74 |                   551.97 |        1.01 |
| RTX 4090   | llama 7B Q4_0   |              8 | pp4096   |                929.35 |                   931.75 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |             16 | pp4096   |               1317.17 |                  1310.32 |        0.99 |
| RTX 4090   | llama 7B Q4_0   |             32 | pp4096   |               1600.31 |                  1606.50 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |             64 | pp4096   |               2119.35 |                  2168.12 |        1.02 |
| RTX 4090   | llama 7B Q4_0   |            128 | pp4096   |               3705.01 |                  3710.46 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |            256 | pp4096   |               6069.55 |                  6057.19 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |            512 | pp4096   |               7829.50 |                  7821.58 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |           1024 | pp4096   |               7843.75 |                  7836.71 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |           2048 | pp4096   |               7864.92 |                  7846.92 |        1.00 |
| RTX 4090   | llama 7B Q4_0   |           4096 | pp4096   |               7854.40 |                  7847.28 |        1.00 |
| RTX 4090   | phi2 3B F16     |              1 | pp4096   |                123.51 |                   123.77 |        1.00 |
| RTX 4090   | phi2 3B F16     |              2 | pp4096   |                203.90 |                   218.77 |        1.07 |
| RTX 4090   | phi2 3B F16     |              4 | pp4096   |                405.53 |                   434.01 |        1.07 |
| RTX 4090   | phi2 3B F16     |              8 | pp4096   |                803.90 |                   852.98 |        1.06 |
| RTX 4090   | phi2 3B F16     |             16 | pp4096   |               1571.15 |                  1673.18 |        1.06 |
| RTX 4090   | phi2 3B F16     |             32 | pp4096   |               3085.40 |                  3206.54 |        1.04 |
| RTX 4090   | phi2 3B F16     |             64 | pp4096   |               5461.86 |                  5863.08 |        1.07 |
| RTX 4090   | phi2 3B F16     |            128 | pp4096   |               9513.56 |                  9499.56 |        1.00 |
| RTX 4090   | phi2 3B F16     |            256 | pp4096   |              15202.10 |                 15237.75 |        1.00 |
| RTX 4090   | phi2 3B F16     |            512 | pp4096   |              17564.81 |                 17577.25 |        1.00 |
| RTX 4090   | phi2 3B F16     |           1024 | pp4096   |              17506.02 |                 17510.25 |        1.00 |
| RTX 4090   | phi2 3B F16     |           2048 | pp4096   |              17565.62 |                 17571.12 |        1.00 |
| RTX 4090   | phi2 3B F16     |           4096 | pp4096   |              17604.26 |                 17618.98 |        1.00 |
| RTX 3090   | gemma 2B F16    |              1 | pp4096   |                135.58 |                   135.96 |        1.00 |
| RTX 3090   | gemma 2B F16    |              2 | pp4096   |                199.72 |                   229.19 |        1.15 |
| RTX 3090   | gemma 2B F16    |              4 | pp4096   |                401.66 |                   462.41 |        1.15 |
| RTX 3090   | gemma 2B F16    |              8 | pp4096   |                795.51 |                   912.27 |        1.15 |
| RTX 3090   | gemma 2B F16    |             16 | pp4096   |               1553.86 |                  1768.38 |        1.14 |
| RTX 3090   | gemma 2B F16    |             32 | pp4096   |               2909.64 |                  3246.80 |        1.12 |
| RTX 3090   | gemma 2B F16    |             64 | pp4096   |               5255.95 |                  5941.40 |        1.13 |
| RTX 3090   | gemma 2B F16    |            128 | pp4096   |               9130.67 |                 10118.23 |        1.11 |
| RTX 3090   | gemma 2B F16    |            256 | pp4096   |              11761.76 |                 11962.81 |        1.02 |
| RTX 3090   | gemma 2B F16    |            512 | pp4096   |              13284.64 |                 13149.46 |        0.99 |
| RTX 3090   | gemma 2B F16    |           1024 | pp4096   |              13546.97 |                 13429.50 |        0.99 |
| RTX 3090   | gemma 2B F16    |           2048 | pp4096   |              13625.12 |                 13651.72 |        1.00 |
| RTX 3090   | gemma 2B F16    |           4096 | pp4096   |              13673.57 |                 13569.27 |        0.99 |
| RTX 3090   | llama 7B Q4_0   |              1 | pp4096   |                125.30 |                   126.03 |        1.01 |
| RTX 3090   | llama 7B Q4_0   |              2 | pp4096   |                225.69 |                   240.07 |        1.06 |
| RTX 3090   | llama 7B Q4_0   |              4 | pp4096   |                383.69 |                   406.05 |        1.06 |
| RTX 3090   | llama 7B Q4_0   |              8 | pp4096   |                533.13 |                   542.02 |        1.02 |
| RTX 3090   | llama 7B Q4_0   |             16 | pp4096   |                569.25 |                   571.30 |        1.00 |
| RTX 3090   | llama 7B Q4_0   |             32 | pp4096   |                629.32 |                   634.80 |        1.01 |
| RTX 3090   | llama 7B Q4_0   |             64 | pp4096   |               1320.76 |                  1348.39 |        1.02 |
| RTX 3090   | llama 7B Q4_0   |            128 | pp4096   |               2236.75 |                  2244.31 |        1.00 |
| RTX 3090   | llama 7B Q4_0   |            256 | pp4096   |               3149.86 |                  3168.56 |        1.01 |
| RTX 3090   | llama 7B Q4_0   |            512 | pp4096   |               3706.48 |                  3737.65 |        1.01 |
| RTX 3090   | llama 7B Q4_0   |           1024 | pp4096   |               3718.74 |                  3745.87 |        1.01 |
| RTX 3090   | llama 7B Q4_0   |           2048 | pp4096   |               3730.79 |                  3746.94 |        1.00 |
| RTX 3090   | llama 7B Q4_0   |           4096 | pp4096   |               3735.57 |                  3749.07 |        1.00 |
| RTX 3090   | phi2 3B F16     |              1 | pp4096   |                106.93 |                   106.64 |        1.00 |
| RTX 3090   | phi2 3B F16     |              2 | pp4096   |                170.42 |                   185.58 |        1.09 |
| RTX 3090   | phi2 3B F16     |              4 | pp4096   |                337.30 |                   369.12 |        1.09 |
| RTX 3090   | phi2 3B F16     |              8 | pp4096   |                666.42 |                   726.71 |        1.09 |
| RTX 3090   | phi2 3B F16     |             16 | pp4096   |               1293.18 |                  1339.44 |        1.04 |
| RTX 3090   | phi2 3B F16     |             32 | pp4096   |               2434.70 |                  2535.57 |        1.04 |
| RTX 3090   | phi2 3B F16     |             64 | pp4096   |               4246.23 |                  4539.63 |        1.07 |
| RTX 3090   | phi2 3B F16     |            128 | pp4096   |               6835.86 |                  6897.72 |        1.01 |
| RTX 3090   | phi2 3B F16     |            256 | pp4096   |               7753.84 |                  7776.34 |        1.00 |
| RTX 3090   | phi2 3B F16     |            512 | pp4096   |               8814.01 |                  8762.43 |        0.99 |
| RTX 3090   | phi2 3B F16     |           1024 | pp4096   |               8585.54 |                  8605.73 |        1.00 |
| RTX 3090   | phi2 3B F16     |           2048 | pp4096   |               8668.73 |                  8666.90 |        1.00 |
| RTX 3090   | phi2 3B F16     |           4096 | pp4096   |               8557.30 |                  8580.58 |        1.00 |

</details>

Performance relative to master:

<details>

| GPU        | Model           |     Batch size | Test     |     t/s master |     t/s jg/flash-attn-20 |     Speedup |
| :--------- | :-------------- | -------------: | :------- | -------------: | -----------------------: | ----------: |
| RTX 4090   | gemma 2B F16    |              1 | pp4096   |         148.07 |                   157.16 |        1.06 |
| RTX 4090   | gemma 2B F16    |              2 | pp4096   |         271.97 |                   275.30 |        1.01 |
| RTX 4090   | gemma 2B F16    |              4 | pp4096   |         557.04 |                   562.81 |        1.01 |
| RTX 4090   | gemma 2B F16    |              8 | pp4096   |        1101.79 |                  1111.80 |        1.01 |
| RTX 4090   | gemma 2B F16    |             16 | pp4096   |        2155.89 |                  2180.48 |        1.01 |
| RTX 4090   | gemma 2B F16    |             32 | pp4096   |        4169.48 |                  4252.16 |        1.02 |
| RTX 4090   | gemma 2B F16    |             64 | pp4096   |        7436.70 |                  7601.76 |        1.02 |
| RTX 4090   | gemma 2B F16    |            128 | pp4096   |       12903.88 |                 13375.50 |        1.04 |
| RTX 4090   | gemma 2B F16    |            256 | pp4096   |       20643.73 |                 20825.66 |        1.01 |
| RTX 4090   | gemma 2B F16    |            512 | pp4096   |       26408.48 |                 28339.54 |        1.07 |
| RTX 4090   | gemma 2B F16    |           1024 | pp4096   |       27284.12 |                 29472.00 |        1.08 |
| RTX 4090   | gemma 2B F16    |           2048 | pp4096   |       27874.57 |                 30055.65 |        1.08 |
| RTX 4090   | gemma 2B F16    |           4096 | pp4096   |       28060.68 |                 30317.35 |        1.08 |
| RTX 4090   | llama 7B Q4_0   |              1 | pp4096   |         135.48 |                   146.38 |        1.08 |
| RTX 4090   | llama 7B Q4_0   |              2 | pp4096   |         270.53 |                   279.32 |        1.03 |
| RTX 4090   | llama 7B Q4_0   |              4 | pp4096   |         532.41 |                   551.97 |        1.04 |
| RTX 4090   | llama 7B Q4_0   |              8 | pp4096   |         902.26 |                   931.75 |        1.03 |
| RTX 4090   | llama 7B Q4_0   |             16 | pp4096   |        1268.07 |                  1310.32 |        1.03 |
| RTX 4090   | llama 7B Q4_0   |             32 | pp4096   |        1550.51 |                  1606.50 |        1.04 |
| RTX 4090   | llama 7B Q4_0   |             64 | pp4096   |        2078.30 |                  2168.12 |        1.04 |
| RTX 4090   | llama 7B Q4_0   |            128 | pp4096   |        3380.61 |                  3710.46 |        1.10 |
| RTX 4090   | llama 7B Q4_0   |            256 | pp4096   |        4705.68 |                  6057.19 |        1.29 |
| RTX 4090   | llama 7B Q4_0   |            512 | pp4096   |        5487.18 |                  7821.58 |        1.43 |
| RTX 4090   | llama 7B Q4_0   |           1024 | pp4096   |        5502.76 |                  7836.71 |        1.42 |
| RTX 4090   | llama 7B Q4_0   |           2048 | pp4096   |        5498.61 |                  7846.92 |        1.43 |
| RTX 4090   | llama 7B Q4_0   |           4096 | pp4096   |        5507.25 |                  7847.28 |        1.42 |
| RTX 4090   | phi2 3B F16     |              1 | pp4096   |         119.42 |                   123.77 |        1.04 |
| RTX 4090   | phi2 3B F16     |              2 | pp4096   |         211.06 |                   218.77 |        1.04 |
| RTX 4090   | phi2 3B F16     |              4 | pp4096   |         418.31 |                   434.01 |        1.04 |
| RTX 4090   | phi2 3B F16     |              8 | pp4096   |         816.89 |                   852.98 |        1.04 |
| RTX 4090   | phi2 3B F16     |             16 | pp4096   |        1563.67 |                  1673.18 |        1.07 |
| RTX 4090   | phi2 3B F16     |             32 | pp4096   |        2922.31 |                  3206.54 |        1.10 |
| RTX 4090   | phi2 3B F16     |             64 | pp4096   |        5083.17 |                  5863.08 |        1.15 |
| RTX 4090   | phi2 3B F16     |            128 | pp4096   |        7471.62 |                  9499.56 |        1.27 |
| RTX 4090   | phi2 3B F16     |            256 | pp4096   |        9204.74 |                 15237.75 |        1.66 |
| RTX 4090   | phi2 3B F16     |            512 | pp4096   |        9661.48 |                 17577.25 |        1.82 |
| RTX 4090   | phi2 3B F16     |           1024 | pp4096   |        9702.15 |                 17510.25 |        1.80 |
| RTX 4090   | phi2 3B F16     |           2048 | pp4096   |        9720.99 |                 17571.12 |        1.81 |
| RTX 4090   | phi2 3B F16     |           4096 | pp4096   |        9733.62 |                 17618.98 |        1.81 |
| RTX 3090   | gemma 2B F16    |              1 | pp4096   |         125.05 |                   135.96 |        1.09 |
| RTX 3090   | gemma 2B F16    |              2 | pp4096   |         224.34 |                   229.19 |        1.02 |
| RTX 3090   | gemma 2B F16    |              4 | pp4096   |         447.26 |                   462.41 |        1.03 |
| RTX 3090   | gemma 2B F16    |              8 | pp4096   |         862.20 |                   912.27 |        1.06 |
| RTX 3090   | gemma 2B F16    |             16 | pp4096   |        1592.68 |                  1768.38 |        1.11 |
| RTX 3090   | gemma 2B F16    |             32 | pp4096   |        3192.15 |                  3246.80 |        1.02 |
| RTX 3090   | gemma 2B F16    |             64 | pp4096   |        5759.86 |                  5941.40 |        1.03 |
| RTX 3090   | gemma 2B F16    |            128 | pp4096   |        9357.61 |                 10118.23 |        1.08 |
| RTX 3090   | gemma 2B F16    |            256 | pp4096   |       10963.78 |                 11962.81 |        1.09 |
| RTX 3090   | gemma 2B F16    |            512 | pp4096   |       12014.60 |                 13149.46 |        1.09 |
| RTX 3090   | gemma 2B F16    |           1024 | pp4096   |       12209.17 |                 13429.50 |        1.10 |
| RTX 3090   | gemma 2B F16    |           2048 | pp4096   |       12230.41 |                 13651.72 |        1.12 |
| RTX 3090   | gemma 2B F16    |           4096 | pp4096   |       12390.53 |                 13569.27 |        1.10 |
| RTX 3090   | llama 7B Q4_0   |              1 | pp4096   |         114.09 |                   126.03 |        1.10 |
| RTX 3090   | llama 7B Q4_0   |              2 | pp4096   |         214.85 |                   240.07 |        1.12 |
| RTX 3090   | llama 7B Q4_0   |              4 | pp4096   |         351.06 |                   406.05 |        1.16 |
| RTX 3090   | llama 7B Q4_0   |              8 | pp4096   |         466.90 |                   542.02 |        1.16 |
| RTX 3090   | llama 7B Q4_0   |             16 | pp4096   |         476.37 |                   571.30 |        1.20 |
| RTX 3090   | llama 7B Q4_0   |             32 | pp4096   |         615.67 |                   634.80 |        1.03 |
| RTX 3090   | llama 7B Q4_0   |             64 | pp4096   |        1214.87 |                  1348.39 |        1.11 |
| RTX 3090   | llama 7B Q4_0   |            128 | pp4096   |        1949.06 |                  2244.31 |        1.15 |
| RTX 3090   | llama 7B Q4_0   |            256 | pp4096   |        2635.02 |                  3168.56 |        1.20 |
| RTX 3090   | llama 7B Q4_0   |            512 | pp4096   |        3008.32 |                  3737.65 |        1.24 |
| RTX 3090   | llama 7B Q4_0   |           1024 | pp4096   |        3009.86 |                  3745.87 |        1.24 |
| RTX 3090   | llama 7B Q4_0   |           2048 | pp4096   |        3015.45 |                  3746.94 |        1.24 |
| RTX 3090   | llama 7B Q4_0   |           4096 | pp4096   |        3011.98 |                  3749.07 |        1.24 |
| RTX 3090   | phi2 3B F16     |              1 | pp4096   |         101.03 |                   106.64 |        1.06 |
| RTX 3090   | phi2 3B F16     |              2 | pp4096   |         176.91 |                   185.58 |        1.05 |
| RTX 3090   | phi2 3B F16     |              4 | pp4096   |         343.75 |                   369.12 |        1.07 |
| RTX 3090   | phi2 3B F16     |              8 | pp4096   |         659.73 |                   726.71 |        1.10 |
| RTX 3090   | phi2 3B F16     |             16 | pp4096   |        1218.31 |                  1339.44 |        1.10 |
| RTX 3090   | phi2 3B F16     |             32 | pp4096   |        2154.24 |                  2535.57 |        1.18 |
| RTX 3090   | phi2 3B F16     |             64 | pp4096   |        3501.02 |                  4539.63 |        1.30 |
| RTX 3090   | phi2 3B F16     |            128 | pp4096   |        4817.51 |                  6897.72 |        1.43 |
| RTX 3090   | phi2 3B F16     |            256 | pp4096   |        5339.66 |                  7776.34 |        1.46 |
| RTX 3090   | phi2 3B F16     |            512 | pp4096   |        5731.00 |                  8762.43 |        1.53 |
| RTX 3090   | phi2 3B F16     |           1024 | pp4096   |        5747.72 |                  8605.73 |        1.50 |
| RTX 3090   | phi2 3B F16     |           2048 | pp4096   |        5766.92 |                  8666.90 |        1.50 |
| RTX 3090   | phi2 3B F16     |           4096 | pp4096   |        5782.52 |                  8580.58 |        1.48 |

</details>

On my systems FlashAttention now seems to be universally faster than master.