### PR TITLE
ggml : use dynamic thread scheduling for matrix multiplication

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -12097,8 +12097,10 @@ UseGgmlGemm2:;
     //printf("nr0 = %lld, nr1 = %lld\n", nr0, nr1);
 
     //If the chunking is poor for the number of threads on this setup, scrap the whole plan.  Re-chunk it by thread.
-    if (nchunk0 * nchunk1 < nth * 4)
+    if (nchunk0 * nchunk1 < nth * 400)
     {
+        //if (ith == 0)
+        //    printf("rechunked");
         // distribute the thread work across the inner or outer loop based on which one is larger
         nchunk0 = nr0 > nr1 ? nth : 1; // parallelize by src0 rows
         nchunk1 = nr0 > nr1 ? 1 : nth; // parallelize by src1 rows
@@ -12107,6 +12109,9 @@ UseGgmlGemm2:;
     //The number of elements in each chunk
     const int64_t dr0 = (nr0 + nchunk0 - 1) / nchunk0;
     const int64_t dr1 = (nr1 + nchunk1 - 1) / nchunk1;
+
+    //if (ith == 0)
+    //    printf("MUL_MAT = [%d, %d, %d, %d] x [%d, %d, %d, %d] = %d x %d = %d.  Fp/Ch %d\n", ne00, ne01, ne02, ne03, ne10, ne11, ne12, ne13, nchunk0, nchunk1, nchunk0 * nchunk1, ne00 * nr0 * nr1 / nchunk0 / nchunk1);
 
     //The first chunk comes from our thread_id, the rest will get auto-assigned.
     int current_chunk = ith;

--- a/ggml.c
+++ b/ggml.c
@@ -19665,7 +19665,7 @@ static void ggml_graph_compute_thread_sync_node(int * node_n, struct ggml_comput
         * node_n = atomic_load(&state->shared->node_n);
         if (* node_n != last_node_n) break;
 #if defined(__SSE3__)
-        //Tell the processor we're spinning.  It's a processor hint for spinlocks.
+        // Tell the processor we're spinning.  It's a processor hint for spinlocks.
         _mm_pause();
 #endif
     }

--- a/ggml.c
+++ b/ggml.c
@@ -19578,6 +19578,10 @@ static void ggml_graph_compute_thread_sync_node(int * node_n, struct ggml_comput
 
         * node_n = atomic_load(&state->shared->node_n);
         if (* node_n != last_node_n) break;
+#if defined(__SSE3__)
+        //Tell the processor we're spinning.  It's a processor hint for spinlocks.
+        _mm_pause();
+#endif
     }
 }
 
@@ -19592,6 +19596,10 @@ static void ggml_graph_compute_thread_sync_task(int * task_phase, struct ggml_co
 
         * task_phase = atomic_load(&state->shared->node_task);
         if (* task_phase != last_task_phase) break;
+#if defined(__SSE3__)
+        //Tell the processor we're spinning.  It's a processor hint for spinlocks.
+        _mm_pause();
+#endif
     }
 }
 

--- a/ggml.c
+++ b/ggml.c
@@ -12097,7 +12097,7 @@ UseGgmlGemm2:;
     //printf("nr0 = %lld, nr1 = %lld\n", nr0, nr1);
 
     //If the chunking is poor for the number of threads on this setup, scrap the whole plan.  Re-chunk it by thread.
-    if (nchunk0 * nchunk1 < nth * 400)
+    if (nchunk0 * nchunk1 < nth * 4 || ggml_is_numa())
     {
         //if (ith == 0)
         //    printf("rechunked");

--- a/ggml.c
+++ b/ggml.c
@@ -11776,10 +11776,7 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     const int64_t ir0_start,
     const int64_t ir0_end,
     const int64_t ir1_start,
-    const int64_t ir1_end,
-
-    const size_t row_size
-) {
+    const int64_t ir1_end) {
 
     const struct ggml_tensor* src0 = dst->src[0];
     const struct ggml_tensor* src1 = dst->src[1];
@@ -11800,6 +11797,7 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     //printf("ir0_start = %6lld, ir0_end = %6lld, ir1_start = %6lld, ir1_end = %6lld\n", ir0_start, ir0_end, ir1_start, ir1_end);
 
     const void* wdata = (src1->type == vec_dot_type) ? src1->data : params->wdata;
+    const size_t row_size = ggml_row_size(vec_dot_type, ne10);
 
     assert(ne12 % ne02 == 0);
     assert(ne13 % ne03 == 0);
@@ -12090,7 +12088,7 @@ UseGgmlGemm2:;
         num_rows_per_vec_dot = 1;
     }
 
-    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end, row_size);
+    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end);
 }
 
 // ggml_compute_forward_mul_mat_id

