### PR TITLE
Fix for Deepseek-V2's low-rank attention weights being quantized

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -16754,6 +16754,13 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         quantize &= name.find("ssm_x.weight")      == std::string::npos;
         quantize &= name.find("ssm_dt.weight")     == std::string::npos;
 
+        // do not quantize Deepseek-v2's low-rank attension weights
+        // NOTE: this will have O(((w-q)^2)^2) rate-distortion otherwise (4-th power quantization error!)
+        quantize &= name.find("attn_q_a.weight") == std::string::npos;
+        quantize &= name.find("attn_q_b.weight") == std::string::npos;
+        quantize &= name.find("attn_kv_a_mqa.weight") == std::string::npos;
+        quantize &= name.find("attn_kv_b.weight") == std::string::npos;
+
         enum ggml_type new_type;
         void * new_data;
         size_t new_size;


### PR DESCRIPTION
This PR fixes the problem of Deepseek-V2's low-rank attention weights being quantized. Due to the unusual names, these are currently falling through the `llama.cpp::llama_tensor_get_type()` function's `if (name.find("attn_v.weight") != std::string::npos)` type tests, and are getting quantized to the same as the default `ftype`. This is likely to be ***severely*** degrading the performance:

Quantizing these weights will have O(((w-q)^2)^2) [rate-distortion](https://en.wikipedia.org/wiki/Rate%E2%80%93distortion_theory) in terms of `W_a.W_b^T` (ie: 4-th power quantization error!) and I think they should almost certainly be left unquantized as other small tensors like `ffn_gate_inp.weight` already are:

```
[   9/ 959]           blk.0.attn_kv_a_mqa.weight - [ 5120,   576,     1,     1], type =    f16, size =    5.625 MB
[  10/ 959]               blk.0.attn_kv_b.weight - [  512, 32768,     1,     1], type =    f16, size =   32.000 MB
[  13/ 959]                blk.0.attn_q_a.weight - [ 5120,  1536,     1,     1], type =    f16, size =   15.000 MB
[  14/ 959]                blk.0.attn_q_b.weight - [ 1536, 24576,     1,     1], type =    f16, size =   72.000 MB
```

This is ~7.5 GB in total (= (5.625+32+15+72)×60). 

Compared to the 7.2GB ***per layer*** for the experts' 3 MLP tensors (= 2400 × 3).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
