### PR TITLE
Resurrect Graph & Op Profiler

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -75,6 +75,7 @@ option(GGML_CCACHE "ggml: use ccache if available"       ON)
 option(GGML_ALL_WARNINGS           "ggml: enable all compiler warnings"                   ON)
 option(GGML_ALL_WARNINGS_3RD_PARTY "ggml: enable all compiler warnings in 3rd party libs" OFF)
 option(GGML_GPROF                  "ggml: enable gprof"                                   OFF)
+option(GGML_GRAPH_PROFILER         "ggml: enable internal Graph and Op profiler"          OFF)
 
 # build
 option(GGML_FATAL_WARNINGS    "ggml: enable -Werror flag"    OFF)

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1313,6 +1313,7 @@ add_library(ggml
             ggml-backend.c
             ggml-quants.c
             ggml-quants.h
+            ggml-profile.cpp
             ${GGML_SOURCES_CUDA}      ${GGML_HEADERS_CUDA}
             ${GGML_SOURCES_METAL}     ${GGML_HEADERS_METAL}
             ${GGML_SOURCES_RPC}       ${GGML_HEADERS_RPC}

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -9,6 +9,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_compile_definitions($<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>)
 endif()
 
+if (GGML_GRAPH_PROFILER)
+    add_compile_definitions(GGML_GRAPH_PROFILER)
+endif()
+
 if (NOT MSVC)
     if (GGML_SANITIZE_THREAD)
         add_compile_options(-fsanitize=thread)

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -176,7 +176,7 @@ struct ggml_cgraph {
     struct ggml_tensor ** grads;
     struct ggml_tensor ** leafs;
 
-    struct ggml_profile_data ** prof;
+    struct ggml_profile_data * prof;
 
     struct ggml_hash_set visited_hash_set;
 

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -157,6 +157,17 @@ static size_t ggml_hash_find_or_insert(struct ggml_hash_set * hash_set, struct g
     GGML_ABORT("fatal error");
 }
 
+// op profile data (per op / per thread)
+enum ggml_profile_event {
+    GGML_PROF_OP_START,
+    GGML_PROF_OP_SYNC,
+    GGML_PROF_OP_END
+};
+
+struct ggml_profile_data {
+    uint64_t nsec[GGML_PROF_OP_END + 1]; // event times in nsec
+};
+
 // computation graph
 
 enum ggml_cgraph_eval_order {
@@ -174,12 +185,20 @@ struct ggml_cgraph {
     struct ggml_tensor ** grads;
     struct ggml_tensor ** leafs;
 
+    struct ggml_profile_data ** prof;
+
     struct ggml_hash_set visited_hash_set;
 
     enum ggml_cgraph_eval_order order;
 };
 
 struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph, int i0, int i1);
+
+void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_free(struct ggml_cgraph *cg);
+void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -157,17 +157,6 @@ static size_t ggml_hash_find_or_insert(struct ggml_hash_set * hash_set, struct g
     GGML_ABORT("fatal error");
 }
 
-// op profile data (per op / per thread)
-enum ggml_profile_event {
-    GGML_PROF_OP_START,
-    GGML_PROF_OP_SYNC,
-    GGML_PROF_OP_END
-};
-
-struct ggml_profile_data {
-    uint64_t nsec[GGML_PROF_OP_END + 1]; // event times in nsec
-};
-
 // computation graph
 
 enum ggml_cgraph_eval_order {
@@ -175,6 +164,8 @@ enum ggml_cgraph_eval_order {
     GGML_CGRAPH_EVAL_ORDER_RIGHT_TO_LEFT,
     GGML_CGRAPH_EVAL_ORDER_COUNT
 };
+
+struct ggml_profile_data;
 
 struct ggml_cgraph {
     int size;
@@ -193,12 +184,6 @@ struct ggml_cgraph {
 };
 
 struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph, int i0, int i1);
-
-void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_free(struct ggml_cgraph *cg);
-void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-profile.cpp
+++ b/ggml/src/ggml-profile.cpp
@@ -1,0 +1,140 @@
+#include "ggml-impl.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <chrono>
+
+extern "C" void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads)
+{
+    if (!getenv("GGML_GRAPH_PROFILE")) { return; }
+
+    // The number of threads may change between passes (pp vs tg).
+    // Allocate for max_n_threads for simplicity for now.
+    // TODO: use aligned allocator
+
+    size_t node_size = sizeof(struct ggml_profile_data) * GGML_MAX_N_THREADS;
+    size_t pvec_size = sizeof(std::intptr_t) * cg->n_nodes;
+    size_t data_size = node_size * cg->n_nodes;
+    size_t t_size    = pvec_size + data_size;
+
+    cg->prof = (struct ggml_profile_data **) malloc(t_size);
+    if (!cg->prof) {
+        fprintf(stderr, "ggml-profile: failed to allocate profiling data : n_threads %d n_nodes %d\n", n_threads, cg->n_nodes);
+        return;
+    }
+
+    memset(cg->prof, 0, t_size);
+
+    // init pre-thread pointers
+    uint8_t * data = (uint8_t *) cg->prof + pvec_size;
+    for (int i=0; i < cg->n_nodes; i++) {
+        cg->prof[i] = (struct ggml_profile_data *) data; data += node_size;
+    }
+}
+
+extern "C" void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads)
+{
+    if (!cg->prof) { ggml_profile_graph_init(cg, n_threads); }
+    if (!cg->prof) { return; }
+}
+
+static inline int ggml_profile_format_tensor_dims(char *str, struct ggml_tensor *t)
+{
+    return sprintf(str, "%d:%d:%d:%d",
+        (int) t->ne[0], (int) t->ne[1], (int) t->ne[3], (int) t->ne[3]);
+}
+
+static inline void ggml_profile_format_op_dims(char *str, struct ggml_tensor *t)
+{
+    char *p = str;
+
+    // append src0 and src1 (if any)
+    if (t->src[0]) {
+       p += ggml_profile_format_tensor_dims(p, t->src[0]);
+
+       for (int i = 1; i < GGML_MAX_SRC && t->src[i]; i++) {
+           p += sprintf(p, " x ");
+           p += ggml_profile_format_tensor_dims(p, t->src[i]);
+       }
+
+       p += sprintf(p, " -> ");
+    }
+
+    // format self dims separately for better visual alignment
+    char self[64];
+    ggml_profile_format_tensor_dims(self, t);
+
+    p += sprintf(p, "%12s", self);
+}
+
+static inline void ggml_profile_format_op_types(char *str, struct ggml_tensor *t)
+{
+    char *p = str;
+
+    // append src0 and src1 (if any)
+    if (t->src[0]) {
+       p += sprintf(p, "%s", ggml_type_name(t->src[0]->type));
+
+       for (int i = 1; i < GGML_MAX_SRC && t->src[i]; i++) {
+           p += sprintf(p, " x ");
+           p += sprintf(p, "%s", ggml_type_name(t->src[i]->type));
+       }
+
+       p += sprintf(p, " -> ");
+    }
+
+    p += sprintf(p, "%3s", ggml_type_name(t->type));
+}
+
+
+extern "C" void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads)
+{
+    if (!cg->prof) { return; }
+
+    fprintf(stderr, "ggml-profile: | node idx | op name | proc (nsec) | sync (nsec) | total (nsec) | op dims | op types | tensor name |\n");
+    fprintf(stderr, "ggml-profile: | -------: | :------ | ----------: | ----------: | -----------: | ------: | -------: | ----------: |\n");
+
+    char dims[64 * GGML_MAX_SRC];
+    char types[16 * GGML_MAX_SRC];
+
+    for (int i = 0; i < cg->n_nodes; i++) {
+        uint64_t p_nsec = 0;
+        uint64_t s_nsec = 0;
+        uint64_t t_nsec = 0;
+
+        // add up per thread counters and reset them
+        for (int t=0; t < n_threads; t++) {
+            p_nsec += cg->prof[i][t].nsec[GGML_PROF_OP_SYNC] - cg->prof[i][t].nsec[GGML_PROF_OP_START];
+            s_nsec += cg->prof[i][t].nsec[GGML_PROF_OP_END]  - cg->prof[i][t].nsec[GGML_PROF_OP_SYNC];
+            t_nsec += cg->prof[i][t].nsec[GGML_PROF_OP_END]  - cg->prof[i][t].nsec[GGML_PROF_OP_START];
+
+            cg->prof[i][t].nsec[GGML_PROF_OP_START] = 0;
+            cg->prof[i][t].nsec[GGML_PROF_OP_SYNC]  = 0;
+            cg->prof[i][t].nsec[GGML_PROF_OP_END]   = 0;
+        }
+
+        ggml_profile_format_op_dims(dims, cg->nodes[i]);
+        ggml_profile_format_op_types(types, cg->nodes[i]);
+
+        fprintf(stderr, "ggml-profile: | %04d | %10s | %10lu | %10lu | %10lu | %46s | %22s | %20s |\n",
+            i, ggml_op_name(cg->nodes[i]->op),
+            (unsigned long) p_nsec, (unsigned long) s_nsec, (unsigned long) t_nsec,
+            dims, types, cg->nodes[i]->name);
+    }
+    fprintf(stderr, "ggml-profile:   \n"); // empty line to split tables
+}
+
+extern "C" void ggml_profile_graph_free(struct ggml_cgraph *cg)
+{
+    if (!cg->prof) { return; }
+
+    free(cg->prof); cg->prof = nullptr;
+}
+
+extern "C" void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith)
+{
+    if (!cg->prof) { return; }
+
+    using clock = std::chrono::high_resolution_clock;
+    cg->prof[node_n][ith].nsec[e] = std::chrono::nanoseconds(clock::now().time_since_epoch()).count();
+}

