### PR TITLE
SimpleChat Completion Mode flexibility and cleanup, Settings gMe, Optional sliding window

### DIFF
--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>SimpleChat (LlamaCPP, ...) </title>
+        <title>SimpleChat LlamaCppEtal </title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="message" content="Save Nature Save Earth" />

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -30,15 +30,12 @@
             <hr>
             <div class="sameline">
                 <label for="system-in">System</label>
-                <input type="text" name="system" id="system-in" class="flex-grow"/>
+                <input type="text" name="system" id="system-in" placeholder="e.g. you are a helpful ai assistant, who provides concise answers" class="flex-grow"/>
             </div>
 
             <hr>
             <div id="chat-div">
-                <p> Enter the system prompt above, before entering/submitting any user query.</p>
-                <p> Enter your text to the ai assistant below.</p>
-                <p> Use shift+enter for inserting enter.</p>
-                <p> Refresh the page to start over fresh.</p>
+                <p> You need to have javascript enabled.</p>
             </div>
 
             <hr>

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -40,7 +40,7 @@
 
             <hr>
             <div class="sameline">
-                <textarea id="user-in" class="flex-grow" rows="3"></textarea>
+                <textarea id="user-in" class="flex-grow" rows="3" placeholder="enter your query to the ai model here" ></textarea>
                 <button id="user-btn">submit</button>
             </div>
 

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -47,6 +47,16 @@ Open this simple web front end from your local browser
 
 Once inside
 * Select between chat and completion mode. By default it is set to chat mode.
+  * in completion mode
+    * the logic by default doesnt insert "THE_ROLE: " prefix wrt each role's message.
+      If the model requires any prefix wrt user role messages, then the end user has to
+      explicitly add the needed prefix, when they enter their chat message.
+      This keeps the logic simple, while still giving flexibility to the end user to
+      manage any templating/tagging requirement wrt their messages to the model.
+    * the logic doesnt insert newline at the begining and end wrt the prompt message generated.
+      However if the chat being sent to completion end point has more than one role's message,
+      then insert newline when moving from one role's message to the next role's message, so
+      that it can be clearly identified.
 * If you want to provide a system prompt, then ideally enter it first, before entering any user query.
   * if chat.add_system_begin is used
     * you cant change the system prompt, after it is has been submitted once along with user query.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -68,6 +68,8 @@ Once inside
     can use it just for normal completion related/based query.
 
 * If you want to provide a system prompt, then ideally enter it first, before entering any user query.
+  Normally Completion mode doesnt need system prompt, while Chat mode can generate better/interesting
+  responses with a suitable system prompt.
   * if chat.add_system_begin is used
     * you cant change the system prompt, after it is has been submitted once along with user query.
     * you cant set a system prompt, after you have submitted any user query
@@ -91,6 +93,13 @@ Once inside
 
 ## Devel note
 
+gChatRequestOptions maintains the list of options/fields to send along with chat request,
+irrespective of whether /chat/completions or /completions endpoint.
+
+  If you want to add additional options/fields to send to the server/ai-model, and or
+  modify the existing options value, for now you can update this global var using
+  browser's development-tools/console.
+
 Sometimes the browser may be stuborn with caching of the file, so your updates to html/css/js
 may not be visible. Also remember that just refreshing/reloading page in browser or for that
 matter clearing site data, dont directly override site caching in all cases. Worst case you may
@@ -103,3 +112,14 @@ not been added, for now.
 
 By switching between chat.add_system_begin/anytime, one can control whether one can change
 the system prompt, anytime during the conversation or only at the beginning.
+
+read_json_early, is to experiment with reading json response data early on, if available,
+so that user can be shown generated data, as and when it is being generated, rather than
+at the end when full data is available.
+
+  the server flow doesnt seem to be sending back data early, atleast for request (inc options)
+  that is currently sent.
+
+  if able to read json data early on in future, as and when ai model is generating data, then
+  this helper needs to indirectly update the chat div with the recieved data, without waiting
+  for the overall data to be available.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -43,20 +43,30 @@ next run this web front end in examples/server/public_simplechat
 ### using the front end
 
 Open this simple web front end from your local browser
