### PR TITLE
py : use cpu-only torch in requirements.txt

### DIFF
--- a/examples/llava/requirements.txt
+++ b/examples/llava/requirements.txt
@@ -1,3 +1,4 @@
 -r ../../requirements/requirements-convert_legacy_llama.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
 pillow~=10.2.0
 torch~=2.2.1

--- a/requirements/requirements-convert_hf_to_gguf.txt
+++ b/requirements/requirements-convert_hf_to_gguf.txt
@@ -1,2 +1,3 @@
 -r ./requirements-convert_legacy_llama.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch~=2.2.1

--- a/requirements/requirements-convert_hf_to_gguf_update.txt
+++ b/requirements/requirements-convert_hf_to_gguf_update.txt
@@ -1,2 +1,3 @@
 -r ./requirements-convert_legacy_llama.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch~=2.2.1


### PR DESCRIPTION
Since #5745 makes the toplevel `pyproject.toml` depend on cpu-only `torch` from `https://download.pytorch.org/whl/cpu`, I think it might be good to also make the `requirements.txt` files use the cpu-only `torch` wheels.

This uses `--extra-index-url`, which [has some pitfalls](https://github.com/pypa/pip/issues/9612) but using it to get platform-specific wheels [seems like an intended use-case](https://github.com/pypa/pip/issues/9612#issuecomment-784848470).

This reduces the network usage of the `check-requirements.sh` script; the check on GitHub seems to go 3x faster than before.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