--- a/ggml/src/ggml-profile.cpp
+++ b/ggml/src/ggml-profile.cpp
@@ -1,8 +1,11 @@
-#include "ggml-impl.h"
+#include "ggml-profile.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 
 #include <chrono>
+
+#ifdef GGML_GRAPH_PROFILER
 
 extern "C" void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads)
 {
@@ -138,3 +141,5 @@ extern "C" void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_pr
     using clock = std::chrono::high_resolution_clock;
     cg->prof[node_n][ith].nsec[e] = std::chrono::nanoseconds(clock::now().time_since_epoch()).count();
 }
+
+#endif // GGML_GRAPH_PROFILER

--- a/ggml/src/ggml-profile.h
+++ b/ggml/src/ggml-profile.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "ggml-impl.h"
+
+// GGML internal header
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// op profile data (per op / per thread)
+enum ggml_profile_event {
+    GGML_PROF_OP_START,
+    GGML_PROF_OP_SYNC,
+    GGML_PROF_OP_END
+};
+
+struct ggml_profile_data {
+    uint64_t nsec[GGML_PROF_OP_END + 1]; // event times in nsec
+};
+
+#ifndef GGML_GRAPH_PROFILER
+
+// Stub out all profiler functions
+
+static inline void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads)
+{
+    GGML_UNUSED(cg);
+    GGML_UNUSED(n_threads);
+}
+
+static inline void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads)
+{
+    GGML_UNUSED(cg);
+    GGML_UNUSED(n_threads);
+}
+
+static inline void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads)
+{
+    GGML_UNUSED(cg);
+    GGML_UNUSED(n_threads);
+}
+
+static inline void ggml_profile_graph_free(struct ggml_cgraph *cg)
+{
+    GGML_UNUSED(cg);
+}
+
+static inline void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith)
+{
+    GGML_UNUSED(cg);
+    GGML_UNUSED(e);
+    GGML_UNUSED(node_n);
+    GGML_UNUSED(ith);
+}
+
+#else
+
+void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads);
+void ggml_profile_graph_free(struct ggml_cgraph *cg);
+void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith);
+
+#endif // GGML_GRAPH_PROFILER
+
+#ifdef __cplusplus
+}
+#endif

