### PR TITLE
Use `llama_chat_apply_template` in `main` (WIP)

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -322,3 +322,13 @@ llama_control_vector_data llama_control_vector_load(const std::vector<llama_cont
 static const char * const LLM_KV_SPLIT_NO            = "split.no";
 static const char * const LLM_KV_SPLIT_COUNT         = "split.count";
 static const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
+
+//
+// Chat templates utils
+//
+typedef struct chat_message {
+    std::string role;
+    std::string content;
+} chat_message;
+
+std::string chat_get_added_part(const std::vector<chat_message> & messages, const std::string & tmpl);

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 
 #include "llama.h"
+#include "common.h"
 
 int main(void) {
     llama_chat_message conversation[] = {
@@ -96,8 +97,19 @@ int main(void) {
         );
         formatted_chat.resize(res);
         std::string output(formatted_chat.data(), formatted_chat.size());
-        std::cout << output << "\n-------------------------\n";
+        std::cout << output << "\n-----\n";
         assert(output == expected);
+
+        std::vector<chat_message> v_messages;
+        for (size_t i = 0; i < message_count; ++i) {
+            v_messages.push_back({
+                conversation[i].role,
+                conversation[i].content,
+            });
+        }
+        std::cout << "chat_get_added_part(): " << chat_get_added_part(v_messages, custom_template);
+        std::cout << "\n-------------------------\n";
+        // TODO: chat_get_added_part is currently printed for debugging. Should we add tests for it in the future?
     }
     return 0;
 }


### PR DESCRIPTION
Resolve #6391

The core idea is to use `llama_chat_apply_template` to apply the template twice: with and without the last user message. Then, we find the diff between 2 output strings and finally feed it into inference.

Example:

```
<start_of_turn>user
You are a helpful assistant

Hello<end_of_turn>
<start_of_turn>model
Hi there<end_of_turn>
<start_of_turn>user
Who are you<end_of_turn>
<start_of_turn>model
I am an assistant<end_of_turn>
<start_of_turn>user
Another question<end_of_turn>
<start_of_turn>model

-----
chat_get_added_part(): <start_of_turn>user
Another question<end_of_turn>
<start_of_turn>model
```

This approach will require minimal effort to maintain the chat template infrastructure, while using the extract same logic for `main` and `server` (remind: server also have the notion of "prompt cache" which works the same way)

Having to re-format the whole chat history each time seems inefficient at first glance, but it is needed because:
- There're some edge cases, see: https://github.com/ggerganov/llama.cpp/issues/6391#issuecomment-2068131134
- That's the same logic with `server` (which is designed to be stateless)

Then, we find the diff between the 2 strings.

- [x] Implement `chat_get_added_part` to get the diff part with / without the last user message
- [ ] `main` must keep track of the list of messages
- [ ] Update arguments for `main`, deprecate `-cml` (but not remove it) while adding `-chat-template` argument