### PR TITLE
CUDA: revert part of the RDNA1 optimizations

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2263,9 +2263,9 @@ static __device__ void mul_mat_q_process_tile(
 
 template <ggml_type type, int mmq_x, int nwarps, bool need_check>
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
-#if defined(RDNA3) || defined(RDNA2) || defined(RDNA1)
+#if defined(RDNA3) || defined(RDNA2)
     __launch_bounds__(WARP_SIZE*nwarps, 2)
-#endif // defined(RDNA3) || defined(RDNA2) || defined(RDNA1)
+#endif // defined(RDNA3) || defined(RDNA2)
 #else
 #if __CUDA_ARCH__ >= CC_VOLTA
     __launch_bounds__(WARP_SIZE*nwarps, 1)


### PR DESCRIPTION
The change on the launch_bounds was causing a small performance drop in prompt processing, apparently this change was only beneficial before I tuned the mmq_y values.

| model                          |       size |     params | backend    | ngl |          test |              t/s master| t/s PR | Speedup |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | ---------------: | ---------------: | ------------:
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  99 |         pp512 |    276.60 ± 0.41 |    300.60 ± 0.46 | 1.09 |
 



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
