### PR TITLE
metal : utilize max shared memory for mul_mat_id

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -1862,9 +1862,10 @@ static enum ggml_status ggml_metal_graph_compute(
                         // ne21 = n_rows
                         const int dst_rows = ne20*ne21;
                         const int dst_rows_min = n_as;
+                        const int dst_rows_max = (ctx->device.maxThreadgroupMemoryLength - 32 - 8192)/4;
 
                         // max size of the rowids array in the kernel shared buffer
-                        GGML_ASSERT(dst_rows <= 2048);
+                        GGML_ASSERT(dst_rows <= dst_rows_max);
 
                         // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
                         // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel


### PR DESCRIPTION
fix https://github.com/ggerganov/llama.cpp/issues/7652

Allows larger batch sizes for MoE models (e.g. DeepSeek v2), though using `-ub 256` remains more efficient in terms of speed


- [x] Review complexity : Low
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
