### PR TITLE
WIP: Use DirectStorage with CUDA interop to more efficient load tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1206,6 +1206,8 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
     add_library(ggml_shared SHARED $<TARGET_OBJECTS:ggml>)
     target_link_libraries(ggml_shared PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
+    target_link_libraries(ggml_shared PUBLIC "${LLAMA_DIRECT_STORAGE_DIR}/native/lib/x64/dstorage.lib" cuda cudart d3d12)
+
     install(TARGETS ggml_shared LIBRARY)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ option(LLAMA_BLAS                            "llama: use BLAS"                  
 option(LLAMA_LLAMAFILE                       "llama: use llamafile SGEMM"                       ${LLAMA_LLAMAFILE_DEFAULT})
 set(LLAMA_BLAS_VENDOR "Generic" CACHE STRING "llama: BLAS library vendor")
 option(LLAMA_CUDA                            "llama: use CUDA"                                  OFF)
+option(LLAMA_CUDA_DIRECT_STORAGE             "llama: use DirectStorage to upload tensors"       OFF)
+set(LLAMA_DIRECT_STORAGE_DIR "" CACHE PATH   "llama: path to DirectStorage directory fetched with nuget. See https://devblogs.microsoft.com/directx/directstorage-api-downloads/" )
 option(LLAMA_CUBLAS                          "llama: use CUDA (deprecated, use LLAMA_CUDA)"     OFF)
 option(LLAMA_CUDA_FORCE_DMMV                 "llama: use dmmv instead of mmvq CUDA kernels"     OFF)
 option(LLAMA_CUDA_FORCE_MMQ                  "llama: use mmq kernels instead of cuBLAS"         OFF)
@@ -152,7 +154,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/scripts/build-info.cmake)
 # Compile flags
 #
 
-if (LLAMA_SYCL)
+if (LLAMA_SYCL OR LLAMA_CUDA_DIRECT_STORAGE)
     set(CMAKE_CXX_STANDARD 17)
 else()
     set(CMAKE_CXX_STANDARD 11)
@@ -411,6 +413,15 @@ if (LLAMA_CUDA)
 
         file(GLOB GGML_SOURCES_CUDA "ggml-cuda/*.cu")
         list(APPEND GGML_SOURCES_CUDA "ggml-cuda.cu")
+
+        if (LLAMA_CUDA_DIRECT_STORAGE)
+            file(GLOB GGML_SOURCES_CUDA_C "ggml-cuda/*.cpp")
+            file(GLOB GGML_SOURCES_CUDA_H "ggml-cuda/*.h")
+            list(APPEND GGML_SOURCES_CUDA ${GGML_SOURCES_CUDA_C})
+            list(APPEND GGML_SOURCES_CUDA ${GGML_SOURCES_CUDA_H})
+
+            add_compile_definitions(GGML_ENABLE_DIRECT_STORAGE_CUDA)
+        endif()
 
         add_compile_definitions(GGML_USE_CUDA)
         if (LLAMA_CUDA_FORCE_DMMV)
@@ -1172,15 +1183,15 @@ add_library(ggml OBJECT
             ggml-backend.h
             ggml-quants.c
             ggml-quants.h
-            ${GGML_SOURCES_CUDA}      ${GGML_HEADERS_CUDA}
-            ${GGML_SOURCES_OPENCL}    ${GGML_HEADERS_OPENCL}
-            ${GGML_SOURCES_METAL}     ${GGML_HEADERS_METAL}
-            ${GGML_SOURCES_MPI}       ${GGML_HEADERS_MPI}
-            ${GGML_SOURCES_EXTRA}     ${GGML_HEADERS_EXTRA}
-            ${GGML_SOURCES_SYCL}      ${GGML_HEADERS_SYCL}
-            ${GGML_SOURCES_KOMPUTE}   ${GGML_HEADERS_KOMPUTE}
-            ${GGML_SOURCES_VULKAN}    ${GGML_HEADERS_VULKAN}
-            ${GGML_SOURCES_ROCM}      ${GGML_HEADERS_ROCM}
+            ${GGML_SOURCES_CUDA}    ${GGML_HEADERS_CUDA}
+            ${GGML_SOURCES_OPENCL}  ${GGML_HEADERS_OPENCL}
+            ${GGML_SOURCES_METAL}   ${GGML_HEADERS_METAL}
+            ${GGML_SOURCES_MPI}     ${GGML_HEADERS_MPI}
+            ${GGML_SOURCES_EXTRA}   ${GGML_HEADERS_EXTRA}
+            ${GGML_SOURCES_SYCL}    ${GGML_HEADERS_SYCL}
+            ${GGML_SOURCES_KOMPUTE} ${GGML_HEADERS_KOMPUTE}
+            ${GGML_SOURCES_VULKAN}  ${GGML_HEADERS_VULKAN}
+            ${GGML_SOURCES_ROCM}    ${GGML_HEADERS_ROCM}
             ${GGML_SOURCES_LLAMAFILE} ${GGML_HEADERS_LLAMAFILE}
             )
 
@@ -1196,6 +1207,14 @@ if (BUILD_SHARED_LIBS)
     add_library(ggml_shared SHARED $<TARGET_OBJECTS:ggml>)
     target_link_libraries(ggml_shared PUBLIC Threads::Threads ${LLAMA_EXTRA_LIBS})
     install(TARGETS ggml_shared LIBRARY)
+endif()
+
+if (LLAMA_CUDA_DIRECT_STORAGE)
+    set_property(TARGET ggml PROPERTY VS_PACKAGE_REFERENCES "Microsoft.Direct3D.DirectStorage_1.2.2")
+
+    target_include_directories(ggml PRIVATE "${LLAMA_DIRECT_STORAGE_DIR}/native/include")
+    target_link_directories(ggml PRIVATE "${LLAMA_DIRECT_STORAGE_DIR}/native/lib/x64")
+    target_link_libraries(ggml PUBLIC "${LLAMA_DIRECT_STORAGE_DIR}/native/lib/x64/dstorage.lib" cuda cudart d3d12)
 endif()
 
 # llama

--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -223,7 +223,8 @@ GGML_CALL void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void *
 
     GGML_ASSERT(buf != NULL && "tensor buffer not set");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    //GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    GGML_ASSERT(offset + (size & ~(1u << 31)) <= ggml_nbytes(tensor) && "tensor write out of bounds");
 
     if (!size) {
         return;

--- a/ggml-cuda/dsc.cpp
+++ b/ggml-cuda/dsc.cpp
@@ -1,0 +1,652 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "dsc.h"
+#include <dstorage.h>
+#include <dxgi1_4.h>
+#include <iostream>
+#include <filesystem>
+#include <fstream>
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <winrt/base.h>
+#include <windows.h>
+#include <sstream>
+#include <cuda.h>
+#include <cuda_d3d11_interop.h>
+#include <Aclapi.h> // WindowsSecurityAttributes
+#include <queue>
+#include <condition_variable>
+#include <mutex>
+
+#include <nvtx3/nvToolsExt.h>
+
+
+class WindowsSecurityAttributes
+{
+protected:
+  SECURITY_ATTRIBUTES m_winSecurityAttributes = {};
+  SECURITY_DESCRIPTOR m_securityDescriptor = {};
+  PSID pSID = 0;
+  PACL pACL = 0;
+
+public:
+  WindowsSecurityAttributes()
+  {
+    InitializeSecurityDescriptor(&m_securityDescriptor, SECURITY_DESCRIPTOR_REVISION);
+
+    SID_IDENTIFIER_AUTHORITY sidIdentifierAuthority = SECURITY_WORLD_SID_AUTHORITY;
+    AllocateAndInitializeSid(&sidIdentifierAuthority, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, &pSID);
+
+    EXPLICIT_ACCESS explicitAccess = {};
+    explicitAccess.grfAccessPermissions = STANDARD_RIGHTS_ALL | SPECIFIC_RIGHTS_ALL;
+    explicitAccess.grfAccessMode = SET_ACCESS;
+    explicitAccess.grfInheritance = INHERIT_ONLY;
+    explicitAccess.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    explicitAccess.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+    explicitAccess.Trustee.ptstrName = reinterpret_cast<LPTSTR>(pSID);
+
+    SetEntriesInAcl(1, &explicitAccess, NULL, &pACL);
+    SetSecurityDescriptorDacl(&m_securityDescriptor, TRUE, pACL, FALSE);
+
+    m_winSecurityAttributes.nLength = sizeof(m_winSecurityAttributes);
+    m_winSecurityAttributes.lpSecurityDescriptor = &m_securityDescriptor;
+    m_winSecurityAttributes.bInheritHandle = TRUE;
+  }
+
+  WindowsSecurityAttributes(WindowsSecurityAttributes const& rhs) = delete;
+  WindowsSecurityAttributes(WindowsSecurityAttributes const&& rhs) = delete;
+
+  ~WindowsSecurityAttributes() {
+    if (pSID)
+    {
+      FreeSid(pSID);
+    }
+    if (pACL)
+    {
+      LocalFree(pACL);
+    }
+  }
+
+  operator SECURITY_ATTRIBUTES const* () const {
+    return &m_winSecurityAttributes;
+  }
+};
+
+DirectStorageCUDA::~DirectStorageCUDA()
+{
+}
+
+struct DirectStorageCUDAFileHandleImpl : DirectStorageCUDAFileHandle
+{
+    ~DirectStorageCUDAFileHandleImpl() {};
+
+    using File = winrt::com_ptr<IDStorageFile>;
+    File file;
+
+    IDStorageFile* get() { return file.get(); }
+    IDStorageFile** put() { return file.put(); }
+};
+
+InteropBuffer::~InteropBuffer()
+{
+}
+
+class InteropBufferImpl : public InteropBuffer
+{
+public:
+  InteropBufferImpl(winrt::com_ptr<ID3D12Device> const& d3d_device, size_t size)
+  {
+
+    // Create the ID3D12Resource buffer which will be used as temporary scratch space for d3d
+    // since it's not possible to import CUDA memory into DX.
+    D3D12_HEAP_PROPERTIES bufferHeapProps = {};
+    bufferHeapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+
+    D3D12_HEAP_DESC hd = {};
+    hd.SizeInBytes = size;
+    hd.Properties = bufferHeapProps;
+    hd.Flags = D3D12_HEAP_FLAG_SHARED;
+    hd.Alignment = 0;
+    d3d_device->CreateHeap(&hd, IID_PPV_ARGS(&m_d3d_heap));
+
+
+    D3D12_RESOURCE_DESC bufferDesc = {};
+    bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    bufferDesc.Width = size;
+    bufferDesc.Height = 1;
+    bufferDesc.DepthOrArraySize = 1;
+    bufferDesc.MipLevels = 1;
+    bufferDesc.Format = DXGI_FORMAT_UNKNOWN;
+    bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    bufferDesc.SampleDesc.Count = 1;
+
+//#define USE_BUFFER
+#if defined(USE_BUFFER) // 
+    winrt::check_hresult(d3d_device->CreateCommittedResource(
+      &bufferHeapProps,
+      D3D12_HEAP_FLAG_NONE | D3D12_HEAP_FLAG_SHARED,
+      &bufferDesc,
+      D3D12_RESOURCE_STATE_COMMON,
+      nullptr,
+      IID_PPV_ARGS(m_d3d_buffer.put())));
+#else
+    winrt::check_hresult(d3d_device->CreatePlacedResource(
+      m_d3d_heap.get(),
+      0,
+      &bufferDesc,
+      D3D12_RESOURCE_STATE_COMMON,
+      nullptr,
+      IID_PPV_ARGS(m_d3d_buffer.put())));
+#endif
+
+#if 0
+    // debug begin
+    bufferHeapProps.Type = D3D12_HEAP_TYPE_READBACK;
+    winrt::check_hresult(d3d_device->CreateCommittedResource(
+      &bufferHeapProps,
+      D3D12_HEAP_FLAG_NONE,
+      &bufferDesc,
+      D3D12_RESOURCE_STATE_COMMON,
+      nullptr,
+      IID_PPV_ARGS(m_host_buffer.put())));
+
+    m_host_buffer->Map(0, nullptr, &m_host_ptr);
+    d3d_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_cmdallocator));
+    d3d_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_cmdallocator.get(), nullptr, IID_PPV_ARGS(&m_cmdlist));
+#endif
+
+    D3D12_COMMAND_QUEUE_DESC qd = {};
+    qd.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+    d3d_device->CreateCommandQueue(&qd, IID_PPV_ARGS(&m_cmd_queue));
+    // debug end
+
+    // create a shared handle to require to import the d3d buffer into CUDA
+    HANDLE sharedHandle;
+    WindowsSecurityAttributes windowsSecurityAttributes;
+    LPCWSTR name = NULL;
+#if USE_BUFFER
+    d3d_device->CreateSharedHandle(m_d3d_buffer.get(), windowsSecurityAttributes, GENERIC_ALL, name, &sharedHandle);
+
+    cudaExternalMemoryHandleDesc externalMemoryHandleDesc = {};
+    externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeD3D12Resource;
+#else
+    d3d_device->CreateSharedHandle(m_d3d_heap.get(), windowsSecurityAttributes, GENERIC_ALL, name, &sharedHandle);
+
+    cudaExternalMemoryHandleDesc externalMemoryHandleDesc = {};
+    externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeD3D12Heap;
+#endif
+    externalMemoryHandleDesc.handle.win32.handle = sharedHandle;
+    externalMemoryHandleDesc.size = bufferDesc.Width;
+    externalMemoryHandleDesc.flags = cudaExternalMemoryDedicated;
+    auto result = cudaImportExternalMemory(&m_externalMemory, &externalMemoryHandleDesc);
+
+    CloseHandle(sharedHandle);
+
+    // get pointer to external memory imported form d3d
+    cudaExternalMemoryBufferDesc externalMemoryBufferDesc = {};
+    externalMemoryBufferDesc.offset = 0;
+    externalMemoryBufferDesc.size = externalMemoryHandleDesc.size;
+    externalMemoryBufferDesc.flags = 0;
+
+    result = cudaExternalMemoryGetMappedBuffer(&m_cuda_dev_ptr, m_externalMemory, &externalMemoryBufferDesc);
+    result = cudaDeviceSynchronize();
+
+    auto err = cudaMemset(m_cuda_dev_ptr, 255, 512*1024*1024);
+    result = cudaDeviceSynchronize();
+    std::cout << "err: " << err << std::endl;
+  }
+
+  ~InteropBufferImpl() {
+    auto result = cudaDestroyExternalMemory(m_externalMemory);
+    cudaFree(m_cuda_dev_ptr);
+    if (result != cudaSuccess) {
+      std::cout << "cudaDestroyExternalMemory interop buffer: " << result << std::endl;
+    }
+  }
+
+  void* get_device_ptr() const {
+    return m_cuda_dev_ptr;
+  }
+
+  ID3D12Resource* get_d3d_buffer() const {
+    return m_d3d_buffer.get();
+  }
+
+  void* get_host_ptr() const {
+#if 0
+    m_cmdlist->Reset(m_cmdallocator.get(), nullptr);
+    m_cmdlist->CopyResource(m_host_buffer.get(), m_d3d_buffer.get());
+    m_cmdlist->Close();
+
+    ID3D12CommandList *ptr = m_cmdlist.get();
+    m_cmd_queue->ExecuteCommandLists(1, &ptr);
+    Sleep(2);
+#endif
+
+    return m_host_ptr;
+  }
+
+private:
+  winrt::com_ptr<ID3D12CommandQueue> m_cmd_queue = {};
+  winrt::com_ptr<ID3D12Resource> m_d3d_buffer = {};
+  winrt::com_ptr<ID3D12Heap> m_d3d_heap = {};
+
+  cudaExternalMemory_t m_externalMemory;
+  void* m_cuda_dev_ptr;
+
+  // debug
+  winrt::com_ptr<ID3D12Resource> m_host_buffer = {};
+  winrt::com_ptr<ID3D12GraphicsCommandList> m_cmdlist = {};
+  winrt::com_ptr<ID3D12CommandAllocator> m_cmdallocator = {};
+  void* m_host_ptr;
+};
+
+class DirectStorageCUDAImpl : public DirectStorageCUDA
+{
+public:
+  DirectStorageCUDAImpl(int scratch_size, int number_of_scratch_spaces);
+
+  virtual ~DirectStorageCUDAImpl() {
+    flush(true);
+    std::cout << "~DirectStorageCudaImpl" << std::endl;
+  }
+
+    struct FileInfo {
+        const std::string& filename;
+        void* cuda_device_ptr;
+        size_t offset;
+        size_t size;
+    };
+
+    virtual std::unique_ptr<InteropBuffer> create_interop_buffer(size_t size);
+    virtual DirectStorageCUDA::File openFile(std::string const& filename);
+    virtual void loadFile(DirectStorageCUDA::File const& file, size_t read_start, size_t read_len, void* cuda_dst_ptr);
+    virtual void loadFile(File const& file, size_t read_start, size_t read_len, InteropBuffer* interop_buffer, size_t interop_buffer_offset);
+    virtual void flush(bool last);
+private:
+    class StagingArea
+    {
+    public:
+      StagingArea(winrt::com_ptr<ID3D12Device> d3d_device, winrt::com_ptr<IDStorageFactory> d3d_factory, size_t chunk_size, size_t number_of_chunks)
+        : m_d3d_device(d3d_device)
+        , m_d3d_factory(d3d_factory)
+        , m_chunk_size(chunk_size)
+        , m_number_of_chunks(number_of_chunks)
+        , m_total_staging_space(chunk_size * number_of_chunks)
+      {
+        // Create a DirectStorage queue which will be used to load data into a
+        // buffer on the GPU.
+        DSTORAGE_QUEUE_DESC queueDesc{};
+        queueDesc.Capacity = DSTORAGE_MAX_QUEUE_CAPACITY;
+        queueDesc.Priority = DSTORAGE_PRIORITY_NORMAL;
+        queueDesc.SourceType = DSTORAGE_REQUEST_SOURCE_FILE;
+        queueDesc.Device = m_d3d_device.get();
+
+        winrt::check_hresult(m_d3d_factory->CreateQueue(&queueDesc, IID_PPV_ARGS(m_d3d_storage_queue.put())));
+
+        // Create the ID3D12Resource buffer which will be used as temporary scratch space for d3d
+        // since it's not possible to import CUDA memory into DX.
+        D3D12_HEAP_PROPERTIES bufferHeapProps = {};
+        bufferHeapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+        D3D12_RESOURCE_DESC bufferDesc = {};
+        bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        bufferDesc.Width = m_chunk_size * m_number_of_chunks;
+        bufferDesc.Height = 1;
+        bufferDesc.DepthOrArraySize = 1;
+        bufferDesc.MipLevels = 1;
+        bufferDesc.Format = DXGI_FORMAT_UNKNOWN;
+        bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        bufferDesc.SampleDesc.Count = 1;
+
+        winrt::check_hresult(m_d3d_device->CreateCommittedResource(
+          &bufferHeapProps,
+          D3D12_HEAP_FLAG_NONE | D3D12_HEAP_FLAG_SHARED,
+          &bufferDesc,
+          D3D12_RESOURCE_STATE_COMMON,
+          nullptr,
+          IID_PPV_ARGS(m_d3d_scratch_space.put())));
+
+
+        // create a shared handle to require to import the d3d buffer into CUDA
+        HANDLE sharedHandle;
+        WindowsSecurityAttributes windowsSecurityAttributes;
+        LPCWSTR name = NULL;
+        m_d3d_device->CreateSharedHandle(m_d3d_scratch_space.get(), windowsSecurityAttributes, GENERIC_ALL, name, &sharedHandle);
+
+        cudaExternalMemoryHandleDesc externalMemoryHandleDesc = {};
+        externalMemoryHandleDesc.type = cudaExternalMemoryHandleTypeD3D12Resource;
+        externalMemoryHandleDesc.handle.win32.handle = sharedHandle;
+        externalMemoryHandleDesc.size = bufferDesc.Width;
+        externalMemoryHandleDesc.flags = cudaExternalMemoryDedicated;
+        auto result = cudaImportExternalMemory(&m_externalMemory, &externalMemoryHandleDesc);
+
+        CloseHandle(sharedHandle);
+
+        // get pointer to external memory imported form d3d
+        cudaExternalMemoryBufferDesc externalMemoryBufferDesc = {};
+        externalMemoryBufferDesc.offset = 0;
+        externalMemoryBufferDesc.size = externalMemoryHandleDesc.size;
+        externalMemoryBufferDesc.flags = 0;
+
+        result = cudaExternalMemoryGetMappedBuffer(&m_cuda_scratch_space, m_externalMemory, &externalMemoryBufferDesc);
+
+        // create d3d fence for synchronization
+        auto resultDx = m_d3d_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&m_d3d_fence));
+
+        // import d3d fence as semaphore into CUDA.
+        cudaExternalSemaphoreHandleDesc extSemHandleDesc = {};
+        extSemHandleDesc.type = cudaExternalSemaphoreHandleTypeD3D12Fence;
+        m_d3d_device->CreateSharedHandle(m_d3d_fence.get(), nullptr, GENERIC_ALL, nullptr, &extSemHandleDesc.handle.win32.handle);
+        result = cudaImportExternalSemaphore(&m_externalSemaphore, &extSemHandleDesc);
+
+        cudaStreamCreate(&m_cudaStream);
+
+        // intialize fence to wait for in flush
+        waitParams.params.fence.value = 1;
+      }
+
+      ~StagingArea()
+      {
+        std::cout << "~StagingArea" << std::endl;
+        auto result = cudaDestroyExternalMemory(m_externalMemory);
+        cudaFree(m_cuda_scratch_space);
+        if (result != cudaSuccess) {
+          std::cout << "cudaDestroyExternalMemory interop buffer: " << result << std::endl;
+        }
+        // TODO ensure that no resources are being leaked
+      }
+
+      // enqueue as much data as possible into the current staging area.
+      // enqueue will return true if all data has been enqueued, false otherwise.
+      // start, len and cuda_dev_ptr will be updated.
+      bool enqueue(DirectStorageCUDA::File const& file, size_t& read_start, size_t& len, void*& cuda_dst_ptr)
+      {
+        if (len == 0)
+          return false;
+
+        m_enqueued = true;
+
+        size_t memcpy_src_start = m_current_staging_offset;
+
+        static size_t load_cnt = 0;
+        size_t read_end = read_start + len;
+        for (size_t src_start = read_start; src_start < read_end; src_start += m_chunk_size)
+        {
+          ++load_cnt;
+          size_t src_end = min(read_end, src_start + m_chunk_size);
+          size_t src_size = src_end - src_start;
+
+          if (m_current_staging_offset + src_size >= m_total_staging_space)
+          {
+            //std::cout << load_cnt << std::endl;
+            load_cnt = 0;
+
+            size_t processed_len = m_current_staging_offset - memcpy_src_start;
+            m_staging_memcpies.push_back(MemcpyOp(cuda_dst_ptr, (void*)((char*)m_cuda_scratch_space + memcpy_src_start), processed_len));
+
+            cuda_dst_ptr = reinterpret_cast<void*>(reinterpret_cast<char*>(cuda_dst_ptr) + processed_len);
+            read_start += processed_len;
+            len -= processed_len;
+
+            flush(false);
+
+            memcpy_src_start = m_current_staging_offset;
+
+            return true;
+          }
+
+          DSTORAGE_REQUEST request = {};
+          request.Options.SourceType = DSTORAGE_REQUEST_SOURCE_FILE;
+          request.Options.DestinationType = DSTORAGE_REQUEST_DESTINATION_BUFFER;
+          request.Source.File.Source = static_cast<DirectStorageCUDAFileHandleImpl*>(file.get())->get();
+          request.Source.File.Offset = src_start;
+          request.Source.File.Size = src_size; // filesize
+          request.UncompressedSize = src_size; // filesize 
+          request.Destination.Buffer.Resource = m_d3d_scratch_space.get();
+          request.Destination.Buffer.Offset = m_current_staging_offset;
+          request.Destination.Buffer.Size = src_size;
+
+          m_d3d_storage_queue->EnqueueRequest(&request);
+
+          m_current_staging_offset += request.Destination.Buffer.Size;
+        }
+
+        m_staging_memcpies.push_back(MemcpyOp((void*)((char*)cuda_dst_ptr), (void*)((char*)m_cuda_scratch_space + memcpy_src_start), m_current_staging_offset - memcpy_src_start));
+
+        size_t processed_len = m_current_staging_offset - memcpy_src_start;
+        cuda_dst_ptr = reinterpret_cast<void*>(reinterpret_cast<char*>(cuda_dst_ptr) + m_current_staging_offset - memcpy_src_start);
+        read_start += processed_len;
+        len -= processed_len;
+
+        return false;
+      }
+
+      void enqueue(DirectStorageCUDA::File const& file, size_t& read_start, size_t& read_len, InteropBuffer* interop_buffer, size_t interop_buffer_offset)
+      {
+        InteropBufferImpl* ibi = static_cast<InteropBufferImpl*>(interop_buffer);
+        bool flushed;
+        while (read_len) {
+          size_t request_size = min(m_chunk_size, read_len);
+
+          DSTORAGE_REQUEST request = {};
+          request.Options.SourceType = DSTORAGE_REQUEST_SOURCE_FILE;
+          request.Options.DestinationType = DSTORAGE_REQUEST_DESTINATION_BUFFER;
+          request.Source.File.Source = static_cast<DirectStorageCUDAFileHandleImpl*>(file.get())->get();
+          request.Source.File.Offset = read_start;
+          request.Source.File.Size = request_size; // filesize
+          request.UncompressedSize = request_size; // filesize 
+          request.Destination.Buffer.Resource = ibi->get_d3d_buffer();
+          request.Destination.Buffer.Offset = interop_buffer_offset;
+          request.Destination.Buffer.Size = request_size;
+          //std::cout << read_start / (1024*1024) << " / " << interop_buffer_offset / (1024 * 1024) << "/" << request_size / (1024 * 1024) << std::endl;
+
+          m_d3d_storage_queue->EnqueueRequest(&request);
+
+          read_len -= request_size;
+          interop_buffer_offset += request_size;
+          read_start += request_size;
+
+          m_enqueued = true;
+          //flush(true);
+        };
+
+      }
+
+
+      void wait()
+      {
+        if (m_enqueued) {
+          cudaStreamSynchronize(m_cudaStream);
+          m_enqueued = false;
+        }
+      }
+
+      void flush(bool last)
+      {
+        m_d3d_storage_queue->EnqueueSignal(m_d3d_fence.get(), waitParams.params.fence.value);
+        m_d3d_storage_queue->Submit();
+
+        nvtxRangePop();
+        nvtxRangePush("wait");
+        cudaWaitExternalSemaphoresAsync(&m_externalSemaphore, &waitParams, 1, m_cudaStream);
+        nvtxRangePop();
+        nvtxRangePush("memcpy");
+#if 1
+        for (auto const& op : m_staging_memcpies) {
+          auto result = cudaMemcpyAsync(op.m_dst, op.m_src, op.m_size, cudaMemcpyDeviceToDevice, m_cudaStream);
+        }
+#endif
+        nvtxRangePop();
+        nvtxRangePush("sync");
+        //cudaStreamSynchronize(m_cudaStream);
+        nvtxRangePop();
+
+        // increase fence value by 1 for next flush call
+        waitParams.params.fence.value += 1;
+
+        // reset staging area
+        m_staging_memcpies.clear();
+        m_current_staging_offset = 0;
+
+#if 1
+        if (last) {
+          DSTORAGE_ERROR_RECORD errorRecord{};
+          m_d3d_storage_queue->RetrieveErrorRecord(&errorRecord);
+          if (FAILED(errorRecord.FirstFailure.HResult))
+          {
+            //
+            // errorRecord.FailureCount - The number of failed requests in the queue since the last
+            //                            RetrieveErrorRecord call.
+            // errorRecord.FirstFailure - Detailed record about the first failed command in the enqueue order.
+            //
+            std::cout << "The DirectStorage request failed! HRESULT=0x" << std::hex << errorRecord.FirstFailure.HResult << std::endl;
+          }
+        }
+#endif
+      }
+
+      winrt::com_ptr<ID3D12Device> m_d3d_device = {};
+      winrt::com_ptr<IDStorageFactory> m_d3d_factory = {};
+      winrt::com_ptr<IDStorageQueue> m_d3d_storage_queue = {};
+      winrt::com_ptr<ID3D12Resource> m_d3d_scratch_space = {};
+      winrt::com_ptr<ID3D12Fence> m_d3d_fence = {};
+
+      // cuda external memory resources
+      cudaExternalMemoryHandleType m_externalMemoryHandleType;
+      cudaExternalMemory_t m_externalMemory;
+      cudaExternalSemaphore_t m_externalSemaphore;
+      cudaExternalSemaphoreWaitParams waitParams = {};
+
+      size_t m_chunk_size;
+      size_t m_number_of_chunks;
+      size_t m_total_staging_space;
+
+      cudaStream_t m_cudaStream;
+      void* m_cuda_scratch_space;
+      bool m_enqueued = false; // is any data enqueued
+
+      // memcpy 
+      size_t m_current_staging_offset = 0; // current offset in the staging buffer
+
+      // memcpies from the staging buffer to the actual CUDA memory
+      struct MemcpyOp {
+        MemcpyOp(void* dst, void* src, size_t size)
+          : m_dst(dst), m_src(src), m_size(size) {}
+        void* m_dst;
+        void* m_src;
+        size_t m_size;
+      };
+      std::vector<MemcpyOp> m_staging_memcpies;
+
+    };
+
+    winrt::com_ptr<ID3D12Device> m_d3d_device = {};
+    winrt::com_ptr<IDStorageFactory> m_d3d_factory = {};
+
+    size_t m_chunk_size;
+    size_t m_number_of_chunks;
+
+    std::vector<std::unique_ptr<StagingArea>> m_staging_areas;
+    size_t m_staging_index = 0;
+};
+
+std::unique_ptr<DirectStorageCUDA> DirectStorageCUDA::create(int scratch_size, int number_of_scratch_spaces)
+{
+    return std::make_unique<DirectStorageCUDAImpl>(scratch_size, number_of_scratch_spaces);
+}
+
+  // copy read_len bytes starting at read_start from the given file to the given cuda ptr
+void DirectStorageCUDAImpl::loadFile(DirectStorageCUDA::File const& file, size_t read_start, size_t read_len, void* cuda_dst_ptr)
+{
+  bool flushed;
+  while (read_len) {
+    flushed = m_staging_areas[m_staging_index]->enqueue(file, read_start, read_len, cuda_dst_ptr);
+    if (flushed) {
+      m_staging_index = (m_staging_index + 1) % m_staging_areas.size();
+      m_staging_areas[m_staging_index]->wait();
+    }
+  };
+}
+
+void DirectStorageCUDAImpl::loadFile(DirectStorageCUDA::File const& file, size_t read_start, size_t read_len, InteropBuffer *interop_buffer, size_t interop_buffer_offset)
+{
+  if (!interop_buffer)
+    return;
+
+  m_staging_areas[m_staging_index]->enqueue(file, read_start, read_len, interop_buffer, interop_buffer_offset);
+}
+
+
+void DirectStorageCUDAImpl::flush(bool last)
+{
+  for (auto& sa : m_staging_areas) {
+    sa->flush(last);
+  }
+  if (last) {
+    for (auto& sa : m_staging_areas) {
+      sa->wait();
+    }
+  }
+}
+
+DirectStorageCUDAImpl::DirectStorageCUDAImpl(int scratch_size, int number_of_scratch_spaces)
+    : m_chunk_size(scratch_size)
+    , m_number_of_chunks(number_of_scratch_spaces)
+{
+  DSTORAGE_CONFIGURATION direct_storage_config = {};
+  direct_storage_config.NumSubmitThreads = 1;
+  DStorageSetConfiguration(&direct_storage_config);
+
+    winrt::check_hresult(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_12_1, IID_PPV_ARGS(&m_d3d_device)));
+    winrt::check_hresult(DStorageGetFactory(IID_PPV_ARGS(m_d3d_factory.put())));
+
+    size_t num_staging_areas = 2;
+    for (size_t idx = 0; idx < num_staging_areas; ++idx) {
+      m_staging_areas.emplace_back(std::make_unique<StagingArea>(m_d3d_device, m_d3d_factory, m_chunk_size, m_number_of_chunks));
+
+    }
+}
+
+DirectStorageCUDAImpl::File DirectStorageCUDAImpl::openFile(std::string const& filename)
+{
+    File file = std::make_unique<DirectStorageCUDAFileHandleImpl>();
+    std::wstring wfilename(filename.begin(), filename.end());
+    nvtxRangePush("factory open file");
+    HRESULT hr = m_d3d_factory->OpenFile(wfilename.c_str(), IID_PPV_ARGS(static_cast<DirectStorageCUDAFileHandleImpl*>(file.get())->put()));
+    if (FAILED(hr))
+    {
+        std::wcout << L"The file '" << wfilename << L"' could not be opened. HRESULT=0x" << std::hex << hr << std::endl;
+        return {};
+    }
+    nvtxRangePop();
+    return file;
+}
+
+std::unique_ptr<InteropBuffer> DirectStorageCUDAImpl::create_interop_buffer(size_t size)
+{
+  return std::make_unique<InteropBufferImpl>(m_d3d_device, size);
+}

