### PR TITLE
tokenize : add --no-parse-special option

### DIFF
--- a/examples/tokenize/tokenize.cpp
+++ b/examples/tokenize/tokenize.cpp
@@ -29,6 +29,7 @@ static void print_usage_information(const char * argv0, FILE * stream) {
     fprintf(stream, "    -p PROMPT, --prompt PROMPT           read prompt from the argument.\n");
     fprintf(stream, "    --stdin                              read prompt from standard input.\n");
     fprintf(stream, "    --no-bos                             do not ever add a BOS token to the prompt, even if normally the model uses a BOS token.\n");
+    fprintf(stream, "    --no-parse-special                   do not parse control tokens.\n");
     fprintf(stream, "    --log-disable                        disable logs. Makes stderr quiet when loading the model.\n");
     fprintf(stream, "    --show-count                         print the total number of tokens.\n");
 }
@@ -195,6 +196,7 @@ int main(int raw_argc, char ** raw_argv) {
     // variables where to put any arguments we see.
     bool printing_ids = false;
     bool no_bos = false;
+    bool no_parse_special = false;
     bool disable_logging = false;
     bool show_token_count = false;
     const char * model_path = NULL;
@@ -228,6 +230,9 @@ int main(int raw_argc, char ** raw_argv) {
         }
         else if (arg == "--no-bos") {
             no_bos = true;
+        }
+        else if (arg == "--no-parse-special") {
+            no_parse_special = true;
         }
         else if (arg == "-p" || arg == "--prompt") {
             if (prompt_set) {
@@ -359,9 +364,10 @@ int main(int raw_argc, char ** raw_argv) {
 
     const bool model_wants_add_bos = llama_should_add_bos_token(model);
     const bool add_bos = model_wants_add_bos && !no_bos;
+    const bool parse_special = !no_parse_special;
 
     std::vector<llama_token> tokens;
-    tokens = ::llama_tokenize(model, prompt, add_bos, true);
+    tokens = ::llama_tokenize(model, prompt, add_bos, parse_special);
 
     if (printing_ids) {
         printf("[");


### PR DESCRIPTION
This should allow more easily explaining how `parse_special` affects tokenization.

I felt the need for this when working on #8228, because the tokenizer tests use `parse_special = true`, but when `parse_special = false`, some tokenizers have problems which were otherwise not really easy to visualize.

For example, with OLMo (which uses a tokenizer very similar to GPT-NeoX), there's a problem with tokenization of consecutive spaces:

```console
$ ./build/bin/llama-tokenize --log-disable -m models/ggml-vocab-olmo.gguf -p "Hello   world of    spaces"
 12092 -> 'Hello'
 50275 -> '   '
 10186 -> 'world'
   273 -> ' of'
 50274 -> '    '
 31748 -> 'spaces'

$ ./build/bin/llama-tokenize --log-disable -m models/ggml-vocab-olmo.gguf -p "Hello   world of    spaces" --no-parse-special
 12092 -> 'Hello'
   245 -> '  '
  1533 -> ' world'
   273 -> ' of'
   341 -> '   '
  8470 -> ' spaces'
```

Notice how when `parse_special = false`, the spaces don't get tokenized correctly (space prefixes, and totally different token ids for spaces), because the user-defined multi-space tokens no longer have priority in the pre-tokenization (but they should!). 

This is one of the problems fixed in #8228

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
