### PR TITLE
convert-hf : print output file name when completed

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -3133,7 +3133,7 @@ def main() -> None:
         else:
             logger.info("Exporting model...")
             model_instance.write()
-            out_path = f"{model_instance.fname_out.parent}/" if is_split else model_instance.fname_out
+            out_path = f"{model_instance.fname_out.parent}{os.sep}" if is_split else model_instance.fname_out
             logger.info(f"Model successfully exported to {out_path}")
 
 

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -3128,11 +3128,11 @@ def main() -> None:
         if args.vocab_only:
             logger.info("Exporting model vocab...")
             model_instance.write_vocab()
-            logger.info("Model vocab successfully exported.")
+            logger.info(f"Model vocab successfully exported to {fname_out}.")
         else:
             logger.info("Exporting model...")
             model_instance.write()
-            logger.info("Model successfully exported.")
+            logger.info(f"Model successfully exported to {fname_out}.")
 
 
 if __name__ == '__main__':

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -3133,7 +3133,7 @@ def main() -> None:
         else:
             logger.info("Exporting model...")
             model_instance.write()
-            out_path = os.path.dirname(model_instance.fname_out) + '/' if is_split else model_instance.fname_out
+            out_path = f"{model_instance.fname_out.parent}/" if is_split else model_instance.fname_out
             logger.info(f"Model successfully exported to {out_path}")
 
 

--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -3091,7 +3091,8 @@ def main() -> None:
         "auto": gguf.LlamaFileType.GUESSED,
     }
 
-    if args.use_temp_file and (args.split_max_tensors > 0 or args.split_max_size != "0"):
+    is_split = args.split_max_tensors > 0 or args.split_max_size != "0"
+    if args.use_temp_file and is_split:
         logger.error("Error: Cannot use temp file when splitting")
         sys.exit(1)
 
@@ -3128,11 +3129,12 @@ def main() -> None:
         if args.vocab_only:
             logger.info("Exporting model vocab...")
             model_instance.write_vocab()
-            logger.info(f"Model vocab successfully exported to {fname_out}.")
+            logger.info(f"Model vocab successfully exported to {model_instance.fname_out}")
         else:
             logger.info("Exporting model...")
             model_instance.write()
-            logger.info(f"Model successfully exported to {fname_out}.")
+            out_path = os.path.dirname(model_instance.fname_out) + '/' if is_split else model_instance.fname_out
+            logger.info(f"Model successfully exported to {out_path}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit adds the output file name to the log message when the conversion is completed.

The motivation for this change is that when `--outfile` option is not specified it migth not be obvious where the output file is written.

With this change the output of running the script will be something like the following:
```console
INFO:hf-to-gguf:Model successfully exported to models/gemma-2-9b-it.gguf.
```



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
