### PR TITLE
Remove .attention from skipped tensors to match more accurately

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1427,7 +1427,7 @@ class LlamaModel(Model):
         experts = dict()
         for name, data_torch in self.get_tensors():
             # we don't need these
-            if name.endswith((".attention.masked_bias", ".attention.bias", ".attention.rotary_emb.inv_freq")):
+            if name.endswith((".attention.masked_bias", ".attention.bias", ".rotary_emb.inv_freq")):
                 continue
 
             old_dtype = data_torch.dtype


### PR DESCRIPTION
This change fixes https://github.com/ggerganov/llama.cpp/issues/7046

https://huggingface.co/nvidia/ChatQA-1.5-8B has tensors called `model.layers.x.self_attn.rotary_emb.inv_freq` instead of `model.layers.x.self_attn.attention.rotary_emb.inv_freq`, this change will capture both and properly skip them.