### PR TITLE
Add llmaz as another platform to run llama.cpp on Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [llama_cpp_canister](https://github.com/onicai/llama_cpp_canister) - llama.cpp as a smart contract on the Internet Computer, using WebAssembly
 - [llama-swap](https://github.com/mostlygeek/llama-swap) - transparent proxy that adds automatic model switching with llama-server
 - [Kalavai](https://github.com/kalavai-net/kalavai-client) - Crowdsource end to end LLM deployment at any scale
-
+- [llmaz](https://github.com/InftyAI/llmaz) - ☸️ Easy, advanced inference platform for large language models on Kubernetes.
 </details>
 
 <details>


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Hi, [llmaz](https://github.com/InftyAI/llmaz) is a platform to serve large language models on Kubernetes, llama.cpp is an vital part of it for CPU inference as well as GPU part. Here's an example:

```
apiVersion: llmaz.io/v1alpha1
kind: OpenModel
metadata:
  name: qwen2-0-5b-gguf
spec:
  familyName: qwen2
  source:
    modelHub:
      modelID: Qwen/Qwen2-0.5B-Instruct-GGUF
      filename: qwen2-0_5b-instruct-q5_k_m.gguf
```
```
apiVersion: inference.llmaz.io/v1alpha1
kind: Playground
metadata:
  name: qwen2-0-5b
spec:
  replicas: 1
  modelClaim:
    modelName: qwen2-0-5b-gguf
  backendConfig:
    name: llamacpp
    args:
    - -fa # use flash attention
```

This is all your need to do, then you can serve models with llama.cpp on Kubernetes.

Thanks!
