### PR TITLE
update HIP_UMA #7399

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -119,6 +119,24 @@ int ggml_cuda_get_device() {
     return id;
 }
 
+// ggml_cuda_host_malloc
+static inline cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
+#if defined(GGML_USE_HIPBLAS)
+#if defined(GGML_HIP_UMA)
+    auto res = hipMallocManaged(ptr, size);
+    if (res == hipSuccess) {
+        // if error we "need" to know why...
+        CUDA_CHECK(hipMemAdvise(*ptr, size, hipMemAdviseSetCoarseGrain, device));
+    }
+    return res;
+#else
+    return hipMalloc(ptr, size);
+#endif
+#else
+    return cudaMalloc(ptr, size);
+#endif
+}
+
 static ggml_cuda_device_info ggml_cuda_init() {
 #ifdef __HIP_PLATFORM_AMD__
     // Workaround for a rocBLAS bug when using multiple graphics cards:
@@ -271,7 +289,7 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
         size_t look_ahead_size = (size_t) (1.05 * size);
         look_ahead_size = 256 * ((look_ahead_size + 255)/256);
         ggml_cuda_set_device(device);
-        CUDA_CHECK(cudaMalloc((void **) &ptr, look_ahead_size));
+        CUDA_CHECK(ggml_cuda_device_malloc(&ptr, look_ahead_size, device));
         *actual_size = look_ahead_size;
         pool_size += look_ahead_size;
 #ifdef DEBUG_CUDA_MALLOC
@@ -537,7 +555,7 @@ GGML_CALL static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffe
     size = std::max(size, (size_t)1); // cudaMalloc returns null for size 0
 
     void * dev_ptr;
-    cudaError_t err = cudaMalloc(&dev_ptr, size);
+    cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device);
     if (err != cudaSuccess) {
         // clear the error
         cudaGetLastError();
@@ -798,7 +816,7 @@ GGML_CALL static void ggml_backend_cuda_split_buffer_init_tensor(ggml_backend_bu
         // currently, init_tensor cannot fail, it needs to be fixed in ggml-backend first
         ggml_cuda_set_device(id);
         char * buf;
-        CUDA_CHECK(cudaMalloc(&buf, size));
+        CUDA_CHECK(ggml_cuda_device_malloc((void**)&buf, size, id));
 
         // set padding to 0 to avoid possible NaN values
         if (size > original_size) {

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -119,19 +119,15 @@ int ggml_cuda_get_device() {
     return id;
 }
 
-// ggml_cuda_host_malloc
-static inline cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
-#if defined(GGML_USE_HIPBLAS)
-#if defined(GGML_HIP_UMA)
+static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
+    ggml_cuda_set_device(device);
+#if defined(GGML_USE_HIPBLAS) && defined(GGML_HIP_UMA)
     auto res = hipMallocManaged(ptr, size);
     if (res == hipSuccess) {
         // if error we "need" to know why...
         CUDA_CHECK(hipMemAdvise(*ptr, size, hipMemAdviseSetCoarseGrain, device));
     }
     return res;
-#else
-    return hipMalloc(ptr, size);
-#endif
 #else
     return cudaMalloc(ptr, size);
 #endif

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -79,11 +79,8 @@
 #define cudaHostRegisterReadOnly hipHostRegisterReadOnly
 #define cudaHostUnregister hipHostUnregister
 #define cudaLaunchHostFunc hipLaunchHostFunc
-#ifdef GGML_HIP_UMA
-#define cudaMallocHost(ptr, size) hipHostMalloc(ptr, size)
-#else
+#define cudaMalloc hipMalloc
 #define cudaMallocHost(ptr, size) hipHostMalloc(ptr, size, hipHostMallocDefault)
-#endif
 #define cudaMemcpy hipMemcpy
 #define cudaMemcpyAsync hipMemcpyAsync
 #define cudaMemcpyPeerAsync hipMemcpyPeerAsync

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -80,10 +80,8 @@
 #define cudaHostUnregister hipHostUnregister
 #define cudaLaunchHostFunc hipLaunchHostFunc
 #ifdef GGML_HIP_UMA
-#define cudaMalloc hipMallocManaged
 #define cudaMallocHost(ptr, size) hipHostMalloc(ptr, size)
 #else
-#define cudaMalloc hipMalloc
 #define cudaMallocHost(ptr, size) hipHostMalloc(ptr, size, hipHostMallocDefault)
 #endif
 #define cudaMemcpy hipMemcpy


### PR DESCRIPTION
Add use of hipMemAdviseSetCoarseGrain when LLAMA_HIP_UMA is enable.

On my Ryzen 7940HS I get some speed up:

build with:
```sh
# gfx1103 not supported use gfx1101 in place:
make -j16 LLAMA_HIPBLAS=1 LLAMA_HIP_UMA=1 AMDGPU_TARGETS=gfx1101
```

run bench with:
```sh
HSA_OVERRIDE_GFX_VERSION=11.0.1 ./main -m ~/LLM/mistral-7b-instruct-v0.2.Q8_0.gguf -ngl 999 --temp 0 -c 2048 -p "[INST] ... [/INST]"
```

I get:
``` sh
# before PR:
llama_print_timings:        load time =    3386,19 ms
llama_print_timings:      sample time =      12,14 ms /   609 runs   (    0,02 ms per token, 50177,14 tokens per second)
llama_print_timings: prompt eval time =   15051,81 ms /  1466 tokens (   10,27 ms per token,    97,40 tokens per second)
llama_print_timings:        eval time =  100420,23 ms /   608 runs   (  165,16 ms per token,     6,05 tokens per second)
llama_print_timings:       total time =  115547,81 ms /  2074 tokens

# after PR:
llama_print_timings:        load time =    2606,81 ms
llama_print_timings:      sample time =      12,19 ms /   609 runs   (    0,02 ms per token, 49946,69 tokens per second)
llama_print_timings: prompt eval time =    8120,08 ms /  1466 tokens (    5,54 ms per token,   180,54 tokens per second)
llama_print_timings:        eval time =   65652,40 ms /   608 runs   (  107,98 ms per token,     9,26 tokens per second)
llama_print_timings:       total time =   73841,90 ms /  2074 tokens
```

