### PR TITLE
[SYCL] Improve the next-token speed of Q4_0

### DIFF
--- a/ggml/src/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl.cpp
@@ -1042,7 +1042,6 @@ static void get_rows_sycl_q4_0(ggml_backend_sycl_context & ctx, const ggml_tenso
 
     GGML_ASSERT(ne00 % 2 == 0);
 
-    
     const sycl::range<3> block_dims(1, 1, SYCL_GET_ROWS_BLOCK_SIZE);
     const int block_num_x = (ne00 + 2 * SYCL_GET_ROWS_BLOCK_SIZE - 1) / (2 * SYCL_GET_ROWS_BLOCK_SIZE);
     const sycl::range<3> block_nums(ne11 * ne12, ne10, block_num_x);

--- a/ggml/src/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl.cpp
@@ -3632,7 +3632,7 @@ static void ggml_sycl_mul_mat(ggml_backend_sycl_context & ctx, const ggml_tensor
     // check data types and tensor shapes for custom matrix multiplication kernels:
     bool use_dequantize_mul_mat_vec = ggml_sycl_supports_dmmv(src0->type)
         && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32
-        && src0->ne[0] % GGML_SYCL_DMMV_X == 0 && src1->ne[1] == 1;
+        && src0->ne[0] % GGML_SYCL_DMMV_X == 0 && src1->ne[1] <= MMVQ_MAX_BATCH_SIZE;
 
     bool use_mul_mat_vec_q =  ggml_is_quantized(src0->type)
         && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32

--- a/ggml/src/ggml-sycl/convert.cpp
+++ b/ggml/src/ggml-sycl/convert.cpp
@@ -139,8 +139,8 @@ static void dequantize_row_q4_0_sycl(const void *vx, dst_t *y, const int k,
 #pragma unroll
                 for (int l = 0; l < QK4_0 / 2; ++l) {
                     int vq = qs[l];
-                    y[l * 2 + 0] = d * ((vq & 0xF) - 8);
-                    y[l * 2 + 1] = d * ((vq >> 4) - 8);
+                    y_ptr[l * 2 + 0] = d * ((vq & 0xF) - 8);
+                    y_ptr[l * 2 + 1] = d * ((vq >> 4) - 8);
                 }
             });
 #else

--- a/ggml/src/ggml-sycl/convert.cpp
+++ b/ggml/src/ggml-sycl/convert.cpp
@@ -125,7 +125,7 @@ static void dequantize_row_q4_0_sycl(const void *vx, dst_t *y, const int k,
                 const int warp_id = item_ct1.get_group(2);
                 const int lane_id = item_ct1.get_local_id(2);
                 const int lane_ib = warp_id * WARP_SIZE + lane_id;
-                if (lane_ib >= k / Q4_0) {
+                if (lane_ib >= k / QK4_0) {
                     return;
                 }
 

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -118,8 +118,8 @@ static void dequantize_mul_mat_vec_q4_0(const void * __restrict__ vx, const dflo
 
         const int vui = x[ib].qs[iqs];
         dfloat2 v;
-        v.x() = (vui & 0xF) * d;
-        v.y() = (vui >> 4) * d;
+        v.x() = ((vui & 0xF) - 8) * d;
+        v.y() = ((vui >> 4) - 8) * d;
 #ifdef GGML_SYCL_F16
         dfloat2 t1{ y[iybs + iqs + 0],
                     y[iybs + iqs + QK4_0 / 2] };

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -93,7 +93,7 @@ static void dequantize_mul_mat_vec(const void * __restrict__ vx, const dfloat * 
 
 static void dequantize_mul_mat_vec_q4_0(const void * __restrict__ vx, const dfloat * __restrict__ y, float * __restrict__ dst, const int ncols, const int nrows,
                                    const sycl::nd_item<3> &item_ct1) {
-    const int row = item_ct1.get_group(2) * item_ct1.get_local_range(1);
+    const int row = item_ct1.get_group(2);
     if (row >= nrows) {
         return;
     }
@@ -110,12 +110,10 @@ static void dequantize_mul_mat_vec_q4_0(const void * __restrict__ vx, const dflo
     static_assert(ColTile == 2);
 
     const block_q4_0 * x = (const block_q4_0 *) vx;
-
+    const int iqs = tid; // x quant index
     for (int i = 0; i < ncols; i += QK4_0) {
-        const int col = i + tid * ColTile;
-        const int ib = (row * ncols + col) / QK4_0; // x block index
-        const int iqs = (col % QK4_0) / QR4_0; // x quant index
-        const int iybs = col - col % QK4_0; // y block start index
+        const int ib = (row * ncols + i) / QK4_0; // x block index
+        const int iybs = i; // y block start index
         const dfloat d = x[ib].d;
 
         const int vui = x[ib].qs[iqs];

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -1113,7 +1113,7 @@ void ggml_sycl_op_dequantize_mul_mat_vec(
     char *src0_test_ptr = src0_test.alloc(ggml_nbytes(src0));
     for (int i = 0; i < src1_ncols; i++)
     {
-        const dfloat* src1_dfloat_bs = src1_dfloat + i * src1_padded_col_size;
+        const dfloat* src1_dfloat_bs = src1_dfloat + i * ne00;
         float* dst_dd_i_bs = dst_dd_i + i * dst->ne[0];
         switch (src0->type) {
         case GGML_TYPE_Q4_0:


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

## Changes:
1. Add a cache-friendly layout of Q4_0 weight.
2. Write a new dmmv kernel for Q4_0 weight.
3. Support dmmv for 1<row
4. Use dmmv as default for 9>prompt_len>0, it's faster than mmvq.
5. 

## Performance:
llama-2-7b.Q4_0.gguf on 12700H+A770m
```
master branch:
 Once you have decided to start a business, you will need to decide what type of business you want to start. Unterscheidung zwischen einem Unternehmen und einer Person.
The
llama_print_timings:        load time =    3462.20 ms
llama_print_timings:      sample time =       0.37 ms /    32 runs   (    0.01 ms per token, 86720.87 tokens per second)
llama_print_timings: prompt eval time =      88.22 ms /     2 tokens (   44.11 ms per token,    22.67 tokens per second)
llama_print_timings:        eval time =     777.04 ms /    31 runs   (   25.07 ms per token,    39.90 tokens per second)
llama_print_timings:       total time =     866.21 ms /    33 tokens
Log end

```
```
PR branch:
 Once you have decided to start a business, you will need to decide what type of business you want to start. Unterscheidung zwischen einem Unternehmen und einer Person.
The
llama_print_timings:        load time =    5027.14 ms
llama_print_timings:      sample time =       0.38 ms /    32 runs   (    0.01 ms per token, 83989.50 tokens per second)
llama_print_timings: prompt eval time =      36.53 ms /     2 tokens (   18.26 ms per token,    54.75 tokens per second)
llama_print_timings:        eval time =     578.50 ms /    31 runs   (   18.66 ms per token,    53.59 tokens per second)
llama_print_timings:       total time =     616.66 ms /    33 tokens
Log end

```
eval performance from 39.90 tokens/s to 53.59 tokens/s, ~34% end2end speedup.
prompt(len<=8) eval performance from 22.67 tokens/s to 54.75 tokens/s, ~140% end2end speedup.