### PR TITLE
ggml : reading the runtime sve config of the cpu

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -37,6 +37,10 @@
 #include <unistd.h>
 #endif
 
+#if defined(__ARM_FEATURE_SVE)
+#include <sys/prctl.h>
+#endif
+
 #ifdef __ARM_FEATURE_MATMUL_INT8
 #undef GGML_USE_LLAMAFILE
 #endif
@@ -21760,7 +21764,7 @@ int ggml_cpu_has_neon(void) {
 int ggml_cpu_has_sve(void) {
 #if defined(__ARM_FEATURE_SVE)
     // TODO: Currently, SVE 256 bit is only supported.
-    GGML_ASSERT(svcntb() == QK8_0);
+    GGML_ASSERT((PR_SVE_VL_LEN_MASK & prctl(PR_SVE_GET_VL)) == QK8_0);
     return 1;
 #else
     return 0;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

To go from SVE512 to SVE256 (or other configurations), one can use the following:
```
$ cat wrapper.c
#include <sys/prctl.h>
#include <unistd.h>
int main(int argc, char *argv[], char *envp[]){
  prctl(PR_SVE_SET_VL,32|PR_SVE_VL_INHERIT);
  execve(argv[1], &argv[1], envp); return 0;
}
$ gcc wrapper.c -o wrapper
$ ./wrapper ./bin/llama-cli ...
```
However, when ggml reads the "current" sve width via `svcntb()` it still gets the wrong value, and only `prctl(PR_SVE_GET_VL)` returns the correct value.