### PR TITLE
gguf-py: Add missing sentencepiece dependency to pyproject.yaml

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -23,6 +23,7 @@ python = ">=3.8"
 numpy = ">=1.17"
 tqdm = ">=4.27"
 pyyaml = ">=5.1"
+sentencepiece = ">=0.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Simple fix - the `pyproject.toml` file in gguf-py is missing the dependency on `sentencepiece` needed by [vocab.py](https://github.com/ggerganov/llama.cpp/blob/gguf-v0.9.1/gguf-py/gguf/vocab.py#L10). This should also fix the pypi package when it is updated.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X ] Low
  - [ ] Medium
  - [ ] High
