### PR TITLE
gguf-dump.py: add --markdown dump output

### DIFF
--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -232,7 +232,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
     markdown_content += f'There is {len(reader.fields)} key/value pair(s) in this file\n'
     markdown_content += '\n'
 
-    kv_dump_table = []
+    kv_dump_table: list[dict[str, str | int]] = []
     for n, field in enumerate(reader.fields.values(), 1):
         if not field.types:
             pretty_type = 'N/A'
@@ -278,9 +278,9 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
 
     if not args.no_tensors:
         # Group tensors by their prefix and maintain order
-        tensor_prefix_order = []
-        tensor_name_to_key = {}
-        tensor_groups = {}
+        tensor_prefix_order: list[str] = []
+        tensor_name_to_key: dict[str, int] = {}
+        tensor_groups: dict[str, list[ReaderTensor]] = {}
         total_elements = sum(tensor.n_elements for tensor in reader.tensors)
 
         # Parsing Tensors Record
@@ -320,7 +320,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             markdown_content += f"### <a name=\"{group.replace('.', '_')}\">{translate_tensor_name(group)} Tensor Group : {element_count_rounded_notation(group_elements)} Elements</a>\n\n"
 
             # Precalculate pretty shape column sizing for visual consistency
-            prettify_dimension_max_widths = {}
+            prettify_dimension_max_widths: dict[int, int] = {}
             for tensor in tensors:
                 for i, dimension_size in enumerate(list(tensor.shape) + [1] * (4 - len(tensor.shape))):
                     if i in prettify_dimension_max_widths:
@@ -329,12 +329,12 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
                         prettify_dimension_max_widths[i] = len(str(dimension_size))
 
             # Generate Tensor Layer Table Content
-            tensor_dump_table = []
+            tensor_dump_table: list[dict[str, str | int]] = []
             for tensor in tensors:
                 human_friendly_name = translate_tensor_name(tensor.name.replace(".weight", ".(W)").replace(".bias", ".(B)"))
-                pretty_dimension = ' x '.join(f'{str(d):^{prettify_dimension_max_widths[i]}}' for i, d in enumerate(list(tensor.shape) + [1] * (4 - len(tensor.shape))))
-                element_count_est = f"({element_count_rounded_notation(tensor.n_elements):>4})"
-                element_count_string = f"{element_count_est:>6} {tensor.n_elements:^8}"
+                pretty_dimension = ' x '.join(f'{str(d):>{prettify_dimension_max_widths[i]}}' for i, d in enumerate(list(tensor.shape) + [1] * (4 - len(tensor.shape))))
+                element_count_est = f"({element_count_rounded_notation(tensor.n_elements):>5})"
+                element_count_string = f"{element_count_est} {tensor.n_elements:>8}"
                 type_name_string = f"{tensor.tensor_type.name}"
                 tensor_dump_table.append({"t_id":tensor_name_to_key[tensor.name], "layer_name":tensor.name, "human_layer_name":human_friendly_name, "element_count":element_count_string, "pretty_dimension":pretty_dimension, "tensor_type":type_name_string})
 

--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -227,8 +227,11 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             tensor_name_to_key[tensor.name] = key
             tensor_groups[tensor_prefix].append(tensor)
 
-        # Generate Markdown metadata
-        markdown_content += "## Tensor Groups\n"
+        # Tensors Mapping Dump
+        markdown_content += f'## Tensors Overview {element_count_rounded_notation(total_elements)} Elements\n'
+        markdown_content += f'Total number of elements in all tensors: {total_elements} Elements\n'
+        markdown_content += '\n'
+
         for group in tensor_prefix_order:
             tensors = tensor_groups[group]
             group_elements = sum(tensor.n_elements for tensor in tensors)

--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -101,11 +101,11 @@ def dump_metadata_json(reader: GGUFReader, args: argparse.Namespace) -> None:
     json.dump(result, sys.stdout)
 
 
-def markdownTableWithAlignmentSupport(header_map, data):
+def markdownTableWithAlignmentSupport(header_map: list[dict[str, str]], data: list[dict[str, Any]]):
     # JSON to Markdown table formatting: https://stackoverflow.com/a/72983854/2850957
 
     # Alignment Utility Function
-    def strAlign(padding:int, alignMode:str, strVal:str):
+    def strAlign(padding: int, alignMode: str | None, strVal: str):
         if alignMode == 'center':
             return strVal.center(padding)
         elif alignMode == 'right':
@@ -115,7 +115,7 @@ def markdownTableWithAlignmentSupport(header_map, data):
         else: # default left
             return ' ' + strVal.ljust(padding - 1)
 
-    def dashAlign(padding:int, alignMode:str):
+    def dashAlign(padding: int, alignMode: str | None):
         if alignMode == 'center':
             return ':' + '-' * (padding - 2) + ':'
         elif alignMode == 'right':
@@ -228,7 +228,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
     markdown_content += f'# {args.model} - GGUF Internal File Dump\n'
     markdown_content += f'* Endian: {file_endian} endian\n'
     markdown_content += '\n'
-    markdown_content += '## Key Value Metadata Store\n'
+    markdown_content += '## Key Value Metadata Store\n\n'
     markdown_content += f'There is {len(reader.fields)} key/value pair(s) in this file\n'
     markdown_content += '\n'
 
@@ -265,9 +265,9 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
         kv_dump_table.append({"n":n, "pretty_type":pretty_type, "total_elements":total_elements, "field_name":field.name, "value":value})
 
     kv_dump_table_header_map = [
-        {'key_name':'n',                'header_name':'POS',      'align':'center'},
+        {'key_name':'n',                'header_name':'POS',      'align':'right'},
         {'key_name':'pretty_type',      'header_name':'TYPE',     'align':'left'},
-        {'key_name':'total_elements',   'header_name':'Count',    'align':'left'},
+        {'key_name':'total_elements',   'header_name':'Count',    'align':'right'},
         {'key_name':'field_name',       'header_name':'Key',      'align':'left'},
         {'key_name':'value',            'header_name':'Value',    'align':'left'},
     ]
