### PR TITLE
add basic tensor data validation function

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1089,6 +1089,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.n_print = std::stoi(argv[i]);
         return true;
     }
+    if (arg == "--check-tensors") {
+        params.check_tensors = true;
+        return true;
+    }
     if (arg == "--ppl-output-type") {
         if (++i >= argc) {
             invalid_param = true;
@@ -1554,6 +1558,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     printf("                        types: int, float, bool. example: --override-kv tokenizer.ggml.add_bos_token=bool:false\n");
     printf("  -ptc N, --print-token-count N\n");
     printf("                        print token count every N tokens (default: %d)\n", params.n_print);
+    printf("  --check-tensors       check model tensor data for invalid values\n");
     printf("\n");
 #ifndef LOG_DISABLE_LOGS
     log_print_usage();
@@ -1774,6 +1779,7 @@ struct llama_model_params llama_model_params_from_gpt_params(const gpt_params & 
     mparams.tensor_split    = params.tensor_split;
     mparams.use_mmap        = params.use_mmap;
     mparams.use_mlock       = params.use_mlock;
+    mparams.check_tensors   = params.check_tensors;
     if (params.kv_overrides.empty()) {
         mparams.kv_overrides = NULL;
     } else {

--- a/common/common.h
+++ b/common/common.h
@@ -161,6 +161,7 @@ struct gpt_params {
     bool dump_kv_cache     = false; // dump the KV cache contents for debugging purposes
     bool no_kv_offload     = false; // disable KV offloading
     bool warmup            = true;  // warmup run
+    bool check_tensors     = false; // validate tensor data
 
     std::string cache_type_k = "f16"; // KV cache data type for the K
     std::string cache_type_v = "f16"; // KV cache data type for the V

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -12613,7 +12613,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
                 const block_iq1_m * q = (const block_iq1_m *) data;
                 for (size_t i = 0; i < nb; ++i) {
                 #if QK_K == 64
-                    if (!validate_f16(q[i].d, i)) {
+                    if (!validate_fp16(q[i].d, i)) {
                         return false;
                     }
                 #else

--- a/ggml-quants.c
+++ b/ggml-quants.c
@@ -12521,7 +12521,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
                     uint32x4_t v = vld1q_u32((const uint32_t *)f + i);
                     uint32x4_t vexp = vandq_u32(v, vdupq_n_u32(0x7f800000));
                     uint32x4_t cmp = vceqq_u32(vexp, vdupq_n_u32(0x7f800000));
-                    uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u32(cmp, 8)), 0);
+                    uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(vshrn_n_u32(cmp, 8)), 0);
                     if (mask) {
                         for (size_t j = 0; j < 4; ++j) {
                             if (!validate_float(f[i + j], i + j)) {

--- a/ggml.h
+++ b/ggml.h
@@ -762,6 +762,8 @@ extern "C" {
     // use this to compute the memory overhead of a tensor
     GGML_API size_t ggml_tensor_overhead(void);
 
+    GGML_API bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbytes);
+
     // main
 
     GGML_API struct ggml_context * ggml_init(struct ggml_init_params params);

--- a/llama.h
+++ b/llama.h
@@ -232,9 +232,10 @@ extern "C" {
         const struct llama_model_kv_override * kv_overrides;
 
         // Keep the booleans together to avoid misalignment during copy-by-value.
-        bool vocab_only; // only load the vocabulary, no weights
-        bool use_mmap;   // use mmap if possible
-        bool use_mlock;  // force system to keep model in RAM
+        bool vocab_only;    // only load the vocabulary, no weights
+        bool use_mmap;      // use mmap if possible
+        bool use_mlock;     // force system to keep model in RAM
+        bool check_tensors; // validate model tensor data
     };
 
     struct llama_context_params {


### PR DESCRIPTION
Adds `ggml_validate_row_data` to validate tensor data, and adds this validation to llama.cpp during model loading. For floating point tensors it checks all the data, for quant types it checks the scales only. The validation consists of checking for `nan` and `inf` values in the tensors.

Should help detect issues with models such as reported in #6841.

Hopefully it won't increase load time too much so that it can be left enabled permanently, but more testing is necessary.