### PR TITLE
Fix self extend on the server.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2029,24 +2029,7 @@ struct server_context {
 
                                 // reuse any previously computed tokens that are common with the new prompt
                                 slot.n_past = common_part(slot.cache_tokens, prompt_tokens);
-                                if (slot.ga_n != 1)
-                                {
-                                    int ga_i = 0;
-                                    int32_t ga_n = slot.ga_n;
-                                    int32_t ga_w = slot.ga_w;
-                                    int32_t slot_npast = 0;
-                                    for (int k = 0; k < slot.n_past; ++k)
-                                    {
-                                        while (slot_npast >= ga_i + ga_w) {
-                                            const int bd = (ga_w/ga_n)*(ga_n - 1);
-                                            slot_npast -= bd;
-                                            ga_i += ga_w/ga_n;
-                                        }
-                                        slot_npast++;
-                                    }
-                                    slot.n_past_se = slot_npast;
-                                    slot.ga_i = ga_i;
-                                }
+                                
                                 // push the prompt into the sampling context (do not apply grammar)
                                 for (int i = 0; i < slot.n_past; ++i) {
                                     llama_sampling_accept(slot.ctx_sampling, ctx, slot.cache_tokens[i], false);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2029,7 +2029,24 @@ struct server_context {
 
                                 // reuse any previously computed tokens that are common with the new prompt
                                 slot.n_past = common_part(slot.cache_tokens, prompt_tokens);
-
+                                if (slot.ga_n != 1)
+                                {
+                                    int ga_i = 0;
+                                    int32_t ga_n = slot.ga_n;
+                                    int32_t ga_w = slot.ga_w;
+                                    int32_t slot_npast = 0;
+                                    for (int k = 0; k < slot.n_past; ++k)
+                                    {
+                                        while (slot_npast >= ga_i + ga_w) {
+                                            const int bd = (ga_w/ga_n)*(ga_n - 1);
+                                            slot_npast -= bd;
+                                            ga_i += ga_w/ga_n;
+                                        }
+                                        slot_npast++;
+                                    }
+                                    slot.n_past_se = slot_npast;
+                                    slot.ga_i = ga_i;
+                                }
                                 // push the prompt into the sampling context (do not apply grammar)
                                 for (int i = 0; i < slot.n_past; ++i) {
                                     llama_sampling_accept(slot.ctx_sampling, ctx, slot.cache_tokens[i], false);


### PR DESCRIPTION
The self extend is broken on the server according to this. 
https://github.com/ggerganov/llama.cpp/issues/7005
This PR tries to fix the self extend mechanism in the server. I tested it with passkey test and it could predict the passkey correctly. I have replicated the passkey test of llama.cpp, because I wasn't sure about how to interpret the results of the behave run. I basically copied the showed prompt from the behave passkey test and added token "[INST]" at the beginning and "[/INST]" at the end. Then  I runned it on the completion endpoint. 

Would be happy if someone could test it and give it a try

Edit:
Did another test with mistral instruct v0.2 with 50.000 context text and the passkey once in the middle. It worked really well. Did another test without self extend enabled and it sayed that the passkey isn't in the text.
