### PR TITLE
fix and speed up compilaton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,3 +28,5 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(llama PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(llama PRIVATE LLAMA_SHARED LLAMA_BUILD)
 endif()
+
+set_source_files_properties(unicode-data.cpp PROPERTIES COMPILE_FLAGS -O1)


### PR DESCRIPTION
unicode-data.cpp takes very long to compile on x86_64 low powered Mac with clang 17.0.6 and aarch64 linux GNU 12.2.0 goes OOM on 1GB RAM SBC

Review Complexity : Low