### PR TITLE
faster avx512 exp implementation

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2317,9 +2317,9 @@ inline static __m512 ggml_v_expf(__m512 x) {
 
   // with the reduced range, we can use a min-maxed polynomial to calculate `e^r`.
   const __m512 expr =_mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(
-    _mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(0x1.a1d714p-13, x, 0x1.6dd982p-10),
-    x, 0x1.126facp-7), x, 0x1.55541cp-5), x, 0x1.555404p-3), x, 0x1p-1), x, 0x1p+0),
-    x, 0x1p+0); 
+    _mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(0x1.a1d714p-13, r, 0x1.6dd982p-10),
+    r, 0x1.126facp-7), r, 0x1.55541cp-5), r, 0x1.555404p-3), r, 0x1p-1), r, 0x1p+0),
+    r, 0x1p+0); 
   // exp(x) = exp(r + intc/log_2(e)) = exp(r)*exp(intc*log(2)) = exp(r)*pow(2,intc)
   return _mm512_scalef_ps(expr, intc);
 }

--- a/ggml.c
+++ b/ggml.c
@@ -2309,11 +2309,10 @@ inline static __m512 ggml_v_expf(__m512 x) {
   const __m512 b =
       _mm512_fnmadd_ps(n, _mm512_set1_ps(0x1.7f7d1cp-20f),
                        _mm512_fnmadd_ps(n, _mm512_set1_ps(0x1.62e4p-1f), x));
-  const __m512i e = _mm512_slli_epi32(_mm512_castps_si512(z), 23);
   const __mmask16 d =
       _mm512_cmp_ps_mask(_mm512_abs_ps(n), _mm512_set1_ps(192), _CMP_GT_OQ);
   const __m512 u = _mm512_mul_ps(b, b);
-  const __m512 jplus1 = _mm512_fmadd_ps(
+  const __m512 j = _mm512_fmadd_ps(
       _mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_set1_ps(0x1.0e4020p-7f), b,
                                       _mm512_set1_ps(0x1.573e2ep-5f)),
                       u,
@@ -2321,13 +2320,13 @@ inline static __m512 ggml_v_expf(__m512 x) {
                                       _mm512_set1_ps(0x1.fffdb6p-2f))),
       u,
       _mm512_fmadd_ps(_mm512_set1_ps(0x1.ffffecp-1f), b, _mm512_set1_ps(1.0F)));
-  const __m512 kjk = _mm512_scalef_ps(jplus1, n);
+  const __m512 res = _mm512_scalef_ps(j, n);
   if (_mm512_kortestz(d, d))
-    return kjk;
+    return res;
   const __m512 zero = _mm512_setzero_ps();
   const __m512 alt = _mm512_mask_blend_ps(
       _mm512_cmp_ps_mask(n, zero, _CMP_LE_OQ), _mm512_set1_ps(INFINITY), zero);
-  return _mm512_mask_blend_ps(d, kjk, alt);
+  return _mm512_mask_blend_ps(d, res, alt);
 }
 
 // computes silu x/(1+exp(-x)) in single precision vector

