### PR TITLE
ggml: handle ggml_init failure to fix NULL pointer deref

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -21096,6 +21096,12 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
         };
 
         *params.ctx = ggml_init(pdata);
+        if (*params.ctx == NULL) {
+            fprintf(stderr, "%s: failed to initialize context\n", __func__);
+            fclose(file);
+            gguf_free(ctx);
+            return NULL;
+        }
 
         struct ggml_context * ctx_data = *params.ctx;
 


### PR DESCRIPTION
`ggml_init` can fail if no unused context is found. In that case, a NULL-pointer deref will happen later in the code during a call to `ggml_set_on_alloc`.

This fixes it by bailing out if no context is found.

This was found during development of the harness in https://github.com/google/oss-fuzz/pull/12274

Stacktrace for issue:

```sh
=================================================================
==18==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000011 (pc 0x55d3c1406ab9 bp 0x7ffdd0f0e1d0 sp 0x7ffdd0f0e080 T0)
==18==The signal is caused by a WRITE memory access.
==18==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x55d3c1406ab9 in ggml_set_no_alloc /src/llama.cpp/ggml/src/ggml.c:3535:19
    #1 0x55d3c1406ab9 in gguf_init_from_file /src/llama.cpp/ggml/src/ggml.c:21123:9
    #2 0x55d3c14e89cd in llama_model_loader::llama_model_loader(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, llama_model_kv_override const*) /src/llama.cpp/src/llama.cpp:3636:16
    #3 0x55d3c1483d85 in llama_model_load /src/llama.cpp/src/llama.cpp:7635:28
    #4 0x55d3c1483d85 in llama_load_model_from_file /src/llama.cpp/src/llama.cpp:16387:18
    #5 0x55d3c199b2c6 in LLVMFuzzerTestOneInput /src/llama.cpp/fuzzers/fuzz_load_model.cpp:44:19
```


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
