### PR TITLE
src: make tail invalid when kv cell is intersection for mamba

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3689,7 +3689,8 @@ static bool llama_kv_cache_seq_rm(
                 if ((0 < p0 && p0 <= cell.pos) || (0 < p1 && p1 <= cell.pos)) {
                     return false;
                 }
-                if (p0 <= cell.pos && p1 < cell.pos) {
+                // invalidate tails which will be cleared
+                if (p0 <= cell.pos && cell.pos < p1) {
                     tail_id = -1;
                 }
             }


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

Reset the tail of kv cell for the common prefix tokens for mamba. That maybe fix  https://github.com/ggerganov/llama.cpp/issues/9170