### PR TITLE
CUDA: refactor and optimize IQ MMVQ

### DIFF
--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -106,19 +106,19 @@ typedef sycl::half2 ggml_half2;
 #define QR6_K 2
 
 #define QI2_XXS (QK_K / (4*QR2_XXS))
-#define QR2_XXS 8
+#define QR2_XXS 4
 
 #define QI2_XS (QK_K / (4*QR2_XS))
-#define QR2_XS 8
+#define QR2_XS 4
 
 #define QI2_S (QK_K / (4*QR2_S))
-#define QR2_S 8
+#define QR2_S 4
 
 #define QI3_XXS (QK_K / (4*QR3_XXS))
-#define QR3_XXS 8
+#define QR3_XXS 4
 
 #define QI3_XS (QK_K / (4*QR3_XS))
-#define QR3_XS 8
+#define QR3_XS 4
 
 #define QI1_S (QK_K / (4*QR1_S))
 #define QR1_S 8
@@ -130,10 +130,10 @@ typedef sycl::half2 ggml_half2;
 #define QR4_NL 2
 
 #define QI4_XS (QK_K / (4*QR4_XS))
-#define QR4_XS 8
+#define QR4_XS 2
 
 #define QI3_S (QK_K / (4*QR3_S))
-#define QR3_S 8
+#define QR3_S 4
 
 #endif // GGML_COMMON_DECL_CUDA || GGML_COMMON_DECL_HIP
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -3,6 +3,7 @@
 #include "ggml.h"
 #include "ggml-cuda.h"
 
+#include <cstdint>
 #include <memory>
 
 #if defined(GGML_USE_HIPBLAS)
@@ -280,33 +281,6 @@ static __device__ __forceinline__ unsigned int __vcmpne4(unsigned int a, unsigne
     return c;
 }
 
