### PR TITLE
Build: Only include execinfo.h on linux systems that support it

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -175,6 +175,11 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
+check_include_file_cxx(execinfo HAVE_EXECINFO)
+if (HAVE_EXECINFO)
+    add_compile_definitions(GLIBC_BACKTRACE_SUPPORTED)
+endif()
+
 #
 # build the library
 #
@@ -207,7 +212,6 @@ set(GGML_PUBLIC_HEADERS
     include/ggml-alloc.h
     include/ggml-backend.h
     include/ggml-blas.h
-    include/ggml-cann.h
     include/ggml-cuda.h
     include/ggml.h
     include/ggml-kompute.h

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -212,6 +212,7 @@ set(GGML_PUBLIC_HEADERS
     include/ggml-alloc.h
     include/ggml-backend.h
     include/ggml-blas.h
+    include/ggml-cann.h
     include/ggml-cuda.h
     include/ggml.h
     include/ggml-kompute.h

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -175,11 +175,6 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
-check_include_file_cxx(execinfo HAVE_EXECINFO)
-if (HAVE_EXECINFO)
-    add_compile_definitions(GLIBC_BACKTRACE_SUPPORTED)
-endif()
-
 #
 # build the library
 #

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -185,7 +185,7 @@ static void ggml_print_backtrace_symbols(void) {
         fprintf(stderr, "%d: %p %s\n", idx, addr, symbol);
     }
 }
-#elif defined(__linux__) && defined(GLIBC_BACKTRACE_SUPPORTED)
+#elif defined(__linux__) && defined(__GLIBC__)
 #include <execinfo.h>
 static void ggml_print_backtrace_symbols(void) {
     void * trace[100];

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -185,7 +185,7 @@ static void ggml_print_backtrace_symbols(void) {
         fprintf(stderr, "%d: %p %s\n", idx, addr, symbol);
     }
 }
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(GLIBC_BACKTRACE_SUPPORTED)
 #include <execinfo.h>
 static void ggml_print_backtrace_symbols(void) {
     void * trace[100];


### PR DESCRIPTION
Only include the `execinfo.h` header if the file is present on the system.

Fixes #8762

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
