### PR TITLE
naming : normalize the name of callback-related identifiers

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1018,7 +1018,7 @@ struct llama_context_params llama_context_params_from_gpt_params(const gpt_param
     cparams.attention_type    = params.attention_type;
     cparams.defrag_thold      = params.defrag_thold;
     cparams.cb_eval           = params.cb_eval;
-    cparams.cb_eval_user_data = params.cb_eval_user_data;
+    cparams.cb_eval_ctx       = params.cb_eval_ctx;
     cparams.offload_kqv       = !params.no_kv_offload;
     cparams.flash_attn        = params.flash_attn;
     cparams.no_perf           = params.no_perf;

--- a/common/common.h
+++ b/common/common.h
@@ -173,8 +173,8 @@ struct gpt_params {
     struct cpu_params draft_cpuparams;
     struct cpu_params draft_cpuparams_batch;
 
-    ggml_backend_sched_eval_callback cb_eval = nullptr;
-    void * cb_eval_user_data                 = nullptr;
+    ggml_backend_sched_eval_callback cb_eval     = nullptr;
+    void *                           cb_eval_ctx = nullptr;
 
     ggml_numa_strategy numa = GGML_NUMA_STRATEGY_DISABLED;
 

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -602,7 +602,7 @@ int main(int argc, char ** argv) {
     // pass the callback to the backend scheduler
     // it will be executed for each node during the graph computation
     params.cb_eval = ik_collect_imatrix;
-    params.cb_eval_user_data = NULL;
+    params.cb_eval_ctx = NULL;
     params.warmup = false;
 
     // init

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -104,7 +104,7 @@ extern "C" {
     GGML_API GGML_CALL bool ggml_backend_is_cpu                (ggml_backend_t backend);
     GGML_API           void ggml_backend_cpu_set_n_threads     (ggml_backend_t backend_cpu, int n_threads);
     GGML_API           void ggml_backend_cpu_set_threadpool    (ggml_backend_t backend_cpu, ggml_threadpool_t threadpool);
-    GGML_API           void ggml_backend_cpu_set_abort_callback(ggml_backend_t backend_cpu, ggml_abort_callback abort_callback, void * abort_callback_data);
+    GGML_API           void ggml_backend_cpu_set_abort_callback(ggml_backend_t backend_cpu, ggml_abort_callback cb, void * cb_ctx);
 
     // Create a backend buffer from an existing pointer
     GGML_API GGML_CALL ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
@@ -177,7 +177,7 @@ extern "C" {
     // when ask == false, the scheduler is passing the node tensor to the user for observation
     // if the user returns false, the scheduler will cancel the graph compute
     //
-    typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * user_data);
+    typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * cb_ctx);
 
     // Initialize a backend scheduler
     GGML_API ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, ggml_backend_buffer_type_t * bufts, int n_backends, size_t graph_size, bool parallel);
@@ -208,7 +208,7 @@ extern "C" {
     GGML_API void                 ggml_backend_sched_reset(ggml_backend_sched_t sched);
 
     // Set a callback to be called for each resulting node during graph compute
-    GGML_API void                 ggml_backend_sched_set_eval_callback(ggml_backend_sched_t sched, ggml_backend_sched_eval_callback callback, void * user_data);
+    GGML_API void                 ggml_backend_sched_set_eval_callback(ggml_backend_sched_t sched, ggml_backend_sched_eval_callback cb, void * cb_ctx);
 
     //
     // Utils
@@ -225,10 +225,10 @@ extern "C" {
     GGML_API struct ggml_backend_graph_copy ggml_backend_graph_copy(ggml_backend_t backend, struct ggml_cgraph * graph);
     GGML_API void                           ggml_backend_graph_copy_free(struct ggml_backend_graph_copy copy);
 
-    typedef bool (*GGML_CALL ggml_backend_eval_callback)(int node_index, struct ggml_tensor * t1, struct ggml_tensor * t2, void * user_data);
+    typedef bool (*GGML_CALL ggml_backend_eval_callback)(int node_index, struct ggml_tensor * t1, struct ggml_tensor * t2, void * cb_ctx);
 
     // Compare the output of two backends
-    GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data);
+    GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback cb_eval, void * cb_eval_ctx);
 
     // Tensor initialization
     GGML_API void ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);

--- a/ggml/include/ggml-metal.h
+++ b/ggml/include/ggml-metal.h
@@ -40,7 +40,7 @@ extern "C" {
 // user-code should use only these functions
 //
 
-GGML_API void ggml_backend_metal_log_set_callback(ggml_log_callback log_callback, void * user_data);
+GGML_API void ggml_backend_metal_log_set_callback(ggml_log_callback cb, void * cb_ctx);
 
 GGML_API ggml_backend_t ggml_backend_metal_init(void);
 
@@ -50,7 +50,7 @@ GGML_API GGML_CALL ggml_backend_buffer_t ggml_backend_metal_buffer_from_ptr(void
 
 GGML_API void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb);
 
-GGML_API void ggml_backend_metal_set_abort_callback(ggml_backend_t backend, ggml_abort_callback abort_callback, void * user_data);
+GGML_API void ggml_backend_metal_set_abort_callback(ggml_backend_t backend, ggml_abort_callback cb, void * cb_ctx);
 
 GGML_API GGML_CALL ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void);
 

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -620,7 +620,7 @@ extern "C" {
     // Abort callback
     // If not NULL, called before ggml computation
     // If it returns true, the computation is aborted
-    typedef bool (*ggml_abort_callback)(void * data);
+    typedef bool (*ggml_abort_callback)(void * cb_ctx);
 
     // Scheduling priorities
     enum ggml_sched_priority {
@@ -655,8 +655,8 @@ extern "C" {
         struct ggml_threadpool * threadpool;
 
         // abort ggml_graph_compute when true
-        ggml_abort_callback abort_callback;
-        void *              abort_callback_data;
+        ggml_abort_callback cb_abort;
+        void *              cb_abort_ctx;
     };
 
     // scratch buffer
@@ -2143,8 +2143,8 @@ extern "C" {
         GGML_LINESEARCH_INVALID_PARAMETERS,
     };
 
-    typedef void (*ggml_opt_callback)(void * data, int accum_step, float * sched, bool * cancel);
-    typedef void (*ggml_log_callback)(enum ggml_log_level level, const char * text, void * user_data);
+    typedef void (*ggml_opt_callback)(void * cb_ctx, int accum_step, float * sched, bool * cancel);
+    typedef void (*ggml_log_callback)(enum ggml_log_level level, const char * text, void * cb_ctx);
 
     // optimization parameters
     //
@@ -2281,8 +2281,8 @@ extern "C" {
             struct ggml_tensor * f,
             struct ggml_cgraph * gf,
             struct ggml_cgraph * gb,
-            ggml_opt_callback callback,
-            void * callback_data);
+            ggml_opt_callback cb_opt,
+            void * cb_opt_ctx);
 
     //
     // tensor flags

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -2183,17 +2183,17 @@ static ggml_backend_buffer_type_t llama_default_buffer_type_cpu(bool host_buffer
 struct llama_state {
     llama_state() {
 #ifdef GGML_USE_METAL
-        ggml_backend_metal_log_set_callback(log_callback, log_callback_user_data);
+        ggml_backend_metal_log_set_callback(cb_log, cb_log_ctx);
 #elif defined(GGML_USE_CUDA)
-        ggml_backend_cuda_log_set_callback(log_callback, log_callback_user_data);
+        ggml_backend_cuda_log_set_callback(cb_log, cb_log_ctx);
 #elif defined(GGML_USE_CANN)
-        ggml_backend_cann_log_set_callback(log_callback, log_callback_user_data);
+        ggml_backend_cann_log_set_callback(cb_log, cb_log_ctx);
 #endif
     }
 
     // We save the log callback globally
-    ggml_log_callback log_callback = llama_log_callback_default;
-    void * log_callback_user_data = nullptr;
+    ggml_log_callback cb_log     = llama_log_callback_default;
+    void *            cb_log_ctx = nullptr;
 };
 
 static llama_state g_state;
@@ -2491,7 +2491,7 @@ struct llama_cparams {
     enum llama_pooling_type pooling_type;
 
     ggml_backend_sched_eval_callback cb_eval;
-    void * cb_eval_user_data;
+    void *                           cb_eval_ctx;
 };
 
 // TODO: separate into "llama_layer_enc" and "llama_layer_dec"
@@ -3263,8 +3263,8 @@ struct llama_context {
     std::vector<uint8_t> buf_compute_meta;
     ggml_backend_sched_t sched = nullptr;
 
-    ggml_abort_callback abort_callback      = nullptr;
-    void *              abort_callback_data = nullptr;
+    ggml_abort_callback cb_abort     = nullptr;
+    void *              cb_abort_ctx = nullptr;
 
     // input tensors
     struct ggml_tensor * inp_tokens;      // I32 [n_batch]
@@ -4901,13 +4901,13 @@ struct llama_model_loader {
     size_t size_data = 0;
     std::vector<std::pair<size_t, size_t>> mmaps_used;
 
-    // Returns false if cancelled by progress_callback
+    // Returns false if cancelled by cb_progress
     bool load_all_data(
             struct ggml_context * ctx,
             llama_buf_map & bufs_mmap,
             llama_mlocks * lmlocks,
-            llama_progress_callback progress_callback,
-            void * progress_callback_user_data) {
+            llama_progress_callback cb_progress,
+            void * cb_progress_ctx) {
         GGML_ASSERT(size_data != 0 && "call init_mappings() first");
 
         std::vector<no_init<uint8_t>> read_buf;
@@ -4958,8 +4958,8 @@ struct llama_model_loader {
                 continue;
             }
 
-            if (progress_callback) {
-                if (!progress_callback((float) size_done / size_data, progress_callback_user_data)) {
+            if (cb_progress) {
+                if (!cb_progress((float) size_done / size_data, cb_progress_ctx)) {
                     return false;
                 }
             }
@@ -5081,10 +5081,10 @@ struct llama_model_loader {
                     }
                 }
             }
-            if (progress_callback) {
+            if (cb_progress) {
                 // Even though the model is done loading, we still honor
                 // cancellation since we need to free allocations.
-                return progress_callback(1.0f, progress_callback_user_data);
+                return cb_progress(1.0f, cb_progress_ctx);
             }
         }
 
@@ -6651,7 +6651,7 @@ static void llm_load_print_meta(llama_model_loader & ml, llama_model & model) {
     }
 }
 
-// Returns false if cancelled by progress_callback
+// Returns false if cancelled by cb_progress
 static bool llm_load_tensors(
         llama_model_loader & ml,
         llama_model & model,
@@ -6660,8 +6660,8 @@ static bool llm_load_tensors(
         int main_gpu,
         const float * tensor_split,
         bool use_mlock,
-        llama_progress_callback progress_callback,
-        void * progress_callback_user_data) {
+        llama_progress_callback cb_progress,
+        void * cb_progress_ctx) {
     auto & hparams = model.hparams;
 
     model.split_mode   = split_mode;
@@ -8581,7 +8581,7 @@ static bool llm_load_tensors(
     for (auto & it : ctx_bufs) {
         ggml_context * ctx = it.first;
         auto & bufs = it.second;
-        if (!ml.load_all_data(ctx, bufs, use_mlock ? &model.mlock_mmaps : NULL, progress_callback, progress_callback_user_data)) {
+        if (!ml.load_all_data(ctx, bufs, use_mlock ? &model.mlock_mmaps : NULL, cb_progress, cb_progress_ctx)) {
             return false;
         }
     }
@@ -8595,7 +8595,7 @@ static bool llm_load_tensors(
     return true;
 }
 
-// Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
+// Returns 0 on success, -1 on error, and -2 on cancellation via llama_cb_progress
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     model.t_start_us = ggml_time_us();
 
@@ -8651,7 +8651,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
 
         if (!llm_load_tensors(
             ml, model, params.n_gpu_layers, params.split_mode,  params.main_gpu, params.tensor_split, params.use_mlock,
-            params.progress_callback, params.progress_callback_user_data
+            params.cb_progress, params.cb_progress_ctx
         )) {
             return -2;
         }
@@ -16046,9 +16046,9 @@ static void llama_graph_compute(
 #endif
 
     if (lctx.backend_cpu != nullptr) {
-        ggml_backend_cpu_set_n_threads(lctx.backend_cpu, n_threads);
-        ggml_backend_cpu_set_threadpool(lctx.backend_cpu, threadpool);
-        ggml_backend_cpu_set_abort_callback(lctx.backend_cpu, lctx.abort_callback, lctx.abort_callback_data);
+        ggml_backend_cpu_set_n_threads     (lctx.backend_cpu, n_threads);
+        ggml_backend_cpu_set_threadpool    (lctx.backend_cpu, threadpool);
+        ggml_backend_cpu_set_abort_callback(lctx.backend_cpu, lctx.cb_abort, lctx.cb_abort_ctx);
     }
 #ifdef GGML_USE_BLAS
     if (lctx.backend_blas != nullptr) {
@@ -16208,7 +16208,7 @@ static int llama_decode_internal(
         //printf("kv_self.n = %5d, kv_self.used = %5d, kv_self.head = %5d\n", kv_self.n, kv_self.used, kv_self.head);
 
         ggml_backend_sched_reset(lctx.sched);
-        ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
+        ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_ctx);
 
         ggml_cgraph * gf = llama_build_graph(lctx, ubatch, false);
 
@@ -16432,7 +16432,7 @@ static int llama_encode_internal(
     GGML_ASSERT(n_threads > 0);
 
     ggml_backend_sched_reset(lctx.sched);
-    ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
+    ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_ctx);
 
     ggml_cgraph * gf = llama_build_graph(lctx, ubatch, false);
 
@@ -17907,8 +17907,8 @@ struct llama_model_params llama_model_default_params() {
         /*.main_gpu                    =*/ 0,
         /*.tensor_split                =*/ nullptr,
         /*.rpc_servers                 =*/ nullptr,
-        /*.progress_callback           =*/ nullptr,
-        /*.progress_callback_user_data =*/ nullptr,
+        /*.cb_progress                 =*/ nullptr,
+        /*.cb_progress_ctx             =*/ nullptr,
         /*.kv_overrides                =*/ nullptr,
         /*.vocab_only                  =*/ false,
         /*.use_mmap                    =*/ true,
@@ -17943,17 +17943,17 @@ struct llama_context_params llama_context_default_params() {
         /*.yarn_beta_slow              =*/ 1.0f,
         /*.yarn_orig_ctx               =*/ 0,
         /*.defrag_thold                =*/ -1.0f,
-        /*.cb_eval                     =*/ nullptr,
-        /*.cb_eval_user_data           =*/ nullptr,
         /*.type_k                      =*/ GGML_TYPE_F16,
         /*.type_v                      =*/ GGML_TYPE_F16,
+        /*.cb_eval                     =*/ nullptr,
+        /*.cb_eval_ctx                 =*/ nullptr,
+        /*.cb_abort                    =*/ nullptr,
+        /*.cb_abort_ctx                =*/ nullptr,
         /*.logits_all                  =*/ false,
         /*.embeddings                  =*/ false,
         /*.offload_kqv                 =*/ true,
         /*.flash_attn                  =*/ false,
         /*.no_perf                     =*/ true,
-        /*.abort_callback              =*/ nullptr,
-        /*.abort_callback_data         =*/ nullptr,
     };
 
     return result;
@@ -18067,9 +18067,9 @@ struct llama_model * llama_load_model_from_file(
     llama_model * model = new llama_model;
 
     unsigned cur_percentage = 0;
-    if (params.progress_callback == NULL) {
-        params.progress_callback_user_data = &cur_percentage;
-        params.progress_callback = [](float progress, void * ctx) {
+    if (params.cb_progress == NULL) {
+        params.cb_progress_ctx = &cur_percentage;
+        params.cb_progress = [](float progress, void * ctx) {
             unsigned * cur_percentage_p = (unsigned *) ctx;
             unsigned percentage = (unsigned) (100 * progress);
             while (percentage > *cur_percentage_p) {
@@ -18189,8 +18189,8 @@ struct llama_context * llama_new_context_with_model(
                                hparams.n_ctx_orig_yarn != 0 ? hparams.n_ctx_orig_yarn :
                                                               hparams.n_ctx_train;
 
-    cparams.cb_eval           = params.cb_eval;
-    cparams.cb_eval_user_data = params.cb_eval_user_data;
+    cparams.cb_eval     = params.cb_eval;
+    cparams.cb_eval_ctx = params.cb_eval_ctx;
 
     auto rope_scaling_type = params.rope_scaling_type;
     if (rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
@@ -18228,8 +18228,8 @@ struct llama_context * llama_new_context_with_model(
     LLAMA_LOG_INFO("%s: freq_base  = %.1f\n",   __func__, cparams.rope_freq_base);
     LLAMA_LOG_INFO("%s: freq_scale = %g\n",     __func__, cparams.rope_freq_scale);
 
-    ctx->abort_callback      = params.abort_callback;
-    ctx->abort_callback_data = params.abort_callback_data;
+    ctx->cb_abort     = params.cb_abort;
+    ctx->cb_abort_ctx = params.cb_abort_ctx;
 
     ctx->logits_all = params.logits_all;
 
@@ -19971,9 +19971,9 @@ int32_t llama_n_threads_batch(struct llama_context * ctx) {
     return ctx->cparams.n_threads_batch;
 }
 
-void llama_set_abort_callback(struct llama_context * ctx, bool (*abort_callback)(void * data), void * abort_callback_data) {
-    ctx->abort_callback      = abort_callback;
-    ctx->abort_callback_data = abort_callback_data;
+void llama_set_abort_callback(struct llama_context * ctx, bool (*cb)(void * data), void * cb_ctx) {
+    ctx->cb_abort     = cb;
+    ctx->cb_abort_ctx = cb_ctx;
 }
 
 void llama_set_embeddings(struct llama_context * ctx, bool embeddings) {
@@ -20761,15 +20761,15 @@ const std::vector<std::pair<std::string, struct ggml_tensor *>> & llama_internal
     return ctx->model.tensors_by_name;
 }
 
-void llama_log_set(ggml_log_callback log_callback, void * user_data) {
-    g_state.log_callback = log_callback ? log_callback : llama_log_callback_default;
-    g_state.log_callback_user_data = user_data;
+void llama_log_set(ggml_log_callback cb, void * cb_ctx) {
+    g_state.cb_log     = cb ? cb : llama_log_callback_default;
+    g_state.cb_log_ctx = cb_ctx;
 #ifdef GGML_USE_METAL
-    ggml_backend_metal_log_set_callback(g_state.log_callback, g_state.log_callback_user_data);
+    ggml_backend_metal_log_set_callback(g_state.cb_log, g_state.cb_log_ctx);
 #elif defined(GGML_USE_CUDA)
-    ggml_backend_cuda_log_set_callback(g_state.log_callback, g_state.log_callback_user_data);
+    ggml_backend_cuda_log_set_callback(g_state.cb_log, g_state.cb_log_ctx);
 #elif defined(GGML_USE_CANN)
-    ggml_backend_cann_log_set_callback(g_state.log_callback, g_state.log_callback_user_data);
+    ggml_backend_cann_log_set_callback(g_state.cb_log, g_state.cb_log_ctx);
 #endif
 }
 
@@ -20779,12 +20779,12 @@ static void llama_log_internal_v(ggml_log_level level, const char * format, va_l
     char buffer[128];
     int len = vsnprintf(buffer, 128, format, args);
     if (len < 128) {
-        g_state.log_callback(level, buffer, g_state.log_callback_user_data);
+        g_state.cb_log(level, buffer, g_state.cb_log_ctx);
     } else {
         char * buffer2 = new char[len + 1];
         vsnprintf(buffer2, len + 1, format, args_copy);
         buffer2[len] = 0;
-        g_state.log_callback(level, buffer2, g_state.log_callback_user_data);
+        g_state.cb_log(level, buffer2, g_state.cb_log_ctx);
         delete[] buffer2;
     }
     va_end(args_copy);
@@ -20797,9 +20797,9 @@ void llama_log_internal(ggml_log_level level, const char * format, ...) {
     va_end(args);
 }
 
-void llama_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
+void llama_log_callback_default(ggml_log_level level, const char * text, void * cb_ctx) {
     (void) level;
-    (void) user_data;
+    (void) cb_ctx;
     fputs(text, stderr);
     fflush(stderr);
 }

--- a/tests/test-model-load-cancel.cpp
+++ b/tests/test-model-load-cancel.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[] ) {
     llama_backend_init();
     auto params = llama_model_params{};
     params.use_mmap = false;
-    params.progress_callback = [](float progress, void * ctx){
+    params.cb_progress = [](float progress, void * ctx){
         (void) ctx;
         return progress > 0.50;
     };


### PR DESCRIPTION
Renames identifiers into the following convention:

```c
foo_callback cb_foo;
void *       cb_foo_ctx;
```

Or when the callback context is unambiguous, simply to:

```c
void foo_set(foo_callback cb, void * cb_ctx);
```

Request for comments: is this change worth it?
