### PR TITLE
common: ensure token addition to batch does not exceed llama_batch size

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1432,6 +1432,8 @@ void llama_batch_add(
                           llama_pos   pos,
     const std::vector<llama_seq_id> & seq_ids,
                                bool   logits) {
+    GGML_ASSERT(batch.seq_id[batch.n_tokens] && "llama_batch size exceeded");
+
     batch.token   [batch.n_tokens] = id;
     batch.pos     [batch.n_tokens] = pos;
     batch.n_seq_id[batch.n_tokens] = seq_ids.size();


### PR DESCRIPTION
fix #9667

A crash was observed when the number of tokens added to a batch exceeds the context size. Assertions have been added to ensure the number of tokens added to batch is within bounds of context size.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
