### PR TITLE
lora : raise error if lm_head is ignored

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -363,11 +363,11 @@ if __name__ == '__main__':
                     yield (name, cast(torch.Tensor, LoraTorchTensor(tensor.A, tensor.B)))
 
             def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-                dest = super().modify_tensors(data_torch, name, bid)
+                dest = list(super().modify_tensors(data_torch, name, bid))
                 # for now, we cannot convert archs that use the same tensor for tok_embd and output
                 # see: https://github.com/ggerganov/llama.cpp/issues/9065
                 if name == "lm_head.weight" and len(dest) == 0:
-                    raise ValueError(f"lm_head is present in adapter, but is ignored in base model")
+                    raise ValueError("lm_head is present in adapter, but is ignored in base model")
                 for dest_name, dest_data in dest:
                     assert isinstance(dest_data, LoraTorchTensor)
                     lora_a, lora_b = dest_data.get_lora_A_B()

--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -364,7 +364,9 @@ if __name__ == '__main__':
 
             def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
                 dest = list(super().modify_tensors(data_torch, name, bid))
-                # for now, we cannot convert archs that use the same tensor for tok_embd and output
+                # some archs may have the same tensor for lm_head and output (tie word embeddings)
+                # in this case, adapters targeting lm_head will fail when using llama-export-lora
+                # therefore, we ignore them for now
                 # see: https://github.com/ggerganov/llama.cpp/issues/9065
                 if name == "lm_head.weight" and len(dest) == 0:
                     raise ValueError("lm_head is present in adapter, but is ignored in base model")

--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -364,6 +364,10 @@ if __name__ == '__main__':
 
             def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
                 dest = super().modify_tensors(data_torch, name, bid)
+                # for now, we cannot convert archs that use the same tensor for tok_embd and output
+                # see: https://github.com/ggerganov/llama.cpp/issues/9065
+                if name == "lm_head.weight" and len(dest) == 0:
+                    raise ValueError(f"lm_head is present in adapter, but is ignored in base model")
                 for dest_name, dest_data in dest:
                     assert isinstance(dest_data, LoraTorchTensor)
                     lora_a, lora_b = dest_data.get_lora_A_B()


### PR DESCRIPTION
Resolve #9065 

We will now raise an error if `lm_head` is ignored in base model.

TODO: @ltoniazzi can you test this? Thanks.

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
