### PR TITLE
convert: add tensor hash general.hash.sha256 to kv store

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -384,6 +384,12 @@ class Model:
 
         self.set_type()
 
+        # Generate sha256 based on tensor content if required
+        if not vocab_only:
+            hash_sha256 = self.gguf_writer.calculate_tensor_hash_sha256()
+            self.gguf_writer.add_hash_sha256(hash_sha256)
+            logger.info(f"tensor hash (sha256): {hash_sha256}")
+
         logger.info("Set meta model")
         self.metadata.set_gguf_meta_model(self.gguf_writer)
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -25,6 +25,9 @@ class Keys:
         ALIGNMENT                  = "general.alignment"
         FILE_TYPE                  = "general.file_type"
 
+        # Tensor Hash
+        HASH_SHA256                = "general.hash.sha256"
+
         # Authorship Metadata
         NAME                       = "general.name"
         AUTHOR                     = "general.author"


### PR DESCRIPTION
While [autogeneration of UUID](https://github.com/ggerganov/llama.cpp/pull/8565) is a bit controversial, I decided to adapt the logic a bit for a straight up sha256 tensor hash in the kv store as `general.hash.sha256`.

While there already other choices like xxhash and sha1, in this context I think we have better value with a known strong cryptographic hash method like sha256. This I think would also pave the way for self signed gguf file so you can be sure it came from a known entity.

I also thought about 'per tensor layer' hash, but not sure how useful it would be at this stage as per layer tensor seems to be more of a 'developer debugging tool' at this stage. So best to keep to whole tensor level hashing instead.

For model repo maintainers like huggingface, this has immediate use in being able to track models even when KV metadata has been updated (e.g. fixing authorship metadata).

For anyone who may be interested, you might want to add some logic to either llama-gguf-hash to self check a gguf tensor data if this hash is present in the kv store. I opted against doing it as I wasn't sure on the utility yet and it would be more work than this current PR.

----

## Testing process I did

During conversion you would get this new print out

```
INFO:hf-to-gguf:blk.7.attn_v.weight,        torch.bfloat16 --> F16, shape = {64, 64}
INFO:hf-to-gguf:output_norm.weight,         torch.bfloat16 --> F32, shape = {64}
INFO:hf-to-gguf:tensor hash (sha256): 8b3e00226cc2a55398b1ffbda7af8464040f9cd7b22ccbef8ba60b227924a2b1
INFO:hf-to-gguf:Set meta model
INFO:hf-to-gguf:Set model parameters
```

Checked that gguf-dump --markdown I can see the new entry:

```
|   4 | STRING    |     1 | general.architecture                   | `llama`                                                                          |
|   5 | STRING    |     1 | general.type                           | `model`                                                                          |
|   6 | STRING    |     1 | general.hash.sha256                    | `8b3e00226cc2a55398b1ffbda7af84`...`0f9cd7b22ccbef8ba60b227924a2b1`              |
|   7 | STRING    |     1 | general.name                           | `TinyLLama`                                                                      |
|   8 | STRING    |     1 | general.author                         | `Maykeye`                                                                        |
```

Checked that the sha256 is consistent with llama-gguf-hash:

```
llama-gguf-hash --all --no-layer TinyLLama-4.6M-v0.0-F16.gguf
xxh64     cbd383cfd4c897e6  TinyLLama-4.6M-v0.0-F16.gguf
sha1      a9de42f2bbeee1eba49bc39b25cf69ff7a0937f6  TinyLLama-4.6M-v0.0-F16.gguf
sha256    8b3e00226cc2a55398b1ffbda7af8464040f9cd7b22ccbef8ba60b227924a2b1  TinyLLama-4.6M-v0.0-F16.gguf
```

So at least it appears the sha256 process is consistent. The logic is similar to my attempt at autogenerated UUID which was also consistent, so less likely to have an error creep in this context.

-----

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
