### PR TITLE
vulkan: initialize devices properly for LLAMA_SPLIT_MODE_NONE

### DIFF
--- a/ggml-vulkan.cpp
+++ b/ggml-vulkan.cpp
@@ -6012,6 +6012,8 @@ static ggml_backend_buffer_type_i ggml_backend_vk_buffer_type_interface = {
 };
 
 GGML_CALL ggml_backend_buffer_type_t ggml_backend_vk_buffer_type(size_t dev_num) {
+    ggml_vk_instance_init();
+
 #ifdef GGML_VULKAN_DEBUG
     std::cerr << "ggml_backend_vk_buffer_type(" << dev_num << ")" << std::endl;
 #endif


### PR DESCRIPTION
Before the change, split mode "none" doesn't work for vulkan because it is not properly initialized before offload:
```
.\bin\main.exe -m "C:\Users\adriankhl\git\models\Meta-Llama-3-8B-Instruct.Q5_K_M.gguf" --prompt "hello" -sm "none"
```
gives an error.


This is because vulkan backend is initialized here
https://github.com/ggerganov/llama.cpp/blob/d6ef0e77dd25f54fb5856af47e3926cf6f36c281/ggml-vulkan.cpp#L6014-L6024
which is being called in `llama_get_device_count`, and `llama_get_device_count` is not being called when split mode is "none"
 
~~This PR make `llm_load_tensors` to call `llama_get_device_count` even when split mode is "none".~~

~~Something worth thinking about, is relying on `llama_get_device_count` to initialize vulkan backend a good idea? Feels like this is a bit cryptic.~~