### PR TITLE
devops : only build some specific targets for full image

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -31,6 +31,7 @@ ENV GGML_CUDA=1
 # Enable cURL
 ENV LLAMA_CURL=1
 
+# Only build targets used by tools.sh
 RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -31,6 +31,6 @@ ENV GGML_CUDA=1
 # Enable cURL
 ENV LLAMA_CURL=1
 
-RUN make -j$(nproc)
+RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.devops/full-rocm.Dockerfile
+++ b/.devops/full-rocm.Dockerfile
@@ -45,6 +45,6 @@ ENV LLAMA_CURL=1
 RUN apt-get update && \
     apt-get install -y libcurl4-openssl-dev
 
-RUN make -j$(nproc)
+RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.devops/full-rocm.Dockerfile
+++ b/.devops/full-rocm.Dockerfile
@@ -45,6 +45,7 @@ ENV LLAMA_CURL=1
 RUN apt-get update && \
     apt-get install -y libcurl4-openssl-dev
 
+# Only build targets used by tools.sh
 RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 
 ENV LLAMA_CURL=1
 
-
+# Only build targets used by tools.sh
 RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENV LC_ALL=C.utf8

--- a/.devops/full.Dockerfile
+++ b/.devops/full.Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 ENV LLAMA_CURL=1
 
 
-RUN make -j$(nproc)
+RUN make -j$(nproc) llama-quantize llama-cli llama-server
 
 ENV LC_ALL=C.utf8
 


### PR DESCRIPTION
Normally, the docker `full-*` image tag build all the targets. However, the entrypoint [tools.sh](https://github.com/ggerganov/llama.cpp/blob/master/.devops/tools.sh) only handle 3 tools: cli, server and quantize

This makes the build very wasteful, since most of the build time and storage space ended up not being used. Some CI run also breaks due to out of space (ref: https://github.com/ggerganov/llama.cpp/actions/runs/10584764326/job/29329766919)

This PR fixes the issue by only build targets used by `tools.sh`

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
