### PR TITLE
server: update cache_prompt documentation [no ci]

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -279,7 +279,7 @@ node index.js
 
     `id_slot`: Assign the completion task to an specific slot. If is -1 the task will be assigned to a Idle slot.  Default: `-1`
 
-    `cache_prompt`: Re-use previously cached prompt from the last request if possible. This may prevent re-caching the prompt from scratch.  Default: `false`
+    `cache_prompt`: Re-use KV cache from a previous request if possible. This way the common prefix does not have to be re-processed, only the suffix that differs between the requests. Because (depending on the backend) the logits are **not** guaranteed to be bit-for-bit identical for different batch sizes (prompt processing vs. token generation) enabling this option can cause nondeterministic results. Default: `false`
 
     `system_prompt`: Change the system prompt (initial prompt of all slots), this is useful for chat applications. [See more](#change-system-prompt-on-runtime)
 


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/7594 .

Generally speaking it is not possible to guarantee bit-for-bit identical results when the batch size is varied. As a consequence `cache_prompt` that caches not only the actual prompt (batch size >> 1) but also the generated tokens (batch size 1) cannot guarantee bit-for-bit identical results. This PR simply updates the documentation to inform users of this.