### PR TITLE
Add support for cpu_get_num_physical_cores() on Windows

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -97,7 +97,11 @@ int32_t cpu_get_num_cores_win(bool print_physical_core_num) {
                 num_cores_win += info->Processor.GroupCount;
             } else {
                 for (WORD i = 0; i < info->Processor.GroupCount; ++i) {
+#ifdef _MSC_VER
                     num_cores_win += __popcnt64(info->Processor.GroupMask[i].Mask);
+#else
+                    num_cores_win += _popcnt64(info->Processor.GroupMask[i].Mask);
+#endif
                 }
             }
         }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -110,7 +110,8 @@ int32_t cpu_get_num_physical_cores() {
     if (result == 0) {
         return num_physical_cores;
     }
-#elif defined(_WIN32)
+#elif defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) // windows 7 and later
+    // TODO: windows + arm64 + mingw64
     DWORD buffer_size = 0;
     GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &buffer_size);
     std::vector<char> buffer(buffer_size);
@@ -1733,7 +1734,8 @@ std::string gpt_params_get_system_info(const gpt_params & params) {
     if (params.n_threads_batch != -1) {
         os << " (n_threads_batch = " << params.n_threads_batch << ")";
     }
-#ifdef _WIN32
+#if defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) // windows 7 and later
+    // TODO: windows + arm64 + mingw64
     DWORD logicalProcessorCount = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
     os << " / " << logicalProcessorCount << " | " << llama_print_system_info();
 #else

--- a/common/common.h
+++ b/common/common.h
@@ -44,9 +44,7 @@ struct llama_control_vector_load_info;
 //
 // CPU utils
 //
-#ifdef _WIN32
-int32_t cpu_get_num_cores_win(bool print_physical_core_num);
-#endif
+
 int32_t cpu_get_num_physical_cores();
 int32_t cpu_get_num_math();
 

--- a/common/common.h
+++ b/common/common.h
@@ -44,7 +44,9 @@ struct llama_control_vector_load_info;
 //
 // CPU utils
 //
-
+#ifdef _WIN32
+int32_t cpu_get_num_cores_win(bool print_physical_core_num);
+#endif
 int32_t cpu_get_num_physical_cores();
 int32_t cpu_get_num_math();
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Add a function `cpu_get_num_cores_win(bool print_physical_core_num)` to detect the physical and logical cores on Windows. Now the program will successfully detect all sockets and CPUs and set the default number of threads more accurately on Windows.

## Test Platform
- OS
  - Windows 10
  - Windows 11
- CPU
  - Intel Xeon CPU E5-2699 v4 (22 physical core per socket,  **2 Sockets in total**)
  - Intel i7-1185G7 (4 physical cores)
  - Intel Core Ultra5 125H (4 P-core + 8 E-core + 2 LPE-core)

## Before
When I run `llama-cli.exe -m <my_model> -p <prompt>`, the output is like this:

### Intel Xeon CPU E5-2699 v4 (2 Sockets)
```shell
system_info: n_threads = 22 / 44 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```
### Intel i7-1185G7
```shell
system_info: n_threads = 4 / 8 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```
### Intel MTL Ultra5
```shell
system_info: n_threads = 9 / 18 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```

## After Modification
### Intel Xeon CPU E5-2699 v4 (2 Sockets)
```shell
system_info: n_threads = 44 / 88 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```
### Intel i7-1185G7
```shell
system_info: n_threads = 4 / 8 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```
### Intel MTL Ultra5
```shell
system_info: n_threads = 14 / 18 | AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | 
```