### PR TITLE
batched : make n_threads and n_threads_batch configurable in batched & batched-bench

### DIFF
--- a/examples/batched-bench/README.md
+++ b/examples/batched-bench/README.md
@@ -10,16 +10,16 @@ There are 2 modes of operation:
 - `prompt is shared` - there is a common prompt of size `PP` used by all batches (i.e. `N_KV = PP + B*TG`)
 
 ```bash
-./batched-bench MODEL_PATH [N_KV_MAX] [N_BATCH] [N_UBATCH] [IS_PP_SHARED] [NGL] [MMQ] <PP> <TG> <PL>
+./batched-bench MODEL_PATH [N_KV_MAX] [N_BATCH] [N_UBATCH] [FATTN] [IS_PP_SHARED] [NGL] [NT] [NTB] <PP> <TG> <PL>
 
 # LLaMA 7B, F16, N_KV_MAX = 16384 (8GB), prompt not shared
-./batched-bench ./models/llama-7b/ggml-model-f16.gguf 16384 2048 512 0 99
+./batched-bench ./models/llama-7b/ggml-model-f16.gguf 16384 2048 512 0 0 99
 
 # LLaMA 7B, Q8_0, N_KV_MAX = 16384 (8GB), prompt is shared
-./batched-bench ./models/llama-7b/ggml-model-q8_0.gguf 16384 2048 512 1 99
+./batched-bench ./models/llama-7b/ggml-model-q8_0.gguf 16384 2048 512 0 1 99
 
 # custom set of batches
-./batched-bench ./models/llama-7b/ggml-model-q8_0.gguf 2048 512 512 0 999 0 128,256,512 128,256 1,2,4,8,16,32
+./batched-bench ./models/llama-7b/ggml-model-q8_0.gguf 16384 2048 512 0 0 999 8 8 128,256,512 128,256 1,2,4,8,16,32
 ```
 
 ## Sample results

--- a/examples/batched/README.md
+++ b/examples/batched/README.md
@@ -3,42 +3,42 @@
 The example demonstrates batched generation from a given prompt
 
 ```bash
-./batched ./models/llama-7b-v2/ggml-model-f16.gguf "Hello my name is" 4
+./batched ./models/llama-7b-v2/llama-2-7b-chat.Q8_0.gguf "Hello my name is" 4
 
 ...
 
-main: n_len = 32, n_ctx = 2048, n_parallel = 4, n_kv_req = 113
+main: n_len = 32, n_ctx = 128, n_batch = 32, n_parallel = 4, n_kv_req = 113, n_threads = 16, n_threads_batch = 16
 
- Hello my name is
+<s> Hello my name is
 
 main: generating 4 sequences ...
 
-main: stream 0 finished
-main: stream 1 finished
-main: stream 2 finished
-main: stream 3 finished
+main: stream 0 finished at n_cur = 32
+main: stream 1 finished at n_cur = 32
+main: stream 2 finished at n_cur = 32
+main: stream 3 finished at n_cur = 32
 
 sequence 0:
 
-Hello my name is Shirley. I am a 25-year-old female who has been working for over 5 years as a b
+Hello my name is [Your Name], and I am a [Your Profession] with [Number of Years] of experience in the [Your Industry
 
 sequence 1:
 
-Hello my name is Renee and I'm a 32 year old female from the United States. I'm looking for a man between
+Hello my name is Drew and I am a 31 year old man from the United States. I have been a fan of anime for as
 
 sequence 2:
 
-Hello my name is Diana. I am looking for a housekeeping job. I have experience with children and have my own transportation. I am
+Hello my name is Tiffany and I am a 30 year old female. I have been experiencing some symptoms that I am concerned about
 
 sequence 3:
 
-Hello my name is Cody. I am a 3 year old neutered male. I am a very friendly cat. I am very playful and
+Hello my name is John and I am a 26 year old man from the United States. I have been experiencing some strange symptoms over the
 
-main: decoded 108 tokens in 3.57 s, speed: 30.26 t/s
+main: decoded 108 tokens in 4.19 s, speed: 25.76 t/s
 
-llama_print_timings:        load time =   587.00 ms
-llama_print_timings:      sample time =     2.56 ms /   112 runs   (    0.02 ms per token, 43664.72 tokens per second)
-llama_print_timings: prompt eval time =  4089.11 ms /   118 tokens (   34.65 ms per token,    28.86 tokens per second)
-llama_print_timings:        eval time =     0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
-llama_print_timings:       total time =  4156.04 ms
+llama_print_timings:        load time =     549.60 ms
+llama_print_timings:      sample time =       4.14 ms /   112 runs   (    0.04 ms per token, 27027.03 tokens per second)
+llama_print_timings: prompt eval time =    4333.64 ms /   113 tokens (   38.35 ms per token,    26.08 tokens per second)
+llama_print_timings:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
+llama_print_timings:       total time =    4742.24 ms /   114 tokens
 ```


### PR DESCRIPTION
This PR make n_threads and n_threads_batch configurable in batched & batched-bench example.

- Add n_threads/n_threads_batch option to batched
- Add n_threads/n_threads_batch option to batched-bench
- Update those README.md

The motivation for this is that it can be used to check how many threads the performance scales in batch inference on many cores systems; it may be useful to determine how many cores to allocate for k8s pod or VM instance.