### PR TITLE
llama : fix empty ring buffer push

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -145,7 +145,7 @@ struct gpt_sampler * gpt_sampler_init(const struct llama_model * model, const st
         /* .params = */ params,
         /* .grmr   = */ llama_sampler_init_grammar(model, params.grammar.c_str(), "root"),
         /* .chain  = */ llama_sampler_chain_init(lparams),
-        /* .prev   = */ ring_buffer<llama_token>(params.n_prev),
+        /* .prev   = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
         /* .cur    = */ {},
         /* .cur_p  = */ {},
     };

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -1226,7 +1226,9 @@ static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .name   = */ [](const struct llama_sampler * /*smpl*/) { return "penalties"; },
     /* .accept = */ [](struct llama_sampler * smpl, llama_token token) {
         auto * ctx = (llama_sampler_penalties *) smpl->ctx;
-        ctx->prev.push_back(token);
+        if (ctx->prev.size()) {
+            ctx->prev.push_back(token);
+        }
     },
     /* .apply  = */ [](struct llama_sampler * smpl, llama_token_data_array * cur_p) {
         auto * ctx = (llama_sampler_penalties *) smpl->ctx;


### PR DESCRIPTION
fix #9356
cont #9294 

Pushing to 0-sized ring buffer caused division by zero

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