+
 * http://127.0.0.1:PORT/index.html
 
 Once inside
+
 * Select between chat and completion mode. By default it is set to chat mode.
-  * in completion mode
-    * the logic by default doesnt insert "THE_ROLE: " prefix wrt each role's message.
-      If the model requires any prefix wrt user role messages, then the end user has to
-      explicitly add the needed prefix, when they enter their chat message.
-      This keeps the logic simple, while still giving flexibility to the end user to
-      manage any templating/tagging requirement wrt their messages to the model.
-    * the logic doesnt insert newline at the begining and end wrt the prompt message generated.
-      However if the chat being sent to completion end point has more than one role's message,
-      then insert newline when moving from one role's message to the next role's message, so
-      that it can be clearly identified.
+
+* In completion mode
+  * logic by default doesnt insert any role specific "ROLE: " prefix wrt each role's message.
+    If the model requires any prefix wrt user role messages, then the end user has to
+    explicitly add the needed prefix, when they enter their chat message.
+    Similarly if the model requires any prefix to trigger assistant/ai-model response,
+    then the end user needs to enter the same.
+    This keeps the logic simple, while still giving flexibility to the end user to
+    manage any templating/tagging requirement wrt their messages to the model.
+  * the logic doesnt insert newline at the begining and end wrt the prompt message generated.
+    However if the chat being sent to /completions end point has more than one role's message,
+    then insert newline when moving from one role's message to the next role's message, so
+    that it can be clearly identified/distinguished.
+  * given that /completions endpoint normally doesnt add additional chat-templating of its
+    own, the above ensures that end user can create a custom single/multi message combo with
+    any tags/special-tokens related chat templating to test out model handshake. Or enduser
+    can use it just for normal completion related/based query.
+
 * If you want to provide a system prompt, then ideally enter it first, before entering any user query.
   * if chat.add_system_begin is used
     * you cant change the system prompt, after it is has been submitted once along with user query.
@@ -65,12 +75,16 @@ Once inside
     * one can change the system prompt any time during chat, by changing the contents of system prompt.
     * inturn the updated/changed system prompt will be inserted into the chat session.
     * this allows for the subsequent user chatting to be driven by the new system prompt set above.
+
 * Enter your query and either press enter or click on the submit button.
   If you want to insert enter (\n) as part of your chat/query to ai model, use shift+enter.
+
 * Wait for the logic to communicate with the server and get the response.
   * the user is not allowed to enter any fresh query during this time.
   * the user input box will be disabled and a working message will be shown in it.
+
 * just refresh the page, to reset wrt the chat history and or system prompt and start afresh.
+
 * Using NewChat one can start independent chat sessions.
   * two independent chat sessions are setup by default.
 

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -97,6 +97,8 @@ Once inside
 
 ## Devel note
 
+### General
+
 Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
 
@@ -156,6 +158,27 @@ at the end when full data is available.
   if able to read json data early on in future, as and when ai model is generating data, then
   this helper needs to indirectly update the chat div with the recieved data, without waiting
   for the overall data to be available.
+
+
+### Default setup
+
+By default things are setup to try and make the user experience a bit better, if possible.
+However a developer when testing the server of ai-model may want to change these value.
+
+Using iRecentUserMsgCnt reduce chat history context sent to the server/ai-model to be
+just the system-prompt, prev-user-request-and-ai-response and cur-user-request, instead of
+full chat history. This way if there is any response with garbage/repeatation, it doesnt
+mess with things beyond the next question/request/query, in some ways.
+
+Set max_tokens to 1024, so that a relatively large previous reponse doesnt eat up the space
+available wrt next query-response. However dont forget that the server when started should
+also be started with a model context size of 1k or more, to be on safe side.
+
+Frequency and presence penalty fields are set to 1.2 in the set of fields sent to server
+along with the user query. So that the model is partly set to try avoid repeating text in
+its response.
+
+A end-user can change these behaviour by editing gMe from browser's devel-tool/console.
 
 
 ## At the end

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -97,6 +97,17 @@ Once inside
 
 ## Devel note
 
