### PR TITLE
make: add --device-debug to NVCC debug flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,9 @@ endif # JETSON_EOL_MODULE_DETECT
 ifdef LLAMA_DEBUG
 	MK_NVCCFLAGS += -lineinfo
 endif # LLAMA_DEBUG
+ifdef LLAMA_CUDA_DEBUG
+	MK_NVCCFLAGS += --device-debug
+endif # LLAMA_CUDA_DEBUG
 ifdef LLAMA_CUDA_NVCC
 	NVCC = $(CCACHE) $(LLAMA_CUDA_NVCC)
 else


### PR DESCRIPTION
This PR adds the `--device-debug` flag to the NVCC compile flags if `LLAMA_DEBUG` is set. This adds device debugging information but also turns off device code optimization so the compilation is faster.