### PR TITLE
feat: remove a sampler from a chain

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1056,6 +1056,9 @@ extern "C" {
     LLAMA_API struct llama_sampler * llama_sampler_chain_get(const struct llama_sampler * chain, int32_t i);
     LLAMA_API int                    llama_sampler_chain_n  (const struct llama_sampler * chain);
 
+    // after removing a sampler, the chain will no longer own it, and it will not be freed when the chain is freed
+    LLAMA_API void                   llama_sampler_chain_remove(   struct llama_sampler * chain, int32_t i);
+
     // available samplers:
 
     LLAMA_API struct llama_sampler * llama_sampler_init_greedy     (void);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1057,7 +1057,7 @@ extern "C" {
     LLAMA_API int                    llama_sampler_chain_n  (const struct llama_sampler * chain);
 
     // after removing a sampler, the chain will no longer own it, and it will not be freed when the chain is freed
-    LLAMA_API void                   llama_sampler_chain_remove(   struct llama_sampler * chain, int32_t i);
+    LLAMA_API struct llama_sampler * llama_sampler_chain_remove(   struct llama_sampler * chain, int32_t i);
 
     // available samplers:
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -349,7 +349,7 @@ void llama_sampler_chain_add(struct llama_sampler * chain, struct llama_sampler 
 struct llama_sampler * llama_sampler_chain_get(const struct llama_sampler * chain, int32_t i) {
     const auto * p = (const llama_sampler_chain *) chain->ctx;
 
-    if (i < 0 || i >= (int32_t) p->samplers.size()) {
+    if (i < 0 || (size_t) i >= p->samplers.size()) {
         return nullptr;
     }
 
@@ -359,7 +359,7 @@ struct llama_sampler * llama_sampler_chain_get(const struct llama_sampler * chai
 struct llama_sampler * llama_sampler_chain_remove(struct llama_sampler * chain, int32_t i) {
     auto * p = (llama_sampler_chain *) chain->ctx;
 
-    if (i < 0 || i >= (int32_t) p->samplers.size()) {
+    if (i < 0 || (size_t) i >= p->samplers.size()) {
         return nullptr;
     }
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -356,6 +356,17 @@ struct llama_sampler * llama_sampler_chain_get(const struct llama_sampler * chai
     return p->samplers[i];
 }
 
+void llama_sampler_chain_remove(struct llama_sampler * chain, int32_t i) {
+    auto * p = (llama_sampler_chain *) chain->ctx;
+
+    if (i < 0 || i >= (int32_t) p->samplers.size()) {
+        return;
+    }
+
+    auto * result = p->samplers[i];
+    p->samplers.erase(p->samplers.begin() + i);
+}
+
 int llama_sampler_chain_n(const struct llama_sampler * chain) {
     const auto * p = (const llama_sampler_chain *) chain->ctx;
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -356,15 +356,17 @@ struct llama_sampler * llama_sampler_chain_get(const struct llama_sampler * chai
     return p->samplers[i];
 }
 
-void llama_sampler_chain_remove(struct llama_sampler * chain, int32_t i) {
+struct llama_sampler * llama_sampler_chain_remove(struct llama_sampler * chain, int32_t i) {
     auto * p = (llama_sampler_chain *) chain->ctx;
 
     if (i < 0 || i >= (int32_t) p->samplers.size()) {
-        return;
+        return nullptr;
     }
 
     auto * result = p->samplers[i];
     p->samplers.erase(p->samplers.begin() + i);
+
+    return result;
 }
 
 int llama_sampler_chain_n(const struct llama_sampler * chain) {


### PR DESCRIPTION
This PR makes it possible to remove a sampler from a chain.
This is useful for removing a sampler from before freeing the chain, to keep an existing state of a specific sampler.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
