### PR TITLE
[CANN]: Fix crash when running on multiple cann devices

### DIFF
--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -227,6 +227,7 @@ struct ggml_backend_cann_context {
      * @brief Destructor for cleaning up resources.
      */
     ~ggml_backend_cann_context() {
+        ggml_cann_set_device(device);
         if (copy_event != nullptr) {
             ACL_CHECK(aclrtDestroyEvent(copy_event));
         }


### PR DESCRIPTION
This PR fixes a crash that occurred when llama-bench was run on multiple cann devices(#9250).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

before the fix：
![image](https://github.com/user-attachments/assets/66521556-684b-4083-8454-fc341037aabb)

after the fix:
![image](https://github.com/user-attachments/assets/7c7d4af0-457b-47a4-bb89-cadf8bd11b84)



