### PR TITLE
use std::chrono::system_clock::now() for random seed

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -1,5 +1,6 @@
 #define LLAMA_API_INTERNAL
 #include "sampling.h"
+#include <chrono>
 #include <random>
 
 struct llama_sampling_context * llama_sampling_init(const struct llama_sampling_params & params) {
@@ -68,7 +69,7 @@ void llama_sampling_reset(llama_sampling_context * ctx) {
 
 void llama_sampling_set_rng_seed(struct llama_sampling_context * ctx, uint32_t seed) {
     if (seed == LLAMA_DEFAULT_SEED) {
-        seed = time(NULL);
+        seed = static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count());
     }
     ctx->rng.seed(seed);
 }


### PR DESCRIPTION
Currently, the default random seed is set by `time(NULL)`, which returns an integer number of seconds. If we call `llama_sampling_init()` many times within a single second, then all of the sampling contexts get the same random seed. Such behavior can come as an unpleasant surprise. I encountered it today while attempting to generate many samples via [ollama](https://github.com/ollama/ollama), which makes use of [an adapted version of llama.cpp/examples/server/server.cpp](https://github.com/ollama/ollama/blob/8fd9e568046d57cc780e64a67b84fd6bce97a457/llm/ext_server/server.cpp).

We can avoid the problem by using a higher-precision clock to set the random seed. On my (Linux) system, `std::chrono::system_clock` measures its ticks in nanoseconds. On Windows/Visual Studio, [a tick is 100 nanoseconds](https://learn.microsoft.com/en-us/cpp/standard-library/system-clock-structure?view=msvc-170). `static_cast<uint32_t>` then truncates the higher-order bits.

An alternative to this clock-based approach would be to use `std::random_device`, as is already done in [utils.hpp](https://github.com/ggerganov/llama.cpp/blob/4dba7e8114d84241c842b986e008af8b88d1a019/examples/server/utils.hpp#L231-L232). I opted against that approach in this PR, however, because, as noted [here](https://en.cppreference.com/w/cpp/numeric/random/random_device), on some platforms `std::random_device` is deterministic.