### PR TITLE
CUDA: fix Pascal FA, deq. KV to FP16 for batch > 8

### DIFF
--- a/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml-cuda/fattn-tile-f16.cu
@@ -278,13 +278,13 @@ void launch_fattn_tile_f16_64_128(ggml_backend_cuda_context & ctx, ggml_tensor *
             constexpr int      D = 64;
             constexpr int nwarps = 8;
             fattn_kernel_t fattn_kernel = flash_attn_tile_ext_f16<D, cols_per_block, nwarps, parallel_blocks>;
-            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         } break;
         case 128: {
             constexpr int      D = 128;
             constexpr int nwarps = 8;
             fattn_kernel_t fattn_kernel = flash_attn_tile_ext_f16<D, cols_per_block, nwarps, parallel_blocks>;
-            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         } break;
         default: {
             GGML_ASSERT(false && "FlashAttention without tensor cores only supports head sizes 64 and 128.");

--- a/ggml-cuda/fattn-tile-f32.cu
+++ b/ggml-cuda/fattn-tile-f32.cu
@@ -275,13 +275,13 @@ void launch_fattn_tile_f32_64_128(ggml_backend_cuda_context & ctx, ggml_tensor *
             constexpr int      D = 64;
             constexpr int nwarps = 8;
             fattn_kernel_t fattn_kernel = flash_attn_tile_ext_f32<D, cols_per_block, nwarps, parallel_blocks>;
-            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         } break;
         case 128: {
             constexpr int      D = 128;
             constexpr int nwarps = 8;
             fattn_kernel_t fattn_kernel = flash_attn_tile_ext_f32<D, cols_per_block, nwarps, parallel_blocks>;
-            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+            launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         } break;
         default: {
             GGML_ASSERT(false && "FlashAttention without tensor cores only supports head sizes 64 and 128.");

--- a/ggml-cuda/fattn-vec-f16.cuh
+++ b/ggml-cuda/fattn-vec-f16.cuh
@@ -290,7 +290,9 @@ template <int D, int cols_per_block, int parallel_blocks, ggml_type type_K, ggml
 void ggml_cuda_flash_attn_ext_vec_f16_case_impl(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     constexpr int nwarps = D/WARP_SIZE;
     fattn_kernel_t fattn_kernel = flash_attn_vec_ext_f16<D, cols_per_block, parallel_blocks, type_K, type_V>;
-    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+    constexpr bool need_f16_K = D != 128;
+    constexpr bool need_f16_V = D != 128 && D != 64;
+    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, need_f16_K, need_f16_V);
 }
 
 template <int D, ggml_type type_K, ggml_type type_V>

--- a/ggml-cuda/fattn-vec-f32.cuh
+++ b/ggml-cuda/fattn-vec-f32.cuh
@@ -271,7 +271,9 @@ template <int D, int cols_per_block, int parallel_blocks, ggml_type type_K, ggml
 void ggml_cuda_flash_attn_ext_vec_f32_case_impl(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     constexpr int nwarps = D/WARP_SIZE;
     fattn_kernel_t fattn_kernel = flash_attn_vec_ext_f32<D, cols_per_block, parallel_blocks, type_K, type_V>;
-    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+    constexpr bool need_f16_K = D != 128;
+    constexpr bool need_f16_V = D != 128 && D != 64;
+    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, need_f16_K, need_f16_V);
 }
 
 template <int D, ggml_type type_K, ggml_type type_V>

--- a/ggml-cuda/fattn-wmma-f16.cuh
+++ b/ggml-cuda/fattn-wmma-f16.cuh
@@ -438,18 +438,18 @@ void ggml_cuda_flash_attn_ext_wmma_f16_case(ggml_backend_cuda_context & ctx, ggm
     if (4*blocks_num_pb1 < 2*nsm) {
         constexpr int parallel_blocks = 4;
         fattn_kernel_t fattn_kernel = flash_attn_ext_f16<D, cols_per_block, nwarps, get_VKQ_stride(D, nwarps, frag_m), parallel_blocks, KQ_acc_t>;
-        launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+        launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         return;
     }
     if (2*blocks_num_pb1 < 2*nsm) {
         constexpr int parallel_blocks = 2;
         fattn_kernel_t fattn_kernel = flash_attn_ext_f16<D, cols_per_block, nwarps, get_VKQ_stride(D, nwarps, frag_m), parallel_blocks, KQ_acc_t>;
-        launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+        launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
         return;
     }
     constexpr int parallel_blocks = 1;
     fattn_kernel_t fattn_kernel = flash_attn_ext_f16<D, cols_per_block, nwarps, get_VKQ_stride(D, nwarps, frag_m), parallel_blocks, KQ_acc_t>;
-    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block);
+    launch_fattn<D, parallel_blocks>(ctx, dst, fattn_kernel, nwarps, cols_per_block, true, true);
 }
 
 #define DECL_FATTN_WMMA_F16_CASE(D, cols_per_block, KQ_acc_t)                         \

