### PR TITLE
examples/gguf-split: Change binary multi-byte units to decimal

### DIFF
--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -61,10 +61,10 @@ static size_t split_str_to_n_bytes(std::string str) {
     int n;
     if (str.back() == 'M') {
         sscanf(str.c_str(), "%d", &n);
-        n_bytes = (size_t)n * 1024 * 1024; // megabytes
+        n_bytes = (size_t)n * 1000 * 1000; // megabytes
     } else if (str.back() == 'G') {
         sscanf(str.c_str(), "%d", &n);
-        n_bytes = (size_t)n * 1024 * 1024 * 1024; // gigabytes
+        n_bytes = (size_t)n * 1000 * 1000 * 1000; // gigabytes
     } else {
         throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
     }
@@ -284,7 +284,7 @@ struct split_strategy {
                 struct ggml_tensor * t = ggml_get_tensor(ctx_meta, gguf_get_tensor_name(ctx_out, i));
                 total_size += ggml_nbytes(t);
             }
-            total_size = total_size / 1024 / 1024; // convert to megabytes
+            total_size = total_size / 1000 / 1000; // convert to megabytes
             printf("split %05d: n_tensors = %d, total_size = %ldM\n", i_split + 1, gguf_get_n_tensors(ctx_out), total_size);
             i_split++;
         }


### PR DESCRIPTION
Noticed while testing the Python convert-split PR #6942: `examples/gguf-split` at present uses binary multi-byte units (KiB, MiB, GiB). 

Decimal units (KB, MB, GB) would be better from a standardization perspective. HuggingFace recommends 5GB per file and imposes a hard limit of 50GB, both decimal, so a user using any splitting script will be more likely to be working in decimal units to comply with these limits. 

However, tools like Linux `du` and Windows File Explorer use binary units, which could potentially lead to user confusion.

This PR simply changes `examples/gguf-split` to use decimal units instead of binary units. SHA256 sums match with splits generated by the Python script #6942.