### PR TITLE
[SYCL] Add oneapi runtime dll files to win release package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -932,6 +932,7 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
+          source "C:/Program Files (x86)/Intel/oneAPI/setvars.bat" intel64 --force
           echo "cp oneAPI running time dll files in ${ONEAPI_ROOT} to ./build/bin"
           cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
           cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -932,6 +932,17 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
+          echo "cp oneAPI running time dll files to ./build/bin"
+          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
+          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
+          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
+
+          cp ${ONEAPI_ROOT}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
+          cp ${ONEAPI_ROOT}/compiler/latest/bin/pi_level_zero.dll ./build/bin
+          cp ${ONEAPI_ROOT}/compiler/latest/bin/sycl7.dll ./build/bin
+          cp ${ONEAPI_ROOT}/compiler/latest/bin/svml_dispmd.dll ./build/bin
+          cp ${ONEAPI_ROOT}/compiler/latest/bin/libmmd.dll ./build/bin
+          echo "cp oneAPI running time dll files to ./build/bin done"
           7z a llama-${{ steps.tag.outputs.name }}-bin-win-sycl-x64.zip ./build/bin/*
 
       - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -932,16 +932,16 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
-          echo "cp oneAPI running time dll files in ${env.ONEAPI_ROOT} to ./build/bin"
-          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
+          echo "cp oneAPI running time dll files in ${{ env.ONEAPI_ROOT }} to ./build/bin"
+          cp "${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll" ./build/bin
 
-          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_level_zero.dll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/sycl7.dll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/svml_dispmd.dll ./build/bin
-          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/libmmd.dll ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_win_proxy_loader.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_level_zero.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/compiler/latest/bin/sycl7.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/compiler/latest/bin/svml_dispmd.dll" ./build/bin
+          cp "${{ env.ONEAPI_ROOT }}/compiler/latest/bin/libmmd.dll" ./build/bin
           echo "cp oneAPI running time dll files to ./build/bin done"
           7z a llama-${{ steps.tag.outputs.name }}-bin-win-sycl-x64.zip ./build/bin/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -932,7 +932,7 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
-          echo "cp oneAPI running time dll files in ${{ ONEAPI_ROOT }} to ./build/bin"
+          echo "cp oneAPI running time dll files in ${ONEAPI_ROOT} to ./build/bin"
           cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
           cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
           cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -932,16 +932,16 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
-          echo "cp oneAPI running time dll files to ./build/bin"
-          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
-          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
-          cp ${ONEAPI_ROOT}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
+          echo "cp oneAPI running time dll files in ${{ ONEAPI_ROOT }} to ./build/bin"
+          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
 
-          cp ${ONEAPI_ROOT}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
-          cp ${ONEAPI_ROOT}/compiler/latest/bin/pi_level_zero.dll ./build/bin
-          cp ${ONEAPI_ROOT}/compiler/latest/bin/sycl7.dll ./build/bin
-          cp ${ONEAPI_ROOT}/compiler/latest/bin/svml_dispmd.dll ./build/bin
-          cp ${ONEAPI_ROOT}/compiler/latest/bin/libmmd.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/pi_level_zero.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/sycl7.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/svml_dispmd.dll ./build/bin
+          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/libmmd.dll ./build/bin
           echo "cp oneAPI running time dll files to ./build/bin done"
           7z a llama-${{ steps.tag.outputs.name }}-bin-win-sycl-x64.zip ./build/bin/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -900,7 +900,7 @@ jobs:
     env:
       WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/62641e01-1e8d-4ace-91d6-ae03f7f8a71f/w_BaseKit_p_2024.0.0.49563_offline.exe
       WINDOWS_DPCPP_MKL: intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.mkl.devel
-
+      ONEAPI_ROOT: "C:/Program Files (x86)/Intel/oneAPI"
     steps:
       - name: Clone
         id: checkout
@@ -932,17 +932,16 @@ jobs:
         id: pack_artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         run: |
-          source "C:/Program Files (x86)/Intel/oneAPI/setvars.bat" intel64 --force
-          echo "cp oneAPI running time dll files in ${ONEAPI_ROOT} to ./build/bin"
-          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
+          echo "cp oneAPI running time dll files in ${env.ONEAPI_ROOT} to ./build/bin"
+          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_sycl_blas.4.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_core.2.dlll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/mkl/latest/bin/mkl_tbb_thread.2.dll ./build/bin
 
-          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/pi_level_zero.dll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/sycl7.dll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/svml_dispmd.dll ./build/bin
-          cp ${{ ONEAPI_ROOT }}/compiler/latest/bin/libmmd.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_win_proxy_loader.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/pi_level_zero.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/sycl7.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/svml_dispmd.dll ./build/bin
+          cp ${{ env.ONEAPI_ROOT }}/compiler/latest/bin/libmmd.dll ./build/bin
           echo "cp oneAPI running time dll files to ./build/bin done"
           7z a llama-${{ steps.tag.outputs.name }}-bin-win-sycl-x64.zip ./build/bin/*
 


### PR DESCRIPTION
Add oneapi runtime dll files to win release package.
So that the user could run the llama.cpp binary tools directly, without install oneAPI base toolkits.

PS: the Intel GPU driver and level-zero are still needed to be installed before run.