### PR TITLE
Fix tensor groups for encoder-decoder models in gguf-dump.py

### DIFF
--- a/gguf-py/scripts/gguf-dump.py
+++ b/gguf-py/scripts/gguf-dump.py
@@ -208,7 +208,9 @@ def translate_tensor_name(name):
         'ssm_d': 'State space model skip connection',
         'ssm_dt': 'State space model time step',
         'ssm_out': 'State space model output projection',
-        'blk': 'Block'
+        'blk': 'Block',
+        'enc': 'Encoder',
+        'dec': 'Decoder',
     }
 
     expanded_words = []
@@ -291,6 +293,10 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             tensor_group_name = "base"
             if tensor_components[0] == 'blk':
                 tensor_group_name = f"{tensor_components[0]}.{tensor_components[1]}"
+            elif tensor_components[0] in ['enc', 'dec'] and tensor_components[1] == 'blk':
+                tensor_group_name = f"{tensor_components[0]}.{tensor_components[1]}.{tensor_components[2]}"
+            elif tensor_components[0] in ['enc', 'dec']:
+                tensor_group_name = f"{tensor_components[0]}"
 
             # Check if new Tensor Group
             if tensor_group_name not in tensor_groups:


### PR DESCRIPTION

[t5-small-dump.txt](https://github.com/user-attachments/files/15952176/t5-small-dump.txt)
This PR corrects tensor groups for encoder-decoder models like T5 and FLAN-T5 family. Separate tensor groups are created for each enc.blk.[bid], additional tensor groups are created for remaining non-blk enc and dec tensors. Example:

```
## Tensors Overview ~61M Elements

Total number of elements in all tensors: 60506880 Elements

- [Decoder Block 0 Tensor Group - ~4M Elements](#dec_blk_0)
- [Decoder Block 1 Tensor Group - ~4M Elements](#dec_blk_1)
- [Decoder Block 2 Tensor Group - ~4M Elements](#dec_blk_2)
- [Decoder Block 3 Tensor Group - ~4M Elements](#dec_blk_3)
- [Decoder Block 4 Tensor Group - ~4M Elements](#dec_blk_4)
- [Decoder Block 5 Tensor Group - ~4M Elements](#dec_blk_5)
- [Decoder Tensor Group - 512 Elements](#dec)
- [Encoder Block 0 Tensor Group - ~3M Elements](#enc_blk_0)
- [Encoder Block 1 Tensor Group - ~3M Elements](#enc_blk_1)
- [Encoder Block 2 Tensor Group - ~3M Elements](#enc_blk_2)
- [Encoder Block 3 Tensor Group - ~3M Elements](#enc_blk_3)
- [Encoder Block 4 Tensor Group - ~3M Elements](#enc_blk_4)
- [Encoder Block 5 Tensor Group - ~3M Elements](#enc_blk_5)
- [Encoder Tensor Group - 512 Elements](#enc)
- [Base Tensor Group - ~16M Elements](#base)
```

In attached file there is a complete output from `python3 gguf-py/scripts/gguf-dump.py --markdown /mnt/md0/models/t5-small.gguf` command.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
