### PR TITLE
fixed off by one error when context shifting in main.cpp example

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -544,7 +544,7 @@ int main(int argc, char ** argv) {
                 // if we run out of context:
                 // - take the n_keep first tokens from the original prompt (via n_past)
                 // - take half of the last (n_ctx - n_keep) tokens and recompute the logits in batches
-                if (n_past + (int) embd.size() + std::max<int>(0, guidance_offset) > n_ctx) {
+                if (n_past + (int) embd.size() + std::max<int>(0, guidance_offset) >= n_ctx) {
                     if (params.n_predict == -2) {
                         LOG_TEE("\n\n%s: context full and n_predict == -%d => stopping\n", __func__, params.n_predict);
                         break;


### PR DESCRIPTION
Is this an error? During my tests, eval throws an error below if `n_past + embd.size() == nctx`, so we need to start shifting one token earlier