### PR TITLE
fix: change first msg check

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -483,8 +483,7 @@ static std::vector<json> format_partial_response_oaicompat(json result, const st
     if (!result.contains("model") || !result.contains("oaicompat_token_ctr")) {
         return std::vector<json>({result});
     }
-
-    bool first = json_value(result, "oaicompat_token_ctr", 0) == 0;
+    bool first = json_value(result, "oaicompat_token_ctr", 1) == 1;
     std::string modelname = json_value(result, "model", std::string(DEFAULT_OAICOMPAT_MODEL));
 
     bool stopped_word   = json_value(result, "stopped_word",  false);


### PR DESCRIPTION
By the time it gets to `format_partial_response_oaicompat`, it already has a token to send so `oaicompat_token_ctr` should be checking for token count to be 1.

* It will send the messages inside `if (first) { ...}`