### PR TITLE
llava-cli: fix base64 prompt

### DIFF
--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -300,14 +300,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    for (auto & image : params.image) {
+    if (prompt_contains_image(params.prompt)) {
         auto ctx_llava = llava_init_context(&params, model);
 
-        auto image_embed = load_image(ctx_llava, &params, image);
-        if (!image_embed) {
-            std::cerr << "error: failed to load image " << image << ". Terminating\n\n";
-            return 1;
-        }
+        auto image_embed = load_image(ctx_llava, &params, "");
 
         // process the prompt
         process_prompt(ctx_llava, image_embed, &params, params.prompt);
@@ -316,7 +312,26 @@ int main(int argc, char ** argv) {
         llava_image_embed_free(image_embed);
         ctx_llava->model = NULL;
         llava_free(ctx_llava);
+    } else {
+        for (auto & image : params.image) {
+            auto ctx_llava = llava_init_context(&params, model);
+
+            auto image_embed = load_image(ctx_llava, &params, image);
+            if (!image_embed) {
+                std::cerr << "error: failed to load image " << image << ". Terminating\n\n";
+                return 1;
+            }
+
+            // process the prompt
+            process_prompt(ctx_llava, image_embed, &params, params.prompt);
+
+            llama_print_timings(ctx_llava->ctx_llama);
+            llava_image_embed_free(image_embed);
+            ctx_llava->model = NULL;
+            llava_free(ctx_llava);
+        }
     }
+
     llama_free_model(model);
 
     return 0;


### PR DESCRIPTION
The multiple image PR https://github.com/ggerganov/llama.cpp/pull/6969 breaks base64 prompt processing in `llava-cli`


Without this change, the main function just iterate through image file paths, ignore base64 code in prompt, you have to add an empty image path `--image ""` as a workaround
```
.\bin\llava-cli.exe -m ..\..\..\models\llava-phi-3-mini-int4.gguf --mmproj ..\..\..\models\llava-phi-3-mini-mmproj-f16.gguf -c 4096 -p "<img src=\`"data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAARklEQVR4nGLpPPSRgRSw2aaBJPVMJKkmA4xaMGrBqAWjFoxaQA3A+NnMjCQN72pkSVI/9INo1IJRC0YtGLVgRFgACAAA//8j+AbTk2+QtAAAAABJRU5ErkJggg==\`">Provide a full description" --image ""
```

Now this works
```
.\bin\llava-cli.exe -m ..\..\..\models\llava-phi-3-mini-int4.gguf --mmproj ..\..\..\models\llava-phi-3-mini-mmproj-f16.gguf -c 4096 -p "<img src=\`"data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAARklEQVR4nGLpPPSRgRSw2aaBJPVMJKkmA4xaMGrBqAWjFoxaQA3A+NnMjCQN72pkSVI/9INo1IJRC0YtGLVgRFgACAAA//8j+AbTk2+QtAAAAABJRU5ErkJggg==\`">Provide a full description"
```