### PR TITLE
gguf-py: Add IQ1_M to GGML_QUANT_SIZES

### DIFF
--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -859,6 +859,7 @@ GGML_QUANT_SIZES = {
     GGMLQuantizationType.I32:     (1, 4),
     GGMLQuantizationType.I64:     (1, 8),
     GGMLQuantizationType.F64:     (1, 8),
+    GGMLQuantizationType.IQ1_M:   (256, QK_K // 8 + QK_K // 16  + QK_K // 32),
 }
 
 


### PR DESCRIPTION
I've noticed that `IQ1_M` is missing in `GGML_QUANT_SIZES`. This PR addresses that issue by adding `IQ1_M` with the type size from this `static_assert`: https://github.com/ggerganov/llama.cpp/blob/bca40e98149c7b673558ddd7a3ebeffef789349d/ggml-common.h#L392