### PR TITLE
doc : server tests require llama to be built with curl enabled

### DIFF
--- a/examples/server/tests/README.md
+++ b/examples/server/tests/README.md
@@ -29,7 +29,7 @@ To mitigate it, you can increase values in `n_predict`, `kv_size`.
 cd ../../..
 mkdir build
 cd build
-cmake ../
+cmake -DLLAMA_CURL=ON ../
 cmake --build . --target server
 ```
 


### PR DESCRIPTION
Server tests require llama.cpp to be built with curl enabled. This updates the tests doc to add `-DLLAMA_CURL=ON` to the build instructions.