### PR TITLE
llama-bench: more compact markdown tables

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1033,6 +1033,27 @@ struct markdown_printer : public printer {
         if (field == "n_gpu_layers") {
             return 3;
         }
+        if (field == "n_threads") {
+            return 7;
+        }
+        if (field == "n_batch") {
+            return 7;
+        }
+        if (field == "n_ubatch") {
+            return 8;
+        }
+        if (field == "type_k" || field == "type_v") {
+            return 6;
+        }
+        if (field == "split_mode") {
+            return 5;
+        }
+        if (field == "flash_attn") {
+            return 2;
+        }
+        if (field == "use_mmap") {
+            return 4;
+        }
         if (field == "test") {
             return 13;
         }


### PR DESCRIPTION
One one of screens the markdown rows produced by `llama-bench` are slightly too wide to fit my terminal. This PR adds extra rules for some of the columns to use a compact layout when it is known that the default 10 character width will not be needed.