### PR TITLE
llava-cli: fix process prompt bug

### DIFF
--- a/examples/llava/llava-cli.cpp
+++ b/examples/llava/llava-cli.cpp
@@ -272,6 +272,15 @@ static void llama_log_callback_logTee(ggml_log_level level, const char * text, v
     LOG_TEE("%s", text);
 }
 
+static std::string replaceWithN(std::string& input) {
+    size_t pos = 0;
+    while ((pos = input.find("\\n", pos)) != std::string::npos) {
+        input.replace(pos, 2, "\n"); 
+        pos += 1; 
+    }
+    return input;
+}
+
 int main(int argc, char ** argv) {
     ggml_time_init();
 
@@ -308,8 +317,9 @@ int main(int argc, char ** argv) {
             std::cerr << "error: failed to load image " << image << ". Terminating\n\n";
             return 1;
         }
-
+        
         // process the prompt
+        params.prompt = replaceWithN(params.prompt);
         process_prompt(ctx_llava, image_embed, &params, params.prompt);
 
         llama_print_timings(ctx_llava->ctx_llama);


### PR DESCRIPTION
Fix #6823 
For example 
```
What credit card company is on the banner in the background?\nAnswer the question using a single word or phrase.
```
Notice the different tokenization result of '\n'
Before fix, the verbose-prompt result is:
```
  2061 -> 'What'
  3884 -> ' credit'
  2657 -> ' card'
  1664 -> ' company'
   318 -> ' is'
   319 -> ' on'
   262 -> ' the'
 17625 -> ' banner'
   287 -> ' in'
   262 -> ' the'
  4469 -> ' background'
    30 -> '?'
    59 -> '\'
    77 -> 'n'
 33706 -> 'Answer'
   262 -> ' the'
  1808 -> ' question'
  1262 -> ' using'
   257 -> ' a'
  2060 -> ' single'
  1573 -> ' word'
   393 -> ' or'
  9546 -> ' phrase'
    13 -> '.'

```
After fix:
```
2061 -> 'What'
  3884 -> ' credit'
  2657 -> ' card'
  1664 -> ' company'
   318 -> ' is'
   319 -> ' on'
   262 -> ' the'
 17625 -> ' banner'
   287 -> ' in'
   262 -> ' the'
  4469 -> ' background'
    30 -> '?'
   198 -> '
'
 33706 -> 'Answer'
   262 -> ' the'
  1808 -> ' question'
  1262 -> ' using'
   257 -> ' a'
  2060 -> ' single'
  1573 -> ' word'
   393 -> ' or'
  9546 -> ' phrase'
    13 -> '.
```