### PR TITLE
Fix gemma2 tokenizer convert

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -2351,7 +2351,6 @@ class Gemma2Model(Model):
         tokens, scores, toktypes, special_vocab = self._set_vocab_sentencepiece(add_to_gguf=False)
         # hack: This is required so that we can properly use start/end-of-turn for chat template
         for i in range(216): # 216 -> last special token
-            scores[i] = -1000.0
             toktypes[i] = SentencePieceTokenTypes.CONTROL
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_scores(scores)


### PR DESCRIPTION
Ref comment:
- Investigation: https://github.com/ggerganov/llama.cpp/issues/8240#issuecomment-2200674401
- Fix proposal: https://github.com/ggerganov/llama.cpp/issues/8240#issuecomment-2200778010

The output model is capable of tokenizing special tokens (used in chat templates):

```
test.txt

<start_of_turn>user
hello discards HOW are you<end_of_turn>
```

```
$ ./llama-tokenize -m ggml-model-f16.gguf -f test.txt

...

     2 -> '<bos>'
   106 -> '<start_of_turn>'
  1645 -> 'user'
   108 -> '
'
 17534 -> 'hello'
  9027 -> ' disc'
  2050 -> 'ards'
 31874 -> ' HOW'
   708 -> ' are'
   692 -> ' you'
   107 -> '<end_of_turn>'
   108 -> '
'
```

Perplexity is also improved from `8.9711` to `7.8952` (I'm using q8_0 because colab notebook does not have enough VRAM for f16)

```
$ !./llama.cpp/llama-perplexity -f ./llama.cpp/wikitext-2-raw/wiki.test.raw -ngl 99 -m ./gemma2/ggml-model-q8_0.gguf -c 1024

[277]7.8267,[278]7.8213,[279]7.8372,[280]7.8424,[281]7.8534,[282]7.8573,[283]7.8760,[284]7.8952,
Final estimate: PPL = 7.8952 +/- 0.05648
```

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
