### PR TITLE
sycl-exp : Re-enabled mul_mat_batched_sycl Path for batched Q*K & KQ*V

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -15228,7 +15228,7 @@ static void ggml_sycl_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1
     } else if (!split && src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && src1->ne[1] == 1) {
         // KQV single-batch
         ggml_sycl_mul_mat_vec_nc(src0, src1, dst);
-    } else if (!split && src0->type == GGML_TYPE_F16 && (src1->type == GGML_TYPE_F16) && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
+    } else if (!split && src0->type == GGML_TYPE_F16 && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2] * src1->ne[3] > 1) {
         // KQ + KQV multi-batch
         ggml_sycl_mul_mat_batched_sycl(src0, src1, dst);
     } else if (use_dequantize_mul_mat_vec) {


### PR DESCRIPTION
This PR re-enables the MUL_MAT path for QK and QKV operations involving MKL's `gemm_batch` through `ggml_sycl_mul_mat_batched_sycl`(otherwise unused as the `src1->type() == GGML_TYPE_F16` is never realized) .
Prompt Processing performance is restored, for e.g. :

- Nvidia A100 + 70B Q4_K (b=p=512): 241 t/s -> 538 t/s
- Intel Arc A770 + 13B Q4_K (b=p=512) : 363 t/s -> 587 t/s
- Nvidia A4000 + 7B Q4_K (b=p=512) : 1710 t/s -> 2033 t/s

Text Generation performance remained the same / showed very small improvements.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
