### PR TITLE
Fix memory leak in src/llama.cpp

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -17656,6 +17656,7 @@ struct llama_data_read {
                 read_to(&n_seq_id, sizeof(n_seq_id));
 
                 if (n_seq_id != 0) {
+                    llama_batch_free(batch);
                     LLAMA_LOG_ERROR("%s: invalid seq_id-agnostic kv cell\n", __func__);
                     return false;
                 }


### PR DESCRIPTION
Fix memory leak in src/llama.cpp
Free `batch` before returning from `read_kv_cache_meta`.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
