### PR TITLE
metal : use F32 prec for K*Q in vec FA

### DIFF
--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -2631,11 +2631,11 @@ kernel void kernel_flash_attn_ext_vec_f16(
         const short iv3 = iq3 / rv3;
 
         // load the queries from shared memory into local memory
-        half4 mq[D4];
+        float4 mq[D4];
 
         for (short ii = 0; ii < D4; ii += NW) {
             short i = ii + tiisg;
-            mq[i] = sq4[i];
+            mq[i] = (float4) sq4[i];
         }
 
         // pointer to the mask
@@ -2661,11 +2661,11 @@ kernel void kernel_flash_attn_ext_vec_f16(
                     for (short ii = 0; ii < D4; ii += NW) {
                         const short i = ii + tiisg;
 
-                        half4x4 mk;
-                        mk[0] = pk4[i + 0*(nb11/8)];
-                        mk[1] = pk4[i + 1*(nb11/8)];
-                        mk[2] = pk4[i + 2*(nb11/8)];
-                        mk[3] = pk4[i + 3*(nb11/8)];
+                        float4x4 mk;
+                        mk[0] = (float4) pk4[i + 0*(nb11/8)];
+                        mk[1] = (float4) pk4[i + 1*(nb11/8)];
+                        mk[2] = (float4) pk4[i + 2*(nb11/8)];
+                        mk[3] = (float4) pk4[i + 3*(nb11/8)];
 
                         mqk += (float4) (mq[i] * mk);
                     }


### PR DESCRIPTION
Noticed that Qwen2-7B-Instruct with Metal FA produces garbage:

```bash
./llama-cli -m ./models/qwen2-7b-instruct/ggml-model-f16.gguf -p "I believe the meaning of life is" -n 16 -s 1 --temp 0.0 -fa
```

### master

```txt
I believe the meaning of life is tobedtls_x509_crt_new_from_pem() create a new
```

### PR

```txt
I believe the meaning of life is to be happy and to be healthy. I believe that the best way to achieve
```

Seems to be again insufficient precision in the K\*Q multiplication, this time only in the vec FA kernel (it works OK with the non-vec kernel). Should make K\*Q always use F32 precision - proves to be very sensitive operation.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
