### PR TITLE
metadata: Assume v1.0 if version metadata is missing

### DIFF
--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -99,6 +99,10 @@ class Metadata:
         if model_name is not None:
             metadata.name = model_name
 
+        # If model is missing a version number then assume v1.0 (First Public Release)
+        if metadata.version is None:
+            metadata.version = "v1.0"
+
         return metadata
 
     @staticmethod


### PR DESCRIPTION
The intent of this PR is to always ensure a version string is provided and to assume v1.0 if not provided.
The reason is because it's rather ambiguous if the chunk after the SizeLabel is a finetune (which is optional) name or an encoding (always there except for vocab?). Without the version string, the regexp I posted in [Validating Above Naming Convention](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md#validating-above-naming-convention) will not be able to match against it.

This will also syncronise the code with the current [spec doc](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md#gguf-naming-convention). If we opt not to do this, we should update the spec doc to match by deleting "If model is missing a version number then assume v1.0 (First Public Release)" and somehow adjusting the regexp validator (or delete the validator regexp and say it's for humans only and to refer to internal metadata only)

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

