### PR TITLE
llama : first attempt to implement vision API (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1477,7 +1477,6 @@ llama-server: \
 	examples/server/json-schema-to-grammar.mjs.hpp \
 	examples/server/loading.html.hpp \
 	common/json.hpp \
-	common/stb_image.h \
 	$(OBJ_ALL)
 	$(CXX) $(CXXFLAGS) -c $< -o $(call GET_OBJ_FILE, $<)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h %.hpp $<,$^) -Iexamples/server $(call GET_OBJ_FILE, $<) -o $@ $(LDFLAGS) $(LWINSOCK2)
@@ -1500,7 +1499,6 @@ libllava.a: examples/llava/llava.cpp \
 	examples/llava/llava.h \
 	examples/llava/clip.cpp \
 	examples/llava/clip.h \
-	common/stb_image.h \
 	common/base64.hpp \
 	$(OBJ_ALL)
 	$(CXX) $(CXXFLAGS) -static -fPIC -c $< -o $@ -Wno-cast-qual

--- a/Makefile
+++ b/Makefile
@@ -1120,6 +1120,7 @@ src/llama.o: \
 	src/llama-vocab.h \
 	src/llama-grammar.h \
 	src/llama-sampling.h \
+	src/llama-vision.h \
 	src/unicode.h \
 	include/llama.h \
 	ggml/include/ggml-cuda.h \
@@ -1150,6 +1151,17 @@ src/llama-sampling.o: \
 	src/llama-sampling.h \
 	src/llama-impl.h \
 	include/llama.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+src/llama-vision.o: \
+	src/llama-vision.cpp \
+	src/llama-vision.h \
+	include/llama.h \
+	ggml/include/ggml-cuda.h \
+	ggml/include/ggml-metal.h \
+	ggml/include/ggml.h \
+	ggml/include/ggml-alloc.h \
+	ggml/include/ggml-backend.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(LIB_LLAMA): \

--- a/Makefile
+++ b/Makefile
@@ -926,6 +926,7 @@ OBJ_LLAMA = \
 	src/llama-vocab.o \
 	src/llama-grammar.o \
 	src/llama-sampling.o \
+	src/llama-vision.o \
 	src/unicode.o \
 	src/unicode-data.o
 
@@ -937,6 +938,7 @@ OBJ_COMMON = \
 	common/ngram-cache.o \
 	common/sampling.o \
 	common/train.o \
+	common/vision.o \
 	common/build-info.o \
 	common/json-schema-to-grammar.o
 
@@ -1219,6 +1221,12 @@ common/train.o: \
 common/ngram-cache.o: \
 	common/ngram-cache.cpp \
 	common/ngram-cache.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+common/vision.o: \
+	common/vision.cpp \
+	common/vision.h \
+	common/stb_image.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(LIB_COMMON): \

--- a/common/common.h
+++ b/common/common.h
@@ -378,6 +378,20 @@ static std::vector<T> string_split(const std::string & str, char delim) {
     return values;
 }
 
+// split string by a `std::string delim` instead of `char delim`
+static std::vector<std::string> string_split(std::string s, const std::string & delimiter) {
+    std::vector<std::string> tokens;
+    size_t pos = 0;
+    std::string token;
+    while ((pos = s.find(delimiter)) != std::string::npos) {
+        token = s.substr(0, pos);
+        tokens.push_back(token);
+        s.erase(0, pos + delimiter.length());
+    }
+    tokens.push_back(s);
+    return tokens;
+}
+
 bool string_parse_kv_override(const char * data, std::vector<llama_model_kv_override> & overrides);
 void string_process_escapes(std::string & input);
 
