### PR TITLE
gguf_dump.py: fix markddown kv array print

### DIFF
--- a/gguf-py/scripts/gguf_dump.py
+++ b/gguf-py/scripts/gguf_dump.py
@@ -249,31 +249,29 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
         if len(field.types) == 1:
             curr_type = field.types[0]
             if curr_type == GGUFValueType.STRING:
-                value = repr(str(bytes(field.parts[-1]), encoding='utf-8')[:60])
+                value = "\"`{strval}`\"".format(strval=str(bytes(field.parts[-1]), encoding='utf-8')[:60])
             elif curr_type in reader.gguf_scalar_to_np:
                 value = str(field.parts[-1][0])
         else:
             if field.types[0] == GGUFValueType.ARRAY:
-                displayed_values = 0
                 curr_type = field.types[1]
+                array_elements = []
                 if curr_type == GGUFValueType.STRING:
                     render_element = min(5, total_elements)
                     for element_pos in range(render_element):
                         truncate_length = 30
-                        value_string = repr(str(bytes(field.parts[-1 - (total_elements - element_pos - 1) * 2]), encoding='utf-8'))
+                        value_string = str(bytes(field.parts[-1 - (total_elements - element_pos - 1) * 2]), encoding='utf-8')
                         if len(value_string) > truncate_length:
