### PR TITLE
Fix: Revert showing control tokens by default for server OpenAI Chat completions

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2328,10 +2328,25 @@ std::vector<llama_token> llama_tokenize(
 
 std::string llama_token_to_piece(const struct llama_context * ctx, llama_token token) {
     std::vector<char> result(8, 0);
-    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), false);
+    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
     if (n_tokens < 0) {
         result.resize(-n_tokens);
-        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), false);
+        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
+        GGML_ASSERT(check == -n_tokens);
+    } else {
+        result.resize(n_tokens);
+    }
+
+    return std::string(result.data(), result.size());
+}
+
+// duplicate with ability to specify whether to use special token
+std::string llama_token_to_piece(const struct llama_context * ctx, llama_token token, bool special) {
+    std::vector<char> result(8, 0);
+    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), special);
+    if (n_tokens < 0) {
+        result.resize(-n_tokens);
+        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), special);
         GGML_ASSERT(check == -n_tokens);
     } else {
         result.resize(n_tokens);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2326,21 +2326,6 @@ std::vector<llama_token> llama_tokenize(
     return result;
 }
 
-std::string llama_token_to_piece(const struct llama_context * ctx, llama_token token) {
-    std::vector<char> result(8, 0);
-    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
-    if (n_tokens < 0) {
-        result.resize(-n_tokens);
-        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
-        GGML_ASSERT(check == -n_tokens);
-    } else {
-        result.resize(n_tokens);
-    }
-
-    return std::string(result.data(), result.size());
-}
-
-// duplicate with ability to specify whether to use special token
 std::string llama_token_to_piece(const struct llama_context * ctx, llama_token token, bool special) {
     std::vector<char> result(8, 0);
     const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), special);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2328,10 +2328,10 @@ std::vector<llama_token> llama_tokenize(
 
 std::string llama_token_to_piece(const struct llama_context * ctx, llama_token token) {
     std::vector<char> result(8, 0);
-    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
+    const int n_tokens = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), false);
     if (n_tokens < 0) {
         result.resize(-n_tokens);
-        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), true);
+        int check = llama_token_to_piece(llama_get_model(ctx), token, result.data(), result.size(), false);
         GGML_ASSERT(check == -n_tokens);
     } else {
         result.resize(n_tokens);

--- a/common/common.h
+++ b/common/common.h
@@ -241,7 +241,14 @@ std::vector<llama_token> llama_tokenize(
 // should work similar to Python's `tokenizer.id_to_piece`
 std::string llama_token_to_piece(
         const struct llama_context * ctx,
-                       llama_token   token);
+                       llama_token   token
+);
+
+std::string llama_token_to_piece(
+        const struct llama_context * ctx,
+                       llama_token   token,
+                       bool          special
+);
 
 // TODO: these should be moved in llama.h C-style API under single `llama_detokenize` function
 //       that takes into account the tokenizer type and decides how to handle the leading space

--- a/common/common.h
+++ b/common/common.h
@@ -237,18 +237,12 @@ std::vector<llama_token> llama_tokenize(
                         bool   add_special,
                         bool   parse_special = false);
 
-// tokenizes a token into a piece
+// tokenizes a token into a piece, optionally renders special/control tokens
 // should work similar to Python's `tokenizer.id_to_piece`
 std::string llama_token_to_piece(
         const struct llama_context * ctx,
-                       llama_token   token
-);
-
-std::string llama_token_to_piece(
-        const struct llama_context * ctx,
                        llama_token   token,
-                       bool          special
-);
+                       bool          special = true);
 
 // TODO: these should be moved in llama.h C-style API under single `llama_detokenize` function
 //       that takes into account the tokenizer type and decides how to handle the leading space

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1118,7 +1118,7 @@ struct server_context {
 
     bool process_token(completion_token_output & result, server_slot & slot) {
         // remember which tokens were sampled - used for repetition penalties during sampling
-        const std::string token_str = llama_token_to_piece(ctx, result.tok);
+        const std::string token_str = llama_token_to_piece(ctx, result.tok, false);
         slot.sampled = result.tok;
 
         // search stop word and delete it


### PR DESCRIPTION
In #6807 @ggerganov added the ability to toggle showing control tokens (e.g. EOS tokens). In `common.cpp` this was set to `true` by default in two places, which broke the `/v1/chat/completions` endpoint as described in #6859 - in short, the OpenAI chat completions endpoint response now includes the EOS / stop token, which is different from past behavior / expected behavior.

I have confirmed that reverting the booleans to be `false` in the two places in `common.cpp` fixes this behavior. 

While this PR fixes the breaking change, it may affect behavior that is dependent on #6807's new default of `true` in other places. This may need to be investigated further, but I propose reverting the change for now to fix the broken `/v1/chat/completions` behavior.

s/o @QueryType for opening #6847 as well which was caused by the same underlying issue. 

## API Response before the change (ChatML model):
![image](https://github.com/ggerganov/llama.cpp/assets/18430555/94844239-6844-4722-ba62-a1f98489e740)

## API Response before the change (Mistral model / llama2 template): 
![image](https://github.com/ggerganov/llama.cpp/assets/18430555/a18dd7f5-8ce0-48ed-9a20-ef337ba10df3)

## Correct API response after this change:
(note the absence of control tokens)

<img width="972" alt="Screenshot 2024-04-23 at 10 34 04 PM" src="https://github.com/ggerganov/llama.cpp/assets/18430555/4a3869fd-14b6-4c27-8d1a-187f0f5b3e6e">
