### PR TITLE
llama:use F32 precision in GLM4 attention and no FA

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8885,7 +8885,7 @@ static struct ggml_tensor * llm_build_kqv(
         struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
         cb(kq, "kq", il);
 
-        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_NEMOTRON) {
+        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_NEMOTRON || model.arch == LLM_ARCH_CHATGLM) {
             // for this arch, we need to perform the KQ multiplication with F32 precision, otherwise we get NaNs
             // ref: https://github.com/ggerganov/llama.cpp/pull/4490#issuecomment-1859055847
             ggml_mul_mat_set_prec(kq, GGML_PREC_F32);


### PR DESCRIPTION
There have been few [reports](https://github.com/ggerganov/llama.cpp/pull/8031#issuecomment-2219752905) of glm4 models generating "GGGG" when FA is disabled. This should it.
I used the following command line, and after modification, there was no GGG in output

```
#!/bin/bashit.
../build/bin/llama-cli -m "/mnt/edge/yhl/model/glm4-9b-chat-Q4_K_M.gguf" -c 8192 -ngl 41 -np 2 -p "hello how are you?"
```
 before
<img width="1560" alt="截屏2024-08-22 16 59 29" src="https://github.com/user-attachments/assets/26030c8a-f11e-4b04-99d6-48cdbeab1fd3">

after
<img width="1556" alt="截屏2024-08-22 17 01 55" src="https://github.com/user-attachments/assets/0d502aec-f7c4-44c4-b9b5-e27ee93c41ea">



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
