### PR TITLE
CUDA: optimize and refactor MMQ

### DIFF
--- a/ggml/src/ggml-cuda/mma.cuh
+++ b/ggml/src/ggml-cuda/mma.cuh
@@ -70,6 +70,10 @@ struct mma_int_A_I16K8 {
         }
 #endif // defined(INT8_MMA_AVAILABLE)
     }
+
+    __device__ __forceinline__ void load_low(const int * __restrict__ xs0, const int & stride) {
+        ((mma_int_A_I16K4 *) x)[0].load(xs0, stride);
+    }
 };
 
 struct mma_int_B_J8K4 {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -8,9 +8,11 @@
 #include <cstdint>
 
 #define MMQ_DP4A_MAX_BATCH_SIZE 64 // Max. batch size to use for dp4a MMQ kernels when FP16 tensor cores are available.
+#define MMQ_ITER_K 256
+#define MMQ_NWARPS 8
 
 typedef void (*load_tiles_mmq_t)(const char * __restrict__ x, int * x_tile, const int & kbx0, const int & i_max, const int & stride);
-typedef void (*vec_dot_mmq_t)(const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0);
+typedef void (*vec_dot_mmq_t)(const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00);
 typedef void (*mmq_write_back_t)(const float * __restrict__ sum, float * __restrict__ dst, const int & stride, const int & i_max, const int & j_max);
 
 struct block_q8_1_mmq {
@@ -79,49 +81,46 @@ static constexpr __device__ int get_mmq_y_device() {
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
 }
 
-#define MMQ_DP4A_TXS_Q4_0 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_0 + mmq_y/QI4_0, 0}
-#define MMQ_DP4A_TXS_Q4_1 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_1 + mmq_y/QI4_1, 0}
-#define MMQ_DP4A_TXS_Q5_0 tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI5_0 + mmq_y/QI5_0, 0}
-#define MMQ_DP4A_TXS_Q5_1 tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI5_1 + mmq_y/QI5_1, 0}
-#define MMQ_DP4A_TXS_Q8_0 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI8_0 + mmq_y/QI8_0, 0}
-#define MMQ_DP4A_TXS_Q2_K tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE       + mmq_y,       0}
-#define MMQ_DP4A_TXS_Q3_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI3_K + mmq_y/QI3_K, mmq_y*WARP_SIZE/4 + mmq_y/4}
-#define MMQ_DP4A_TXS_Q4_K tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_K + mmq_y/QI4_K, mmq_y*WARP_SIZE/8 + mmq_y/8}
-#define MMQ_DP4A_TXS_Q5_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI5_K + mmq_y/QI5_K, mmq_y*WARP_SIZE/8 + mmq_y/8}
-#define MMQ_DP4A_TXS_Q6_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI6_K + mmq_y/QI6_K, mmq_y*WARP_SIZE/8 + mmq_y/8}
+#define MMQ_DP4A_TXS_Q4_0 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_0   + mmq_y/QI4_0,     0}
+#define MMQ_DP4A_TXS_Q4_1 tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_1   + mmq_y/QI4_1,     0}
+#define MMQ_DP4A_TXS_Q8_0 tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE*2/QI8_0 + mmq_y/(QI8_0/2), 0}
+#define MMQ_DP4A_TXS_Q8_1 tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE*2/QI8_1 + mmq_y/(QI8_1/2), 0}
+#define MMQ_DP4A_TXS_Q2_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE         + mmq_y,           0}
+#define MMQ_DP4A_TXS_Q3_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y,                                     mmq_y*WARP_SIZE/8 + mmq_y/8}
+#define MMQ_DP4A_TXS_Q4_K tile_x_sizes{mmq_y*WARP_SIZE   + mmq_y, mmq_y*WARP_SIZE/QI4_K   + mmq_y/QI4_K,     mmq_y*WARP_SIZE/8 + mmq_y/8}
+#define MMQ_DP4A_TXS_Q5_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI5_K   + mmq_y/QI5_K,     mmq_y*WARP_SIZE/8 + mmq_y/8}
+#define MMQ_DP4A_TXS_Q6_K tile_x_sizes{mmq_y*WARP_SIZE*2 + mmq_y, mmq_y*WARP_SIZE/QI6_K   + mmq_y/QI6_K,     mmq_y*WARP_SIZE/8 + mmq_y/8}
 
 static constexpr __host__ __device__ tile_x_sizes mmq_get_dp4a_tile_x_sizes(ggml_type type, int mmq_y) {
     return type == GGML_TYPE_Q4_0 ? MMQ_DP4A_TXS_Q4_0 :
         type == GGML_TYPE_Q4_1    ? MMQ_DP4A_TXS_Q4_1 :
-        type == GGML_TYPE_Q5_0    ? MMQ_DP4A_TXS_Q5_0 :
-        type == GGML_TYPE_Q5_1    ? MMQ_DP4A_TXS_Q5_1 :
+        type == GGML_TYPE_Q5_0    ? MMQ_DP4A_TXS_Q8_0 :
+        type == GGML_TYPE_Q5_1    ? MMQ_DP4A_TXS_Q8_1 :
         type == GGML_TYPE_Q8_0    ? MMQ_DP4A_TXS_Q8_0 :
         type == GGML_TYPE_Q2_K    ? MMQ_DP4A_TXS_Q2_K :
         type == GGML_TYPE_Q3_K    ? MMQ_DP4A_TXS_Q3_K :
         type == GGML_TYPE_Q4_K    ? MMQ_DP4A_TXS_Q4_K :
         type == GGML_TYPE_Q5_K    ? MMQ_DP4A_TXS_Q5_K :
         type == GGML_TYPE_Q6_K    ? MMQ_DP4A_TXS_Q6_K :
-        type == GGML_TYPE_IQ4_XS  ? MMQ_DP4A_TXS_Q5_0 :
-        type == GGML_TYPE_IQ4_NL  ? MMQ_DP4A_TXS_Q5_0 :
+        type == GGML_TYPE_IQ4_XS  ? MMQ_DP4A_TXS_Q8_0 :
+        type == GGML_TYPE_IQ4_NL  ? MMQ_DP4A_TXS_Q8_0 :
         tile_x_sizes{0, 0, 0};
 }
 
-#define MMQ_MMA_TILE_X_K_Q4_0 (1*WARP_SIZE + WARP_SIZE/QI4_0               + 4)
-#define MMQ_MMA_TILE_X_K_Q4_1 (1*WARP_SIZE + WARP_SIZE/QI4_1               + 4)
-#define MMQ_MMA_TILE_X_K_Q5_0 (2*WARP_SIZE + WARP_SIZE/QI5_0               + 4)
-#define MMQ_MMA_TILE_X_K_Q5_1 (2*WARP_SIZE + WARP_SIZE/QI5_1               + 4)
-#define MMQ_MMA_TILE_X_K_Q8_0 (1*WARP_SIZE + WARP_SIZE/QI8_0               + 0)
-#define MMQ_MMA_TILE_X_K_Q2_K (1*WARP_SIZE + WARP_SIZE                     + 4)
-#define MMQ_MMA_TILE_X_K_Q3_K (2*WARP_SIZE + WARP_SIZE/QI3_K + WARP_SIZE/4 + 2)
-#define MMQ_MMA_TILE_X_K_Q4_K (1*WARP_SIZE + WARP_SIZE/QI4_K + WARP_SIZE/8 + 7)
-#define MMQ_MMA_TILE_X_K_Q5_K (2*WARP_SIZE + WARP_SIZE/QI5_K + WARP_SIZE/8 + 7)
-#define MMQ_MMA_TILE_X_K_Q6_K (2*WARP_SIZE + WARP_SIZE/QI6_K + WARP_SIZE/8 + 7)
+#define MMQ_MMA_TILE_X_K_Q4_0 (1*WARP_SIZE + WARP_SIZE/QI4_0                   + 4)
+#define MMQ_MMA_TILE_X_K_Q4_1 (1*WARP_SIZE + WARP_SIZE/QI4_1                   + 4)
+#define MMQ_MMA_TILE_X_K_Q8_0 (2*WARP_SIZE + 2*WARP_SIZE/QI8_0                 + 4)
+#define MMQ_MMA_TILE_X_K_Q8_1 (2*WARP_SIZE + 2*WARP_SIZE/QI8_0                 + 4)
+#define MMQ_MMA_TILE_X_K_Q2_K (2*WARP_SIZE + WARP_SIZE                         + 4)
+#define MMQ_MMA_TILE_X_K_Q3_K (2*WARP_SIZE + WARP_SIZE/(2*QI3_K) + WARP_SIZE/8 + 7)
+#define MMQ_MMA_TILE_X_K_Q4_K (1*WARP_SIZE + WARP_SIZE/QI4_K     + WARP_SIZE/8 + 7)
+#define MMQ_MMA_TILE_X_K_Q5_K (2*WARP_SIZE + WARP_SIZE/QI5_K     + WARP_SIZE/8 + 7)
+#define MMQ_MMA_TILE_X_K_Q6_K (2*WARP_SIZE + WARP_SIZE/QI6_K     + WARP_SIZE/8 + 7)
 
 static_assert(MMQ_MMA_TILE_X_K_Q4_0 % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q4_1 % 8 == 4, "Wrong padding.");
-static_assert(MMQ_MMA_TILE_X_K_Q5_0 % 8 == 4, "Wrong padding.");
-static_assert(MMQ_MMA_TILE_X_K_Q5_1 % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q8_0 % 8 == 4, "Wrong padding.");
+static_assert(MMQ_MMA_TILE_X_K_Q8_1 % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q2_K % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q3_K % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q4_K % 8 == 4, "Wrong padding.");
@@ -131,21 +130,20 @@ static_assert(MMQ_MMA_TILE_X_K_Q6_K % 8 == 4, "Wrong padding.");
 static constexpr __host__ __device__ int mmq_get_mma_tile_x_k(ggml_type type) {
     return type == GGML_TYPE_Q4_0 ? MMQ_MMA_TILE_X_K_Q4_0 :
         type == GGML_TYPE_Q4_1    ? MMQ_MMA_TILE_X_K_Q4_1 :
-        type == GGML_TYPE_Q5_0    ? MMQ_MMA_TILE_X_K_Q5_0 :
-        type == GGML_TYPE_Q5_1    ? MMQ_MMA_TILE_X_K_Q5_1 :
+        type == GGML_TYPE_Q5_0    ? MMQ_MMA_TILE_X_K_Q8_0 :
+        type == GGML_TYPE_Q5_1    ? MMQ_MMA_TILE_X_K_Q8_1 :
         type == GGML_TYPE_Q8_0    ? MMQ_MMA_TILE_X_K_Q8_0 :
         type == GGML_TYPE_Q2_K    ? MMQ_MMA_TILE_X_K_Q2_K :
         type == GGML_TYPE_Q3_K    ? MMQ_MMA_TILE_X_K_Q3_K :
         type == GGML_TYPE_Q4_K    ? MMQ_MMA_TILE_X_K_Q4_K :
         type == GGML_TYPE_Q5_K    ? MMQ_MMA_TILE_X_K_Q5_K :
         type == GGML_TYPE_Q6_K    ? MMQ_MMA_TILE_X_K_Q6_K :
-        type == GGML_TYPE_IQ4_XS  ? MMQ_MMA_TILE_X_K_Q5_0 :
-        type == GGML_TYPE_IQ4_NL  ? MMQ_MMA_TILE_X_K_Q5_0 :
+        type == GGML_TYPE_IQ4_XS  ? MMQ_MMA_TILE_X_K_Q8_0 :
+        type == GGML_TYPE_IQ4_NL  ? MMQ_MMA_TILE_X_K_Q8_0 :
         0;
 }
 
 #define MMQ_TILE_Y_K (WARP_SIZE + WARP_SIZE/QI8_1)
-#define MMQ_NWARPS 8
 
 static int mmq_get_granularity_host(const int mmq_x, const int cc) {
     return int8_mma_available(cc) && mmq_x >= 48 ? 16 : 8;
@@ -218,7 +216,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_0_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_0, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -226,34 +224,39 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_0*VDR_Q4_0_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
-
-            const int kyqs = k0 % (QI8_1/2) + QI8_1 * (k0 / (QI8_1/2));
-
-            int u[2*VDR_Q4_0_Q8_1_MMQ];
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
 #pragma unroll
-            for (int l = 0; l < VDR_Q4_0_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI4_0) % WARP_SIZE];
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                const int kyqs = QI8_1 * ((k01/2) / (QI8_1/2)) + (k01/2) % (QI8_1/2);
+
+                int u[2*VDR_Q4_0_Q8_1_MMQ];
+
+#pragma unroll
+                for (int l = 0; l < VDR_Q4_0_Q8_1_MMQ; ++l) {
+                    u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + kyqs +  l];
+                    u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + kyqs + (l + QI4_0)];
+                }
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_0_q8_1_impl<VDR_Q4_0_Q8_1_MMQ>
+                    (&x_qs[i*(WARP_SIZE + 1) + k0/QR4_0], u,
+                     x_df[i*(WARP_SIZE/QI4_0) + i/QI4_0 + k0/(QR4_0*QI4_0)], y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
             }
-
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_0_q8_1_impl<VDR_Q4_0_Q8_1_MMQ>
-                (&x_qs[i*(WARP_SIZE + 1) + k0], u, x_df[i*(WARP_SIZE/QI4_0) + i/QI4_0 + k0/QI4_0],
-                y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
@@ -271,52 +274,60 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_mma(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-    mma_A A[ntx];
-    float dA[ntx][mma_C::ne/2];
+    mma_A A[ntx][4];
+    float dA[ntx][mma_C::ne/2][4];
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int l = 0; l < mma_A::ne; ++l) {
-            const int i     = i0 + n*mma_A::I + mma_A::get_i(l);
-            const int k     = k0              + mma_A::get_k(l) % QI4_0;
-            const int shift =                4*(mma_A::get_k(l) / QI4_0);
-
-            A[n].x[l] = __vsubss4((x_qs[i*MMQ_MMA_TILE_X_K_Q4_0 + k] >> shift) & 0x0F0F0F0F, 0x08080808);
-        }
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_0*QI4_0) {
+            const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+            for (int l = 0; l < mma_A::ne; ++l) {
+                const int i     = i0 + n*mma_A::I + mma_A::get_i(l);
+                const int k     = k0/QR4_0        + mma_A::get_k(l) % QI4_0;
+                const int shift =                4*(mma_A::get_k(l) / QI4_0);
 
-            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q4_0 + k0/QI4_0];
+                A[n][k01/(QR4_0*QI4_0)].x[l] = __vsubss4((x_qs[i*MMQ_MMA_TILE_X_K_Q4_0 + k] >> shift) & 0x0F0F0F0F, 0x08080808);
+            }
+
+#pragma unroll
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+
+                dA[n][l][k01/(QR4_0*QI4_0)] = x_df[i*MMQ_MMA_TILE_X_K_Q4_0 + k0/(QR4_0*QI4_0)];
+            }
         }
     }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B  B;
-        float dB[mma_C::ne/2];
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_0*QI4_0) {
+            mma_B  B;
+            float dB[mma_C::ne/2];
 
-        B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE, MMQ_TILE_Y_K);
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
 
-            dB[l] = __low2float(y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
-        }
-
-#pragma unroll
-    for (int n = 0; n < ntx; ++n) {
-            mma_C C;
-            C.mma_K8(A[n], B);
+                dB[l] = __low2float(y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += dA[n][l/2]*dB[l%2]*C.x[l];
+            for (int n = 0; n < ntx; ++n) {
+                mma_C C;
+                C.mma_K8(A[n][k01/(QR4_0*QI4_0)], B);
+
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] += dA[n][l/2][k01/(QR4_0*QI4_0)]*dB[l%2]*C.x[l];
+                }
             }
         }
     }
@@ -381,7 +392,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_1_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_1, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -389,34 +400,39 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_1*VDR_Q4_1_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
-
-            const int kyqs = k0 % (QI8_1/2) + QI8_1 * (k0 / (QI8_1/2));
-
-            int u[2*VDR_Q4_1_Q8_1_MMQ];
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
 #pragma unroll
-            for (int l = 0; l < VDR_Q4_1_Q8_1_MMQ; ++l) {
-                u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l)         % WARP_SIZE];
-                u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + (kyqs + l + QI4_1) % WARP_SIZE];
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                const int kyqs = QI8_1 * ((k01/2) / (QI8_1/2)) + (k01/2) % (QI8_1/2);
+
+                int u[2*VDR_Q4_1_Q8_1_MMQ];
+
+#pragma unroll
+                for (int l = 0; l < VDR_Q4_1_Q8_1_MMQ; ++l) {
+                    u[2*l+0] = y_qs[j*MMQ_TILE_Y_K + kyqs +  l];
+                    u[2*l+1] = y_qs[j*MMQ_TILE_Y_K + kyqs + (l + QI4_1)];
+                }
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_1_q8_1_impl<VDR_Q4_1_Q8_1_MMQ>
+                    (&x_qs[i*(WARP_SIZE + 1) + k0/QR4_1], u,
+                     x_dm[i*(WARP_SIZE/QI4_1) + i/QI4_1 + k0/(QR4_1*QI4_1)], y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
             }
