### PR TITLE
fix typo: LAMMAFILE -> LLAMAFILE

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -17729,9 +17729,9 @@ const char * llama_print_system_info(void) {
     s += "VSX = "         + std::to_string(ggml_cpu_has_vsx())         + " | ";
     s += "MATMUL_INT8 = " + std::to_string(ggml_cpu_has_matmul_int8()) + " | ";
 #ifdef GGML_USE_LLAMAFILE
-    s += "LAMMAFILE = 1 | ";
+    s += "LLAMAFILE = 1 | ";
 #else
-    s += "LAMMAFILE = 0 | ";
+    s += "LLAMAFILE = 0 | ";
 #endif
 
     return s.c_str();


### PR DESCRIPTION
I noticed that the console out said "LAMMAFILE". I'm assuming that this is a simple typo and that it's actually supposed to say "LLAMAFILE". This PR does the corresponding change.