-static __device__ __forceinline__ int __dp4a(const int a, const int b, int c) {
-#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx1030__)
-    c = __builtin_amdgcn_sdot4(a, b, c, false);
-#elif defined(RDNA3)
-    c = __builtin_amdgcn_sudot4( true, a, true, b, c, false);
-#elif defined(__gfx1010__) || defined(__gfx900__)
-    int tmp1;
-    int tmp2;
-    asm("\n \
-        v_mul_i32_i24 %1, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:BYTE_0 \n \
-        v_mul_i32_i24 %2, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:BYTE_1 \n \
-        v_add3_u32 %0, %1, %2, %0 \n \
-        v_mul_i32_i24 %1, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_2 src1_sel:BYTE_2 \n \
-        v_mul_i32_i24 %2, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:BYTE_3 \n \
-        v_add3_u32 %0, %1, %2, %0 \n \
-        "
-        : "+v"(c), "=&v"(tmp1), "=&v"(tmp2)
-        : "v"(a), "v"(b)
-    );
-#else
-    const int8x4_t va = reinterpret_cast<const int8x4_t&>(a);
-    const int8x4_t vb = reinterpret_cast<const int8x4_t&>(b);
-    c += va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2] + va[3] * vb[3];
-#endif
-    return c;
-}
-
 #if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION < 50600000
 // __shfl_xor() for half2 was added in ROCm 5.6
 static __device__ __forceinline__ half2 __shfl_xor(half2 var, int laneMask, int width) {
@@ -478,6 +452,46 @@ static __device__ __forceinline__ uint32_t __hgt2_mask(const half2 a, const half
     return mask_low | mask_high;
 }
 #endif // CUDART_VERSION < 12000
+
+static __device__ __forceinline__ int ggml_cuda_dp4a(const int a, const int b, int c) {
+#if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx1030__)
+    c = __builtin_amdgcn_sdot4(a, b, c, false);
+#elif defined(RDNA3)
+    c = __builtin_amdgcn_sudot4( true, a, true, b, c, false);
+#elif defined(__gfx1010__) || defined(__gfx900__)
+    int tmp1;
+    int tmp2;
+    asm("\n \
+        v_mul_i32_i24 %1, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:BYTE_0 \n \
+        v_mul_i32_i24 %2, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:BYTE_1 \n \
+        v_add3_u32 %0, %1, %2, %0 \n \
+        v_mul_i32_i24 %1, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_2 src1_sel:BYTE_2 \n \
+        v_mul_i32_i24 %2, sext(%3), sext(%4) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_3 src1_sel:BYTE_3 \n \
+        v_add3_u32 %0, %1, %2, %0 \n \
+        "
+        : "+v"(c), "=&v"(tmp1), "=&v"(tmp2)
+        : "v"(a), "v"(b)
+    );
+#else
+    const int8x4_t va = reinterpret_cast<const int8x4_t&>(a);
+    const int8x4_t vb = reinterpret_cast<const int8x4_t&>(b);
+    c += va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2] + va[3] * vb[3];
+#endif
+    return c;
+
+#else // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+
+#if __CUDA_ARCH__ >= MIN_CC_DP4A
+    return __dp4a(a, b, c);
+#else // __CUDA_ARCH__ >= MIN_CC_DP4A
+    const int8_t * a8 = (const int8_t *) &a;
+    const int8_t * b8 = (const int8_t *) &b;
+    return c + a8[0]*b8[0] + a8[1]*b8[1] + a8[2]*b8[2] + a8[3]*b8[3];
+#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
+
+#endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+}
 
 // TODO: move to ggml-common.h
 static constexpr __device__ int8_t kvalues_iq4nl[16] = {-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113};

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -268,6 +268,18 @@ static __device__ __forceinline__ unsigned int __vcmpeq4(unsigned int a, unsigne
     return c;
 }
 
+static __device__ __forceinline__ unsigned int __vcmpne4(unsigned int a, unsigned int b) {
+    const uint8x4_t& va = reinterpret_cast<const uint8x4_t&>(a);
+    const uint8x4_t& vb = reinterpret_cast<const uint8x4_t&>(b);
+    unsigned int c;
+    uint8x4_t& vc = reinterpret_cast<uint8x4_t&>(c);
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        vc[i] = va[i] == vb[i] ? 0x00 : 0xff;
+    }
+    return c;
+}
+
 static __device__ __forceinline__ int __dp4a(const int a, const int b, int c) {
 #if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx1030__)
     c = __builtin_amdgcn_sdot4(a, b, c, false);
@@ -468,7 +480,7 @@ static __device__ __forceinline__ uint32_t __hgt2_mask(const half2 a, const half
 #endif // CUDART_VERSION < 12000
 
 // TODO: move to ggml-common.h
-static const __device__ int8_t kvalues_iq4nl[16] = {-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113};
+static constexpr __device__ int8_t kvalues_iq4nl[16] = {-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113};
 
 typedef void (*dequantize_kernel_t)(const void * vx, const int64_t ib, const int iqs, dfloat2 & v);
 

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -58,7 +58,7 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_0(
     const block_q4_0 * K_q4_0 = (const block_q4_0 *) K_c;
     GGML_UNUSED(Q_v);
 
-    half sum = 0.0f;
+    T sum = 0.0f;
 
 #pragma unroll
     for (int k_KQ_0 = 0; k_KQ_0 < D/sizeof(int); k_KQ_0 += WARP_SIZE) {

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -72,7 +72,7 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_0(
         const int v = (get_int_from_uint8(K_q4_0[ib].qs, iqs4) >> shift) & 0x0F0F0F0F;
         const int u = Q_q8[k_KQ_0/WARP_SIZE];
 
-        const int sumi = __dp4a(v, u, 0);
+        const int sumi = ggml_cuda_dp4a(v, u, 0);
 
 #ifdef FP16_AVAILABLE
         if (std::is_same<T, half>::value) {
@@ -120,7 +120,7 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_1(
         const int v = (get_int_from_uint8_aligned(K_q4_1[ib].qs, iqs4) >> shift) & 0x0F0F0F0F;
         const int u = Q_q8[k_KQ_0/WARP_SIZE];
 
-        const int sumi = __dp4a(v, u, 0);
+        const int sumi = ggml_cuda_dp4a(v, u, 0);
 
 #ifdef FP16_AVAILABLE
         if (std::is_same<T, half>::value) {
@@ -179,7 +179,7 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_0(
 
         const int u = Q_q8[k_KQ_0/WARP_SIZE];
 
-        const int sumi = __dp4a(v, u, 0);
+        const int sumi = ggml_cuda_dp4a(v, u, 0);
 
 #ifdef FP16_AVAILABLE
         if (std::is_same<T, half>::value) {
@@ -234,7 +234,7 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_1(
 
         const int u = Q_q8[k_KQ_0/WARP_SIZE];
 
-        const int sumi = __dp4a(v, u, 0);
+        const int sumi = ggml_cuda_dp4a(v, u, 0);
 
 #ifdef FP16_AVAILABLE
         if (std::is_same<T, half>::value) {

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -54,7 +54,6 @@ typedef float (*vec_dot_KQ_f32_t)(
 template<typename T, int D>
 static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_0(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A
 
     const block_q4_0 * K_q4_0 = (const block_q4_0 *) K_c;
     GGML_UNUSED(Q_v);
@@ -90,19 +89,11 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_0(
     }
 
     return sum;
-#else
-    GGML_UNUSED(K_c);
-    GGML_UNUSED(Q_v);
-    GGML_UNUSED(Q_q8);
-    GGML_UNUSED(Q_ds_v);
-    NO_DEVICE_CODE;
-#endif  // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template<typename T, int D>
 static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_1(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A
 
     const block_q4_1 * K_q4_1 = (const block_q4_1 *) K_c;
     GGML_UNUSED(Q_v);
@@ -142,19 +133,11 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q4_1(
     }
 
     return sum;
-#else
-    GGML_UNUSED(K_c);
-    GGML_UNUSED(Q_v);
-    GGML_UNUSED(Q_q8);
-    GGML_UNUSED(Q_ds_v);
-    NO_DEVICE_CODE;
-#endif  // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template<typename T, int D>
 static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_0(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A
 
     const block_q5_0 * K_q5_0 = (const block_q5_0 *) K_c;
     GGML_UNUSED(Q_v);
@@ -197,19 +180,11 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_0(
     }
 
     return sum;
-#else
-    GGML_UNUSED(K_c);
-    GGML_UNUSED(Q_v);
-    GGML_UNUSED(Q_q8);
-    GGML_UNUSED(Q_ds_v);
-    NO_DEVICE_CODE;
-#endif  // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template<typename T, int D>
 static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_1(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A
 
     const block_q5_1 * K_q5_1 = (const block_q5_1 *) K_c;
     GGML_UNUSED(Q_v);
@@ -256,19 +231,11 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q5_1(
     }
 
     return sum;
-#else
-    GGML_UNUSED(K_c);
-    GGML_UNUSED(Q_v);
-    GGML_UNUSED(Q_q8);
-    GGML_UNUSED(Q_ds_v);
-    NO_DEVICE_CODE;
-#endif  // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template <typename T, int D>
 static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q8_0(
     const char * __restrict__ K_c, const void * __restrict__ Q_v, const int * __restrict__ Q_q8, const void * __restrict__ Q_ds_v) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A
 
     const block_q8_0 * K_q8_0 = (const block_q8_0 *) K_c;
     GGML_UNUSED(Q_v);
@@ -297,13 +264,6 @@ static __device__ __forceinline__ T vec_dot_fattn_vec_KQ_q8_0(
     }
 
     return sum;
-#else
-    GGML_UNUSED(K_c);
-    GGML_UNUSED(Q_v);
-    GGML_UNUSED(Q_q8);
-    GGML_UNUSED(Q_ds_v);
-    NO_DEVICE_CODE;
-#endif  // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template <typename T, int D>

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -28,16 +28,22 @@ static constexpr __device__ vec_dot_q_cuda_t get_vec_dot_q_cuda(ggml_type type) 
 
 static constexpr __device__ int get_vdr_mmvq(ggml_type type) {
     return type == GGML_TYPE_Q4_0 ? VDR_Q4_0_Q8_1_MMVQ :
-        type == GGML_TYPE_Q4_1 ? VDR_Q4_1_Q8_1_MMVQ :
-        type == GGML_TYPE_Q5_0 ? VDR_Q5_0_Q8_1_MMVQ :
-        type == GGML_TYPE_Q5_1 ? VDR_Q5_1_Q8_1_MMVQ :
-        type == GGML_TYPE_Q8_0 ? VDR_Q8_0_Q8_1_MMVQ :
-        type == GGML_TYPE_Q2_K ? VDR_Q2_K_Q8_1_MMVQ :
-        type == GGML_TYPE_Q3_K ? VDR_Q3_K_Q8_1_MMVQ :
-        type == GGML_TYPE_Q4_K ? VDR_Q4_K_Q8_1_MMVQ :
-        type == GGML_TYPE_Q5_K ? VDR_Q5_K_Q8_1_MMVQ :
-        type == GGML_TYPE_Q6_K ? VDR_Q6_K_Q8_1_MMVQ :
-        type == GGML_TYPE_IQ4_NL ? VDR_Q4_K_Q8_1_MMVQ :
+        type == GGML_TYPE_Q4_1    ? VDR_Q4_1_Q8_1_MMVQ :
+        type == GGML_TYPE_Q5_0    ? VDR_Q5_0_Q8_1_MMVQ :
+        type == GGML_TYPE_Q5_1    ? VDR_Q5_1_Q8_1_MMVQ :
+        type == GGML_TYPE_Q8_0    ? VDR_Q8_0_Q8_1_MMVQ :
+        type == GGML_TYPE_Q2_K    ? VDR_Q2_K_Q8_1_MMVQ :
+        type == GGML_TYPE_Q3_K    ? VDR_Q3_K_Q8_1_MMVQ :
+        type == GGML_TYPE_Q4_K    ? VDR_Q4_K_Q8_1_MMVQ :
+        type == GGML_TYPE_Q5_K    ? VDR_Q5_K_Q8_1_MMVQ :
+        type == GGML_TYPE_Q6_K    ? VDR_Q6_K_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ2_XXS ? VDR_IQ2_XXS_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ2_XS  ? VDR_IQ2_XS_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ2_S   ? VDR_IQ2_S_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ3_XXS ? VDR_IQ3_XXS_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ3_S   ? VDR_IQ3_S_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ4_NL  ? VDR_IQ4_NL_Q8_1_MMVQ :
+        type == GGML_TYPE_IQ4_XS  ? VDR_IQ4_XS_Q8_1_MMVQ :
         1;
 }
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -846,7 +846,7 @@ static __device__ __forceinline__ float vec_dot_iq2_xxs_q8_1(
 
     const int q2 = get_int_b2(bq2->qs, iqs);
     const uint8_t * aux8 = (const uint8_t *) &q2;
-    const uint aux32 = get_int_b2(bq2->qs, iqs + 1);
+    const uint32_t aux32 = get_int_b2(bq2->qs, iqs + 1);
 
     int sumi = 0;
 #pragma unroll
@@ -976,7 +976,7 @@ static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
 
     const int2 q3_packed = make_int2(get_int_b2(bq3->qs, iqs), get_int_b2(bq3->qs, iqs+1));
     const uint8_t * q3 = (const uint8_t *) &q3_packed;
-    const uint aux32 = get_int_b2(bq3->qs, QK_K/16 + iqs/2);
+    const uint32_t aux32 = get_int_b2(bq3->qs, QK_K/16 + iqs/2);
 
     int sumi = 0;
 #pragma unroll

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -51,7 +51,6 @@ static __device__ __forceinline__ int get_int_b4(const void * x, const int & i32
 template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_impl(
     const int * v, const int * u, const float & d4, const half2 & ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -68,9 +67,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_imp
 
     // second part effectively subtracts 8 from each quant value
     return d4 * (sumi * ds8f.x - (8*vdr/QI4_0) * ds8f.y);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q4_1_Q8_1_MMVQ 2
@@ -79,7 +75,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_imp
 template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_impl(
     const int * v, const int * u, const half2 & dm4, const half2 & ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -105,9 +100,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_imp
 
     // scale second part of sum by QI8_1/(vdr * QR4_1) to compensate for multiple threads adding it
     return sumi * d4d8 + m4s8 / (QI8_1 / (vdr * QR4_1));
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q5_0_Q8_1_MMVQ 2
@@ -116,7 +108,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_imp
 template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_impl(
     const int * vl, const int * vh, const int * u, const float & d5, const half2 & ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -140,9 +131,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_imp
 
     // second part effectively subtracts 16 from each quant value
     return d5 * (sumi * ds8f.x - (16*vdr/QI5_0) * ds8f.y);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q5_1_Q8_1_MMVQ 2
@@ -151,7 +139,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_imp
 template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_impl(
     const int * vl, const int * vh, const int * u, const half2 & dm5, const half2 & ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -184,10 +171,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_imp
 
     // scale second part of sum by QI5_1 / vdr to compensate for multiple threads adding it
     return sumi*d5d8 + m5s8 / (QI5_1 / vdr);
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q8_0_Q8_1_MMVQ 2
@@ -196,7 +179,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_imp
 template <typename T, int vdr> static __device__ __forceinline__ T vec_dot_q8_0_q8_1_impl(
     const int * v, const int * u, const T & d8_0, const T & d8_1) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -206,15 +188,11 @@ template <typename T, int vdr> static __device__ __forceinline__ T vec_dot_q8_0_
     }
 
     return d8_0*d8_1 * ((T) sumi);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_impl(
     const int * v, const int * u, const half2 & dm8, const half2 & ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -236,9 +214,6 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_imp
 
     // scale second part of sum by QI8_1/ vdr to compensate for multiple threads adding it
     return sumi*d8d8 + m8s8 / (QI8_1 / vdr);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q2_K_Q8_1_MMVQ 1
@@ -249,7 +224,6 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
     const int & v, const int * __restrict__ u, const uint8_t * __restrict__ scales,
     const half2 & dm2, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -271,16 +245,12 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
     const float2 dm2f = __half22float2(dm2);
 
     return dm2f.x*sumf_d - dm2f.y*sumf_m;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 // contiguous u/y values
 static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const half2 * dm2, const float & d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -303,9 +273,6 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
     }
 
     return d8*(sumf_d - sumf_m);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q3_K_Q8_1_MMVQ 1
@@ -316,7 +283,6 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
     const int & vl, const int & vh, const int * __restrict__ u, const uint8_t * __restrict__ scales,
     const int & scale_offset, const float & d3, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf = 0.0f;
 
 #pragma unroll
@@ -343,9 +309,6 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
     }
 
     return d3 * sumf;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 // contiguous u/y values
@@ -353,7 +316,6 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const int8_t * __restrict__ scales,
     const float & d3, const float & d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     int sumi = 0;
 
 #pragma unroll
@@ -370,9 +332,6 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     }
 
     return d3*d8 * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q4_K_Q8_1_MMVQ 2
@@ -383,7 +342,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -402,10 +360,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
     const float2 dm4f = __half22float2(dm4);
 
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 // contiguous u/y values
@@ -413,7 +367,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const half2 * __restrict__ ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -435,10 +388,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
     const float2 dm4f = __half22float2(dm4);
 
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q5_K_Q8_1_MMVQ 2
@@ -449,7 +398,6 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
     const int * __restrict__ vl, const int * __restrict__ vh, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm5, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -475,10 +423,6 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
     const float2 dm5f = __half22float2(dm5);
 
     return dm5f.x*sumf_d - dm5f.y*sumf_m;
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 // contiguous u/y values
@@ -486,7 +430,6 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const uint8_t * __restrict__ sc,
     const uint8_t * __restrict__ m, const half2 & dm4, const half2 * __restrict__ ds8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
     float sumf_m = 0.0f;
 
@@ -508,10 +451,6 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
     const float2 dm4f = __half22float2(dm4);
 
     return dm4f.x*sumf_d - dm4f.y*sumf_m;
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_Q6_K_Q8_1_MMVQ 1
@@ -522,7 +461,6 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
     const int & vl, const int & vh, const int * __restrict__ u, const int8_t * __restrict__ scales,
     const float & d, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf = 0.0f;
 
 #pragma unroll
@@ -539,9 +477,6 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
     }
 
     return d*sumf;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 // contiguous u/y values
@@ -549,7 +484,6 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     const int * __restrict__ v, const int * __restrict__ u, const int8_t * __restrict__ sc,
     const float & d6, const float * __restrict__ d8) {
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
     float sumf_d = 0.0f;
 
 #pragma unroll
@@ -569,10 +503,6 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     }
 
     return d6 * sumf_d;
-
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 static __device__ __forceinline__ float vec_dot_q4_0_q8_1(
@@ -841,7 +771,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1(
 
 static __device__ __forceinline__ float vec_dot_iq2_xxs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq2_xxs * bq2 = (const block_iq2_xxs *) vbq + kbx;
 
     const int q2 = get_int_b2(bq2->qs, iqs);
@@ -869,16 +799,13 @@ static __device__ __forceinline__ float vec_dot_iq2_xxs_q8_1(
     sumi = (ls*sumi + sumi/2)/4;
     const float d = __half2float(bq2->d) * __low2float(bq8_1[iqs/2].ds);
     return d * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif
 }
 
 #define VDR_IQ2_XS_Q8_1_MMVQ 2
 
 static __device__ __forceinline__ float vec_dot_iq2_xs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq2_xs * bq2 = (const block_iq2_xs *) vbq + kbx;
 
     const int2 q2_packed = make_int2(get_int_b2(bq2->qs, iqs + 0), get_int_b2(bq2->qs, iqs + 1));
@@ -910,17 +837,13 @@ static __device__ __forceinline__ float vec_dot_iq2_xs_q8_1(
     const int sumi = (sumi0*ls0 + sumi1*ls1 + (sumi0 + sumi1)/2)/4;
     const float d = __half2float(bq2->d) * __low2float(bq8_1[iqs/2].ds);
     return d * sumi;
-#else
-    GGML_UNUSED(ksigns64);
-    NO_DEVICE_CODE;
-#endif
 }
 
 #define VDR_IQ2_S_Q8_1_MMVQ 2
 
 static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq2_s * bq2 = (const block_iq2_s *) vbq + kbx;
 
     const int       qs_packed = get_int_b2(bq2->qs, iqs/2);
@@ -961,17 +884,13 @@ static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
 
     const float d = __half2float(bq2->d) * __low2float(bq8_1[iqs/2].ds);
     return d * sumi;
-#else
-    GGML_UNUSED(ksigns64);
-    NO_DEVICE_CODE;
-#endif
 }
 
 #define VDR_IQ3_XXS_Q8_1_MMVQ 2
 
 static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq3_xxs * bq3 = (const block_iq3_xxs *) vbq + kbx;
 
     const int2 q3_packed = make_int2(get_int_b2(bq3->qs, iqs), get_int_b2(bq3->qs, iqs+1));
@@ -999,9 +918,6 @@ static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
     sumi = (ls*sumi + sumi/2)/2;
     const float d = __half2float(bq3->d) * __low2float(bq8_1[iqs/2].ds);
     return d * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif
 }
 
 #define VDR_IQ3_S_Q8_1_MMVQ 2
@@ -1009,7 +925,7 @@ static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
 // TODO: don't use lookup table for signs
 static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq3_s * bq3 = (const block_iq3_s *) vbq + kbx;
 
     const int2      qs_packed = make_int2(get_int_b2(bq3->qs, iqs + 0), get_int_b2(bq3->qs, iqs + 1));
@@ -1044,15 +960,12 @@ static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
 
     const float d = __half2float(bq3->d) * __low2float(bq8_1[iqs/2].ds);
     return d * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif
 }
 
 static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
     const block_iq1_s * bq1 = (const block_iq1_s *) vbq + kbx;
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const int       qs_packed = get_int_b2(bq1->qs, iqs);
     const uint8_t * qs        = (const uint8_t *) &qs_packed;
 
@@ -1077,14 +990,11 @@ static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
     const float  delta = -1.0f + IQ1S_DELTA - (qh & 0x8000) * (2.0f*IQ1S_DELTA/0x8000);
     const float2 ds    = __half22float2(bq8_1[iqs].ds);
     return d1q * (ds.x*sumi + ds.y*delta);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 static __device__ __forceinline__ float vec_dot_iq1_m_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq1_m * bq1 = (const block_iq1_m *) vbq + kbx;
 
     const int       qs_packed = get_int_b4(bq1->qs, iqs);
@@ -1124,12 +1034,8 @@ static __device__ __forceinline__ float vec_dot_iq1_m_q8_1(
     const int sc0 = 2*((tmp >> 0) & 0x07) + 1;
     const int sc1 = 2*((tmp >> 3) & 0x07) + 1;
     return d * ((sumi[0] + sumf[0]) * sc0 + (sumi[1] + sumf[1]) * sc1);
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
 static __device__ __forceinline__ int2 get_int_from_table_16(const int & q4) {
     const int      q0_32  = (q4 >> 0) & 0x0F0F0F0F;
     const int8_t * q0_8   = (const int8_t *) &q0_32;
@@ -1143,13 +1049,12 @@ static __device__ __forceinline__ int2 get_int_from_table_16(const int & q4) {
 
     return make_int2(*((const int *) &val0_8), *((const int *) &val1_8));
 }
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 
 #define VDR_IQ4_NL_Q8_1_MMVQ 2
 
 static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq4_nl * bq4 = (const block_iq4_nl *) vbq + kbx;
 
     const int * q8 = (const int *) bq8_1->qs + iqs;
@@ -1166,16 +1071,13 @@ static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
 
     const float d = __half2float(bq4->d) * __low2float(bq8_1->ds);
     return d * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }
 
 #define VDR_IQ4_XS_Q8_1_MMVQ 4
 
 static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
-#if __CUDA_ARCH__ >= MIN_CC_DP4A // lowest compute capability for integer intrinsics
+
     const block_iq4_xs * bq4 = (const block_iq4_xs *) vbq + kbx;
 
     int sumi = 0;
@@ -1196,7 +1098,4 @@ static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
 
     const float d = __half2float(bq4->d) * __low2float(bq8_1[iqs/4].ds);
     return d * sumi;
-#else
-    NO_DEVICE_CODE;
-#endif // __CUDA_ARCH__ >= MIN_CC_DP4A
 }

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -60,8 +60,8 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_0_q8_1_imp
         const int vi1 = (v[i] >> 4) & 0x0F0F0F0F;
 
         // SIMD dot product of quantized values
-        sumi = __dp4a(vi0, u[2*i+0], sumi);
-        sumi = __dp4a(vi1, u[2*i+1], sumi);
+        sumi = ggml_cuda_dp4a(vi0, u[2*i+0], sumi);
+        sumi = ggml_cuda_dp4a(vi1, u[2*i+1], sumi);
     }
 
     const float2 ds8f = __half22float2(ds8);
@@ -88,8 +88,8 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q4_1_q8_1_imp
         const int vi1 = (v[i] >> 4) & 0x0F0F0F0F;
 
         // SIMD dot product of quantized values
-        sumi = __dp4a(vi0, u[2*i+0], sumi);
-        sumi = __dp4a(vi1, u[2*i+1], sumi);
+        sumi = ggml_cuda_dp4a(vi0, u[2*i+0], sumi);
+        sumi = ggml_cuda_dp4a(vi1, u[2*i+1], sumi);
     }
 
 #ifdef GGML_CUDA_F16
@@ -126,14 +126,14 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_0_q8_1_imp
         vi0    |= (vh[i] << 11) & 0x00001000; // 1 -> 12
         vi0    |= (vh[i] << 18) & 0x00100000; // 2 -> 20
         vi0    |= (vh[i] << 25) & 0x10000000; // 3 -> 28
-        sumi = __dp4a(vi0, u[2*i+0], sumi); // SIMD dot product of quantized values
+        sumi = ggml_cuda_dp4a(vi0, u[2*i+0], sumi); // SIMD dot product of quantized values
 
         int vi1 = (vl[i] >>  4) & 0x0F0F0F0F; // upper 4 qs bits, still need qh as 5th bits
         vi1    |= (vh[i] >> 12) & 0x00000010; // 16 ->  4
         vi1    |= (vh[i] >>  5) & 0x00001000; // 17 -> 12
         vi1    |= (vh[i] <<  2) & 0x00100000; // 18 -> 20
         vi1    |= (vh[i] <<  9) & 0x10000000; // 19 -> 28
-        sumi = __dp4a(vi1, u[2*i+1], sumi); // SIMD dot product of quantized values
+        sumi = ggml_cuda_dp4a(vi1, u[2*i+1], sumi); // SIMD dot product of quantized values
     }
 
     const float2 ds8f = __half22float2(ds8);
@@ -161,14 +161,14 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q5_1_q8_1_imp
         vi0    |= (vh[i] << 11) & 0x00001000; // 1 -> 12
         vi0    |= (vh[i] << 18) & 0x00100000; // 2 -> 20
         vi0    |= (vh[i] << 25) & 0x10000000; // 3 -> 28
-        sumi = __dp4a(vi0, u[2*i+0], sumi); // SIMD dot product of quantized values
+        sumi = ggml_cuda_dp4a(vi0, u[2*i+0], sumi); // SIMD dot product of quantized values
 
         int vi1 = (vl[i] >>  4) & 0x0F0F0F0F; // upper 4 qs bits, still need qh as 5th bits
         vi1    |= (vh[i] >> 12) & 0x00000010; // 16 ->  4
         vi1    |= (vh[i] >>  5) & 0x00001000; // 17 -> 12
         vi1    |= (vh[i] <<  2) & 0x00100000; // 18 -> 20
         vi1    |= (vh[i] <<  9) & 0x10000000; // 19 -> 28
-        sumi = __dp4a(vi1, u[2*i+1], sumi); // SIMD dot product of quantized values
+        sumi = ggml_cuda_dp4a(vi1, u[2*i+1], sumi); // SIMD dot product of quantized values
     }
 
 #ifdef GGML_CUDA_F16
@@ -202,7 +202,7 @@ template <typename T, int vdr> static __device__ __forceinline__ T vec_dot_q8_0_
 #pragma unroll
     for (int i = 0; i < vdr; ++i) {
         // SIMD dot product of quantized values
-        sumi = __dp4a(v[i], u[i], sumi);
+        sumi = ggml_cuda_dp4a(v[i], u[i], sumi);
     }
 
     return d8_0*d8_1 * ((T) sumi);
@@ -220,7 +220,7 @@ template <int vdr> static __device__ __forceinline__ float vec_dot_q8_1_q8_1_imp
 #pragma unroll
     for (int i = 0; i < vdr; ++i) {
         // SIMD dot product of quantized values
-        sumi = __dp4a(v[i], u[i], sumi);
+        sumi = ggml_cuda_dp4a(v[i], u[i], sumi);
     }
 
 #ifdef GGML_CUDA_F16
@@ -259,13 +259,13 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
 
         const int vi = (v >> (2*i)) & 0x03030303;
 
-        sumf_d += d8[i] * (__dp4a(vi, u[i], 0) * (sc & 0xF)); // SIMD dot product
+        sumf_d += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * (sc & 0xF)); // SIMD dot product
 
         // fill int with 4x m
         int m = sc >> 4;
         m |= m <<  8;
         m |= m << 16;
-        sumf_m += d8[i] * __dp4a(m, u[i], 0); // multiply constant q2_K part with sum of q8_1 values
+        sumf_m += d8[i] * ggml_cuda_dp4a(m, u[i], 0); // multiply constant q2_K part with sum of q8_1 values
     }
 
     const float2 dm2f = __half22float2(dm2);
@@ -294,8 +294,8 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
 #pragma unroll
         for (int i = i0; i < i0 + QI8_1/2; ++i) {
             const int vi = (vi0 >> (2*(i % (QI8_1/2)))) & 0x03030303;
-            sumi_d = __dp4a(vi,         u[i], sumi_d); // SIMD dot product
-            sumi_m = __dp4a(0x01010101, u[i], sumi_m);
+            sumi_d = ggml_cuda_dp4a(vi,         u[i], sumi_d); // SIMD dot product
+            sumi_m = ggml_cuda_dp4a(0x01010101, u[i], sumi_m);
         }
 
         sumf_d += dm2f.x * sumi_d;
@@ -339,7 +339,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
 
         const int vi = __vsubss4(vil, vih);
 
-        sumf += d8[i] * (__dp4a(vi, u[i], 0) * sc); // SIMD dot product
+        sumf += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * sc); // SIMD dot product
     }
 
     return d3 * sumf;
@@ -363,7 +363,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
 #pragma unroll
         for (int i = i0; i < i0 + QI8_1/2; ++i) {
             const int vi = __vsubss4((v[i/2] >> (4*(i%2))) & 0x0F0F0F0F, 0x04040404);
-            sumi_sc = __dp4a(vi, u[i], sumi_sc); // SIMD dot product
+            sumi_sc = ggml_cuda_dp4a(vi, u[i], sumi_sc); // SIMD dot product
         }
 
         sumi += sumi_sc * scales[i0 / (QI8_1/2)];
@@ -392,8 +392,8 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
         const int v0i = (v[0] >> (4*i)) & 0x0F0F0F0F;
         const int v1i = (v[1] >> (4*i)) & 0x0F0F0F0F;
 
-        const int dot1 = __dp4a(v1i, u[2*i+1], __dp4a(v0i, u[2*i+0], 0)); // SIMD dot product
-        const int dot2 = __dp4a(0x01010101, u[2*i+1], __dp4a(0x01010101, u[2*i+0], 0)); // sum of u
+        const int dot1 = ggml_cuda_dp4a(v1i, u[2*i+1], ggml_cuda_dp4a(v0i, u[2*i+0], 0)); // SIMD dot product
+        const int dot2 = ggml_cuda_dp4a(0x01010101, u[2*i+1], ggml_cuda_dp4a(0x01010101, u[2*i+0], 0)); // sum of u
 
         sumf_d += d8[i] * (dot1 * sc[i]);
         sumf_m += d8[i] * (dot2 * m[i]);  // multiply constant part of q4_K with sum of q8_1 values
@@ -423,7 +423,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
 
 #pragma unroll
         for (int j = 0; j < QI8_1; ++j) {
-            sumi_d = __dp4a((v[j] >> (4*i)) & 0x0F0F0F0F, u[i*QI8_1 + j], sumi_d); // SIMD dot product
+            sumi_d = ggml_cuda_dp4a((v[j] >> (4*i)) & 0x0F0F0F0F, u[i*QI8_1 + j], sumi_d); // SIMD dot product
         }
 
         const float2 ds8f = __half22float2(ds8[i]);
@@ -464,8 +464,8 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
         const int v0i = vl0i | vh0i;
         const int v1i = vl1i | vh1i;
 
-        const int dot1 = __dp4a(v0i, u[2*i+0], __dp4a(v1i, u[2*i+1], 0)); // SIMD dot product
-        const int dot2 = __dp4a(0x01010101, u[2*i+0], __dp4a(0x01010101, u[2*i+1], 0)); // sum of u
+        const int dot1 = ggml_cuda_dp4a(v0i, u[2*i+0], ggml_cuda_dp4a(v1i, u[2*i+1], 0)); // SIMD dot product
+        const int dot2 = ggml_cuda_dp4a(0x01010101, u[2*i+0], ggml_cuda_dp4a(0x01010101, u[2*i+1], 0)); // sum of u
 
         sumf_d += d8[i] * (dot1 * sc[i]);
         sumf_m += d8[i] * (dot2 * m[i]);
@@ -496,7 +496,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
 
 #pragma unroll
         for (int j = 0; j < QI8_1; ++j) {
-            sumi_d = __dp4a(v[i*QI8_1 + j], u[i*QI8_1 + j], sumi_d); // SIMD dot product
+            sumi_d = ggml_cuda_dp4a(v[i*QI8_1 + j], u[i*QI8_1 + j], sumi_d); // SIMD dot product
         }
 
         const float2 ds8f = __half22float2(ds8[i]);
@@ -535,7 +535,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
 
         const int vi = __vsubss4((vil | vih), 0x20202020); // vi = (vil | vih) - 32
 
-        sumf += d8[i] * (__dp4a(vi, u[i], 0) * sc); // SIMD dot product
+        sumf += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * sc); // SIMD dot product
     }
 
     return d*sumf;
@@ -558,11 +558,11 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
 
 #pragma unroll
         for (int i = i0; i < i0 + 2; ++i) {
-            sumi_d.x = __dp4a(v[2*i+0], u[2*i+0], sumi_d.x); // SIMD dot product
-            sumi_d.x = __dp4a(v[2*i+1], u[2*i+1], sumi_d.x); // SIMD dot product
+            sumi_d.x = ggml_cuda_dp4a(v[2*i+0], u[2*i+0], sumi_d.x); // SIMD dot product
+            sumi_d.x = ggml_cuda_dp4a(v[2*i+1], u[2*i+1], sumi_d.x); // SIMD dot product
 
-            sumi_d.y = __dp4a(v[2*i+4], u[2*i+4], sumi_d.y); // SIMD dot product
-            sumi_d.y = __dp4a(v[2*i+5], u[2*i+5], sumi_d.y); // SIMD dot product
+            sumi_d.y = ggml_cuda_dp4a(v[2*i+4], u[2*i+4], sumi_d.y); // SIMD dot product
+            sumi_d.y = ggml_cuda_dp4a(v[2*i+5], u[2*i+5], sumi_d.y); // SIMD dot product
         }
 
         sumf_d += d8[i0/4] * (sc[i0/2+0]*sumi_d.x + sc[i0/2+1]*sumi_d.y);
@@ -857,12 +857,12 @@ static __device__ __forceinline__ float vec_dot_iq2_xxs_q8_1(
         const int signs0 = __vcmpne4(((signs_packed & 0x03) << 7) | ((signs_packed & 0x0C) << 21), 0x00000000);
         const int grid0 = __vsub4(grid_pos[0] ^ signs0, signs0);
         const int u0 = get_int_b4(bq8_1[iqs/2].qs, k0 + 0);
-        sumi = __dp4a(grid0, u0, sumi);
+        sumi = ggml_cuda_dp4a(grid0, u0, sumi);
 
         const int signs1 = __vcmpne4(((signs_packed & 0x30) << 3) | ((signs_packed & 0xC0) << 17), 0x00000000);
         const int grid1 = __vsub4(grid_pos[1] ^ signs1, signs1);
         const int u1 = get_int_b4(bq8_1[iqs/2].qs, k0 + 1);
-        sumi = __dp4a(grid1, u1, sumi);
+        sumi = ggml_cuda_dp4a(grid1, u1, sumi);
     }
 
     const int ls = aux32 >> 28;
@@ -900,11 +900,11 @@ static __device__ __forceinline__ float vec_dot_iq2_xs_q8_1(
         const int u1 = get_int_b4(bq8_1[iqs/2].qs, l0 + 1);
 
         if (l0 < 4) {
-            sumi0 = __dp4a(grid_l, u0, sumi0);
-            sumi0 = __dp4a(grid_h, u1, sumi0);
+            sumi0 = ggml_cuda_dp4a(grid_l, u0, sumi0);
+            sumi0 = ggml_cuda_dp4a(grid_h, u1, sumi0);
         } else {
-            sumi1 = __dp4a(grid_l, u0, sumi1);
-            sumi1 = __dp4a(grid_h, u1, sumi1);
+            sumi1 = ggml_cuda_dp4a(grid_l, u0, sumi1);
+            sumi1 = ggml_cuda_dp4a(grid_h, u1, sumi1);
         }
     }
     const int sumi = (sumi0*ls0 + sumi1*ls1 + (sumi0 + sumi1)/2)/4;
@@ -950,11 +950,11 @@ static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
         const int u1 = get_int_b4(bq8_1[iqs/2].qs, l0 + 1);
 
         if (l0 < 4) {
-            sumi0 = __dp4a(grid_l, u0, sumi0);
-            sumi0 = __dp4a(grid_h, u1, sumi0);
+            sumi0 = ggml_cuda_dp4a(grid_l, u0, sumi0);
+            sumi0 = ggml_cuda_dp4a(grid_h, u1, sumi0);
         } else {
-            sumi1 = __dp4a(grid_l, u0, sumi1);
-            sumi1 = __dp4a(grid_h, u1, sumi1);
+            sumi1 = ggml_cuda_dp4a(grid_l, u0, sumi1);
+            sumi1 = ggml_cuda_dp4a(grid_h, u1, sumi1);
         }
     }
     const int sumi = (sumi0*ls0 + sumi1*ls1 + (sumi0 + sumi1)/2)/4;
@@ -991,8 +991,8 @@ static __device__ __forceinline__ float vec_dot_iq3_xxs_q8_1(
         const int u0 = get_int_b4(bq8_1[iqs/2].qs, l0 + 0);
         const int u1 = get_int_b4(bq8_1[iqs/2].qs, l0 + 1);
 
-        sumi = __dp4a(grid_l, u0, sumi);
-        sumi = __dp4a(grid_h, u1, sumi);
+        sumi = ggml_cuda_dp4a(grid_l, u0, sumi);
+        sumi = ggml_cuda_dp4a(grid_h, u1, sumi);
     }
 
     const int ls = aux32 >> 28;
@@ -1036,8 +1036,8 @@ static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
         const int u0 = get_int_b4(bq8_1[iqs/2].qs, l0 + 0);
         const int u1 = get_int_b4(bq8_1[iqs/2].qs, l0 + 1);
 
-        sumi = __dp4a(grid_l, u0, sumi);
-        sumi = __dp4a(grid_h, u1, sumi);
+        sumi = ggml_cuda_dp4a(grid_l, u0, sumi);
+        sumi = ggml_cuda_dp4a(grid_h, u1, sumi);
     }
 
     sumi *= 1 + 2*((bq3->scales[iqs/4] >> ((iqs << 1) & 0x04)) & 0x0F);
@@ -1069,8 +1069,8 @@ static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
         const int u0 = get_int_b4(bq8_1[iqs].qs, l0 + 0);
         const int u1 = get_int_b4(bq8_1[iqs].qs, l0 + 1);
 
-        sumi = __dp4a(grid0, u0, sumi);
-        sumi = __dp4a(grid1, u1, sumi);
+        sumi = ggml_cuda_dp4a(grid0, u0, sumi);
+        sumi = ggml_cuda_dp4a(grid1, u1, sumi);
     }
 
     const float  d1q   = __half2float(bq1->d) * (((qh >> 11) & 0x0E) + 1);
@@ -1104,13 +1104,13 @@ static __device__ __forceinline__ float vec_dot_iq1_m_q8_1(
         const int u0 = get_int_b4(bq8_1[iqs].qs, l0 + 0);
         const int u1 = get_int_b4(bq8_1[iqs].qs, l0 + 1);
 
-        sumi[l0/4] = __dp4a(grid0, u0, sumi[l0/4]);
-        sumi[l0/4] = __dp4a(grid1, u1, sumi[l0/4]);
+        sumi[l0/4] = ggml_cuda_dp4a(grid0, u0, sumi[l0/4]);
+        sumi[l0/4] = ggml_cuda_dp4a(grid1, u1, sumi[l0/4]);
 
         const float delta = -1.0f + IQ1M_DELTA - (qhl & 0x08) * (2.0f*IQ1M_DELTA/0x08);
         int sumy = 0;
-        sumy = __dp4a(u0, 0x01010101, sumy);
-        sumy = __dp4a(u1, 0x01010101, sumy);
+        sumy = ggml_cuda_dp4a(u0, 0x01010101, sumy);
+        sumy = ggml_cuda_dp4a(u1, 0x01010101, sumy);
         sumf[l0/4] += delta*sumy;
     }
 
@@ -1160,8 +1160,8 @@ static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
         const int aux_q4 = get_int_b2(bq4->qs, iqs + l);
         const int2 v = get_int_from_table_16(aux_q4);
 
-        sumi = __dp4a(v.x, q8[l + 0], sumi);
-        sumi = __dp4a(v.y, q8[l + 4], sumi);
+        sumi = ggml_cuda_dp4a(v.x, q8[l + 0], sumi);
+        sumi = ggml_cuda_dp4a(v.y, q8[l + 4], sumi);
     }
 
     const float d = __half2float(bq4->d) * __low2float(bq8_1->ds);
@@ -1187,8 +1187,8 @@ static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
         const int u0 = get_int_b4(bq8_1[iqs/4].qs, j + 0);
         const int u1 = get_int_b4(bq8_1[iqs/4].qs, j + 4);
 
-        sumi = __dp4a(v.x, u0, sumi);
-        sumi = __dp4a(v.y, u1, sumi);
+        sumi = ggml_cuda_dp4a(v.x, u0, sumi);
+        sumi = ggml_cuda_dp4a(v.y, u1, sumi);
     }
 
     const int ls = ((bq4->scales_l[iqs/8] >> (iqs & 0x04)) & 0x0F) | (((bq4->scales_h >> (iqs/2)) & 0x03) << 4);

--- a/ggml/src/ggml-sycl/mmvq.cpp
+++ b/ggml/src/ggml-sycl/mmvq.cpp
@@ -735,7 +735,7 @@ static void mul_mat_vec_iq2_xxs_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq2_xxs_q8_1<QK_K, QI2_XXS, block_iq2_xxs, 1>(
+                        mul_mat_vec_q_iq2_xxs_q8_1<QK_K, QI2_XXS/2, block_iq2_xxs, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });
@@ -760,7 +760,7 @@ static void mul_mat_vec_iq2_xs_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq2_xs_q8_1<QK_K, QI2_XS, block_iq2_xs, 1>(
+                        mul_mat_vec_q_iq2_xs_q8_1<QK_K, QI2_XS/2, block_iq2_xs, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });
@@ -785,7 +785,7 @@ static void mul_mat_vec_iq2_s_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq2_s_q8_1<QK_K, QI2_S, block_iq2_s, 1>(
+                        mul_mat_vec_q_iq2_s_q8_1<QK_K, QI2_S/2, block_iq2_s, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });
@@ -810,7 +810,7 @@ static void mul_mat_vec_iq3_xxs_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq3_xxs_q8_1<QK_K, QI3_XXS, block_iq3_xxs, 1>(
+                        mul_mat_vec_q_iq3_xxs_q8_1<QK_K, QI3_XXS/2, block_iq3_xxs, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });
@@ -834,7 +834,7 @@ static void mul_mat_vec_iq3_s_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq3_s_q8_1<QK_K, QI3_XS, block_iq3_s, 1>(
+                        mul_mat_vec_q_iq3_s_q8_1<QK_K, QI3_S/2, block_iq3_s, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });
@@ -924,7 +924,7 @@ static void mul_mat_vec_iq4_xs_q8_1_sycl(const void *vx, const void *vy,
                 sycl::nd_range<3>(block_nums * block_dims, block_dims),
                 [=](sycl::nd_item<3> item_ct1)
                     [[intel::reqd_sub_group_size(32)]] {
-                        mul_mat_vec_q_iq4_xs_q8_1<QK_K, QI4_XS, block_iq4_xs, 1>(
+                        mul_mat_vec_q_iq4_xs_q8_1<QK_K, QI4_XS/4, block_iq4_xs, 1>(
                             vx, vy, dst, ncols, nrows, item_ct1);
                     });
         });

