### PR TITLE
Makefile was missing an object file on `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1206,6 +1206,7 @@ clean:
 	rm -rvf ggml/*.dll
 	rm -rvf ggml/*.so
 	rm -vrf ggml/src/*.o
+	rm -rvf ggml/src/llamafile/*.o
 	rm -rvf common/build-info.cpp
 	rm -vrf ggml/src/ggml-metal-embed.metal
 	rm -vrf ggml/src/ggml-cuda/*.o


### PR DESCRIPTION
`ggml/src/llamafile/sgemm.o` was not deleted on `make clean`

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Sorry for this rather trivial PR but I lost a few hours tracking this down in a cross compiling setting.