### PR TITLE
sched : support async weight copy

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1358,6 +1358,7 @@ int main(int argc, char ** argv) {
         }
 
         p->print_test(t);
+        fflush(p->fout);
 
         llama_print_timings(ctx);
 

--- a/ggml-backend-impl.h
+++ b/ggml-backend-impl.h
@@ -114,6 +114,8 @@ extern "C" {
         void                 (*GGML_CALL event_record)      (ggml_backend_event_t event);
         void                 (*GGML_CALL event_wait)        (ggml_backend_t backend, ggml_backend_event_t event);
         void                 (*GGML_CALL event_synchronize) (ggml_backend_event_t event);
+
+        ggml_backend_t (*GGML_CALL backend_dup)(ggml_backend_t backend);
     };
 
     struct ggml_backend {

--- a/ggml-backend.h
+++ b/ggml-backend.h
@@ -50,9 +50,10 @@ extern "C" {
     // Backend
     //
 
-    GGML_API ggml_guid_t  ggml_backend_guid(ggml_backend_t backend);
-    GGML_API const char * ggml_backend_name(ggml_backend_t backend);
-    GGML_API void         ggml_backend_free(ggml_backend_t backend);
+    GGML_API ggml_guid_t    ggml_backend_guid(ggml_backend_t backend);
+    GGML_API const char *   ggml_backend_name(ggml_backend_t backend);
+    GGML_API void           ggml_backend_free(ggml_backend_t backend);
+    GGML_API ggml_backend_t ggml_backend_dup(ggml_backend_t backend);
 
     GGML_API ggml_backend_buffer_type_t ggml_backend_get_default_buffer_type(ggml_backend_t backend);
     GGML_API ggml_backend_buffer_t      ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size);

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2920,6 +2920,12 @@ static void ggml_backend_cuda_event_synchronize(ggml_backend_event_t event) {
     CUDA_CHECK(cudaEventSynchronize((cudaEvent_t)event->context));
 }
 
+static ggml_backend_t ggml_backend_cuda_dup(ggml_backend_t backend) {
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+
+    return ggml_backend_cuda_init(cuda_ctx->device);
+}
+
 static ggml_backend_i ggml_backend_cuda_interface = {
     /* .get_name                = */ ggml_backend_cuda_name,
     /* .free                    = */ ggml_backend_cuda_free,
@@ -2939,6 +2945,7 @@ static ggml_backend_i ggml_backend_cuda_interface = {
     /* .event_record            = */ ggml_backend_cuda_event_record,
     /* .event_wait              = */ ggml_backend_cuda_event_wait,
     /* .event_synchronize       = */ ggml_backend_cuda_event_synchronize,
+    /* .backend_dup             = */ ggml_backend_cuda_dup,
 };
 
 static ggml_guid_t ggml_backend_cuda_guid() {


### PR DESCRIPTION
Adds support for copying the weights asynchronously with partial offload, so that the next weight can be uploaded while the current one is being used.

-ngl 0 -fa 1:
| GPU         | Model         | Test   |   t/s master |   t/s sl/async-weight-copy |   Speedup |
|:------------|:--------------|:-------|-------------:|---------------------------:|----------:|
| RTX 3090 Ti | llama 7B Q4_0 | pp512  |       750.72 |                     956.93 |      1.27 |
| RTX 3090 Ti | llama 7B Q4_0 | pp1024 |      1241.37 |                    1656.96 |      1.33 |
| RTX 3090 Ti | llama 7B Q4_0 | pp2048 |      1543.42 |                    2492.75 |      1.62 |
| RTX 3090 Ti | llama 7B Q4_0 | pp4096 |      1830.87 |                    2478.10 |      1.35 |
| RTX 3090 Ti | llama 7B Q4_0 | pp8192 |      1868.97 |                    2205.80 |      1.18 |


While it improves performance significantly, it is still far below what should be possible because the KV cache is still copied synchronously, which results in a stall in every layer which pretty much destroys the performance. Fixing that is going to be more complicated.