### PR TITLE
un-ignore `build-info.cmake` and `build-info.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 
 .cache/
 .ccls-cache/
-.clang-tidy
 .direnv/
 .DS_Store
 .envrc

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ gcovr-report/
 
 tags
 build*
+!build-info.cmake
+!build-info.sh
 !build.zig
 cmake-build-*
 android-ndk-*

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,6 @@ examples/server/*.mjs.hpp
 !examples/*/*/*.kts
 !examples/sycl/*.bat
 !examples/sycl/*.sh
-!IDEWorkspaceChecks.plist
 
 # Python
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,93 +1,125 @@
-*.o
+# Extensions
+
 *.a
-*.so
+*.bat
+*.bin
+*.dll
+*.dot
+*.etag
+*.exe
+*.gcda
+*.gcno
+*.gcov
 *.gguf
 *.gguf.json
-*.bin
-*.exe
-*.dll
-*.log
-*.gcov
-*.gcno
-*.gcda
-*.dot
-*.bat
-*.tmp
-*.metallib
-*.etag
 *.lastModified
-.DS_Store
-.build/
+*.log
+*.metallib
+*.o
+*.so
+*.tmp
+
+# IDE / OS
+
 .cache/
 .ccls-cache/
-.direnv/
-.envrc
-.swiftpm
-.venv
 .clang-tidy
+.direnv/
+.DS_Store
+.envrc
+.idea/
+.swiftpm
 .vs/
 .vscode/
-.idea/
+nppBackup
 
-ggml-metal-embed.metal
 
-lcov-report/
+# Coverage
+
 gcovr-report/
+lcov-report/
+
+# Build Artifacts
 
 tags
+.build/
 build*
 !build-info.cmake
 !build-info.cpp.in
 !build-info.sh
 !build.zig
-cmake-build-*
+/libllama.so
+/llama-*
 android-ndk-*
+arm_neon.h
+cmake-build-*
+CMakeSettings.json
+compile_commands.json
+ggml-metal-embed.metal
+llama-batched-swift
 out/
 tmp/
 
+# CI
+
+!.github/workflows/*.yml
+
+# Models
+
 models/*
 models-mnt
+!models/.editorconfig
+!models/ggml-vocab-*.gguf*
 
-/Pipfile
-/libllama.so
-/llama-*
-llama-batched-swift
-/common/build-info.cpp
-arm_neon.h
-compile_commands.json
-CMakeSettings.json
-
-__pycache__
-dist
+# Zig
 
 zig-out/
 zig-cache/
+
+# Logs
 
 ppl-*.txt
 qnt-*.txt
 perf-*.txt
 
+# Examples
+
 examples/jeopardy/results.txt
+examples/server/*.css.hpp
 examples/server/*.html.hpp
 examples/server/*.js.hpp
 examples/server/*.mjs.hpp
-examples/server/*.css.hpp
+!build_64.sh
+!examples/*.bat
+!examples/*/*.kts
+!examples/*/*/*.kts
+!examples/sycl/*.bat
+!examples/sycl/*.sh
+!IDEWorkspaceChecks.plist
 
+# Python
+
+__pycache__
+.venv
+/Pipfile
+dist
 poetry.lock
 poetry.toml
-nppBackup
 
 # Test binaries
-/tests/test-grammar-parser
-/tests/test-llama-grammar
+/tests/test-backend-ops
 /tests/test-double-float
 /tests/test-grad0
+/tests/test-grammar-parser
+/tests/test-llama-grammar
 /tests/test-opt
 /tests/test-quantize-fns
 /tests/test-quantize-perf
+/tests/test-rope
 /tests/test-sampling
 /tests/test-tokenizer-0
-/tests/test-tokenizer-1-spm
 /tests/test-tokenizer-1-bpe
-/tests/test-rope
-/tests/test-backend-ops
+/tests/test-tokenizer-1-spm
+
+# Scripts
+!/scripts/install-oneapi.bat

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ gcovr-report/
 tags
 build*
 !build-info.cmake
+!build-info.cpp.in
 !build-info.sh
 !build.zig
 cmake-build-*


### PR DESCRIPTION
If they are ignored it can break some build tools that consider if a file is ignored, even if it's committed, it should not exist at all. I am assuming ignoring it was a mistake.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
