### PR TITLE
ci: server: fix python installation again

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -58,6 +58,7 @@ jobs:
             git \
             cmake \
             python3-pip \
+            python3-venv \
             curl \
             wget \
             language-pack-en \
@@ -100,16 +101,13 @@ jobs:
               -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON ;
           cmake --build . --config ${{ matrix.build_type }} -j $(nproc) --target server
 
-      - name: Python setup
-        id: setup_python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Tests dependencies
-        id: test_dependencies
+      - name: Setup python env
+        id: pipenv
         run: |
-          pip install -r examples/server/tests/requirements.txt
+          cd examples/server/tests
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
 
       - name: Tests
         id: server_integration_tests


### PR DESCRIPTION
First attempt to fix failed:

- #6918 

It is painful because of `pull_request_target` need first to be merged to master.

I reused the approach from :

https://github.com/ggerganov/llama.cpp/blob/83b72cb086ce46a33dececc86bfe4648b6120aa8/.github/workflows/bench.yml#L64-L71

Hope it will fix the issue:
https://github.com/ggerganov/llama.cpp/actions/runs/8844678402/job/24287026323
