### PR TITLE
CUDA: revise q8_1 data layout for mul_mat_q

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1347,10 +1347,30 @@ static void ggml_cuda_set_peer_access(const int n_tokens, int main_device) {
     GGML_UNUSED(main_device);
 }
 
+static cudaError_t ggml_cuda_Memcpy2DPeerAsync(
+    void * dst, int dstDevice, size_t dpitch, void * src, int srcDevice, size_t spitch, size_t width, size_t height, cudaStream_t stream) {
+
+#if !defined(GGML_USE_HIPBLAS)
+    // cudaMemcpy2DAsync may fail with copies between vmm pools of different devices
+    cudaMemcpy3DPeerParms p = {};
+    p.dstDevice = dstDevice;
+    p.dstPtr = make_cudaPitchedPtr(dst, dpitch, dpitch, height);
+    p.srcDevice = srcDevice;
+    p.srcPtr = make_cudaPitchedPtr(src, spitch, spitch, height);
+    p.extent = make_cudaExtent(width, height, 1);
+    return cudaMemcpy3DPeerAsync(&p, stream);
+#else
+    // HIP does not support cudaMemcpy3DPeerAsync or vmm pools
+    GGML_UNUSED(dstDevice);
+    GGML_UNUSED(srcDevice);
+    return cudaMemcpy2DAsync(dst, dpitch, src, spitch, width, height, cudaMemcpyDeviceToDevice, stream);
+#endif // !defined(GGML_USE_HIPBLAS)
+}
+
 static void ggml_cuda_op_mul_mat(
     ggml_backend_cuda_context & ctx,
     const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, ggml_cuda_op_mul_mat_t op,
-    const bool convert_src1_to_q8_1) {
+    quantize_cuda_t quantize_src1) {
 
     const int64_t ne00 = src0->ne[0];
     const int64_t ne01 = src0->ne[1];
@@ -1407,7 +1427,9 @@ static void ggml_cuda_op_mul_mat(
     }
 
     struct dev_data {
-        ggml_cuda_pool_alloc<char>  src0_dd_alloc;
+        int cc;
+
+        ggml_cuda_pool_alloc<char>   src0_dd_alloc;
         ggml_cuda_pool_alloc<float> src1_ddf_alloc;
         ggml_cuda_pool_alloc<char>  src1_ddq_alloc;
         ggml_cuda_pool_alloc<float>   dst_dd_alloc;
@@ -1426,6 +1448,8 @@ static void ggml_cuda_op_mul_mat(
     int used_devices = 0;
 
     for (int id = 0; id < ggml_backend_cuda_get_device_count(); ++id) {
+        dev[id].cc = ggml_cuda_info().devices[id].cc;
+
         // by default, use all rows
         dev[id].row_low  = 0;
         dev[id].row_high = ne01;
@@ -1476,11 +1500,15 @@ static void ggml_cuda_op_mul_mat(
             dev[id].src1_ddf = dev[id].src1_ddf_alloc.alloc(ctx.pool(id), ggml_nelements(src1));
         }
 
-        if (convert_src1_to_q8_1) {
-            dev[id].src1_ddq = dev[id].src1_ddq_alloc.alloc(ctx.pool(id), nrows1*src1_padded_col_size*q8_1_ts/q8_1_bs);
+        if (quantize_src1) {
+            size_t src_1_ddq_size = nrows1*src1_padded_col_size*q8_1_ts/q8_1_bs;
+            if (quantize_src1 == quantize_mmq_q8_1_cuda) {
+                src_1_ddq_size += get_mmq_x_max_host(dev[id].cc)*sizeof(block_q8_1_mmq);
+            }
+            dev[id].src1_ddq = dev[id].src1_ddq_alloc.alloc(ctx.pool(id), src_1_ddq_size);
 
             if (src1_on_device && src1_is_contiguous) {
-                quantize_row_q8_1_cuda(dev[id].src1_ddf, dev[id].src1_ddq, ne10, nrows1, src1_padded_col_size, stream);
+                quantize_src1(dev[id].src1_ddf, dev[id].src1_ddq, ne10, ne11, ne12*ne13, src1_padded_col_size, src0->type, stream);
                 CUDA_CHECK(cudaGetLastError());
             }
         }
@@ -1526,7 +1554,12 @@ static void ggml_cuda_op_mul_mat(
                 const int64_t i03 = i0 / ne12;
                 const int64_t i02 = i0 % ne12;
 
-                const size_t src1_ddq_i_offset = (i0*ne11 + src1_col_0) * src1_padded_col_size*q8_1_ts/q8_1_bs;
+                size_t src1_ddq_i_offset = i0*ne11 * src1_padded_col_size*q8_1_ts/q8_1_bs;
+                if (quantize_src1 == quantize_mmq_q8_1_cuda) {
+                    src1_ddq_i_offset += src1_col_0 * sizeof(block_q8_1_mmq);
+                } else {
+                    src1_ddq_i_offset += src1_col_0 * src1_padded_col_size*q8_1_ts/q8_1_bs;
+                }
 
                 // for split tensors the data begins at i0 == i0_offset_low
                 char  *  src0_dd_i =  dev[id].src0_dd + (i0/i02_divisor) * (ne01*ne00*src0_ts)/src0_bs;
@@ -1543,10 +1576,17 @@ static void ggml_cuda_op_mul_mat(
                 // copy src0, src1 to device if necessary
                 if (src1_is_contiguous) {
                     if (id != ctx.device) {
-                        if (convert_src1_to_q8_1) {
+                        if (quantize_src1) {
                             char * src1_ddq_i_source = dev[ctx.device].src1_ddq + src1_ddq_i_offset;
-                            CUDA_CHECK(cudaMemcpyPeerAsync(src1_ddq_i, id, src1_ddq_i_source, ctx.device,
-                                                            src1_ncols*src1_padded_col_size*q8_1_ts/q8_1_bs, stream));
+                            if (quantize_src1 == quantize_mmq_q8_1_cuda) {
+                                const size_t pitch = ne11*sizeof(block_q8_1_mmq);
+                                const size_t width = src1_ncols*sizeof(block_q8_1_mmq);
+                                const size_t height = src1_padded_col_size/(4*QK8_1);
+                                CUDA_CHECK(ggml_cuda_Memcpy2DPeerAsync(src1_ddq_i, id, pitch, src1_ddq_i_source, ctx.device, pitch, width, height, stream));
+                            } else {
+                                CUDA_CHECK(cudaMemcpyPeerAsync(
+                                    src1_ddq_i, id, src1_ddq_i_source, ctx.device, src1_ncols*src1_padded_col_size*q8_1_ts/q8_1_bs, stream));
+                            }
                         } else {
                             float * src1_ddf_i_source = (float *) src1->data;
                             src1_ddf_i_source += (i0*ne11 + src1_col_0) * ne10;
@@ -1561,8 +1601,8 @@ static void ggml_cuda_op_mul_mat(
                     GGML_ASSERT(false);
                 }
 
-                if (convert_src1_to_q8_1 && !src1_is_contiguous) {
-                    quantize_row_q8_1_cuda(src1_ddf_i, src1_ddq_i, ne10, src1_ncols, src1_padded_col_size, stream);
+                if (quantize_src1 && !src1_is_contiguous) {
+                    quantize_src1(src1_ddf_i, src1_ddq_i, ne10, src1_ncols, 1, src1_padded_col_size, src0->type, stream);
                     CUDA_CHECK(cudaGetLastError());
                 }
 
@@ -1587,22 +1627,8 @@ static void ggml_cuda_op_mul_mat(
                         float * dhf_dst_i = (float *) ((char *) dst_off_device + i02*nb2 + i03*nb3);
                         GGML_ASSERT(dst->nb[1] == ne0*sizeof(float));
                         dhf_dst_i += src1_col_0*ne0 + dev[id].row_low;
-#if !defined(GGML_USE_HIPBLAS)
-                        // cudaMemcpy2DAsync may fail with copies between vmm pools of different devices
-                        cudaMemcpy3DPeerParms p = {};
-                        p.dstDevice = ctx.device;
-                        p.dstPtr = make_cudaPitchedPtr(dhf_dst_i, ne0*sizeof(float), row_diff, src1_ncols);
-                        p.srcDevice = id;
-                        p.srcPtr = make_cudaPitchedPtr(dst_dd_i, row_diff*sizeof(float), row_diff, src1_ncols);
-                        p.extent = make_cudaExtent(row_diff*sizeof(float), src1_ncols, 1);
-                        CUDA_CHECK(cudaMemcpy3DPeerAsync(&p, stream));
-#else
-                        // HIP does not support cudaMemcpy3DPeerAsync or vmm pools
-                        CUDA_CHECK(cudaMemcpy2DAsync(dhf_dst_i, ne0*sizeof(float),
-                                                        dst_dd_i, row_diff*sizeof(float),
-                                                        row_diff*sizeof(float), src1_ncols,
-                                                        cudaMemcpyDeviceToDevice, stream));
-#endif
+                        CUDA_CHECK(ggml_cuda_Memcpy2DPeerAsync(
+                            dhf_dst_i, ctx.device, ne0*sizeof(float), dst_dd_i, id, row_diff*sizeof(float), row_diff*sizeof(float), src1_ncols, stream));
                     } else {
                         float * dhf_dst_i = (float *) ((char *) dst_off_device + i02*nb2 + i03*nb3);
                         GGML_ASSERT(dst->nb[1] == ne0*sizeof(float));
@@ -1941,13 +1967,13 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         // KQ + KQV multi-batch
         ggml_cuda_mul_mat_batched_cublas(ctx, src0, src1, dst);
     } else if (use_dequantize_mul_mat_vec) {
-        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_dequantize_mul_mat_vec, false);
+        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_dequantize_mul_mat_vec, nullptr);
     } else if (use_mul_mat_vec_q) {
-        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_vec_q, true);
+        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_vec_q, quantize_row_q8_1_cuda);
     } else if (use_mul_mat_q) {
-        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_q, true);
+        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_q, quantize_mmq_q8_1_cuda);
     } else {
-        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_cublas, false);
+        ggml_cuda_op_mul_mat(ctx, src0, src1, dst, ggml_cuda_op_mul_mat_cublas, nullptr);
     }
 }
 

--- a/ggml-cuda/mmq.cu
+++ b/ggml-cuda/mmq.cu
@@ -11,6 +11,7 @@ void ggml_cuda_op_mul_mat_q(
     const int64_t nb01 = src0->nb[1];
 
     const int64_t ne10 = src1->ne[0];
+    const int64_t ne11 = src1->ne[1];
     GGML_ASSERT(ne10 % QK8_1 == 0);
 
     const int64_t ne0 = dst->ne[0];
@@ -25,7 +26,7 @@ void ggml_cuda_op_mul_mat_q(
     // nrows_dst == nrows of the matrix that the kernel writes into
     const int64_t nrows_dst = id == ctx.device ? ne0 : row_diff;
 
-    const mmq_args args = {src0_dd_i, src1_ddq_i, dst_dd_i, ne00, row_diff, stride00, src1_padded_row_size, src1_ncols, nrows_dst};
+    const mmq_args args = {src0_dd_i, src1_ddq_i, dst_dd_i, ne00, row_diff, stride00, src1_padded_row_size, src1_ncols, ne11, nrows_dst};
 
     switch (src0->type) {
         case GGML_TYPE_Q4_0:

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -1,15 +1,26 @@
+#pragma once
+
 #include "common.cuh"
 #include "vecdotq.cuh"
 
 #include <climits>
 #include <cstdint>
 
+#define MMQ_TILE_Y_K (WARP_SIZE + WARP_SIZE/QI8_1)
+
 typedef void (*load_tiles_mmq_t)(
     const char * __restrict__ x, int * __restrict__ x_ql, half2 * __restrict__ x_dm, int * __restrict__ x_qh,
     int * __restrict__ x_sc, const int & kbx0, const int & i_max, const int & stride);
 typedef void (*vec_dot_mmq_t)(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ms, float * __restrict__ sum, const int & k0);
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0);
+
+struct block_q8_1_mmq {
+    half2  ds[4];
+    int8_t qs[4*QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 4*QK8_1 + 4*sizeof(half2), "Unexpected block_q8_1_mmq size");
+static_assert(sizeof(block_q8_1_mmq) == 4*sizeof(block_q8_1),      "Unexpected block_q8_1_mmq size");
 
 struct tile_x_sizes {
     int ql;
@@ -132,9 +143,13 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh); GGML_UNUSED(x_sc);
+
+    const float * x_dmf = (const float *) x_dm;
+    const int   * y_qs  = (const int   *) y + 4;
+    const half2 * y_ds  = (const half2 *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -145,19 +160,18 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mul_mat(
             const int i = i0 + threadIdx.x;
 
             const int kyqs = k0 % (QI8_1/2) + QI8_1 * (k0 / (QI8_1/2));
-            const float * x_dmf = (const float *) x_dm;
 
             int u[2*VDR_Q4_0_Q8_1_MMQ];
 
 #pragma unroll
             for (int l = 0; l < VDR_Q4_0_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j * WARP_SIZE + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j * WARP_SIZE + (kyqs + l + QI4_0) % WARP_SIZE];
+                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
+                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI4_0) % WARP_SIZE];
             }
 
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_0_q8_1_impl<VDR_Q4_0_Q8_1_MMQ>
-                (&x_ql[i * (WARP_SIZE + 1) + k0], u, x_dmf[i * (WARP_SIZE/QI4_0) + i/QI4_0 + k0/QI4_0],
-                y_ds[j * (WARP_SIZE/QI8_1) + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
+                (&x_ql[i*(WARP_SIZE + 1) + k0], u, x_dmf[i*(WARP_SIZE/QI4_0) + i/QI4_0 + k0/QI4_0],
+                y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
@@ -203,9 +217,12 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh); GGML_UNUSED(x_sc);
+
+    const int   * y_qs = (const int   *) y + 4;
+    const half2 * y_ds = (const half2 *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -221,13 +238,13 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mul_mat(
 
 #pragma unroll
             for (int l = 0; l < VDR_Q4_1_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j * WARP_SIZE + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j * WARP_SIZE + (kyqs + l + QI4_1) % WARP_SIZE];
+                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
+                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI4_1) % WARP_SIZE];
             }
 
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_1_q8_1_impl<VDR_Q4_1_Q8_1_MMQ>
-                (&x_ql[i * (WARP_SIZE + 1) + k0], u, x_dm[i * (WARP_SIZE/QI4_1) + i/QI4_1 + k0/QI4_1],
-                y_ds[j * (WARP_SIZE/QI8_1) + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
+                (&x_ql[i*(WARP_SIZE + 1) + k0], u, x_dm[i*(WARP_SIZE/QI4_1) + i/QI4_1 + k0/QI4_1],
+                y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
@@ -293,9 +310,13 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh); GGML_UNUSED(x_sc);
+
+    const float * x_dmf = (const float *) x_dm;
+    const int   * y_qs  = (const int   *) y + 4;
+    const float * y_df  = (const float *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -306,20 +327,18 @@ static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mul_mat(
             const int i = i0 + threadIdx.x;
 
             const int kyqs = k0 % (QI8_1/2) + QI8_1 * (k0 / (QI8_1/2));
-            const int index_bx = i * (WARP_SIZE/QI5_0) + i/QI5_0 + k0/QI5_0;
-            const float * x_dmf = (const float *) x_dm;
-            const float * y_df  = (const float *) y_ds;
+            const int index_bx = i*(WARP_SIZE/QI5_0) + i/QI5_0 + k0/QI5_0;
 
             int u[2*VDR_Q5_0_Q8_1_MMQ];
 
 #pragma unroll
             for (int l = 0; l < VDR_Q5_0_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j * WARP_SIZE + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j * WARP_SIZE + (kyqs + l + QI5_0) % WARP_SIZE];
+                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
+                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI5_0) % WARP_SIZE];
             }
 
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_0_q8_1_impl<float, QR5_0*VDR_Q5_0_Q8_1_MMQ>
-                (&x_ql[i * (2*WARP_SIZE + 1) + 2 * k0], u, x_dmf[index_bx], y_df[j * (WARP_SIZE/QI8_1) + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
+                (&x_ql[i*(2*WARP_SIZE + 1) + 2*k0], u, x_dmf[index_bx], y_df[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
@@ -383,9 +402,12 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh); GGML_UNUSED(x_sc);
+
+    const int   * y_qs  = (const int   *) y + 4;
+    const half2 * y_ds  = (const half2 *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -396,18 +418,18 @@ static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mul_mat(
             const int i = i0 + threadIdx.x;
 
             const int kyqs = k0 % (QI8_1/2) + QI8_1 * (k0 / (QI8_1/2));
-            const int index_bx = i * (WARP_SIZE/QI5_1) + + i/QI5_1 + k0/QI5_1;
+            const int index_bx = i*(WARP_SIZE/QI5_1) + i/QI5_1 + k0/QI5_1;
 
             int u[2*VDR_Q5_1_Q8_1_MMQ];
 
 #pragma unroll
             for (int l = 0; l < VDR_Q5_1_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j * WARP_SIZE + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j * WARP_SIZE + (kyqs + l + QI5_1) % WARP_SIZE];
+                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
+                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI5_1) % WARP_SIZE];
             }
 
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_1_q8_1_impl<QR5_1*VDR_Q5_1_Q8_1_MMQ>
-                (&x_ql[i * (2*WARP_SIZE + 1) + 2 * k0], u, x_dm[index_bx], y_ds[j * (WARP_SIZE/QI8_1) + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
+                (&x_ql[i*(2*WARP_SIZE + 1) + 2*k0], u, x_dm[index_bx], y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
@@ -455,9 +477,13 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh); GGML_UNUSED(x_sc);
+
+    const float * x_dmf = (const float *) x_dm;
+    const int   * y_qs  = (const int   *) y + 4;
+    const float * y_df  = (const float *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -467,12 +493,9 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mul_mat(
         for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
             const int i = i0 + threadIdx.x;
 
-            const float * x_dmf = (const float *) x_dm;
-            const float * y_df  = (const float *) y_ds;
-
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_0_q8_1_impl<float, VDR_Q8_0_Q8_1_MMQ>
-                (&x_ql[i * (WARP_SIZE + 1) + k0], &y_qs[j * WARP_SIZE + k0], x_dmf[i * (WARP_SIZE/QI8_0) + i/QI8_0 + k0/QI8_0],
-                y_df[j * (WARP_SIZE/QI8_1) + k0/QI8_1]);
+                (&x_ql[i*(WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k0], x_dmf[i*(WARP_SIZE/QI8_0) + i/QI8_0 + k0/QI8_0],
+                y_df[j*MMQ_TILE_Y_K + k0/QI8_1]);
         }
     }
 }
@@ -531,9 +554,12 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh);
+
+    const int   * y_qs  = (const int   *) y + 4;
+    const float * y_df  = (const float *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -545,11 +571,10 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mul_mat(
 
             const int kbx = k0 / QI2_K;
             const int ky  = (k0 % QI2_K) * QR2_K;
-            const float * y_df = (const float *) y_ds;
 
             int v[QR2_K*VDR_Q2_K_Q8_1_MMQ];
 
-            const int kqsx = i * (WARP_SIZE + 1) + kbx*QI2_K + (QI2_K/2) * (ky/(2*QI2_K)) + ky % (QI2_K/2);
+            const int kqsx = i*(WARP_SIZE + 1) + kbx*QI2_K + (QI2_K/2) * (ky/(2*QI2_K)) + ky % (QI2_K/2);
             const int shift = 2 * ((ky % (2*QI2_K)) / (QI2_K/2));
 
 #pragma unroll
@@ -557,11 +582,11 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mul_mat(
                 v[l] = (x_ql[kqsx + l] >> shift) & 0x03030303;
             }
 
-            const uint8_t * scales = ((const uint8_t *) &x_sc[i * (WARP_SIZE/4) + i/4 + kbx*4]) + ky/4;
+            const uint8_t * scales = ((const uint8_t *) &x_sc[i*(WARP_SIZE/4) + i/4 + kbx*4]) + ky/4;
 
-            const int index_y = j * WARP_SIZE + (QR2_K*k0) % WARP_SIZE;
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q2_K_q8_1_impl_mmq(
-                v, &y_qs[index_y], scales, x_dm[i * (WARP_SIZE/QI2_K) + i/QI2_K + kbx], y_df[index_y/QI8_1]);
+                v, &y_qs[j*MMQ_TILE_Y_K + (QR2_K*k0) % WARP_SIZE], scales,
+                x_dm[i*(WARP_SIZE/QI2_K) + i/QI2_K + kbx], y_df[j*MMQ_TILE_Y_K + ((QR2_K*k0) % WARP_SIZE)/QI8_1]);
         }
     }
 }
@@ -646,7 +671,11 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+
+    const float * x_dmf = (const float *) x_dm;
+    const int   * y_qs  = (const int   *) y + 4;
+    const float * y_df  = (const float *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -658,8 +687,6 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mul_mat(
 
             const int kbx  = k0 / QI3_K;
             const int ky  = (k0 % QI3_K) * QR3_K;
-            const float * x_dmf = (const float *) x_dm;
-            const float * y_df  = (const float *) y_ds;
 
             const int8_t * scales = ((const int8_t *) (x_sc + i * (WARP_SIZE/4) + i/4 + kbx*4)) + ky/4;
 
@@ -667,19 +694,19 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mul_mat(
 
 #pragma unroll
             for (int l = 0; l < QR3_K*VDR_Q3_K_Q8_1_MMQ; ++l) {
-                const int kqsx = i * (WARP_SIZE + 1) + kbx*QI3_K + (QI3_K/2) * (ky/(2*QI3_K)) + ky % (QI3_K/2);
+                const int kqsx = i*(WARP_SIZE + 1) + kbx*QI3_K + (QI3_K/2) * (ky/(2*QI3_K)) + ky % (QI3_K/2);
                 const int shift = 2 * ((ky % 32) / 8);
                 const int vll = (x_ql[kqsx + l] >> shift) & 0x03030303;
 
-                const int vh = x_qh[i * (WARP_SIZE/2) + i/2 + kbx * (QI3_K/2) + (ky+l)%8] >> ((ky+l) / 8);
+                const int vh = x_qh[i*(WARP_SIZE/2) + i/2 + kbx * (QI3_K/2) + (ky+l)%8] >> ((ky+l) / 8);
                 const int vlh = (vh << 2) & 0x04040404;
 
                 v[l] = __vsubss4(vll, vlh);
             }
 
-            const int index_y = j * WARP_SIZE + (k0*QR3_K) % WARP_SIZE;
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q3_K_q8_1_impl_mmq(
-                v, &y_qs[index_y], scales, x_dmf[i * (WARP_SIZE/QI3_K) + i/QI3_K + kbx], y_df[index_y/QI8_1]);
+                v, &y_qs[j*MMQ_TILE_Y_K + (k0*QR3_K) % WARP_SIZE], scales,
+                x_dmf[i*(WARP_SIZE/QI3_K) + i/QI3_K + kbx], y_df[j*MMQ_TILE_Y_K + ((k0*QR3_K) % WARP_SIZE)/QI8_1]);
         }
     }
 }
@@ -746,9 +773,12 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh);
+
+    const int   * y_qs = (const int   *) y + 4;
+    const half2 * y_ds = (const half2 *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -760,9 +790,9 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mul_mat(
 
             const uint8_t * sc = ((const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/16]) + 2*((k0 % 16) / 8);
 
-            const int index_y = j * WARP_SIZE + (QR4_K*k0) % WARP_SIZE;
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_K_q8_1_impl_mmq(
-                &x_ql[i * (WARP_SIZE + 1) + k0], &y_qs[index_y], sc, sc+8, x_dm[i * (WARP_SIZE/QI4_K) + i/QI4_K], &y_ds[index_y/QI8_1]);
+                &x_ql[i*(WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + (QR4_K*k0) % WARP_SIZE], sc, sc+8,
+                x_dm[i*(WARP_SIZE/QI4_K) + i/QI4_K], &y_ds[j*MMQ_TILE_Y_K + ((QR4_K*k0) % WARP_SIZE)/QI8_1]);
         }
     }
 }
@@ -842,9 +872,12 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh);
+
+    const int   * y_qs  = (const int   *) y + 4;
+    const half2 * y_ds  = (const half2 *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -856,10 +889,9 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mul_mat(
 
             const uint8_t * sc = ((const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/16]) + 2 * ((k0 % 16) / 8);
 
-            const int index_x = i * (QR5_K*WARP_SIZE + 1) +  QR5_K*k0;
-            const int index_y = j * WARP_SIZE             + (QR5_K*k0) % WARP_SIZE;
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q5_K_q8_1_impl_mmq(
-                &x_ql[index_x], &y_qs[index_y], sc, sc+8, x_dm[i * (WARP_SIZE/QI5_K) + i/QI5_K], &y_ds[index_y/QI8_1]);
+                &x_ql[i*(QR5_K*WARP_SIZE + 1) + QR5_K*k0], &y_qs[j*MMQ_TILE_Y_K + (QR5_K*k0) % WARP_SIZE], sc, sc+8,
+                x_dm[i*(WARP_SIZE/QI5_K) + i/QI5_K], &y_ds[j*MMQ_TILE_Y_K + ((QR5_K*k0) % WARP_SIZE)/QI8_1]);
         }
     }
 }
@@ -932,9 +964,13 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mul_mat(
     const int * __restrict__ x_ql, const half2 * __restrict__ x_dm, const int * __restrict__ x_qh, const int * __restrict__ x_sc,
-    const int * __restrict__ y_qs, const half2 * __restrict__ y_ds, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
 
     GGML_UNUSED(x_qh);
+
+    const float * x_dmf = (const float *) x_dm;
+    const int   * y_qs  = (const int   *) y + 4;
+    const float * y_df  = (const float *) y;
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -944,15 +980,11 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mul_mat(
         for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
             const int i = i0 + threadIdx.x;
 
-            const float * x_dmf = (const float *) x_dm;
-            const float * y_df  = (const float *) y_ds;
-
             const int8_t * sc = ((const int8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/8]);
 
-            const int index_x = i * (QR6_K*WARP_SIZE + 1) +  QR6_K*k0;
-            const int index_y = j * WARP_SIZE             + (QR6_K*k0) % WARP_SIZE;
             sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q6_K_q8_1_impl_mmq(
-                &x_ql[index_x], &y_qs[index_y], sc, x_dmf[i * (WARP_SIZE/QI6_K) + i/QI6_K], &y_df[index_y/QI8_1]);
+                &x_ql[i*(QR6_K*WARP_SIZE + 1) + QR6_K*k0], &y_qs[j*MMQ_TILE_Y_K + (QR6_K*k0) % WARP_SIZE], sc,
+                x_dmf[i*(WARP_SIZE/QI6_K) + i/QI6_K], &y_df[j*MMQ_TILE_Y_K + ((QR6_K*k0) % WARP_SIZE)/QI8_1]);
         }
     }
 }
@@ -964,7 +996,6 @@ struct mmq_type_traits;
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_0> {
-    static constexpr bool             need_sum   = true;
     static constexpr int              vdr        = VDR_Q4_0_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q4_0<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q4_0_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -972,7 +1003,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_0> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_1> {
-    static constexpr bool             need_sum   = true;
     static constexpr int              vdr        = VDR_Q4_1_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q4_1<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q4_1_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -980,7 +1010,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_1> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_0> {
-    static constexpr bool             need_sum   = false;
     static constexpr int              vdr        = VDR_Q5_0_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q5_0<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q5_0_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -988,7 +1017,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_0> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_1> {
-    static constexpr bool             need_sum   = true;
     static constexpr int              vdr        = VDR_Q5_1_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q5_1<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q5_1_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -996,7 +1024,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_1> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q8_0> {
-    static constexpr bool             need_sum   = false;
     static constexpr int              vdr        = VDR_Q8_0_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q8_0<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q8_0_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -1004,7 +1031,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q8_0> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q2_K> {
-    static constexpr bool             need_sum   = false;
     static constexpr int              vdr        = VDR_Q2_K_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q2_K<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q2_K_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -1012,7 +1038,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q2_K> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q3_K> {
-    static constexpr bool             need_sum   = false;
     static constexpr int              vdr        = VDR_Q3_K_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q3_K<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q3_K_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -1020,7 +1045,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q3_K> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_K> {
-    static constexpr bool             need_sum   = true;
     static constexpr int              vdr        = VDR_Q4_K_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q4_K<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q4_K_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -1028,7 +1052,6 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q4_K> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_K> {
-    static constexpr bool             need_sum   = true;
     static constexpr int              vdr        = VDR_Q5_K_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q5_K<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q5_K_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
@@ -1036,11 +1059,35 @@ struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_K> {
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q6_K> {
-    static constexpr bool             need_sum   = false;
     static constexpr int              vdr        = VDR_Q6_K_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles = load_tiles_q6_K<mmq_y, nwarps, need_check>;
     static constexpr vec_dot_mmq_t    vec_dot    = vec_dot_q6_K_q8_1_mul_mat<mmq_x, mmq_y, nwarps>;
 };
+
+static int mmq_need_sum(const ggml_type type_x) {
+    switch (type_x) {
+        case GGML_TYPE_Q4_0:
+        case GGML_TYPE_Q4_1:
+            return true;
+        case GGML_TYPE_Q5_0:
+            return false;
+        case GGML_TYPE_Q5_1:
+            return true;
+        case GGML_TYPE_Q8_0:
+        case GGML_TYPE_Q2_K:
+        case GGML_TYPE_Q3_K:
+            return false;
+        case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q5_K:
+            return true;
+        case GGML_TYPE_Q6_K:
+            return false;
+        default:
+            GGML_ASSERT(false);
+            break;
+    }
+    return false;
+}
 
 template <ggml_type type, int mmq_x, int nwarps, bool need_check>
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
@@ -1056,7 +1103,7 @@ template <ggml_type type, int mmq_x, int nwarps, bool need_check>
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
 static __global__ void mul_mat_q(
     const char * __restrict__ x, const char * __restrict__ yc, float * __restrict__ dst,
-    const int ne00, const int ne01, const int stride00, const int ne10, const int ne11, const int ne0) {
+    const int ne00, const int ne01, const int stride01, const int ne10, const int ne11, const int stride11, const int ne0) {
 
     // Skip unused template specializations for faster compilation:
     if (mmq_x > get_mmq_x_max_device()) {
@@ -1068,7 +1115,6 @@ static __global__ void mul_mat_q(
     constexpr int              qr         = ggml_cuda_type_traits<type>::qr;
     constexpr int              qi         = ggml_cuda_type_traits<type>::qi;
     constexpr int              mmq_y      = get_mmq_y_device(mmq_x);
-    constexpr bool             need_sum   = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::need_sum;
     constexpr int              vdr        = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::vdr;
     constexpr load_tiles_mmq_t load_tiles = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::load_tiles;
     constexpr vec_dot_mmq_t    vec_dot    = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::vec_dot;
@@ -1080,62 +1126,38 @@ static __global__ void mul_mat_q(
     half2 * tile_x_dm = (half2 *) (tile_x_ql + txs.ql);
     int   * tile_x_qh = (int   *) (tile_x_dm + txs.dm);
     int   * tile_x_sc = (int   *) (tile_x_qh + txs.qh);
-    int   * tile_y_qs = (int   *) (tile_x_sc + txs.sc);          // [mmq_x * WARP_SIZE]
-    half2 * tile_y_ds = (half2 *) (tile_y_qs + mmq_x*WARP_SIZE); // [mmq_x * WARP_SIZE/QI8_1];
-
-    const block_q8_1 * y = (const block_q8_1 *) yc;
+    int   * tile_y    = (int   *) (tile_x_sc + txs.sc); // [mmq_x * (WARP_SIZE + WARP_SIZE/QI8_1)]
 
     const int blocks_per_row_x = ne00 / qk;
-    const int blocks_per_col_y = ne10 / QK8_1;
     const int blocks_per_warp = WARP_SIZE / qi;
 
     const int & ne1 = ne11;
 
     const int tile_x_max_i = ne01 - blockIdx.x*mmq_y - 1;
 
+    const int * y = (const int *) yc + blockIdx.y*(mmq_x*sizeof(block_q8_1_mmq)/sizeof(int));
+
     float sum[(mmq_x/nwarps) * (mmq_y/WARP_SIZE)] = {0.0f};
 
     for (int kb0 = 0; kb0 < blocks_per_row_x; kb0 += blocks_per_warp) {
 
-        load_tiles(x, tile_x_ql, tile_x_dm, tile_x_qh, tile_x_sc, stride00*blockIdx.x*mmq_y + kb0, tile_x_max_i, stride00);
+        load_tiles(x, tile_x_ql, tile_x_dm, tile_x_qh, tile_x_sc, stride01*blockIdx.x*mmq_y + kb0, tile_x_max_i, stride01);
 
 #pragma unroll
         for (int kr = 0; kr < qr; ++kr) {
-            const int kqs = kr*WARP_SIZE + threadIdx.x;
-            const int kbxd = kqs / QI8_1;
-
+            const int * by0 = y + stride11*(kb0*(qk*sizeof(block_q8_1_mmq) / (4*QK8_1*sizeof(int))) + kr*sizeof(block_q8_1_mmq)/sizeof(int));
 #pragma unroll
-            for (int i0 = 0; i0 < mmq_x; i0 += nwarps) {
-                const int i = min(blockIdx.y*mmq_x + threadIdx.y + i0, ne11-1); // to prevent out-of-bounds memory accesses
+            for (int l0 = 0; l0 < mmq_x*MMQ_TILE_Y_K; l0 += nwarps*WARP_SIZE) {
+                int l = l0 + threadIdx.y*WARP_SIZE + threadIdx.x;
 
-                const block_q8_1 * by0 = &y[i*blocks_per_col_y + kb0 * (qk/QK8_1) + kbxd];
-
-                const int index_y = (i0 + threadIdx.y) * WARP_SIZE + kqs % WARP_SIZE;
-                tile_y_qs[index_y] = get_int_from_int8_aligned(by0->qs, threadIdx.x % QI8_1);
-            }
-
-#pragma unroll
-            for (int ids0 = 0; ids0 < mmq_x; ids0 += nwarps * QI8_1) {
-                const int ids = (ids0 + threadIdx.y * QI8_1 + threadIdx.x / (WARP_SIZE/QI8_1)) % mmq_x;
-                const int kby = threadIdx.x % (WARP_SIZE/QI8_1);
-                const int i_y_eff = min(blockIdx.y*mmq_x + ids, ne11-1);
-
-                // if the sum is not needed it's faster to transform the scale to f32 ahead of time
-                const half2 * dsi_src = &y[i_y_eff*blocks_per_col_y + kb0 * (qk/QK8_1) + kr*(WARP_SIZE/QI8_1) + kby].ds;
-                half2       * dsi_dst = &tile_y_ds[ids * (WARP_SIZE/QI8_1) + kby];
-                if (need_sum) {
-                    *dsi_dst = *dsi_src;
-                } else {
-                    float * dfi_dst = (float *) dsi_dst;
-                    *dfi_dst = __low2float(*dsi_src);
-                }
+                tile_y[l] = by0[l];
             }
 
             __syncthreads();
 
 // #pragma unroll // unrolling this loop causes too much register pressure
             for (int k0 = kr*WARP_SIZE/qr; k0 < (kr+1)*WARP_SIZE/qr; k0 += vdr) {
-                vec_dot(tile_x_ql, tile_x_dm, tile_x_qh, tile_x_sc, tile_y_qs, tile_y_ds, sum, k0);
+                vec_dot(tile_x_ql, tile_x_dm, tile_x_qh, tile_x_sc, tile_y, sum, k0);
             }
 
             __syncthreads();
@@ -1165,8 +1187,8 @@ static __global__ void mul_mat_q(
 
 struct mmq_args {
     const char * x; const char * y; float * dst;
-    int64_t ne00; int64_t ne01; int64_t stride00;
-    int64_t ne10; int64_t ne11;
+    int64_t ne00; int64_t ne01; int64_t stride01;
+    int64_t ne10; int64_t ne11; int64_t stride11;
     int64_t ne0;
 };
 
@@ -1184,7 +1206,7 @@ static void launch_mul_mat_q(const mmq_args & args, cudaStream_t stream) {
     const tile_x_sizes txs = get_tile_x_sizes_host(type, mmq_y);
     const int shmem_x = txs.ql*sizeof(int) + txs.dm*sizeof(half2) + txs.qh*sizeof(int) + txs.sc*sizeof(int);
     const int shmem_y = mmq_x*WARP_SIZE*sizeof(int) + mmq_x*(WARP_SIZE/QI8_1)*sizeof(half2);
-    const int shmem = shmem_x + shmem_y;
+    const int shmem = shmem_x + GGML_PAD(shmem_y, nwarps*WARP_SIZE*sizeof(int));
 
 #if !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__))
     static bool shmem_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
@@ -1198,11 +1220,11 @@ static void launch_mul_mat_q(const mmq_args & args, cudaStream_t stream) {
     if (args.ne01 % mmq_y == 0) {
         const bool need_check = false;
         mul_mat_q<type, mmq_x, nwarps, need_check><<<block_nums, block_dims, shmem, stream>>>
-            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride00, args.ne10, args.ne11, args.ne0);
+            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
     } else {
         const bool need_check = true;
         mul_mat_q<type, mmq_x, nwarps, need_check><<<block_nums, block_dims, shmem, stream>>>
-            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride00, args.ne10, args.ne11, args.ne0);
+            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
     }
 }
 

--- a/ggml-cuda/quantize.cu
+++ b/ggml-cuda/quantize.cu
@@ -1,22 +1,23 @@
 #include "quantize.cuh"
+#include <cstdint>
 
-static __global__ void quantize_q8_1(const float * __restrict__ x, void * __restrict__ vy, const int64_t kx, const int64_t kx_padded) {
-    const int64_t ix = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
+static __global__ void quantize_q8_1(const float * __restrict__ x, void * __restrict__ vy, const int64_t kx, const int64_t kx0_padded) {
+    const int64_t ix0 = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
 
-    if (ix >= kx_padded) {
+    if (ix0 >= kx0_padded) {
         return;
     }
 
-    const int64_t iy = (int64_t)blockDim.y*blockIdx.y + threadIdx.y;
+    const int64_t ix1 = blockIdx.y;
 
-    const int64_t i_padded = (int64_t)iy*kx_padded + ix;
+    const int64_t i_padded = ix1*kx0_padded + ix0;
 
     block_q8_1 * y = (block_q8_1 *) vy;
 
     const int64_t ib = i_padded / QK8_1; // block index
     const int64_t iqs = i_padded % QK8_1; // quant index
 
-    const float xi = ix < kx ? x[iy*kx + ix] : 0.0f;
+    const float xi = ix0 < kx ? x[ix1*kx + ix0] : 0.0f;
     float amax = fabsf(xi);
     float sum = xi;
 
@@ -36,10 +37,76 @@ static __global__ void quantize_q8_1(const float * __restrict__ x, void * __rest
     reinterpret_cast<half&>(y[ib].ds.y) = sum;
 }
 
-void quantize_row_q8_1_cuda(const float * x, void * vy, const int64_t kx, const int64_t ky, const int64_t kx_padded, cudaStream_t stream) {
-    const int64_t block_num_x = (kx_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
-    const dim3 num_blocks(block_num_x, ky, 1);
-    const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
-    quantize_q8_1<<<num_blocks, block_size, 0, stream>>>(x, vy, kx, kx_padded);
+template <bool need_sum>
+static __global__ void quantize_mmq_q8_1(
+    const float * __restrict__ x, void * __restrict__ vy, const int64_t kx0, const int64_t kx1, const int64_t kx0_padded) {
+
+    const int64_t ix0 = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (ix0 >= kx0_padded) {
+        return;
+    }
+
+    const int64_t ix1 = kx1*blockIdx.z + blockIdx.y;
+
+    block_q8_1_mmq * y = (block_q8_1_mmq *) vy;
+
+    const int64_t ib0 = blockIdx.z*(gridDim.y*gridDim.x*blockDim.x/(4*QK8_1)); // first block of channel
+    const int64_t ib  = ib0 + (ix0 / (4*QK8_1))*kx1 + blockIdx.y;              // block index in channel
+    const int64_t iqs = ix0 % (4*QK8_1);                                       // quant index in block
+
+    const float xi = ix0 < kx0 ? x[ix1*kx0 + ix0] : 0.0f;
+    float amax = fabsf(xi);
+
+    amax = warp_reduce_max(amax);
+
+    float sum;
+    if (need_sum) {
+        sum = warp_reduce_sum(xi);
+    }
+
+    const float d = amax / 127;
+    const int8_t q = amax == 0.0f ? 0 : roundf(xi / d);
+
+    y[ib].qs[iqs] = q;
+
+    if (iqs % QK8_1 != 0) {
+        return;
+    }
+
+    if (need_sum) {
+        y[ib].ds[iqs/QK8_1] = make_half2(d, sum);
+    } else {
+        ((float *) y[ib].ds)[iqs/QK8_1] = d;
+    }
 }
 
+void quantize_row_q8_1_cuda(
+    const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels,
+    const int64_t kx0_padded, const ggml_type type_x, cudaStream_t stream) {
+
+    GGML_ASSERT(kx0_padded % QK8_1 == 0);
+
+    const int64_t block_num_x = (kx0_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+    const dim3 num_blocks(block_num_x, kx1*channels, 1);
+    const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+    quantize_q8_1<<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx0_padded);
+
+    GGML_UNUSED(type_x);
+}
+
+void quantize_mmq_q8_1_cuda(
+    const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels,
+    const int64_t kx0_padded, const ggml_type type_x, cudaStream_t stream) {
+
+    GGML_ASSERT(kx0_padded % (4*QK8_1) == 0);
+
+    const int64_t block_num_x = (kx0_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+    const dim3 num_blocks(block_num_x, kx1, channels);
+    const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+    if (mmq_need_sum(type_x)) {
+        quantize_mmq_q8_1<true><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    } else {
+        quantize_mmq_q8_1<false><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    }
+}

--- a/ggml-cuda/quantize.cuh
+++ b/ggml-cuda/quantize.cuh
@@ -1,5 +1,20 @@
+#pragma once
+
 #include "common.cuh"
+#include "mmq.cuh"
+
+#include <cstdint>
 
 #define CUDA_QUANTIZE_BLOCK_SIZE 256
 
-void quantize_row_q8_1_cuda(const float * x, void * vy, const int64_t kx, const int64_t ky, const int64_t kx_padded, cudaStream_t stream);
+typedef void (*quantize_cuda_t)(
+    const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels, const int64_t kx0_padded,
+    const ggml_type type_x, cudaStream_t stream);
+
+void quantize_row_q8_1_cuda(
+    const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels, const int64_t kx0_padded,
+    const ggml_type type_x, cudaStream_t stream);
+
+void quantize_mmq_q8_1_cuda(
+    const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels, const int64_t kx0_padded,
+    const ggml_type type_x, cudaStream_t stream);


### PR DESCRIPTION
This PR changes the data layout for the FP32 values quantized to q8_1 in conjunction with MMQ. The blocks with 32 values are consolidated into larger blocks of 128 values in order to make them align to 16 bits and have the same data layout in global and shared memory. This is relevant for asynchronous data loading (Ampere or newer, not in this PR). The memory layout in shared memory now also allows for more efficient data loading for int8 tensor cores; for optimal performance you need an offset of 16 bytes between columns and it just so happens that for 128 values this is the exact size that the q8_1 scales take up.

The q8_1 memory layout in global memory for MMQ is that values are first consolidated into blocks of size 128 along ne10. These blocks are then treated as individual elements and transposed.

In `ggml-cuda.cu` I changed the argument for whether or not src1 should be quantized to a function pointer to the specific function that should be used. The data transfer for `--split-mode row` needs to be different. I added a utility function `cudaMemcpy2DPeerAsync` since it for whatever reason does not exist in the CUDA toolkit.

Performance on RTX4090/RTX3090 stays mostly the same, the changes for P40/RX 6800 are larger. The performance increases on average. 

<details>
<summary>Specific numbers</summary>

| GPU        | Model             |     Microbatch size | FlashAttention     | Test     |     t/s master |     t/s cuda-mmq-q8_1-2 |     Speedup |
| :--------- | :---------------- | ------------------: | :----------------- | :------- | -------------: | ----------------------: | ----------: |
| RTX 4090   | llama 8B Q2_K_M   |                  16 | Yes                | pp512    |        1102.82 |                 1118.51 |        1.01 |
| RTX 4090   | llama 8B Q2_K_M   |                  32 | Yes                | pp512    |        1562.51 |                 1584.70 |        1.01 |
| RTX 4090   | llama 8B Q2_K_M   |                  64 | Yes                | pp512    |        2022.17 |                 2033.73 |        1.01 |
| RTX 4090   | llama 8B Q2_K_M   |                 128 | Yes                | pp512    |        3726.70 |                 3728.89 |        1.00 |
| RTX 4090   | llama 8B Q2_K_M   |                 256 | Yes                | pp512    |        5989.97 |                 5990.15 |        1.00 |
| RTX 4090   | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |        7825.63 |                 7816.57 |        1.00 |
| RTX 4090   | llama 8B Q3_K_S   |                  16 | Yes                | pp512    |         888.89 |                  887.58 |        1.00 |
| RTX 4090   | llama 8B Q3_K_S   |                  32 | Yes                | pp512    |        1342.94 |                 1367.00 |        1.02 |
| RTX 4090   | llama 8B Q3_K_S   |                  64 | Yes                | pp512    |        1878.46 |                 1895.10 |        1.01 |
| RTX 4090   | llama 8B Q3_K_S   |                 128 | Yes                | pp512    |        3627.84 |                 3626.18 |        1.00 |
| RTX 4090   | llama 8B Q3_K_S   |                 256 | Yes                | pp512    |        5881.27 |                 5882.97 |        1.00 |
| RTX 4090   | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |        7728.16 |                 7744.08 |        1.00 |
| RTX 4090   | llama 8B Q4_0     |                  16 | Yes                | pp512    |        1598.48 |                 1642.08 |        1.03 |
| RTX 4090   | llama 8B Q4_0     |                  32 | Yes                | pp512    |        2616.94 |                 2644.69 |        1.01 |
| RTX 4090   | llama 8B Q4_0     |                  64 | Yes                | pp512    |        3693.61 |                 3764.31 |        1.02 |
| RTX 4090   | llama 8B Q4_0     |                 128 | Yes                | pp512    |        3580.46 |                 3577.67 |        1.00 |
| RTX 4090   | llama 8B Q4_0     |                 256 | Yes                | pp512    |        5838.55 |                 5839.45 |        1.00 |
| RTX 4090   | llama 8B Q4_0     |                 512 | Yes                | pp512    |        7775.65 |                 7807.98 |        1.00 |
| RTX 4090   | llama 8B Q4_1     |                  16 | Yes                | pp512    |        1560.23 |                 1568.59 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                  32 | Yes                | pp512    |        2574.10 |                 2563.09 |        1.00 |
| RTX 4090   | llama 8B Q4_1     |                  64 | Yes                | pp512    |        3670.49 |                 3702.49 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                 128 | Yes                | pp512    |        3535.60 |                 3538.59 |        1.00 |
| RTX 4090   | llama 8B Q4_1     |                 256 | Yes                | pp512    |        5785.55 |                 5788.89 |        1.00 |
| RTX 4090   | llama 8B Q4_1     |                 512 | Yes                | pp512    |        7658.33 |                 7668.97 |        1.00 |
| RTX 4090   | llama 8B Q4_K_S   |                  16 | Yes                | pp512    |        1392.65 |                 1409.09 |        1.01 |
| RTX 4090   | llama 8B Q4_K_S   |                  32 | Yes                | pp512    |        2367.72 |                 2405.85 |        1.02 |
| RTX 4090   | llama 8B Q4_K_S   |                  64 | Yes                | pp512    |        3131.95 |                 3163.14 |        1.01 |
| RTX 4090   | llama 8B Q4_K_S   |                 128 | Yes                | pp512    |        3582.14 |                 3583.80 |        1.00 |
| RTX 4090   | llama 8B Q4_K_S   |                 256 | Yes                | pp512    |        5850.85 |                 5865.58 |        1.00 |
| RTX 4090   | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |        7783.61 |                 7789.94 |        1.00 |
| RTX 4090   | llama 8B Q5_0     |                  16 | Yes                | pp512    |        1257.68 |                 1252.06 |        1.00 |
| RTX 4090   | llama 8B Q5_0     |                  32 | Yes                | pp512    |        1988.88 |                 1984.19 |        1.00 |
| RTX 4090   | llama 8B Q5_0     |                  64 | Yes                | pp512    |        2919.13 |                 2956.97 |        1.01 |
| RTX 4090   | llama 8B Q5_0     |                 128 | Yes                | pp512    |        3480.97 |                 3479.59 |        1.00 |
| RTX 4090   | llama 8B Q5_0     |                 256 | Yes                | pp512    |        5729.44 |                 5731.15 |        1.00 |
| RTX 4090   | llama 8B Q5_0     |                 512 | Yes                | pp512    |        7690.57 |                 7696.39 |        1.00 |
| RTX 4090   | llama 8B Q5_1     |                  16 | Yes                | pp512    |        1303.03 |                 1315.82 |        1.01 |
| RTX 4090   | llama 8B Q5_1     |                  32 | Yes                | pp512    |        2156.25 |                 2044.06 |        0.95 |
| RTX 4090   | llama 8B Q5_1     |                  64 | Yes                | pp512    |        2991.30 |                 2888.40 |        0.97 |
| RTX 4090   | llama 8B Q5_1     |                 128 | Yes                | pp512    |        3494.70 |                 3490.87 |        1.00 |
| RTX 4090   | llama 8B Q5_1     |                 256 | Yes                | pp512    |        5709.80 |                 5707.48 |        1.00 |
| RTX 4090   | llama 8B Q5_1     |                 512 | Yes                | pp512    |        7644.22 |                 7655.42 |        1.00 |
| RTX 4090   | llama 8B Q5_K_S   |                  16 | Yes                | pp512    |        1194.83 |                 1271.99 |        1.06 |
| RTX 4090   | llama 8B Q5_K_S   |                  32 | Yes                | pp512    |        1913.44 |                 2047.03 |        1.07 |
| RTX 4090   | llama 8B Q5_K_S   |                  64 | Yes                | pp512    |        2695.83 |                 2800.62 |        1.04 |
| RTX 4090   | llama 8B Q5_K_S   |                 128 | Yes                | pp512    |        3547.30 |                 3544.97 |        1.00 |
| RTX 4090   | llama 8B Q5_K_S   |                 256 | Yes                | pp512    |        5789.94 |                 5790.79 |        1.00 |
| RTX 4090   | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |        7723.31 |                 7725.42 |        1.00 |
| RTX 4090   | llama 8B Q6_K     |                  16 | Yes                | pp512    |        1096.41 |                 1125.48 |        1.03 |
| RTX 4090   | llama 8B Q6_K     |                  32 | Yes                | pp512    |        1839.73 |                 1783.85 |        0.97 |
| RTX 4090   | llama 8B Q6_K     |                  64 | Yes                | pp512    |        2574.44 |                 2584.98 |        1.00 |
| RTX 4090   | llama 8B Q6_K     |                 128 | Yes                | pp512    |        3456.14 |                 3457.61 |        1.00 |
| RTX 4090   | llama 8B Q6_K     |                 256 | Yes                | pp512    |        5640.23 |                 5644.63 |        1.00 |
| RTX 4090   | llama 8B Q6_K     |                 512 | Yes                | pp512    |        7442.21 |                 7445.44 |        1.00 |
| RTX 4090   | llama 8B Q8_0     |                  16 | Yes                | pp512    |        1036.27 |                 1054.82 |        1.02 |
| RTX 4090   | llama 8B Q8_0     |                  32 | Yes                | pp512    |        1795.01 |                 1973.04 |        1.10 |
| RTX 4090   | llama 8B Q8_0     |                  64 | Yes                | pp512    |        2988.63 |                 3063.31 |        1.02 |
| RTX 4090   | llama 8B Q8_0     |                 128 | Yes                | pp512    |        3377.35 |                 3373.79 |        1.00 |
| RTX 4090   | llama 8B Q8_0     |                 256 | Yes                | pp512    |        5574.59 |                 5571.14 |        1.00 |
| RTX 4090   | llama 8B Q8_0     |                 512 | Yes                | pp512    |        7515.20 |                 7524.32 |        1.00 |
| RTX 3090   | llama 8B Q2_K_M   |                  16 | Yes                | pp512    |         530.92 |                  528.76 |        1.00 |
| RTX 3090   | llama 8B Q2_K_M   |                  32 | Yes                | pp512    |         630.30 |                  621.68 |        0.99 |
| RTX 3090   | llama 8B Q2_K_M   |                  64 | Yes                | pp512    |         918.81 |                  895.11 |        0.97 |
| RTX 3090   | llama 8B Q2_K_M   |                 128 | Yes                | pp512    |        1159.97 |                 1138.32 |        0.98 |
| RTX 3090   | llama 8B Q2_K_M   |                 256 | Yes                | pp512    |        1502.26 |                 1464.59 |        0.97 |
| RTX 3090   | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |        1541.40 |                 1562.12 |        1.01 |
| RTX 3090   | llama 8B Q3_K_S   |                  16 | Yes                | pp512    |         419.23 |                  415.71 |        0.99 |
| RTX 3090   | llama 8B Q3_K_S   |                  32 | Yes                | pp512    |         539.39 |                  527.62 |        0.98 |
| RTX 3090   | llama 8B Q3_K_S   |                  64 | Yes                | pp512    |         858.80 |                  841.15 |        0.98 |
| RTX 3090   | llama 8B Q3_K_S   |                 128 | Yes                | pp512    |        1203.35 |                 1170.51 |        0.97 |
| RTX 3090   | llama 8B Q3_K_S   |                 256 | Yes                | pp512    |        1555.93 |                 1560.10 |        1.00 |
| RTX 3090   | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |        1652.37 |                 1663.21 |        1.01 |
| RTX 3090   | llama 8B Q4_0     |                  16 | Yes                | pp512    |         949.48 |                  939.88 |        0.99 |
| RTX 3090   | llama 8B Q4_0     |                  32 | Yes                | pp512    |        1267.78 |                 1264.83 |        1.00 |
| RTX 3090   | llama 8B Q4_0     |                  64 | Yes                | pp512    |        1737.34 |                 1726.78 |        0.99 |
| RTX 3090   | llama 8B Q4_0     |                 128 | Yes                | pp512    |        2054.06 |                 2052.54 |        1.00 |
| RTX 3090   | llama 8B Q4_0     |                 256 | Yes                | pp512    |        2491.75 |                 2500.63 |        1.00 |
| RTX 3090   | llama 8B Q4_0     |                 512 | Yes                | pp512    |        2620.33 |                 2604.94 |        0.99 |
| RTX 3090   | llama 8B Q4_1     |                  16 | Yes                | pp512    |         925.82 |                  920.58 |        0.99 |
| RTX 3090   | llama 8B Q4_1     |                  32 | Yes                | pp512    |        1239.31 |                 1217.35 |        0.98 |
| RTX 3090   | llama 8B Q4_1     |                  64 | Yes                | pp512    |        1623.27 |                 1625.47 |        1.00 |
| RTX 3090   | llama 8B Q4_1     |                 128 | Yes                | pp512    |        1955.09 |                 1963.57 |        1.00 |
| RTX 3090   | llama 8B Q4_1     |                 256 | Yes                | pp512    |        2352.57 |                 2298.17 |        0.98 |
| RTX 3090   | llama 8B Q4_1     |                 512 | Yes                | pp512    |        2479.74 |                 2461.23 |        0.99 |
| RTX 3090   | llama 8B Q4_K_S   |                  16 | Yes                | pp512    |         738.96 |                  741.87 |        1.00 |
| RTX 3090   | llama 8B Q4_K_S   |                  32 | Yes                | pp512    |         980.60 |                  984.92 |        1.00 |
| RTX 3090   | llama 8B Q4_K_S   |                  64 | Yes                | pp512    |        1466.61 |                 1436.16 |        0.98 |
| RTX 3090   | llama 8B Q4_K_S   |                 128 | Yes                | pp512    |        1742.16 |                 1737.24 |        1.00 |
| RTX 3090   | llama 8B Q4_K_S   |                 256 | Yes                | pp512    |        2123.83 |                 2140.76 |        1.01 |
| RTX 3090   | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |        2277.97 |                 2307.83 |        1.01 |
| RTX 3090   | llama 8B Q5_0     |                  16 | Yes                | pp512    |         657.66 |                  648.62 |        0.99 |
| RTX 3090   | llama 8B Q5_0     |                  32 | Yes                | pp512    |         935.54 |                  916.87 |        0.98 |
| RTX 3090   | llama 8B Q5_0     |                  64 | Yes                | pp512    |        1359.57 |                 1305.98 |        0.96 |
| RTX 3090   | llama 8B Q5_0     |                 128 | Yes                | pp512    |        1782.90 |                 1758.54 |        0.99 |
| RTX 3090   | llama 8B Q5_0     |                 256 | Yes                | pp512    |        2245.18 |                 2206.38 |        0.98 |
| RTX 3090   | llama 8B Q5_0     |                 512 | Yes                | pp512    |        2380.48 |                 2394.16 |        1.01 |
| RTX 3090   | llama 8B Q5_1     |                  16 | Yes                | pp512    |         723.15 |                  712.35 |        0.99 |
| RTX 3090   | llama 8B Q5_1     |                  32 | Yes                | pp512    |         938.94 |                  949.47 |        1.01 |
| RTX 3090   | llama 8B Q5_1     |                  64 | Yes                | pp512    |        1368.83 |                 1356.26 |        0.99 |
| RTX 3090   | llama 8B Q5_1     |                 128 | Yes                | pp512    |        1753.49 |                 1657.81 |        0.95 |
| RTX 3090   | llama 8B Q5_1     |                 256 | Yes                | pp512    |        2186.09 |                 2136.65 |        0.98 |
| RTX 3090   | llama 8B Q5_1     |                 512 | Yes                | pp512    |        2312.84 |                 2291.97 |        0.99 |
| RTX 3090   | llama 8B Q5_K_S   |                  16 | Yes                | pp512    |         598.35 |                  643.18 |        1.07 |
| RTX 3090   | llama 8B Q5_K_S   |                  32 | Yes                | pp512    |         856.19 |                  851.94 |        1.00 |
| RTX 3090   | llama 8B Q5_K_S   |                  64 | Yes                | pp512    |        1308.06 |                 1234.13 |        0.94 |
| RTX 3090   | llama 8B Q5_K_S   |                 128 | Yes                | pp512    |        1591.37 |                 1593.33 |        1.00 |
| RTX 3090   | llama 8B Q5_K_S   |                 256 | Yes                | pp512    |        1994.02 |                 1976.63 |        0.99 |
| RTX 3090   | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |        2135.53 |                 2143.79 |        1.00 |
| RTX 3090   | llama 8B Q6_K     |                  16 | Yes                | pp512    |         564.58 |                  565.88 |        1.00 |
| RTX 3090   | llama 8B Q6_K     |                  32 | Yes                | pp512    |         825.75 |                  822.66 |        1.00 |
| RTX 3090   | llama 8B Q6_K     |                  64 | Yes                | pp512    |        1230.89 |                 1239.15 |        1.01 |
| RTX 3090   | llama 8B Q6_K     |                 128 | Yes                | pp512    |        1541.75 |                 1536.46 |        1.00 |
| RTX 3090   | llama 8B Q6_K     |                 256 | Yes                | pp512    |        1927.92 |                 1970.42 |        1.02 |
| RTX 3090   | llama 8B Q6_K     |                 512 | Yes                | pp512    |        2088.83 |                 2116.00 |        1.01 |
| RTX 3090   | llama 8B Q8_0     |                  16 | Yes                | pp512    |         603.33 |                  645.74 |        1.07 |
| RTX 3090   | llama 8B Q8_0     |                  32 | Yes                | pp512    |         982.85 |                  984.64 |        1.00 |
| RTX 3090   | llama 8B Q8_0     |                  64 | Yes                | pp512    |        1430.97 |                 1456.70 |        1.02 |
| RTX 3090   | llama 8B Q8_0     |                 128 | Yes                | pp512    |        1856.46 |                 1876.76 |        1.01 |
| RTX 3090   | llama 8B Q8_0     |                 256 | Yes                | pp512    |        2325.70 |                 2321.93 |        1.00 |
| RTX 3090   | llama 8B Q8_0     |                 512 | Yes                | pp512    |        2471.43 |                 2497.23 |        1.01 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         157.08 |                  163.49 |        1.04 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         193.74 |                  194.98 |        1.01 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         249.34 |                  243.46 |        0.98 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         288.20 |                  277.75 |        0.96 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         332.58 |                  324.61 |        0.98 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | No                 | pp512    |         358.45 |                  353.03 |        0.98 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         109.38 |                  110.86 |        1.01 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         146.56 |                  147.55 |        1.01 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         216.45 |                  199.18 |        0.92 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         244.60 |                  223.69 |        0.91 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         287.36 |                  262.28 |        0.91 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | No                 | pp512    |         308.01 |                  284.77 |        0.92 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         329.44 |                  350.80 |        1.06 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         424.81 |                  447.06 |        1.05 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         488.25 |                  564.61 |        1.16 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         559.76 |                  649.50 |        1.16 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         616.12 |                  698.43 |        1.13 |
| RX 6800    | llama 8B Q4_0     |                 512 | No                 | pp512    |         660.46 |                  744.04 |        1.13 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         313.23 |                  332.41 |        1.06 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         395.47 |                  410.29 |        1.04 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         447.77 |                  521.64 |        1.16 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         516.29 |                  604.12 |        1.17 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         575.27 |                  653.40 |        1.14 |
| RX 6800    | llama 8B Q4_1     |                 512 | No                 | pp512    |         615.71 |                  696.65 |        1.13 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         279.38 |                  288.81 |        1.03 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         346.94 |                  343.54 |        0.99 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         391.23 |                  417.93 |        1.07 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         432.29 |                  473.87 |        1.10 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         495.26 |                  531.17 |        1.07 |
| RX 6800    | llama 8B Q4_K_S   |                 512 | No                 | pp512    |         531.88 |                  572.07 |        1.08 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         254.52 |                  265.04 |        1.04 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         370.51 |                  386.30 |        1.04 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         458.79 |                  518.40 |        1.13 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         532.04 |                  599.45 |        1.13 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         582.78 |                  648.47 |        1.11 |
| RX 6800    | llama 8B Q5_0     |                 512 | No                 | pp512    |         620.75 |                  688.35 |        1.11 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         266.91 |                  272.65 |        1.02 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         363.78 |                  373.59 |        1.03 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         437.54 |                  488.39 |        1.12 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         515.97 |                  574.23 |        1.11 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         572.46 |                  627.92 |        1.10 |
| RX 6800    | llama 8B Q5_1     |                 512 | No                 | pp512    |         612.17 |                  671.81 |        1.10 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         262.77 |                  265.41 |        1.01 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         348.23 |                  356.84 |        1.02 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         412.91 |                  412.09 |        1.00 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         464.64 |                  463.63 |        1.00 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         526.68 |                  523.03 |        0.99 |
| RX 6800    | llama 8B Q5_K_S   |                 512 | No                 | pp512    |         562.90 |                  562.30 |        1.00 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         235.89 |                  240.19 |        1.02 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         303.47 |                  309.41 |        1.02 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         368.56 |                  359.06 |        0.97 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         412.96 |                  398.44 |        0.96 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         471.93 |                  457.72 |        0.97 |
| RX 6800    | llama 8B Q6_K     |                 512 | No                 | pp512    |         502.60 |                  489.37 |        0.97 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         282.22 |                  296.78 |        1.05 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         397.59 |                  422.71 |        1.06 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         525.22 |                  544.64 |        1.04 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         618.31 |                  634.40 |        1.03 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         675.13 |                  692.29 |        1.03 |
| RX 6800    | llama 8B Q8_0     |                 512 | No                 | pp512    |         723.71 |                  738.57 |        1.02 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         237.34 |                  245.33 |        1.03 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         346.03 |                  365.32 |        1.06 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         425.68 |                  499.35 |        1.17 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         514.15 |                  572.58 |        1.11 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         569.00 |                  623.27 |        1.10 |
| P40        | llama 8B Q2_K_M   |                 512 | Yes                | pp512    |         599.91 |                  653.08 |        1.09 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         191.82 |                  196.45 |        1.02 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         308.71 |                  323.82 |        1.05 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         403.49 |                  485.15 |        1.20 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         494.54 |                  555.72 |        1.12 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         549.80 |                  602.46 |        1.10 |
| P40        | llama 8B Q3_K_S   |                 512 | Yes                | pp512    |         580.61 |                  634.97 |        1.09 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         449.64 |                  450.38 |        1.00 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         631.98 |                  643.95 |        1.02 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         725.83 |                  765.18 |        1.05 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         846.09 |                  891.05 |        1.05 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         938.43 |                  977.63 |        1.04 |
| P40        | llama 8B Q4_0     |                 512 | Yes                | pp512    |         977.94 |                 1021.74 |        1.04 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         449.09 |                  459.07 |        1.02 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         551.55 |                  634.79 |        1.15 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         709.22 |                  746.86 |        1.05 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         832.00 |                  877.13 |        1.05 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         924.13 |                  959.59 |        1.04 |
| P40        | llama 8B Q4_1     |                 512 | Yes                | pp512    |         959.92 |                  994.99 |        1.04 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         401.29 |                  412.25 |        1.03 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         508.90 |                  530.00 |        1.04 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         656.57 |                  684.11 |        1.04 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         770.55 |                  803.24 |        1.04 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         844.89 |                  887.66 |        1.05 |
| P40        | llama 8B Q4_K_S   |                 512 | Yes                | pp512    |         884.86 |                  931.31 |        1.05 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         340.35 |                  343.69 |        1.01 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         481.09 |                  544.34 |        1.13 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         683.82 |                  690.55 |        1.01 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         796.89 |                  800.14 |        1.00 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         870.45 |                  886.13 |        1.02 |
| P40        | llama 8B Q5_0     |                 512 | Yes                | pp512    |         905.58 |                  921.42 |        1.02 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         381.26 |                  380.18 |        1.00 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         505.76 |                  508.57 |        1.01 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         675.41 |                  697.82 |        1.03 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         788.00 |                  811.61 |        1.03 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         864.09 |                  887.09 |        1.03 |
| P40        | llama 8B Q5_1     |                 512 | Yes                | pp512    |         891.85 |                  923.47 |        1.04 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         307.56 |                  361.05 |        1.17 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         455.28 |                  537.45 |        1.18 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         630.29 |                  658.55 |        1.04 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         725.76 |                  763.59 |        1.05 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         800.00 |                  840.82 |        1.05 |
| P40        | llama 8B Q5_K_S   |                 512 | Yes                | pp512    |         840.87 |                  887.07 |        1.05 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         290.65 |                  337.85 |        1.16 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         454.24 |                  467.11 |        1.03 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         608.92 |                  636.37 |        1.05 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         699.30 |                  744.69 |        1.06 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         777.11 |                  816.01 |        1.05 |
| P40        | llama 8B Q6_K     |                 512 | Yes                | pp512    |         809.58 |                  841.91 |        1.04 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         327.28 |                  328.31 |        1.00 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         515.54 |                  532.33 |        1.03 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         681.38 |                  671.99 |        0.99 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         813.87 |                  808.15 |        0.99 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         902.11 |                  894.44 |        0.99 |
| P40        | llama 8B Q8_0     |                 512 | Yes                | pp512    |         947.15 |                  936.98 |        0.99 |

</details>