### PR TITLE
ci : tmp disable gguf-split

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -161,7 +161,7 @@ function gg_run_test_scripts_debug {
     set -e
 
     # TODO: too slow, run on dedicated node
-    (cd ./examples/gguf-split && time bash tests.sh "$SRC/build-ci-debug/bin" "$MNT/models") 2>&1 | tee -a $OUT/${ci}-scripts.log
+   #(cd ./examples/gguf-split && time bash tests.sh "$SRC/build-ci-debug/bin" "$MNT/models") 2>&1 | tee -a $OUT/${ci}-scripts.log
    #(cd ./examples/quantize   && time bash tests.sh "$SRC/build-ci-debug/bin" "$MNT/models") 2>&1 | tee -a $OUT/${ci}-scripts.log
 
     set +e


### PR DESCRIPTION
This should alleviate ~4min of the current runtime on of the `ggml-4` node

Will soon move these tests to a separate node since they don't need to run on all nodes - the functionality is in the C++ layer so it does not depend on the underlying hardware