### PR TITLE
[SYCL] Revert "use the correct SYCL context for host USM allocations"

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -13089,12 +13089,9 @@ void *ggml_sycl_host_malloc(size_t size) try {
         return nullptr;
     }
 
-    ggml_sycl_set_device(g_main_device);
-    dpct::queue_ptr main_stream = g_syclStreams[g_main_device][0];
-
     void * ptr = nullptr;
     dpct::err0 err = CHECK_TRY_ERROR(
-        ptr = (void *)sycl::malloc_host(size, *main_stream));
+        ptr = (void *)sycl::malloc_host(size, dpct::get_in_order_queue()));
 
     if (err != 0) {
         // clear the error
@@ -13115,9 +13112,7 @@ catch (sycl::exception const &exc) {
 }
 
 void ggml_sycl_host_free(void *ptr) try {
-    ggml_sycl_set_device(g_main_device);
-    dpct::queue_ptr main_stream = g_syclStreams[g_main_device][0];
-    SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, *main_stream)));
+    SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, dpct::get_in_order_queue())));
 }
 catch (sycl::exception const &exc) {
   std::cerr << exc.what() << "Exception caught at file:" << __FILE__


### PR DESCRIPTION
Reverts ggerganov/llama.cpp#7777. This PR broke `llama-bench` and `main` as when pinned memory is allocated during the models creating the backend is not initialized. This means the `g_sycl_gpu_mgr` is not constructed with the relevant devices. Causing a segfault as no devices exist within the manager. 

I think we should try to reintroduce #7777 in a more suitable way that addresses this issue.