### PR TITLE
fix: add missing macro definitions

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1175,4 +1175,5 @@ endif()
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_compile_definitions(ggml PRIVATE GGML_SHARED GGML_BUILD)
 endif()


### PR DESCRIPTION
The macros `GGML_SHARED` and `GGML_BUILD` are missing for ggml project
Without these macros, while building ggml as DLL on Windows, linking ggml to llama will fail with error LNK2019

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