--- a/ggml-cuda/fattn.cu
+++ b/ggml-cuda/fattn.cu
@@ -298,17 +298,13 @@ static void ggml_cuda_flash_attn_ext_vec_f32(ggml_backend_cuda_context & ctx, gg
 void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * KQV = dst;
     const ggml_tensor * Q   = dst->src[0];
-    const ggml_tensor * K   = dst->src[1];
-    const ggml_tensor * V   = dst->src[2];
 
     ggml_cuda_set_device(ctx.device);
     const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
     const int32_t precision = KQV->op_params[2];
 
-    const bool quantized_KV = ggml_is_quantized(K->type) || ggml_is_quantized(V->type);
-
     // On AMD the tile kernels perform poorly, use the vec kernel instead:
-    if (cc >= CC_OFFSET_AMD || quantized_KV) {
+    if (cc >= CC_OFFSET_AMD) {
         if (precision == GGML_PREC_DEFAULT && fast_fp16_available(cc)) {
             ggml_cuda_flash_attn_ext_vec_f16(ctx, dst);
         } else {


### PR DESCRIPTION
The check against `__CUDA_ARCH__` for the quantized KV cache is incorrect (> instead of >=). This PR fixes this.

It also implements the dequantization of the KV cache for large batch sizes to FP16 in order to make use of the kernels optimized for large batch sizes. I didn't put this into https://github.com/ggerganov/llama.cpp/pull/7527 because I thought it would cause issues for some cases but it seems to be a straight upgrade:

| GPU        | Model           | Microbatch size | Test     | t/s vec dot | t/s dequantize | Speedup | VRAM use vec dot [MiB] | VRAM use dequantize [MiB] | Difference [MiB] |
| :--------- | :-------------- | --------------: | :------- | ----------: | -------------: | ------- | ---------------------- | ------------------------- | ---------------- |
| RTX 4090   | llama 8B Q4_0   |              16 | pp4096   |      690.25 |        1262.91 |    1.83 |                   4698 |                      4714 |               16 |
| RTX 4090   | llama 8B Q4_0   |              32 | pp4096   |     1019.16 |        1487.62 |    1.46 |                   4706 |                      4722 |               16 |
| RTX 4090   | llama 8B Q4_0   |              64 | pp4096   |     1364.91 |        1756.76 |    1.29 |                   4848 |                      4848 |                0 |
| RTX 4090   | llama 8B Q4_0   |             128 | pp4096   |     2153.01 |        3354.63 |    1.56 |                   4882 |                      4882 |                0 |
| RTX 4090   | llama 8B Q4_0   |             256 | pp4096   |     2835.49 |        5488.44 |    1.94 |                   4950 |                      4950 |                0 |
| RTX 4090   | llama 8B Q4_0   |             512 | pp4096   |     3159.38 |        7359.91 |    2.33 |                   5088 |                      5088 |                0 |
| RTX 4090   | llama 8B Q4_0   |            1024 | pp4096   |     3183.10 |        8578.46 |    2.70 |                   5364 |                      5364 |                0 |
| P40        | Mistral 7b Q4_0 |              16 | pp4096   |      100.54 |         176.49 |    1.76 |                   4146 |                      4162 |               16 |
| P40        | Mistral 7b Q4_0 |              32 | pp4096   |      149.40 |         333.25 |    2.23 |                   4148 |                      4166 |               18 |
| P40        | Mistral 7b Q4_0 |              64 | pp4096   |      208.42 |         527.25 |    2.53 |                   4154 |                      4168 |               14 |
| P40        | Mistral 7b Q4_0 |             128 | pp4096   |      234.56 |         639.55 |    2.73 |                   4164 |                      4178 |               14 |
| P40        | Mistral 7b Q4_0 |             256 | pp4096   |      243.69 |         725.21 |    2.98 |                   4188 |                      4200 |               12 |
| P40        | Mistral 7b Q4_0 |             512 | pp4096   |      239.61 |         766.93 |    3.20 |                   4234 |                      4242 |                8 |
| P40        | Mistral 7b Q4_0 |            1024 | pp4096   |      223.96 |         760.20 |    3.39 |                   4326 |                      4326 |                0 |

Even at a batch size of 16 dequantizing the KV cache is already faster and the increase in VRAM usage is negligible.

Edit: the numbers are for `-ctk q4_0 -ctv q4_0`.