### PR TITLE
github-actions-labeler: initial commit

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,97 @@
+# https://github.com/actions/labeler
+
+## AUTO DIFFICULTIES MARKER
+############################
+
+"review complexity : high":
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml-cuda/*.cu
+            - ggml-cuda/*.cuh
+            - ggml-vulkan.cpp
+            - ggml-sycl.cpp
+            - ggml_vk_generate_shaders.py
+            - ggml-sycl.cpp
+"review complexity : medium":
+    - changed-files:
+        - any-glob-to-any-file:
+            - .devops/**
+            - .github/**
+            - ci/**
+#'review complexity : low':
+
+
+## AUTO CATEGORIZATION
+#######################
+
+SYCL:
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml-sycl.h
+            - ggml-sycl.cpp
+            - README-sycl.md
+Nvidia GPU:
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml-cuda/**
+Vulkan:
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml_vk_generate_shaders.py
+            - ggml-vulkan*
+documentation:
+    - changed-files:
+        - any-glob-to-any-file:
+            - docs/**
+            - media/**
+testing:
+    - changed-files:
+        - any-glob-to-any-file:
+            - tests/**
+build:
+    - changed-files:
+        - any-glob-to-any-file:
+            - cmake/**
+            - CMakeLists.txt
+            - CMakePresets.json
+            - codecov.yml
+examples:
+    - changed-files:
+        - any-glob-to-any-file: examples/**
+devops:
+    - changed-files:
+        - any-glob-to-any-file:
+            - .devops/**
+            - .github/**
+            - ci/**
+python:
+    - changed-files:
+        - any-glob-to-any-file:
+            - "**/*.py"
+            - requirements/**
+            - gguf-py/**
+            - .flake8
+script:
+    - changed-files:
+        - any-glob-to-any-file:
+            - scripts/**
+android:
+    - changed-files:
+        - any-glob-to-any-file:
+            - examples/llama.android/**
+server:
+    - changed-files:
+        - any-glob-to-any-file:
+            - examples/server/**
+ggml:
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml-*.c
+            - ggml-*.h
+            - ggml-cuda/**
+nix:
+    - changed-files:
+        - any-glob-to-any-file:
+            - "**/*.nix"
+            - .github/workflows/nix-*.yml
+            - .devops/nix/nixpkgs-instances.nix

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,5 @@
 # https://github.com/actions/labeler
 
-## AUTO DIFFICULTIES MARKER
-############################
-
-"review complexity : high":
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml-cuda/*.cu
-            - ggml-cuda/*.cuh
-            - ggml-vulkan.cpp
-            - ggml-sycl.cpp
-            - ggml_vk_generate_shaders.py
-            - ggml-sycl.cpp
-"review complexity : medium":
-    - changed-files:
-        - any-glob-to-any-file:
-            - .devops/**
-            - .github/**
-            - ci/**
-#'review complexity : low':
-
-
-## AUTO CATEGORIZATION
-#######################
-
 SYCL:
     - changed-files:
         - any-glob-to-any-file:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This is an attempt at solving this idea https://github.com/ggerganov/llama.cpp/issues/7174 of using https://github.com/actions/labeler to help assist in auto labeling PR based on file edited content.

Was hoping for PR complexity automation, but this particular github action doesn't appear to have enough flexibility for such logic. But this should help if it works.

I don't have a way to test this, so maybe have a quick lookover and it if makes sense and we can risk it, let's give it a shot.

----

Also made an issue ticket directly to the team at labeler to see if there is a possibility of having enumerated labels so we can better add auto complexity marking. https://github.com/actions/labeler/issues/781 