### PR TITLE
Rebalancing Metal threads workload in dot product kernel kernel_mul_mv_f16_f32_l4

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1588,13 +1588,13 @@ static enum ggml_status ggml_metal_graph_compute(
                                         nth1 = 1;
                                         if (src1t == GGML_TYPE_F32) {
                                             if (ne11 * ne12 < 4) {
+                                                pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_F16_F32_1ROW].pipeline;
+                                            } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
                                                 if (ne01 > 128) {
                                                     pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_F16_F32_L4_LARGE].pipeline;
                                                 } else {
                                                     pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_F16_F32_L4].pipeline;
                                                 }
-                                            } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
-                                                pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_F16_F32_L4].pipeline;
                                                 nrows = ne11;
                                             } else {
                                                 pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_F16_F32].pipeline;

--- a/ggml-metal.metal
+++ b/ggml-metal.metal
@@ -1598,6 +1598,64 @@ kernel void kernel_mul_mv_f16_f32_l4(
     }
 }
 
+kernel void kernel_mul_mv_f16_f32_l4_large(
+        device const  char * src0,
+        device const  char * src1,
+        device       float * dst,
+        constant   int64_t & ne00,
+        constant   int64_t & ne01,
+        constant   int64_t & ne02,
+        constant  uint64_t & nb00,
+        constant  uint64_t & nb01,
+        constant  uint64_t & nb02,
+        constant   int64_t & ne10,
+        constant   int64_t & ne11,
+        constant   int64_t & ne12,
+        constant  uint64_t & nb10,
+        constant  uint64_t & nb11,
+        constant  uint64_t & nb12,
+        constant   int64_t & ne0,
+        constant   int64_t & ne1,
+        constant   uint    & r2,
+        constant   uint    & r3,
+        uint3 tgpig[[threadgroup_position_in_grid]],
+        uint tiisg[[thread_index_in_simdgroup]]) {
+
+    const int nrows = ne11;
+    const int64_t base_r0 = tgpig.x*32;
+    const int64_t im = tgpig.z;
+    threadgroup float partial_sums[32]; // Shared memory for partial sums for each SIMD group
+
+    const uint i12 = im%ne12;
+    const uint i13 = im/ne12;
+
+    for (int j = 0; j < 32; ++j) {
+        const int64_t r0 = base_r0 + j;
+        const uint offset0 = r0*nb01 + (i12/r2)*nb02 + (i13/r3)*nb02*ne02;
+        device const half4 * x4 = (device const half4 *) (src0 + offset0);
+
+        partial_sums[tiisg] = 0.0f;
+        for (int r1 = 0; r1 < nrows; ++r1) {
+            device const float4 * y4 = (device const float4 *) (src1 + r1*nb11 + im*nb12);
+
+            for (int i = tiisg; i < ne00/4; i += 32) {
+                for (int k = 0; k < 4; ++k) partial_sums[tiisg] += (float) x4[i][k] * y4[i][k];
+            }
+
+            // Barrier to ensure all threads have written their partial sums
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            float sumf = simd_sum(partial_sums[tiisg]);
+            // Barrier to ensure reduction is complete before writing the result
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (tiisg == 0) {
+                dst[im*ne1*ne0 + r1*ne0 + r0] = sumf;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+    }
+}
+
 static float rope_yarn_ramp(const float low, const float high, const int i0) {
     const float y = (i0 / 2 - low) / max(0.001f, high - low);
     return 1.0f - min(1.0f, max(0.0f, y));


### PR DESCRIPTION
This pull request is related to issue #6089. When profiling Metal implementation for large (16k+) token size prompts, I found that most of the time is spent in kernel_mul_mv_f16_f32_l4 Metal kernel. During this time GPU ALUs utilization is 7%, because current implementation fires as many threads as there are tokens, and each thread only performs 4 FP operations (plus reduction), so GPU is mostly starting and stopping threads. This applies to non-batched generation, when adding batching utilization goes up.

This change makes it spawn 32x less threads, and each thread to perform 32x more operations. This brings GPU ALUs utilization to 99%, and provides significant performance improvement for generation speeds for large contexts. 
For 16384 context, I measured 1.3x improvement on M2 Max, and for 96k context I measured 1.8x improvement on M2 Max and 2.4x improvement on M3 Max.

For small context (less than 1k) I measure the same or slightly worse performance, and to avoid it the kernel selector lines
 if (ne01 > 128) {
could be replaced e.g. with 
 if (ne01 > 8192) {
