### PR TITLE
common : fix parallel shard download interleaving output

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1866,7 +1866,7 @@ void llama_batch_add(
 
 #ifdef LLAMA_USE_CURL
 
-static bool llama_download_file(CURL * curl, const char * url, const char * path, boolean_t is_shard) {
+static bool llama_download_file(CURL * curl, const char * url, const char * path, bool is_shard) {
     bool force_download = false;
 
     // Set the URL, allow to follow http redirection

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1896,6 +1896,21 @@ static int shard_progress_callback(void* clientp, double dltotal, double dlnow, 
     return 0;
 }
 
+// function to get the console width
+static int get_console_width() {
+#ifdef _WIN32
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+    return csbi.dwSize.X;
+#elif defined(__linux__) || defined(__APPLE__)
+    struct winsize ws;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
+    return ws.ws_col;
+#else
+    return 80; // Default value
+#endif
+}
+
 static void print_shard_progress_table(bool first_progress) {
     if (first_progress) {
         fprintf(stderr, "=========================\n");
@@ -1910,9 +1925,8 @@ static void print_shard_progress_table(bool first_progress) {
         }
     }
 
-    struct winsize ws;
-    ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
-    int progress_bar_width = ws.ws_col - LLAMA_PROGRESS_PERCENTAGE_WIDTH;
+
+    int progress_bar_width = get_console_width() - LLAMA_PROGRESS_PERCENTAGE_WIDTH;
 
     // Print the progress information for each downloading file
     {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2000,9 +2000,9 @@ static bool llama_download_file(CURL * curl, const char * url, const char * path
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);
 
         //  display download progress if not sharded
-        if(isShard){
+        if (isShard) {
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-        }else{
+        } else {
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
         }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -70,6 +70,7 @@
 #define LLAMA_CURL_MAX_HEADER_LENGTH 256
 #define LLAMA_PROGRESS_UPDATE_INTERVAL 1
 #define LLAMA_PROGRESS_PERCENTAGE_WIDTH 10
+#define LLAMA_DEFAULT_CONSOLE_WIDTH 80
 #endif // LLAMA_USE_CURL
 
 using json = nlohmann::ordered_json;
@@ -1907,7 +1908,7 @@ static int get_console_width() {
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
     return ws.ws_col;
 #else
-    return 80; // Default value
+    return LLAMA_DEFAULT_CONSOLE_WIDTH; // Default value
 #endif
 }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1884,7 +1884,7 @@ static int shard_progress_callback(void* clientp, double dltotal, double dlnow, 
     (void) ultotal;
     (void) ulnow;
     char* url = static_cast<char*>(clientp);
-    
+
     std::lock_guard<std::mutex> lock(progress_mutex);
 
     shard_file_progress& progress = progress_table[url];
@@ -1893,7 +1893,7 @@ static int shard_progress_callback(void* clientp, double dltotal, double dlnow, 
 
     std::string url_string = static_cast<std::string>(url);
     progress.filename = url_string.substr(url_string.find_last_of('/') + 1);
-    
+
     return 0;
 }
 
@@ -2084,7 +2084,7 @@ static bool llama_download_file(CURL * curl, const char * url, const char * path
 
         //  display download progress
         curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-        
+
         // custom progress callback on sharded download
         if (is_shard) {
             curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, shard_progress_callback);
@@ -2250,7 +2250,7 @@ struct llama_model * llama_load_model_from_url(
                 return res;
             }, idx));
         }
-        
+
         bool first_progress = true;
         while (true) {
             // Print the progress table periodically

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1999,17 +1999,10 @@ static bool llama_download_file(CURL * curl, const char * url, const char * path
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, static_cast<CURLOPT_WRITEFUNCTION_PTR>(write_callback));
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);
 
-        //  display download progress
-        //curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-        std::cout<<"HEREEEEEEEEEEEEEE\n";
-        std::cout<<isShard<<"\n";
-        std::cout<<"ENDDDDDDDDDDDDD\n";
-        //curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L); // original
+        //  display download progress if not sharded
         if(isShard){
-            std::cout<<"AAAAAAAAAAAA";
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
         }else{
-            std::cout<<"BBBBBBBBBBBB";
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
         }
 
@@ -2086,7 +2079,6 @@ struct llama_model * llama_load_model_from_url(
         const char * model_url,
         const char * path_model,
         const struct llama_model_params & params) {
-    std::cout<<"ISSSSSSUUUUUUEEEEEEE\n";
     // Basic validation of the model_url
     if (!model_url || strlen(model_url) == 0) {
         fprintf(stderr, "%s: invalid model_url\n", __func__);
@@ -2129,8 +2121,6 @@ struct llama_model * llama_load_model_from_url(
 
     curl_easy_cleanup(curl);
 
-    std::cout<<"HELLLLLLLOOOOOO\n";
-    std::cout<<"SPLITS "<<n_split<<"\n";
     if (n_split > 1) {
         char split_prefix[PATH_MAX] = {0};
         char split_url_prefix[LLAMA_CURL_MAX_URL_LENGTH] = {0};

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1866,7 +1866,7 @@ void llama_batch_add(
 
 #ifdef LLAMA_USE_CURL
 
-static bool llama_download_file(CURL * curl, const char * url, const char * path, boolean_t isShard) {
+static bool llama_download_file(CURL * curl, const char * url, const char * path, boolean_t is_shard) {
     bool force_download = false;
 
     // Set the URL, allow to follow http redirection
@@ -2000,7 +2000,7 @@ static bool llama_download_file(CURL * curl, const char * url, const char * path
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);
 
         //  display download progress if not sharded
-        if (isShard) {
+        if (is_shard) {
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
         } else {
             curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);


### PR DESCRIPTION
### Motivation
Currently when downloading model shards, the progress output shown is interleaved, which is difficult to interpret. To fix this, we case on whether the download is a shard, and create a global table that stores the progress information for each model shard. We continuously update a progress bar for each of the shards in `llama_load_model_from_url` until all downloads are complete.
Closes #6537 

### Changes
- * [x] Add boolean value to `llama_download_file` to indicate whether a download is a shard
- * [x] Add curl property to use a custom progress callback
- * [x] Create a `progressTable` global to store progress information
- * [x] Print information to console every second as progress bar output while shards are downloading
- * [x] Buffer the download finished/file saved output and print to stderr once ALL downloads complete to prevent interleaving output

### Before and after:
![Screen Shot 2024-04-21 at 6 53 58 PM](https://github.com/ggerganov/llama.cpp/assets/43354492/1010a500-185f-44c1-b39d-56c18406ba30) | ![Screen Shot 2024-04-28 at 8 17 52 PM](https://github.com/ggerganov/llama.cpp/assets/43354492/9f6916c5-e2f4-4d46-8d9c-419d4be0174d)
:-------------------------:|:-------------------------:

### Testing:
Tested using the following command on CPU:
```
./main --hf-repo ggml-org/models \
       --hf-file tinyllamas/split/stories15M-00001-of-00003.gguf \
       --model models/test-model-00001-of-00003.gguf \
       -ngl 0 \
       --prompt "I believe the meaning of life is"
```

