### PR TITLE
the function "clip" should be int

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1623,7 +1623,7 @@ static void normalize_image_u8_to_f32(const clip_image_u8* src, clip_image_f32* 
     }
 }
 
-inline float clip(float x, float lower, float upper) {
+inline int clip(int x, int lower, int upper) {
     return std::max(lower, std::min(x, upper));
 }
 
@@ -1825,10 +1825,6 @@ static std::pair<int, int> uhd_get_refine_size(std::pair<int, int> original_size
   //  std::pair<int, int> refine_size = std::make_tuple(best_grid_width * grid_x, best_grid_height * grid_y); (old line)
     std::pair<int, int> refine_size = std::make_pair(best_grid_width * grid_x, best_grid_height * grid_y); // (new line)
     return refine_size;
-}
-
-inline int clip(int x, int lower, int upper) {
-    return std::max(lower, std::min(x, upper));
 }
 
 static std::pair<int, int> uhd_best_grid(const int max_slice_nums, const int multiple, const float log_ratio) {


### PR DESCRIPTION
This function is only used in the interpolation function, and is only used to calculate int data. So it should not be a float function. 
And I found that if it is a float function, it will cause the coordinate calculation error of the interpolation function (bicubic_resize), resulting in a precision decrease in the C++ code. And if the coordinate appears at the end, it will cause access to an illegal address and crash.