-
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_1_q8_1_impl<VDR_Q4_1_Q8_1_MMQ>
-                (&x_qs[i*(WARP_SIZE + 1) + k0], u, x_dm[i*(WARP_SIZE/QI4_1) + i/QI4_1 + k0/QI4_1],
-                y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
@@ -435,50 +451,58 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_mma(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-    mma_A A[ntx];
-    half2 dmA[ntx][mma_C::ne/2];
+    mma_A A[ntx][4];
+    half2 dmA[ntx][mma_C::ne/2][4];
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
-        ((mma_A_K4 *) &A[n])[0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q4_1 + k0, MMQ_MMA_TILE_X_K_Q4_1);
-        A[n].x[2]  = (A[n].x[0] >> 4) & 0x0F0F0F0F;
-        A[n].x[3]  = (A[n].x[1] >> 4) & 0x0F0F0F0F;
-        A[n].x[0] &= 0x0F0F0F0F;
-        A[n].x[1] &= 0x0F0F0F0F;
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_1*QI4_1) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/(QR4_1*QI4_1)].load_low(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q4_1 + k0/QR4_1, MMQ_MMA_TILE_X_K_Q4_1);
+            A[n][k01/(QR4_1*QI4_1)].x[2]  = (A[n][k01/(QR4_1*QI4_1)].x[0] >> 4) & 0x0F0F0F0F;
+            A[n][k01/(QR4_1*QI4_1)].x[3]  = (A[n][k01/(QR4_1*QI4_1)].x[1] >> 4) & 0x0F0F0F0F;
+            A[n][k01/(QR4_1*QI4_1)].x[0] &= 0x0F0F0F0F;
+            A[n][k01/(QR4_1*QI4_1)].x[1] &= 0x0F0F0F0F;
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q4_1 + k0/QI4_1];
+                dmA[n][l][k01/(QR4_1*QI4_1)] = x_dm[i*MMQ_MMA_TILE_X_K_Q4_1 + k0/(QR4_1*QI4_1)];
+            }
         }
     }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B;
-        half2 dsB[mma_C::ne/2];
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_1*QI4_1) {
+            mma_B B;
+            half2 dsB[mma_C::ne/2];
 
-        B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE, MMQ_TILE_Y_K);
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
 
-            dsB[l] = y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)];
-        }
-
-#pragma unroll
-        for (int n = 0; n < ntx; ++n) {
-            mma_C C;
-            C.mma_K8(A[n], B);
+                dsB[l] = y_ds[j*MMQ_TILE_Y_K + k01/QI8_1];
+            }
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                const half2 dmA_dsB = dmA[n][l/2]*dsB[l%2];
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
+            for (int n = 0; n < ntx; ++n) {
+                mma_C C;
+                C.mma_K8(A[n][k01/(QR4_1*QI4_1)], B);
+
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    const half2 dmA_dsB = dmA[n][l/2][k01/(QR4_1*QI4_1)]*dsB[l%2];
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
+                }
             }
         }
     }
@@ -531,8 +555,8 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         qs1     = __vsubss4(qs1, 0x10101010); // subtract 16
 
 #ifdef INT8_MMA_AVAILABLE
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + kbx*(2*QI5_0) + kqsx + 0]     = qs0;
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + kbx*(2*QI5_0) + kqsx + QI5_0] = qs1;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kbx*(2*QI5_0) + kqsx + 0]     = qs0;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kbx*(2*QI5_0) + kqsx + QI5_0] = qs1;
 #else
         x_qs[i*(2*WARP_SIZE + 1)     + kbx*(2*QI5_0) + kqsx + 0]     = qs0;
         x_qs[i*(2*WARP_SIZE + 1)     + kbx*(2*QI5_0) + kqsx + QI5_0] = qs1;
@@ -553,104 +577,11 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_q5_0 * bxi = (const block_q5_0 *) x + kbx0 + i*stride + kbxd;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_df[i*MMQ_MMA_TILE_X_K_Q5_0       + kbxd] = bxi->d;
+        x_df[i*MMQ_MMA_TILE_X_K_Q8_0       + kbxd] = bxi->d;
 #else
         x_df[i*(WARP_SIZE/QI5_0) + i/QI5_0 + kbxd] = bxi->d;
 #endif // INT8_MMA_AVAILABLE
     }
-}
-
-template <int mmq_x, int mmq_y, int nwarps>
-static __device__ __forceinline__ void vec_dot_q5_0_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
-
-    constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_0, mmq_y);
-    const int   * x_qs = (const int   *) x;
-    const float * x_df = (const float *) x_qs + txs.qs;
-    const int   * y_qs = (const int   *) y + 4;
-    const float * y_df = (const float *) y;
-
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
-
-#pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
-
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_0_q8_1_impl<float, QR5_0*VDR_Q5_0_Q8_1_MMQ>
-                (&x_qs[i*(2*WARP_SIZE + 1) + 2*k0], &y_qs[j*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE],
-                 x_df[i*(WARP_SIZE/QI5_0) + i/QI5_0 + k0/QI5_0], y_df[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
-        }
-    }
-}
-
-template <int mmq_x, int mmq_y, int nwarps>
-static __device__ __forceinline__ void vec_dot_q5_0_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
-#ifdef INT8_MMA_AVAILABLE
-
-    typedef mma_int_A_I16K8 mma_A;
-    typedef mma_int_B_J8K8  mma_B;
-    typedef mma_int_C_I16J8 mma_C;
-
-    constexpr int granularity = mmq_get_granularity_device(mmq_x);
-    constexpr int rows_per_warp = 2 * granularity;
-    constexpr int ntx = rows_per_warp/mma_C::I; // Number of x minitiles per warp.
-
-    y += (threadIdx.y % ntx) * (mma_B::J*MMQ_TILE_Y_K);
-
-    const int   * x_qs = (const int   *) x;
-    const float * x_df = (const float *) x_qs + WARP_SIZE*2;
-    const int   * y_qs = (const int   *) y + 4;
-    const float * y_df = (const float *) y;
-
-    mma_A A[ntx];
-    float dA[ntx][mma_C::ne/2];
-
-    const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
-
-#pragma unroll
-    for (int n = 0; n < ntx; ++n) {
-        A[n].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q5_0 + QR5_1*k0, MMQ_MMA_TILE_X_K_Q5_0);
-
-#pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int i = i0 + mma_C::get_i(2*l) + n*mma_C::I;
-
-            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q5_0 + k0/QI5_0];
-        }
-    }
-
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B;
-        float dB[mma_C::ne/2];
-
-        B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE, MMQ_TILE_Y_K);
-
-#pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
-
-            dB[l] = y_df[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)];
-        }
-
-#pragma unroll
-        for (int n = 0; n < ntx; ++n) {
-            mma_C C;
-            C.mma_K8(A[n], B);
-
-#pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += dA[n][l/2]*dB[l%2]*C.x[l];
-            }
-        }
-    }
-#else
-    GGML_UNUSED(x); GGML_UNUSED(y); GGML_UNUSED(sum);
-    NO_DEVICE_CODE;
-#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q5_1(
@@ -694,8 +625,8 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         qs1    |= (qh <<  9) & 0x10000000; // 19 -> 28
 
 #ifdef INT8_MMA_AVAILABLE
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_1 + kbx*(2*QI5_1) + kqsx + 0]     = qs0;
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_1 + kbx*(2*QI5_1) + kqsx + QI5_1] = qs1;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_1 + kbx*(2*QI5_1) + kqsx + 0]     = qs0;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_1 + kbx*(2*QI5_1) + kqsx + QI5_1] = qs1;
 #else
         x_qs[i*(2*WARP_SIZE + 1)     + kbx*(2*QI5_1) + kqsx + 0]     = qs0;
         x_qs[i*(2*WARP_SIZE + 1)     + kbx*(2*QI5_1) + kqsx + QI5_1] = qs1;
@@ -716,105 +647,11 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_q5_1 * bxi = (const block_q5_1 *) x + kbx0 + i*stride + kbxd;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_dm[i*MMQ_MMA_TILE_X_K_Q5_1       + kbxd] = bxi->dm;
+        x_dm[i*MMQ_MMA_TILE_X_K_Q8_1       + kbxd] = bxi->dm;
 #else
         x_dm[i*(WARP_SIZE/QI5_1) + i/QI5_1 + kbxd] = bxi->dm;
 #endif // INT8_MMA_AVAILABLE
     }
-}
-
-template <int mmq_x, int mmq_y, int nwarps>
-static __device__ __forceinline__ void vec_dot_q5_1_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
-
-    constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_1, mmq_y);
-    const int   * x_qs = (const int   *) x;
-    const half2 * x_dm = (const half2 *) x_qs + txs.qs;
-    const int   * y_qs = (const int   *) y + 4;
-    const half2 * y_ds = (const half2 *) y;
-
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
-
-#pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
-
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_1_q8_1_impl<QR5_1*VDR_Q5_1_Q8_1_MMQ>
-                (&x_qs[i*(2*WARP_SIZE + 1) + 2*k0], &y_qs[j*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE],
-                 x_dm[i*(WARP_SIZE/QI5_1) + i/QI5_1 + k0/QI5_1], y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)]);
-        }
-    }
-}
-
-template <int mmq_x, int mmq_y, int nwarps>
-static __device__ __forceinline__ void vec_dot_q5_1_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
-#ifdef INT8_MMA_AVAILABLE
-
-    typedef mma_int_A_I16K8 mma_A;
-    typedef mma_int_B_J8K8  mma_B;
-    typedef mma_int_C_I16J8 mma_C;
-
-    constexpr int granularity = mmq_get_granularity_device(mmq_x);
-    constexpr int rows_per_warp = 2 * granularity;
-    constexpr int ntx = rows_per_warp/mma_C::I; // Number of x minitiles per warp.
-
-    y += (threadIdx.y % ntx) * (mma_B::J*MMQ_TILE_Y_K);
-
-    const int   * x_qs = (const int   *) x;
-    const half2 * x_dm = (const half2 *) x_qs + 2*WARP_SIZE;
-    const int   * y_qs = (const int   *) y + 4;
-    const half2 * y_ds = (const half2 *) y;
-
-    mma_A A[ntx];
-    half2 dmA[ntx][mma_C::ne/2];
-
-    const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
-
-#pragma unroll
-    for (int n = 0; n < ntx; ++n) {
-        A[n].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q5_1 + QR5_1*k0, MMQ_MMA_TILE_X_K_Q5_1);
-
-#pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int i = i0 + mma_C::get_i(2*l) + n*mma_C::I;
-
-            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q5_1 + k0/QI5_1];
-        }
-    }
-
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B;
-        half2 dsB[mma_C::ne/2];
-
-        B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0) % WARP_SIZE, MMQ_TILE_Y_K);
-
-#pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
-
-            dsB[l] = y_ds[j*MMQ_TILE_Y_K + (2*k0/QI8_1) % (WARP_SIZE/QI8_1)];
-        }
-
-#pragma unroll
-        for (int n = 0; n < ntx; ++n) {
-            mma_C C;
-            C.mma_K8(A[n], B);
-
-#pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                const half2 dmA_dsB = dmA[n][l/2]*dsB[l%2];
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
-            }
-        }
-    }
-#else
-    GGML_UNUSED(x); GGML_UNUSED(y); GGML_UNUSED(sum);
-    NO_DEVICE_CODE;
-#endif // INT8_MMA_AVAILABLE
 }
 
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_q8_0(
@@ -822,7 +659,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 #ifdef INT8_MMA_AVAILABLE
     int   * x_qs = (int   *)  x_tile;
-    float * x_df = (float *) (x_tile + WARP_SIZE);
+    float * x_df = (float *) (x_tile + 2*WARP_SIZE);
 #else
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q8_0, mmq_y);
     int   * x_qs = (int   *)  x_tile;
@@ -843,18 +680,20 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbx;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + threadIdx.x] = get_int_b2(bxi->qs, kqsx);
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 0         + threadIdx.x] = get_int_b2(bxi[0].qs,               kqsx);
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + WARP_SIZE + threadIdx.x] = get_int_b2(bxi[WARP_SIZE/QI8_0].qs, kqsx);
 #else
-        x_qs[i*(WARP_SIZE + 1)       + threadIdx.x] = get_int_b2(bxi->qs, kqsx);
+        x_qs[i*(2*WARP_SIZE + 1)     + 0         + threadIdx.x] = get_int_b2(bxi[0].qs,               kqsx);
+        x_qs[i*(2*WARP_SIZE + 1)     + WARP_SIZE + threadIdx.x] = get_int_b2(bxi[WARP_SIZE/QI8_0].qs, kqsx);
 #endif // INT8_MMA_AVAILABLE
     }
 
-    const int blocks_per_tile_x_row = WARP_SIZE / QI8_0;
+    const int blocks_per_tile_x_row = 2*WARP_SIZE / QI8_0;
     const int kbxd = threadIdx.x % blocks_per_tile_x_row;
 
 #pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * QI8_0) {
-        int i = i0 + threadIdx.y * QI8_0 + threadIdx.x / blocks_per_tile_x_row;
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * QI8_0/2) {
+        int i = i0 + threadIdx.y * (QI8_0/2) + threadIdx.x / blocks_per_tile_x_row;
 
         if (need_check) {
             i = min(i, i_max);
@@ -863,16 +702,16 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbxd;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_df[i*MMQ_MMA_TILE_X_K_Q8_0         + kbxd] = bxi->d;
+        x_df[i*MMQ_MMA_TILE_X_K_Q8_0             + kbxd] = bxi->d;
 #else
-        x_df[i*(WARP_SIZE/QI8_0) + i / QI8_0 + kbxd] = bxi->d;
+        x_df[i*(2*WARP_SIZE/QI8_0) + i/(QI8_0/2) + kbxd] = bxi->d;
 #endif // INT8_MMA_AVAILABLE
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q8_0_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q8_0, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -880,24 +719,29 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const float * y_df = (const float *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += VDR_Q8_0_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_0_q8_1_impl<float, VDR_Q8_0_Q8_1_MMQ>
-                (&x_qs[i*(WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k0], x_df[i*(WARP_SIZE/QI8_0) + i/QI8_0 + k0/QI8_0],
-                y_df[j*MMQ_TILE_Y_K + k0/QI8_1]);
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_0_q8_1_impl<float, VDR_Q8_0_Q8_1_MMQ>
+                    (&x_qs[i*(2*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k0 % WARP_SIZE],
+                     x_df[i*(2*WARP_SIZE/QI8_0) + i/(QI8_0/2) + k0/QI8_0], y_df[j*MMQ_TILE_Y_K + (k0/QI8_1) % (WARP_SIZE/QI8_1)]);
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
@@ -911,49 +755,178 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
     y += (threadIdx.y % ntx) * (mma_B::J*MMQ_TILE_Y_K);
 
     const int   * x_qs = (const int   *) x;
-    const float * x_df = (const float *) x_qs + WARP_SIZE;
+    const float * x_df = (const float *) x_qs + 2*WARP_SIZE;
     const int   * y_qs = (const int   *) y + 4;
     const float * y_df = (const float *) y;
 
-    mma_A A[ntx];
-    float dA[ntx][mma_C::ne/2];
+    mma_A A[ntx][WARP_SIZE/QI8_0];
+    float dA[ntx][mma_C::ne/2][WARP_SIZE/QI8_0];
 
     const int i0 = (threadIdx.y/ntx)*rows_per_warp;
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
-        A[n].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q8_0 + k0, MMQ_MMA_TILE_X_K_Q8_0);
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_0) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/QI8_0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q8_0 + k0, MMQ_MMA_TILE_X_K_Q8_0);
+        }
 
 #pragma unroll
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_A::I + mma_C::get_i(2*l);
 
-            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + k0/QI8_0];
+#pragma unroll
+            for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_0) {
+                const int k0 = k00 + k01;
+
+                dA[n][l][k01/QI8_0] = x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + k0/QI8_0];
+            }
         }
     }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B;
-        float dB[mma_C::ne/2];
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_0) {
+            const int k0 = k00 + k01;
 
-        B.load(y_qs + j0*MMQ_TILE_Y_K + k0, MMQ_TILE_Y_K);
+            mma_B B;
+            float dB[mma_C::ne/2];
+
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k0 % WARP_SIZE, MMQ_TILE_Y_K);
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
 
-            dB[l] = y_df[j*MMQ_TILE_Y_K + k0/QI8_1];
+                dB[l] = y_df[j*MMQ_TILE_Y_K + (k0/QI8_1) % (WARP_SIZE/QI8_1)];
+            }
+
+#pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                mma_C C;
+                C.mma_K8(A[n][k01/QI8_0], B);
+
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] += C.x[l]*dA[n][l/2][k01/QI8_0]*dB[l%2];
+                }
+            }
+        }
+    }
+#else
+    GGML_UNUSED(x); GGML_UNUSED(y); GGML_UNUSED(sum);
+    NO_DEVICE_CODE;
+#endif // INT8_MMA_AVAILABLE
+}
+
+template <int mmq_x, int mmq_y, int nwarps>
+static __device__ __forceinline__ void vec_dot_q8_1_q8_1_dp4a(
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
+
+    constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_1, mmq_y);
+    const int   * x_qs = (const int   *) x;
+    const half2 * x_dm = (const half2 *) x_qs + txs.qs;
+    const int   * y_qs = (const int   *) y + 4;
+    const half2 * y_ds = (const half2 *) y;
+
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += VDR_Q8_0_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
+
+#pragma unroll
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
+
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q8_1_q8_1_impl<QR5_1*VDR_Q5_1_Q8_1_MMQ>
+                    (&x_qs[i*(2*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01],
+                    x_dm[i*(WARP_SIZE/QI5_1) + i/QI5_1 + k0/QI8_1], y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
+        }
+    }
+}
+
+template <int mmq_x, int mmq_y, int nwarps>
+static __device__ __forceinline__ void vec_dot_q8_1_q8_1_mma(
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
+#ifdef INT8_MMA_AVAILABLE
+
+    typedef mma_int_A_I16K8 mma_A;
+    typedef mma_int_B_J8K8  mma_B;
+    typedef mma_int_C_I16J8 mma_C;
+
+    constexpr int granularity = mmq_get_granularity_device(mmq_x);
+    constexpr int rows_per_warp = 2 * granularity;
+    constexpr int ntx = rows_per_warp/mma_C::I; // Number of x minitiles per warp.
+
+    y += (threadIdx.y % ntx) * (mma_B::J*MMQ_TILE_Y_K);
+
+    const int   * x_qs = (const int   *) x;
+    const half2 * x_dm = (const half2 *) x_qs + 2*WARP_SIZE;
+    const int   * y_qs = (const int   *) y + 4;
+    const half2 * y_dm = (const half2 *) y;
+
+    mma_A   A[ntx][WARP_SIZE/QI8_1];
+    half2 dmA[ntx][mma_C::ne/2][WARP_SIZE/QI8_1];
+
+    const int i0 = (threadIdx.y/ntx)*rows_per_warp;
+
+#pragma unroll
+    for (int n = 0; n < ntx; ++n) {
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/QI8_1].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q8_1 + k0, MMQ_MMA_TILE_X_K_Q8_1);
         }
 
 #pragma unroll