+### Reason behind this
+
+The idea is to be easy enough to use for basic purposes, while also being simple and easily discernable
+by developers who may not be from web frontend background (so inturn may not be familiar with template /
+end-use-specific-language-extensions driven flows) so that they can use it to explore/experiment things.
+
+And given that the idea is also to help explore/experiment for developers, some flexibility is provided
+to change behaviour easily using the devel-tools/console, for now. And skeletal logic has been implemented
+to explore some of the end points and ideas/implications around them.
+
+
 ### General
 
 Me/gMe consolidates the settings which control the behaviour into one object.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -93,12 +93,21 @@ Once inside
 
 ## Devel note
 
-gChatRequestOptions maintains the list of options/fields to send along with chat request,
-irrespective of whether /chat/completions or /completions endpoint.
+Me/gMe consolidates the settings which control the behaviour into one object.
+One can see the current settings, as well as change/update them using browsers devel-tool/console.
 
-  If you want to add additional options/fields to send to the server/ai-model, and or
-  modify the existing options value, for now you can update this global var using
-  browser's development-tools/console.
+  bCompletionFreshChatAlways - whether Completion mode collates completion history when communicating
+  with the server.
+
+  bCompletionInsertStandardRolePrefix - whether Completion mode inserts role related prefix wrt the
+  messages that get inserted into prompt field wrt /Completion endpoint.
+
+  chatRequestOptions - maintains the list of options/fields to send along with chat request,
+  irrespective of whether /chat/completions or /completions endpoint.
+
+    If you want to add additional options/fields to send to the server/ai-model, and or
+    modify the existing options value, for now you can update this global var using
+    browser's development-tools/console.
 
 Sometimes the browser may be stuborn with caching of the file, so your updates to html/css/js
 may not be visible. Also remember that just refreshing/reloading page in browser or for that

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -174,6 +174,10 @@ Set max_tokens to 1024, so that a relatively large previous reponse doesnt eat u
 available wrt next query-response. However dont forget that the server when started should
 also be started with a model context size of 1k or more, to be on safe side.
 
+  The /completions endpoint of examples/server doesnt take max_tokens, instead it takes the
+  internal n_predict, for now add the same here on the client side, maybe later add max_tokens
+  to /completions endpoint handling code on server side.
+
 Frequency and presence penalty fields are set to 1.2 in the set of fields sent to server
 along with the user query. So that the model is partly set to try avoid repeating text in
 its response.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -14,11 +14,15 @@ own system prompts.
 The UI follows a responsive web design so that the layout can adapt to available display space in a usable
 enough manner, in general.
 
-NOTE: Given that the idea is for basic minimal testing, it doesnt bother with any model context length and
-culling of old messages from the chat.
+Allows developer/end-user to control some of the behaviour by updating gMe members from browser's devel-tool
+console.
 
-NOTE: It doesnt set any parameters other than temperature for now. However if someone wants they can update
-the js file as needed.
+NOTE: Given that the idea is for basic minimal testing, it doesnt bother with any model context length and
+culling of old messages from the chat by default. However by enabling the sliding window chat logic, a crude
+form of old messages culling can be achieved.
+
+NOTE: It doesnt set any parameters other than temperature and max_tokens for now. However if someone wants
+they can update the js file or equivalent member in gMe as needed.
 
 
 ## usage
@@ -96,8 +100,8 @@ Once inside
 Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
 
-  bCompletionFreshChatAlways - whether Completion mode collates completion history when communicating
-  with the server.
+  bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
+  communicating with the server or only sends the latest user query/message.
 
   bCompletionInsertStandardRolePrefix - whether Completion mode inserts role related prefix wrt the
   messages that get inserted into prompt field wrt /Completion endpoint.
@@ -106,21 +110,41 @@ One can see the current settings, as well as change/update them using browsers d
   irrespective of whether /chat/completions or /completions endpoint.
 
     If you want to add additional options/fields to send to the server/ai-model, and or
