### PR TITLE
[server] Cleanup a memory leak on exit

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -673,6 +673,8 @@ struct server_context {
             llama_free_model(model);
             model = nullptr;
         }
+
+	llama_batch_free(batch);
     }
 
     bool load_model(const gpt_params & params_) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -674,7 +674,7 @@ struct server_context {
             model = nullptr;
         }
 
-	llama_batch_free(batch);
+        llama_batch_free(batch);
     }
 
     bool load_model(const gpt_params & params_) {


### PR DESCRIPTION
There are a couple memory leaks on exit of the server. This hides others. After cleaning this up, you can see leaks on slots. But that is another patch to be sent after this.