### PR TITLE
rpc: remove backend handle from global map when freed

### DIFF
--- a/ggml-rpc.cpp
+++ b/ggml-rpc.cpp
@@ -521,6 +521,7 @@ static ggml_backend_buffer_type_i ggml_backend_rpc_buffer_type_interface = {
     /* .is_host          = */ NULL,
 };
 
+static std::unordered_map<std::string, ggml_backend_t> instances;
 
 GGML_CALL static const char * ggml_backend_rpc_name(ggml_backend_t backend) {
     ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
@@ -531,6 +532,7 @@ GGML_CALL static const char * ggml_backend_rpc_name(ggml_backend_t backend) {
 GGML_CALL static void ggml_backend_rpc_free(ggml_backend_t backend) {
     ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
     ggml_backend_rpc_buffer_type_context * buft_ctx = (ggml_backend_rpc_buffer_type_context *)rpc_ctx->buft->context;
+    instances.erase(rpc_ctx->endpoint);
     delete buft_ctx;
     delete rpc_ctx->buft;
     delete rpc_ctx;
@@ -623,8 +625,6 @@ static ggml_backend_i ggml_backend_rpc_interface = {
     /* .event_wait              = */ NULL,
     /* .event_synchronize       = */ NULL,
 };
-
-static std::unordered_map<std::string, ggml_backend_t> instances;
 
 GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint) {
     ggml_backend_t backend = ggml_backend_rpc_init(endpoint);


### PR DESCRIPTION
Found an app crash occurring when trying to reload a new llm model after another model has been unloaded.

When built with ASan, it shows a `heap-buffer-overflow` error in `ggml_backend_rpc_get_device_memory`. The relevant log is as follows:
```log
READ of size 8 at 0x60e00039c6f8 thread T78
    #0 0x7666861ff0b3 in ggml_backend_rpc_get_device_memory (libllama.so+0x1ff0b3)
    #1 0x76668633644e  (libllama.so+0x33644e)
    #2 0x7666863af017 in llama_load_model_from_file (libllama.so+0x3af017)
    ...
```

Upon investigating the source code, discovered that in `ggml-rpc.cpp`, the `ggml_backend_t` instances are stored in a map called `instances`. However, inside the `ggml_backend_rpc_free` function, we forgot to remove the `ggml_backend_t` item from the map when it is freed:

[ggml-rpc.cpp#L531](https://github.com/ggerganov/llama.cpp/blob/0df0aa8e43c3378975269a51f9b876c8692e70da/ggml-rpc.cpp#L531)
```c++
GGML_CALL static void ggml_backend_rpc_free(ggml_backend_t backend) {
    ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
    ggml_backend_rpc_buffer_type_context * buft_ctx = (ggml_backend_rpc_buffer_type_context *)rpc_ctx->buft->context;
    delete buft_ctx;
    delete rpc_ctx->buft;
    delete rpc_ctx;
    delete backend;   // delete the backend object without removing it from map.
}
```

Here we insert `ggml_backend_t` into map:
[ggml-rpc.cpp#L679](https://github.com/ggerganov/llama.cpp/blob/0df0aa8e43c3378975269a51f9b876c8692e70da/ggml-rpc.cpp#L679)
```c++
GGML_CALL ggml_backend_t ggml_backend_rpc_init(const char * endpoint) {
    ...

    instances[endpoint] = new ggml_backend {
        /* .guid      = */ ggml_backend_rpc_guid(),
        /* .interface = */ ggml_backend_rpc_interface,
        /* .context   = */ ctx
    };

    return instances[endpoint];
}
```

