### PR TITLE
server: do not remove whitespace at the start of a completion chunk

### DIFF
--- a/examples/server/public/index.html
+++ b/examples/server/public/index.html
@@ -594,7 +594,7 @@
           message = html`<${Probabilities} data=${data} />`
         } else {
           const text = isArrayMessage ?
-            data.map(msg => msg.content).join('').replace(/^\s+/, '') :
+            data.map(msg => msg.content).join('') :
             data;
           message = isCompletionMode ?
             text :


### PR DESCRIPTION
When using Completion mode of the server in recent builds, the first token of the predicted text is typically appended to the prompt without a space character. This can lead to problems when manually editing the text and then predicting again, because the missing space will appear in the new prompt.

Leading spaces are explicitly trimmed in `CompletionControls()`, which appears to be unnecessary after #2810 because even the initial prompt will not contain any extra leading space, and all further spaces should be resulting from predictions.

So, this PR proposes removing this trimming in Completion mode (but not in Chat mode, where it is still done in `runLlama()` and looks necessary to avoid an extra space between the role name and the prompt).