### PR TITLE
llama : add ability to load model from memory buffer

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2284,7 +2284,7 @@ extern "C" {
 
     GGML_API struct gguf_context * gguf_init_empty(void);
     GGML_API struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params);
-    //GGML_API struct gguf_context * gguf_init_from_buffer(..);
+    GGML_API struct gguf_context * gguf_init_from_buffer(const char * buffer, size_t size, struct gguf_init_params params);
 
     GGML_API void gguf_free(struct gguf_context * ctx);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -415,6 +415,12 @@ extern "C" {
     // lora adapter
     struct llama_lora_adapter;
 
+    // to be used by llama_load_model_from_buffers
+    struct llama_model_shard_buffer {
+        const char * data;
+        size_t       size;
+    };
+
     // Helpers for getting default parameters
     LLAMA_API struct llama_model_params llama_model_default_params(void);
     LLAMA_API struct llama_context_params llama_context_default_params(void);
@@ -433,7 +439,12 @@ extern "C" {
 
     LLAMA_API struct llama_model * llama_load_model_from_file(
                              const char * path_model,
-            struct llama_model_params     params);
+              struct llama_model_params   params);
+
+    LLAMA_API struct llama_model * llama_load_model_from_buffers(
+        struct llama_model_shard_buffer * shards,
+                                 size_t   n_shards,
+              struct llama_model_params   params);
 
     LLAMA_API void llama_free_model(struct llama_model * model);
 


### PR DESCRIPTION
TODO: add some tests

Currently, loading a model depends on file system. That means the model must firstly be saved onto disk, then being loaded using `llama_load_model_from_file`

However, when compiled to [web assembly](https://github.com/ngxson/wllama), the virtual fs implementation is very inefficient and does not support files bigger than 2GB. Allow loading file directly from a buffer will be bypass the need of fs.

This PR introduce 2 new APIs:
- `gguf_init_from_buffer` ==> this was left as a TODO, so I implemented it
- `llama_load_model_from_buffers` ==> support loading multiple model shards (or model splits)

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