--- a/ggml-cuda/dsc.h
+++ b/ggml-cuda/dsc.h
@@ -34,7 +34,10 @@ class InteropBuffer {
 public:
   virtual ~InteropBuffer() = 0;
   virtual void* get_device_ptr() const = 0;
+
+#if defined(DEBUG_READBACK)
   virtual void* get_host_ptr() const = 0;
+#endif
 };
 
 class DirectStorageCUDA

--- a/ggml-cuda/dsc.h
+++ b/ggml-cuda/dsc.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+struct DirectStorageCUDAFileHandle {
+    virtual ~DirectStorageCUDAFileHandle() {};
+};
+
+class InteropBuffer {
+public:
+  virtual ~InteropBuffer() = 0;
+  virtual void* get_device_ptr() const = 0;
+  virtual void* get_host_ptr() const = 0;
+};
+
+class DirectStorageCUDA
+{
+public:
+    virtual ~DirectStorageCUDA();
+
+    using File = std::unique_ptr<DirectStorageCUDAFileHandle>;
+
+    virtual std::unique_ptr<InteropBuffer> create_interop_buffer(size_t size) = 0;
+
+    virtual File openFile(std::string const& filename) = 0;
+    virtual void loadFile(File const& file, size_t read_start, size_t read_len, void* cuda_dst_ptr) = 0;
+    virtual void loadFile(File const& file, size_t read_start, size_t read_len, InteropBuffer *interop_buffer, size_t interop_buffer_offset) = 0;
+    virtual void flush(bool last = false) = 0;
+
+    static std::unique_ptr<DirectStorageCUDA> create(int scratch_size, int number_of_scratch_spaces);
+};
+