--- a/ggml/src/ggml-profile.h
+++ b/ggml/src/ggml-profile.h
@@ -8,45 +8,66 @@
 extern "C" {
 #endif
 
-// op profile data (per op / per thread)
+// op profile events & timing (per op / per thread)
 enum ggml_profile_event {
     GGML_PROF_OP_START,
     GGML_PROF_OP_SYNC,
     GGML_PROF_OP_END
 };
 
-struct ggml_profile_data {
+struct ggml_profile_timing {
     uint64_t nsec[GGML_PROF_OP_END + 1]; // event times in nsec
 };
+
+struct ggml_profile_output;
+
+struct ggml_profile_data {
+    struct ggml_profile_output *output;
+    struct ggml_profile_timing ** timing; // per op / per thread timing
+};
+
+// check if profiling is enabled for this graph
+static inline bool ggml_graph_profile_enabled(const struct ggml_cgraph *cg)
+{
+    return cg->prof != NULL;
+}
+
+// get pointer to the timing data for specific node / thread
+// can be used by the backends to populate data collected internally
+static inline struct ggml_profile_timing * ggml_graph_profile_timing(const struct ggml_cgraph *cg, int node_n, int ith)
+{
+    if (!cg->prof) { return NULL; }
+    return &cg->prof->timing[node_n][ith];
+}
 
 #ifndef GGML_GRAPH_PROFILER
 
 // Stub out all profiler functions
 
-static inline void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads)
+static inline void ggml_graph_profile_init(struct ggml_cgraph *cg, int n_threads)
 {
     GGML_UNUSED(cg);
     GGML_UNUSED(n_threads);
 }
 
-static inline void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads)
+static inline void ggml_graph_profile_start(struct ggml_cgraph *cg, int n_threads)
 {
     GGML_UNUSED(cg);
     GGML_UNUSED(n_threads);
 }
 
