### PR TITLE
CUDA: fix misaligned shared memory read

### DIFF
--- a/ggml-cuda/mma.cuh
+++ b/ggml-cuda/mma.cuh
@@ -23,7 +23,7 @@ struct mma_int_A_I16K4 {
 
     __device__ __forceinline__ void load(const int * __restrict__ xs0, const int & stride) {
 #if defined(INT8_MMA_AVAILABLE)
-        const int * xs = xs0 + (threadIdx.x%I)*stride + (threadIdx.x/I)*(K/2);
+        const int * xs = xs0 + (threadIdx.x%I)*stride;
         asm("ldmatrix.sync.aligned.m8n8.x2.b16 {%0, %1}, [%2];"
             : "+r"(x[0]), "+r"(x[1])
             : "l"(xs));


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/8117 . The problem is the `ldmatrix` shared memory reads. The problem is that half the threads have a garbage address (due to me copypasting the code and not adapting it correctly). Those address are never supposed to be used. However, the documentation reads:

>For .target sm_75 or below, all threads must contain valid addresses. Otherwise, the behavior is undefined. For .num = .x1 and .num = .x2, addresses contained in lower threads can be copied to higher threads to achieve the expected behavior.

So in a sense it's lucky that the bad addresses cause a crash instead of being ignored on Turing because otherwise I may have never noticed this.