### PR TITLE
make : change GNU make default CXX from g++ to c++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,17 @@ ifndef UNAME_M
 UNAME_M := $(shell uname -m)
 endif
 
+# In GNU make default CXX is g++ instead of c++.  Let's fix that so that users
+# of non-gcc compilers don't have to provide g++ alias or wrapper.
+DEFCC  := cc
+DEFCXX := c++
+ifeq ($(origin CC),default)
+CC  := $(DEFCC)
+endif
+ifeq ($(origin CXX),default)
+CXX := $(DEFCXX)
+endif
+
 # Mac OS + Arm can report x86_64
 # ref: https://github.com/ggerganov/whisper.cpp/issues/66#issuecomment-1282546789
 ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
Analogous change to the one from sister project:

- https://github.com/ggerganov/whisper.cpp/pull/2100

Assuming `g++` is the default C++ compiler is the sin of [GNU make](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#index-CXX).