### PR TITLE
server : fix templates for llama2, llama3 and zephyr in new UI

### DIFF
--- a/examples/server/public/prompt-formats.js
+++ b/examples/server/public/prompt-formats.js
@@ -56,7 +56,7 @@ export const promptFormats = {
   // ----------------------------
 
   "llama2": {
-  template: `<s>[INST] <<SYS>>\n{{prompt}}\n<</SYS>>\n\nTest Message [/INST] Test Successful </s>{{history}}`,
+  template: `[INST] <<SYS>>\n{{prompt}}\n<</SYS>>\n\nTest Message [/INST] Test Successful </s>{{history}}`,
 
   historyTemplate: `{{message}}`,
 
@@ -75,7 +75,7 @@ export const promptFormats = {
   // ----------------------------
 
   "llama3": {
-  template: `<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{{prompt}}<|eot_id|>\n{{history}}<|start_header_id|>{{char}}<|end_header_id|>\n\n`,
+  template: `<|start_header_id|>system<|end_header_id|>\n\n{{prompt}}<|eot_id|>\n{{history}}<|start_header_id|>{{char}}<|end_header_id|>\n\n`,
 
   historyTemplate: `<|start_header_id|>{{name}}<|end_header_id|>\n\n{{message}}<|eot_id|>\n`,
 

--- a/examples/server/public/prompt-formats.js
+++ b/examples/server/public/prompt-formats.js
@@ -75,9 +75,9 @@ export const promptFormats = {
   // ----------------------------
 
   "llama3": {
-  template: `<|start_header_id|>system<|end_header_id|>\n\n{{prompt}}<|eot_id|>\n{{history}}<|start_header_id|>{{char}}<|end_header_id|>\n\n`,
+  template: `<|start_header_id|>system<|end_header_id|>\n\n{{prompt}}<|eot_id|>{{history}}<|start_header_id|>{{char}}<|end_header_id|>\n\n`,
 
-  historyTemplate: `<|start_header_id|>{{name}}<|end_header_id|>\n\n{{message}}<|eot_id|>\n`,
+  historyTemplate: `<|start_header_id|>{{name}}<|end_header_id|>\n\n{{message}}<|eot_id|>`,
 
   char: "assistant",
   charMsgPrefix: "",

--- a/examples/server/public/prompt-formats.js
+++ b/examples/server/public/prompt-formats.js
@@ -56,9 +56,9 @@ export const promptFormats = {
   // ----------------------------
 
   "llama2": {
-  template: `<s>[INST] <<SYS>>\n{{prompt}}\n<</SYS>>\n\nTest Message [/INST] Test Successfull </s>{{history}}{{char}}`,
+  template: `<s>[INST] <<SYS>>\n{{prompt}}\n<</SYS>>\n\nTest Message [/INST] Test Successful </s>{{history}}`,
 
-  historyTemplate: `{{name}}: {{message}}`,
+  historyTemplate: `{{message}}`,
 
   char: "Assistant",
   charMsgPrefix: "",
@@ -75,9 +75,9 @@ export const promptFormats = {
   // ----------------------------
 
   "llama3": {
-  template: `<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{{prompt}}{{history}}{{char}}`,
+  template: `<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{{prompt}}<|eot_id|>\n{{history}}<|start_header_id|>{{char}}<|end_header_id|>\n\n`,
 
-  historyTemplate: `<|start_header_id|>{{name}}<|end_header_id|>\n\n{{message}}<|eot_id|>`,
+  historyTemplate: `<|start_header_id|>{{name}}<|end_header_id|>\n\n{{message}}<|eot_id|>\n`,
 
   char: "assistant",
   charMsgPrefix: "",
@@ -314,7 +314,7 @@ export const promptFormats = {
   // ----------------------------
 
   "zephyr": {
-  template: `<|system|>\n{{prompt}}</s>\n{{history}}{{char}}`,
+  template: `<|system|>\n{{prompt}}</s>\n{{history}}<|{{char}}|>\n`,
 
   historyTemplate: `<|{{name}}|>\n{{message}}</s>\n`,
 
@@ -328,4 +328,6 @@ export const promptFormats = {
 
   stops: ""
   }
+  // ref: https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha
+
   };


### PR DESCRIPTION
This change makes some adjustments to the pre-defined chat templates in the new server UI, which in my interpretation bring them in line to the recommended versions. I have done this for the following templates:

- Llama2
- Llama3
- Zephyr

as these are the models I have some experience with. There might be further similar discrepancies for other templates, but I have not checked those. For the Llama models, I have also removed the start-of-text tokens at the beginning, as they are automatically added by the server, and their duplication leads to a warning message.

It would of course be nicer to connect this to the `llama_chat_apply_template()` implementation to have only one set of templates to maintain and test in the codebase, for example by making the server UI use the chat endpoint rather than the completion one. Is anyone already working on this?

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
