### PR TITLE
SimpleChat: Simple histogram/repeatMatching driven garbageTrimming, Settings UI, Streaming mode, OpenAi Compat (Model, Authorization Bearer), Save/Restore session, Auto Settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Typically finetunes of the base models below are supported as well.
 
 [llama.cpp web server](./examples/server) is a lightweight [OpenAI API](https://github.com/openai/openai-openapi) compatible HTTP server that can be used to serve local models and easily connect them to existing clients.
 
+[simplechat](./examples/server/public_simplechat) is a simple chat client, which can be used to chat with the model exposed using above web server, from a local web browser.
+
 **Bindings:**
 
 - Python: [abetlen/llama-cpp-python](https://github.com/abetlen/llama-cpp-python)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Typically finetunes of the base models below are supported as well.
 
 [llama.cpp web server](./examples/server) is a lightweight [OpenAI API](https://github.com/openai/openai-openapi) compatible HTTP server that can be used to serve local models and easily connect them to existing clients.
 
-[simplechat](./examples/server/public_simplechat) is a simple chat client, which can be used to chat with the model exposed using above web server, from a local web browser.
+[simplechat](./examples/server/public_simplechat) is a simple chat client, which can be used to chat with the model exposed using above web server (use --path to point to simplechat), from a local web browser.
 
 **Bindings:**
 

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -185,3 +185,17 @@ export function trim_hist_garbage_at_end_loop(sIn, maxType, maxUniq, maxMatchLen
         sCur = got.data;
     }
 }
+
+/**
+ * Try trim garbage at the end by using both the hist-driven-garbage-trimming as well as
+ * skip-a-bit-if-reqd-then-repeat-pattern-based-garbage-trimming, with blind retrying.
+ * @param {string} sIn
+ */
+export function trim_garbage_at_end(sIn) {
+    let sCur = sIn;
+    for(let i=0; i<2; i++) {
+        sCur = trim_hist_garbage_at_end_loop(sCur, 8, 24, 72);
+        sCur = trim_repeat_garbage_at_end_loop(sCur, 32, 72, 12);
+    }
+    return sCur;
+}

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -202,7 +202,9 @@ export function trim_garbage_at_end(sIn) {
 
 
 /**
- * NewLines array helper
+ * NewLines array helper.
+ * Allow for maintaining a list of lines.
+ * Allow for a line to be builtup/appended part by part.
  */
 export class NewLines {
 
@@ -244,7 +246,20 @@ export class NewLines {
         }
     }
 
-    shift() {
+    /**
+     * Shift the oldest/0th line in the array.
+     * Optionally control whether only full lines will be returned
+     * or will a partial line (last line) be returned.
+     * @param {boolean} bFullOnly
+     */
+    shift(bFullOnly=true) {
+        let line = this.lines[0];
+        if (line == undefined) {
+            return undefined;
+        }
+        if ((line[line.length-1] != "\n") && bFullOnly){
+            return undefined;
+        }
         return this.lines.shift();
     }
 

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -42,16 +42,28 @@ export function trim_repeat_garbage_at_end(sIn, maxSubL=10, maxMatchLenThreshold
 
 /**
  * Simple minded logic to help remove repeating garbage at end of the string, till it cant.
+ * If its not able to trim, then it will try to skip a char at end and then trim, a few times.
  * @param {string} sIn
  * @param {number} maxSubL
  * @param {number | undefined} [maxMatchLenThreshold]
  */
-export function trim_repeat_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThreshold) {
+export function trim_repeat_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThreshold, skipMax=16) {
     let sCur = sIn;
+    let sSaved = "";
+    let iTry = 0;
     while(true) {
         let got = trim_repeat_garbage_at_end(sCur, maxSubL, maxMatchLenThreshold);
         if (got.trimmed != true) {
-            return got.data;
+            if (iTry == 0) {
+                sSaved = got.data;
+            }
+            iTry += 1;
+            if (iTry >= skipMax) {
+                return sSaved;
+            }
+            got.data = got.data.substring(0,got.data.length-1);
+        } else {
+            iTry = 0;
         }
         sCur = got.data;
     }

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -6,12 +6,12 @@
 
 /**
  * Simple minded logic to help remove repeating garbage at end of the string.
- * TODO: Initial skeleton
  * @param {string} sIn
+ * @param {number} maxSubL
+ * @param {number} maxMatchLenThreshold
  */
-export function trim_repeat_garbage_at_end(sIn, maxSubL=10) {
+export function trim_repeat_garbage_at_end(sIn, maxSubL=10, maxMatchLenThreshold=40) {
     let rCnt = [0];
-    const MaxMatchLenThreshold = maxSubL*4;
     let maxMatchLen = maxSubL;
     let iMML = -1;
     for(let subL=1; subL < maxSubL; subL++) {
@@ -32,9 +32,27 @@ export function trim_repeat_garbage_at_end(sIn, maxSubL=10) {
         }
     }
     console.log("DBUG:DU:TrimRepeatGarbage:", rCnt);
-    if ((iMML == -1) || (maxMatchLen < MaxMatchLenThreshold)) {
-        return sIn;
+    if ((iMML == -1) || (maxMatchLen < maxMatchLenThreshold)) {
+        return {trimmed: false, data: sIn};
     }
-    let iEnd = sIn.length - maxMatchLen + iMML;
-    return sIn.substring(0,iEnd)
+    let iEnd = sIn.length - maxMatchLen;
+    return { trimmed: true, data: sIn.substring(0, iEnd) };
+}
+
+
+/**
+ * Simple minded logic to help remove repeating garbage at end of the string, till it cant.
+ * @param {string} sIn
+ * @param {number} maxSubL
+ * @param {number | undefined} [maxMatchLenThreshold]
+ */
+export function trim_repeat_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThreshold) {
+    let sCur = sIn;
+    while(true) {
+        let got = trim_repeat_garbage_at_end(sCur, maxSubL, maxMatchLenThreshold);
+        if (got.trimmed != true) {
+            return got.data;
+        }
+        sCur = got.data;
+    }
 }

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -199,3 +199,53 @@ export function trim_garbage_at_end(sIn) {
     }
     return sCur;
 }
+
+
+/**
+ * NewLines array helper
+ */
+export class NewLines {
+
+    constructor() {
+        /** @type {string[]} */
+        this.lines = [];
+    }
+
+    /**
+     * Extracts lines from the passed string and inturn either
+     * append to a previous partial line or add a new line.
+     * @param {string} sLines
+     */
+    add_append(sLines) {
+        let aLines = sLines.split("\n");
+        let lCnt = 0;
+        for(let line of aLines) {
+            lCnt += 1;
+            // Add back newline removed if any during split
+            if (lCnt < aLines.length) {
+                line += "\n";
+            } else {
+                if (sLines.endsWith("\n")) {
+                    line += "\n";
+                }
+            }
+            // Append if required
+            if (lCnt == 1) {
+                let lastLine = this.lines[this.lines.length-1];
+                if (lastLine != undefined) {
+                    if (!lastLine.endsWith("\n")) {
+                        this.lines[this.lines.length-1] += line;
+                        continue;
+                    }
+                }
+            }
+            // Add new line
+            this.lines.push(line);
+        }
+    }
+
+    shift() {
+        return this.lines.shift();
+    }
+
+}

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -31,10 +31,11 @@ export function trim_repeat_garbage_at_end(sIn, maxSubL=10, maxMatchLenThreshold
             rCnt[subL] += 1;
         }
     }
-    console.log("DBUG:DU:TrimRepeatGarbage:", rCnt);
+    console.debug("DBUG:DU:TrimRepeatGarbage:", rCnt);
     if ((iMML == -1) || (maxMatchLen < maxMatchLenThreshold)) {
         return {trimmed: false, data: sIn};
     }
+    console.debug("DBUG:TrimRepeatGarbage:TrimmedCharLen:", maxMatchLen);
     let iEnd = sIn.length - maxMatchLen;
     return { trimmed: true, data: sIn.substring(0, iEnd) };
 }
@@ -114,7 +115,7 @@ export function trim_hist_garbage_at_end(sIn, maxType, maxUniq, maxMatchLenThres
             hist[c] = 1;
         }
     }
-    console.log("DBUG:TrimHistGarbage:", hist);
+    console.debug("DBUG:TrimHistGarbage:", hist);
     if ((iAlp > maxType) || (iNum > maxType) || (iOth > maxType)) {
         return { trimmed: false, data: sIn };
     }
@@ -125,9 +126,11 @@ export function trim_hist_garbage_at_end(sIn, maxType, maxUniq, maxMatchLenThres
             if (i < maxMatchLenThreshold) {
                 return { trimmed: false, data: sIn };
             }
+            console.debug("DBUG:TrimHistGarbage:TrimmedCharLen:", i);
             return { trimmed: true, data: sIn.substring(0, sIn.length-i+1) };
         }
     }
+    console.debug("DBUG:TrimHistGarbage:Trimmed fully");
     return { trimmed: true, data: "" };
 }
 

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -247,17 +247,17 @@ export class NewLines {
     }
 
     /**
-     * Shift the oldest/0th line in the array.
-     * Optionally control whether only full lines will be returned
-     * or will a partial line (last line) be returned.
-     * @param {boolean} bFullOnly
+     * Shift the oldest/earliest/0th line in the array. [Old-New|Earliest-Latest]
+     * Optionally control whether only full lines (ie those with newline at end) will be returned
+     * or will a partial line without a newline at end (can only be the last line) be returned.
+     * @param {boolean} bFullWithNewLineOnly
      */
