### PR TITLE
Fix autoawq gemma convert

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -2262,6 +2262,11 @@ class GemmaModel(Model):
         tensor_map = gguf.get_tensor_name_map(self.model_arch, block_count)
 
         for name, data_torch in self.get_tensors():
+            # lm_head is not used in llama.cpp, while autoawq will include this tensor in model
+            # To prevent errors, skip loading lm_head.weight.
+            if "lm_head.weight" in name:
+                    continue
+
             old_dtype = data_torch.dtype
 
             # convert any unsupported data types to float32

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -2279,8 +2279,9 @@ class GemmaModel(Model):
         for name, data_torch in self.get_tensors():
             # lm_head is not used in llama.cpp, while autoawq will include this tensor in model
             # To prevent errors, skip loading lm_head.weight.
-            if "lm_head.weight" in name:
-                    continue
+            if name == "lm_head.weight":
+                print(f"Skipping get tensor {name!r} in safetensors so that convert can end normally.")
+                continue
 
             old_dtype = data_torch.dtype
 


### PR DESCRIPTION
when using autoawq to quantize gemma-2b-it model, output model-00001-of-00002.safetensors will include lm_head.weight, this pr could prevent convert error happening in

`python convert-hf-to-gguf.py ${quantized_path} --outfile model.gguf`

fix #6633 