### PR TITLE
llama : update llama_timings.n_p_eval setting

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -17879,7 +17879,7 @@ struct llama_timings llama_get_timings(struct llama_context * ctx) {
         /*.t_eval_ms   =*/ 1e-3 * ctx->t_eval_us,
 
         /*.n_sample =*/ std::max(1, ctx->n_sample),
-        /*.n_p_eval =*/ std::max(1, ctx->n_p_eval),
+        /*.n_p_eval =*/ std::max(0, ctx->n_p_eval),
         /*.n_eval   =*/ std::max(1, ctx->n_eval),
     };
 


### PR DESCRIPTION
This commit changes the value assigned to llama_timings.n_p_eval when ctx->n_p_eval is 0 to be 1 instead of 1 which is the current value.

The motivation for this change is that if session caching is enabled, for example using the `--prompt-cache main-session.txt` command line argument for the main example, and if the same prompt is used then on subsequent runs, the prompt tokens will not actually be passed to llama_decode, and n_p_eval will not be updated by llama_synchoronize.

But the value of n_p_eval will be set 1 by llama_get_timings because ctx->n_p_eval will be 0. This could be interpreted as 1 token was evaluated for the prompt which could be misleading for applications using this value.

----
<details><summary> Example using main</summary>

### Current behavior on master
First run:
```console
./main -m models/tinyllama-1.1b-1t-openorca.Q2_K.gguf --prompt 'Hello world' -n 3 --verbose-prompt --prompt-cache main-session.txt
...
main: prompt: 'Hello world'
main: number of tokens in prompt = 3
     1 -> '<s>'
 15043 -> ' Hello'
  3186 -> ' world'

sampling: 
	repeat_last_n = 64, repeat_penalty = 1,000, frequency_penalty = 0,000, presence_penalty = 0,000
	top_k = 40, tfs_z = 1,000, top_p = 0,950, min_p = 0,050, typical_p = 1,000, temp = 0,800
	mirostat = 0, mirostat_lr = 0,100, mirostat_ent = 5,000
sampling order: 
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature 
generate: n_ctx = 512, n_batch = 2048, n_predict = 3, n_keep = 1


<s> Hello world, what is
llama_print_timings:        load time =     109,87 ms
llama_print_timings:      sample time =       0,07 ms /     3 runs   (    0,02 ms per token, 44776,12 tokens per second)
llama_print_timings: prompt eval time =     129,70 ms /     3 tokens (   43,23 ms per token,    23,13 tokens per second)
llama_print_timings:        eval time =     109,38 ms /     2 runs   (   54,69 ms per token,    18,29 tokens per second)
llama_print_timings:       total time =     240,37 ms /     5 tokens
```
Second run:
```console
./main -m models/tinyllama-1.1b-1t-openorca.Q2_K.gguf --prompt 'Hello world' -n 3 --verbose-prompt --prompt-cache main-session.txt
...
main: prompt: 'Hello world'
main: number of tokens in prompt = 3
     1 -> '<s>'
 15043 -> ' Hello'
  3186 -> ' world'

sampling: 
	repeat_last_n = 64, repeat_penalty = 1,000, frequency_penalty = 0,000, presence_penalty = 0,000
	top_k = 40, tfs_z = 1,000, top_p = 0,950, min_p = 0,050, typical_p = 1,000, temp = 0,800
	mirostat = 0, mirostat_lr = 0,100, mirostat_ent = 5,000
sampling order: 
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature 
generate: n_ctx = 512, n_batch = 2048, n_predict = 3, n_keep = 1


<s> Hello world, this is
llama_print_timings:        load time =     136,40 ms
llama_print_timings:      sample time =       0,07 ms /     3 runs   (    0,02 ms per token, 46153,85 tokens per second)
llama_print_timings: prompt eval time =       0,00 ms /     1 tokens (    0,00 ms per token,      inf tokens per second)
llama_print_timings:        eval time =     101,48 ms /     2 runs   (   50,74 ms per token,    19,71 tokens per second)
llama_print_timings:       total time =     123,87 ms /     3 tokens

```

### Current behavior using this pull request
First run is the same as the first run above.

Second run:
```console
./main -m models/tinyllama-1.1b-1t-openorca.Q2_K.gguf --prompt 'Hello world' -n 3 --verbose-prompt --prompt-cache main-session.txt
...
main: prompt: 'Hello world'
main: number of tokens in prompt = 3
     1 -> '<s>'
 15043 -> ' Hello'
  3186 -> ' world'

sampling: 
	repeat_last_n = 64, repeat_penalty = 1,000, frequency_penalty = 0,000, presence_penalty = 0,000
	top_k = 40, tfs_z = 1,000, top_p = 0,950, min_p = 0,050, typical_p = 1,000, temp = 0,800
	mirostat = 0, mirostat_lr = 0,100, mirostat_ent = 5,000
sampling order: 
CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature 
generate: n_ctx = 512, n_batch = 2048, n_predict = 3, n_keep = 1


<s> Hello worlds in which
llama_print_timings:        load time =     122,11 ms
llama_print_timings:      sample time =       0,06 ms /     3 runs   (    0,02 ms per token, 50847,46 tokens per second)
llama_print_timings: prompt eval time =       0,00 ms /     0 tokens (    -nan ms per token,     -nan tokens per second)
llama_print_timings:        eval time =     100,23 ms /     2 runs   (   50,12 ms per token,    19,95 tokens per second)
llama_print_timings:       total time =     122,41 ms /     2 tokens
```
</details>