### PR TITLE
llama-bench : fix NUL terminators in CPU name

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -124,6 +124,9 @@ static std::string get_cpu_info() {
                         (LPBYTE)cpu_brand,
                         &cpu_brand_size) == ERROR_SUCCESS) {
         id.assign(cpu_brand, cpu_brand_size);
+        if (id.find('\0') != std::string::npos) {
+            id.resize(id.find('\0'));
+        }
     }
     RegCloseKey(hKey);
 #endif


### PR DESCRIPTION
The result returned by `RegQueryValueExA` may be NUL terminated, which then ends as a NUL character in the `std::string`.

Fixes #9312