### PR TITLE
Gemma2: 9B query_pre_attn_scalar = 256 not 224

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2474,11 +2474,6 @@ class Gemma2Model(Model):
         )
         self.gguf_writer.add_sliding_window(self.hparams["sliding_window"])
 
-        # sanity check
-        attn_scalar = self.hparams["query_pre_attn_scalar"]
-        if attn_scalar != hparams["hidden_size"] / hparams["num_attention_heads"]:
-            raise ValueError("query_pre_attn_scalar must be equal to n_embd / n_head")
-
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         del bid  # unused
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

See https://github.com/google/gemma_pytorch/commit/03e657582d17cb5a8617ebf333c1c16f3694670e
Gemma 9b should use 256 and not 224 (self.config.hidden_size // self.config.num_attention_heads).

Google engineers confirmed only the 9B is affected and not the 27B. This PR just disables the sanity check, since the latest HF repo for Gemma2 9B has been updated already - see https://huggingface.co/google/gemma-2-9b-it/blob/1937c70277fcc5f7fb0fc772fc5bc69378996e71/config.json#L24