--- a/ggml.c
+++ b/ggml.c
@@ -11834,17 +11834,17 @@ static void ggml_compute_forward_mul_mat_one_chunk(
                 const int64_t i2 = i12;
                 const int64_t i3 = i13;
 
-                const char* src0_row = (const char*)src0->data + (0 + i02 * nb02 + i03 * nb03);
+                const char * src0_row = (const char*)src0->data + (0 + i02 * nb02 + i03 * nb03);
 
                 // desc: when src1 is not a contiguous memory block we have to calculate the offset using the strides
                 //       if it is, then we have either copied the data to params->wdata and made it contiguous or we are using
                 //       the original src1 data pointer, so we should index using the indices directly
                 // TODO: this is a bit of a hack, we should probably have a better way to handle this
-                const char* src1_col = (const char*)wdata +
+                const char * src1_col = (const char*)wdata +
                     (src1_cont || src1->type != vec_dot_type
                         ? (i11 + i12 * ne11 + i13 * ne12 * ne11) * row_size
                         : (i11 * nb11 + i12 * nb12 + i13 * nb13));
-                float* dst_col = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
+                float * dst_col = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
                 //for (int64_t ir0 = iir0; ir0 < iir0 + blck_0 && ir0 < ir0_end; ++ir0) {
                 //    vec_dot(ne00, &dst_col[ir0], src0_row + ir0*nb01, src1_col);

--- a/ggml.c
+++ b/ggml.c
@@ -11779,9 +11779,7 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     const int64_t ir1_end,
 
     const bool src1_cont,
-    enum ggml_type vec_dot_type,
-    const size_t row_size,
-    const ggml_vec_dot_t vec_dot
+    const size_t row_size
 ) {
 
     const struct ggml_tensor* src0 = dst->src[0];
@@ -11791,13 +11789,16 @@ static void ggml_compute_forward_mul_mat_one_chunk(
 
     const enum ggml_type type = src0->type;
 
-    const void* wdata = (src1->type == vec_dot_type) ? src1->data : params->wdata;
+    ggml_vec_dot_t    const vec_dot = type_traits[type].vec_dot;
+    enum ggml_type    const vec_dot_type = type_traits[type].vec_dot_type;
 
     // broadcast factors
     const int64_t r2 = ne12 / ne02;
     const int64_t r3 = ne13 / ne03;
 
     //printf("ir0_start = %6lld, ir0_end = %6lld, ir1_start = %6lld, ir1_end = %6lld\n", ir0_start, ir0_end, ir1_start, ir1_end);
+
+    const void* wdata = (src1->type == vec_dot_type) ? src1->data : params->wdata;
 
     assert(ne12 % ne02 == 0);
     assert(ne13 % ne03 == 0);
@@ -11875,7 +11876,6 @@ static void ggml_compute_forward_mul_mat(
 
     const bool src1_cont = ggml_is_contiguous(src1);
 
-    ggml_vec_dot_t    const vec_dot               = type_traits[type].vec_dot;
     enum ggml_type    const vec_dot_type          = type_traits[type].vec_dot_type;
     ggml_from_float_t const from_float_to_vec_dot = type_traits[vec_dot_type].from_float;
     int64_t           const vec_dot_num_rows      = type_traits[type].nrows;
@@ -12089,7 +12089,7 @@ UseGgmlGemm2:;
         num_rows_per_vec_dot = 1;
     }
 
-    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end, src1_cont, vec_dot_type, row_size, vec_dot);
+    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end, src1_cont, row_size);
 }
 
 // ggml_compute_forward_mul_mat_id

--- a/ggml.c
+++ b/ggml.c
@@ -12106,12 +12106,6 @@ UseGgmlGemm2:;
         const int64_t ir1_start = dr1 * ith1;
         const int64_t ir1_end = MIN(ir1_start + dr1, nr1);
 
-    // threads with no work simply yield (not sure if it helps)
-    if (ir0_start >= ir0_end || ir1_start >= ir1_end) {
-        sched_yield();
-        return;
-    }
-
         ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end);
 
 #ifdef GGML_PERF

--- a/ggml.c
+++ b/ggml.c
@@ -12103,14 +12103,14 @@ UseGgmlGemm2:;
         nchunk1 = nr0 > nr1 ? 1 : nth; // parallelize by src1 rows
     }
 
-    //The number of elements in each chunk
+    // The number of elements in each chunk
     const int64_t dr0 = (nr0 + nchunk0 - 1) / nchunk0;
     const int64_t dr1 = (nr1 + nchunk1 - 1) / nchunk1;
 
     //if (ith == 0)
     //    printf("MUL_MAT = [%d, %d, %d, %d] x [%d, %d, %d, %d] = %d x %d = %d.  Fp Ops/Ch %d\n", ne00, ne01, ne02, ne03, ne10, ne11, ne12, ne13, nchunk0, nchunk1, nchunk0 * nchunk1, ne00 * nr0 * nr1 / nchunk0 / nchunk1);
 
