### PR TITLE
two converter py files needs basicConfig() added

### DIFF
--- a/convert-hf-to-gguf-update.py
+++ b/convert-hf-to-gguf-update.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This script downloads the tokenizer models of the specified models from Huggingface and
 # generates the get_vocab_base_pre() function for convert-hf-to-gguf.py
 #
@@ -32,6 +34,7 @@ from enum import IntEnum, auto
 from transformers import AutoTokenizer
 
 logger = logging.getLogger("convert-hf-to-gguf-update")
+logging.basicConfig(level=logging.INFO)
 
 
 class TOKENIZER_TYPE(IntEnum):

--- a/convert-lora-to-ggml.py
+++ b/convert-lora-to-ggml.py
@@ -17,6 +17,7 @@ if 'NO_LOCAL_GGUF' not in os.environ:
 import gguf
 
 logger = logging.getLogger("lora-to-gguf")
+logging.basicConfig(level=logging.INFO)
 
 NUMPY_TYPE_TO_FTYPE: dict[str, int] = {"float32": 0, "float16": 1}
 


### PR DESCRIPTION
Address for now an issue of two .py file not printing https://github.com/ggerganov/llama.cpp/pull/6511#issuecomment-2094014941

Also made a py file executable.

This is a stopgap fix until ArgumentParser() is added so its easier to add `--verbose` mode (which I won't be doing yet, so others can give it a shot)