--- a/ggml/src/ggml-sycl/vecdotq.hpp
+++ b/ggml/src/ggml-sycl/vecdotq.hpp
@@ -820,7 +820,6 @@ vec_dot_iq2_xxs_q8_1(const void *__restrict__ vbq,
 #if QK_K == 256
     const block_iq2_xxs * bq2 = (const block_iq2_xxs *) vbq;
 
-#if QR2_XXS == 8
     const int ib32 = iqs;
     const uint16_t * q2 = bq2->qs + 4*ib32;
     const uint8_t  * aux8 = (const uint8_t *)q2;
@@ -838,26 +837,6 @@ vec_dot_iq2_xxs_q8_1(const void *__restrict__ vbq,
     }
     const float d = (float)bq2->d * (0.5f + aux32) * bq8_1[ib32].ds[0] * 0.25f;
     return d * sumi;
-#else
-    // iqs is 0...15
-    const int ib32 = iqs/2;
-    const int il = iqs%2;
-    const uint16_t * q2 = bq2->qs + 4*ib32;
-    const uint8_t  * aux8 = (const uint8_t *)q2;
-    const uint8_t  * grid1 = (const uint8_t *)(iq2xxs_grid + aux8[2*il+0]);
-    const uint8_t  * grid2 = (const uint8_t *)(iq2xxs_grid + aux8[2*il+1]);
-    const uint32_t aux32 = q2[2] | (q2[3] << 16);
-    const float d = (float)bq2->d * (0.5f + (aux32 >> 28)) * bq8_1[ib32].ds[0] * 0.25f;
-    const uint8_t signs1 = ksigns_iq2xs[(aux32 >> 14*il) & 127];
-    const uint8_t signs2 = ksigns_iq2xs[(aux32 >> (14*il + 7)) & 127];
-    const int8_t * q8 = bq8_1[ib32].qs + 16*il;
-    int sumi1 = 0, sumi2 = 0;
-    for (int j = 0; j < 8; ++j) {
-        sumi1 += q8[j+0] * grid1[j] * (signs1 & kmask_iq2xs[j] ? -1 : 1);
-        sumi2 += q8[j+8] * grid2[j] * (signs2 & kmask_iq2xs[j] ? -1 : 1);
-    }
-    return d * (sumi1 + sumi2);
-#endif
 #else
     assert(false);
     return 0.f;


### PR DESCRIPTION
This PR refactors and optimizes the IQ MMVQ CUDA code. Notably as part of these changes I'm changing some values in `ggml-common.h`. The "qr" values are meant to represent how many low bit data values are contained in a single 8 bit integer. This value is used to derive "qi" which represents how many 32 bit integers are needed to represent the low bit data values of a quantized block. These values are intended to be properties of the data type independent of any kernels.

In MMVQ qr and qi are used to determine how one load of 32 integers for the quantized weights needs to be aligned with the loads of the q8 activations. It is oftentimes beneficial to load more values at once which is intended to be done via the "vdr" value which is a factor that increases the number of simultaneous loads so that the total stride per invocation of `vec_dot_q_cuda` is qr*vdr. However, for the IQ quants this was instead done by increasing QR. This does not matter for MMVQ but it's a problem for MMQ where the values of qr and qi matter for determining how much shared memory needs to be allocated and how the activations need to be loaded. So for this reason I'm changing the qr and qi values of the IQ quants to the originally intended values. Notably this affects the SYCL backend but I am **not** able to test the corresponding changes myself due to a lack of Intel hardware. @arthw @airMeng I don't know who to tag in terms of llama.cpp SYCL developers; please either test my changes or tell me who I should contact.

<details>
<summary>Performance changes</summary>

| Model                         | GPU      |   Microbatch size | Test   |   t/s master |   t/s 59f5fe59 |   Speedup |
|:------------------------------|:---------|------------------:|:-------|-------------:|---------------:|----------:|
| llama 8B IQ1_M - 1.75 bpw     | RX 6800  |                 1 | pp512  |        53.40 |          49.22 |      0.92 |
| llama 8B IQ1_M - 1.75 bpw     | RX 6800  |                 2 | pp512  |        85.65 |          86.32 |      1.01 |
| llama 8B IQ1_M - 1.75 bpw     | RX 6800  |                 4 | pp512  |       113.24 |         112.06 |      0.99 |
| llama 8B IQ1_M - 1.75 bpw     | RX 6800  |                 8 | pp512  |       163.77 |         137.24 |      0.84 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 3090 |                 1 | pp512  |       157.19 |         167.03 |      1.06 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 3090 |                 2 | pp512  |       257.59 |         271.74 |      1.05 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 3090 |                 4 | pp512  |       369.37 |         396.47 |      1.07 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 3090 |                 8 | pp512  |       509.12 |         577.37 |      1.13 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 4090 |                 1 | pp512  |       303.46 |         315.04 |      1.04 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 4090 |                 2 | pp512  |       491.38 |         505.95 |      1.03 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 4090 |                 4 | pp512  |       768.49 |         800.65 |      1.04 |
| llama 8B IQ1_M - 1.75 bpw     | RTX 4090 |                 8 | pp512  |      1104.59 |        1199.08 |      1.09 |
| llama 8B IQ1_M - 1.75 bpw     | P40      |                 1 | pp512  |        51.24 |          55.00 |      1.07 |
| llama 8B IQ1_M - 1.75 bpw     | P40      |                 2 | pp512  |        59.62 |          62.14 |      1.04 |
| llama 8B IQ1_M - 1.75 bpw     | P40      |                 4 | pp512  |        79.55 |          87.26 |      1.10 |
| llama 8B IQ1_M - 1.75 bpw     | P40      |                 8 | pp512  |       100.85 |         123.60 |      1.23 |
| llama 8B IQ1_S - 1.5625 bpw   | RX 6800  |                 1 | pp512  |        55.56 |          54.13 |      0.97 |
| llama 8B IQ1_S - 1.5625 bpw   | RX 6800  |                 2 | pp512  |        89.01 |          92.03 |      1.03 |
| llama 8B IQ1_S - 1.5625 bpw   | RX 6800  |                 4 | pp512  |       119.90 |         143.32 |      1.20 |
| llama 8B IQ1_S - 1.5625 bpw   | RX 6800  |                 8 | pp512  |       163.32 |         177.29 |      1.09 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 3090 |                 1 | pp512  |       171.96 |         182.08 |      1.06 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 3090 |                 2 | pp512  |       294.86 |         321.29 |      1.09 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 3090 |                 4 | pp512  |       400.41 |         454.23 |      1.13 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 3090 |                 8 | pp512  |       547.64 |         613.82 |      1.12 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 4090 |                 1 | pp512  |       314.54 |         324.53 |      1.03 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 4090 |                 2 | pp512  |       532.28 |         536.75 |      1.01 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 4090 |                 4 | pp512  |       802.89 |         869.56 |      1.08 |
| llama 8B IQ1_S - 1.5625 bpw   | RTX 4090 |                 8 | pp512  |      1135.76 |        1215.14 |      1.07 |
| llama 8B IQ1_S - 1.5625 bpw   | P40      |                 1 | pp512  |        54.77 |          60.16 |      1.10 |
| llama 8B IQ1_S - 1.5625 bpw   | P40      |                 2 | pp512  |        62.83 |          65.50 |      1.04 |
| llama 8B IQ1_S - 1.5625 bpw   | P40      |                 4 | pp512  |        83.18 |          91.52 |      1.10 |
| llama 8B IQ1_S - 1.5625 bpw   | P40      |                 8 | pp512  |       103.75 |         101.55 |      0.98 |
| llama 8B IQ2_M - 2.7 bpw      | RX 6800  |                 1 | pp512  |        37.80 |          40.21 |      1.06 |
| llama 8B IQ2_M - 2.7 bpw      | RX 6800  |                 2 | pp512  |        65.40 |          71.74 |      1.10 |
| llama 8B IQ2_M - 2.7 bpw      | RX 6800  |                 4 | pp512  |        89.33 |         108.04 |      1.21 |
| llama 8B IQ2_M - 2.7 bpw      | RX 6800  |                 8 | pp512  |       118.42 |         138.37 |      1.17 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 3090 |                 1 | pp512  |       144.67 |         154.45 |      1.07 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 3090 |                 2 | pp512  |       247.07 |         257.73 |      1.04 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 3090 |                 4 | pp512  |       355.66 |         364.56 |      1.03 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 3090 |                 8 | pp512  |       523.70 |         538.26 |      1.03 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 4090 |                 1 | pp512  |       256.04 |         256.11 |      1.00 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 4090 |                 2 | pp512  |       436.39 |         434.25 |      1.00 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 4090 |                 4 | pp512  |       691.87 |         693.52 |      1.00 |
| llama 8B IQ2_M - 2.7 bpw      | RTX 4090 |                 8 | pp512  |      1149.50 |        1154.73 |      1.00 |
| llama 8B IQ2_M - 2.7 bpw      | P40      |                 1 | pp512  |        50.45 |          53.80 |      1.07 |
| llama 8B IQ2_M - 2.7 bpw      | P40      |                 2 | pp512  |        55.44 |          58.77 |      1.06 |
| llama 8B IQ2_M - 2.7 bpw      | P40      |                 4 | pp512  |        80.85 |          83.89 |      1.04 |
| llama 8B IQ2_M - 2.7 bpw      | P40      |                 8 | pp512  |       119.35 |         120.94 |      1.01 |
| llama 8B IQ2_S - 2.5 bpw      | RX 6800  |                 1 | pp512  |        46.08 |          46.31 |      1.00 |
| llama 8B IQ2_S - 2.5 bpw      | RX 6800  |                 2 | pp512  |        75.10 |          81.27 |      1.08 |
| llama 8B IQ2_S - 2.5 bpw      | RX 6800  |                 4 | pp512  |        96.45 |         123.49 |      1.28 |
| llama 8B IQ2_S - 2.5 bpw      | RX 6800  |                 8 | pp512  |       116.69 |         140.50 |      1.20 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 3090 |                 1 | pp512  |       146.70 |         151.47 |      1.03 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 3090 |                 2 | pp512  |       255.82 |         251.69 |      0.98 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 3090 |                 4 | pp512  |       378.84 |         377.85 |      1.00 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 3090 |                 8 | pp512  |       535.84 |         535.17 |      1.00 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 4090 |                 1 | pp512  |       274.49 |         276.89 |      1.01 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 4090 |                 2 | pp512  |       469.03 |         454.41 |      0.97 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 4090 |                 4 | pp512  |       776.19 |         769.60 |      0.99 |
| llama 8B IQ2_S - 2.5 bpw      | RTX 4090 |                 8 | pp512  |      1184.92 |        1168.13 |      0.99 |
| llama 8B IQ2_S - 2.5 bpw      | P40      |                 1 | pp512  |        46.43 |          46.90 |      1.01 |
| llama 8B IQ2_S - 2.5 bpw      | P40      |                 2 | pp512  |        57.69 |          58.24 |      1.01 |
| llama 8B IQ2_S - 2.5 bpw      | P40      |                 4 | pp512  |        81.95 |          86.35 |      1.05 |
| llama 8B IQ2_S - 2.5 bpw      | P40      |                 8 | pp512  |       117.88 |         117.48 |      1.00 |
| llama 8B IQ2_XS - 2.3125 bpw  | RX 6800  |                 1 | pp512  |        48.85 |          47.87 |      0.98 |
| llama 8B IQ2_XS - 2.3125 bpw  | RX 6800  |                 2 | pp512  |        85.05 |          82.40 |      0.97 |
| llama 8B IQ2_XS - 2.3125 bpw  | RX 6800  |                 4 | pp512  |       113.93 |         122.77 |      1.08 |
| llama 8B IQ2_XS - 2.3125 bpw  | RX 6800  |                 8 | pp512  |       142.12 |         137.76 |      0.97 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 3090 |                 1 | pp512  |       150.82 |         154.55 |      1.02 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 3090 |                 2 | pp512  |       261.42 |         256.79 |      0.98 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 3090 |                 4 | pp512  |       387.68 |         382.61 |      0.99 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 3090 |                 8 | pp512  |       539.88 |         536.58 |      0.99 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 4090 |                 1 | pp512  |       283.86 |         285.14 |      1.00 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 4090 |                 2 | pp512  |       483.41 |         468.26 |      0.97 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 4090 |                 4 | pp512  |       799.44 |         793.42 |      0.99 |
| llama 8B IQ2_XS - 2.3125 bpw  | RTX 4090 |                 8 | pp512  |      1181.49 |        1165.17 |      0.99 |
| llama 8B IQ2_XS - 2.3125 bpw  | P40      |                 1 | pp512  |        48.15 |          48.11 |      1.00 |
| llama 8B IQ2_XS - 2.3125 bpw  | P40      |                 2 | pp512  |        60.15 |          60.02 |      1.00 |
| llama 8B IQ2_XS - 2.3125 bpw  | P40      |                 4 | pp512  |        83.81 |          88.44 |      1.06 |
| llama 8B IQ2_XS - 2.3125 bpw  | P40      |                 8 | pp512  |       119.43 |         117.26 |      0.98 |
| llama 8B IQ2_XXS - 2.0625 bpw | RX 6800  |                 1 | pp512  |        51.04 |          42.05 |      0.82 |
| llama 8B IQ2_XXS - 2.0625 bpw | RX 6800  |                 2 | pp512  |        70.78 |          76.72 |      1.08 |
| llama 8B IQ2_XXS - 2.0625 bpw | RX 6800  |                 4 | pp512  |        90.88 |         122.41 |      1.35 |
| llama 8B IQ2_XXS - 2.0625 bpw | RX 6800  |                 8 | pp512  |       108.26 |         147.99 |      1.37 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 3090 |                 1 | pp512  |       108.48 |         160.28 |      1.48 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 3090 |                 2 | pp512  |       173.38 |         269.81 |      1.56 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 3090 |                 4 | pp512  |       203.23 |         381.82 |      1.88 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 3090 |                 8 | pp512  |       258.22 |         558.16 |      2.16 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 4090 |                 1 | pp512  |       238.67 |         303.88 |      1.27 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 4090 |                 2 | pp512  |       378.23 |         494.32 |      1.31 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 4090 |                 4 | pp512  |       470.38 |         723.03 |      1.54 |
| llama 8B IQ2_XXS - 2.0625 bpw | RTX 4090 |                 8 | pp512  |       633.18 |        1195.46 |      1.89 |
| llama 8B IQ2_XXS - 2.0625 bpw | P40      |                 1 | pp512  |        29.94 |          46.71 |      1.56 |
| llama 8B IQ2_XXS - 2.0625 bpw | P40      |                 2 | pp512  |        40.33 |          54.33 |      1.35 |
| llama 8B IQ2_XXS - 2.0625 bpw | P40      |                 4 | pp512  |        40.90 |          81.67 |      2.00 |
| llama 8B IQ2_XXS - 2.0625 bpw | P40      |                 8 | pp512  |        37.94 |         116.89 |      3.08 |
| llama 8B IQ3_S - 3.4375 bpw   | RX 6800  |                 1 | pp512  |        33.10 |          38.16 |      1.15 |
| llama 8B IQ3_S - 3.4375 bpw   | RX 6800  |                 2 | pp512  |        40.60 |          74.50 |      1.83 |
| llama 8B IQ3_S - 3.4375 bpw   | RX 6800  |                 4 | pp512  |        45.80 |         123.68 |      2.70 |
| llama 8B IQ3_S - 3.4375 bpw   | RX 6800  |                 8 | pp512  |        48.94 |         151.62 |      3.10 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 3090 |                 1 | pp512  |       131.03 |         143.17 |      1.09 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 3090 |                 2 | pp512  |       221.41 |         234.53 |      1.06 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 3090 |                 4 | pp512  |       332.33 |         350.82 |      1.06 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 3090 |                 8 | pp512  |       501.54 |         526.60 |      1.05 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 4090 |                 1 | pp512  |       220.21 |         221.34 |      1.01 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 4090 |                 2 | pp512  |       368.67 |         369.48 |      1.00 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 4090 |                 4 | pp512  |       664.61 |         662.90 |      1.00 |
| llama 8B IQ3_S - 3.4375 bpw   | RTX 4090 |                 8 | pp512  |      1122.96 |        1144.50 |      1.02 |
| llama 8B IQ3_S - 3.4375 bpw   | P40      |                 1 | pp512  |        39.70 |          44.13 |      1.11 |
| llama 8B IQ3_S - 3.4375 bpw   | P40      |                 2 | pp512  |        47.98 |          52.10 |      1.09 |
| llama 8B IQ3_S - 3.4375 bpw   | P40      |                 4 | pp512  |        74.74 |          79.60 |      1.07 |
| llama 8B IQ3_S - 3.4375 bpw   | P40      |                 8 | pp512  |       111.09 |         115.68 |      1.04 |
| llama 8B IQ3_S mix - 3.66 bpw | RX 6800  |                 1 | pp512  |        34.07 |          38.58 |      1.13 |
| llama 8B IQ3_S mix - 3.66 bpw | RX 6800  |                 2 | pp512  |        42.81 |          73.89 |      1.73 |
| llama 8B IQ3_S mix - 3.66 bpw | RX 6800  |                 4 | pp512  |        48.75 |         118.86 |      2.44 |
| llama 8B IQ3_S mix - 3.66 bpw | RX 6800  |                 8 | pp512  |        52.12 |         142.37 |      2.73 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 3090 |                 1 | pp512  |       133.40 |         144.93 |      1.09 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 3090 |                 2 | pp512  |       223.57 |         235.91 |      1.06 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 3090 |                 4 | pp512  |       331.13 |         347.12 |      1.05 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 3090 |                 8 | pp512  |       485.86 |         504.17 |      1.04 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 4090 |                 1 | pp512  |       216.78 |         217.79 |      1.00 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 4090 |                 2 | pp512  |       365.57 |         368.64 |      1.01 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 4090 |                 4 | pp512  |       661.20 |         663.19 |      1.00 |
| llama 8B IQ3_S mix - 3.66 bpw | RTX 4090 |                 8 | pp512  |      1089.92 |        1113.22 |      1.02 |
| llama 8B IQ3_S mix - 3.66 bpw | P40      |                 1 | pp512  |        40.91 |          45.28 |      1.11 |
| llama 8B IQ3_S mix - 3.66 bpw | P40      |                 2 | pp512  |        49.27 |          53.23 |      1.08 |
| llama 8B IQ3_S mix - 3.66 bpw | P40      |                 4 | pp512  |        76.73 |          81.46 |      1.06 |
| llama 8B IQ3_S mix - 3.66 bpw | P40      |                 8 | pp512  |       111.40 |         115.70 |      1.04 |
| llama 8B IQ3_XS - 3.3 bpw     | RX 6800  |                 1 | pp512  |        39.95 |          42.88 |      1.07 |
| llama 8B IQ3_XS - 3.3 bpw     | RX 6800  |                 2 | pp512  |        56.50 |          80.17 |      1.42 |
| llama 8B IQ3_XS - 3.3 bpw     | RX 6800  |                 4 | pp512  |        69.21 |         127.19 |      1.84 |
| llama 8B IQ3_XS - 3.3 bpw     | RX 6800  |                 8 | pp512  |        75.96 |         154.91 |      2.04 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 3090 |                 1 | pp512  |       131.71 |         142.08 |      1.08 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 3090 |                 2 | pp512  |       225.58 |         236.88 |      1.05 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 3090 |                 4 | pp512  |       348.83 |         360.71 |      1.03 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 3090 |                 8 | pp512  |       511.77 |         527.72 |      1.03 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 4090 |                 1 | pp512  |       229.77 |         231.39 |      1.01 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 4090 |                 2 | pp512  |       391.05 |         392.01 |      1.00 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 4090 |                 4 | pp512  |       710.10 |         714.86 |      1.01 |
| llama 8B IQ3_XS - 3.3 bpw     | RTX 4090 |                 8 | pp512  |      1141.69 |        1152.60 |      1.01 |
| llama 8B IQ3_XS - 3.3 bpw     | P40      |                 1 | pp512  |        39.44 |          42.72 |      1.08 |
| llama 8B IQ3_XS - 3.3 bpw     | P40      |                 2 | pp512  |        50.67 |          50.65 |      1.00 |
| llama 8B IQ3_XS - 3.3 bpw     | P40      |                 4 | pp512  |        73.72 |          80.02 |      1.09 |
| llama 8B IQ3_XS - 3.3 bpw     | P40      |                 8 | pp512  |       110.53 |         112.94 |      1.02 |
| llama 8B IQ3_XXS - 3.0625 bpw | RX 6800  |                 1 | pp512  |        46.62 |          46.60 |      1.00 |
| llama 8B IQ3_XXS - 3.0625 bpw | RX 6800  |                 2 | pp512  |        78.05 |          83.07 |      1.06 |
| llama 8B IQ3_XXS - 3.0625 bpw | RX 6800  |                 4 | pp512  |       110.96 |         126.46 |      1.14 |
| llama 8B IQ3_XXS - 3.0625 bpw | RX 6800  |                 8 | pp512  |       131.35 |         155.94 |      1.19 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 3090 |                 1 | pp512  |       135.27 |         143.46 |      1.06 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 3090 |                 2 | pp512  |       233.96 |         242.70 |      1.04 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 3090 |                 4 | pp512  |       360.31 |         367.51 |      1.02 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 3090 |                 8 | pp512  |       519.38 |         527.16 |      1.01 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 4090 |                 1 | pp512  |       236.20 |         235.58 |      1.00 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 4090 |                 2 | pp512  |       404.28 |         403.91 |      1.00 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 4090 |                 4 | pp512  |       722.81 |         731.84 |      1.01 |
| llama 8B IQ3_XXS - 3.0625 bpw | RTX 4090 |                 8 | pp512  |      1152.84 |        1162.57 |      1.01 |
| llama 8B IQ3_XXS - 3.0625 bpw | P40      |                 1 | pp512  |        40.21 |          42.77 |      1.06 |
| llama 8B IQ3_XXS - 3.0625 bpw | P40      |                 2 | pp512  |        51.78 |          50.33 |      0.97 |
| llama 8B IQ3_XXS - 3.0625 bpw | P40      |                 4 | pp512  |        74.36 |          79.64 |      1.07 |
| llama 8B IQ3_XXS - 3.0625 bpw | P40      |                 8 | pp512  |       111.46 |         112.72 |      1.01 |
| llama 8B IQ4_NL - 4.5 bpw     | RX 6800  |                 1 | pp512  |        53.35 |          53.31 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RX 6800  |                 2 | pp512  |        98.53 |          95.45 |      0.97 |
| llama 8B IQ4_NL - 4.5 bpw     | RX 6800  |                 4 | pp512  |       144.67 |         154.64 |      1.07 |
| llama 8B IQ4_NL - 4.5 bpw     | RX 6800  |                 8 | pp512  |       155.23 |         137.54 |      0.89 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 3090 |                 1 | pp512  |       122.65 |         122.39 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 3090 |                 2 | pp512  |       213.90 |         214.49 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 3090 |                 4 | pp512  |       332.52 |         334.08 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 3090 |                 8 | pp512  |       474.78 |         473.78 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 4090 |                 1 | pp512  |       186.29 |         186.63 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 4090 |                 2 | pp512  |       330.35 |         339.99 |      1.03 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 4090 |                 4 | pp512  |       641.99 |         641.73 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | RTX 4090 |                 8 | pp512  |      1030.30 |        1037.84 |      1.01 |
| llama 8B IQ4_NL - 4.5 bpw     | P40      |                 1 | pp512  |        38.95 |          39.11 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | P40      |                 2 | pp512  |        52.43 |          52.37 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw     | P40      |                 4 | pp512  |        85.21 |          84.63 |      0.99 |
| llama 8B IQ4_NL - 4.5 bpw     | P40      |                 8 | pp512  |       133.29 |         133.45 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw    | RX 6800  |                 1 | pp512  |        59.13 |          58.71 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | RX 6800  |                 2 | pp512  |       100.45 |          96.94 |      0.97 |
| llama 8B IQ4_XS - 4.25 bpw    | RX 6800  |                 4 | pp512  |       131.00 |         135.02 |      1.03 |
| llama 8B IQ4_XS - 4.25 bpw    | RX 6800  |                 8 | pp512  |       185.85 |         167.36 |      0.90 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 3090 |                 1 | pp512  |       128.99 |         128.28 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 3090 |                 2 | pp512  |       208.93 |         210.96 |      1.01 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 3090 |                 4 | pp512  |       310.73 |         309.15 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 3090 |                 8 | pp512  |       480.94 |         475.20 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 4090 |                 1 | pp512  |       194.54 |         193.03 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 4090 |                 2 | pp512  |       343.13 |         343.17 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 4090 |                 4 | pp512  |       637.72 |         637.37 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw    | RTX 4090 |                 8 | pp512  |      1087.27 |        1075.96 |      0.99 |
| llama 8B IQ4_XS - 4.25 bpw    | P40      |                 1 | pp512  |        36.07 |          37.07 |      1.03 |
| llama 8B IQ4_XS - 4.25 bpw    | P40      |                 2 | pp512  |        40.50 |          44.89 |      1.11 |
| llama 8B IQ4_XS - 4.25 bpw    | P40      |                 4 | pp512  |        68.90 |          76.90 |      1.12 |
| llama 8B IQ4_XS - 4.25 bpw    | P40      |                 8 | pp512  |       113.47 |         110.05 |      0.97 |

</details>