### PR TITLE
ci: fix job are cancelling each other

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ on:
     -  cron: '04 2 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-${{ github.event.inputs.sha }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ github.event.inputs.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -23,7 +23,7 @@ on:
     -  cron: '2 4 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Context

Jobs have the source branch instead of the current branch in the concurrency group name: `Canceling since a higher priority waiting request for 'Benchmark-refs/heads/master-' exists`

see: 
- https://github.com/ggerganov/llama.cpp/actions/runs/8752700017

This only applies to job with trigger: `pull_request_target`.

### References
- #6243
- #6486
- https://docs.github.com/en/actions/learn-github-actions/contexts