### PR TITLE
labeler.yml: Use settings from ggerganov/llama.cpp [no ci]

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: "ggerganov/llama.cpp"
     - uses: actions/labeler@v5
+      with:
+        configuration-path: '.github/labeler.yml'


### PR DESCRIPTION
Noticed actions is sometimes not working on PR that has the older commits without the config settings file for labeler.

https://github.com/actions/labeler#using-configuration-path-input-together-with-the-actionscheckout-action Recommends the use of checkout action to use the correct repo context when applying settings for PR labels

e.g. they suggested add this

```yaml
    steps:
    - uses: actions/checkout@v4 # Uploads repository content to the runner
      with:
        repository: "owner/repositoryName" # The one of the available inputs, visit https://github.com/actions/checkout#readme to find more
    - uses: actions/labeler@v5
      with:
        configuration-path: 'path/to/the/uploaded/configuration/file'
```