### PR TITLE
IBM Granite Architecture

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4081,7 +4081,7 @@ class ExaoneModel(Model):
 
 
 @Model.register("GraniteForCausalLM")
-class GraniteModel(Model):
+class GraniteModel(LlamaModel):
     """Conversion for IBM's GraniteForCausalLM"""
     model_arch = gguf.MODEL_ARCH.GRANITE
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4090,20 +4090,22 @@ class GraniteModel(LlamaModel):
 
         - No head_dim support
         - New multiplier params:
-            - attention_multiplier
-            - embedding_multiplier
-            - residual_multiplier
+            - attention_scale
+            - embedding_scale
+            - residual_scale
         - logits_scaling
         """
         if head_dim := self.hparams.pop("head_dim", None):
             logger.warning("Ignoring head_dim (%s) from config for Granite", head_dim)
         super().set_gguf_parameters()
-        if attention_multiplier := self.hparams.get("attention_multiplier"):
-            self.gguf_writer.add_attention_multiplier(attention_multiplier)
-        if embedding_multiplier := self.hparams.get("embedding_multiplier"):
-            self.gguf_writer.add_embedding_multiplier(embedding_multiplier)
-        if residual_multiplier := self.hparams.get("residual_multiplier"):
-            self.gguf_writer.add_residual_multiplier(residual_multiplier)
+        # NOTE: Convert _multiplier params to _scale params for naming
+        #   consistency
+        if attention_scale := self.hparams.get("attention_multiplier"):
+            self.gguf_writer.add_attention_scale(attention_scale)
+        if embedding_scale := self.hparams.get("embedding_multiplier"):
+            self.gguf_writer.add_embedding_scale(embedding_scale)
+        if residual_scale := self.hparams.get("residual_multiplier"):
+            self.gguf_writer.add_residual_scale(residual_scale)
         if logits_scaling := self.hparams.get("logits_scaling"):
             self.gguf_writer.add_logit_scale(logits_scaling)
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -97,8 +97,8 @@ class Keys:
         RESCALE_EVERY_N_LAYERS            = "{arch}.rescale_every_n_layers"
         TIME_MIX_EXTRA_DIM                = "{arch}.time_mix_extra_dim"
         TIME_DECAY_EXTRA_DIM              = "{arch}.time_decay_extra_dim"
-        RESIDUAL_MULTIPLIER               = "{arch}.residual_multiplier"
-        EMBEDDING_MULTIPLIER              = "{arch}.embedding_multiplier"
+        RESIDUAL_SCALE                    = "{arch}.residual_scale"
+        EMBEDDING_SCALE                   = "{arch}.embedding_scale"
 
     class Attention:
         HEAD_COUNT        = "{arch}.attention.head_count"
@@ -114,7 +114,7 @@ class Keys:
         KV_LORA_RANK      = "{arch}.attention.kv_lora_rank"
         REL_BUCKETS_COUNT = "{arch}.attention.relative_buckets_count"
         SLIDING_WINDOW    = "{arch}.attention.sliding_window"
-        MULTIPLIER        = "{arch}.attention.multiplier"
+        SCALE             = "{arch}.attention.scale"
 
     class Rope:
         DIMENSION_COUNT         = "{arch}.rope.dimension_count"

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -97,6 +97,8 @@ class Keys:
         RESCALE_EVERY_N_LAYERS            = "{arch}.rescale_every_n_layers"
         TIME_MIX_EXTRA_DIM                = "{arch}.time_mix_extra_dim"
         TIME_DECAY_EXTRA_DIM              = "{arch}.time_decay_extra_dim"
+        RESIDUAL_MULTIPLIER               = "{arch}.residual_multiplier"
+        EMBEDDING_MULTIPLIER              = "{arch}.embedding_multiplier"
 
     class Attention:
         HEAD_COUNT        = "{arch}.attention.head_count"
@@ -112,6 +114,7 @@ class Keys:
         KV_LORA_RANK      = "{arch}.attention.kv_lora_rank"
         REL_BUCKETS_COUNT = "{arch}.attention.relative_buckets_count"
         SLIDING_WINDOW    = "{arch}.attention.sliding_window"
+        MULTIPLIER        = "{arch}.attention.multiplier"
 
     class Rope:
         DIMENSION_COUNT         = "{arch}.rope.dimension_count"
@@ -231,6 +234,7 @@ class MODEL_ARCH(IntEnum):
     JAIS         = auto()
     NEMOTRON     = auto()
     EXAONE       = auto()
+    GRANITE      = auto()
 
 
 class MODEL_TENSOR(IntEnum):
@@ -387,6 +391,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.JAIS:           "jais",
     MODEL_ARCH.NEMOTRON:       "nemotron",
     MODEL_ARCH.EXAONE:         "exaone",
+    MODEL_ARCH.GRANITE:        "granite",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
@@ -1219,6 +1224,19 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.ATTN_V,
         MODEL_TENSOR.ATTN_OUT,
         MODEL_TENSOR.ATTN_ROT_EMBD,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_GATE,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
+    ],
+    MODEL_ARCH.GRANITE: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
         MODEL_TENSOR.FFN_NORM,
         MODEL_TENSOR.FFN_GATE,
         MODEL_TENSOR.FFN_DOWN,

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -679,11 +679,11 @@ class GGUFWriter:
     def add_time_decay_extra_dim(self, dim: int) -> None:
         self.add_uint32(Keys.LLM.TIME_DECAY_EXTRA_DIM.format(arch=self.arch), dim)
 
-    def add_residual_multiplier(self, value: float) -> None:
-        self.add_float32(Keys.LLM.RESIDUAL_MULTIPLIER.format(arch=self.arch), value)
+    def add_residual_scale(self, value: float) -> None:
+        self.add_float32(Keys.LLM.RESIDUAL_SCALE.format(arch=self.arch), value)
 
-    def add_embedding_multiplier(self, value: float) -> None:
-        self.add_float32(Keys.LLM.EMBEDDING_MULTIPLIER.format(arch=self.arch), value)
+    def add_embedding_scale(self, value: float) -> None:
+        self.add_float32(Keys.LLM.EMBEDDING_SCALE.format(arch=self.arch), value)
 
     def add_wkv_head_size(self, size: int) -> None:
         self.add_uint32(Keys.WKV.HEAD_SIZE.format(arch=self.arch), size)
@@ -709,8 +709,8 @@ class GGUFWriter:
     def add_sliding_window(self, value: int) -> None:
         self.add_uint32(Keys.Attention.SLIDING_WINDOW.format(arch=self.arch), value)
 
-    def add_attention_multiplier(self, value: float) -> None:
-        self.add_float32(Keys.Attention.MULTIPLIER.format(arch=self.arch), value)
+    def add_attention_scale(self, value: float) -> None:
+        self.add_float32(Keys.Attention.SCALE.format(arch=self.arch), value)
 
     def add_pooling_type(self, value: PoolingType) -> None:
         self.add_uint32(Keys.LLM.POOLING_TYPE.format(arch=self.arch), value.value)

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -679,6 +679,12 @@ class GGUFWriter:
     def add_time_decay_extra_dim(self, dim: int) -> None:
         self.add_uint32(Keys.LLM.TIME_DECAY_EXTRA_DIM.format(arch=self.arch), dim)
 
+    def add_residual_multiplier(self, value: float) -> None:
+        self.add_float32(Keys.LLM.RESIDUAL_MULTIPLIER.format(arch=self.arch), value)
+
+    def add_embedding_multiplier(self, value: float) -> None:
+        self.add_float32(Keys.LLM.EMBEDDING_MULTIPLIER.format(arch=self.arch), value)
+
     def add_wkv_head_size(self, size: int) -> None:
         self.add_uint32(Keys.WKV.HEAD_SIZE.format(arch=self.arch), size)
 
@@ -702,6 +708,9 @@ class GGUFWriter:
 
     def add_sliding_window(self, value: int) -> None:
         self.add_uint32(Keys.Attention.SLIDING_WINDOW.format(arch=self.arch), value)
+
+    def add_attention_multiplier(self, value: float) -> None:
+        self.add_float32(Keys.Attention.MULTIPLIER.format(arch=self.arch), value)
 
     def add_pooling_type(self, value: PoolingType) -> None:
         self.add_uint32(Keys.LLM.POOLING_TYPE.format(arch=self.arch), value.value)

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5455,7 +5455,7 @@ static void llm_load_hparams(
                         // granite uses a vocab with len 49152
                         case 32: model.type = hparams.n_vocab == 49152 ? e_model::MODEL_3B : (hparams.n_vocab < 40000 ? e_model::MODEL_7B : e_model::MODEL_8B); break;
                         case 36: model.type = e_model::MODEL_8B; break; // granite
-                        case 40: model.type = hparams.n_vocab == 49152 ? e_model::MODEL_3B : e_model::MODEL_13B; break;
+                        case 40: model.type = (hparams.n_vocab == 49152 || hparams.n_vocab == 49156) ? e_model::MODEL_3B : e_model::MODEL_13B; break;
                         case 48: model.type = e_model::MODEL_34B; break;
                         case 60: model.type = e_model::MODEL_30B; break;
                         case 80: model.type = hparams.n_head() == hparams.n_head_kv() ? e_model::MODEL_65B : e_model::MODEL_70B; break;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5438,7 +5438,6 @@ static void llm_load_hparams(
     // arch-specific KVs
     switch (model.arch) {
         case LLM_ARCH_LLAMA:
-        case LLM_ARCH_GRANITE:
             {
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
 
@@ -5455,19 +5454,12 @@ static void llm_load_hparams(
                         // granite uses a vocab with len 49152
                         case 32: model.type = hparams.n_vocab == 49152 ? e_model::MODEL_3B : (hparams.n_vocab < 40000 ? e_model::MODEL_7B : e_model::MODEL_8B); break;
                         case 36: model.type = e_model::MODEL_8B; break; // granite
-                        case 40: model.type = (hparams.n_vocab == 49152 || hparams.n_vocab == 49156) ? e_model::MODEL_3B : e_model::MODEL_13B; break;
+                        case 40: model.type = e_model::MODEL_13B; break;
                         case 48: model.type = e_model::MODEL_34B; break;
                         case 60: model.type = e_model::MODEL_30B; break;
                         case 80: model.type = hparams.n_head() == hparams.n_head_kv() ? e_model::MODEL_65B : e_model::MODEL_70B; break;
                         default: model.type = e_model::MODEL_UNKNOWN;
                     }
-                }
-                // Extra multipliers for Granite architecture
-                if (model.arch == LLM_ARCH_GRANITE) {
-                    ml.get_key(LLM_KV_LOGIT_SCALE, hparams.f_logit_scale);
-                    ml.get_key(LLM_KV_RESIDUAL_SCALE, hparams.f_residual_scale);
-                    ml.get_key(LLM_KV_EMBEDDING_SCALE, hparams.f_embedding_scale);
-                    ml.get_key(LLM_KV_ATTENTION_SCALE, hparams.f_attention_scale);
                 }
             } break;
         case LLM_ARCH_MINICPM:
@@ -6056,6 +6048,20 @@ static void llm_load_hparams(
                             default: model.type = e_model::MODEL_UNKNOWN;
                         } break;
                     case 61: model.type = e_model::MODEL_14B; break;
+                    default: model.type = e_model::MODEL_UNKNOWN;
+                }
+            } break;
+        case LLM_ARCH_GRANITE:
+            {
+                ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+                ml.get_key(LLM_KV_LOGIT_SCALE, hparams.f_logit_scale);
+                ml.get_key(LLM_KV_RESIDUAL_SCALE, hparams.f_residual_scale);
+                ml.get_key(LLM_KV_EMBEDDING_SCALE, hparams.f_embedding_scale);
+                ml.get_key(LLM_KV_ATTENTION_SCALE, hparams.f_attention_scale);
+
+                switch (hparams.n_layer) {
+                    case 40: model.type = e_model::MODEL_3B; break;
+                    // Add additional layer/vocab/etc checks here for other model sizes
                     default: model.type = e_model::MODEL_UNKNOWN;
                 }
             } break;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

## Description

This PR introduces the `granite` model architecture from IBM. It emulates the `transformers` changes in [this PR](https://github.com/huggingface/transformers/pull/31502).

The `granite` architecture is closely related to `llama` and therefore reuses many of the existing `llama` code paths. The primary differences are:

1. `embeddings_multiplier`: A scaling factor applied to the input embeddings
2. `attention_multiplier`: A configurable scaling factor applied to the output of each attention block that replaces `1 / sqrt(n_embd_head)`
3. `residual_multiplier`: A scaling factor applied when recombining the attention output with the residual and again when combining the FFN output with the residual
4. `logits_scale`: A scaling factor applied to the final logits before decoding

## Design Decisions/Questions

Since this is my first model addition, there were a couple of design choices that I took my best guess on, but would like to point out for further discussion:

* In `convert_hf_to_gguf.py`, I derived `GraniteModel` from `LlamaModel` to avoid copy-pasting the defaults there. I see that other models derive directly from `Model` and avoid inheritance, so I would be open to following that pattern if it's preferred.
* Parameter naming (`llama.cpp`):
    * There was no clear existing parameter for `embeddings_multiplier`/`attention_multiplier`/`residual_multiplier`, so I opted to use the same names that are used in `transformers`. This does, however, leave an ugly asymmetry with `logits_scale`, so I thought about `*_scale` as well.
    * I noticed that in `llama_hparams`, some variables have a prefix character, while others don't. I opted to follow the `f_` prefix notation, but am happy to remove that if it's not to convention.
* `build_llama`: Similar to using `LlamaModel` as a base class, I opted to make small tweaks to the `build_llama` function rather than copy-paste into a clean-room `build_granite` function with the small deltas.
* Unit Testing: I see that there are not unit tests for each architecture and other model addition PRs don't seem to include them, so I did not either

## Testing

To test the model architecture, I am working with IBM's preview model [ibm/PowerLM-3b](https://huggingface.co/ibm/PowerLM-3b).

```sh
huggingface-cli download ibm/PowerLM-3b --local-dir $HOME/models/powerlm-3b
```

### Conversion

```sh
python convert_hf_to_gguf.py --verbose $HOME/models/powerlm-3b/
```

### Simple Execution

```sh
./build/bin/llama-simple -m $HOME/models/powerlm-3b/powerlm-3B-F16.gguf -p "Write a code to find the maximum value in a list of numbers." -n 100
```

> ASSISTANT: Here's a code to find the maximum value in a list of numbers:
> ```
> def find_max(numbers):
>  max_value = numbers[0]
>  for num in numbers:
>  if num > max_value:
>  max_value = num
>  return max_value
> ```
> This code defines a function called `find_max` that takes a list of numbers as

### Quantization

```sh
./build/bin/llama-quantize $HOME/models/powerlm-3b/powerlm-3B-F16.gguf Q4_K_M

# Simple with the quantized model
./build/bin/llama-simple -m /Users/ghart/models/powerlm-3b/ggml-model-Q4_K_M.gguf -p "Write a code to find the maximum value in a list of numbers." -n 100
```

> ASSISTANT: Sure, here's a code to find the maximum value in a list of numbers:
> ```
> def find_max(numbers):
>  max_value = numbers[0]
>  for num in numbers:
>  if num > max_value:
>  max_value = num
>  return max_value
> ```
> This code defines a function called `find_max` that takes a list of