### PR TITLE
CUDA: faster q2_K, q3_K MMQ + int8 tensor cores

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -188,13 +188,15 @@ static ggml_cuda_device_info ggml_cuda_init() {
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
 
+        info.devices[id].nsm   = prop.multiProcessorCount;
+        info.devices[id].smpb  = prop.sharedMemPerBlock;
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+        info.devices[id].smpbo = prop.sharedMemPerBlock;
         info.devices[id].cc = 100*prop.major + 10*prop.minor + CC_OFFSET_AMD;
 #else
+        info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-        info.devices[id].smpb = prop.sharedMemPerBlock;
-        info.devices[id].nsm  = prop.multiProcessorCount;
     }
 
     for (int id = 0; id < info.device_count; ++id) {

--- a/ggml-cuda/argsort.cu
+++ b/ggml-cuda/argsort.cu
@@ -73,6 +73,7 @@ static void argsort_f32_i32_cuda(const float * x, int * dst, const int ncols, co
     const dim3 block_nums(1, nrows, 1);
     const size_t shared_mem = ncols_pad * sizeof(int);
 
+    // FIXME: this limit could be raised by ~2-4x on Ampere or newer
     GGML_ASSERT(shared_mem <= ggml_cuda_info().devices[ggml_cuda_get_device()].smpb);
 
     if (order == GGML_SORT_ORDER_ASC) {

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -661,6 +661,7 @@ struct ggml_cuda_device_info {
         int     cc;                 // compute capability
         int     nsm;                // number of streaming multiprocessors
         size_t  smpb;               // max. shared memory per block
+        size_t  smpbo;              // max. shared memory per block (with opt-in)
         bool    vmm;                // virtual memory support
         size_t  vmm_granularity;    // granularity of virtual memory
         size_t  total_vram;

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -331,6 +331,10 @@ static __device__ __forceinline__ half2 __shfl_xor(half2 var, int laneMask, int 
 #define FP16_AVAILABLE
 #endif // (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ >= CC_PASCAL
 
+#if defined(FP16_AVAILABLE) && __CUDA_ARCH__ != 610
+#define FAST_FP16_AVAILABLE
+#endif // defined(FP16_AVAILABLE) && __CUDA_ARCH__ != 610
+
 #if !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) && __CUDA_ARCH__ >= CC_VOLTA
 #define FP16_MMA_AVAILABLE
 #endif // !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) && __CUDA_ARCH__ >= CC_VOLTA

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -839,7 +839,14 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         }
 
         const int sc_m = bxi->scales[kqsx];
-        x_dm[i*(WARP_SIZE + 1) + threadIdx.x] = bxi->dm * make_half2(sc_m & 0x0F, sc_m >> 4);
+#ifdef FAST_FP16_AVAILABLE
+        const half2 x_dm_ik = __hmul2(bxi->dm, make_half2(sc_m & 0x0F, sc_m >> 4));
+#else
+        const float2 bxi_dmf = __half22float2(bxi->dm);
+        const half2 x_dm_ik = make_half2(bxi_dmf.x*(sc_m & 0x0F), bxi_dmf.y*(sc_m >> 4));
+#endif // FAST_FP16_AVAILABLE
+
+        x_dm[i*(WARP_SIZE + 1) + threadIdx.x] = x_dm_ik;
     }
 }
 

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -194,7 +194,9 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -328,7 +330,9 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
     half2 dmA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -485,7 +489,9 @@ static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -635,7 +641,9 @@ static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mma(
     half2 dmA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -762,7 +770,9 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -886,7 +896,9 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     float  dA[mma_C::ne/2][2];
@@ -1071,7 +1083,9 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
     const float * y_df = (const float *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1234,7 +1248,9 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1419,7 +1435,9 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1599,7 +1617,9 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
     const float * y_df = (const float *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[4];
     int   scA[mma_C::ne/2][4];
@@ -1702,7 +1722,9 @@ static __device__ __forceinline__ void mmq_write_back_mma(const float * __restri
     typedef mma_int_C_I16J8 mma_C;
 
     const int i0 = threadIdx.y*mma_C::I;
+#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_C::I == mmq_y, "nwarps*mma_C::I != mmq_y");
+#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += mma_C::J) {

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -180,6 +180,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
     GGML_UNUSED(x_sc);
 
     typedef mma_int_A_I16K8 mma_A;
@@ -194,9 +195,7 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -239,6 +238,10 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
             sum[(j0/B.J)*C.ne + l] += dA[l/2]*__low2float(dsB[l%2])*C.x[l];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q4_1(
@@ -317,6 +320,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
     GGML_UNUSED(x_sc);
 
     typedef mma_int_A_I16K8 mma_A;
@@ -330,9 +334,7 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
     half2 dmA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -376,6 +378,10 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
             sum[(j0/B.J)*C.ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q5_0(
@@ -475,6 +481,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
     GGML_UNUSED(x_sc);
 
     typedef mma_int_A_I16K8 mma_A;
@@ -489,9 +496,7 @@ static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -533,6 +538,10 @@ static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mma(
             sum[(j0/B.J)*C.ne + l] += dA[l/2]*dB[l%2]*C.x[l];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q5_1(
@@ -628,6 +637,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
     GGML_UNUSED(x_sc);
 
     typedef mma_int_A_I16K8 mma_A;
@@ -641,9 +651,7 @@ static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mma(
     half2 dmA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -686,6 +694,10 @@ static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mma(
             sum[(j0/B.J)*C.ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q8_0(
@@ -756,6 +768,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
     GGML_UNUSED(x_sc);
 
     typedef mma_int_A_I16K8 mma_A;
@@ -770,9 +783,7 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
     float dA[mma_C::ne/2];
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
 #pragma unroll
     for (int l = 0; l < mma_A::ne; ++l) {
@@ -814,6 +825,10 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
             sum[(j0/B.J)*C.ne + l] += C.x[l]*dA[l/2]*dB[l%2];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q2_K(
@@ -887,6 +902,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
     typedef mma_int_B_J8K4  mma_B;
@@ -896,9 +912,7 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     float  dA[mma_C::ne/2][2];
@@ -961,6 +975,10 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
             sum[(j0/mma_B::J)*mma_C::ne + l] += (C[0].x[l]*dA[l/2][0] + C[1].x[l]*dA[l/2][1] + mA[l/2][0]*sB[l%2][0] + mA[l/2][1]*sB[l%2][1])*dB[l%2];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q3_K(
@@ -1073,6 +1091,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
     typedef mma_int_B_J8K4  mma_B;
@@ -1083,9 +1102,7 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
     const float * y_df = (const float *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1150,6 +1167,10 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
             sum[(j0/mma_B::J)*mma_C::ne + l] += (C[0].x[l]*scA[l/2][0] + C[1].x[l]*scA[l/2][1])*dA[l/2]*dB[l%2];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q4_K(
@@ -1239,6 +1260,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
     typedef mma_int_B_J8K8  mma_B;
@@ -1248,9 +1270,7 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1324,6 +1344,10 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
             sum[(j0/mma_B::J)*mma_C::ne + l] += __low2float(dmA[l/2])*tmpd[l] - __high2float(dmA[l/2])*tmpm[l];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q5_K(
@@ -1426,6 +1450,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
     typedef mma_int_B_J8K8  mma_B;
@@ -1435,9 +1460,7 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
     const half2 * y_ds = (const half2 *) y;
 
     const int i0 = threadIdx.y*mma_A::I;
-#ifdef INT8_MMA_AVAILABLE
     static_assert(nwarps*mma_A::I == mmq_y, "nwarps*mma_A::I != mmq_y");
-#endif // INT8_MMA_AVAILABLE
 
     mma_A   A[2];
     int   scA[mma_C::ne/2][2];
@@ -1511,6 +1534,10 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
             sum[(j0/mma_B::J)*mma_C::ne + l] += __low2float(dmA[l/2])*tmpd[l] - __high2float(dmA[l/2])*tmpm[l];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q6_K(
@@ -1607,6 +1634,7 @@ template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+#ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
     typedef mma_int_B_J8K4  mma_B;
@@ -1692,6 +1720,10 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
             sum[(j0/mma_B::J)*mma_C::ne + l] += tmp[l]*dA[l/2];
         }
     }
+#else
+    GGML_UNUSED(x_qs); GGML_UNUSED(x_dm); GGML_UNUSED(x_sc); GGML_UNUSED(y); GGML_UNUSED(sum); GGML_UNUSED(k0);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
 }
 
 template<int mmq_x, int mmq_y, int nwarps, bool need_check>

--- a/ggml-cuda/quantize.cu
+++ b/ggml-cuda/quantize.cu
@@ -1,4 +1,5 @@
 #include "quantize.cuh"
+#include <cmath>
 #include <cstdint>
 
 static __global__ void quantize_q8_1(const float * __restrict__ x, void * __restrict__ vy, const int64_t kx, const int64_t kx0_padded) {
@@ -37,7 +38,7 @@ static __global__ void quantize_q8_1(const float * __restrict__ x, void * __rest
     reinterpret_cast<half&>(y[ib].ds.y) = sum;
 }
 
-template <bool need_sum>
+template <int need_sum>
 static __global__ void quantize_mmq_q8_1(
     const float * __restrict__ x, void * __restrict__ vy, const int64_t kx0, const int64_t kx1, const int64_t kx0_padded) {
 
@@ -60,24 +61,48 @@ static __global__ void quantize_mmq_q8_1(
 
     amax = warp_reduce_max(amax);
 
-    float sum;
-    if (need_sum) {
-        sum = warp_reduce_sum(xi);
-    }
-
     const float d = amax / 127;
     const int8_t q = amax == 0.0f ? 0 : roundf(xi / d);
 
     y[ib].qs[iqs] = q;
 
-    if (iqs % QK8_1 != 0) {
-        return;
-    }
+    static_assert(need_sum >= 0 && need_sum <= 2, "Invalid need_sum value.");
+    if (need_sum == 0) {
+        if (iqs % QK8_1 != 0) {
+            return;
+        }
 
-    if (need_sum) {
+        ((float *) y[ib].ds)[iqs/QK8_1] = d;
+    } else if (need_sum == 1) {
+        const float sum = warp_reduce_sum(xi);
+
+        if (iqs % QK8_1 != 0) {
+            return;
+        }
+
         y[ib].ds[iqs/QK8_1] = make_half2(d, sum);
     } else {
-        ((float *) y[ib].ds)[iqs/QK8_1] = d;
+        float sum = xi;
+
+        // Calculate sum per 16 values:
+#pragma unroll
+        for (int mask = 8; mask > 0; mask >>= 1) {
+            sum += __shfl_xor_sync(0xffffffff, sum, mask, 32);
+        }
+
+        if (iqs % (QK8_1/2) != 0) {
+            return;
+        }
+
+        int8_t * si = (int8_t *) &y[ib].ds[iqs/QK8_1].y;
+        const int tmp = roundf(amax == 0.0f ? 0.0f : -8*sum/amax);
+        si[(iqs % QK8_1)/(QK8_1/2)] = min(tmp, 127);
+
+        if (iqs % QK8_1 != 0) {
+            return;
+        }
+
+        reinterpret_cast<half&>(y[ib].ds[iqs/QK8_1].x) = d;
     }
 }
 
@@ -104,9 +129,14 @@ void quantize_mmq_q8_1_cuda(
     const int64_t block_num_x = (kx0_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
     const dim3 num_blocks(block_num_x, kx1, channels);
     const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
-    if (mmq_need_sum(type_x)) {
-        quantize_mmq_q8_1<true><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    const int need_sum = mmq_need_sum(type_x);
+    if (need_sum == 0) {
+        quantize_mmq_q8_1<0><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    } else if (need_sum == 1) {
+        quantize_mmq_q8_1<1><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    } else if (need_sum == 2) {
+        quantize_mmq_q8_1<2><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
     } else {
-        quantize_mmq_q8_1<false><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+        GGML_ASSERT(false);
     }
 }

--- a/ggml-cuda/softmax.cu
+++ b/ggml-cuda/softmax.cu
@@ -130,6 +130,7 @@ static void soft_max_f32_cuda(const float * x, const T * mask, float * dst, cons
     const float m0 = powf(2.0f, -(max_bias       ) / n_head_log2);
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2);
 
+    // FIXME: this limit could be raised by ~2-4x on Ampere or newer
     if (shmem < ggml_cuda_info().devices[ggml_cuda_get_device()].smpb) {
         switch (ncols_x) {
             case 32:

--- a/ggml-cuda/vecdotq.cuh
+++ b/ggml-cuda/vecdotq.cuh
@@ -265,36 +265,32 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
 
 // contiguous u/y values
 static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
-    const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ scales,
-    const half2 & dm2, const float & d8) {
+    const int * __restrict__ v, const int * __restrict__ u, const half2 * dm2, const half2 & ds8) {
 
 #if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
-    int sumi_d = 0;
-    int sumi_m = 0;
+    float sumf_d = 0.0f;
+    float sumf_m = 0.0f;
+
+    const float    d8  = __low2float(ds8);
+    const int8_t * s8i = (const int8_t *) &ds8.y;
 
 #pragma unroll
     for (int i0 = 0; i0 < QI8_1; i0 += QI8_1/2) {
-        int sumi_d_sc = 0;
+        const float2 dm2f = __half22float2(dm2[i0/(QI8_1/2)]);
+        int sumi_d = 0;
 
-        const int sc = scales[i0 / (QI8_1/2)];
-
-        // fill int with 4x m
-        int m = sc >> 4;
-        m |= m <<  8;
-        m |= m << 16;
-
+        const int vi0 = v[i0/(QI8_1/2)];
 #pragma unroll
         for (int i = i0; i < i0 + QI8_1/2; ++i) {
-            sumi_d_sc = __dp4a(v[i], u[i], sumi_d_sc); // SIMD dot product
-            sumi_m    = __dp4a(m,    u[i], sumi_m); // multiply sum of q8_1 values with m
+            const int vi = (vi0 >> (2*(i % (QI8_1/2)))) & 0x03030303;
+            sumi_d = __dp4a(vi, u[i], sumi_d); // SIMD dot product
         }
 
-        sumi_d += sumi_d_sc * (sc & 0xF);
+        sumf_d += dm2f.x * sumi_d;
+        sumf_m += dm2f.y * s8i[i0/(QI8_1/2)];
     }
 
-    const float2 dm2f = __half22float2(dm2);
-
-    return d8 * (dm2f.x*sumi_d - dm2f.y*sumi_m);
+    return d8*(sumf_d + (127.0f/8.0f)*sumf_m);
 #else
     NO_DEVICE_CODE;
 #endif // __CUDA_ARCH__ >= MIN_CC_DP4A
@@ -352,8 +348,10 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     for (int i0 = 0; i0 < QR3_K*VDR_Q3_K_Q8_1_MMQ; i0 += QI8_1/2) {
         int sumi_sc = 0;
 
+#pragma unroll
         for (int i = i0; i < i0 + QI8_1/2; ++i) {
-            sumi_sc = __dp4a(v[i], u[i], sumi_sc); // SIMD dot product
+            const int vi = __vsubss4((v[i/2] >> (4*(i%2))) & 0x0F0F0F0F, 0x04040404);
+            sumi_sc = __dp4a(vi, u[i], sumi_sc); // SIMD dot product
         }
 
         sumi += sumi_sc * scales[i0 / (QI8_1/2)];


### PR DESCRIPTION
This PR overhauls the q2_K and q3_K mul_mat_q kernels and adds int8 tensor core support. Now that all MMQ-supported quantization formats have int8 tensor core support it was possible to simplify the code a little. To make q2_K work I had to implement an alternative data format for q8_1 where instead of the per-block sum the per-halfblock sums are stored (as int8 relative to the max value). The precision loss from doing this seems to be negligible.

`ggml-cuda.cu` now queries and stores the maximum opt-in shared memory per streaming multiprocessor. This is the actual value that should be used as the upper limit for shared memory for kernel launches (needs an additional function call to explicitly raise).

<details>
<summary>Performance vs. master MMQ</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-ptx-mma-17 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | ----------------------: | ----------: |
| RTX 4090   | llama 8B Q2_K_M   |                  16 | pp2048   |        1190.56 |                 1702.40 |        1.43 |
| RTX 4090   | llama 8B Q2_K_M   |                  32 | pp2048   |        1588.46 |                 2689.24 |        1.69 |
| RTX 4090   | llama 8B Q2_K_M   |                  64 | pp2048   |        2462.88 |                 4120.64 |        1.67 |
| RTX 4090   | llama 8B Q2_K_M   |                 128 | pp2048   |        2868.68 |                 5635.31 |        1.96 |
| RTX 4090   | llama 8B Q2_K_M   |                 256 | pp2048   |        3553.10 |                 7022.20 |        1.98 |
| RTX 4090   | llama 8B Q2_K_M   |                 512 | pp2048   |        3909.38 |                 7639.35 |        1.95 |
| RTX 4090   | llama 8B Q2_K_M   |                1024 | pp2048   |        4105.15 |                 7755.40 |        1.89 |
| RTX 4090   | llama 8B Q2_K_M   |                2048 | pp2048   |        3936.76 |                 7083.78 |        1.80 |
| RTX 4090   | llama 8B Q3_K_S   |                  16 | pp2048   |         997.96 |                 1611.31 |        1.61 |
| RTX 4090   | llama 8B Q3_K_S   |                  32 | pp2048   |        1346.93 |                 2644.87 |        1.96 |
| RTX 4090   | llama 8B Q3_K_S   |                  64 | pp2048   |        2289.07 |                 4190.48 |        1.83 |
| RTX 4090   | llama 8B Q3_K_S   |                 128 | pp2048   |        2836.75 |                 6014.07 |        2.12 |
| RTX 4090   | llama 8B Q3_K_S   |                 256 | pp2048   |        3710.10 |                 7712.51 |        2.08 |
| RTX 4090   | llama 8B Q3_K_S   |                 512 | pp2048   |        4183.62 |                 8659.58 |        2.07 |
| RTX 4090   | llama 8B Q3_K_S   |                1024 | pp2048   |        4397.62 |                 8644.62 |        1.97 |
| RTX 4090   | llama 8B Q3_K_S   |                2048 | pp2048   |        4248.61 |                 7935.98 |        1.87 |
| RTX 3090   | llama 8B Q2_K_M   |                  16 | pp2048   |         595.56 |                  977.44 |        1.64 |
| RTX 3090   | llama 8B Q2_K_M   |                  32 | pp2048   |         799.47 |                 1378.14 |        1.72 |
| RTX 3090   | llama 8B Q2_K_M   |                  64 | pp2048   |         937.48 |                 1932.08 |        2.06 |
| RTX 3090   | llama 8B Q2_K_M   |                 128 | pp2048   |        1211.96 |                 2414.37 |        1.99 |
| RTX 3090   | llama 8B Q2_K_M   |                 256 | pp2048   |        1516.43 |                 2956.45 |        1.95 |
| RTX 3090   | llama 8B Q2_K_M   |                 512 | pp2048   |        1582.72 |                 3084.91 |        1.95 |
| RTX 3090   | llama 8B Q2_K_M   |                1024 | pp2048   |        1646.13 |                 3196.07 |        1.94 |
| RTX 3090   | llama 8B Q2_K_M   |                2048 | pp2048   |        1628.12 |                 3125.93 |        1.92 |
| RTX 3090   | llama 8B Q3_K_S   |                  16 | pp2048   |         492.46 |                  923.08 |        1.87 |
| RTX 3090   | llama 8B Q3_K_S   |                  32 | pp2048   |         649.50 |                 1315.24 |        2.03 |
| RTX 3090   | llama 8B Q3_K_S   |                  64 | pp2048   |         859.15 |                 1943.93 |        2.26 |
| RTX 3090   | llama 8B Q3_K_S   |                 128 | pp2048   |        1230.25 |                 2646.62 |        2.15 |
| RTX 3090   | llama 8B Q3_K_S   |                 256 | pp2048   |        1543.02 |                 3305.31 |        2.14 |
| RTX 3090   | llama 8B Q3_K_S   |                 512 | pp2048   |        1665.09 |                 3487.42 |        2.09 |
| RTX 3090   | llama 8B Q3_K_S   |                1024 | pp2048   |        1743.56 |                 3575.74 |        2.05 |
| RTX 3090   | llama 8B Q3_K_S   |                2048 | pp2048   |        1735.05 |                 3470.47 |        2.00 |
| RX 6800    | llama 8B Q2_K_M   |                  16 | pp2048   |         140.08 |                  153.15 |        1.09 |
| RX 6800    | llama 8B Q2_K_M   |                  32 | pp2048   |         159.30 |                  197.70 |        1.24 |
| RX 6800    | llama 8B Q2_K_M   |                  64 | pp2048   |         191.10 |                  238.01 |        1.25 |
| RX 6800    | llama 8B Q2_K_M   |                 128 | pp2048   |         228.92 |                  295.19 |        1.29 |
| RX 6800    | llama 8B Q2_K_M   |                 256 | pp2048   |         273.17 |                  349.91 |        1.28 |
| RX 6800    | llama 8B Q2_K_M   |                 512 | pp2048   |         288.55 |                  364.26 |        1.26 |
| RX 6800    | llama 8B Q2_K_M   |                1024 | pp2048   |         277.80 |                  345.47 |        1.24 |
| RX 6800    | llama 8B Q2_K_M   |                2048 | pp2048   |         256.47 |                  311.28 |        1.21 |
| RX 6800    | llama 8B Q3_K_S   |                  16 | pp2048   |         115.97 |                  134.14 |        1.16 |
| RX 6800    | llama 8B Q3_K_S   |                  32 | pp2048   |         127.77 |                  160.74 |        1.26 |
| RX 6800    | llama 8B Q3_K_S   |                  64 | pp2048   |         164.16 |                  206.02 |        1.26 |
| RX 6800    | llama 8B Q3_K_S   |                 128 | pp2048   |         192.03 |                  249.73 |        1.30 |
| RX 6800    | llama 8B Q3_K_S   |                 256 | pp2048   |         228.57 |                  292.16 |        1.28 |
| RX 6800    | llama 8B Q3_K_S   |                 512 | pp2048   |         242.35 |                  306.31 |        1.26 |
| RX 6800    | llama 8B Q3_K_S   |                1024 | pp2048   |         235.30 |                  294.04 |        1.25 |
| RX 6800    | llama 8B Q3_K_S   |                2048 | pp2048   |         220.55 |                  269.35 |        1.22 |
| P40   | llama 8B Q2_K_M |                16 | pp2048 |       273.10 |         314.75 |      1.15 |
| P40   | llama 8B Q2_K_M |                32 | pp2048 |       358.76 |         427.85 |      1.19 |
| P40   | llama 8B Q2_K_M |                64 | pp2048 |       464.29 |         558.64 |      1.20 |
| P40   | llama 8B Q2_K_M |               128 | pp2048 |       534.66 |         677.66 |      1.27 |
| P40   | llama 8B Q2_K_M |               256 | pp2048 |       582.77 |         731.19 |      1.25 |
| P40   | llama 8B Q2_K_M |               512 | pp2048 |       613.71 |         768.46 |      1.25 |
| P40   | llama 8B Q2_K_M |              1024 | pp2048 |       613.27 |         759.92 |      1.24 |
| P40   | llama 8B Q2_K_M |              2048 | pp2048 |       590.71 |         728.91 |      1.23 |
| P40        | llama 8B Q3_K_S   |                  16 | pp2048   |         241.94 |                  249.37 |        1.03 |
| P40        | llama 8B Q3_K_S   |                  32 | pp2048   |         320.23 |                  355.26 |        1.11 |
| P40        | llama 8B Q3_K_S   |                  64 | pp2048   |         452.54 |                  491.01 |        1.09 |
| P40        | llama 8B Q3_K_S   |                 128 | pp2048   |         520.61 |                  572.41 |        1.10 |
| P40        | llama 8B Q3_K_S   |                 256 | pp2048   |         564.99 |                  620.82 |        1.10 |
| P40        | llama 8B Q3_K_S   |                 512 | pp2048   |         592.96 |                  652.16 |        1.10 |
| P40        | llama 8B Q3_K_S   |                1024 | pp2048   |         586.02 |                  643.80 |        1.10 |
| P40        | llama 8B Q3_K_S   |                2048 | pp2048   |         565.22 |                  618.79 |        1.09 |

</details>

<details>
<summary>Performance vs. master cuBLAS</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-ptx-mma-17 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | ----------------------: | ----------: |
| RTX 4090   | llama 8B Q2_K_M   |                  16 | pp2048   |        1189.99 |                 1702.40 |        1.43 |
| RTX 4090   | llama 8B Q2_K_M   |                  32 | pp2048   |        1580.39 |                 2689.24 |        1.70 |
| RTX 4090   | llama 8B Q2_K_M   |                  64 | pp2048   |        2454.15 |                 4120.64 |        1.68 |
| RTX 4090   | llama 8B Q2_K_M   |                 128 | pp2048   |        3642.99 |                 5635.31 |        1.55 |
| RTX 4090   | llama 8B Q2_K_M   |                 256 | pp2048   |        5897.75 |                 7022.20 |        1.19 |
| RTX 4090   | llama 8B Q2_K_M   |                 512 | pp2048   |        7797.40 |                 7639.35 |        0.98 |
| RTX 4090   | llama 8B Q2_K_M   |                1024 | pp2048   |        9039.66 |                 7755.40 |        0.86 |
| RTX 4090   | llama 8B Q2_K_M   |                2048 | pp2048   |        8915.95 |                 7083.78 |        0.79 |
| RTX 4090   | llama 8B Q3_K_S   |                  16 | pp2048   |         991.74 |                 1611.31 |        1.62 |
| RTX 4090   | llama 8B Q3_K_S   |                  32 | pp2048   |        1344.66 |                 2644.87 |        1.97 |
| RTX 4090   | llama 8B Q3_K_S   |                  64 | pp2048   |        2287.11 |                 4190.48 |        1.83 |
| RTX 4090   | llama 8B Q3_K_S   |                 128 | pp2048   |        3542.60 |                 6014.07 |        1.70 |
| RTX 4090   | llama 8B Q3_K_S   |                 256 | pp2048   |        5785.44 |                 7712.51 |        1.33 |
| RTX 4090   | llama 8B Q3_K_S   |                 512 | pp2048   |        7704.78 |                 8659.58 |        1.12 |
| RTX 4090   | llama 8B Q3_K_S   |                1024 | pp2048   |        9015.20 |                 8644.62 |        0.96 |
| RTX 4090   | llama 8B Q3_K_S   |                2048 | pp2048   |        8939.09 |                 7935.98 |        0.89 |
| RTX 3090   | llama 8B Q2_K_M   |                  16 | pp2048   |         585.72 |                  977.44 |        1.67 |
| RTX 3090   | llama 8B Q2_K_M   |                  32 | pp2048   |         778.38 |                 1378.14 |        1.77 |
| RTX 3090   | llama 8B Q2_K_M   |                  64 | pp2048   |         913.46 |                 1932.08 |        2.12 |
| RTX 3090   | llama 8B Q2_K_M   |                 128 | pp2048   |        2274.05 |                 2414.37 |        1.06 |
| RTX 3090   | llama 8B Q2_K_M   |                 256 | pp2048   |        3354.70 |                 2956.45 |        0.88 |
| RTX 3090   | llama 8B Q2_K_M   |                 512 | pp2048   |        3984.17 |                 3084.91 |        0.77 |
| RTX 3090   | llama 8B Q2_K_M   |                1024 | pp2048   |        4692.10 |                 3196.07 |        0.68 |
| RTX 3090   | llama 8B Q2_K_M   |                2048 | pp2048   |        4739.62 |                 3125.93 |        0.66 |
| RTX 3090   | llama 8B Q3_K_S   |                  16 | pp2048   |         477.93 |                  923.08 |        1.93 |
| RTX 3090   | llama 8B Q3_K_S   |                  32 | pp2048   |         625.05 |                 1315.24 |        2.10 |
| RTX 3090   | llama 8B Q3_K_S   |                  64 | pp2048   |         829.36 |                 1943.93 |        2.34 |
| RTX 3090   | llama 8B Q3_K_S   |                 128 | pp2048   |        2102.58 |                 2646.62 |        1.26 |
| RTX 3090   | llama 8B Q3_K_S   |                 256 | pp2048   |        3151.56 |                 3305.31 |        1.05 |
| RTX 3090   | llama 8B Q3_K_S   |                 512 | pp2048   |        3847.53 |                 3487.42 |        0.91 |
| RTX 3090   | llama 8B Q3_K_S   |                1024 | pp2048   |        4594.82 |                 3575.74 |        0.78 |
| RTX 3090   | llama 8B Q3_K_S   |                2048 | pp2048   |        4694.42 |                 3470.47 |        0.74 |

</details>

The performance on Ampere and Ada Lovelace seems to still be suboptimal relative to FP16 cuBLAS GEMM.