### PR TITLE
Add token healing to `main` and `server`

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1095,21 +1095,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
     }
     if (arg == "-th" || arg == "--token-healing") {
         CHECK_ARG
-        sparams.token_healing_enabled = true;
-        auto & th_type = sparams.token_healing_type;
-        auto & th_n_rollback = sparams.token_healing_n_rollback;
         std::string value(argv[i]);
-        /**/ if (value    == "0" ) { sparams.token_healing_enabled = false; }
-        else if (value    == "1" ) { th_type = llama_token_healing_type::ROLLBACK_LAST; }
-        else if (value    == "d1") { th_type = llama_token_healing_type::DYNAMIC_ONCE; }
-        else if (value    == "d" ) { th_type = llama_token_healing_type::DYNAMIC_MULTI; }
-        else if (value[0] == 'r' ) {
-            th_type = llama_token_healing_type::ROLLBACK_MULTI;
-            th_n_rollback = std::stoi(value.substr(1));
-            if (th_n_rollback <= 0) {
-                sparams.token_healing_enabled = false;
-            }
-        } else { invalid_param = true; }
+        invalid_param = !llama_token_healing_parse_params(value, sparams.token_healing);
         return true;
     }
     if (arg == "--override-kv") {

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -67,7 +67,16 @@ static llama_token_healing_output llama_token_healing_get_prefix(
 
     const llama_model * model = llama_get_model(ctx_main);
     auto is_special_token = [&](const llama_token token_id) {
-        return llama_token_is_control(model, token_id) || llama_token_is_eog(model, token_id);
+        return llama_token_is_control(model,    token_id)
+            || llama_token_bos       (model) == token_id
+            || llama_token_eos       (model) == token_id
+            || llama_token_cls       (model) == token_id
+            || llama_token_sep       (model) == token_id
+            || llama_token_pad       (model) == token_id
+            || llama_token_prefix    (model) == token_id
+            || llama_token_middle    (model) == token_id
+            || llama_token_suffix    (model) == token_id
+            || llama_token_eot       (model) == token_id;
     };
 
     if (th_type == llama_token_healing_type::DYNAMIC_ONCE || th_type == llama_token_healing_type::DYNAMIC_MULTI) {

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -128,8 +128,8 @@ static llama_token_healing_output llama_token_healing_get_prefix(
 
 llama_token_healing_output llama_token_healing_rollback(
                            const llama_context * ctx_main,
-                           llama_token_healing_type th_type,
                            std::vector<llama_token> & tokens,
+                           llama_token_healing_type th_type,
                            int max_to_remove) {
     // NB. To avoid returning empty `tokens`, at least 1 token will remain in `tokens` after rolling back.
     //     It is the caller's responsibility to add BOS to the start of the prompt if they want to roll back the whole prompt.

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -568,8 +568,6 @@ static llama_token_data_array llama_sampling_prepare_impl(
         llama_sample_apply_guidance(ctx_main, logits, logits_guidance, params.cfg_scale);
     }
 
-    cur.resize(n_vocab);
-
     // Constrain tokens based on the remaining token healing prefix (if any)
     const auto & th_prefix = ctx_sampling->token_healing_prefix;
     if (params.token_healing.enabled && !th_prefix.empty()) {
@@ -583,10 +581,12 @@ static llama_token_data_array llama_sampling_prepare_impl(
         }
 
         // N.B. We could also set token constraints by setting rejected tokens' logits to -inf
+        cur.clear();
         for (const llama_token token_id : th_candidates) {
-            cur[token_id] = llama_token_data{token_id, logits[token_id], 0.0f};
+            cur.emplace_back(llama_token_data{token_id, logits[token_id], 0.0f});
         }
     } else {
+        cur.resize(n_vocab);
         for (llama_token token_id = 0; token_id < n_vocab; token_id++) {
             cur[token_id] = llama_token_data{token_id, logits[token_id], 0.0f};
         }

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -19,6 +19,13 @@ enum class llama_sampler_type : char {
     TEMPERATURE = 't'
 };
 
+enum class llama_token_healing_type : uint8_t {
+    ROLLBACK_LAST,   // roll back last token with a single constrained decoding step
+    ROLLBACK_MULTI,  // roll back a fixed amount of tokens, multiple constrained decoding steps
+    DYNAMIC_ONCE,    // dynamic roll back, single constrained decoding step
+    DYNAMIC_MULTI    // dynamic roll back, multiple constrained decoding steps
+};
+
 // sampling parameters
 typedef struct llama_sampling_params {
     int32_t     n_prev                = 64;                 // number of previous tokens to remember
@@ -62,6 +69,10 @@ typedef struct llama_sampling_params {
 
     std::vector<llama_token> penalty_prompt_tokens;
     bool                     use_penalty_prompt_tokens = false;
+
+    llama_token_healing_type token_healing_type       = llama_token_healing_type::ROLLBACK_LAST;
+    bool                     token_healing_enabled    = false;
+    int                      token_healing_n_rollback = -1;  // number of tokens to roll back
 } llama_sampling_params;
 
 // general sampler context
@@ -77,6 +88,8 @@ struct llama_sampling_context {
 
     // internal
     grammar_parser::parse_state parsed_grammar;
+
+    std::string token_healing_prefix;  // remaining prefix to constrain sampling
 
     // TODO: replace with ring-buffer
     std::vector<llama_token>      prev;
@@ -158,3 +171,18 @@ void llama_sampling_accept(
         struct llama_context * ctx_main,
         llama_token id,
         bool apply_grammar);
+
+//
+// Token healing
+//
+
+// Roll back `tokens` for constrained generation according to the token healing
+// strategy. Returns the prefix for constrained generation.
+std::string llama_token_healing_rollback(
+            const llama_context * ctx_main,
+            llama_token_healing_type th_type,
+            std::vector<llama_token> & tokens,
+            int max_to_remove = -1,
+            int * n_removed = nullptr);
+
+void llama_token_healing_set_prefix(llama_sampling_context * ctx_sampling, const std::string & prefix);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -176,13 +176,17 @@ void llama_sampling_accept(
 // Token healing
 //
 
-// Roll back `tokens` for constrained generation according to the token healing
-// strategy. Returns the prefix for constrained generation.
-std::string llama_token_healing_rollback(
-            const llama_context * ctx_main,
-            llama_token_healing_type th_type,
-            std::vector<llama_token> & tokens,
-            int max_to_remove = -1,
-            int * n_removed = nullptr);
+struct llama_token_healing_output {
+    std::string prefix;
+    int n_tokens_removed;
+};
+
+// Roll back `tokens` for constrained generation according to the token healing strategy.
+// Call `llama_token_healing_set_prefix` with the returned prefix before the first sampling.
+llama_token_healing_output llama_token_healing_rollback(
+                           const llama_context * ctx_main,
+                           llama_token_healing_type th_type,
+                           std::vector<llama_token> & tokens,
+                           int max_to_remove = -1);
 
 void llama_token_healing_set_prefix(llama_sampling_context * ctx_sampling, const std::string & prefix);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -189,8 +189,8 @@ struct llama_token_healing_output {
 // Call `llama_token_healing_set_prefix` with the returned prefix before the first sampling.
 llama_token_healing_output llama_token_healing_rollback(
                            const llama_context * ctx_main,
-                           llama_token_healing_type th_type,
                            std::vector<llama_token> & tokens,
+                           llama_token_healing_type th_type,
                            int max_to_remove = -1);
 
 void llama_token_healing_set_prefix(llama_sampling_context * ctx_sampling, const std::string & prefix);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -26,6 +26,12 @@ enum class llama_token_healing_type : uint8_t {
     DYNAMIC_MULTI    // dynamic roll back, multiple constrained decoding steps
 };
 
+struct llama_token_healing_params {
+    bool enabled                  = false;
+    llama_token_healing_type type = llama_token_healing_type::DYNAMIC_MULTI;
+    int n_rollback                = -1;  // number of tokens to roll back
+};
+
 // sampling parameters
 typedef struct llama_sampling_params {
     int32_t     n_prev                = 64;                 // number of previous tokens to remember
@@ -70,9 +76,7 @@ typedef struct llama_sampling_params {
     std::vector<llama_token> penalty_prompt_tokens;
     bool                     use_penalty_prompt_tokens = false;
 
-    llama_token_healing_type token_healing_type       = llama_token_healing_type::ROLLBACK_LAST;
-    bool                     token_healing_enabled    = false;
-    int                      token_healing_n_rollback = -1;  // number of tokens to roll back
+    llama_token_healing_params token_healing;
 } llama_sampling_params;
 
 // general sampler context
@@ -190,3 +194,6 @@ llama_token_healing_output llama_token_healing_rollback(
                            int max_to_remove = -1);
 
 void llama_token_healing_set_prefix(llama_sampling_context * ctx_sampling, const std::string & prefix);
+
+// Helper for parsing token healing params from a string.
+bool llama_token_healing_parse_params(const std::string & params, llama_token_healing_params & th_params);

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -251,6 +251,19 @@ A more practical use case might be to prevent the generation of `\code{begin}` a
 
 Example usage: `--logit-bias 29905-inf`
 
+### Token healing
+
+-   `-th {0,1,d1,d,r{N}}, --token-healing {0,1,d1,d,r{N}}`: Set the token healing strategy (default: 0, 0 = disabled).
+
+Token healing (a.k.a. token alignment) alleviates tokenization artifacts for text completion.
+
+- `-th 1`: Roll back the last token and constrain the bytes of the next token to start with the chopped off last token [0, 2].
+- `-th d1`: Roll back multiple tokens until there doesn't exist a token which can cover the prompt's suffix and do a single constrained decoding step [2].
+- `-th d`: Like `d1` but allow multiple decoding steps until the removed suffix is generated.
+- `-th r{N}`: Like `d` but roll back `N` tokens, where `-th r3` is recommended [1].
+
+Sources: [0](https://github.com/guidance-ai/guidance/blob/main/notebooks/art_of_prompt_design/prompt_boundaries_and_token_healing.ipynb), [1](https://arxiv.org/abs/2403.08688), [2](https://arxiv.org/abs/2402.01035).
+
 ### RNG Seed
 
 -   `-s SEED, --seed SEED`: Set the random number generator (RNG) seed (default: -1, -1 = random seed).

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -291,14 +291,14 @@ int main(int argc, char ** argv) {
         LOG("tokens: %s\n", LOG_TOKENS_TOSTR_PRETTY(ctx, embd_inp).c_str());
     }
 
-    if (sparams.token_healing_enabled && (params.conversation || !params.input_suffix.empty())) {
-        sparams.token_healing_enabled = false;
+    if (sparams.token_healing.enabled && (params.conversation || !params.input_suffix.empty())) {
+        sparams.token_healing.enabled = false;
         LOG("token healing: disabled due to custom suffix/conversation mode");
     }
     llama_token_healing_output token_healing_out{};
-    if (!params.interactive_first && sparams.token_healing_enabled) {
-        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing_type, embd_inp,
-                                                              sparams.token_healing_n_rollback);
+    if (!params.interactive_first && sparams.token_healing.enabled) {
+        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing.type, embd_inp,
+                                                              sparams.token_healing.n_rollback);
     }
 
     // Should not run without any tokens
@@ -956,13 +956,13 @@ int main(int argc, char ** argv) {
                     embd_inp.insert(embd_inp.end(), line_inp.begin(), line_inp.end());
                     embd_inp.insert(embd_inp.end(), line_sfx.begin(), line_sfx.end());
 
-                    if (sparams.token_healing_enabled) {
+                    if (sparams.token_healing.enabled) {
                         // Limit token healing rollback to new tokens only (otherwise would need to shift everything)
                         const int n_new_tokens = embd_inp.size() - original_size;
-                        const int max_to_remove = sparams.token_healing_n_rollback < 0
+                        const int max_to_remove = sparams.token_healing.n_rollback < 0
                                                    ? n_new_tokens
-                                                   : std::min(sparams.token_healing_n_rollback, n_new_tokens);
-                        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing_type, embd_inp, max_to_remove);
+                                                   : std::min(sparams.token_healing.n_rollback, n_new_tokens);
+                        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing.type, embd_inp, max_to_remove);
                         n_bytes_to_skip = token_healing_out.prefix.size();
                     }
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -293,7 +293,7 @@ int main(int argc, char ** argv) {
 
     if (sparams.token_healing_enabled && (params.conversation || !params.input_suffix.empty())) {
         sparams.token_healing_enabled = false;
-        LOG("token_healing: disabled due to custom suffix/conversation mode");
+        LOG("token healing: disabled due to custom suffix/conversation mode");
     }
     std::string token_healing_prefix;
     int token_healing_n_removed = 0;

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -297,8 +297,8 @@ int main(int argc, char ** argv) {
     }
     llama_token_healing_output token_healing_out{};
     if (!params.interactive_first && sparams.token_healing.enabled) {
-        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing.type, embd_inp,
-                                                              sparams.token_healing.n_rollback);
+        token_healing_out = llama_token_healing_rollback(ctx, embd_inp,
+            sparams.token_healing.type, sparams.token_healing.n_rollback);
     }
 
     // Should not run without any tokens
@@ -962,7 +962,7 @@ int main(int argc, char ** argv) {
                         const int max_to_remove = sparams.token_healing.n_rollback < 0
                                                    ? n_new_tokens
                                                    : std::min(sparams.token_healing.n_rollback, n_new_tokens);
-                        token_healing_out = llama_token_healing_rollback(ctx, sparams.token_healing.type, embd_inp, max_to_remove);
+                        token_healing_out = llama_token_healing_rollback(ctx, embd_inp, sparams.token_healing.type, max_to_remove);
                         n_bytes_to_skip = token_healing_out.prefix.size();
                     }
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -436,6 +436,8 @@ node index.js
 
     `json_schema`: Set a JSON schema for grammar-based sampling (e.g. `{"items": {"type": "string"}, "minItems": 10, "maxItems": 100}` of a list of strings, or `{}` for any JSON). See [tests](../../tests/test-json-schema-to-grammar.cpp) for supported features.  Default: no JSON schema.
 
+    `token_healing`: Set token healing strategy. Default: `0`, which is disabled.
+
     `seed`: Set the random number generator (RNG) seed.  Default: `-1`, which is a random seed.
 
     `ignore_eos`: Ignore end of stream token and continue generating.  Default: `false`

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -436,7 +436,7 @@ node index.js
 
     `json_schema`: Set a JSON schema for grammar-based sampling (e.g. `{"items": {"type": "string"}, "minItems": 10, "maxItems": 100}` of a list of strings, or `{}` for any JSON). See [tests](../../tests/test-json-schema-to-grammar.cpp) for supported features.  Default: no JSON schema.
 
-    `token_healing`: Set token healing strategy. Default: `0`, which is disabled.
+    `token_healing`: Set the token healing strategy. Default: `0`, which is disabled. Possible values: `1` to replace one token, `d1` to replace the longest suffix with a single token, `d` to replace the longest suffix, `rN` to roll back N tokens (e.g. `r3`). See [here](../main/README.md#token-healing) for more details.
 
     `seed`: Set the random number generator (RNG) seed.  Default: `-1`, which is a random seed.
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2100,8 +2100,8 @@ struct server_context {
 
                             if (slot.sparams.token_healing.enabled) {
                                 // For FIM roll back only the prefix part (i.e. cursor location)
-                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing.type,
-                                    prefix_tokens, slot.sparams.token_healing.n_rollback);
+                                token_healing_out = llama_token_healing_rollback(ctx, prefix_tokens,
+                                    slot.sparams.token_healing.type, slot.sparams.token_healing.n_rollback);
                             }
 
                             auto embd_inp = params.spm_infill ? suffix_tokens : prefix_tokens;
@@ -2121,8 +2121,8 @@ struct server_context {
                             prompt_tokens = tokenize(slot.prompt, system_prompt.empty()); // add BOS if there isn't system prompt
 
                             if (slot.sparams.token_healing.enabled) {
-                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing.type,
-                                    prompt_tokens, slot.sparams.token_healing.n_rollback);
+                                token_healing_out = llama_token_healing_rollback(ctx, prompt_tokens,
+                                    slot.sparams.token_healing.type, slot.sparams.token_healing.n_rollback);
                             }
                         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -185,6 +185,7 @@ struct server_slot {
     // stats
     size_t n_sent_text = 0; // number of sent text character
     size_t n_sent_token_probs = 0;
+    size_t n_th_prefix = 0; // size of remaining token healing prefix
 
     int64_t t_start_process_prompt;
     int64_t t_start_generation;
@@ -206,6 +207,7 @@ struct server_slot {
         infill             = false;
         ga_i               = 0;
         n_past_se          = 0;
+        n_th_prefix        = 0;
 
         generated_token_probs.clear();
     }
@@ -1095,6 +1097,36 @@ struct server_context {
         }
 
         {
+            const auto & token_healing_str = data.find("token_healing");
+            auto & th_enabled = slot.sparams.token_healing_enabled;
+            th_enabled = default_sparams.token_healing_enabled;
+            if (token_healing_str != data.end() && token_healing_str->is_string()) {
+                const auto value = token_healing_str->get<std::string>();
+                auto & th_type = slot.sparams.token_healing_type;
+                auto & th_n_rollback = slot.sparams.token_healing_n_rollback;
+                th_enabled = true;
+                /**/ if (value    == "0" ) { th_enabled = false; }
+                else if (value    == "1" ) { th_type = llama_token_healing_type::ROLLBACK_LAST; }
+                else if (value    == "d1") { th_type = llama_token_healing_type::DYNAMIC_ONCE; }
+                else if (value    == "d" ) { th_type = llama_token_healing_type::DYNAMIC_MULTI; }
+                else if (value[0] == 'r' ) {
+                    th_type = llama_token_healing_type::ROLLBACK_MULTI;
+                    th_n_rollback = std::stoi(value.substr(1));
+                    if (th_n_rollback <= 0) {
+                        th_enabled = false;
+                    }
+                } else { th_enabled = false; }
+
+                LOG_VERBOSE("token healing", {
+                    {"id_slot", slot.id},
+                    {"enabled", th_enabled},
+                    {"type", th_type},
+                    {"n_rollback", th_n_rollback}
+                });
+            }
+        }
+
+        {
             if (slot.ctx_sampling != nullptr) {
                 llama_sampling_free(slot.ctx_sampling);
             }
@@ -1189,14 +1221,26 @@ struct server_context {
     }
 
     bool process_token(completion_token_output & result, server_slot & slot) {
-        // remember which tokens were sampled - used for repetition penalties during sampling
         const std::string token_str = llama_token_to_piece(ctx, result.tok, params.special);
         slot.sampled = result.tok;
-
-        // search stop word and delete it
-        slot.generated_text += token_str;
         slot.has_next_token = true;
 
+        // Suppress generating the token healing prefix to not repeat the input prompt's suffix
+        bool is_token_healing = false;
+        if (slot.n_th_prefix > 0) {
+            if (slot.n_th_prefix < token_str.size()) {
+                slot.generated_text += token_str.substr(slot.n_th_prefix);
+                slot.n_th_prefix = 0;
+                is_token_healing = false;  // to send partial token text when streaming
+            } else {
+                slot.n_th_prefix -= token_str.size();
+                is_token_healing = true;
+            }
+        } else {
+            slot.generated_text += token_str;
+        }
+
+        // remember which tokens were sampled - used for repetition penalties during sampling
         if (slot.ctx_sampling->params.use_penalty_prompt_tokens && result.tok != -1) {
             // we can change penalty_prompt_tokens because it is always created from scratch each request
             slot.ctx_sampling->params.penalty_prompt_tokens.push_back(result.tok);
@@ -1224,7 +1268,7 @@ struct server_context {
             break;
         }
 
-        if (!incomplete) {
+        if (!incomplete && !is_token_healing) {
             size_t pos = std::min(slot.n_sent_text, slot.generated_text.size());
 
             const std::string str_test = slot.generated_text.substr(pos);
@@ -1256,7 +1300,7 @@ struct server_context {
             }
         }
 
-        if (incomplete) {
+        if (incomplete || is_token_healing) {
             slot.has_next_token = true;
         }
 
@@ -1361,7 +1405,8 @@ struct server_context {
             {"n_probs",                   slot.sparams.n_probs},
             {"min_keep",                  slot.sparams.min_keep},
             {"grammar",                   slot.sparams.grammar},
-            {"samplers",                  samplers_sequence}
+            {"samplers",                  samplers_sequence},
+            {"token_healing_enabled",     slot.sparams.token_healing_enabled}
         };
     }
 
@@ -2106,6 +2151,21 @@ struct server_context {
                             continue;
                         }
 
+                        // Roll back prompt tokens if token healing
+                        llama_token_healing_output token_healing_out{};
+                        if (slot.sparams.token_healing_enabled) {
+                            token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
+                                prompt_tokens, slot.sparams.token_healing_n_rollback);
+                            slot.n_th_prefix = token_healing_out.prefix.size();
+                            slot.n_prompt_tokens = prompt_tokens.size();
+                            LOG_VERBOSE("token healing prompt", {
+                                {"id_slot", slot.id},
+                                {"id_task", slot.id_task},
+                                {"removed_suffix", token_healing_out.prefix},
+                                {"n_tokens_removed", token_healing_out.n_tokens_removed}
+                            });
+                        }
+
                         if (slot.embedding) {
                             // this prompt is too large to process - discard it
                             if (slot.n_prompt_tokens > n_ubatch) {
@@ -2156,6 +2216,9 @@ struct server_context {
                             }
 
                             llama_sampling_reset(slot.ctx_sampling);
+                            if (slot.sparams.token_healing_enabled) {
+                                llama_token_healing_set_prefix(slot.ctx_sampling, token_healing_out.prefix);
+                            }
 
                             if (!slot.params.cache_prompt) {
                                 slot.n_past_se = 0;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1098,31 +1098,20 @@ struct server_context {
 
         {
             const auto & token_healing_str = data.find("token_healing");
-            auto & th_enabled = slot.sparams.token_healing_enabled;
-            th_enabled = default_sparams.token_healing_enabled;
             if (token_healing_str != data.end() && token_healing_str->is_string()) {
                 const auto value = token_healing_str->get<std::string>();
-                auto & th_type = slot.sparams.token_healing_type;
-                auto & th_n_rollback = slot.sparams.token_healing_n_rollback;
-                th_enabled = true;
-                /**/ if (value    == "0" ) { th_enabled = false; }
-                else if (value    == "1" ) { th_type = llama_token_healing_type::ROLLBACK_LAST; }
-                else if (value    == "d1") { th_type = llama_token_healing_type::DYNAMIC_ONCE; }
-                else if (value    == "d" ) { th_type = llama_token_healing_type::DYNAMIC_MULTI; }
-                else if (value[0] == 'r' ) {
-                    th_type = llama_token_healing_type::ROLLBACK_MULTI;
-                    th_n_rollback = std::stoi(value.substr(1));
-                    if (th_n_rollback <= 0) {
-                        th_enabled = false;
-                    }
-                } else { th_enabled = false; }
-
+                if (!llama_token_healing_parse_params(value, slot.sparams.token_healing)) {
+                    send_error(task, "\"token_healing\" parse error", ERROR_TYPE_INVALID_REQUEST);
+                    return false;
+                }
                 LOG_VERBOSE("token healing", {
                     {"id_slot", slot.id},
-                    {"enabled", th_enabled},
-                    {"type", th_type},
-                    {"n_rollback", th_n_rollback}
+                    {"enabled", slot.sparams.token_healing.enabled},
+                    {"type", slot.sparams.token_healing.type},
+                    {"n_rollback", slot.sparams.token_healing.n_rollback}
                 });
+            } else {
+                slot.sparams.token_healing = default_sparams.token_healing;
             }
         }
 
@@ -1406,7 +1395,7 @@ struct server_context {
             {"min_keep",                  slot.sparams.min_keep},
             {"grammar",                   slot.sparams.grammar},
             {"samplers",                  samplers_sequence},
-            {"token_healing_enabled",     slot.sparams.token_healing_enabled}
+            {"token_healing_enabled",     slot.sparams.token_healing.enabled}
         };
     }
 
@@ -2109,10 +2098,10 @@ struct server_context {
                             prefix_tokens.insert(prefix_tokens.begin(), llama_token_prefix(model));
                             suffix_tokens.insert(suffix_tokens.begin(), llama_token_suffix(model));
 
-                            if (slot.sparams.token_healing_enabled) {
+                            if (slot.sparams.token_healing.enabled) {
                                 // For FIM roll back only the prefix part (i.e. cursor location)
-                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
-                                    prefix_tokens, slot.sparams.token_healing_n_rollback);
+                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing.type,
+                                    prefix_tokens, slot.sparams.token_healing.n_rollback);
                             }
 
                             auto embd_inp = params.spm_infill ? suffix_tokens : prefix_tokens;
@@ -2131,9 +2120,9 @@ struct server_context {
                         } else {
                             prompt_tokens = tokenize(slot.prompt, system_prompt.empty()); // add BOS if there isn't system prompt
 
-                            if (slot.sparams.token_healing_enabled) {
-                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
-                                    prompt_tokens, slot.sparams.token_healing_n_rollback);
+                            if (slot.sparams.token_healing.enabled) {
+                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing.type,
+                                    prompt_tokens, slot.sparams.token_healing.n_rollback);
                             }
                         }
 
@@ -2149,7 +2138,7 @@ struct server_context {
                             {"prompt_tokens",   tokens_to_str(ctx, prompt_tokens.cbegin(), prompt_tokens.cend())},
                         });
 
-                        if (slot.sparams.token_healing_enabled) {
+                        if (slot.sparams.token_healing.enabled) {
                             slot.n_th_prefix = token_healing_out.prefix.size();
                             LOG_VERBOSE("token healing prompt", {
                                 {"id_slot", slot.id},
@@ -2224,7 +2213,7 @@ struct server_context {
                             }
 
                             llama_sampling_reset(slot.ctx_sampling);
-                            if (slot.sparams.token_healing_enabled) {
+                            if (slot.sparams.token_healing.enabled) {
                                 llama_token_healing_set_prefix(slot.ctx_sampling, token_healing_out.prefix);
                             }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2088,6 +2088,8 @@ struct server_context {
                         slot.t_start_process_prompt = ggml_time_us();
                         slot.t_start_generation = 0;
 
+                        llama_token_healing_output token_healing_out{};
+
                         if (slot.infill) {
                             const bool add_bos = llama_should_add_bos_token(model);
                             bool suff_rm_leading_spc = true;
@@ -2107,6 +2109,12 @@ struct server_context {
                             prefix_tokens.insert(prefix_tokens.begin(), llama_token_prefix(model));
                             suffix_tokens.insert(suffix_tokens.begin(), llama_token_suffix(model));
 
+                            if (slot.sparams.token_healing_enabled) {
+                                // For FIM roll back only the prefix part (i.e. cursor location)
+                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
+                                    prefix_tokens, slot.sparams.token_healing_n_rollback);
+                            }
+
                             auto embd_inp = params.spm_infill ? suffix_tokens : prefix_tokens;
                             auto embd_end = params.spm_infill ? prefix_tokens : suffix_tokens;
                             if (add_bos) {
@@ -2122,6 +2130,11 @@ struct server_context {
                             prompt_tokens = embd_inp;
                         } else {
                             prompt_tokens = tokenize(slot.prompt, system_prompt.empty()); // add BOS if there isn't system prompt
+
+                            if (slot.sparams.token_healing_enabled) {
+                                token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
+                                    prompt_tokens, slot.sparams.token_healing_n_rollback);
+                            }
                         }
 
                         slot.n_past = 0;
@@ -2136,6 +2149,16 @@ struct server_context {
                             {"prompt_tokens",   tokens_to_str(ctx, prompt_tokens.cbegin(), prompt_tokens.cend())},
                         });
 
+                        if (slot.sparams.token_healing_enabled) {
+                            slot.n_th_prefix = token_healing_out.prefix.size();
+                            LOG_VERBOSE("token healing prompt", {
+                                {"id_slot", slot.id},
+                                {"id_task", slot.id_task},
+                                {"removed_suffix", token_healing_out.prefix},
+                                {"n_tokens_removed", token_healing_out.n_tokens_removed}
+                            });
+                        }
+
                         // empty prompt passed -> release the slot and send empty response
                         if (prompt_tokens.empty()) {
                             LOG_INFO("empty prompt - releasing slot", {
@@ -2149,21 +2172,6 @@ struct server_context {
                             slot.print_timings();
                             send_final_response(slot);
                             continue;
-                        }
-
-                        // Roll back prompt tokens if token healing
-                        llama_token_healing_output token_healing_out{};
-                        if (slot.sparams.token_healing_enabled) {
-                            token_healing_out = llama_token_healing_rollback(ctx, slot.sparams.token_healing_type,
-                                prompt_tokens, slot.sparams.token_healing_n_rollback);
-                            slot.n_th_prefix = token_healing_out.prefix.size();
-                            slot.n_prompt_tokens = prompt_tokens.size();
-                            LOG_VERBOSE("token healing prompt", {
-                                {"id_slot", slot.id},
-                                {"id_task", slot.id_task},
-                                {"removed_suffix", token_healing_out.prefix},
-                                {"n_tokens_removed", token_healing_out.n_tokens_removed}
-                            });
                         }
 
                         if (slot.embedding) {


### PR DESCRIPTION
Add different token healing strategies to `main` and `server`. Token healing works by chopping off some tokens from the tokenized prompt and then constraining the decoding to match the bytes of the removed tokens.

Example usage:
```bash
# with token healing
$ ./llama-cli -m ./models/phi-2/ggml-model-q4_0.gguf --temp 0 -p "print('Hello, wo" -th d
print('Hello, world!')

# without token healing
$ ./llama-cli -m ./models/phi-2/ggml-model-q4_0.gguf --temp 0 -p "print('Hello, wo" -th 0
print('Hello, woof!')
```

Server usage:
```bash
prompt='print(\"Hello, Wo'

curl --request POST \
    --url http://localhost:8080/completion \
    --header "Content-Type: application/json" \
    --data '
    {
      "prompt": '\""${prompt}"\"',
      "n_predict": 10,
      "temperature": 0
    }
' | jq '. | {prompt, content}'

curl --request POST \
    --url http://localhost:8080/completion \
    --header "Content-Type: application/json" \
    --data '
    {
      "prompt": '\""${prompt}"\"',
      "n_predict": 10,
      "temperature": 0,
      "token_healing": "d"
    }
' | jq '. | {prompt, content}'
```

Solves https://github.com/ggerganov/llama.cpp/issues/5765.