### PR TITLE
server : handle content array in chat API

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -132,7 +132,7 @@ inline std::string format_chat(const struct llama_model * model, const std::stri
             } else if (curr_msg["content"].is_array()) {
                 for (const auto & part : curr_msg["content"]) {
                     if (part.contains("text")) {
-                        content += part["text"].get<std::string>();
+                        content += "\n" + part["text"].get<std::string>();
                     }
                 }
             } else {

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -122,8 +122,26 @@ inline std::string format_chat(const struct llama_model * model, const std::stri
 
     for (size_t i = 0; i < messages.size(); ++i) {
         const auto & curr_msg = messages[i];
-        std::string role    = json_value(curr_msg, "role",    std::string(""));
-        std::string content = json_value(curr_msg, "content", std::string(""));
+
+        std::string role = json_value(curr_msg, "role", std::string(""));
+
+        std::string content;
+        if (curr_msg.contains("content")) {
+            if (curr_msg["content"].is_string()) {
+                content = curr_msg["content"].get<std::string>();
+            } else if (curr_msg["content"].is_array()) {
+                for (const auto & part : curr_msg["content"]) {
+                    if (part.contains("text")) {
+                        content += part["text"].get<std::string>();
+                    }
+                }
+            } else {
+                throw std::runtime_error("Invalid 'content' type (ref: https://github.com/ggerganov/llama.cpp/issues/8367)");
+            }
+        } else {
+            throw std::runtime_error("Missing 'content' (ref: https://github.com/ggerganov/llama.cpp/issues/8367)");
+        }
+
         chat.push_back({role, content});
     }
 


### PR DESCRIPTION
fix #8367 

Testing:

```bash
make -j && ./llama-server --hf-repo "Qwen/Qwen2-0.5B-Instruct-GGUF" --hf-file qwen2-0_5b-instruct-q2_k.gguf

curl \
  --request POST --url http://localhost:8080/v1/chat/completions \
  --header "Content-Type: application/json" \
  --data '{"temperature": 0.0, "messages": [ { "role": "system", "content": "You are a helpful assistant." }, { "role": "user", "content": [ { "type": "text", "text": "tell me a " }, { "type": "text", "text": "riddle" } ] } ] }'
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
