### PR TITLE
ci : disable bench workflow

### DIFF
--- a/.github/workflows/bench.yml.disabled
+++ b/.github/workflows/bench.yml.disabled
@@ -1,3 +1,6 @@
+# TODO: there have been some issues with the workflow, so disabling for now
+#       https://github.com/ggerganov/llama.cpp/issues/7893
+#
 # Benchmark
 name: Benchmark
 


### PR DESCRIPTION
The workflow has been disabled in the `llama.cpp` repo for [the past 2 months](https://github.com/ggerganov/llama.cpp/actions/workflows/bench.yml), mainly due to https://github.com/ggerganov/llama.cpp/issues/7893. Still it's better to disable it explicitly for all forks just in case

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
