### PR TITLE
Fix macos x86 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           name: llama-bin-macos-arm64.zip
 
   macOS-latest-cmake-x64:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Clone


### PR DESCRIPTION
- Self Reported Review Complexity:
    - [X] Review Complexity : Low
- [X] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)

On April 2 github actions `macos-latest` became arm https://github.com/actions/runner-images/pull/9601/files

The old `macos-latest` had the alias `macos-12`

Potentially will fix: https://github.com/ggerganov/llama.cpp/issues/6975

Starting from b2715 all precompiled macos x86 have the wrong architecture

```
% file build/bin/server 
build/bin/server: Mach-O 64-bit executable arm64
```
