### PR TITLE
convert-hf : support direct Q8_0 conversion

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -240,23 +240,6 @@ class Model:
         return False
 
     def write_tensors(self):
-        # same as ggml_compute_fp32_to_bf16 in ggml-impl.h
-        def np_fp32_to_bf16(n: np.ndarray):
-            # force nan to quiet
-            n = np.where((n & 0x7fffffff) > 0x7f800000, (n & 0xffff0000) | (64 << 16), n)
-            # flush subnormals to zero
-            n = np.where((n & 0x7f800000) == 0, n & 0x80000000, n)
-            # round to nearest even
-            n = (n + (0x7fff + ((n >> 16) & 1))) >> 16
-            return n.astype(np.int16)
-
-        # Doing this row-wise is much, much faster than element-wise, hence the signature
-        v_fp32_to_bf16 = np.vectorize(np_fp32_to_bf16, otypes=[np.int16], signature="(n)->(n)")
-        if self.lazy:
-            # TODO: find a way to implicitly wrap np.vectorize functions
-            # NOTE: the type is changed to reflect otypes passed to np.vectorize above
-            v_fp32_to_bf16 = gguf.LazyNumpyTensor._wrap_fn(v_fp32_to_bf16, meta_noop=np.int16)
-
         max_name_len = max(len(s) for _, s in self.tensor_map.mapping.values()) + len(".weight,")
 
         for name, data_torch in self.get_tensors():
@@ -309,27 +292,31 @@ class Model:
                 ))
 
                 if self.ftype != gguf.LlamaFileType.ALL_F32 and extra_f16 and not extra_f32:
-                    if self.ftype == gguf.LlamaFileType.MOSTLY_F16:
+                    if self.ftype == gguf.LlamaFileType.MOSTLY_BF16:
+                        data = gguf.quantize_bf16(data)
+                        assert data.dtype == np.int16
+                        data_qtype = gguf.GGMLQuantizationType.BF16
+
+                    elif self.ftype == gguf.LlamaFileType.MOSTLY_Q8_0 and gguf.can_quantize_to_q8_0(data):
+                        data = gguf.quantize_q8_0(data)
+                        assert data.dtype == np.uint8
+                        data_qtype = gguf.GGMLQuantizationType.Q8_0
+
+                    else:  # default to float16 for quantized tensors
                         if data_dtype != np.float16:
                             data = data.astype(np.float16)
                         data_qtype = gguf.GGMLQuantizationType.F16
 
-                    elif self.ftype == gguf.LlamaFileType.MOSTLY_BF16:
-                        if data_dtype != np.float32:
-                            data = data.astype(np.float32)
-                        data = v_fp32_to_bf16(data.view(np.int32))
-                        assert data.dtype == np.int16
-                        data_qtype = gguf.GGMLQuantizationType.BF16
-
-                else:  # by default, convert to float32
+                if data_qtype is None:  # by default, convert to float32
                     if data_dtype != np.float32:
                         data = data.astype(np.float32)
                     data_qtype = gguf.GGMLQuantizationType.F32
 
-                assert data_qtype is not None
-
+                block_size, type_size = gguf.GGML_QUANT_SIZES[data_qtype]
                 # reverse shape to make it similar to the internal ggml dimension order
-                shape_str = f"{{{', '.join(str(n) for n in reversed(data.shape))}}}"
+                shape_str = f"""{{{', '.join(str(n) for n in reversed(
+                    (*data.shape[:-1], data.shape[-1] * data.dtype.itemsize // type_size * block_size))
+                )}}}"""
 
                 # n_dims is implicit in the shape
                 logger.info(f"{f'%-{max_name_len}s' % f'{new_name},'} {old_dtype} --> {data_qtype.name}, shape = {shape_str}")