@@ -443,6 +457,17 @@ std::vector<llama_token> llama_tokenize(
 
 std::vector<llama_token> llama_tokenize(
     const struct llama_model * model,
+           const std::string & text,
+                        bool   add_special,
+                        bool   parse_special = false);
+
+const llama_token TOKEN_IMG_PLACEMENT = -1000;
+
+// tokenize with "placeholder" for image embedding tokens
+// "<img_placement>" will be replaced with TOKEN_IMG_PLACEMENT
+// TODO: this function is hacky, need to be improved
+std::vector<llama_token> llama_tokenize_with_img(
+  const struct llama_context * ctx,
            const std::string & text,
                         bool   add_special,
                         bool   parse_special = false);

--- a/common/vision.cpp
+++ b/common/vision.cpp
@@ -1,0 +1,37 @@
+#include "vision.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+#include <vector>
+#include <fstream>
+
+llama_img * load_image_from_file(const char * fname) {
+    std::ifstream file(fname, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Unable to open file");
+    }
+    std::vector<char> image_bytes = std::vector<char>(
+        std::istreambuf_iterator<char>(file),
+        std::istreambuf_iterator<char>());
+    // decode image to byte array
+    int nx, ny, nc;
+    auto * bytes = (unsigned char *) image_bytes.data();
+    auto * img = stbi_load_from_memory(bytes, image_bytes.size(), &nx, &ny, &nc, 3);
+    if (!img) {
+        throw std::runtime_error("failed to decode image bytes");
+    }
+    // printf("nx=%d ny=%d nc=%d\n", nx, ny, nc);
+    // GGML_ASSERT(nc == 3);
+    // for (int y = 0; y < ny; y++) {
+    //     for (int x = 0; x < nx; x++) {
+    //         unsigned char * pix = img + x*nc + y*nc*nx;
+    //         printf("%02x%02x%02x ", pix[0], pix[1], pix[2]);
+    //     }
+    //     printf("\n");
+    // }
+    // printf("\n");
+    llama_img * result = llama_img_alloc(nx, ny);
+    memcpy(result->data, bytes, nx*ny*nc);
+    return result;
+}

--- a/common/vision.cpp
+++ b/common/vision.cpp
@@ -31,7 +31,7 @@ llama_img * load_image_from_file(const char * fname) {
     //     printf("\n");
     // }
     // printf("\n");
-    llama_img * result = llama_img_alloc(nx, ny);
+    llama_img * result = llama_img_init(nx, ny);
     memcpy(result->data, img, nx*ny*3);
     stbi_image_free(img);
     return result;

--- a/common/vision.cpp
+++ b/common/vision.cpp
@@ -32,6 +32,7 @@ llama_img * load_image_from_file(const char * fname) {
     // }
     // printf("\n");
     llama_img * result = llama_img_alloc(nx, ny);
-    memcpy(result->data, bytes, nx*ny*nc);
+    memcpy(result->data, img, nx*ny*3);
+    stbi_image_free(img);
     return result;
 }

--- a/common/vision.h
+++ b/common/vision.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "llama.h"
+
+#include <string>
+#include <vector>
+
+llama_img * load_image_from_file(const char * fname);

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -471,7 +471,7 @@ class Model:
                     text_config = AutoConfig.from_pretrained(text_config["_name_or_path"]).to_dict()
                 hparams = {**text_config, **hparams}
             return hparams
-        
+
     @staticmethod
     def load_preprocessor_config(dir_model: Path):
         file_path = dir_model / "preprocessor_config.json"
@@ -1590,7 +1590,7 @@ class LlamaModel(Model):
 
         # For vision model
         if self.vparams is not None and self.preprocessor_config is not None:
-            self.gguf_writer.add_vision_type("clip")
+            self.gguf_writer.add_vision_type("clip-vit")
             self.gguf_writer.add_vision_image_size(self.vparams["image_size"])
             self.gguf_writer.add_vision_patch_size(self.vparams["patch_size"])
             self.gguf_writer.add_vision_clip_architecture("llava")
@@ -1600,6 +1600,8 @@ class LlamaModel(Model):
             self.gguf_writer.add_vision_clip_head_count(self.vparams["num_attention_heads"])
             self.gguf_writer.add_vision_clip_image_mean(self.preprocessor_config["image_mean"])
             self.gguf_writer.add_vision_clip_image_std(self.preprocessor_config["image_std"])
+            self.gguf_writer.add_vision_clip_select_layer(self.hparams["vision_feature_layer"])
+            self.gguf_writer.add_vision_clip_patch_merge_type(gguf.CLIPPatchMergeType.FLAT)
             max_pos_embd = (self.vparams["image_size"] // self.vparams["patch_size"])**2 + 1
             self.gguf_writer.add_vision_clip_max_position_embeddings(max_pos_embd)
             # TODO: should not hardcode these, but they are currently missing from config.json

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1583,6 +1583,9 @@ class LlamaModel(Model):
             self.gguf_writer.add_vision_clip_embedding_length(self.vparams["hidden_size"])
             self.gguf_writer.add_vision_clip_feed_forward_length(self.vparams["intermediate_size"])
             self.gguf_writer.add_vision_clip_head_count(self.vparams["num_attention_heads"])
+            # TODO: should not hardcode these, but they are currently missing from config.json
+            self.gguf_writer.add_vision_clip_max_position_embeddings(577)
+            self.gguf_writer.add_vision_clip_layer_norm_epsilon(1e-05)
 
     @staticmethod
     def permute(weights: Tensor, n_head: int, n_head_kv: int | None):

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1584,8 +1584,13 @@ class LlamaModel(Model):
             self.gguf_writer.add_vision_clip_feed_forward_length(self.vparams["intermediate_size"])
             self.gguf_writer.add_vision_clip_head_count(self.vparams["num_attention_heads"])
             # TODO: should not hardcode these, but they are currently missing from config.json
+            self.gguf_writer.add_vision_clip_projector_type(gguf.constants.CLIPProjectorType.MLP)
             self.gguf_writer.add_vision_clip_max_position_embeddings(577)
             self.gguf_writer.add_vision_clip_layer_norm_epsilon(1e-05)
+            default_image_mean = [0.48145466, 0.4578275, 0.40821073]
+            default_image_std = [0.26862954, 0.26130258, 0.27577711]
+            self.gguf_writer.add_vision_clip_image_mean(default_image_mean)
+            self.gguf_writer.add_vision_clip_image_std(default_image_std)
 
     @staticmethod
     def permute(weights: Tensor, n_head: int, n_head_kv: int | None):

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -23,7 +23,7 @@
 #include "ggml-vulkan.h"
 #endif
 
-#define STB_IMAGE_IMPLEMENTATION
+#include "vision.h" // without this, we get duplicated symbol error
 #include "stb_image.h"
 
 #include <cassert>

--- a/examples/simple/simple.cpp
+++ b/examples/simple/simple.cpp
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "log.h"
 #include "llama.h"
+#include "vision.h"
 
 #include <vector>
 
@@ -60,6 +61,19 @@ int main(int argc, char ** argv) {
     llama_sampler * smpl = llama_sampler_chain_init(sparams);
 
     llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+
+
+
+
+    // TODO: this is for testing; DELETE ME
+    llama_img_batch ibatch;
+    ibatch.n_imgs = 1;
+    ibatch.imgs = (llama_img **) malloc(1024);
+    ibatch.imgs[0] = load_image_from_file("media/llama0-logo.png");
+    llama_vision_encode(ctx, &ibatch);
+    return 0;
+
+
 
     // tokenize the prompt
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -178,6 +178,26 @@ class Keys:
         TYPE       = "adapter.type"
         LORA_ALPHA = "adapter.lora.alpha"
 
+    class Vision:
+        # only support vision.type = "clip" for now
+        TYPE                = "vision.type"
+        IMAGE_SIZE          = "vision.image_size"
+        PATCH_SIZE          = "vision.patch_size"
+        IMAGE_MEAN          = "vision.image_mean"
+        IMAGE_STD           = "vision.image_std"
+
+        class Clip:
+            ARCHITECTURE        = "vision.clip.architecture"
+            CONTEXT_LENGTH      = "vision.clip.context_length"
+            EMBEDDING_LENGTH    = "vision.clip.embedding_length"
+            BLOCK_COUNT         = "vision.clip.block_count"
+            FEED_FORWARD_LENGTH = "vision.clip.feed_forward_length"
+            PROJECTION_TYPE     = "vision.clip.projection_type"
+            PROJECTION_DIM      = "vision.clip.projection_dim"
+            USE_GELU            = "vision.clip.use_gelu"
+            HEAD_COUNT          = "vision.clip.attention.head_count"
+            LAYERNORM_EPS       = "vision.clip.attention.layer_norm_epsilon"
+
 #
 # recommended mapping of model tensor names for storage in gguf
 #
@@ -238,6 +258,8 @@ class MODEL_ARCH(IntEnum):
     GRANITE      = auto()
     GRANITE_MOE  = auto()
     CHAMELEON    = auto()
+    # vision models
+    LLAVA_VISION = auto()
 
 
 class MODEL_TENSOR(IntEnum):
@@ -345,6 +367,22 @@ class MODEL_TENSOR(IntEnum):
     ENC_FFN_DOWN         = auto()
     ENC_FFN_UP           = auto()
     ENC_OUTPUT_NORM      = auto()
+    # vision
+    V_MMPROJ_A           = auto()
+    V_MMPROJ_B           = auto()
+    V_ENC_EMBD_CLS       = auto()
+    V_ENC_EMBD_PATCH     = auto()
+    V_ENC_EMBD_POS       = auto()
+    V_ENC_ATTN_Q         = auto()
+    V_ENC_ATTN_K         = auto()
+    V_ENC_ATTN_V         = auto()
+    V_ENC_INPUT_NORM     = auto()
+    V_ENC_OUTPUT         = auto()
+    V_ENC_OUTPUT_NORM    = auto()
+    V_ENC_FFN_UP         = auto()
+    V_ENC_FFN_DOWN       = auto()
+    V_PRE_NORM           = auto()
+    V_POST_NORM          = auto()
 
 
 MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
@@ -397,6 +435,8 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.GRANITE:        "granite",
     MODEL_ARCH.GRANITE_MOE:    "granitemoe",
     MODEL_ARCH.CHAMELEON:      "chameleon",
+    # vision
+    MODEL_ARCH.LLAVA_VISION:   "llava",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
@@ -504,6 +544,22 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.ENC_FFN_DOWN:              "enc.blk.{bid}.ffn_down",
     MODEL_TENSOR.ENC_FFN_UP:                "enc.blk.{bid}.ffn_up",
     MODEL_TENSOR.ENC_OUTPUT_NORM:           "enc.output_norm",
+    # vision
+    MODEL_TENSOR.V_MMPROJ_A:                "v.mmproj_a",
+    MODEL_TENSOR.V_MMPROJ_B:                "v.mmproj_b",
+    MODEL_TENSOR.V_ENC_EMBD_CLS:            "v.enc.embd.cls",
+    MODEL_TENSOR.V_ENC_EMBD_PATCH:          "v.enc.embd.patch",
+    MODEL_TENSOR.V_ENC_EMBD_POS:            "v.enc.embd.pos",
+    MODEL_TENSOR.V_ENC_ATTN_Q:              "v.enc.blk.{bid}.attn_q",
+    MODEL_TENSOR.V_ENC_ATTN_K:              "v.enc.blk.{bid}.attn_k",
+    MODEL_TENSOR.V_ENC_ATTN_V:              "v.enc.blk.{bid}.attn_v",
+    MODEL_TENSOR.V_ENC_INPUT_NORM:          "v.enc.blk.{bid}.input_norm",
+    MODEL_TENSOR.V_ENC_OUTPUT:              "v.enc.blk.{bid}.output",
+    MODEL_TENSOR.V_ENC_OUTPUT_NORM:         "v.enc.blk.{bid}.output_norm",
+    MODEL_TENSOR.V_ENC_FFN_UP:              "v.enc.blk.{bid}.ffn_up",
+    MODEL_TENSOR.V_ENC_FFN_DOWN:            "v.enc.blk.{bid}.ffn_down",
+    MODEL_TENSOR.V_PRE_NORM:                "v.pre_norm",
+    MODEL_TENSOR.V_POST_NORM:               "v.post_norm",
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -1278,6 +1334,23 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE,
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
+    ],
+    MODEL_ARCH.LLAVA_VISION: [
+        MODEL_TENSOR.V_MMPROJ_A,
+        MODEL_TENSOR.V_MMPROJ_B,
+        MODEL_TENSOR.V_ENC_EMBD_CLS,
+        MODEL_TENSOR.V_ENC_EMBD_PATCH,
+        MODEL_TENSOR.V_ENC_EMBD_POS,
+        MODEL_TENSOR.V_ENC_ATTN_Q,
+        MODEL_TENSOR.V_ENC_ATTN_K,
+        MODEL_TENSOR.V_ENC_ATTN_V,
+        MODEL_TENSOR.V_ENC_INPUT_NORM,
+        MODEL_TENSOR.V_ENC_OUTPUT,
+        MODEL_TENSOR.V_ENC_OUTPUT_NORM,
+        MODEL_TENSOR.V_ENC_FFN_UP,
+        MODEL_TENSOR.V_ENC_FFN_DOWN,
+        MODEL_TENSOR.V_PRE_NORM,
+        MODEL_TENSOR.V_POST_NORM,
     ],
     # TODO
 }

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -196,6 +196,7 @@ class Keys:
             PROJECTION_DIM      = "vision.clip.projection_dim"
             USE_GELU            = "vision.clip.use_gelu"
             MAX_POS_EMBEDDING   = "vision.clip.max_position_embeddings"
+            PROJECTOR_TYPE      = "vision.clip.projector_type"
             HEAD_COUNT          = "vision.clip.attention.head_count"
             LAYERNORM_EPS       = "vision.clip.attention.layer_norm_epsilon"
 
@@ -1423,6 +1424,10 @@ class PoolingType(IntEnum):
     NONE = 0
     MEAN = 1
     CLS  = 2
+
+
+class CLIPProjectorType(Enum):
+    MLP = 'mlp'
 
 
 class GGMLQuantizationType(IntEnum):

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -195,6 +195,7 @@ class Keys:
             PROJECTION_TYPE     = "vision.clip.projection_type"
             PROJECTION_DIM      = "vision.clip.projection_dim"
             USE_GELU            = "vision.clip.use_gelu"
+            MAX_POS_EMBEDDING   = "vision.clip.max_position_embeddings"
             HEAD_COUNT          = "vision.clip.attention.head_count"
             LAYERNORM_EPS       = "vision.clip.attention.layer_norm_epsilon"
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -375,8 +375,7 @@ class MODEL_TENSOR(IntEnum):
     ENC_FFN_UP           = auto()
     ENC_OUTPUT_NORM      = auto()
     # vision
-    V_MMPROJ_A           = auto()
-    V_MMPROJ_B           = auto()
+    V_MMPROJ             = auto()
     V_ENC_EMBD_CLS       = auto()
     V_ENC_EMBD_PATCH     = auto()
     V_ENC_EMBD_POS       = auto()
@@ -552,8 +551,7 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.ENC_FFN_UP:                "enc.blk.{bid}.ffn_up",
     MODEL_TENSOR.ENC_OUTPUT_NORM:           "enc.output_norm",
     # vision
-    MODEL_TENSOR.V_MMPROJ_A:                "v.mmproj_a",
-    MODEL_TENSOR.V_MMPROJ_B:                "v.mmproj_b",
+    MODEL_TENSOR.V_MMPROJ:                  "v.mmproj_{bid}",
     MODEL_TENSOR.V_ENC_EMBD_CLS:            "v.enc.embd.cls",
     MODEL_TENSOR.V_ENC_EMBD_PATCH:          "v.enc.embd.patch",
     MODEL_TENSOR.V_ENC_EMBD_POS:            "v.enc.embd.pos",
@@ -1343,8 +1341,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_UP,
     ],
     MODEL_ARCH.LLAVA_VISION: [
-        MODEL_TENSOR.V_MMPROJ_A,
-        MODEL_TENSOR.V_MMPROJ_B,
+        MODEL_TENSOR.V_MMPROJ,
         MODEL_TENSOR.V_ENC_EMBD_CLS,
         MODEL_TENSOR.V_ENC_EMBD_PATCH,
         MODEL_TENSOR.V_ENC_EMBD_POS,

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -173,13 +173,15 @@ class Keys:
         MIDDLE_ID            = "tokenizer.ggml.middle_token_id"
         EOT_ID               = "tokenizer.ggml.eot_token_id"
         EOM_ID               = "tokenizer.ggml.eom_token_id"
+        IMAGE_START_ID       = "tokenizer.ggml.image_start_token_id"
+        IMAGE_END_ID         = "tokenizer.ggml.image_end_token_id"
 
     class Adapter:
         TYPE       = "adapter.type"
         LORA_ALPHA = "adapter.lora.alpha"
 
     class Vision:
-        # only support vision.type = "clip" for now
+        # only support vision.type = "clip-vit" for now
         TYPE                = "vision.type"
         IMAGE_SIZE          = "vision.image_size"
         PATCH_SIZE          = "vision.patch_size"
@@ -196,7 +198,10 @@ class Keys:
             PROJECTION_DIM      = "vision.clip.projection_dim"
             USE_GELU            = "vision.clip.use_gelu"
             MAX_POS_EMBEDDING   = "vision.clip.max_position_embeddings"
+            MAX_SLICES          = "vision.clip.max_slices"
             PROJECTOR_TYPE      = "vision.clip.projector_type"
+            SELECT_LAYER        = "vision.clip.select_layer"
+            PATCH_MERGE_TYPE    = "vision.clip.patch_merge_type"
             HEAD_COUNT          = "vision.clip.attention.head_count"
             LAYERNORM_EPS       = "vision.clip.attention.layer_norm_epsilon"
 
@@ -1428,6 +1433,11 @@ class PoolingType(IntEnum):
 
 class CLIPProjectorType(Enum):
     MLP = 'mlp'
+
+
+class CLIPPatchMergeType(Enum):
+    FLAT = 'flat'
+    SPATIAL_UNPAD = 'spatial_unpad'
 
 
 class GGMLQuantizationType(IntEnum):

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -26,6 +26,7 @@ from .constants import (
     RopeScalingType,
     PoolingType,
     TokenType,
+    CLIPProjectorType,
 )
 
 from .quants import quant_shape_from_byte_shape
@@ -844,8 +845,17 @@ class GGUFWriter:
     def add_vision_clip_max_position_embeddings(self, value: int) -> None:
         self.add_uint32(Keys.Vision.Clip.MAX_POS_EMBEDDING, value)
 
+    def add_vision_clip_projector_type(self, value: CLIPProjectorType) -> None:
+        self.add_string(Keys.Vision.Clip.PROJECTOR_TYPE, value.value)
+
     def add_vision_clip_layer_norm_epsilon(self, value: float) -> None:
         self.add_float32(Keys.Vision.Clip.LAYERNORM_EPS, value)
+
+    def add_vision_clip_image_mean(self, value: Sequence[float]) -> None:
+        self.add_array(Keys.Vision.IMAGE_MEAN, value)
+
+    def add_vision_clip_image_std(self, value: Sequence[float]) -> None:
+        self.add_array(Keys.Vision.IMAGE_STD, value)
 
     def add_chat_template(self, value: str | Sequence[Mapping[str, str]]) -> None:
         if not isinstance(value, str):

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -814,6 +814,36 @@ class GGUFWriter:
     def add_precompiled_charsmap(self, charsmap: Sequence[bytes]) -> None:
         self.add_array(Keys.Tokenizer.PRECOMPILED_CHARSMAP, charsmap)
 
+    def add_vision_type(self, value: str) -> None:
+        self.add_string(Keys.Vision.TYPE, value)
+
+    def add_vision_image_size(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.IMAGE_SIZE, value)
+
+    def add_vision_patch_size(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.PATCH_SIZE, value)
+
+    def add_vision_clip_architecture(self, value: str) -> None:
+        self.add_string(Keys.Vision.Clip.ARCHITECTURE, value)
+
+    def add_vision_clip_context_length(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.CONTEXT_LENGTH, value)
+
+    def add_vision_clip_embedding_length(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.EMBEDDING_LENGTH, value)
+
+    def add_vision_clip_block_count(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.BLOCK_COUNT, value)
+
+    def add_vision_clip_feed_forward_length(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.FEED_FORWARD_LENGTH, value)
+
+    def add_vision_clip_head_count(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.HEAD_COUNT, value)
+
+    def add_vision_clip_layer_norm_epsilon(self, value: float) -> None:
+        self.add_float32(Keys.Vision.Clip.LAYERNORM_EPS, value)
+
     def add_chat_template(self, value: str | Sequence[Mapping[str, str]]) -> None:
         if not isinstance(value, str):
             template_default = None

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -27,6 +27,7 @@ from .constants import (
     PoolingType,
     TokenType,
     CLIPProjectorType,
+    CLIPPatchMergeType,
 )
 
 from .quants import quant_shape_from_byte_shape
@@ -847,6 +848,15 @@ class GGUFWriter:
 
     def add_vision_clip_projector_type(self, value: CLIPProjectorType) -> None:
         self.add_string(Keys.Vision.Clip.PROJECTOR_TYPE, value.value)
+
+    def add_vision_clip_max_slices(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.MAX_SLICES, value)
+
+    def add_vision_clip_select_layer(self, value: int) -> None:
+        self.add_int32(Keys.Vision.Clip.SELECT_LAYER, value)
+
+    def add_vision_clip_patch_merge_type(self, value: CLIPPatchMergeType) -> None:
+        self.add_string(Keys.Vision.Clip.PATCH_MERGE_TYPE, value.value)
 
     def add_vision_clip_layer_norm_epsilon(self, value: float) -> None:
         self.add_float32(Keys.Vision.Clip.LAYERNORM_EPS, value)

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -841,6 +841,9 @@ class GGUFWriter:
     def add_vision_clip_head_count(self, value: int) -> None:
         self.add_uint32(Keys.Vision.Clip.HEAD_COUNT, value)
 
+    def add_vision_clip_max_position_embeddings(self, value: int) -> None:
+        self.add_uint32(Keys.Vision.Clip.MAX_POS_EMBEDDING, value)
+
     def add_vision_clip_layer_norm_epsilon(self, value: float) -> None:
         self.add_float32(Keys.Vision.Clip.LAYERNORM_EPS, value)
 

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -679,6 +679,66 @@ class TensorNameMap:
         MODEL_TENSOR.ENC_OUTPUT_NORM: (
             "encoder.final_layer_norm", # t5
         ),
+
+        MODEL_TENSOR.V_MMPROJ_A: (
+            "multi_modal_projector.linear_1",
+        ),
+
+        MODEL_TENSOR.V_MMPROJ_B: (
+            "multi_modal_projector.linear_2",
+        ),
+
+        MODEL_TENSOR.V_ENC_EMBD_CLS: (
+            "vision_tower.vision_model.embeddings.class_embedding",
+        ),
+
+        MODEL_TENSOR.V_ENC_EMBD_PATCH: (
+            "vision_tower.vision_model.embeddings.patch_embedding",
+        ),
+
+        MODEL_TENSOR.V_ENC_EMBD_POS: (
+            "vision_tower.vision_model.embeddings.position_embedding",
+        ),
+
+        MODEL_TENSOR.V_ENC_ATTN_Q: (
+            "vision_tower.vision_model.encoder.layers.{bid}.self_attn.q_proj",
+        ),
+
+        MODEL_TENSOR.V_ENC_ATTN_K: (
+            "vision_tower.vision_model.encoder.layers.{bid}.self_attn.k_proj",
+        ),
+
+        MODEL_TENSOR.V_ENC_ATTN_V: (
+            "vision_tower.vision_model.encoder.layers.{bid}.self_attn.v_proj",
+        ),
+
+        MODEL_TENSOR.V_ENC_INPUT_NORM: (
+            "vision_tower.vision_model.encoder.layers.{bid}.layer_norm1",
+        ),
+
+        MODEL_TENSOR.V_ENC_OUTPUT: (
+            "vision_tower.vision_model.encoder.layers.{bid}.self_attn.out_proj",
+        ),
+
+        MODEL_TENSOR.V_ENC_OUTPUT_NORM: (
+            "vision_tower.vision_model.encoder.layers.{bid}.layer_norm2",
+        ),
+
+        MODEL_TENSOR.V_ENC_FFN_UP: (
+            "vision_tower.vision_model.encoder.layers.{bid}.mlp.fc1",
+        ),
+
+        MODEL_TENSOR.V_ENC_FFN_DOWN: (
+            "vision_tower.vision_model.encoder.layers.{bid}.mlp.fc2",
+        ),
+
+        MODEL_TENSOR.V_PRE_NORM: (
+            "vision_tower.vision_model.pre_layrnorm",
+        ),
+
+        MODEL_TENSOR.V_POST_NORM: (
+            "vision_tower.vision_model.post_layernorm",
+        ),
     }
 
     # architecture-specific block mappings

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -680,12 +680,12 @@ class TensorNameMap:
             "encoder.final_layer_norm", # t5
         ),
 
