### PR TITLE
Fix false flags used in termux demo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ $mv /sdcard/llama.cpp/llama-2-7b-chat.Q4_K_M.gguf /data/data/com.termux/files/ho
 Now, you can start chatting:
 ```
 $cd /data/data/com.termux/files/home/bin
-$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -n 128 -cml
+$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -n 128 --repeat_penalty 1.0 --color -i -r "User:" -f prompts/chat-with-bob.txt
 ```
 
 Here's a demo of an interactive session running on Pixel 5 phone:

--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ $mv /sdcard/llama.cpp/llama-2-7b-chat.Q4_K_M.gguf /data/data/com.termux/files/ho
 Now, you can start chatting:
 ```
 $cd /data/data/com.termux/files/home/bin
-$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -n 128 --repeat_penalty 1.0 --color -i -r "User:" -f prompts/chat-with-bob.txt
+$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -cnv
 ```
 
 Here's a demo of an interactive session running on Pixel 5 phone:


### PR DESCRIPTION
The flag `-cml` used in the example in the readme for the termux android interactive is incorrect, that flag is either depreciated or an error

`$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -n 128 -cml`

[Interactive Mode in root README](https://github.com/ggerganov/llama.cpp?tab=readme-ov-file#interactive-mode)
has the correct approach

`$./llama-cli -m ../model/llama-2-7b-chat.Q4_K_M.gguf -n 128 --repeat_penalty 1.0 --color -i -r "User:" -f prompts/chat-with-bob.txt`

the [llama-cli README](https://github.com/ggerganov/llama.cpp/blob/master/examples/main/README.md) doesn't mention anything like -cml

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
