### PR TITLE
JSON Schema to GBNF integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1051,7 +1051,7 @@ tests/test-grammar-parser: tests/test-grammar-parser.cpp ggml.o llama.o grammar-
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
 
-tests/test-grammar-integration: tests/test-grammar-integration.cpp ggml.o llama.o grammar-parser.o $(OBJS)
+tests/test-grammar-integration: tests/test-grammar-integration.cpp json-schema-to-grammar.o ggml.o llama.o grammar-parser.o $(OBJS)
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
 

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -86,6 +86,23 @@ static void test_grammar(const std::string & test_desc, const std::string & gram
 
         if (!matched) {
             fprintf(stderr, "❌ (failed to match)\n");
+
+            // DEBUG: Write strings to files so that we can analyze more easily with gbnf-validator program to see exactly where things failed.
+            // DEBUG: Write the grammar_str to test-grammar-integration.grammar.gbnf
+            FILE* grammar_file = fopen("test-grammar-integration.grammar.gbnf", "w");
+            if (grammar_file) {
+                fprintf(grammar_file, "%s", grammar_str.c_str());
+                fclose(grammar_file);
+            }
+
+            // DEBUG: Write the test string to test-grammar-integration.string.txt
+            FILE* string_file = fopen("test-grammar-integration.string.txt", "w");
+            if (string_file) {
+                fprintf(string_file, "%s", test_string.c_str());
+                fclose(string_file);
+            }
+
+            fprintf(stderr, "    Analyze in detail by running: `./gbnf-validator test-grammar-integration.grammar.gbnf test-grammar-integration.string.txt`\n");
         } else {
             fprintf(stdout, "✅︎\n");
         }
@@ -475,7 +492,7 @@ static void test_json_schema() {
     // Otherwise, this test structure is the same.
 
     test_grammar(
-        "empty schema",
+        "empty schema (object)",
         // Grammar
         json_schema_to_grammar(nlohmann::ordered_json::parse(
             R"""(
@@ -492,6 +509,536 @@ static void test_json_schema() {
             "",
         }
     );
+
+    test_grammar(
+        "exotic formats (list)",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+  "items": [
+    { "format": "date" },
+    { "format": "uuid" },
+    { "format": "time" },
+    { "format": "date-time" }
+  ]
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            // "{}", // NOTE: This string passes for this schema on https://www.jsonschemavalidator.net/ -- should it?
+            // "[]", // NOTE: This string passes for this schema on https://www.jsonschemavalidator.net/ -- should it?
+            R"""(["2012-04-23", "12345678-1234-1234-1234-1234567890ab", "18:25:43.511Z", "2012-04-23T18:25:43.511Z"])""",
+            //R"""(["2012-04-23","12345678-1234-1234-1234-1234567890ab"])""", // NOTE: This string passes for this schema on https://www.jsonschemavalidator.net/ -- should it?
+            //R"""({"foo": "bar"})""", // NOTE: This string passes for this schema on https://www.jsonschemavalidator.net/ -- should it?
+        },
+        // Failing strings
+        {
+            R"""(["foo", "bar"])""",
+            R"""(["12345678-1234-1234-1234-1234567890ab"])""",
+        }
+    );
+
+    test_grammar(
+        "string",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "string"
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+            "\"bar\"",
+            "\"\"",
+        },
+        // Failing strings
+        {
+            "{}",
+            "\"foo\": \"bar\"",
+        }
+    );
+
+    test_grammar(
+        "string w/ min length 1",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "string",
+    "minLength": 1
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+            "\"bar\"",
+        },
+        // Failing strings
+        {
+            "\"\"",
+            "{}",
+            "\"foo\": \"bar\"",
+        }
+    );
+
+    test_grammar(
+        "string w/ min length 3",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "string",
+    "minLength": 3
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+            "\"bar\"",
+            "\"foobar\"",
+        },
+        // Failing strings
+        {
+            "\"\"",
+            "\"f\"",
+            "\"fo\"",
+        }
+    );
+
+    test_grammar(
+        "string w/ max length",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "string",
+    "maxLength": 3
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+            "\"bar\"",
+            "\"\"",
+            "\"f\"",
+            "\"fo\"",
+        },
+        // Failing strings
+        {
+            "\"foobar\"",
+        }
+    );
+
+    test_grammar(
+        "string w/ min & max length",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 4
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+            "\"bar\"",
+            "\"f\"",
+            "\"barf\"",
+        },
+        // Failing strings
+        {
+            "\"\"",
+            "\"barfo\"",
+            "\"foobar\"",
+        }
+    );
+
+    test_grammar(
+        "boolean",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "boolean"
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "true",
+            "false",
+        },
+        // Failing strings
+        {
+            "\"\"",
+            "\"true\"",
+            "True",
+            "FALSE",
+        }
+    );
+
+    test_grammar(
+        "integer",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "type": "integer"
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "0",
+            "12345",
+            "1234567890123456"
+        },
+        // Failing strings
+        {
+            "",
+            "01",
+            "007",
+            "12345678901234567"
+        }
+    );
+
+    test_grammar(
+        "string const",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "const": "foo"
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"foo\"",
+        },
+        // Failing strings
+        {
+            "foo",
+            "\"bar\"",
+        }
+    );
+
+    test_grammar(
+        "non-string const",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "const": true
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "true",
+        },
+        // Failing strings
+        {
+            "",
+            "foo",
+            "\"true\"",
+        }
+    );
+
+    test_grammar(
+        "non-string const",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "enum": ["red", "amber", "green", null, 42, ["foo"]]
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "\"red\"",
+            "null",
+            "42",
+            "[\"foo\"]",
+        },
+        // Failing strings
+        {
+            "",
+            "420",
+            "true",
+            "foo",
+        }
+    );
+
+
+    test_grammar(
+        "min+max items",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "items": {
+        "type": ["number", "integer"]
+    },
+    "minItems": 3,
+    "maxItems": 5
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "[1, 2, 3]",
+            "[1, 2, 3, 4]",
+            "[1, 2, 3, 4, 5]",
+        },
+        // Failing strings
+        {
+            "[1, 2]",
+            "[1, 2, 3, 4, 5, 6]",
+            "1"
+        }
+    );
+
+    // Properties (from: https://json-schema.org/understanding-json-schema/reference/object#properties)
+    test_grammar(
+        "object properties",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+  "type": "object",
+  "properties": {
+    "number": { "type": "number" },
+    "street_name": { "type": "string" },
+    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+  }
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+            // "By default, leaving out properties is valid"
+            R"""({ "street_name": "Pennsylvania" })""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
+            // "By extension, even an empty object is valid"
+            R"""({})""",
+            // "By default, providing additional properties is valid"
+            // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
+            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
+            // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
+            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+        },
+        // Failing strings
+        {
+            // Change datatype from number to string
+            R"""({ "number": "1600", "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+            // Reorder properties
+            R"""({ "street_name": "Pennsylvania", "number": 1600 })""",
+            // Reorder properties
+            R"""({ "number": "1600", "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+        }
+    );
+
+
+    // Properties (from: https://json-schema.org/understanding-json-schema/reference/object#properties)
+    test_grammar(
+        "object properties, additionalProperties: true",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+  "type": "object",
+  "properties": {
+    "number": { "type": "number" },
+    "street_name": { "type": "string" },
+    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+  },
+  "additionalProperties": true
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            //R"""({"number":1600,"street_name":"Pennsylvania","street_type":"Avenue"})""",
+            // "By default, leaving out properties is valid"
+            //R"""({ "street_name": "Pennsylvania" })""",
+            //R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
+            // "By extension, even an empty object is valid"
+            R"""({})""",
+            // "By default, providing additional properties is valid"
+            // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
+            //R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
+            // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
+            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+        },
+        // Failing strings
+        {
+            // Change datatype from number to string
+            R"""({ "number": "1600", "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+            // Reorder properties
+            R"""({ "street_name": "Pennsylvania", "number": 1600, "street_type":"Avenue"})""",
+        }
+    );
+
+    // Additional properties: false
+    test_grammar(
+        "required + optional props each in original order",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+  "type": "object",
+  "properties": {
+    "number": { "type": "number" },
+    "street_name": { "type": "string" },
+    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+  },
+  "additionalProperties": false
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            R"""({ "street_name": "Pennsylvania" })""",
+            R"""({ "number": 1600, "street_type":"Avenue"})""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+            // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
+            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+        },
+        // Failing strings
+        {
+            // Reorder properties
+            R"""({ "street_type": "Avenue", "number": 1600 })""",
+            // Add "direction"
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue", "direction": "NW" })""",
+        }
+    );
+
+    test_grammar(
+        "required + optional props each in original order",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+    "properties": {
+        "b": {"type": "string"},
+        "a": {"type": "string"},
+        "d": {"type": "string"},
+        "c": {"type": "string"}
+    },
+    "required": ["a", "b"],
+    "additionalProperties": false
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "{\"b\": \"foo\", \"a\": \"bar\"}",
+            "{\"b\":\"foo\",\"a\":\"bar\",\"d\":\"qux\"}",
+            "{\"b\":\"foo\", \"a\":\"bar\", \"d\":\"qux\", \"c\":\"baz\"}",
+        },
+        // Failing strings
+        {
+            "{\"a\": \"foo\", \"b\": \"bar\"}",
+            "{\"b\": \"bar\"}",
+            "{\"a\": \"foo\", \"c\": \"baz\"}",
+            "{\"a\":\"foo\", \"b\":\"bar\", \"c\":\"baz\", \"d\":\"qux\"}",
+        }
+    );
+
+    // NOTE: Example from https://json-schema.org/learn/getting-started-step-by-step#define-required-properties
+    test_grammar(
+        "required props",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "productName": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "description": "The price of the product",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "tags": {
+      "description": "Tags for the product",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "dimensions": {
+      "type": "object",
+      "properties": {
+        "length": {
+          "type": "number"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [ "length", "width", "height" ]
+    }
+  },
+  "required": [ "productId", "productName", "price" ]
+}
+            )"""
+            )),
+        // Passing strings
+        {
+            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50}",
+            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\"]}",
+            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\"], \"dimensions\": {\"length\": 785, \"width\": 250.5, \"height\": -0.359}}",
+        },
+        // Failing strings
+        {
+            "{}", // Missing all required properties
+            "{\"productName\": \"A green door\", \"price\": 12.50, \"productId\": 1}", // Out of order properties
+            // TODO: The following line should fail, but currently it passes. `exclusiveMinimum` is not supported, as it would likely be too difficult to implement.
+            //  Perhaps special checks for minimum and maximum values of 0 could be added (since that's relatively easy to do with grammars), but anything else would likely be too complex.
+            // "{\"productId\": 1, \"productName\": \"A green door\", \"price\": -12.50}",
+            "{\"productId\": 1, \"productName\": \"A green door\"}", // Missing required property (price)
+            "{\"productName\": \"A green door\", \"price\": 12.50}", // Missing required property (productId)
+            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": []}", // tags is empty, but minItems is 1
+            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"dimensions\": {\"length\": 785, \"width\": 250.5, \"height\": -0.359}, \"tags\": [\"home\", \"green\"]}", // Tags and dimensions are out of order
+            // TODO: The following line should fail, but currently it passes. `uniqueItems` is not supported, as it would likely be too difficult to implement.
+            // "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\", \"home\"]}",
+
+        }
+    );
+
+
 }
 
 int main() {

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -428,10 +428,11 @@ static void test_quantifiers() {
 static void test_failure_missing_root() {
     fprintf(stderr, "⚫ Testing missing root node:\n");
     // Test case for a grammar that is missing a root rule
-    const std::string grammar_str = R"""(rot ::= expr
-expr ::= term ("+" term)*
-term ::= number
-number ::= [0-9]+)""";
+    const std::string grammar_str = R"""(
+        rot ::= expr
+        expr ::= term ("+" term)*
+        term ::= number
+        number ::= [0-9]+)""";
 
     grammar_parser::parse_state parsed_grammar = grammar_parser::parse(grammar_str.c_str());
 
@@ -448,10 +449,10 @@ static void test_failure_missing_reference() {
 
     // Test case for a grammar that is missing a referenced rule
     const std::string grammar_str =
-R"""(root ::= expr
-expr ::= term ("+" term)*
-term ::= numero
-number ::= [0-9]+)""";
+        R"""(root ::= expr
+        expr ::= term ("+" term)*
+        term ::= numero
+        number ::= [0-9]+)""";
 
     fprintf(stderr, "    Expected error:  ");
 
@@ -473,24 +474,24 @@ static void test_failure_left_recursion() {
 
     // Test more complicated left recursion detection
     const std::string medium_str = R"""(
-root ::= asdf
-asdf ::= "a" | asdf "a"
-)""";
+        root ::= asdf
+        asdf ::= "a" | asdf "a"
+        )""";
     assert(test_build_grammar_fails(medium_str));
 
     // Test even more complicated left recursion detection
     const std::string hard_str = R"""(
-root ::= asdf
-asdf ::= "a" | foo "b"
-foo ::= "c" | asdf "d" | "e")""";
+        root ::= asdf
+        asdf ::= "a" | foo "b"
+        foo ::= "c" | asdf "d" | "e")""";
     assert(test_build_grammar_fails(hard_str));
 
     // Test yet even more complicated left recursion detection
     const std::string hardest_str = R"""(
-root ::= asdf
-asdf ::= "a" | foo "b"
-foo ::= "c" | empty asdf "d" | "e"
-empty ::= "blah" | )""";
+        root ::= asdf
+        asdf ::= "a" | foo "b"
+        foo ::= "c" | empty asdf "d" | "e"
+        empty ::= "blah" | )""";
     assert(test_build_grammar_fails(hardest_str));
 
     fprintf(stderr, "  ✅︎ Passed\n");
@@ -505,7 +506,7 @@ static void test_json_schema() {
         "empty schema (object)",
         // Schema
         R"""(
-{}
+            {}
         )""",
         // Passing strings
         {
@@ -526,14 +527,14 @@ static void test_json_schema() {
         "exotic formats (list)",
         // Schema
         R"""(
-{
-  "items": [
-    { "format": "date" },
-    { "format": "uuid" },
-    { "format": "time" },
-    { "format": "date-time" }
-  ]
-}
+            {
+            "items": [
+                { "format": "date" },
+                { "format": "uuid" },
+                { "format": "time" },
+                { "format": "date-time" }
+            ]
+            }
         )""",
         // Passing strings
         {
@@ -554,9 +555,9 @@ static void test_json_schema() {
         "string",
         // Schema
         R"""(
-{
-    "type": "string"
-}
+            {
+                "type": "string"
+            }
         )""",
         // Passing strings
         {
@@ -575,10 +576,10 @@ static void test_json_schema() {
         "string w/ min length 1",
         // Schema
         R"""(
-{
-    "type": "string",
-    "minLength": 1
-}
+            {
+                "type": "string",
+                "minLength": 1
+            }
         )""",
         // Passing strings
         {
@@ -597,10 +598,10 @@ static void test_json_schema() {
         "string w/ min length 3",
         // Schema
         R"""(
-{
-    "type": "string",
-    "minLength": 3
-}
+            {
+                "type": "string",
+                "minLength": 3
+            }
         )""",
         // Passing strings
         {
@@ -620,10 +621,10 @@ static void test_json_schema() {
         "string w/ max length",
         // Schema
         R"""(
-{
-    "type": "string",
-    "maxLength": 3
-}
+            {
+                "type": "string",
+                "maxLength": 3
+            }
         )""",
         // Passing strings
         {
@@ -643,11 +644,11 @@ static void test_json_schema() {
         "string w/ min & max length",
         // Schema
         R"""(
-{
-    "type": "string",
-    "minLength": 1,
-    "maxLength": 4
-}
+            {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4
+            }
         )""",
         // Passing strings
         {
@@ -668,9 +669,9 @@ static void test_json_schema() {
         "boolean",
         // Schema
         R"""(
-{
-    "type": "boolean"
-}
+            {
+                "type": "boolean"
+            }
         )""",
         // Passing strings
         {
@@ -690,9 +691,9 @@ static void test_json_schema() {
         "integer",
         // Schema
         R"""(
-{
-    "type": "integer"
-}
+            {
+                "type": "integer"
+            }
         )""",
         // Passing strings
         {
@@ -713,9 +714,9 @@ static void test_json_schema() {
         "string const",
         // Schema
         R"""(
-{
-    "const": "foo"
-}
+            {
+                "const": "foo"
+            }
         )""",
         // Passing strings
         {
@@ -732,9 +733,9 @@ static void test_json_schema() {
         "non-string const",
         // Schema
         R"""(
-{
-    "const": true
-}
+            {
+                "const": true
+            }
         )""",
         // Passing strings
         {
@@ -752,9 +753,9 @@ static void test_json_schema() {
         "non-string const",
         // Schema
         R"""(
-{
-    "enum": ["red", "amber", "green", null, 42, ["foo"]]
-}
+            {
+                "enum": ["red", "amber", "green", null, 42, ["foo"]]
+            }
         )""",
         // Passing strings
         {
@@ -777,13 +778,13 @@ static void test_json_schema() {
         "min+max items",
         // Schema
         R"""(
-{
-    "items": {
-        "type": ["number", "integer"]
-    },
-    "minItems": 3,
-    "maxItems": 5
-}
+            {
+                "items": {
+                    "type": ["number", "integer"]
+                },
+                "minItems": 3,
+                "maxItems": 5
+            }
         )""",
         // Passing strings
         {
@@ -804,14 +805,14 @@ static void test_json_schema() {
         "object properties",
         // Schema
         R"""(
-{
-  "type": "object",
-  "properties": {
-    "number": { "type": "number" },
-    "street_name": { "type": "string" },
-    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
-  }
-}
+            {
+            "type": "object",
+            "properties": {
+                "number": { "type": "number" },
+                "street_name": { "type": "string" },
+                "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+            }
+            }
         )""",
         // Passing strings
         {
@@ -846,15 +847,15 @@ static void test_json_schema() {
         "object properties, additionalProperties: true",
         // Schema
         R"""(
-{
-  "type": "object",
-  "properties": {
-    "number": { "type": "number" },
-    "street_name": { "type": "string" },
-    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
-  },
-  "additionalProperties": true
-}
+            {
+            "type": "object",
+            "properties": {
+                "number": { "type": "number" },
+                "street_name": { "type": "string" },
+                "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+            },
+            "additionalProperties": true
+            }
         )""",
         // Passing strings
         {
@@ -889,15 +890,15 @@ static void test_json_schema() {
         "required + optional props each in original order",
         // Schema
         R"""(
-{
-  "type": "object",
-  "properties": {
-    "number": { "type": "number" },
-    "street_name": { "type": "string" },
-    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
-  },
-  "additionalProperties": false
-}
+            {
+            "type": "object",
+            "properties": {
+                "number": { "type": "number" },
+                "street_name": { "type": "string" },
+                "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
+            },
+            "additionalProperties": false
+            }
         )""",
         // Passing strings
         {
@@ -923,16 +924,16 @@ static void test_json_schema() {
         "required + optional props each in original order",
         // Schema
         R"""(
-{
-    "properties": {
-        "b": {"type": "string"},
-        "a": {"type": "string"},
-        "d": {"type": "string"},
-        "c": {"type": "string"}
-    },
-    "required": ["a", "b"],
-    "additionalProperties": false
-}
+            {
+                "properties": {
+                    "b": {"type": "string"},
+                    "a": {"type": "string"},
+                    "d": {"type": "string"},
+                    "c": {"type": "string"}
+                },
+                "required": ["a", "b"],
+                "additionalProperties": false
+            }
         )""",
         // Passing strings
         {
@@ -954,53 +955,53 @@ static void test_json_schema() {
         "required props",
         // Schema
         R"""(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.com/product.schema.json",
-  "title": "Product",
-  "description": "A product from Acme's catalog",
-  "type": "object",
-  "properties": {
-    "productId": {
-      "description": "The unique identifier for a product",
-      "type": "integer"
-    },
-    "productName": {
-      "description": "Name of the product",
-      "type": "string"
-    },
-    "price": {
-      "description": "The price of the product",
-      "type": "number",
-      "exclusiveMinimum": 0
-    },
-    "tags": {
-      "description": "Tags for the product",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "dimensions": {
-      "type": "object",
-      "properties": {
-        "length": {
-          "type": "number"
-        },
-        "width": {
-          "type": "number"
-        },
-        "height": {
-          "type": "number"
-        }
-      },
-      "required": [ "length", "width", "height" ]
-    }
-  },
-  "required": [ "productId", "productName", "price" ]
-}
+            {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/product.schema.json",
+            "title": "Product",
+            "description": "A product from Acme's catalog",
+            "type": "object",
+            "properties": {
+                "productId": {
+                "description": "The unique identifier for a product",
+                "type": "integer"
+                },
+                "productName": {
+                "description": "Name of the product",
+                "type": "string"
+                },
+                "price": {
+                "description": "The price of the product",
+                "type": "number",
+                "exclusiveMinimum": 0
+                },
+                "tags": {
+                "description": "Tags for the product",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 1,
+                "uniqueItems": true
+                },
+                "dimensions": {
+                "type": "object",
+                "properties": {
+                    "length": {
+                    "type": "number"
+                    },
+                    "width": {
+                    "type": "number"
+                    },
+                    "height": {
+                    "type": "number"
+                    }
+                },
+                "required": [ "length", "width", "height" ]
+                }
+            },
+            "required": [ "productId", "productName", "price" ]
+            }
         )""",
         // Passing strings
         {

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -15,6 +15,8 @@
 
 using json = nlohmann::ordered_json;
 
+//#define INCLUDE_FAILING_TESTS 1
+
 static llama_grammar* build_grammar(const std::string & grammar_str) {
     auto parsed_grammar = grammar_parser::parse(grammar_str.c_str());
 
@@ -816,10 +818,12 @@ static void test_json_schema() {
             // "By extension, even an empty object is valid"
             R"""({})""",
             // "By default, providing additional properties is valid"
+#ifdef INCLUDE_FAILING_TESTS
             // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
             R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
             // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
             R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+#endif
         },
         // Failing strings
         {
@@ -850,6 +854,9 @@ static void test_json_schema() {
         )""",
         // Passing strings
         {
+            // "By extension, even an empty object is valid"
+            R"""({})""",
+#ifdef INCLUDE_FAILING_TESTS
             // TODO: Following line should pass and doesn't
             R"""({"number":1600,"street_name":"Pennsylvania","street_type":"Avenue"})""",
             // "By default, leaving out properties is valid"
@@ -857,13 +864,12 @@ static void test_json_schema() {
             R"""({ "street_name": "Pennsylvania" })""",
             // TODO: Following line should pass and doesn't
             R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
-            // "By extension, even an empty object is valid"
-            R"""({})""",
             // "By default, providing additional properties is valid"
             // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
             R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
             // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
             R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+#endif
         },
         // Failing strings
         {
@@ -895,8 +901,10 @@ static void test_json_schema() {
             R"""({ "number": 1600, "street_type":"Avenue"})""",
             R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
             R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue"})""",
+#ifdef INCLUDE_FAILING_TESTS
             // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
-            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+#endif
         },
         // Failing strings
         {

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -102,7 +102,7 @@ static void test_grammar(const std::string & test_desc, const std::string & gram
                 fclose(string_file);
             }
 
-            fprintf(stderr, "    Analyze in detail by running: `./gbnf-validator test-grammar-integration.grammar.gbnf test-grammar-integration.string.txt`\n");
+            fprintf(stderr, "\n NOTE: Debug grammar file generated. To analyze this failure in detail, run the following command:     ./gbnf-validator test-grammar-integration.grammar.gbnf test-grammar-integration.string.txt\n\n");
         } else {
             fprintf(stdout, "✅︎\n");
         }
@@ -837,9 +837,9 @@ static void test_json_schema() {
             R"""({})""",
             // "By default, providing additional properties is valid"
             // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
-            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
             // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
-            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
         },
         // Failing strings
         {
@@ -872,17 +872,20 @@ static void test_json_schema() {
             )),
         // Passing strings
         {
-            //R"""({"number":1600,"street_name":"Pennsylvania","street_type":"Avenue"})""",
+            // TODO: Following line should pass and doesn't
+            R"""({"number":1600,"street_name":"Pennsylvania","street_type":"Avenue"})""",
             // "By default, leaving out properties is valid"
-            //R"""({ "street_name": "Pennsylvania" })""",
-            //R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
+            // TODO: Following line should pass and doesn't
+            R"""({ "street_name": "Pennsylvania" })""",
+            // TODO: Following line should pass and doesn't
+            R"""({ "number": 1600, "street_name": "Pennsylvania" })""",
             // "By extension, even an empty object is valid"
             R"""({})""",
             // "By default, providing additional properties is valid"
             // TODO: The following should pass, but currently FAILS. Additional properties should be permitted by default.
-            //R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type":"Avenue", "direction":"NW"})""",
             // TODO: Spaces should be permitted around enum values, but currently they fail to pass.
-            // R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
+            R"""({ "number": 1600, "street_name": "Pennsylvania", "street_type": "Avenue" })""",
         },
         // Failing strings
         {

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -106,7 +106,7 @@ static void test(const std::string & test_desc, const std::string & grammar_str,
                 fclose(string_file);
             }
 
-            fprintf(stderr, "\n NOTE: Debug grammar file generated. To analyze this failure in detail, run the following command:     ./gbnf-validator test-grammar-integration.grammar.gbnf test-grammar-integration.string.txt\n\n");
+            fprintf(stderr, "\n NOTE: Debug grammar file generated. To analyze this failure in detail, run the following command:     ./llama-gbnf-validator test-grammar-integration.grammar.gbnf test-grammar-integration.string.txt\n\n");
         } else {
             fprintf(stdout, "✅︎\n");
         }
@@ -510,11 +510,15 @@ static void test_json_schema() {
         // Passing strings
         {
             "{}",
-            "{\"foo\": \"bar\"}",
+            R"""({"foo": "bar"})""",
         },
         // Failing strings
         {
             "",
+            "[]",
+            "null",
+            "\"\"",
+            "true",
         }
     );
 
@@ -932,16 +936,16 @@ static void test_json_schema() {
         )""",
         // Passing strings
         {
-            "{\"b\": \"foo\", \"a\": \"bar\"}",
-            "{\"b\":\"foo\",\"a\":\"bar\",\"d\":\"qux\"}",
-            "{\"b\":\"foo\", \"a\":\"bar\", \"d\":\"qux\", \"c\":\"baz\"}",
+            R"""({"b": "foo", "a": "bar"})""",
+            R"""({"b":"foo","a":"bar","d":"qux"})""",
+            R"""({"b":"foo", "a":"bar", "d":"qux", "c":"baz"})""",
         },
         // Failing strings
         {
-            "{\"a\": \"foo\", \"b\": \"bar\"}",
-            "{\"b\": \"bar\"}",
-            "{\"a\": \"foo\", \"c\": \"baz\"}",
-            "{\"a\":\"foo\", \"b\":\"bar\", \"c\":\"baz\", \"d\":\"qux\"}",
+            R"""({"a": "foo", "b": "bar"})""",
+            R"""({"b": "bar"})""",
+            R"""({"a": "foo", "c": "baz"})""",
+            R"""({"a":"foo", "b":"bar", "c":"baz", "d":"qux"})""",
         }
     );
 
@@ -1000,24 +1004,23 @@ static void test_json_schema() {
         )""",
         // Passing strings
         {
-            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50}",
-            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\"]}",
-            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\"], \"dimensions\": {\"length\": 785, \"width\": 250.5, \"height\": -0.359}}",
+            R"""({"productId": 1, "productName": "A green door", "price": 12.50})""",
+            R"""({"productId": 1, "productName": "A green door", "price": 12.50, "tags": ["home", "green"]})""",
+            R"""({"productId": 1, "productName": "A green door", "price": 12.50, "tags": ["home", "green"], "dimensions": {"length": 785, "width": 250.5, "height": -0.359}})""",
         },
         // Failing strings
         {
-            "{}", // Missing all required properties
-            "{\"productName\": \"A green door\", \"price\": 12.50, \"productId\": 1}", // Out of order properties
+            R"""({})""", // Missing all required properties
+            R"""({"productName": "A green door", "price": 12.50, "productId": 1})""", // Out of order properties
             // TODO: The following line should fail, but currently it passes. `exclusiveMinimum` is not supported, as it would likely be too difficult to implement.
             //  Perhaps special checks for minimum and maximum values of 0 could be added (since that's relatively easy to do with grammars), but anything else would likely be too complex.
-            // "{\"productId\": 1, \"productName\": \"A green door\", \"price\": -12.50}",
-            "{\"productId\": 1, \"productName\": \"A green door\"}", // Missing required property (price)
-            "{\"productName\": \"A green door\", \"price\": 12.50}", // Missing required property (productId)
-            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": []}", // tags is empty, but minItems is 1
-            "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"dimensions\": {\"length\": 785, \"width\": 250.5, \"height\": -0.359}, \"tags\": [\"home\", \"green\"]}", // Tags and dimensions are out of order
+            // R"""({"productId": 1, "productName": "A green door", "price": -12.50})""",
+            R"""({"productId": 1, "productName": "A green door"})""", // Missing required property (price)
+            R"""({"productName": "A green door", "price": 12.50})""", // Missing required property (productId)
+            R"""({"productId": 1, "productName": "A green door", "price": 12.50, "tags": []})""", // tags is empty, but minItems is 1
+            R"""({"productId": 1, "productName": "A green door", "price": 12.50, "dimensions": {"length": 785, "width": 250.5, "height": -0.359}, "tags": ["home", "green"]})""", // Tags and dimensions are out of order
             // TODO: The following line should fail, but currently it passes. `uniqueItems` is not supported, as it would likely be too difficult to implement.
-            // "{\"productId\": 1, \"productName\": \"A green door\", \"price\": 12.50, \"tags\": [\"home\", \"green\", \"home\"]}",
-
+            // R"""({"productId": 1, "productName": "A green door", "price": 12.50, "tags": ["home", "green", "home"]})""",
         }
     );
 }

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -7,6 +7,7 @@
 #include "ggml.h"
 #include "llama.h"
 #include "grammar-parser.h"
+#include "json-schema-to-grammar.h"
 #include "unicode.h"
 #include <cassert>
 #include <string>
@@ -468,6 +469,31 @@ empty ::= "blah" | )""";
     fprintf(stderr, "  ✅︎ Passed\n");
 }
 
+static void test_json_schema() {
+    // Note that this is similar to the regular grammar tests,
+    //  but we convert each json schema to a grammar before parsing.
+    // Otherwise, this test structure is the same.
+
+    test_grammar(
+        "empty schema",
+        // Grammar
+        json_schema_to_grammar(nlohmann::ordered_json::parse(
+            R"""(
+{}
+            )"""
+            )),
+        // Passing strings
+        {
+            "{}",
+            "{\"foo\": \"bar\"}",
+        },
+        // Failing strings
+        {
+            "",
+        }
+    );
+}
+
 int main() {
     fprintf(stdout, "Running grammar integration tests...\n");
     test_simple_grammar();
@@ -477,6 +503,7 @@ int main() {
     test_failure_missing_root();
     test_failure_missing_reference();
     test_failure_left_recursion();
+    test_json_schema();
     fprintf(stdout, "All tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
This adds a number of FAILING tests to exercise JSON schema conversion. These failures are good, as they show bugs in our current schema-to-grammar system (as noted by #7703 and #7789 ).

I originally started writing these tests to help me dig into the root causes behind #7703 , but I ran into some other issues along the way (hence #7789 ).

Of the failing tests, in particular, there are a number of "pass" test cases that are marked with TODO that SHOULD pass and currently do NOT.

The "fail" test cases that are improperly passing are not as big of a deal (these are things that we can't really expect to support, such as numeric minimums or ensuring uniqueness of array entries), so feel free to ignore those TODO entries.

This is meant as an aide to anyone else who wants to chip in on any of the json-schema features / bugs and wants an easier way to debug the json schema generation and test it against sample generations. Very helpfully the json-schema.org documentation often includes examples of matching and non-matching strings for example schemas in their documentation, and I have begun copying those into these integration tests directly.