### PR TITLE
convert-hf : match model part name prefix and suffix

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -72,10 +72,10 @@ class Model:
         self.endianess = gguf.GGUFEndian.BIG if is_big_endian else gguf.GGUFEndian.LITTLE
         self.use_temp_file = use_temp_file
         self.lazy = not eager
-        self.part_names = Model.get_model_part_names(self.dir_model, ".safetensors")
+        self.part_names = Model.get_model_part_names(self.dir_model, "model", ".safetensors")
         self.is_safetensors = len(self.part_names) > 0
         if not self.is_safetensors:
-            self.part_names = Model.get_model_part_names(self.dir_model, ".bin")
+            self.part_names = Model.get_model_part_names(self.dir_model, "pytorch_model", ".bin")
         self.hparams = Model.load_hparams(self.dir_model)
         self.block_count = self.find_hparam(["n_layers", "num_hidden_layers", "n_layer"])
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
@@ -334,10 +334,10 @@ class Model:
         self.gguf_writer.close()
 
     @staticmethod
-    def get_model_part_names(dir_model: Path, suffix: str) -> list[str]:
+    def get_model_part_names(dir_model: Path, prefix: str, suffix: str) -> list[str]:
         part_names: list[str] = []
         for filename in os.listdir(dir_model):
-            if filename.endswith(suffix):
+            if filename.startswith(prefix) and filename.endswith(suffix):
                 part_names.append(filename)
 
         part_names.sort()


### PR DESCRIPTION
TL;DR This should fix conversion of <https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3>

(thanks to @teleprint-me for noticing this problem in <https://github.com/ggerganov/llama.cpp/pull/7379#issuecomment-2143633845>)

Before #7075, `convert-hf-to-gguf.py` checked for specific model part names according to the number of `*.bin` files or `*.safetensors` files.

https://github.com/ggerganov/llama.cpp/blob/bc4bba364fb96d908f2698e908648df5e6f55e02/convert-hf-to-gguf.py#L224-L232

But then, #7075, to fix the conversion of ([some](https://huggingface.co/jtatman/TinyMistral-248m-v2.5-4x-Moe/tree/main)) models using `model-00001-of-00001.safetensors` instead of `model.safetensors` for a single model part, simply used the same logic as the part count to get the part names. That is, using only the suffix of the files.

https://github.com/ggerganov/llama.cpp/blob/f98eb31c517c95960df1d0abc48002787f145f3b/convert-hf-to-gguf.py#L285-L293

But this doesn't always work correctly, like when unusual additional model files like `consolidated.safetensors` in <https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3> are present.

Note that the previous way it was done would still have failed, since the model count still only relied on the suffixes.

I think matching both the prefix and the suffix of the model part names should fix this problem without breaking any previously-supported upstream models.