### PR TITLE
compare-llama-bench.py: add missing basicConfig

### DIFF
--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -93,8 +93,11 @@ help_s = (
     "specified values are averaged WITHOUT weighing by the --repetitions parameter of llama-bench."
 )
 parser.add_argument("-s", "--show", help=help_s)
+parser.add_argument("--verbose", action="store_true", help="increase output verbosity")
 
 known_args, unknown_args = parser.parse_known_args()
+
+logging.basicConfig(level=logging.DEBUG if known_args.verbose else logging.INFO)
 
 if unknown_args:
     logger.error(f"Received unknown args: {unknown_args}.")

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -100,7 +100,7 @@ known_args, unknown_args = parser.parse_known_args()
 logging.basicConfig(level=logging.DEBUG if known_args.verbose else logging.INFO)
 
 if unknown_args:
-    logger.error(f"Received unknown args: {unknown_args}.")
+    logger.error(f"Received unknown args: {unknown_args}.\n")
     parser.print_help()
     sys.exit(1)
 
@@ -113,7 +113,7 @@ if input_file is None:
         input_file = sqlite_files[0]
 
 if input_file is None:
-    logger.error("Cannot find a suitable input file, please provide one.")
+    logger.error("Cannot find a suitable input file, please provide one.\n")
     parser.print_help()
     sys.exit(1)
 
@@ -205,12 +205,12 @@ elif repo is not None:
     hexsha8_baseline = find_parent_in_data(repo.heads.master.commit)
 
     if hexsha8_baseline is None:
-        logger.error("No baseline was provided and did not find data for any master branch commits.")
+        logger.error("No baseline was provided and did not find data for any master branch commits.\n")
         parser.print_help()
         sys.exit(1)
 else:
     logger.error("No baseline was provided and the current working directory "
-                 "is not part of a git repository from which a baseline could be inferred.")
+                 "is not part of a git repository from which a baseline could be inferred.\n")
     parser.print_help()
     sys.exit(1)
 
@@ -241,7 +241,7 @@ elif repo is not None:
             break
 
     if hexsha8_compare is None:
-        logger.error("No compare target was provided and did not find data for any non-master commits.")
+        logger.error("No compare target was provided and did not find data for any non-master commits.\n")
         parser.print_help()
         sys.exit(1)
 else:

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -364,7 +364,7 @@ if "gpu_info" in show:
 headers  = [PRETTY_NAMES[p] for p in show]
 headers += ["Test", f"t/s {name_baseline}", f"t/s {name_compare}", "Speedup"]
 
-logger.info(tabulate(
+print(tabulate( # noqa: NP100
     table,
     headers=headers,
     floatfmt=".2f",


### PR DESCRIPTION
Source Issue: https://github.com/ggerganov/llama.cpp/pull/6511 

@csaben 

> This has broken compare-llama-bench.py.

I believe it's due to missing this line `logging.basicConfig(level=logging.DEBUG if known_args.verbose else logging.INFO)`. See if this fixes the issue for you.