### PR TITLE
Fixed save_imatrix to match old behaviour for MoE

### DIFF
--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -121,10 +121,7 @@ bool IMatrixCollector::collect_imatrix(struct ggml_tensor * t, bool ask, void * 
 
         auto & e = m_stats[wname];
 
-        // We select top-k experts, the number of calls for the expert tensors will be k times larger.
-        // NOTE: This will trigger the "if (e.ncall > m_last_call)" save conditional on the first active expert.
-        //       The commented out "if (idx == t->src[0]->ne[0] - 1) ++e.ncall;" doesn't work.
-        if (((int32_t *) t->op_params)[0] == 0) ++e.ncall;
+        ++e.ncall;
 
         if (e.values.empty()) {
             e.values.resize(src1->ne[0]*n_as, 0);

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -284,7 +284,7 @@ bool IMatrixCollector::load_imatrix(const char * imatrix_file, std::unordered_ma
             e.values.resize(nval, 0);
             e.counts.resize(nval, 0);
         }
-        
+
         std::vector<float> tmp(nval);
         in.read((char*)tmp.data(), nval*sizeof(float));
         if (in.fail()) {
@@ -297,9 +297,9 @@ bool IMatrixCollector::load_imatrix(const char * imatrix_file, std::unordered_ma
         for (int i = 0; i < nval; i++) {
             e.values[i] += tmp[i];
             e.counts[i] += ncall;
-        } 
+        }
         e.ncall += ncall;
-        
+
     }
     return true;
 }

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -124,11 +124,11 @@ bool IMatrixCollector::collect_imatrix(struct ggml_tensor * t, bool ask, void * 
         // We select top-k experts, the number of calls for the expert tensors will be k times larger.
         // NOTE: This will trigger the "if (e.ncall > m_last_call)" save conditional on the first active expert.
         //       The commented out "if (idx == t->src[0]->ne[0] - 1) ++e.ncall;" doesn't work.
-        if (idx == 0) ++e.ncall;
+        if (((int32_t *) t->op_params)[0] == 0) ++e.ncall;
 
         if (e.values.empty()) {
             e.values.resize(src1->ne[0]*n_as, 0);
-            e.counts.resize(src1->ne[0]*n_as, 0); // +++
+            e.counts.resize(src1->ne[0]*n_as, 0);
         }
         else if (e.values.size() != (size_t)src1->ne[0]*n_as) {
             fprintf(stderr, "Oops: inconsistent size for %s (%d vs %d)\n", wname.c_str(), (int)e.values.size(), (int)src1->ne[0]*n_as);
@@ -232,7 +232,7 @@ void IMatrixCollector::save_imatrix(const char * fname, const char * dataset) co
             for (int i = 0; i < nval; i++) {
                 tmp[i] = (p.second.values[i] / static_cast<float>(p.second.counts[i])) * static_cast<float>(p.second.ncall);
             }
-            out.write((const char*)tmp.data(), nval*sizeof(float))
+            out.write((const char*)tmp.data(), nval*sizeof(float));
         }
     }
 

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -297,9 +297,9 @@ bool IMatrixCollector::load_imatrix(const char * imatrix_file, std::unordered_ma
         for (int i = 0; i < nval; i++) {
             e.values[i] += tmp[i];
             e.counts[i] += ncall;
-        }
+        } 
+        e.ncall += ncall;
         
-        e.ncall = ncall;
     }
     return true;
 }

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -278,13 +278,27 @@ bool IMatrixCollector::load_imatrix(const char * imatrix_file, std::unordered_ma
             imatrix_data = {};
             return false;
         }
-        e.values.resize(nval);
-        in.read((char*)e.values.data(), nval*sizeof(float));
+
+        // When re-called from load_imatrix() with add set, this will already be created.
+        if (e.values.empty()) {
+            e.values.resize(nval, 0);
+            e.counts.resize(nval, 0);
+        }
+        
+        std::vector<float> tmp(nval);
+        in.read((char*)tmp.data(), nval*sizeof(float));
         if (in.fail()) {
             printf("%s: failed reading data for entry %d\n",__func__,i);
             imatrix_data = {};
             return false;
         }
+
+        // Recreate the state as expected by save_imatrix(), and corerct for weighted sum.
+        for (int i = 0; i < nval; i++) {
+            e.values[i] += tmp[i];
+            e.counts[i] += ncall;
+        }
+        
         e.ncall = ncall;
     }
     return true;


### PR DESCRIPTION
This fix is simple and clear, but unnecessarily doubles the memory overhead...

It can be used as a test to refactor `collect_imatrix()` and/or make `struct Stats` only use O(d + n_experts) memory.

Also the commented out `if (idx == t->src[0]->ne[0] - 1) ++e.ncall` code didn't work as intended (ie: increment on the last top-k expert callback) and I had to use `if (idx == 0)` instead. This will have the possibly unwanted effect of triggering the `if (e.ncall > m_last_call)` conditional below to save the imatrix on the first top-k expert rather than the last.