-static inline void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads)
+static inline void ggml_graph_profile_finish(struct ggml_cgraph *cg, int n_threads)
 {
     GGML_UNUSED(cg);
     GGML_UNUSED(n_threads);
 }
 
-static inline void ggml_profile_graph_free(struct ggml_cgraph *cg)
+static inline void ggml_graph_profile_free(struct ggml_cgraph *cg)
 {
     GGML_UNUSED(cg);
 }
 
-static inline void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith)
+static inline void ggml_graph_profile_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith)
 {
     GGML_UNUSED(cg);
     GGML_UNUSED(e);
@@ -56,11 +77,11 @@ static inline void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml
 
 #else
 
-void ggml_profile_graph_init(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_start(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_finish(struct ggml_cgraph *cg, int n_threads);
-void ggml_profile_graph_free(struct ggml_cgraph *cg);
-void ggml_profile_op_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith);
+void ggml_graph_profile_init(struct ggml_cgraph *cg, int n_threads);
+void ggml_graph_profile_start(struct ggml_cgraph *cg, int n_threads);
+void ggml_graph_profile_finish(struct ggml_cgraph *cg, int n_threads);
+void ggml_graph_profile_free(struct ggml_cgraph *cg);
+void ggml_graph_profile_event(const struct ggml_cgraph *cg, enum ggml_profile_event e, int node_n, int ith);
 
 #endif // GGML_GRAPH_PROFILER
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7,6 +7,7 @@
 #include "ggml-quants.h"
 #include "ggml.h"
 #include "ggml-aarch64.h"
+#include "ggml-profile.h"
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <malloc.h> // using malloc.h with MSC/MINGW


### PR DESCRIPTION
I needed to generate some per-Op profiling data (same thing that LLAMA_PERF used to generate) and realized that that feature is gone. My guess is probably due to completely different parallel graph processing (and probably the backend interface introduction).

Here is a first attempt at reintroducing that feature (I'm calling it `GGML_GRAPH_PROFILER`) with some additional features.
Definitely not ready for the merge but I wanted to get some input before I invest more time :-)

Features:
- Profiling data is collected per op / per thread and aggregated during the report
- We collect three per-op events: START, SYNC, END
  - This allows for measuring sync overhead per op
  - All timing data is in nanoseconds
- The output is the markdown table
  - See example below (nice and readable output both in the terminal and rendedered)
- The output includes a compact dump of all tensor dims and data-types of the Op (see Flash Attention in the sample below)
   This might be handy in other places.
- Changes to the graph_compute are minimal / clean
- If `GGML_GRAPH_PROFILER` is not defined there is zero overhead (well, besides the extra pointer in the graph).
  - If profiler is compiled but not enabled the overhead is relatively small (3 extra if checks per graph node)
  - We can probably optimize that out further (ie like a separate compute loop without profiling calls)
- Tested on a couple platforms (M2 Max and Snapdragon Gen 3) with and without TSAN

Known issues:
- Using env var is just a hack for now
  - I'm thinking of adding `ggml_init_param.graph_profile`
  - If set it'll enable profiling for all the graphs created from that context
  - The parms will probably be a string (`filename:format` or something like that)
- The profile_data allocation is leaky
  - If the overall approach looks / sounds good I'll change it to do the same thing `ggml_new_graph_custom`
     i.e provide the size of the data we need for profiling stuff and use the ctx buffer
- Currently it only works with the CPU backend
  - If there is interest it should be easy to extend to other backends where they could update per-node/per-thread `ggml_profile_timing` data (they'd have to collect it on the accelerator and then export into this common format.  

Let me know how this sounds.

<details>

Example of the terminal output

```
| node idx | op name | proc (nsec) | sync (nsec) | total (nsec) | op dims | op types | tensor name |
| -------: | :------ | ----------: | ----------: | -----------: | ------: | -------: | ----------: |
| 0000 |   GET_ROWS |      22863 |   47566042 |   47588905 |      4096:128256:1:1 x 2:1:1:1 ->   4096:2:1:1 |      q4_0 x i32 -> f32 |             inp_embd |
| 0001 |   RMS_NORM |      96926 |   47859323 |   47956249 |                     4096:2:1:1 ->   4096:2:1:1 |             f32 -> f32 |               norm-0 |
| 0002 |        MUL |      11875 |   36215730 |   36227605 |        4096:2:1:1 x 4096:1:1:1 ->   4096:2:1:1 |       f32 x f32 -> f32 |          attn_norm-0 |
| 0003 |    MUL_MAT |   27633698 |   21271875 |   48905573 |     4096:4096:1:1 x 4096:2:1:1 ->   4096:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Qcur-0 |
| 0004 |    RESHAPE |       9167 |   22963435 |   22972602 |                     4096:2:1:1 ->   128:32:1:1 |             f32 -> f32 |    Qcur-0 (reshaped) |
| 0005 |       ROPE |    1787239 |   22215678 |   24002917 |           128:32:1:1 x 2:1:1:1 ->   128:32:1:1 |       f32 x i32 -> f32 |               Qcur-0 |
| 0006 |    MUL_MAT |   20612237 |     698388 |   21310625 |     4096:1024:1:1 x 4096:2:1:1 ->   1024:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Kcur-0 |
| 0007 |    RESHAPE |      10989 |       7033 |      18022 |                     1024:2:1:1 ->    128:8:1:1 |             f32 -> f32 |    Kcur-0 (reshaped) |
| 0008 |       ROPE |    2566925 |     332969 |    2899894 |            128:8:1:1 x 2:1:1:1 ->    128:8:1:1 |       f32 x i32 -> f32 |               Kcur-0 |
| 0009 |    MUL_MAT |     489845 |      98229 |     588074 |     4096:1024:1:1 x 4096:2:1:1 ->   1024:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Vcur-0 |
| 0010 |       VIEW |       7396 |       3074 |      10470 |                  4194304:1:1:1 ->   2048:1:1:1 |           q4_0 -> q4_0 |       k_cache_view-0 |
| 0011 |        CPY |      15782 |       7186 |      22968 |         128:8:1:1 x 2048:1:1:1 ->   2048:1:1:1 |     f32 x q4_0 -> q4_0 | k_cache_view-0 (copy of Kcur-0) |
| 0012 |       VIEW |       5836 |       2444 |       8280 |                  4194304:1:1:1 ->   2048:1:1:1 |           q4_0 -> q4_0 |       v_cache_view-0 |
| 0013 |        CPY |      14324 |      12865 |      27189 |        1024:2:1:1 x 2048:1:1:1 ->   2048:1:1:1 |     f32 x q4_0 -> q4_0 | v_cache_view-0 (copy of Vcur-0) |
| 0014 |    PERMUTE |       5572 |       2240 |       7812 |                     128:32:1:1 ->    128:2:1:1 |             f32 -> f32 |                  q-0 |
| 0015 |       VIEW |      10469 |       3543 |      14012 |                  4194304:1:1:1 ->  128:256:1:1 |           q4_0 -> q4_0 |                  k-0 |
| 0016 |       VIEW |       9375 |       3071 |      12446 |                  4194304:1:1:1 ->  128:256:1:1 |           q4_0 -> q4_0 |                  v-0 |
| 0017 |        CPY |      10053 |       4635 |      14688 |        256:32:1:1 x 256:32:1:1 ->   256:32:1:1 |       f32 x f16 -> f16 |       KQ_mask (copy) |
| 0018 | FLASH_ATTN_EXT |     113753 |      17809 |     131562 | 128:2:1:1 x 128:256:1:1 x 128:256:1:1 x 256:32:1:1 ->   128:32:1:1 | f32 x q4_0 x q4_0 x f16 -> f32 |              node_18 |
```

Same example in rendered MarkDown

| node idx | op name | proc (nsec) | sync (nsec) | total (nsec) | op dims | op types | tensor name |
| -------: | :------ | ----------: | ----------: | -----------: | ------: | -------: | ----------: |
| 0000 |   GET_ROWS |      22863 |   47566042 |   47588905 |      4096:128256:1:1 x 2:1:1:1 ->   4096:2:1:1 |      q4_0 x i32 -> f32 |             inp_embd |
| 0001 |   RMS_NORM |      96926 |   47859323 |   47956249 |                     4096:2:1:1 ->   4096:2:1:1 |             f32 -> f32 |               norm-0 |
| 0002 |        MUL |      11875 |   36215730 |   36227605 |        4096:2:1:1 x 4096:1:1:1 ->   4096:2:1:1 |       f32 x f32 -> f32 |          attn_norm-0 |
| 0003 |    MUL_MAT |   27633698 |   21271875 |   48905573 |     4096:4096:1:1 x 4096:2:1:1 ->   4096:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Qcur-0 |
| 0004 |    RESHAPE |       9167 |   22963435 |   22972602 |                     4096:2:1:1 ->   128:32:1:1 |             f32 -> f32 |    Qcur-0 (reshaped) |
| 0005 |       ROPE |    1787239 |   22215678 |   24002917 |           128:32:1:1 x 2:1:1:1 ->   128:32:1:1 |       f32 x i32 -> f32 |               Qcur-0 |
| 0006 |    MUL_MAT |   20612237 |     698388 |   21310625 |     4096:1024:1:1 x 4096:2:1:1 ->   1024:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Kcur-0 |
| 0007 |    RESHAPE |      10989 |       7033 |      18022 |                     1024:2:1:1 ->    128:8:1:1 |             f32 -> f32 |    Kcur-0 (reshaped) |
| 0008 |       ROPE |    2566925 |     332969 |    2899894 |            128:8:1:1 x 2:1:1:1 ->    128:8:1:1 |       f32 x i32 -> f32 |               Kcur-0 |
| 0009 |    MUL_MAT |     489845 |      98229 |     588074 |     4096:1024:1:1 x 4096:2:1:1 ->   1024:2:1:1 |  q4_0_4x8 x f32 -> f32 |               Vcur-0 |
| 0010 |       VIEW |       7396 |       3074 |      10470 |                  4194304:1:1:1 ->   2048:1:1:1 |           q4_0 -> q4_0 |       k_cache_view-0 |
| 0011 |        CPY |      15782 |       7186 |      22968 |         128:8:1:1 x 2048:1:1:1 ->   2048:1:1:1 |     f32 x q4_0 -> q4_0 | k_cache_view-0 (copy of Kcur-0) |
| 0012 |       VIEW |       5836 |       2444 |       8280 |                  4194304:1:1:1 ->   2048:1:1:1 |           q4_0 -> q4_0 |       v_cache_view-0 |
| 0013 |        CPY |      14324 |      12865 |      27189 |        1024:2:1:1 x 2048:1:1:1 ->   2048:1:1:1 |     f32 x q4_0 -> q4_0 | v_cache_view-0 (copy of Vcur-0) |
| 0014 |    PERMUTE |       5572 |       2240 |       7812 |                     128:32:1:1 ->    128:2:1:1 |             f32 -> f32 |                  q-0 |
| 0015 |       VIEW |      10469 |       3543 |      14012 |                  4194304:1:1:1 ->  128:256:1:1 |           q4_0 -> q4_0 |                  k-0 |
| 0016 |       VIEW |       9375 |       3071 |      12446 |                  4194304:1:1:1 ->  128:256:1:1 |           q4_0 -> q4_0 |                  v-0 |
| 0017 |        CPY |      10053 |       4635 |      14688 |        256:32:1:1 x 256:32:1:1 ->   256:32:1:1 |       f32 x f16 -> f16 |       KQ_mask (copy) |
| 0018 | FLASH_ATTN_EXT |     113753 |      17809 |     131562 | 128:2:1:1 x 128:256:1:1 x 128:256:1:1 x 256:32:1:1 ->   128:32:1:1 | f32 x q4_0 x q4_0 x f16 -> f32 |              node_18 |

</details>



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
