### PR TITLE
[SYCL] Prevent q_xxs using mul_mat_q

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -15243,6 +15243,7 @@ static void ggml_sycl_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1
             }
         } else {
             bool use_mul_mat_q = min_compute_capability >= VER_4VEC && ggml_is_quantized(src0->type);
+            use_mul_mat_q = use_mul_mat_q && (src0->type != GGML_TYPE_IQ2_XXS);
 
             if (use_xmx && min_compute_capability >= VER_GEN9 && src1->ne[1] > XMX_MAX_BATCH_SIZE) {
                 use_mul_mat_q = false;


### PR DESCRIPTION
There is currently a test failure for the A100 GPU which attempts to use `mul_mat_q` for q_xxs quantization. This quantization type is not supported in this approach, and results in an assert.

This change gets all expect one MUL_MAT test passing for the A100 GPU, it does not effect the ARC and PVC paths.
As the A100 has its `min_compute_capability` high enough to enable the `use_mul_mat_q` path.