@@ -2415,25 +2402,15 @@ class LazyTorchTensor(gguf.LazyBase):
     def numpy(self) -> gguf.LazyNumpyTensor:
         dtype = self._dtype_map[self.dtype]
         return gguf.LazyNumpyTensor(
-            meta=np.lib.stride_tricks.as_strided(np.zeros(1, dtype), self.shape, (0 for _ in self.shape)),
+            meta=gguf.LazyNumpyTensor.meta_with_dtype_and_shape(dtype, self.shape),
             lazy=self._lazy,
             args=(self,),
             func=(lambda s: s[0].numpy())
         )
 
     @classmethod
-    def eager_to_meta(cls, t: Tensor) -> Tensor:
-        if t.is_meta:
-            return t
-        return t.detach().to("meta")
-
-    @classmethod
-    def meta_with_dtype(cls, m: Tensor, dtype: torch.dtype) -> Tensor:
-        m = m.detach()
-        if not m.is_meta:
-            m = m.to("meta")
-        m.dtype = dtype
-        return m
+    def meta_with_dtype_and_shape(cls, dtype: torch.dtype, shape: torch.Size) -> Tensor:
+        return torch.empty(size=shape, dtype=dtype, device="meta")
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
@@ -2464,8 +2441,8 @@ def parse_args() -> argparse.Namespace:
         help="path to write to; default: based on input. {ftype} will be replaced by the outtype.",
     )
     parser.add_argument(
-        "--outtype", type=str, choices=["f32", "f16", "bf16", "auto"], default="f16",
-        help="output format - use f32 for float32, f16 for float16, bf16 for bfloat16, auto for the highest-fidelity 16-bit float type depending on the first loaded tensor type",
+        "--outtype", type=str, choices=["f32", "f16", "bf16", "q8_0", "auto"], default="f16",
+        help="output format - use f32 for float32, f16 for float16, bf16 for bfloat16, q8_0 for Q8_0, auto for the highest-fidelity 16-bit float type depending on the first loaded tensor type",
     )
     parser.add_argument(
         "--bigendian", action="store_true",
@@ -2523,6 +2500,7 @@ def main() -> None:
         "f32": gguf.LlamaFileType.ALL_F32,
         "f16": gguf.LlamaFileType.MOSTLY_F16,
         "bf16": gguf.LlamaFileType.MOSTLY_BF16,
+        "q8_0": gguf.LlamaFileType.MOSTLY_Q8_0,
         "auto": gguf.LlamaFileType.GUESSED,
     }
 

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1202,6 +1202,7 @@ class StableLMModel(Model):
         self.gguf_writer.add_head_count_kv(hparams["num_key_value_heads"])
         self.gguf_writer.add_parallel_residual(hparams["use_parallel_residual"] if "use_parallel_residual" in hparams else True)
         self.gguf_writer.add_layer_norm_eps(self.find_hparam(["layer_norm_eps", "norm_eps"]))
+        self.gguf_writer.add_file_type(self.ftype)
 
     _q_norms: list[dict[str, Tensor]] | None = None
     _k_norms: list[dict[str, Tensor]] | None = None