-        MODEL_TENSOR.V_MMPROJ_A: (
-            "multi_modal_projector.linear_1",
+        MODEL_TENSOR.V_MMPROJ: (
+            "multi_modal_projector.linear_{bid}",
         ),
 
-        MODEL_TENSOR.V_MMPROJ_B: (
-            "multi_modal_projector.linear_2",
+        MODEL_TENSOR.V_MMPROJ: (
+            "multi_modal_projector.linear_{bid}",
         ),
 
         MODEL_TENSOR.V_ENC_EMBD_CLS: (

--- a/include/llama.h
+++ b/include/llama.h
@@ -233,10 +233,11 @@ extern "C" {
     } llama_img;
 
     // Input data for llama_vision_decode
-    typedef struct llama_img_batch {
+    typedef struct llama_batch_img {
         int32_t      n_imgs;
         llama_img ** imgs;
-    } llama_img_batch;
+        llama_pos *  pos;
+    } llama_batch_img;
 
     // Input data for llama_decode
     // A llama_batch object can contain input about one or many sequences
@@ -894,16 +895,18 @@ extern "C" {
     //
 
     // create new RGB image for input
-    LLAMA_API llama_img * llama_img_alloc(int width, int height);
-    LLAMA_API void llama_img_free(llama_img * img);
+    LLAMA_API llama_img * llama_img_init(int width, int height);
+    LLAMA_API void        llama_img_free(llama_img * img);
 
-    // encode image into embeddings
-    LLAMA_API int32_t llama_vision_encode(struct llama_context * ctx, llama_img_batch * batch);
+    // get number of tokens that an image occupies, used to determine the position in the batch
+    LLAMA_API int32_t llama_img_n_tokens(struct llama_context * ctx, llama_img * img);
 
-    // get output embeddings, to be put into language batch
-    LLAMA_API float * llama_vision_get_embeddings(struct llama_context * ctx, int32_t idx);
+    // create new image batch
+    LLAMA_API llama_batch_img llama_batch_img_init(int n_imgs);
+    LLAMA_API void            llama_batch_img_free(llama_batch_img batch);
 
-    LLAMA_API int32_t llama_vision_n_patches(struct llama_context * ctx);
+    // encode the input image batch
+    LLAMA_API int32_t llama_encode_vision(struct llama_context * ctx, llama_batch_img batch);
 
     //
     // Vocab
@@ -1237,6 +1240,7 @@ extern "C" {
     LLAMA_API void                           llama_perf_sampler_reset(      struct llama_sampler * chain);
 
     LLAMA_API void llama_perf_dump_yaml(FILE * stream, const struct llama_context * ctx);
+    LLAMA_API float * _test_get_img_embd(struct llama_context * ctx);
 
 #ifdef __cplusplus
 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -234,8 +234,8 @@ extern "C" {
 
     // Input data for llama_vision_decode
     typedef struct llama_img_batch {
-        int32_t     n_imgs;
-        llama_img * imgs;
+        int32_t      n_imgs;
+        llama_img ** imgs;
     } llama_img_batch;
 
     // Input data for llama_decode
@@ -892,6 +892,10 @@ extern "C" {
     //
     // Vision
     //
+
+    // create new RGB image for input
+    LLAMA_API llama_img * llama_img_alloc(int width, int height);
+    LLAMA_API void llama_img_free(llama_img * img);
 
     // encode image into embeddings
     LLAMA_API int32_t llama_vision_encode(struct llama_context * ctx, llama_img_batch * batch);

--- a/include/llama.h
+++ b/include/llama.h
@@ -224,6 +224,20 @@ extern "C" {
 
     typedef bool (*llama_progress_callback)(float progress, void * user_data);
 
+    // represent an RGB image
+    // size of data must be equal to 3*nx*ny
+    typedef struct llama_img {
+        uint32_t nx;
+        uint32_t ny;
+        unsigned char * data;
+    } llama_img;
+
+    // Input data for llama_vision_decode
+    typedef struct llama_img_batch {
+        int32_t     n_imgs;
+        llama_img * imgs;
+    } llama_img_batch;
+
     // Input data for llama_decode
     // A llama_batch object can contain input about one or many sequences
     // The provided arrays (i.e. token, embd, pos, etc.) must have size of n_tokens
@@ -874,6 +888,16 @@ extern "C" {
     // Returns NULL if pooling_type is LLAMA_POOLING_TYPE_NONE
     // shape: [n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
+
+    //
+    // Vision
+    //
+
+    // encode image into embeddings
+    LLAMA_API int32_t llama_vision_encode(struct llama_context * ctx, llama_img_batch * batch);
+
+    // get output embeddings, to be put into language batch
+    LLAMA_API float * llama_vision_get_embeddings(struct llama_context * ctx, int32_t idx);
 
     //
     // Vocab

--- a/include/llama.h
+++ b/include/llama.h
@@ -903,6 +903,8 @@ extern "C" {
     // get output embeddings, to be put into language batch
     LLAMA_API float * llama_vision_get_embeddings(struct llama_context * ctx, int32_t idx);
 
+    LLAMA_API int32_t llama_vision_n_patches(struct llama_context * ctx);
+
     //
     // Vocab
     //

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(llama
             llama-vocab.cpp
             llama-grammar.cpp
             llama-sampling.cpp
+            llama-vision.cpp
             unicode.h
             unicode.cpp
             unicode-data.cpp

--- a/src/llama-vision.cpp
+++ b/src/llama-vision.cpp
@@ -54,6 +54,22 @@ struct clip_image_f32 {
 using clip_image_f32_batch = std::vector<clip_image_f32>;
 using clip_image_f8_batch  = std::vector<clip_image_u8>;
 
+clip_projector_type projector_type_from_name(std::string & name) {
+    if (name == "mlp") {
+        return CLIP_PROJECTOR_TYPE_MLP;
+    }
+    return CLIP_PROJECTOR_TYPE_UNKNOWN;
+}
+
+mm_patch_merge mm_patch_merge_from_name(std::string & name) {
+    if (name == "flat") {
+        return MM_PATCH_MERGE_FLAT;
+    } else if (name == "spatial_unpad") {
+        return MM_PATCH_MERGE_SPATIAL_UNPAD;
+    }
+    return MM_PATCH_MERGE_UNKNOWN;
+}
+
 int clip_n_patches(const clip_context & ctx) {
     auto & hparams = ctx.model->hparams;
     int n_patches = (hparams.image_size / hparams.patch_size) * (hparams.image_size / hparams.patch_size);
@@ -456,7 +472,7 @@ static ggml_cgraph * clip_image_build_graph(clip_context & ctx, int batch_size, 
     }
 
     // loop over layers
-    for (int il = 0; il < (int)hparams.n_layer - 2; il++) {
+    for (int il = 0; il < (int)hparams.n_layer + hparams.select_layer; il++) {
         struct ggml_tensor * cur = embeddings;
 
         // layernorm1

--- a/src/llama-vision.cpp
+++ b/src/llama-vision.cpp
@@ -1,0 +1,5 @@
+#include "llama.h"
+
+#include "llama-vision.h"
+
+

--- a/src/llama-vision.cpp
+++ b/src/llama-vision.cpp
@@ -78,14 +78,10 @@ int clip_n_patches(const clip_context & ctx) {
 
 int clip_n_mmproj_embd(const clip_context & ctx) {
     if (ctx.model->hparams.proj_type == CLIP_PROJECTOR_TYPE_MLP) {
-        return ctx.model->mm_b_b->ne[0];
+        return ctx.model->mm_2_b->ne[0];
     } else {
         GGML_ASSERT(false && "invalid proj type");
     }
-}
-
-int clip_n_embd(const clip_context & ctx) {
-    return clip_n_patches(ctx) * clip_n_mmproj_embd(ctx);
 }
 
 /**
@@ -575,12 +571,12 @@ static ggml_cgraph * clip_image_build_graph(clip_context & ctx, int batch_size, 
         embeddings = ggml_get_rows(ctx0, embeddings, patches);
 
         if (hparams.proj_type == CLIP_PROJECTOR_TYPE_MLP) {
-            embeddings = ggml_mul_mat(ctx0, model.mm_a_w, embeddings);
-            embeddings = ggml_add(ctx0, embeddings, model.mm_a_b);
+            embeddings = ggml_mul_mat(ctx0, model.mm_1_w, embeddings);
+            embeddings = ggml_add(ctx0, embeddings, model.mm_1_b);
 
             embeddings = ggml_gelu(ctx0, embeddings);
-            embeddings = ggml_mul_mat(ctx0, model.mm_b_w, embeddings);
-            embeddings = ggml_add(ctx0, embeddings, model.mm_b_b);
+            embeddings = ggml_mul_mat(ctx0, model.mm_2_w, embeddings);
+            embeddings = ggml_add(ctx0, embeddings, model.mm_2_b);
         } else {
             GGML_ASSERT(false && "unsupported proj type");
         }
@@ -681,7 +677,9 @@ static int32_t clip_image_batch_encode(clip_context & ctx, const clip_image_f32_
     ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(ctx.sched, embeddings);
 
     // copy the embeddings to the location passed by the user
-    output.resize(clip_n_embd(ctx));
+    size_t out_nbytes = clip_n_patches(ctx)*clip_n_mmproj_embd(ctx)*sizeof(float);
+    GGML_ASSERT(out_nbytes == ggml_nbytes(embeddings));
+    output.resize(out_nbytes);
     ggml_backend_tensor_get_async(backend_embd, embeddings, output.data(), 0, ggml_nbytes(embeddings));
 
     ggml_backend_sched_synchronize(ctx.sched);
@@ -731,15 +729,18 @@ static int32_t encode_image_with_clip(clip_context & ctx, const llama_img img, s
 ////////////////////////////////////////////////////////////////////////////////////////
 // public API
 
-int32_t llama_vision_encode_internal(clip_context & ctx, llama_img_batch * batch) {
+int32_t llama_encode_vision_internal(clip_context & ctx, llama_batch_img * batch) {
     if (batch->n_imgs == 0) {
         return 0;
     }
 
     // TODO: batching is not working atm, should be fixed later
-    const int n_embd = clip_n_embd(ctx);
-    ctx.output.resize(n_embd * batch->n_imgs);
-    ctx.n_output = batch->n_imgs;
+    const int n_embd = clip_n_mmproj_embd(ctx);
+    const int n_tokens_per_img = clip_n_patches(ctx);
+    const int n_pos = n_tokens_per_img*batch->n_imgs;
+
+    ctx.out_embd.resize(n_embd*n_pos);
+    ctx.out_pos.resize(n_pos);
 
     for (int i = 0; i < batch->n_imgs; i++) {
         std::vector<float> output_single;
@@ -748,12 +749,21 @@ int32_t llama_vision_encode_internal(clip_context & ctx, llama_img_batch * batch
             return status;
         }
         // copy output embeddings to result
-        for (int k = 0; k < n_embd; k++) {
-            ctx.output[n_embd*i + k] = output_single[k];
+        for (int k = 0; k < n_embd*n_tokens_per_img; k++) {
+            ctx.out_embd[n_embd*n_tokens_per_img*i + k] = output_single[k];
+        }
+        // fill position for all output tokens
+        for (int p = 0; p < n_tokens_per_img; p++) {
+            ctx.out_pos[n_tokens_per_img*i + p] = batch->pos[i] + p;
         }
     }
 
     return 0;
+}
+
+void llama_vision_clear_output(clip_context & ctx) {
+    ctx.out_embd.clear();
+    ctx.out_pos.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/llama-vision.cpp
+++ b/src/llama-vision.cpp
@@ -1,5 +1,496 @@
 #include "llama.h"
 
 #include "llama-vision.h"
+#include "llama-impl.h"
 
+struct clip_image_size {
+    int width;
+    int height;
+};
+
+// RGB uint8 image
+// Memory layout: RGBRGBRGB...
+struct clip_image_u8 {
+    int nx;
+    int ny;
+    std::vector<uint8_t> buf;
+    clip_image_u8() {}
+    clip_image_u8(const llama_img img) {
+        nx = img.nx;
+        ny = img.ny;
+        buf.resize(nx*ny*3);
+        memcpy(buf.data(), img.data, buf.size());
+    }
+};
+
+struct clip_image_u8_batch {
+    struct clip_image_u8 * data;
+    size_t size;
+};
+
+// RGB float32 image (NHWC)
+// Memory layout: RGBRGBRGB...
+struct clip_image_f32 {
+    int nx;
+    int ny;
+    std::vector<float> buf;
+};
+
+using clip_image_f32_batch = std::vector<clip_image_f32>;
+using clip_image_f8_batch  = std::vector<clip_image_u8>;
+
+int32_t clip_image_encode      (const clip_context & ctx, const clip_image_f32 & img,        std::vector<float> & output);
+int32_t clip_image_batch_encode(const clip_context & ctx, const clip_image_f32_batch & imgs, std::vector<float> & output);
+
+/**
+ * Selects the best resolution from a list of possible resolutions based on the original size.
+ *
+ * @param original_size The original size of the image in the format (width, height).
+ * @param possible_resolutions A list of possible resolutions in the format [(width1, height1), (width2, height2), ...].
+ * @return The best fit resolution in the format (width, height).
+ */
+static clip_image_size select_best_resolution(const clip_image_size & original_size, const std::vector<clip_image_size>& possible_resolutions) {
+    int original_width  = original_size.width;
+    int original_height = original_size.height;
+
+    clip_image_size best_fit;
+    int max_effective_resolution = 0;
+    int min_wasted_resolution = std::numeric_limits<int>::max();
+
+    for (const auto& resolution : possible_resolutions) {
+        int width   = resolution.width;
+        int height  = resolution.height;
+        float scale = std::min(static_cast<float>(width) / original_width, static_cast<float>(height) / original_height);
+        int downscaled_width  = static_cast<int>(original_width * scale);
+        int downscaled_height = static_cast<int>(original_height * scale);
+        int effective_resolution = std::min(downscaled_width * downscaled_height, original_width * original_height);
+        int wasted_resolution = (width * height) - effective_resolution;
+        // LOG_DBG("resolution: %d %d, scale: %f, downscaled: %d %d, effective: %d, wasted: %d\n", width, height, scale, downscaled_width, downscaled_height, effective_resolution, wasted_resolution);
+        if (effective_resolution > max_effective_resolution || (effective_resolution == max_effective_resolution && wasted_resolution < min_wasted_resolution)) {
+            max_effective_resolution = effective_resolution;
+            min_wasted_resolution = wasted_resolution;
+            best_fit = resolution;
+        }
+    }
+
+    return best_fit;
+}
+
+static bool bicubic_resize(const clip_image_u8 & img, clip_image_u8 & dst, int target_width, int target_height) {
+    auto clip = [](int x, int lower, int upper) -> int {
+        return std::max(lower, std::min(x, upper));
+    };
+
+    const int nx = img.nx;
+    const int ny = img.ny;
+
+    dst.nx = target_width;
+    dst.ny = target_height;
+    dst.buf.resize(3 * target_width * target_height);
+
+    float Cc;
+    float C[5];
+    float d0, d2, d3, a0, a1, a2, a3;
+    int i, j, k, jj;
+    int x, y;
+    float dx, dy;
+    float tx, ty;
+
+    tx = (float)nx / (float)target_width;
+    ty = (float)ny / (float)target_height;
+
+    // Bicubic interpolation; adapted from ViT.cpp, inspired from :
+    //    -> https://github.com/yglukhov/bicubic-interpolation-image-processing/blob/master/libimage.c#L36
+    //    -> https://en.wikipedia.org/wiki/Bicubic_interpolation
+
+    for (i = 0; i < target_height; i++) {
+        for (j = 0; j < target_width; j++) {
+            x = (int)(tx * j);
+            y = (int)(ty * i);
+
+            dx = tx * j - x;
+            dy = ty * i - y;
+
+            for (k = 0; k < 3; k++) {
+                for (jj = 0; jj <= 3; jj++) {
+                    d0 = img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x - 1, 0, nx - 1)) * 3 + k] - img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x, 0, nx - 1)) * 3 + k];
+                    d2 = img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x + 1, 0, nx - 1)) * 3 + k] - img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x, 0, nx - 1)) * 3 + k];
+                    d3 = img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x + 2, 0, nx - 1)) * 3 + k] - img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x, 0, nx - 1)) * 3 + k];
+                    a0 = img.buf[(clip(y - 1 + jj, 0, ny - 1) * nx + clip(x, 0, nx - 1)) * 3 + k];
+
+                    a1 = -1.0 / 3 * d0 + d2 - 1.0 / 6 * d3;
+                    a2 =  1.0 / 2 * d0 +      1.0 / 2 * d2;
+                    a3 = -1.0 / 6 * d0 -      1.0 / 2 * d2 + 1.0 / 6 * d3;
+
+                    C[jj] = a0 + a1 * dx + a2 * dx * dx + a3 * dx * dx * dx;
+
+                    d0 = C[0] - C[1];
+                    d2 = C[2] - C[1];
+                    d3 = C[3] - C[1];
+                    a0 = C[1];
+                    a1 = -1.0 / 3 * d0 + d2 - 1.0 / 6 * d3;
+                    a2 =  1.0 / 2 * d0 +      1.0 / 2 * d2;
+                    a3 = -1.0 / 6 * d0 -      1.0 / 2 * d2 + 1.0 / 6 * d3;
+                    Cc = a0 + a1 * dy + a2 * dy * dy + a3 * dy * dy * dy;
+
+                    const uint8_t Cc2 = std::min(std::max(std::round(Cc), 0.0f), 255.0f);
+                    dst.buf[(i * target_width + j) * 3 + k] = float(Cc2);
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+static std::vector<clip_image_u8> divide_to_patches_u8(const clip_image_u8 & image, int patch_size) {
+    std::vector<clip_image_u8> patches;
+    int width = image.nx;
+    int height = image.ny;
+    for (int i = 0; i < height; i += patch_size) {
+        for (int j = 0; j < width; j += patch_size) {
+            clip_image_u8 patch;
+            patch.nx = std::min(patch_size, width - j);
+            patch.ny = std::min(patch_size, height - i);
+            patch.buf.resize(3 * patch.nx * patch.ny);
+            for (int y = 0; y < patch.ny; ++y) {
+                for (int x = 0; x < patch.nx; ++x) {
+                    for (int c = 0; c < 3; ++c) {
+                        patch.buf[3 * (y * patch.nx + x) + c] = image.buf[3 * ((i + y) * width + (j + x)) + c];
+                    }
+                }
+            }
+            patches.push_back(patch);
+        }
+    }
+    return patches;
+}
+
+// llava-1.6 type of resize_and_pad (black)
+static void resize_and_pad_image(const clip_image_u8 & image, clip_image_u8 & image_output, const clip_image_size & target_resolution) {
+    int target_width  = target_resolution.width;
+    int target_height = target_resolution.height;
+
+    float scale_w = static_cast<float>(target_width) / image.nx;
+    float scale_h = static_cast<float>(target_height) / image.ny;
+
+    int new_width, new_height;
+
+    if (scale_w < scale_h) {
+        new_width = target_width;
+        new_height = std::min(static_cast<int>(std::ceil(image.ny * scale_w)), target_height);
+    } else {
+        new_height = target_height;
+        new_width = std::min(static_cast<int>(std::ceil(image.nx * scale_h)), target_width);
+    }
+
+    clip_image_u8 resized_image;
+    // bilinear_resize(image, resized_image, new_width, new_height);
+    bicubic_resize(image, resized_image, new_width, new_height);
+
+    clip_image_u8 padded_image;
+    padded_image.nx = target_width;
+    padded_image.ny = target_height;
+    padded_image.buf.resize(3 * target_width * target_height, 0); // Initialize with black
+
+    // Calculate padding offsets
+    int pad_x = (target_width - new_width) / 2;
+    int pad_y = (target_height - new_height) / 2;
+
+    // Copy the resized image into the center of the padded buffer
+    for (int y = 0; y < new_height; ++y) {
+        for (int x = 0; x < new_width; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                padded_image.buf[3 * ((y + pad_y) * target_width + (x + pad_x)) + c] = resized_image.buf[3 * (y * new_width + x) + c];
+            }
+        }
+    }
+    image_output = std::move(padded_image);
+}
+
+static void normalize_image_u8_to_f32(const clip_image_u8 src, clip_image_f32 dst, const std::array<float, 3> & mean, const std::array<float, 3> & std) {
+    dst.nx = src.nx;
+    dst.ny = src.ny;
+    dst.buf.resize(src.buf.size());
+
+    for (size_t i = 0; i < src.buf.size(); ++i) {
+        int c = i % 3; // rgb
+        dst.buf[i] = (static_cast<float>(src.buf[i]) / 255.0f - mean[c]) / std[c];
+    }
+}
+
+// returns the normalized float tensor for llava-1.5, for spatial_unpad with anyres processing for llava-1.6 it returns the normalized image patch tensors as a vector
+// res_imgs memory is being allocated here, previous allocations will be freed if found
+bool clip_image_preprocess(const clip_context & ctx, const clip_image_u8 & img, clip_image_f32_batch & output_imgs) {
+    bool pad_to_square = true;
+    auto & params = ctx.model.hparams;
+    // The model config actually contains all we need to decide on how to preprocess, here we automatically switch to the new llava-1.6 preprocessing
+    if (params.mm_patch_merge_type == MM_PATCH_MERGE_SPATIAL_UNPAD) {
+        pad_to_square = false;
+    }
+
+    // the logic below is to pad the shorter side to the longer side with a background color: rgb(122, 116, 104)
+    // see https://github.com/haotian-liu/LLaVA/blob/e854a2bf85118c504f6f16bf5c3c7c92f8fa8c6b/llava/conversation.py#L113-L156
+
+    clip_image_u8 temp;
+    if (pad_to_square && img.nx != img.ny) {
+        int longer_side = std::max(img.nx, img.ny);
+        temp.nx = longer_side;
+        temp.ny = longer_side;
+        temp.buf.resize(3 * longer_side * longer_side);
+        const uint8_t bc[3] = {122, 116, 104}; // background color in RGB from LLaVA (this is the mean rgb color * 255)
+
+        // fill with background color
+        for (size_t i = 0; i < temp.buf.size(); i++) {
+            temp.buf[i] = bc[i % 3];
+        }
+
+        // copy from the input image
+        for (int y = 0; y < img.ny; y++) {
+            for (int x = 0; x < img.nx; x++) {
+                const int i = 3 * (y * img.nx + x);
+                const int j = 3 * (y * temp.nx + x);
+                temp.buf[j]   = img.buf[i];
+                temp.buf[j+1] = img.buf[i+1];
+                temp.buf[j+2] = img.buf[i+2];
+            }
+        }
+    } else {
+        if (params.image_grid_pinpoints[0] != 0) {
+            // "spatial_unpad" with "anyres" processing for llava-1.6
+            std::vector<clip_image_size> possible_resolutions;
+            for (int i = 0; i < 32 && params.image_grid_pinpoints[i] != 0; i += 2) {
+                clip_image_size s;
+                s.width  = params.image_grid_pinpoints[i];
+                s.height = params.image_grid_pinpoints[i+1];
+                possible_resolutions.push_back(s);
+            }
+            clip_image_size best_resolution = select_best_resolution({img.nx, img.ny}, possible_resolutions);
+            // clip_image_save_to_bmp(*img, "input.bmp");
+            resize_and_pad_image(img, temp, best_resolution);  // we do not pad with mean-bg color anymore in llava-1.6
+            // clip_image_save_to_bmp(*temp, "resized.bmp");
+
+            std::vector<clip_image_u8> patches = divide_to_patches_u8(temp, params.image_size); // prepare spatial sorted main patches of image_size each (336 in llava-1.6)
+
+            clip_image_u8 image_original_resize;
+            // bilinear_resize(*img, *image_original_resize, params.image_size, params.image_size); // in python this is "shortest_edge", but all CLIP are square
+            bicubic_resize(img, image_original_resize, params.image_size, params.image_size); // in python this is "shortest_edge", but all CLIP are square
+            patches.insert(patches.begin(), image_original_resize);
+            // clip_image_f32_batch_init(patches.size());
+            output_imgs.resize(patches.size());
+            int num = 0;
+            for (auto & patch : patches) {
+                normalize_image_u8_to_f32(patch, output_imgs[num], params.image_mean, params.image_std);
+                num++;
+            }
+            return true;
+        } else {
+            temp.nx = img.nx;
+            temp.ny = img.ny;
+            temp.buf.resize(img.buf.size());
+            memcpy(temp.buf.data(), img.buf.data(), temp.buf.size());
+        }
+    }
+
+    const int nx = temp.nx;
+    const int ny = temp.ny;
+    // clip_image_save_to_bmp(*temp, "resized_vanilla.bmp");
+
+    const int nx2 = params.image_size;
+    const int ny2 = params.image_size;
+    clip_image_f32 res;
+    res.nx = nx2;
+    res.ny = ny2;
+    res.buf.resize(3 * nx2 * ny2);
+
+    const float scale = std::max(nx, ny) / (float)params.image_size;
+
+    const int nx3 = int(nx / scale + 0.5f);
+    const int ny3 = int(ny / scale + 0.5f);
+
+    const auto & m3 = params.image_mean; // {0.48145466f, 0.4578275f, 0.40821073f};
+    const auto & s3 = params.image_std;  // {0.26862954f, 0.26130258f, 0.27577711f};
+
+    for (int y = 0; y < ny3; y++) {
+        for (int x = 0; x < nx3; x++) {
+            for (int c = 0; c < 3; c++) {
+                // linear interpolation
+                const float sx = (x + 0.5f) * scale - 0.5f;
+                const float sy = (y + 0.5f) * scale - 0.5f;
+
+                const int x0 = std::max(0, (int)std::floor(sx));
+                const int y0 = std::max(0, (int)std::floor(sy));
+
+                const int x1 = std::min(x0 + 1, nx - 1);
+                const int y1 = std::min(y0 + 1, ny - 1);
+
+                const float dx = sx - x0;
+                const float dy = sy - y0;
+
+                const int j00 = 3 * (y0 * nx + x0) + c;
+                const int j01 = 3 * (y0 * nx + x1) + c;
+                const int j10 = 3 * (y1 * nx + x0) + c;
+                const int j11 = 3 * (y1 * nx + x1) + c;
+
+                const float v00 = temp.buf[j00];
+                const float v01 = temp.buf[j01];
+                const float v10 = temp.buf[j10];
+                const float v11 = temp.buf[j11];
+
+                const float v0 = v00 * (1.0f - dx) + v01 * dx;
+                const float v1 = v10 * (1.0f - dx) + v11 * dx;
+
+                const float v = v0 * (1.0f - dy) + v1 * dy;
+
+                const uint8_t v2 = std::min(std::max(std::round(v), 0.0f), 255.0f);
+
+                const int i = 3 * (y * nx3 + x) + c;
+
+                res.buf[i] = ((float(v2) / 255.0f) - m3[c]) / s3[c];
+            }
+        }
+    }
+
+    output_imgs.resize(1);
+    output_imgs[0] = std::move(res);
+
+    return true;
+}
+
+int clip_n_patches(const clip_context & ctx) {
+    auto & hparams = ctx.model.hparams;
+    int n_patches = (hparams.image_size / hparams.patch_size) * (hparams.image_size / hparams.patch_size);
+    return n_patches;
+}
+
+static bool encode_image_with_clip(clip_context & ctx_clip, const llama_img img) {
+    clip_image_u8 img_u8(img);
+    clip_image_f32_batch img_res_v;
+    std::vector<float> image_embd; // output vectors
+    auto & hparams = ctx_clip.model.hparams;
+    int n_output;
+
+    if (!clip_image_preprocess(ctx_clip, img_u8, img_res_v)) {
+        LLAMA_LOG_ERROR("%s: unable to preprocess image\n", __func__);
+        return false;
+    }
+
+    if (hparams.mm_patch_merge_type != MM_PATCH_MERGE_SPATIAL_UNPAD) {
+        // flat / default llava-1.5 type embedding
+        n_output = clip_n_patches(ctx_clip);
+        bool encoded = clip_image_encode(ctx_clip, img_res_v[0], image_embd);
+        if (!encoded) {
+            LLAMA_LOG_ERROR("Unable to encode image\n");
+            return false;
+        }
+    }
+}
+
+int32_t clip_image_encode(const clip_context & ctx, const clip_image_f32 & img, std::vector<float> & output) {
+    clip_image_f32_batch imgs{img};
+    return clip_image_batch_encode(ctx, imgs, output);
+}
+
+int32_t clip_image_batch_encode(const clip_context & ctx, const clip_image_f32_batch & imgs, std::vector<float> & output) {
+    int batch_size = imgs.size();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+// for debugging
+#ifndef NDEBUG
+
+#include <fstream>
+#include <vector>
+#include <cstdint>
+#include <iostream>
+
+// export clip_image_u8 to bmp file for debugging
+// https://codereview.stackexchange.com/questions/195121/writing-a-bitmap-image-from-c
+inline int bmp_export(const clip_image_u8 &img, const std::string &location) {
+    const uint32_t width = img.nx;
+    const uint32_t height = img.ny;
+    const std::vector<uint8_t> &buffer = img.buf;
+    const bool hasAlphaChannel = false;
+
+    std::ofstream fout(location, std::ios::out | std::ios::binary);
+
+    if (fout.fail()) {
+        return 0;
+    }
+
+    //Padding
+    const uint8_t padding = hasAlphaChannel ? 0 : (4 - (width * 3) % 4) % 4;
+
+    //Bitmap file header.
+    const char signature[2] = { 'B', 'M' };
+    const uint32_t fileSize = buffer.size() * sizeof(uint8_t) + padding * (height - 1) + 14 + 124;
+    const uint32_t offset = 14 + 124;
+
+    //Bitmap information header file
+    const uint32_t DIBSize = 124;
+    const int32_t bitmapWidth = width;
+    const int32_t bitmapHeight = height;
+    const uint16_t numPlanes = 1;
+    const uint16_t bitsPerPixel = (hasAlphaChannel) ? 32 : 24;
+    const uint32_t compressionMethod = (hasAlphaChannel) ? 3 : 0; //BI_RGB = 0, BI_BITFIELDS = 3
+    const uint32_t bitmapSize = buffer.size() * sizeof(uint8_t);
+    const int32_t horizontalResolution = 2834;
+    const int32_t verticalResolution = 2834;
+    const uint32_t numColors = 0;
+    const uint32_t impColorCount = 0;
+    const uint32_t redBitmask = (hasAlphaChannel) ? 0x0000FF00 : 0; //ARGB32 pixel format
+    const uint32_t greenBitmask = (hasAlphaChannel) ? 0x00FF0000 : 0;
+    const uint32_t blueBitmask = (hasAlphaChannel) ? 0xFF000000 : 0;
+    const uint32_t alphaBitmask = (hasAlphaChannel) ? 0x000000FF : 0;
+
+    //Writing the file header and information header to the file 
+    std::vector<uint8_t> header(offset, 0);
+    header[0] = signature[0];
+    header[1] = signature[1];
+
+#define BMP_HEADERS(i, variableName)    header[i] = variableName; header[i+1] = variableName >> 8; header[i+2] = variableName >> 16; header[i+3] = variableName >> 24;
+
+    BMP_HEADERS(2, fileSize);
+    BMP_HEADERS(6, 0);
+    BMP_HEADERS(10, offset);
+    BMP_HEADERS(14, DIBSize);
+    BMP_HEADERS(18, bitmapWidth);
+    BMP_HEADERS(22, bitmapHeight);
+
+    header[26] = (uint8_t)numPlanes;
+    header[27] = (uint8_t)(numPlanes >> 8);
+    header[28] = (uint8_t)bitsPerPixel;
+    header[29] = (uint8_t)(bitsPerPixel >> 8);
+
+    BMP_HEADERS(30, compressionMethod);
+    BMP_HEADERS(34, (unsigned char)bitmapSize);
+    BMP_HEADERS(38, (unsigned char)horizontalResolution);
+    BMP_HEADERS(42, (unsigned char)verticalResolution);
+    BMP_HEADERS(46, (unsigned char)numColors);
+    BMP_HEADERS(50, (unsigned char)impColorCount);
+    BMP_HEADERS(54, (unsigned char)redBitmask);
+    BMP_HEADERS(58, (unsigned char)greenBitmask);
+    BMP_HEADERS(62, (unsigned char)blueBitmask);
+    BMP_HEADERS(66, alphaBitmask);
+
+#undef BMP_HEADERS
+
+    fout.write((char *)header.data(), sizeof(uint8_t) * header.size());
+
+    //Writing the pixel array
+    const uint32_t bWidth = bitsPerPixel / 8 * width;
+
+    for (int i = height - 1; i >= 0; i--) {
+        std::vector<uint8_t> row(buffer.begin() + i * bWidth, buffer.begin() + i * bWidth + bWidth);
+        fout.write((char *)row.data(), row.size() * sizeof(uint8_t));
+        fout.seekp(padding * sizeof(uint8_t), std::ios::cur);
+    }
+
+    fout.close();
+    return 1;
+}
+
+#endif
 

--- a/src/llama-vision.h
+++ b/src/llama-vision.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "ggml.h"
+
+#include <vector>
+
+enum vision_arch {
+    VISION_ARCH_LLAVA,
+    VISION_ARCH_UNKNOWN,
+};
+
+enum mm_patch_merge {
+    MM_PATCH_MERGE_FLAT,
+    MM_PATCH_MERGE_SPATIAL_UNPAD,
+};
+
+struct clip_hparams {
+    vision_arch arch = VISION_ARCH_UNKNOWN;
+
+    uint32_t image_size;
+    uint32_t patch_size;
+    uint32_t hidden_size;
+    uint32_t n_intermediate;
+    uint32_t projection_dim;
+    uint32_t n_head;
+    uint32_t n_layer;
+    uint32_t max_pos_embd;
+
+    float eps;
+
+    mm_patch_merge mm_patch_merge_type = MM_PATCH_MERGE_FLAT;
+
+    int32_t image_grid_pinpoints[32];
+    int32_t image_crop_resolution;
+};
+
+struct clip_layer {
+    // attention
+    struct ggml_tensor * k_w;
+    struct ggml_tensor * k_b;
+    struct ggml_tensor * q_w;
+    struct ggml_tensor * q_b;
+    struct ggml_tensor * v_w;
+    struct ggml_tensor * v_b;
+
+    struct ggml_tensor * output_w;
+    struct ggml_tensor * output_b;
+
+    // layernorm 1
+    struct ggml_tensor * norm_in_w;
+    struct ggml_tensor * norm_in_b;
+
+    // ff
+    struct ggml_tensor * ffn_up_w;
+    struct ggml_tensor * ffn_up_b;
+
+    struct ggml_tensor * ffn_down_w;
+    struct ggml_tensor * ffn_down_b;
+
+    // layernorm 2
+    struct ggml_tensor * norm_out_w;
+    struct ggml_tensor * norm_out_b;
+};
+
+struct clip_vision_model {
+    struct clip_hparams hparams;
+
+    // embeddings
+    struct ggml_tensor * class_embedding;
+    struct ggml_tensor * patch_embeddings;
+    struct ggml_tensor * patch_bias;
+    struct ggml_tensor * position_embeddings;
+
+    struct ggml_tensor * pre_norm_w;
+    struct ggml_tensor * pre_norm_b;
+
+    std::vector<clip_layer> layers;
+
+    struct ggml_tensor * post_norm_w;
+    struct ggml_tensor * post_norm_b;
+
+    struct ggml_tensor * projection;
+
+    // LLaVA projection
+    struct ggml_tensor * mm_a_w = NULL;
+    struct ggml_tensor * mm_a_b = NULL;
+    struct ggml_tensor * mm_b_w = NULL;
+    struct ggml_tensor * mm_b_b = NULL;
+
+    struct ggml_tensor * image_newline = NULL;
+};

--- a/src/llama-vision.h
+++ b/src/llama-vision.h
@@ -9,6 +9,10 @@ enum vision_arch {
     VISION_ARCH_UNKNOWN,
 };
 
+enum clip_projector_type {
+    CLIP_PROJECTOR_TYPE_MLP,
+};
+
 enum mm_patch_merge {
     MM_PATCH_MERGE_FLAT,
     MM_PATCH_MERGE_SPATIAL_UNPAD,
@@ -28,9 +32,13 @@ struct clip_hparams {
 
     float eps;
 
+    clip_projector_type proj_type = CLIP_PROJECTOR_TYPE_MLP;
     mm_patch_merge mm_patch_merge_type = MM_PATCH_MERGE_FLAT;
 
-    int32_t image_grid_pinpoints[32];
+    std::array<float, 3> image_mean;
+    std::array<float, 3> image_std;
+
+    std::array<int32_t, 32> image_grid_pinpoints;
     int32_t image_crop_resolution;
 };
 
@@ -88,4 +96,12 @@ struct clip_vision_model {
     struct ggml_tensor * mm_b_b = NULL;
 
     struct ggml_tensor * image_newline = NULL;
+};
+
+struct clip_context {
+    struct ggml_context * ctx_ggml;
+    clip_vision_model model;
+
+    int32_t n_output;
+    float * output;
 };

--- a/src/llama-vision.h
+++ b/src/llama-vision.h
@@ -6,8 +6,8 @@
 #include <array>
 
 enum vision_arch {
-    VISION_ARCH_LLAVA,
     VISION_ARCH_UNKNOWN,
+    VISION_ARCH_LLAVA,
 };
 
 enum clip_projector_type {
@@ -111,5 +111,9 @@ struct clip_context {
     int n_output;
     std::vector<float> output; // size == n_output * n_embd
 };
+
+int clip_n_patches(const clip_context & ctx);
+int clip_n_mmproj_embd(const clip_context & ctx);
+int clip_n_embd(const clip_context & ctx);
 
 int32_t llama_vision_encode_internal(clip_context & ctx, llama_img_batch * batch);

--- a/src/llama-vision.h
+++ b/src/llama-vision.h
@@ -11,10 +11,12 @@ enum vision_arch {
 };
 
 enum clip_projector_type {
+    CLIP_PROJECTOR_TYPE_UNKNOWN,
     CLIP_PROJECTOR_TYPE_MLP,
 };
 
 enum mm_patch_merge {
+    MM_PATCH_MERGE_UNKNOWN,
     MM_PATCH_MERGE_FLAT,
     MM_PATCH_MERGE_SPATIAL_UNPAD,
 };
@@ -30,11 +32,12 @@ struct clip_hparams {
     uint32_t n_head;
     uint32_t n_layer;
     uint32_t max_pos_embd;
+    int32_t select_layer = 0;
     bool use_gelu = false;
 
     float eps;
 
-    clip_projector_type proj_type = CLIP_PROJECTOR_TYPE_MLP;
+    clip_projector_type proj_type = CLIP_PROJECTOR_TYPE_UNKNOWN;
     mm_patch_merge mm_patch_merge_type = MM_PATCH_MERGE_FLAT;
 
     std::array<float, 3> image_mean;
@@ -112,6 +115,8 @@ struct clip_context {
     std::vector<float> output; // size == n_output * n_embd
 };
 
+mm_patch_merge mm_patch_merge_from_name(std::string & name);
+clip_projector_type projector_type_from_name(std::string & name);
 int clip_n_patches(const clip_context & ctx);
 int clip_n_mmproj_embd(const clip_context & ctx);
 int clip_n_embd(const clip_context & ctx);

--- a/src/llama-vision.h
+++ b/src/llama-vision.h
@@ -95,10 +95,10 @@ struct clip_vision_model {
     struct ggml_tensor * projection = NULL;
 
     // LLaVA projection
-    struct ggml_tensor * mm_a_w = NULL;
-    struct ggml_tensor * mm_a_b = NULL;
-    struct ggml_tensor * mm_b_w = NULL;
-    struct ggml_tensor * mm_b_b = NULL;
+    struct ggml_tensor * mm_1_w = NULL;
+    struct ggml_tensor * mm_1_b = NULL;
+    struct ggml_tensor * mm_2_w = NULL;
+    struct ggml_tensor * mm_2_b = NULL;
 
     struct ggml_tensor * image_newline = NULL;
 };
@@ -110,15 +110,15 @@ struct clip_context {
 
     const clip_vision_model * model;
 
-    // temporary output data
-    int n_output;
-    std::vector<float> output; // size == n_output * n_embd
+    // temporary output data, to be picked up by llama_decode()
+    std::vector<float>     out_embd;  // size == n_tokens * n_embd
+    std::vector<llama_pos> out_pos;   // position of each token
 };
 
 mm_patch_merge mm_patch_merge_from_name(std::string & name);
 clip_projector_type projector_type_from_name(std::string & name);
 int clip_n_patches(const clip_context & ctx);
 int clip_n_mmproj_embd(const clip_context & ctx);
-int clip_n_embd(const clip_context & ctx);
 
-int32_t llama_vision_encode_internal(clip_context & ctx, llama_img_batch * batch);
+int32_t llama_encode_vision_internal(clip_context & ctx, llama_batch_img * batch);
+void llama_vision_clear_output(clip_context & ctx);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -658,8 +658,7 @@ enum llm_tensor {
 };
 
 enum vision_tensor {
-    VISION_TENSOR_MMPROJ_A,
-    VISION_TENSOR_MMPROJ_B,
+    VISION_TENSOR_MMPROJ,
     VISION_TENSOR_ENC_EMBD_CLS,
     VISION_TENSOR_ENC_EMBD_PATCH,
     VISION_TENSOR_ENC_EMBD_POS,
@@ -1601,8 +1600,7 @@ static const std::map<vision_arch, std::map<vision_tensor, std::string>> VISION_
     {
         VISION_ARCH_LLAVA,
         {
-            { VISION_TENSOR_MMPROJ_A,                "v.mmproj_a"                  },
-            { VISION_TENSOR_MMPROJ_B,                "v.mmproj_b"                  },
+            { VISION_TENSOR_MMPROJ,                  "v.mmproj"                    },
             { VISION_TENSOR_ENC_EMBD_CLS,            "v.enc.embd.cls"              },
             { VISION_TENSOR_ENC_EMBD_PATCH,          "v.enc.embd.patch"            },
             { VISION_TENSOR_ENC_EMBD_POS,            "v.enc.embd.pos"              },
@@ -8992,10 +8990,10 @@ static bool llm_load_tensors(
         switch (vparams.arch) {
             case VISION_ARCH_LLAVA:
                 {
-                    model.clip.mm_a_w = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ_A, "weight"), {n_embd, n_ff});
-                    model.clip.mm_a_b = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ_A, "bias"  ), {n_ff});
-                    model.clip.mm_b_w = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ_B, "weight"), {n_ff,   n_ff});
-                    model.clip.mm_b_b = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ_B, "bias"  ), {n_ff});
+                    model.clip.mm_a_w = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ, "weight", 1), {n_embd, n_ff});
+                    model.clip.mm_a_b = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ, "bias"  , 1), {n_ff});
+                    model.clip.mm_b_w = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ, "weight", 2), {n_ff,   n_ff});
+                    model.clip.mm_b_b = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_MMPROJ, "bias"  , 2), {n_ff});
 
                     model.clip.class_embedding     = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_ENC_EMBD_CLS            ), {n_embd});
                     model.clip.patch_embeddings    = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_ENC_EMBD_PATCH, "weight"), {patch_size, patch_size, n_channel, n_embd});

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6239,7 +6239,7 @@ static void llm_load_hparams(
         ml.get_key(LLM_KV_VISION_CLIP_FEED_FORWARD_LENGTH, vparams.n_intermediate, true);
         ml.get_key(LLM_KV_VISION_CLIP_HEAD_COUNT,          vparams.n_head,         true);
         ml.get_key(LLM_KV_VISION_CLIP_LAYERNORM_EPS,       vparams.eps,            true);
-        ml.get_key(LLM_KV_VISION_CLIP_PROJECTOR_TYPE,      proj_type,                   true);
+        ml.get_key(LLM_KV_VISION_CLIP_PROJECTOR_TYPE,      proj_type,              true);
         if (proj_type == "mlp") {
             vparams.proj_type = CLIP_PROJECTOR_TYPE_MLP;
         } else {
@@ -8987,9 +8987,9 @@ static bool llm_load_tensors(
                     model.clip.position_embeddings = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_ENC_EMBD_POS,   "weight"), {n_embd, max_pos_embd});
 
                     model.clip.pre_norm_w          = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_PRE_NORM,       "weight"), {n_embd});
