### PR TITLE
ggml : suppress unknown pragma 'GCC' on windows

### DIFF
--- a/ggml/src/ggml-aarch64.c
+++ b/ggml/src/ggml-aarch64.c
@@ -14,7 +14,9 @@
 
 #include "ggml-aarch64.h"
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Woverlength-strings"
+#endif
 
 #define UNUSED GGML_UNUSED
 


### PR DESCRIPTION
This commit adds a macro guard to pragma GCC to avoid the following warning on windows:

```console
C:\llama.cpp\ggml\src\ggml-aarch64.c(17,9): warning C4068:
unknown pragma 'GCC' [C:\lama.cpp\build\ggml\src\ggml.vcxproj]
```
----
Is it alright to open pull request for ggml in this repository or is it preferred to do so in the ggml repo?


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