-        for (int n = 0; n < ntx; ++n) {
-            mma_C C;
-            C.mma_K8(A[n], B);
+        for (int l = 0; l < mma_C::ne/2; ++l) {
+            const int i = i0 + n*mma_A::I + mma_C::get_i(2*l);
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += C.x[l]*dA[n][l/2]*dB[l%2];
+            for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1) {
+                const int k0 = k00 + k01;
+
+                dmA[n][l][k01/QI8_1] = x_dm[i*MMQ_MMA_TILE_X_K_Q8_1 + k0/QI8_1];
+            }
+        }
+    }
+
+#pragma unroll
+    for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1) {
+            const int k0 = k00 + k01;
+
+            mma_B   B;
+            half2 dsB[mma_C::ne/2];
+
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k0 % WARP_SIZE, MMQ_TILE_Y_K);
+
+#pragma unroll
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
+
+                dsB[l] = y_dm[j*MMQ_TILE_Y_K + (k0/QI8_1) % (WARP_SIZE/QI8_1)];
+            }
+
+#pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                mma_C C;
+                C.mma_K8(A[n][k01/QI8_1], B);
+
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                const half2 dmA_dsB = dmA[n][l/2][k01/QI8_1]*dsB[l%2];
+                sum[(j0/mma_C::J + n)*mma_C::ne + l] += __low2float(dmA_dsB)*C.x[l] + __high2float(dmA_dsB);
+                }
             }
         }
     }
@@ -968,44 +941,37 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 #ifdef INT8_MMA_AVAILABLE
     int   * x_qs = (int   *)  x_tile;
-    half2 * x_dm = (half2 *) (x_qs + WARP_SIZE);
+    half2 * x_dm = (half2 *) (x_qs + 2*WARP_SIZE);
 #else
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q2_K, mmq_y);
     int   * x_qs = (int   *)  x_tile;
     half2 * x_dm = (half2 *) (x_qs + txs.qs);
 #endif // INT8_MMA_AVAILABLE
 
-    const int kbx  = threadIdx.x / QI2_K;
     const int kqsx = threadIdx.x % QI2_K;
 
 #pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nwarps) {
-        int i = i0 + threadIdx.y;
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * WARP_SIZE/QI2_K) {
+        int i = i0 + threadIdx.y*(WARP_SIZE/QI2_K) + threadIdx.x/QI2_K;
 
         if (need_check) {
             i = min(i, i_max);
         }
 
-        const block_q2_K * bxi = (const block_q2_K *) x + kbx0 + i*stride + kbx;
+        const block_q2_K * bxi = (const block_q2_K *) x + kbx0 + i*stride;
 
         const int x_ql_0 = get_int_b2(bxi->qs, kqsx);
 
 #pragma unroll
         for (int l = 0; l < QR2_K; ++l) {
-            const int k = kbx*QI2_K + (kqsx/8)*8 + l*2 + (kqsx % 8)/4;
+            const int k = (kqsx/8)*32 + l*8 + kqsx % 8;
 
-            int x_qs_k = ((x_ql_0 >> (2*l)) & 0x03030303) << (2*(kqsx % 4));
-            x_qs_k |= __shfl_xor_sync(0xFFFFFFFF, x_qs_k, 1, WARP_SIZE);
-            x_qs_k |= __shfl_xor_sync(0xFFFFFFFF, x_qs_k, 2, WARP_SIZE);
-
-            if (kqsx % QR2_K != 0) {
-                continue;
-            }
+            const int x_qs_k = (x_ql_0 >> (2*l)) & 0x03030303;
 
 #ifdef INT8_MMA_AVAILABLE
             x_qs[i*MMQ_MMA_TILE_X_K_Q2_K + k] = x_qs_k;
 #else
-            x_qs[i*(WARP_SIZE + 1)       + k] = x_qs_k;
+            x_qs[i*(2*WARP_SIZE + 1)     + k] = x_qs_k;
 #endif // INT8_MMA_AVAILABLE
         }
 
@@ -1018,44 +984,68 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 #endif // FAST_FP16_AVAILABLE
 
 #ifdef INT8_MMA_AVAILABLE
-        x_dm[i*MMQ_MMA_TILE_X_K_Q2_K + threadIdx.x] = x_dm_ik;
+        x_dm[i*MMQ_MMA_TILE_X_K_Q2_K + kqsx] = x_dm_ik;
 #else
-        x_dm[i*(WARP_SIZE + 1)       + threadIdx.x] = x_dm_ik;
+        x_dm[i*(WARP_SIZE + 1)       + kqsx] = x_dm_ik;
 #endif // INT8_MMA_AVAILABLE
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q2_K_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q2_K, mmq_y);
     const int   * x_qs = (const int   *) x;
     const half2 * x_dm = (const half2 *) x_qs + txs.qs;
     const int   * y_qs = (const int   *) y + 4;
-    const float * y_df = (const float *) y;
+    const half2 * y_ds = (const half2 *) y;
 
+    float2 y_df[mmq_x/nwarps];
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
         const int j = j0 + threadIdx.y;
 
-#pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        y_df[j0/nwarps] = __half22float2(y_ds[j*MMQ_TILE_Y_K]);
+    }
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q2_K_q8_1_impl_mmq(
-                &x_qs[i*(WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + (QR2_K*k0) % WARP_SIZE],
-                &x_dm[i*(WARP_SIZE + 1) + k0], y_df[j*MMQ_TILE_Y_K + ((QR2_K*k0) % WARP_SIZE)/QI8_1]);
+#pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR2_K*VDR_Q2_K_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
+
+#pragma unroll
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
+
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
+
+                if (k01 < WARP_SIZE/2) {
+                    constexpr int ns = 2;
+                    sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q2_K_q8_1_impl_mmq<ns>(
+                        &x_qs[i*(2*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01],
+                        &x_dm[i*(WARP_SIZE + 1) + k0/4], k01 < WARP_SIZE/2 ? y_df[j0/nwarps].x : y_df[j0/nwarps].y,
+                        &y_ds[j*MMQ_TILE_Y_K + (1 + k01/QI8_1)]);
+                } else {
+                    constexpr int ns = 1;
+                    sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q2_K_q8_1_impl_mmq<ns>(
+                        &x_qs[i*(2*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01],
+                        &x_dm[i*(WARP_SIZE + 1) + k0/4], k01 < WARP_SIZE/2 ? y_df[j0/nwarps].x : y_df[j0/nwarps].y,
+                        &y_ds[j*MMQ_TILE_Y_K + (1 + k01/QI8_1)]);
+                }
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
+    typedef mma_int_A_I16K8 mma_A_K8;
     typedef mma_int_B_J8K4  mma_B;
     typedef mma_int_C_I16J8 mma_C;
 
@@ -1066,74 +1056,107 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
     y += (threadIdx.y % ntx) * (mma_B::J*MMQ_TILE_Y_K);
 
     const int   * x_qs = (const int   *) x;
-    const half2 * x_dm = (const half2 *) x_qs + WARP_SIZE;
+    const half2 * x_dm = (const half2 *) x_qs + WARP_SIZE*2;
     const int   * y_qs = (const int   *) y + 4;
-    const float * y_df = (const float *) y;
+    const half2 * y_ds = (const half2 *) y;
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
-    mma_A   A[ntx][2];
-    float  dA[ntx][mma_C::ne/2][2];
-    float  mA[ntx][mma_C::ne/2][2];
+    mma_A   A[ntx][8];
+    float  dA[ntx][mma_C::ne/2][8];
+    float  mA[ntx][mma_C::ne/2][8];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int l = 0; l < mma_A::ne; ++l) {
-            const int i = i0 + n*mma_A::I + mma_A::get_i(l);
-            const int shift = 2*mma_A::get_k(l);
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1) {
+            const int k0 = k00 + k01;
 
-            A[n][0].x[l] = (x_qs[i*MMQ_MMA_TILE_X_K_Q2_K + k0 + 0] >> shift) & 0x03030303;
-            A[n][1].x[l] = (x_qs[i*MMQ_MMA_TILE_X_K_Q2_K + k0 + 1] >> shift) & 0x03030303;
+            ((mma_A_K8 *) A[n])[k01/QI8_1].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q2_K + k0, MMQ_MMA_TILE_X_K_Q2_K);
         }
+    }
 
+#pragma unroll
+    for (int n = 0; n < ntx; ++n) {
 #pragma unroll
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
 #pragma unroll
-            for (int kdm = 0; kdm < 2; ++kdm) {
-                const float2 dm = __half22float2(x_dm[i*MMQ_MMA_TILE_X_K_Q2_K + k0 + kdm]);
+            for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1/2) {
+                const int k0 = k00 + k01;
 
-                dA[n][l][kdm] = dm.x;
-                mA[n][l][kdm] = dm.y;
+                const float2 dm = __half22float2(x_dm[i*MMQ_MMA_TILE_X_K_Q2_K + k0/(QI8_1/2)]);
+
+                dA[n][l][k01/(QI8_1/2)] = dm.x;
+                mA[n][l][k01/(QI8_1/2)] = dm.y;
             }
         }
     }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B[2];
-        float dB[mma_C::ne/2];
-
-        B[0].load(y_qs + j0*MMQ_TILE_Y_K + (QR2_K*k0 + 0)        % WARP_SIZE, MMQ_TILE_Y_K);
-        B[1].load(y_qs + j0*MMQ_TILE_Y_K + (QR2_K*k0 + mma_B::K) % WARP_SIZE, MMQ_TILE_Y_K);
+        float2 dB[mma_C::ne/2];
 
 #pragma unroll
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int j = j0 + mma_C::get_j(l);
 
-            dB[l] = y_df[j*MMQ_TILE_Y_K + ((4*k0)/QI8_1) % (WARP_SIZE/QI8_1)];
+            dB[l] = __half22float2(y_ds[j*MMQ_TILE_Y_K]);
         }
 
-        mma_C Cm[2];
-        mma_A A1;
-        A1.x[0] = 0x01010101;
-        A1.x[1] = 0x01010101;
-        Cm[0].mma_K4(A1, B[0]);
-        Cm[1].mma_K4(A1, B[1]);
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QI8_1) {
+            mma_B B[2];
+
+            B[0].load(y_qs + j0*MMQ_TILE_Y_K + (k01 + 0),        MMQ_TILE_Y_K);
+            B[1].load(y_qs + j0*MMQ_TILE_Y_K + (k01 + mma_B::K), MMQ_TILE_Y_K);
+
+            mma_C Cm[2];
+            if (k01 >= WARP_SIZE * 3/4) {
+                mma_A A1;
+                A1.x[0] = 0x01010101;
+                A1.x[1] = 0x01010101;
+                Cm[0].mma_K4(A1, B[0]);
+                Cm[1].mma_K4(A1, B[1]);
+            }
 
 #pragma unroll
-    for (int n = 0; n < ntx; ++n) {
-            mma_C Cd[2];
+            for (int n = 0; n < ntx; ++n) {
+                mma_C Cd[2];
 
-            Cd[0].mma_K4(A[n][0], B[0]);
-            Cd[1].mma_K4(A[n][1], B[1]);
+                Cd[0].mma_K4(A[n][k01/4 + 0], B[0]);
+                Cd[1].mma_K4(A[n][k01/4 + 1], B[1]);
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += (
-                    Cd[0].x[l]*dA[n][l/2][0] + Cd[1].x[l]*dA[n][l/2][1] - Cm[0].x[l]*mA[n][l/2][0] - Cm[1].x[l]*mA[n][l/2][1])*dB[l%2];
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    float tmp = Cd[0].x[l]*dA[n][l/2][k01/4 + 0] + Cd[1].x[l]*dA[n][l/2][k01/4 + 1];
+                    if (k01 >= WARP_SIZE * 3/4) {
+                        tmp -= Cm[0].x[l]*mA[n][l/2][k01/4 + 0] + Cm[1].x[l]*mA[n][l/2][k01/4 + 1];
+                    }
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] += tmp*(k01 < WARP_SIZE/2 ? dB[l%2].x : dB[l%2].y);
+                }
+            }
+        }
+
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE * 3/4; k01 += QI8_1) {
+            float2 sB[mma_C::ne/2];
+
+#pragma unroll
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
+
+                sB[l] = __half22float2(y_ds[j*MMQ_TILE_Y_K + (1 + k01/QI8_1)]);
+            }
+
+#pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] -= mA[n][l/2][k01/4 + 0]*sB[l%2].x;
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] -= mA[n][l/2][k01/4 + 1]*sB[l%2].y;
+                }
             }
         }
     }
@@ -1149,7 +1172,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 #ifdef INT8_MMA_AVAILABLE
     int   * x_qs = (int   *)  x_tile;
     float * x_df = (float *) (x_qs + WARP_SIZE*2);
-    int   * x_sc = (int   *) (x_df + WARP_SIZE/QI3_K);
+    int   * x_sc = (int   *) (x_df + 1);
 #else
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q3_K, mmq_y);
     int   * x_qs = (int   *)  x_tile;
@@ -1157,75 +1180,66 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
     int   * x_sc = (int   *) (x_df + txs.dm);
 #endif // INT8_MMA_AVAILABLE
 
-    const int kbx  = threadIdx.x / QI3_K;
     const int kqsx = threadIdx.x % QI3_K;
 
 #pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nwarps) {
-        int i = i0 + threadIdx.y;
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * WARP_SIZE/QI3_K) {
+        int i = i0 + threadIdx.y * (WARP_SIZE/QI3_K) + threadIdx.x / QI3_K;
 
         if (need_check) {
             i = min(i, i_max);
         }
 
-        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride + kbx;
+        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride;
 
         const int x_ql_0 = get_int_b2(bxi->qs,    kqsx);
         const int x_qh_0 = get_int_b2(bxi->hmask, kqsx % (QI3_K/2)) >> (4 * (kqsx / (QI3_K/2)));
 
 #pragma unroll
         for (int l = 0; l < QR3_K; ++l) {
-            const int k = kbx*(QR3_K*QI3_K) + (kqsx/8)*32 + l*8 + kqsx % 8;
+            const int k = (kqsx/8)*32 + l*8 + kqsx % 8;
 
             const int x_ql_k =  (x_ql_0 >> (2*l))       & 0x03030303;
             const int x_qh_k = ((x_qh_0 >>    l)  << 2) & 0x04040404;
 
-            int x_qs_k = (x_ql_k | x_qh_k) << (4*(k%2));
-            x_qs_k |= __shfl_xor_sync(0xFFFFFFFF, x_qs_k, 1, WARP_SIZE);
-
-            if (kqsx % 2 != 0) {
-                continue;
-            }
+            const int x_qs_k = __vsubss4(x_ql_k | x_qh_k, 0x04040404);
 
 #ifdef INT8_MMA_AVAILABLE
-            x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k/2] = x_qs_k;
+            x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k] = x_qs_k;
 #else
-            x_qs[i*(2*WARP_SIZE + 1)     + k/2] = x_qs_k;
+            x_qs[i*(2*WARP_SIZE + 1)     + k] = x_qs_k;
 #endif // INT8_MMA_AVAILABLE
         }
     }
 
-    const int blocks_per_tile_x_row = WARP_SIZE / QI3_K;
-    const int kbxd = threadIdx.x % blocks_per_tile_x_row;
-
 #pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * QI3_K) {
-        int i = (i0 + threadIdx.y * QI3_K + threadIdx.x / blocks_per_tile_x_row) % mmq_y;
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps*WARP_SIZE) {
+        int i = (i0 + threadIdx.y*WARP_SIZE + threadIdx.x) % mmq_y;
 
         if (need_check) {
             i = min(i, i_max);
         }
 
-        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride + kbxd;
+        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_df[i*MMQ_MMA_TILE_X_K_Q3_K       + kbxd] = bxi->d;
+        x_df[i*MMQ_MMA_TILE_X_K_Q3_K] = bxi->d;
 #else
-        x_df[i*(WARP_SIZE/QI3_K) + i/QI3_K + kbxd] = bxi->d;
+        x_df[i]                       = bxi->d;
 #endif // INT8_MMA_AVAILABLE
     }
 
 #pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nwarps * 4) {
