### PR TITLE
common,train,examples: using C++17 constexpr string and strlen

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -280,12 +280,12 @@ void gpt_params_handle_model_default(gpt_params & params) {
 bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
     bool invalid_param = false;
     std::string arg;
-    const std::string arg_prefix = "--";
+    static constexpr auto arg_prefix = "--";
     llama_sampling_params & sparams = params.sparams;
 
     for (int i = 1; i < argc; i++) {
         arg = argv[i];
-        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
             std::replace(arg.begin(), arg.end(), '_', '-');
         }
         if (!gpt_params_find_arg(argc, argv, arg, params, i, invalid_param)) {

--- a/common/train.cpp
+++ b/common/train.cpp
@@ -1147,8 +1147,8 @@ bool consume_common_train_arg(
 ) {
     int& i = *idx;
     std::string arg = argv[i];
-    const std::string arg_prefix = "--";
-    if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+    static constexpr auto arg_prefix = "--";
+    if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
         std::replace(arg.begin(), arg.end(), '_', '-');
     }
     if (arg == "--train-data") {

--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -812,11 +812,11 @@ static bool params_parse(int argc, char ** argv, struct train_params * params) {
     bool reqd_param_found = false;
     std::string arg;
     struct train_params default_params = get_default_train_params();
-    const std::string arg_prefix = "--";
+    static constexpr auto arg_prefix = "--";
 
     for (int i = 1; i < argc; i++) {
         arg = argv[i];
-        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
             std::replace(arg.begin(), arg.end(), '_', '-');
         }
 

--- a/examples/cvector-generator/cvector-generator.cpp
+++ b/examples/cvector-generator/cvector-generator.cpp
@@ -349,10 +349,10 @@ static bool get_hidden_layers(llama_context * ctx, std::vector<llama_token> & to
 static void export_gguf(const std::vector<struct ggml_tensor *> & v_ctrl, const std::string fname, const std::string model_hint) {
     struct gguf_context * ctx = gguf_init_empty();
 
-    const std::string arch = "controlvector";
-    gguf_set_val_str(ctx, "general.architecture", arch.c_str());
-    gguf_set_val_str(ctx, (arch + ".model_hint").c_str(), model_hint.c_str());
-    gguf_set_val_i32(ctx, (arch + ".layer_count").c_str(), v_ctrl.size());
+    static constexpr auto arch = "controlvector";
+    gguf_set_val_str(ctx, "general.architecture", arch);
+    gguf_set_val_str(ctx, (std::string{arch} + ".model_hint").c_str(), model_hint.c_str());
+    gguf_set_val_i32(ctx, (std::string{arch} + ".layer_count").c_str(), v_ctrl.size());
 
     for (size_t i = 0; i < v_ctrl.size(); ++i) {
         gguf_add_tensor(ctx, v_ctrl[i]);

--- a/examples/gguf-hash/gguf-hash.cpp
+++ b/examples/gguf-hash/gguf-hash.cpp
@@ -115,12 +115,12 @@ static void hash_print_usage(const char * executable) {
 static void hash_params_parse_ex(int argc, const char ** argv, hash_params & params) {
     std::string arg;
     bool invalid_param = false;
-    const std::string arg_prefix = "--";
+    static constexpr auto arg_prefix = "--";
 
     int arg_idx = 1;
     for (; arg_idx < argc && strncmp(argv[arg_idx], "--", 2) == 0; arg_idx++) {
         arg = argv[arg_idx];
-        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
             std::replace(arg.begin(), arg.end(), '_', '-');
         }
 

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -76,13 +76,13 @@ static size_t split_str_to_n_bytes(std::string str) {
 
 static void split_params_parse_ex(int argc, const char ** argv, split_params & params) {
     std::string arg;
-    const std::string arg_prefix = "--";
+    static constexpr auto arg_prefix = "--";
     bool invalid_param = false;
 
     int arg_idx = 1;
     for (; arg_idx < argc && strncmp(argv[arg_idx], "--", 2) == 0; arg_idx++) {
         arg = argv[arg_idx];
-        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
             std::replace(arg.begin(), arg.end(), '_', '-');
         }
 

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -330,7 +330,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     cmd_params params;
     std::string arg;
     bool invalid_param = false;
-    const std::string arg_prefix = "--";
+    static constexpr auto arg_prefix = "--";
     const char split_delim = ',';
 
     params.verbose = cmd_params_defaults.verbose;
@@ -341,7 +341,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
 
     for (int i = 1; i < argc; i++) {
         arg = argv[i];
-        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
+        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
             std::replace(arg.begin(), arg.end(), '_', '-');
         }
 


### PR DESCRIPTION
@JohannesGaessler 

Before:
```cpp
static cmd_params parse_cmd_params(int argc, char ** argv) {
    cmd_params params;
    std::string arg;
    bool invalid_param = false;
    const std::string arg_prefix = "--";
    const char split_delim = ',';

    params.verbose = cmd_params_defaults.verbose;
    params.output_format = cmd_params_defaults.output_format;
    params.output_format_stderr = cmd_params_defaults.output_format_stderr;
    params.reps = cmd_params_defaults.reps;
    params.numa = cmd_params_defaults.numa;

    for (int i = 1; i < argc; i++) {
        arg = argv[i];
        if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
            std::replace(arg.begin(), arg.end(), '_', '-');
        }
```

Assembly `-std=c++17 -fPIC -O3 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wmissing-declarations -Wmissing-noreturn -pthread -fopenmp -march=native -mtune=native -Wno-array-bounds -Wno-format-truncation -Wextra-semi -Iggml/include -Iggml/src -Iinclude -Isrc -Icommon -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DGGML_USE_OPENMP -DGGML_USE_LLAMAFILE -c`
```asm
parse_cmd_params(int, char**):
	push	rbp
	lea	rax, 48[rdi]
	vpxor	xmm0, xmm0, xmm0
	mov	rbp, rsp
	push	r15
	push	r14
	mov	r15, rdi
	push	r13
	push	r12
	push	rbx
	mov	ebx, esi
	sub	rsp, 1000
	mov	QWORD PTR -912[rbp], rax
	lea	rax, 96[rdi]
	mov	DWORD PTR -844[rbp], esi
	mov	QWORD PTR -952[rbp], rax
	lea	rax, 144[rdi]
	vmovdqu	XMMWORD PTR [rdi], xmm0
	lea	rsi, .LC237[rip]
	mov	QWORD PTR -944[rbp], rax
	lea	rax, 192[rdi]
	vmovdqu	XMMWORD PTR 16[rdi], xmm0
	mov	QWORD PTR -936[rbp], rax
	lea	rax, 240[rdi]
	vmovdqu	XMMWORD PTR 32[rdi], xmm0
	vmovdqu	XMMWORD PTR 48[rdi], xmm0
	vmovdqu	XMMWORD PTR 64[rdi], xmm0
	vmovdqu	XMMWORD PTR 80[rdi], xmm0
	vmovdqu	XMMWORD PTR 96[rdi], xmm0
	vmovdqu	XMMWORD PTR 112[rdi], xmm0
	vmovdqu	XMMWORD PTR 128[rdi], xmm0
	vmovdqu	XMMWORD PTR 144[rdi], xmm0
	vmovdqu	XMMWORD PTR 160[rdi], xmm0
	vmovdqu	XMMWORD PTR 176[rdi], xmm0
	mov	QWORD PTR -840[rbp], rdx
	vmovdqu	XMMWORD PTR 192[rdi], xmm0
	mov	QWORD PTR -928[rbp], rax
	lea	rax, -592[rbp]
	mov	QWORD PTR -608[rbp], rax
	lea	rax, -576[rbp]
	vmovdqu	XMMWORD PTR 208[rdi], xmm0
	vmovdqu	XMMWORD PTR 224[rdi], xmm0
	vmovdqu	XMMWORD PTR 240[rdi], xmm0
	vmovdqu	XMMWORD PTR 256[rdi], xmm0
	vmovdqu	XMMWORD PTR 272[rdi], xmm0
	vmovdqu	XMMWORD PTR 288[rdi], xmm0
	vmovdqu	XMMWORD PTR 304[rdi], xmm0
	mov	DWORD PTR 320[rdi], 0
	mov	QWORD PTR 328[rdi], 0
	mov	DWORD PTR 336[rdi], 0
	vmovdqu	XMMWORD PTR 344[rdi], xmm0
	mov	DWORD PTR 360[rdi], 0
	mov	QWORD PTR 368[rdi], 0
	mov	DWORD PTR 376[rdi], 0
	vmovdqu	XMMWORD PTR 384[rdi], xmm0
	vmovdqu	XMMWORD PTR 400[rdi], xmm0
	mov	QWORD PTR 416[rdi], 0
	mov	DWORD PTR 424[rdi], 0
	mov	QWORD PTR 432[rdi], 0
	mov	DWORD PTR 440[rdi], 0
	vmovdqu	XMMWORD PTR 448[rdi], xmm0
	mov	DWORD PTR 464[rdi], 0
	mov	QWORD PTR 472[rdi], 0
	mov	DWORD PTR 480[rdi], 0
	mov	QWORD PTR 488[rdi], 0
	mov	rdi, rax
	mov	QWORD PTR -600[rbp], 0
	mov	BYTE PTR -592[rbp], 0
	mov	QWORD PTR -920[rbp], rax
	call	std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&).constprop.0
	movzx	eax, BYTE PTR cmd_params_defaults[rip+504]
	mov	BYTE PTR 504[r15], al
	lea	rax, 508[r15]
	mov	QWORD PTR -960[rbp], rax
	mov	rax, QWORD PTR cmd_params_defaults[rip+508]
	mov	QWORD PTR 508[r15], rax
	mov	eax, DWORD PTR cmd_params_defaults[rip+500]
	mov	DWORD PTR 500[r15], eax
	mov	eax, DWORD PTR cmd_params_defaults[rip+496]
	mov	DWORD PTR 496[r15], eax
	cmp	ebx, 1
	jle	.L9663
	lea	rax, -608[rbp]
	mov	r14d, 1
	mov	BYTE PTR -845[rbp], 0
	mov	QWORD PTR -856[rbp], rax
.L9258:
	mov	rax, QWORD PTR -840[rbp]
	movsx	rbx, r14d
	sal	rbx, 3
	mov	r13, QWORD PTR [rax+rbx]
	mov	rdi, r13
	call	strlen@PLT
	mov	rdx, QWORD PTR -600[rbp]
	mov	rcx, r13
	xor	esi, esi
	mov	rdi, QWORD PTR -856[rbp]
	mov	r8, rax
	call	std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_replace(unsigned long, unsigned long, char const*, unsigned long)@PLT
	mov	rcx, QWORD PTR -568[rbp]
	mov	r12, QWORD PTR -600[rbp]
	mov	rdi, QWORD PTR -608[rbp]
	cmp	rcx, r12
	mov	r13, r12
	cmovbe	r13, rcx
	mov	QWORD PTR -880[rbp], rdi
	test	r13, r13
	je	.L9042
	mov	rsi, QWORD PTR -576[rbp]
	mov	rdx, r13
	mov	QWORD PTR -832[rbp], rcx
	call	memcmp@PLT
	mov	rcx, QWORD PTR -832[rbp]
	test	eax, eax
	jne	.L9043
```


After:
```cpp
static cmd_params parse_cmd_params(int argc, char ** argv) {
    cmd_params params;
    std::string arg;
    bool invalid_param = false;
    static constexpr auto arg_prefix = "--";
    const char split_delim = ',';

    params.verbose = cmd_params_defaults.verbose;
    params.output_format = cmd_params_defaults.output_format;
    params.output_format_stderr = cmd_params_defaults.output_format_stderr;
    params.reps = cmd_params_defaults.reps;
    params.numa = cmd_params_defaults.numa;

    for (int i = 1; i < argc; i++) {
        arg = argv[i];
        if (arg.compare(0, std::char_traits<char>::length(arg_prefix), arg_prefix) == 0) {
            std::replace(arg.begin(), arg.end(), '_', '-');
        }
```


Assembly  `-std=c++17 -fPIC -O3 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wmissing-declarations -Wmissing-noreturn -pthread -fopenmp -march=native -mtune=native -Wno-array-bounds -Wno-format-truncation -Wextra-semi -Iggml/include -Iggml/src -Iinclude -Isrc -Icommon -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DGGML_USE_OPENMP -DGGML_USE_LLAMAFILE -c`
```asm
parse_cmd_params(int, char**):
	push	rbp
	lea	rax, 48[rdi]
	vpxor	xmm0, xmm0, xmm0
	mov	rbp, rsp
	push	r15
	push	r14
	mov	r14, rdi
	push	r13
	push	r12
	push	rbx
	sub	rsp, 968
	mov	QWORD PTR -880[rbp], rax
	lea	rax, 96[rdi]
	mov	DWORD PTR -812[rbp], esi
	mov	QWORD PTR -912[rbp], rax
	lea	rax, 144[rdi]
	mov	QWORD PTR -808[rbp], rdx
	mov	QWORD PTR -904[rbp], rax
	lea	rax, 192[rdi]
	vmovdqu	XMMWORD PTR [rdi], xmm0
	mov	QWORD PTR -896[rbp], rax
	lea	rax, 240[rdi]
	vmovdqu	XMMWORD PTR 16[rdi], xmm0
	vmovdqu	XMMWORD PTR 32[rdi], xmm0
	vmovdqu	XMMWORD PTR 48[rdi], xmm0
	vmovdqu	XMMWORD PTR 64[rdi], xmm0
	vmovdqu	XMMWORD PTR 80[rdi], xmm0
	vmovdqu	XMMWORD PTR 96[rdi], xmm0
	vmovdqu	XMMWORD PTR 112[rdi], xmm0
	vmovdqu	XMMWORD PTR 128[rdi], xmm0
	vmovdqu	XMMWORD PTR 144[rdi], xmm0
	vmovdqu	XMMWORD PTR 160[rdi], xmm0
	vmovdqu	XMMWORD PTR 176[rdi], xmm0
	vmovdqu	XMMWORD PTR 192[rdi], xmm0
	mov	QWORD PTR -888[rbp], rax
	lea	rax, -560[rbp]
	vmovdqu	XMMWORD PTR 208[rdi], xmm0
	vmovdqu	XMMWORD PTR 224[rdi], xmm0
	vmovdqu	XMMWORD PTR 240[rdi], xmm0
	vmovdqu	XMMWORD PTR 256[rdi], xmm0
	vmovdqu	XMMWORD PTR 272[rdi], xmm0
	vmovdqu	XMMWORD PTR 288[rdi], xmm0
	vmovdqu	XMMWORD PTR 304[rdi], xmm0
	vmovdqu	XMMWORD PTR 384[rdi], xmm0
	vmovdqu	XMMWORD PTR 400[rdi], xmm0
	mov	QWORD PTR -576[rbp], rax
	mov	DWORD PTR 320[rdi], 0
	mov	QWORD PTR 328[rdi], 0
	mov	DWORD PTR 336[rdi], 0
	vmovdqu	XMMWORD PTR 344[rdi], xmm0
	mov	DWORD PTR 360[rdi], 0
	mov	QWORD PTR 368[rdi], 0
	mov	DWORD PTR 376[rdi], 0
	mov	QWORD PTR 416[rdi], 0
	mov	DWORD PTR 424[rdi], 0
	mov	QWORD PTR 432[rdi], 0
	mov	DWORD PTR 440[rdi], 0
	vmovdqu	XMMWORD PTR 448[rdi], xmm0
	mov	DWORD PTR 464[rdi], 0
	mov	QWORD PTR 472[rdi], 0
	mov	DWORD PTR 480[rdi], 0
	mov	QWORD PTR 488[rdi], 0
	mov	QWORD PTR -568[rbp], 0
	mov	BYTE PTR -560[rbp], 0
	movzx	eax, BYTE PTR cmd_params_defaults[rip+504]
	mov	BYTE PTR 504[rdi], al
	lea	rax, 508[rdi]
	mov	QWORD PTR -920[rbp], rax
	mov	rax, QWORD PTR cmd_params_defaults[rip+508]
	mov	QWORD PTR 508[rdi], rax
	mov	eax, DWORD PTR cmd_params_defaults[rip+500]
	mov	DWORD PTR 500[rdi], eax
	mov	eax, DWORD PTR cmd_params_defaults[rip+496]
	mov	DWORD PTR 496[rdi], eax
	cmp	esi, 1
	jle	.L9657
	lea	rax, -576[rbp]
	xor	r13d, r13d
	mov	r15d, 1
	mov	BYTE PTR -813[rbp], 0
	mov	QWORD PTR -824[rbp], rax
.L9258:
	mov	rax, QWORD PTR -808[rbp]
	movsx	rbx, r15d
	sal	rbx, 3
	mov	r12, QWORD PTR [rax+rbx]
	mov	rdi, r12
	call	strlen@PLT
	mov	rdi, QWORD PTR -824[rbp]
	mov	rcx, r12
	mov	rdx, r13
	mov	r8, rax
	xor	esi, esi
	call	std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_replace(unsigned long, unsigned long, char const*, unsigned long)@PLT
	mov	r12, QWORD PTR -568[rbp]
	test	r12, r12
	je	.L9054
	mov	rax, QWORD PTR -576[rbp]
	mov	r13d, 2
	lea	rsi, .LC238[rip]
	cmp	r12, r13
	cmovbe	r13, r12
	mov	rdx, r13
	sub	r13, 2
	mov	rdi, rax
	mov	QWORD PTR -800[rbp], rax
	call	memcmp@PLT
	or	eax, r13d
	jne	.L9045
	mov	rax, QWORD PTR -800[rbp]
	lea	rdx, [rax+r12]
	cmp	rdx, rax
	je	.L9046
```



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