-    shift(bFullOnly=true) {
+    shift(bFullWithNewLineOnly=true) {
         let line = this.lines[0];
         if (line == undefined) {
             return undefined;
         }
-        if ((line[line.length-1] != "\n") && bFullOnly){
+        if ((line[line.length-1] != "\n") && bFullWithNewLineOnly){
             return undefined;
         }
         return this.lines.shift();

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -68,3 +68,55 @@ export function trim_repeat_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThresho
         sCur = got.data;
     }
 }
+
+
+/**
+ * A simple minded try trim garbage at end using histogram characteristics
+ * @param {string} sIn
+ * @param {number} maxSubL
+ * @param {number} maxMatchLenThreshold
+ */
+export function trim_hist_garbage_at_end(sIn, maxSubL, maxMatchLenThreshold) {
+    if (sIn.length < maxMatchLenThreshold) {
+        return { trimmed: false, data: sIn };
+    }
+    // Learn
+    let hist = {};
+    for(let i=0; i<maxSubL; i++) {
+        let c = sIn[sIn.length-1-i];
+        if (c in hist) {
+            hist[c] += 1;
+        } else {
+            hist[c] = 1;
+        }
+    }
+    console.log("DBUG:TrimHistGarbage:", hist);
+    // Catch and Trim
+    for(let i=0; i < sIn.length; i++) {
+        let c = sIn[sIn.length-1-i];
+        if (!(c in hist)) {
+            if (i < maxMatchLenThreshold) {
+                return { trimmed: false, data: sIn };
+            }
+            return { trimmed: true, data: sIn.substring(0, sIn.length-i+1) };
+        }
+    }
+    return { trimmed: true, data: "" };
+}
+
+/**
+ * Keep trimming repeatedly using hist_garbage logic, till you no longer can
+ * @param {any} sIn
+ * @param {number} maxSubL
+ * @param {number} maxMatchLenThreshold
+ */
+export function trim_hist_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThreshold) {
+    let sCur = sIn;
+    while (true) {
+        let got = trim_hist_garbage_at_end(sCur, maxSubL, maxMatchLenThreshold);
+        if (!got.trimmed) {
+            return got.data;
+        }
+        sCur = got.data;
+    }
+}

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -73,20 +73,25 @@ export function trim_repeat_garbage_at_end_loop(sIn, maxSubL, maxMatchLenThresho
 /**
  * A simple minded try trim garbage at end using histogram characteristics
  * @param {string} sIn
- * @param {number} maxSubL
+ * @param {number} maxUniq
  * @param {number} maxMatchLenThreshold
  */
-export function trim_hist_garbage_at_end(sIn, maxSubL, maxMatchLenThreshold) {
+export function trim_hist_garbage_at_end(sIn, maxUniq, maxMatchLenThreshold) {
     if (sIn.length < maxMatchLenThreshold) {
         return { trimmed: false, data: sIn };
     }
     // Learn
     let hist = {};
-    for(let i=0; i<maxSubL; i++) {
+    let iUniq = 0;
+    for(let i=0; i<maxMatchLenThreshold; i++) {
         let c = sIn[sIn.length-1-i];
         if (c in hist) {
             hist[c] += 1;
         } else {
+            iUniq += 1;
+            if (iUniq >= maxUniq) {
+                break;
+            }
             hist[c] = 1;
         }
     }

--- a/examples/server/public_simplechat/datautils.mjs
+++ b/examples/server/public_simplechat/datautils.mjs
@@ -1,0 +1,40 @@
+//@ts-check
+// Helpers to work with different data types
+// by Humans for All
+//
+
+
+/**
+ * Simple minded logic to help remove repeating garbage at end of the string.
+ * TODO: Initial skeleton
+ * @param {string} sIn
+ */
+export function trim_repeat_garbage_at_end(sIn, maxSubL=10) {
+    let rCnt = [0];
+    const MaxMatchLenThreshold = maxSubL*4;
+    let maxMatchLen = maxSubL;
+    let iMML = -1;
+    for(let subL=1; subL < maxSubL; subL++) {
+        rCnt.push(0);
+        let i;
+        let refS = sIn.substring(sIn.length-subL, sIn.length);
+        for(i=sIn.length; i > 0; i -= subL) {
+            let curS = sIn.substring(i-subL, i);
+            if (refS != curS) {
+                let curMatchLen = rCnt[subL]*subL;
+                if (maxMatchLen < curMatchLen) {
+                    maxMatchLen = curMatchLen;
+                    iMML = subL;
+                }
+                break;
+            }
+            rCnt[subL] += 1;
+        }
+    }
+    console.log("DBUG:DU:TrimRepeatGarbage:", rCnt);
+    if ((iMML == -1) || (maxMatchLen < MaxMatchLenThreshold)) {
+        return sIn;
+    }
+    let iEnd = sIn.length - maxMatchLen + iMML;
+    return sIn.substring(0,iEnd)
+}

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -32,7 +32,7 @@
             <hr>
             <div class="sameline">
                 <label for="system-in">System</label>
-                <input type="text" name="system" id="system-in" placeholder="e.g. you are a helpful ai assistant, who provides concise answers" class="flex-grow"/>
+                <textarea name="system" id="system-in" rows="2" placeholder="e.g. you are a helpful ai assistant, who provides concise answers" class="flex-grow"></textarea>
             </div>
 
             <hr>
@@ -42,7 +42,7 @@
 
             <hr>
             <div class="sameline">
-                <textarea id="user-in" class="flex-grow" rows="3" placeholder="enter your query to the ai model here" ></textarea>
+                <textarea id="user-in" class="flex-grow" rows="2" placeholder="enter your query to the ai model here" ></textarea>
                 <button id="user-btn">submit</button>
             </div>
 

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -11,7 +11,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "datautils": "./datautils.mjs"
+                    "datautils": "./datautils.mjs",
+                    "ui": "./ui.mjs"
                 }
             }
         </script>

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -22,16 +22,9 @@
     <body>
         <div class="samecolumn" id="fullbody">
 
-            <div class="sameline">
+            <div class="sameline" id="heading">
                 <p class="heading flex-grow" > <b> SimpleChat </b> </p>
                 <button id="settings">Settings</button>
-                <div class="sameline">
-                    <label for="api-ep">Mode:</label>
-                    <select name="api-ep" id="api-ep">
-                    <option value="chat" selected>Chat</option>
-                    <option value="completion">Completion</option>
-                    </select>
-                </div>
             </div>
 
             <div id="sessions-div" class="sameline"></div>

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -8,7 +8,14 @@
         <meta name="description" content="SimpleChat: trigger LLM web service endpoints /chat/completions and /completions, single/multi chat sessions" />
         <meta name="author" content="by Humans for All" />
         <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-        <script src="simplechat.js" defer></script>
+        <script type="importmap">
+            {
+                "imports": {
+                    "datautils": "./datautils.mjs"
+                }
+            }
+        </script>
+        <script src="simplechat.js" type="module" defer></script>
         <link rel="stylesheet" href="simplechat.css" />
     </head>
     <body>

--- a/examples/server/public_simplechat/index.html
+++ b/examples/server/public_simplechat/index.html
@@ -24,6 +24,7 @@
 
             <div class="sameline">
                 <p class="heading flex-grow" > <b> SimpleChat </b> </p>
+                <button id="settings">Settings</button>
                 <div class="sameline">
                     <label for="api-ep">Mode:</label>
                     <select name="api-ep" id="api-ep">

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -29,6 +29,9 @@ the chat history before sending to the ai model.
 NOTE: Wrt options sent with the request, it mainly sets temperature, max_tokens and optionaly stream for now.
 However if someone wants they can update the js file or equivalent member in gMe as needed.
 
+NOTE: One may be able to use this to chat with openai api web-service /chat/completions endpoint, in a very
+limited / minimal way. One will need to set openai url and authorization bearer key in settings ui.
+
 
 ## usage
 
@@ -155,6 +158,10 @@ It is attached to the document object. Some of these can also be updated using t
     modify the existing options value or remove them, for now you can update this global var
     using browser's development-tools/console.
 
+  headers - maintains the list of http headers sent when request is made to the server. By default
+  Content-Type is set to application/json. Additionally Authorization entry is provided, which can
+  be set if needed using the settings ui.
+
   iRecentUserMsgCnt - a simple minded SlidingWindow to limit context window load at Ai Model end.
   This is disabled by default. However if enabled, then in addition to latest system message, only
   the last/latest iRecentUserMsgCnt user messages after the latest system prompt and its responses
@@ -214,6 +221,27 @@ wrt repeatations in general in the generated text response.
 
 A end-user can change these behaviour by editing gMe from browser's devel-tool/console or by
 using the providing settings ui.
+
+
+### OpenAi / Equivalent API WebService
+
+One may be abe to handshake with OpenAI/Equivalent api web service's /chat/completions endpoint
+for a minimal chatting experimentation by setting the below.
+
+* the baseUrl in settings ui
+  * https://api.openai.com/v1 or similar
+
+* Wrt request body - gMe.chatRequestOptions
+  * model
+  * any additional fields if required in future
+
+* Wrt request headers - gMe.headers
+  * Authorization (available through settings ui)
+    * Bearer THE_OPENAI_API_KEY
+  * any additional optional header entries like "OpenAI-Organization", "OpenAI-Project" or so
+
+NOTE: Not tested, as there is no free tier api testing available. However logically this might
+work.
 
 
 ## At the end

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -26,8 +26,8 @@ any adaptive culling of old messages nor of replacing them with summary of their
 is a optional sliding window based chat logic, which provides a simple minded culling of old messages from
 the chat history before sending to the ai model.
 
-NOTE: It doesnt set any parameters other than temperature and max_tokens for now. However if someone wants
-they can update the js file or equivalent member in gMe as needed.
+NOTE: Wrt options sent with the request, it mainly sets temperature, max_tokens and optionaly stream for now.
+However if someone wants they can update the js file or equivalent member in gMe as needed.
 
 
 ## usage
@@ -58,6 +58,7 @@ Open this simple web front end from your local browser
 Once inside
 
 * If you want to, you can change many of the default global settings
+  * the base url (ie ip addr / domain name, port)
   * chat (default) vs completion mode
   * try trim garbage in response or not
   * amount of chat history in the context sent to server/ai-model
@@ -124,6 +125,11 @@ Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
 It is attached to the document object. Some of these can also be updated using the Settings UI.
 
+  baseURL - the domain-name/ip-address and inturn the port to send the request.
+
+  bStream - control between oneshot-at-end and live-stream-as-its-generated collating and showing
+  of the generated response.
+
   apiEP - select between /completions and /chat/completions endpoint provided by the server/ai-model.
 
   bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
@@ -183,18 +189,6 @@ By switching between chat.add_system_begin/anytime, one can control whether one 
 the system prompt, anytime during the conversation or only at the beginning.
 
 
-read_json_early, is to experiment with reading json response data early on, if available,
-so that user can be shown generated data, as and when it is being generated, rather than
-at the end when full data is available.
-
-  the server flow doesnt seem to be sending back data early, atleast for request (inc options)
-  that is currently sent.
-
-  if able to read json data early on in future, as and when ai model is generating data, then
-  this helper needs to indirectly update the chat div with the recieved data, without waiting
-  for the overall data to be available.
-
-
 ### Default setup
 
 By default things are setup to try and make the user experience a bit better, if possible.
@@ -218,7 +212,8 @@ NOTE: One may want to experiment with frequency/presence penalty fields in chatR
 wrt the set of fields sent to server along with the user query. To check how the model behaves
 wrt repeatations in general in the generated text response.
 
-A end-user can change these behaviour by editing gMe from browser's devel-tool/console.
+A end-user can change these behaviour by editing gMe from browser's devel-tool/console or by
+using the providing settings ui.
 
 
 ## At the end

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -30,7 +30,7 @@ NOTE: Wrt options sent with the request, it mainly sets temperature, max_tokens 
 However if someone wants they can update the js file or equivalent member in gMe as needed.
 
 NOTE: One may be able to use this to chat with openai api web-service /chat/completions endpoint, in a very
-limited / minimal way. One will need to set openai url and authorization bearer key in settings ui.
+limited / minimal way. One will need to set model, openai url and authorization bearer key in settings ui.
 
 
 ## usage
@@ -232,7 +232,7 @@ for a minimal chatting experimentation by setting the below.
   * https://api.openai.com/v1 or similar
 
 * Wrt request body - gMe.chatRequestOptions
-  * model
+  * model (settings ui)
   * any additional fields if required in future
 
 * Wrt request headers - gMe.headers

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -108,6 +108,9 @@ Once inside
 * Using NewChat one can start independent chat sessions.
   * two independent chat sessions are setup by default.
 
+* When you want to print, switching ChatHistoryInCtxt to Full and clicking on the chat session button of
+  interest, will display the full chat history till then wrt same, if you want full history for printing.
+
 
 ## Devel note
 
@@ -134,6 +137,13 @@ It is attached to the document object. Some of these can also be updated using t
   of the generated response.
 
     the logic assumes that the text sent from the server follows utf-8 encoding.
+
+    in streaming mode - if there is any exception, the logic traps the same and tries to ensure
+    that text generated till then is not lost.
+
+      if a very long text is being generated, which leads to no user interaction for sometime and
+      inturn the machine goes into power saving mode or so, the platform may stop network connection,
+      leading to exception.
 
   apiEP - select between /completions and /chat/completions endpoint provided by the server/ai-model.
 

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -133,6 +133,8 @@ It is attached to the document object. Some of these can also be updated using t
   bStream - control between oneshot-at-end and live-stream-as-its-generated collating and showing
   of the generated response.
 
+    the logic assumes that the text sent from the server follows utf-8 encoding.
+
   apiEP - select between /completions and /chat/completions endpoint provided by the server/ai-model.
 
   bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
@@ -150,6 +152,9 @@ It is attached to the document object. Some of these can also be updated using t
     is enabled as part of the chat-history-in-context setting), and chances are the ai-model will
     continue starting from the trimmed part, thus allows long response to be recovered/continued
     indirectly, in many cases.
+
+    The histogram/freq based trimming logic is currently tuned for english language wrt its
+    is-it-a-alpabetic|numeral-char regex match logic.
 
   chatRequestOptions - maintains the list of options/fields to send along with chat request,
   irrespective of whether /chat/completions or /completions endpoint.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -54,9 +54,10 @@ Open this simple web front end from your local browser
 
 Once inside
 
-* Select between chat and completion mode. By default it is set to chat mode.
-
-* Change the default global settings, if one wants to.
+* If you want to, you can change many of the default global settings
+  * chat (default) vs completion mode
+  * try trim garbage in response or not
+  * amount of chat history in the context sent to server/ai-model
 
 * In completion mode
   * logic by default doesnt insert any role specific "ROLE: " prefix wrt each role's message.
@@ -92,6 +93,7 @@ Once inside
 * Wait for the logic to communicate with the server and get the response.
   * the user is not allowed to enter any fresh query during this time.
   * the user input box will be disabled and a working message will be shown in it.
+  * if trim garbage is enabled, the logic will try to trim repeating text kind of garbage to some extent.
 
 * just refresh the page, to reset wrt the chat history and or system prompt and start afresh.
 
@@ -118,6 +120,8 @@ Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
 It is attached to the document object. Some of these can also be updated using the Settings UI.
 
+  apiEP - select between /completions and /chat/completions endpoint provided by the server/ai-model.
+
   bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
   communicating with the server or only sends the latest user query/message.
 
@@ -129,8 +133,8 @@ It is attached to the document object. Some of these can also be updated using t
   subsequent chat history. At the same time the actual trimmed text is shown to the user, once
   when it was generated, so user can check if any useful info/data was there in the response.
 
-    One may be able to request the ai-model to continue (wrt the last response) (if chat-history is
-    enabled as part of the chat-history-in-context setting), and chances are the ai-model will
+    One may be able to request the ai-model to continue (wrt the last response) (if chat-history
+    is enabled as part of the chat-history-in-context setting), and chances are the ai-model will
     continue starting from the trimmed part, thus allows long response to be recovered/continued
     indirectly, in many cases.
 
@@ -155,7 +159,8 @@ It is attached to the document object. Some of these can also be updated using t
 
 By using gMe's iRecentUserMsgCnt and chatRequestOptions.max_tokens one can try to control the
 implications of loading of the ai-model's context window by chat history, wrt chat response to
-some extent in a simple crude way.
+some extent in a simple crude way. You may also want to control the context size enabled when
+the server loads ai-model, on the server end.
 
 
 Sometimes the browser may be stuborn with caching of the file, so your updates to html/css/js
@@ -194,7 +199,8 @@ However a developer when testing the server of ai-model may want to change these
 Using iRecentUserMsgCnt reduce chat history context sent to the server/ai-model to be
 just the system-prompt, prev-user-request-and-ai-response and cur-user-request, instead of
 full chat history. This way if there is any response with garbage/repeatation, it doesnt
-mess with things beyond the next question/request/query, in some ways.
+mess with things beyond the next question/request/query, in some ways. The trim garbage
+option also tries to help avoid issues with garbage in the context to an extent.
 
 Set max_tokens to 1024, so that a relatively large previous reponse doesnt eat up the space
 available wrt next query-response. However dont forget that the server when started should

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -116,13 +116,23 @@ Skeletal logic has been implemented to explore some of the end points and ideas/
 
 Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
-It is attached to the document object.
+It is attached to the document object. Some of these can also be updated using the Settings UI.
 
   bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
   communicating with the server or only sends the latest user query/message.
 
   bCompletionInsertStandardRolePrefix - whether Completion mode inserts role related prefix wrt the
   messages that get inserted into prompt field wrt /Completion endpoint.
+
+  bTrimGarbage - whether garbage repeatation at the end of the generated ai response, should be
+  trimmed or left as is. If enabled, it will be trimmed so that it wont be sent back as part of
+  subsequent chat history. At the same time the actual trimmed text is shown to the user, once
+  when it was generated, so user can check if any useful info/data was there in the response.
+
+    One may be able to request the ai-model to continue (wrt the last response) (if chat-history is
+    enabled as part of the chat-history-in-context setting), and chances are the ai-model will
+    continue starting from the trimmed part, thus allows long response to be recovered/continued
+    indirectly, in many cases.
 
   chatRequestOptions - maintains the list of options/fields to send along with chat request,
   irrespective of whether /chat/completions or /completions endpoint.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -15,11 +15,13 @@ The UI follows a responsive web design so that the layout can adapt to available
 enough manner, in general.
 
 Allows developer/end-user to control some of the behaviour by updating gMe members from browser's devel-tool
-console.
+console. Parallely some of the directly useful to end-user settings can also be changed using the provided
+settings ui.
 
-NOTE: Given that the idea is for basic minimal testing, it doesnt bother with any model context length and
-culling of old messages from the chat by default. However by enabling the sliding window chat logic, a crude
-form of old messages culling can be achieved.
+NOTE: Current web service api doesnt expose the model context length directly, so client logic doesnt provide
+any adaptive culling of old messages nor of replacing them with summary of their content etal. However there
+is a optional sliding window based chat logic, which provides a simple minded culling of old messages from
+the chat history before sending to the ai model.
 
 NOTE: It doesnt set any parameters other than temperature and max_tokens for now. However if someone wants
 they can update the js file or equivalent member in gMe as needed.
@@ -53,6 +55,8 @@ Open this simple web front end from your local browser
 Once inside
 
 * Select between chat and completion mode. By default it is set to chat mode.
+
+* Change the default global settings, if one wants to.
 
 * In completion mode
   * logic by default doesnt insert any role specific "ROLE: " prefix wrt each role's message.
@@ -104,14 +108,15 @@ by developers who may not be from web frontend background (so inturn may not be 
 end-use-specific-language-extensions driven flows) so that they can use it to explore/experiment things.
 
 And given that the idea is also to help explore/experiment for developers, some flexibility is provided
-to change behaviour easily using the devel-tools/console, for now. And skeletal logic has been implemented
-to explore some of the end points and ideas/implications around them.
+to change behaviour easily using the devel-tools/console or provided minimal settings ui (wrt few aspects).
+Skeletal logic has been implemented to explore some of the end points and ideas/implications around them.
 
 
 ### General
 
 Me/gMe consolidates the settings which control the behaviour into one object.
 One can see the current settings, as well as change/update them using browsers devel-tool/console.
+It is attached to the document object.
 
   bCompletionFreshChatAlways - whether Completion mode collates complete/sliding-window history when
   communicating with the server or only sends the latest user query/message.
@@ -189,9 +194,9 @@ also be started with a model context size of 1k or more, to be on safe side.
   internal n_predict, for now add the same here on the client side, maybe later add max_tokens
   to /completions endpoint handling code on server side.
 
-Frequency and presence penalty fields are set to 1.2 in the set of fields sent to server
-along with the user query. So that the model is partly set to try avoid repeating text in
-its response.
+NOTE: One may want to experiment with frequency/presence penalty fields in chatRequestOptions
+wrt the set of fields sent to server along with the user query. To check how the model behaves
+wrt repeatations in general in the generated text response.
 
 A end-user can change these behaviour by editing gMe from browser's devel-tool/console.
 

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -11,6 +11,9 @@ in a simple way with minimal code from a common code base. Inturn additionally i
 multiple independent back and forth chatting to an extent, with the ai llm model at a basic level, with their
 own system prompts.
 
+This allows seeing the generated text / ai-model response in oneshot at the end, after it is fully generated,
+or potentially as it is being generated, in a streamed manner from the server/ai-model.
+
 The UI follows a responsive web design so that the layout can adapt to available display space in a usable
 enough manner, in general.
 
@@ -58,6 +61,7 @@ Once inside
   * chat (default) vs completion mode
   * try trim garbage in response or not
   * amount of chat history in the context sent to server/ai-model
+  * oneshot or streamed mode.
 
 * In completion mode
   * logic by default doesnt insert any role specific "ROLE: " prefix wrt each role's message.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -68,6 +68,7 @@ Once inside
   * oneshot or streamed mode.
 
 * In completion mode
+  * one normally doesnt use a system prompt in completion mode.
   * logic by default doesnt insert any role specific "ROLE: " prefix wrt each role's message.
     If the model requires any prefix wrt user role messages, then the end user has to
     explicitly add the needed prefix, when they enter their chat message.

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -14,6 +14,9 @@ own system prompts.
 This allows seeing the generated text / ai-model response in oneshot at the end, after it is fully generated,
 or potentially as it is being generated, in a streamed manner from the server/ai-model.
 
+Auto saves the chat session locally as and when the chat is progressing and inturn at a later time when you
+open SimpleChat, option is provided to restore the old chat session, if a matching one exists.
+
 The UI follows a responsive web design so that the layout can adapt to available display space in a usable
 enough manner, in general.
 
@@ -202,10 +205,9 @@ matter clearing site data, dont directly override site caching in all cases. Wor
 have to change port. Or in dev tools of browser, you may be able to disable caching fully.
 
 
-Concept of multiple chat sessions with different servers, as well as saving and restoring of
-those across browser usage sessions, can be woven around the SimpleChat/MultiChatUI class and
-its instances relatively easily, however given the current goal of keeping this simple, it has
-not been added, for now.
+Currently the server to communicate with is maintained globally and not as part of a specific
+chat session. So if one changes the server ip/url in setting, then all chat sessions will auto
+switch to this new server, when you try using those sessions.
 
 
 By switching between chat.add_system_begin/anytime, one can control whether one can change

--- a/examples/server/public_simplechat/readme.md
+++ b/examples/server/public_simplechat/readme.md
@@ -177,6 +177,10 @@ It is attached to the document object. Some of these can also be updated using t
     modify the existing options value or remove them, for now you can update this global var
     using browser's development-tools/console.
 
+    For string and numeric fields in chatRequestOptions, including even those added by a user
+    at runtime by directly modifying gMe.chatRequestOptions, setting ui entries will be auto
+    created.
+
   headers - maintains the list of http headers sent when request is made to the server. By default
   Content-Type is set to application/json. Additionally Authorization entry is provided, which can
   be set if needed using the settings ui.

--- a/examples/server/public_simplechat/simplechat.css
+++ b/examples/server/public_simplechat/simplechat.css
@@ -25,6 +25,14 @@
     background-color: lightpink;
 }
 
