### PR TITLE
gguf : enforce that tensor names are unique

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -21360,6 +21360,10 @@ void gguf_set_kv(struct gguf_context * ctx, struct gguf_context * src) {
 void gguf_add_tensor(
              struct gguf_context * ctx,
         const struct ggml_tensor * tensor) {
+    if (gguf_find_tensor(ctx, tensor->name) != -1) {
+        GGML_ASSERT(false && "duplicated tensor name");
+    }
+    
     const int idx = ctx->header.n_tensors;
     ctx->infos = realloc(ctx->infos, (idx + 1)*sizeof(struct gguf_tensor_info));
 

--- a/ggml.c
+++ b/ggml.c
@@ -20824,6 +20824,14 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
 
             gguf_tensor_info_sanitize(info);
 
+            // make sure there is no duplicated tensor names
+            for (uint64_t j = 0; j < i; ++j) {
+                if (strcmp(info->name.data, ctx->infos[j].name.data) == 0) {
+                    fprintf(stderr, "%s: duplicated tensor name %s\n", __func__, info->name.data);
+                    ok = false;
+                }
+            }
+
             if (!ok) {
                 fprintf(stderr, "%s: failed to read tensor info\n", __func__);
                 fclose(file);
@@ -21363,7 +21371,7 @@ void gguf_add_tensor(
     if (gguf_find_tensor(ctx, tensor->name) != -1) {
         GGML_ASSERT(false && "duplicated tensor name");
     }
-    
+
     const int idx = ctx->header.n_tensors;
     ctx->infos = realloc(ctx->infos, (idx + 1)*sizeof(struct gguf_tensor_info));
 

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -234,8 +234,14 @@ class GGUFReader:
 
     def _build_tensors(self, start_offs: int, fields: list[ReaderField]) -> None:
         tensors = []
+        tensor_names = [] # keep track of name to prevent duplicated tensors
         for field in fields:
             _name_len, name_data, _n_dims, dims, raw_dtype, offset_tensor = field.parts
+            # check if there's any tensor having same name already in the list
+            tensor_name = str(bytes(name_data), encoding = 'utf-8')
+            if tensor_name in tensor_names:
+                raise ValueError(f'Found duplicated tensor with name {tensor_name}')
+            tensor_names.add(tensor_name)
             ggml_type = GGMLQuantizationType(raw_dtype[0])
             n_elems = np.prod(dims)
             block_size, type_size = GGML_QUANT_SIZES[ggml_type]
@@ -267,7 +273,7 @@ class GGUFReader:
                 item_count = n_bytes
                 item_type = np.uint8
             tensors.append(ReaderTensor(
-                name = str(bytes(name_data), encoding = 'utf-8'),
+                name = tensor_name,
                 tensor_type = ggml_type,
                 shape = dims,
                 n_elements = n_elems,

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -234,7 +234,7 @@ class GGUFReader:
 
     def _build_tensors(self, start_offs: int, fields: list[ReaderField]) -> None:
         tensors = []
-        tensor_names = [] # keep track of name to prevent duplicated tensors
+        tensor_names = set() # keep track of name to prevent duplicated tensors
         for field in fields:
             _name_len, name_data, _n_dims, dims, raw_dtype, offset_tensor = field.parts
             # check if there's any tensor having same name already in the list

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -63,6 +63,7 @@ class GGUFWriter:
         self.kv_data_count = 0
         self.ti_data = bytearray()
         self.ti_data_count = 0
+        self.ti_names = set()
         self.use_temp_file = use_temp_file
         self.temp_file = None
         self.tensors = []
@@ -196,6 +197,10 @@ class GGUFWriter:
     ) -> None:
         if self.state is not WriterState.EMPTY:
             raise ValueError(f'Expected output file to be empty, got {self.state}')
+
+        if name in self.ti_names:
+            raise ValueError(f'Duplicated tensor name {name}')
+        self.ti_names.add(name)
 
         encoded_name = name.encode("utf8")
         self.ti_data += self._pack("Q", len(encoded_name))

--- a/llama.cpp
+++ b/llama.cpp
@@ -3118,7 +3118,7 @@ struct llama_model_loader {
             const std::string name(w.tensor->name);
             auto found = tensor_names.find(name);
             if (found != tensor_names.end()) {
-                LLAMA_LOG_ERROR("%s: Found duplicated tensor name %s", __func__, w.tensor->name);
+                throw std::runtime_error(format("invalid model: tensor '%s' is duplicated", w.tensor->name));
             }
             tensor_names.insert(name);
         }

--- a/llama.cpp
+++ b/llama.cpp
@@ -3110,9 +3110,17 @@ struct llama_model_loader {
 
         fver = (enum llama_fver) gguf_get_version(meta);
 
+        std::set<std::string> tensor_names;
         for (auto & w : weights) {
             n_elements += ggml_nelements(w.tensor);
             n_bytes    += ggml_nbytes(w.tensor);
+            // make sure there is no duplicated tensor names
+            const std::string name(w.tensor->name);
+            auto found = tensor_names.find(name);
+            if (found != tensor_names.end()) {
+                LLAMA_LOG_ERROR("%s: Found duplicated tensor name %s", __func__, w.tensor->name);
+            }
+            tensor_names.insert(name);
         }
 
         LLAMA_LOG_INFO("%s: loaded meta data with %d key-value pairs and %d tensors from %s (version %s)\n",


### PR DESCRIPTION
Resolve #6836

For now, only adding duplicated tensor is prevented:
- `ggml.c` uses `gguf_find_tensor` to check for duplicated tensor. This is a linear search so may not be a suitable implementation when loading the gguf (but acceptable when writing gguf, since writing is not happen very often). What do you think about this point @slaren ?
- `GGUFWriter` from gguf-py uses a set to keep track of tensor names when writing a gguf. We can use the same logic for `GGUFReader`