### PR TITLE
gguf : fix mismatch between alloc and free functions

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -20987,7 +20987,7 @@ void gguf_free(struct gguf_context * ctx) {
         GGML_FREE(ctx->infos);
     }
 
-    GGML_ALIGNED_FREE(ctx);
+    GGML_FREE(ctx);
 }
 
 const char * gguf_type_name(enum gguf_type type) {


### PR DESCRIPTION
The gguf contexts are no longer allocated with `GGML_ALIGNED_MALLOC`, so the free function must also be updated to match.

@ggerganov This should fix the tokenizer tests under windows.