### PR TITLE
CUDA: fix matrix multiplication logic for tests

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1946,7 +1946,7 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
     } else if (!split && !fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && src1->ne[1] == 1) {
         // KQV single-batch
         ggml_cuda_mul_mat_vec_nc(ctx, src0, src1, dst);
-    } else if (!split && fp16_performance_good && src0->type == GGML_TYPE_F16 && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
+    } else if (!split && src0->type == GGML_TYPE_F16 && (src1->type == GGML_TYPE_F16 || fp16_performance_good) && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
         // KQ + KQV multi-batch
         ggml_cuda_mul_mat_batched_cublas(ctx, src0, src1, dst);
     } else if (use_dequantize_mul_mat_vec) {


### PR DESCRIPTION
This PR fixes `tests/test-backend-ops` on Pascal. The issue is that the tests pass an instance of `src1` with `GGML_TYPE_F16`. This does not happen during actual inference and was therefore not considered for the logic for selecting a matrix multiplication kernel. For Pascal cards other than the P100 there is no fast evaluation code available either. But since this is a case that does not appear during actual inference it's fine to use the slow code for the tests only. Ceveat: (I think) the tests still fail on Maxwell but honestly I don't think it would be worth the effort to investigate and fix.