### PR TITLE
Improve HIP compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,6 +571,7 @@ ifdef LLAMA_HIP_UMA
 	MK_CPPFLAGS += -DGGML_HIP_UMA
 endif # LLAMA_HIP_UMA
 	MK_LDFLAGS  += -L$(ROCM_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib
+	MK_LDFLAGS  += -L$(ROCM_PATH)/lib64 -Wl,-rpath=$(ROCM_PATH)/lib64
 	MK_LDFLAGS	+= -lhipblas -lamdhip64 -lrocblas
 	HIPFLAGS    += $(addprefix --offload-arch=,$(AMDGPU_TARGETS))
 	HIPFLAGS    += -DGGML_CUDA_DMMV_X=$(LLAMA_CUDA_DMMV_X)


### PR DESCRIPTION
When building the ROCm sdk on my own machine I've noticed that some files aren't located in `(ROCM_PATH)/lib` but they're in `(ROCM_PATH)/lib64`.

Appending the `lib64` folder to the makefile solves this issue.