### PR TITLE
Add option to keep output and embed tensors at f16

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3602,7 +3602,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--z", action="store_true",
-        help="Keep output and ambed tensors at F16"
+        help="Keep output and embed tensors at F16"
     )
 
     return parser.parse_args()

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3678,7 +3678,8 @@ def main() -> None:
                                      metadata_override=args.metadata, model_name=args.model_name,
                                      split_max_tensors=args.split_max_tensors,
                                      split_max_size=split_str_to_n_bytes(args.split_max_size), dry_run=args.dry_run,
-                                     small_first_shard=args.no_tensor_first_split,z=args.z)
+                                     small_first_shard=args.no_tensor_first_split,
+                                     z=args.z)
 
         if args.vocab_only:
             logger.info("Exporting model vocab...")


### PR DESCRIPTION
Add option to keep output and embed tensors at f16

Normally to do this takes 2 steps: convert then quantize.
In this way it's possible for example to convert directly a model to **q8_0** but the output and embed tensors to **f16**

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
