### PR TITLE
fix: Fixes wrong input type for raw_dtype in ggml to gguf scripts

### DIFF
--- a/convert_llama_ggml_to_gguf.py
+++ b/convert_llama_ggml_to_gguf.py
@@ -116,7 +116,7 @@ class Tensor:
         assert quant is not None, 'Unknown tensor type'
         (blksize, tysize) = quant
         offset += 12
-        self.dtype= dtype
+        self.dtype= gguf.GGMLQuantizationType(dtype)
         self.dims = struct.unpack(f'<{n_dims}I', data[offset:offset + (4 * n_dims)])
         offset += 4 * n_dims
         self.name = bytes(data[offset:offset + name_len])


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
  
A wrong data type has been passed from the `add_tensor` and `add_tensor_info` to this function causing another exception while raising another exception. So I changed the input types based on the name `raw_dtype` and later converted it to an `GGMLQuantizationType` object which can also handle invalid arguments itself.
related issue #8929
