### PR TITLE
SYCL: do not skip CPU or FPGA if explicitly selected

### DIFF
--- a/ggml/src/ggml-sycl/dpct/helper.hpp
+++ b/ggml/src/ggml-sycl/dpct/helper.hpp
@@ -910,15 +910,17 @@ namespace dpct
             auto platform_list = sycl::platform::get_platforms();
 
             for (const auto& platform : platform_list) {
-                auto devices = platform.get_devices();
-                auto gpu_dev = std::find_if(devices.begin(), devices.end(), [](const sycl::device& d) {
-                    return d.is_gpu();
-                });
+                if (!env || !std::strstr(env, "cpu")) {
+                    auto devices = platform.get_devices();
+                    auto gpu_dev = std::find_if(devices.begin(), devices.end(), [](const sycl::device& d) {
+                        return d.is_gpu();
+                    });
 
-                if (gpu_dev == devices.end()) {
-                    // cout << "platform [" << platform_name
-                    //      << "] does not contain GPU devices, skipping\n";
-                    continue;
+                    if (gpu_dev == devices.end()) {
+                        // cout << "platform [" << platform_name
+                        //      << "] does not contain GPU devices, skipping\n";
+                        continue;
+                    }
                 }
 
                 auto platform_name = platform.get_info<sycl::info::platform::name>();


### PR DESCRIPTION
It can be useful to be able to use SYCL on CPU
e.g. to run tests on a machine without a GPU.

With this commit a user can enable the use
of the CPU with the following env variable:

export ONEAPI_DEVICE_SELECTOR="opencl:cpu"



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

I ran the CI locally with this change and I got this error:

```
NORM(type=f32,ne=[64,10,10,10],eps=0.000001): /home/debian/llama.cpp/ggml/src/ggml-sycl/norm.cpp:11: void norm_f32(const
 float *, float *, const int, const float, const sycl::nd_item<3> &, sycl::float2 *, int): global id: [0,0,0], local id: [0,0,0] Assertion `nwarps % WARP_SIZE == 0` failed.
```

I guess this only happens because the code isn't supposed to run on a CPU at all and I'm running it on a CPU using this commit.

Would it be okay to make the code more generic so that it could also run on CPU? Or do you think that it would be *a lot* of work?

The main reason why I'm doing this is that I don't have access to a GPU that the current SYCL code can use and I had to make some changes to SYCL code because of https://github.com/ggerganov/ggml/pull/940 and I didn't know how to test those changes.
Personally I don't have a problem if some tests fail on CPU, maybe this could be a "use at your own risk" mode?
