### PR TITLE
llama : make cell_id const in inp_s_mask block

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -15826,7 +15826,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_ubatch & batch) {
 
             // clear unused states
             for (int i = 0; i < n_kv; ++i) {
-                uint32_t        cell_id = i + kv_self.head;
+                const uint32_t  cell_id = i + kv_self.head;
                 llama_kv_cell & kv_cell = lctx.kv_self.cells[cell_id];
 
                 data[i] = (float) (kv_cell.src >= 0);


### PR DESCRIPTION
This commit makes the cell_id variable const in the inp_s_mask block.

The motivation for this change is consistency with the code in the inp_s_copy block.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
