### PR TITLE
bench: server add stop word for PHI-2

### DIFF
--- a/examples/server/bench/script.js
+++ b/examples/server/bench/script.js
@@ -90,7 +90,8 @@ export default function () {
         "model": model,
         "stream": true,
         "seed": 42,
-        "max_tokens": max_tokens
+        "max_tokens": max_tokens,
+        "stop": ["<|im_end|>"] // This is temporary for phi-2 base (i.e. not instructed) since the server expects that the model always to emit BOS
     }
 
     const params = {method: 'POST', body: JSON.stringify(payload)};


### PR DESCRIPTION
### Context

Since we properly support BOS/EOT with `llama_token_is_eog` and removed hardcoded stop words in `utils.hpp`, the phi-2 base model never ends generation. So one can think the benchmark figures decrease.

This temporary fix before switching to an instruct model in the server benchmark.

### References

- #6745