### PR TITLE
Removing extra blank lines that were breaking Lint.

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -973,8 +973,6 @@ class XverseModel(Model):
         if max_vocab_index >= vocab_size:
             raise ValueError("Vocabulary size exceeds expected maximum size.")
 
-
-
         reverse_vocab: dict[int, str] = {id_: encoded_tok for encoded_tok, id_ in tokenizer.vocab.items()}
         added_vocab = tokenizer.get_added_vocab()
 


### PR DESCRIPTION
Some extra blank lines were introduced in #8015 that [broke Lint in CI](https://github.com/ggerganov/llama.cpp/actions/runs/9586913085/job/26435841222#step:4:82). Not a big deal, but would be nice to get this check passing again.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

