### PR TITLE
nvidia uses the LLaMAForCausalLM string in their config.json, example…

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1487,7 +1487,7 @@ class StableLMModel(Model):
                 raise ValueError(f"Unprocessed norms: {norms}")
 
 
-@Model.register("LlamaForCausalLM", "MistralForCausalLM", "MixtralForCausalLM")
+@Model.register("LLaMAForCausalLM", "LlamaForCausalLM", "MistralForCausalLM", "MixtralForCausalLM")
 class LlamaModel(Model):
     model_arch = gguf.MODEL_ARCH.LLAMA
 


### PR DESCRIPTION
Nvidia uses the `LLaMAForCausalLM` string in their config.json so though there's support for LlamaForCausalLM 
`@Model.register("LlamaForCausalLM", "MistralForCausalLM", "MixtralForCausalLM")`
the conversion failes on the case.

I've added the `LLaMAForCausalLM`

Example models with this arch string:
- nvidia/Llama3-ChatQA-2-8B
- nvidia/Llama3-ChatQA-2-70B


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