-        int i = i0 + threadIdx.y * 4 + threadIdx.x / (WARP_SIZE/4);
+    for (int i0 = 0; i0 < mmq_y; i0 += nwarps*8) {
+        int i = i0 + threadIdx.y*8 + threadIdx.x/(WARP_SIZE/8);
 
         if (need_check) {
             i = min(i, i_max);
         }
 
-        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride + (threadIdx.x % (WARP_SIZE/4)) / (QI3_K/4);
+        const block_q3_K * bxi = (const block_q3_K *) x + kbx0 + i*stride;
 
-        const int ksc = threadIdx.x % (QI3_K/4);
+        const int ksc = threadIdx.x % (WARP_SIZE/8);
 
         const int ksc_low = ksc % (QI3_K/8);
         const int shift_low = 4 * (ksc / (QI3_K/8));
@@ -1238,16 +1252,16 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const int sc = __vsubss4(sc_low | sc_high, 0x20202020);
 
 #ifdef INT8_MMA_AVAILABLE
-        x_sc[i*MMQ_MMA_TILE_X_K_Q3_K + threadIdx.x % (WARP_SIZE/4)] = sc;
+        x_sc[i*MMQ_MMA_TILE_X_K_Q3_K + threadIdx.x % (WARP_SIZE/8)] = sc;
 #else
-        x_sc[i*(WARP_SIZE/4) + i/4   + threadIdx.x % (WARP_SIZE/4)] = sc;
+        x_sc[i*(WARP_SIZE/8) + i/8   + threadIdx.x % (WARP_SIZE/8)] = sc;
 #endif // INT8_MMA_AVAILABLE
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q3_K_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q3_K, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -1256,32 +1270,35 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const float * y_df = (const float *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR3_K*VDR_Q3_K_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
-            const int kbx  = k0 / QI3_K;
-            const int ky  = (k0 % QI3_K) * QR3_K;
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
 
-            const int8_t * scales = ((const int8_t *) (x_sc + i * (WARP_SIZE/4) + i/4 + kbx*4)) + ky/4;
+                const int8_t * scales = ((const int8_t *) (x_sc + i*(WARP_SIZE/8) + i/8)) + k0/4;
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q3_K_q8_1_impl_mmq(
-                &x_qs[i*(2*WARP_SIZE + 1) + 2*k0], &y_qs[j*MMQ_TILE_Y_K + (k0*QR3_K) % WARP_SIZE], scales,
-                x_df[i*(WARP_SIZE/QI3_K) + i/QI3_K + kbx], y_df[j*MMQ_TILE_Y_K + ((k0*QR3_K) % WARP_SIZE)/QI8_1]);
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q3_K_q8_1_impl_mmq(
+                    &x_qs[i*(2*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01], scales,
+                    x_df[i], y_df[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
+    typedef mma_int_A_I16K8 mma_A_K8;
     typedef mma_int_B_J8K4  mma_B;
     typedef mma_int_C_I16J8 mma_C;
 
@@ -1293,73 +1310,74 @@ static __device__ __forceinline__ void vec_dot_q3_K_q8_1_mma(
 
     const int   * x_qs = (const int   *) x;
     const float * x_df = (const float *) x_qs + WARP_SIZE*2;
-    const int   * x_sc = (const int   *) x_df + WARP_SIZE/QI3_K;
+    const int   * x_sc = (const int   *) x_df + 1;
     const int   * y_qs = (const int   *) y + 4;
     const float * y_df = (const float *) y;
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
-    mma_A   A[ntx][2];
-    int   scA[ntx][mma_C::ne/2][2];
+    mma_A   A[ntx][8];
+    int   scA[ntx][mma_C::ne/2][8];
     float  dA[ntx][mma_C::ne/2];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int l = 0; l < mma_A::ne; ++l) {
-            const int i = i0 + n*mma_A::I + mma_A::get_i(l);
-            const int k = QR3_K*k0 + mma_A::get_k(l);
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
+            const int k0 = k00 + k01;
 
-            A[n][0].x[l] = (x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k/2 + 0]          >> (4*(k%2))) & 0x0F0F0F0F;
-            A[n][1].x[l] = (x_qs[i*MMQ_MMA_TILE_X_K_Q3_K + k/2 + mma_A::K/2] >> (4*(k%2))) & 0x0F0F0F0F;
-            A[n][0].x[l] = __vsubss4(A[n][0].x[l], 0x04040404);
-            A[n][1].x[l] = __vsubss4(A[n][1].x[l], 0x04040404);
+            ((mma_A_K8 *) A[n])[k01/8].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q3_K + k0, MMQ_MMA_TILE_X_K_Q3_K);
         }
 
 #pragma unroll
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-            const int kbx  = k0 / QI3_K;
-            const int ky  = (k0 % QI3_K) * QR3_K;
-            const int8_t * sc = ((const int8_t *) (x_sc + i*MMQ_MMA_TILE_X_K_Q3_K + kbx*4)) + ky/4;
+#pragma unroll
+            for (int k01 = 0; k01 < WARP_SIZE; k01 += 16) {
+                const int k0 = k00 + k01;
 
-            scA[n][l][0] = sc[0];
-            scA[n][l][1] = sc[1];
-        }
+                const int sc_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q3_K + k0/16];
+                const int8_t * sc = (const int8_t *) &sc_packed;
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+                for (int ksc = 0; ksc < sizeof(int); ++ksc) {
+                    scA[n][l][k01/4 + ksc] = sc[ksc];
+                }
+            }
 
-            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q3_K + k0/QI3_K];
+            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q3_K];
         }
     }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += ntx*mma_C::J) {
-        mma_B B[2];
-        float dB[mma_C::ne/2];
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += QR3_K*VDR_Q3_K_Q8_1_MMQ) {
+            mma_B B[2];
+            float dB[mma_C::ne/2];
 
-        B[0].load(y_qs + j0*MMQ_TILE_Y_K + (QR3_K*k0 + 0)        % WARP_SIZE, MMQ_TILE_Y_K);
-        B[1].load(y_qs + j0*MMQ_TILE_Y_K + (QR3_K*k0 + mma_B::K) % WARP_SIZE, MMQ_TILE_Y_K);
+            B[0].load(y_qs + j0*MMQ_TILE_Y_K + (k01 + 0),        MMQ_TILE_Y_K);
+            B[1].load(y_qs + j0*MMQ_TILE_Y_K + (k01 + mma_B::K), MMQ_TILE_Y_K);
 
 #pragma unroll
-        for (int l = 0; l < mma_C::ne/2; ++l) {
-            const int j = j0 + mma_C::get_j(l);
+            for (int l = 0; l < mma_C::ne/2; ++l) {
+                const int j = j0 + mma_C::get_j(l);
 
-            dB[l] = y_df[j*MMQ_TILE_Y_K + ((4*k0)/QI8_1) % (WARP_SIZE/QI8_1)];
-        }
-
-#pragma unroll
-        for (int n = 0; n < ntx; ++n) {
-            mma_C C[2];
-            C[0].mma_K4(A[n][0], B[0]);
-            C[1].mma_K4(A[n][1], B[1]);
+                dB[l] = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
+            }
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne; ++l) {
-                sum[(j0/mma_C::J + n)*mma_C::ne + l] += (C[0].x[l]*scA[n][l/2][0] + C[1].x[l]*scA[n][l/2][1])*dA[n][l/2]*dB[l%2];
+            for (int n = 0; n < ntx; ++n) {
+                mma_C C[2];
+                C[0].mma_K4(A[n][k01/4 + 0], B[0]);
+                C[1].mma_K4(A[n][k01/4 + 1], B[1]);
+
+#pragma unroll
+                for (int l = 0; l < mma_C::ne; ++l) {
+                    sum[(j0/mma_C::J + n)*mma_C::ne + l] += dA[n][l/2]*dB[l%2]*
+                        (C[0].x[l]*scA[n][l/2][k01/4 + 0] + C[1].x[l]*scA[n][l/2][k01/4 + 1]);
+                }
             }
         }
     }
@@ -1451,7 +1469,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_K_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_K, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -1460,26 +1478,31 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR4_K*VDR_Q4_K_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
-            const uint8_t * sc = ((const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/16]) + 2*((k0 % 16) / 8);
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_K_q8_1_impl_mmq(
-                &x_qs[i*(WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + (QR4_K*k0) % WARP_SIZE], sc, sc+8,
-                x_dm[i*(WARP_SIZE/QI4_K) + i/QI4_K], &y_ds[j*MMQ_TILE_Y_K + ((QR4_K*k0) % WARP_SIZE)/QI8_1]);
+                const uint8_t * sc = (const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/32] + 2*(k01/16);
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q4_K_q8_1_impl_mmq(
+                    &x_qs[i*(WARP_SIZE + 1) + k0/2], &y_qs[j*MMQ_TILE_Y_K + k01], sc, sc+8,
+                    x_dm[i*(WARP_SIZE/QI4_K) + i/QI4_K], &y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
@@ -1500,35 +1523,40 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
-    mma_A   A[ntx][2];
-    int   scA[ntx][mma_C::ne/2][2];
-    int    mA[ntx][mma_C::ne/2][2];
+    mma_A   A[ntx][4];
+    int   scA[ntx][mma_C::ne/2][4];
+    int    mA[ntx][mma_C::ne/2][4];
     half2 dmA[ntx][mma_C::ne/2];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q4_K_Q8_1_MMQ; kvdr += 8) {
-            A[n][kvdr/4 + 0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q4_K + k0, MMQ_MMA_TILE_X_K_Q4_K);
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 16) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/8 + 0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q4_K + k0/QR4_K, MMQ_MMA_TILE_X_K_Q4_K);
 
 #pragma unroll
             for (int l = 0; l < mma_A::ne; ++l) {
-                A[n][kvdr/4 + 1].x[l]  = (A[n][kvdr/4 + 0].x[l] >> 4) & 0x0F0F0F0F;
-                A[n][kvdr/4 + 0].x[l] &= 0x0F0F0F0F;
+                A[n][k01/8 + 1].x[l]  = (A[n][k01/8 + 0].x[l] >> 4) & 0x0F0F0F0F;
+                A[n][k01/8 + 0].x[l] &= 0x0F0F0F0F;
             }
         }
 
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q4_K_Q8_1_MMQ; kvdr += 4) {
+        for (int l = 0; l < mma_C::ne/2; ++l) {
+            const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+
+            const int sc_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q4_K + (k00/32 + 0)];
+            const int  m_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q4_K + (k00/32 + 2)];
+
+            const uint8_t * sc = (const uint8_t *) &sc_packed;
+            const uint8_t *  m = (const uint8_t *)  &m_packed;
+
 #pragma unroll
-            for (int l = 0; l < mma_C::ne/2; ++l) {
-                const int i = i0 + n*mma_A::I + mma_C::get_i(2*l);
-
-                const uint8_t * sc = ((const uint8_t *) &x_sc[i*MMQ_MMA_TILE_X_K_Q4_K + k0/16]) + 2 * ((k0 % 16) / 8);
-                const uint8_t *  m = sc + 8;
-
-                scA[n][l][kvdr/4] = sc[kvdr/4];
-                mA[n][l][kvdr/4]  =  m[kvdr/4];
+            for (int ksc = 0; ksc < sizeof(int); ++ksc) {
+                scA[n][l][ksc] = sc[ksc];
+                mA[n][l][ksc]  =  m[ksc];
             }
         }
 
@@ -1536,7 +1564,7 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_A::I + mma_C::get_i(2*l);
 
-            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q4_K + k0/QI4_K];
+            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q4_K];
         }
     }
 
@@ -1546,28 +1574,28 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_mma(
         float tmpm[ntx][mma_C::ne] = {{0.0f}};
 
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q4_K_Q8_1_MMQ; kvdr += 4) {
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
             mma_B   B;
             half2 dsB[mma_C::ne/2];
 
-            B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0 + 2*kvdr) % WARP_SIZE, MMQ_TILE_Y_K);
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
 
 #pragma unroll
             for (int l = 0; l < mma_C::ne/2; ++l) {
                 const int j = j0 + mma_C::get_j(l);
 
-                dsB[l] = y_ds[j*MMQ_TILE_Y_K + ((2*k0 + 2*kvdr)/QI8_1) % (WARP_SIZE/QI8_1)];
+                dsB[l] = y_ds[j*MMQ_TILE_Y_K + k01/QI8_1];
             }
 
 #pragma unroll
             for (int n = 0; n < ntx; ++n) {
                 mma_C C;
-                C.mma_K8(A[n][kvdr/4], B);
+                C.mma_K8(A[n][k01/8], B);
 
 #pragma unroll
                 for (int l = 0; l < mma_C::ne; ++l) {
-                    tmpd[n][l] += (C.x[l]*scA[n][l/2][kvdr/4]) *  __low2float(dsB[l%2]);
-                    tmpm[n][l] += mA[n][l/2][kvdr/4]           * __high2float(dsB[l%2]);
+                    tmpd[n][l] += (C.x[l]*scA[n][l/2][k01/8]) *  __low2float(dsB[l%2]);
+                    tmpm[n][l] += mA[n][l/2][k01/8]           * __high2float(dsB[l%2]);
                 }
             }
         }
@@ -1682,7 +1710,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_K_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_K, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -1691,26 +1719,31 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const half2 * y_ds = (const half2 *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR5_K*VDR_Q5_K_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
-            const uint8_t * sc = ((const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/16]) + 2 * ((k0 % 16) / 8);
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q5_K_q8_1_impl_mmq(
-                &x_qs[i*(QR5_K*WARP_SIZE + 1) + QR5_K*k0], &y_qs[j*MMQ_TILE_Y_K + (QR5_K*k0) % WARP_SIZE], sc, sc+8,
-                x_dm[i*(WARP_SIZE/QI5_K) + i/QI5_K], &y_ds[j*MMQ_TILE_Y_K + ((QR5_K*k0) % WARP_SIZE)/QI8_1]);
+                const uint8_t * sc = ((const uint8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k00/32]) + 2*(k01/16);
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q5_K_q8_1_impl_mmq(
+                    &x_qs[i*(QR5_K*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01], sc, sc+8,
+                    x_dm[i*(WARP_SIZE/QI5_K) + i/QI5_K], &y_ds[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K8 mma_A;
@@ -1731,26 +1764,34 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
-    mma_A   A[ntx][2];
-    int   scA[ntx][mma_C::ne/2][2];
-    int    mA[ntx][mma_C::ne/2][2];
+    mma_A   A[ntx][4];
+    int   scA[ntx][mma_C::ne/2][4];
+    int    mA[ntx][mma_C::ne/2][4];
     half2 dmA[ntx][mma_C::ne/2];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q5_K_Q8_1_MMQ; kvdr += 4) {
-            A[n][kvdr/4].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q5_K + (QR5_K*k0 + QR5_K*kvdr), MMQ_MMA_TILE_X_K_Q5_K);
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/8].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q5_K + k0, MMQ_MMA_TILE_X_K_Q5_K);
+        }
 
 #pragma unroll
-            for (int l = 0; l < mma_C::ne/2; ++l) {
-                const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
+        for (int l = 0; l < mma_C::ne/2; ++l) {
+            const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-                const uint8_t * sc = ((const uint8_t *) &x_sc[i*MMQ_MMA_TILE_X_K_Q5_K + k0/16]) + 2 * ((k0 % 16) / 8);
-                const uint8_t *  m = sc + 8;
+            const int sc_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q5_K + (k00/32 + 0)];
+            const int  m_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q5_K + (k00/32 + 2)];
 
-                scA[n][l][kvdr/4] = sc[kvdr/4];
-                mA[n][l][kvdr/4]  =  m[kvdr/4];
+            const uint8_t * sc = (const uint8_t *) &sc_packed;
+            const uint8_t *  m = (const uint8_t *)  &m_packed;
+
+#pragma unroll
+            for (int ksc = 0; ksc < sizeof(int); ++ksc) {
+                scA[n][l][ksc] = sc[ksc];
+                mA[n][l][ksc]  =  m[ksc];
             }
         }
 
@@ -1758,7 +1799,7 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q5_K + k0/QI5_K];
+            dmA[n][l] = x_dm[i*MMQ_MMA_TILE_X_K_Q5_K];
         }
     }
 
@@ -1768,28 +1809,30 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_mma(
         float tmpm[ntx][mma_C::ne] = {{0.0f}};
 
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q5_K_Q8_1_MMQ; kvdr += 4) {
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
+            const int k0 = k00 + k01;
+
             mma_B   B;
             half2 dsB[mma_C::ne/2];
 
-            B.load(y_qs + j0*MMQ_TILE_Y_K + (2*k0 + 2*kvdr) % WARP_SIZE, MMQ_TILE_Y_K);
+            B.load(y_qs + j0*MMQ_TILE_Y_K + k0 % WARP_SIZE, MMQ_TILE_Y_K);
 
 #pragma unroll
             for (int l = 0; l < mma_C::ne/2; ++l) {
                 const int j = j0 + mma_C::get_j(l);
 
-                dsB[l] = y_ds[j*MMQ_TILE_Y_K + ((2*k0 + 2*kvdr)/QI8_1) % (WARP_SIZE/QI8_1)];
+                dsB[l] = y_ds[j*MMQ_TILE_Y_K + (k0/QI8_1) % (WARP_SIZE/QI8_1)];
             }
 
 #pragma unroll
         for (int n = 0; n < ntx; ++n) {
                 mma_C C;
-                C.mma_K8(A[n][kvdr/4], B);
+                C.mma_K8(A[n][k01/8], B);
 
 #pragma unroll
                 for (int l = 0; l < mma_C::ne; ++l) {
-                    tmpd[n][l] += (C.x[l]*scA[n][l/2][kvdr/4]) *  __low2float(dsB[l%2]);
-                    tmpm[n][l] += mA[n][l/2][kvdr/4]           * __high2float(dsB[l%2]);
+                    tmpd[n][l] += (C.x[l]*scA[n][l/2][k01/8]) *  __low2float(dsB[l%2]);
+                    tmpm[n][l] += mA[n][l/2][k01/8]           * __high2float(dsB[l%2]);
                 }
             }
         }
@@ -1896,7 +1939,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q6_K_q8_1_dp4a(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q6_K, mmq_y);
     const int   * x_qs = (const int   *) x;
@@ -1905,26 +1948,31 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_dp4a(
     const int   * y_qs = (const int   *) y + 4;
     const float * y_df = (const float *) y;
 
-#pragma unroll
-    for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
-        const int j = j0 + threadIdx.y;
+// #pragma unroll
+    for (int k01 = 0; k01 < WARP_SIZE; k01 += QR6_K*VDR_Q6_K_Q8_1_MMQ) {
+        const int k0 = k00 + k01;
 
 #pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
-            const int i = i0 + threadIdx.x;
+        for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
+            const int j = j0 + threadIdx.y;
 
-            const int8_t * sc = ((const int8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/8]);
+#pragma unroll
+            for (int i0 = 0; i0 < mmq_y; i0 += WARP_SIZE) {
+                const int i = i0 + threadIdx.x;
 
-            sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q6_K_q8_1_impl_mmq(
-                &x_qs[i*(QR6_K*WARP_SIZE + 1) + QR6_K*k0], &y_qs[j*MMQ_TILE_Y_K + (QR6_K*k0) % WARP_SIZE], sc,
-                x_df[i*(WARP_SIZE/QI6_K) + i/QI6_K], &y_df[j*MMQ_TILE_Y_K + ((QR6_K*k0) % WARP_SIZE)/QI8_1]);
+                const int8_t * sc = ((const int8_t *) &x_sc[i * (WARP_SIZE/8) + i/8 + k0/16]);
+
+                sum[j0/nwarps*mmq_y/WARP_SIZE + i0/WARP_SIZE] += vec_dot_q6_K_q8_1_impl_mmq(
+                    &x_qs[i*(QR6_K*WARP_SIZE + 1) + k0], &y_qs[j*MMQ_TILE_Y_K + k01], sc,
+                    x_df[i*(WARP_SIZE/QI6_K) + i/QI6_K], &y_df[j*MMQ_TILE_Y_K + k01/QI8_1]);
+            }
         }
     }
 }
 
 template <int mmq_x, int mmq_y, int nwarps>
 static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
