### PR TITLE
docs: add aikit to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Unless otherwise noted these projects are open-source with permissive licensing:
 - [KodiBot](https://github.com/firatkiral/kodibot) (GPL)
 - [eva](https://github.com/ylsdamxssjxxdd/eva) (MIT)
 - [AI Sublime Text plugin](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) (MIT)
+- [AIKit](https://github.com/sozercan/aikit) (MIT)
 
 *(to have a project listed here, it should clearly state that it depends on `llama.cpp`)*
 
@@ -390,7 +391,7 @@ In order to build llama.cpp you have four different options.
 
 ### Homebrew
 
-On Mac and Linux, the homebrew package manager can be used via 
+On Mac and Linux, the homebrew package manager can be used via
 ```
 brew install llama.cpp
 ```


### PR DESCRIPTION
Thank you for maintaining this project! This PR adds downstream project https://github.com/sozercan/aikit to the readme

Docs mention that it depends on llama.cpp:
https://sozercan.github.io/aikit/llama-cpp


