### PR TITLE
Imatrix input data should not be unescaped

### DIFF
--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -572,6 +572,7 @@ int main(int argc, char ** argv) {
 
     params.n_ctx = 512;
     params.logits_all = true;
+    params.escape = false;
 
     if (!gpt_params_parse(argc, argv, params, LLAMA_EXAMPLE_IMATRIX, print_usage)) {
         return 1;


### PR DESCRIPTION
At some point prompt input unescaping was turned on by default, which is fine in itself, but imatrix is usually generated from `prompt_file`, which is fed into `params.prompt` and then unescaped, generating bad input data.

This will (and has) go(ne) unnoticed until you have sequences like `\xdef` in your input data, which will throw an "invalid character" error (only with BPE tokenizer).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
