### PR TITLE
server: fix seed being reported back

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -102,7 +102,6 @@ struct slot_params {
     bool stream       = true;
     bool cache_prompt = false; // remember the prompt to avoid reprocessing all prompt
 
-    uint32_t seed      = -1; // RNG seed
     int32_t  n_keep    =  0; // number of tokens to keep from initial prompt
     int32_t  n_discard =  0; // number of tokens after n_keep that may be discarded when shifting context, 0 defaults to half
     int32_t  n_predict = -1; // new tokens to predict
@@ -1264,7 +1263,7 @@ struct server_context {
             {"n_ctx",                     slot.n_ctx},
             {"n_predict",                 slot.n_predict},
             {"model",                     params.model_alias},
-            {"seed",                      slot.params.seed},
+            {"seed",                      slot.sparams.seed},
             {"temperature",               slot.sparams.temp},
             {"dynatemp_range",            slot.sparams.dynatemp_range},
             {"dynatemp_exponent",         slot.sparams.dynatemp_exponent},


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/7381 .

When I fixed multiple slots using the same RNG state in https://github.com/ggerganov/llama.cpp/pull/6835 I forgot to adapt the code that reports the seed back to the user. As a consequence the default seed is always being reported back regardless of what seed is actually being used. This PR simply changes the seed being reported back to the one actually being used.