### PR TITLE
Fix clip build on windows + clang

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -3,6 +3,7 @@
 // I'll gradually clean and extend it
 // Note: Even when using identical normalized image inputs (see normalize_image_u8_to_f32()) we have a significant difference in resulting embeddings compared to pytorch
 #include "clip.h"
+#include "common.h"
 #include "log.h"
 #include "ggml.h"
 #include "ggml-alloc.h"


### PR DESCRIPTION
Building on windows with clang errors without common.h included before log.h

```
2024-04-26T00:23:04.3278937Z C:/a/ollama/ollama/llm/llama.cpp/examples/llava/../../common\log.h:467:5: error: expected ')'
2024-04-26T00:23:04.3281132Z     LOG("01 Hello World to nobody, because logs are disabled!\n");
2024-04-26T00:23:04.3281887Z     ^
2024-04-26T00:23:04.3282880Z C:/a/ollama/ollama/llm/llama.cpp/examples/llava/../../common\log.h:300:27: note: expanded from macro 'LOG'
2024-04-26T00:23:04.3284337Z     #define LOG(str, ...) LOG_IMPL("%s" str, "", ##__VA_ARGS__, "")
```