### PR TITLE
ggml-backend: refine backend subsystem for CPU&GPU / CPU&NPU mixed inference more easily for a specified GGML backend

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -17247,7 +17247,8 @@ static void ggml_compute_forward_cross_entropy_loss_back(
 
 /////////////////////////////////
 
-static void ggml_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor, struct ggml_compute_state * state) {
+void ggml_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor, struct ggml_compute_state * state);
+void ggml_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor, struct ggml_compute_state * state) {
     GGML_ASSERT(params);
 
     if (tensor->op == GGML_OP_NONE || ggml_is_empty(tensor)) {


### PR DESCRIPTION
<h4>Purpose</h4>

This PR is intent to refine ggml backend subsystem to enable mixed inference between CPU & GPU / CPU & NPU more easily.

There already is "Backend Scheduler" feature in ggml backend subsystem but the "Backend Scheduler" is too complex and not a straight way and some backend APIs is not make sense: 

For example,  ggml_backend_supports_op is only called/used in https://github.com/ggerganov/llama.cpp/blob/master/tests/test-backend-ops.cpp#L406, 

For example, ggml_backend_offload_op is not reasonable.

In the all, a special backend doesn't need to implement all GGML OPs and much of them can fallback to the default GGML backend(this is a long-term problem in ggml backend subsystem):

 - The entire framework of existing ggml backend subystem is really excellent, but part of subsystem seems too strict to a special backend;
 
- GPU/NPU computing might be slower then CPU computing in some special scenarios if we considering data copy/data preparation between CPU/GPU or CPU/NPU and memory size or KV cache size.

<h4>Pros</h4>

This PR less then one hundred LoC based on the existing ggml backend subsystem and <b>NO</b> side-effect to existing codes.

This PR follow the existing OO principle in ggml.c&ggml-backend.c.

This PR works very fine/well with whisper.cpp and llama.cpp using QNN backend as expected on local dev side.



 The GGML QNN backend and many other GGML backends will/might be benefit from this PR greatly.

 It's very simple and straightforward and easy to understand.

<h4>Cons</h4>

[A static function in ggml.c](https://github.com/zhouwg/llama.cpp/blob/refine-ggml-backend-subsystem/ggml.c#L17251) is changed to a global function and referenced in this PR. this is not make sense but the cost might be acceptable. A workaround to fix this problem is merge the entire ggml-backend.c to ggml.c and ggml-backend.h to ggml.h accordingly.

<h4>Todo</h4>

more sophisticated algorithm for mixed inference between CPU/GPU or CPU/NPU but this PR is a simple and concise and straight implementation for address a long-term problem in ggml backend subsystem.