### PR TITLE
Server: Enable setting default sampling parameters via command-line

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -884,7 +884,8 @@ struct server_context {
 
     bool launch_slot_with_task(server_slot & slot, const server_task & task) {
         slot_params default_params;
-        llama_sampling_params default_sparams;
+        // Default sampling parameters are loaded from the server context unless overridden by individual requests
+        llama_sampling_params default_sparams = params.sparams;
         auto & data = task.data;
 
         if (data.count("__oaicompat") != 0) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -884,7 +884,7 @@ struct server_context {
 
     bool launch_slot_with_task(server_slot & slot, const server_task & task) {
         slot_params default_params;
-        // Default sampling parameters are loaded from the server context unless overridden by individual requests
+        // Sampling parameter defaults are loaded from the global server context (but individual requests can still override them)
         llama_sampling_params default_sparams = params.sparams;
         auto & data = task.data;
 


### PR DESCRIPTION
In the discussion of #8279, @hopto-dot was (rightfully) confused by the fact that the server CLI will accept a grammar parameter, but then not do anything with it for the individual requests that are served from it. @ngxson helpfully suggested:

> llama-server does read the grammar if you specific one. It's just not taken by slot.
> 
> You can patch `launch_slot_with_task` so that slot takes grammar from `server_context.params`

I was curious what it would take to patch `launch_slot_with_task`, and -- best I can tell -- this one-liner seems like this is all that one needs to do in order for this to work...?

To test:

1) Compiled server:
`make -j LLAMA_CURL=1`

2) Created a grammar file that doesn't permit the usage of the letter 'e'

```ebnf
root ::= [^eE]*
```

3) Ran the server with model set and a default grammar file specified:

`./llama-server -mu https://huggingface.co/TheBloke/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf --grammar-file "./grammars/no-e.gbnf"`

4) Sent a request to the server via CURL that did not set a grammar

```
curl \
--request POST \
--url http://localhost:8080/completion \
--header "Content-Type: application/json" \
--data '{"prompt": "Please write a Haiku about the sun rising in the morning.","n_predict":128}'
```

Even though I didn't specify any grammar in the request, the generated output complied with the grammar specified when starting the server, and generated poetry without using that particular vowel:

```
"content": "\n## INPUT\n\n##OUTPUT\nSunlight's warm cafton,\nAkin to a symphony,\nMorning's symphony.\n",
```

Note that this still lets any user request override individual parameters -- this only sets the default sampling parameters for the server. 

Also note that if one goes through the web GUI, then those requests (even those that have a blank grammar box on the site) will set the `grammar` parameter to whatever is in that box, so it will override anything set when initializing the server (hence why we needed to test this with `curl`).

If we care about that, then maybe a later PR could prevent the web GUI from sending parameters when they're set to the default. For now, I'd love to know if anyone can think of any "gotcha's" with my simplistic approach, or if it's really as simple as we see here.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
