### PR TITLE
server : support reading arguments from environment variables

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -89,10 +89,17 @@ get_env(std::string name, T & target) {
 }
 
 template<typename T>
-static typename std::enable_if<!std::is_same<T, bool>::value &&std::is_integral<T>::value, void>::type
+static typename std::enable_if<!std::is_same<T, bool>::value && std::is_integral<T>::value, void>::type
 get_env(std::string name, T & target) {
     char * value = std::getenv(name.c_str());
     target = value ? std::stoi(value) : target;
+}
+
+template<typename T>
+static typename std::enable_if<std::is_floating_point<T>::value, void>::type
+get_env(std::string name, T & target) {
+    char * value = std::getenv(name.c_str());
+    target = value ? std::stof(value) : target;
 }
 
 template<typename T>
@@ -332,6 +339,8 @@ void gpt_params_parse_from_env(gpt_params & params) {
     get_env("LLAMA_ARG_ENDPOINT_METRICS", params.endpoint_metrics);
     get_env("LLAMA_ARG_ENDPOINT_SLOTS",   params.endpoint_slots);
     get_env("LLAMA_ARG_EMBEDDINGS",       params.embedding);
+    get_env("LLAMA_ARG_FLASH_ATTN",       params.flash_attn);
+    get_env("LLAMA_ARG_DEFRAG_THOLD",     params.defrag_thold);
 }
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -78,6 +78,34 @@
 using json = nlohmann::ordered_json;
 
 //
+// Environment variable utils
+//
+
+template<typename T>
+static typename std::enable_if<std::is_same<T, std::string>::value, void>::type
+get_env(std::string name, T & target) {
+    char * value = std::getenv(name.c_str());
+    target = value ? std::string(value) : target;
+}
+
+template<typename T>
+static typename std::enable_if<!std::is_same<T, bool>::value &&std::is_integral<T>::value, void>::type
+get_env(std::string name, T & target) {
+    char * value = std::getenv(name.c_str());
+    target = value ? std::stoi(value) : target;
+}
+
+template<typename T>
+static typename std::enable_if<std::is_same<T, bool>::value, void>::type
+get_env(std::string name, T & target) {
+    char * value = std::getenv(name.c_str());
+    if (value) {
+        std::string val(value);
+        target = val == "1" || val == "true";
+    }
+}
+
+//
 // CPU utils
 //
 
