### PR TITLE
llama : fix qs.n_attention_wv for DeepSeek-V2

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -16820,7 +16820,8 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
 
         // TODO: avoid hardcoded tensor names - use the TN_* constants
         if (name.find("attn_v.weight")   != std::string::npos ||
-            name.find("attn_qkv.weight") != std::string::npos) {
+            name.find("attn_qkv.weight") != std::string::npos ||
+            name.find("attn_kv_b.weight")!= std::string::npos) {
             ++qs.n_attention_wv;
         } else if (name == LLM_TN(model.arch)(LLM_TENSOR_OUTPUT, "weight")) {
             qs.has_output = true;


### PR DESCRIPTION
Should fix #9155

This previously (before #8526) did not trigger the assertion because a value of `0` was accepted for recurrent models, but DeepSeek-V2(-Lite) is not a recurrent model.

Counting either `attn_kv_a_mqa.weight` or `attn_kv_b.weight` should fix this, but I went with the shorter of the two to fit vertically with the other conditions in the `if` which counts those tensors.

@mann1x can you confirm whether or not this fixes the problem?

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
