### PR TITLE
Fixed packages versions

### DIFF
--- a/requirements/requirements-convert-hf-to-gguf-update.txt
+++ b/requirements/requirements-convert-hf-to-gguf-update.txt
@@ -1,2 +1,2 @@
 -r ./requirements-convert-legacy-llama.txt
-torch~=2.1.1
+torch~=2.2.1

--- a/requirements/requirements-convert-hf-to-gguf.txt
+++ b/requirements/requirements-convert-hf-to-gguf.txt
@@ -1,2 +1,2 @@
 -r ./requirements-convert-legacy-llama.txt
-torch~=2.1.1
+torch~=2.2.1

--- a/requirements/requirements-convert-legacy-llama.txt
+++ b/requirements/requirements-convert-legacy-llama.txt
@@ -1,4 +1,4 @@
-numpy~=1.24.4
+numpy~=1.26.4
 sentencepiece~=0.2.0
 transformers>=4.40.1,<5.0.0
 gguf>=0.1.0


### PR DESCRIPTION
This PR was made as a follow up of a request made by another contributor to split my https://github.com/ggerganov/llama.cpp/pull/7925 PR into two separate PRs.

This PR makes minor changes to a few versions of some packages :
- numpy : because it used deprecated python code that broke when installing the `requirements.txt`
- torch : because it kept saying that the version `2.1.1` didn't exist and proposed other versions like `2.2.0`, `2.2.1`, etc

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
