### PR TITLE
server : fix missing lock

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -412,6 +412,7 @@ struct server_queue {
 
     // multi-task version of post()
     int post(std::vector<server_task> & tasks, bool front = false) {
+        std::unique_lock<std::mutex> lock(mutex_tasks);
         for (auto & task : tasks) {
             if (task.id == -1) {
                 task.id = id++;


### PR DESCRIPTION
Add missing lock that causes the server to randomly crash

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
