### PR TITLE
pydantic : replace uses of __annotations__ with get_type_hints

### DIFF
--- a/examples/pydantic_models_to_grammar.py
+++ b/examples/pydantic_models_to_grammar.py
@@ -53,35 +53,38 @@ class PydanticDataType(Enum):
 
 
 def map_pydantic_type_to_gbnf(pydantic_type: type[Any]) -> str:
-    if isclass(pydantic_type) and issubclass(pydantic_type, str):
+    origin_type = get_origin(pydantic_type)
+    origin_type = pydantic_type if origin_type is None else origin_type
+
+    if isclass(origin_type) and issubclass(origin_type, str):
         return PydanticDataType.STRING.value
-    elif isclass(pydantic_type) and issubclass(pydantic_type, bool):
+    elif isclass(origin_type) and issubclass(origin_type, bool):
         return PydanticDataType.BOOLEAN.value
-    elif isclass(pydantic_type) and issubclass(pydantic_type, int):
+    elif isclass(origin_type) and issubclass(origin_type, int):
         return PydanticDataType.INTEGER.value
-    elif isclass(pydantic_type) and issubclass(pydantic_type, float):
+    elif isclass(origin_type) and issubclass(origin_type, float):
         return PydanticDataType.FLOAT.value
-    elif isclass(pydantic_type) and issubclass(pydantic_type, Enum):
+    elif isclass(origin_type) and issubclass(origin_type, Enum):
         return PydanticDataType.ENUM.value
 
-    elif isclass(pydantic_type) and issubclass(pydantic_type, BaseModel):
-        return format_model_and_field_name(pydantic_type.__name__)
-    elif get_origin(pydantic_type) is list:
+    elif isclass(origin_type) and issubclass(origin_type, BaseModel):
+        return format_model_and_field_name(origin_type.__name__)
+    elif origin_type is list:
         element_type = get_args(pydantic_type)[0]
         return f"{map_pydantic_type_to_gbnf(element_type)}-list"
-    elif get_origin(pydantic_type) is set:
+    elif origin_type is set:
         element_type = get_args(pydantic_type)[0]
         return f"{map_pydantic_type_to_gbnf(element_type)}-set"
-    elif get_origin(pydantic_type) is Union:
+    elif origin_type is Union:
         union_types = get_args(pydantic_type)
         union_rules = [map_pydantic_type_to_gbnf(ut) for ut in union_types]
         return f"union-{'-or-'.join(union_rules)}"
-    elif get_origin(pydantic_type) is Optional:
+    elif origin_type is Optional:
         element_type = get_args(pydantic_type)[0]
         return f"optional-{map_pydantic_type_to_gbnf(element_type)}"
-    elif isclass(pydantic_type):
-        return f"{PydanticDataType.CUSTOM_CLASS.value}-{format_model_and_field_name(pydantic_type.__name__)}"
-    elif get_origin(pydantic_type) is dict:
+    elif isclass(origin_type):
+        return f"{PydanticDataType.CUSTOM_CLASS.value}-{format_model_and_field_name(origin_type.__name__)}"
+    elif origin_type is dict:
         key_type, value_type = get_args(pydantic_type)
         return f"custom-dict-key-type-{format_model_and_field_name(map_pydantic_type_to_gbnf(key_type))}-value-type-{format_model_and_field_name(map_pydantic_type_to_gbnf(value_type))}"
     else:
