### PR TITLE
Fix Linux /sys cpu path to guess number of cores

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -76,7 +76,7 @@ int32_t get_num_physical_cores() {
     // enumerate the set of thread siblings, num entries is num cores
     std::unordered_set<std::string> siblings;
     for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
-        std::ifstream thread_siblings("/sys/devices/system/cpu"
+        std::ifstream thread_siblings("/sys/devices/system/cpu/cpu"
             + std::to_string(cpu) + "/topology/thread_siblings");
         if (!thread_siblings.is_open()) {
             break; // no more cpus


### PR DESCRIPTION
The path was wrong on linux so it always went to the fallback case.