### PR TITLE
Type cast AVX512_BF16 data types based on compiler instead of the OS platform

### DIFF
--- a/ggml-impl.h
+++ b/ggml-impl.h
@@ -17,7 +17,7 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 
 #define m512bh(p) p
 #define m512i(p) p


### PR DESCRIPTION
The change in PR #7258 was intended to fix the issues faced while compiling with MSVC Compiler. In my machine with cmake in windows, MSVC was taken as the default compiler in windows.  Following the issue reported in #7655, the code was updated to do type casts based on the compiler used. Explicit type casts are required in GCC and Clang, whereas its not required in MSVC. Thanks