### PR TITLE
Extend README with brew installation instruction [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,14 @@ In order to build llama.cpp you have four different options.
     CLBLAST support for use OpenCL GPU acceleration in FreeBSD. Please read
     the instructions for use and activate this options in this document below.
 
+### Homebrew
+
+On Mac and Linux, the homebrew package manager can be used via 
+```
+brew install llama.cpp
+```
+The formula is automatically updated with new `llama.cpp` releases.
+
 ### Metal Build
 
 On MacOS, Metal is enabled by default. Using Metal makes the computation run on the GPU.


### PR DESCRIPTION
`llama.cpp` is now available in Homebrew (see [here](https://github.com/Homebrew/homebrew-core/pull/172915) and [here](https://x.com/ggerganov/status/1795525077930529001)). I think it would be helpful to extend the README to raise awareness of that installation possibility. This PR is adding that information to the README file. 

I am not sure if this information should be positioned somewhere else in the README, maybe right before the [Prepare and Quantize](https://github.com/ggerganov/llama.cpp?tab=readme-ov-file#prepare-and-quantize) chapter or even before the [Get the Code](https://github.com/ggerganov/llama.cpp?tab=readme-ov-file#get-the-code) chapter, I am happy to receive feedback on that as well.