### PR TITLE
Add missing short command line argument -mli to enable multiline input

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -757,7 +757,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.cache_type_v = argv[++i];
         return true;
     }
-    if (arg == "--multiline-input") {
+    if (arg == "-mli" || arg == "--multiline-input") {
         params.multiline_input = true;
         return true;
     }


### PR DESCRIPTION
Command line usage lists '-mli' as a short version of '--multiline-input'.
In practice, gpt_params_find_arg() does not parse '-mli' as a valid option.
This adds missing check for '-mli'.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
