### PR TITLE
fix performance regression on woa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
     set(INS_ENB ON)
 endif()
 
+option(LLAMA_LSE_ATOMICS                     "llama: enable LSE atomics"                        ON)
 option(LLAMA_SVE                             "llama: enable SVE"                                OFF)
 option(LLAMA_AVX                             "llama: enable AVX"                                ${INS_ENB})
 option(LLAMA_AVX2                            "llama: enable AVX2"                               ${INS_ENB})
@@ -1001,6 +1002,10 @@ if (CMAKE_OSX_ARCHITECTURES STREQUAL "arm64" OR CMAKE_GENERATOR_PLATFORM_LWR STR
         add_compile_definitions(__aarch64__) # MSVC defines _M_ARM64 instead
         add_compile_definitions(__ARM_NEON)
         add_compile_definitions(__ARM_FEATURE_FMA)
+
+        if (LLAMA_LSE_ATOMICS)
+            list(APPEND ARCH_FLAGS /arch:armv8.1)
+        endif()
 
         set(CMAKE_REQUIRED_FLAGS_PREV ${CMAKE_REQUIRED_FLAGS})
         string(JOIN " " CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} "/arch:armv8.2")

--- a/README.md
+++ b/README.md
@@ -351,6 +351,13 @@ In order to build llama.cpp you have four different options.
       cmake --build build --config Debug
       ```
 
+    **Note**: (MSVC only) for Windows on ARM builds target preceding armv8.0, e.g. snapdragon 835 (ms8998):
+
+    ```bash
+    cmake -B build -DLLAMA_LSE_ATOMICS=OFF
+    cmake --build build --config Release
+    ```
+
 - Using `Zig` (version 0.11 or later):
 
     Building for optimization levels and CPU features can be accomplished using standard build arguments, for example AVX2, FMA, F16C,


### PR DESCRIPTION
Add /arch:armv8.1 as default MSVC flag to windows on arm builds.
This PR should solve #6417 for woa devices equipped with lse atomics extension.