### PR TITLE
cmake : use ggml-metal.metal from source dir to build default.metallib

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -117,7 +117,7 @@ if (GGML_METAL)
 
         add_custom_command(
             OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/default.metallib
-            COMMAND xcrun -sdk macosx metal    ${XC_FLAGS} -c ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.metal -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.air
+            COMMAND xcrun -sdk macosx metal    ${XC_FLAGS} -c ${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.metal       -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.air
             COMMAND xcrun -sdk macosx metallib                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.air   -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/default.metallib
             COMMAND rm -f ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.air
             COMMAND rm -f ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-common.h


### PR DESCRIPTION
I noticed an edge case while building the `ggml-metal` target with Ninja more than once. The specific steps to reproduce are:
```console
$ cmake -B build -G Ninja -DGGML_METAL_EMBED_LIBRARY=OFF  # copies ggml-metal.metal to build/bin/ 
$ ninja -C build ggml-metal  # succeeds, removes build/bin/ggml-metal.metal
$ ninja -C build clean  # removes generated default.metallib, but ggml-metal.metal is still gone
$ ninja -C build ggml-metal  # fails to find build/bin/ggml-metal.metal
ninja: Entering directory `build'
[1/1] Compiling Metal kernels
FAILED: bin/default.metallib /Users/jared/src/forks/llama.cpp/build/bin/default.metallib
cd /Users/jared/src/forks/llama.cpp/build/ggml/src && xcrun -sdk macosx metal -O3 -c /Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.metal -o /Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.air && xcrun -sdk macosx metallib /Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.air -o /Users/jared/src/forks/llama.cpp/build/bin/default.metallib && rm -f /Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.air && rm -f /Users/jared/src/forks/llama.cpp/build/bin/ggml-common.h && rm -f /Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.metal
metal: error: no such file or directory: '/Users/jared/src/forks/llama.cpp/build/bin/ggml-metal.metal'
metal: error: no input files
ninja: build stopped: subcommand failed.
```

This does not happen with `make`, since it notices the missing files and runs cmake again to regenerate the byproducts (which are created at configure time via `configure_file` yet deleted at build time). This still happens after this PR, which is not ideal, but I don't fully understand why we are deleting build artifacts based on the target you select. @ggerganov Are the `rm` commands important here?

This also does not happen with the default of `GGML_METAL_EMBED_LIBRARY=ON`, since it does not `rm` the input files afterwards.

The simple fix is to use `ggml-metal.metal` from the *source* dir to build `default.metallib`, which exists regardless of whether you have previously run the target.

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High