### PR DESCRIPTION
On Windows File I've seen file IO in the range of 3GB/s - 4GB/s using a single IO thread and mmaped files. The newest NVMe drives can do >14GB/s and good raid controllers can read with to ~55GB/s. To get read speeds close to NVMe raid speed without stressing CPU RAM bw DirectStorage can be used.

On Linux CUDA supports the cuFile API, on Windows one currently has to use DirectStorage for DX with CUDA interop as done in this POC. I've seen speedups of 3x over mmap (15s->5s) when streaming from a single NVMe drive. There is a code path which can stream from two NVMe drives at once (lacking a RAID) which improves the speedup even more, but is currently limited by DX/CUDA interop limitations in combination with llama.cpp.

For now I have hijacked the non-mmaped code path and pass a struct passing the file information to the tensor_set function. For a clean solution it'd be good if there was a way to have some abstract way to import tensor data from a ggml file handle which depends on the backend. A special file handle is created because the different DirectStorage APIs all have special ways to open a file for the DirectStorage operation.

The most simple interface one could imagine would be `ggml_tensor_set(filename, offset, size).`. Passing a filename only would require opening the file on each set operation which is potentially more expensive than the read itself. Thus my proposal is to have two new functions
```
file = ggml_backend_file_open(filename)
ggml_backend_tensor_set_from_file(tensor, file, offset, size);
```

Since IO ops are completely asynchronous eventually there must be a way to synchronize all file io, or at least to add an event to the file io queue to ensure that all file io is done. Currently the hack is using a nullptr passed as file to trigger this sync.

