### PR TITLE
common : support for lifecycle scripts

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -3248,6 +3248,6 @@ void script_execute(const std::string & script) {
     int result = std::system(script.c_str());
 
     if (result != 0) {
-        fprintf(stderr, "%s: error: unable to execute script '%s'. exit code: %d\n", __func__, script.c_str(), result);
+        fprintf(stderr, "%s: error: script '%s' failed with exit code %d\n", __func__, script.c_str(), result);
     }
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -331,6 +331,21 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
         return true;
     }
+    if (arg == "--on-start") {
+        CHECK_ARG
+        params.on_start = argv[i];
+        return true;
+    }
+    if (arg == "--on-inference-start") {
+        CHECK_ARG
+        params.on_inference_start = argv[i];
+        return true;
+    }
+    if (arg == "--on-inference-end") {
+        CHECK_ARG
+        params.on_inference_end = argv[i];
+        return true;
+    }
     if (arg == "-p" || arg == "--prompt") {
         CHECK_ARG
         params.prompt = argv[i];
@@ -1403,6 +1418,11 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-s,    --seed SEED",            "RNG seed (default: %d, use random seed for < 0)", params.seed });
     options.push_back({ "*",           "-t,    --threads N",            "number of threads to use during generation (default: %d)", params.n_threads });
     options.push_back({ "*",           "-tb,   --threads-batch N",      "number of threads to use during batch and prompt processing (default: same as --threads)" });
+    options.push_back({ "*",           "       --on-start SCRIPT",      "call the specified script at application startup" });
+    options.push_back({ "*",           "       --on-inference-start SCRIPT",
+                                                                        "call the specified script before starting the inference" });
+    options.push_back({ "*",           "       --on-inference-end SCRIPT",
+                                                                        "call the specified script when the inference is complete" });
     options.push_back({ "speculative", "-td,   --threads-draft N",      "number of threads to use during generation (default: same as --threads)" });
     options.push_back({ "speculative", "-tbd,  --threads-batch-draft N",
                                                                         "number of threads to use during batch and prompt processing (default: same as --threads-draft)" });
@@ -3222,4 +3242,12 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "typical_p: %f # default: 1.0\n", sparams.typical_p);
     fprintf(stream, "verbose_prompt: %s # default: false\n", params.verbose_prompt ? "true" : "false");
     fprintf(stream, "display_prompt: %s # default: true\n", params.display_prompt ? "true" : "false");
+}
+
+void script_execute(const std::string & script) {
+    int result = std::system(script.c_str());
+
+    if (result != 0) {
+        fprintf(stderr, "%s: error: unable to execute script '%s'. exit code: %d\n", __func__, script.c_str(), result);
+    }
 }

--- a/common/common.h
+++ b/common/common.h
@@ -61,6 +61,11 @@ enum dimre_method {
 struct gpt_params {
     uint32_t seed                 = LLAMA_DEFAULT_SEED; // RNG seed
 
+    // lifecycle scripts
+    std::string on_start           = ""; // script that will be called on application start
+    std::string on_inference_start = ""; // script that will be called when inference starts
+    std::string on_inference_end   = ""; // script that will be called when inference ends
+
     int32_t n_threads             = cpu_get_num_math();
     int32_t n_threads_draft       =    -1;
     int32_t n_threads_batch       =    -1; // number of threads to use for batch processing (-1 = use n_threads)
@@ -455,3 +460,9 @@ void yaml_dump_string_multiline(FILE * stream, const char * prop_name, const cha
 void yaml_dump_non_result_info(
     FILE * stream, const gpt_params & params, const llama_context * lctx,
     const std::string & timestamp, const std::vector<int> & prompt_tokens, const char * model_desc);
+
+//
+// Script utils
+//
+
+void script_execute(const std::string & script);

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -137,6 +137,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    if (!params.on_start.empty()) {
+        script_execute(params.on_start);
+    }
+
     llama_sampling_params & sparams = params.sparams;
 
 #ifndef LOG_DISABLE_LOGS
@@ -532,6 +536,10 @@ int main(int argc, char ** argv) {
     if (!ctx_sampling) {
         fprintf(stderr, "%s: failed to initialize sampling subsystem\n", __func__);
         exit(1);
+    }
+
+    if (!params.on_inference_start.empty()) {
+        script_execute(params.on_inference_start);
     }
 
     if (llama_model_has_encoder(model)) {
@@ -969,6 +977,10 @@ int main(int argc, char ** argv) {
             n_remain = params.n_predict;
             is_interacting = true;
         }
+    }
+
+    if (!params.on_inference_end.empty()) {
+        script_execute(params.on_inference_end);
     }
 
     if (!path_session.empty() && params.prompt_cache_all && !params.prompt_cache_ro) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1106,6 +1106,10 @@ struct server_context {
             {"id_task", slot.id_task},
         });
 
+        if (!params.on_inference_start.empty()) {
+            script_execute(params.on_inference_start);
+        }
+
         return true;
     }
 
@@ -1913,6 +1917,10 @@ struct server_context {
                     kv_cache_clear();
                 }
 
+                if (!params.on_inference_end.empty()) {
+                    script_execute(params.on_inference_end);
+                }
+
                 return;
             }
         }
@@ -2494,6 +2502,10 @@ int main(int argc, char ** argv) {
     if (!gpt_params_parse(argc, argv, params)) {
         gpt_params_print_usage(argc, argv, params);
         return 1;
+    }
+
+    if (!params.on_start.empty()) {
+        script_execute(params.on_start);
     }
 
     // TODO: not great to use extern vars


### PR DESCRIPTION
As an alternative to integrating the performance state switch directly into llama.cpp, I decided to add support for so-called lifecycle scripts that can be called on specific events.

The `main` and `server` examples are currently supported. I don't think this should be added to every example, only to those used by end users.

Currently supported events are:
- [x] on_start - When the application starts, right after parsing the arguments
- [x] on_inference_start - Before performing any GPU-intensive work
- [x] on_inference_end - After any GPU-intensive work is done

Can be also added:
- [ ] on_ready - After the application is ready, i.e. the model is loaded, in the case of a server, ready to receive requests

Closes #8116

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
