### PR TITLE
llama : suppress unary minus operator warning

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -21144,7 +21144,7 @@ int32_t llama_token_to_piece(const struct llama_model * model, llama_token token
             size--;
         }
         if (length < (int32_t)size) {
-            return (int32_t) -size;
+            return -(int32_t) size;
         }
         memcpy(buf, token, size);
         return (int32_t) size;


### PR DESCRIPTION
This commit updates the _try_copy lambda and moves the unary minus operator to after the cast to int32_t.

The motivation for this that currently the following warning is generated on windows:

```console
llama.cpp\src\llama.cpp(21147,30): warning C4146: unary minus operator applied to unsigned type, result still unsigned
```



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
