### PR TITLE
Update log text (EOS to EOG)

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -796,7 +796,7 @@ int main(int argc, char ** argv) {
 
             // deal with end of generation tokens in interactive mode
             if (llama_token_is_eog(model, llama_sampling_last(ctx_sampling))) {
-                LOG("found some EOG token\n");
+                LOG("found an EOG token\n");
 
                 if (params.interactive) {
                     if (!params.antiprompt.empty()) {

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -796,7 +796,7 @@ int main(int argc, char ** argv) {
 
             // deal with end of generation tokens in interactive mode
             if (llama_token_is_eog(model, llama_sampling_last(ctx_sampling))) {
-                LOG("found EOS token\n");
+                LOG("found some EOG token\n");
 
                 if (params.interactive) {
                     if (!params.antiprompt.empty()) {


### PR DESCRIPTION
The log text "found EOS" is no longer always correct, here, because there is now an is-EOG check that also returns true for EOT.