### PR TITLE
[SYCL] Re-enabled mul_mat_batched_sycl

### DIFF
--- a/ggml-sycl.cpp
+++ b/ggml-sycl.cpp
@@ -4620,7 +4620,7 @@ static void ggml_sycl_mul_mat(ggml_backend_sycl_context & ctx, const ggml_tensor
     } else if (!split && src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && src1->ne[1] == 1) {
         // KQV single-batch
         ggml_sycl_mul_mat_vec_nc(ctx, src0, src1, dst);
-    } else if (!split && src0->type == GGML_TYPE_F16 && (src1->type == GGML_TYPE_F16) && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
+    } else if (!split && src0->type == GGML_TYPE_F16 && !ggml_is_transposed(src0) && !ggml_is_transposed(src1) && src1->ne[2]*src1->ne[3] > 1) {
         // KQ + KQV multi-batch
         ggml_sycl_mul_mat_batched_sycl(ctx, src0, src1, dst);
     } else if (use_dequantize_mul_mat_vec) {


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

cherry-pick from https://github.com/ggerganov/llama.cpp/pull/8057, thanks @OuadiElfarouki  and @joeatodd 

Before

```
hengyume@mlp-618:~/llama.cpp/master$ ./bin/llama-bench -m ~/llama-2-7b.Q4_0.gguf -ngl 99 -sm none -mg 0
...
|  |                   |                                       |       |Max    |        |Max  |Global |                     |
|  |                   |                                       |       |compute|Max work|sub  |mem    |                     |
|ID|        Device Type|                                   Name|Version|units  |group   |group|size   |       Driver version|
|--|-------------------|---------------------------------------|-------|-------|--------|-----|-------|---------------------|
| 0| [level_zero:gpu:0]|               Intel Arc A770M Graphics|    1.3|    512|    1024|   32| 16225M|            1.3.28202|
...
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | SYCL       |  99 |  none |         pp512 |     11.10 ± 3.48 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | SYCL       |  99 |  none |         tg128 |     26.38 ± 0.15 |

build: d62e4aaa (3215)
```
After

```
hengyume@mlp-618:~/llama.cpp/build$ ./bin/llama-bench -m ~/llama-2-7b.Q4_0.gguf -ngl 99 -sm none -mg 0
...
|  |                   |                                       |       |Max    |        |Max  |Global |                     |
|  |                   |                                       |       |compute|Max work|sub  |mem    |                     |
|ID|        Device Type|                                   Name|Version|units  |group   |group|size   |       Driver version|
|--|-------------------|---------------------------------------|-------|-------|--------|-----|-------|---------------------|
| 0| [level_zero:gpu:0]|               Intel Arc A770M Graphics|    1.3|    512|    1024|   32| 16225M|            1.3.28202|
...
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | SYCL       |  99 |  none |         pp512 |  212.07 ± 335.47 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | SYCL       |  99 |  none |         tg128 |     28.74 ± 0.13 |

build: a8a9f6c1 (3216)
```