### PR TITLE
use the correct SYCL context for host USM allocations

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -13148,10 +13148,12 @@ void *ggml_sycl_host_malloc(size_t size) try {
         return nullptr;
     }
 
+    ggml_sycl_set_device(g_main_device);
+    dpct::queue_ptr main_stream = g_syclStreams[g_main_device][0];
+
     void * ptr = nullptr;
-    //allow to use dpct::get_in_order_queue() for host malloc
     dpct::err0 err = CHECK_TRY_ERROR(
-        ptr = (void *)sycl::malloc_host(size, dpct::get_in_order_queue()));
+        ptr = (void *)sycl::malloc_host(size, *main_stream));
 
     if (err != 0) {
         // clear the error
@@ -13172,8 +13174,9 @@ catch (sycl::exception const &exc) {
 }
 
 void ggml_sycl_host_free(void *ptr) try {
-    //allow to use dpct::get_in_order_queue() for host malloc
-    SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, dpct::get_in_order_queue())));
+    ggml_sycl_set_device(g_main_device);
+    dpct::queue_ptr main_stream = g_syclStreams[g_main_device][0];
+    SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, *main_stream)));
 }
 catch (sycl::exception const &exc) {
   std::cerr << exc.what() << "Exception caught at file:" << __FILE__


### PR DESCRIPTION
Hello, I found an issue testing SYCL with the OpenCL backend: the SYCL host USM allocations are happening against a different queue (and hence a different context) than the other allocations, which is undefined behavior according to the SYCL spec:

> Each USM allocation has an associated SYCL [context](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#context), and any access to that memory must use the same context. Specifically, any [SYCL kernel function](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sycl-kernel-function) that dereferences a pointer to a USM allocation must be submitted to a [queue](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#queue) that was constructed with the same context that was used to allocate that memory. The explicit memory operation [commands](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#command) that take USM pointers have a similar restriction. (See [Section 4.9.4.3](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:explicitmemory) for details.) Violations of these requirements result in undefined behavior.

The specific error I am seeing is:

```
Native API failed. Native API returns: -5 (PI_ERROR_OUT_OF_RESOURCES) -5 (PI_ERROR_OUT_OF_RESOURCES)
Exception caught at file:/home/bashbaug/git/llama.cpp/ggml-sycl.cpp, line:17172, func:operator()
SYCL error: CHECK_TRY_ERROR(g_syclStreams[sycl_ctx->device][0]->memcpy( data, (const char *)tensor->data + offset, size).wait()): Meet error in this line code!
  in function ggml_backend_sycl_get_tensor_async at /home/bashbaug/git/llama.cpp/ggml-sycl.cpp:17172
GGML_ASSERT: /home/bashbaug/git/llama.cpp/ggml-sycl.cpp:3069: !"SYCL error"
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Operation not permitted.
No stack.
The program is not being run.
Aborted (core dumped)
```

The changes in this PR are intended to use the same queue for USM host allocations as for other allocations, which works for both the OpenCL backend and the Level Zero backend (tested with an Intel integrated GPU and an Intel discrete GPU).

Specifically, I tested with:

```sh
$ ONEAPI_DEVICE_SELECTOR=opencl:* ./bin/main -m ~/Downloads/models/llama-2-7b.Q4_0.gguf -p "Building a website can be done in 10 simple steps:" -n 400 -e -ngl 33 -sm none -mg 0 -s 999
$ ONEAPI_DEVICE_SELECTOR=ext_oneapi_level_zero:* ./bin/main -m ~/Downloads/models/llama-2-7b.Q4_0.gguf -p "Building a website can be done in 10 simple steps:" -n 400 -e -ngl 33 -sm none -mg 0 -s 999
```

Both backends generated the same results.