### PR TITLE
Added error handling for malloc and strdup

### DIFF
--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -60,6 +60,12 @@ GGML_CALL ggml_backend_buffer_t ggml_backend_buffer_init(
                size_t                          size) {
     ggml_backend_buffer_t buffer = malloc(sizeof(struct ggml_backend_buffer));
 
+    if (buffer == NULL) {
+        // Log the error and handle appropriately
+        fprintf(stderr, "Memory allocation failed in ggml_backend_buffer_init\n");
+        return NULL; // or handle the error as appropriate
+    }
+
     (*buffer) = (struct ggml_backend_buffer) {
         /* .interface = */ iface,
         /* .buft      = */ buft,

--- a/ggml/src/ggml-kompute.cpp
+++ b/ggml/src/ggml-kompute.cpp
@@ -238,6 +238,11 @@ static std::vector<ggml_vk_device> ggml_vk_available_devices_internal(size_t mem
         d.type = dev_props.deviceType;
         d.heapSize = heapSize;
         d.vendor = strdup(ggml_vk_getVendorName(dev_props.vendorID));
+        if (d.vendor == NULL) {
+            // Handle strdup failure
+            std::cerr << __func__ << ": strdup failed for vendor name\n";
+            continue; // or handle the error as appropriate
+        }
         d.subgroupSize = subgroup_props.subgroupSize;
         d.bufferAlignment = dev_props.limits.minStorageBufferOffsetAlignment;
 
@@ -253,6 +258,12 @@ static std::vector<ggml_vk_device> ggml_vk_available_devices_internal(size_t mem
             name += " (" + std::to_string(n_idx) + ")";
         }
         d.name = strdup(name.c_str());
+        if (d.name == NULL) {
+            // Handle strdup failure
+            std::cerr << __func__ << ": strdup failed for device name\n";
+            free(d.vendor); // Clean up the previously allocated vendor name
+            continue; // or handle the error as appropriate
+        }
 
         results.push_back(d);
     }


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High


### Description

This pull request adds error handling for the following functions:
- `malloc` in `ggml_backend_buffer_init`
- `strdup` in `ggml_vk_available_devices_internal`

### Changes Made

- Added checks for the return value of `malloc` to handle memory allocation failures.
- Added checks for the return value of `strdup` to handle string duplication failures.

### Rationale

These changes improve the robustness of the code by ensuring that errors are caught and handled appropriately. This helps prevent potential crashes and undefined behavior caused by unhandled errors.

### Testing

- Simulated conditions where `malloc` and `strdup` might fail.
- Verified that the error handling correctly logs the errors and prevents crashes.

### Additional Context

- This PR addresses issue #7489.
- If you have any suggestions for further improvements or changes, please let me know.
