### PR TITLE
Add friendlier error message to fopen errors

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19019,7 +19019,7 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
         FILE * fout = ggml_fopen(fname, "wb");
 
         if (!fout) {
-            fprintf(stderr, "%s: failed to open %s\n", __func__, fname);
+            fprintf(stderr, "%s: failed to open %s: %s\n", __func__, fname, strerror(errno));
             return;
         }
 
@@ -19156,7 +19156,7 @@ struct ggml_cgraph * ggml_graph_import(const char * fname, struct ggml_context *
     {
         FILE * fin = ggml_fopen(fname, "rb");
         if (!fin) {
-            fprintf(stderr, "%s: failed to open %s\n", __func__, fname);
+            fprintf(stderr, "%s: failed to open %s: %s\n", __func__, fname, strerror(errno));
             return result;
         }
 
@@ -20830,7 +20830,7 @@ struct gguf_context * gguf_init_empty(void) {
 struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params) {
     FILE * file = ggml_fopen(fname, "rb");
     if (!file) {
-        fprintf(stderr, "%s: failed to open file '%s' with error '%s'\n", __func__, fname, strerror(errno));
+        fprintf(stderr, "%s: failed to open '%s': '%s'\n", __func__, fname, strerror(errno));
         return NULL;
     }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -20830,6 +20830,7 @@ struct gguf_context * gguf_init_empty(void) {
 struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params) {
     FILE * file = ggml_fopen(fname, "rb");
     if (!file) {
+        fprintf(stderr, "%s: failed to open file '%s' with error '%s'\n", __func__, fname, strerror(errno));
         return NULL;
     }
 


### PR DESCRIPTION
# Motivation

When a model file fails to load, if the reason is because the file is missing or has bad permissions, the error message gives little indication _why_ the model failed to load, and it can result in a poor new-user-experience (such as [this one](https://github.com/ggerganov/llama.cpp/issues/7181#issuecomment-2157688098))

## Before
If a user simply downloads llama.cpp and attempts to run `llama-cli` (without also downloading a model and putting it in the proper place), then this is what they might see:

```
./llama-cli
Log start
main: build = 3358 (a59f8fdc)
main: built with Apple clang version 15.0.0 (clang-1500.3.9.4) for arm64-apple-darwin23.4.0
main: seed  = 1721322531
llama_model_load: error loading model: llama_model_loader: failed to load model from models/7B/ggml-model-f16.gguf

llama_load_model_from_file: failed to load model
llama_init_from_gpt_params: error: failed to load model 'models/7B/ggml-model-f16.gguf'
main: error: unable to load model
```

## After

With this PR, it adds `strerror(errno)` information after (most) instances of `fopen` so that the user is now told more clearly that the model failed to load because the file is missing (note the addition of the text `'No such file or directory'`)

```
./llama-cli
Log start
main: build = 3416 (0c5f49d5)
main: built with Apple clang version 15.0.0 (clang-1500.3.9.4) for arm64-apple-darwin23.4.0
main: seed  = 1721323069
gguf_init_from_file: failed to open 'models/7B/ggml-model-f16.gguf': 'No such file or directory'
llama_model_load: error loading model: llama_model_loader: failed to load model from models/7B/ggml-model-f16.gguf

llama_load_model_from_file: failed to load model
llama_init_from_gpt_params: error: failed to load model 'models/7B/ggml-model-f16.gguf'
main: error: unable to load model
```

We were already including `strerror(errno)` information in most other `fopen` instances in the project, but there were a few that were missing (most notably, the common failure point in `gguf_init_from_file`, which is the main thrust of this PR).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
