### PR TITLE
server: do not remove whitespace at the start of a completion chunk (reapply to new UI)

### DIFF
--- a/examples/server/public/index-new.html
+++ b/examples/server/public/index-new.html
@@ -416,7 +416,7 @@
           message = html`<${Probabilities} data=${data} />`
         } else {
           const text = isArrayMessage ?
-            data.map(msg => msg.content).join('').replace(/^\s+/, '') :
+            data.map(msg => msg.content).join('') :
             data;
           message = isCompletionMode ?
             text :


### PR DESCRIPTION
This merges the change in #7524 to the new UI to keep the two implementations in sync.

Original description:

> When using Completion mode of the server in recent builds, the first token of the predicted text is typically appended to the prompt without a space character. This can lead to problems when manually editing the text and then predicting again, because the missing space will appear in the new prompt.

When looking at this change again, I noticed that the code is also used in Chat mode, but in this case HTML rendering removes the whitespace at the start of a conversation turn (after "assistant"), and the conversation transcript looks to be okay afterwards.