### PR TITLE
Add assertion informing the API user about missing llama_encode() call

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13200,6 +13200,8 @@ struct llm_build_context {
                     LLM_NORM_RMS, cb, -1);
             cb(cur, "result_norm", -1);
         } else {
+            GGML_ASSERT(n_outputs_enc > 0 && "call llama_encode() first");
+
             struct ggml_tensor * embd_enc       = llm_build_inp_embd_enc();
             struct ggml_tensor * pos_bucket_dec = llm_build_pos_bucket(true);
 


### PR DESCRIPTION
Using encoder-decoder models like T5 without calling `llama_encode()` first currently results in a cryptic error message:

```GGML_ASSERT: ggml/src/ggml.c:5278: !ggml_is_transposed(a)```

that is already causing confusion: #8398.

This PR adds an assertion to `build_t5()` that informs the API user about the necessity of calling `llama_encode()` first if there are no encoder outputs present during `llama_decode()`. With this PR the error message is:

```GGML_ASSERT: src/llama.cpp:13203: n_outputs_enc > 0 && "call llama_encode() first"```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
