### PR TITLE
scripts : verify py deps at the start of compare

### DIFF
--- a/scripts/compare-commits.sh
+++ b/scripts/compare-commits.sh
@@ -8,6 +8,9 @@ fi
 set -e
 set -x
 
+# verify at the start that the compare script has all the necessary dependencies installed
+./scripts/compare-llama-bench.py --check
+
 bench_args="${@:3}"
 
 rm -f llama-bench.sqlite > /dev/null

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -92,12 +92,17 @@ help_s = (
     "If the columns are manually specified, then the results for each unique combination of the "
     "specified values are averaged WITHOUT weighing by the --repetitions parameter of llama-bench."
 )
+parser.add_argument("--check", action="store_true", help="check if all required Python libraries are installed")
 parser.add_argument("-s", "--show", help=help_s)
 parser.add_argument("--verbose", action="store_true", help="increase output verbosity")
 
 known_args, unknown_args = parser.parse_known_args()
 
 logging.basicConfig(level=logging.DEBUG if known_args.verbose else logging.INFO)
+
+if known_args.check:
+    # Check if all required Python libraries are installed. Would have failed earlier if not.
+    sys.exit(0)
 
 if unknown_args:
     logger.error(f"Received unknown args: {unknown_args}.\n")


### PR DESCRIPTION
Minor QoL - instead of waiting for the full `./scripts/compare-commits.sh` to finish just to find out that there is a missing python dependency, do the check at the start.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
