### PR TITLE
metadata: if LICENSE exist then include a copy of it

### DIFF
--- a/examples/convert_legacy_llama.py
+++ b/examples/convert_legacy_llama.py
@@ -458,6 +458,7 @@ LazyModel: TypeAlias = 'dict[str, LazyTensor]'
 
 ModelFormat: TypeAlias = Literal['ggml', 'torch', 'safetensors', 'none']
 
+
 @dataclass
 class ModelPlus:
     model: LazyModel
@@ -810,6 +811,8 @@ class OutputFile:
                 self.gguf.add_license_name(metadata.license_name)
             if metadata.license_link is not None:
                 self.gguf.add_license_link(metadata.license_link)
+            if metadata.license_content is not None:
+                self.gguf.add_license_content(metadata.license_content)
 
             if metadata.url is not None:
                 self.gguf.add_url(metadata.url)

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -43,6 +43,7 @@ class Keys:
         LICENSE                    = "general.license"
         LICENSE_NAME               = "general.license.name"
         LICENSE_LINK               = "general.license.link"
+        LICENSE_CONTENT            = "general.license.content"
 
         # Typically represents the converted GGUF repo (Unless native)
         URL                        = "general.url" # Model Website/Paper

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -529,6 +529,9 @@ class GGUFWriter:
     def add_license_link(self, license: str) -> None:
         self.add_string(Keys.General.LICENSE_LINK, license)
 
+    def add_license_content(self, license: str) -> None:
+        self.add_string(Keys.General.LICENSE_CONTENT, license)
+
     def add_url(self, url: str) -> None:
         self.add_string(Keys.General.URL, url)
 

--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -381,7 +381,6 @@ class Metadata:
             use_model_card_metadata("license", "license")
             use_model_card_metadata("license_name", "license_name")
             use_model_card_metadata("license_link", "license_link")
-            use_model_card_metadata("license_content", "license_content")
 
             use_array_model_card_metadata("tags", "tags")
             use_array_model_card_metadata("tags", "pipeline_tag")
@@ -436,11 +435,12 @@ class Metadata:
 
         # Detect LICENSE file and include a copy
         #########################################
-        if metadata.license_content is None:
-            standard_license_file_path = Path("LICENSE")
-            if standard_license_file_path.is_file():
-                with open(standard_license_file_path, 'r') as file:
-                    metadata.license_content = file.read()
+        if isinstance(metadata.license_link, str) and not (metadata.license_link.startswith("http://") or metadata.license_link.startswith("https://")):
+            if metadata.license_content is None:
+                standard_license_file_path = Path("LICENSE")
+                if standard_license_file_path.is_file():
+                    with open(standard_license_file_path, 'r') as file:
+                        metadata.license_content = file.read()
 
         return metadata
 

--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -38,6 +38,7 @@ class Metadata:
     license: Optional[str] = None
     license_name: Optional[str] = None
     license_link: Optional[str] = None
+    license_content: Optional[str] = None
     base_models: Optional[list[dict]] = None
     tags: Optional[list[str]] = None
     languages: Optional[list[str]] = None
@@ -379,6 +380,7 @@ class Metadata:
             use_model_card_metadata("license", "license")
             use_model_card_metadata("license_name", "license_name")
             use_model_card_metadata("license_link", "license_link")
+            use_model_card_metadata("license_content", "license_content")
 
             use_array_model_card_metadata("tags", "tags")
             use_array_model_card_metadata("tags", "pipeline_tag")
@@ -431,6 +433,14 @@ class Metadata:
             if metadata.size_label is None and size_label is not None:
                 metadata.size_label = size_label
 
+        # Detect LICENSE file and include a copy
+        #########################################
+        if metadata.license_content is None:
+            standard_license_file_path = Path("LICENSE")
+            if standard_license_file_path.is_file():
+                with open(standard_license_file_path, 'r') as file:
+                    metadata.license_content = file.read()
+
         return metadata
 
     def set_gguf_meta_model(self, gguf_writer: gguf.GGUFWriter):
@@ -463,6 +473,8 @@ class Metadata:
             gguf_writer.add_license_name(self.license_name)
         if self.license_link is not None:
             gguf_writer.add_license_link(self.license_link)
+        if self.license_content is not None:
+            gguf_writer.add_license_content(self.license_content)
 
         if self.url is not None:
             gguf_writer.add_url(self.url)

--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -78,6 +78,7 @@ class Metadata:
         metadata.size_label      = metadata_override.get(Keys.General.SIZE_LABEL,      metadata.size_label)
         metadata.license_name    = metadata_override.get(Keys.General.LICENSE_NAME,    metadata.license_name)
         metadata.license_link    = metadata_override.get(Keys.General.LICENSE_LINK,    metadata.license_link)
+        metadata.license_content = metadata_override.get(Keys.General.LICENSE_CONTENT, metadata.license_content)
 
         metadata.url             = metadata_override.get(Keys.General.URL,             metadata.url)
         metadata.doi             = metadata_override.get(Keys.General.DOI,             metadata.doi)


### PR DESCRIPTION
Based on observation by @compilade  in https://github.com/ggerganov/llama.cpp/pull/8810 that there are companies and individuals who may want to write their own license e.g. https://huggingface.co/apple/OpenELM-270M-Instruct/blob/079458728ac069399c968eb2aba519b1411725ff/README.md?code=true#L4 

So this PR will just copy any LICENSE file and adds a new kv store named `general.license.content` to the metadata store.

There are future opportunities to auto-match and extract SPDX if we include a python module to detect it... but I think that's asking a bit much of us. Let's see if people be willing to fill in the model card properly. This just accounts for when there is a legitimate reason to not link to an external license (ergo self written license).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
