### PR TITLE
convert-*.py: add general.name kv override

### DIFF
--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -62,6 +62,7 @@ class Metadata:
         # This is based on LLM_KV_NAMES mapping in llama.cpp
         metadata_override = Metadata.load_metadata_override(metadata_override_path)
 
+        metadata.name            = metadata_override.get(Keys.General.NAME,            metadata.name)
         metadata.author          = metadata_override.get(Keys.General.AUTHOR,          metadata.author)
         metadata.version         = metadata_override.get(Keys.General.VERSION,         metadata.version)
         metadata.organization    = metadata_override.get(Keys.General.ORGANIZATION,    metadata.organization)


### PR DESCRIPTION
Looks like I missed a line that would allow for overriding `general.name` in authorship metadata

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
