### PR TITLE
gguf-py : bump version from 0.9.1 to 0.10.0

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.9.1"
+version = "0.10.0"
 description = "Read and write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
There recently have been changes in `gguf-py` which happen to be useful for other projects, like #8939 which allows dequantizing most quant types.

ref: https://github.com/huggingface/transformers/issues/27712#issuecomment-2290525539

There's also https://github.com/city96/ComfyUI-GGUF which already uses this feature.

Bumping the version is [a necessary step to publish it to PyPI](https://github.com/ggerganov/llama.cpp/blob/4b9afbbe9037f8a2d659097c0c7d9fce32c6494c/gguf-py/README.md#automatic-publishing-with-ci), then a tag (`gguf-v0.10.0`) will need to be added.

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low