### PR TITLE
gfx908 optimizations

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1911,7 +1911,7 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
 
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
 
-    const bool fp16_performance_good = min_compute_capability >= CC_RDNA1;
+    const bool fp16_performance_good = min_compute_capability >= CC_GCN4;
 
 #ifdef CUDA_USE_TENSOR_CORES
     use_mul_mat_q = use_mul_mat_q && min_compute_capability < CC_RDNA3;

--- a/ggml-cuda/common.cuh
+++ b/ggml-cuda/common.cuh
@@ -142,6 +142,9 @@
 #define CC_TURING     750
 #define CC_AMPERE     800
 #define CC_OFFSET_AMD 1000000
+#define CC_GCN4      (CC_OFFSET_AMD + 803)
+#define CC_VEGA      (CC_OFFSET_AMD + 900)
+#define CC_CDNA      (CC_OFFSET_AMD + 908)
 #define CC_RDNA1      (CC_OFFSET_AMD + 1010)
 #define CC_RDNA2      (CC_OFFSET_AMD + 1030)
 #define CC_RDNA3      (CC_OFFSET_AMD + 1100)
@@ -232,6 +235,14 @@ typedef float2 dfloat2;
 
 #if defined(GGML_USE_HIPBLAS)
 #define __CUDA_ARCH__ 1300
+
+#if defined(__gfx908__) || defined(__gfx90a__)
+#define CDNA
+#endif
+
+#if defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__)
+#define GCN
+#endif
 
 #if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) || \
     defined(__gfx1150__) || defined(__gfx1151__)

--- a/ggml-cuda/mmq.cuh
+++ b/ggml-cuda/mmq.cuh
@@ -53,7 +53,11 @@ static constexpr __device__ int get_mmq_x_max_device() {
 
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+#if defined(CDNA) || defined(GCN)
+    return 32;
+#else
     return 128;
+#endif // defined(CDNA)
 #else
 #if __CUDA_ARCH__ >= CC_VOLTA
     return 128;
@@ -1972,7 +1976,7 @@ static __device__ void mul_mat_q_process_tile(
 
 template <ggml_type type, int mmq_x, int nwarps, bool need_check>
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-#if defined(RDNA3) || defined(RDNA2)
+#if defined(RDNA3) || defined(RDNA2) || defined(CDNA)
     __launch_bounds__(WARP_SIZE*nwarps, 2)
 #endif // defined(RDNA3) || defined(RDNA2)
 #else


### PR DESCRIPTION
This minor optimization work increases CDNA performance by around 10x. 

Current master:
| model                          |       size |     params | backend    | ngl |          test |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | ---------------: |
| llama 70B Q4_K - Medium        |  39.59 GiB |    70.55 B | ROCm       |  99 |        pp1024 |     56.73 ± 0.34 |
| llama 7B Q4_K - Medium         |   4.07 GiB |     7.24 B | ROCm       |  99 |        pp1024 |    585.58 ± 0.86 |

This pr:
| model                          |       size |     params | backend    | ngl |          test |              t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | ---------------: |
| llama 70B Q4_K - Medium        |  39.59 GiB |    70.55 B | ROCm       |  99 |        pp1024 |    462.30 ± 0.95 |
| llama 7B Q4_K - Medium         |   4.07 GiB |     7.24 B | ROCm       |  99 |        pp1024 |   3196.68 ± 1.97 |

As now most of the of the remaining time is spent in attn kernels, merging https://github.com/ggerganov/llama.cpp/pull/7011 further increases performance by 2x

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
