### PR TITLE
use std::random_device{}() for default random seed

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -68,7 +68,7 @@ void llama_sampling_reset(llama_sampling_context * ctx) {
 
 void llama_sampling_set_rng_seed(struct llama_sampling_context * ctx, uint32_t seed) {
     if (seed == LLAMA_DEFAULT_SEED) {
-        seed = time(NULL);
+        seed = std::random_device{}();
     }
     ctx->rng.seed(seed);
 }


### PR DESCRIPTION
Currently, the default random seed is set by `time(NULL)`, which returns an integer number of seconds. If we call `llama_sampling_init()` many times within a single second, then all of the sampling contexts get the same random seed. Such behavior can come as an unpleasant surprise. I encountered it recently while attempting to generate many samples via [ollama](https://github.com/ollama/ollama), which makes use of [an adapted version of llama.cpp/examples/server/server.cpp](https://github.com/ollama/ollama/blob/8fd9e568046d57cc780e64a67b84fd6bce97a457/llm/ext_server/server.cpp).

We can avoid the problem by using [`std::random_device`](https://en.cppreference.com/w/cpp/numeric/random/random_device), as is already done in [utils.hpp](https://github.com/ggerganov/llama.cpp/blob/4dba7e8114d84241c842b986e008af8b88d1a019/examples/server/utils.hpp#L231-L232).

Note that on old versions of libstd++ on vxworks and mingw `std::random_device` was sometimes deterministic, however [that was considered a bug and was fixed](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85494).

I don't believe there should be any performance issues with using `std::random_device{}()`. On my Linux machine, it does not even require a system call, I think because it's using one of the [special CPU instructions `RDSEED` or `RDRAND`](https://en.wikipedia.org/wiki/RDRAND).