### PR TITLE
llama : add comments about experimental flags

### DIFF
--- a/llama.h
+++ b/llama.h
@@ -264,6 +264,8 @@ extern "C" {
         bool check_tensors; // validate model tensor data
     };
 
+    // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
+    //       https://github.com/ggerganov/llama.cpp/pull/7544
     struct llama_context_params {
         uint32_t seed;              // RNG seed, -1 for random
         uint32_t n_ctx;             // text context, 0 = from model
@@ -290,14 +292,14 @@ extern "C" {
         ggml_backend_sched_eval_callback cb_eval;
         void * cb_eval_user_data;
 
-        enum ggml_type type_k; // data type for K cache
-        enum ggml_type type_v; // data type for V cache
+        enum ggml_type type_k; // data type for K cache [EXPERIMENTAL]
+        enum ggml_type type_v; // data type for V cache [EXPERIMENTAL]
 
         // Keep the booleans together to avoid misalignment during copy-by-value.
         bool logits_all;  // the llama_decode() call computes all logits, not just the last one (DEPRECATED - set llama_batch.logits instead)
         bool embeddings;  // if true, extract embeddings (together with logits)
         bool offload_kqv; // whether to offload the KQV ops (including the KV cache) to GPU
-        bool flash_attn;  // whether to use flash attention
+        bool flash_attn;  // whether to use flash attention [EXPERIMENTAL]
 
         // Abort callback
         // if it returns true, execution of llama_decode() will be aborted


### PR DESCRIPTION
Certain combinations of `[EXPERIMENTAL] llama_context_params` are not always supported:

```c
    struct llama_context_params {
        ...

        enum ggml_type type_k; // data type for K cache [EXPERIMENTAL]
        enum ggml_type type_v; // data type for V cache [EXPERIMENTAL]

        bool flash_attn;  // whether to use flash attention [EXPERIMENTAL]

        ...
    };
```

Here is a list of known incompatibilities (we can try to update it in the future):

- `flash_attn == true && type_k == F16 && type_v == F16`
  - [x] CPU
    - Generally slower compared to no-FA, mostly used for testing purposes
  - [x] CUDA
  - [x] Metal
    - Slow or can't build for models with head size = 256 (https://github.com/ggerganov/llama.cpp/issues/7261)
  - [ ] Vulkan
  - [ ] SYCL

- `flash_attn == true && (type_k != F16 || type_v != F16)`
  - [x] CPU
  - [x] CUDA - partial support (https://github.com/ggerganov/llama.cpp/pull/7527)
  - [ ] Metal
  - [ ] Vulkan
  - [ ] SYCL

- `flash_attn == false && type_v != F16`
  - [ ] Not supported because the V cache is stored transposed, which prevents quantization