### PR TITLE
Update main-intel.Dockerfile base image to 2024.1.0

### DIFF
--- a/.devops/main-intel.Dockerfile
+++ b/.devops/main-intel.Dockerfile
@@ -1,4 +1,4 @@
-ARG ONEAPI_VERSION=2024.0.1-devel-ubuntu22.04
+ARG ONEAPI_VERSION=2024.1.0-devel-ubuntu22.04
 
 FROM intel/oneapi-basekit:$ONEAPI_VERSION as build
 


### PR DESCRIPTION
To address https://github.com/ggerganov/llama.cpp/issues/7507 .

Suspect intel discarded an old GPG key, so may need to update dockerfile tag.

Found tag from: https://hub.docker.com/r/intel/oneapi-basekit/tags?page=&page_size=&ordering=&name=