### PR TITLE
Fix CORS for /health endpoint

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3110,6 +3110,7 @@ int main(int argc, char ** argv) {
     //
 
     const auto handle_health = [&](const httplib::Request & req, httplib::Response & res) {
+        res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         server_state current_state = state.load();
         switch (current_state) {
             case SERVER_STATE_READY:


### PR DESCRIPTION
`/health` is missing `Access-Control-Allow-Origin`. This sets it to the request origin, in line with the other endpoints.