### PR TITLE
Update main's interactive mode to use the chat handshake templates support already available in llama.cpp (and currently only used by server,...)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(${TARGET} STATIC
     train.cpp
     ngram-cache.h
     ngram-cache.cpp
+    chaton.hpp
     )
 
 if (BUILD_SHARED_LIBS)

--- a/common/chaton.hpp
+++ b/common/chaton.hpp
@@ -7,18 +7,24 @@
 #include "log.h"
 
 inline std::string llama_chat_apply_template_simple(
-            const std::string & tmpl,
+            const std::string &tmpl,
             const std::string &role,
             const std::string &content,
             bool add_ass) {
     llama_chat_message msg = { role.c_str(), content.c_str() };
-    std::vector<llama_chat_message> msgs{ msg };
+    //std::vector<llama_chat_message> msgs{ msg };
     std::vector<char> buf(content.size() * 2);
 
-    int32_t slen =  llama_chat_apply_template(nullptr, tmpl.c_str(), msgs.data(), msgs.size(), add_ass, buf.data(), buf.size());
+    int32_t slen =  llama_chat_apply_template(nullptr, tmpl.c_str(), &msg, 1, add_ass, buf.data(), buf.size());
+    LOG_TEELN("DBUG:%s:AA:%s:LengthNeeded:%d:BufSizeWas:%zu", __func__, role.c_str(), slen, buf.size());
+    if (slen == -1) {
+        LOG_TEELN("WARN:%s:Unknown template [%s] encounted", __func__, tmpl.c_str());
+        return "";
+    }
     if ((size_t) slen > buf.size()) {
         buf.resize(slen);
-        slen = llama_chat_apply_template(nullptr, tmpl.c_str(), msgs.data(), msgs.size(), add_ass, buf.data(), buf.size());
+        slen = llama_chat_apply_template(nullptr, tmpl.c_str(), &msg, 1, add_ass, buf.data(), buf.size());
+        LOG_TEELN("DBUG:%s:BB:%s:LengthNeeded:%d:BufSizeWas:%zu", __func__, role.c_str(), slen, buf.size());
     }
 
     const std::string tagged_msg(buf.data(), slen);
@@ -28,11 +34,13 @@ inline std::string llama_chat_apply_template_simple(
 
 // return what should be the reverse prompt for the given template id
 // ie possible end text tag(s) of specified model type's chat query response
-std::vector<std::string> llama_chat_reverse_prompt(std::string &template_id) {
+inline std::vector<std::string> llama_chat_reverse_prompt(std::string &template_id) {
     std::vector<std::string> rends;
 
     if (template_id == "chatml") {
         rends.push_back("<|im_start|>user\n");
+    } else if (template_id == "llama2") {
+        rends.push_back("</s>");
     } else if (template_id == "llama3") {
         rends.push_back("<|eot_id|>");
     }

--- a/common/chaton.hpp
+++ b/common/chaton.hpp
@@ -1,5 +1,21 @@
 #pragma once
 
+/**
+ *
+ * Provides a simple and dumb helpers which help chat with llm chat/instruct models
+ * using the chat template expected by them.
+ *
+ * Normally used to tag system prompt and user messages.
+ * Currently used by example/main programs.
+ *
+ * This builds on the llama_chat_apply_template. When adding support for new chat templates
+ * remember to update llama_chat_apply_template_internal as well as llama_chat_reverse_prompt.
+ *
+ * example/main program uses this when --chaton TEMPLATE_ID is passed to it along with -i
+ * sample TEMPLATE_ID's include chatml, llama2, llama3, ...
+ *
+ */
+
 #include <vector>
 #include <string>
 

--- a/common/chaton.hpp
+++ b/common/chaton.hpp
@@ -6,30 +6,33 @@
 #include "llama.h"
 #include "log.h"
 
-inline std::string llama_chat_apply_template_simple(
+// Tag the passed message suitabley as expected by the specified chat handshake template
+// and the role. If the specified template is not supported logic will return false.
+inline bool llama_chat_apply_template_simple(
             const std::string &tmpl,
             const std::string &role,
             const std::string &content,
+            std::string &dst,
             bool add_ass) {
     llama_chat_message msg = { role.c_str(), content.c_str() };
-    //std::vector<llama_chat_message> msgs{ msg };
-    std::vector<char> buf(content.size() * 2);
+    std::vector<char> buf(content.size() * 2); // This may under allot for small messages and over allot for large messages
 
     int32_t slen =  llama_chat_apply_template(nullptr, tmpl.c_str(), &msg, 1, add_ass, buf.data(), buf.size());
-    LOG_TEELN("DBUG:%s:AA:%s:LengthNeeded:%d:BufSizeWas:%zu", __func__, role.c_str(), slen, buf.size());
     if (slen == -1) {
-        LOG_TEELN("WARN:%s:Unknown template [%s] encounted", __func__, tmpl.c_str());
-        return "";
+        LOG_TEELN("WARN:%s:Unknown template [%s] requested", __func__, tmpl.c_str());
+        dst = "";
+        return false;
     }
     if ((size_t) slen > buf.size()) {
+        LOGLN("INFO:%s:%s:LengthNeeded:%d:BufSizeWas:%zu", __func__, role.c_str(), slen, buf.size());
         buf.resize(slen);
         slen = llama_chat_apply_template(nullptr, tmpl.c_str(), &msg, 1, add_ass, buf.data(), buf.size());
-        LOG_TEELN("DBUG:%s:BB:%s:LengthNeeded:%d:BufSizeWas:%zu", __func__, role.c_str(), slen, buf.size());
     }
 
     const std::string tagged_msg(buf.data(), slen);
-    LOGLN("INFO:%s:%s", __func__, tagged_msg.c_str());
-    return tagged_msg;
+    LOGLN("INFO:%s:%s:%s", __func__, role.c_str(), tagged_msg.c_str());
+    dst = tagged_msg;
+    return true;
 }
 
 // return what should be the reverse prompt for the given template id

--- a/common/chaton.hpp
+++ b/common/chaton.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "llama.h"
+#include "log.h"
+
+inline std::string llama_chat_apply_template_simple(
+            const std::string & tmpl,
+            const std::string &role,
+            const std::string &content,
+            bool add_ass) {
+    llama_chat_message msg = { role.c_str(), content.c_str() };
+    std::vector<llama_chat_message> msgs{ msg };
+    std::vector<char> buf(content.size() * 2);
+
+    int32_t slen =  llama_chat_apply_template(nullptr, tmpl.c_str(), msgs.data(), msgs.size(), add_ass, buf.data(), buf.size());
+    if ((size_t) slen > buf.size()) {
+        buf.resize(slen);
+        slen = llama_chat_apply_template(nullptr, tmpl.c_str(), msgs.data(), msgs.size(), add_ass, buf.data(), buf.size());
+    }
+
+    const std::string tagged_msg(buf.data(), slen);
+    LOGLN("INFO:%s:%s", __func__, tagged_msg.c_str());
+    return tagged_msg;
+}
+
+// return what should be the reverse prompt for the given template id
+// ie possible end text tag(s) of specified model type's chat query response
+std::vector<std::string> llama_chat_reverse_prompt(std::string &template_id) {
+    std::vector<std::string> rends;
+
+    if (template_id == "chatml") {
+        rends.push_back("<|im_start|>user\n");
+    } else if (template_id == "llama3") {
+        rends.push_back("<|eot_id|>");
+    }
+    return rends;
+}

--- a/common/chaton.hpp
+++ b/common/chaton.hpp
@@ -36,16 +36,18 @@ inline bool llama_chat_apply_template_simple(
 }
 
 // return what should be the reverse prompt for the given template id
-// ie possible end text tag(s) of specified model type's chat query response
-inline std::vector<std::string> llama_chat_reverse_prompt(std::string &template_id) {
-    std::vector<std::string> rends;
-
+// ie possible end text tag(s) of specified model type's chat query response.
+// Note that It adds these reverse prompts to any that may already exist in the passed vector.
+inline bool llama_chat_reverse_prompt(std::string &template_id, std::vector<std::string> &rprompts) {
     if (template_id == "chatml") {
-        rends.push_back("<|im_start|>user\n");
+        rprompts.push_back("<|im_start|>user\n");
     } else if (template_id == "llama2") {
-        rends.push_back("</s>");
+        rprompts.push_back("</s>");
     } else if (template_id == "llama3") {
-        rends.push_back("<|eot_id|>");
+        rprompts.push_back("<|eot_id|>");
+    } else {
+        LOG_TEELN("WARN:%s:Unknown template [%s] requested", __func__, template_id.c_str());
+        return false;
     }
-    return rends;
+    return true;
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -868,6 +868,15 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.chatml = true;
         return true;
     }
+    if (arg == "--chaton") {
+        params.chaton = true;
+        if (++i >= argc) {
+            invalid_param = true;
+            return true;
+        }
+        params.chaton_template_id = argv[i];
+        return true;
+    }
     if (arg == "--infill") {
         params.infill = true;
         return true;
@@ -1378,6 +1387,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("  --version             show version and build info\n");
     printf("  -i, --interactive     run in interactive mode\n");
     printf("  --interactive-first   run in interactive mode and wait for input right away\n");
+    printf("  --chaton TEMPLATE_ID  allow the interactive mode to apply the specified chat template before sending user input to model (you need to specify -i also)\n");
+    printf("                        TEMPLATE_ID could be chatml, llama3, ...\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
     printf("  -cml, --chatml        run in chatml mode (use with ChatML-compatible models)\n");
     printf("  --multiline-input     allows you to write or paste multiple lines without ending each in '\\'\n");

--- a/common/common.h
+++ b/common/common.h
@@ -139,6 +139,8 @@ struct gpt_params {
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
     bool chatml            = false; // chatml mode (used for models trained on chatml syntax)
+    bool chaton            = false; // chaton mode (used to chat with models which have been trained for chat and or instruct operation)
+    std::string chaton_template_id = "";   // the internal chat template to use
     bool prompt_cache_all  = false; // save user input and generations to prompt cache
     bool prompt_cache_ro   = false; // open the prompt cache read-only and do not update it
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -258,7 +258,9 @@ int main(int argc, char ** argv) {
             params.prompt = "<|im_start|>system\n" + params.prompt + "<|im_end|>";
         }
         if (params.chaton) {
+            LOG_TEELN("DBUG:%s:AA:%s", __func__, params.prompt.c_str());
             params.prompt = llama_chat_apply_template_simple(params.chaton_template_id, "system", params.prompt, false);
+            LOG_TEELN("DBUG:%s:BB:%s", __func__, params.prompt.c_str());
         }
         embd_inp = ::llama_tokenize(ctx, params.prompt, true, true);
     } else {
@@ -372,7 +374,7 @@ int main(int argc, char ** argv) {
         params.interactive_first = true;
         std::vector<std::string> resp_ends = llama_chat_reverse_prompt(params.chaton_template_id);
         if (resp_ends.size() == 0) {
-            LOG_TEELN("ERRR:%s:ChatOn:Unsupported ChatType:%s", __func__, params.chaton_template_id.c_str());
+            LOG_TEELN("ERRR:%s:ChatOn:Unsupported ChatTemplateType:%s", __func__, params.chaton_template_id.c_str());
             exit(1);
         }
         for (size_t i = 0; i < resp_ends.size(); i++)

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -258,9 +258,10 @@ int main(int argc, char ** argv) {
             params.prompt = "<|im_start|>system\n" + params.prompt + "<|im_end|>";
         }
         if (params.chaton) {
-            LOG_TEELN("DBUG:%s:AA:%s", __func__, params.prompt.c_str());
-            params.prompt = llama_chat_apply_template_simple(params.chaton_template_id, "system", params.prompt, false);
-            LOG_TEELN("DBUG:%s:BB:%s", __func__, params.prompt.c_str());
+            if (!llama_chat_apply_template_simple(params.chaton_template_id, "system", params.prompt, params.prompt, false)) {
+                LOG_TEELN("ERRR:%s:Wrt:%s:%s:%s", __func__, params.chaton_template_id.c_str(), "system", params.prompt.c_str());
+                exit(2);
+            }
         }
         embd_inp = ::llama_tokenize(ctx, params.prompt, true, true);
     } else {
@@ -897,7 +898,11 @@ int main(int argc, char ** argv) {
 
                     std::vector<int> line_inp;
                     if (params.chaton) {
-                        std::string f_chat = llama_chat_apply_template_simple(params.chaton_template_id, "user", buffer.c_str(), true);
+                        std::string f_chat;
+                        if (!llama_chat_apply_template_simple(params.chaton_template_id, "user", buffer.c_str(), f_chat, true)) {
+                            LOG_TEELN("ERRR:%s:Wrt:%s:%s:%s", __func__, params.chaton_template_id.c_str(), "user", params.prompt.c_str());
+                            exit(2);
+                        }
                         line_inp = ::llama_tokenize(ctx, f_chat, false, true);
                         LOG("formatted input tokens: %s\n", LOG_TOKENS_TOSTR_PRETTY(ctx, line_inp).c_str());
                         embd_inp.insert(embd_inp.end(), line_inp.begin(), line_inp.end());

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -373,14 +373,9 @@ int main(int argc, char ** argv) {
     // handle chaton mode, it adds on to any reverse prompt specified explicitly by the user
     if (params.chaton) {
         params.interactive_first = true;
-        std::vector<std::string> resp_ends = llama_chat_reverse_prompt(params.chaton_template_id);
-        if (resp_ends.size() == 0) {
+        if (!llama_chat_reverse_prompt(params.chaton_template_id, params.antiprompt)) {
             LOG_TEELN("ERRR:%s:ChatOn:Unsupported ChatTemplateType:%s", __func__, params.chaton_template_id.c_str());
             exit(1);
-        }
-        for (size_t i = 0; i < resp_ends.size(); i++)
-        {
-            params.antiprompt.emplace_back(resp_ends[i]);
         }
     }
 


### PR DESCRIPTION
Currently the interactive mode of main doesnt add any tags to identify system or user messages to the model, by default.

One will have to either
* use the seperate chatml mode to specifically work with chatml supported models.
* or pass in-prefix, in-suffix and reverse-prompt arguments as required to try and match the required chatting template.

This PR tries to add a generic chat mode to main, which can make use of any chat templates already added to llama_chat_apply_template_internal, which is currently used by server logic, but not main logic.

To help with the same a new chaton.hpp file is added to common, which contains
* llama_chat_apply_template_simple, which is a wrapper around llama_chat_apply_template(inturn internal) of lama.cpp
* llama_chat_reverse_prompt which helps add any needed reverse prompts for the requested template standard

To add new chat handshake templates remember to add needed logic to
* llama_chat_apply_template_internal (llama.cpp) and
* llama_chat_reverse_prompt (common/chaton.hpp)

To use this support pass -i and --chaton TEMPLATE_ID to main.
Currently supported templates is chatml and llama2, for other chat handshake template standards already support by chat_apply_template_internal, suitable reverse prompts need to be added to llama_chat_reverse_prompt.


