### PR TITLE
main: replace --no-special with --special (and also set control token output to stdout to off by default)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -904,8 +904,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.interactive_specials = true;
         return true;
     }
-    if (arg == "--no-special") {
-        params.no_special = true;
+    if (arg == "--special") {
+        params.special = true;
         return true;
     }
     if (arg == "--embedding") {
@@ -1366,9 +1366,9 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     printf("  -h, --help            show this help message and exit\n");
     printf("  --version             show version and build info\n");
     printf("  -i, --interactive     run in interactive mode\n");
+    printf("  --special             special tokens output enabled\n");
     printf("  --interactive-specials allow special tokens in user text, in interactive mode\n");
     printf("  --interactive-first   run in interactive mode and wait for input right away\n");
-    printf("  --no-special          control tokens output disabled\n");
     printf("  -cnv, --conversation  run in conversation mode (does not print special tokens and suffix/prefix)\n");
     printf("  -ins, --instruct      run in instruction mode (use with Alpaca models)\n");
     printf("  -cml, --chatml        run in chatml mode (use with ChatML-compatible models)\n");

--- a/common/common.h
+++ b/common/common.h
@@ -146,7 +146,7 @@ struct gpt_params {
     bool use_color         = false; // use color to distinguish generations and inputs
     bool interactive       = false; // interactive mode
     bool interactive_specials = false; // whether to allow special tokens from user, during interactive mode
-    bool no_special        = false; // disable control token output
+    bool special           = false; // enable special token output
     bool conversation      = false; // conversation mode (does not print special tokens and suffix/prefix)
     bool chatml            = false; // chatml mode (used for models trained on chatml syntax)
     bool prompt_cache_all  = false; // save user input and generations to prompt cache

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -740,16 +740,10 @@ int main(int argc, char ** argv) {
         // display text
         if (input_echo && display) {
             for (auto id : embd) {
-                const std::string token_str = llama_token_to_piece(ctx, id);
+                const std::string token_str = llama_token_to_piece(ctx, id, params.special);
 
                 // Console/Stream Output
-                if (!llama_token_is_control(llama_get_model(ctx), id)) {
-                    // Stream Output Token To Standard Output
-                    fprintf(stdout, "%s", token_str.c_str());
-                } else if (!params.no_special && !params.conversation) {
-                    // Stream Control Token To Standard Output Stream
-                    fprintf(stdout, "%s", token_str.c_str());
-                }
+                fprintf(stdout, "%s", token_str.c_str());
 
                 // Record Displayed Tokens To Log
                 // Note: Generated tokens are created one by one hence this check


### PR DESCRIPTION
This is to solve a pain point for those not expecting output control tokens but who have written scripts already that relied on an output that has no control tokens.

I have also been made aware that the inclusion of control tokens as a default behavior is actually a relatively recent feature in last few week when `--conversation` and `--interactive-specials` was included.

On checking so far, I'm not aware of the practical purpose of control tokens being active by default. So I think it makes sense to reverse the current default state of outputting control tokens to the original behavior of not outputting control tokens.

For those who do need control tokens in stdout, they can use `--special` to enable this feature.

In terms of those relying on `--no-token`, this was merged in today and only a single release 2hr ago was done so far. So the impact of reversing this feature is minimal in my opinion.

However the regressive change of the control tokens being included by default has been present for a few weeks now, so we will need to alert users of this change back to original behavior in the readme.

----

## Regarding overall learnability of using `--special` over `--no-special`

On studying the arguments I think adding `--special` and changing the output default behavior is actually a more consistent behavior as these two commands are symmetrical in that they 'enable' special token in input or the output.

```
--special              special tokens output enabled
--interactive-specials allow special tokens in user text, in interactive mode
```
