### PR TITLE
ggml : Add GGML_USE_SVE macro to disable SVE by default

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -963,6 +963,7 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
             list(APPEND ARCH_FLAGS -mno-unaligned-access)
         endif()
         if (GGML_SVE)
+            list(APPEND GGML_CDEF_PUBLIC GGML_USE_SVE)
             list(APPEND ARCH_FLAGS -march=armv8.6-a+sve)
         endif()
     endif()

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -144,7 +144,7 @@ extern "C" {
 #endif
 #endif
 
-#if defined(__ARM_FEATURE_SVE)
+#if (defined(__ARM_FEATURE_SVE) && defined(GGML_USE_SVE))
 #include <arm_sve.h>
 #endif
 

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -3813,7 +3813,7 @@ void ggml_vec_dot_q4_0_q8_0(int n, float * restrict s, size_t bs, const void * r
         return;
     }
 #endif
-#if defined(__ARM_FEATURE_SVE)
+#if (defined(__ARM_FEATURE_SVE) && defined(GGML_USE_SVE))
     const svbool_t ptrueh = svptrue_pat_b8(SV_VL16);
     const svbool_t ptruel = svnot_b_z(svptrue_b8(), ptrueh);
 
@@ -5421,7 +5421,7 @@ void ggml_vec_dot_q8_0_q8_0(int n, float * restrict s, size_t bs, const void * r
         return;
     }
 #endif
-#if defined(__ARM_FEATURE_SVE)
+#if (defined(__ARM_FEATURE_SVE) && defined(GGML_USE_SVE))
     svfloat32_t sumv0 = svdup_n_f32(0.0f);
     svfloat32_t sumv1 = svdup_n_f32(0.0f);
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -21758,7 +21758,7 @@ int ggml_cpu_has_neon(void) {
 }
 
 int ggml_cpu_has_sve(void) {
-#if defined(__ARM_FEATURE_SVE)
+#if (defined(__ARM_FEATURE_SVE) && defined(GGML_USE_SVE))
     // TODO: Currently, SVE 256 bit is only supported.
     GGML_ASSERT(svcntb() == QK8_0);
     return 1;


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

---

This PR addresses an issue introduced in #8109.

In the previous update, GGML_NATIVE was enabled by default, which in turn enabled SVE by default. However, SVE currently only supports 256-bit operations in vec_dot, leading to errors when running on SVE 128-bit CPUs.

This fix ensures that SVE is not enabled unless GGML_SVE=ON is explicitly set at compile time.