### PR TITLE
llama : keep track of all EOG tokens in the vocab

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1570,11 +1570,7 @@ llama_token_attr llama_token_get_attr_impl(const struct llama_vocab & vocab, lla
 }
 
 bool llama_token_is_eog_impl(const struct llama_vocab & vocab, llama_token token) {
-    return token != -1 && (
-        token == llama_token_eos_impl(vocab) ||
-        token == llama_token_eot_impl(vocab) ||
-        token == llama_token_eom_impl(vocab)
-    );
+    return token != -1 && vocab.special_eog_ids.count(token) > 0;
 }
 
 bool llama_token_is_control_impl(const struct llama_vocab & vocab, llama_token token) {

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <map>
+#include <set>
 
 struct llama_vocab {
     using id    = llama_token;
@@ -49,12 +50,15 @@ struct llama_vocab {
     id special_eot_id    = -1; // TODO: move above after "eos_id", and here add "file separator" token
     id special_eom_id    = -1;
 
+    // set of all tokens that cause "end of generation"
+    std::set<id> special_eog_ids;
+
     // tokenizer flags
-    bool tokenizer_add_space_prefix = false;
-    bool tokenizer_add_bos          = false;
-    bool tokenizer_add_eos          = false;
-    bool tokenizer_ignore_merges    = false;
-    bool tokenizer_clean_spaces     = false;  // clean_up_tokenization_spaces
+    bool tokenizer_add_space_prefix           = false;
+    bool tokenizer_add_bos                    = false;
+    bool tokenizer_add_eos                    = false;
+    bool tokenizer_ignore_merges              = false;
+    bool tokenizer_clean_spaces               = false;  // clean_up_tokenization_spaces
     bool tokenizer_remove_extra_whitespaces   = false;
     bool tokenizer_escape_whitespaces         = true;
     bool tokenizer_treat_whitespace_as_suffix = false;


### PR DESCRIPTION
fix https://github.com/ggerganov/llama.cpp/issues/9606

Upon vocab construction, iterate over all tokens and store all that look like a token that might cause an "end of generation" event (e.g. `<EOT>`, `<endoftext>`, `<im_end>`, etc.). `llama_token_is_eog` will now check this set of tokens to determine the EOG status.

Detected EOG tokens are printed like this (`Qwen2.5-Coder`):

```txt
0.00.190.685 I llm_load_print_meta: model size       = 14.19 GiB (16.00 BPW) 
0.00.190.685 I llm_load_print_meta: general.name     = Qwen2.5 Coder 7B Instruct
0.00.190.685 I llm_load_print_meta: BOS token        = 151643 '<|endoftext|>'
0.00.190.686 I llm_load_print_meta: EOS token        = 151645 '<|im_end|>'
0.00.190.686 I llm_load_print_meta: PAD token        = 151643 '<|endoftext|>'
0.00.190.686 I llm_load_print_meta: LF token         = 148848 'ÄĬ'
0.00.190.696 I llm_load_print_meta: EOT token        = 151645 '<|im_end|>'
0.00.190.697 I llm_load_print_meta: EOG token        = 151643 '<|endoftext|>'
0.00.190.697 I llm_load_print_meta: EOG token        = 151645 '<|im_end|>'
0.00.190.698 I llm_load_print_meta: max token length = 256
0.00.190.734 I llm_load_tensors: ggml ctx size =    0.30 MiB
```

This is yet another hack for handling end-of-... tokens. The best way to fix this is to have proper tokenizer configurations, but as discussed in #9606, this is unlikely to happen.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
