### PR TITLE
Fix(server): stopped_word always true

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -431,7 +431,7 @@ static json oaicompat_completion_params_parse(
 }
 
 static json format_final_response_oaicompat(const json & request, json result, const std::string & completion_id, bool streaming = false) {
-    bool stopped_word        = result.count("stopped_word") != 0;
+    bool stopped_word        = json_value(result, "stopped_word", false);
     bool stopped_eos         = json_value(result, "stopped_eos", false);
     int num_tokens_predicted = json_value(result, "tokens_predicted", 0);
     int num_prompt_tokens    = json_value(result, "tokens_evaluated", 0);


### PR DESCRIPTION
`bool stopped_word` is always true, thus `finish_reason` will never be `length`,  which makes the anti-degeneration failed to detect the repeating words.

```shell
bin/server -m MODEL -c 128
# provide a long sentence `彼女x10`,  with repetition_penalty=0.2
# post  /v1/chat/completion
# output is a long sentence: `她xN`
# stop_reason is `stop` rather than `length`.
```