### PR TITLE
ci : exempt confirmed bugs from being tagged as stale

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          exempt-issue-labels: "refactor,help wanted,good first issue,research"
+          exempt-issue-labels: "refactor,help wanted,good first issue,research,bug"
           days-before-issue-stale: 30
           days-before-issue-close: 14
           stale-issue-label: "stale"


### PR DESCRIPTION
Prevent marking from stale issues with the `bug` tag (as opposed to `bug-unconfirmed`), since these should have been verified to be bugs by a collaborator.