### PR TITLE
ggml : add AVX512DQ requirement for AVX512 builds

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1186,6 +1186,7 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
         endif()
         if (GGML_AVX512)
             list(APPEND ARCH_FLAGS -mavx512f)
+            list(APPEND ARCH_FLAGS -mavx512dq)
             list(APPEND ARCH_FLAGS -mavx512bw)
         endif()
         if (GGML_AVX512_VBMI)


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

#9532 introduces references to `_mm512_inserti32x8`, intrinsic for AVX512DQ instruction `VINSERTI32X8`, while the current CMakeLists.txt only specifies AVX512F and AVX512BW instruction sets. Thus, explicit AVX512 builds will fail with a "target specific option mismatch" error ([example](https://github.com/EZForever/llama.cpp-static/actions/runs/11006901861/job/30561929912)).

This PR adds AVX512DQ as a build requirement. AVX512BW and AVX512DQ instruction sets are always implemented together according to my crude research, so this should not introduce any compatibility problem.