-    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k0) {
+    const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int & k00) {
 #ifdef INT8_MMA_AVAILABLE
 
     typedef mma_int_A_I16K4 mma_A;
@@ -1945,25 +1993,35 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
 
     const int i0 = (threadIdx.y / ntx) * (ntx*mma_A::I);
 
-    mma_A   A[ntx][4];
-    int   scA[ntx][mma_C::ne/2][4];
+    mma_A   A[ntx][8];
+    int   scA[ntx][mma_C::ne/2][8];
     float  dA[ntx][mma_C::ne/2];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q6_K_Q8_1_MMQ; kvdr += 4) {
-            A[n][kvdr/2 + 0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q6_K + (QR6_K*k0 + QR6_K*kvdr + 0),        MMQ_MMA_TILE_X_K_Q6_K);
-            A[n][kvdr/2 + 1].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q6_K + (QR6_K*k0 + QR6_K*kvdr + mma_A::K), MMQ_MMA_TILE_X_K_Q6_K);
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
+            const int k0 = k00 + k01;
+
+            A[n][k01/4 + 0].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q6_K + (k0 + 0),        MMQ_MMA_TILE_X_K_Q6_K);
+            A[n][k01/4 + 1].load(x_qs + (i0 + n*mma_A::I)*MMQ_MMA_TILE_X_K_Q6_K + (k0 + mma_A::K), MMQ_MMA_TILE_X_K_Q6_K);
+        }
+
+#pragma unroll
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 16) {
+            const int k0 = k00 + k01;
 
 #pragma unroll
             for (int l = 0; l < mma_C::ne/2; ++l) {
                 const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-                const int8_t * sc = ((const int8_t *) &x_sc[i*MMQ_MMA_TILE_X_K_Q6_K + k0/8]);
+                const int      sc_packed = x_sc[i*MMQ_MMA_TILE_X_K_Q6_K + k0/16];
+                const int8_t * sc        = (const int8_t *) &sc_packed;
 
-                scA[n][l][kvdr/2 + 0] = sc[kvdr/2 + 0];
-                scA[n][l][kvdr/2 + 1] = sc[kvdr/2 + 1];
+#pragma unroll
+                for (int ksc = 0; ksc < sizeof(int); ++ksc) {
+                    scA[n][l][k01/4 + ksc] = sc[ksc];
+                }
             }
         }
 
@@ -1971,7 +2029,7 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
         for (int l = 0; l < mma_C::ne/2; ++l) {
             const int i = i0 + n*mma_C::I + mma_C::get_i(2*l);
 
-            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q6_K + k0/QI6_K];
+            dA[n][l] = x_df[i*MMQ_MMA_TILE_X_K_Q6_K];
         }
     }
 
@@ -1980,30 +2038,29 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
         float tmp[ntx][mma_C::ne] = {{0.0f}};
 
 #pragma unroll
-        for (int kvdr = 0; kvdr < VDR_Q6_K_Q8_1_MMQ; kvdr += 4) {
+        for (int k01 = 0; k01 < WARP_SIZE; k01 += 8) {
             mma_B B[2];
             float dB[mma_C::ne/2];
 
-            const int k0B = (2*k0 + 2*kvdr) % WARP_SIZE;
-            B[0].load(y_qs + j0*MMQ_TILE_Y_K + 0        + k0B, MMQ_TILE_Y_K);
-            B[1].load(y_qs + j0*MMQ_TILE_Y_K + mma_B::K + k0B, MMQ_TILE_Y_K);
+            B[0].load(y_qs + j0*MMQ_TILE_Y_K + 0        + k01, MMQ_TILE_Y_K);
+            B[1].load(y_qs + j0*MMQ_TILE_Y_K + mma_B::K + k01, MMQ_TILE_Y_K);
 
 #pragma unroll
             for (int l = 0; l < mma_C::ne/2; ++l) {
                 const int j = j0 + mma_C::get_j(l);
 
-                dB[l] = y_df[j*MMQ_TILE_Y_K + ((2*k0 + 2*kvdr)/QI8_1) % (WARP_SIZE/QI8_1)];
+                dB[l] = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
             }
 
 #pragma unroll
             for (int n = 0; n < ntx; ++n) {
                 mma_C C[2];
-                C[0].mma_K4(A[n][kvdr/2 + 0], B[0]);
-                C[1].mma_K4(A[n][kvdr/2 + 1], B[1]);
+                C[0].mma_K4(A[n][k01/4 + 0], B[0]);
+                C[1].mma_K4(A[n][k01/4 + 1], B[1]);
 
 #pragma unroll
                 for (int l = 0; l < mma_C::ne; ++l) {
-                    tmp[n][l] += (C[0].x[l]*scA[n][l/2][kvdr/2 + 0] + C[1].x[l]*scA[n][l/2][kvdr/2 + 1])*dB[l%2];
+                    tmp[n][l] += (C[0].x[l]*scA[n][l/2][k01/4 + 0] + C[1].x[l]*scA[n][l/2][k01/4 + 1])*dB[l%2];
                 }
             }
         }
@@ -2051,8 +2108,8 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const int2 v = get_int_from_table_16(aux_q4);
         const int k0 = 8 * (threadIdx.x / 4) + threadIdx.x % 4;
 #ifdef INT8_MMA_AVAILABLE
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + k0 + 0] = v.x;
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + k0 + 4] = v.y;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + k0 + 0] = v.x;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + k0 + 4] = v.y;
 #else
         x_qs[i*(2*WARP_SIZE + 1)     + k0 + 0] = v.x;
         x_qs[i*(2*WARP_SIZE + 1)     + k0 + 4] = v.y;
@@ -2073,7 +2130,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_iq4_nl * bxi = (const block_iq4_nl *) x + kbx0 + i*stride + kbxd;
 
 #ifdef INT8_MMA_AVAILABLE
-        x_df[i*MMQ_MMA_TILE_X_K_Q5_0 + kbxd] = __half2float(bxi->d);
+        x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + kbxd] = __half2float(bxi->d);
 #else
         x_df[i*(WARP_SIZE/4) + i/4   + kbxd] = __half2float(bxi->d);
 #endif // INT8_MMA_AVAILABLE
@@ -2109,8 +2166,8 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const int2 v = get_int_from_table_16(aux_q4);
         const int k0 = 8 * (threadIdx.x / 4) + threadIdx.x % 4;
 #ifdef INT8_MMA_AVAILABLE
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + k0 + 0] = v.x;
-        x_qs[i*MMQ_MMA_TILE_X_K_Q5_0 + k0 + 4] = v.y;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + k0 + 0] = v.x;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + k0 + 4] = v.y;
 #else
         x_qs[i*(2*WARP_SIZE + 1)     + k0 + 0] = v.x;
         x_qs[i*(2*WARP_SIZE + 1)     + k0 + 4] = v.y;
@@ -2133,7 +2190,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
             | (((bxi->scales_h >> (2*(threadIdx.x % 8))) & 0x03) << 4);
 
 #ifdef INT8_MMA_AVAILABLE
-        x_df[i*MMQ_MMA_TILE_X_K_Q5_0 + threadIdx.x % 8] = d * (ls - 32);
+        x_df[i*MMQ_MMA_TILE_X_K_Q8_0 + threadIdx.x % 8] = d * (ls - 32);
 #else
         x_df[i*(WARP_SIZE/4) + i/4   + threadIdx.x % 8] = d * (ls - 32);
 #endif // INT8_MMA_AVAILABLE
@@ -2229,16 +2286,16 @@ template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_0> {
     static constexpr int              vdr          = VDR_Q5_0_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_q5_0<mmq_y, nwarps, need_check>;
-    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q5_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
-    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q5_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q8_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
 };
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_Q5_1> {
     static constexpr int              vdr          = VDR_Q5_1_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_q5_1<mmq_y, nwarps, need_check>;
-    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q5_1_q8_1_mma<mmq_x, mmq_y, nwarps>;
-    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q5_1_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q8_1_q8_1_mma<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q8_1_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
 };
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
@@ -2293,43 +2350,45 @@ template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_IQ4_NL> {
     static constexpr int              vdr          = VDR_IQ4_NL_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_iq4_nl<mmq_y, nwarps, need_check>;
-    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q5_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
-    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q5_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q8_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
 };
 
 template <int mmq_x, int mmq_y, int nwarps, bool need_check>
 struct mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, GGML_TYPE_IQ4_XS> {
     static constexpr int              vdr          = VDR_IQ4_XS_Q8_1_MMQ;
     static constexpr load_tiles_mmq_t load_tiles   = load_tiles_iq4_xs<mmq_y, nwarps, need_check>;
-    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q5_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
-    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q5_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_mma  = vec_dot_q8_0_q8_1_mma<mmq_x, mmq_y, nwarps>;
+    static constexpr vec_dot_mmq_t    vec_dot_dp4a = vec_dot_q8_0_q8_1_dp4a<mmq_x, mmq_y, nwarps>;
 };
 
