### PR TITLE
llama.cpp: Add a missing header for cpp23

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -5,6 +5,7 @@
 #include "unicode.h"
 #include "unicode-data.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
The problem occurs when compiling using cpp23 due to the use of `std::upper_bound`.

If you are interested in adding a matrix for cpp17/23 in the CI I can do that.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
