### PR TITLE
llama : model-based max number of graph nodes

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3657,10 +3657,10 @@ namespace GGUFMeta {
 using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
 
 // TODO: update when needed or think of some clever automatic way to do this
-static size_t llama_model_max_nodes(const llama_model & model) {
-    if (model.arch == LLM_ARCH_LLAMA && model.hparams.n_layer > 400) { // llama-3 405B
-        return 32768;
-    }
+static size_t llama_model_max_nodes(const llama_model & /*model*/) {
+    //if (model.arch == LLM_ARCH_LLAMA && model.hparams.n_layer > ??) { // llama-3 405B
+    //    return 32768;
+    //}
 
     return 8192;
 }


### PR DESCRIPTION
fix #8615

Propose to determine the max number of nodes based on the model info (arch, hparams, etc.)

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
