### PR TITLE
llama : set attrs of mislabelled EOT/EOM tokens

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6399,6 +6399,11 @@ static void llm_load_vocab(
                         )
                    ) {
                     vocab.special_eot_id = t.second;
+                    if ((vocab.id_to_token[t.second].attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
+                        LLAMA_LOG_WARN("%s: control-looking token: '%s' was not control-type; this is probably a bug in the model. its type will be overridden\n",
+                            __func__, t.first.c_str());
+                        vocab.id_to_token[t.second].attr = LLAMA_TOKEN_ATTR_CONTROL;
+                    }
                     break;
                 }
             }
@@ -6412,6 +6417,11 @@ static void llm_load_vocab(
             const auto & t = vocab.token_to_id.find("<|eom_id|>");
             if (t != vocab.token_to_id.end()) {
                 vocab.special_eom_id = t->second;
+                if ((vocab.id_to_token[t->second].attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
+                    LLAMA_LOG_WARN("%s: control-looking token: '%s' was not control-type; this is probably a bug in the model. its type will be overridden\n",
+                        __func__, t->first.c_str());
+                    vocab.id_to_token[t->second].attr = LLAMA_TOKEN_ATTR_CONTROL;
+                }
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Some models (such as the official [phi-3-mini-4k-instruct-gguf](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf)) have an `<|end|>` or similar token which is detected as being EOT or EOM but which is [not marked as control](https://github.com/ggerganov/llama.cpp/issues/6903#issuecomment-2104007318).

This [causes](https://github.com/ggerganov/llama.cpp/issues/8291) [issues](https://github.com/ggerganov/llama.cpp/issues/6903) where the token will be included in the output when it shouldn't. A complete reproduction is to install the phi-3-mini-4k-instruct-gguf linked above and then run

```
./llama-cli -m ./models/Phi-3-mini-4k-instruct-q4.gguf --prompt "What kind of thing is a llama? Response: " --no-display-prompt --temp 0 --grammar 'root ::= "animal" | "object"'
```
which will print `animal<|end|>`.

In these cases, manually set the token's `attr` to `LLAMA_TOKEN_ATTR_CONTROL` so that we know not to print it. That fixes the above repro to correctly print just `animal`.