### PR TITLE
log more info when metal fails

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -2590,6 +2590,45 @@ static enum ggml_status ggml_metal_graph_compute(
         MTLCommandBufferStatus status = [command_buffer status];
         if (status != MTLCommandBufferStatusCompleted) {
             GGML_METAL_LOG_INFO("%s: command buffer %d failed with status %lu\n", __func__, i, status);
+            if (status == MTLCommandBufferStatusError) {
+                MTLCommandBufferError error_code = [command_buffer error].code;
+                switch (error_code) {
+                    case MTLCommandBufferErrorNone:
+                        GGML_METAL_LOG_INFO("no error code reported\n");
+                        break;
+                    case MTLCommandBufferErrorTimeout:
+                        GGML_METAL_LOG_INFO("timeout\n");
+                        break;
+                    case MTLCommandBufferErrorPageFault:
+                        GGML_METAL_LOG_INFO("unserviceable page fault\n");
+                        break;
+                    case MTLCommandBufferErrorOutOfMemory:
+                        GGML_METAL_LOG_INFO("out of memory\n");
+                        break;
+                    case MTLCommandBufferErrorInvalidResource:
+                        GGML_METAL_LOG_INFO("invalid reference to resource\n");
+                        break;
+                    case MTLCommandBufferErrorMemoryless:
+                        GGML_METAL_LOG_INFO("GPU ran out of one or more of its internal resources that support memoryless render pass attachments\n");
+                        break;
+                    case MTLCommandBufferErrorDeviceRemoved:
+                        GGML_METAL_LOG_INFO("device removed\n");
+                        break;
+                    case MTLCommandBufferErrorStackOverflow:
+                        GGML_METAL_LOG_INFO("kernel function of tile shader used too many stack frames\n");
+                        break;
+                    case MTLCommandBufferErrorAccessRevoked:
+                        GGML_METAL_LOG_INFO("access to device revoked by system\n");
+                        break;
+                    case MTLCommandBufferErrorInternal:
+                        GGML_METAL_LOG_INFO("internal error\n");
+                        break;
+                    default:
+                        GGML_METAL_LOG_INFO("unknown error %lu\n", error_code);
+                        break;
+                }
+            }
+
             return GGML_STATUS_FAILED;
         }
     }


### PR DESCRIPTION
Messages codes are documented [here](https://developer.apple.com/documentation/metal/mtlcommandbuffererror/mtlcommandbuffererrordeviceremoved?language=objc).

Now if you try to use too much memory, instead of just

```
ggml_metal_graph_compute: command buffer 6 failed with status 5
```

you get

```
ggml_metal_graph_compute: command buffer 6 failed with status 5
out of memory
```

which is much nicer!

The "status 5" thing is kind of misleading, since [that status is just "error"](https://developer.apple.com/documentation/metal/mtlcommandbufferstatus?language=objc) - the other statuses shouldn't be reachable after the earlier [waitUntilCompleted](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1443039-waituntilcompleted?language=objc), if I'm reading the docs right. Happy to tweak that part too while I'm here if you'd ike.