### PR TITLE
[Vulkan] Fix compilation of `vulkan-shaders-gen` on w64devkit after `e31a4f6`

### DIFF
--- a/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <string>
 #include <stdexcept>
-#include <algorithm>
 #include <array>
 #include <vector>
 #include <map>
@@ -23,6 +22,7 @@
 #ifdef _WIN32
     #include <windows.h>
     #include <direct.h> // For _mkdir on Windows
+    #include <algorithm> // For std::replace on w64devkit
 #else
     #include <unistd.h>
     #include <sys/wait.h>

--- a/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 #include <stdexcept>
+#include <algorithm>
 #include <array>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Fixes compilation issue introduced by https://github.com/ggerganov/llama.cpp/commit/e31a4f679779220312c165b0f5994c680a610e38 on w64devkit.
Seems like deliberately including `algorithm` is enough.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