+.gridx2 {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    border-bottom-style: dotted;
+    border-bottom-width: thin;
+    border-bottom-color: lightblue;
+}
+
 .flex-grow {
     flex-grow: 1;
 }

--- a/examples/server/public_simplechat/simplechat.css
+++ b/examples/server/public_simplechat/simplechat.css
@@ -21,6 +21,9 @@
 .role-user {
     background-color: lightgray;
 }
+.role-trim {
+    background-color: lightpink;
+}
 
 .flex-grow {
     flex-grow: 1;

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -502,7 +502,7 @@ class MultiChatUI {
             }
             this.handle_user_submit(this.curChatId, gMe.apiEP).catch((/** @type{Error} */reason)=>{
                 let msg = `ERRR:SimpleChat\nMCUI:HandleUserSubmit:${this.curChatId}\n${reason.name}:${reason.message}`;
-                console.debug(msg.replace("\n", ":"));
+                console.error(msg.replace("\n", ":"));
                 alert(msg);
                 this.ui_reset_userinput();
             });

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -39,18 +39,15 @@ class ApiEP {
 let gUsageMsg = `
     <p class="role-system">Usage</p>
     <ul class="ul1">
-    <li> Set system prompt above, to try control ai response charactersitic, if model supports same.</li>
+    <li> System prompt above, to try control ai response characteristics.</li>
         <ul class="ul2">
-        <li> Completion mode normally wont have a system prompt.</li>
+        <li> Completion mode - no system prompt normally.</li>
         </ul>
+    <li> Use shift+enter for inserting enter/newline.</li>
     <li> Enter your query to ai assistant below.</li>
-        <ul class="ul2">
-        <li> Completion mode doesnt insert user/role: prefix implicitly.</li>
-        <li> Use shift+enter for inserting enter/newline.</li>
-        </ul>
     <li> Default ContextWindow = [System, Last Query+Resp, Cur Query].</li>
         <ul class="ul2">
-        <li> experiment iRecentUserMsgCnt, max_tokens, model ctxt window to expand</li>
+        <li> ChatHistInCtxt, MaxTokens, ModelCtxt window to expand</li>
         </ul>
     </ul>
 `;
@@ -542,6 +539,8 @@ class MultiChatUI {
             // allow user to insert enter into the system prompt using shift+enter.
             // while just pressing enter key will lead to setting the system prompt.
             if ((ev.key === "Enter") && (!ev.shiftKey)) {
+                let value = this.elInSystem.value;
+                this.elInSystem.value = value.substring(0,value.length-1);
                 let chat = this.simpleChats[this.curChatId];
                 chat.add_system_anytime(this.elInSystem.value, this.curChatId);
                 chat.show(this.elDivChat);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -428,6 +428,8 @@ class SimpleChat {
                 this.latestResponse = "";
             } catch (error) {
                 theResp.assistant = this.latestResponse;
+                this.add(Roles.Assistant, theResp.assistant);
+                this.latestResponse = "";
                 throw error;
             }
         } else {
@@ -438,6 +440,7 @@ class SimpleChat {
             theResp.assistant = du.trim_garbage_at_end(origMsg);
             theResp.trimmed = origMsg.substring(theResp.assistant.length);
         }
+        this.add(Roles.Assistant, theResp.assistant);
         return theResp;
     }
 
@@ -601,7 +604,6 @@ class MultiChatUI {
         });
 
         let theResp = await chat.handle_response(resp, apiEP, this.elDivChat);
-        chat.add(Roles.Assistant, theResp.assistant);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);
             if (theResp.trimmed.length > 0) {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -759,7 +759,7 @@ class Me {
 
         ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
 
-        ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`, elDiv);
+        ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions, null, "\t")}`, elDiv);
 
         ui.el_create_append_p(`ApiEndPoint:${this.apiEP}`, elDiv);
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -699,6 +699,7 @@ class Me {
         }
         // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
         this.chatRequestOptions = {
+            "model": "gpt-3.5-turbo",
             "temperature": 0.7,
             "max_tokens": 1024,
             "n_predict": 1024,
@@ -761,6 +762,11 @@ class Me {
             this.headers["Authorization"] = val;
         });
         inp.el.placeholder = "Bearer OPENAI_API_KEY";
+        elDiv.appendChild(inp.div);
+
+        inp = ui.el_creatediv_input("SetModel", "Model", "text", this.chatRequestOptions["model"], (val)=>{
+            this.chatRequestOptions["model"] = val;
+        });
         elDiv.appendChild(inp.div);
 
         let bb = ui.el_creatediv_boolbutton("SetStream", "Stream", {true: "[+] yes stream", false: "[-] do oneshot"}, this.bStream, (val)=>{

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -164,6 +164,12 @@ class SimpleChat {
         return last;
     }
 
+    /**
+     * Setup the fetch headers.
+     * It picks the headers from gMe.headers.
+     * It inserts Authorization only if its non-empty.
+     * @param {string} apiEP
+     */
     fetch_headers(apiEP) {
         let headers = new Headers();
         for(let k in gMe.headers) {
@@ -171,7 +177,7 @@ class SimpleChat {
             if ((k == "Authorization") && (v.trim() == "")) {
                 continue;
             }
-            headers[k] = v;
+            headers.append(k, v);
         }
         return headers;
     }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -11,17 +11,28 @@ class Roles {
     static Assistant = "assistant";
 }
 
-let gBaseURL = "http://127.0.0.1:8080";
-
 class ApiEP {
     static Type = {
         Chat: "chat",
         Completion: "completion",
     }
-    static Url = {
-        'chat': `${gBaseURL}/chat/completions`,
-        'completion': `${gBaseURL}/completions`,
+    static UrlSuffix = {
+        'chat': `/chat/completions`,
+        'completion': `/completions`,
     }
+
+    /**
+     * Build the url from given baseUrl and apiEp id.
+     * @param {string} baseUrl
+     * @param {string} apiEP
+     */
+    static Url(baseUrl, apiEP) {
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length-1);
+        }
+        return `${baseUrl}${this.UrlSuffix[apiEP]}`;
+    }
+
 }
 
 
@@ -542,7 +553,7 @@ class MultiChatUI {
         }
         chat.show(this.elDivChat);
 
-        let theUrl = ApiEP.Url[apiEP];
+        let theUrl = ApiEP.Url(gMe.baseURL, apiEP);
         let theBody = chat.request_jsonstr(apiEP);
 
         this.elInUser.value = "working...";
@@ -649,6 +660,7 @@ class MultiChatUI {
 class Me {
 
     constructor() {
+        this.baseURL = "http://127.0.0.1:8080";
         this.defaultChatIds = [ "Default", "Other" ];
         this.multiChat = new MultiChatUI();
         this.bStream = true;

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -728,6 +728,8 @@ class Me {
 
         ui.el_create_append_p(`baseURL:${this.baseURL}`, elDiv);
 
+        ui.el_create_append_p(`Authorization:${this.headers["Authorization"]}`, elDiv);
+
         ui.el_create_append_p(`bStream:${this.bStream}`, elDiv);
 
         ui.el_create_append_p(`bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`, elDiv);
@@ -752,6 +754,11 @@ class Me {
 
         let inp = ui.el_creatediv_input("SetBaseURL", "BaseURL", "text", this.baseURL, (val)=>{
             this.baseURL = val;
+        });
+        elDiv.appendChild(inp);
+
+        inp = ui.el_creatediv_input("SetAuthorization", "Authorization", "text", this.headers["Authorization"], (val)=>{
+            this.headers["Authorization"] = val;
         });
         elDiv.appendChild(inp);
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -739,29 +739,35 @@ class Me {
     /**
      * Show the configurable parameters info in the passed Div element.
      * @param {HTMLDivElement} elDiv
+     * @param {boolean} bAll
      */
-    show_info(elDiv) {
+    show_info(elDiv, bAll=false) {
 
         let p = ui.el_create_append_p("Settings (devel-tools-console document[gMe])", elDiv);
         p.className = "role-system";
 
-        ui.el_create_append_p(`baseURL:${this.baseURL}`, elDiv);
+        if (bAll) {
 
-        ui.el_create_append_p(`Authorization:${this.headers["Authorization"]}`, elDiv);
+            ui.el_create_append_p(`baseURL:${this.baseURL}`, elDiv);
 
-        ui.el_create_append_p(`bStream:${this.bStream}`, elDiv);
+            ui.el_create_append_p(`Authorization:${this.headers["Authorization"]}`, elDiv);
 
-        ui.el_create_append_p(`bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`, elDiv);
+            ui.el_create_append_p(`bStream:${this.bStream}`, elDiv);
 
-        ui.el_create_append_p(`bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`, elDiv);
+            ui.el_create_append_p(`bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`, elDiv);
 
-        ui.el_create_append_p(`bTrimGarbage:${this.bTrimGarbage}`, elDiv);
+            ui.el_create_append_p(`bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`, elDiv);
 
-        ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
+            ui.el_create_append_p(`bTrimGarbage:${this.bTrimGarbage}`, elDiv);
 
-        ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions, null, "\t")}`, elDiv);
+            ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
 
-        ui.el_create_append_p(`ApiEndPoint:${this.apiEP}`, elDiv);
+            ui.el_create_append_p(`ApiEndPoint:${this.apiEP}`, elDiv);
+
+        }
+
+        ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions, null, " - ")}`, elDiv);
+        ui.el_create_append_p(`headers:${JSON.stringify(this.headers, null, " - ")}`, elDiv);
 
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -164,6 +164,18 @@ class SimpleChat {
         return last;
     }
 
+    fetch_headers(apiEP) {
+        let headers = new Headers();
+        for(let k in gMe.headers) {
+            let v = gMe.headers[k];
+            if ((k == "Authorization") && (v.trim() == "")) {
+                continue;
+            }
+            headers[k] = v;
+        }
+        return headers;
+    }
+
     /**
      * Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
      * The needed fields/options are picked from a global object.
@@ -559,11 +571,10 @@ class MultiChatUI {
         this.elInUser.value = "working...";
         this.elInUser.disabled = true;
         console.debug(`DBUG:SimpleChat:MCUI:${chatId}:HandleUserSubmit:${theUrl}:ReqBody:${theBody}`);
+        let theHeaders = chat.fetch_headers(apiEP);
         let resp = await fetch(theUrl, {
             method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers: theHeaders,
             body: theBody,
         });
 
@@ -676,6 +687,10 @@ class Me {
             "Last4": 5,
         };
         this.apiEP = ApiEP.Type.Chat;
+        this.headers = {
+            "Content-Type": "application/json",
+            "Authorization": "", // Authorization: Bearer OPENAI_API_KEY
+        }
         // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
         this.chatRequestOptions = {
             "temperature": 0.7,

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -422,19 +422,19 @@ class SimpleChat {
             assistant: "",
             trimmed: "",
         }
-        let origMsg;
         if (gMe.bStream) {
             try {
-                origMsg = await this.handle_response_multipart(resp, apiEP, elDiv);
+                theResp.assistant = await this.handle_response_multipart(resp, apiEP, elDiv);
                 this.latestResponse = "";
             } catch (error) {
-                origMsg = this.latestResponse;
+                theResp.assistant = this.latestResponse;
                 throw error;
             }
         } else {
-            origMsg = await this.handle_response_oneshot(resp, apiEP);
+            theResp.assistant = await this.handle_response_oneshot(resp, apiEP);
         }
         if (gMe.bTrimGarbage) {
+            let origMsg = theResp.assistant;
             theResp.assistant = du.trim_garbage_at_end(origMsg);
             theResp.trimmed = origMsg.substring(theResp.assistant.length);
         }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -705,6 +705,8 @@ class Me {
         let p = ui.el_create_append_p("Settings (devel-tools-console document[gMe])", elDiv);
         p.className = "role-system";
 
+        ui.el_create_append_p(`baseURL:${this.baseURL}`, elDiv);
+
         ui.el_create_append_p(`bStream:${this.bStream}`, elDiv);
 
         ui.el_create_append_p(`bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`, elDiv);
@@ -726,6 +728,11 @@ class Me {
      * @param {HTMLDivElement} elDiv
      */
     show_settings(elDiv) {
+
+        let inp = ui.el_creatediv_input("SetBaseURL", "BaseURL", "text", this.baseURL, (val)=>{
+            this.baseURL = val;
+        });
+        elDiv.appendChild(inp);
 
         let bb = ui.el_creatediv_boolbutton("SetStream", "Stream", {true: "[+] yes stream", false: "[-] do oneshot"}, this.bStream, (val)=>{
             this.bStream = val;

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -755,42 +755,43 @@ class Me {
         let inp = ui.el_creatediv_input("SetBaseURL", "BaseURL", "text", this.baseURL, (val)=>{
             this.baseURL = val;
         });
-        elDiv.appendChild(inp);
+        elDiv.appendChild(inp.div);
 
         inp = ui.el_creatediv_input("SetAuthorization", "Authorization", "text", this.headers["Authorization"], (val)=>{
             this.headers["Authorization"] = val;
         });
-        elDiv.appendChild(inp);
+        inp.el.placeholder = "Bearer OPENAI_API_KEY";
+        elDiv.appendChild(inp.div);
 
         let bb = ui.el_creatediv_boolbutton("SetStream", "Stream", {true: "[+] yes stream", false: "[-] do oneshot"}, this.bStream, (val)=>{
             this.bStream = val;
         });
-        elDiv.appendChild(bb);
+        elDiv.appendChild(bb.div);
 
         bb = ui.el_creatediv_boolbutton("SetCompletionFreshChatAlways", "CompletionFreshChatAlways", {true: "[+] yes fresh", false: "[-] no, with history"}, this.bCompletionFreshChatAlways, (val)=>{
             this.bCompletionFreshChatAlways = val;
         });
-        elDiv.appendChild(bb);
+        elDiv.appendChild(bb.div);
 
         bb = ui.el_creatediv_boolbutton("SetCompletionInsertStandardRolePrefix", "CompletionInsertStandardRolePrefix", {true: "[+] yes insert", false: "[-] dont insert"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
             this.bCompletionInsertStandardRolePrefix = val;
         });
-        elDiv.appendChild(bb);
+        elDiv.appendChild(bb.div);
 
         bb = ui.el_creatediv_boolbutton("SetTrimGarbage", "TrimGarbage", {true: "[+] yes trim", false: "[-] dont trim"}, this.bTrimGarbage, (val)=>{
             this.bTrimGarbage = val;
         });
-        elDiv.appendChild(bb);
+        elDiv.appendChild(bb.div);
 
         let sel = ui.el_creatediv_select("SetChatHistoryInCtxt", "ChatHistoryInCtxt", this.sRecentUserMsgCnt, this.iRecentUserMsgCnt, (val)=>{
             this.iRecentUserMsgCnt = this.sRecentUserMsgCnt[val];
         });
-        elDiv.appendChild(sel);
+        elDiv.appendChild(sel.div);
 
         sel = ui.el_creatediv_select("SetApiEP", "ApiEndPoint", ApiEP.Type, this.apiEP, (val)=>{
             this.apiEP = ApiEP.Type[val];
         });
-        elDiv.appendChild(sel);
+        elDiv.appendChild(sel.div);
 
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -481,7 +481,7 @@ class MultiChatUI {
                 assistantMsg = respBody["content"];
             }
         }
-        assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 12, 72);
+        assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 8, 16, 72);
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -134,7 +134,6 @@ class SimpleChat {
             if (bClear) {
                 div.innerHTML = gUsageMsg;
                 gMe.show_info(div);
-                gMe.show_settings(div);
             }
         }
     }
@@ -266,12 +265,14 @@ class MultiChatUI {
         this.elInUser = /** @type{HTMLInputElement} */(document.getElementById("user-in"));
         this.elSelectApiEP = /** @type{HTMLSelectElement} */(document.getElementById("api-ep"));
         this.elDivSessions = /** @type{HTMLDivElement} */(document.getElementById("sessions-div"));
+        this.elBtnSettings = /** @type{HTMLButtonElement} */(document.getElementById("settings"));
 
         this.validate_element(this.elInSystem, "system-in");
         this.validate_element(this.elDivChat, "chat-div");
         this.validate_element(this.elInUser, "user-in");
         this.validate_element(this.elSelectApiEP, "api-ep");
         this.validate_element(this.elDivChat, "sessions-div");
+        this.validate_element(this.elBtnSettings, "settings");
     }
 
     /**
@@ -311,6 +312,11 @@ class MultiChatUI {
         if (bSwitchSession) {
             this.handle_session_switch(this.curChatId);
         }
+
+        this.elBtnSettings.addEventListener("click", (ev)=>{
+            this.elDivChat.replaceChildren();
+            gMe.show_settings(this.elDivChat);
+        });
 
         this.elBtnUser.addEventListener("click", (ev)=>{
             if (this.elInUser.disabled) {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -124,10 +124,8 @@ class SimpleChat {
         }
         let last = undefined;
         for(const x of this.recent_chat(gMe.iRecentUserMsgCnt)) {
-            let entry = document.createElement("p");
+            let entry = ui.el_create_append_p(`${x.role}: ${x.content}`, div);
             entry.className = `role-${x.role}`;
-            entry.innerText = `${x.role}: ${x.content}`;
-            div.appendChild(entry);
             last = entry;
         }
         if (last !== undefined) {
@@ -547,30 +545,21 @@ class Me {
     }
 
     /**
+     * Show the configurable parameters info in the passed Div element.
      * @param {HTMLDivElement} elDiv
      */
     show_info(elDiv) {
 
-        var p = document.createElement("p");
-        p.innerText = "Settings (devel-tools-console gMe)";
+        let p = ui.el_create_append_p("Settings (devel-tools-console document[gMe])", elDiv);
         p.className = "role-system";
-        elDiv.appendChild(p);
 
-        var p = document.createElement("p");
-        p.innerText = `bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`;
-        elDiv.appendChild(p);
+        ui.el_create_append_p(`bCompletionFreshChatAlways:${this.bCompletionFreshChatAlways}`, elDiv);
 
-        p = document.createElement("p");
-        p.innerText = `bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`;
-        elDiv.appendChild(p);
+        ui.el_create_append_p(`bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`, elDiv);
 
-        p = document.createElement("p");
-        p.innerText = `iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`;
-        elDiv.appendChild(p);
+        ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
 
-        p = document.createElement("p");
-        p.innerText = `chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`;
-        elDiv.appendChild(p);
+        ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`, elDiv);
 
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -481,7 +481,7 @@ class MultiChatUI {
                 assistantMsg = respBody["content"];
             }
         }
-        assistantMsg = du.trim_repeat_garbage_at_end(assistantMsg, 32);
+        assistantMsg = du.trim_repeat_garbage_at_end_loop(assistantMsg, 32, 72);
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -673,6 +673,16 @@ class Me {
     }
 
     /**
+     * Disable console.debug by mapping it to a empty function.
+     */
+    debug_disable() {
+        this.console_debug = console.debug;
+        console.debug = () => {
+
+        };
+    }
+
+    /**
      * Show the configurable parameters info in the passed Div element.
      * @param {HTMLDivElement} elDiv
      */
@@ -744,6 +754,7 @@ let gMe;
 function startme() {
     console.log("INFO:SimpleChat:StartMe:Starting...");
     gMe = new Me();
+    gMe.debug_disable();
     document["gMe"] = gMe;
     document["du"] = du;
     for (let cid of gMe.defaultChatIds) {

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -3,6 +3,7 @@
 // by Humans for All
 
 import * as du from "./datautils.mjs";
+import * as ui from "./ui.mjs"
 
 class Roles {
     static System = "system";
@@ -251,46 +252,6 @@ let gChatURL = {
 }
 
 
-/**
- * Set the class of the children, based on whether it is the idSelected or not.
- * @param {HTMLDivElement} elBase
- * @param {string} idSelected
- * @param {string} classSelected
- * @param {string} classUnSelected
- */
-function el_children_config_class(elBase, idSelected, classSelected, classUnSelected="") {
-    for(let child of elBase.children) {
-        if (child.id == idSelected) {
-            child.className = classSelected;
-        } else {
-            child.className = classUnSelected;
-        }
-    }
-}
-
-/**
- * Create button and set it up.
- * @param {string} id
- * @param {(this: HTMLButtonElement, ev: MouseEvent) => any} callback
- * @param {string | undefined} name
- * @param {string | undefined} innerText
- */
-function el_create_button(id, callback, name=undefined, innerText=undefined) {
-    if (!name) {
-        name = id;
-    }
-    if (!innerText) {
-        innerText = id;
-    }
-    let btn = document.createElement("button");
-    btn.id = id;
-    btn.name = name;
-    btn.innerText = innerText;
-    btn.addEventListener("click", callback);
-    return btn;
-}
-
-
 class MultiChatUI {
 
     constructor() {
@@ -503,7 +464,7 @@ class MultiChatUI {
         }
         elDiv.replaceChildren();
         // Btn for creating new chat session
-        let btnNew = el_create_button("New CHAT", (ev)=> {
+        let btnNew = ui.el_create_button("New CHAT", (ev)=> {
             if (this.elInUser.disabled) {
                 console.error(`ERRR:SimpleChat:MCUI:NewChat:Current session [${this.curChatId}] awaiting response, ignoring request...`);
                 alert("ERRR:SimpleChat\nMCUI:NewChat\nWait for response to pending query, before starting new chat session");
@@ -517,7 +478,7 @@ class MultiChatUI {
             }
             this.new_chat_session(chatIdGot, true);
             this.create_session_btn(elDiv, chatIdGot);
-            el_children_config_class(elDiv, chatIdGot, "session-selected", "");
+            ui.el_children_config_class(elDiv, chatIdGot, "session-selected", "");
         });
         elDiv.appendChild(btnNew);
         // Btns for existing chat sessions
@@ -531,7 +492,7 @@ class MultiChatUI {
     }
 
     create_session_btn(elDiv, cid) {
-        let btn = el_create_button(cid, (ev)=>{
+        let btn = ui.el_create_button(cid, (ev)=>{
             let target = /** @type{HTMLButtonElement} */(ev.target);
             console.debug(`DBUG:SimpleChat:MCUI:SessionClick:${target.id}`);
             if (this.elInUser.disabled) {
@@ -540,7 +501,7 @@ class MultiChatUI {
                 return;
             }
             this.handle_session_switch(target.id);
-            el_children_config_class(elDiv, target.id, "session-selected", "");
+            ui.el_children_config_class(elDiv, target.id, "session-selected", "");
         });
         elDiv.appendChild(btn);
         return btn;

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -134,6 +134,7 @@ class SimpleChat {
             if (bClear) {
                 div.innerHTML = gUsageMsg;
                 gMe.show_info(div);
+                gMe.show_settings(div);
             }
         }
     }
@@ -560,6 +561,24 @@ class Me {
         ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
 
         ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`, elDiv);
+
+    }
+
+    /**
+     * Show settings ui for configurable parameters, in the passed Div element.
+     * @param {HTMLDivElement} elDiv
+     */
+    show_settings(elDiv) {
+
+        let bb = ui.el_create_boolbutton("SetCompletionFreshChatAlways", {true: "[+] CompletionFreshChatAlways", false: "[-] CompletionFreshChatAlways"}, this.bCompletionFreshChatAlways, (val)=>{
+            this.bCompletionFreshChatAlways = val;
+        });
+        elDiv.appendChild(bb);
+
+        bb = ui.el_create_boolbutton("SetCompletionInsertStandardRolePrefix", {true: "[+] CompletionInsertStandardRolePrefix", false: "[-] CompletionInsertStandardRolePrefix"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
+            this.bCompletionInsertStandardRolePrefix = val;
+        });
+        elDiv.appendChild(bb);
 
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -150,6 +150,7 @@ class SimpleChat {
                 gMe.show_info(div);
             }
         }
+        return last;
     }
 
     /**
@@ -316,8 +317,10 @@ class SimpleChat {
      * Handle the multipart response from server/ai-model
      * @param {Response} resp
      * @param {string} apiEP
+     * @param {HTMLDivElement} elDiv
      */
-    async handle_response_multipart(resp, apiEP) {
+    async handle_response_multipart(resp, apiEP, elDiv) {
+        let elP = ui.el_create_append_p("", elDiv);
         if (!resp.body) {
             throw Error("ERRR:SimpleChat:SC:ReadJsonEarly:No body...");
         }
@@ -343,6 +346,8 @@ class SimpleChat {
                     gotBody += this.response_extract_stream(curJson, apiEP);
                 }
             }
+            elP.innerText = gotBody;
+            elP.scrollIntoView(false);
             if (done) {
                 break;
             }
@@ -367,15 +372,16 @@ class SimpleChat {
      * Also take care of the optional garbage trimming.
      * @param {Response} resp
      * @param {string} apiEP
+     * @param {HTMLDivElement} elDiv
      */
-    async handle_response(resp, apiEP) {
+    async handle_response(resp, apiEP, elDiv) {
         let theResp = {
             assistant: "",
             trimmed: "",
         }
         let origMsg;
         if (gMe.bStream) {
-            origMsg = await this.handle_response_multipart(resp, apiEP);
+            origMsg = await this.handle_response_multipart(resp, apiEP, elDiv);
         } else {
             origMsg = await this.handle_response_oneshot(resp, apiEP);
         }
@@ -546,7 +552,7 @@ class MultiChatUI {
             body: theBody,
         });
 
-        let theResp = await chat.handle_response(resp, apiEP);
+        let theResp = await chat.handle_response(resp, apiEP, this.elDivChat);
         chat.add(Roles.Assistant, theResp.assistant);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -579,6 +579,7 @@ class Me {
             "Last0": 1,
             "Last1": 2,
             "Last2": 3,
+            "Last4": 5,
         };
         this.apiEP = ApiEP.Type.Chat;
         // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -540,9 +540,9 @@ class Me {
         this.chatRequestOptions = {
             "temperature": 0.7,
             "max_tokens": 1024,
-            "frequency_penalty": 1.2,
-            "presence_penalty": 1.2,
-            "n_predict": 1024
+            "n_predict": 1024,
+            //"frequency_penalty": 1.2,
+            //"presence_penalty": 1.2,
         };
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -450,14 +450,15 @@ class MultiChatUI {
         }
         if (gMe.bTrimGarbage) {
             let origMsg = assistantMsg;
-            assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 8, 16, 72);
+            assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 8, 24, 72);
             trimmedMsg = origMsg.substring(assistantMsg.length);
         }
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);
             if (trimmedMsg.length > 0) {
-                ui.el_create_append_p(`TRIMMED:${trimmedMsg}`, this.elDivChat);
+                let p = ui.el_create_append_p(`TRIMMED:${trimmedMsg}`, this.elDivChat);
+                p.className="role-trim";
             }
         } else {
             console.debug(`DBUG:SimpleChat:MCUI:HandleUserSubmit:ChatId has changed:[${chatId}] [${this.curChatId}]`);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -576,17 +576,17 @@ class Me {
      */
     show_settings(elDiv) {
 
-        let bb = ui.el_create_boolbutton("SetCompletionFreshChatAlways", {true: "[+] CompletionFreshChatAlways", false: "[-] CompletionFreshChatAlways"}, this.bCompletionFreshChatAlways, (val)=>{
+        let bb = ui.el_creatediv_boolbutton("SetCompletionFreshChatAlways", "CompletionFreshChatAlways", {true: "[+] CompletionFreshChatAlways", false: "[-] CompletionFreshChatAlways"}, this.bCompletionFreshChatAlways, (val)=>{
             this.bCompletionFreshChatAlways = val;
         });
         elDiv.appendChild(bb);
 
-        bb = ui.el_create_boolbutton("SetCompletionInsertStandardRolePrefix", {true: "[+] CompletionInsertStandardRolePrefix", false: "[-] CompletionInsertStandardRolePrefix"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
+        bb = ui.el_creatediv_boolbutton("SetCompletionInsertStandardRolePrefix", "CompletionInsertStandardRolePrefix", {true: "[+] CompletionInsertStandardRolePrefix", false: "[-] CompletionInsertStandardRolePrefix"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
             this.bCompletionInsertStandardRolePrefix = val;
         });
         elDiv.appendChild(bb);
 
-        let sel = ui.el_create_select("SetChatHistoryInCtxt", this.sRecentUserMsgCnt, this.iRecentUserMsgCnt, (val)=>{
+        let sel = ui.el_creatediv_select("SetChatHistoryInCtxt", "ChatHistoryInCtxt", this.sRecentUserMsgCnt, this.iRecentUserMsgCnt, (val)=>{
             this.iRecentUserMsgCnt = this.sRecentUserMsgCnt[val];
         });
         elDiv.appendChild(sel);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -586,7 +586,7 @@ class Me {
         });
         elDiv.appendChild(bb);
 
-        let sel = ui.el_create_select("SetChatHistoryInCtxt", Object.keys(this.sRecentUserMsgCnt), "Last0", (val)=>{
+        let sel = ui.el_create_select("SetChatHistoryInCtxt", this.sRecentUserMsgCnt, this.iRecentUserMsgCnt, (val)=>{
             this.iRecentUserMsgCnt = this.sRecentUserMsgCnt[val];
         });
         elDiv.appendChild(sel);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -535,6 +535,12 @@ class Me {
         this.bCompletionFreshChatAlways = true;
         this.bCompletionInsertStandardRolePrefix = false;
         this.iRecentUserMsgCnt = 2;
+        this.sRecentUserMsgCnt = {
+            "Full": -1,
+            "Last0": 1,
+            "Last1": 2,
+            "Last2": 3,
+        };
         // Add needed fields wrt json object to be sent wrt LLM web services completions endpoint.
         this.chatRequestOptions = {
             "temperature": 0.7,
@@ -579,6 +585,11 @@ class Me {
             this.bCompletionInsertStandardRolePrefix = val;
         });
         elDiv.appendChild(bb);
+
+        let sel = ui.el_create_select("SetChatHistoryInCtxt", Object.keys(this.sRecentUserMsgCnt), "Last0", (val)=>{
+            this.iRecentUserMsgCnt = this.sRecentUserMsgCnt[val];
+        });
+        elDiv.appendChild(sel);
 
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -582,12 +582,12 @@ class Me {
      */
     show_settings(elDiv) {
 
-        let bb = ui.el_creatediv_boolbutton("SetCompletionFreshChatAlways", "CompletionFreshChatAlways", {true: "[+] CompletionFreshChatAlways", false: "[-] CompletionFreshChatAlways"}, this.bCompletionFreshChatAlways, (val)=>{
+        let bb = ui.el_creatediv_boolbutton("SetCompletionFreshChatAlways", "CompletionFreshChatAlways", {true: "[+] yes fresh", false: "[-] no, with history"}, this.bCompletionFreshChatAlways, (val)=>{
             this.bCompletionFreshChatAlways = val;
         });
         elDiv.appendChild(bb);
 
-        bb = ui.el_creatediv_boolbutton("SetCompletionInsertStandardRolePrefix", "CompletionInsertStandardRolePrefix", {true: "[+] CompletionInsertStandardRolePrefix", false: "[-] CompletionInsertStandardRolePrefix"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
+        bb = ui.el_creatediv_boolbutton("SetCompletionInsertStandardRolePrefix", "CompletionInsertStandardRolePrefix", {true: "[+] yes insert", false: "[-] dont insert"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
             this.bCompletionInsertStandardRolePrefix = val;
         });
         elDiv.appendChild(bb);

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -228,7 +228,7 @@ class SimpleChat {
         }
         if (gMe.bTrimGarbage) {
             let origMsg = theResp.assistant;
-            theResp.assistant = du.trim_hist_garbage_at_end_loop(theResp.assistant, 8, 24, 72);
+            theResp.assistant = du.trim_garbage_at_end(theResp.assistant);
             theResp.trimmed = origMsg.substring(theResp.assistant.length);
         }
         return theResp;

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -438,6 +438,7 @@ class MultiChatUI {
         //let respBody = await this.read_json_early(resp);
         console.debug(`DBUG:SimpleChat:MCUI:${chatId}:HandleUserSubmit:RespBody:${JSON.stringify(respBody)}`);
         let assistantMsg;
+        let trimmedMsg = "";
         if (apiEP == ApiEP.Chat) {
             assistantMsg = respBody["choices"][0]["message"]["content"];
         } else {
@@ -447,10 +448,17 @@ class MultiChatUI {
                 assistantMsg = respBody["content"];
             }
         }
-        assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 8, 16, 72);
+        if (gMe.bTrimGarbage) {
+            let origMsg = assistantMsg;
+            assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 8, 16, 72);
+            trimmedMsg = origMsg.substring(assistantMsg.length);
+        }
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);
+            if (trimmedMsg.length > 0) {
+                ui.el_create_append_p(`TRIMMED:${trimmedMsg}`, this.elDivChat);
+            }
         } else {
             console.debug(`DBUG:SimpleChat:MCUI:HandleUserSubmit:ChatId has changed:[${chatId}] [${this.curChatId}]`);
         }
@@ -540,6 +548,7 @@ class Me {
         this.multiChat = new MultiChatUI();
         this.bCompletionFreshChatAlways = true;
         this.bCompletionInsertStandardRolePrefix = false;
+        this.bTrimGarbage = true;
         this.iRecentUserMsgCnt = 2;
         this.sRecentUserMsgCnt = {
             "Full": -1,
@@ -570,6 +579,8 @@ class Me {
 
         ui.el_create_append_p(`bCompletionInsertStandardRolePrefix:${this.bCompletionInsertStandardRolePrefix}`, elDiv);
 
+        ui.el_create_append_p(`bTrimGarbage:${this.bTrimGarbage}`, elDiv);
+
         ui.el_create_append_p(`iRecentUserMsgCnt:${this.iRecentUserMsgCnt}`, elDiv);
 
         ui.el_create_append_p(`chatRequestOptions:${JSON.stringify(this.chatRequestOptions)}`, elDiv);
@@ -589,6 +600,11 @@ class Me {
 
         bb = ui.el_creatediv_boolbutton("SetCompletionInsertStandardRolePrefix", "CompletionInsertStandardRolePrefix", {true: "[+] yes insert", false: "[-] dont insert"}, this.bCompletionInsertStandardRolePrefix, (val)=>{
             this.bCompletionInsertStandardRolePrefix = val;
+        });
+        elDiv.appendChild(bb);
+
+        bb = ui.el_creatediv_boolbutton("SetTrimGarbage", "TrimGarbage", {true: "[+] yes trim", false: "[-] dont trim"}, this.bTrimGarbage, (val)=>{
+            this.bTrimGarbage = val;
         });
         elDiv.appendChild(bb);
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -481,7 +481,7 @@ class MultiChatUI {
                 assistantMsg = respBody["content"];
             }
         }
-        assistantMsg = du.trim_repeat_garbage_at_end_loop(assistantMsg, 32, 72);
+        assistantMsg = du.trim_hist_garbage_at_end_loop(assistantMsg, 12, 72);
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);
@@ -623,6 +623,7 @@ function startme() {
     console.log("INFO:SimpleChat:StartMe:Starting...");
     gMe = new Me();
     document["gMe"] = gMe;
+    document["du"] = du;
     for (let cid of gMe.defaultChatIds) {
         gMe.multiChat.new_chat_session(cid);
     }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -330,11 +330,13 @@ class SimpleChat {
         let xLines = new du.NewLines();
         while(true) {
             let { value: cur,  done: done } = await rr.read();
-            let curBody = tdUtf8.decode(cur);
-            console.debug("DBUG:SC:PART:Str:", curBody);
-            xLines.add_append(curBody);
+            if (cur) {
+                let curBody = tdUtf8.decode(cur, {stream: true});
+                console.debug("DBUG:SC:PART:Str:", curBody);
+                xLines.add_append(curBody);
+            }
             while(true) {
-                let curLine = xLines.shift();
+                let curLine = xLines.shift(!done);
                 if (curLine == undefined) {
                     break;
                 }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -2,6 +2,8 @@
 // A simple completions and chat/completions test related web front end logic
 // by Humans for All
 
+import * as du from "./datautils.mjs";
+
 class Roles {
     static System = "system";
     static User = "user";
@@ -479,6 +481,7 @@ class MultiChatUI {
                 assistantMsg = respBody["content"];
             }
         }
+        assistantMsg = du.trim_repeat_garbage_at_end(assistantMsg, 32);
         chat.add(Roles.Assistant, assistantMsg);
         if (chatId == this.curChatId) {
             chat.show(this.elDivChat);
@@ -619,6 +622,7 @@ let gMe;
 function startme() {
     console.log("INFO:SimpleChat:StartMe:Starting...");
     gMe = new Me();
+    document["gMe"] = gMe;
     for (let cid of gMe.defaultChatIds) {
         gMe.multiChat.new_chat_session(cid);
     }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -766,6 +766,9 @@ class Me {
      * @param {SimpleChat} chat
      */
     setup_load(div, chat) {
+        if (!(chat.ods_key() in localStorage)) {
+            return;
+        }
         div.innerHTML += `<p class="role-system">Restore</p>
         <p>Load previously saved chat session, if available</p>`;
         let btn = ui.el_create_button(chat.ods_key(), (ev)=>{

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -189,6 +189,15 @@ class SimpleChat {
         } else {
             if (bClear) {
                 div.innerHTML = gUsageMsg;
+                div.innerHTML += `<p class="role-system">Restore</p>`;
+                let btn = ui.el_create_button(this.ods_key(), (ev)=>{
+                    console.log("DBUG:SimpleChat:SC:Load", this);
+                    this.load();
+                    queueMicrotask(()=>{
+                        this.show(div);
+                    });
+                });
+                div.appendChild(btn);
                 gMe.show_info(div);
             }
         }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -189,15 +189,7 @@ class SimpleChat {
         } else {
             if (bClear) {
                 div.innerHTML = gUsageMsg;
-                div.innerHTML += `<p class="role-system">Restore</p>`;
-                let btn = ui.el_create_button(this.ods_key(), (ev)=>{
-                    console.log("DBUG:SimpleChat:SC:Load", this);
-                    this.load();
-                    queueMicrotask(()=>{
-                        this.show(div);
-                    });
-                });
-                div.appendChild(btn);
+                gMe.setup_load(div, this);
                 gMe.show_info(div);
             }
         }
@@ -766,6 +758,25 @@ class Me {
         console.debug = () => {
 
         };
+    }
+
+    /**
+     * Setup the load saved chat ui.
+     * @param {HTMLDivElement} div
+     * @param {SimpleChat} chat
+     */
+    setup_load(div, chat) {
+        div.innerHTML += `<p class="role-system">Restore</p>
+        <p>Load previously saved chat session, if available</p>`;
+        let btn = ui.el_create_button(chat.ods_key(), (ev)=>{
+            console.log("DBUG:SimpleChat:SC:Load", chat);
+            chat.load();
+            queueMicrotask(()=>{
+                chat.show(div);
+                this.multiChat.elInSystem.value = chat.get_system_latest();
+            });
+        });
+        div.appendChild(btn);
     }
 
     /**

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -78,14 +78,18 @@ class SimpleChat {
         this.iLastSys = -1;
     }
 
+    ods_key() {
+        return `SimpleChat-${this.chatId}`
+    }
+
     save() {
         /** @type {SimpleChatODS} */
         let ods = {iLastSys: this.iLastSys, xchat: this.xchat};
-        localStorage.setItem(this.chatId, JSON.stringify(ods));
+        localStorage.setItem(this.ods_key(), JSON.stringify(ods));
     }
 
     load() {
-        let sods = localStorage.getItem(this.chatId);
+        let sods = localStorage.getItem(this.ods_key());
         if (sods == null) {
             return;
         }

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -55,6 +55,8 @@ let gUsageMsg = `
 
 /** @typedef {{role: string, content: string}[]} ChatMessages */
 
+/** @typedef {{iLastSys: number, xchat: ChatMessages}} SimpleChatODS */
+
 class SimpleChat {
 
     /**
@@ -74,6 +76,23 @@ class SimpleChat {
     clear() {
         this.xchat = [];
         this.iLastSys = -1;
+    }
+
+    save() {
+        /** @type {SimpleChatODS} */
+        let ods = {iLastSys: this.iLastSys, xchat: this.xchat};
+        localStorage.setItem(this.chatId, JSON.stringify(ods));
+    }
+
+    load() {
+        let sods = localStorage.getItem(this.chatId);
+        if (sods == null) {
+            return;
+        }
+        /** @type {SimpleChatODS} */
+        let ods = JSON.parse(sods);
+        this.iLastSys = ods.iLastSys;
+        this.xchat = ods.xchat;
     }
 
     /**
@@ -142,6 +161,7 @@ class SimpleChat {
         if (role == Roles.System) {
             this.iLastSys = this.xchat.length - 1;
         }
+        this.save();
         return true;
     }
 

--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -818,6 +818,37 @@ class Me {
     }
 
     /**
+     * Auto create ui input elements for fields in ChatRequestOptions
+     * Currently supports text and number field types.
+     * @param {HTMLDivElement} elDiv
+     */
+    show_settings_chatrequestoptions(elDiv) {
+        let typeDict = {
+            "string": "text",
+            "number": "number",
+        };
+        let fs = document.createElement("fieldset");
+        let legend = document.createElement("legend");
+        legend.innerText = "ChatRequestOptions";
+        fs.appendChild(legend);
+        elDiv.appendChild(fs);
+        for(const k in this.chatRequestOptions) {
+            let val = this.chatRequestOptions[k];
+            let type = typeof(val);
+            if (!((type == "string") || (type == "number"))) {
+                continue;
+            }
+            let inp = ui.el_creatediv_input(`Set${k}`, k, typeDict[type], this.chatRequestOptions[k], (val)=>{
+                if (type == "number") {
+                    val = Number(val);
+                }
+                this.chatRequestOptions[k] = val;
+            });
+            fs.appendChild(inp.div);
+        }
+    }
+
+    /**
      * Show settings ui for configurable parameters, in the passed Div element.
      * @param {HTMLDivElement} elDiv
      */
@@ -832,11 +863,6 @@ class Me {
             this.headers["Authorization"] = val;
         });
         inp.el.placeholder = "Bearer OPENAI_API_KEY";
-        elDiv.appendChild(inp.div);
-
-        inp = ui.el_creatediv_input("SetModel", "Model", "text", this.chatRequestOptions["model"], (val)=>{
-            this.chatRequestOptions["model"] = val;
-        });
         elDiv.appendChild(inp.div);
 
         let bb = ui.el_creatediv_boolbutton("SetStream", "Stream", {true: "[+] yes stream", false: "[-] do oneshot"}, this.bStream, (val)=>{
@@ -868,6 +894,8 @@ class Me {
             this.apiEP = ApiEP.Type[val];
         });
         elDiv.appendChild(sel.div);
+
+        this.show_settings_chatrequestoptions(elDiv);
 
     }
 

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -161,3 +161,45 @@ export function el_creatediv_select(id, label, options, defaultOption, cb) {
     div.appendChild(sel);
     return div;
 }
+
+
+/**
+ * Create a input ui element.
+ *
+ * @param {string} id
+ * @param {string} type
+ * @param {any} defaultValue
+ * @param {function(any):void} cb
+ */
+export function el_create_input(id, type, defaultValue, cb) {
+    let el = document.createElement("input");
+    el.type = type;
+    el.value = defaultValue;
+    if (id) {
+        el.id = id;
+    }
+    el.addEventListener('change', (ev)=>{
+        cb(el.value);
+    })
+    return el;
+}
+
+/**
+ * Create a div wrapped button which represents bool value using specified text wrt true and false.
+ *
+ * @param {string} id
+ * @param {string} label
+ * @param {string} type
+ * @param {any} defaultValue
+ * @param {function(any):void} cb
+ */
+export function el_creatediv_input(id, label, type, defaultValue, cb) {
+    let div = document.createElement("div");
+    let lbl = document.createElement("label");
+    lbl.setAttribute("for", id);
+    lbl.innerText = label;
+    div.appendChild(lbl);
+    let el = el_create_input(id, type, defaultValue, cb);
+    div.appendChild(el);
+    return div;
+}

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -100,9 +100,9 @@ export function el_creatediv_boolbutton(id, label, texts, defaultValue, cb) {
     lbl.setAttribute("for", id);
     lbl.innerText = label;
     div.appendChild(lbl);
-    let sel = el_create_boolbutton(id, texts, defaultValue, cb);
-    div.appendChild(sel);
-    return div;
+    let btn = el_create_boolbutton(id, texts, defaultValue, cb);
+    div.appendChild(btn);
+    return { div: div, el: btn };
 }
 
 
@@ -159,7 +159,7 @@ export function el_creatediv_select(id, label, options, defaultOption, cb) {
     div.appendChild(lbl);
     let sel = el_create_select(id, options,defaultOption, cb);
     div.appendChild(sel);
-    return div;
+    return { div: div, el: sel };
 }
 
 
@@ -185,7 +185,7 @@ export function el_create_input(id, type, defaultValue, cb) {
 }
 
 /**
- * Create a div wrapped button which represents bool value using specified text wrt true and false.
+ * Create a div wrapped input.
  *
  * @param {string} id
  * @param {string} label
@@ -201,5 +201,5 @@ export function el_creatediv_input(id, label, type, defaultValue, cb) {
     div.appendChild(lbl);
     let el = el_create_input(id, type, defaultValue, cb);
     div.appendChild(el);
-    return div;
+    return { div: div, el: el };
 }

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -93,9 +93,11 @@ export function el_create_boolbutton(id, texts, defaultValue, cb) {
  * @param {{ true: string; false: string; }} texts
  * @param {boolean} defaultValue
  * @param {(arg0: boolean) => void} cb
+ * @param {string} className
  */
-export function el_creatediv_boolbutton(id, label, texts, defaultValue, cb) {
+export function el_creatediv_boolbutton(id, label, texts, defaultValue, cb, className="gridx2") {
     let div = document.createElement("div");
+    div.className = className;
     let lbl = document.createElement("label");
     lbl.setAttribute("for", id);
     lbl.innerText = label;
@@ -150,9 +152,11 @@ export function el_create_select(id, options, defaultOption, cb) {
  * @param {{ [x: string]: any; }} options
  * @param {any} defaultOption
  * @param {(arg0: string) => void} cb
+ * @param {string} className
  */
-export function el_creatediv_select(id, label, options, defaultOption, cb) {
+export function el_creatediv_select(id, label, options, defaultOption, cb, className="gridx2") {
     let div = document.createElement("div");
+    div.className = className;
     let lbl = document.createElement("label");
     lbl.setAttribute("for", id);
     lbl.innerText = label;
@@ -192,9 +196,11 @@ export function el_create_input(id, type, defaultValue, cb) {
  * @param {string} type
  * @param {any} defaultValue
  * @param {function(any):void} cb
+ * @param {string} className
  */
-export function el_creatediv_input(id, label, type, defaultValue, cb) {
+export function el_creatediv_input(id, label, type, defaultValue, cb, className="gridx2") {
     let div = document.createElement("div");
+    div.className = className;
     let lbl = document.createElement("label");
     lbl.setAttribute("for", id);
     lbl.innerText = label;

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -83,3 +83,34 @@ export function el_create_boolbutton(id, texts, defaultValue, cb) {
     })
     return el;
 }
+
+/**
+ * @param {string} id
+ * @param {string[]} options
+ * @param {string} defaultOption
+ * @param {function(string):void} cb
+ */
+export function el_create_select(id, options, defaultOption, cb) {
+    let el = document.createElement("select");
+    el["xselected"] = defaultOption;
+    el["xoptions"] = structuredClone(options);
+    for(let cur of options) {
+        let op = document.createElement("option");
+        op.value = cur;
+        op.innerText = cur;
+        if (cur == defaultOption) {
+            op.selected = true;
+        }
+        el.appendChild(op);
+    }
+    if (id) {
+        el.id = id;
+        el.name = id;
+    }
+    el.addEventListener('click', (ev)=>{
+        let target = /** @type{HTMLSelectElement} */(ev.target);
+        console.log("DBUG:UI:Select:", id, ":", target.value);
+        cb(target.value);
+    })
+    return el;
+}

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -86,19 +86,19 @@ export function el_create_boolbutton(id, texts, defaultValue, cb) {
 
 /**
  * @param {string} id
- * @param {string[]} options
- * @param {string} defaultOption
+ * @param {Object<string,*>} options
+ * @param {*} defaultOption
  * @param {function(string):void} cb
  */
 export function el_create_select(id, options, defaultOption, cb) {
     let el = document.createElement("select");
     el["xselected"] = defaultOption;
     el["xoptions"] = structuredClone(options);
-    for(let cur of options) {
+    for(let cur of Object.keys(options)) {
         let op = document.createElement("option");
         op.value = cur;
         op.innerText = cur;
-        if (cur == defaultOption) {
+        if (options[cur] == defaultOption) {
             op.selected = true;
         }
         el.appendChild(op);
@@ -107,7 +107,7 @@ export function el_create_select(id, options, defaultOption, cb) {
         el.id = id;
         el.name = id;
     }
-    el.addEventListener('click', (ev)=>{
+    el.addEventListener('change', (ev)=>{
         let target = /** @type{HTMLSelectElement} */(ev.target);
         console.log("DBUG:UI:Select:", id, ":", target.value);
         cb(target.value);

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -42,3 +42,21 @@ export function el_create_button(id, callback, name=undefined, innerText=undefin
     btn.addEventListener("click", callback);
     return btn;
 }
+
+/**
+ * Create a para and set it up. Optionaly append it to a passed parent.
+ * @param {string} text
+ * @param {HTMLElement | undefined} elParent
+ * @param {string | undefined} id
+ */
+export function el_create_append_p(text, elParent=undefined, id=undefined) {
+    let para = document.createElement("p");
+    para.innerText = text;
+    if (id) {
+        para.id = id;
+    }
+    if (elParent) {
+        elParent.appendChild(para);
+    }
+    return para;
+}

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -1,0 +1,44 @@
+//@ts-check
+// Helpers to work with html elements
+// by Humans for All
+//
+
+
+/**
+ * Set the class of the children, based on whether it is the idSelected or not.
+ * @param {HTMLDivElement} elBase
+ * @param {string} idSelected
+ * @param {string} classSelected
+ * @param {string} classUnSelected
+ */
+export function el_children_config_class(elBase, idSelected, classSelected, classUnSelected="") {
+    for(let child of elBase.children) {
+        if (child.id == idSelected) {
+            child.className = classSelected;
+        } else {
+            child.className = classUnSelected;
+        }
+    }
+}
+
+/**
+ * Create button and set it up.
+ * @param {string} id
+ * @param {(this: HTMLButtonElement, ev: MouseEvent) => any} callback
+ * @param {string | undefined} name
+ * @param {string | undefined} innerText
+ */
+export function el_create_button(id, callback, name=undefined, innerText=undefined) {
+    if (!name) {
+        name = id;
+    }
+    if (!innerText) {
+        innerText = id;
+    }
+    let btn = document.createElement("button");
+    btn.id = id;
+    btn.name = name;
+    btn.innerText = innerText;
+    btn.addEventListener("click", callback);
+    return btn;
+}

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -62,7 +62,9 @@ export function el_create_append_p(text, elParent=undefined, id=undefined) {
 }
 
 /**
- * Create a para and set it up. Optionaly append it to a passed parent.
+ * Create a button which represents bool value using specified text wrt true and false.
+ * When ever user clicks the button, it will toggle the value and update the shown text.
+ *
  * @param {string} id
  * @param {{true: string, false: string}} texts
  * @param {boolean} defaultValue
@@ -85,6 +87,31 @@ export function el_create_boolbutton(id, texts, defaultValue, cb) {
 }
 
 /**
+ * Create a div wrapped button which represents bool value using specified text wrt true and false.
+ * @param {string} id
+ * @param {string} label
+ * @param {{ true: string; false: string; }} texts
+ * @param {boolean} defaultValue
+ * @param {(arg0: boolean) => void} cb
+ */
+export function el_creatediv_boolbutton(id, label, texts, defaultValue, cb) {
+    let div = document.createElement("div");
+    let lbl = document.createElement("label");
+    lbl.setAttribute("for", id);
+    lbl.innerText = label;
+    div.appendChild(lbl);
+    let sel = el_create_boolbutton(id, texts, defaultValue, cb);
+    div.appendChild(sel);
+    return div;
+}
+
+
+/**
+ * Create a select ui element, with a set of options to select from.
+ * * options: an object which contains name-value pairs
+ * * defaultOption: the value whose name should be choosen, by default.
+ * * cb : the call back returns the name string of the option selected.
+ *
  * @param {string} id
  * @param {Object<string,*>} options
  * @param {*} defaultOption
@@ -113,4 +140,24 @@ export function el_create_select(id, options, defaultOption, cb) {
         cb(target.value);
     })
     return el;
+}
+
+/**
+ * Create a div wrapped select ui element, with a set of options to select from.
+ *
+ * @param {string} id
+ * @param {any} label
+ * @param {{ [x: string]: any; }} options
+ * @param {any} defaultOption
+ * @param {(arg0: string) => void} cb
+ */
+export function el_creatediv_select(id, label, options, defaultOption, cb) {
+    let div = document.createElement("div");
+    let lbl = document.createElement("label");
+    lbl.setAttribute("for", id);
+    lbl.innerText = label;
+    div.appendChild(lbl);
+    let sel = el_create_select(id, options,defaultOption, cb);
+    div.appendChild(sel);
+    return div;
 }

--- a/examples/server/public_simplechat/ui.mjs
+++ b/examples/server/public_simplechat/ui.mjs
@@ -60,3 +60,26 @@ export function el_create_append_p(text, elParent=undefined, id=undefined) {
     }
     return para;
 }
+
+/**
+ * Create a para and set it up. Optionaly append it to a passed parent.
+ * @param {string} id
+ * @param {{true: string, false: string}} texts
+ * @param {boolean} defaultValue
+ * @param {function(boolean):void} cb
+ */
+export function el_create_boolbutton(id, texts, defaultValue, cb) {
+    let el = document.createElement("button");
+    el["xbool"] = defaultValue;
+    el["xtexts"] = structuredClone(texts);
+    el.innerText = el["xtexts"][String(defaultValue)];
+    if (id) {
+        el.id = id;
+    }
+    el.addEventListener('click', (ev)=>{
+        el["xbool"] = !el["xbool"];
+        el.innerText = el["xtexts"][String(el["xbool"])];
+        cb(el["xbool"]);
+    })
+    return el;
+}


### PR DESCRIPTION
### garbage trimming

Given the limited context size of local LLMs and , many a times when context gets filled between the prompt and the response, it can lead to repeating text garbage generation. And many a times setting penalty wrt repeatation leads to over-intelligent garbage repeatation with slight variations. These garbage inturn leads to overloading of the available model context, leading to less valuable response for subsequent prompts/queries, if chat history is sent to ai model.

So two simple minded garbage trimming logics are tried.
* one based on progressively-larger-substring-based-repeat-matching-with-partial-skip and
* another based on char-histogram/freq-driven garbage trimming.

The char-histogram driven one is a bit more flexible in that it allows for some variations in the repeatation. It tracks the chars and their frequency in a specified length of substring at the end of the generated text and inturn checks if moving further into the generated text from the end remains within the same char subset or goes beyond it and based on that either trims the string at the end or not. This allows to filter garbage at the end, including even if there are certain kind of small variations in the repeated text wrt position of seen chars.

The repeat-matching based trimming can be let loose on longer substring based probing, given its more well defined characteristics.


### settings ui

a simple ui is added to change some of the behaviour, without needing to open the browser's devel-tool/console.

Setting the option ChatHistoryInCtxt to Last0, stops any chat history from being sent to the server/ai-model, thus ensuring that the response is purely based on the set system-prompt and the current-query.

Keeping ChatHistoryInCtxt to the default "Last1" mode and bTrimGarbage to the default enabled state, can many a times allow the user to recover/continue the previous large response with garbage at the end, from the part where the garbage is automatically removed, by requesting the ai to continue the last response like "please continue" or so.


### Streaming mode

Allow user to set between oneshot (at the end) and streamed viewing (as it is being generated) of ai-model generative text response. The streaming mode pushes more packets over the network, but at the same time it allows one to view the response, as it is being generated. For long responses, this allows the user to view the response as it is becoming available, instead of having to wait till the end of response generation.


### OpenAi Compat

The basic skeleton is implement to chat with a openai/equivalent (including llama.cpp's) server, at a basic level.


### Save/Restore

Auto saves chat session locally using browser's localStorage, as the chat is occuring. Inturn on a fresh start, the option is given to restore a previously saved corresponding chat session.


### ChatRequestOptions auto Settings UI

String/Numeric fields (including any added by user at runtime) in gMe.chatRequestOptions will get entries in Settings UI automatically.


### cleanup/structure

Move to a multi file based js code structure, so that some of the helpers can be moved into their own files. Also bring in bit more of the request and response handling into SimpleChat class itself.

