### PR TITLE
Removing flake8-no-print plugin, due to dependency conflict

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -19,5 +19,3 @@ jobs:
           python-version: "3.11"
       - name: flake8 Lint
         uses: py-actions/flake8@v2
-        with:
-            plugins: "flake8-no-print"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,3 @@ repos:
   rev: 7.0.0
   hooks:
   -   id: flake8
-      additional_dependencies: [flake8-no-print]


### PR DESCRIPTION
This will mean some relaxing of the tests. But having print in your code isn't such a big of a deal imho. The github action isn't affected. But linting must be in sync to maintain dev sanity. 

The module should be returned only after it gets new release. 

https://github.com/vyahello/flake8-debug/issues/10

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
