### PR TITLE
ggml: fix build error when enable GGML_VULKAN_DEBUG

### DIFF
--- a/ggml/src/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan.cpp
@@ -2480,7 +2480,7 @@ static void ggml_vk_dispatch_pipeline(ggml_backend_vk_context* ctx, vk_context& 
     const uint32_t wg2 = CEIL_DIV(elements[2], pipeline->wg_denoms[2]);
     VK_LOG_DEBUG("ggml_vk_dispatch_pipeline(" << pipeline->name << ", {";
     for (auto& buffer : descriptor_buffer_infos) {
-        std::cerr << "(" << buffer << ", " << buffer.offset << ", " << buffer.size << "), ";
+        std::cerr << "(" << buffer.buffer << ", " << buffer.offset << ", " << buffer.range << "), ";
     }
     std::cerr << "}, (" << wg0 << "," << wg1 << "," << wg2 << "))");
     GGML_ASSERT(pipeline->descriptor_set_idx < pipeline->descriptor_sets.size());


### PR DESCRIPTION
llama.cpp/ggml/src/ggml-vulkan.cpp:2483:26: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>’ and ‘const vk::DescriptorBufferInfo’)
 2483 |         std::cerr << "(" << buffer << ", " << buffer.offset << ", " << buffer.size << "), ";
      |         ~~~~~~~~~~~~~~~~ ^~ ~~~~~~
      |                   |         |
      |                   |         const vk::DescriptorBufferInfo
      |                   std::basic_ostream<char>
llama.cpp/ggml/src/ggml-vulkan.cpp:61:40: note: in definition of macro ‘VK_LOG_DEBUG’



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x ] Low
  - [ ] Medium
  - [ ] High