-                            value += value_string[:truncate_length // 2] + "..." + value_string[-truncate_length // 2:]
+                            array_elements.append(value_string[:truncate_length // 2] + "`...`" + value_string[-truncate_length // 2:])
                         else:
-                            value += value_string
-                        displayed_values += 1
-                        if (total_elements - 1) > element_pos:
-                            value += ", "
+                            array_elements.append(value_string)
+                    value_array_inner = ["\"`{strval}`\"".format(strval=strval) for strval in array_elements]
+                    value = f'[ {", ".join(value_array_inner).strip()}{", ..." if total_elements > len(array_elements) else ""} ]'
                 elif curr_type in reader.gguf_scalar_to_np:
                     render_element = min(7, total_elements)
                     for element_pos in range(render_element):
-                        value += str(field.parts[-1 - (total_elements - element_pos - 1)][0]) + (", " if total_elements > 1 else "")
-                        displayed_values += 1
-                value = f'[ {value}{"..." if total_elements > displayed_values else ""} ]'
+                        array_elements.append(str(field.parts[-1 - (total_elements - element_pos - 1)][0]))
+                    value = f'[ {", ".join(array_elements).strip()}{", ..." if total_elements > len(array_elements) else ""} ]'
         kv_dump_table.append({"n":n, "pretty_type":pretty_type, "total_elements":total_elements, "field_name":field.name, "value":value})
 
     kv_dump_table_header_map = [

--- a/gguf-py/scripts/gguf_dump.py
+++ b/gguf-py/scripts/gguf_dump.py
@@ -266,7 +266,7 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
                         else:
                             value += value_string
                         displayed_values += 1
-                        if (total_elements - 1)  > element_pos:
+                        if (total_elements - 1) > element_pos:
                             value += ", "
                 elif curr_type in reader.gguf_scalar_to_np:
                     render_element = min(7, total_elements)

--- a/gguf-py/scripts/gguf_dump.py
+++ b/gguf-py/scripts/gguf_dump.py
@@ -250,6 +250,11 @@ def dump_markdown_metadata(reader: GGUFReader, args: argparse.Namespace) -> None
             # wrap string with appropriate number of backticks required to escape it
             max_backticks = max((len(match.group(0)) for match in re.finditer(r'`+', value_string)), default=0)
             inline_code_marker = '`' * (max_backticks + 1)
+
+            # If the string starts or ends with a backtick, add a space at the beginning and end
+            if value_string.startswith('`') or value_string.endswith('`'):
+                value_string = f" {value_string} "
+
             return f"{inline_code_marker}{value_string}{inline_code_marker}"
 
         total_elements = len(field.data)


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

The initial gguf dump didn't match the output of main.cpp so must have read it wrong. Adjusted the python script until it matched

| POS | TYPE      | Count | Key                                    | Value                                                                    |
|----:|:----------|------:|:---------------------------------------|:-------------------------------------------------------------------------|
|   1 | UINT32    |     1 | GGUF.version                           | 3                                                                        |
|   2 | UINT64    |     1 | GGUF.tensor_count                      | 75                                                                       |
|   3 | UINT64    |     1 | GGUF.kv_count                          | 33                                                                       |
|   4 | STRING    |     1 | general.architecture                   | 'llama'                                                                  |
|   5 | STRING    |     1 | general.type                           | 'model'                                                                  |
|   6 | STRING    |     1 | general.name                           | 'TinyLLama'                                                              |
|   7 | STRING    |     1 | general.author                         | 'Maykeye'                                                                |
|   8 | STRING    |     1 | general.version                        | 'v0.0'                                                                   |
|   9 | STRING    |     1 | general.description                    | 'This gguf is ported from a first version of Maykeye attempt '           |
|  10 | STRING    |     1 | general.quantized_by                   | 'Mofosyne'                                                               |
|  11 | STRING    |     1 | general.size_label                     | '4.6M'                                                                   |
|  12 | STRING    |     1 | general.license                        | 'apache-2.0'                                                             |
|  13 | STRING    |     1 | general.url                            | 'https://huggingface.co/mofosyne/TinyLLama-v0-llamafile'                 |
|  14 | STRING    |     1 | general.source.url                     | 'https://huggingface.co/Maykeye/TinyLLama-v0'                            |
|  15 | [STRING]  |     5 | general.tags                           | [ 'text generation', 'transformer', 'llama', 'tiny', 'tiny model' ]      |
|  16 | [STRING]  |     1 | general.languages                      | [ 'en' ]                                                                 |
|  17 | [STRING]  |     2 | general.datasets                       | [ 'https://huggin...GPT4-train.txt', 'https://huggin...GPT4-valid.txt' ] |
|  18 | UINT32    |     1 | llama.block_count                      | 8                                                                        |
|  19 | UINT32    |     1 | llama.context_length                   | 2048                                                                     |
|  20 | UINT32    |     1 | llama.embedding_length                 | 64                                                                       |
|  21 | UINT32    |     1 | llama.feed_forward_length              | 256                                                                      |
|  22 | UINT32    |     1 | llama.attention.head_count             | 16                                                                       |
|  23 | FLOAT32   |     1 | llama.attention.layer_norm_rms_epsilon | 1e-06                                                                    |
|  24 | UINT32    |     1 | general.file_type                      | 1                                                                        |
|  25 | UINT32    |     1 | llama.vocab_size                       | 32000                                                                    |
|  26 | UINT32    |     1 | llama.rope.dimension_count             | 4                                                                        |
|  27 | STRING    |     1 | tokenizer.ggml.model                   | 'llama'                                                                  |
|  28 | STRING    |     1 | tokenizer.ggml.pre                     | 'default'                                                                |
|  29 | [STRING]  | 32000 | tokenizer.ggml.tokens                  | [ '<unk>', '<s>', '</s>', '<0x00>', '<0x01>', ... ]                      |
|  30 | [FLOAT32] | 32000 | tokenizer.ggml.scores                  | [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ... ]                               |
|  31 | [INT32]   | 32000 | tokenizer.ggml.token_type              | [ 2, 3, 3, 6, 6, 6, 6, ... ]                                             |
|  32 | UINT32    |     1 | tokenizer.ggml.bos_token_id            | 1                                                                        |
|  33 | UINT32    |     1 | tokenizer.ggml.eos_token_id            | 2                                                                        |
|  34 | UINT32    |     1 | tokenizer.ggml.unknown_token_id        | 0                                                                        |
|  35 | UINT32    |     1 | tokenizer.ggml.padding_token_id        | 0                                                                        |
|  36 | UINT32    |     1 | general.quantization_version           | 2                                                                        |


From main.cpp:

```
llama_model_loader: loaded meta data with 33 key-value pairs and 75 tensors from Tinyllama-4.6M-v0.0-F16.gguf (version GGUF V3 (latest))
llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
llama_model_loader: - kv   0:                       general.architecture str              = llama
llama_model_loader: - kv   1:                               general.type str              = model
llama_model_loader: - kv   2:                               general.name str              = TinyLLama
llama_model_loader: - kv   3:                             general.author str              = Maykeye
llama_model_loader: - kv   4:                            general.version str              = v0.0
llama_model_loader: - kv   5:                        general.description str              = This gguf is ported from a first vers...
llama_model_loader: - kv   6:                       general.quantized_by str              = Mofosyne
llama_model_loader: - kv   7:                         general.size_label str              = 4.6M
llama_model_loader: - kv   8:                            general.license str              = apache-2.0
llama_model_loader: - kv   9:                                general.url str              = https://huggingface.co/mofosyne/TinyL...
llama_model_loader: - kv  10:                         general.source.url str              = https://huggingface.co/Maykeye/TinyLL...
llama_model_loader: - kv  11:                               general.tags arr[str,5]       = ["text generation", "transformer", "l...
llama_model_loader: - kv  12:                          general.languages arr[str,1]       = ["en"]
llama_model_loader: - kv  13:                           general.datasets arr[str,2]       = ["https://huggingface.co/datasets/ron...
llama_model_loader: - kv  14:                          llama.block_count u32              = 8
llama_model_loader: - kv  15:                       llama.context_length u32              = 2048
llama_model_loader: - kv  16:                     llama.embedding_length u32              = 64
llama_model_loader: - kv  17:                  llama.feed_forward_length u32              = 256
llama_model_loader: - kv  18:                 llama.attention.head_count u32              = 16
llama_model_loader: - kv  19:     llama.attention.layer_norm_rms_epsilon f32              = 0.000001
llama_model_loader: - kv  20:                          general.file_type u32              = 1
llama_model_loader: - kv  21:                           llama.vocab_size u32              = 32000
llama_model_loader: - kv  22:                 llama.rope.dimension_count u32              = 4
llama_model_loader: - kv  23:                       tokenizer.ggml.model str              = llama
llama_model_loader: - kv  24:                         tokenizer.ggml.pre str              = default
llama_model_loader: - kv  25:                      tokenizer.ggml.tokens arr[str,32000]   = ["<unk>", "<s>", "</s>", "<0x00>", "<...
llama_model_loader: - kv  26:                      tokenizer.ggml.scores arr[f32,32000]   = [0.000000, 0.000000, 0.000000, 0.0000...
llama_model_loader: - kv  27:                  tokenizer.ggml.token_type arr[i32,32000]   = [2, 3, 3, 6, 6, 6, 6, 6, 6, 6, 6, 6, ...
llama_model_loader: - kv  28:                tokenizer.ggml.bos_token_id u32              = 1
llama_model_loader: - kv  29:                tokenizer.ggml.eos_token_id u32              = 2
llama_model_loader: - kv  30:            tokenizer.ggml.unknown_token_id u32              = 0
llama_model_loader: - kv  31:            tokenizer.ggml.padding_token_id u32              = 0
llama_model_loader: - kv  32:               general.quantization_version u32              = 2
```