### PR TITLE
examples: refine tensor_sum_elements(tensor dump) in examples/benchmark/benchmark-matmult.cpp

### DIFF
--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -39,9 +39,15 @@ typedef struct {
 } block_q8_0;
 
 static inline float ggml_compute_fp16_to_fp32(uint16_t h) {
+#if defined(__ARM_NEON)
+    __fp16 tmp;
+    memcpy(&tmp, &h, sizeof(uint16_t));
+    return (float) tmp;
+#else
     uint16_t tmp;
     memcpy(&tmp, &h, sizeof(uint16_t));
     return (float) tmp;
+#endif
 }
 
 static float tensor_sum_elements(const ggml_tensor * tensor) {

--- a/examples/benchmark/benchmark-matmult.cpp
+++ b/examples/benchmark/benchmark-matmult.cpp
@@ -33,17 +33,9 @@ static void ggml_graph_compute_helper(std::vector<uint8_t> & buf, ggml_cgraph * 
 }
 
 static float tensor_sum_elements(const ggml_tensor * tensor) {
-    double sum                  = 0;
-    float  floatvalue           = 0;
+    double sum                  = 0.0;
+    float  floatvalue           = 0.0f;
     unsigned short shortvalue   = 0;
-
-    if (tensor->type == GGML_TYPE_I8) {
-        for (int j = 0; j < tensor->ne[1]; j++) {
-            for (int k = 0; k < tensor->ne[0]; k++) {
-                sum += ((int8_t *) tensor->data)[j * tensor->ne[0] + k];
-            }
-        }
-    }
 
     if (tensor->type == GGML_TYPE_F16) {
         for (int j = 0; j < tensor->ne[1]; j++) {
@@ -53,17 +45,13 @@ static float tensor_sum_elements(const ggml_tensor * tensor) {
                 sum        += floatvalue;
             }
         }
-    }
-
-    if (tensor->type == GGML_TYPE_F32) {
+    } else if (tensor->type == GGML_TYPE_F32) {
         for (int j = 0; j < tensor->ne[1]; j++) {
             for (int k = 0; k < tensor->ne[0]; k++) {
                 sum += ((float *) tensor->data)[j * tensor->ne[0] + k];
             }
         }
-    }
-
-    if (ggml_is_quantized(tensor->type)) {
+    } else if (ggml_is_quantized(tensor->type)) {
         std::vector<float> f32out(ggml_nelements(tensor));
         ggml_type_traits_t qtype = ggml_internal_get_type_traits(tensor->type);
         qtype.to_float((void *)tensor->data, f32out.data(), f32out.size());


### PR DESCRIPTION
Self Reported Review Complexity

- [x] Review Complexity : Low
- [ ] Review Complexity : Medium
- [ ] Review Complexity : High
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)


BTW, can the original author or core maintainer add a 
```
void ggml_tensor_print(const struct ggml_tensor * tensor, const char * name) 

```
utility function (with all supported data type and dump the accurate value in the tensor as m ( < 8) x n ( < 8) format) in ggml.h&ggml.c, it will might be very useful/helpful for programmers/developers. thanks so much.