-                    model.clip.pre_norm_w          = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_PRE_NORM,       "bias"  ), {n_embd});
-                    model.clip.post_norm_w         = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_POST_NORM,      "weight"), {n_embd});
-                    model.clip.post_norm_w         = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_POST_NORM,      "bias"  ), {n_embd});
+                    model.clip.pre_norm_b          = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_PRE_NORM,       "bias"  ), {n_embd});
+                    // model.clip.post_norm_w         = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_POST_NORM,      "weight"), {n_embd});
+                    // model.clip.post_norm_b         = ml.create_tensor(ctx_vision, tn(VISION_TENSOR_POST_NORM,      "bias"  ), {n_embd});
 
                     for (int i = 0; i < n_layer; ++i) {
                         ggml_context * ctx_layer = ctx_for_layer(i);
@@ -21813,6 +21813,10 @@ int32_t llama_vision_encode(struct llama_context * ctx, llama_img_batch * batch)
 
 float * llama_vision_get_embeddings(struct llama_context * ctx, int32_t idx) {
     return ctx->clip.output.data();
+}
+
+int32_t llama_vision_n_patches(struct llama_context * ctx) {
+    return clip_n_patches(ctx->clip);
 }
 
 //


### PR DESCRIPTION
(Hopefully) fix #8010

> [!IMPORTANT]
> This is still WIP, only `simple` example is working
> Collaborators are encouraged to discuss and give feedback on this

## Motivation

Currently, the vision capability is provided by `llava` example, which is a CLIP implementation in ggml. While it's a good start, the API need some refactoring to be cleaner and more future-proof.

Inspired by current rework on sampling API, I propose to move the CLIP implementation into the main `libllama`, providing user a stable, easy-to-use API like what we did for `llama_encode`

The goals of this refactoring are:
- Provide a good API and code architecture for more models to come in the future
- Single gguf file for both vision+language (so, no more model surgery)
- Only llava for now (because it simple for me to understand)
- Have `llama-cli` accept image input

The no-goals:
- No change to `llama-server`. It will be another PR
- No minicpm, llama-3.2-vision, phi-3-vision, etc. Again, will be another PR

## Plan

- [x] define the plan:
  - gguf metadata and tensor naming scheme
  - define API to be exposed from `libllama`
- [x] upgrade `convert_hf_to_gguf.py` to support llava --> not an ideal implementation, but kinda works
- [ ] extend `llama_model` and `llama_context` to hold vision-related data
- [ ] add `llama-vision.{cpp|h}`
- [ ] add image capability to `llama-cli`

## Implementation

### Naming scheme

For metadata, we will add `vision.*` namespace.
- `vision.type`: the type of vision encoder. We only support `"clip"` for now (not sure if there are any other implementation out there)
- `vision.*`: other params for vision encoding, for example patch size, image size, etc
- `vision.clip.*`: CLIP-related params

Example:

```
vision.type = 'clip'
vision.image_size = 336
vision.patch_size = 14
vision.clip.architecture = 'llava'
vision.clip.block_count = 24
vision.clip.embedding_length = 1024
vision.clip.feed_forward_length = 4096
vision.clip.attention.head_count = 16
```

For tensor naming scheme, we will prefix all vision-related tensor with `v.enc.*`. For example:

```
v.mmproj_a.bias
v.mmproj_a.weight
v.enc.embd.cls
v.enc.embd.patch.weight
v.enc.embd.pos.weight
v.enc.blk.0.input_norm.bias
v.enc.blk.0.input_norm.weight
```

### API

`libllama`will be responsible for:
- Accepting bitmap image (RGB format) and split it into patches
- It will NOT process specific format like PNG, JPG, etc. User must convert these format into bitmap (for example, using STB) before giving to llama
- The API returns embeddings that can be add to a language batch

```cpp
// represent an RGB image
// size of data must be equal to 3*nx*ny
struct llama_img {
    uint32_t nx;
    uint32_t ny;
    unsigned char * data;
};

typedef struct llama_img_batch {
    int32_t     n_imgs;
    llama_img * imgs;
    // add other things in future?
}

// encode image into embeddings
int32_t llama_vision_encode(struct llama_context * ctx, llama_img_batch * batch);

// get output embeddings, to be put into language batch
float * llama_vision_get_embeddings(struct llama_context * ctx, int32_t idx);

```

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] High
