### PR TITLE
Add left recursion check: quit early instead of going into an infinite loop

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -13179,13 +13179,6 @@ static bool llama_grammar_detect_left_recursion(
         size_t                                                  rule_index,
         std::vector<bool>                                     * rules_visited,
         std::vector<bool>                                     * rules_in_progress,
-        std::vector<bool>                                     * rules_may_be_empty);
-
-static bool llama_grammar_detect_left_recursion(
-        const std::vector<std::vector<llama_grammar_element>> & rules,
-        size_t                                                  rule_index,
-        std::vector<bool>                                     * rules_visited,
-        std::vector<bool>                                     * rules_in_progress,
         std::vector<bool>                                     * rules_may_be_empty) {
     if ((*rules_in_progress)[rule_index]) {
         return true;

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -28,6 +28,18 @@ static llama_grammar* build_grammar(const std::string & grammar_str) {
     return grammar;
 }
 
+static bool test_build_grammar_fails(const std::string & grammar_str) {
+    bool grammar_fails = false;
+    try {
+        build_grammar(grammar_str);
+        fprintf(stderr, "❌ Expected build failure, but succeeded: %s\n", grammar_str.c_str());
+    } catch (const std::exception & err) {
+        grammar_fails = true;
+        fprintf(stdout, "✅︎\n");
+    }
+    return grammar_fails;
+}
+
 static bool match_string(const std::string & input, llama_grammar* grammar) {
     auto decoded = decode_utf8(input, {});
 
@@ -320,6 +332,30 @@ number ::= [0-9]+)""";
     fprintf(stderr, "  ✅︎ Passed\n");
 }
 
+static void test_failure_left_recursion() {
+    fprintf(stderr, "⚫ Testing left recursion detection:\n");
+
+    // Test simple left recursion detection
+    const std::string simple_str = R"""(root ::= "a" | root "a")""";
+    assert(test_build_grammar_fails(simple_str));
+
+    // Test more complicated left recursion detection
+    const std::string medium_str = R"""(
+root ::= asdf
+asdf ::= "a" | asdf "a"
+)""";
+    assert(test_build_grammar_fails(medium_str));
+
+    // Test even more complicated left recursion detection
+    const std::string hard_str = R"""(
+root ::= asdf
+asdf ::= "a" | foo "b"
+foo ::= "c" | asdf "d" | "e")""";
+    assert(test_build_grammar_fails(hard_str));
+
+    fprintf(stderr, "  ✅︎ Passed\n");
+}
+
 int main() {
     fprintf(stdout, "Running grammar integration tests...\n");
     test_simple_grammar();
@@ -327,6 +363,7 @@ int main() {
     test_quantifiers();
     test_failure_missing_root();
     test_failure_missing_reference();
+    test_failure_left_recursion();
     fprintf(stdout, "All tests passed.\n");
     return 0;
 }

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -29,13 +29,14 @@ static llama_grammar* build_grammar(const std::string & grammar_str) {
 }
 
 static bool test_build_grammar_fails(const std::string & grammar_str) {
+    fprintf(stderr, "⚫ Testing failure for grammar: %s\n", grammar_str.c_str());
     bool grammar_fails = false;
     try {
         build_grammar(grammar_str);
-        fprintf(stderr, "❌ Expected build failure, but succeeded: %s\n", grammar_str.c_str());
+        fprintf(stderr, "  ❌ Expected build failure, but succeeded\n");
     } catch (const std::exception & err) {
         grammar_fails = true;
-        fprintf(stdout, "✅︎\n");
+        fprintf(stdout, "  ✅︎\n");
     }
     return grammar_fails;
 }
@@ -352,6 +353,14 @@ root ::= asdf
 asdf ::= "a" | foo "b"
 foo ::= "c" | asdf "d" | "e")""";
     assert(test_build_grammar_fails(hard_str));
+
+    // Test yet even more complicated left recursion detection
+    const std::string hardest_str = R"""(
+root ::= asdf
+asdf ::= "a" | foo "b"
+foo ::= "c" | empty asdf "d" | "e"
+empty ::= "blah" | )""";
+    assert(test_build_grammar_fails(hardest_str));
 
     fprintf(stderr, "  ✅︎ Passed\n");
 }


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/6492

Adds a check to see if the grammar has left recursion, and quits instead of going into an infinite loop.

I'm not sure if this is the best place for it, happy to move it around if not.

attn: @HanClinto 