### PR TITLE
sycl: always set the main device after initialization

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -3307,7 +3307,7 @@ class sycl_gpu_mgr {
 
         void detect_sycl_gpu_list_with_max_cu() try {
             int device_count = dpct::dev_mgr::instance().device_count();
-            sycl::backend backend;
+            sycl::platform platform;
 
             for (int id = 0; id < device_count; id++) {
                 sycl::device device = dpct::dev_mgr::instance().get_device(id);
@@ -3317,7 +3317,7 @@ class sycl_gpu_mgr {
                 dpct::get_device_info(prop, device);
                 if (max_compute_units < prop.get_max_compute_units()) {
                     max_compute_units = prop.get_max_compute_units();
-                    backend = device.get_backend();
+                    platform = device.get_platform();
                 }
             }
 
@@ -3328,7 +3328,7 @@ class sycl_gpu_mgr {
                 dpct::device_info prop;
                 dpct::get_device_info(prop, device);
                 if (max_compute_units == prop.get_max_compute_units() &&
-                    backend == device.get_backend()) {
+                    platform == device.get_platform()) {
                     gpus.push_back(id);
                     devices.push_back(device);
                     work_group_size = prop.get_max_work_group_size();


### PR DESCRIPTION
Fixes an issue reported in llama-bench and elsewhere after merging #7777, see also #7858.

Because we are using the main device to determine the SYCL context for USM host allocations, we need to ensure it is set to a valid value after initialization, so set device zero as the initial main device.

Also, adds a small refactor to the SYCL GPU detection logic, to ensure all GPUs are from the same backend.  Although unlikely due to the max compute unit check, the prior code would attempt to use GPUs from different backends together if they happened to have the same maximum number of compute units.  As an added bonus, the updates work with GPUs using the OpenCL backend, also.

Testing done (on an Intel A750) - all commands executed successfully:

```sh
$ ./llama-bench -m ./models/llama-2-7b-chat.Q4_K_M.gguf -ngl 77 --mmap 0
$ ONEAPI_DEVICE_SELECTOR=opencl:gpu ./llama-bench -m ./models/llama-2-7b-chat.Q4_K_M.gguf -ngl 77 --mmap 0
$ ONEAPI_DEVICE_SELECTOR=ext_oneapi_level_zero:* ./llama-bench -m ./models/llama-2-7b-chat.Q4_K_M.gguf -ngl 77 --mmap 0
```

- Self Reported Review Complexity:
    - [ ] Review Complexity : Low
    - [x] Review Complexity : Medium
    - [ ] Review Complexity : High
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)

