### PR TITLE
add llama_get_pooling_type function

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -86,8 +86,8 @@ struct gpt_params {
 
     ggml_numa_strategy numa = GGML_NUMA_STRATEGY_DISABLED;
 
-    llama_rope_scaling_type rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED;
-    llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED; // pooling type for embeddings
+    enum llama_rope_scaling_type rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED;
+    enum llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED; // pooling type for embeddings
 
     // // sampling parameters
     struct llama_sampling_params sparams;

--- a/llama.cpp
+++ b/llama.cpp
@@ -15406,6 +15406,10 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
     return LLAMA_ROPE_TYPE_NONE;
 }
 
+enum llama_pooling_type llama_pooling_type(const struct llama_context * ctx) {
+    return ctx->cparams.pooling_type;
+}
+
 int32_t llama_n_vocab(const struct llama_model * model) {
     return model->hparams.n_vocab;
 }

--- a/llama.h
+++ b/llama.h
@@ -390,8 +390,9 @@ extern "C" {
     LLAMA_API uint32_t llama_n_ubatch   (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_seq_max  (const struct llama_context * ctx);
 
-    LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_model * model);
-    LLAMA_API enum llama_rope_type  llama_rope_type (const struct llama_model * model);
+    LLAMA_API enum llama_vocab_type   llama_vocab_type  (const struct llama_model   * model);
+    LLAMA_API enum llama_rope_type    llama_rope_type   (const struct llama_model   * model);
+    LLAMA_API enum llama_pooling_type llama_pooling_type(const struct llama_context * model);
 
     LLAMA_API int32_t llama_n_vocab    (const struct llama_model * model);
     LLAMA_API int32_t llama_n_ctx_train(const struct llama_model * model);

--- a/llama.h
+++ b/llama.h
@@ -390,9 +390,10 @@ extern "C" {
     LLAMA_API uint32_t llama_n_ubatch   (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_seq_max  (const struct llama_context * ctx);
 
+    LLAMA_API enum llama_pooling_type llama_pooling_type(const struct llama_context * ctx);
+
     LLAMA_API enum llama_vocab_type   llama_vocab_type  (const struct llama_model   * model);
     LLAMA_API enum llama_rope_type    llama_rope_type   (const struct llama_model   * model);
-    LLAMA_API enum llama_pooling_type llama_pooling_type(const struct llama_context * model);
 
     LLAMA_API int32_t llama_n_vocab    (const struct llama_model * model);
     LLAMA_API int32_t llama_n_ctx_train(const struct llama_model * model);


### PR DESCRIPTION
This allows the user to inspect the realized value of the context's `pooling_type`. In cases where `UNSPECIFIED` is passed as the context parameter, this helps identify the default pooling type coming from the model. This is useful because, depending on the pooling type, different values for `logits` in the batch may need to be passed and the embeddings outputs are of different size (and require different functions to access).