### PR TITLE
Retrieval: Fix Memory Leak in Retrieval Query Handling

### DIFF
--- a/examples/retrieval/retrieval.cpp
+++ b/examples/retrieval/retrieval.cpp
@@ -267,7 +267,6 @@ int main(int argc, char ** argv) {
         std::vector<float> query_emb(n_embd, 0);
         batch_decode(ctx, query_batch, query_emb.data(), 1, n_embd);
 
-        
         llama_batch_clear(query_batch);
 
         // compute cosine similarities

--- a/examples/retrieval/retrieval.cpp
+++ b/examples/retrieval/retrieval.cpp
@@ -253,6 +253,8 @@ int main(int argc, char ** argv) {
         chunks[i].tokens.clear();
     }
 
+    struct llama_batch query_batch = llama_batch_init(n_batch, 0, 1);
+
     // start loop, receive query and return top k similar chunks based on cosine similarity
     std::string query;
     while (true) {
@@ -260,13 +262,13 @@ int main(int argc, char ** argv) {
         std::getline(std::cin, query);
         std::vector<int32_t> query_tokens = llama_tokenize(ctx, query, true);
 
-        struct llama_batch query_batch = llama_batch_init(n_batch, 0, 1);
         batch_add_seq(query_batch, query_tokens, 0);
 
         std::vector<float> query_emb(n_embd, 0);
         batch_decode(ctx, query_batch, query_emb.data(), 1, n_embd);
 
-        llama_batch_free(query_batch);
+        
+        llama_batch_clear(query_batch);
 
         // compute cosine similarities
         {
@@ -293,6 +295,7 @@ int main(int argc, char ** argv) {
     }
 
     // clean up
+    llama_batch_free(query_batch);
     llama_print_timings(ctx);
     llama_free(ctx);
     llama_free_model(model);

--- a/examples/retrieval/retrieval.cpp
+++ b/examples/retrieval/retrieval.cpp
@@ -266,7 +266,7 @@ int main(int argc, char ** argv) {
         std::vector<float> query_emb(n_embd, 0);
         batch_decode(ctx, query_batch, query_emb.data(), 1, n_embd);
 
-        llama_batch_clear(query_batch);
+        llama_batch_free(query_batch);
 
         // compute cosine similarities
         {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

- Description
This pull request addresses a memory leak issue in the `retrieval.cpp` file, specifically when continuously accepting query inputs. The problem arises from the `llama_batch` initialization and clearing process.

- Problem
The `llama_batch_init` function allocates memory on the heap for the batch. However, the current implementation uses `llama_batch_clear` to reset the batch size to `0`, which does not properly free the allocated heap memory. This results in a continuous increase in memory usage as the process runs.

- Solution
The solution involves ensuring that the allocated memory for `llama_batch` is properly freed after each query is processed. This prevents the memory leak and stabilizes the memory usage of the process.

- Changes
Replaced `llama_batch_clear` with `llama_batch_free` to ensure proper memory deallocation.