### PR TITLE
Added checks for cmake,make and ctest in ci->run.sh

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -747,8 +747,6 @@ if [ -z ${GG_BUILD_LOW_PERF} ]; then
     pip install --editable gguf-py --disable-pip-version-check
 fi
 
-
-
 ret=0
 
 test $ret -eq 0 && gg_run ctest_debug

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -103,6 +103,9 @@ function gg_run_ctest_debug {
 
     set -e
 
+    # Check cmake, make and ctest are installed
+    gg_check_build_requirements
+
     (time cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_EXTRA} .. ) 2>&1 | tee -a $OUT/${ci}-cmake.log
     (time make -j                                          ) 2>&1 | tee -a $OUT/${ci}-make.log
 
@@ -130,6 +133,9 @@ function gg_run_ctest_release {
     rm -rf build-ci-release && mkdir build-ci-release && cd build-ci-release
 
     set -e
+
+    # Check cmake, make and ctest are installed
+    gg_check_build_requirements
 
     (time cmake -DCMAKE_BUILD_TYPE=Release ${CMAKE_EXTRA} .. ) 2>&1 | tee -a $OUT/${ci}-cmake.log
     (time make -j                                            ) 2>&1 | tee -a $OUT/${ci}-make.log
@@ -701,6 +707,20 @@ function gg_run_embd_bge_small {
     set +e
 }
 
+function gg_check_build_requirements {
+    if ! command -v cmake &> /dev/null; then
+        gg_printf 'cmake not found, please install'
+    fi
+
+    if ! command -v make &> /dev/null; then
+        gg_printf 'make not found, please install'
+    fi
+
+    if ! command -v ctest &> /dev/null; then
+        gg_printf 'ctest not found, please install'
+    fi
+}
+
 function gg_sum_embd_bge_small {
     gg_printf '### %s\n\n' "${ci}"
 
@@ -726,6 +746,8 @@ if [ -z ${GG_BUILD_LOW_PERF} ]; then
     pip install -r ${SRC}/requirements.txt --disable-pip-version-check
     pip install --editable gguf-py --disable-pip-version-check
 fi
+
+
 
 ret=0
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

I realised that it is possible to run the shell script without **cmake** or **make** installed and it would just report a line number rather than a specific error.

Since llama.cpp can be build with either make or cmake we should identity when one is not installed.