### PR TITLE
Server: add test for num slots, fails on master

### DIFF
--- a/examples/server/tests/features/results.feature
+++ b/examples/server/tests/features/results.feature
@@ -7,44 +7,16 @@ Feature: Results
     And   a model file tinyllamas/split/stories15M-00001-of-00003.gguf from HF repo ggml-org/models
     And   a model file test-model-00001-of-00003.gguf
     And   128 as batch size
-    And   256 KV cache size
+    And   1024 KV cache size
     And   128 max tokens to predict
-
-  Scenario Outline: Multi users completion
-    Given <n_slots> slots
     And   continuous batching
+
+  Scenario Outline: consistent results with same seed
+    Given <n_slots> slots
     Then  the server is starting
     Then  the server is healthy
 
-    Given 42 as seed
-    And a prompt:
-      """
-      Write a very long story about AI.
-      """
-
-    Given 42 as seed
-    And a prompt:
-      """
-      Write a very long story about AI.
-      """
-
-    Given 42 as seed
-    And a prompt:
-      """
-      Write a very long story about AI.
-      """
-
-    Given 42 as seed
-    And a prompt:
-      """
-      Write a very long story about AI.
-      """
-
-    Given 42 as seed
-    And a prompt:
-      """
-      Write a very long story about AI.
-      """
+    Given 4 prompts "Title: Little Red Riding Hood But In Space\n\nSummary:" with seed 42
 
     Given concurrent completion requests
     Then the server is busy
@@ -55,3 +27,55 @@ Feature: Results
       | n_slots |
       | 1       |
       | 2       |
+
+  Scenario Outline: different results with different seed
+    Given <n_slots> slots
+    Then  the server is starting
+    Then  the server is healthy
+
+    Given 1 prompts "Title: Little Red Riding Hood But In Space\n\nSummary:" with seed 42
+    Given 1 prompts "Title: Little Red Riding Hood But In Space\n\nSummary:" with seed 43
+    Given 1 prompts "Title: Little Red Riding Hood But In Space\n\nSummary:" with seed 44
+    Given 1 prompts "Title: Little Red Riding Hood But In Space\n\nSummary:" with seed 45
+
+    Given concurrent completion requests
+    Then the server is busy
+    Then the server is idle
+    And  all slots are idle
+    Then all predictions are different
+    Examples:
+      | n_slots |
+      | 1       |
+      | 2       |
+
+  Scenario Outline: consistent results with same seed and varying batch size
+    Given 4 slots
+    And   <temp> temperature
+    # And   0 as draft
+    Then  the server is starting
+    Then  the server is healthy
+
+    Given 1 prompts "Write a very long story about AI." with seed 42
+    And   concurrent completion requests
+    # Then the server is busy # Not all slots will be utilized.
+    Then  the server is idle
+    And   all slots are idle
+
+    Given <n_parallel> prompts "Write a very long story about AI." with seed 42
+    And   concurrent completion requests
+    # Then the server is busy # Not all slots will be utilized.
+    Then the server is idle
+    And  all slots are idle
+
+    Then all predictions are equal
+    Examples:
+      | n_parallel | temp |
+      |  1         | 0.0  |
+      |  2         | 0.0  |
+      |  4         | 0.0  |
+      |  1         | 1.0  |
+      # FIXME: These tests fail on master. The problem seems to be the unified KV cache.
+      # See https://github.com/ggerganov/whisper.cpp/issues/1941#issuecomment-1986923227
+      # and https://github.com/ggerganov/llama.cpp/pull/6122#discussion_r1531405574 .
+      # |  2         | 1.0  |
+      # |  4         | 1.0  |


### PR DESCRIPTION
While working on https://github.com/ggerganov/llama.cpp/pull/6828 I've been writing more tests to ensure that the results remain the same. However, while doing so I've noticed that for a given seed and a varying number of slots the results produced by the server are **not** deterministic. What I think is happening is that llama.cpp does not produce bit-for-bit identical results as the batch size is changed. Therefore, after some number of tokens two otherwise identical sequences randomly sample different tokens at which point they completely diverge.

I don't know if this can be fixed at all since the only way to get bit-for-bit identical results with floating point numbers is to do the exact same operations in the exact same order which would likely not yield good performance. Unless the CPU backend (which I used for testing) is supposed to produce bit-for-bit identical results in which case this would be indicative of a bug. In any case, feedback would be appreciated.

<details>
<summary>Sample outputs</summary>

```
content 0:  She was very proud of her story.
One day, she found an old cardboard box in her room. She was curious and decided to cut it in her project. She worked hard all day, cutting and tying until the box was ready.
Just then, her mom came into the room and said, "What are you doing, Sarah?"
Sarah smiled, "I'm cutting the box. I'm making a story about the truth!"
Her mom smiled and said, "That's very good. I'm so proud of you! Can I help you?"
Sarah nod
content 1:  She was very proud of her story.
One day, she found an old cardboard box in her room. She was curious and decided to cut it in her project. She worked hard all day, cutting and tying until the box was ready.
Just then, her mom came into the room and said, "What are you doing, Sarah?"
Sarah smiled, "I'm cutting the box. I'm making a story about the first one. Can you help me?"
Her mom smiled and said, "Of course! Let me see the surprise."
She took out a tube and showed
```

</details>