### PR TITLE
llama : rename ctx to user_data in progress_callback

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -171,7 +171,7 @@ extern "C" {
         bool sorted;
     } llama_token_data_array;
 
-    typedef bool (*llama_progress_callback)(float progress, void *user_data);
+    typedef bool (*llama_progress_callback)(float progress, void * user_data);
 
     // Input data for llama_decode
     // A llama_batch object can contain input about one or many sequences

--- a/llama.h
+++ b/llama.h
@@ -171,7 +171,7 @@ extern "C" {
         bool sorted;
     } llama_token_data_array;
 
-    typedef bool (*llama_progress_callback)(float progress, void *ctx);
+    typedef bool (*llama_progress_callback)(float progress, void *user_data);
 
     // Input data for llama_decode
     // A llama_batch object can contain input about one or many sequences


### PR DESCRIPTION
This commit renames the `ctx` parameter to `user_data` in the `llama_progress_callback` typedef.

The motivation for this is that other callbacks use `user_data` or `data`, and using `ctx` in this case might be confusing as it could be confused with `llama_context`.