### PR TITLE
cmake : allow external ggml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,10 @@ llama_option_depr(WARNING     LLAMA_SYCL_F16            GGML_SYCL_F16)
 # build the library
 #
 
-add_subdirectory(ggml)
+if (NOT TARGET ggml)
+    add_subdirectory(ggml)
+    # ... otherwise assume ggml is added by a parent CMakeLists.txt
+endif()
 add_subdirectory(src)
 
 #


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity: Very low

This is a minor change which allows the use of llama.cpp as a subdirectory with ggml provided externally (at one's own risk of course). As in:

```cmake
add_subdirectory(ggml)
add_subdirectory(llama.cpp)
```

Check whether ggml is a target and if it is, assume it's added from a parent project