### PR TITLE
Fix phi 3 conversion

### DIFF
--- a/convert-hf-to-gguf.py
+++ b/convert-hf-to-gguf.py
@@ -1934,7 +1934,7 @@ class Phi3MiniModel(Model):
         if len(rope_scaling_type) == 0:
             raise KeyError('Missing the required key rope_scaling.type')
 
-        if rope_scaling_type == 'su':
+        if rope_scaling_type == 'su' or rope_scaling_type == 'longrope':
             attn_factor = math.sqrt(1 + math.log(scale) / math.log(orig_max_pos_embds)) if scale > 1.0 else 1.0
         elif rope_scaling_type == 'yarn':
             attn_factor = 0.1 * math.log(scale) + 1.0 if scale > 1.0 else 1.0


### PR DESCRIPTION
Reflect the change in latest update: https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/commit/10d25dfa1593265daf4a3bac573ab76ccf61d60f

The only changes are:
- Rope type name changed to `longrope`
- Scaling factor list changed ==> model need to be re-converted

Related to https://github.com/ggerganov/llama.cpp/issues/6849#issuecomment-2203839232

Example result after conversion:

```
make llama-cli -j && ./llama-cli -m ../_hf/Phi-3-mini-128k-instruct/ggml-model-q8_0.gguf -p "You are AI" -c 1024 -cnv

> What is 2+2
 2+2 equals 4. The operation here is a simple addition, which is one of the four basic arithmetic operations. Adding two units to two units results in four units.
```

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
