### PR TITLE
Add checking for mixtrals new tensor naming to convert-hf-to-gguf.py

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1367,7 +1367,7 @@ class LlamaModel(Model):
                 return tensors
             else:
                 return []
-        
+
         if name.find("feed_forward.experts") != -1 and name.find("feed_forward.experts.w") == -1:
             n_experts = self.hparams["num_local_experts"]
 


### PR DESCRIPTION
The new mixtral model calls their tensors feed_forward.experts.0.w1.weight

This check sees if feed_forward.experts is in the name, but NOT feed_forward.experts.w, which would represent a tensor with the right name

I'm very open to alternatives, but this does work and generates functional GGUF conversions and quants

Mixtral model can be found here:

https://github.com/mistralai/mistral-inference?tab=readme-ov-file#model-download

Working conversions (and in an hour quants) can be found here:

https://huggingface.co/bartowski/mixtral-8x22B-Instruct-v0.3-GGUF