### PR TITLE
Fix encoding in python scripts

### DIFF
--- a/convert-hf-to-gguf-update.py
+++ b/convert-hf-to-gguf-update.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 # This script downloads the tokenizer models of the specified models from Huggingface and
 # generates the get_vocab_base_pre() function for convert-hf-to-gguf.py

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 from __future__ import annotations
 


### PR DESCRIPTION
`convert-hf-to-gguf.py` shouldn't have any problems since encodings are manually specified where they are needed, but `convert-hf-to-gguf-update.py` was broken on windows.

fixes #7706 