### PR TITLE
CUDA: fix Gemma 2 numerical issues for FA

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8877,7 +8877,7 @@ static struct ggml_tensor * llm_build_kqv(
         cur = ggml_flash_attn_ext(ctx, q, k, v, kq_mask, kq_scale, hparams.f_max_alibi_bias,
                                   hparams.attn_soft_cap ? hparams.f_attn_logit_softcapping : 0.0f);
 
-        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX) {
+        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_GEMMA2) {
             ggml_flash_attn_ext_set_prec(cur, GGML_PREC_F32);
         }
 


### PR DESCRIPTION
Fixup to https://github.com/ggerganov/llama.cpp/pull/8542 .

There seem to be numerical issues which (depending on the inputs) can cause incorrect results with Gemma 2 when using FlashAttention. This PR sets the FA precision to FP32 which fixes the issue described in https://github.com/ggerganov/llama.cpp/pull/8542#issuecomment-2308578334 .