### PR TITLE
fix: use `vm_allocate` instead of `posix_memalign` for Metal on macOS

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -2944,14 +2944,16 @@ GGML_CALL static ggml_backend_buffer_t ggml_backend_metal_buffer_type_alloc_buff
     ctx->owned = true;
     ctx->n_buffers = 1;
 
-    ctx->buffers[0].data = ctx->all_data;
-    ctx->buffers[0].size = size;
-    ctx->buffers[0].metal = [device newBufferWithBytesNoCopy:ctx->all_data
-                    length:size_aligned
-                    options:MTLResourceStorageModeShared
-                    deallocator:nil];
+    if (ctx->all_data != NULL) {
+        ctx->buffers[0].data = ctx->all_data;
+        ctx->buffers[0].size = size;
+        ctx->buffers[0].metal = [device newBufferWithBytesNoCopy:ctx->all_data
+                        length:size_aligned
+                        options:MTLResourceStorageModeShared
+                        deallocator:nil];
+    }
 
-    if (ctx->buffers[0].metal == nil) {
+    if (ctx->all_data == NULL || ctx->buffers[0].metal == nil) {
         GGML_METAL_LOG_ERROR("%s: error: failed to allocate buffer, size = %8.2f MiB\n", __func__, size_aligned / 1024.0 / 1024.0);
         free(ctx);
         ggml_backend_metal_free_device();

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -264,10 +264,9 @@ static void ggml_metal_log(enum ggml_log_level level, const char * format, ...){
 }
 
 static void * ggml_metal_host_malloc(size_t n) {
-    void * data = NULL;
-    const int result = posix_memalign((void **) &data, sysconf(_SC_PAGESIZE), n);
-    if (result != 0) {
-        GGML_METAL_LOG_ERROR("%s: error: posix_memalign failed\n", __func__);
+    void * data = malloc(n);
+    if (data == null) {
+        GGML_METAL_LOG_ERROR("%s: error: malloc failed\n", __func__);
         return NULL;
     }
 

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -265,7 +265,7 @@ static void ggml_metal_log(enum ggml_log_level level, const char * format, ...){
 
 static void * ggml_metal_host_malloc(size_t n) {
     void * data = malloc(n);
-    if (data == null) {
+    if (data == NULL) {
         GGML_METAL_LOG_ERROR("%s: error: malloc failed\n", __func__);
         return NULL;
     }


### PR DESCRIPTION
Creating a context in an Electron app using `node-llama-cpp` crashes the process with some models ([issue](https://github.com/withcatai/node-llama-cpp/issues/212)), so I've investigated what's happening and found that allocating a large memory block using `posix_memalign` is the culprit.

For some reason, it happens only on Electron and not on Nodejs, but I couldn't figure out why.

From my testings in Electron:
* `posix_memalign((void **) &data, 16384, 587218944)` - works fine
* `posix_memalign((void **) &data, 16384, 1073741824)` - crashes the process with SIGTRAP
> Tested on an M1 Max machine with 32GB of RAM

I tried switching from `posix_memalign` to `malloc` in `ggml-metal.m`, and it seems that everything still works correctly, but maybe I'm missing something.
I assume that `posix_memalign` is used there for a reason, but since it seems to me that everything still works great with `malloc`, maybe the original reason for using `posix_memalign` is irrelevant by now?

I'm not sure whether the change I made in this PR is a good idea, so I opened it so someone more knowledgable in this area can take a look.

This may be a bug specific to Electron, so I shared [my findings on the Electron repo](https://github.com/electron/electron/issues/41513#issuecomment-2094327194), but since I haven't noticed any side effect of this workaround in `llama.cpp`, I think it may be a good idea to also solve this issue here.