### PR TITLE
llama-bench : Generate full token count during warm up

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1390,7 +1390,7 @@ int main(int argc, char ** argv) {
             test_prompt(ctx, t.n_prompt, 0, t.n_batch, t.n_threads);
         }
         if (t.n_gen > 0) {
-            test_gen(ctx, 1, 0, t.n_threads);
+            test_gen(ctx, t.n_gen, 0, t.n_threads);
         }
 
         for (int i = 0; i < params.reps; i++) {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

We noticed during some performance analysis that the warm-up phase for Text Generation only generates a single token. This can cause the first TG benchmarking iteration to be slow because the code path taken by MulMat is quite different when the context is full. In our case, this means we have an expensive `dlopen` and a lot of thread activity during the first iteration of our TG benchmark.

This change forces the warm-up to generate the full `n_gen` tokens, ensuring all libraries are loaded and everything is ready/hot for the benchmarking loop.

Pinging @ggerganov for visibility, since this might affect TG benchmark perf for many backends.