### PR TITLE
common: warmup: Handle situation when eos=bos=-1

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2531,7 +2531,12 @@ struct llama_init_result llama_init_from_gpt_params(gpt_params & params) {
         if (bos != -1) {
             tmp.push_back(bos);
         }
-        tmp.push_back(eos);
+        if (eos != -1) {
+            tmp.push_back(eos);
+        }
+        if (tmp.empty()) {
+            tmp.push_back(0);
+        }
 
         if (llama_model_has_encoder(model)) {
             llama_encode(lctx, llama_batch_get_one(tmp.data(), tmp.size(), 0, 0));


### PR DESCRIPTION
RWKV doesn't have eos/bos specified in convert_hf_to_gguf.py. It has vocab.tokenizer_add_eos/vocab.tokenizer_add_bos being false either. This results in crashes without the `--no-warmup`.

This fix makes it work right now. I'm not sure if the bos_token should be set to "\n\n" instead. @BlinkDL @LaylBongers Do you have any ideas?

This PR should fix #9315

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
