### PR TITLE
Removing fsep token from GPTRefactForCausalLM

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1203,11 +1203,10 @@ class RefactModel(Model):
 
         # TODO: how to determine special FIM tokens automatically?
         special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=False,
-                                          special_token_types = ['prefix', 'suffix', 'middle', 'fsep', 'eot'])
+                                          special_token_types = ['prefix', 'suffix', 'middle', 'eot'])
         special_vocab._set_special_token("prefix", 1)
         special_vocab._set_special_token("suffix", 3)
         special_vocab._set_special_token("middle", 2)
-        special_vocab._set_special_token("fsep",   4) # is this correct?
         special_vocab.add_to_gguf(self.gguf_writer)
 
     def set_gguf_parameters(self):


### PR DESCRIPTION
The `<filename>` token used by Refact doesn't serve the same purpose as the `<file_separator>` from CodeGemma.

I've been going through docs for both Refact and CodeGemma, and came to conclusion that `<filename>` isn't a good fit for the file separator token. The biggest issue is the lack of documentation on the matter. 
Only mention of the `<filename>` token on Huggingface and other sources comes from description of Starcoder training[0] where it is used to mark start of filename for prompt. This is substantially different from the way it is used by CodeGemma[1].

Repos of Small Magellanic Cloud AI on github and HF don't provide more information. 

With that in mind, I believe it's better not to set it as fsep token. 



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

[0] https://huggingface.co/blog/starcoder#evaluation 
[1] https://ai.google.dev/gemma/docs/formatting