### PR TITLE
vulkan: fix clang-cl debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,12 @@ if (LLAMA_VULKAN)
 
         add_compile_definitions(GGML_USE_VULKAN)
 
+        # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build
+        # Posssibly relevant: https://stackoverflow.com/questions/74748276/visual-studio-no-displays-the-correct-length-of-stdvector
+        if (MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            add_compile_definitions(_ITERATOR_DEBUG_LEVEL=0)
+        endif()
+
         if (LLAMA_VULKAN_CHECK_RESULTS)
             add_compile_definitions(GGML_VULKAN_CHECK_RESULTS)
         endif()


### PR DESCRIPTION
As discussed here https://github.com/ggerganov/llama.cpp/issues/7130

With `clang-cl` 18.1.5, MSVC 19.40.33808, vulkan SDK 1.3.283.0

An MSVC runtime error shows up: "Expression: can't dereference invalidated vector iterator" when I run the debug build of embedding with vulkan backend. I think I have also seen it somewhere when I run main/llava but I didn't manage to reproduce it.

The problem happens here

https://github.com/ggerganov/llama.cpp/blob/e23b974f4cf9270d05062d446f406e3ff55d9451/ggml-vulkan.cpp#L625-L646

~~`ctx->seqs.size()` shows 1 but MSVC thinks it is of size 0 when I step through the code using lldb. I believe it comes from this [issue](https://stackoverflow.com/questions/74748276/visual-studio-no-displays-the-correct-length-of-stdvector). The stackoverflow answer suggested adding a `/Zc:nrvo-` flag, and it doesn't work for `clang-cl` so I added another `_ITERATOR_DEBUG_LEVEL=0` definition for `clang-cl`.~~

Seems like the problem in MSVC is gone , `clang-cl` still needs `_ITERATOR_DEBUG_LEVEL=0` to work