### PR TITLE
server: disable context shift

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -691,7 +691,7 @@ gpt_params_context gpt_params_parser_init(gpt_params & params, llama_example ex,
         [](gpt_params & params) {
             params.ctx_shift = false;
         }
-    ).set_examples({LLAMA_EXAMPLE_MAIN}));
+    ).set_examples({LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER}));
     add_opt(llama_arg(
         {"--chunks"}, "N",
         format("max number of chunks to process (default: %d, -1 = all)", params.n_chunks),

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -37,6 +37,7 @@ The project is under active development, and we are [looking for feedback and co
 | `--poll-batch <0\|1>` | use polling to wait for work (default: same as --poll) |
 | `-c, --ctx-size N` | size of the prompt context (default: 0, 0 = loaded from model)<br/>(env: LLAMA_ARG_CTX_SIZE) |
 | `-n, --predict, --n-predict N` | number of tokens to predict (default: -1, -1 = infinity, -2 = until context filled)<br/>(env: LLAMA_ARG_N_PREDICT) |
+| `--no-context-shift` | stop generation when context window is full (default: context shift is enabled)<br/> |
 | `-b, --batch-size N` | logical maximum batch size (default: 2048)<br/>(env: LLAMA_ARG_BATCH) |
 | `-ub, --ubatch-size N` | physical maximum batch size (default: 512)<br/>(env: LLAMA_ARG_UBATCH) |
 | `--keep N` | number of tokens to keep from the initial prompt (default: 0, -1 = all) |

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1949,7 +1949,7 @@ struct server_context {
                         // context shift is disabled and prompt is too large - discard it
                         if (!params.ctx_shift && (slot.n_prompt_tokens > slot.n_ctx) ){
                             slot.release();
-                            send_error(slot, "Input is too large to process. Enable context shift or increase the context length", ERROR_TYPE_SERVER);
+                            send_error(slot, "Input is too large to process. Either enable context shift or increase the context length.", ERROR_TYPE_SERVER);
                             continue;
                         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1464,11 +1464,10 @@ struct server_context {
         std::vector<server_task_result> results(id_tasks.size());
         for (size_t i = 0; i < id_tasks.size(); i++) {
             server_task_result result = queue_results.recv(id_tasks);
-
             if (result.error) {
                 error_handler(result.data);
                 cancel_tasks(id_tasks);
-                break;
+                return;
             }
 
             size_t idx = result.data["index"];
@@ -1948,9 +1947,9 @@ struct server_context {
                             continue;
                         }
                         // context shift is disabled and prompt is too large - discard it
-                        if (!params.ctx_shift && slot.n_prompt_tokens > slot.n_ctx ){
+                        if (!params.ctx_shift && (slot.n_prompt_tokens > slot.n_ctx) ){
                             slot.release();
-                            send_error(slot, "input is too large to process. enable context shift or increase the context length", ERROR_TYPE_SERVER);
+                            send_error(slot, "Input is too large to process. Enable context shift or increase the context length", ERROR_TYPE_SERVER);
                             continue;
                         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1950,7 +1950,7 @@ struct server_context {
                         // context shift is disabled and prompt is too large - discard it
                         if (!params.ctx_shift && slot.n_prompt_tokens > slot.n_ctx ){
                             slot.release();
-                            send_error(slot, "Input is too large to process. Either disable context shift or increase context length. ", ERROR_TYPE_SERVER);
+                            send_error(slot, "input is too large to process. enable context shift or increase the context length", ERROR_TYPE_SERVER);
                             continue;
                         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1949,7 +1949,7 @@ struct server_context {
                         // context shift is disabled and prompt is too large - discard it
                         if (!params.ctx_shift && (slot.n_prompt_tokens > slot.n_ctx) ){
                             slot.release();
-                            send_error(slot, "Input is too large to process. Either enable context shift or increase the context length.", ERROR_TYPE_SERVER);
+                            send_error(slot, "Input is too large to process. Either enable context shift or increase the context length.", ERROR_TYPE_INVALID_REQUEST);
                             continue;
                         }
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

This enables the `--no-context-shift` argument to be passed to the server.
The server will generate `n_predict` tokens such that `n_predict <=  n_ctx - n_tokens_prompt`.
If `n_tokens_prompts > n_ctx`, an error will be thrown and the slot is discarded.

Implements feature request #9390 
