### PR TITLE
Reset schedule earlier to allow overlap with ggml graph computation on device

### DIFF
--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -1780,12 +1780,15 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
 
 void ggml_backend_sched_reset(ggml_backend_sched_t sched) {
     // reset state for the next run
-    size_t hash_size = sched->hash_set.size;
-    memset(sched->hash_set.keys,      0, sizeof(sched->hash_set.keys[0])     * hash_size); // NOLINT
-    memset(sched->tensor_backend_id, -1, sizeof(sched->tensor_backend_id[0]) * hash_size);
-    memset(sched->tensor_copies,      0, sizeof(sched->tensor_copies[0])     * hash_size);
+    if(!sched->is_reset)
+    {
+        size_t hash_size = sched->hash_set.size;
+        memset(sched->hash_set.keys,      0, sizeof(sched->hash_set.keys[0])     * hash_size); // NOLINT
+        memset(sched->tensor_backend_id, -1, sizeof(sched->tensor_backend_id[0]) * hash_size);
+        memset(sched->tensor_copies,      0, sizeof(sched->tensor_copies[0])     * hash_size);
 
-    sched->is_reset = true;
+        sched->is_reset = true;
+    }
     sched->is_alloc = false;
 }
 

--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -1780,8 +1780,7 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
 
 void ggml_backend_sched_reset(ggml_backend_sched_t sched) {
     // reset state for the next run
-    if(!sched->is_reset)
-    {
+    if (!sched->is_reset) {
         size_t hash_size = sched->hash_set.size;
         memset(sched->hash_set.keys,      0, sizeof(sched->hash_set.keys[0])     * hash_size); // NOLINT
         memset(sched->tensor_backend_id, -1, sizeof(sched->tensor_backend_id[0]) * hash_size);

--- a/llama.cpp
+++ b/llama.cpp
@@ -16773,6 +16773,11 @@ float * llama_get_logits(struct llama_context * ctx) {
 
 float * llama_get_logits_ith(struct llama_context * ctx, int32_t i) {
     int32_t j = -1;
+
+    // Reset state for the next run before the following backend sync,
+    // to allow the CPU activities in the reset to overlap with device computation.
+    ggml_backend_sched_reset(ctx->sched);
+
     llama_synchronize(ctx);
 
     try {

--- a/llama.cpp
+++ b/llama.cpp
@@ -11205,6 +11205,10 @@ static int llama_decode_internal(
         }
     }
 
+    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
+    // overlap with device computation.
+    ggml_backend_sched_reset(lctx.sched);
+
     return 0;
 }
 
@@ -16773,11 +16777,6 @@ float * llama_get_logits(struct llama_context * ctx) {
 
 float * llama_get_logits_ith(struct llama_context * ctx, int32_t i) {
     int32_t j = -1;
-
-    // Reset state for the next run before the following backend sync,
-    // to allow the CPU activities in the reset to overlap with device computation.
-    ggml_backend_sched_reset(ctx->sched);
-
     llama_synchronize(ctx);
 
     try {


### PR DESCRIPTION
Previously, significant CPU memset calls between each token generation were on critical path. 
This change performs these earlier, while the CPU is waiting for the previous token to be 
generated on the device. 

Refs #6763