### PR TITLE
Fix floating point error with ndot progress printing in Perplexity and show stats with < 100 tasks

### DIFF
--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -1425,7 +1425,7 @@ static void multiple_choice_score(llama_context * ctx, const gpt_params & params
         // Use all tasks
         tasks.resize(n_task);
         printf("%s: reading tasks", __func__);
-        int n_dot = n_task/100;
+        int n_dot = std::max((int) n_task/100, 1);
         int i = 0;
         for (auto& task : tasks) {
             ++i;
@@ -1675,7 +1675,7 @@ static void multiple_choice_score(llama_context * ctx, const gpt_params & params
 
     llama_batch_free(batch);
 
-    if (n_done < 100) return;
+    if (n_done < 100 && (params.multiple_choice_tasks != 0 && params.multiple_choice_tasks < (size_t)n_task)) return;
 
     float p = 1.f*n_correct/n_done;
     float sigma = sqrt(p*(1-p)/(n_done-1));


### PR DESCRIPTION
This simple 2 line PR is to allow --multiple-choice with a --binary-file that has less than 100 tasks.  

I've made a JSON->bin encoder, but as I [discovered here](https://github.com/ggerganov/llama.cpp/pull/5047#issuecomment-2116090792) when testing the encoder, with fewer than 100 tasks you get a floating point error on a simple function that just prints progress dots.

I've also changed a line to allow printing the stats at the end (score % vs guess %) if you're using all multiple choice tasks (of any number), rather than just >= 100.