@@ -302,7 +302,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             tensor_name_to_key[tensor.name] = key
 
         # Tensors Mapping Dump
-        markdown_content += f'## Tensors Overview {element_count_rounded_notation(total_elements)} Elements\n'
+        markdown_content += f'## Tensors Overview {element_count_rounded_notation(total_elements)} Elements\n\n'
         markdown_content += f'Total number of elements in all tensors: {total_elements} Elements\n'
         markdown_content += '\n'
 
@@ -317,7 +317,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             tensors = tensor_groups[group]
             group_elements = sum(tensor.n_elements for tensor in tensors)
             group_percentage = group_elements / total_elements * 100
-            markdown_content += f"### <a name=\"{group.replace('.', '_')}\">{translate_tensor_name(group)} Tensor Group : {element_count_rounded_notation(group_elements)} Elements</a>\n"
+            markdown_content += f"### <a name=\"{group.replace('.', '_')}\">{translate_tensor_name(group)} Tensor Group : {element_count_rounded_notation(group_elements)} Elements</a>\n\n"
 
             tensor_dump_table = []
             for tensor in tensors:
@@ -328,7 +328,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
                 tensor_dump_table.append({"t_id":tensor_name_to_key[tensor.name], "layer_name":tensor.name, "human_layer_name":human_friendly_name, "element_count":element_count_string, "pretty_dims":prettydims, "tensor_type":type_name_string})
 
             tensor_dump_table_header_map = [
-                {'key_name':'t_id',             'header_name':'T_ID',                             'align':'center'},
+                {'key_name':'t_id',             'header_name':'T_ID',                             'align':'right'},
                 {'key_name':'layer_name',       'header_name':'Tensor Layer Name',                'align':'left'},
                 {'key_name':'human_layer_name', 'header_name':'Human Friendly Tensor Layer Name', 'align':'left'},
                 {'key_name':'element_count',    'header_name':'Elements',                         'align':'left'},

--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -101,25 +101,150 @@ def dump_metadata_json(reader: GGUFReader, args: argparse.Namespace) -> None:
     json.dump(result, sys.stdout)
 
 
+def element_count_rounded_notation(count: int) -> str:
+    if count > 1e15 :
+        # Quadrillion
+        scaled_amount = count * 1e-15
+        scale_suffix = "Q"
+    elif count > 1e12 :
+        # Trillions
+        scaled_amount = count * 1e-12
+        scale_suffix = "T"
+    elif count > 1e9 :
+        # Billions
+        scaled_amount = count * 1e-9
+        scale_suffix = "B"
+    elif count > 1e6 :
+        # Millions
+        scaled_amount = count * 1e-6
+        scale_suffix = "M"
+    elif count > 1e3 :
+        # Thousands
+        scaled_amount = count * 1e-3
+        scale_suffix = "K"
+    else:
+        # Under Thousands
+        scaled_amount = count
+        scale_suffix = ""
+    return f"{'~' if count > 1e3 else ''}{round(scaled_amount)}{scale_suffix}"
+
+
+def translate_tensor_name(name):
+    import re
+    words = re.split(r"[._]", name)
+
+    abbreviation_dictionary = {
+        'ffn' : 'Feed Forward',
+        'attn' : 'Attention',
+        'blk' : 'Block',
+        'norm' : 'Normalization',
+        'embd' : 'Embedding',
+    }
+
+    expanded_words = []
+    for word in words:
+        word_norm = word.strip().lower()
+        if word_norm in abbreviation_dictionary:
+            expanded_words.append(abbreviation_dictionary[word_norm])
+        else:
+            expanded_words.append(word.title())
+
+    return ' '.join(expanded_words)
+
+
+def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None:
+    host_endian, file_endian = get_file_host_endian(reader)
+    print(f'# {args.model} - GGUF Internal File Dump')  # noqa: NP100
+    print(f'* Endian: {file_endian} endian')  # noqa: NP100
+    print('')  # noqa: NP100
+    print('## Key Value Metadata Store')  # noqa: NP100
+    print(f'There is {len(reader.fields)} key/value pair(s) in this file')  # noqa: NP100
+    print('')  # noqa: NP100
+
+    print('| POS | TYPE       | Elements | Key                                    | Value                                                                          |')  # noqa: NP100
+    print('|-----|------------|----------|----------------------------------------|--------------------------------------------------------------------------------|')  # noqa: NP100
+
+    for n, field in enumerate(reader.fields.values(), 1):
+        if not field.types:
+            pretty_type = 'N/A'
+        elif field.types[0] == GGUFValueType.ARRAY:
+            nest_count = len(field.types) - 1
+            pretty_type = '[' * nest_count + str(field.types[-1].name) + ']' * nest_count
+        else:
+            pretty_type = str(field.types[-1].name)
+
+        if len(field.types) == 1:
+            curr_type = field.types[0]
+            if curr_type == GGUFValueType.STRING:
+                value = repr(str(bytes(field.parts[-1]), encoding='utf-8')[:60])
+            elif field.types[0] in reader.gguf_scalar_to_np:
+                value = field.parts[-1][0]
+        print(f'| {n:3} | {pretty_type:10} | {len(field.data):8} | {field.name:38} | {value:<78} |')  # noqa: NP100
+
+    print("\n")  # noqa: NP100
+
+    if not args.no_tensors:
+        # Group tensors by their prefix and maintain order
+        tensor_prefix_order = []
+        tensor_groups = {}
+        total_elements = sum(tensor.n_elements for tensor in reader.tensors)
+
+        for tensor in reader.tensors:
+            tensor_name = tensor.name.replace(".weight", "")
+            tensor_components = tensor_name.split('.')
+            tensor_prefix = tensor_components[0]
+            if tensor_prefix == 'blk':
+                tensor_prefix = f"{tensor_components[0]}.{tensor_components[1]}"
+
+            if tensor_prefix not in tensor_groups:
+                tensor_groups[tensor_prefix] = []
+                tensor_prefix_order.append(tensor_prefix)
+
+            tensor_groups[tensor_prefix].append(tensor)
+
+        # Generate Markdown metadata
+        for group in tensor_prefix_order:
+            tensors = tensor_groups[group]
+            group_elements = sum(tensor.n_elements for tensor in tensors)
+            group_percentage = group_elements / total_elements * 100
+
+            print(f"## {translate_tensor_name(group)} Tensor Group : {element_count_rounded_notation(group_elements)} Elements")  # noqa: NP100
+            print("| Tensor Name          | Human Friendly Name                 |  Elements      | Shape                           | Type |")  # noqa: NP100
+            print("|----------------------|-------------------------------------|----------------|---------------------------------|------|")  # noqa: NP100
+
+            for tensor in tensors:
+                tensor_name = tensor.name.replace(".weight", "")
+                human_friendly_name = translate_tensor_name(tensor.name.replace(".weight", ""))
+                prettydims = ' x '.join('{0:^5}'.format(d) for d in list(tensor.shape) + [1] * (4 - len(tensor.shape)))
+                print(f"| {tensor_name:20} | {human_friendly_name:35} | ({element_count_rounded_notation(tensor.n_elements):>4}) {tensor.n_elements:7} | [{prettydims:29}] | {tensor.tensor_type.name:4} |")  # noqa: NP100
+            print("")  # noqa: NP100
+            print(f"- Total elements in {group}: ({element_count_rounded_notation(group_elements):>4}) {group_elements}")  # noqa: NP100
+            print(f"- Percentage of total elements: {group_percentage:.2f}%")  # noqa: NP100
+            print("\n")  # noqa: NP100
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Dump GGUF file metadata")
     parser.add_argument("model",           type=str,            help="GGUF format model filename")
     parser.add_argument("--no-tensors", action="store_true", help="Don't dump tensor metadata")
     parser.add_argument("--json",       action="store_true", help="Produce JSON output")
     parser.add_argument("--json-array", action="store_true", help="Include full array values in JSON output (long)")
+    parser.add_argument("--markdown",   action="store_true", help="Produce markdown output")
     parser.add_argument("--verbose",    action="store_true", help="increase output verbosity")
 
     args = parser.parse_args(None if len(sys.argv) > 1 else ["--help"])
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    if not args.json:
+    if not args.json and not args.markdown:
         logger.info(f'* Loading: {args.model}')
 
     reader = GGUFReader(args.model, 'r')
 
     if args.json:
         dump_metadata_json(reader, args)
+    elif args.markdown:
+        dump_markdown_metadata(reader, args)
     else:
         dump_metadata(reader, args)
 

--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -225,11 +225,11 @@ def translate_tensor_name(name):
 def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None:
     host_endian, file_endian = get_file_host_endian(reader)
     markdown_content = ""
-    markdown_content += f'# {args.model} - GGUF Internal File Dump\n'
-    markdown_content += f'* Endian: {file_endian} endian\n'
+    markdown_content += f'# {args.model} - GGUF Internal File Dump\n\n'
+    markdown_content += f'- Endian: {file_endian} endian\n'
     markdown_content += '\n'
     markdown_content += '## Key Value Metadata Store\n\n'
-    markdown_content += f'There is {len(reader.fields)} key/value pair(s) in this file\n'
+    markdown_content += f'There are {len(reader.fields)} key-value pairs in this file\n'
     markdown_content += '\n'
 
     kv_dump_table: list[dict[str, str | int]] = []


### PR DESCRIPTION
This will allow `$gguf-dump.py Tinyllama-5M-v0.2-Q8_0.gguf  --markdown` to output a markdown formatted dump that is designed to be as easy as possible to read as a markdown file.

It's sent to stdout so you can do stuff like `$gguf-dump.py Tinyllama-5M-v0.2-Q8_0.gguf  --markdown | mdless` to render the markdown dump directly. Alternatively it might be part of your workflow to render this file when creating a new gguf.

Why do this when you can still manually dump it whenever? Well in a github / huggingface repo, it still might be good courtesy to have an easy to read technical dump of the layers. Note that I also added a function that reads the tensor name and converts it into a human friendly name as devs coming across it may not necessarily know what ffn etc.. means.

Below is how it currently renders. Feel free to suggest changes to it to make it as useful as possible for you.

---

<details><summary>Example Output</summary>

```markdown
# phi-2.Q6_K.gguf - GGUF Internal File Dump
* Endian: LITTLE endian

## Key Value Metadata Store

There is 23 key/value pair(s) in this file

| POS | TYPE     | Count | Key                               | Value                                                                             |
|----:|:---------|------:|:----------------------------------|:----------------------------------------------------------------------------------|
|   1 | UINT32   |     1 | GGUF.version                      | 3                                                                                 |
|   2 | UINT64   |     1 | GGUF.tensor_count                 | 325                                                                               |
|   3 | UINT64   |     1 | GGUF.kv_count                     | 20                                                                                |
|   4 | STRING   |     1 | general.architecture              | 'phi2'                                                                            |
|   5 | STRING   |     1 | general.name                      | 'Phi2'                                                                            |
|   6 | UINT32   |     1 | phi2.context_length               | 2048                                                                              |
|   7 | UINT32   |     1 | phi2.embedding_length             | 2560                                                                              |
|   8 | UINT32   |     1 | phi2.feed_forward_length          | 10240                                                                             |
|   9 | UINT32   |     1 | phi2.block_count                  | 32                                                                                |
|  10 | UINT32   |     1 | phi2.attention.head_count         | 32                                                                                |
|  11 | UINT32   |     1 | phi2.attention.head_count_kv      | 32                                                                                |
|  12 | FLOAT32  |     1 | phi2.attention.layer_norm_epsilon | 1e-05                                                                             |
|  13 | UINT32   |     1 | phi2.rope.dimension_count         | 32                                                                                |
|  14 | UINT32   |     1 | general.file_type                 | 18                                                                                |
|  15 | BOOL     |     1 | tokenizer.ggml.add_bos_token      | False                                                                             |
|  16 | STRING   |     1 | tokenizer.ggml.model              | 'gpt2'                                                                            |
|  17 | [STRING] | 51200 | tokenizer.ggml.tokens             | [ '[PAD5', '\n\x00\x00\x00\x00', '[PAD5', '\n\x00\x00\x00\x00', '[PAD5',  ... ]   |
|  18 | [INT32]  | 51200 | tokenizer.ggml.token_type         | [ 4, 4, 4, 4, 4, 4, 4,  ... ]                                                     |
|  19 | [STRING] | 50000 | tokenizer.ggml.merges             | [ 'Ġg az', '\x08\x00\x00\x00\x00', 'Ġinfo', '\r\x00\x00\x00\x00', 'ĠColl',  ... ] |
|  20 | UINT32   |     1 | tokenizer.ggml.bos_token_id       | 50256                                                                             |
|  21 | UINT32   |     1 | tokenizer.ggml.eos_token_id       | 50256                                                                             |
|  22 | UINT32   |     1 | tokenizer.ggml.unknown_token_id   | 50256                                                                             |
|  23 | UINT32   |     1 | general.quantization_version      | 2                                                                                 |

## Tensors Overview ~3B Elements

Total number of elements in all tensors: 2779683840 Elements

- [Base Tensor Group - ~262M Elements](#base)
- [Block 0 Tensor Group - ~79M Elements](#blk_0)
- [Block 1 Tensor Group - ~79M Elements](#blk_1)
- [Block 10 Tensor Group - ~79M Elements](#blk_10)
- [Block 11 Tensor Group - ~79M Elements](#blk_11)
- [Block 12 Tensor Group - ~79M Elements](#blk_12)
- [Block 13 Tensor Group - ~79M Elements](#blk_13)
- [Block 14 Tensor Group - ~79M Elements](#blk_14)
- [Block 15 Tensor Group - ~79M Elements](#blk_15)
- [Block 16 Tensor Group - ~79M Elements](#blk_16)
- [Block 17 Tensor Group - ~79M Elements](#blk_17)
- [Block 18 Tensor Group - ~79M Elements](#blk_18)
- [Block 19 Tensor Group - ~79M Elements](#blk_19)
- [Block 2 Tensor Group - ~79M Elements](#blk_2)
- [Block 20 Tensor Group - ~79M Elements](#blk_20)
- [Block 21 Tensor Group - ~79M Elements](#blk_21)
- [Block 22 Tensor Group - ~79M Elements](#blk_22)
- [Block 23 Tensor Group - ~79M Elements](#blk_23)
- [Block 24 Tensor Group - ~79M Elements](#blk_24)
- [Block 25 Tensor Group - ~79M Elements](#blk_25)
- [Block 26 Tensor Group - ~79M Elements](#blk_26)
- [Block 27 Tensor Group - ~79M Elements](#blk_27)
- [Block 28 Tensor Group - ~79M Elements](#blk_28)
- [Block 29 Tensor Group - ~79M Elements](#blk_29)
- [Block 3 Tensor Group - ~79M Elements](#blk_3)
- [Block 30 Tensor Group - ~79M Elements](#blk_30)
- [Block 4 Tensor Group - ~79M Elements](#blk_4)
- [Block 5 Tensor Group - ~79M Elements](#blk_5)
- [Block 6 Tensor Group - ~79M Elements](#blk_6)
- [Block 7 Tensor Group - ~79M Elements](#blk_7)
- [Block 8 Tensor Group - ~79M Elements](#blk_8)
- [Block 9 Tensor Group - ~79M Elements](#blk_9)
- [Block 31 Tensor Group - ~79M Elements](#blk_31)

### <a name="base">Base Tensor Group : ~262M Elements</a>

| T_ID | Tensor Layer Name  | Human Friendly Tensor Layer Name | Elements          | Shape                 | Type |
|-----:|:-------------------|:---------------------------------|:------------------|:----------------------|:-----|
|    0 | token_embd.weight  | Token Embedding (W)              | (~131M) 131072000 |  2560 x 51200 x 1 x 1 | Q6_K |
|  303 | output.bias        | Output (B)                       | ( ~51K)     51200 | 51200 x     1 x 1 x 1 | F32  |
|  304 | output.weight      | Output (W)                       | (~131M) 131072000 |  2560 x 51200 x 1 x 1 | Q6_K |
|  305 | output_norm.bias   | Output Normalization (B)         | (  ~3K)      2560 |  2560 x     1 x 1 x 1 | F32  |
|  306 | output_norm.weight | Output Normalization (W)         | (  ~3K)      2560 |  2560 x     1 x 1 x 1 | F32  |

- Total elements in base: (~262M) 262200320
- Percentage of total elements: 9.43%


### <a name="blk_0">Block 0 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|    1 | blk.0.attn_norm.bias     | Block 0 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|    2 | blk.0.attn_norm.weight   | Block 0 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|    3 | blk.0.attn_qkv.bias      | Block 0 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|    4 | blk.0.attn_qkv.weight    | Block 0 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|    5 | blk.0.attn_output.bias   | Block 0 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|    6 | blk.0.attn_output.weight | Block 0 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|    7 | blk.0.ffn_up.bias        | Block 0 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|    8 | blk.0.ffn_up.weight      | Block 0 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|    9 | blk.0.ffn_down.bias      | Block 0 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   10 | blk.0.ffn_down.weight    | Block 0 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.0: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_1">Block 1 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|   11 | blk.1.attn_norm.bias     | Block 1 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   12 | blk.1.attn_norm.weight   | Block 1 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   13 | blk.1.attn_qkv.bias      | Block 1 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   14 | blk.1.attn_qkv.weight    | Block 1 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   15 | blk.1.attn_output.bias   | Block 1 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   16 | blk.1.attn_output.weight | Block 1 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   17 | blk.1.ffn_up.bias        | Block 1 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   18 | blk.1.ffn_up.weight      | Block 1 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   19 | blk.1.ffn_down.bias      | Block 1 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   20 | blk.1.ffn_down.weight    | Block 1 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.1: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_10">Block 10 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   21 | blk.10.attn_norm.bias     | Block 10 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   22 | blk.10.attn_norm.weight   | Block 10 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   23 | blk.10.attn_qkv.bias      | Block 10 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   24 | blk.10.attn_qkv.weight    | Block 10 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   25 | blk.10.attn_output.bias   | Block 10 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   26 | blk.10.attn_output.weight | Block 10 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   27 | blk.10.ffn_up.bias        | Block 10 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   28 | blk.10.ffn_up.weight      | Block 10 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   29 | blk.10.ffn_down.bias      | Block 10 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   30 | blk.10.ffn_down.weight    | Block 10 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.10: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_11">Block 11 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   31 | blk.11.attn_norm.bias     | Block 11 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   32 | blk.11.attn_norm.weight   | Block 11 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   33 | blk.11.attn_qkv.bias      | Block 11 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   34 | blk.11.attn_qkv.weight    | Block 11 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   35 | blk.11.attn_output.bias   | Block 11 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   36 | blk.11.attn_output.weight | Block 11 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   37 | blk.11.ffn_up.bias        | Block 11 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   38 | blk.11.ffn_up.weight      | Block 11 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   39 | blk.11.ffn_down.bias      | Block 11 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   40 | blk.11.ffn_down.weight    | Block 11 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.11: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_12">Block 12 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   41 | blk.12.attn_norm.bias     | Block 12 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   42 | blk.12.attn_norm.weight   | Block 12 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   43 | blk.12.attn_qkv.bias      | Block 12 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   44 | blk.12.attn_qkv.weight    | Block 12 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   45 | blk.12.attn_output.bias   | Block 12 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   46 | blk.12.attn_output.weight | Block 12 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   47 | blk.12.ffn_up.bias        | Block 12 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   48 | blk.12.ffn_up.weight      | Block 12 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   49 | blk.12.ffn_down.bias      | Block 12 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   50 | blk.12.ffn_down.weight    | Block 12 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.12: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_13">Block 13 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   51 | blk.13.attn_norm.bias     | Block 13 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   52 | blk.13.attn_norm.weight   | Block 13 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   53 | blk.13.attn_qkv.bias      | Block 13 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   54 | blk.13.attn_qkv.weight    | Block 13 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   55 | blk.13.attn_output.bias   | Block 13 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   56 | blk.13.attn_output.weight | Block 13 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   57 | blk.13.ffn_up.bias        | Block 13 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   58 | blk.13.ffn_up.weight      | Block 13 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   59 | blk.13.ffn_down.bias      | Block 13 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   60 | blk.13.ffn_down.weight    | Block 13 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.13: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_14">Block 14 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   61 | blk.14.attn_norm.bias     | Block 14 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   62 | blk.14.attn_norm.weight   | Block 14 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   63 | blk.14.attn_qkv.bias      | Block 14 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   64 | blk.14.attn_qkv.weight    | Block 14 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   65 | blk.14.attn_output.bias   | Block 14 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   66 | blk.14.attn_output.weight | Block 14 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   67 | blk.14.ffn_up.bias        | Block 14 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   68 | blk.14.ffn_up.weight      | Block 14 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   69 | blk.14.ffn_down.bias      | Block 14 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   70 | blk.14.ffn_down.weight    | Block 14 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.14: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_15">Block 15 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   71 | blk.15.attn_norm.bias     | Block 15 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   72 | blk.15.attn_norm.weight   | Block 15 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   73 | blk.15.attn_qkv.bias      | Block 15 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   74 | blk.15.attn_qkv.weight    | Block 15 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   75 | blk.15.attn_output.bias   | Block 15 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   76 | blk.15.attn_output.weight | Block 15 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   77 | blk.15.ffn_up.bias        | Block 15 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   78 | blk.15.ffn_up.weight      | Block 15 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   79 | blk.15.ffn_down.bias      | Block 15 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   80 | blk.15.ffn_down.weight    | Block 15 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.15: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_16">Block 16 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   81 | blk.16.attn_norm.bias     | Block 16 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   82 | blk.16.attn_norm.weight   | Block 16 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   83 | blk.16.attn_qkv.bias      | Block 16 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   84 | blk.16.attn_qkv.weight    | Block 16 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   85 | blk.16.attn_output.bias   | Block 16 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   86 | blk.16.attn_output.weight | Block 16 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   87 | blk.16.ffn_up.bias        | Block 16 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   88 | blk.16.ffn_up.weight      | Block 16 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   89 | blk.16.ffn_down.bias      | Block 16 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   90 | blk.16.ffn_down.weight    | Block 16 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.16: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_17">Block 17 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|   91 | blk.17.attn_norm.bias     | Block 17 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   92 | blk.17.attn_norm.weight   | Block 17 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   93 | blk.17.attn_qkv.bias      | Block 17 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|   94 | blk.17.attn_qkv.weight    | Block 17 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|   95 | blk.17.attn_output.bias   | Block 17 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|   96 | blk.17.attn_output.weight | Block 17 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|   97 | blk.17.ffn_up.bias        | Block 17 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|   98 | blk.17.ffn_up.weight      | Block 17 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|   99 | blk.17.ffn_down.bias      | Block 17 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  100 | blk.17.ffn_down.weight    | Block 17 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.17: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_18">Block 18 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  101 | blk.18.attn_norm.bias     | Block 18 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  102 | blk.18.attn_norm.weight   | Block 18 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  103 | blk.18.attn_qkv.bias      | Block 18 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  104 | blk.18.attn_qkv.weight    | Block 18 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  105 | blk.18.attn_output.bias   | Block 18 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  106 | blk.18.attn_output.weight | Block 18 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  107 | blk.18.ffn_up.bias        | Block 18 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  108 | blk.18.ffn_up.weight      | Block 18 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  109 | blk.18.ffn_down.bias      | Block 18 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  110 | blk.18.ffn_down.weight    | Block 18 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.18: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_19">Block 19 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  111 | blk.19.attn_norm.bias     | Block 19 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  112 | blk.19.attn_norm.weight   | Block 19 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  113 | blk.19.attn_qkv.bias      | Block 19 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  114 | blk.19.attn_qkv.weight    | Block 19 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  115 | blk.19.attn_output.bias   | Block 19 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  116 | blk.19.attn_output.weight | Block 19 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  117 | blk.19.ffn_up.bias        | Block 19 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  118 | blk.19.ffn_up.weight      | Block 19 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  119 | blk.19.ffn_down.bias      | Block 19 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  120 | blk.19.ffn_down.weight    | Block 19 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.19: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_2">Block 2 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  121 | blk.2.attn_norm.bias     | Block 2 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  122 | blk.2.attn_norm.weight   | Block 2 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  123 | blk.2.attn_qkv.bias      | Block 2 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  124 | blk.2.attn_qkv.weight    | Block 2 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  125 | blk.2.attn_output.bias   | Block 2 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  126 | blk.2.attn_output.weight | Block 2 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  127 | blk.2.ffn_up.bias        | Block 2 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  128 | blk.2.ffn_up.weight      | Block 2 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  129 | blk.2.ffn_down.bias      | Block 2 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  130 | blk.2.ffn_down.weight    | Block 2 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.2: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_20">Block 20 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  131 | blk.20.attn_norm.bias     | Block 20 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  132 | blk.20.attn_norm.weight   | Block 20 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  133 | blk.20.attn_qkv.bias      | Block 20 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  134 | blk.20.attn_qkv.weight    | Block 20 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  135 | blk.20.attn_output.bias   | Block 20 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  136 | blk.20.attn_output.weight | Block 20 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  137 | blk.20.ffn_up.bias        | Block 20 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  138 | blk.20.ffn_up.weight      | Block 20 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  139 | blk.20.ffn_down.bias      | Block 20 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  140 | blk.20.ffn_down.weight    | Block 20 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.20: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_21">Block 21 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  141 | blk.21.attn_norm.bias     | Block 21 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  142 | blk.21.attn_norm.weight   | Block 21 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  143 | blk.21.attn_qkv.bias      | Block 21 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  144 | blk.21.attn_qkv.weight    | Block 21 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  145 | blk.21.attn_output.bias   | Block 21 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  146 | blk.21.attn_output.weight | Block 21 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  147 | blk.21.ffn_up.bias        | Block 21 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  148 | blk.21.ffn_up.weight      | Block 21 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  149 | blk.21.ffn_down.bias      | Block 21 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  150 | blk.21.ffn_down.weight    | Block 21 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.21: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_22">Block 22 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  151 | blk.22.attn_norm.bias     | Block 22 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  152 | blk.22.attn_norm.weight   | Block 22 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  153 | blk.22.attn_qkv.bias      | Block 22 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  154 | blk.22.attn_qkv.weight    | Block 22 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  155 | blk.22.attn_output.bias   | Block 22 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  156 | blk.22.attn_output.weight | Block 22 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  157 | blk.22.ffn_up.bias        | Block 22 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  158 | blk.22.ffn_up.weight      | Block 22 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  159 | blk.22.ffn_down.bias      | Block 22 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  160 | blk.22.ffn_down.weight    | Block 22 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.22: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_23">Block 23 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  161 | blk.23.attn_norm.bias     | Block 23 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  162 | blk.23.attn_norm.weight   | Block 23 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  163 | blk.23.attn_qkv.bias      | Block 23 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  164 | blk.23.attn_qkv.weight    | Block 23 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  165 | blk.23.attn_output.bias   | Block 23 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  166 | blk.23.attn_output.weight | Block 23 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  167 | blk.23.ffn_up.bias        | Block 23 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  168 | blk.23.ffn_up.weight      | Block 23 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  169 | blk.23.ffn_down.bias      | Block 23 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  170 | blk.23.ffn_down.weight    | Block 23 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.23: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_24">Block 24 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  171 | blk.24.attn_norm.bias     | Block 24 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  172 | blk.24.attn_norm.weight   | Block 24 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  173 | blk.24.attn_qkv.bias      | Block 24 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  174 | blk.24.attn_qkv.weight    | Block 24 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  175 | blk.24.attn_output.bias   | Block 24 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  176 | blk.24.attn_output.weight | Block 24 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  177 | blk.24.ffn_up.bias        | Block 24 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  178 | blk.24.ffn_up.weight      | Block 24 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  179 | blk.24.ffn_down.bias      | Block 24 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  180 | blk.24.ffn_down.weight    | Block 24 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.24: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_25">Block 25 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  181 | blk.25.attn_norm.bias     | Block 25 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  182 | blk.25.attn_norm.weight   | Block 25 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  183 | blk.25.attn_qkv.bias      | Block 25 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  184 | blk.25.attn_qkv.weight    | Block 25 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  185 | blk.25.attn_output.bias   | Block 25 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  186 | blk.25.attn_output.weight | Block 25 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  187 | blk.25.ffn_up.bias        | Block 25 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  188 | blk.25.ffn_up.weight      | Block 25 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  189 | blk.25.ffn_down.bias      | Block 25 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  190 | blk.25.ffn_down.weight    | Block 25 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.25: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_26">Block 26 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  191 | blk.26.attn_norm.bias     | Block 26 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  192 | blk.26.attn_norm.weight   | Block 26 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  193 | blk.26.attn_qkv.bias      | Block 26 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  194 | blk.26.attn_qkv.weight    | Block 26 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  195 | blk.26.attn_output.bias   | Block 26 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  196 | blk.26.attn_output.weight | Block 26 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  197 | blk.26.ffn_up.bias        | Block 26 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  198 | blk.26.ffn_up.weight      | Block 26 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  199 | blk.26.ffn_down.bias      | Block 26 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  200 | blk.26.ffn_down.weight    | Block 26 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.26: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_27">Block 27 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  201 | blk.27.attn_norm.bias     | Block 27 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  202 | blk.27.attn_norm.weight   | Block 27 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  203 | blk.27.attn_qkv.bias      | Block 27 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  204 | blk.27.attn_qkv.weight    | Block 27 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  205 | blk.27.attn_output.bias   | Block 27 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  206 | blk.27.attn_output.weight | Block 27 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  207 | blk.27.ffn_up.bias        | Block 27 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  208 | blk.27.ffn_up.weight      | Block 27 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  209 | blk.27.ffn_down.bias      | Block 27 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  210 | blk.27.ffn_down.weight    | Block 27 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.27: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_28">Block 28 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  211 | blk.28.attn_norm.bias     | Block 28 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  212 | blk.28.attn_norm.weight   | Block 28 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  213 | blk.28.attn_qkv.bias      | Block 28 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  214 | blk.28.attn_qkv.weight    | Block 28 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  215 | blk.28.attn_output.bias   | Block 28 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  216 | blk.28.attn_output.weight | Block 28 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  217 | blk.28.ffn_up.bias        | Block 28 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  218 | blk.28.ffn_up.weight      | Block 28 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  219 | blk.28.ffn_down.bias      | Block 28 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  220 | blk.28.ffn_down.weight    | Block 28 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.28: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_29">Block 29 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  221 | blk.29.attn_norm.bias     | Block 29 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  222 | blk.29.attn_norm.weight   | Block 29 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  223 | blk.29.attn_qkv.bias      | Block 29 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  224 | blk.29.attn_qkv.weight    | Block 29 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  225 | blk.29.attn_output.bias   | Block 29 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  226 | blk.29.attn_output.weight | Block 29 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  227 | blk.29.ffn_up.bias        | Block 29 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  228 | blk.29.ffn_up.weight      | Block 29 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  229 | blk.29.ffn_down.bias      | Block 29 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  230 | blk.29.ffn_down.weight    | Block 29 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.29: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_3">Block 3 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  231 | blk.3.attn_norm.bias     | Block 3 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  232 | blk.3.attn_norm.weight   | Block 3 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  233 | blk.3.attn_qkv.bias      | Block 3 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  234 | blk.3.attn_qkv.weight    | Block 3 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  235 | blk.3.attn_output.bias   | Block 3 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  236 | blk.3.attn_output.weight | Block 3 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  237 | blk.3.ffn_up.bias        | Block 3 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  238 | blk.3.ffn_up.weight      | Block 3 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  239 | blk.3.ffn_down.bias      | Block 3 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  240 | blk.3.ffn_down.weight    | Block 3 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.3: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_30">Block 30 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  241 | blk.30.attn_norm.bias     | Block 30 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  242 | blk.30.attn_norm.weight   | Block 30 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  307 | blk.30.attn_qkv.bias      | Block 30 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  308 | blk.30.attn_qkv.weight    | Block 30 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  309 | blk.30.attn_output.bias   | Block 30 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  310 | blk.30.attn_output.weight | Block 30 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  311 | blk.30.ffn_up.bias        | Block 30 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  312 | blk.30.ffn_up.weight      | Block 30 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  313 | blk.30.ffn_down.bias      | Block 30 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  314 | blk.30.ffn_down.weight    | Block 30 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.30: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_4">Block 4 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  243 | blk.4.attn_norm.bias     | Block 4 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  244 | blk.4.attn_norm.weight   | Block 4 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  245 | blk.4.attn_qkv.bias      | Block 4 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  246 | blk.4.attn_qkv.weight    | Block 4 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  247 | blk.4.attn_output.bias   | Block 4 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  248 | blk.4.attn_output.weight | Block 4 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  249 | blk.4.ffn_up.bias        | Block 4 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  250 | blk.4.ffn_up.weight      | Block 4 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  251 | blk.4.ffn_down.bias      | Block 4 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  252 | blk.4.ffn_down.weight    | Block 4 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.4: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_5">Block 5 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  253 | blk.5.attn_norm.bias     | Block 5 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  254 | blk.5.attn_norm.weight   | Block 5 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  255 | blk.5.attn_qkv.bias      | Block 5 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  256 | blk.5.attn_qkv.weight    | Block 5 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  257 | blk.5.attn_output.bias   | Block 5 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  258 | blk.5.attn_output.weight | Block 5 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  259 | blk.5.ffn_up.bias        | Block 5 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  260 | blk.5.ffn_up.weight      | Block 5 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  261 | blk.5.ffn_down.bias      | Block 5 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  262 | blk.5.ffn_down.weight    | Block 5 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.5: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_6">Block 6 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  263 | blk.6.attn_norm.bias     | Block 6 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  264 | blk.6.attn_norm.weight   | Block 6 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  265 | blk.6.attn_qkv.bias      | Block 6 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  266 | blk.6.attn_qkv.weight    | Block 6 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  267 | blk.6.attn_output.bias   | Block 6 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  268 | blk.6.attn_output.weight | Block 6 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  269 | blk.6.ffn_up.bias        | Block 6 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  270 | blk.6.ffn_up.weight      | Block 6 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  271 | blk.6.ffn_down.bias      | Block 6 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  272 | blk.6.ffn_down.weight    | Block 6 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.6: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_7">Block 7 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  273 | blk.7.attn_norm.bias     | Block 7 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  274 | blk.7.attn_norm.weight   | Block 7 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  275 | blk.7.attn_qkv.bias      | Block 7 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  276 | blk.7.attn_qkv.weight    | Block 7 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  277 | blk.7.attn_output.bias   | Block 7 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  278 | blk.7.attn_output.weight | Block 7 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  279 | blk.7.ffn_up.bias        | Block 7 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  280 | blk.7.ffn_up.weight      | Block 7 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  281 | blk.7.ffn_down.bias      | Block 7 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  282 | blk.7.ffn_down.weight    | Block 7 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.7: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_8">Block 8 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  283 | blk.8.attn_norm.bias     | Block 8 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  284 | blk.8.attn_norm.weight   | Block 8 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  285 | blk.8.attn_qkv.bias      | Block 8 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  286 | blk.8.attn_qkv.weight    | Block 8 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  287 | blk.8.attn_output.bias   | Block 8 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  288 | blk.8.attn_output.weight | Block 8 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  289 | blk.8.ffn_up.bias        | Block 8 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  290 | blk.8.ffn_up.weight      | Block 8 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  291 | blk.8.ffn_down.bias      | Block 8 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  292 | blk.8.ffn_down.weight    | Block 8 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.8: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_9">Block 9 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name        | Human Friendly Tensor Layer Name        | Elements        | Shape                 | Type |
|-----:|:-------------------------|:----------------------------------------|:----------------|:----------------------|:-----|
|  293 | blk.9.attn_norm.bias     | Block 9 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  294 | blk.9.attn_norm.weight   | Block 9 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  295 | blk.9.attn_qkv.bias      | Block 9 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  296 | blk.9.attn_qkv.weight    | Block 9 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  297 | blk.9.attn_output.bias   | Block 9 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  298 | blk.9.attn_output.weight | Block 9 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  299 | blk.9.ffn_up.bias        | Block 9 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  300 | blk.9.ffn_up.weight      | Block 9 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  301 | blk.9.ffn_down.bias      | Block 9 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  302 | blk.9.ffn_down.weight    | Block 9 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.9: (~79M) 78671360
- Percentage of total elements: 2.83%


### <a name="blk_31">Block 31 Tensor Group : ~79M Elements</a>

| T_ID | Tensor Layer Name         | Human Friendly Tensor Layer Name         | Elements        | Shape                 | Type |
|-----:|:--------------------------|:-----------------------------------------|:----------------|:----------------------|:-----|
|  315 | blk.31.attn_norm.bias     | Block 31 Attention Normalization (B)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  316 | blk.31.attn_norm.weight   | Block 31 Attention Normalization (W)     | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  317 | blk.31.attn_qkv.bias      | Block 31 Attention Query-Key-Value (B)   | ( ~8K)     7680 |  7680 x     1 x 1 x 1 | F32  |
|  318 | blk.31.attn_qkv.weight    | Block 31 Attention Query-Key-Value (W)   | (~20M) 19660800 |  2560 x  7680 x 1 x 1 | Q6_K |
|  319 | blk.31.attn_output.bias   | Block 31 Attention Output (B)            | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  320 | blk.31.attn_output.weight | Block 31 Attention Output (W)            | ( ~7M)  6553600 |  2560 x  2560 x 1 x 1 | Q6_K |
|  321 | blk.31.ffn_up.bias        | Block 31 Feed-Forward Network "Up" (B)   | (~10K)    10240 | 10240 x     1 x 1 x 1 | F32  |
|  322 | blk.31.ffn_up.weight      | Block 31 Feed-Forward Network "Up" (W)   | (~26M) 26214400 |  2560 x 10240 x 1 x 1 | Q6_K |
|  323 | blk.31.ffn_down.bias      | Block 31 Feed-Forward Network "Down" (B) | ( ~3K)     2560 |  2560 x     1 x 1 x 1 | F32  |
|  324 | blk.31.ffn_down.weight    | Block 31 Feed-Forward Network "Down" (W) | (~26M) 26214400 | 10240 x  2560 x 1 x 1 | Q6_K |

- Total elements in blk.31: (~79M) 78671360
- Percentage of total elements: 2.83%
```

</details>


