### PR TITLE
`llama_supports_rpc()` function

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -15937,6 +15937,14 @@ bool llama_supports_mlock(void) {
     return llama_mlock::SUPPORTED;
 }
 
+bool llama_supports_rpc(void) {
+#if defined(GGML_USE_RPC)
+    return true;
+#else
+    return false;
+#endif
+}
+
 bool llama_supports_gpu_offload(void) {
 #if defined(GGML_USE_CUDA) || defined(GGML_USE_METAL)   || defined(GGML_USE_VULKAN) || \
     defined(GGML_USE_SYCL) || defined(GGML_USE_KOMPUTE) || defined(GGML_USE_RPC)

--- a/llama.h
+++ b/llama.h
@@ -430,7 +430,7 @@ extern "C" {
 
     LLAMA_API bool llama_supports_mmap       (void);
     LLAMA_API bool llama_supports_mlock      (void);
-    LLAMA_API bool llama_supports_rpc        (void);
+    LLAMA_API bool llama_supports_rpc        (void); // TMP: https://github.com/ggerganov/llama.cpp/pull/7647#issuecomment-2140234367
     LLAMA_API bool llama_supports_gpu_offload(void);
 
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);

--- a/llama.h
+++ b/llama.h
@@ -430,6 +430,7 @@ extern "C" {
 
     LLAMA_API bool llama_supports_mmap       (void);
     LLAMA_API bool llama_supports_mlock      (void);
+    LLAMA_API bool llama_supports_rpc        (void);
     LLAMA_API bool llama_supports_gpu_offload(void);
 
     LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);


### PR DESCRIPTION
Added `llama_supports_rpc` function to test for RPC support at runtime. This is useful for libraries such as LLamaSharp which need to check what the binaries were compiled with before trying to use certain features.