### PR TITLE
fix missing slash in `fs_get_cache_directory()`

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1863,7 +1863,7 @@ std::string fs_get_cache_directory() {
         return p;
     };
     if (getenv("LLAMA_CACHE")) {
-        cache_directory = ensure_trailing_slash(std::getenv("LLAMA_CACHE"));
+        cache_directory = std::getenv("LLAMA_CACHE");
     } else {
 #ifdef __linux__
         if (std::getenv("XDG_CACHE_HOME")) {
@@ -1878,9 +1878,8 @@ std::string fs_get_cache_directory() {
 #endif // __linux__
         cache_directory = ensure_trailing_slash(cache_directory);
         cache_directory += "llama.cpp";
-        cache_directory += DIRECTORY_SEPARATOR;
     }
-    return cache_directory;
+    return ensure_trailing_slash(cache_directory);
 }
 
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1874,7 +1874,7 @@ std::string fs_get_cache_directory() {
 #elif defined(__APPLE__)
         cache_directory = std::getenv("HOME") + std::string("/Library/Caches/");
 #elif defined(_WIN32)
-        cache_directory = std::getenv("APPDATA");
+        cache_directory = std::getenv("LOCALAPPDATA");
 #endif // __linux__
         cache_directory = ensure_trailing_slash(cache_directory);
         cache_directory += "llama.cpp";

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1855,11 +1855,15 @@ bool fs_create_directory_with_parents(const std::string & path) {
 
 std::string fs_get_cache_directory() {
     std::string cache_directory = "";
-    if (getenv("LLAMA_CACHE")) {
-        cache_directory = std::getenv("LLAMA_CACHE");
-        if (cache_directory.back() != DIRECTORY_SEPARATOR) {
-            cache_directory += DIRECTORY_SEPARATOR;
+    auto ensure_trailing_slash = [](std::string p) {
+        // Make sure to add trailing slash
+        if (p.back() != DIRECTORY_SEPARATOR) {
+            p += DIRECTORY_SEPARATOR;
         }
+        return p;
+    };
+    if (getenv("LLAMA_CACHE")) {
+        cache_directory = ensure_trailing_slash(std::getenv("LLAMA_CACHE"));
     } else {
 #ifdef __linux__
         if (std::getenv("XDG_CACHE_HOME")) {
@@ -1872,6 +1876,7 @@ std::string fs_get_cache_directory() {
 #elif defined(_WIN32)
         cache_directory = std::getenv("APPDATA");
 #endif // __linux__
+        cache_directory = ensure_trailing_slash(cache_directory);
         cache_directory += "llama.cpp";
         cache_directory += DIRECTORY_SEPARATOR;
     }


### PR DESCRIPTION
Follow up #7353

There is a bug when `XDG_CACHE_HOME` is set without a trailing slash, it produces the path: `/home/USER/.cachellama.cpp` instead of `/home/USER/.cache/llama.cpp`

Also use `LOCALAPPDATA` for Windows (as suggested by @cebtenzzre )