### PR TITLE
CUDA: int8 tensor cores for MMQ (q4_K, q5_K, q6_K)

### DIFF
--- a/ggml-cuda/mma.cuh
+++ b/ggml-cuda/mma.cuh
@@ -1,5 +1,27 @@
 #include "common.cuh"
 
+struct mma_int_A_I16K4 {
+    static constexpr int I  = 16;
+    static constexpr int K  = 4;
+    static constexpr int ne = 2;
+
+    int x[ne] = {0};
+
+    static __device__ __forceinline__ int get_i(const int l) {
+        const int ret = (l%2) * (I/2) + threadIdx.x / K;
+        GGML_CUDA_ASSUME(ret >= 0);
+        GGML_CUDA_ASSUME(ret <  I);
+        return ret;
+    }
+
+    static __device__ __forceinline__ int get_k(const int /* l */) {
+        const int ret = threadIdx.x % K;
+        GGML_CUDA_ASSUME(ret >= 0);
+        GGML_CUDA_ASSUME(ret <  K);
+        return ret;
+    }
+};
+
 struct mma_int_A_I16K8 {
     static constexpr int I  = 16;
     static constexpr int K  = 8;
@@ -16,6 +38,28 @@ struct mma_int_A_I16K8 {
 
     static __device__ __forceinline__ int get_k(const int l) {
         const int ret = (l/2) * (K/2) + threadIdx.x % (K/2);
+        GGML_CUDA_ASSUME(ret >= 0);
+        GGML_CUDA_ASSUME(ret <  K);
+        return ret;
+    }
+};
+
+struct mma_int_B_J8K4 {
+    static constexpr int J  = 8;
+    static constexpr int K  = 4;
+    static constexpr int ne = 1;
+
+    int x[ne] = {0};
+
+    static __device__ __forceinline__ int get_j(const int /* l */) {
+        const int ret = threadIdx.x / K;
+        GGML_CUDA_ASSUME(ret >= 0);
+        GGML_CUDA_ASSUME(ret <  J);
+        return ret;
+    }
+
+    static __device__ __forceinline__ int get_k(const int /* l */) {
+        const int ret = threadIdx.x % K;
         GGML_CUDA_ASSUME(ret >= 0);
         GGML_CUDA_ASSUME(ret <  K);
         return ret;
@@ -63,6 +107,28 @@ struct mma_int_C_I16J8 {
         GGML_CUDA_ASSUME(ret >= 0);
         GGML_CUDA_ASSUME(ret <  J);
         return ret;
+    }
+
+    __device__ __forceinline__ void mma_K4(const mma_int_A_I16K4 & mma_A, const mma_int_B_J8K4 & mma_B) {
+#ifdef INT8_MMA_AVAILABLE
+#if __CUDA_ARCH__ >= CC_AMPERE
+        asm("mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%0, %1, %2, %3};"
+            : "+r"(x[0]), "+r"(x[1]), "+r"(x[2]), "+r"(x[3])
+            : "r"(mma_A.x[0]), "r"(mma_A.x[1]), "r"(mma_B.x[0]));
+#else
+        // On Turing m16n8k16 mma is not available, use 2x m8n8k16 mma instead:
+        asm("mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%2}, {%3}, {%0, %1};"
+            : "+r"(x[0]), "+r"(x[1])
+            : "r"(mma_A.x[0]), "r"(mma_B.x[0]));
+        asm("mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%2}, {%3}, {%0, %1};"
+            : "+r"(x[2]), "+r"(x[3])
+            : "r"(mma_A.x[1]), "r"(mma_B.x[0]));
+#endif // __CUDA_ARCH__ >= CC_AMPERE
+#else
+        GGML_UNUSED(mma_A);
+        GGML_UNUSED(mma_B);
+        NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
     }
 
     __device__ __forceinline__ void mma_K8(const mma_int_A_I16K8 & mma_A, const mma_int_B_J8K8 & mma_B) {


### PR DESCRIPTION
This PR adds int8 tensor core support for the q4_K, q5_K, and q6_K mul_mat_q kernels. Originally I wanted to put all k-quants into the same PR but in retrospect the MMQ code for q2_K and q3_K is kind of bad so I think it's in need of general refactoring before I try to add int8 tensor core support.

<details>
<summary>Performance vs. master MMQ</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-ptx-mma-12 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | ----------------------: | ----------: |
| RTX 4090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1463.94 |                 1946.01 |        1.33 |
| RTX 4090   | llama 8B Q4_K_S   |                  32 | pp2048   |        2341.23 |                 3358.03 |        1.43 |
| RTX 4090   | llama 8B Q4_K_S   |                  64 | pp2048   |        3387.63 |                 5349.26 |        1.58 |
| RTX 4090   | llama 8B Q4_K_S   |                 128 | pp2048   |        4443.87 |                 6901.00 |        1.55 |
| RTX 4090   | llama 8B Q4_K_S   |                 256 | pp2048   |        5222.84 |                 8555.10 |        1.64 |
| RTX 4090   | llama 8B Q4_K_S   |                 512 | pp2048   |        5611.17 |                 9278.55 |        1.65 |
| RTX 4090   | llama 8B Q4_K_S   |                1024 | pp2048   |        5806.79 |                 9265.84 |        1.60 |
| RTX 4090   | llama 8B Q4_K_S   |                2048 | pp2048   |        5549.92 |                 8655.44 |        1.56 |
| RTX 4090   | llama 8B Q5_K_S   |                  16 | pp2048   |        1344.52 |                 1675.27 |        1.25 |
| RTX 4090   | llama 8B Q5_K_S   |                  32 | pp2048   |        2007.37 |                 2792.81 |        1.39 |
| RTX 4090   | llama 8B Q5_K_S   |                  64 | pp2048   |        3135.71 |                 4592.53 |        1.46 |
| RTX 4090   | llama 8B Q5_K_S   |                 128 | pp2048   |        3930.48 |                 6058.36 |        1.54 |
| RTX 4090   | llama 8B Q5_K_S   |                 256 | pp2048   |        4785.05 |                 7758.42 |        1.62 |
| RTX 4090   | llama 8B Q5_K_S   |                 512 | pp2048   |        5211.79 |                 8671.69 |        1.66 |
| RTX 4090   | llama 8B Q5_K_S   |                1024 | pp2048   |        5437.78 |                 8783.84 |        1.62 |
| RTX 4090   | llama 8B Q5_K_S   |                2048 | pp2048   |        5212.39 |                 8263.49 |        1.59 |
| RTX 4090   | llama 8B Q6_K     |                  16 | pp2048   |        1163.29 |                 1413.55 |        1.22 |
| RTX 4090   | llama 8B Q6_K     |                  32 | pp2048   |        1756.61 |                 2460.78 |        1.40 |
| RTX 4090   | llama 8B Q6_K     |                  64 | pp2048   |        2838.87 |                 4424.35 |        1.56 |
| RTX 4090   | llama 8B Q6_K     |                 128 | pp2048   |        3844.01 |                 6071.93 |        1.58 |
| RTX 4090   | llama 8B Q6_K     |                 256 | pp2048   |        4654.52 |                 7997.45 |        1.72 |
| RTX 4090   | llama 8B Q6_K     |                 512 | pp2048   |        5150.89 |                 8796.22 |        1.71 |
| RTX 4090   | llama 8B Q6_K     |                1024 | pp2048   |        5318.41 |                 8910.36 |        1.68 |
| RTX 4090   | llama 8B Q6_K     |                2048 | pp2048   |        5080.49 |                 8255.21 |        1.62 |
| RTX 3090   | llama 8B Q4_K_S   |                  16 | pp2048   |         801.95 |                 1234.40 |        1.54 |
| RTX 3090   | llama 8B Q4_K_S   |                  32 | pp2048   |        1074.81 |                 1774.68 |        1.65 |
| RTX 3090   | llama 8B Q4_K_S   |                  64 | pp2048   |        1451.21 |                 2341.89 |        1.61 |
| RTX 3090   | llama 8B Q4_K_S   |                 128 | pp2048   |        1747.08 |                 2897.55 |        1.66 |
| RTX 3090   | llama 8B Q4_K_S   |                 256 | pp2048   |        2090.00 |                 3460.06 |        1.66 |
| RTX 3090   | llama 8B Q4_K_S   |                 512 | pp2048   |        2214.67 |                 3694.28 |        1.67 |
| RTX 3090   | llama 8B Q4_K_S   |                1024 | pp2048   |        2318.00 |                 3808.69 |        1.64 |
| RTX 3090   | llama 8B Q4_K_S   |                2048 | pp2048   |        2251.89 |                 3643.31 |        1.62 |
| RTX 3090   | llama 8B Q5_K_S   |                  16 | pp2048   |         702.35 |                 1006.02 |        1.43 |
| RTX 3090   | llama 8B Q5_K_S   |                  32 | pp2048   |         944.24 |                 1447.94 |        1.53 |
| RTX 3090   | llama 8B Q5_K_S   |                  64 | pp2048   |        1240.48 |                 1944.35 |        1.57 |
| RTX 3090   | llama 8B Q5_K_S   |                 128 | pp2048   |        1583.12 |                 2569.41 |        1.62 |
| RTX 3090   | llama 8B Q5_K_S   |                 256 | pp2048   |        1895.89 |                 3250.03 |        1.71 |
| RTX 3090   | llama 8B Q5_K_S   |                 512 | pp2048   |        2060.21 |                 3401.43 |        1.65 |
| RTX 3090   | llama 8B Q5_K_S   |                1024 | pp2048   |        2152.24 |                 3503.48 |        1.63 |
| RTX 3090   | llama 8B Q5_K_S   |                2048 | pp2048   |        2106.41 |                 3440.64 |        1.63 |
| RTX 3090   | llama 8B Q6_K     |                  16 | pp2048   |         590.82 |                  884.87 |        1.50 |
| RTX 3090   | llama 8B Q6_K     |                  32 | pp2048   |         888.50 |                 1379.53 |        1.55 |
| RTX 3090   | llama 8B Q6_K     |                  64 | pp2048   |        1198.96 |                 2018.45 |        1.68 |
| RTX 3090   | llama 8B Q6_K     |                 128 | pp2048   |        1497.54 |                 2756.86 |        1.84 |
| RTX 3090   | llama 8B Q6_K     |                 256 | pp2048   |        1891.89 |                 3333.43 |        1.76 |
| RTX 3090   | llama 8B Q6_K     |                 512 | pp2048   |        2002.13 |                 3491.20 |        1.74 |
| RTX 3090   | llama 8B Q6_K     |                1024 | pp2048   |        2076.91 |                 3593.81 |        1.73 |
| RTX 3090   | llama 8B Q6_K     |                2048 | pp2048   |        2034.32 |                 3525.21 |        1.73 |


</details>

<details>
<summary>Performance vs. master FP16 cuBLAS</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-ptx-mma-12 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | ----------------------: | ----------: |
| RTX 4090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1464.96 |                 1943.99 |        1.33 |
| RTX 4090   | llama 8B Q4_K_S   |                  32 | pp2048   |        2340.40 |                 3356.56 |        1.43 |
| RTX 4090   | llama 8B Q4_K_S   |                  64 | pp2048   |        3391.27 |                 5359.39 |        1.58 |
| RTX 4090   | llama 8B Q4_K_S   |                 128 | pp2048   |        3483.04 |                 6901.05 |        1.98 |
| RTX 4090   | llama 8B Q4_K_S   |                 256 | pp2048   |        5750.04 |                 8531.97 |        1.48 |
| RTX 4090   | llama 8B Q4_K_S   |                 512 | pp2048   |        7694.01 |                 9267.19 |        1.20 |
| RTX 4090   | llama 8B Q4_K_S   |                1024 | pp2048   |        9019.89 |                 9280.11 |        1.03 |
| RTX 4090   | llama 8B Q4_K_S   |                2048 | pp2048   |        9020.72 |                 8650.88 |        0.96 |
| RTX 4090   | llama 8B Q5_K_S   |                  16 | pp2048   |        1339.82 |                 1675.33 |        1.25 |
| RTX 4090   | llama 8B Q5_K_S   |                  32 | pp2048   |        1999.00 |                 2788.10 |        1.39 |
| RTX 4090   | llama 8B Q5_K_S   |                  64 | pp2048   |        3136.95 |                 4581.04 |        1.46 |
| RTX 4090   | llama 8B Q5_K_S   |                 128 | pp2048   |        3451.99 |                 6037.27 |        1.75 |
| RTX 4090   | llama 8B Q5_K_S   |                 256 | pp2048   |        5674.22 |                 7752.61 |        1.37 |
| RTX 4090   | llama 8B Q5_K_S   |                 512 | pp2048   |        7631.15 |                 8676.09 |        1.14 |
| RTX 4090   | llama 8B Q5_K_S   |                1024 | pp2048   |        8942.08 |                 8780.76 |        0.98 |
| RTX 4090   | llama 8B Q5_K_S   |                2048 | pp2048   |        8988.51 |                 8256.40 |        0.92 |
| RTX 4090   | llama 8B Q6_K     |                  16 | pp2048   |        1160.29 |                 1408.84 |        1.21 |
| RTX 4090   | llama 8B Q6_K     |                  32 | pp2048   |        1756.13 |                 2459.62 |        1.40 |
| RTX 4090   | llama 8B Q6_K     |                  64 | pp2048   |        2847.17 |                 4418.16 |        1.55 |
| RTX 4090   | llama 8B Q6_K     |                 128 | pp2048   |        3383.93 |                 6068.10 |        1.79 |
| RTX 4090   | llama 8B Q6_K     |                 256 | pp2048   |        5576.11 |                 8028.77 |        1.44 |
| RTX 4090   | llama 8B Q6_K     |                 512 | pp2048   |        7516.95 |                 8795.13 |        1.17 |
| RTX 4090   | llama 8B Q6_K     |                1024 | pp2048   |        8759.06 |                 8900.03 |        1.02 |
| RTX 4090   | llama 8B Q6_K     |                2048 | pp2048   |        8660.30 |                 8151.61 |        0.94 |
| RTX 3090   | llama 8B Q4_K_S   |                  16 | pp2048   |         798.51 |                 1226.10 |        1.54 |
| RTX 3090   | llama 8B Q4_K_S   |                  32 | pp2048   |        1073.65 |                 1731.00 |        1.61 |
| RTX 3090   | llama 8B Q4_K_S   |                  64 | pp2048   |        1441.52 |                 2279.13 |        1.58 |
| RTX 3090   | llama 8B Q4_K_S   |                 128 | pp2048   |        2259.12 |                 2826.25 |        1.25 |
| RTX 3090   | llama 8B Q4_K_S   |                 256 | pp2048   |        3341.46 |                 3411.38 |        1.02 |
| RTX 3090   | llama 8B Q4_K_S   |                 512 | pp2048   |        3963.55 |                 3651.70 |        0.92 |
| RTX 3090   | llama 8B Q4_K_S   |                1024 | pp2048   |        4626.58 |                 3767.43 |        0.81 |
| RTX 3090   | llama 8B Q4_K_S   |                2048 | pp2048   |        4687.16 |                 3619.86 |        0.77 |
| RTX 3090   | llama 8B Q5_K_S   |                  16 | pp2048   |         700.59 |                  989.79 |        1.41 |
| RTX 3090   | llama 8B Q5_K_S   |                  32 | pp2048   |         940.47 |                 1431.55 |        1.52 |
| RTX 3090   | llama 8B Q5_K_S   |                  64 | pp2048   |        1229.62 |                 1929.57 |        1.57 |
| RTX 3090   | llama 8B Q5_K_S   |                 128 | pp2048   |        2210.56 |                 2536.07 |        1.15 |
| RTX 3090   | llama 8B Q5_K_S   |                 256 | pp2048   |        3272.96 |                 3147.95 |        0.96 |
| RTX 3090   | llama 8B Q5_K_S   |                 512 | pp2048   |        3892.85 |                 3321.21 |        0.85 |
| RTX 3090   | llama 8B Q5_K_S   |                1024 | pp2048   |        4566.61 |                 3431.34 |        0.75 |
| RTX 3090   | llama 8B Q5_K_S   |                2048 | pp2048   |        4628.11 |                 3393.07 |        0.73 |
| RTX 3090   | llama 8B Q6_K     |                  16 | pp2048   |         589.97 |                  877.42 |        1.49 |
| RTX 3090   | llama 8B Q6_K     |                  32 | pp2048   |         887.02 |                 1350.14 |        1.52 |
| RTX 3090   | llama 8B Q6_K     |                  64 | pp2048   |        1197.92 |                 1949.14 |        1.63 |
| RTX 3090   | llama 8B Q6_K     |                 128 | pp2048   |        2221.86 |                 2666.57 |        1.20 |
| RTX 3090   | llama 8B Q6_K     |                 256 | pp2048   |        3288.91 |                 3240.44 |        0.99 |
| RTX 3090   | llama 8B Q6_K     |                 512 | pp2048   |        3891.56 |                 3401.65 |        0.87 |
| RTX 3090   | llama 8B Q6_K     |                1024 | pp2048   |        4551.18 |                 3531.57 |        0.78 |
| RTX 3090   | llama 8B Q6_K     |                2048 | pp2048   |        4575.31 |                 3451.87 |        0.75 |


</details>