### PR TITLE
opencl alignment size should be converted from bits to bytes

### DIFF
--- a/ggml-opencl.cpp
+++ b/ggml-opencl.cpp
@@ -2119,7 +2119,7 @@ static size_t ggml_backend_opencl_buffer_type_get_alignment(ggml_backend_buffer_
     if (alignment == (cl_uint)-1) {
         ggml_cl_init();
         clGetDeviceInfo(device, CL_DEVICE_MEM_BASE_ADDR_ALIGN, sizeof(cl_uint), &alignment, NULL);
-        alignment >>= 3;
+        alignment /= 8; // bits to bytes
     }
     return alignment;
 

--- a/ggml-opencl.cpp
+++ b/ggml-opencl.cpp
@@ -2119,6 +2119,7 @@ static size_t ggml_backend_opencl_buffer_type_get_alignment(ggml_backend_buffer_
     if (alignment == (cl_uint)-1) {
         ggml_cl_init();
         clGetDeviceInfo(device, CL_DEVICE_MEM_BASE_ADDR_ALIGN, sizeof(cl_uint), &alignment, NULL);
+        alignment >>= 3;
     }
     return alignment;
 


### PR DESCRIPTION
Reference: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_DEVICE_MEM_BASE_ADDR_ALIGN

> Alignment requirement (in bits) for sub-buffer offsets.