### PR TITLE
ggml : remove ggml_cplan + rework ggml_cgraph 

### DIFF
--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -183,7 +183,9 @@ static bool clip_llava_handle_patches(clip_ctx * ctx_clip, std::vector<float *> 
     struct ggml_tensor *flatten = ggml_view_2d(model.ctx, permuted_cont, clip_n_mmproj_embd(ctx_clip), num_patches_height * num_patches_width * num_patches_per_side * num_patches_per_side,  size_ele * clip_n_mmproj_embd(ctx_clip), 0);
     // ggml_tensor_printf(flatten,"flatten",__LINE__,false,false);
     ggml_build_forward_expand(gf, flatten);
-    ggml_graph_compute_with_ctx(model.ctx, gf, 1);
+    ggml_graph_prepare(gf, 1, nullptr);
+    ggml_graph_work_init(gf, model.ctx);
+    ggml_graph_compute(gf);
     struct ggml_tensor* result = ggml_graph_node(gf, -1);
 
     memcpy(image_embd_out, image_embd_v[0], clip_embd_nbytes(ctx_clip)); // main image as global context

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2064,7 +2064,7 @@ extern "C" {
     // =================================================================================================
     // CPU-only API for ggml_cgraph
     //
-    // TODO: move as a separate backend
+    // TODO: move to the CPU backend
     // NOTE: avoid using, will be removed
     //
 

--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -751,10 +751,9 @@ GGML_CALL static ggml_backend_buffer_type_t ggml_backend_cpu_get_default_buffer_
     GGML_UNUSED(backend);
 }
 
-// TODO: this struct should no longer be needed
-//       instead, the new ggml_graph_work_init() + ggml_graph_work_free() API should be enough to replace this
-//       for now, keeping the implementation as it is, to avoid making a mistake
 struct ggml_backend_plan_cpu {
+    // TODO: move member from ggml_cgraph here when the public CPU-only API is removed
+
     struct ggml_cgraph cgraph;
 };
 

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -773,6 +773,17 @@ struct ggml_cgraph {
     struct ggml_hash_set visited_hash_set;
 
     enum ggml_cgraph_eval_order order;
+
+    bool      work_own;
+    size_t    work_size; // size of work buffer, calculated by `ggml_graph_plan()`
+    uint8_t * work_data; // work buffer, to be allocated by caller before calling to `ggml_graph_compute()`
+
+    int n_threads;
+    struct ggml_threadpool * threadpool;
+
+    // abort ggml_graph_compute when true
+    ggml_abort_callback abort_callback;
+    void *              abort_callback_data;
 };
 
 struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph, int i0, int i1);

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -774,6 +774,8 @@ struct ggml_cgraph {
 
     enum ggml_cgraph_eval_order order;
 
+    // TODO: after the CPU-only API is removed, we can move the members below to ggml_backend_plan_cpu
+
     bool      work_own;
     size_t    work_size; // size of work buffer, calculated by `ggml_graph_plan()`
     uint8_t * work_data; // work buffer, to be allocated by caller before calling to `ggml_graph_compute()`

--- a/tests/test-grad0.cpp
+++ b/tests/test-grad0.cpp
@@ -242,12 +242,16 @@ static bool check_gradient(
     ggml_graph_cpy(gf, gb);
     ggml_build_backward_expand(ctx0, gf, gb, false);
 
-    ggml_graph_compute_with_ctx(ctx0, gf, n_threads);
+    ggml_graph_prepare(gf, n_threads, nullptr);
+    ggml_graph_work_init(gf, ctx0);
+    ggml_graph_compute(gf);
 
     ggml_graph_reset  (gf);
     ggml_set_f32      (f->grad, 1.0f);
 
-    ggml_graph_compute_with_ctx(ctx0, gb, n_threads);
+    ggml_graph_prepare(gb, n_threads, nullptr);
+    ggml_graph_work_init(gb, ctx0);
+    ggml_graph_compute(gb);
 
     // ggml_graph_dump_dot(gf, NULL, "test-grad0-forward.dot");
     // ggml_graph_dump_dot(gb, gf,  "test-grad0-backward.dot");
@@ -262,13 +266,17 @@ static bool check_gradient(
             const float xp = x0 + eps;
             ggml_set_f32_1d(x[i], k, xp);
 
-            ggml_graph_compute_with_ctx(ctx0, gf, n_threads);
+            ggml_graph_prepare(gf, n_threads, nullptr);
+            ggml_graph_work_init(gf, ctx0);
+            ggml_graph_compute(gf);
 
             const double f0 = ggml_get_f32_1d(f, 0);
 
             ggml_set_f32_1d(x[i], k, xm);
 
-            ggml_graph_compute_with_ctx(ctx0, gf, n_threads);
+            ggml_graph_prepare(gf, n_threads, nullptr);
+            ggml_graph_work_init(gf, ctx0);
+            ggml_graph_compute(gf);
 
             const double f1 = ggml_get_f32_1d(f, 0);
             const double g0 = (f0 - f1)/(2.0*(double) eps);
@@ -301,7 +309,9 @@ static bool check_gradient(
             ggml_graph_reset  (gf);
             ggml_set_f32      (f->grad, 1.0f);
 
-            ggml_graph_compute_with_ctx(ctx0, gb, n_threads);
+            ggml_graph_prepare(gb, n_threads, nullptr);
+            ggml_graph_work_init(gb, ctx0);
+            ggml_graph_compute(gb);
 
             const double g1 = ggml_get_f32_1d(x[i]->grad, k);
 

--- a/tests/test-opt.cpp
+++ b/tests/test-opt.cpp
@@ -113,7 +113,10 @@ int main(void) {
     ggml_build_forward_expand(ge, e);
     ggml_graph_reset(ge);
 
-    ggml_graph_compute_with_ctx(ctx, ge, /*n_threads*/ 1);
+    ggml_graph_prepare(ge, 1, nullptr);
+    ggml_graph_work_init(ge, nullptr);
+    ggml_graph_compute(ge);
+    ggml_graph_work_free(ge);
 
     const float fe = ggml_get_f32_1d(e, 0);
     printf("%s: e = %.4f\n", __func__, fe);
@@ -124,7 +127,10 @@ int main(void) {
 
     ggml_graph_reset(ge);
 
-    ggml_graph_compute_with_ctx(ctx, ge, /*n_threads*/ 1);
+    ggml_graph_prepare(ge, 1, nullptr);
+    ggml_graph_work_init(ge, nullptr);
+    ggml_graph_compute(ge);
+    ggml_graph_work_free(ge);
 
     const float fe_opt = ggml_get_f32_1d(e, 0);
     printf("%s: original  e = %.4f\n", __func__, fe);


### PR DESCRIPTION
target #9408 

- Merge `ggml_cplan` into `ggml_cgraph`
- Rework the `ggml_cgraph` API
- Add comments indicating the CPU-specific `ggml_cgraph` API

I am thinking this could be a step towards removing the CPU-specific `ggml` interface and aligned with the idea from https://github.com/ggerganov/ggml/pull/949#issuecomment-2332714709