@@ -220,12 +248,6 @@ int32_t cpu_get_num_math() {
 // CLI argument parsing
 //
 
-void gpt_params_handle_hf_token(gpt_params & params) {
-    if (params.hf_token.empty() && std::getenv("HF_TOKEN")) {
-        params.hf_token = std::getenv("HF_TOKEN");
-    }
-}
-
 void gpt_params_handle_model_default(gpt_params & params) {
     if (!params.hf_repo.empty()) {
         // short-hand to avoid specifying --hf-file -> default it to --model
@@ -273,7 +295,9 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
 
     gpt_params_handle_model_default(params);
 
-    gpt_params_handle_hf_token(params);
+    if (params.hf_token.empty()) {
+        get_env("HF_TOKEN", params.hf_token);
+    }
 
     if (params.escape) {
         string_process_escapes(params.prompt);
@@ -291,6 +315,23 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
     }
 
     return true;
+}
+
+void gpt_params_parse_from_env(gpt_params & params) {
+    // we only care about server-related params for now
+    get_env("LLAMA_ARG_MODEL",            params.model);
+    get_env("LLAMA_ARG_THREADS",          params.n_threads);
+    get_env("LLAMA_ARG_CTX_SIZE",         params.n_ctx);
+    get_env("LLAMA_ARG_N_PARALLEL",       params.n_parallel);
+    get_env("LLAMA_ARG_BATCH",            params.n_batch);
+    get_env("LLAMA_ARG_UBATCH",           params.n_ubatch);
+    get_env("LLAMA_ARG_N_GPU_LAYERS",     params.n_gpu_layers);
+    get_env("LLAMA_ARG_THREADS_HTTP",     params.n_threads_http);
+    get_env("LLAMA_ARG_CHAT_TEMPLATE",    params.chat_template);
+    get_env("LLAMA_ARG_N_PREDICT",        params.n_predict);
+    get_env("LLAMA_ARG_ENDPOINT_METRICS", params.endpoint_metrics);
+    get_env("LLAMA_ARG_ENDPOINT_SLOTS",   params.endpoint_slots);
+    get_env("LLAMA_ARG_EMBEDDINGS",       params.embedding);
 }
 
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -267,7 +267,7 @@ struct gpt_params {
     std::string lora_outfile = "ggml-lora-merged-f16.gguf";
 };
 
-void gpt_params_handle_hf_token(gpt_params & params);
+void gpt_params_parse_from_env(gpt_params & params);
 void gpt_params_handle_model_default(gpt_params & params);
 
 bool gpt_params_parse_ex   (int argc, char ** argv, gpt_params & params);

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -262,6 +262,8 @@ Available environment variables (if specified, these variables will override par
 - `LLAMA_ARG_ENDPOINT_METRICS`
 - `LLAMA_ARG_ENDPOINT_SLOTS`
 - `LLAMA_ARG_EMBEDDINGS`
+- `LLAMA_ARG_FLASH_ATTN`
+- `LLAMA_ARG_DEFRAG_THOLD`
 
 ## Build
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -247,6 +247,21 @@ logging:
          --log-append             Don't truncate the old log file.
 ```
 
+Available environment variables (if specified, these variables will override parameters specified in arguments):
+
+- `LLAMA_ARG_MODEL`
+- `LLAMA_ARG_THREADS`
+- `LLAMA_ARG_CTX_SIZE`
+- `LLAMA_ARG_N_PARALLEL`
+- `LLAMA_ARG_BATCH`
+- `LLAMA_ARG_UBATCH`
+- `LLAMA_ARG_N_GPU_LAYERS`
+- `LLAMA_ARG_THREADS_HTTP`
+- `LLAMA_ARG_CHAT_TEMPLATE`
+- `LLAMA_ARG_N_PREDICT`
+- `LLAMA_ARG_ENDPOINT_METRICS`
+- `LLAMA_ARG_ENDPOINT_SLOTS`
+- `LLAMA_ARG_EMBEDDINGS`
 
 ## Build
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -249,6 +249,8 @@ logging:
 
 Available environment variables (if specified, these variables will override parameters specified in arguments):
 
+- `LLAMA_CACHE` (cache directory, used by `--hf-repo`)
+- `HF_TOKEN` (Hugging Face access token, used when accessing a gated model with `--hf-repo`)
 - `LLAMA_ARG_MODEL`
 - `LLAMA_ARG_THREADS`
 - `LLAMA_ARG_CTX_SIZE`

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2507,6 +2507,9 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // parse arguments from environment variables
+    gpt_params_parse_from_env(params);
+
     // TODO: not great to use extern vars
     server_log_json = params.log_json;
     server_verbose = params.verbosity > 0;


### PR DESCRIPTION
## Motivation

When deploying to HF inference endpoint, we only have control over the environment variables that can be passed to docker. That's why currently we need to build a custom container and specify these variables via `LLAMACPP_ARGS` (ref: https://github.com/ggerganov/llama.cpp/discussions/9041)

This PR add some server-related arguments to environment variables (see a full list in `server/README.md`)

Variables are being prefixed `LLAMA_ARG_` to distinguish them from compile-time variables like `LLAMA_CURL`.

## Example

```sh
LLAMA_ARG_MODEL=../models/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf LLAMA_ARG_CTX_SIZE=1024 LLAMA_ARG_N_PARALLEL=2 LLAMA_ARG_ENDPOINT_METRICS=1 ./llama-server
```

In case the same variable is specified in both env and arg, we prioritize env variable:

```sh
LLAMA_ARG_MODEL=my_model.gguf ./llama-server -m another_model.gguf
# Expected behavior: we load my_model.gguf
# (in other words, "-m another_model.gguf" is ignored)
```

On HF infrefence endpoint, these variables can be set from "Settings" tab. (In near future, these variable will be exposed as pre-defined input fields in the UI)

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/831525c4-1107-47fa-b2bc-3dd5ea8b96f6">

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