-    //The first chunk comes from our thread_id, the rest will get auto-assigned.
+    // The first chunk comes from our thread_id, the rest will get auto-assigned.
     int current_chunk = ith;
 
     while (current_chunk < nchunk0 * nchunk1) {

--- a/ggml.c
+++ b/ggml.c
@@ -12062,6 +12062,9 @@ UseGgmlGemm1:;
 UseGgmlGemm2:;
 #endif
 
+    int chunk_size = 16;
+    UNUSED(chunk_size);
+
 #ifdef GGML_PERF
     int chunks_executed = 0;
     UNUSED(chunks_executed);

--- a/ggml.c
+++ b/ggml.c
@@ -11899,6 +11899,12 @@ static void ggml_compute_forward_mul_mat(
     GGML_ASSERT(nb1 <= nb2);
     GGML_ASSERT(nb2 <= nb3);
 
+    // broadcast factors
+    const int64_t r2 = ne12 / ne02;
+    const int64_t r3 = ne13 / ne03;
+    UNUSED(r2);
+    UNUSED(r3);
+
     // nb01 >= nb00 - src0 is not transposed
     //   compute by src0 rows
 
@@ -11980,10 +11986,6 @@ static void ggml_compute_forward_mul_mat(
 
 #if GGML_USE_LLAMAFILE
     const bool src1_cont = ggml_is_contiguous(src1);
-
-    // broadcast factors
-    const int64_t r2 = ne12 / ne02;
-    const int64_t r3 = ne13 / ne03;
 
     if (src1_cont) {
         for (int64_t i13 = 0; i13 < ne13; i13++)

--- a/ggml.c
+++ b/ggml.c
@@ -11778,7 +11778,6 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     const int64_t ir1_start,
     const int64_t ir1_end,
 
-    const bool src1_cont,
     const size_t row_size
 ) {
 
@@ -11788,6 +11787,8 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const enum ggml_type type = src0->type;
+
+    const bool src1_cont = ggml_is_contiguous(src1);
 
     ggml_vec_dot_t    const vec_dot = type_traits[type].vec_dot;
     enum ggml_type    const vec_dot_type = type_traits[type].vec_dot_type;
@@ -12089,7 +12090,7 @@ UseGgmlGemm2:;
         num_rows_per_vec_dot = 1;
     }
 
-    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end, src1_cont, row_size);
+    ggml_compute_forward_mul_mat_one_chunk(params, dst, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end, row_size);
 }
 
 // ggml_compute_forward_mul_mat_id

--- a/ggml.c
+++ b/ggml.c
@@ -19683,7 +19683,7 @@ static void ggml_graph_compute_thread_sync_task(int * task_phase, struct ggml_co
         * task_phase = atomic_load(&state->shared->node_task);
         if (* task_phase != last_task_phase) break;
 #if defined(__SSE3__)
-        //Tell the processor we're spinning.  It's a processor hint for spinlocks.
+        // Tell the processor we're spinning.  It's a processor hint for spinlocks.
         _mm_pause();
 #endif
     }

--- a/ggml.c
+++ b/ggml.c
@@ -12091,8 +12091,10 @@ UseGgmlGemm2:;
     const int64_t nchunk0 = nr0 > nr1 ? nth : 1; // parallelize by src0 rows
     const int64_t nchunk1 = nr0 > nr1 ? 1 : nth; // parallelize by src1 rows
 
+    //The first chunk comes from our thread_id, the rest will get auto-assigned.
     int current_chunk = ith;
 
+    while (current_chunk < nchunk0 * nchunk1)
     {
         const int64_t ith0 = current_chunk % nchunk0;
         const int64_t ith1 = current_chunk / nchunk0;
@@ -12112,6 +12114,10 @@ UseGgmlGemm2:;
         chunks_executed++;
 #endif
 
+        if (nth >= nchunk0 * nchunk1)
+            break;
+
+        current_chunk = atomic_fetch_add(&state->shared->current_chunk, 1);
     }
 
 #ifdef GGML_PERF


### PR DESCRIPTION
This is a draft of an idea I want feedback/thoughts/suggestions on.

I was working on a different issue, and I was having problems getting stable timing results.  I ran llama-bench, and was getting pretty different results with each run.  See [before.txt](https://github.com/ggerganov/llama.cpp/files/15123143/before.txt)   PP timings varied between 21.46 to 32.42 t/s.   TG was between 11.59 to 12.86 t/s.

So I looked at how the threading works in ``ggml_compute_forward_mul_mat``.  Since work is pre-dispatched to the thread, each thread will always do the same amount of work, and not adapt if one thread is stalled by the OS, that'll delay the whole operation. 
 So what I did was break it into 16*number_of_threads slices, and had it work through the slices.  I pulled all the guts of the operation out into it's own function, and used the existing logic that divides up into 16x more chunks.  Each thread then grabs an ID of what the next chunk of work to do.  This gave a more stable and faster timing results.  
[after.txt](https://github.com/ggerganov/llama.cpp/files/15123349/after.txt)     PP between 20.83-35.12 t/s  and TG between 12.82-13.47 t/s.

So the range of the average went from 1.27 to 0.65, along with the speed going up.   Do you have a better metric I should try for measuring this?  Maybe I need to do llama-bench with -r 100 or something silly and let it run overnight, and compare the two results?  I'm trying to improve my testing process so I'm more sure about the results.

What are your thoughts on the general idea of changing like this?  I don't like the global I had to add, but I didn't want to add it to ``ggml_compute_params`` because I'd have to add ``atomic.h`` to the header... but maybe that's okay?  I'll do more tests, and test it on Linux before posting this as a PR, plus I wanna fix that global, get better timing comparisons, etc, etc.