### PR TITLE
fixed the order of linking libraries for llama-quantize

### DIFF
--- a/examples/quantize/CMakeLists.txt
+++ b/examples/quantize/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TARGET llama-quantize)
 add_executable(${TARGET} quantize.cpp)
 install(TARGETS ${TARGET} RUNTIME)
-target_link_libraries(${TARGET} PRIVATE llama common ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(${TARGET} PRIVATE ../../common)
 target_compile_features(${TARGET} PRIVATE cxx_std_11)


### PR DESCRIPTION
While working on [this](https://github.com/ggerganov/llama.cpp/pull/9339) pr, I discovered that when building with `-DGGML_STATIC=ON` flag, the next error occurs:
```
[99/105] Linking CXX executable bin/llama-quantize
ld: warning: ignoring duplicate libraries: 'src/libllama.a'
```
In this request the library linking order has been corrected to get rid of the error. This order also corresponds to all other examples.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

