### PR TITLE
grammars: early exit when no next_candidates to reject

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -13187,6 +13187,10 @@ static std::vector<llama_grammar_candidate> llama_grammar_reject_candidates_for_
         }
     }
 
+    if (next_candidates.empty()) {
+        return rejects;
+    }
+
     const auto * stack_pos_after = llama_grammar_match_char(stack_pos, 0).second;
 
     // update top of stack to next element, if any


### PR DESCRIPTION
**Edit**: superseded by https://github.com/ggerganov/llama.cpp/pull/7424 (see [benchmarks](https://gist.github.com/ochafik/56733ecd349874fd66cedcfdfa619e9c) comparing different fix combinations)

This speeds up grammar sampling *only in some cases* (https://github.com/ggerganov/llama.cpp/issues/4218).

(extracted from https://github.com/ggerganov/llama.cpp/pull/6811 which other change needs a bit more work)

For instance the example taken from @AlienKevin (see https://github.com/ggerganov/llama.cpp/issues/4218#issuecomment-1836540046; download [issue4218.gbnf](https://gist.githubusercontent.com/ochafik/e5b1731e4e574ac1aed2e49e5f9c5899/raw/c0c1411377500f6e0d66ec7dbfea22686178986c/issue4218.gbnf) and [issue4218.txt](https://gist.githubusercontent.com/ochafik/e5b1731e4e574ac1aed2e49e5f9c5899/raw/c0c1411377500f6e0d66ec7dbfea22686178986c/issue4218.txt)) runs **1.4x faster** (total time; sampling itself went from 28.5 ms per token to 11.7 ms per token, a **2.4x sampling speedup**)

```bash
# git remote add ochafik https://github.com/ochafik/llama.cpp.git
# git fetch ochafik
( export COMMON_ARGS=(
    -mu https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf
    --prompt-cache issue4218.bin
    --grammar-file issue4218.gbnf
    -f issue4218.txt
    -c 3400
  ) && \
  hyperfine --warmup 1 --runs 5 \
    -L branch ochafik/grammars-early-exit,master \
    --setup "\
      git checkout {branch} && \
      make clean && make -j LLAMA_CURL=1 main && \
      rm -f issue4218.bin && \
      ./main ${COMMON_ARGS[*]} -n 1" \
    "BRANCH={branch} \
      ./main ${COMMON_ARGS[*]} -n 128 --prompt-cache-ro --seed 12345 --no-display-prompt" )
```

<details>
<summary>Show output</summary>

```bash
Benchmark 1: BRANCH=grammars-early-exit       ./main -mu https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf --prompt-cache issue4218.bin --grammar-file issue4218.gbnf -f issue4218.txt -c 3400 -n 128 --prompt-cache-ro --seed 12345 --no-display-prompt
  Time (mean ± σ):      5.697 s ±  0.057 s    [User: 1.705 s, System: 0.247 s]
  Range (min … max):    5.639 s …  5.772 s    5 runs
 
Benchmark 2: BRANCH=master       ./main -mu https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf --prompt-cache issue4218.bin --grammar-file issue4218.gbnf -f issue4218.txt -c 3400 -n 128 --prompt-cache-ro --seed 12345 --no-display-prompt
  Time (mean ± σ):      7.946 s ±  0.048 s    [User: 3.838 s, System: 0.257 s]
  Range (min … max):    7.915 s …  8.027 s    5 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (8.027 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Summary
  'BRANCH=grammars-early-exit       ./main -mu https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf --prompt-cache issue4218.bin --grammar-file issue4218.gbnf -f issue4218.txt -c 3400 -n 128 --prompt-cache-ro --seed 12345 --no-display-prompt' ran
    1.39 ± 0.02 times faster than 'BRANCH=master       ./main -mu https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf --prompt-cache issue4218.bin --grammar-file issue4218.gbnf -f issue4218.txt -c 3400 -n 128 --prompt-cache-ro --seed 12345 --no-display-prompt'
```

`master`:

```
llama_print_timings:        load time =     323.50 ms
llama_print_timings:      sample time =    3651.29 ms /   128 runs   (   28.53 ms per token,    35.06 tokens per second)
llama_print_timings: prompt eval time =       0.00 ms /     0 tokens (     nan ms per token,      nan tokens per second)
llama_print_timings:        eval time =    3408.83 ms /   127 runs   (   26.84 ms per token,    37.26 tokens per second)
llama_print_timings:       total time =    7273.18 ms /   127 tokens
```

this PR:

```
llama_print_timings:        load time =     311.38 ms
llama_print_timings:      sample time =    1491.73 ms /   128 runs   (   11.65 ms per token,    85.81 tokens per second)
llama_print_timings: prompt eval time =       0.00 ms /     0 tokens (     nan ms per token,      nan tokens per second)
llama_print_timings:        eval time =    3363.72 ms /   127 runs   (   26.49 ms per token,    37.76 tokens per second)
llama_print_timings:       total time =    5073.34 ms /   127 tokens
```

</details>

cc/ @HanClinto 