### PR TITLE
ci: server: fix python installation

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -100,6 +100,12 @@ jobs:
               -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON ;
           cmake --build . --config ${{ matrix.build_type }} -j $(nproc) --target server
 
+      - name: Python setup
+        id: setup_python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Tests dependencies
         id: test_dependencies
         run: |


### PR DESCRIPTION
### Context

CI server tests are running under latest ubuntu, it is not possible to override anymore python system packages without `--break-system-packages`.

Example:
https://github.com/ggerganov/llama.cpp/actions/runs/8842929133/job/24282362740

### Solution

Properly configure python in the workflow with the action [actions/setup-python@v5 ](https://github.com/actions/setup-python)