### PR TITLE
Fix the encoding in the convert-hf-to-gguf-update.py file

### DIFF
--- a/convert-hf-to-gguf-update.py
+++ b/convert-hf-to-gguf-update.py
@@ -214,7 +214,7 @@ src_func = f"""
 """
 
 convert_py_pth = pathlib.Path("convert-hf-to-gguf.py")
-convert_py = convert_py_pth.read_text()
+convert_py = convert_py_pth.read_text(encoding="utf-8")
 convert_py = re.sub(
     r"(# Marker: Start get_vocab_base_pre)(.+?)( +# Marker: End get_vocab_base_pre)",
     lambda m: m.group(1) + src_func + m.group(3),
@@ -222,7 +222,7 @@ convert_py = re.sub(
     flags=re.DOTALL | re.MULTILINE,
 )
 
-convert_py_pth.write_text(convert_py)
+convert_py_pth.write_text(convert_py, encoding="utf-8")
 
 logger.info("+++ convert-hf-to-gguf.py was updated")
 


### PR DESCRIPTION
This PR was made as a follow up of a request made by another contributer to split my [last](https://github.com/ggerganov/llama.cpp/pull/7925) PR into two separate PRs.

In this PR the `convert-hf-to-gguf-update.py` was updated to use `encoding="utf-8"` when reading and writing on `convert-hf-to-gguf.py` because some characters kept breaking the execution of the `convert-hf-to-gguf-update.py` (mostly hexadecimal characters that weren't recognized under windows default encoding) like the rocket emojis "🚀"

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
