### PR TITLE
llama : change fallback type IQ4_NL -> Q4_0

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -18090,10 +18090,10 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
             case GGML_TYPE_IQ1_M:
             case GGML_TYPE_Q2_K:
             case GGML_TYPE_Q3_K:
-            case GGML_TYPE_IQ4_XS: new_type = GGML_TYPE_IQ4_NL; break;
-            case GGML_TYPE_Q4_K:   new_type = GGML_TYPE_Q5_0;   break;
-            case GGML_TYPE_Q5_K:   new_type = GGML_TYPE_Q5_1;   break;
-            case GGML_TYPE_Q6_K:   new_type = GGML_TYPE_Q8_0;   break;
+            case GGML_TYPE_IQ4_XS: new_type = GGML_TYPE_Q4_0; break;
+            case GGML_TYPE_Q4_K:   new_type = GGML_TYPE_Q5_0; break;
+            case GGML_TYPE_Q5_K:   new_type = GGML_TYPE_Q5_1; break;
+            case GGML_TYPE_Q6_K:   new_type = GGML_TYPE_Q8_0; break;
             default: throw std::runtime_error("\nUnsupported tensor size encountered\n");
         }
         LLAMA_LOG_WARN(" - using fallback quantization %s\n", ggml_type_name(new_type));


### PR DESCRIPTION
https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2227826702

Fallback to `Q4_0` instead of `IQ4_NL` due to lack of implementation in of the latter in some backends

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
