### PR TITLE
convert_hf : faster lazy safetensors

### DIFF
--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -602,14 +602,12 @@ class TensorNameMap:
             for tensor, keys in self.block_mappings_cfg.items():
                 if tensor not in MODEL_TENSORS[arch]:
                     continue
-                # TODO: make this configurable
-                n_experts = 160
-                for xid in range(n_experts):
-                    tensor_name = TENSOR_NAMES[tensor].format(bid = bid, xid = xid)
-                    self.mapping[tensor_name] = (tensor, tensor_name)
-                    for key in keys:
-                        key = key.format(bid = bid, xid = xid)
-                        self.mapping[key] = (tensor, tensor_name)
+
+                tensor_name = TENSOR_NAMES[tensor].format(bid = bid)
+                self.mapping[tensor_name] = (tensor, tensor_name)
+                for key in keys:
+                    key = key.format(bid = bid)
+                    self.mapping[key] = (tensor, tensor_name)
 
     def get_type_and_name(self, key: str, try_suffixes: Sequence[str] = ()) -> tuple[MODEL_TENSOR, str] | None:
         result = self.mapping.get(key)


### PR DESCRIPTION
Currently, with Lazy conversion, a relatively big portion of the model files is read before even beginning to write the output file, and then if the disk cache it smaller than the model, it will be read from disk again when actually converting.

Most of the time in the initial read is spent on `model_part.get_tensor(name)` (at least when using `safetensors`).

Turns out `safetensors` has the much faster [`.get_slice(name)`](https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/src/lib.rs#L616) which doesn't read the tensor data before it's needed, while still giving access to the shape and dtype of each tensor.

As a nice result, this makes `convert_hf_to_gguf.py --dry-run` much, much faster than before for slow disks and/or big models (seconds instead of minutes). Normal lazy conversion is also faster, since the initial metadata reading step doesn't unnecessarily read all the data anymore.

Note that I've also removed some unused code in `gguf-py/gguf/tensor_mapping.py` related to the number of experts. `xid` does not exist in the mappings since stacked experts were implemented, so `.format(xid = xid)` does not do anything.

# Testing

After fixing the problem found in <https://github.com/ggerganov/llama.cpp/pull/8482#issuecomment-2229244224>, I've ran some more tests.

`-no-slices-` means `master` at commit <https://github.com/ggerganov/llama.cpp/commit/97bdd26eee11fe109dec00de75690ceef61c03f2>, while `-slices-recurse-` means after the memory leak was fixed in <https://github.com/ggerganov/llama.cpp/pull/8482/commits/b971122eb1a10c0d1f1369ef425da027c894850c>.

- [x] TinyMistral MoE (<https://huggingface.co/jtatman/TinyMistral-248m-v2.5-4x-Moe>)
    ```console
    $ sha256sum tinymistral-moe-no-slices-q8_0.gguf tinymistral-moe-slices-recurse-q8_0.gguf 
    19f86b44d7bc10a2053d0afb3f7815d7901450755b715fa4c04e323c5e0ea036  tinymistral-moe-no-slices-q8_0.gguf
    19f86b44d7bc10a2053d0afb3f7815d7901450755b715fa4c04e323c5e0ea036  tinymistral-moe-slices-recurse-q8_0.gguf
    ```
- [x] CosMoE 1x4b (<https://huggingface.co/Lambent/cosmoem-4x1b>)
    ```console
    $ sha256sum cosmoem-4x1b-no-slices-q8_0.gguf cosmoem-4x1b-slices-recurse-q8_0.gguf 
    98bff7846527e103468045d498e1a856dc70e555ecabdc4fedc9ae6087c35926  cosmoem-4x1b-no-slices-q8_0.gguf
    98bff7846527e103468045d498e1a856dc70e555ecabdc4fedc9ae6087c35926  cosmoem-4x1b-slices-recurse-q8_0.gguf
    ```
- [x] InternLM2 (<https://huggingface.co/internlm/internlm2-chat-1_8b>)
    ```console
    $ sha256sum internlm2-1.8B-no-slices-q8_0.gguf internlm2-1.8B-slices-recurse-q8_0.gguf 
    ddb5d5ecb7c12c61f197a513f1de407809b48d13ffb18ed78a336cb12173ef28  internlm2-1.8B-no-slices-q8_0.gguf
    ddb5d5ecb7c12c61f197a513f1de407809b48d13ffb18ed78a336cb12173ef28  internlm2-1.8B-slices-recurse-q8_0.gguf
    ```
- [x] Mamba (<https://huggingface.co/state-spaces/mamba-130m-hf>)
    ```console
    $ sha256sum mamba-130m-no-slices-q8_0.gguf mamba-130m-slices-recurse-q8_0.gguf 
    ababd062531d9f961db3681b170dd31937a5a98d774baf6a6eb9a8c8caf5edcd  mamba-130m-no-slices-q8_0.gguf
    ababd062531d9f961db3681b170dd31937a5a98d774baf6a6eb9a8c8caf5edcd  mamba-130m-slices-recurse-q8_0.gguf
    ```
- [x] Bloom LoRA (<https://huggingface.co/player1537/Bloom-560m-LoRA-trained-on-Dolphin> with base <https://huggingface.co/bigscience/bloom-560m>)
    ```console
    $ sha256sum lora-bloom-dolphin-no-slices-f16.gguf lora-bloom-dolphin-slices-recurse-f16.gguf 
    2a176f1df5892af05475cce9659dfbf801bcdae1ffc2b0007ca1d88970c8f252  lora-bloom-dolphin-no-slices-f16.gguf
    2a176f1df5892af05475cce9659dfbf801bcdae1ffc2b0007ca1d88970c8f252  lora-bloom-dolphin-slices-recurse-f16.gguf
    ```
---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low