### PR TITLE
docs: Added initial PR template with directions for doc only changes and squash merges [no ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,40 @@
+# Pull Request Template
+
+## Summary
+
+* [Briefly describe the changes made in this PR.]
+* [Include any relevant context, such as the issue or feature being addressed.]
+
+## Changes Made
+
+* [List specific files or directories affected by these changes]
+* [Describe any significant updates, rewrites, or new code added]
+* [Mention any removed or deleted files or code]
+
+## Relevant Details
+
+* **Affected Code**: [List specific code paths, functions, or classes changed or updated]
+* **Impact**: [Explain how the changes affect the project's functionality, performance, or security]
+* **New Features/Changes**: [Describe new features or significant changes added in this PR]
+* **Fixed Issues**: [List specific issues or bugs fixed by these changes]
+
+## Verification
+
+To verify this PR, you can:
+
+* Run automated tests or scripts to ensure the changes do not introduce errors
+* Review code for style, security, and best practices
+* Verify that all changed files are properly formatted and consistent
+
+## Additional Information (Optional)
+
+[Add any additional context, explanations, or requests that are relevant to this PR.]
+
+**Important Notes**
+
+* If this pull request only contains documentation changes (e.g., updating
+READMEs, adding new wiki pages), please add `[no ci]` to the commit title.
+This will skip unnecessary CI checks and help reduce build times.
+* When squashing multiple commits on merge, use the following format for
+your commit title: `<module>:<commit title> (#<issue_number>)`. For example: `utils: Fix typo in utils.py (#1234)`
+* Please ensure that this PR follows our contributing guidelines, available at [](README.md). This includes formatting code according to our style guide and ensuring that all changes are thoroughly tested.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,16 +1,1 @@
-## Summary
-[Summarize your changes]
-
-## How would you rate the complexity of this PR? (Easy, Medium, Hard)
-[Review complexity]
-
-## Verification
-
-To verify this PR, you can:
-
-* Make sure that your PR follows the [contributing guidelines](CONTRIBUTING.md) and the [coding guidelines](https://github.com/ggerganov/llama.cpp/blob/master/README.md#coding-guidelines)
-* Test your changes using the commands in the [`tests`](tests) folder
-    * For instance, running the `./tests/test-backend-ops` command tests different backend implementations of the GGML library
-    * 
-
-* Execute [the full CI locally on your machine](ci/README.md) before publishing
+- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,40 +1,16 @@
-# Pull Request Template
-
 ## Summary
+[Summarize your changes]
 
-* [Briefly describe the changes made in this PR.]
-* [Include any relevant context, such as the issue or feature being addressed.]
-
-## Changes Made
-
-* [List specific files or directories affected by these changes]
-* [Describe any significant updates, rewrites, or new code added]
-* [Mention any removed or deleted files or code]
-
-## Relevant Details
-
-* **Affected Code**: [List specific code paths, functions, or classes changed or updated]
-* **Impact**: [Explain how the changes affect the project's functionality, performance, or security]
-* **New Features/Changes**: [Describe new features or significant changes added in this PR]
-* **Fixed Issues**: [List specific issues or bugs fixed by these changes]
+## How would you rate the complexity of this PR? (Easy, Medium, Hard)
+[Review complexity]
 
 ## Verification
 
 To verify this PR, you can:
 
-* Run automated tests or scripts to ensure the changes do not introduce errors
-* Review code for style, security, and best practices
-* Verify that all changed files are properly formatted and consistent
+* Make sure that your PR follows the [contributing guidelines](CONTRIBUTING.md) and the [coding guidelines](https://github.com/ggerganov/llama.cpp/blob/master/README.md#coding-guidelines)
+* Test your changes using the commands in the [`tests`](tests) folder
+    * For instance, running the `./tests/test-backend-ops` command tests different backend implementations of the GGML library
+    * 
 
-## Additional Information (Optional)
-
-[Add any additional context, explanations, or requests that are relevant to this PR.]
-
-**Important Notes**
-
-* If this pull request only contains documentation changes (e.g., updating
-READMEs, adding new wiki pages), please add `[no ci]` to the commit title.
-This will skip unnecessary CI checks and help reduce build times.
-* When squashing multiple commits on merge, use the following format for
-your commit title: `<module>:<commit title> (#<issue_number>)`. For example: `utils: Fix typo in utils.py (#1234)`
-* Please ensure that this PR follows our contributing guidelines, available at [](README.md). This includes formatting code according to our style guide and ensuring that all changes are thoroughly tested.
+* Execute [the full CI locally on your machine](ci/README.md) before publishing

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,1 +1,5 @@
+- Self Reported Review Complexity:
+    - [ ] Review Complexity : Low
+    - [ ] Review Complexity : Medium
+    - [ ] Review Complexity : High
 - [ ] I have read the [contributing guidelines](CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing Guidelines
+
+* If the pull request only contains documentation changes (e.g., updating
+READMEs, adding new wiki pages), please add `[no ci]` to the commit title. This will skip unnecessary CI checks and help reduce build times.
+* When squashing multiple commits on merge, use the following format for your commit title: `<module>:<commit title> (#<issue_number>)`. For example: `utils: Fix typo in utils.py (#1234)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## PR formatting
 
-* Please rate the complexity of your PR (i.e. `easy`, `medium`, `hard`). This makes it easier for maintainers to triage the PRs.
-* If the pull request only contains documentation changes (e.g., updating
-READMEs, adding new wiki pages), please add `[no ci]` to the commit title. This will skip unnecessary CI checks and help reduce build times.
+* Please rate the complexity of your PR (i.e. `Review Complexity : Low`, `Review Complexity : Medium`, `Review Complexity : High`). This makes it easier for maintainers to triage the PRs.
+    - The PR template has a series of review complexity checkboxes `[ ]` that you can mark as `[X]` for your conveience. Refer to [About task lists](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists) for more information.
+* If the pull request only contains documentation changes (e.g., updating READMEs, adding new wiki pages), please add `[no ci]` to the commit title. This will skip unnecessary CI checks and help reduce build times.
 * When squashing multiple commits on merge, use the following format for your commit title: `<module> : <commit title> (#<issue_number>)`. For example: `utils : Fix typo in utils.py (#1234)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing Guidelines
 
+## Checklist
+
+* Make sure your PR follows the [coding guidelines](https://github.com/ggerganov/llama.cpp/blob/master/README.md#coding-guidelines)
+* Test your changes using the commands in the [`tests`](tests) folder. For instance, running the `./tests/test-backend-ops` command tests different backend implementations of the GGML library
+* Execute [the full CI locally on your machine](ci/README.md) before publishing
+
+## PR formatting
+
+* Please rate the complexity of your PR (i.e. `easy`, `medium`, `hard`). This makes it easier for maintainers to triage the PRs.
 * If the pull request only contains documentation changes (e.g., updating
 READMEs, adding new wiki pages), please add `[no ci]` to the commit title. This will skip unnecessary CI checks and help reduce build times.
 * When squashing multiple commits on merge, use the following format for your commit title: `<module>:<commit title> (#<issue_number>)`. For example: `utils: Fix typo in utils.py (#1234)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@
 * Please rate the complexity of your PR (i.e. `easy`, `medium`, `hard`). This makes it easier for maintainers to triage the PRs.
 * If the pull request only contains documentation changes (e.g., updating
 READMEs, adding new wiki pages), please add `[no ci]` to the commit title. This will skip unnecessary CI checks and help reduce build times.
-* When squashing multiple commits on merge, use the following format for your commit title: `<module>:<commit title> (#<issue_number>)`. For example: `utils: Fix typo in utils.py (#1234)`
+* When squashing multiple commits on merge, use the following format for your commit title: `<module> : <commit title> (#<issue_number>)`. For example: `utils : Fix typo in utils.py (#1234)`

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ docker run --gpus all -v /path/to/models:/models local/llama.cpp:server-cuda -m 
 
 - Contributors can open PRs
 - Collaborators can push to branches in the `llama.cpp` repo and merge PRs into the `master` branch
-- Collaborators should follow the PR template when adding a PR
+- Collaborators should follow the [PR template](.github/PULL_REQUEST_TEMPLATE/pull_request_template.md) when adding a PR
 - Collaborators will be invited based on contributions
 - Any help with managing issues and PRs is very appreciated!
 - Make sure to read this: [Inference at the edge](https://github.com/ggerganov/llama.cpp/discussions/205)

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,6 @@ docker run --gpus all -v /path/to/models:/models local/llama.cpp:server-cuda -m 
 
 - Contributors can open PRs
 - Collaborators can push to branches in the `llama.cpp` repo and merge PRs into the `master` branch
-- Collaborators should follow the [PR template](.github/PULL_REQUEST_TEMPLATE/pull_request_template.md) when adding a PR
 - Collaborators will be invited based on contributions
 - Any help with managing issues and PRs is very appreciated!
 - Make sure to read this: [Inference at the edge](https://github.com/ggerganov/llama.cpp/discussions/205)

--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,7 @@ docker run --gpus all -v /path/to/models:/models local/llama.cpp:server-cuda -m 
 
 - Contributors can open PRs
 - Collaborators can push to branches in the `llama.cpp` repo and merge PRs into the `master` branch
+- Collaborators should follow the PR template when adding a PR
 - Collaborators will be invited based on contributions
 - Any help with managing issues and PRs is very appreciated!
 - Make sure to read this: [Inference at the edge](https://github.com/ggerganov/llama.cpp/discussions/205)


### PR DESCRIPTION
# Summary
- Solves issue #7657

# Changes Made
- Added directions to the `README` so that collaborators follow the PR template when sending a PR
- Added a general pull request template
  - Suggests to collaborators to add `[no ci]` to the commit title
  - Suggests to collaborators to format commit titles `<module>:<commit title> (#<issue_number>)` when squashing multiple commits on merge

# Additional Information
- The general PR template is very rough, so adding changes is welcome!