### PR TITLE
Update build.yml, enable rpc for windows cuda builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -857,7 +857,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_CUDA=ON -DBUILD_SHARED_LIBS=ON
+          cmake .. -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_CUDA=ON -DBUILD_SHARED_LIBS=ON -DGGML_RPC=ON
           cmake --build . --config Release -j $((${env:NUMBER_OF_PROCESSORS} - 1)) -t ggml
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
 


### PR DESCRIPTION
enable rpc for windows cuda builds

The current windows cuda build's llama-server ignores --rpc arguments, and it does not build cuda enabled rpc-server.

I have tested several models, with 1 llama-server and 1 remote rpc-server, most models work, only one mixtral q4km quant crashes with

ggml/src/ggml-rpc.cpp:893: GGML_ASSERT(tensor->data + tensor_size >= tensor->data) failed

I think it should be fine to build rpc enabled cuda llama-server and cuda enabled rpc-server by default.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
