### PR TITLE
CUDA: fix --split-mode row race condition

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2742,6 +2742,7 @@ struct mmq_args {
     int64_t ne00; int64_t ne01; int64_t stride01;
     int64_t ne10; int64_t ne11; int64_t stride11;
     int64_t ne0;
+    bool use_stream_k;
 };
 
 template<ggml_type type>
@@ -2777,8 +2778,7 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const int ntx = (args.ne11 + mmq_x - 1) / mmq_x;
     const dim3 block_nums_xy_tiling(nty, ntx, 1);
 
-    const bool use_stream_k = cc >= CC_VOLTA && cc < CC_OFFSET_AMD;
-    if (!use_stream_k) {
+    if (!args.use_stream_k) {
         if (args.ne01 % mmq_y == 0) {
             constexpr bool need_check = false;
             mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, shmem, stream>>>


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/8801#issuecomment-2332899701 .

The problem is that `--split-mode row` uses multiple CUDA streams to overlap data transfer with computation but on CUDA GPUs that are Volta or newer each of these streams allocates a temporary buffer for the stream-k fixup. And because it's not safe to allocate temporary buffers with multiple CUDA streams in parallel this leads to a race condition. However, because both stream-k decomposition and `--split-mode row` mitigates tail effects it's fine to just not use stream-k if multiple parallel CUDA streams are in use; the performance difference with 3x RTX 4090 is ~1%.

Long-term it may make sense to think about how we can safely handle multiple parallel CUDA streams. I think a good approach would be to move the parallelism from something CUDA-specific to something at the level of GGML compute graphs. That would also enable the reuse of the code for other backends.