### PR TITLE
server : refactor multitask handling

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -92,7 +92,7 @@ struct server_task {
     server_task_cmpl_type cmpl_type = SERVER_TASK_CMPL_TYPE_NORMAL;
 
     // utility function
-    static std::unordered_set<int> get_list_id(std::vector<server_task> tasks) {
+    static std::unordered_set<int> get_list_id(const std::vector<server_task> & tasks) {
         std::unordered_set<int> ids(tasks.size());
         for (size_t i = 0; i < tasks.size(); i++) {
             ids.insert(tasks[i].id);
@@ -533,7 +533,7 @@ struct server_response {
         waiting_task_ids.insert(id_task);
     }
 
-    void add_waiting_tasks(std::vector<server_task> & tasks) {
+    void add_waiting_tasks(const std::vector<server_task> & tasks) {
         for (const auto & t : tasks) {
             add_waiting_task_id(t.id);
         }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2899,7 +2899,12 @@ int main(int argc, char ** argv) {
         }
     };
 
-    const auto handle_slots_action = [&res_error, &handle_slots_save, &handle_slots_restore, &handle_slots_erase](const httplib::Request & req, httplib::Response & res) {
+    const auto handle_slots_action = [&params, &res_error, &handle_slots_save, &handle_slots_restore, &handle_slots_erase](const httplib::Request & req, httplib::Response & res) {
+        if (params.slot_save_path.empty()) {
+            res_error(res, format_error_response("This server does not support slots action. Start it with `--slot-save-path`", ERROR_TYPE_NOT_SUPPORTED));
+            return;
+        }
+
         std::string id_slot_str = req.path_params.at("id_slot");
         int id_slot;
 
@@ -3237,10 +3242,7 @@ int main(int argc, char ** argv) {
     svr->Post("/lora-adapters",       handle_lora_adapters_apply);
     // Save & load slots
     svr->Get ("/slots",               handle_slots);
-    if (!params.slot_save_path.empty()) {
-        // only enable slot endpoints if slot_save_path is set
-        svr->Post("/slots/:id_slot",  handle_slots_action);
-    }
+    svr->Post("/slots/:id_slot",      handle_slots_action);
 
     //
     // Start the server

--- a/examples/server/tests/features/parallel.feature
+++ b/examples/server/tests/features/parallel.feature
@@ -52,8 +52,8 @@ Feature: Parallel
     Then all prompts are predicted with <n_predict> tokens
     Examples:
       | streaming | n_predict |
-      | disabled  | 128       |
-      | enabled   | 64        |
+      | disabled  | 200       |
+      | enabled   | 200       |
 
   Scenario Outline: Multi users OAI completions compatibility no v1
     Given a system prompt You are a writer.

--- a/examples/server/tests/features/steps/steps.py
+++ b/examples/server/tests/features/steps/steps.py
@@ -818,7 +818,7 @@ async def concurrent_requests(context, f_completion, *args, **kwargs):
     for prompt_no in range(context.n_prompts):
         shifted_args = [context.prompts.pop(), seeds[prompt_no], *args]
         context.concurrent_tasks.append(asyncio.create_task(f_completion(*shifted_args, **kwargs)))
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.01)
 
 
 @step('the slot {slot_id:d} is saved with filename "{filename}"')

--- a/examples/server/tests/features/wrong_usages.feature
+++ b/examples/server/tests/features/wrong_usages.feature
@@ -8,9 +8,12 @@ Feature: Wrong usage of llama.cpp server
   Scenario: Infinite loop
     Given a server listening on localhost:8080
     And   a model file tinyllamas/stories260K.gguf from HF repo ggml-org/models
+    And   42 as server seed
+    And   2048 KV cache size
     # Uncomment below to fix the issue
     #And   64 server max tokens to predict
     Then  the server is starting
+    Then  the server is healthy
     Given a prompt:
       """
       Go to: infinite loop

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -279,6 +279,18 @@ static size_t find_partial_stop_string(const std::string &stop, const std::strin
     return std::string::npos;
 }
 
+static bool json_is_array_of_numbers(json data) {
+    if (data.is_array()) {
+        for (const auto & e : data) {
+            if (!e.is_number()) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 // TODO: reuse llama_detokenize
 template <class Iter>
 static std::string tokens_to_str(llama_context * ctx, Iter begin, Iter end) {


### PR DESCRIPTION
## Motivation

The server example has grown up in term of functionalities. I think it would be nice to start looking at how to simplify some parts and to make the code more manage-able.

The goal here is to make the http part and engine part more separated, so they can easily be debugged and probably optimized in the future.

The current architecture contains of 5 main parts:
- HTTP stack / handler
- Task queue
- Result queue
- Task dispatcher: responsible of loading tasks into slots
- Slot dispatcher: responsible of batching and calling `llama_decode`

## In this PR

Currently, multitask is added as a "super-task" that linked to other smaller tasks. However, this introduce some complexity to the task queue level. I believe that moving it to HTTP handler will simplify the task queue.

On the way doing so, I also made some small refactoring to `struct server_task` and HTTP handlers, for example:
- new `enum server_task_cmpl_type` for completion task type: normal, embedding, infill
- reuse the same http handler for both infill and completion endpoint

## Future works

I also take time to dive deeper into [httplib source code](https://github.com/yhirose/cpp-httplib) to see if there are anything else we can take advantage of. Turns out we can maybe even get rid of the notion of `deferred` tasks (in case there is no free slots to process the incoming request). I will investigate this more in another issue/PR.

In addition, one small [issue](https://github.com/ggerganov/llama.cpp/issues/9273) regarding to cancelling task also be address. However, no fix is being planned for now.

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Medium
