### PR TITLE
Add newline after chat example in llama-server

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3179,7 +3179,7 @@ int main(int argc, char ** argv) {
     }
 
     // print sample chat example to make it clear which template is used
-    LOG_INF("%s: chat template, built_in: %d, chat_example: '%s\n'", __func__, params.chat_template.empty(), llama_chat_format_example(ctx_server.model, params.chat_template).c_str());
+    LOG_INF("%s: chat template, built_in: %d, chat_example: '%s'\n", __func__, params.chat_template.empty(), llama_chat_format_example(ctx_server.model, params.chat_template).c_str());
 
     ctx_server.queue_tasks.on_new_task(std::bind(
                 &server_context::process_single_task, &ctx_server, std::placeholders::_1));


### PR DESCRIPTION
Currently llama-server doesn't add a newline after the chat example in the log. Here's an example log output from B3812:
```log
I main: model loaded
I main: chat template, built_in: 1, chat_example: '<|system|>
You are a helpful assistant<|end|>
<|user|>
Hello<|end|>
<|assistant|>
Hi there<|end|>
<|user|>
How are you?<|end|>
<|assistant|>

'I main: server is listening on 127.0.0.1:8080 - starting the main loop
```
This change simple puts a newline after the chat example.
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
