### PR TITLE
embedding: free the batch after execution

### DIFF
--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -211,6 +211,7 @@ int main(int argc, char ** argv) {
 
     // clean up
     llama_print_timings(ctx);
+    llama_batch_free(batch);
     llama_free(ctx);
     llama_free_model(model);
     llama_backend_free();


### PR DESCRIPTION
Similar to PR #7212, I added `llama_batch_free` at the end of the embedding example to release the resources occupied by the batch.