### PR TITLE
Fix load time calculation error in llama_bench

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1557,6 +1557,8 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             prev_inst = &inst;
+        } else {
+            llama_model_reset_time(lmodel);
         }
 
         llama_context * ctx = llama_new_context_with_model(lmodel, inst.to_llama_cparams());

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1558,7 +1558,8 @@ int main(int argc, char ** argv) {
             }
             prev_inst = &inst;
         } else {
-            llama_model_reset_time(lmodel);
+            // ensure load_time dost not accumulate in llama_bench when not loading the same model
+            llama_reset_model_time(lmodel);
         }
 
         llama_context * ctx = llama_new_context_with_model(lmodel, inst.to_llama_cparams());

--- a/include/llama.h
+++ b/include/llama.h
@@ -414,6 +414,8 @@ extern "C" {
                              const char * path_model,
               struct llama_model_params   params);
 
+    LLAMA_API void llama_model_reset_time(struct llama_model * model);
+
     LLAMA_API void llama_free_model(struct llama_model * model);
 
     // TODO: rename to llama_init_from_model

--- a/include/llama.h
+++ b/include/llama.h
@@ -414,7 +414,7 @@ extern "C" {
                              const char * path_model,
               struct llama_model_params   params);
 
-    LLAMA_API void llama_model_reset_time(struct llama_model * model);
+    LLAMA_API void llama_reset_model_time(struct llama_model * model);
 
     LLAMA_API void llama_free_model(struct llama_model * model);
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -18690,7 +18690,7 @@ struct llama_model * llama_load_model_from_file(
     return model;
 }
 
-void llama_reset_model_time(llama_model * model) {
+void llama_reset_model_time(struct llama_model * model) {
     model->t_start_us = ggml_time_us() - model->t_load_us;
 }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8809,11 +8809,6 @@ static bool llm_load_tensors(
     return true;
 }
 
-void llama_model_reset_time(llama_model * model) {
-    model->t_start_us = ggml_time_us();
-    model->t_load_us = ggml_time_us() - model->t_start_us;
-}
-
 // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     model.t_start_us = ggml_time_us();
@@ -18693,6 +18688,10 @@ struct llama_model * llama_load_model_from_file(
     }
 
     return model;
+}
+
+void llama_reset_model_time(llama_model * model) {
+    model->t_start_us = ggml_time_us() - model->t_load_us;
 }
 
 void llama_free_model(struct llama_model * model) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8809,6 +8809,11 @@ static bool llm_load_tensors(
     return true;
 }
 
+void llama_model_reset_time(llama_model * model) {
+    model->t_start_us = ggml_time_us();
+    model->t_load_us = ggml_time_us() - model->t_start_us;
+}
+
 // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     model.t_start_us = ggml_time_us();


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Fix #9286

Fix load time calculation error in llama_bench when running multi-benchmark with same model. 

From the test results, we can see that the modified load_time remains basically the same and has almost no impact on the benchmark results.



## Test Results:
### load_time Testing
- Command: `./build/bin/llama-bench -m ../gguf_models/llama-2-7b.Q2_K.gguf -n 1,2,4,8,16,32 -p 0 -v`
#### Original
```
llama_perf_context_print:        load time =     172.46 ms
llama_perf_context_print:        load time =     596.39 ms
llama_perf_context_print:        load time =    1362.16 ms
llama_perf_context_print:        load time =    2820.51 ms
llama_perf_context_print:        load time =    5678.16 ms
llama_perf_context_print:        load time =   11295.91 ms

```

#### After modification
```
llama_perf_context_print:        load time =     171.97 ms
llama_perf_context_print:        load time =     171.44 ms
llama_perf_context_print:        load time =     167.02 ms
llama_perf_context_print:        load time =     166.92 ms
llama_perf_context_print:        load time =     168.78 ms
llama_perf_context_print:        load time =     167.03 ms
```

### bench result testing
- Command: `./build/bin/llama-bench -m ../gguf_models/llama-2-7b.Q2_K.gguf -n 1,2,4,8,16,32 -p 0`
#### Original
```
| model                          |       size |     params | backend    | threads |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------: | -------------------: |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg1 |         14.49 ± 0.01 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg2 |         14.48 ± 0.06 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg4 |         14.48 ± 0.02 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg8 |         14.48 ± 0.03 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |          tg16 |         14.47 ± 0.01 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |          tg32 |         14.45 ± 0.00 |

build: 8a308354 (3782)
```

#### After modification
```
| model                          |       size |     params | backend    | threads |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------: | -------------------: |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg1 |         14.49 ± 0.03 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg2 |         14.44 ± 0.04 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg4 |         14.42 ± 0.03 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |           tg8 |         14.47 ± 0.01 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |          tg16 |         14.45 ± 0.02 |
| llama 7B Q2_K - Medium         |   2.63 GiB |     6.74 B | CPU        |       8 |          tg32 |         14.37 ± 0.04 |

build: 216e7d96 (3784)
```