### PR TITLE
Build with correct CUDA release flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,6 +868,7 @@ if (LLAMA_ALL_WARNINGS)
 endif()
 
 set(CUDA_CXX_FLAGS "")
+set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 if (LLAMA_CUDA)
     set(CUDA_FLAGS -use_fast_math)


### PR DESCRIPTION
For some reason this defaults to empty.

I couldn't get `CMAKE_CUDA_FLAGS_RELEASE_INIT` to work, if someone knows a better solution please chime in!

Closes #7175