### PR TITLE
llama : default n_swa for phi-3

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4892,7 +4892,6 @@ static void llm_load_hparams(
             } break;
         case LLM_ARCH_PHI3:
             {
-                ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
 
                 switch (hparams.n_layer) {
@@ -4901,6 +4900,17 @@ static void llm_load_hparams(
                     case 40: model.type = e_model::MODEL_14B; break;
                     default: model.type = e_model::MODEL_UNKNOWN;
                 }
+
+                if ((hparams.n_layer == 32 || hparams.n_layer == 40)) {
+                    if (hparams.n_ctx_train == 4096) {
+                        // default value for Phi-3-mini-4k-instruct and Phi-3-medium-4k-instruct
+                        hparams.n_swa = 2047;
+                    } else if (hparams.n_ctx_train == 131072) {
+                        // default value for Phi-3-mini-128k-instruct and Phi-3-medium-128k-instruct
+                        hparams.n_swa = 131072;
+                    }
+                }
+                ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
             } break;
         case LLM_ARCH_PLAMO:
             {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4912,7 +4912,10 @@ static void llm_load_hparams(
                     // default value for Phi-3-medium-128k-instruct
                     hparams.n_swa = 131072;
                 }
-                ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
+                bool found_swa = ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
+                if (!found_swa && hparams.n_swa == 0) {
+                    throw std::runtime_error("invalid value for sliding_window");
+                }
             } break;
         case LLM_ARCH_PLAMO:
             {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4901,14 +4901,16 @@ static void llm_load_hparams(
                     default: model.type = e_model::MODEL_UNKNOWN;
                 }
 
-                if ((hparams.n_layer == 32 || hparams.n_layer == 40)) {
-                    if (hparams.n_ctx_train == 4096) {
-                        // default value for Phi-3-mini-4k-instruct and Phi-3-medium-4k-instruct
-                        hparams.n_swa = 2047;
-                    } else if (hparams.n_ctx_train == 131072) {
-                        // default value for Phi-3-mini-128k-instruct and Phi-3-medium-128k-instruct
-                        hparams.n_swa = 131072;
-                    }
+                // for backward compatibility ; see: https://github.com/ggerganov/llama.cpp/pull/8931
+                if ((hparams.n_layer == 32 || hparams.n_layer == 40) && hparams.n_ctx_train == 4096) {
+                    // default value for Phi-3-mini-4k-instruct and Phi-3-medium-4k-instruct
+                    hparams.n_swa = 2047;
+                } else if (hparams.n_layer == 32 && hparams.n_head_kv(0) == 32 && hparams.n_ctx_train == 131072) {
+                    // default value for Phi-3-mini-128k-instruct
+                    hparams.n_swa = 262144;
+                } else if (hparams.n_layer == 40 && hparams.n_ctx_train == 131072) {
+                    // default value for Phi-3-medium-128k-instruct
+                    hparams.n_swa = 131072;
                 }
                 ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
             } break;


### PR DESCRIPTION
Related to #8627

`phi3.attention.sliding_window` is marked as required, this break many existing models as some users can't re-convert the new version (ref: https://github.com/ngxson/wllama/issues/106)

This PR propose default value for certain models:
| model | n_layers | n_ctx_train | n_swa |
| -- | -- | -- | -- |
| [Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/config.json) | 32 | 4096 | 2047 |
| [Phi-3-medium-4k-instruct](https://huggingface.co/microsoft/Phi-3-medium-4k-instruct/blob/main/config.json) | 40 | 4096 | 2047 |
| [Phi-3-mini-128k-instruct](https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/blob/main/config.json) | 32 (n_head_kv = 32) | 131072 | 262144 |
| [Phi-3-medium-128k-instruct](https://huggingface.co/microsoft/Phi-3-medium-128k-instruct/blob/main/config.json) | 40 | 131072 | 131072 |
| [Phi-3-small-8k-instruct](https://huggingface.co/microsoft/Phi-3-small-8k-instruct/blob/main/config.json) | 32 (n_head_kv = 8) | 8192 | none |
| [Phi-3-small-128k-instruct](https://huggingface.co/microsoft/Phi-3-small-128k-instruct/blob/main/config.json) | 32 (n_head_kv = 8) | 131072 | none |

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
