### PR TITLE
server: Retrieve prompt template in /props

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -367,7 +367,7 @@ Notice that each `probs` is an array of length `n_probs`.
   "user_name": "",
   "default_generation_settings": { ... },
   "total_slots": 1,
-  "model_template": ""
+  "chat_template": ""
 }
 ```
 
@@ -375,7 +375,7 @@ Notice that each `probs` is an array of length `n_probs`.
 - `user_name` - the required anti-prompt to generate the prompt in case you have specified a system prompt for all slots.
 - `default_generation_settings` - the default generation settings for the `/completion` endpoint, which has the same fields as the `generation_settings` response object from the `/completion` endpoint.
 - `total_slots` - the total number of slots for process requests (defined by `--parallel` option)
-- `model_template` - the model's original Jinja2 prompt template
+- `chat_template` - the model's original Jinja2 prompt template
 
 - **POST** `/v1/chat/completions`: OpenAI-compatible Chat Completions API. Given a ChatML-formatted json description in `messages`, it returns the predicted completion. Both synchronous and streaming mode are supported, so scripted and interactive applications work fine. While no strong claims of compatibility with OpenAI API spec is being made, in our experience it suffices to support many apps. Only models with a [supported chat template](https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template) can be used optimally with this endpoint. By default, the ChatML template will be used.
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -366,7 +366,8 @@ Notice that each `probs` is an array of length `n_probs`.
   "assistant_name": "",
   "user_name": "",
   "default_generation_settings": { ... },
-  "total_slots": 1
+  "total_slots": 1,
+  "model_template": ""
 }
 ```
 
@@ -374,6 +375,7 @@ Notice that each `probs` is an array of length `n_probs`.
 - `user_name` - the required anti-prompt to generate the prompt in case you have specified a system prompt for all slots.
 - `default_generation_settings` - the default generation settings for the `/completion` endpoint, which has the same fields as the `generation_settings` response object from the `/completion` endpoint.
 - `total_slots` - the total number of slots for process requests (defined by `--parallel` option)
+- `model_template` - the model's original Jinja2 prompt template
 
 - **POST** `/v1/chat/completions`: OpenAI-compatible Chat Completions API. Given a ChatML-formatted json description in `messages`, it returns the predicted completion. Both synchronous and streaming mode are supported, so scripted and interactive applications work fine. While no strong claims of compatibility with OpenAI API spec is being made, in our experience it suffices to support many apps. Only models with a [supported chat template](https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template) can be used optimally with this endpoint. By default, the ChatML template will be used.
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2970,10 +2970,8 @@ int main(int argc, char ** argv) {
         std::string template_key = "tokenizer.chat_template", curr_tmpl;
         int32_t tlen = llama_model_meta_val_str(ctx_server.model, template_key.c_str(), nullptr, 0);
         if (tlen > 0) {
-            std::vector<char> model_template(tlen + 1, 0);
-            if (llama_model_meta_val_str(ctx_server.model, template_key.c_str(), model_template.data(), model_template.size()) > 0) {
-                curr_tmpl = std::string(model_template.data(), model_template.size());
-            }
+            curr_tmpl.resize(tlen + 1);
+            llama_model_meta_val_str(ctx_server.model, template_key.c_str(), &curr_tmpl[0], curr_tmpl.size());
         }
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         json data = {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2967,10 +2967,13 @@ int main(int argc, char ** argv) {
     };
 
     const auto handle_props = [&ctx_server](const httplib::Request & req, httplib::Response & res) {
-        std::vector<char> model_template(2048, 0); // longest known template is about 1200 bytes
         std::string template_key = "tokenizer.chat_template", curr_tmpl;
-        if (llama_model_meta_val_str(ctx_server.model, template_key.c_str(), model_template.data(), model_template.size()) > 0) {
-            curr_tmpl = std::string(model_template.data(), model_template.size());
+        int32_t tlen = llama_model_meta_val_str(ctx_server.model, template_key.c_str(), nullptr, 0);
+        if (tlen > 0) {
+            std::vector<char> model_template(tlen + 1, 0);
+            if (llama_model_meta_val_str(ctx_server.model, template_key.c_str(), model_template.data(), model_template.size()) > 0) {
+                curr_tmpl = std::string(model_template.data(), model_template.size());
+            }
         }
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         json data = {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2970,8 +2970,10 @@ int main(int argc, char ** argv) {
         std::string template_key = "tokenizer.chat_template", curr_tmpl;
         int32_t tlen = llama_model_meta_val_str(ctx_server.model, template_key.c_str(), nullptr, 0);
         if (tlen > 0) {
-            curr_tmpl.resize(tlen + 1);
-            llama_model_meta_val_str(ctx_server.model, template_key.c_str(), &curr_tmpl[0], curr_tmpl.size());
+            std::vector<char> curr_tmpl_buf(tlen + 1, 0);
+            if (llama_model_meta_val_str(ctx_server.model, template_key.c_str(), curr_tmpl_buf.data(), curr_tmpl_buf.size()) == tlen) {
+                curr_tmpl = std::string(curr_tmpl_buf.data(), tlen);
+            }
         }
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         json data = {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2978,7 +2978,7 @@ int main(int argc, char ** argv) {
             { "system_prompt",               ctx_server.system_prompt.c_str() },
             { "default_generation_settings", ctx_server.default_generation_settings_for_props },
             { "total_slots",                 ctx_server.params.n_parallel },
-            { "model_template",              curr_tmpl.c_str() }
+            { "chat_template",               curr_tmpl.c_str() }
         };
 
         res.set_content(data.dump(), "application/json; charset=utf-8");


### PR DESCRIPTION
This PR adds the following:
- Expose the actual Jinja2 prompt template of the model in the /props endpoint.
- Change log-level from Error to Warning for warning about template mismatch.

The front-end stands a better chance of actually executing the Jinja template format correctly. Server is currently just guessing it.

Ideally this should have been inside a JSON block that expose the same key/value pairs as listed during startup in `llm_load_print_meta` function, allowing front-end to read a plethora of model properties.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
