### PR TITLE
CUDA: stream-k decomposition for MMQ

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -635,7 +635,7 @@ static int64_t get_row_rounding(const std::array<float, GGML_CUDA_MAX_DEVICES> &
         }
 
         const int cc = ggml_cuda_info().devices[id].cc;
-        row_rounding = std::max(row_rounding, (int64_t)get_mmq_y_host(cc, get_mmq_x_max_host(cc)));
+        row_rounding = std::max(row_rounding, (int64_t)get_mmq_y_host(cc));
     }
     return row_rounding;
 }

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -652,8 +652,8 @@ static int get_mmq_x_max_host(const int cc) {
 }
 
 // Round rows to this value for --split-mode row:
-static int get_mmq_y_host(const int cc, const int mmq_x) {
-    return cc >= CC_VOLTA && mmq_x >= 32 ? 128 : 64;
+static int get_mmq_y_host(const int cc) {
+    return cc >= CC_VOLTA ? 128 : 64;
 }
 
 //////////////////////

--- a/ggml-cuda/mmq.cu
+++ b/ggml-cuda/mmq.cu
@@ -30,34 +30,34 @@ void ggml_cuda_op_mul_mat_q(
 
     switch (src0->type) {
         case GGML_TYPE_Q4_0:
-            mul_mat_q_case<GGML_TYPE_Q4_0>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q4_0>(ctx, args, stream);
             break;
         case GGML_TYPE_Q4_1:
-            mul_mat_q_case<GGML_TYPE_Q4_1>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q4_1>(ctx, args, stream);
             break;
         case GGML_TYPE_Q5_0:
-            mul_mat_q_case<GGML_TYPE_Q5_0>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q5_0>(ctx, args, stream);
             break;
         case GGML_TYPE_Q5_1:
-            mul_mat_q_case<GGML_TYPE_Q5_1>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q5_1>(ctx, args, stream);
             break;
         case GGML_TYPE_Q8_0:
-            mul_mat_q_case<GGML_TYPE_Q8_0>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q8_0>(ctx, args, stream);
             break;
         case GGML_TYPE_Q2_K:
-            mul_mat_q_case<GGML_TYPE_Q2_K>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q2_K>(ctx, args, stream);
             break;
         case GGML_TYPE_Q3_K:
-            mul_mat_q_case<GGML_TYPE_Q3_K>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q3_K>(ctx, args, stream);
             break;
         case GGML_TYPE_Q4_K:
-            mul_mat_q_case<GGML_TYPE_Q4_K>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q4_K>(ctx, args, stream);
             break;
         case GGML_TYPE_Q5_K:
-            mul_mat_q_case<GGML_TYPE_Q5_K>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q5_K>(ctx, args, stream);
             break;
         case GGML_TYPE_Q6_K:
-            mul_mat_q_case<GGML_TYPE_Q6_K>(args, stream);
+            mul_mat_q_case<GGML_TYPE_Q6_K>(ctx, args, stream);
             break;
         default:
             GGML_ASSERT(false);

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #define MMQ_TILE_Y_K (WARP_SIZE + WARP_SIZE/QI8_1)
+#define MMQ_NWARPS 8
 
 typedef void (*load_tiles_mmq_t)(
     const char * __restrict__ x, int * __restrict__ x_qs, half2 * __restrict__ x_dm,
@@ -15,7 +16,7 @@ typedef void (*load_tiles_mmq_t)(
 typedef void (*vec_dot_mmq_t)(
     const int * __restrict__ x_qs, const half2 * __restrict__ x_dm, const int * __restrict__ x_sc,
     const int * __restrict__ y, float * __restrict__ sum, const int & k0);
-typedef void (*mmq_write_back_t)(const float * __restrict__ sum, float * __restrict__ dst, const int & ne0, const int & ne1);
+typedef void (*mmq_write_back_t)(const float * __restrict__ sum, float * __restrict__ dst, const int & stride, const int & i_max, const int & j_max);
 
 struct block_q8_1_mmq {
     half2  ds[4];
@@ -50,21 +51,17 @@ static constexpr __device__ int get_mmq_x_max_device() {
 
 // get_mmq_y_host is in common.cuh so that it can be used to determine the correct way to round for --split-mode row
 
+static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-static constexpr __device__ int get_mmq_y_device(int mmq_x) {
-    return mmq_x >= 32 ? 128 : 64;
-}
+    return 128;
 #else
 #if __CUDA_ARCH__ >= CC_VOLTA
-static constexpr __device__ int get_mmq_y_device(int mmq_x) {
-    return mmq_x >= 32 ? 128 : 64;
-}
+    return 128;
 #else
-static constexpr __device__ int get_mmq_y_device(int /*mmq_x*/) {
     return 64;
-}
 #endif // __CUDA_ARCH__ >= CC_VOLTA
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+}
 
 #define TILE_X_SIZES_Q4_0 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_0 + mmq_y/QI4_0, 0}
 #define TILE_X_SIZES_Q4_1 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_1 + mmq_y/QI4_1, 0}
@@ -1734,30 +1731,34 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
 }
 
 template<int mmq_x, int mmq_y, int nwarps, bool need_check>
-static __device__ __forceinline__ void mmq_write_back_dp4a(const float * __restrict__ sum, float * __restrict__ dst, const int & ne0, const int & ne1) {
+static __device__ __forceinline__ void mmq_write_back_dp4a(
+    const float * __restrict__ sum, float * __restrict__ dst, const int & stride, const int & i_max, const int & j_max) {
+
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = blockIdx.y*mmq_x + j0 + threadIdx.y;
+        const int j = j0 + threadIdx.y;
 
-        if (j >= ne1) {
+        if (j > j_max) {
             return;
         }
 
 #pragma unroll
         for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = blockIdx.x*mmq_y + i0 + threadIdx.x;
+            const int i = i0 + threadIdx.x;
 
-            if (need_check && i >= ne0) {
+            if (need_check && i > i_max) {
                 continue;
             }
 
-            dst[j*ne0 + i] = sum[(j0/nwarps) * (mmq_y/WARP_SIZE) + i0/WARP_SIZE];
+            dst[j*stride + i] = sum[(j0/nwarps) * (mmq_y/WARP_SIZE) + i0/WARP_SIZE];
         }
     }
 }
 
 template<int mmq_x, int mmq_y, int nwarps, bool need_check>
-static __device__ __forceinline__ void mmq_write_back_mma(const float * __restrict__ sum, float * __restrict__ dst, const int & ne0, const int & ne1) {
+static __device__ __forceinline__ void mmq_write_back_mma(
+    const float * __restrict__ sum, float * __restrict__ dst, const int & stride, const int & i_max, const int & j_max) {
+
     typedef mma_int_C_I16J8 mma_C;
 
     const int i0 = threadIdx.y*mma_C::I;
@@ -1769,19 +1770,19 @@ static __device__ __forceinline__ void mmq_write_back_mma(const float * __restri
     for (int j0 = 0; j0 < mmq_x; j0 += mma_C::J) {
 #pragma unroll
         for (int l = 0; l < mma_C::ne; ++l) {
-            const int j = blockIdx.y*mmq_x + j0 + mma_C::get_j(l);
+            const int j = j0 + mma_C::get_j(l);
 
-            if (j >= ne1) {
+            if (j > j_max) {
                 continue;
             }
 
-            const int i = blockIdx.x*mmq_y + i0 + mma_C::get_i(l);
+            const int i = i0 + mma_C::get_i(l);
 
-            if (need_check && i >= ne0) {
+            if (need_check && i > i_max) {
                 continue;
             }
 
-            dst[j*ne0 + i] = sum[(j0/mma_C::J)*mma_C::ne + l];
+            dst[j*stride + i] = sum[(j0/mma_C::J)*mma_C::ne + l];
         }
     }
 }
@@ -1896,32 +1897,16 @@ static bool mmq_need_sum(const ggml_type type_x) {
     return false;
 }
 
-template <ggml_type type, int mmq_x, int nwarps, bool need_check>
-#if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-#if defined(RDNA3) || defined(RDNA2)
-    __launch_bounds__(WARP_SIZE*nwarps, 2)
-#endif // defined(RDNA3) || defined(RDNA2)
-#else
-#if __CUDA_ARCH__ >= CC_VOLTA
-    __launch_bounds__(WARP_SIZE*nwarps, 1)
-#else
-    __launch_bounds__(WARP_SIZE*nwarps, 2)
-#endif // __CUDA_ARCH__ >= CC_VOLTA
-#endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-static __global__ void mul_mat_q(
-    const char * __restrict__ x, const char * __restrict__ yc, float * __restrict__ dst,
-    const int ne00, const int ne01, const int stride01, const int ne10, const int ne11, const int stride11, const int ne0) {
-
-    // Skip unused template specializations for faster compilation:
-    if (mmq_x > get_mmq_x_max_device()) {
-        NO_DEVICE_CODE;
-        return;
-    }
+template <ggml_type type, int mmq_x, int nwarps, bool need_check, bool fixup>
+static __device__ void mul_mat_q_process_tile(
+    const char * __restrict__ x, const char * __restrict__ yc, float * __restrict__ dst, float * __restrict__ tmp_fixup,
+    const int & ne00, const int & ne01, const int & stride01, const int & ne10, const int & ne11, const int & stride11, const int & ne0,
+    const int & it, const int & jt, const int & kb0_start, const int & kb0_stop) {
 
     constexpr int              qk         = ggml_cuda_type_traits<type>::qk;
     constexpr int              qr         = ggml_cuda_type_traits<type>::qr;
     constexpr int              qi         = ggml_cuda_type_traits<type>::qi;
-    constexpr int              mmq_y      = get_mmq_y_device(mmq_x);
+    constexpr int              mmq_y      = get_mmq_y_device();
     constexpr int              vdr        = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::vdr;
     constexpr load_tiles_mmq_t load_tiles = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::load_tiles;
 
@@ -1941,20 +1926,18 @@ static __global__ void mul_mat_q(
     int   * tile_x_sc = (int   *) (tile_x_dm + txs.dm);
     int   * tile_y    = (int   *) (tile_x_sc + txs.sc); // [mmq_x * (WARP_SIZE + WARP_SIZE/QI8_1)]
 
-    const int blocks_per_row_x = ne00 / qk;
-    const int blocks_per_warp = WARP_SIZE / qi;
-
-    const int & ne1 = ne11;
-
-    const int tile_x_max_i = ne01 - blockIdx.x*mmq_y - 1;
-
-    const int * y = (const int *) yc + blockIdx.y*(mmq_x*sizeof(block_q8_1_mmq)/sizeof(int));
+    constexpr int blocks_per_warp = WARP_SIZE / qi;
 
     float sum[mmq_x*mmq_y / (nwarps*WARP_SIZE)] = {0.0f};
 
-    for (int kb0 = 0; kb0 < blocks_per_row_x; kb0 += blocks_per_warp) {
+    const int tile_x_max_i = ne01 - it*mmq_y - 1;
+    const int tile_y_max_j = ne11 - jt*mmq_x - 1;
 
-        load_tiles(x, tile_x_qs, tile_x_dm, tile_x_sc, stride01*blockIdx.x*mmq_y + kb0, tile_x_max_i, stride01);
+    const int * y = (const int *) yc + jt*(mmq_x*sizeof(block_q8_1_mmq)/sizeof(int));
+
+    for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_warp) {
+
+        load_tiles(x, tile_x_qs, tile_x_dm, tile_x_sc, stride01*it*mmq_y + kb0, tile_x_max_i, stride01);
 
 #pragma unroll
         for (int kr = 0; kr < qr; ++kr) {
@@ -1977,7 +1960,173 @@ static __global__ void mul_mat_q(
         }
     }
 
-    write_back(sum, dst, ne0, ne1);
+    if (fixup) {
+        write_back(sum, tmp_fixup + blockIdx.x*(mmq_x*mmq_y), mmq_y, mmq_y, mmq_x);
+    } else {
+        write_back(sum, dst + jt*mmq_x*ne0 + it*mmq_y, ne0, tile_x_max_i, tile_y_max_j);
+    }
+}
+
+
+// The mul_mat_q kernel implements "stream-k" work partitioning as described in https://arxiv.org/abs/2301.03598
+
+template <ggml_type type, int mmq_x, int nwarps, bool need_check>
+#if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+#if defined(RDNA3) || defined(RDNA2)
+    __launch_bounds__(WARP_SIZE*nwarps, 2)
+#endif // defined(RDNA3) || defined(RDNA2)
+#else
+#if __CUDA_ARCH__ >= CC_VOLTA
+    __launch_bounds__(WARP_SIZE*nwarps, 1)
+#else
+    __launch_bounds__(WARP_SIZE*nwarps, 2)
+#endif // __CUDA_ARCH__ >= CC_VOLTA
+#endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+static __global__ void mul_mat_q(
+    const char * __restrict__ x, const char * __restrict__ yc, float * __restrict__ dst, float * __restrict__ tmp_fixup,
+    const int ne00, const int ne01, const int stride01, const int ne10, const int ne11, const int stride11, const int ne0) {
+
+    // Skip unused template specializations for faster compilation:
+    if (mmq_x > get_mmq_x_max_device()) {
+        NO_DEVICE_CODE;
+        return;
+    }
+
+    constexpr int qk    = ggml_cuda_type_traits<type>::qk;
+    constexpr int qi    = ggml_cuda_type_traits<type>::qi;
+    constexpr int mmq_y = get_mmq_y_device();
+
+    // On AMD or old CUDA the performance with stream-k was worse, use conventional tiling instead:
+#if (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ < CC_VOLTA
+    {
+        constexpr bool fixup = false;
+        mul_mat_q_process_tile<type, mmq_x, nwarps, need_check, fixup>
+            (x, yc, dst, tmp_fixup, ne00, ne01, stride01, ne10, ne11, stride11, ne0,
+                blockIdx.x, blockIdx.y, 0, ne00/qk);
+        return;
+    }
+#endif // (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ < CC_VOLTA
+
+    const     int64_t blocks_per_ne00 = ne00 / qk;
+    constexpr int     blocks_per_warp = WARP_SIZE / qi;
+
+    const int ntx = (ne11 + mmq_x - 1) / mmq_x; // Number of tiles x
+    const int nty = (ne01 + mmq_y - 1) / mmq_y; // Number of tiles y
+
+    // kbc == k block continuous, current index in continuous ijk space.
+    int64_t       kbc      = GGML_PAD((int64_t) blockIdx.x     *blocks_per_ne00*ntx*nty / gridDim.x, blocks_per_warp);
+    const int64_t kbc_stop = GGML_PAD((int64_t)(blockIdx.x + 1)*blocks_per_ne00*ntx*nty / gridDim.x, blocks_per_warp);
+
+    // kb0 == k index when doing the matrix multiplication for an output tile.
+    int kb0_start = kbc % blocks_per_ne00;
+    int kb0_stop  = min(blocks_per_ne00, kb0_start + kbc_stop - kbc);
+    while (kbc < kbc_stop && kb0_stop == blocks_per_ne00) {
+        const int jt =  kbc /    (blocks_per_ne00*nty);                    // j index of current tile.
+        const int it = (kbc - jt*(blocks_per_ne00*nty)) / blocks_per_ne00; // i index of current tile.
+
+        constexpr bool fixup = false; // All but (potentially) the last iterations write their data to dst rather than the fixup buffer.
+        mul_mat_q_process_tile<type, mmq_x, nwarps, need_check, fixup>
+            (x, yc, dst, tmp_fixup, ne00, ne01, stride01, ne10, ne11, stride11, ne0,
+             it, jt, kb0_start, kb0_stop);
+
+        kbc += blocks_per_ne00;
+        kbc -= kbc % blocks_per_ne00;
+
+        kb0_start = 0;
+        kb0_stop  = min(blocks_per_ne00, kbc_stop - kbc);
+    }
+
+    if (kbc >= kbc_stop) {
+        return;
+    }
+
+    const int jt =  kbc /    (blocks_per_ne00*nty);
+    const int it = (kbc - jt*(blocks_per_ne00*nty)) / blocks_per_ne00;
+
+    constexpr bool fixup = true; // Last index writes it data to fixup buffer to avoid data races with other blocks.
+    mul_mat_q_process_tile<type, mmq_x, nwarps, need_check, fixup>
+        (x, yc, dst, tmp_fixup, ne00, ne01, stride01, ne10, ne11, stride11, ne0,
+            it, jt, kb0_start, kb0_stop);
+}
+
+
+template <ggml_type type, int mmq_x, int nwarps, bool need_check>
+static __global__ void mul_mat_q_stream_k_fixup(
+    float * __restrict__ dst, const float * __restrict__ tmp_last_tile, const int ne00, const int ne01, const int ne11, const int ne0, const int block_num_mmq) {
+
+    constexpr int     mmq_y           = get_mmq_y_device();
+    constexpr int     qk              = ggml_cuda_type_traits<type>::qk;
+    constexpr int     qi              = ggml_cuda_type_traits<type>::qi;
+    constexpr int     blocks_per_warp = WARP_SIZE / qi;
+    const     int64_t blocks_per_ne00 = ne00 / qk;
+
+    float sum[mmq_x*mmq_y / (nwarps*WARP_SIZE)] = {0.0f};
+
+    const int ntx = (ne11 + mmq_x - 1) / mmq_x;
+    const int nty = (ne01 + mmq_y - 1) / mmq_y;
+
+    bool any_fixup = false;
+
+    const int bidx_start = (blockIdx.y*nty + blockIdx.x)     * block_num_mmq / (gridDim.y*gridDim.x);
+    const int bidx_stop  = (blockIdx.y*nty + blockIdx.x + 1) * block_num_mmq / (gridDim.y*gridDim.x) + 1;
+
+    for (int bidx = bidx_start; bidx < bidx_stop; ++bidx) {
+        const int64_t kb_stop = GGML_PAD((int64_t)(bidx + 1)*blocks_per_ne00*ntx*nty / block_num_mmq, blocks_per_warp);
+
+        if (kb_stop % blocks_per_ne00 == 0) {
+            continue;
+        }
+
+        const int jt =  kb_stop /    (blocks_per_ne00*nty);
+        const int it = (kb_stop - jt*(blocks_per_ne00*nty)) / blocks_per_ne00;
+
+        if (it != blockIdx.x || jt != blockIdx.y) {
+            continue;
+        }
+
+        any_fixup = true;
+
+#pragma unroll
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
+
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                sum[(j0/nwarps) * (mmq_y/WARP_SIZE) + i0/WARP_SIZE] += tmp_last_tile[bidx*(mmq_x*mmq_y) + j*mmq_y + i];
+            }
+        }
+    }
+
+    if (!any_fixup) {
+        return;
+    }
+
+    dst += blockIdx.y*mmq_x*ne0 + blockIdx.x*mmq_y;
+
+    const int i_max = ne01 - blockIdx.x*mmq_y - 1;
+    const int j_max = ne11 - blockIdx.y*mmq_x - 1;
+
+#pragma unroll
+    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+        const int j = j0 + threadIdx.y;
+
+        if (j > j_max) {
+            return;
+        }
+
+#pragma unroll
+        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+            const int i = i0 + threadIdx.x;
+
+            if (need_check && i > i_max) {
+                continue;
+            }
+
+            dst[j*ne0 + i] += sum[(j0/nwarps) * (mmq_y/WARP_SIZE) + i0/WARP_SIZE];
+        }
+    }
 }
 
 struct mmq_args {
@@ -1987,124 +2136,151 @@ struct mmq_args {
     int64_t ne0;
 };
 
-constexpr int mmq_get_nwarps(int mmq_x) {
-    return mmq_x >= 32 ? 8 : 4;
-}
-
 static int mmq_get_shmem(const ggml_type type, const int mmq_x, const int mmq_y) {
     const tile_x_sizes txs = get_tile_x_sizes_host(type, mmq_y);
-    const int nwarps = mmq_get_nwarps(mmq_x);
 
     const int shmem_x = txs.qs*sizeof(int) + txs.dm*sizeof(half2) + txs.sc*sizeof(int);
     const int shmem_y = mmq_x*WARP_SIZE*sizeof(int) + mmq_x*(WARP_SIZE/QI8_1)*sizeof(half2);
-    return shmem_x + GGML_PAD(shmem_y, nwarps*WARP_SIZE*sizeof(int));
+    return shmem_x + GGML_PAD(shmem_y, MMQ_NWARPS*WARP_SIZE*sizeof(int));
 }
 
-template <ggml_type type, int mmq_x, int nwarps>
-static void launch_mul_mat_q(const mmq_args & args, cudaStream_t stream) {
+template <ggml_type type, int mmq_x>
+static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
     const int id = ggml_cuda_get_device();
     const int cc = ggml_cuda_info().devices[id].cc;
-    const int mmq_y = get_mmq_y_host(cc, mmq_x);
+    const int nsm = ggml_cuda_info().devices[id].nsm;
+    const int mmq_y = get_mmq_y_host(cc);
 
-    const int block_num_x = (args.ne01 + mmq_y - 1) / mmq_y;
-    const int block_num_y = (args.ne11 + mmq_x - 1) / mmq_x;
-    const dim3 block_nums(block_num_x, block_num_y, 1);
-    const dim3 block_dims(WARP_SIZE, nwarps, 1);
+    const dim3 block_dims(WARP_SIZE, MMQ_NWARPS, 1);
 
     const int shmem = mmq_get_shmem(type, mmq_x, mmq_y);
 
 #if !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__))
     static bool shmem_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
     if (!shmem_limit_raised[id]) {
-        CUDA_CHECK(cudaFuncSetAttribute(mul_mat_q<type, mmq_x, nwarps, false>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
-        CUDA_CHECK(cudaFuncSetAttribute(mul_mat_q<type, mmq_x, nwarps, true>,  cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        CUDA_CHECK(cudaFuncSetAttribute(mul_mat_q<type, mmq_x, MMQ_NWARPS, false>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
+        CUDA_CHECK(cudaFuncSetAttribute(mul_mat_q<type, mmq_x, MMQ_NWARPS, true>,  cudaFuncAttributeMaxDynamicSharedMemorySize, shmem));
         shmem_limit_raised[id] = true;
     }
 #endif // !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__))
 
+    const int nty = (args.ne01 + mmq_y - 1) / mmq_y;
+    const int ntx = (args.ne11 + mmq_x - 1) / mmq_x;
+    const dim3 block_nums_xy_tiling(nty, ntx, 1);
+
+    const bool use_stream_k = cc >= CC_VOLTA && cc < CC_OFFSET_AMD;
+    if (!use_stream_k) {
+        if (args.ne01 % mmq_y == 0) {
+            constexpr bool need_check = false;
+            mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, shmem, stream>>>
+                (args.x, args.y, args.dst, nullptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        } else {
+            constexpr bool need_check = true;
+            mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, shmem, stream>>>
+                (args.x, args.y, args.dst, nullptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        }
+        return;
+    }
+
+    const dim3 block_nums_mmq(nsm, 1, 1);
+
+    ggml_cuda_pool & pool = ctx.pool();
+    ggml_cuda_pool_alloc<float> tmp_fixup(pool, block_nums_mmq.x * mmq_x*mmq_y);
+
     if (args.ne01 % mmq_y == 0) {
-        const bool need_check = false;
-        mul_mat_q<type, mmq_x, nwarps, need_check><<<block_nums, block_dims, shmem, stream>>>
-            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        constexpr bool need_check = false;
+
+        mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_mmq, block_dims, shmem, stream>>>
+            (args.x, args.y, args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+
+        mul_mat_q_stream_k_fixup<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, 0, stream>>>
+            (args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.ne11, args.ne0, block_nums_mmq.x);
     } else {
-        const bool need_check = true;
-        mul_mat_q<type, mmq_x, nwarps, need_check><<<block_nums, block_dims, shmem, stream>>>
-            (args.x, args.y, args.dst, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        constexpr bool need_check = true;
+
+        mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_mmq, block_dims, shmem, stream>>>
+            (args.x, args.y, args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+
+        mul_mat_q_stream_k_fixup<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, 0, stream>>>
+            (args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.ne11, args.ne0, block_nums_mmq.x);
     }
 }
 
 template <ggml_type type>
-void mul_mat_q_case(const mmq_args & args, cudaStream_t stream) {
+void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
     const int id    = ggml_cuda_get_device();
     const int nsm   = ggml_cuda_info().devices[id].nsm;
     const int cc    = ggml_cuda_info().devices[id].cc;
     const int smpbo = ggml_cuda_info().devices[id].smpbo;
 
     const int mmq_x_max = get_mmq_x_max_host(cc);
-    const int mmq_y = get_mmq_y_host(cc, mmq_x_max);
+    const int mmq_y = get_mmq_y_host(cc);
     const int block_num_y = (args.ne01 + mmq_y - 1) / mmq_y;
+    const bool use_stream_k = cc >= CC_VOLTA && cc < CC_OFFSET_AMD;
 
     int mmq_x_best  = 0;
-    int nwaves_best = INT_MAX;
+    int nparts_best = INT_MAX;
 
-    for (int mmq_x = 8; mmq_x <= mmq_x_max && nwaves_best > 1; mmq_x += 8) {
-        const int block_num_x = (args.ne11 + mmq_x - 1) / mmq_x;
-        const int nwaves = (block_num_x*block_num_y + nsm - 1) / nsm;
+    for (int mmq_x = 8; mmq_x <= mmq_x_max && nparts_best > 1; mmq_x += 8) {
+        const int ntiles_x = (args.ne11 + mmq_x - 1) / mmq_x;
+        const int nwaves_xy_tiling = ntiles_x*block_num_y;
 
-        if (nwaves < nwaves_best && mmq_get_shmem(type, mmq_x, mmq_y) <= smpbo) {
+        const int nparts = use_stream_k ? ntiles_x : nwaves_xy_tiling;
+
+        if (nparts < nparts_best && mmq_get_shmem(type, mmq_x, mmq_y) <= smpbo) {
             mmq_x_best  = mmq_x;
-            nwaves_best = nwaves;
+            nparts_best = nparts;
         }
     }
 
     switch (mmq_x_best) {
         case   8:
-            launch_mul_mat_q<type,   8, mmq_get_nwarps(  8)>(args, stream);
+            launch_mul_mat_q<type,   8>(ctx, args, stream);
             break;
         case  16:
-            launch_mul_mat_q<type,  16, mmq_get_nwarps( 16)>(args, stream);
+            launch_mul_mat_q<type,  16>(ctx, args, stream);
             break;
         case  24:
-            launch_mul_mat_q<type,  24, mmq_get_nwarps( 24)>(args, stream);
+            launch_mul_mat_q<type,  24>(ctx, args, stream);
             break;
         case  32:
-            launch_mul_mat_q<type,  32, mmq_get_nwarps( 32)>(args, stream);
+            launch_mul_mat_q<type,  32>(ctx, args, stream);
             break;
         case  40:
-            launch_mul_mat_q<type,  40, mmq_get_nwarps( 40)>(args, stream);
+            launch_mul_mat_q<type,  40>(ctx, args, stream);
             break;
         case  48:
-            launch_mul_mat_q<type,  48, mmq_get_nwarps( 48)>(args, stream);
+            launch_mul_mat_q<type,  48>(ctx, args, stream);
             break;
         case  56:
-            launch_mul_mat_q<type,  56, mmq_get_nwarps( 56)>(args, stream);
+            launch_mul_mat_q<type,  56>(ctx, args, stream);
             break;
         case  64:
-            launch_mul_mat_q<type,  64, mmq_get_nwarps( 64)>(args, stream);
+            launch_mul_mat_q<type,  64>(ctx, args, stream);
             break;
         case  72:
-            launch_mul_mat_q<type,  72, mmq_get_nwarps( 72)>(args, stream);
+            launch_mul_mat_q<type,  72>(ctx, args, stream);
             break;
         case  80:
-            launch_mul_mat_q<type,  80, mmq_get_nwarps( 80)>(args, stream);
+            launch_mul_mat_q<type,  80>(ctx, args, stream);
             break;
         case  88:
-            launch_mul_mat_q<type,  88, mmq_get_nwarps( 88)>(args, stream);
+            launch_mul_mat_q<type,  88>(ctx, args, stream);
             break;
         case  96:
-            launch_mul_mat_q<type,  96, mmq_get_nwarps( 96)>(args, stream);
+            launch_mul_mat_q<type,  96>(ctx, args, stream);
             break;
         case 104:
-            launch_mul_mat_q<type, 104, mmq_get_nwarps(104)>(args, stream);
+            launch_mul_mat_q<type, 104>(ctx, args, stream);
             break;
         case 112:
-            launch_mul_mat_q<type, 112, mmq_get_nwarps(112)>(args, stream);
+            launch_mul_mat_q<type, 112>(ctx, args, stream);
             break;
         case 120:
-            launch_mul_mat_q<type, 120, mmq_get_nwarps(120)>(args, stream);
+            launch_mul_mat_q<type, 120>(ctx, args, stream);
             break;
         case 128:
-            launch_mul_mat_q<type, 128, mmq_get_nwarps(128)>(args, stream);
+            launch_mul_mat_q<type, 128>(ctx, args, stream);
             break;
         default:
             fprintf(stderr, "mmq_x_best=%d\n", mmq_x_best);
@@ -2114,7 +2290,7 @@ void mul_mat_q_case(const mmq_args & args, cudaStream_t stream) {
 }
 
 #define DECL_MMQ_CASE(type)                                                        \
-    template void mul_mat_q_case<type>(const mmq_args & args, cudaStream_t stream) \
+    template void mul_mat_q_case<type>(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) \
 
 extern DECL_MMQ_CASE(GGML_TYPE_Q4_0);
 extern DECL_MMQ_CASE(GGML_TYPE_Q4_1);


### PR DESCRIPTION
This PR implements "stream-k decomposition" as described in [this](https://arxiv.org/abs/2301.03598) paper for the MMQ kernels. The idea is that instead of dividing the output tensor into tiles and assigning those tiles to the streaming multiprocessors in waves you instead assign partial tiles to the streaming multiprocessors that you then combine with an additional "fixup" kernel. Notably the number of tiles that you need to fix is constant and equal to the number of streaming multiprocessors (vs. e.g. splitting all tiles).

<details>
<summary>Performance vs. master MMQ</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-mmq-stream-k-2 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | --------------------------: | ----------: |
| RTX 4090   | llama 8B Q2_K_M   |                  16 | pp2048   |        1845.03 |                     1974.88 |        1.07 |
| RTX 4090   | llama 8B Q2_K_M   |                  32 | pp2048   |        2704.27 |                     3052.64 |        1.13 |
| RTX 4090   | llama 8B Q2_K_M   |                  63 | pp2048   |        3974.88 |                     4310.72 |        1.08 |
| RTX 4090   | llama 8B Q2_K_M   |                 128 | pp2048   |        5464.22 |                     5528.70 |        1.01 |
| RTX 4090   | llama 8B Q2_K_M   |                 256 | pp2048   |        6815.42 |                     7109.27 |        1.04 |
| RTX 4090   | llama 8B Q2_K_M   |                 512 | pp2048   |        7416.65 |                     7558.46 |        1.02 |
| RTX 4090   | llama 8B Q2_K_M   |                1024 | pp2048   |        7537.06 |                     7469.47 |        0.99 |
| RTX 4090   | llama 8B Q2_K_M   |                2048 | pp2048   |        7004.78 |                     6950.96 |        0.99 |
| RTX 4090   | llama 8B Q3_K_S   |                  16 | pp2048   |        1657.97 |                     1766.89 |        1.07 |
| RTX 4090   | llama 8B Q3_K_S   |                  32 | pp2048   |        2615.77 |                     2986.33 |        1.14 |
| RTX 4090   | llama 8B Q3_K_S   |                  63 | pp2048   |        4055.24 |                     4484.16 |        1.11 |
| RTX 4090   | llama 8B Q3_K_S   |                 128 | pp2048   |        5920.58 |                     6369.46 |        1.08 |
| RTX 4090   | llama 8B Q3_K_S   |                 256 | pp2048   |        7733.07 |                     8454.78 |        1.09 |
| RTX 4090   | llama 8B Q3_K_S   |                 512 | pp2048   |        8676.65 |                     8966.30 |        1.03 |
| RTX 4090   | llama 8B Q3_K_S   |                1024 | pp2048   |        8708.10 |                     8828.17 |        1.01 |
| RTX 4090   | llama 8B Q3_K_S   |                2048 | pp2048   |        8053.46 |                     8111.16 |        1.01 |
| RTX 4090   | llama 8B Q4_0     |                  16 | pp2048   |        1873.62 |                     1989.96 |        1.06 |
| RTX 4090   | llama 8B Q4_0     |                  32 | pp2048   |        3269.12 |                     3456.99 |        1.06 |
| RTX 4090   | llama 8B Q4_0     |                  63 | pp2048   |        5104.59 |                     5284.82 |        1.04 |
| RTX 4090   | llama 8B Q4_0     |                 128 | pp2048   |        7114.91 |                     7227.59 |        1.02 |
| RTX 4090   | llama 8B Q4_0     |                 256 | pp2048   |        9318.58 |                     9514.91 |        1.02 |
| RTX 4090   | llama 8B Q4_0     |                 512 | pp2048   |       10198.79 |                    10317.21 |        1.01 |
| RTX 4090   | llama 8B Q4_0     |                1024 | pp2048   |       10158.53 |                    10065.18 |        0.99 |
| RTX 4090   | llama 8B Q4_0     |                2048 | pp2048   |        9241.77 |                     9119.39 |        0.99 |
| RTX 4090   | llama 8B Q4_1     |                  16 | pp2048   |        1858.86 |                     1880.17 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                  32 | pp2048   |        3179.30 |                     2999.65 |        0.94 |
| RTX 4090   | llama 8B Q4_1     |                  63 | pp2048   |        5412.60 |                     5084.00 |        0.94 |
| RTX 4090   | llama 8B Q4_1     |                 128 | pp2048   |        6581.02 |                     6982.92 |        1.06 |
| RTX 4090   | llama 8B Q4_1     |                 256 | pp2048   |        8990.72 |                     9070.09 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                 512 | pp2048   |        9667.64 |                     9783.97 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                1024 | pp2048   |        9930.18 |                     9568.42 |        0.96 |
| RTX 4090   | llama 8B Q4_1     |                2048 | pp2048   |        9154.70 |                     8782.85 |        0.96 |
| RTX 4090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1937.52 |                     2004.38 |        1.03 |
| RTX 4090   | llama 8B Q4_K_S   |                  32 | pp2048   |        3342.11 |                     3399.52 |        1.02 |
| RTX 4090   | llama 8B Q4_K_S   |                  63 | pp2048   |        5154.91 |                     5080.20 |        0.99 |
| RTX 4090   | llama 8B Q4_K_S   |                 128 | pp2048   |        6874.51 |                     6758.06 |        0.98 |
| RTX 4090   | llama 8B Q4_K_S   |                 256 | pp2048   |        8434.04 |                     8750.48 |        1.04 |
| RTX 4090   | llama 8B Q4_K_S   |                 512 | pp2048   |        9195.77 |                     9421.38 |        1.02 |
| RTX 4090   | llama 8B Q4_K_S   |                1024 | pp2048   |        9169.23 |                     9306.70 |        1.01 |
| RTX 4090   | llama 8B Q4_K_S   |                2048 | pp2048   |        8629.07 |                     8523.98 |        0.99 |
| RTX 4090   | llama 8B Q5_0     |                  16 | pp2048   |        1480.94 |                     1673.97 |        1.13 |
| RTX 4090   | llama 8B Q5_0     |                  32 | pp2048   |        2509.59 |                     3051.97 |        1.22 |
| RTX 4090   | llama 8B Q5_0     |                  63 | pp2048   |        4162.96 |                     4628.07 |        1.11 |
| RTX 4090   | llama 8B Q5_0     |                 128 | pp2048   |        6207.95 |                     6629.96 |        1.07 |
| RTX 4090   | llama 8B Q5_0     |                 256 | pp2048   |        8006.74 |                     8867.56 |        1.11 |
| RTX 4090   | llama 8B Q5_0     |                 512 | pp2048   |        9223.85 |                     9702.41 |        1.05 |
| RTX 4090   | llama 8B Q5_0     |                1024 | pp2048   |        9277.39 |                     9535.97 |        1.03 |
| RTX 4090   | llama 8B Q5_0     |                2048 | pp2048   |        8710.12 |                     8780.70 |        1.01 |
| RTX 4090   | llama 8B Q5_1     |                  16 | pp2048   |        1619.67 |                     1580.42 |        0.98 |
| RTX 4090   | llama 8B Q5_1     |                  32 | pp2048   |        2584.57 |                     2547.53 |        0.99 |
| RTX 4090   | llama 8B Q5_1     |                  63 | pp2048   |        4297.61 |                     4222.33 |        0.98 |
| RTX 4090   | llama 8B Q5_1     |                 128 | pp2048   |        5975.51 |                     6523.30 |        1.09 |
| RTX 4090   | llama 8B Q5_1     |                 256 | pp2048   |        7744.80 |                     8451.57 |        1.09 |
| RTX 4090   | llama 8B Q5_1     |                 512 | pp2048   |        8823.13 |                     9127.40 |        1.03 |
| RTX 4090   | llama 8B Q5_1     |                1024 | pp2048   |        8931.16 |                     9039.22 |        1.01 |
| RTX 4090   | llama 8B Q5_1     |                2048 | pp2048   |        8335.92 |                     8360.64 |        1.00 |
| RTX 4090   | llama 8B Q5_K_S   |                  16 | pp2048   |        1669.68 |                     1705.77 |        1.02 |
| RTX 4090   | llama 8B Q5_K_S   |                  32 | pp2048   |        2776.29 |                     2777.08 |        1.00 |
| RTX 4090   | llama 8B Q5_K_S   |                  63 | pp2048   |        4419.73 |                     4356.69 |        0.99 |
| RTX 4090   | llama 8B Q5_K_S   |                 128 | pp2048   |        5981.22 |                     6426.45 |        1.07 |
| RTX 4090   | llama 8B Q5_K_S   |                 256 | pp2048   |        7698.50 |                     8275.37 |        1.07 |
| RTX 4090   | llama 8B Q5_K_S   |                 512 | pp2048   |        8615.20 |                     8939.98 |        1.04 |
| RTX 4090   | llama 8B Q5_K_S   |                1024 | pp2048   |        8703.88 |                     8884.14 |        1.02 |
| RTX 4090   | llama 8B Q5_K_S   |                2048 | pp2048   |        8158.43 |                     8242.38 |        1.01 |
| RTX 4090   | llama 8B Q6_K     |                  16 | pp2048   |        1410.39 |                     1455.31 |        1.03 |
| RTX 4090   | llama 8B Q6_K     |                  32 | pp2048   |        2452.60 |                     2754.07 |        1.12 |
| RTX 4090   | llama 8B Q6_K     |                  63 | pp2048   |        4258.11 |                     4430.69 |        1.04 |
| RTX 4090   | llama 8B Q6_K     |                 128 | pp2048   |        6049.71 |                     6309.51 |        1.04 |
| RTX 4090   | llama 8B Q6_K     |                 256 | pp2048   |        7968.27 |                     8277.67 |        1.04 |
| RTX 4090   | llama 8B Q6_K     |                 512 | pp2048   |        8751.79 |                     8968.23 |        1.02 |
| RTX 4090   | llama 8B Q6_K     |                1024 | pp2048   |        8837.98 |                     8852.53 |        1.00 |
| RTX 4090   | llama 8B Q6_K     |                2048 | pp2048   |        8155.85 |                     8044.97 |        0.99 |
| RTX 4090   | llama 8B Q8_0     |                  16 | pp2048   |        1123.00 |                     1276.92 |        1.14 |
| RTX 4090   | llama 8B Q8_0     |                  32 | pp2048   |        2178.68 |                     2374.20 |        1.09 |
| RTX 4090   | llama 8B Q8_0     |                  63 | pp2048   |        3911.79 |                     4065.28 |        1.04 |
| RTX 4090   | llama 8B Q8_0     |                 128 | pp2048   |        6343.39 |                     6563.01 |        1.03 |
| RTX 4090   | llama 8B Q8_0     |                 256 | pp2048   |        8656.65 |                     9411.70 |        1.09 |
| RTX 4090   | llama 8B Q8_0     |                 512 | pp2048   |        9933.38 |                    10591.37 |        1.07 |
| RTX 4090   | llama 8B Q8_0     |                1024 | pp2048   |       10310.62 |                    10554.57 |        1.02 |
| RTX 4090   | llama 8B Q8_0     |                2048 | pp2048   |        9672.82 |                     9544.11 |        0.99 |
| RTX 3090   | llama 8B Q2_K_M   |                  16 | pp2048   |         860.08 |                      983.08 |        1.14 |
| RTX 3090   | llama 8B Q2_K_M   |                  32 | pp2048   |        1191.51 |                     1425.70 |        1.20 |
| RTX 3090   | llama 8B Q2_K_M   |                  63 | pp2048   |        1575.38 |                     1893.31 |        1.20 |
| RTX 3090   | llama 8B Q2_K_M   |                 128 | pp2048   |        2007.22 |                     2262.78 |        1.13 |
| RTX 3090   | llama 8B Q2_K_M   |                 256 | pp2048   |        2487.20 |                     2536.22 |        1.02 |
| RTX 3090   | llama 8B Q2_K_M   |                 512 | pp2048   |        2592.80 |                     2647.31 |        1.02 |
| RTX 3090   | llama 8B Q2_K_M   |                1024 | pp2048   |        2646.01 |                     2639.46 |        1.00 |
| RTX 3090   | llama 8B Q2_K_M   |                2048 | pp2048   |        2604.77 |                     2608.64 |        1.00 |
| RTX 3090   | llama 8B Q3_K_S   |                  16 | pp2048   |         809.98 |                      920.54 |        1.14 |
| RTX 3090   | llama 8B Q3_K_S   |                  32 | pp2048   |        1139.97 |                     1485.39 |        1.30 |
| RTX 3090   | llama 8B Q3_K_S   |                  63 | pp2048   |        1644.27 |                     2087.77 |        1.27 |
| RTX 3090   | llama 8B Q3_K_S   |                 128 | pp2048   |        2331.84 |                     2736.05 |        1.17 |
| RTX 3090   | llama 8B Q3_K_S   |                 256 | pp2048   |        2906.75 |                     3057.93 |        1.05 |
| RTX 3090   | llama 8B Q3_K_S   |                 512 | pp2048   |        3053.04 |                     3191.71 |        1.05 |
| RTX 3090   | llama 8B Q3_K_S   |                1024 | pp2048   |        3173.62 |                     3236.57 |        1.02 |
| RTX 3090   | llama 8B Q3_K_S   |                2048 | pp2048   |        3092.63 |                     3172.58 |        1.03 |
| RTX 3090   | llama 8B Q4_0     |                  16 | pp2048   |        1076.43 |                     1173.33 |        1.09 |
| RTX 3090   | llama 8B Q4_0     |                  32 | pp2048   |        1556.26 |                     1788.35 |        1.15 |
| RTX 3090   | llama 8B Q4_0     |                  63 | pp2048   |        2144.28 |                     2534.95 |        1.18 |
| RTX 3090   | llama 8B Q4_0     |                 128 | pp2048   |        2830.76 |                     3166.94 |        1.12 |
| RTX 3090   | llama 8B Q4_0     |                 256 | pp2048   |        3438.60 |                     3599.03 |        1.05 |
| RTX 3090   | llama 8B Q4_0     |                 512 | pp2048   |        3701.21 |                     3784.69 |        1.02 |
| RTX 3090   | llama 8B Q4_0     |                1024 | pp2048   |        3832.97 |                     3795.66 |        0.99 |
| RTX 3090   | llama 8B Q4_0     |                2048 | pp2048   |        3643.18 |                     3634.57 |        1.00 |
| RTX 3090   | llama 8B Q4_1     |                  16 | pp2048   |        1179.37 |                     1268.37 |        1.08 |
| RTX 3090   | llama 8B Q4_1     |                  32 | pp2048   |        1614.90 |                     1652.84 |        1.02 |
| RTX 3090   | llama 8B Q4_1     |                  63 | pp2048   |        2031.74 |                     2382.21 |        1.17 |
| RTX 3090   | llama 8B Q4_1     |                 128 | pp2048   |        2755.17 |                     2966.05 |        1.08 |
| RTX 3090   | llama 8B Q4_1     |                 256 | pp2048   |        3232.95 |                     3322.46 |        1.03 |
| RTX 3090   | llama 8B Q4_1     |                 512 | pp2048   |        3579.61 |                     3469.01 |        0.97 |
| RTX 3090   | llama 8B Q4_1     |                1024 | pp2048   |        3718.61 |                     3526.51 |        0.95 |
| RTX 3090   | llama 8B Q4_1     |                2048 | pp2048   |        3624.65 |                     3442.58 |        0.95 |
| RTX 3090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1125.44 |                     1242.52 |        1.10 |
| RTX 3090   | llama 8B Q4_K_S   |                  32 | pp2048   |        1585.72 |                     1693.02 |        1.07 |
| RTX 3090   | llama 8B Q4_K_S   |                  63 | pp2048   |        2032.91 |                     2312.02 |        1.14 |
| RTX 3090   | llama 8B Q4_K_S   |                 128 | pp2048   |        2564.13 |                     2812.79 |        1.10 |
| RTX 3090   | llama 8B Q4_K_S   |                 256 | pp2048   |        3073.94 |                     3181.44 |        1.03 |
| RTX 3090   | llama 8B Q4_K_S   |                 512 | pp2048   |        3313.49 |                     3325.57 |        1.00 |
| RTX 3090   | llama 8B Q4_K_S   |                1024 | pp2048   |        3444.24 |                     3376.12 |        0.98 |
| RTX 3090   | llama 8B Q4_K_S   |                2048 | pp2048   |        3250.36 |                     3291.11 |        1.01 |
| RTX 3090   | llama 8B Q5_0     |                  16 | pp2048   |         776.15 |                      946.39 |        1.22 |
| RTX 3090   | llama 8B Q5_0     |                  32 | pp2048   |        1217.41 |                     1621.45 |        1.33 |
| RTX 3090   | llama 8B Q5_0     |                  63 | pp2048   |        1687.45 |                     2198.64 |        1.30 |
| RTX 3090   | llama 8B Q5_0     |                 128 | pp2048   |        2404.10 |                     2902.89 |        1.21 |
| RTX 3090   | llama 8B Q5_0     |                 256 | pp2048   |        3087.93 |                     3296.47 |        1.07 |
| RTX 3090   | llama 8B Q5_0     |                 512 | pp2048   |        3219.13 |                     3451.26 |        1.07 |
| RTX 3090   | llama 8B Q5_0     |                1024 | pp2048   |        3363.65 |                     3484.96 |        1.04 |
| RTX 3090   | llama 8B Q5_0     |                2048 | pp2048   |        3298.89 |                     3401.04 |        1.03 |
| RTX 3090   | llama 8B Q5_1     |                  16 | pp2048   |         930.03 |                      987.19 |        1.06 |
| RTX 3090   | llama 8B Q5_1     |                  32 | pp2048   |        1365.85 |                     1423.36 |        1.04 |
| RTX 3090   | llama 8B Q5_1     |                  63 | pp2048   |        1727.76 |                     2091.52 |        1.21 |
| RTX 3090   | llama 8B Q5_1     |                 128 | pp2048   |        2362.19 |                     2726.86 |        1.15 |
| RTX 3090   | llama 8B Q5_1     |                 256 | pp2048   |        2978.09 |                     3068.63 |        1.03 |
| RTX 3090   | llama 8B Q5_1     |                 512 | pp2048   |        3090.98 |                     3242.92 |        1.05 |
| RTX 3090   | llama 8B Q5_1     |                1024 | pp2048   |        3216.80 |                     3274.03 |        1.02 |
| RTX 3090   | llama 8B Q5_1     |                2048 | pp2048   |        3187.65 |                     3211.42 |        1.01 |
| RTX 3090   | llama 8B Q5_K_S   |                  16 | pp2048   |         903.89 |                     1016.46 |        1.12 |
| RTX 3090   | llama 8B Q5_K_S   |                  32 | pp2048   |        1296.51 |                     1448.98 |        1.12 |
| RTX 3090   | llama 8B Q5_K_S   |                  63 | pp2048   |        1715.60 |                     2032.78 |        1.18 |
| RTX 3090   | llama 8B Q5_K_S   |                 128 | pp2048   |        2326.05 |                     2652.85 |        1.14 |
| RTX 3090   | llama 8B Q5_K_S   |                 256 | pp2048   |        2894.26 |                     3004.17 |        1.04 |
| RTX 3090   | llama 8B Q5_K_S   |                 512 | pp2048   |        3061.19 |                     3129.73 |        1.02 |
| RTX 3090   | llama 8B Q5_K_S   |                1024 | pp2048   |        3163.91 |                     3190.35 |        1.01 |
| RTX 3090   | llama 8B Q5_K_S   |                2048 | pp2048   |        3097.12 |                     3135.12 |        1.01 |
| RTX 3090   | llama 8B Q6_K     |                  16 | pp2048   |         813.79 |                      926.20 |        1.14 |
| RTX 3090   | llama 8B Q6_K     |                  32 | pp2048   |        1251.80 |                     1552.21 |        1.24 |
| RTX 3090   | llama 8B Q6_K     |                  63 | pp2048   |        1771.66 |                     2216.34 |        1.25 |
| RTX 3090   | llama 8B Q6_K     |                 128 | pp2048   |        2452.64 |                     2705.40 |        1.10 |
| RTX 3090   | llama 8B Q6_K     |                 256 | pp2048   |        3003.60 |                     3084.47 |        1.03 |
| RTX 3090   | llama 8B Q6_K     |                 512 | pp2048   |        3186.07 |                     3211.52 |        1.01 |
| RTX 3090   | llama 8B Q6_K     |                1024 | pp2048   |        3283.36 |                     3254.43 |        0.99 |
| RTX 3090   | llama 8B Q6_K     |                2048 | pp2048   |        3252.64 |                     3165.70 |        0.97 |
| RTX 3090   | llama 8B Q8_0     |                  16 | pp2048   |         766.31 |                      935.77 |        1.22 |
| RTX 3090   | llama 8B Q8_0     |                  32 | pp2048   |        1314.52 |                     1622.77 |        1.23 |
| RTX 3090   | llama 8B Q8_0     |                  63 | pp2048   |        1955.76 |                     2426.60 |        1.24 |
| RTX 3090   | llama 8B Q8_0     |                 128 | pp2048   |        2800.84 |                     3208.42 |        1.15 |
| RTX 3090   | llama 8B Q8_0     |                 256 | pp2048   |        3525.69 |                     3732.82 |        1.06 |
| RTX 3090   | llama 8B Q8_0     |                 512 | pp2048   |        3758.75 |                     3876.41 |        1.03 |
| RTX 3090   | llama 8B Q8_0     |                1024 | pp2048   |        3890.72 |                     3932.16 |        1.01 |
| RTX 3090   | llama 8B Q8_0     |                2048 | pp2048   |        3820.42 |                     3822.87 |        1.00 |

</details>

<details>
<summary>Performance vs. master cuBLAS</summary>

| GPU        | Model             |     Microbatch size | Test     |     t/s master |     t/s cuda-mmq-stream-k-2 |     Speedup |
| :--------- | :---------------- | ------------------: | :------- | -------------: | --------------------------: | ----------: |
| RTX 4090   | llama 8B Q2_K_M   |                  16 | pp2048   |        1849.42 |                     1961.85 |        1.06 |
| RTX 4090   | llama 8B Q2_K_M   |                  32 | pp2048   |        2702.03 |                     3033.47 |        1.12 |
| RTX 4090   | llama 8B Q2_K_M   |                  63 | pp2048   |        3978.71 |                     4287.27 |        1.08 |
| RTX 4090   | llama 8B Q2_K_M   |                 128 | pp2048   |        3648.30 |                     5499.50 |        1.51 |
| RTX 4090   | llama 8B Q2_K_M   |                 256 | pp2048   |        5905.04 |                     7096.81 |        1.20 |
| RTX 4090   | llama 8B Q2_K_M   |                 512 | pp2048   |        7778.63 |                     7527.15 |        0.97 |
| RTX 4090   | llama 8B Q2_K_M   |                1024 | pp2048   |        9022.73 |                     7470.52 |        0.83 |
| RTX 4090   | llama 8B Q2_K_M   |                2048 | pp2048   |        8976.75 |                     6932.79 |        0.77 |
| RTX 4090   | llama 8B Q3_K_S   |                  16 | pp2048   |        1653.20 |                     1758.20 |        1.06 |
| RTX 4090   | llama 8B Q3_K_S   |                  32 | pp2048   |        2612.20 |                     2975.96 |        1.14 |
| RTX 4090   | llama 8B Q3_K_S   |                  63 | pp2048   |        4051.31 |                     4482.28 |        1.11 |
| RTX 4090   | llama 8B Q3_K_S   |                 128 | pp2048   |        3541.55 |                     6370.11 |        1.80 |
| RTX 4090   | llama 8B Q3_K_S   |                 256 | pp2048   |        5774.83 |                     8420.01 |        1.46 |
| RTX 4090   | llama 8B Q3_K_S   |                 512 | pp2048   |        7685.85 |                     8980.66 |        1.17 |
| RTX 4090   | llama 8B Q3_K_S   |                1024 | pp2048   |        9014.36 |                     8813.25 |        0.98 |
| RTX 4090   | llama 8B Q3_K_S   |                2048 | pp2048   |        8885.37 |                     8100.26 |        0.91 |
| RTX 4090   | llama 8B Q4_0     |                  16 | pp2048   |        1876.38 |                     1987.65 |        1.06 |
| RTX 4090   | llama 8B Q4_0     |                  32 | pp2048   |        3268.51 |                     3451.60 |        1.06 |
| RTX 4090   | llama 8B Q4_0     |                  63 | pp2048   |        5112.46 |                     5256.57 |        1.03 |
| RTX 4090   | llama 8B Q4_0     |                 128 | pp2048   |        3472.33 |                     7181.49 |        2.07 |
| RTX 4090   | llama 8B Q4_0     |                 256 | pp2048   |        5737.60 |                     9492.50 |        1.65 |
| RTX 4090   | llama 8B Q4_0     |                 512 | pp2048   |        7773.21 |                    10256.46 |        1.32 |
| RTX 4090   | llama 8B Q4_0     |                1024 | pp2048   |        9080.33 |                    10055.02 |        1.11 |
| RTX 4090   | llama 8B Q4_0     |                2048 | pp2048   |        8988.66 |                     9095.03 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                  16 | pp2048   |        1855.97 |                     1877.27 |        1.01 |
| RTX 4090   | llama 8B Q4_1     |                  32 | pp2048   |        3160.56 |                     2991.37 |        0.95 |
| RTX 4090   | llama 8B Q4_1     |                  63 | pp2048   |        5428.70 |                     5071.75 |        0.93 |
| RTX 4090   | llama 8B Q4_1     |                 128 | pp2048   |        3462.05 |                     6973.87 |        2.01 |
| RTX 4090   | llama 8B Q4_1     |                 256 | pp2048   |        5685.58 |                     9015.68 |        1.59 |
| RTX 4090   | llama 8B Q4_1     |                 512 | pp2048   |        7639.11 |                     9708.85 |        1.27 |
| RTX 4090   | llama 8B Q4_1     |                1024 | pp2048   |        8947.06 |                     9524.67 |        1.06 |
| RTX 4090   | llama 8B Q4_1     |                2048 | pp2048   |        8868.91 |                     8692.50 |        0.98 |
| RTX 4090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1938.40 |                     2004.50 |        1.03 |
| RTX 4090   | llama 8B Q4_K_S   |                  32 | pp2048   |        3339.09 |                     3399.47 |        1.02 |
| RTX 4090   | llama 8B Q4_K_S   |                  63 | pp2048   |        5190.26 |                     5088.44 |        0.98 |
| RTX 4090   | llama 8B Q4_K_S   |                 128 | pp2048   |        3478.24 |                     6745.80 |        1.94 |
| RTX 4090   | llama 8B Q4_K_S   |                 256 | pp2048   |        5745.87 |                     8736.13 |        1.52 |
| RTX 4090   | llama 8B Q4_K_S   |                 512 | pp2048   |        7658.49 |                     9375.75 |        1.22 |
| RTX 4090   | llama 8B Q4_K_S   |                1024 | pp2048   |        8967.41 |                     9290.54 |        1.04 |
| RTX 4090   | llama 8B Q4_K_S   |                2048 | pp2048   |        8946.40 |                     8517.78 |        0.95 |
| RTX 4090   | llama 8B Q5_0     |                  16 | pp2048   |        1472.88 |                     1673.13 |        1.14 |
| RTX 4090   | llama 8B Q5_0     |                  32 | pp2048   |        2501.81 |                     3049.99 |        1.22 |
| RTX 4090   | llama 8B Q5_0     |                  63 | pp2048   |        4154.21 |                     4622.38 |        1.11 |
| RTX 4090   | llama 8B Q5_0     |                 128 | pp2048   |        3390.37 |                     6613.48 |        1.95 |
| RTX 4090   | llama 8B Q5_0     |                 256 | pp2048   |        5620.71 |                     8840.13 |        1.57 |
| RTX 4090   | llama 8B Q5_0     |                 512 | pp2048   |        7589.73 |                     9679.36 |        1.28 |
| RTX 4090   | llama 8B Q5_0     |                1024 | pp2048   |        8914.41 |                     9532.62 |        1.07 |
| RTX 4090   | llama 8B Q5_0     |                2048 | pp2048   |        8969.12 |                     8679.60 |        0.97 |
| RTX 4090   | llama 8B Q5_1     |                  16 | pp2048   |        1622.59 |                     1575.96 |        0.97 |
| RTX 4090   | llama 8B Q5_1     |                  32 | pp2048   |        2590.62 |                     2539.50 |        0.98 |
| RTX 4090   | llama 8B Q5_1     |                  63 | pp2048   |        4292.55 |                     4213.50 |        0.98 |
| RTX 4090   | llama 8B Q5_1     |                 128 | pp2048   |        3427.44 |                     6527.37 |        1.90 |
| RTX 4090   | llama 8B Q5_1     |                 256 | pp2048   |        5601.15 |                     8404.73 |        1.50 |
| RTX 4090   | llama 8B Q5_1     |                 512 | pp2048   |        7524.07 |                     9037.00 |        1.20 |
| RTX 4090   | llama 8B Q5_1     |                1024 | pp2048   |        8825.99 |                     8971.98 |        1.02 |
| RTX 4090   | llama 8B Q5_1     |                2048 | pp2048   |        8949.14 |                     8316.25 |        0.93 |
| RTX 4090   | llama 8B Q5_K_S   |                  16 | pp2048   |        1672.64 |                     1701.35 |        1.02 |
| RTX 4090   | llama 8B Q5_K_S   |                  32 | pp2048   |        2755.45 |                     2780.01 |        1.01 |
| RTX 4090   | llama 8B Q5_K_S   |                  63 | pp2048   |        4430.13 |                     4369.05 |        0.99 |
| RTX 4090   | llama 8B Q5_K_S   |                 128 | pp2048   |        3455.75 |                     6424.47 |        1.86 |
| RTX 4090   | llama 8B Q5_K_S   |                 256 | pp2048   |        5679.23 |                     8255.02 |        1.45 |
| RTX 4090   | llama 8B Q5_K_S   |                 512 | pp2048   |        7603.42 |                     8940.02 |        1.18 |
| RTX 4090   | llama 8B Q5_K_S   |                1024 | pp2048   |        8911.92 |                     8860.79 |        0.99 |
| RTX 4090   | llama 8B Q5_K_S   |                2048 | pp2048   |        9002.91 |                     8208.66 |        0.91 |
| RTX 4090   | llama 8B Q6_K     |                  16 | pp2048   |        1407.55 |                     1454.38 |        1.03 |
| RTX 4090   | llama 8B Q6_K     |                  32 | pp2048   |        2451.52 |                     2755.87 |        1.12 |
| RTX 4090   | llama 8B Q6_K     |                  63 | pp2048   |        4250.79 |                     4425.15 |        1.04 |
| RTX 4090   | llama 8B Q6_K     |                 128 | pp2048   |        3379.81 |                     6300.29 |        1.86 |
| RTX 4090   | llama 8B Q6_K     |                 256 | pp2048   |        5569.55 |                     8264.67 |        1.48 |
| RTX 4090   | llama 8B Q6_K     |                 512 | pp2048   |        7487.04 |                     8990.42 |        1.20 |
| RTX 4090   | llama 8B Q6_K     |                1024 | pp2048   |        8725.02 |                     8816.08 |        1.01 |
| RTX 4090   | llama 8B Q6_K     |                2048 | pp2048   |        8608.72 |                     8085.01 |        0.94 |
| RTX 4090   | llama 8B Q8_0     |                  16 | pp2048   |        1122.75 |                     1279.34 |        1.14 |
| RTX 4090   | llama 8B Q8_0     |                  32 | pp2048   |        2178.11 |                     2375.24 |        1.09 |
| RTX 4090   | llama 8B Q8_0     |                  63 | pp2048   |        3924.24 |                     4062.17 |        1.04 |
| RTX 4090   | llama 8B Q8_0     |                 128 | pp2048   |        3304.34 |                     6570.09 |        1.99 |
| RTX 4090   | llama 8B Q8_0     |                 256 | pp2048   |        5469.02 |                     9388.70 |        1.72 |
| RTX 4090   | llama 8B Q8_0     |                 512 | pp2048   |        7388.73 |                    10572.18 |        1.43 |
| RTX 4090   | llama 8B Q8_0     |                1024 | pp2048   |        8741.50 |                    10490.88 |        1.20 |
| RTX 4090   | llama 8B Q8_0     |                2048 | pp2048   |        8834.26 |                     9645.92 |        1.09 |
| RTX 3090   | llama 8B Q2_K_M   |                  16 | pp2048   |         876.71 |                      980.01 |        1.12 |
| RTX 3090   | llama 8B Q2_K_M   |                  32 | pp2048   |        1204.85 |                     1421.12 |        1.18 |
| RTX 3090   | llama 8B Q2_K_M   |                  63 | pp2048   |        1592.05 |                     1855.78 |        1.17 |
| RTX 3090   | llama 8B Q2_K_M   |                 128 | pp2048   |        2085.35 |                     2216.94 |        1.06 |
| RTX 3090   | llama 8B Q2_K_M   |                 256 | pp2048   |        3072.04 |                     2480.35 |        0.81 |
| RTX 3090   | llama 8B Q2_K_M   |                 512 | pp2048   |        3630.75 |                     2584.63 |        0.71 |
| RTX 3090   | llama 8B Q2_K_M   |                1024 | pp2048   |        4259.26 |                     2630.49 |        0.62 |
| RTX 3090   | llama 8B Q2_K_M   |                2048 | pp2048   |        4282.13 |                     2602.09 |        0.61 |
| RTX 3090   | llama 8B Q3_K_S   |                  16 | pp2048   |         820.72 |                      919.68 |        1.12 |
| RTX 3090   | llama 8B Q3_K_S   |                  32 | pp2048   |        1143.83 |                     1472.94 |        1.29 |
| RTX 3090   | llama 8B Q3_K_S   |                  63 | pp2048   |        1652.83 |                     2081.18 |        1.26 |
| RTX 3090   | llama 8B Q3_K_S   |                 128 | pp2048   |        1920.37 |                     2706.25 |        1.41 |
| RTX 3090   | llama 8B Q3_K_S   |                 256 | pp2048   |        2907.74 |                     3046.21 |        1.05 |
| RTX 3090   | llama 8B Q3_K_S   |                 512 | pp2048   |        3489.15 |                     3146.05 |        0.90 |
| RTX 3090   | llama 8B Q3_K_S   |                1024 | pp2048   |        4142.09 |                     3195.93 |        0.77 |
| RTX 3090   | llama 8B Q3_K_S   |                2048 | pp2048   |        4240.70 |                     3149.05 |        0.74 |
| RTX 3090   | llama 8B Q4_0     |                  16 | pp2048   |        1106.45 |                     1145.99 |        1.04 |
| RTX 3090   | llama 8B Q4_0     |                  32 | pp2048   |        1634.97 |                     1784.24 |        1.09 |
| RTX 3090   | llama 8B Q4_0     |                  63 | pp2048   |        2259.05 |                     2485.26 |        1.10 |
| RTX 3090   | llama 8B Q4_0     |                 128 | pp2048   |        2204.20 |                     3092.43 |        1.40 |
| RTX 3090   | llama 8B Q4_0     |                 256 | pp2048   |        3232.61 |                     3500.21 |        1.08 |
| RTX 3090   | llama 8B Q4_0     |                 512 | pp2048   |        3803.77 |                     3683.54 |        0.97 |
| RTX 3090   | llama 8B Q4_0     |                1024 | pp2048   |        4434.49 |                     3729.28 |        0.84 |
| RTX 3090   | llama 8B Q4_0     |                2048 | pp2048   |        4463.80 |                     3628.15 |        0.81 |
| RTX 3090   | llama 8B Q4_1     |                  16 | pp2048   |        1219.23 |                     1276.05 |        1.05 |
| RTX 3090   | llama 8B Q4_1     |                  32 | pp2048   |        1682.41 |                     1652.77 |        0.98 |
| RTX 3090   | llama 8B Q4_1     |                  63 | pp2048   |        2078.54 |                     2366.28 |        1.14 |
| RTX 3090   | llama 8B Q4_1     |                 128 | pp2048   |        2146.32 |                     2931.50 |        1.37 |
| RTX 3090   | llama 8B Q4_1     |                 256 | pp2048   |        3149.25 |                     3271.09 |        1.04 |
| RTX 3090   | llama 8B Q4_1     |                 512 | pp2048   |        3694.63 |                     3403.65 |        0.92 |
| RTX 3090   | llama 8B Q4_1     |                1024 | pp2048   |        4349.90 |                     3472.35 |        0.80 |
| RTX 3090   | llama 8B Q4_1     |                2048 | pp2048   |        4411.96 |                     3381.65 |        0.77 |
| RTX 3090   | llama 8B Q4_K_S   |                  16 | pp2048   |        1134.98 |                     1235.53 |        1.09 |
| RTX 3090   | llama 8B Q4_K_S   |                  32 | pp2048   |        1592.72 |                     1706.50 |        1.07 |
| RTX 3090   | llama 8B Q4_K_S   |                  63 | pp2048   |        2036.81 |                     2307.37 |        1.13 |
| RTX 3090   | llama 8B Q4_K_S   |                 128 | pp2048   |        2110.53 |                     2821.77 |        1.34 |
| RTX 3090   | llama 8B Q4_K_S   |                 256 | pp2048   |        3107.55 |                     3172.70 |        1.02 |
| RTX 3090   | llama 8B Q4_K_S   |                 512 | pp2048   |        3586.36 |                     3325.16 |        0.93 |
| RTX 3090   | llama 8B Q4_K_S   |                1024 | pp2048   |        4164.70 |                     3379.66 |        0.81 |
| RTX 3090   | llama 8B Q4_K_S   |                2048 | pp2048   |        4271.58 |                     3321.58 |        0.78 |
| RTX 3090   | llama 8B Q5_0     |                  16 | pp2048   |         802.70 |                      948.99 |        1.18 |
| RTX 3090   | llama 8B Q5_0     |                  32 | pp2048   |        1261.06 |                     1624.05 |        1.29 |
| RTX 3090   | llama 8B Q5_0     |                  63 | pp2048   |        1742.79 |                     2191.72 |        1.26 |
| RTX 3090   | llama 8B Q5_0     |                 128 | pp2048   |        2041.06 |                     2895.32 |        1.42 |
| RTX 3090   | llama 8B Q5_0     |                 256 | pp2048   |        3016.43 |                     3273.40 |        1.09 |
| RTX 3090   | llama 8B Q5_0     |                 512 | pp2048   |        3638.16 |                     3439.15 |        0.95 |
| RTX 3090   | llama 8B Q5_0     |                1024 | pp2048   |        4263.78 |                     3472.91 |        0.81 |
| RTX 3090   | llama 8B Q5_0     |                2048 | pp2048   |        4350.71 |                     3380.50 |        0.78 |
| RTX 3090   | llama 8B Q5_1     |                  16 | pp2048   |         957.84 |                      985.70 |        1.03 |
| RTX 3090   | llama 8B Q5_1     |                  32 | pp2048   |        1392.74 |                     1412.94 |        1.01 |
| RTX 3090   | llama 8B Q5_1     |                  63 | pp2048   |        1753.05 |                     2091.18 |        1.19 |
| RTX 3090   | llama 8B Q5_1     |                 128 | pp2048   |        2027.25 |                     2727.02 |        1.35 |
| RTX 3090   | llama 8B Q5_1     |                 256 | pp2048   |        2998.97 |                     3069.79 |        1.02 |
| RTX 3090   | llama 8B Q5_1     |                 512 | pp2048   |        3619.35 |                     3220.80 |        0.89 |
| RTX 3090   | llama 8B Q5_1     |                1024 | pp2048   |        4230.62 |                     3253.31 |        0.77 |
| RTX 3090   | llama 8B Q5_1     |                2048 | pp2048   |        4290.47 |                     3189.35 |        0.74 |
| RTX 3090   | llama 8B Q5_K_S   |                  16 | pp2048   |         913.16 |                     1007.55 |        1.10 |
| RTX 3090   | llama 8B Q5_K_S   |                  32 | pp2048   |        1306.56 |                     1449.53 |        1.11 |
| RTX 3090   | llama 8B Q5_K_S   |                  63 | pp2048   |        1722.17 |                     2050.22 |        1.19 |
| RTX 3090   | llama 8B Q5_K_S   |                 128 | pp2048   |        2056.14 |                     2679.60 |        1.30 |
| RTX 3090   | llama 8B Q5_K_S   |                 256 | pp2048   |        3048.91 |                     3022.22 |        0.99 |
| RTX 3090   | llama 8B Q5_K_S   |                 512 | pp2048   |        3558.73 |                     3169.98 |        0.89 |
| RTX 3090   | llama 8B Q5_K_S   |                1024 | pp2048   |        4161.86 |                     3211.52 |        0.77 |
| RTX 3090   | llama 8B Q5_K_S   |                2048 | pp2048   |        4225.06 |                     3153.45 |        0.75 |
| RTX 3090   | llama 8B Q6_K     |                  16 | pp2048   |         814.28 |                      919.77 |        1.13 |
| RTX 3090   | llama 8B Q6_K     |                  32 | pp2048   |        1242.22 |                     1532.72 |        1.23 |
| RTX 3090   | llama 8B Q6_K     |                  63 | pp2048   |        1760.44 |                     2197.74 |        1.25 |
| RTX 3090   | llama 8B Q6_K     |                 128 | pp2048   |        2081.49 |                     2668.01 |        1.28 |
| RTX 3090   | llama 8B Q6_K     |                 256 | pp2048   |        3048.52 |                     3032.60 |        0.99 |
| RTX 3090   | llama 8B Q6_K     |                 512 | pp2048   |        3583.21 |                     3196.87 |        0.89 |
| RTX 3090   | llama 8B Q6_K     |                1024 | pp2048   |        4172.73 |                     3208.81 |        0.77 |
| RTX 3090   | llama 8B Q6_K     |                2048 | pp2048   |        4198.13 |                     3147.56 |        0.75 |
| RTX 3090   | llama 8B Q8_0     |                  16 | pp2048   |         766.11 |                      934.73 |        1.22 |
| RTX 3090   | llama 8B Q8_0     |                  32 | pp2048   |        1324.08 |                     1587.96 |        1.20 |
| RTX 3090   | llama 8B Q8_0     |                  63 | pp2048   |        1970.85 |                     2371.24 |        1.20 |
| RTX 3090   | llama 8B Q8_0     |                 128 | pp2048   |        2062.85 |                     3159.14 |        1.53 |
| RTX 3090   | llama 8B Q8_0     |                 256 | pp2048   |        3058.36 |                     3675.12 |        1.20 |
| RTX 3090   | llama 8B Q8_0     |                 512 | pp2048   |        3644.68 |                     3868.97 |        1.06 |
| RTX 3090   | llama 8B Q8_0     |                1024 | pp2048   |        4276.15 |                     3900.21 |        0.91 |
| RTX 3090   | llama 8B Q8_0     |                2048 | pp2048   |        4334.50 |                     3824.55 |        0.88 |

</details>

The performance increase for small batch sizes (where you suffer more from tail effects) is quite noticeable, for large batch sizes it's only a few percent. You could potentially get more performance if you were to make the implementation nondeterministic with atomic adds (on my desktop with the RTX 3090 the matrix multiplication kernels need 70-760 µs, the fixup kernel needs ~20 µs). For my P40 and RX 6800 the stream-k kernel was slower so there is no change for those cards.

@ggerganov IIRC you have an RTX 2060, can you check the performance of this PR vs. master (both with `LLAMA_CUDA_FORCE_MMQ`)? Compared to my GPUs that GPU has significantly fewer SMs so I would expect this PR to provide comparatively less benefit (but still some overhead from the fixup kernel which may outweigh the speedup).