### PR TITLE
Fixed the model conversion bug caused by minicpm's GQA structure。After testing minicpm's GQA, the converted model generates all <h>. This is because the number of k and v matrices of Gqa should be the same as kv_head, not the same as head/kv_head.

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1605,7 +1605,7 @@ class MiniCPMModel(Model):
 
     def _reverse_hf_permute(self, weights: Tensor, n_head: int, n_kv_head: int | None = None) -> Tensor:
         if n_kv_head is not None and n_head != n_kv_head:
-            n_head //= n_kv_head
+            n_head = n_kv_head
 
         return (
             weights.reshape(n_head, 2, weights.shape[0] // n_head // 2, *weights.shape[1:])


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