-    modify the existing options value, for now you can update this global var using
-    browser's development-tools/console.
+    modify the existing options value or remove them, for now you can update this global var
+    using browser's development-tools/console.
+
+  iRecentUserMsgCnt - a simple minded SlidingWindow to limit context window load at Ai Model end.
+  This is disabled by default. However if enabled, then in addition to latest system message, only
+  the last/latest iRecentUserMsgCnt user messages after the latest system prompt and its responses
+  from the ai model will be sent to the ai-model, when querying for a new response. IE if enabled,
+  only user messages after the latest system message/prompt will be considered.
+
+    This specified sliding window user message count also includes the latest user query.
+    <0 : Send entire chat history to server
+     0 : Send only the system message if any to the server
+    >0 : Send the latest chat history from the latest system prompt, limited to specified cnt.
+
+
+By using gMe's iRecentUserMsgCnt and chatRequestOptions.max_tokens one can try to control the
+implications of loading of the ai-model's context window by chat history, wrt chat response to
+some extent in a simple crude way.
+
 
 Sometimes the browser may be stuborn with caching of the file, so your updates to html/css/js
 may not be visible. Also remember that just refreshing/reloading page in browser or for that
 matter clearing site data, dont directly override site caching in all cases. Worst case you may
 have to change port. Or in dev tools of browser, you may be able to disable caching fully.
 
+
 Concept of multiple chat sessions with different servers, as well as saving and restoring of
 those across browser usage sessions, can be woven around the SimpleChat/MultiChatUI class and
 its instances relatively easily, however given the current goal of keeping this simple, it has
 not been added, for now.
 
+
 By switching between chat.add_system_begin/anytime, one can control whether one can change
 the system prompt, anytime during the conversation or only at the beginning.
+
 
 read_json_early, is to experiment with reading json response data early on, if available,
 so that user can be shown generated data, as and when it is being generated, rather than
@@ -132,3 +156,8 @@ at the end when full data is available.
   if able to read json data early on in future, as and when ai model is generating data, then
   this helper needs to indirectly update the chat div with the recieved data, without waiting
   for the overall data to be available.
+
+
+## At the end
+
+Also a thank you to all open source and open model developers, who strive for the common good.

--- a/examples/server/public_simplechat/simplechat.css
+++ b/examples/server/public_simplechat/simplechat.css
@@ -48,6 +48,13 @@ button {
     flex-direction: column;
 }
 
+.ul1 {
+    padding-inline-start: 2vw;
+}
+.ul2 {
+    padding-inline-start: 2vw;
+}
+
 * {
     margin: 0.6vmin;
 }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -25,11 +25,9 @@ let gUsageMsg = `
         <li> Completion mode doesnt insert user/role: prefix implicitly.</li>
         <li> Use shift+enter for inserting enter/newline.</li>
         </ul>
-    <li> If strange responses, Refresh page to start over fresh.</li>
+    <li> Default ContextWindow = [System, Last Query+Resp, Cur Query].</li>
         <ul class="ul2">
-        <li> [default] old msgs from chat not culled, when sending to server.</li>
-        <li> either use New CHAT, or refresh if chat getting long, or</li>
-        <li> experiment iRecentUserMsgCnt, max_tokens, model ctxt window.</li>
+        <li> experiment iRecentUserMsgCnt, max_tokens, model ctxt window to expand</li>
         </ul>
     </ul>
 `;
