### PR TITLE
Bug fix for server crash if first token is the stop word and asking for logprobs

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1383,9 +1383,10 @@ struct server_context {
             if (!slot.params.stream && slot.stopped_word) {
                 const std::vector<llama_token> stop_word_toks = llama_tokenize(ctx, slot.stopping_word, false);
 
+                size_t safe_offset = std::min(slot.generated_token_probs.size(), stop_word_toks.size());
                 probs = std::vector<completion_token_output>(
                         slot.generated_token_probs.begin(),
-                        slot.generated_token_probs.end() - stop_word_toks.size());
+                        slot.generated_token_probs.end() - safe_offset);
             } else {
                 probs = std::vector<completion_token_output>(
                         slot.generated_token_probs.begin(),


### PR DESCRIPTION
If the stop token is the first suggested token from the model and we ask for logprobs the server will crash when generating the logprobs vector

Currently this fix makes the allocation of the vector to be safer and wont crash the server. 
it returns an empty content but also does not return any logprobs...  

Toy example to reproduce on LLama2-13b

{'prompt': 'Q: hello world \nA: ',
 'stop': ['\n'],
 'temperature': 0.0,
 'n_predict': 10,
 'cache_prompt': True,
 'n_probs': 10}