### PR TITLE
url: save -mu downloads to new cache location

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -191,6 +191,15 @@ int32_t cpu_get_num_math() {
 // CLI argument parsing
 //
 
+static std::string get_cached_file(const std::string & path) {
+    std::string cache_directory = fs_get_cache_directory();
+    const bool success = fs_create_directory_with_parents(cache_directory);
+    if (!success) {
+        throw std::runtime_error("failed to create cache directory: " + cache_directory);
+    }
+    return cache_directory + string_split(path, '/').back();
+}
+
 void gpt_params_handle_model_default(gpt_params & params) {
     if (!params.hf_repo.empty()) {
         // short-hand to avoid specifying --hf-file -> default it to --model
@@ -200,19 +209,13 @@ void gpt_params_handle_model_default(gpt_params & params) {
             }
             params.hf_file = params.model;
         } else if (params.model.empty()) {
-            std::string cache_directory = fs_get_cache_directory();
-            const bool success = fs_create_directory_with_parents(cache_directory);
-            if (!success) {
-                throw std::runtime_error("failed to create cache directory: " + cache_directory);
-            }
-            params.model = cache_directory + string_split(params.hf_file, '/').back();
+            params.model = get_cached_file(params.hf_file);
         }
     } else if (!params.model_url.empty()) {
         if (params.model.empty()) {
             auto f = string_split(params.model_url, '#').front();
             f = string_split(f, '?').front();
-            f = string_split(f, '/').back();
-            params.model =  "models/" + f;
+            params.model = get_cached_file(f);
         }
     } else if (params.model.empty()) {
         params.model = DEFAULT_MODEL_PATH;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -191,15 +191,6 @@ int32_t cpu_get_num_math() {
 // CLI argument parsing
 //
 
-static std::string get_cached_file(const std::string & path) {
-    std::string cache_directory = fs_get_cache_directory();
-    const bool success = fs_create_directory_with_parents(cache_directory);
-    if (!success) {
-        throw std::runtime_error("failed to create cache directory: " + cache_directory);
-    }
-    return cache_directory + string_split(path, '/').back();
-}
-
 void gpt_params_handle_model_default(gpt_params & params) {
     if (!params.hf_repo.empty()) {
         // short-hand to avoid specifying --hf-file -> default it to --model
@@ -209,13 +200,13 @@ void gpt_params_handle_model_default(gpt_params & params) {
             }
             params.hf_file = params.model;
         } else if (params.model.empty()) {
-            params.model = get_cached_file(params.hf_file);
+            params.model = fs_get_cache_file_path(params.hf_file);
         }
     } else if (!params.model_url.empty()) {
         if (params.model.empty()) {
             auto f = string_split(params.model_url, '#').front();
             f = string_split(f, '?').front();
-            params.model = get_cached_file(f);
+            params.model = fs_get_cache_file_path(f);
         }
     } else if (params.model.empty()) {
         params.model = DEFAULT_MODEL_PATH;
@@ -2280,6 +2271,15 @@ std::string fs_get_cache_directory() {
         cache_directory += "llama.cpp";
     }
     return ensure_trailing_slash(cache_directory);
+}
+
+std::string fs_get_cache_file_path(const std::string & path) {
+    std::string cache_directory = fs_get_cache_directory();
+    const bool success = fs_create_directory_with_parents(cache_directory);
+    if (!success) {
+        throw std::runtime_error("failed to create cache directory: " + cache_directory);
+    }
+    return cache_directory + string_split(path, '/').back();
 }
 
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -200,13 +200,13 @@ void gpt_params_handle_model_default(gpt_params & params) {
             }
             params.hf_file = params.model;
         } else if (params.model.empty()) {
-            params.model = fs_get_cache_file_path(params.hf_file);
+            params.model = fs_get_cache_file(string_split(params.hf_file, '/').back());
         }
     } else if (!params.model_url.empty()) {
         if (params.model.empty()) {
             auto f = string_split(params.model_url, '#').front();
             f = string_split(f, '?').front();
-            params.model = fs_get_cache_file_path(f);
+            params.model = fs_get_cache_file(string_split(f, '/').back());
         }
     } else if (params.model.empty()) {
         params.model = DEFAULT_MODEL_PATH;
@@ -2273,13 +2273,14 @@ std::string fs_get_cache_directory() {
     return ensure_trailing_slash(cache_directory);
 }
 
-std::string fs_get_cache_file_path(const std::string & path) {
+std::string fs_get_cache_file(const std::string & filename) {
+    GGML_ASSERT(filename.find(DIRECTORY_SEPARATOR) == std::string::npos);
     std::string cache_directory = fs_get_cache_directory();
     const bool success = fs_create_directory_with_parents(cache_directory);
     if (!success) {
         throw std::runtime_error("failed to create cache directory: " + cache_directory);
     }
-    return cache_directory + string_split(path, '/').back();
+    return cache_directory + filename;
 }
 
 

--- a/common/common.h
+++ b/common/common.h
@@ -277,7 +277,7 @@ bool fs_validate_filename(const std::string & filename);
 bool fs_create_directory_with_parents(const std::string & path);
 
 std::string fs_get_cache_directory();
-std::string fs_get_cache_file_path(const std::string & path);
+std::string fs_get_cache_file(const std::string & filename);
 
 //
 // Model utils

--- a/common/common.h
+++ b/common/common.h
@@ -277,6 +277,7 @@ bool fs_validate_filename(const std::string & filename);
 bool fs_create_directory_with_parents(const std::string & path);
 
 std::string fs_get_cache_directory();
+std::string fs_get_cache_file_path(const std::string & path);
 
 //
 // Model utils


### PR DESCRIPTION
This makes `-mu` (updated in https://github.com/ggerganov/llama.cpp/pull/6930) save/lookup files in the cache just like  `-hfr` + `-hff` (https://github.com/ggerganov/llama.cpp/pull/7353) by default (unless `-m` is provided explicitly). Also see https://github.com/ggerganov/llama.cpp/issues/7252

```bash
./server -mu https://huggingface.co/NousResearch/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf
```


After this gets merged, if you have already downloaded `.gguf` / `.gguf.json` file pairs to `models/`, simply move them to the cache folder:
- `$LLAMA_CACHE` if defined,
- `~/Library/Caches/llama.cpp/` on Mac,
- `~/.cache/llama.cpp` on Linux (or `$XDG_CACHE_HOME/llama.cpp` if defined)
- `%LOCALAPPDATA%\llama.cpp` on Windows