### PR TITLE
ggml: link MATH_LIBRARY not by its full path

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1341,7 +1341,7 @@ list(APPEND GGML_EXTRA_LIBS_PRIVATE Threads::Threads)
 find_library(MATH_LIBRARY m)
 if (MATH_LIBRARY)
     if (NOT WIN32 OR NOT GGML_SYCL)
-        target_link_libraries(ggml PRIVATE ${MATH_LIBRARY})
+        list(APPEND GGML_EXTRA_LIBS_PRIVATE m)
     endif()
 endif()
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

The current `MATH_LIBRARY` linkage method works if the llama.cpp library is installed on the same machine where it will be used. If the built and installed artefacts were transferred to another machine, an error like this may occur:
```
error: '/Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/lib/libm.tbd', needed by '***/llama-inference', missing and no known rule to make it
```
due to the fact that the `llama-config.cmake` specifies the full path to the library. The proposed fix changes the config to 
`set(_llama_link_deps "${ggml_LIBRARY}" "Threads::Threads;m")`. Which helps with portability.