--- a/ggml.c
+++ b/ggml.c
@@ -2303,25 +2303,31 @@ inline static float32x4_t ggml_v_silu(float32x4_t x) {
 // numbers above 88.38 will flush to infinity
 // numbers beneath -103.97 will flush to zero
 inline static __m512 ggml_v_expf(__m512 x) {
-  // large constant that rounds `float`s; floats are 1 apart at this magnitude
-  const __m512 round = _mm512_set1_ps(0x1.8p+23);
-  // these `float`s are integer-valued due to +/- `round`
-  // intc = round(log_2(e) * x)
-  const __m512 intc =_mm512_sub_ps(fma(x, _mm512_set1_ps(0x1.715476p+0), round), round);
-  // r = x - intc / log_2(e)
-  // To attain the needed accuracy, we do this using both the hi and low parts
-  // of `(-1 / log_2(e))` = -log(2), i.e. fma(lo, intc, fma(hi, intc, x));
-  // r is in the range [-lcg(2)/2, log(2)/2).
-  const __m512 r = _mm512_fmadd_ps(_mm512_set1_ps(0x1.05c61p-29), intc,
-                                   _mm512_fmadd_ps(_mm512_set1_ps(-0x1.62e43p-1), intc, x));
-
-  // with the reduced range, we can use a min-maxed polynomial to calculate `e^r`.
-  const __m512 expr =_mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(
-    _mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_fmadd_ps(0x1.a1d714p-13, r, 0x1.6dd982p-10),
-    r, 0x1.126facp-7), r, 0x1.55541cp-5), r, 0x1.555404p-3), r, 0x1p-1), r, 0x1p+0),
-    r, 0x1p+0); 
-  // exp(x) = exp(r + intc/log_2(e)) = exp(r)*exp(intc*log(2)) = exp(r)*pow(2,intc)
-  return _mm512_scalef_ps(expr, intc);
+  const __m512 r = _mm512_set1_ps(0x1.8p23f);
+  const __m512 z = _mm512_fmadd_ps(x, _mm512_set1_ps(0x1.715476p+0f), r);
+  const __m512 n = _mm512_sub_ps(z, r);
+  const __m512 b =
+      _mm512_fnmadd_ps(n, _mm512_set1_ps(0x1.7f7d1cp-20f),
+                       _mm512_fnmadd_ps(n, _mm512_set1_ps(0x1.62e4p-1f), x));
+  const __m512i e = _mm512_slli_epi32(_mm512_castps_si512(z), 23);
+  const __mmask16 d =
+      _mm512_cmp_ps_mask(_mm512_abs_ps(n), _mm512_set1_ps(192), _CMP_GT_OQ);
+  const __m512 u = _mm512_mul_ps(b, b);
+  const __m512 jplus1 = _mm512_fmadd_ps(
+      _mm512_fmadd_ps(_mm512_fmadd_ps(_mm512_set1_ps(0x1.0e4020p-7f), b,
+                                      _mm512_set1_ps(0x1.573e2ep-5f)),
+                      u,
+                      _mm512_fmadd_ps(_mm512_set1_ps(0x1.555e66p-3f), b,
+                                      _mm512_set1_ps(0x1.fffdb6p-2f))),
+      u,
+      _mm512_fmadd_ps(_mm512_set1_ps(0x1.ffffecp-1f), b, _mm512_set1_ps(1.0F)));
+  const __m512 kjk = _mm512_scalef_ps(jplus1, n);
+  if (_mm512_kortestz(d, d))
+    return kjk;
+  const __m512 zero = _mm512_setzero_ps();
+  const __m512 alt = _mm512_mask_blend_ps(
+      _mm512_cmp_ps_mask(n, zero, _CMP_LE_OQ), _mm512_set1_ps(INFINITY), zero);
+  return _mm512_mask_blend_ps(d, kjk, alt);
 }
 
 // computes silu x/(1+exp(-x)) in single precision vector


### PR DESCRIPTION
@jart do you have accuracy, edge case, and performance tests to run?

I added comments explaining the algorithm.

I also have a C++ implementation here https://github.com/chriselrod/ExpAVX512
The C++ implementation allows for unrolling and interleaving in loops, showing this can yield substantial performance benefits
```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations CACHE-MISSES     CYCLES INSTRUCTIONS
-----------------------------------------------------------------------------------------------------------------
BM_simd_exp_run<16, 1>/4096              783 ns          781 ns       885101     109.592u   3.04656k       4.872k
BM_simd_exp_run<16, 4>/4096              597 ns          596 ns      1191770     11.7472u   2.33025k       4.301k
```
When running on vectors of length 4096, unrolling by 4x increased perf from 783ns -> 597ns on my 10980xe.
If trying to maximize performance, it'd also be worth considering if you can somehow use `exp2` instead of `exp`. Note that mathematically `exp(x) = exp2(log2(e)*x)`. This isn't true numerically, but it could for example be possible to fold the `*log2(e)` in with another scaling if there was one. Or maybe it's possible to compensate for that error in a way I couldn't figure out. It seems like it'd be oversight to introduce a `vreduce` instruction but have it only be useful for computing the reduction in `exp2`, so I suspect there's just something I'm missing there.

You should also double check the loops where this is called to make sure everything is inlined so that the many constants can be hoisted out.