### PR TITLE
threadpool: skip polling for unused threads

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ llama_target_and_test(test-grammar-parser.cpp)
 llama_target_and_test(test-llama-grammar.cpp)
 llama_target_and_test(test-grammar-integration.cpp)
 llama_target_and_test(test-grad0.cpp)
+llama_target_and_test(test-barrier.cpp)
 # llama_target_and_test(test-opt.cpp) # SLOW
 llama_target_and_test(test-backend-ops.cpp)
 

--- a/tests/test-barrier.cpp
+++ b/tests/test-barrier.cpp
@@ -1,0 +1,93 @@
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <chrono>
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <vector>
+
+#define MAX_NARGS 2
+
+int main(int argc, char *argv[]) {
+
+    int n_threads = 4;
+    int n_rounds  = 100;
+
+    if (argc > 1) {
+        n_threads = std::atoi(argv[1]);
+    }
+
+    if (argc > 2) {
+        n_rounds  = std::atoi(argv[2]);
+    }
+
+    struct ggml_init_params params = {
+        /* .mem_size   = */ 1024*1024*1024,
+        /* .mem_buffer = */ NULL,
+        /* .no_alloc   = */ false,
+    };
+
+    struct ggml_context * ctx = ggml_init(params);
+
+    // Create graph
+    struct ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    // Lots of small, parallel ops where barriers in between will dominate
+    struct ggml_tensor * out = ggml_new_tensor_1d(ctx, GGML_TYPE_F32,  64);
+    for (int i = 0; i < 1000; i++) {
+        struct ggml_tensor * a = ggml_new_tensor_2d(ctx, GGML_TYPE_Q4_0, 64, 128);
+        out = ggml_mul_mat(ctx, a, out);
+
+        struct ggml_tensor * d = ggml_new_tensor_2d(ctx, GGML_TYPE_Q4_0, 128, 64);
+        out = ggml_mul_mat(ctx, d, out);
+    }
+
+    ggml_build_forward_expand(gf, out);
+    int n_nodes = ggml_graph_n_nodes(gf);
+
+    // Create threadpool
+    struct ggml_threadpool_params tpp  = ggml_threadpool_params_default(n_threads);
+    struct ggml_threadpool* threadpool = ggml_threadpool_new(&tpp);
+    if (!threadpool) {
+        fprintf(stderr, "threadpool create failed : n_threads %d\n", n_threads);
+        exit(1);
+    }
+
+    // Create compute plan
+    struct ggml_cplan cplan = ggml_graph_plan(gf, n_threads, threadpool);
+
+    std::vector<uint8_t> work_data(cplan.work_size);
+    cplan.work_data = work_data.data();
+
+    std::cerr << "graph-compute with"
+              << "\n n_threads: " << n_threads
+              << "\n   n_nodes: " << n_nodes
+              << "\n  n_rounds: " << n_rounds
+              << "\n";
+    // ggml_graph_print(gf);
+
+    // Warmup
+    ggml_graph_compute(gf, &cplan);
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    for (int i=0; i < n_rounds; i++) {
+        ggml_graph_compute(gf, &cplan);
+    }
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    auto usec = std::chrono::duration_cast<std::chrono::microseconds>(t1-t0).count();
+    auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(t1-t0).count();
+    std::cerr << "graph-compute took " << usec << " usec "
+              << "\n " << (float) usec / n_rounds << " usec per-iter"
+              << "\n " << (float) nsec / (n_rounds * n_nodes) << " nsec per-node"
+              << "\n";
+
+    ggml_free(ctx);
+    ggml_threadpool_free(threadpool);
+
+    return 0;
+}

--- a/tests/test-barrier.cpp
+++ b/tests/test-barrier.cpp
@@ -86,8 +86,8 @@ int main(int argc, char *argv[]) {
               << "\n " << (float) nsec / (n_rounds * n_nodes) << " nsec per-node"
               << "\n";
 
-    ggml_free(ctx);
     ggml_threadpool_free(threadpool);
+    ggml_free(ctx);
 
     return 0;
 }


### PR DESCRIPTION
Currently all threads do N polling rounds even if only 1 thread is active (n_threads_cur == 1). 
For smaller graphs/models/prompts the unused threads may end up always polling and never sleeping because we keep getting new graphs to work on. 
 
This PR adds support for skipping the polling for unused threads (ith >= n_threads_cur). They simply go to sleep and we wake them up when we get a new graph to work on. 

`n_threads_cur` is now an `atomic_int` to explicitly tell the compiler and thread sanitizer that it is written from one thread and read from other threads (free from race conditions). All loads and stores use relaxed memory order so there is no additional overhead.

Here are some scenarios with the default build on M2 Max, with debug prints for n_thread updates, and for threads going to sleep.

### Full offload (Metal)   
8 threads are started. Only 1 is active, so the other 7 skip the polling and go to sleep.

```
./llama-cli -m ../gguf/llama-v2-115m.q4_0.gguf --seed 42 -p 'what is the most popular cookie in the world?' -n 4

threadpool: n_threads_cur 1 n_threads 1
 what is the most popular cookie in the world?threadpool: n_threads_cur 8 n_threads 1
thread #1 waiting for work (sleeping)
thread #2 waiting for work (sleeping)
thread #3 waiting for work (sleeping)
thread #5 waiting for work (sleeping)
thread #7 waiting for work (sleeping)
thread #6 waiting for work (sleeping)
thread #4 waiting for work (sleeping)

threadpool: n_threads_cur 1 n_threads 1
thread #1 waiting for work (sleeping)
thread #2 waiting for work (sleeping)
thread #5 waiting for work (sleeping)
thread #3 waiting for work (sleeping)
thread #7 waiting for work (sleeping)
thread #4 waiting for work (sleeping)
thread #6 waiting for work (sleeping)
```

### CPU only 
8 threads are started, and they are all active. hybrid-polling enabled by default prevents them from going to sleep.

```
./llama-cli -m ../gguf/llama-v2-115m.q4_0.gguf --seed 42 -p 'what is the most popular cookie in the world?' -n 4 -ngl 0

threadpool: n_threads_cur 8 n_threads 8
 what is the most popular cookie in the world?threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
```

### No KV offload
8 threads are started, and we alternate between using all 8 and just one for different parts of the graph.

```
./llama-cli -m ../gguf/llama-v2-115m.q4_0.gguf --seed 42 -p 'what is the most popular cookie in the world?' -n 4 -nkvo

threadpool: n_threads_cur 1 n_threads 1
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8

 what is the most popular cookie in the world?threadpool: n_threads_cur 8 n_threads 1
threadpool: n_threads_cur 1 n_threads 8
thread #5 waiting for work (sleeping)
thread #7 waiting for work (sleeping)
thread #6 waiting for work (sleeping)
thread #2 waiting for work (sleeping)
thread #4 waiting for work (sleeping)
thread #3 waiting for work (sleeping)
thread #1 waiting for work (sleeping)
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 8
threadpool: n_threads_cur 8 n_threads 1
threadpool: n_threads_cur 1 n_threads 8
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ x] Low
  - [ ] Medium
  - [ ] High
