### PR TITLE
gguf_hash.py: Add sha256

### DIFF
--- a/gguf-py/scripts/gguf_hash.py
+++ b/gguf-py/scripts/gguf_hash.py
@@ -83,7 +83,7 @@ def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar: bool, no_
     # Display Hash Output
     print("sha1      {0}  {1}".format(sha1.hexdigest(), filename)) # noqa: NP100
     print("sha256    {0}  {1}".format(sha256.hexdigest(), filename)) # noqa: NP100
-    print("UUIDv5    {0}  {1}".format(uuid.UUID(bytes=uuidv5_sha1.digest()[:16], version=5), filename)) # noqa: NP100
+    print("uuid      {0}  {1}".format(uuid.UUID(bytes=uuidv5_sha1.digest()[:16], version=5), filename)) # noqa: NP100
 
 
 def main() -> None:

--- a/gguf-py/scripts/gguf_hash.py
+++ b/gguf-py/scripts/gguf_hash.py
@@ -27,8 +27,9 @@ UUID_NAMESPACE_LLAMA_CPP = uuid.UUID('ef001206-dadc-5f6d-a15f-3359e577d4e5')
 
 # For more information about what field.parts and field.data represent,
 # please see the comments in the modify_gguf.py example.
-def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar) -> None:
+def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar: bool, no_layer:bool) -> None:
     sha1 = hashlib.sha1()
+    sha256 = hashlib.sha256()
     uuidv5_sha1 = hashlib.sha1()
     uuidv5_sha1.update(UUID_NAMESPACE_LLAMA_CPP.bytes)
 
@@ -50,7 +51,7 @@ def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar) -> None:
     bar = tqdm(desc="Hashing", total=total_weights, unit="weights", unit_scale=True, disable=disable_progress_bar)
 
     # Hashing Process
-    for n, tensor in enumerate(reader.tensors, 1):
+    for tensor in reader.tensors:
 
         # We don't need these
         if tensor.name.endswith((".attention.masked_bias", ".attention.bias", ".rotary_emb.inv_freq")):
@@ -62,29 +63,39 @@ def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar) -> None:
             sum_weights_in_tensor *= dim
         bar.update(sum_weights_in_tensor)
 
-        sha1_layer = hashlib.sha1()
-        sha1_layer.update(tensor.data.data)
+        if not no_layer:
+
+            sha1_layer = hashlib.sha1()
+            sha1_layer.update(tensor.data.data)
+            print("sha1      {0}  {1}:{2}".format(sha1_layer.hexdigest(), filename, tensor.name)) # noqa: NP100
+
+            sha256_layer = hashlib.sha256()
+            sha256_layer.update(tensor.data.data)
+            print("sha256    {0}  {1}:{2}".format(sha256_layer.hexdigest(), filename, tensor.name)) # noqa: NP100
+
         sha1.update(tensor.data.data)
+        sha256.update(tensor.data.data)
         uuidv5_sha1.update(tensor.data.data)
-        print("sha1    {0}  {1}:{2}".format(sha1_layer.hexdigest(), filename, tensor.name)) # noqa: NP100
 
     # Flush Hash Progress Bar
     bar.close()
 
     # Display Hash Output
-    print("sha1    {0}  {1}".format(sha1.hexdigest(), filename)) # noqa: NP100
-    print("UUIDv5  {0}  {1}".format(uuid.UUID(bytes=uuidv5_sha1.digest()[:16], version=5), filename)) # noqa: NP100
+    print("sha1      {0}  {1}".format(sha1.hexdigest(), filename)) # noqa: NP100
+    print("sha256    {0}  {1}".format(sha256.hexdigest(), filename)) # noqa: NP100
+    print("UUIDv5    {0}  {1}".format(uuid.UUID(bytes=uuidv5_sha1.digest()[:16], version=5), filename)) # noqa: NP100
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Dump GGUF file metadata")
     parser.add_argument("model",         type=str,            help="GGUF format model filename")
+    parser.add_argument("--no-layer",    action="store_true", help="exclude per layer hash")
     parser.add_argument("--verbose",     action="store_true", help="increase output verbosity")
     parser.add_argument("--progressbar", action="store_true", help="enable progressbar")
     args = parser.parse_args(None if len(sys.argv) > 1 else ["--help"])
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
     reader = GGUFReader(args.model, 'r')
-    gguf_hash(reader, args.model, not args.progressbar)
+    gguf_hash(reader, args.model, not args.progressbar, args.no_layer)
 
 
 if __name__ == '__main__':

--- a/gguf-py/scripts/gguf_hash.py
+++ b/gguf-py/scripts/gguf_hash.py
@@ -27,7 +27,7 @@ UUID_NAMESPACE_LLAMA_CPP = uuid.UUID('ef001206-dadc-5f6d-a15f-3359e577d4e5')
 
 # For more information about what field.parts and field.data represent,
 # please see the comments in the modify_gguf.py example.
-def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar: bool, no_layer:bool) -> None:
+def gguf_hash(reader: GGUFReader, filename: str, disable_progress_bar: bool, no_layer: bool) -> None:
     sha1 = hashlib.sha1()
     sha256 = hashlib.sha256()
     uuidv5_sha1 = hashlib.sha1()


### PR DESCRIPTION
Found out that python [hashlib](https://docs.python.org/3/library/hashlib.html) that is already included in this repo has sha256 in addition to the sha1 we are already using for sha1 and uuid hash.

We have already implemented this in the C version of llama-gguf-hash so might as well include it in the python version.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

----

## Cross Checking `gguf_hash.py` with the C implementation `llama-gguf-hash`

```bash
$ ~/llama.cpp/gguf-py/scripts/gguf_hash.py Maykeye_Tinyllama-5M-v0.2-F16.gguf --no-layer
sha1      a9de42f2bbeee1eba49bc39b25cf69ff7a0937f6  Maykeye_Tinyllama-5M-v0.2-F16.gguf
sha256    8b3e00226cc2a55398b1ffbda7af8464040f9cd7b22ccbef8ba60b227924a2b1  Maykeye_Tinyllama-5M-v0.2-F16.gguf
uuid      86b1ebff-d754-50fc-9245-d23fe329817c  Maykeye_Tinyllama-5M-v0.2-F16.gguf

$ ~/llama.cpp/llama-gguf-hash --all --no-layer --uuid Maykeye_Tinyllama-5M-v0.2-F16.gguf
xxh64     cbd383cfd4c897e6  Maykeye_Tinyllama-5M-v0.2-F16.gguf
sha1      a9de42f2bbeee1eba49bc39b25cf69ff7a0937f6  Maykeye_Tinyllama-5M-v0.2-F16.gguf
sha256    8b3e00226cc2a55398b1ffbda7af8464040f9cd7b22ccbef8ba60b227924a2b1  Maykeye_Tinyllama-5M-v0.2-F16.gguf
uuid      86b1ebff-d754-50fc-9245-d23fe329817c  Maykeye_Tinyllama-5M-v0.2-F16.gguf
```

----

(side thought: Would it be worth having `general.sha256` to have self validating gguf files... sounds interesting... but likely only makes sense in the context of cryptographic signing of tensor data... which will require more thought on standardizing the authenticity and verification of tensor weights as not being tampered with... and llama.cpp is a bit too new to do something like that in my opinion)