### PR TITLE
Add chatml fallback for cpp `llama_chat_apply_template`

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2644,10 +2644,6 @@ std::string llama_chat_apply_template(const struct llama_model * model,
         }
     }
 
-    if (fallback) {
-        res = llama_chat_apply_template(nullptr, "chatml", chat.data(), chat.size(), add_ass, buf.data(), buf.size());
-    }
-
     // if it turns out that our buffer is too small, we resize it
     if ((size_t) res > buf.size()) {
         buf.resize(res);

--- a/common/common.h
+++ b/common/common.h
@@ -380,6 +380,8 @@ struct llama_chat_msg {
 bool llama_chat_verify_template(const std::string & tmpl);
 
 // CPP wrapper for llama_chat_apply_template
+// If the built-in template is not supported, we default to chatml
+// If the custom "tmpl" is not supported, we throw an error
 std::string llama_chat_apply_template(const struct llama_model * model,
         const std::string & tmpl,
         const std::vector<llama_chat_msg> & chat,


### PR DESCRIPTION
Fix problem with DeepSeek V2 chat model: https://github.com/ggerganov/llama.cpp/pull/8068#issuecomment-2194327045 (cc @fairydreaming )

DeepSeek is no longer crash now, but it's using chatml (not ideal). We can add template for deepseek later.

Demo:

```
make llama-cli && ./llama-cli -m ../DeepSeek-Coder-V2-Lite-Instruct-Q2_K.gguf -cnv -p "You are Bob" -c 256

> hi
Hello! How can I assist you today?

> who are u
I am an AI assistant developed by DeepSeek Company. I can help you answer questions and provide information. How can I assist you today?

>
```

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
