### PR TITLE
Tidy Android Instructions README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,7 +990,7 @@ cd storage/downloads
 mv model.gguf ~/
 ```
 
-[Follow Linux Build instruction](https://github.com/ggerganov/llama.cpp#build) to build & run `llama.cpp`.
+[Follow Linux Build instruction](https://github.com/ggerganov/llama.cpp#build) to build `llama.cpp`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -984,7 +984,7 @@ apt update && apt upgrade -y
 apt install git
 ```
 
-It's essential to move your model inside the `~/` directory for best performance:
+It's recommended to move your model inside the `~/` directory for best performance:
 ```
 cd storage/downloads
 mv model.gguf ~/

--- a/README.md
+++ b/README.md
@@ -996,6 +996,7 @@ mv model.gguf ~/
 
 Build & run `llama.cpp`:
 ```
+apt install git
 $HOME
 git clone https://github.com/ggerganov/llama.cpp
 cd llama.cpp

--- a/README.md
+++ b/README.md
@@ -979,13 +979,9 @@ https://user-images.githubusercontent.com/271616/225014776-1d567049-ad71-4ef2-b0
 
 #### Build on Android using Termux (F-Droid)
 F-Droid Termux is an alternative to execute `llama.cpp` on an Android device(*no root required*).
-
-Below are instructions to install `llama.cpp` including CPU and OpenBLAS inference.
-
-If you opt to utilize OpenBLAS, you'll need to install the corresponding package.
 ```
 apt update && apt upgrade -y
-apt install libopenblas
+apt install git
 ```
 
 Due to permission limitations in the Android API, it's essential to move your model inside the `~/` directory for best performance:
@@ -994,16 +990,7 @@ cd storage/downloads
 mv model.gguf ~/
 ```
 
-Build & run `llama.cpp`:
-```
-apt install git
-$HOME
-git clone https://github.com/ggerganov/llama.cpp
-cd llama.cpp
-cmake -B build -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS && cd build && cmake --build . --config Release
-cd bin
-./main -m ~/model.gguf -p "Building a website can be done in 10 simple steps:\nStep 1:"
-```
+[Follow Linux Build instruction](https://github.com/ggerganov/llama.cpp#build) to build & run `llama.cpp`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -977,48 +977,32 @@ Here is a demo of an interactive session running on Pixel 5 phone:
 
 https://user-images.githubusercontent.com/271616/225014776-1d567049-ad71-4ef2-b050-55b0b3b9274c.mp4
 
-#### Building the Project using Termux (F-Droid)
-Termux from F-Droid offers an alternative route to execute the project on an Android device. This method empowers you to construct the project right from within the terminal, negating the requirement for a rooted device or SD Card.
+#### Build on Android using Termux (F-Droid)
+F-Droid Termux is an alternative to execute `llama.cpp` on an Android device(*no root required*).
 
-Outlined below are the directives for installing the project using OpenBLAS and CLBlast. This combination is specifically designed to deliver peak performance on recent devices that feature a GPU.
+Below are instructions to install `llama.cpp` including CPU and OpenBLAS inference.
 
 If you opt to utilize OpenBLAS, you'll need to install the corresponding package.
 ```
+apt update && apt upgrade -y
 apt install libopenblas
 ```
 
-Subsequently, if you decide to incorporate CLBlast, you'll first need to install the requisite OpenCL packages:
+Due to permission limitations in the Android API, it's essential to move your model inside the `~/` directory for best performance:
 ```
-apt install ocl-icd opencl-headers opencl-clhpp clinfo
-```
-
-In order to compile CLBlast, you'll need to first clone the respective Git repository, which can be found at this URL: https://github.com/CNugteren/CLBlast. Alongside this, clone this repository into your home directory. Once this is done, navigate to the CLBlast folder and execute the commands detailed below:
-```
-cmake .
-make
-cp libclblast.so* $PREFIX/lib
-cp ./include/clblast.h ../llama.cpp
+cd storage/downloads
+mv model.gguf ~/
 ```
 
-Following the previous steps, navigate to the LlamaCpp directory. To compile it with OpenBLAS and CLBlast, execute the command provided below:
+Build & run `llama.cpp`:
 ```
