### PR TITLE
Fix Safari Compatibility Issue: Replace URL.parse Method in llama-server UI

### DIFF
--- a/examples/server/public/index-new.html
+++ b/examples/server/public/index-new.html
@@ -225,7 +225,7 @@
         throw new Error("already running");
       }
       controller.value = new AbortController();
-      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, api_url: URL.parse('.', document.baseURI).href })) {
+      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, api_url: new URL('.', document.baseURI).href })) {
         const data = chunk.data;
         if (data.stop) {
           while (

--- a/examples/server/public/index.html
+++ b/examples/server/public/index.html
@@ -479,7 +479,7 @@
         throw new Error("already running");
       }
       controller.value = new AbortController();
-      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, api_url: URL.parse('.', document.baseURI).href })) {
+      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, api_url: new URL('.', document.baseURI).href })) {
         const data = chunk.data;
 
         if (data.stop) {


### PR DESCRIPTION
The `URL.parse` method is not available in all browsers, particularly Safari, which causes the UI interface for llama-server to break. This pull request replaces the `URL.parse` method with the `new URL()` constructor to ensure compatibility across all browsers. Using `new URL()` provides a more standardized and widely supported way to parse URLs, resolving the issue with Safari and improving overall browser compatibility.

Fixes #8631 



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
