### PR TITLE
Setting stop and error fields of the result struct

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1852,6 +1852,8 @@ struct server_context {
                     llama_lora_adapters_apply(ctx, lora_adapters);
                     server_task_result result;
                     result.id = task.id;
+                    result.stop = true;
+                    result.error = false;
                     result.data = json{{ "success", true }};
                     queue_results.send(result);
                 } break;


### PR DESCRIPTION
Two fields of the struct were left uninitialized. This could cause issues if they were accessed down the line. 

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
