### PR TITLE
llama : add `llama_lora_adapter_clear`

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -529,11 +529,15 @@ extern "C" {
             struct llama_lora_adapter * adapter,
             float scale);
 
-    // Remove a LoRA adapter from given context
+    // Remove a specific LoRA adapter from given context
     // Return -1 if the adapter is not present in the context
     LLAMA_API int32_t llama_lora_adapter_remove(
             struct llama_context * ctx,
             struct llama_lora_adapter * adapter);
+
+    // Remove all LoRA adapters from given context
+    LLAMA_API void llama_lora_adapter_clear(
+            struct llama_context * ctx);
 
     // Manually free a LoRA adapter
     // Note: loaded adapters will be free when the associated model is deleted

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -16201,6 +16201,10 @@ int32_t llama_lora_adapter_remove(
     return -1;
 }
 
+void llama_lora_adapter_clear(struct llama_context * ctx) {
+    ctx->lora_adapters.clear();
+}
+
 void llama_lora_adapter_free(struct llama_lora_adapter * adapter) {
     delete adapter;
 }


### PR DESCRIPTION
Ref discussion: https://github.com/ggerganov/llama.cpp/pull/8636#discussion_r1688268085

`llama_lora_adapter_clear()` can be used when user want to switch the adapter, but don't know which adapters are loaded into `llama_context` to be removed.

For simple task switching application, user can write their own code based on this function:

```cpp
void switch_my_adapter(struct llama_context * ctx, struct llama_lora_adapter * adapter) {
  llama_lora_adapter_clear(ctx);
  llama_lora_adapter_set(ctx, adapter, 1.0);
}
```

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
