### PR TITLE
CUDA: remove incorrect precision check

### DIFF
--- a/ggml-cuda/fattn-tile-f32.cu
+++ b/ggml-cuda/fattn-tile-f32.cu
@@ -286,9 +286,6 @@ void ggml_cuda_flash_attn_ext_tile_f32(ggml_backend_cuda_context & ctx, ggml_ten
     const ggml_tensor * KQV = dst;
     const ggml_tensor * Q   = dst->src[0];
 
-    const int32_t precision = KQV->op_params[2];
-    GGML_ASSERT(precision == GGML_PREC_DEFAULT);
-
     if (Q->ne[1] <= 16) {
         constexpr int cols_per_block = 16;
         constexpr int parallel_blocks = 4;


### PR DESCRIPTION
Fixes the issue described in https://github.com/ggerganov/llama.cpp/pull/7314#issuecomment-2123654070 . The problem is that there is an assert for precision in the FP32 code even though that check should only be in the FP16 code.