### PR TITLE
Fix conversion of some BERT embedding models

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -2482,6 +2482,10 @@ class BertModel(Model):
                 print(f"Can not map tensor {name!r}")
                 sys.exit()
 
+            # convert any unsupported data types to float32
+            if data_torch.dtype not in (torch.float16, torch.float32):
+                data_torch = data_torch.to(torch.float32)
+
             data = data_torch.squeeze().numpy()
             n_dims = len(data.shape)
             new_dtype: type[np.floating[Any]]


### PR DESCRIPTION
BERT-based embedding models require the use of `convert-hf-to-gguf.py` to be converted from safetensors/PyTorch format to GGML. The `BertModel` class was missing logic that resolves unsupported datatypes, resulting in some models like [acge_text_embedding](https://huggingface.co/aspire/acge_text_embedding) failing with `TypeError: Got unsupported ScalarType BFloat16` when running the line `data = data_torch.squeeze().numpy()`.

This is rectified by converting unsupported datatypes to f32 - this is done in every other model class, so it was probably just missed in BERT models. This fix allows for satisfactory conversion and subsequent quantization, as seen in [this GGUF quantization of acge_text_embedding](https://huggingface.co/ChristianAzinn/acge_text_embedding-gguf) created with this fix.

It's also literally just two lines of code, so unless converting tensors in BERT models specifically is undesirable, I hope this is an easy fix.