### PR TITLE
[SYCL] Fix DMMV dequantization

### DIFF
--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -47,6 +47,7 @@ static void dequantize_mul_mat_vec(const void * __restrict__ vx, const dfloat * 
 
     for (int i = 0; i < ncols; i += iter_stride) {
         const int col = i + vals_per_iter*tid;
+        if (col >= ncols) break; 
         const int ib = (row*ncols + col)/qk; // x block index
         const int iqs = (col%qk)/qr; // x quant index
         const int iybs = col - col%qk; // y block start index
@@ -54,6 +55,7 @@ static void dequantize_mul_mat_vec(const void * __restrict__ vx, const dfloat * 
 // processing >2 values per i iter is faster for fast GPUs
 #pragma unroll
         for (int j = 0; j < vals_per_iter; j += 2) {
+            if (col + j >= ncols) break;
             // process 2 vals per j iter
 
             // dequantize

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -77,7 +77,6 @@ static void dequantize_mul_mat_vec(const void * __restrict__ vx, const dfloat * 
 
     // sum up partial sums and write back result
     const int mask_start = ncols > GGML_SYCL_DMMV_X ? WARP_SIZE >> 1 : WARP_SIZE >> 2;
-#pragma unroll
     for (int mask = mask_start; mask > 0; mask >>= 1) {
         tmp +=
             dpct::permute_sub_group_by_xor(item_ct1.get_sub_group(), tmp, mask);

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -55,7 +55,6 @@ static void dequantize_mul_mat_vec(const void * __restrict__ vx, const dfloat * 
 // processing >2 values per i iter is faster for fast GPUs
 #pragma unroll
         for (int j = 0; j < vals_per_iter; j += 2) {
-            if (col + j >= ncols) break;
             // process 2 vals per j iter
 
             // dequantize


### PR DESCRIPTION
MUL_MAT test-backend-ops currently fail on intel GPUs for Q4_1, Q5_0, Q5_1 and Q8_0 due to a small edge-case issue in the `dequantize_mul_mat_vec` kernel _(when ncols <= GGML_SYCL_DMMV_X specifically)_.

This is a minor fix that halts the access to out-bound/extra quant elements in the kernel reduction step.

All unit-tests are passing following this fix.
Performance on intel GPUs is almost not affected.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
