### PR TITLE
add back the --special flag in llama-server

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -818,7 +818,7 @@ gpt_params_context gpt_params_parser_init(gpt_params & params, llama_example ex,
         [](gpt_params & params) {
             params.special = true;
         }
-    ).set_examples({LLAMA_EXAMPLE_MAIN}));
+    ).set_examples({LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER}));
     add_opt(llama_arg(
         {"-cnv", "--conversation"},
         format(


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x ] Low
  - [ ] Medium
  - [ ] High

This PR adds back the --special flag in llama-server.

Use case: llama 3.1 tool calling. Special tags like `<|python_tag|>` are sent to the client which can then execute the code generated by llama 3.1