### PR TITLE
common: free ctx_gguf when exiting llama_control_vector_load_one

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2977,6 +2977,8 @@ static llama_control_vector_data llama_control_vector_load_one(const llama_contr
         }
     }
 
+    gguf_free(ctx_gguf);
+
     return result;
 }
 


### PR DESCRIPTION
ctx_gguf is initialized by gguf_init_from_file. It appears to be otherwise unused throughout the function. Someone more familar with the code might want to consider if gguf_init_from_file is necessary at all. But in the mean time, free the context when exiting so we don't leak memory.