### PR TITLE
passkey : add short intro to README.md [no-ci]

### DIFF
--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -1,4 +1,5 @@
 # llama.cpp/example/passkey
+
 A passkey retrieval task is an evaluation method used to measure a language
 models ability to recall information from long contexts.
 

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -1,4 +1,6 @@
 # llama.cpp/example/passkey
+A passkey retrieval task is an evaluation method used to measure a language
+models ability to recall information from long contexts.
 
 See the following PRs for more info:
 


### PR DESCRIPTION
This commit adds a short introduction to the README.md file in the examples/passkey directory.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
