### PR TITLE
CPU F16->F32 conversion speed improvement

### DIFF
--- a/ggml-impl.h
+++ b/ggml-impl.h
@@ -106,6 +106,9 @@ typedef uint16_t ggml_fp16_internal_t;
 #ifdef _MSC_VER
 #define GGML_COMPUTE_FP16_TO_FP32(x) _mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(x)))
 #define GGML_COMPUTE_FP32_TO_FP16(x) _mm_extract_epi16(_mm_cvtps_ph(_mm_set_ss(x), 0), 0)
+//If we have F16C, testing shows it's much faster than using the lookup tables.
+#define GGML_FP16_TO_FP32(x) GGML_COMPUTE_FP16_TO_FP32(x)
+#define GGML_FP32_TO_FP16(x) GGML_COMPUTE_FP32_TO_FP16(x)
 #else
 #define GGML_COMPUTE_FP16_TO_FP32(x) _cvtsh_ss(x)
 #define GGML_COMPUTE_FP32_TO_FP16(x) _cvtss_sh(x, 0)


### PR DESCRIPTION
I did some testing of pure CPU inference on AVX2 processor, and found that the F16->F32 conversion was a bottleneck when inferencing a Q4_K model.  roughly 10% of the time is spent in ``ggml_vec_dot_q4_K_q8_K`` is spent in ``GGML_FP16_TO_FP32``.

When doing inference on a CPU, if you have F16C available, it's better to use AVX instead of the lookup table to do the conversion.  Currently the code uses AVX to populate a F16->F32 conversion table, and lookups are done on that table.  Calling off to AVX, this should be doable in 3 clocks, and will always be faster then reading the memory table.  Targets that don't have F16C are not impacted.  I don't see any way that the old code will be faster for anyone that has F16C.

Speeds from a few different platforms:

Against a Q4 model, Ryzen 7xxx processor  (my computer)

```
=== Before ===

llama_print_timings:        load time =    2433.44 ms
llama_print_timings:      sample time =      54.51 ms /   400 runs   (    0.14 ms per token,  7338.51 tokens per second)
llama_print_timings: prompt eval time =   13711.82 ms /    19 tokens (  721.67 ms per token,     1.39 tokens per second)
llama_print_timings:        eval time =  321072.29 ms /   399 runs   (  804.69 ms per token,     1.24 tokens per second)
llama_print_timings:       total time =  335346.16 ms /   418 tokens
Log end


llama_print_timings:        load time =    2512.94 ms
llama_print_timings:      sample time =      18.02 ms /   129 runs   (    0.14 ms per token,  7160.30 tokens per second)
llama_print_timings: prompt eval time =   13168.16 ms /    19 tokens (  693.06 ms per token,     1.44 tokens per second)
llama_print_timings:        eval time =  110176.79 ms /   128 runs   (  860.76 ms per token,     1.16 tokens per second)
llama_print_timings:       total time =  123534.11 ms /   147 tokens
Log end


llama_print_timings:        load time =    2455.85 ms
llama_print_timings:      sample time =      19.49 ms /   139 runs   (    0.14 ms per token,  7130.40 tokens per second)
llama_print_timings: prompt eval time =   13201.04 ms /    19 tokens (  694.79 ms per token,     1.44 tokens per second)
llama_print_timings:        eval time =  113009.18 ms /   138 runs   (  818.91 ms per token,     1.22 tokens per second)
llama_print_timings:       total time =  126409.26 ms /   157 tokens
Log end


=== After ===


llama_print_timings:        load time =    2049.71 ms
llama_print_timings:      sample time =      27.37 ms /   199 runs   (    0.14 ms per token,  7271.00 tokens per second)
llama_print_timings: prompt eval time =    9971.78 ms /    19 tokens (  524.83 ms per token,     1.91 tokens per second)
llama_print_timings:        eval time =  126573.58 ms /   198 runs   (  639.26 ms per token,     1.56 tokens per second)
llama_print_timings:       total time =  136830.32 ms /   217 tokens
Log end


llama_print_timings:        load time =    1993.39 ms
llama_print_timings:      sample time =      54.28 ms /   400 runs   (    0.14 ms per token,  7368.65 tokens per second)
llama_print_timings: prompt eval time =   10006.23 ms /    19 tokens (  526.64 ms per token,     1.90 tokens per second)
llama_print_timings:        eval time =  243163.04 ms /   399 runs   (  609.43 ms per token,     1.64 tokens per second)
llama_print_timings:       total time =  253728.56 ms /   418 tokens
Log end


llama_print_timings:        load time =    2039.17 ms
llama_print_timings:      sample time =      20.30 ms /   150 runs   (    0.14 ms per token,  7389.16 tokens per second)
llama_print_timings: prompt eval time =    9980.97 ms /    19 tokens (  525.31 ms per token,     1.90 tokens per second)
llama_print_timings:        eval time =   88841.93 ms /   149 runs   (  596.25 ms per token,     1.68 tokens per second)
llama_print_timings:       total time =   99030.65 ms /   168 tokens
Log end
```

On my machine, the Before and After T/s data is pretty tightly grouped, and shows a prompt eval speed increase of 1.4 t/s, to 1.9 t/s.  Eval time went from 1.2 t/s to 1.6 t/s.

I then had two other users test this out.
One was using a 1700X processor, against a Q4K_S model, and went from GenerationSpeed  3.83T/s to 3.99T/s    ProcessingSpeed  1.32T/s to 1.55T/s.  5% in generation, 10% in prompt processing.

Second user was using an Intel E5-2697v2 (So no AVX2, but yes F16C)  against the Mistral 7B Q6KM model.  This is more of a control, I don't expect this to be much of an impact because most of the operations aren't the F16->F32 conversion.  But it's good to see that I didn't somehow make intel processors worse somehow.

ProcessingSpeed   went from 19.65T/s  to 19.64T/s   GenerationSpeed went from 8.92T/s to 9.05T/s.  A slight increase.