### PR TITLE
rpc : throw an exception when the RPC endpoint is unreachable

### DIFF
--- a/ggml-rpc.cpp
+++ b/ggml-rpc.cpp
@@ -671,7 +671,7 @@ GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const
     }
     auto sock = get_socket(endpoint);
     if (sock == nullptr) {
-        return nullptr;
+        throw std::runtime_error("Failed to connect to " + std::string(endpoint));
     }
     size_t alignment = get_alignment(sock);
     size_t max_size = get_max_size(sock);


### PR DESCRIPTION
Returning nullptr in this case leads to obscure crashes, better fail fast

- Self Reported Review Complexity:
    - [x] Review Complexity : Low
    - [ ] Review Complexity : Medium
    - [ ] Review Complexity : High
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
