### PR TITLE
Add support for getting cpu info on Windows for llama_bench

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -116,26 +116,15 @@ static std::string get_cpu_info() {
     }
     char cpu_brand[256];
     DWORD cpu_brand_size = sizeof(cpu_brand);
-    if (RegQueryValueEx(hKey,
+    if (RegQueryValueExA(hKey,
                         TEXT("ProcessorNameString"),
                         NULL,
                         NULL,
                         (LPBYTE)cpu_brand,
-                        &cpu_brand_size) != ERROR_SUCCESS) {
-        RegCloseKey(hKey);
-        // fail to read processor information
-        return "";
+                        &cpu_brand_size) == ERROR_SUCCESS) {
+        id.assign(cpu_brand, cpu_brand_size);
     }
     RegCloseKey(hKey);
-
-    // ensure the string is null-terminated
-    if (cpu_brand_size >= sizeof(cpu_brand)) {
-        cpu_brand[sizeof(cpu_brand) - 1] = '\0';
-    } else {
-        cpu_brand[cpu_brand_size] = '\0';
-    }
-
-    id = std::string(cpu_brand);
 #endif
     // TODO: other platforms
     return id;


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

When run ` llama-bench -m model_name -o json` on Windows, before this change, output: 

```shell
    "build_commit": "a15ef8f8",
    "build_number": 3416,
    "cuda": false,
    "vulkan": false,
    "kompute": false,
    "metal": false,
    "sycl": false,
    "rpc": "0",
    "gpu_blas": false,
    "blas": false,
    "cpu_info": "",
    ....
```

after this change, output:
```shell
    "build_commit": "68504f09",
    "build_number": 3455,
    "cuda": false,
    "vulkan": false,
    "kompute": false,
    "metal": false,
    "sycl": false,
    "rpc": "0",
    "gpu_blas": false,
    "blas": false,
    "cpu_info": "Intel(R) Core(TM) Ultra 5 125H",
```

