### PR TITLE
server : fix crash when error handler dumps invalid utf-8 json

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2572,7 +2572,7 @@ int main(int argc, char ** argv) {
 
     auto res_error = [](httplib::Response & res, json error_data) {
         json final_response {{"error", error_data}};
-        res.set_content(final_response.dump(), MIMETYPE_JSON);
+        res.set_content(final_response.dump(-1, ' ', false, json::error_handler_t::replace), MIMETYPE_JSON);
         res.status = json_value(error_data, "code", 500);
     };
 


### PR DESCRIPTION
Was experiencing multiple crashes per day due to bad UTF-8 values in output.

```
llama-server [falcon-7b:2048:10]: terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_3::detail::type_error'
llama-server [falcon-7b:2048:10]:   what():  [json.exception.type_error.316] invalid UTF-8 byte at index 612: 0x5C
Error in request to /completion: socket hang up
```

This patch adjusts the JSON dump call in the error handler to use the UTF-8 replacement character instead of throwing errors (matching the output dumping behavior that is used on successful output).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High