### PR TITLE
[SYCL] Add a space between the string and the variable to supress a cmake warning

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -550,7 +550,7 @@ if (GGML_SYCL)
     list(APPEND GGML_SOURCES_SYCL "ggml-sycl.cpp")
 
     find_package(DNNL)
-    message("-- DNNL found:"${DNNL_FOUND})
+    message("-- DNNL found:" ${DNNL_FOUND})
     if (GGML_SYCL_TARGET STREQUAL "INTEL")
         add_compile_definitions(GGML_SYCL_DNNL=${DNNL_FOUND})
     else()


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High


Lack of this space create a cmake warning:

![image](https://github.com/user-attachments/assets/4b003717-edbd-46e2-a0b3-0d4316947dd6)

The warning is due to the lack of whitespace between the string and the variable in this line:
```
message("-- DNNL found: ${DNNL_FOUND}")
```

I did brought that up while reviewing #9091 but it was ignored for some reason. So, I am opening a PR here.

This change ensures that the CMake syntax is properly followed, eliminating unnecessary warnings during the build process.

cc: @airMeng I couldn't add you as a reviewer here so, mentioning you here... 