### PR TITLE
Qwen2: assume tied weights if lm_head/output weights is missing

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -5184,7 +5184,13 @@ static bool llm_load_tensors(
                     // output
                     {
                         model.output_norm = ml.create_tensor(ctx_output,       tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
-                        model.output      = ml.create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab});
+                        model.output      = ml.create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, false);
+                        // if output is NULL, init from the input tok embed
+                        if (model.output == NULL) {
+                            model.output = ml.create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
+                            ml.n_created--; // artificial tensor
+                            ml.size_data += ggml_nbytes(model.output);
+                        }
                     }
 
                     for (int i = 0; i < n_layer; ++i) {


### PR DESCRIPTION
This PR adds the proper support of Qwen2-0.5B, which uses tied word embeddings. Example config: <https://huggingface.co/Qwen/Qwen1.5-0.5B-Chat/blob/main/config.json#L21>.

Previous attempt: <https://github.com/ggerganov/llama.cpp/pull/6578>