### PR TITLE
llama : model-based max number of graph nodes calculation

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3576,7 +3576,7 @@ namespace GGUFMeta {
 using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
 
 static size_t llama_model_max_nodes(const llama_model & model) {
-    return std::max(8192, (int)model.tensors_by_name.size()*5);
+    return std::max<size_t>(8192, model.tensors_by_name.size()*5);
 }
 
 struct llama_model_loader {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3575,13 +3575,8 @@ namespace GGUFMeta {
 
 using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
 
-// TODO: update when needed or think of some clever automatic way to do this
-static size_t llama_model_max_nodes(const llama_model & /*model*/) {
-    //if (model.arch == LLM_ARCH_LLAMA && model.hparams.n_layer > ??) { // llama-3 405B
-    //    return 32768;
-    //}
-
-    return 8192;
+static size_t llama_model_max_nodes(const llama_model & model) {
+    return std::max(8192, (int)model.tensors_by_name.size()*5);
 }
 
 struct llama_model_loader {


### PR DESCRIPTION
This fixes #8950 and #8615
This PR builds on top of the changes made in #8622

Calculate the max number of nodes using `max(8192, model.tensors_by_name.size()*5)` as recommended by @slaren in https://github.com/ggerganov/llama.cpp/issues/8950#issuecomment-2278807100. I specified 8192 as minimum to ensure this change will not break any currently working models.

Thanks to this change I was able to run inference on BigLlama-3.1-681B-Instruct and Meta-Llama-3-405B-Instruct-Up-Merge booth of which did not load prior to this change.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