@@ -573,11 +571,13 @@ class Me {
         this.multiChat = new MultiChatUI();
         this.bCompletionFreshChatAlways = true;
         this.bCompletionInsertStandardRolePrefix = false;
-        this.iRecentUserMsgCnt = -1;
+        this.iRecentUserMsgCnt = 2;
         // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
         this.chatRequestOptions = {
             "temperature": 0.7,
-            "max_tokens": 512
+            "max_tokens": 1024,
+            "frequency_penalty": 1.2,
+            "presence_penalty": 1.2,
         };
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -24,6 +24,11 @@ let gUsageMsg = `
     </ul>
 `;
 
+// Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
+let gChatRequestOptions = {
+    "temperature": 0.7
+};
+
 class SimpleChat {
 
     constructor() {
@@ -83,12 +88,15 @@ class SimpleChat {
     }
 
     /**
-     * Add needed fields wrt json object to be sent wrt LLM web services completions endpoint
+     * Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
+     * The needed fields/options are picked from a global object.
      * Convert the json into string.
      * @param {Object} obj
      */
     request_jsonstr(obj) {
-        obj["temperature"] = 0.7;
+        for(let k in gChatRequestOptions) {
+            obj[k] = gChatRequestOptions[k];
+        }
         return JSON.stringify(obj);
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -343,6 +343,29 @@ class MultiChatUI {
     }
 
     /**
+     * Try read json response early, if available.
+     * @param {Response} resp
+     */
+    async read_json_early(resp) {
+        if (!resp.body) {
+            throw Error("ERRR:SimpleChat:MCUI:ReadJsonEarly:No body...");
+        }
+        let tdUtf8 = new TextDecoder("utf-8");
+        let rr = resp.body.getReader();
+        let gotBody = "";
+        while(true) {
+            let { value: cur,  done: done} = await rr.read();
+            let curBody = tdUtf8.decode(cur);
+            console.debug("DBUG:SC:PART:", curBody);
+            gotBody += curBody;
+            if (done) {
+                break;
+            }
+        }
+        return JSON.parse(gotBody);
+    }
+
+    /**
      * Handle user query submit request, wrt specified chat session.
      * @param {string} chatId
      * @param {string} apiEP
@@ -388,6 +411,7 @@ class MultiChatUI {
         });
 
         let respBody = await resp.json();
+        //let respBody = await this.read_json_early(resp);
         console.debug(`DBUG:SimpleChat:MCUI:${chatId}:HandleUserSubmit:RespBody:${JSON.stringify(respBody)}`);
         let assistantMsg;
         if (apiEP == ApiEP.Chat) {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -16,8 +16,10 @@ class ApiEP {
 let gUsageMsg = `
     <ul>
     <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
+    <li> + Completion mode normally wont have a system prompt.</li>
     <li> Enter your query to ai assistant below.</li>
-    <li> Use shift+enter for inserting enter.</li>
+    <li> + Completion mode doesnt insert user: prefix implicitly.</li>
+    <li> + Use shift+enter for inserting enter/newline.</li>
     <li> Refresh the page to start over fresh.</li>
     </ul>
 `;
@@ -303,6 +305,8 @@ class MultiChatUI {
             // allow user to insert enter into their message using shift+enter.
             // while just pressing enter key will lead to submitting.
             if ((ev.key === "Enter") && (!ev.shiftKey)) {
+                let value = this.elInUser.value;
+                this.elInUser.value = value.substring(0,value.length-1);
                 this.elBtnUser.click();
                 ev.preventDefault();
             }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -351,6 +351,14 @@ class MultiChatUI {
 
         let chat = this.simpleChats[chatId];
 
+        // In completion mode, if configured, clear any previous chat history.
+        // So if user wants to simulate a multi-chat based completion query,
+        // they will have to enter the full thing, as a suitable multiline
+        // user input/query.
+        if ((apiEP == ApiEP.Completion) && (gbCompletionFreshChatAlways)) {
+            chat.clear();
+        }
+
         chat.add_system_anytime(this.elInSystem.value, chatId);
 
         let content = this.elInUser.value;
@@ -396,13 +404,6 @@ class MultiChatUI {
             chat.show(this.elDivChat);
         } else {
             console.debug(`DBUG:SimpleChat:MCUI:HandleUserSubmit:ChatId has changed:[${chatId}] [${this.curChatId}]`);
-        }
-        // Purposefully clear at end rather than begin of this function
-        // so that one can switch from chat to completion mode and sequece
-        // in a completion mode with multiple user-assistant chat data
-        // from before to be sent/occur once.
-        if ((apiEP == ApiEP.Completion) && (gbCompletionFreshChatAlways)) {
-            chat.clear();
         }
         this.ui_reset_userinput();
     }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -14,6 +14,7 @@ class ApiEP {
 }
 
 let gUsageMsg = `
+    <p class="role-system">Usage</p>
     <ul class="ul1">
     <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
         <ul class="ul2">
@@ -32,11 +33,6 @@ let gUsageMsg = `
     </ul>
 `;
 
-// Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
-let gChatRequestOptions = {
-    "temperature": 0.7,
-    "max_tokens": 512
-};
 
 class SimpleChat {
 
@@ -92,6 +88,7 @@ class SimpleChat {
         } else {
             if (bClear) {
                 div.innerHTML = gUsageMsg;
+                gMe.show_info(div);
             }
         }
     }
@@ -103,8 +100,8 @@ class SimpleChat {
      * @param {Object} obj
      */
     request_jsonstr(obj) {
-        for(let k in gChatRequestOptions) {
-            obj[k] = gChatRequestOptions[k];
+        for(let k in gMe.chatRequestOptions) {
+            obj[k] = gMe.chatRequestOptions[k];
         }
         return JSON.stringify(obj);
     }
@@ -206,8 +203,6 @@ let gChatURL = {
     'chat': `${gBaseURL}/chat/completions`,
     'completion': `${gBaseURL}/completions`,
 }
-const gbCompletionFreshChatAlways = true;
-let gbCompletionInsertStandardRolePrefix = false;
 
 
 /**
@@ -395,7 +390,7 @@ class MultiChatUI {
         // So if user wants to simulate a multi-chat based completion query,
         // they will have to enter the full thing, as a suitable multiline
         // user input/query.
-        if ((apiEP == ApiEP.Completion) && (gbCompletionFreshChatAlways)) {
+        if ((apiEP == ApiEP.Completion) && (gMe.bCompletionFreshChatAlways)) {
             chat.clear();
         }
 
@@ -413,7 +408,7 @@ class MultiChatUI {
         if (apiEP == ApiEP.Chat) {
             theBody = chat.request_messages_jsonstr();
         } else {
-            theBody = chat.request_prompt_jsonstr(gbCompletionInsertStandardRolePrefix);
+            theBody = chat.request_prompt_jsonstr(gMe.bCompletionInsertStandardRolePrefix);
         }
 
         this.elInUser.value = "working...";
@@ -525,17 +520,58 @@ class MultiChatUI {
 }
 
 
-let gMultiChat;
-const gChatIds = [ "Default", "Other" ];
+class Me {
+
+    constructor() {
+        this.defaultChatIds = [ "Default", "Other" ];
+        this.multiChat = new MultiChatUI();
+        this.bCompletionFreshChatAlways = true;
+        this.bCompletionInsertStandardRolePrefix = false;
+        // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
+        this.chatRequestOptions = {
+            "temperature": 0.7,
+            "max_tokens": 512
+        };
+    }
+
+    /**
+     * @param {HTMLDivElement} elDiv
+     */
+    show_info(elDiv) {
+
+        var p = document.createElement("p");
+        p.innerText = "Settings (gMe)";
+        p.className = "role-system";
+        elDiv.appendChild(p);
+
+        var p = document.createElement("p");
+        p.innerText = `bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`;
+        elDiv.appendChild(p);
+
+        p = document.createElement("p");
+        p.innerText = `bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`;
+        elDiv.appendChild(p);
+
+        p = document.createElement("p");
+        p.innerText = `chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`;
+        elDiv.appendChild(p);
+
+    }
+
+}
+
+
+/** @type {Me} */
+let gMe;
 
 function startme() {
     console.log("INFO:SimpleChat:StartMe:Starting...");
-    gMultiChat = new MultiChatUI();
-    for (let cid of gChatIds) {
-        gMultiChat.new_chat_session(cid);
+    gMe = new Me();
+    for (let cid of gMe.defaultChatIds) {
+        gMe.multiChat.new_chat_session(cid);
     }
-    gMultiChat.setup_ui(gChatIds[0], true);
-    gMultiChat.show_sessions();
+    gMe.multiChat.setup_ui(gMe.defaultChatIds[0], true);
+    gMe.multiChat.show_sessions();
 }
 
 document.addEventListener("DOMContentLoaded", startme);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -34,7 +34,8 @@ let gUsageMsg = `
 
 // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
 let gChatRequestOptions = {
-    "temperature": 0.7
+    "temperature": 0.7,
+    "max_tokens": 2048
 };
 
 class SimpleChat {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -97,11 +97,15 @@ class SimpleChat {
 
     /**
      * Return a string form of json object suitable for /completions
+     * @param {boolean} bInsertStandardRolePrefix Insert "<THE_ROLE>: " as prefix wrt each role's message
      */
-    request_prompt_jsonstr() {
+    request_prompt_jsonstr(bInsertStandardRolePrefix) {
         let prompt = "";
         for(const chat of this.xchat) {
-            prompt += `${chat.role}: ${chat.content}\n`;
+            if (bInsertStandardRolePrefix) {
+                prompt += `${chat.role}: `;
+            }
+            prompt += `${chat.content}\n`;
         }
         let req = {
             prompt: prompt,
@@ -174,6 +178,7 @@ let gChatURL = {
     'completion': `${gBaseURL}/completions`,
 }
 const gbCompletionFreshChatAlways = true;
+let gbCompletionInsertStandardRolePrefix = true;
 
 
 /**
@@ -346,7 +351,7 @@ class MultiChatUI {
         if (apiEP == ApiEP.Chat) {
             theBody = chat.request_messages_jsonstr();
         } else {
-            theBody = chat.request_prompt_jsonstr();
+            theBody = chat.request_prompt_jsonstr(gbCompletionInsertStandardRolePrefix);
         }
 
         this.elInUser.value = "working...";

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -508,17 +508,17 @@ class MultiChatUI {
 }
 
 
-let gMuitChat;
+let gMultiChat;
 const gChatIds = [ "Default", "Other" ];
 
 function startme() {
     console.log("INFO:SimpleChat:StartMe:Starting...");
-    gMuitChat = new MultiChatUI();
+    gMultiChat = new MultiChatUI();
     for (let cid of gChatIds) {
-        gMuitChat.new_chat_session(cid);
+        gMultiChat.new_chat_session(cid);
     }
-    gMuitChat.setup_ui(gChatIds[0], true);
-    gMuitChat.show_sessions();
+    gMultiChat.setup_ui(gChatIds[0], true);
+    gMultiChat.show_sessions();
 }
 
 document.addEventListener("DOMContentLoaded", startme);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -35,7 +35,7 @@ let gUsageMsg = `
 // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
 let gChatRequestOptions = {
     "temperature": 0.7,
-    "max_tokens": 2048
+    "max_tokens": 512
 };
 
 class SimpleChat {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -35,6 +35,11 @@ class SimpleChat {
         this.iLastSys = -1;
     }
 
+    clear() {
+        this.xchat = [];
+        this.iLastSys = -1;
+    }
+
     /**
      * Add an entry into xchat
      * @param {string} role
@@ -397,7 +402,7 @@ class MultiChatUI {
         // in a completion mode with multiple user-assistant chat data
         // from before to be sent/occur once.
         if ((apiEP == ApiEP.Completion) && (gbCompletionFreshChatAlways)) {
-            chat.xchat.length = 0;
+            chat.clear();
         }
         this.ui_reset_userinput();
     }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -14,10 +14,12 @@ class ApiEP {
 }
 
 let gUsageMsg = `
-    <p> Enter the system prompt above, before entering/submitting any user query.</p>
-    <p> Enter your text to the ai assistant below.</p>
-    <p> Use shift+enter for inserting enter.</p>
-    <p> Refresh the page to start over fresh.</p>
+    <ul>
+    <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
+    <li> Enter your query to ai assistant below.</li>
+    <li> Use shift+enter for inserting enter.</li>
+    <li> Refresh the page to start over fresh.</li>
+    </ul>
 `;
 
 class SimpleChat {
@@ -471,7 +473,7 @@ function startme() {
     for (let cid of gChatIds) {
         gMuitChat.new_chat_session(cid);
     }
-    gMuitChat.setup_ui(gChatIds[0]);
+    gMuitChat.setup_ui(gChatIds[0], true);
     gMuitChat.show_sessions();
 }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -578,6 +578,7 @@ class Me {
             "max_tokens": 1024,
             "frequency_penalty": 1.2,
             "presence_penalty": 1.2,
+            "n_predict": 1024
         };
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -18,7 +18,7 @@ let gUsageMsg = `
     <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
     <li> + Completion mode normally wont have a system prompt.</li>
     <li> Enter your query to ai assistant below.</li>
-    <li> + Completion mode doesnt insert user: prefix implicitly.</li>
+    <li> + Completion mode doesnt insert user/role: prefix implicitly.</li>
     <li> + Use shift+enter for inserting enter/newline.</li>
     <li> Refresh the page to start over fresh.</li>
     </ul>

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -14,13 +14,21 @@ class ApiEP {
 }
 
 let gUsageMsg = `
-    <ul>
+    <ul class="ul1">
     <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
-    <li> + Completion mode normally wont have a system prompt.</li>
+        <ul class="ul2">
+        <li> Completion mode normally wont have a system prompt.</li>
+        </ul>
     <li> Enter your query to ai assistant below.</li>
-    <li> + Completion mode doesnt insert user/role: prefix implicitly.</li>
-    <li> + Use shift+enter for inserting enter/newline.</li>
+        <ul class="ul2">
+        <li> Completion mode doesnt insert user/role: prefix implicitly.</li>
+        <li> Use shift+enter for inserting enter/newline.</li>
+        </ul>
     <li> Refresh the page to start over fresh.</li>
+        <ul class="ul2">
+        <li> old chat is not culled when sending to server/ai-model.</li>
+        <li> either use New CHAT, or refresh if chat getting long.</li>
+        </ul>
     </ul>
 `;
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -101,11 +101,16 @@ class SimpleChat {
      */
     request_prompt_jsonstr(bInsertStandardRolePrefix) {
         let prompt = "";
+        let iCnt = 0;
         for(const chat of this.xchat) {
+            iCnt += 1;
+            if (iCnt > 1) {
+                prompt += "\n";
+            }
             if (bInsertStandardRolePrefix) {
                 prompt += `${chat.role}: `;
             }
-            prompt += `${chat.content}\n`;
+            prompt += `${chat.content}`;
         }
         let req = {
             prompt: prompt,
@@ -178,7 +183,7 @@ let gChatURL = {
     'completion': `${gBaseURL}/completions`,
 }
 const gbCompletionFreshChatAlways = true;
-let gbCompletionInsertStandardRolePrefix = true;
+let gbCompletionInsertStandardRolePrefix = false;
 
 
 /**


### PR DESCRIPTION
In Completion mode

* now by default, the logic doesnt insert any role related "THE_ROLE: " prefix to the message, when generating the prompt json entry to the server for /completions endpoint. This gives full control to the end user to decide if they want to insert any prefix or not, based on the model they are communicating with in the completion mode. Given that /completion endpoint doesnt add any additional in-between special-tokens/tags/chat-templating of its own, using the multiline user input support, a end user could generate any combinatiion of messages with special tokens etal, as they see fit to check how the model will respond. Or use it just for a normal completion related query.

* avoid the implicit textarea enter-key/newline char wrt the user-input, however if the end user explicitly wants newline in the sent message, they can always use shift+enter key press to insert the same.

* fix a corner case with normally unexpected system prompt with completion mode, messing with the logic. Now its up to the end user if they want to put a system prompt (normally not expected nor needed in completion mode) or not, the logic wont raise an exception.

In general

* update the readme as well as the usage message to capture the flow better.

* add a placeholder hint wrt the system prompt

@mofosyne, do wait for half a day (12 hours), I will cross check things once later today, before you merge this. At sametime if anyone is trying to use SimpleChat in the mean time, the commits in this PR could be useful.