### PR TITLE
fix CI failures

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        sanitizer: [ADDRESS, THREAD, UNDEFINED]
+        sanitizer: [ADDRESS, UNDEFINED] # THREAD is broken
         build_type: [RelWithDebInfo]
         include:
           - build_type: Release

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -785,6 +785,10 @@ struct test_cpy : public test_case {
         return VARS_TO_STR3(type_src, type_dst, ne);
     }
 
+    double max_nmse_err() override {
+        return 1e-6;
+    }
+
     size_t op_size(ggml_tensor * t) override {
         return ggml_nbytes(t) + ggml_nbytes(t->src[0]);
     }


### PR DESCRIPTION
Patches for common intermittent CI failures in `test-backend-ops` with `CPY` and `server.yml` with thread sanitizer.