### PR TITLE
Changing vulkan GGML_VK_FORCE_MAX_ALLOCATION_SIZE to parse 64-bit not 32-bit

### DIFF
--- a/ggml-vulkan.cpp
+++ b/ggml-vulkan.cpp
@@ -1773,7 +1773,7 @@ static void ggml_vk_init(ggml_backend_vk_context * ctx, size_t idx) {
         const char* GGML_VK_FORCE_MAX_ALLOCATION_SIZE = getenv("GGML_VK_FORCE_MAX_ALLOCATION_SIZE");
 
         if (GGML_VK_FORCE_MAX_ALLOCATION_SIZE != nullptr) {
-            ctx->device->max_memory_allocation_size = std::stoi(GGML_VK_FORCE_MAX_ALLOCATION_SIZE);
+            ctx->device->max_memory_allocation_size = std::stol(GGML_VK_FORCE_MAX_ALLOCATION_SIZE);
         } else if (maintenance4_support) {
             ctx->device->max_memory_allocation_size = std::min(props3.maxMemoryAllocationSize, props4.maxBufferSize);
         } else {


### PR DESCRIPTION
I was trying to use multi-gpu to run some larger 70b models and was getting errors about OOM. Looking in aPR(https://github.com/ggerganov/llama.cpp/pull/5835) showed there's an env override to get higher levels of VRAM allocations.



I wasn't able to set this env variable high enough without getting `stoi` errors

![image](https://github.com/ggerganov/llama.cpp/assets/294042/508956d7-8f03-41af-af30-2e796a033e4a)

changing this to `stol` to get a 64-bit long

![image](https://github.com/ggerganov/llama.cpp/assets/294042/e88f9064-17fa-45d0-af23-56444a52e9f8)

@0cc4m
