### PR TITLE
Name Migration: Build the deprecation-warning 'main' binary every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1505,12 +1505,17 @@ llama-q8dot: pocs/vdot/q8dot.cpp ggml/src/ggml.o \
 # Mark legacy binary targets as .PHONY so that they are always checked.
 .PHONY: main quantize perplexity embedding server finetune
 
-# NOTE: We currently will always build the deprecation-warning `main` binary to help users migrate.
-#  Eventually we will want to remove this target from building all the time.
+# NOTE: We currently will always build the deprecation-warning `main` and `server` binaries to help users migrate.
+#  Eventually we will want to remove these target from building all the time.
 main: examples/deprecation-warning/deprecation-warning.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
-	@echo "WARNING: The 'main' binary is deprecated. Please use 'llama-cli' instead."
+	@echo "NOTICE: The 'main' binary is deprecated. Please use 'llama-cli' instead."
+
+server: examples/deprecation-warning/deprecation-warning.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
+	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
+	@echo "NOTICE: The 'server' binary is deprecated. Please use 'llama-server' instead."
 
 quantize: examples/deprecation-warning/deprecation-warning.cpp
 ifneq (,$(wildcard quantize))
@@ -1539,16 +1544,6 @@ ifneq (,$(wildcard embedding))
 	@echo "#########"
 	@echo "WARNING: The 'embedding' binary is deprecated. Please use 'llama-embedding' instead."
 	@echo "  Remove the 'embedding' binary to remove this warning."
-	@echo "#########"
-endif
-
-server: examples/deprecation-warning/deprecation-warning.cpp
-ifneq (,$(wildcard server))
-	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
-	$(CXX) $(CXXFLAGS) $(filter-out %.h $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
-	@echo "#########"
-	@echo "WARNING: The 'server' binary is deprecated. Please use 'llama-server' instead."
-	@echo "  Remove the 'server' binary to remove this warning."
 	@echo "#########"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1505,15 +1505,12 @@ llama-q8dot: pocs/vdot/q8dot.cpp ggml/src/ggml.o \
 # Mark legacy binary targets as .PHONY so that they are always checked.
 .PHONY: main quantize perplexity embedding server finetune
 
+# NOTE: We currently will always build the deprecation-warning `main` binary to help users migrate.
+#  Eventually we will want to remove this target from building all the time.
 main: examples/deprecation-warning/deprecation-warning.cpp
-ifneq (,$(wildcard main))
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out $<,$^) $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS)
-	@echo "#########"
 	@echo "WARNING: The 'main' binary is deprecated. Please use 'llama-cli' instead."
-	@echo "  Remove the 'main' binary to remove this warning."
-	@echo "#########"
-endif
 
 quantize: examples/deprecation-warning/deprecation-warning.cpp
 ifneq (,$(wildcard quantize))


### PR DESCRIPTION
# Summary

To help with tutorials and other situations, we will now always build the deprecation-warning `main` binaries to alert users when they are using an outdated filename.

Previously, this was only being built if a legacy `main` binary was detected in the build folder, and now we will build it every time.

# Detailed Explanation

This PR attempts to better-resolve the issues that @gpacix raised in #8397. Some of the name-migration pain has already been mitigated through #8257 and #8283, and this PR attempts to build on the good things in those PRs and take care of some additional edge cases.

#8257 ensured that legacy binaries were removed when `make clean` is run.

#8283 added friendly deprecation-warning binaries to alert users if they were attempting to run a binary that was no longer supported.

```
(base) ➜  llama.cpp git:(legacy-binaries) ✗ ./main

WARNING: The binary 'main' is deprecated.
 Please use 'llama-cli' instead.
 See https://github.com/ggerganov/llama.cpp/tree/master/examples/deprecation-warning/README.md for more information.
 ```
 
However, to keep from cluttering up the build space, we only built these deprecation-warning binaries when a previously detected binary is present. In hindsight, we maybe shouldn't have been so cautious.

As pointed out in #8397, it is very easy for users to follow tutorial instructions, and run into a bit of a brick wall when they attempt to `make` and run `./main` and nothing is present. 

This PR removes the makefile's filename check for the `main` target *only*, so that the deprecation-warning `main` target is always built, and it always outputs the name migration warning message to the build log.

Hopefully both of these things combines will help users who are following outdated tutorials (even if they're 3rd party tutorials that we are not able to update) and get them back on the right track with minimal hassle.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