-static bool mmq_need_sum(const ggml_type type_x) {
+static int mmq_need_sum(const ggml_type type_x) {
     switch (type_x) {
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
-            return true;
+            return 1;
         case GGML_TYPE_Q5_0:
-            return false;
+            return 0;
         case GGML_TYPE_Q5_1:
-            return true;
+            return 1;
         case GGML_TYPE_Q8_0:
+            return 0;
         case GGML_TYPE_Q2_K:
+            return 2;
         case GGML_TYPE_Q3_K:
-            return false;
+            return 0;
         case GGML_TYPE_Q4_K:
         case GGML_TYPE_Q5_K:
-            return true;
+            return 1;
         case GGML_TYPE_Q6_K:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
-            return false;
+            return 0;
         default:
             GGML_ASSERT(false);
             break;
     }
-    return false;
+    return -1;
 }
 
 template <ggml_type type, int mmq_x, int nwarps, bool need_check, bool fixup>
@@ -2339,10 +2398,7 @@ static __device__ void mul_mat_q_process_tile(
     const int & it, const int & jt, const int & kb0_start, const int & kb0_stop) {
 
     constexpr int              qk         = ggml_cuda_type_traits<type>::qk;
-    constexpr int              qr         = ggml_cuda_type_traits<type>::qr;
-    constexpr int              qi         = ggml_cuda_type_traits<type>::qi;
     constexpr int              mmq_y      = get_mmq_y_device();
-    constexpr int              vdr        = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::vdr;
     constexpr load_tiles_mmq_t load_tiles = mmq_type_traits<mmq_x, mmq_y, nwarps, need_check, type>::load_tiles;
 
     extern __shared__ char data_mul_mat_q[];
@@ -2357,7 +2413,7 @@ static __device__ void mul_mat_q_process_tile(
     constexpr mmq_write_back_t write_back = mmq_write_back_dp4a<mmq_x, mmq_y, nwarps, need_check>;
 #endif // INT8_MMA_AVAILABLE
 
-    constexpr int blocks_per_warp = WARP_SIZE / qi;
+    constexpr int blocks_per_iter = MMQ_ITER_K / qk;
 
     float sum[mmq_x*mmq_y / (nwarps*WARP_SIZE)] = {0.0f};
 
@@ -2366,29 +2422,40 @@ static __device__ void mul_mat_q_process_tile(
 
     const int * y = (const int *) yc + jt*(mmq_x*sizeof(block_q8_1_mmq)/sizeof(int));
 
-    for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_warp) {
-
+    for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
         load_tiles(x, tile_x, stride01*it*mmq_y + kb0, tile_x_max_i, stride01);
 
-#pragma unroll
-        for (int kr = 0; kr < qr; ++kr) {
-            const int * by0 = y + stride11*(kb0*(qk*sizeof(block_q8_1_mmq) / (4*QK8_1*sizeof(int))) + kr*sizeof(block_q8_1_mmq)/sizeof(int));
+        {
+            const int * by0 = y + stride11*(kb0*(qk*sizeof(block_q8_1_mmq) / (4*QK8_1*sizeof(int))) + 0*sizeof(block_q8_1_mmq)/sizeof(int));
 #pragma unroll
             for (int l0 = 0; l0 < mmq_x*MMQ_TILE_Y_K; l0 += nwarps*WARP_SIZE) {
                 int l = l0 + threadIdx.y*WARP_SIZE + threadIdx.x;
 
                 tile_y[l] = by0[l];
             }
-
-            __syncthreads();
-
-// #pragma unroll // unrolling this loop causes too much register pressure
-            for (int k0 = kr*WARP_SIZE/qr; k0 < (kr+1)*WARP_SIZE/qr; k0 += vdr) {
-                vec_dot(tile_x, tile_y, sum, k0);
-            }
-
-            __syncthreads();
         }
+
+        __syncthreads();
+
+        vec_dot(tile_x, tile_y, sum, 0);
+
+        __syncthreads();
+
+        {
+            const int * by0 = y + stride11*(kb0*(qk*sizeof(block_q8_1_mmq) / (4*QK8_1*sizeof(int))) + 1*sizeof(block_q8_1_mmq)/sizeof(int));
+#pragma unroll
+            for (int l0 = 0; l0 < mmq_x*MMQ_TILE_Y_K; l0 += nwarps*WARP_SIZE) {
+                int l = l0 + threadIdx.y*WARP_SIZE + threadIdx.x;
+
+                tile_y[l] = by0[l];
+            }
+        }
+
+        __syncthreads();
+
+        vec_dot(tile_x, tile_y, sum, WARP_SIZE);
+
+        __syncthreads();
     }
 
     if (fixup) {
@@ -2424,7 +2491,6 @@ static __global__ void mul_mat_q(
     }
 
     constexpr int qk    = ggml_cuda_type_traits<type>::qk;
-    constexpr int qi    = ggml_cuda_type_traits<type>::qi;
     constexpr int mmq_y = get_mmq_y_device();
 
     // On AMD or old CUDA the performance with stream-k was worse, use conventional tiling instead:
@@ -2439,7 +2505,7 @@ static __global__ void mul_mat_q(
 #endif // (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ < CC_VOLTA
 
     const     int64_t blocks_per_ne00 = ne00 / qk;
-    constexpr int     blocks_per_warp = WARP_SIZE / qi;
+    constexpr int     blocks_per_iter = MMQ_ITER_K / qk;
 
     const int ntx = (ne11 + mmq_x - 1) / mmq_x; // Number of tiles x
     const int nty = (ne01 + mmq_y - 1) / mmq_y; // Number of tiles y
@@ -2448,8 +2514,8 @@ static __global__ void mul_mat_q(
     int64_t kbc      = (int64_t) blockIdx.x     *blocks_per_ne00*ntx*nty / gridDim.x;
     int64_t kbc_stop = (int64_t)(blockIdx.x + 1)*blocks_per_ne00*ntx*nty / gridDim.x;
 
-    kbc      -= (kbc      % blocks_per_ne00) % blocks_per_warp;
-    kbc_stop -= (kbc_stop % blocks_per_ne00) % blocks_per_warp;
+    kbc      -= (kbc      % blocks_per_ne00) % blocks_per_iter;
+    kbc_stop -= (kbc_stop % blocks_per_ne00) % blocks_per_iter;
 
     // kb0 == k index when doing the matrix multiplication for an output tile.
     int kb0_start = kbc % blocks_per_ne00;
@@ -2490,8 +2556,7 @@ static __global__ void mul_mat_q_stream_k_fixup(
 
     constexpr int     mmq_y           = get_mmq_y_device();
     constexpr int     qk              = ggml_cuda_type_traits<type>::qk;
-    constexpr int     qi              = ggml_cuda_type_traits<type>::qi;
-    constexpr int     blocks_per_warp = WARP_SIZE / qi;
+    constexpr int     blocks_per_iter = MMQ_ITER_K / qk;
     const     int64_t blocks_per_ne00 = ne00 / qk;
 
     float sum[mmq_x*mmq_y / (nwarps*WARP_SIZE)] = {0.0f};
@@ -2501,15 +2566,18 @@ static __global__ void mul_mat_q_stream_k_fixup(
 
     bool any_fixup = false;
 
-    const int bidx_start = (blockIdx.y*nty + blockIdx.x)     * block_num_mmq / (gridDim.y*gridDim.x);
-    const int bidx_stop  = (blockIdx.y*nty + blockIdx.x + 1) * block_num_mmq / (gridDim.y*gridDim.x) + 1;
+    const int bidx_start = ((blockIdx.y*nty + blockIdx.x)     * block_num_mmq)                           / (gridDim.y*gridDim.x);
+    const int bidx_stop  = ((blockIdx.y*nty + blockIdx.x + 1) * block_num_mmq + gridDim.y*gridDim.x - 1) / (gridDim.y*gridDim.x);
+
+    int64_t kbc_0;
+    int64_t kbc_stop_0 = (int64_t) bidx_start*blocks_per_ne00*ntx*nty / block_num_mmq;
 
     for (int bidx = bidx_start; bidx < bidx_stop; ++bidx) {
-        int64_t kbc      = (int64_t) bidx     *blocks_per_ne00*ntx*nty / block_num_mmq;
-        int64_t kbc_stop = (int64_t)(bidx + 1)*blocks_per_ne00*ntx*nty / block_num_mmq;
+        kbc_0 = kbc_stop_0;
+        kbc_stop_0 = (int64_t) (bidx + 1)*blocks_per_ne00*ntx*nty / block_num_mmq;
 
-        kbc      -= (kbc      % blocks_per_ne00) % blocks_per_warp;
-        kbc_stop -= (kbc_stop % blocks_per_ne00) % blocks_per_warp;
+        const int64_t kbc      = kbc_0      - (kbc_0      % blocks_per_ne00) % blocks_per_iter;
+        const int64_t kbc_stop = kbc_stop_0 - (kbc_stop_0 % blocks_per_ne00) % blocks_per_iter;
 
         // Skip fixup tile if the MMQ CUDA block never wrote anything to it:
         if (kbc == kbc_stop || kbc_stop % blocks_per_ne00 == 0) {

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -37,9 +37,12 @@ static __global__ void quantize_q8_1(const float * __restrict__ x, void * __rest
     reinterpret_cast<half&>(y[ib].ds.y) = sum;
 }
 
-template <int need_sum>
+template <mmq_q8_1_ds_layout ds_layout>
 static __global__ void quantize_mmq_q8_1(
     const float * __restrict__ x, void * __restrict__ vy, const int64_t kx0, const int64_t kx1, const int64_t kx0_padded) {
+
+    constexpr int vals_per_scale = ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6 ? 64 : 32;
+    constexpr int vals_per_sum   = ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6 ? 16 : 32;
 
     const int64_t ix0 = ((int64_t)blockDim.x*blockIdx.x + threadIdx.x)*4;
 
@@ -57,22 +60,26 @@ static __global__ void quantize_mmq_q8_1(
     const int64_t ib  = ib0 + (ix0 / (4*QK8_1))*kx1 + blockIdx.y;                   // block index in channel
     const int64_t iqs = ix0 % (4*QK8_1);                                            // quant index in block
 
+    // Load 4 floats per thread and calculate max. abs. value between them:
     const float4 xi = ix0 < kx0 ? x4[(ix1*kx0 + ix0)/4] : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
     float amax = fabsf(xi.x);
     amax = fmaxf(amax, fabsf(xi.y));
     amax = fmaxf(amax, fabsf(xi.z));
     amax = fmaxf(amax, fabsf(xi.w));
 
+    // Exchange max. abs. value between vals_per_scale/4 threads.
 #pragma unroll
-    for (int mask = need_sum == 2 ? 8 : 4; mask > 0; mask >>= 1) {
+    for (int mask = vals_per_scale/8; mask > 0; mask >>= 1) {
         amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, WARP_SIZE));
     }
 
     float sum;
-    if (need_sum > 0) {
+    if (ds_layout != MMQ_Q8_1_DS_LAYOUT_D4) {
         sum = xi.x + xi.y + xi.z + xi.w;
+
+        // Exchange calculate sum across vals_per_sum/4 threads.
 #pragma unroll
-        for (int mask = need_sum == 2 ? 2 : 4; mask > 0; mask >>= 1) {
+        for (int mask = vals_per_sum/8; mask > 0; mask >>= 1) {
             sum += __shfl_xor_sync(0xFFFFFFFF, sum, mask, WARP_SIZE);
         }
     }
@@ -84,36 +91,38 @@ static __global__ void quantize_mmq_q8_1(
     q.z = roundf(xi.z*d_inv);
     q.w = roundf(xi.w*d_inv);
 
+    // Write back 4 int8 values as a single 32 bit value for better memroy bandwidth:
     char4 * yqs4 = (char4 *) y[ib].qs;
     yqs4[iqs/4] = q;
 
-    if (need_sum < 2) {
-        if (iqs % QK8_1 != 0) {
+    if (ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6) {
+        if (iqs % 16 != 0 || iqs >= 96) {
+            return;
+        }
+
+        y[ib].d2s6[2 + iqs/16] = sum;
+
+        if (iqs % 64 != 0) {
             return;
         }
 
         const float d = 1.0f / d_inv;
 
-        if (need_sum > 0) {
-            y[ib].ds[iqs/QK8_1] = make_half2(d, sum);
-        } else {
-            ((float *) y[ib].ds)[iqs/QK8_1] = d;
-        }
+        y[ib].d2s6[iqs/64] = d;
+
+        return;
+    }
+
+    if (iqs % 32 != 0) {
+        return;
+    }
+
+    const float d = 1.0f / d_inv;
+
+    if (ds_layout == MMQ_Q8_1_DS_LAYOUT_DS4) {
+        y[ib].ds4[iqs/32] = make_half2(d, sum);
     } else {
-        if (iqs % (QK8_1/2) != 0 || iqs >= (3*QK8_1)) {
-            return;
-        }
-
-        half * ydsh = (half *) y[ib].ds;
-        ydsh[2 + iqs/(QK8_1/2)] = sum;
-
-        if (iqs % (QK8_1*2) != 0) {
-            return;
-        }
-
-        const float d = 1.0f / d_inv;
-
-        ydsh[iqs/(QK8_1*2)] = d;
+        y[ib].d4[iqs/32]  = d;
     }
 }
 
@@ -140,15 +149,18 @@ void quantize_mmq_q8_1_cuda(
     const int64_t block_num_x = (kx0_padded + 4*CUDA_QUANTIZE_BLOCK_SIZE_MMQ - 1) / (4*CUDA_QUANTIZE_BLOCK_SIZE_MMQ);
     const dim3 num_blocks(block_num_x, kx1, channels);
     const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE_MMQ, 1, 1);
-    switch (mmq_need_sum(type_x)) {
-        case 0:
-            quantize_mmq_q8_1<0><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+    switch (mmq_get_q8_1_ds_layout(type_x)) {
+        case MMQ_Q8_1_DS_LAYOUT_D4:
+            quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D4>
+                <<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
             break;
-        case 1:
-            quantize_mmq_q8_1<1><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+        case MMQ_Q8_1_DS_LAYOUT_DS4:
+            quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_DS4>
+                <<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
             break;
-        case 2:
-            quantize_mmq_q8_1<2><<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
+        case MMQ_Q8_1_DS_LAYOUT_D2S6:
+            quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D2S6>
+                <<<num_blocks, block_size, 0, stream>>>(x, vy, kx0, kx1, kx0_padded);
             break;
         default:
             GGML_ASSERT(false);

--- a/ggml/src/ggml-cuda/quantize.cuh
+++ b/ggml/src/ggml-cuda/quantize.cuh
@@ -5,7 +5,11 @@
 
 #include <cstdint>
 
-#define CUDA_QUANTIZE_BLOCK_SIZE 256
+#define CUDA_QUANTIZE_BLOCK_SIZE     256
+#define CUDA_QUANTIZE_BLOCK_SIZE_MMQ 128
+
+static_assert(MATRIX_ROW_PADDING %    CUDA_QUANTIZE_BLOCK_SIZE      == 0, "Risk of out-of-bounds access.");
+static_assert(MATRIX_ROW_PADDING % (4*CUDA_QUANTIZE_BLOCK_SIZE_MMQ) == 0, "Risk of out-of-bounds access.");
 
 typedef void (*quantize_cuda_t)(
     const float * x, void * vy, const int64_t kx0, const int64_t kx1, const int64_t channels, const int64_t kx0_padded,


### PR DESCRIPTION
This PR optimizes MMQ performance and refactors the code in preparation for i-quants. Brief summary of changes:

* The k dimension of the shared memory tiles for matrix multiplication is set to 256 logical values. Previously the k dimension was such that each warp would load a single 32 bit value and then unpack it. While this is beneficial for memory bandwidth it causes problems with shared memory and register use being very different between quantization formats which makes optimization much harder. The affected formats are q2_K, q3_K, and q8_0.
* The loop structure for tensor core kernels is optimized in such a way that reduces register pressure which in turn allows for more aggressive loop unrolling.
* q8_0 and q5_0 now use the same code except for loading the data.
* The q8_1 activations for q2_K now use a single FP16 scale per 64 values instead of per 32 values in order to fit more pre-quantization partial sums per 16 values. For the vector dot product 6/8 blocks of size 16 can be sped up (instead of 4/8 with 1 scale per 32 values).
* The auxiliary kernels for quantizing the activations and the stream-k fixup have received optimizations.

Precision loss for q2_K:

| Model          | imatrix | Code   |      PPL | KL Divergence vs. FP16 | Mean Δp |  RMS Δp |
|----------------|---------|--------|----------|------------------------|---------|---------|
| LLaMA 3 q2_K_M | WT 10m  | master | 8.730622 |               0.342380 | -6.776% | 19.187% |
| LLaMA 3 q2_K_M | WT 10m  | PR     | 8.734961 |               0.342814 | -6.774% | 19.190% |
| LLaMA 3 q2_K_S | WT 10m  | master | 9.371474 |               0.408614 | -7.289% | 20.149% |
| LLaMA 3 q2_K_S | WT 10m  | PR     | 9.378482 |               0.409435 | -7.319% | 20.175% |

I would argue that this is negligible.

<details>
<summary>Performance changes</summary>

| Model                        | GPU        |     Microbatch size | Test     |     t/s 6b2a849d |     t/s cuda-mmq-256k-5 |     Speedup |
| :--------------------------- | :--------- | ------------------: | :------- | ---------------: | ----------------------: | ----------: |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                  16 | pp2048   |           236.52 |                  237.22 |        1.00 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                  32 | pp2048   |           328.45 |                  332.38 |        1.01 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                  64 | pp2048   |           404.76 |                  411.18 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                 128 | pp2048   |           509.28 |                  516.32 |        1.01 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                 256 | pp2048   |           603.86 |                  617.01 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                 512 | pp2048   |           612.29 |                  621.83 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                1024 | pp2048   |           686.38 |                  700.95 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RX 6800    |                2048 | pp2048   |           627.16 |                  640.30 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                  16 | pp2048   |          1084.71 |                 1088.77 |        1.00 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                  32 | pp2048   |          1760.23 |                 1787.89 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                  64 | pp2048   |          2678.81 |                 2776.67 |        1.04 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                 128 | pp2048   |          3306.59 |                 3585.50 |        1.08 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                 256 | pp2048   |          3720.80 |                 4095.23 |        1.10 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                 512 | pp2048   |          3852.71 |                 4298.42 |        1.12 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                1024 | pp2048   |          3886.39 |                 4341.15 |        1.12 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 3090   |                2048 | pp2048   |          3775.64 |                 4201.85 |        1.11 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                  16 | pp2048   |          1897.16 |                 1950.39 |        1.03 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                  32 | pp2048   |          3343.59 |                 3428.25 |        1.03 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                  64 | pp2048   |          5449.91 |                 5671.69 |        1.04 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                 128 | pp2048   |          7380.43 |                 7964.68 |        1.08 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                 256 | pp2048   |          9588.41 |                10556.45 |        1.10 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                 512 | pp2048   |         10303.19 |                11383.62 |        1.10 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                1024 | pp2048   |         10008.66 |                11077.53 |        1.11 |
| llama 8B IQ4_NL - 4.5 bpw    | RTX 4090   |                2048 | pp2048   |          9077.18 |                 9842.67 |        1.08 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                  16 | pp2048   |           249.55 |                  253.31 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                  32 | pp2048   |           417.65 |                  416.95 |        1.00 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                  64 | pp2048   |           572.82 |                  582.69 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                 128 | pp2048   |           680.85 |                  690.43 |        1.01 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                 256 | pp2048   |           768.59 |                  780.00 |        1.01 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                 512 | pp2048   |           792.24 |                  805.79 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                1024 | pp2048   |           760.64 |                  777.41 |        1.02 |
| llama 8B IQ4_NL - 4.5 bpw    | P40        |                2048 | pp2048   |           723.52 |                  724.94 |        1.00 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                  16 | pp2048   |           235.71 |                  235.49 |        1.00 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                  32 | pp2048   |           331.57 |                  333.53 |        1.01 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                  64 | pp2048   |           405.95 |                  410.99 |        1.01 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                 128 | pp2048   |           510.76 |                  520.78 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                 256 | pp2048   |           608.01 |                  619.50 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                 512 | pp2048   |           614.68 |                  624.71 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                1024 | pp2048   |           690.04 |                  702.35 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RX 6800    |                2048 | pp2048   |           627.83 |                  639.34 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                  16 | pp2048   |          1092.11 |                 1112.37 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                  32 | pp2048   |          1756.50 |                 1839.03 |        1.05 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                  64 | pp2048   |          2665.05 |                 2791.84 |        1.05 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                 128 | pp2048   |          3253.58 |                 3600.24 |        1.11 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                 256 | pp2048   |          3644.70 |                 4113.13 |        1.13 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                 512 | pp2048   |          3779.13 |                 4314.15 |        1.14 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                1024 | pp2048   |          3793.53 |                 4348.22 |        1.15 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 3090   |                2048 | pp2048   |          3686.52 |                 4217.29 |        1.14 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                  16 | pp2048   |          1963.94 |                 2014.78 |        1.03 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                  32 | pp2048   |          3408.65 |                 3550.23 |        1.04 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                  64 | pp2048   |          5569.97 |                 5814.91 |        1.04 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                 128 | pp2048   |          7355.95 |                 8064.64 |        1.10 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                 256 | pp2048   |          9445.91 |                10645.13 |        1.13 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                 512 | pp2048   |         10131.50 |                11475.40 |        1.13 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                1024 | pp2048   |          9808.51 |                11156.90 |        1.14 |
| llama 8B IQ4_XS - 4.25 bpw   | RTX 4090   |                2048 | pp2048   |          8951.82 |                10025.18 |        1.12 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                  16 | pp2048   |           258.44 |                  256.69 |        0.99 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                  32 | pp2048   |           418.49 |                  421.41 |        1.01 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                  64 | pp2048   |           581.16 |                  596.30 |        1.03 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                 128 | pp2048   |           686.45 |                  703.01 |        1.02 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                 256 | pp2048   |           773.25 |                  794.03 |        1.03 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                 512 | pp2048   |           806.87 |                  828.14 |        1.03 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                1024 | pp2048   |           763.50 |                  795.61 |        1.04 |
| llama 8B IQ4_XS - 4.25 bpw   | P40        |                2048 | pp2048   |           732.66 |                  744.06 |        1.02 |
| llama 8B Q2_K_M              | RX 6800    |                  16 | pp2048   |           126.96 |                  184.08 |        1.45 |
| llama 8B Q2_K_M              | RX 6800    |                  32 | pp2048   |           188.46 |                  261.40 |        1.39 |
| llama 8B Q2_K_M              | RX 6800    |                  64 | pp2048   |           241.87 |                  286.11 |        1.18 |
| llama 8B Q2_K_M              | RX 6800    |                 128 | pp2048   |           299.51 |                  354.08 |        1.18 |
| llama 8B Q2_K_M              | RX 6800    |                 256 | pp2048   |           364.77 |                  425.51 |        1.17 |
| llama 8B Q2_K_M              | RX 6800    |                 512 | pp2048   |           383.76 |                  439.03 |        1.14 |
| llama 8B Q2_K_M              | RX 6800    |                1024 | pp2048   |           416.47 |                  481.05 |        1.16 |
| llama 8B Q2_K_M              | RX 6800    |                2048 | pp2048   |           398.74 |                  455.77 |        1.14 |
| llama 8B Q2_K_M              | RTX 3090   |                  16 | pp2048   |          1081.38 |                 1228.22 |        1.14 |
| llama 8B Q2_K_M              | RTX 3090   |                  32 | pp2048   |          1561.28 |                 1868.28 |        1.20 |
| llama 8B Q2_K_M              | RTX 3090   |                  64 | pp2048   |          2146.91 |                 2516.09 |        1.17 |
| llama 8B Q2_K_M              | RTX 3090   |                 128 | pp2048   |          2651.83 |                 2577.82 |        0.97 |
| llama 8B Q2_K_M              | RTX 3090   |                 256 | pp2048   |          2971.92 |                 3081.47 |        1.04 |
| llama 8B Q2_K_M              | RTX 3090   |                 512 | pp2048   |          3112.39 |                 3353.02 |        1.08 |
| llama 8B Q2_K_M              | RTX 3090   |                1024 | pp2048   |          3134.75 |                 3505.83 |        1.12 |
| llama 8B Q2_K_M              | RTX 3090   |                2048 | pp2048   |          3093.43 |                 3451.92 |        1.12 |
| llama 8B Q2_K_M              | RTX 4090   |                  16 | pp2048   |          2009.40 |                 2132.92 |        1.06 |
| llama 8B Q2_K_M              | RTX 4090   |                  32 | pp2048   |          3077.56 |                 3637.09 |        1.18 |
| llama 8B Q2_K_M              | RTX 4090   |                  64 | pp2048   |          4608.38 |                 5385.63 |        1.17 |
| llama 8B Q2_K_M              | RTX 4090   |                 128 | pp2048   |          6048.25 |                 5467.48 |        0.90 |
| llama 8B Q2_K_M              | RTX 4090   |                 256 | pp2048   |          7741.86 |                 7518.69 |        0.97 |
| llama 8B Q2_K_M              | RTX 4090   |                 512 | pp2048   |          8270.00 |                 9055.11 |        1.09 |
| llama 8B Q2_K_M              | RTX 4090   |                1024 | pp2048   |          8143.32 |                 9159.31 |        1.12 |
| llama 8B Q2_K_M              | RTX 4090   |                2048 | pp2048   |          7539.51 |                 8445.80 |        1.12 |
| llama 8B Q2_K_M              | P40        |                  16 | pp2048   |           281.13 |                  332.60 |        1.18 |
| llama 8B Q2_K_M              | P40        |                  32 | pp2048   |           404.55 |                  504.05 |        1.25 |
| llama 8B Q2_K_M              | P40        |                  64 | pp2048   |           497.27 |                  573.08 |        1.15 |
| llama 8B Q2_K_M              | P40        |                 128 | pp2048   |           604.08 |                  664.99 |        1.10 |
| llama 8B Q2_K_M              | P40        |                 256 | pp2048   |           674.40 |                  749.42 |        1.11 |
| llama 8B Q2_K_M              | P40        |                 512 | pp2048   |           685.04 |                  788.49 |        1.15 |
| llama 8B Q2_K_M              | P40        |                1024 | pp2048   |           666.09 |                  774.29 |        1.16 |
| llama 8B Q2_K_M              | P40        |                2048 | pp2048   |           629.81 |                  724.67 |        1.15 |
| llama 8B Q3_K_S              | RX 6800    |                  16 | pp2048   |            97.78 |                  218.59 |        2.24 |
| llama 8B Q3_K_S              | RX 6800    |                  32 | pp2048   |           151.35 |                  294.39 |        1.95 |
| llama 8B Q3_K_S              | RX 6800    |                  64 | pp2048   |           202.30 |                  318.56 |        1.57 |
| llama 8B Q3_K_S              | RX 6800    |                 128 | pp2048   |           250.39 |                  397.31 |        1.59 |
| llama 8B Q3_K_S              | RX 6800    |                 256 | pp2048   |           302.50 |                  471.41 |        1.56 |
| llama 8B Q3_K_S              | RX 6800    |                 512 | pp2048   |           319.38 |                  483.63 |        1.51 |
| llama 8B Q3_K_S              | RX 6800    |                1024 | pp2048   |           343.96 |                  531.08 |        1.54 |
| llama 8B Q3_K_S              | RX 6800    |                2048 | pp2048   |           332.81 |                  495.86 |        1.49 |
| llama 8B Q3_K_S              | RTX 3090   |                  16 | pp2048   |          1114.12 |                 1169.83 |        1.05 |
| llama 8B Q3_K_S              | RTX 3090   |                  32 | pp2048   |          1601.18 |                 1890.46 |        1.18 |
| llama 8B Q3_K_S              | RTX 3090   |                  64 | pp2048   |          2163.78 |                 2734.38 |        1.26 |
| llama 8B Q3_K_S              | RTX 3090   |                 128 | pp2048   |          2890.74 |                 3226.13 |        1.12 |
| llama 8B Q3_K_S              | RTX 3090   |                 256 | pp2048   |          3191.09 |                 3680.64 |        1.15 |
| llama 8B Q3_K_S              | RTX 3090   |                 512 | pp2048   |          3316.23 |                 3894.79 |        1.17 |
| llama 8B Q3_K_S              | RTX 3090   |                1024 | pp2048   |          3334.05 |                 3977.03 |        1.19 |
| llama 8B Q3_K_S              | RTX 3090   |                2048 | pp2048   |          3269.66 |                 3879.93 |        1.19 |
| llama 8B Q3_K_S              | RTX 4090   |                  16 | pp2048   |          1883.09 |                 1908.42 |        1.01 |
| llama 8B Q3_K_S              | RTX 4090   |                  32 | pp2048   |          3029.86 |                 3615.06 |        1.19 |
| llama 8B Q3_K_S              | RTX 4090   |                  64 | pp2048   |          4480.88 |                 5639.45 |        1.26 |
| llama 8B Q3_K_S              | RTX 4090   |                 128 | pp2048   |          6515.56 |                 7656.04 |        1.18 |
| llama 8B Q3_K_S              | RTX 4090   |                 256 | pp2048   |          8307.18 |                 9696.19 |        1.17 |
| llama 8B Q3_K_S              | RTX 4090   |                 512 | pp2048   |          8762.30 |                10233.61 |        1.17 |
| llama 8B Q3_K_S              | RTX 4090   |                1024 | pp2048   |          8568.31 |                10104.30 |        1.18 |
| llama 8B Q3_K_S              | RTX 4090   |                2048 | pp2048   |          7907.97 |                 9156.33 |        1.16 |
| llama 8B Q3_K_S              | P40        |                  16 | pp2048   |           220.20 |                  348.10 |        1.58 |
| llama 8B Q3_K_S              | P40        |                  32 | pp2048   |           319.66 |                  491.34 |        1.54 |
| llama 8B Q3_K_S              | P40        |                  64 | pp2048   |           427.35 |                  580.71 |        1.36 |
| llama 8B Q3_K_S              | P40        |                 128 | pp2048   |           512.99 |                  657.29 |        1.28 |
| llama 8B Q3_K_S              | P40        |                 256 | pp2048   |           546.78 |                  701.47 |        1.28 |
| llama 8B Q3_K_S              | P40        |                 512 | pp2048   |           559.32 |                  706.64 |        1.26 |
| llama 8B Q3_K_S              | P40        |                1024 | pp2048   |           545.48 |                  677.40 |        1.24 |
| llama 8B Q3_K_S              | P40        |                2048 | pp2048   |           524.01 |                  656.32 |        1.25 |
| llama 8B Q4_0                | RX 6800    |                  16 | pp2048   |           267.42 |                  269.53 |        1.01 |
| llama 8B Q4_0                | RX 6800    |                  32 | pp2048   |           371.21 |                  372.44 |        1.00 |
| llama 8B Q4_0                | RX 6800    |                  64 | pp2048   |           431.24 |                  435.60 |        1.01 |
| llama 8B Q4_0                | RX 6800    |                 128 | pp2048   |           538.75 |                  548.28 |        1.02 |
| llama 8B Q4_0                | RX 6800    |                 256 | pp2048   |           635.11 |                  647.32 |        1.02 |
| llama 8B Q4_0                | RX 6800    |                 512 | pp2048   |           638.26 |                  648.59 |        1.02 |
| llama 8B Q4_0                | RX 6800    |                1024 | pp2048   |           717.49 |                  731.47 |        1.02 |
| llama 8B Q4_0                | RX 6800    |                2048 | pp2048   |           650.85 |                  662.03 |        1.02 |
| llama 8B Q4_0                | RTX 3090   |                  16 | pp2048   |          1281.27 |                 1306.26 |        1.02 |
| llama 8B Q4_0                | RTX 3090   |                  32 | pp2048   |          1935.28 |                 2088.34 |        1.08 |
| llama 8B Q4_0                | RTX 3090   |                  64 | pp2048   |          2711.35 |                 2859.45 |        1.05 |
| llama 8B Q4_0                | RTX 3090   |                 128 | pp2048   |          3499.77 |                 3673.60 |        1.05 |
| llama 8B Q4_0                | RTX 3090   |                 256 | pp2048   |          3916.27 |                 4194.32 |        1.07 |
| llama 8B Q4_0                | RTX 3090   |                 512 | pp2048   |          4179.44 |                 4404.74 |        1.05 |
| llama 8B Q4_0                | RTX 3090   |                1024 | pp2048   |          4220.53 |                 4459.62 |        1.06 |
| llama 8B Q4_0                | RTX 3090   |                2048 | pp2048   |          4074.92 |                 4306.90 |        1.06 |
| llama 8B Q4_0                | RTX 4090   |                  16 | pp2048   |          1913.70 |                 1970.75 |        1.03 |
| llama 8B Q4_0                | RTX 4090   |                  32 | pp2048   |          3391.11 |                 3547.00 |        1.05 |
| llama 8B Q4_0                | RTX 4090   |                  64 | pp2048   |          5319.52 |                 5662.40 |        1.06 |
| llama 8B Q4_0                | RTX 4090   |                 128 | pp2048   |          7420.40 |                 8062.83 |        1.09 |
| llama 8B Q4_0                | RTX 4090   |                 256 | pp2048   |          9683.83 |                10592.87 |        1.09 |
| llama 8B Q4_0                | RTX 4090   |                 512 | pp2048   |         10723.48 |                11469.81 |        1.07 |
| llama 8B Q4_0                | RTX 4090   |                1024 | pp2048   |         10498.61 |                11155.82 |        1.06 |
| llama 8B Q4_0                | RTX 4090   |                2048 | pp2048   |          9539.28 |                10074.84 |        1.06 |
| llama 8B Q4_0                | P40        |                  16 | pp2048   |           441.42 |                  444.28 |        1.01 |
| llama 8B Q4_0                | P40        |                  32 | pp2048   |           623.30 |                  621.07 |        1.00 |
| llama 8B Q4_0                | P40        |                  64 | pp2048   |           679.84 |                  683.57 |        1.01 |
| llama 8B Q4_0                | P40        |                 128 | pp2048   |           797.60 |                  803.85 |        1.01 |
| llama 8B Q4_0                | P40        |                 256 | pp2048   |           886.51 |                  890.30 |        1.00 |
| llama 8B Q4_0                | P40        |                 512 | pp2048   |           927.27 |                  930.13 |        1.00 |
| llama 8B Q4_0                | P40        |                1024 | pp2048   |           906.63 |                  913.20 |        1.01 |
| llama 8B Q4_0                | P40        |                2048 | pp2048   |           861.62 |                  865.13 |        1.00 |
| llama 8B Q4_1                | RX 6800    |                  16 | pp2048   |           250.31 |                  249.05 |        0.99 |
| llama 8B Q4_1                | RX 6800    |                  32 | pp2048   |           345.15 |                  349.96 |        1.01 |
| llama 8B Q4_1                | RX 6800    |                  64 | pp2048   |           403.89 |                  403.89 |        1.00 |
| llama 8B Q4_1                | RX 6800    |                 128 | pp2048   |           506.08 |                  509.53 |        1.01 |
| llama 8B Q4_1                | RX 6800    |                 256 | pp2048   |           597.20 |                  603.53 |        1.01 |
| llama 8B Q4_1                | RX 6800    |                 512 | pp2048   |           605.02 |                  611.31 |        1.01 |
| llama 8B Q4_1                | RX 6800    |                1024 | pp2048   |           674.91 |                  683.83 |        1.01 |
| llama 8B Q4_1                | RX 6800    |                2048 | pp2048   |           616.99 |                  624.88 |        1.01 |
| llama 8B Q4_1                | RTX 3090   |                  16 | pp2048   |          1392.57 |                 1400.65 |        1.01 |
| llama 8B Q4_1                | RTX 3090   |                  32 | pp2048   |          1782.54 |                 2138.78 |        1.20 |
| llama 8B Q4_1                | RTX 3090   |                  64 | pp2048   |          2747.31 |                 2931.09 |        1.07 |
| llama 8B Q4_1                | RTX 3090   |                 128 | pp2048   |          3351.07 |                 3294.11 |        0.98 |
| llama 8B Q4_1                | RTX 3090   |                 256 | pp2048   |          3739.25 |                 3764.51 |        1.01 |
| llama 8B Q4_1                | RTX 3090   |                 512 | pp2048   |          3901.46 |                 4013.45 |        1.03 |
| llama 8B Q4_1                | RTX 3090   |                1024 | pp2048   |          3909.61 |                 4098.31 |        1.05 |
| llama 8B Q4_1                | RTX 3090   |                2048 | pp2048   |          3785.17 |                 3997.97 |        1.06 |
| llama 8B Q4_1                | RTX 4090   |                  16 | pp2048   |          1813.98 |                 1852.97 |        1.02 |
| llama 8B Q4_1                | RTX 4090   |                  32 | pp2048   |          2945.00 |                 3356.13 |        1.14 |
| llama 8B Q4_1                | RTX 4090   |                  64 | pp2048   |          5398.91 |                 5665.09 |        1.05 |
| llama 8B Q4_1                | RTX 4090   |                 128 | pp2048   |          7280.85 |                 7536.47 |        1.04 |
| llama 8B Q4_1                | RTX 4090   |                 256 | pp2048   |          9357.25 |                 9716.65 |        1.04 |
| llama 8B Q4_1                | RTX 4090   |                 512 | pp2048   |         10040.79 |                10494.50 |        1.05 |
| llama 8B Q4_1                | RTX 4090   |                1024 | pp2048   |          9814.30 |                10393.62 |        1.06 |
| llama 8B Q4_1                | RTX 4090   |                2048 | pp2048   |          8964.59 |                 9337.89 |        1.04 |
| llama 8B Q4_1                | P40        |                  16 | pp2048   |           450.16 |                  451.50 |        1.00 |
| llama 8B Q4_1                | P40        |                  32 | pp2048   |           612.08 |                  612.42 |        1.00 |
| llama 8B Q4_1                | P40        |                  64 | pp2048   |           666.95 |                  674.17 |        1.01 |
| llama 8B Q4_1                | P40        |                 128 | pp2048   |           785.71 |                  793.62 |        1.01 |
| llama 8B Q4_1                | P40        |                 256 | pp2048   |           865.36 |                  876.04 |        1.01 |
| llama 8B Q4_1                | P40        |                 512 | pp2048   |           902.32 |                  914.56 |        1.01 |
| llama 8B Q4_1                | P40        |                1024 | pp2048   |           886.82 |                  896.99 |        1.01 |
| llama 8B Q4_1                | P40        |                2048 | pp2048   |           842.85 |                  851.55 |        1.01 |
| llama 8B Q4_K_S              | RX 6800    |                  16 | pp2048   |           231.04 |                  231.56 |        1.00 |
| llama 8B Q4_K_S              | RX 6800    |                  32 | pp2048   |           296.76 |                  302.02 |        1.02 |
| llama 8B Q4_K_S              | RX 6800    |                  64 | pp2048   |           330.54 |                  337.78 |        1.02 |
| llama 8B Q4_K_S              | RX 6800    |                 128 | pp2048   |           407.30 |                  418.60 |        1.03 |
| llama 8B Q4_K_S              | RX 6800    |                 256 | pp2048   |           490.15 |                  505.31 |        1.03 |
| llama 8B Q4_K_S              | RX 6800    |                 512 | pp2048   |           504.09 |                  518.25 |        1.03 |
| llama 8B Q4_K_S              | RX 6800    |                1024 | pp2048   |           557.35 |                  574.65 |        1.03 |
| llama 8B Q4_K_S              | RX 6800    |                2048 | pp2048   |           519.62 |                  533.56 |        1.03 |
| llama 8B Q4_K_S              | RTX 3090   |                  16 | pp2048   |          1376.25 |                 1408.99 |        1.02 |
| llama 8B Q4_K_S              | RTX 3090   |                  32 | pp2048   |          2030.30 |                 2157.70 |        1.06 |
| llama 8B Q4_K_S              | RTX 3090   |                  64 | pp2048   |          2652.98 |                 2899.88 |        1.09 |
| llama 8B Q4_K_S              | RTX 3090   |                 128 | pp2048   |          3251.68 |                 3437.08 |        1.06 |
| llama 8B Q4_K_S              | RTX 3090   |                 256 | pp2048   |          3623.10 |                 3934.53 |        1.09 |
| llama 8B Q4_K_S              | RTX 3090   |                 512 | pp2048   |          3771.06 |                 4181.71 |        1.11 |
| llama 8B Q4_K_S              | RTX 3090   |                1024 | pp2048   |          3831.95 |                 4284.17 |        1.12 |
| llama 8B Q4_K_S              | RTX 3090   |                2048 | pp2048   |          3737.99 |                 4163.34 |        1.11 |
| llama 8B Q4_K_S              | RTX 4090   |                  16 | pp2048   |          2003.27 |                 2041.99 |        1.02 |
| llama 8B Q4_K_S              | RTX 4090   |                  32 | pp2048   |          3531.27 |                 3647.90 |        1.03 |
| llama 8B Q4_K_S              | RTX 4090   |                  64 | pp2048   |          5458.35 |                 5893.00 |        1.08 |
| llama 8B Q4_K_S              | RTX 4090   |                 128 | pp2048   |          7328.10 |                 7902.76 |        1.08 |
| llama 8B Q4_K_S              | RTX 4090   |                 256 | pp2048   |          9284.65 |                10190.76 |        1.10 |
| llama 8B Q4_K_S              | RTX 4090   |                 512 | pp2048   |          9954.41 |                11032.18 |        1.11 |
| llama 8B Q4_K_S              | RTX 4090   |                1024 | pp2048   |          9787.04 |                10898.24 |        1.11 |
| llama 8B Q4_K_S              | RTX 4090   |                2048 | pp2048   |          9005.04 |                 9864.98 |        1.10 |
| llama 8B Q4_K_S              | P40        |                  16 | pp2048   |           406.29 |                  406.26 |        1.00 |
| llama 8B Q4_K_S              | P40        |                  32 | pp2048   |           503.41 |                  512.72 |        1.02 |
| llama 8B Q4_K_S              | P40        |                  64 | pp2048   |           619.38 |                  627.37 |        1.01 |
| llama 8B Q4_K_S              | P40        |                 128 | pp2048   |           729.17 |                  734.96 |        1.01 |
| llama 8B Q4_K_S              | P40        |                 256 | pp2048   |           779.99 |                  788.10 |        1.01 |
| llama 8B Q4_K_S              | P40        |                 512 | pp2048   |           791.46 |                  799.43 |        1.01 |
| llama 8B Q4_K_S              | P40        |                1024 | pp2048   |           766.79 |                  780.88 |        1.02 |
| llama 8B Q4_K_S              | P40        |                2048 | pp2048   |           725.33 |                  733.57 |        1.01 |
| llama 8B Q5_0                | RX 6800    |                  16 | pp2048   |           226.09 |                  226.36 |        1.00 |
| llama 8B Q5_0                | RX 6800    |                  32 | pp2048   |           330.01 |                  335.07 |        1.02 |
| llama 8B Q5_0                | RX 6800    |                  64 | pp2048   |           402.30 |                  407.39 |        1.01 |
| llama 8B Q5_0                | RX 6800    |                 128 | pp2048   |           501.50 |                  510.97 |        1.02 |
| llama 8B Q5_0                | RX 6800    |                 256 | pp2048   |           586.79 |                  600.49 |        1.02 |
| llama 8B Q5_0                | RX 6800    |                 512 | pp2048   |           592.98 |                  605.56 |        1.02 |
| llama 8B Q5_0                | RX 6800    |                1024 | pp2048   |           663.32 |                  678.13 |        1.02 |
| llama 8B Q5_0                | RX 6800    |                2048 | pp2048   |           606.36 |                  620.93 |        1.02 |
| llama 8B Q5_0                | RTX 3090   |                  16 | pp2048   |          1085.35 |                 1037.79 |        0.96 |
| llama 8B Q5_0                | RTX 3090   |                  32 | pp2048   |          1839.64 |                 1861.96 |        1.01 |
| llama 8B Q5_0                | RTX 3090   |                  64 | pp2048   |          2810.22 |                 2869.14 |        1.02 |
| llama 8B Q5_0                | RTX 3090   |                 128 | pp2048   |          3443.30 |                 3704.81 |        1.08 |
| llama 8B Q5_0                | RTX 3090   |                 256 | pp2048   |          3896.08 |                 4218.52 |        1.08 |
| llama 8B Q5_0                | RTX 3090   |                 512 | pp2048   |          4077.99 |                 4455.14 |        1.09 |
| llama 8B Q5_0                | RTX 3090   |                1024 | pp2048   |          4088.51 |                 4549.91 |        1.11 |
| llama 8B Q5_0                | RTX 3090   |                2048 | pp2048   |          3949.49 |                 4362.42 |        1.10 |
| llama 8B Q5_0                | RTX 4090   |                  16 | pp2048   |          1644.45 |                 1630.53 |        0.99 |
| llama 8B Q5_0                | RTX 4090   |                  32 | pp2048   |          3024.16 |                 3101.52 |        1.03 |
| llama 8B Q5_0                | RTX 4090   |                  64 | pp2048   |          5173.85 |                 5349.46 |        1.03 |
| llama 8B Q5_0                | RTX 4090   |                 128 | pp2048   |          7218.09 |                 7957.21 |        1.10 |
| llama 8B Q5_0                | RTX 4090   |                 256 | pp2048   |          9491.88 |                10658.20 |        1.12 |
| llama 8B Q5_0                | RTX 4090   |                 512 | pp2048   |         10487.57 |                11545.50 |        1.10 |
| llama 8B Q5_0                | RTX 4090   |                1024 | pp2048   |         10270.52 |                11383.14 |        1.11 |
| llama 8B Q5_0                | RTX 4090   |                2048 | pp2048   |          9419.49 |                10201.96 |        1.08 |
| llama 8B Q5_0                | P40        |                  16 | pp2048   |           355.58 |                  359.96 |        1.01 |
| llama 8B Q5_0                | P40        |                  32 | pp2048   |           531.72 |                  533.27 |        1.00 |
| llama 8B Q5_0                | P40        |                  64 | pp2048   |           617.74 |                  629.08 |        1.02 |
| llama 8B Q5_0                | P40        |                 128 | pp2048   |           717.33 |                  731.98 |        1.02 |
| llama 8B Q5_0                | P40        |                 256 | pp2048   |           800.06 |                  817.11 |        1.02 |
| llama 8B Q5_0                | P40        |                 512 | pp2048   |           838.73 |                  857.04 |        1.02 |
| llama 8B Q5_0                | P40        |                1024 | pp2048   |           827.11 |                  845.22 |        1.02 |
| llama 8B Q5_0                | P40        |                2048 | pp2048   |           788.75 |                  803.56 |        1.02 |
| llama 8B Q5_1                | RX 6800    |                  16 | pp2048   |           222.78 |                  223.49 |        1.00 |
| llama 8B Q5_1                | RX 6800    |                  32 | pp2048   |           322.53 |                  323.28 |        1.00 |
| llama 8B Q5_1                | RX 6800    |                  64 | pp2048   |           391.56 |                  395.53 |        1.01 |
| llama 8B Q5_1                | RX 6800    |                 128 | pp2048   |           492.43 |                  500.66 |        1.02 |
| llama 8B Q5_1                | RX 6800    |                 256 | pp2048   |           581.63 |                  591.55 |        1.02 |
| llama 8B Q5_1                | RX 6800    |                 512 | pp2048   |           591.61 |                  599.74 |        1.01 |
| llama 8B Q5_1                | RX 6800    |                1024 | pp2048   |           660.05 |                  672.26 |        1.02 |
| llama 8B Q5_1                | RX 6800    |                2048 | pp2048   |           604.36 |                  613.82 |        1.02 |
| llama 8B Q5_1                | RTX 3090   |                  16 | pp2048   |          1105.27 |                 1107.41 |        1.00 |
| llama 8B Q5_1                | RTX 3090   |                  32 | pp2048   |          1632.07 |                 1768.71 |        1.08 |
| llama 8B Q5_1                | RTX 3090   |                  64 | pp2048   |          2479.76 |                 2684.07 |        1.08 |
| llama 8B Q5_1                | RTX 3090   |                 128 | pp2048   |          3261.49 |                 3085.09 |        0.95 |
| llama 8B Q5_1                | RTX 3090   |                 256 | pp2048   |          3642.14 |                 3581.00 |        0.98 |
| llama 8B Q5_1                | RTX 3090   |                 512 | pp2048   |          3804.44 |                 3812.90 |        1.00 |
| llama 8B Q5_1                | RTX 3090   |                1024 | pp2048   |          3824.69 |                 3916.59 |        1.02 |
| llama 8B Q5_1                | RTX 3090   |                2048 | pp2048   |          3729.99 |                 3872.03 |        1.04 |
| llama 8B Q5_1                | RTX 4090   |                  16 | pp2048   |          1572.05 |                 1606.43 |        1.02 |
| llama 8B Q5_1                | RTX 4090   |                  32 | pp2048   |          2672.81 |                 2860.89 |        1.07 |
| llama 8B Q5_1                | RTX 4090   |                  64 | pp2048   |          4440.16 |                 5273.79 |        1.19 |
| llama 8B Q5_1                | RTX 4090   |                 128 | pp2048   |          7094.02 |                 7149.64 |        1.01 |
| llama 8B Q5_1                | RTX 4090   |                 256 | pp2048   |          9060.70 |                 9178.58 |        1.01 |
| llama 8B Q5_1                | RTX 4090   |                 512 | pp2048   |          9861.47 |                10070.20 |        1.02 |
| llama 8B Q5_1                | RTX 4090   |                1024 | pp2048   |          9746.59 |                10128.23 |        1.04 |
| llama 8B Q5_1                | RTX 4090   |                2048 | pp2048   |          8897.90 |                 9259.38 |        1.04 |
| llama 8B Q5_1                | P40        |                  16 | pp2048   |           375.78 |                  380.30 |        1.01 |
| llama 8B Q5_1                | P40        |                  32 | pp2048   |           550.57 |                  561.59 |        1.02 |
| llama 8B Q5_1                | P40        |                  64 | pp2048   |           633.51 |                  635.96 |        1.00 |
| llama 8B Q5_1                | P40        |                 128 | pp2048   |           732.92 |                  735.79 |        1.00 |
| llama 8B Q5_1                | P40        |                 256 | pp2048   |           819.88 |                  820.69 |        1.00 |
| llama 8B Q5_1                | P40        |                 512 | pp2048   |           856.29 |                  857.99 |        1.00 |
| llama 8B Q5_1                | P40        |                1024 | pp2048   |           838.17 |                  845.51 |        1.01 |
| llama 8B Q5_1                | P40        |                2048 | pp2048   |           794.40 |                  803.97 |        1.01 |
| llama 8B Q5_K_S              | RX 6800    |                  16 | pp2048   |           221.02 |                  222.01 |        1.00 |
| llama 8B Q5_K_S              | RX 6800    |                  32 | pp2048   |           304.83 |                  305.84 |        1.00 |
| llama 8B Q5_K_S              | RX 6800    |                  64 | pp2048   |           326.12 |                  334.29 |        1.03 |
| llama 8B Q5_K_S              | RX 6800    |                 128 | pp2048   |           399.84 |                  412.08 |        1.03 |
| llama 8B Q5_K_S              | RX 6800    |                 256 | pp2048   |           482.44 |                  499.21 |        1.03 |
| llama 8B Q5_K_S              | RX 6800    |                 512 | pp2048   |           496.96 |                  513.65 |        1.03 |
| llama 8B Q5_K_S              | RX 6800    |                1024 | pp2048   |           549.13 |                  568.78 |        1.04 |
| llama 8B Q5_K_S              | RX 6800    |                2048 | pp2048   |           511.45 |                  528.45 |        1.03 |
| llama 8B Q5_K_S              | RTX 3090   |                  16 | pp2048   |          1161.60 |                 1182.85 |        1.02 |
| llama 8B Q5_K_S              | RTX 3090   |                  32 | pp2048   |          1845.83 |                 1977.99 |        1.07 |
| llama 8B Q5_K_S              | RTX 3090   |                  64 | pp2048   |          2436.93 |                 2747.16 |        1.13 |
| llama 8B Q5_K_S              | RTX 3090   |                 128 | pp2048   |          3070.83 |                 3305.02 |        1.08 |
| llama 8B Q5_K_S              | RTX 3090   |                 256 | pp2048   |          3424.08 |                 3811.23 |        1.11 |
| llama 8B Q5_K_S              | RTX 3090   |                 512 | pp2048   |          3566.58 |                 4068.29 |        1.14 |
| llama 8B Q5_K_S              | RTX 3090   |                1024 | pp2048   |          3606.63 |                 4155.53 |        1.15 |
| llama 8B Q5_K_S              | RTX 3090   |                2048 | pp2048   |          3545.85 |                 4037.04 |        1.14 |
| llama 8B Q5_K_S              | RTX 4090   |                  16 | pp2048   |          1712.71 |                 1749.88 |        1.02 |
| llama 8B Q5_K_S              | RTX 4090   |                  32 | pp2048   |          3161.70 |                 3265.98 |        1.03 |
| llama 8B Q5_K_S              | RTX 4090   |                  64 | pp2048   |          5040.32 |                 5521.94 |        1.10 |
| llama 8B Q5_K_S              | RTX 4090   |                 128 | pp2048   |          6886.68 |                 7644.84 |        1.11 |
| llama 8B Q5_K_S              | RTX 4090   |                 256 | pp2048   |          8726.65 |                 9782.59 |        1.12 |
| llama 8B Q5_K_S              | RTX 4090   |                 512 | pp2048   |          9422.20 |                10634.01 |        1.13 |
| llama 8B Q5_K_S              | RTX 4090   |                1024 | pp2048   |          9329.98 |                10606.55 |        1.14 |
| llama 8B Q5_K_S              | RTX 4090   |                2048 | pp2048   |          8621.52 |                 9589.72 |        1.11 |
| llama 8B Q5_K_S              | P40        |                  16 | pp2048   |           350.42 |                  361.75 |        1.03 |
| llama 8B Q5_K_S              | P40        |                  32 | pp2048   |           449.11 |                  470.73 |        1.05 |
| llama 8B Q5_K_S              | P40        |                  64 | pp2048   |           590.43 |                  611.75 |        1.04 |
| llama 8B Q5_K_S              | P40        |                 128 | pp2048   |           694.95 |                  714.26 |        1.03 |
| llama 8B Q5_K_S              | P40        |                 256 | pp2048   |           755.47 |                  757.14 |        1.00 |
| llama 8B Q5_K_S              | P40        |                 512 | pp2048   |           765.46 |                  765.82 |        1.00 |
| llama 8B Q5_K_S              | P40        |                1024 | pp2048   |           742.85 |                  748.53 |        1.01 |
| llama 8B Q5_K_S              | P40        |                2048 | pp2048   |           695.89 |                  712.74 |        1.02 |
| llama 8B Q6_K                | RX 6800    |                  16 | pp2048   |           207.37 |                  213.56 |        1.03 |
| llama 8B Q6_K                | RX 6800    |                  32 | pp2048   |           283.20 |                  277.09 |        0.98 |
| llama 8B Q6_K                | RX 6800    |                  64 | pp2048   |           287.87 |                  301.34 |        1.05 |
| llama 8B Q6_K                | RX 6800    |                 128 | pp2048   |           351.28 |                  372.26 |        1.06 |
| llama 8B Q6_K                | RX 6800    |                 256 | pp2048   |           423.73 |                  447.08 |        1.06 |
| llama 8B Q6_K                | RX 6800    |                 512 | pp2048   |           440.74 |                  462.90 |        1.05 |
| llama 8B Q6_K                | RX 6800    |                1024 | pp2048   |           481.65 |                  507.73 |        1.05 |
| llama 8B Q6_K                | RX 6800    |                2048 | pp2048   |           453.79 |                  476.32 |        1.05 |
| llama 8B Q6_K                | RTX 3090   |                  16 | pp2048   |          1008.80 |                 1038.01 |        1.03 |
| llama 8B Q6_K                | RTX 3090   |                  32 | pp2048   |          1740.13 |                 1784.98 |        1.03 |
| llama 8B Q6_K                | RTX 3090   |                  64 | pp2048   |          2568.33 |                 2611.05 |        1.02 |
| llama 8B Q6_K                | RTX 3090   |                 128 | pp2048   |          3129.10 |                 3270.89 |        1.05 |
| llama 8B Q6_K                | RTX 3090   |                 256 | pp2048   |          3537.01 |                 3777.64 |        1.07 |
| llama 8B Q6_K                | RTX 3090   |                 512 | pp2048   |          3696.48 |                 3980.75 |        1.08 |
| llama 8B Q6_K                | RTX 3090   |                1024 | pp2048   |          3724.88 |                 4026.53 |        1.08 |
| llama 8B Q6_K                | RTX 3090   |                2048 | pp2048   |          3596.34 |                 3892.68 |        1.08 |
| llama 8B Q6_K                | RTX 4090   |                  16 | pp2048   |          1452.60 |                 1479.91 |        1.02 |
| llama 8B Q6_K                | RTX 4090   |                  32 | pp2048   |          2785.91 |                 2842.04 |        1.02 |
| llama 8B Q6_K                | RTX 4090   |                  64 | pp2048   |          4710.12 |                 4555.03 |        0.97 |
| llama 8B Q6_K                | RTX 4090   |                 128 | pp2048   |          6728.92 |                 7180.00 |        1.07 |
| llama 8B Q6_K                | RTX 4090   |                 256 | pp2048   |          8717.74 |                 9366.04 |        1.07 |
| llama 8B Q6_K                | RTX 4090   |                 512 | pp2048   |          9488.11 |                10199.94 |        1.08 |
| llama 8B Q6_K                | RTX 4090   |                1024 | pp2048   |          9300.89 |                10097.27 |        1.09 |
| llama 8B Q6_K                | RTX 4090   |                2048 | pp2048   |          8473.21 |                 9150.08 |        1.08 |
| llama 8B Q6_K                | P40        |                  16 | pp2048   |           333.72 |                  295.57 |        0.89 |
| llama 8B Q6_K                | P40        |                  32 | pp2048   |           460.03 |                  466.11 |        1.01 |
| llama 8B Q6_K                | P40        |                  64 | pp2048   |           581.10 |                  590.98 |        1.02 |
| llama 8B Q6_K                | P40        |                 128 | pp2048   |           649.29 |                  661.03 |        1.02 |
| llama 8B Q6_K                | P40        |                 256 | pp2048   |           685.27 |                  701.79 |        1.02 |
| llama 8B Q6_K                | P40        |                 512 | pp2048   |           696.77 |                  711.19 |        1.02 |
| llama 8B Q6_K                | P40        |                1024 | pp2048   |           681.71 |                  700.28 |        1.03 |
| llama 8B Q6_K                | P40        |                2048 | pp2048   |           648.71 |                  659.70 |        1.02 |
| llama 8B Q8_0                | RX 6800    |                  16 | pp2048   |           254.44 |                  248.89 |        0.98 |
| llama 8B Q8_0                | RX 6800    |                  32 | pp2048   |           355.17 |                  352.40 |        0.99 |
| llama 8B Q8_0                | RX 6800    |                  64 | pp2048   |           418.60 |                  435.19 |        1.04 |
| llama 8B Q8_0                | RX 6800    |                 128 | pp2048   |           527.21 |                  547.83 |        1.04 |
| llama 8B Q8_0                | RX 6800    |                 256 | pp2048   |           627.28 |                  650.18 |        1.04 |
| llama 8B Q8_0                | RX 6800    |                 512 | pp2048   |           634.19 |                  657.36 |        1.04 |
| llama 8B Q8_0                | RX 6800    |                1024 | pp2048   |           714.38 |                  739.91 |        1.04 |
| llama 8B Q8_0                | RX 6800    |                2048 | pp2048   |           647.66 |                  671.90 |        1.04 |
| llama 8B Q8_0                | RTX 3090   |                  16 | pp2048   |           989.94 |                  977.21 |        0.99 |
| llama 8B Q8_0                | RTX 3090   |                  32 | pp2048   |          1739.38 |                 1834.08 |        1.05 |
| llama 8B Q8_0                | RTX 3090   |                  64 | pp2048   |          2784.83 |                 2895.64 |        1.04 |
| llama 8B Q8_0                | RTX 3090   |                 128 | pp2048   |          3681.37 |                 3751.25 |        1.02 |
| llama 8B Q8_0                | RTX 3090   |                 256 | pp2048   |          4243.38 |                 4395.91 |        1.04 |
| llama 8B Q8_0                | RTX 3090   |                 512 | pp2048   |          4434.48 |                 4641.51 |        1.05 |
| llama 8B Q8_0                | RTX 3090   |                1024 | pp2048   |          4482.22 |                 4733.34 |        1.06 |
| llama 8B Q8_0                | RTX 3090   |                2048 | pp2048   |          4291.45 |                 4533.04 |        1.06 |
| llama 8B Q8_0                | RTX 4090   |                  16 | pp2048   |          1233.64 |                 1364.73 |        1.11 |
| llama 8B Q8_0                | RTX 4090   |                  32 | pp2048   |          2340.64 |                 2536.91 |        1.08 |
| llama 8B Q8_0                | RTX 4090   |                  64 | pp2048   |          4201.01 |                 4469.49 |        1.06 |
| llama 8B Q8_0                | RTX 4090   |                 128 | pp2048   |          6776.67 |                 7006.66 |        1.03 |
| llama 8B Q8_0                | RTX 4090   |                 256 | pp2048   |          9835.87 |                10517.99 |        1.07 |
| llama 8B Q8_0                | RTX 4090   |                 512 | pp2048   |         11124.57 |                11976.77 |        1.08 |
| llama 8B Q8_0                | RTX 4090   |                1024 | pp2048   |         11070.31 |                11805.52 |        1.07 |
| llama 8B Q8_0                | RTX 4090   |                2048 | pp2048   |         10117.85 |                10644.41 |        1.05 |
| llama 8B Q8_0                | P40        |                  16 | pp2048   |           318.64 |                  352.32 |        1.11 |
| llama 8B Q8_0                | P40        |                  32 | pp2048   |           562.07 |                  559.65 |        1.00 |
| llama 8B Q8_0                | P40        |                  64 | pp2048   |           609.36 |                  629.17 |        1.03 |
| llama 8B Q8_0                | P40        |                 128 | pp2048   |           731.95 |                  751.52 |        1.03 |
| llama 8B Q8_0                | P40        |                 256 | pp2048   |           815.45 |                  846.11 |        1.04 |
| llama 8B Q8_0                | P40        |                 512 | pp2048   |           854.82 |                  886.85 |        1.04 |
| llama 8B Q8_0                | P40        |                1024 | pp2048   |           840.69 |                  865.01 |        1.03 |
| llama 8B Q8_0                | P40        |                2048 | pp2048   |           798.29 |                  820.32 |        1.03 |

</details>