### PR TITLE
metal : fix uninitialized abort_callback

### DIFF
--- a/ggml/src/ggml-metal.m
+++ b/ggml/src/ggml-metal.m
@@ -310,7 +310,7 @@ static struct ggml_backend_metal_context * ggml_metal_init(int n_cb) {
     GGML_METAL_LOG_INFO("%s: picking default device: %s\n", __func__, [[device name] UTF8String]);
 
     // Configure context
-    struct ggml_backend_metal_context * ctx = malloc(sizeof(struct ggml_backend_metal_context));
+    struct ggml_backend_metal_context * ctx = calloc(1, sizeof(struct ggml_backend_metal_context));
     ctx->device = device;
     ctx->n_cb   = MIN(n_cb, GGML_METAL_MAX_BUFFERS);
     ctx->queue  = [ctx->device newCommandQueue];


### PR DESCRIPTION
`abort_callback` may be used uninitialized, resulting in a crash.

Fixes #8961