### PR TITLE
Python - Pre-compiled CFFI module for CPU and CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Typically finetunes of the base models below are supported as well.
 **Bindings:**
 
 - Python: [abetlen/llama-cpp-python](https://github.com/abetlen/llama-cpp-python)
+- Python (Pre-compiled CFFI module for CPU and CUDA): [tangledgroup/llama-cpp-cffi](https://github.com/tangledgroup/llama-cpp-cffi)
 - Go: [go-skynet/go-llama.cpp](https://github.com/go-skynet/go-llama.cpp)
 - Node.js: [withcatai/node-llama-cpp](https://github.com/withcatai/node-llama-cpp)
 - JS/TS (llama.cpp server client): [lgrammel/modelfusion](https://modelfusion.dev/integration/model-provider/llamacpp)


### PR DESCRIPTION
Pre-compiled Python binding for llama.cpp using **cffi**. Supports CPU and CUDA 12.5 execution. Binary  distribution which does not require complex compilation steps.

Installation is as simple and fast as `pip install llama-cpp-cffi` .

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
