### PR TITLE
ggml : fix missing `cpu_set_t` on emscripten

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19556,7 +19556,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
     return true;
 }
 
-#elif (defined(__gnu_linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__))
+#elif defined(__gnu_linux__)
 // TODO: this may not work on BSD, to be verified
 
 static bool ggml_thread_apply_affinity(const bool * mask) {
@@ -19572,7 +19572,14 @@ static bool ggml_thread_apply_affinity(const bool * mask) {
         }
     }
 
+#ifdef __ANDROID__
+    err = sched_setaffinity(0, sizeof(cpuset), &cpuset);
+    if (err < 0) {
+        err = errno;
+    }
+#else
     err = pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
+#endif
     if (err != 0) {
         fprintf(stderr, "warn: failed to set affinity mask 0x%llx : %s (%d)\n", (unsigned long long)mask, strerror(err), err);
         return false;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19556,7 +19556,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
     return true;
 }
 
-#elif ((defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)) && !defined(__EMSCRIPTEN__))
+#elif (defined(__gnu_linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__))
 // TODO: this may not work on BSD, to be verified
 
 static bool ggml_thread_apply_affinity(const bool * mask) {
@@ -19572,14 +19572,7 @@ static bool ggml_thread_apply_affinity(const bool * mask) {
         }
     }
 
-#ifdef __ANDROID__
-    err = sched_setaffinity(0, sizeof(cpuset), &cpuset);
-    if (err < 0) {
-        err = errno;
-    }
-#else
     err = pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
-#endif
     if (err != 0) {
         fprintf(stderr, "warn: failed to set affinity mask 0x%llx : %s (%d)\n", (unsigned long long)mask, strerror(err), err);
         return false;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19556,7 +19556,8 @@ static bool ggml_thread_apply_priority(int32_t prio) {
     return true;
 }
 
-#else // posix?
+#elif ((defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)) && !defined(__EMSCRIPTEN__))
+// TODO: this may not work on BSD, to be verified
 
 static bool ggml_thread_apply_affinity(const bool * mask) {
     cpu_set_t cpuset;
@@ -19608,6 +19609,18 @@ static bool ggml_thread_apply_priority(int32_t prio) {
         return false;
     }
 
+    return true;
+}
+
+#else // unsupported platforms
+
+static bool ggml_thread_apply_affinity(const bool * mask) {
+    UNUSED(mask);
+    return true;
+}
+
+static bool ggml_thread_apply_priority(int32_t prio) {
+    UNUSED(prio);
     return true;
 }
 


### PR DESCRIPTION
`cpu_set_t` doesn't exist on emscripten, we need to add `#ifdef __gnu_linux__`. The feature was added in #8672

The same method was already used in the other part of the code (for `numa`):

https://github.com/ggerganov/llama.cpp/blob/409dc4f8bb5185786087f52259ee4626be93f54d/ggml/src/ggml.c#L3134-L3136

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
