### PR TITLE
gguf-py: fix gguf-py/examples/writer.py

### DIFF
--- a/gguf-py/examples/writer.py
+++ b/gguf-py/examples/writer.py
@@ -15,7 +15,6 @@ def writer_example() -> None:
     # Example usage with a file
     gguf_writer = GGUFWriter("example.gguf", "llama")
 
-    gguf_writer.add_architecture()
     gguf_writer.add_block_count(12)
     gguf_writer.add_uint32("answer", 42)  # Write a 32-bit integer
     gguf_writer.add_float32("answer_in_float", 42.0)  # Write a 32-bit float


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Double-call to `add_architecture()` in example results in ValueError.

Example is instantiating `GGUFWriter` in example:
https://github.com/ggerganov/llama.cpp/blob/3071c0a5f218f107dabd13b73f6090af683ef5ec/gguf-py/examples/writer.py#L16-L18

But constructor already has the `add_architecture()` call here:
https://github.com/ggerganov/llama.cpp/blob/3071c0a5f218f107dabd13b73f6090af683ef5ec/gguf-py/gguf/gguf_writer.py#L108

# Before (today)
```
(gguf-py3.11) gguf-py % python examples/writer.py
Traceback (most recent call last):
  File "/Users/mmortari/git/llama.cpp/gguf-py/examples/writer.py", line 40, in <module>
    writer_example()
  File "/Users/mmortari/git/llama.cpp/gguf-py/examples/writer.py", line 18, in writer_example
    gguf_writer.add_architecture()
  File "/Users/mmortari/git/llama.cpp/gguf-py/gguf/gguf_writer.py", line 484, in add_architecture
    self.add_string(Keys.General.ARCHITECTURE, self.arch)
  File "/Users/mmortari/git/llama.cpp/gguf-py/gguf/gguf_writer.py", line 312, in add_string
    self.add_key_value(key, val, GGUFValueType.STRING)
  File "/Users/mmortari/git/llama.cpp/gguf-py/gguf/gguf_writer.py", line 272, in add_key_value
    raise ValueError(f'Duplicated key name {key!r}')
ValueError: Duplicated key name 'general.architecture'
```

# After
```
(gguf-py3.11) gguf-py % python examples/writer.py                                  
(gguf-py3.11) gguf-py % ls -la *.gguf
-rw-r--r--@ 1 mmortari  staff  1088 Aug  9 16:36 example.gguf
```