### PR TITLE
finetune: Rename command name in README.md

### DIFF
--- a/examples/finetune/README.md
+++ b/examples/finetune/README.md
@@ -87,4 +87,4 @@ The LORA rank can be configured for each model tensor type separately with these
 
 The LORA rank of 'norm' tensors should always be 1.
 
-To see all available options use `finetune --help`.
+To see all available options use `llama-finetune --help`.


### PR DESCRIPTION
Rename an old command name "finetune" to "llama-finetune" in README.md


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