@@ -297,17 +300,20 @@ def generate_gbnf_rule_for_type(
     field_name = format_model_and_field_name(field_name)
     gbnf_type = map_pydantic_type_to_gbnf(field_type)
 
-    if isclass(field_type) and issubclass(field_type, BaseModel):
+    origin_type = get_origin(field_type)
+    origin_type = field_type if origin_type is None else origin_type
+
+    if isclass(origin_type) and issubclass(origin_type, BaseModel):
         nested_model_name = format_model_and_field_name(field_type.__name__)
         nested_model_rules, _ = generate_gbnf_grammar(field_type, processed_models, created_rules)
         rules.extend(nested_model_rules)
         gbnf_type, rules = nested_model_name, rules
-    elif isclass(field_type) and issubclass(field_type, Enum):
+    elif isclass(origin_type) and issubclass(origin_type, Enum):
         enum_values = [f'"\\"{e.value}\\""' for e in field_type]  # Adding escaped quotes
         enum_rule = f"{model_name}-{field_name} ::= {' | '.join(enum_values)}"
         rules.append(enum_rule)
         gbnf_type, rules = model_name + "-" + field_name, rules
-    elif get_origin(field_type) == list:  # Array
+    elif origin_type is list:  # Array
         element_type = get_args(field_type)[0]
         element_rule_name, additional_rules = generate_gbnf_rule_for_type(
             model_name, f"{field_name}-element", element_type, is_optional, processed_models, created_rules
@@ -317,7 +323,7 @@ def generate_gbnf_rule_for_type(
         rules.append(array_rule)
         gbnf_type, rules = model_name + "-" + field_name, rules
 
-    elif get_origin(field_type) == set or field_type == set:  # Array
+    elif origin_type is set:  # Array
         element_type = get_args(field_type)[0]
         element_rule_name, additional_rules = generate_gbnf_rule_for_type(
             model_name, f"{field_name}-element", element_type, is_optional, processed_models, created_rules
@@ -371,7 +377,7 @@ def generate_gbnf_rule_for_type(
             gbnf_type = f"{model_name}-{field_name}-optional"
         else:
             gbnf_type = f"{model_name}-{field_name}-union"
-    elif isclass(field_type) and issubclass(field_type, str):
+    elif isclass(origin_type) and issubclass(origin_type, str):
         if field_info and hasattr(field_info, "json_schema_extra") and field_info.json_schema_extra is not None:
             triple_quoted_string = field_info.json_schema_extra.get("triple_quoted_string", False)
             markdown_string = field_info.json_schema_extra.get("markdown_code_block", False)
@@ -387,8 +393,8 @@ def generate_gbnf_rule_for_type(
             gbnf_type = PydanticDataType.STRING.value
 
     elif (
-        isclass(field_type)
-        and issubclass(field_type, float)
+        isclass(origin_type)
+        and issubclass(origin_type, float)
         and field_info
         and hasattr(field_info, "json_schema_extra")
         and field_info.json_schema_extra is not None
@@ -413,8 +419,8 @@ def generate_gbnf_rule_for_type(
         )
 
     elif (
-        isclass(field_type)
-        and issubclass(field_type, int)
+        isclass(origin_type)
+        and issubclass(origin_type, int)
         and field_info
         and hasattr(field_info, "json_schema_extra")
         and field_info.json_schema_extra is not None
@@ -754,14 +760,17 @@ def generate_field_markdown(
     field_info = model.model_fields.get(field_name)
     field_description = field_info.description if field_info and field_info.description else ""
 
-    if get_origin(field_type) == list:
+    origin_type = get_origin(field_type)
+    origin_type = field_type if origin_type is None else origin_type
+
+    if origin_type == list:
         element_type = get_args(field_type)[0]
         field_text = f"{indent}{field_name} ({format_model_and_field_name(field_type.__name__)} of {format_model_and_field_name(element_type.__name__)})"
         if field_description != "":
             field_text += ":\n"
         else:
             field_text += "\n"
-    elif get_origin(field_type) == Union:
+    elif origin_type == Union:
         element_types = get_args(field_type)
         types = []
         for element_type in element_types:
@@ -792,7 +801,7 @@ def generate_field_markdown(
             example_text = f"'{field_example}'" if isinstance(field_example, str) else field_example
             field_text += f"{indent}  Example: {example_text}\n"
 
-    if isclass(field_type) and issubclass(field_type, BaseModel):
+    if isclass(origin_type) and issubclass(origin_type, BaseModel):
         field_text += f"{indent}  Details:\n"
         for name, type_ in get_type_hints(field_type).items():
             field_text += generate_field_markdown(name, type_, field_type, depth + 2)

--- a/examples/pydantic_models_to_grammar_examples.py
+++ b/examples/pydantic_models_to_grammar_examples.py
@@ -20,6 +20,8 @@ def create_completion(prompt, grammar):
     response = requests.post("http://127.0.0.1:8080/completion", headers=headers, json=data)
     data = response.json()
 
+    assert data.get("error") is None, data
+
     print(data["content"])
     return data["content"]
 

--- a/requirements/requirements-pydantic.txt
+++ b/requirements/requirements-pydantic.txt
@@ -1,2 +1,3 @@
 docstring_parser~=0.15
 pydantic~=2.6.3
+requests


### PR DESCRIPTION
This should fix #8471.

The problem was triggered in #8341 by adding this specific line:

https://github.com/ggerganov/llama.cpp/blob/17eb6aa8a992cda37ee65cf848d9289bd6cad860/examples/pydantic_models_to_grammar_examples.py#L2

This uncovered the existing problem in `examples/pydantic_models_to_grammar.py` of directly using `obj.__annotations__` instead of using `typing.get_type_hints` as suggested in [PEP563](https://peps.python.org/pep-0563/#resolving-type-hints-at-runtime).

<details><summary>I've tested the script with <code>Qwen2-0.5B-Instruct</code>.</summary>

```console
$ python3 pydantic_models_to_grammar_examples.py 
root ::= function
function ::= (" "| "\n") "{" ws "\"function\""  ":" ws grammar-models
grammar-models ::= send-message-to-user-grammar-model | calculator-grammar-model
send-message-to-user-grammar-model ::= "\"SendMessageToUser\"" "," ws "\"function_parameters\"" ":" ws send-message-to-user
calculator-grammar-model ::= "\"Calculator\"" "," ws "\"function_parameters\"" ":" ws calculator
send-message-to-user ::= "{" "\n"  ws "\"chain_of_thought\"" ":" ws string "," "\n"  ws "\"message\"" ":" ws string "\n" ws "}""\n" ws "}"
calculator ::= "{" "\n"  ws "\"number_one\"" ":" ws calculator-number-one-union "," "\n"  ws "\"operation\"" ":" ws calculator-operation "," "\n"  ws "\"number_two\"" ":" ws calculator-number-two-union "\n" ws "}""\n" ws "}"
calculator-number-one-union ::= integer | float
calculator-operation ::= "\"add\"" | "\"subtract\"" | "\"multiply\"" | "\"divide\""
calculator-number-two-union ::= integer | float
boolean ::= "true" | "false"
null ::= "null"
string ::= "\"" (
        [^"\\] |
        "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
      )* "\"" ws
ws ::= ([ \t\n] ws)?
float ::= ("-"? ([0] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
integer ::= [0-9]+
Function: SendMessageToUser
  Description: Send a message to the User.
  Parameters:
    chain_of_thought (str):
        Description: Your chain of thought while sending the message.
    message (str):
        Description: Message you want to send to the user.

Function: Calculator
  Description: Perform a math operation on two numbers.
  Parameters:
    number_one (int or float):
        Description: First number.
    operation (math-operation):
        Description: Math operation to perform.
    number_two (int or float):
        Description: Second number.



{
  "function": "Calculator",
  "function_parameters": {
    "number_one": 42,
    "operation": "multiply",
    "number_two": 42
  }
}

{
  "title": "Feynman Lectures on Physics",
  "author": "Richard Feynman",
  "published_year": 1961,
  "keywords": ["physics", "laboratory", "caltech", "lectures"],
  "category": "Fiction",
  "summary": "A physics textbook based on some lectures by Richard Feynman, a Nobel laureate who has sometimes been called " 
        }
title='Feynman Lectures on Physics' author='Richard Feynman' published_year=1961 keywords=['physics', 'laboratory', 'caltech', 'lectures'] category=<Category.Fiction: 'Fiction'> summary='A physics textbook based on some lectures by Richard Feynman, a Nobel laureate who has sometimes been called '

[
    {
        "function": "get_current_datetime",
        "params": {
            "output_format": "%Y-%m-%d %H:%M:%S"
        }
    },
    {
        "function": "get_current_weather",
        "params": {
            "location": "London",
            "unit": "celsius"
        }
    },
    {
        "function": "Calculator",
        "params": {
            "number_one": 42,
            "operation": "multiply",
            "number_two": 42
        }
    },
    {
        "function": "Calculator",
        "params": {
            "number_one": 42,
            "operation": "divide",
            "number_two": 42
        }
    },
    {
        "function": "Calculator",
        "params": {
            "number_one": 42,
            "operation": "add",
            "number_two": 42
        }
    },
    {
        "function": "Calculator",
        "params": {
            "number_one": 42,
            "operation": "subtract",
            "number_two": 42
        }
    }
]
[{'function': 'get_current_datetime', 'params': {'output_format': '%Y-%m-%d %H:%M:%S'}}, {'function': 'get_current_weather', 'params': {'location': 'London', 'unit': 'celsius'}}, {'function': 'Calculator', 'params': {'number_one': 42, 'operation': 'multiply', 'number_two': 42}}, {'function': 'Calculator', 'params': {'number_one': 42, 'operation': 'divide', 'number_two': 42}}, {'function': 'Calculator', 'params': {'number_one': 42, 'operation': 'add', 'number_two': 42}}, {'function': 'Calculator', 'params': {'number_one': 42, 'operation': 'subtract', 'number_two': 42}}]
2024-07-13 17:07:35
{"location": "London", "temperature": "42", "unit": "celsius"}
1764
1.0
84
0
```

There is no longer an error.

</details>

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