-cp /data/data/com.termux/files/usr/include/openblas/cblas.h .
-cp /data/data/com.termux/files/usr/include/openblas/openblas_config.h .
-make LLAMA_CLBLAST=1 //(sometimes you need to run this command twice)
+$HOME
+git clone https://github.com/ggerganov/llama.cpp
+cd llama.cpp
+cmake -B build -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=OpenBLAS && cd build && cmake --build . --config Release
+cd bin
+./main -m ~/model.gguf -p "Building a website can be done in 10 simple steps:\nStep 1:"
 ```
-
-Upon completion of the aforementioned steps, you will have successfully compiled the project. To run it using CLBlast, a slight adjustment is required: a command must be issued to direct the operations towards your device's physical GPU, rather than the virtual one. The necessary command is detailed below:
-```
-GGML_OPENCL_PLATFORM=0
-GGML_OPENCL_DEVICE=0
-export LD_LIBRARY_PATH=/vendor/lib64:$LD_LIBRARY_PATH
-```
-
-(Note: some Android devices, like the Zenfone 8, need the following command instead - "export LD_LIBRARY_PATH=/system/vendor/lib64:$LD_LIBRARY_PATH". Source: https://www.reddit.com/r/termux/comments/kc3ynp/opencl_working_in_termux_more_in_comments/ )
-
-For easy and swift re-execution, consider documenting this final part in a .sh script file. This will enable you to rerun the process with minimal hassle.
-
-Place your desired model into the `~/llama.cpp/models/` directory and execute the `./main (...)` script.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -984,7 +984,7 @@ apt update && apt upgrade -y
 apt install git
 ```
 
-Due to permission limitations in the Android API, it's essential to move your model inside the `~/` directory for best performance:
+It's essential to move your model inside the `~/` directory for best performance:
 ```
 cd storage/downloads
 mv model.gguf ~/

--- a/README.md
+++ b/README.md
@@ -990,7 +990,7 @@ cd storage/downloads
 mv model.gguf ~/
 ```
 
-[Follow Linux Build instruction](https://github.com/ggerganov/llama.cpp#build) to build `llama.cpp`.
+[Follow the Linux build instructions](https://github.com/ggerganov/llama.cpp#build) to build `llama.cpp`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -977,8 +977,8 @@ Here is a demo of an interactive session running on Pixel 5 phone:
 
 https://user-images.githubusercontent.com/271616/225014776-1d567049-ad71-4ef2-b050-55b0b3b9274c.mp4
 
-#### Build on Android using Termux (F-Droid)
-F-Droid Termux is an alternative to execute `llama.cpp` on an Android device (no root required).
+#### Build on Android using Termux
+[Termux](https://github.com/termux/termux-app#installation) is an alternative to execute `llama.cpp` on an Android device (no root required).
 ```
 apt update && apt upgrade -y
 apt install git

--- a/README.md
+++ b/README.md
@@ -978,7 +978,7 @@ Here is a demo of an interactive session running on Pixel 5 phone:
 https://user-images.githubusercontent.com/271616/225014776-1d567049-ad71-4ef2-b050-55b0b3b9274c.mp4
 
 #### Build on Android using Termux (F-Droid)
-F-Droid Termux is an alternative to execute `llama.cpp` on an Android device(*no root required*).
+F-Droid Termux is an alternative to execute `llama.cpp` on an Android device (no root required).
 ```
 apt update && apt upgrade -y
 apt install git


### PR DESCRIPTION
It's [better to tidy](https://github.com/ggerganov/llama.cpp/issues/6995#issuecomment-2085184041) readme regarding `CLBlast` instructions for Android.

Removed CLBlast instructions(*outdated*). Simplified Android CPU Build instructions.
