### PR TITLE
ggml : dynamic ggml_sched_max_splits based on graph_size

### DIFF
--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -1120,8 +1120,15 @@ static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, co
     return -1;
 }
 
+#if 0
+#define GGML_SCHED_MAX_SPLITS_DEBUG 4096
+static char causes[GGML_DEFAULT_GRAPH_SIZE*16 + GGML_SCHED_MAX_SPLITS_DEBUG*GGML_SCHED_MAX_SPLIT_INPUTS][128]; // debug only
+#define SET_CAUSE(node, ...) sprintf(causes[hash_id(node)], __VA_ARGS__)
+#define GET_CAUSE(node) causes[hash_id(node)]
+#else
 #define SET_CAUSE(node, ...)
 #define GET_CAUSE(node) ""
+#endif
 
 // returns the backend that should be used for the node based on the current locations
 static int ggml_backend_sched_backend_id_from_cur(ggml_backend_sched_t sched, struct ggml_tensor * tensor) {


### PR DESCRIPTION
This fixes https://github.com/ggerganov/llama.cpp/issues/9044

Sets ggml_sched_max_splits to be equal to graph_size as recommended by @slaren in https://github.com/ggerganov/llama.cpp/issues/9044#issuecomment-2291681364 since at most there is one split for each node in the graph.

Thanks to this change I was able to run GPU accelerated inference on BigLlama-3.1-681B-Instruct which prior to this change caused llama.cpp to crash.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High