### PR TITLE
add alias for lora adaptors

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -443,6 +443,10 @@ extern "C" {
                      struct llama_model * model,
             struct llama_context_params   params);
 
+    LLAMA_API void llama_ctx_switch_adaptor(
+        struct llama_context* ctx,
+        const char* adaptor_alias);
+
     // Frees all allocated memory
     LLAMA_API void llama_free(struct llama_context * ctx);
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Added the ability to create aliases for adaptors, allowing for more intuitive and flexible naming conventions.
This feature simplifies referencing adaptors in different contexts, reducing potential errors and enhancing code clarity.

`...
--lora taskA_alias=ggml-lora-for-taskA-f16.gguf`