### PR TITLE
llama_get_embeddings_mean_pooled

### DIFF
--- a/examples/gritlm/gritlm.cpp
+++ b/examples/gritlm/gritlm.cpp
@@ -57,8 +57,10 @@ static std::vector<std::vector<float>> encode(llama_context * ctx, const std::ve
         float * raw_embed = emb_unorm.data();
 
         // retrieve summed up token embeddings, skipping instruction tokens,
-        // and writes the result to raw_embed
-        llama_get_embeddings_mean_pooled(ctx, n_inst, n_toks, raw_embed);
+        // and writes the result to raw_embed. We pass 0 for number of
+        // instructions to skip as we have already marked logits = false in the
+        // llama_batch_add loop for instruction tokens.
+        llama_get_embeddings_mean_pooled(ctx, 0, raw_embed);
         std::vector<float> emb_norm(emb_unorm.size());
         llama_embd_normalize(emb_unorm.data(), emb_norm.data(), n_embd);
         result.push_back(emb_norm);

--- a/llama.cpp
+++ b/llama.cpp
@@ -16609,19 +16609,24 @@ float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id
     return it->second.data();
 }
 
-void llama_get_embeddings_mean_pooled(struct llama_context * ctx, int32_t skip_tokens, int32_t batch_tokens, float *dest) {
+void llama_get_embeddings_mean_pooled(struct llama_context * ctx, int32_t skip_tokens, float *dest) {
     GGML_ASSERT(dest);
-    GGML_ASSERT(batch_tokens > 0);
     GGML_ASSERT(skip_tokens >= 0);
+
+    int32_t n_embd = ctx->model.hparams.n_embd;
+    int32_t batch_tokens = ctx->n_outputs;
     GGML_ASSERT(skip_tokens < batch_tokens);
+    GGML_ASSERT(ctx->embd_size >= (size_t)(batch_tokens * n_embd));
+
     float inv_tokens_to_pool = 1.0f / (batch_tokens - skip_tokens);
     GGML_ASSERT(inv_tokens_to_pool > 0.0f);
     GGML_ASSERT(inv_tokens_to_pool <= 1.0f);
-    float * all_token_embedddings = ctx->embd.data();
-    const llama_model * mdl = llama_get_model(ctx);
-    int32_t n_embd = llama_n_embd(mdl); // length of each embedding
+
+    for (int32_t i = 0; i < n_embd; i++) {
+        dest[i] = 0.0f;
+    }
     for (int32_t i = skip_tokens; i < batch_tokens; i++) {
-        float * token_embedding = all_token_embedddings + i * n_embd;
+        float * token_embedding = ctx->embd + i * n_embd;
         for (int32_t j = 0; j < n_embd; j++) {
             dest[j] += token_embedding[j];
         }

--- a/llama.h
+++ b/llama.h
@@ -773,34 +773,22 @@ extern "C" {
     // shape: [n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
 
-    // Get the mean pooled embeddings for a subset of the tokens from the encoding.
-    //
-    // They will not be normalized. see llama_embd_normalize for that.
-    //
-    // The mean pooling here is done outside of the device and thus will work
-    // for model types that currently refuse to build a pooling layer in the
-    // device. Currently two large llama embedding models, GritLM and
-    // e5-mistral are supported; notably both of those are initialized via
-    // build_llama which won't have a pooling layer, inp_mean. Both models rely
-    // on prompts that are tokenized and which contribute to the attention but
-    // which may or may not be included in the mean pooling, depending on the
-    // application.
-    //
-    // TODO: 1. support inp_mean in llama models when mean pooling is specified
-    // so we can have the man calculated on the device and
-    // TODO: 2. also have the context own the destination pooled embedding
-    // memory to be more consistent with other apis, but also continue to
-    // allow application control over skipping some tokens.
-    //
-    // skip_tokens: The number of tokens to skip from the beginning of the batch tokens
-    // batch_tokens: The number of tokens in the batch
-    // dest: The destination array to store the mean pooled embeddings
-    //
-    // 'dest' array pointer must have the same length as the embeddings
-    // 'batch_tokens' - 'skip_tokens' is the number of tokens to pool
-    // [skip_tokens, batch_tokens) is the range of tokens to pool
-    //
-    LLAMA_API void llama_get_embeddings_mean_pooled(struct llama_context * ctx, int32_t skip_tokens, int32_t batch_tokens, float *dest);
+    /// @details: Get the mean pooled embeddings for a subset of the tokens from the encoding.
+    /// @param ctx Pointer to the llama_context.
+    /// @param skip_tokens  The number of tokens to skip from the beginning of the embeddings array of arrays.
+    /// @param dest will store the mean pooled embeddings, so it must point to sizeof(float) * llama_n_embd(model) bytes
+    ///
+    /// If you used llama_batch_get_one and have instructions to skip from the
+    /// embedding, or used llama_batch_add but wish to skip some tokens from the
+    /// beginning even though they have the 'logits' boolean set to true, then
+    /// set skip_tokens to a non-zero value.
+    ///
+    /// Results will not be normalized. Pass the dest of this as src to llama_embd_normalize for that.
+    ///
+    /// The mean pooling here is done outside of the device and thus will work
+    /// for model types that currently don't use the inp_mean pooling layer in the
+    /// device. See the examples/gritlm/gritlm.cpp for an example of how to use this.
+    LLAMA_API void llama_get_embeddings_mean_pooled(struct llama_context * ctx, int32_t skip_tokens, float *dest);
 
     //
     // Vocab

--- a/llama.h
+++ b/llama.h
@@ -773,6 +773,35 @@ extern "C" {
     // shape: [n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
 
+    // Get the mean pooled embeddings for a subset of the tokens from the encoding.
+    //
+    // They will not be normalized. see llama_embd_normalize for that.
+    //
+    // The mean pooling here is done outside of the device and thus will work
+    // for model types that currently refuse to build a pooling layer in the
+    // device. Currently two large llama embedding models, GritLM and
+    // e5-mistral are supported; notably both of those are initialized via
+    // build_llama which won't have a pooling layer, inp_mean. Both models rely
+    // on prompts that are tokenized and which contribute to the attention but
+    // which may or may not be included in the mean pooling, depending on the
+    // application.
+    //
+    // TODO: 1. support inp_mean in llama models when mean pooling is specified
+    // so we can have the man calculated on the device and
+    // TODO: 2. also have the context own the destination pooled embedding
+    // memory to be more consistent with other apis, but also continue to
+    // allow application control over skipping some tokens.
+    //
+    // skip_tokens: The number of tokens to skip from the beginning of the batch tokens
+    // batch_tokens: The number of tokens in the batch
+    // dest: The destination array to store the mean pooled embeddings
+    //
+    // 'dest' array pointer must have the same length as the embeddings
+    // 'batch_tokens' - 'skip_tokens' is the number of tokens to pool
+    // [skip_tokens, batch_tokens) is the range of tokens to pool
+    //
+    LLAMA_API void llama_get_embeddings_mean_pooled(struct llama_context * ctx, int32_t skip_tokens, int32_t batch_tokens, float *dest);
+
     //
     // Vocab
     //


### PR DESCRIPTION
## the problem being solved here

described in https://github.com/ggerganov/llama.cpp/issues/6754 , which was created for the PR.

### It's hard to use llama.cpp on the state of the art embedding models when using language bindings

Several leading models on the MTEB embeddings leaderboard use "large" transformer models that have been fine tuned to produce embeddings instead of or in addition to generating tokens, and in all 3 cases an instruction sequence of tokens is prepended to the query. Examples include GritLM, e5-mistral, and echo-mistral. (links below). While echo-mistral was evaluated using just the last token of the last hidden layer, both GritLM and e5-mistral have been trained and evaluated using mean pooling on the embeddings of the last hidden layer. In the GritLM example we implement that in custom c++ outside of the device.

When attempting to utilize the same functionality with a language binding like `llama_cpp.rb` one quickly finds that you have a choice between:

1. doing the mean polling in the binding language, which is not fast in the case of ruby unless you implement a whole other fast math layer in addition to gguf, or
2. adding llama.cpp mean polling into the binding layer, where it really doesn't seem to belong, or
3. add external mean pooling to llama.cpp at the risk of duplicating the BERT specific mean pooling that is currently available.
4. extending the mean pooling available to non-BERT models, but in a way that allows the application control over how many instruction tokens to skip.

Note that the token skipping requirements would be more complicated if the echo-mistral approach is combined with mean pooling.

I chose option 3 here, because options 1 & 2 seem wrong and I don't know the project well enough to attempt 4, never mind make option 4 flexible enough.

## the change

I refactored the off device mean pooling from examples/gritlm/gritlm.cpp to `llama_get_embeddings_mean_pooled` where it can be picked up by language bindings, or potentially used in a server endpoint.

## testing

I ran `./gritlm --model ./models/ggml-gritlm-7b-q4_k.gguf` before and after the change. I got the same similarities between the vectors before and after:

        Cosine similarity between "Bitcoin: A Peer-to-Peer Electronic Cash System" and "A purely peer-to-peer version of electronic cash w" is: 0.601
        Cosine similarity between "Bitcoin: A Peer-to-Peer Electronic Cash System" and "All text-based language problems can be reduced to" is: 0.098
        Cosine similarity between "Generative Representational Instruction Tuning" and "A purely peer-to-peer version of electronic cash w" is: 0.124
        Cosine similarity between "Generative Representational Instruction Tuning" and "All text-based language problems can be reduced to" is: 0.552
