### PR TITLE
Dequant improvements rebase

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -351,4 +351,10 @@ static __dpct_inline__ float warp_reduce_max(float x,
     return x;
 }
 
+// Helper for vec loading aligned data
+template <typename Tp, int n>
+inline sycl::vec<Tp, n> vec_aligned_load(const Tp* aligned_ptr) {
+    return *reinterpret_cast<const sycl::vec<Tp, n>*>(aligned_ptr);
+}
+
 #endif // GGML_SYCL_COMMON_HPP

--- a/ggml/src/ggml-sycl/dequantize.hpp
+++ b/ggml/src/ggml-sycl/dequantize.hpp
@@ -304,7 +304,7 @@ static inline void get_scale_min_k4(int j, const uint8_t * q, uint8_t & d, uint8
 
 template<typename dst_t>
 static void dequantize_block_q4_K(const void * __restrict__ vx, dst_t * __restrict__ yy,
-                                  const sycl::nd_item<3> &item_ct1) {
+                                  uint8_t* scales_local, const sycl::nd_item<3> &item_ct1) {
     const block_q4_K * x = (const block_q4_K *) vx;
 
     const int i = item_ct1.get_group(2);
@@ -323,15 +323,20 @@ static void dequantize_block_q4_K(const void * __restrict__ vx, dst_t * __restri
     const float dall = dm[0];
     const float dmin = dm[1];
 
+    if (tid < 12)
+        scales_local[tid] = x[i].scales[tid];
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+
     const uint8_t * q = x[i].qs + 32*il + n*ir;
 
     uint8_t sc, m;
-    get_scale_min_k4(is + 0, x[i].scales, sc, m);
+    get_scale_min_k4(is + 0, scales_local, sc, m);
     const float d1 = dall * sc;
     const float m1 = dmin * m;
-    get_scale_min_k4(is + 1, x[i].scales, sc, m);
+    get_scale_min_k4(is + 1, scales_local, sc, m);
     const float d2 = dall * sc;
     const float m2 = dmin * m;
+
     for (int l = 0; l < n; ++l) {
         y[l + 0] = d1 * (q[l] & 0xF) - m1;
         y[l +32] = d2 * (q[l] >>  4) - m2;

--- a/ggml/src/ggml-sycl/dequantize.hpp
+++ b/ggml/src/ggml-sycl/dequantize.hpp
@@ -319,8 +319,9 @@ static void dequantize_block_q4_K(const void * __restrict__ vx, dst_t * __restri
 
     dst_t * y = yy + i*QK_K + 64*il + n*ir;
 
-    const float dall = x[i].dm[0];
-    const float dmin = x[i].dm[1];
+    const sycl::half2 dm = x[i].dm;
+    const float dall = dm[0];
+    const float dmin = dm[1];
 
     const uint8_t * q = x[i].qs + 32*il + n*ir;
 

--- a/ggml/src/ggml-sycl/dequantize.hpp
+++ b/ggml/src/ggml-sycl/dequantize.hpp
@@ -293,7 +293,8 @@ static void dequantize_block_q3_K(const void * __restrict__ vx, dst_t * __restri
 #if QK_K == 256
 static inline void get_scale_min_k4(int j, const uint8_t * q, uint8_t & d, uint8_t & m) {
     if (j < 4) {
-        d = q[j] & 63; m = q[j + 4] & 63;
+        d = q[j] & 63;
+        m = q[j + 4] & 63;
     } else {
         d = (q[j+4] & 0xF) | ((q[j-4] >> 6) << 4);
         m = (q[j+4] >>  4) | ((q[j-0] >> 6) << 4);
@@ -325,9 +326,11 @@ static void dequantize_block_q4_K(const void * __restrict__ vx, dst_t * __restri
 
     uint8_t sc, m;
     get_scale_min_k4(is + 0, x[i].scales, sc, m);
-    const float d1 = dall * sc; const float m1 = dmin * m;
+    const float d1 = dall * sc;
+    const float m1 = dmin * m;
     get_scale_min_k4(is + 1, x[i].scales, sc, m);
-    const float d2 = dall * sc; const float m2 = dmin * m;
+    const float d2 = dall * sc;
+    const float m2 = dmin * m;
     for (int l = 0; l < n; ++l) {
         y[l + 0] = d1 * (q[l] & 0xF) - m1;
         y[l +32] = d2 * (q[l] >>  4) - m2;


### PR DESCRIPTION
This PR provides improvements to the `dequantize_block_q4_K` kernel. It focuses on improving the global memory accesses.

Three main changes are implemented:
- Single 32 bit load for half2 rather than two 16 bit loads
- Load all scales in to local memory then do random access on results
- Vectorize the q load so we load 32bits each time rather than 8bits

All results below collected on A100 GPU
|                  |                           | Without Changes | With Changes | % Change |                           |
|------------------|---------------------------|-----------------|--------------|----------|---------------------------|
| LLama-bench 70 B | PP Throughput (t/s)       | 503.36          | 564.04       | -11.85   | Negative change is better |
|                  | NSYS Avg Kernel time (us) | 587.54          | 409.52       | 30.30    | Positive change is better |

No meaningful change in Intel GPU results have been observed.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
