### PR TITLE
Fixed packages version problem + fixed problem with convert-hf-to-gguf-update.py

### DIFF
--- a/convert-hf-to-gguf-update.py
+++ b/convert-hf-to-gguf-update.py
@@ -213,7 +213,7 @@ src_func = f"""
 """
 
 convert_py_pth = pathlib.Path("convert-hf-to-gguf.py")
-convert_py = convert_py_pth.read_text()
+convert_py = convert_py_pth.read_text(encoding="utf-8")
 convert_py = re.sub(
     r"(# Marker: Start get_vocab_base_pre)(.+?)( +# Marker: End get_vocab_base_pre)",
     lambda m: m.group(1) + src_func + m.group(3),
@@ -221,7 +221,7 @@ convert_py = re.sub(
     flags=re.DOTALL | re.MULTILINE,
 )
 
-convert_py_pth.write_text(convert_py)
+convert_py_pth.write_text(convert_py, encoding="utf-8")
 
 logger.info("+++ convert-hf-to-gguf.py was updated")
 

--- a/requirements/requirements-convert-hf-to-gguf-update.txt
+++ b/requirements/requirements-convert-hf-to-gguf-update.txt
@@ -1,2 +1,2 @@
 -r ./requirements-convert-legacy-llama.txt
-torch~=2.1.1
+torch~=2.2.1

--- a/requirements/requirements-convert-hf-to-gguf.txt
+++ b/requirements/requirements-convert-hf-to-gguf.txt
@@ -1,2 +1,2 @@
 -r ./requirements-convert-legacy-llama.txt
-torch~=2.1.1
+torch~=2.2.1

--- a/requirements/requirements-convert-legacy-llama.txt
+++ b/requirements/requirements-convert-legacy-llama.txt
@@ -1,4 +1,4 @@
-numpy~=1.24.4
+numpy~=1.26.4
 sentencepiece~=0.2.0
 transformers>=4.40.1,<5.0.0
 gguf>=0.1.0


### PR DESCRIPTION
This PR make minor changes ro a few things including the version of some packages : 

- numpy : because it used deprecated python code that broke when installing the `requirements.txt`
- torch : because it kept saying that the version `2.1.1` didn't exist and proposed other versions like `2.2.0`, `2.2.1`, etc

and also the `convert-hf-to-gguf-update.py` was updated to use `encoding="utf-8"` when reading and writing on `convert-hf-to-gguf.py` because some characters kept breaking the execution of the `convert-hf-to-gguf-update.py` (mostly hexadecimal characters that weren't recognized under windows default encoding) like the rocket emojis "🚀"

- Self Reported Review Complexity:
    - [X] Review Complexity : Low
    - [ ] Review Complexity : Medium
    - [ ] Review Complexity : High
- [X] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
