### PR TITLE
Add option to ignore tokens with 2+ English characters

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -90,7 +90,8 @@ struct gpt_params {
     float   yarn_beta_slow        =  1.0f; // YaRN high correction dim
     int32_t yarn_orig_ctx         =     0; // YaRN original context length
     float   defrag_thold          = -1.0f; // KV cache defragmentation threshold
-
+    bool ignore_english_tokens = false; // Experimental: Attempt to not sample tokens containing English characters
+    
     ggml_backend_sched_eval_callback cb_eval = nullptr;
     void * cb_eval_user_data                 = nullptr;
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -41,6 +41,7 @@ typedef struct llama_sampling_params {
     float       mirostat_eta          = 0.10f;              // learning rate
     bool        penalize_nl           = false;              // consider newlines as a repeatable token
     uint32_t    seed                  = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampling_context
+    bool        ignore_english_tokens = false;              // Ignore tokens with 3+ English characters (except those with angle brackets)
 
     std::vector<llama_sampler_type> samplers_sequence = {
         llama_sampler_type::TOP_K,


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

This PR adds an option called `ignore_english_tokens`. When enabled, it attempts to prevent the model from sampling tokens that contain two or more English characters, unless they include angle brackets (for example `<EOS>`).

The intention behind this option is to stop multilingual LLMs from generating text with mixed in English.

For example, when prompted to respond in Japanese, instead of generating:

> 彼は milk を買いに店に行った。 (He went to the shop to buy \**milk*\*.)

The LLM should now correctly generate:

> 彼はミルクを買いに店に行った。 (He went to the shop to buy milk.)

I am not well-versed in cpp and haven't tested to see if the code works as I'm unsure of how to do this on Windows, I mainly made this PR to propose the feature and tried my best.

That said, I did test a workaround to this option not existing by generating a value for the `logit_bias` argument. I wrote a python script to read through the `tokenizer.json` of a model, then assign all English token IDs to a value of -100 to ban them. This stops the mixed language issue, but the problem is that no frontend is able to do this automatically for any model due to the nature of this being a backend related problem.