@@ -1578,6 +1579,7 @@ class QwenModel(Model):
         self.gguf_writer.add_rope_dimension_count(self.hparams["hidden_size"] // self.hparams["num_attention_heads"])
         self.gguf_writer.add_head_count(self.hparams["num_attention_heads"])
         self.gguf_writer.add_layer_norm_rms_eps(self.hparams["layer_norm_epsilon"])
+        self.gguf_writer.add_file_type(self.ftype)
 
 
 @Model.register("Qwen2ForCausalLM")
@@ -1815,6 +1817,7 @@ class PlamoModel(Model):
         self.gguf_writer.add_head_count(hparams["num_attention_heads"])
         self.gguf_writer.add_head_count_kv(5)  # hparams["num_key_value_heads"]) is wrong
         self.gguf_writer.add_layer_norm_rms_eps(hparams["rms_norm_eps"])
+        self.gguf_writer.add_file_type(self.ftype)
 
     def shuffle_attn_q_weight(self, data_torch):
         assert data_torch.size() == (5120, 5120)
@@ -1994,6 +1997,7 @@ in chat mode so that the conversation can end normally.")
         self.gguf_writer.add_head_count(self.hparams["num_attention_heads"])
         self.gguf_writer.add_layer_norm_rms_eps(self.hparams["rms_norm_eps"])
         self.gguf_writer.add_head_count_kv(self.hparams["num_key_value_heads"])
+        self.gguf_writer.add_file_type(self.ftype)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         num_heads = self.hparams["num_attention_heads"]

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -846,6 +846,7 @@ class BaichuanModel(Model):
         self.gguf_writer.add_head_count(head_count)
         self.gguf_writer.add_head_count_kv(head_count_kv)
         self.gguf_writer.add_layer_norm_rms_eps(self.hparams["rms_norm_eps"])
+        self.gguf_writer.add_file_type(self.ftype)
 
         if self.hparams.get("rope_scaling") is not None and "factor" in self.hparams["rope_scaling"]:
             if self.hparams["rope_scaling"].get("type") == "linear":
@@ -968,6 +969,7 @@ class XverseModel(Model):
         self.gguf_writer.add_head_count(head_count)
         self.gguf_writer.add_head_count_kv(head_count_kv)
         self.gguf_writer.add_layer_norm_rms_eps(self.hparams["rms_norm_eps"])
+        self.gguf_writer.add_file_type(self.ftype)
 
         if self.hparams.get("rope_scaling") is not None and "factor" in self.hparams["rope_scaling"]:
             if self.hparams["rope_scaling"].get("type") == "linear":

--- a/gguf-py/gguf/__init__.py
+++ b/gguf-py/gguf/__init__.py
@@ -2,5 +2,6 @@ from .constants import *
 from .lazy import *
 from .gguf_reader import *
 from .gguf_writer import *
+from .quants import *
 from .tensor_mapping import *
 from .vocab import *

--- a/gguf-py/gguf/lazy.py
+++ b/gguf-py/gguf/lazy.py
@@ -174,7 +174,12 @@ class LazyBase(ABC, metaclass=LazyMeta):
             while _t._data is None:
                 lt = _t._lazy.popleft()
                 if lt._data is not None:
-                    raise ValueError(f"{lt} did not belong in the lazy queue")
+                    # Lazy tensor did not belong in the lazy queue.
+                    # Weirdly only happens with Bloom models...
+                    # likely because tensors aren't unique in the queue.
+                    # The final output is still the same as in eager mode,
+                    # so it's safe to ignore this.
+                    continue
                 assert lt._func is not None
                 lt._args = cls._recurse_apply(lt._args, already_eager_to_eager)
                 lt._data = lt._func(lt._args)

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from typing import Callable
+
+from numpy.typing import DTypeLike
+
+from .constants import GGML_QUANT_SIZES, GGMLQuantizationType
+from .lazy import LazyNumpyTensor
+
+import numpy as np
+
+
+# same as ggml_compute_fp32_to_bf16 in ggml-impl.h
+def __compute_fp32_to_bf16(n: np.ndarray) -> np.ndarray:
+    n = n.astype(np.float32, copy=False).view(np.int32)
+    # force nan to quiet
+    n = np.where((n & 0x7fffffff) > 0x7f800000, (n & 0xffff0000) | (64 << 16), n)
+    # flush subnormals to zero
+    n = np.where((n & 0x7f800000) == 0, n & 0x80000000, n)
+    # round to nearest even
+    n = (n + (0x7fff + ((n >> 16) & 1))) >> 16
+    return n.astype(np.int16)
+
+
+# This is faster than np.vectorize and np.apply_along_axis because it works on more than one row at a time
+def __apply_over_grouped_rows(func: Callable[[np.ndarray], np.ndarray], arr: np.ndarray, otype: DTypeLike, oshape: tuple[int, ...]) -> np.ndarray:
+    rows = arr.reshape((-1, arr.shape[-1]))
+    osize = 1
+    for dim in oshape:
+        osize *= dim
+    out = np.empty(shape=osize, dtype=otype)
+    # compute over groups of 16 rows (arbitrary, but seems good for performance)
+    n_groups = rows.shape[0] // 16
+    np.concatenate([func(group).ravel() for group in np.array_split(rows, n_groups)], axis=0, out=out)
+    return out.reshape(oshape)
+
+
+def __quantize_bf16_array(n: np.ndarray) -> np.ndarray:
+    return __apply_over_grouped_rows(__compute_fp32_to_bf16, arr=n, otype=np.int16, oshape=n.shape)
+
+
+__quantize_bf16_lazy = LazyNumpyTensor._wrap_fn(__quantize_bf16_array, meta_noop=np.int16)
+
+
+def quantize_bf16(n: np.ndarray):
+    if type(n) is LazyNumpyTensor:
+        return __quantize_bf16_lazy(n)
+    else:
+        return __quantize_bf16_array(n)
+
+
+__q8_block_size, __q8_type_size = GGML_QUANT_SIZES[GGMLQuantizationType.Q8_0]
+
+
+def can_quantize_to_q8_0(n: np.ndarray) -> bool:
+    return n.shape[-1] % __q8_block_size == 0
+
+
+# round away from zero
+# ref: https://stackoverflow.com/a/59143326/22827863
+def np_roundf(n: np.ndarray) -> np.ndarray:
+    a = abs(n)
+    floored = np.floor(a)
+    b = floored + np.floor(2 * (a - floored))
+    return np.sign(n) * b
+
+
+def __quantize_q8_0_shape_change(s: tuple[int, ...]) -> tuple[int, ...]:
+    return (*s[:-1], s[-1] // __q8_block_size * __q8_type_size)
+
+
+# Implementation of Q8_0 with bit-exact same results as reference implementation in ggml-quants.c
+def __quantize_q8_0_rows(n: np.ndarray) -> np.ndarray:
+    shape = n.shape
+    assert shape[-1] % __q8_block_size == 0
+
+    n_blocks = n.size // __q8_block_size
+
+    blocks = n.reshape((n_blocks, __q8_block_size)).astype(np.float32, copy=False)
+
+    d = abs(blocks).max(axis=1, keepdims=True) / 127
+    with np.errstate(divide="ignore"):
+        id = np.where(d == 0, 0, 1 / d)
+    qs = np_roundf(blocks * id)
+
+    # (n_blocks, 2)
+    d = d.astype(np.float16).view(np.uint8)
+    # (n_blocks, block_size)
+    qs = qs.astype(np.int8).view(np.uint8)
+
+    assert d.shape[1] + qs.shape[1] == __q8_type_size
+
+    return np.concatenate([d, qs], axis=1).reshape(__quantize_q8_0_shape_change(shape))
+
+
+def __quantize_q8_0_array(n: np.ndarray) -> np.ndarray:
+    return __apply_over_grouped_rows(__quantize_q8_0_rows, arr=n, otype=np.uint8, oshape=__quantize_q8_0_shape_change(n.shape))
+
+
+__quantize_q8_0_lazy = LazyNumpyTensor._wrap_fn(
+    __quantize_q8_0_array,
+    meta_noop=(np.uint8, __quantize_q8_0_shape_change),
+)
+
+
+def quantize_q8_0(data: np.ndarray):
+    if type(data) is LazyNumpyTensor:
+        return __quantize_q8_0_lazy(data)
+    else:
+        return __quantize_q8_0_array(data)


### PR DESCRIPTION
This adds `Q8_0` conversion to `convert-hf-to-gguf.py`, and it results in EXACTLY the same files as if converted with `./quantize` from an `f32` model.

Note that this was NOT the case for `convert.py`, because it rounds to nearest even and divides by the scale, while the reference implementation in `ggml-quants.c` rounds away from zero and multiplies by the inverse of the scale.

# Summary of changes

- Add missing `self.gguf_writer.add_file_type(self.ftype)` for `StableLMModel`, `InternLM2Model`, `PlamoModel`, `QwenModel`, `BaichuanModel`, and `XverseModel`.
  - This was messing up the checksums otherwise
- Add `gguf-py/gguf/quants.py` to put the `Q8_0` implementation there and also move `bf16` conversion in there too.
- Make lazy tensors support shape and dtype changes from operations which won't run on meta tensors
  - Useful with Numpy which doesn't have true meta tensors
- Performance improvement for `bf16` conversion, from `40-60 MB/s` on my machine to `104 MB/s`
- make `GGUFWriter` support arbitrary quants with `np.uint8` dtype
  - it now corrects the shape using the type size and the block size of the `raw_dtype`

# TODO:

- [ ] Maybe rename `Model.extra_f16_tensors` to `Model.extra_quantized_tensors`
- [ ] Maybe also fix `Q8_0` in `convert.py` to round in the same way as the reference implementation?

# Testing

To be sure this Python implementation of `Q8_0` really is working in the exact same way as the reference implementation from `ggml-quants.c`, I'm testing conversion and quantization of a bunch of different model architectures.

I recently got a big external hard drive, which makes storing the output of these tests much easier.

I'm doing pretty much this for each for every model architecture tested below
(using `outfile` `{ftype}` templating introduced in #7158) : 
```console
$ python3 convert-hf-to-gguf.py --outtype f32 --outfile /srv/LLMstash/tmp/model-name-lazy-convert.{ftype}.gguf /srv/LLMstash/src/model-dir/
$ python3 convert-hf-to-gguf.py --outtype bf16 --outfile /srv/LLMstash/tmp/model-name-lazy-convert.{ftype}.gguf /srv/LLMstash/src/model-dir/
$ python3 convert-hf-to-gguf.py --outtype q8_0 --outfile /srv/LLMstash/tmp/model-name-lazy-convert.{ftype}.gguf /srv/LLMstash/src/model-dir/
$ ./build/bin/quantize /srv/LLMstash/tmp/model-name-{lazy-convert.f32,quantize.bf16}.gguf bf16
$ ./build/bin/quantize /srv/LLMstash/tmp/model-name-{lazy-convert.f32,quantize.q8_0}.gguf q8_0
$ sha256sum /srv/LLMstash/tmp/model-name-*.{bf16,q8_0}.gguf
```

I'd say there is *some* suspense when the checksums begin to appear. Will they match?

- [x] BERT bge-small (`torch.float32`) <https://huggingface.co/BAAI/bge-small-en-v1.5>
  - @compilade checksums match
    ```console
    $ sha256sum bge-small-*.{bf16,q8_0}.gguf
    95d9de5f3b6118b62d668b3e1cf1a675ed1a7334d37c0e08904fd2fe89afa880  bge-small-lazy-convert.bf16.gguf
    95d9de5f3b6118b62d668b3e1cf1a675ed1a7334d37c0e08904fd2fe89afa880  bge-small-quantize.bf16.gguf
    2940cc3f35e94fcc9e2cc35ed75e6524941d4c45ecec8a29a4cb013934bf3b1a  bge-small-lazy-convert.q8_0.gguf
    2940cc3f35e94fcc9e2cc35ed75e6524941d4c45ecec8a29a4cb013934bf3b1a  bge-small-quantize.q8_0.gguf
    ```
- [x] Tinyllama (`torch.bfloat16`) <https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0>
  - @compilade checkums match
    ```console
    $ sha256sum tinyllama-*.{bf16,q8_0}.gguf
    5af5abc9122fd3cd113b5bdd828e0f1c1737a432e3de0b80cd403a32659f07a6  tinyllama-lazy-convert.bf16.gguf
    5af5abc9122fd3cd113b5bdd828e0f1c1737a432e3de0b80cd403a32659f07a6  tinyllama-quantize.bf16.gguf
    06d3a29d46ac6d2a128a4c357544f24e311a582eb9af18134db76fe3044111e8  tinyllama-lazy-convert.q8_0.gguf
    06d3a29d46ac6d2a128a4c357544f24e311a582eb9af18134db76fe3044111e8  tinyllama-quantize.q8_0.gguf
    ```
- [x] TinyMistral MoE (`torch.float32`) <https://huggingface.co/jtatman/TinyMistral-248m-v2.5-4x-Moe>
  - @compilade checksums match
    ```console
    $ sha256sum tinymistral-moe-*.{bf16,q8_0}.gguf
    d6e6e1977ffa9cc365d425c107d7a79770b9425cab9db04d695e092fedd00d72  tinymistral-moe-lazy-convert.bf16.gguf
    d6e6e1977ffa9cc365d425c107d7a79770b9425cab9db04d695e092fedd00d72  tinymistral-moe-quantize.bf16.gguf
    316c22ee97cd3717736ff7cd4ee6cabfdb811b389bc23c4d7cf071c0b514144b  tinymistral-moe-lazy-convert.q8_0.gguf
    316c22ee97cd3717736ff7cd4ee6cabfdb811b389bc23c4d7cf071c0b514144b  tinymistral-moe-quantize.q8_0.gguf
    ```
- [x] Refact 1.6B fim (`torch.bfloat16`) <https://huggingface.co/smallcloudai/Refact-1_6B-fim>
  - @compilade checksums match
    ```console
    $ sha256sum refact-*.{bf16,q8_0}.gguf
    7536808b072cb49466d4346e9421379cb20b3730a22615ffc32d2e8fad1a794d  refact-lazy-convert.bf16.gguf
    7536808b072cb49466d4346e9421379cb20b3730a22615ffc32d2e8fad1a794d  refact-quantize.bf16.gguf
    0f904f322b3857bfa40e608b6d18fad96cb85bfa000769ccf67957f9a91194e8  refact-lazy-convert.q8_0.gguf
    0f904f322b3857bfa40e608b6d18fad96cb85bfa000769ccf67957f9a91194e8  refact-quantize.q8_0.gguf
    ```
- [x] Rocket 3B (StableLM) (`torch.float16`) <https://huggingface.co/pansophic/rocket-3B>
  - @compilade It's already in `f16`, but I'm quantizing from `f32` anyway for consistency with the other tests.
    :warning: checksums DON'T match. Not sure why. Anyone know of a program for diffing very large files?
    AhA! Looking at the diff of the `gguf-dump` of each model shows this is a metadata problem! The `ftype` was missing!
    ```console
    $ sha256sum rocket-3b-*.{bf16,q8_0}.gguf
    b9f3713f40ae8c567125b58e714f40af6fd4345fa86ca5ba95beb6f63ba84915  rocket-3b-lazy-convert.bf16.gguf
    356822c055c353e2291c147632607f61d16c66b4de117f00cf3acb88975c7057  rocket-3b-quantize.bf16.gguf
    356822c055c353e2291c147632607f61d16c66b4de117f00cf3acb88975c7057  rocket-3b-quantize-from-f16.bf16.gguf
    64ac7a549278d9dcf0bc13317d779409ae8e86a0894dad9678b923d634197021  rocket-3b-lazy-convert.q8_0.gguf
    3c9664651c5b5319c1c1d8b592527a228442a56d2ceb05ff349818d1ad707d4a  rocket-3b-quantize.q8_0.gguf
    3c9664651c5b5319c1c1d8b592527a228442a56d2ceb05ff349818d1ad707d4a  rocket-3b-quantize-from-f16.q8_0.gguf
    ```
    :heavy_check_mark: After adding the `ftype` in <https://github.com/ggerganov/llama.cpp/commit/2b1e5ea37b2a657a797dac7c84ac10bcb003fc2a>: CHECKSUMS MATCH!!!
    ```console
    $ sha256sum rocket-3b-{lazy-convert,quantize}.{bf16,q8_0}.gguf
    5c7478a782b593835422b865b9a639809e2cdac23ce479bb571e94e8124b275e  rocket-3b-lazy-convert.bf16.gguf
    5c7478a782b593835422b865b9a639809e2cdac23ce479bb571e94e8124b275e  rocket-3b-quantize.bf16.gguf
    9a9c298964e4d3ee1ff318e4b4d8235b7fa2f7912a52748a4fc4ab1eef502793  rocket-3b-lazy-convert.q8_0.gguf
    9a9c298964e4d3ee1ff318e4b4d8235b7fa2f7912a52748a4fc4ab1eef502793  rocket-3b-quantize.q8_0.gguf
    ```
- [x] StableLM 2 1.6B (`torch.float16`)
  - @compilade Had to ignore the pre-tokenizer detection error.
    :warning: checksums DON'T match. Is this specific to StableLM or to `torch.float16` models? Bloom is in `float16`, yet it still worked for it.
    AHA, the problem is that the `ftype` is not put in the model!!!
    ```console
    $ sha256sum stablelm2-1_6b-*.{bf16,q8_0}.gguf
    8125ba3fb52d8c23b7775a6cbb4349e6d3ee327a4fb8eabf0b967af5f1f0ec52  stablelm2-1_6b-lazy-convert.bf16.gguf
    503fb278646f090c3a9bff44c4e863ed7bdf5e641c4b5654013ea675e8bb1e83  stablelm2-1_6b-quantize.bf16.gguf
    4ea2ed24eda9dc0014cd9d114bff312dde96538b7a1e4b3471f15ccdfa0342d8  stablelm2-1_6b-lazy-convert.q8_0.gguf
    3b208039d839de88d21c22d50d3ebb50fa5f9ff96ee36ecaeb7c3ed04b5e55ae  stablelm2-1_6b-quantize.q8_0.gguf
    ```
    :heavy_check_mark: After adding the `ftype` in <https://github.com/ggerganov/llama.cpp/commit/2b1e5ea37b2a657a797dac7c84ac10bcb003fc2a>: CHECKSUMS MATCH!!!!
    ```console
    $ sha256sum stablelm2-1_6b-{lazy-convert,quantize}.{bf16,q8_0}.gguf
    44070519faa81b81b5720a0441e82e070698f9e7dc1f2be777878697a8ddd3a1  stablelm2-1_6b-lazy-convert.bf16.gguf
    44070519faa81b81b5720a0441e82e070698f9e7dc1f2be777878697a8ddd3a1  stablelm2-1_6b-quantize.bf16.gguf
    a41c8ef9e3728506c27d5fd0bb73257b6ee781bd7d2ad83623d4e85319a36423  stablelm2-1_6b-lazy-convert.q8_0.gguf
    a41c8ef9e3728506c27d5fd0bb73257b6ee781bd7d2ad83623d4e85319a36423  stablelm2-1_6b-quantize.q8_0.gguf
    ```
- [x] Mamba 2.8B (`torch.float32`) <https://huggingface.co/jondurbin/bagel-dpo-2.8b-v0.2>
  - @compilade checksums match
    ```console
    $ sha256sum mamba-bagel-*.{bf16,q8_0}.gguf
    5243cbf5e394709db46332c71d66841bd077a195c714fa942ad2e1952501c1e4  mamba-bagel-lazy-convert.bf16.gguf
    5243cbf5e394709db46332c71d66841bd077a195c714fa942ad2e1952501c1e4  mamba-bagel-quantize.bf16.gguf
    0d11e763fae7d8b2186d6b72a90974832e1f095a49f7c9bb66e21c8f1fc7484d  mamba-bagel-lazy-convert.q8_0.gguf
    0d11e763fae7d8b2186d6b72a90974832e1f095a49f7c9bb66e21c8f1fc7484d  mamba-bagel-quantize.q8_0.gguf
    ```
- [x] Bloom 560m (`torch.float16`) <https://huggingface.co/bigscience/bloom-560m>
  - @compilade checksums match
    ```console
    sha256sum bloom-560m-*.{bf16,q8_0}.gguf
    00914f5c6cda007f183ff748a97ee0d0ae409328837f4099a502927e6f2e3a9e  bloom-560m-lazy-convert.bf16.gguf
    00914f5c6cda007f183ff748a97ee0d0ae409328837f4099a502927e6f2e3a9e  bloom-560m-quantize.bf16.gguf
    1f389f7c25659580269e4f1d986ac93ba6307d0dbcb14f4d05a120406b287580  bloom-560m-lazy-convert.q8_0.gguf
    1f389f7c25659580269e4f1d986ac93ba6307d0dbcb14f4d05a120406b287580  bloom-560m-quantize.q8_0.gguf
    ```
- [x] Qwen 1.6B Chat (`torch.bfloat16`) <https://huggingface.co/Qwen/Qwen-1_8B-Chat>
  - @compilade :warning: same problem as with `StableLMModel`, the `ftype` is missing.
    ```console
    $ sha256sum qwen-1_8-*.{bf16,q8_0}.gguf
    73168f805cec5ac836c6de8f62babbb57268a11bf1a5971704bdf28eb3989bfa  qwen-1_8-lazy-convert.bf16.gguf
    3168513b9a2e1d09f1e29ff165dd29a9808f8fbee4c67a3ce27186c73701d033  qwen-1_8-quantize.bf16.gguf
    71a1a117122290dac59bc3b6d0a94e481d6bd333c4c7a1cb50671a44d98fd248  qwen-1_8-lazy-convert.q8_0.gguf
    d5beaa3052d82fcae0098d641a03c2fb7e36f7db8c1100463f4f38d995237ab7  qwen-1_8-quantize.q8_0.gguf
    ```
    :heavy_check_mark: After adding the `ftype` in <https://github.com/ggerganov/llama.cpp/commit/2b1e5ea37b2a657a797dac7c84ac10bcb003fc2a>: checksums match!
    ```console
    $ sha256sum qwen-1_8-{lazy-convert,quantize}.{bf16,q8_0}.gguf
    f3e6576265bb0a9a3a5143c55980539d46feed959fdce141d7607ae98a075408  qwen-1_8-lazy-convert.bf16.gguf
    f3e6576265bb0a9a3a5143c55980539d46feed959fdce141d7607ae98a075408  qwen-1_8-quantize.bf16.gguf
    62ed4a9fe70fdf2c32f4d127e3a231fa6000d9fed9ae838a22297032f6409e7f  qwen-1_8-lazy-convert.q8_0.gguf
    62ed4a9fe70fdf2c32f4d127e3a231fa6000d9fed9ae838a22297032f6409e7f  qwen-1_8-quantize.q8_0.gguf
    ```
- [x] InternLM2 (`torch.bfloat16`) <https://huggingface.co/internlm/internlm2-chat-1_8b>
  - @compilade The `ftype` was missing, but I noticed it before first converting. After adding the `ftype` in <https://github.com/ggerganov/llama.cpp/commit/2b1e5ea37b2a657a797dac7c84ac10bcb003fc2a>: checksums match!
    ```console
    $ sha256sum internlm2-chat-1_8b-{lazy-convert,quantize}.{bf16,q8_0}.gguf
    6eb940c38b768314b57c3df7bb42fd4b5d87e0f7cb9297a6685f9c602a9f310c  internlm2-chat-1_8b-lazy-convert.bf16.gguf
    6eb940c38b768314b57c3df7bb42fd4b5d87e0f7cb9297a6685f9c602a9f310c  internlm2-chat-1_8b-quantize.bf16.gguf
    2ba4217854da0ba0a7489ef0c44692aa298343a907e77acf486ba9f6d4915e9f  internlm2-chat-1_8b-lazy-convert.q8_0.gguf
    2ba4217854da0ba0a7489ef0c44692aa298343a907e77acf486ba9f6d4915e9f  internlm2-chat-1_8b-quantize.q8_0.gguf
    ```
- [ ] Other architectures (will most likely work)