### PR TITLE
Fixed RNG seed docs

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -911,7 +911,7 @@ gpt_params_context gpt_params_parser_init(gpt_params & params, llama_example ex,
     ).set_sparam());
     add_opt(llama_arg(
         {"-s", "--seed"}, "SEED",
-        format("RNG seed (default: %u, use random seed for %u)", params.sparams.seed, LLAMA_DEFAULT_SEED),
+        format("RNG seed (default: %d, use random seed for %d)", params.sparams.seed, LLAMA_DEFAULT_SEED),
         [](gpt_params & params, const std::string & value) {
             params.sparams.seed = std::stoul(value);
         }

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -100,7 +100,7 @@ The project is under active development, and we are [looking for feedback and co
 | Argument | Explanation |
 | -------- | ----------- |
 | `--samplers SAMPLERS` | samplers that will be used for generation in the order, separated by ';'<br/>(default: top_k;tfs_z;typ_p;top_p;min_p;temperature) |
-| `-s, --seed SEED` | RNG seed (default: 4294967295, use random seed for 4294967295) |
+| `-s, --seed SEED` | RNG seed (default: -1, use random seed for -1) |
 | `--sampling-seq SEQUENCE` | simplified sequence for samplers that will be used (default: kfypmt) |
 | `--ignore-eos` | ignore end of stream token and continue generating (implies --logit-bias EOS-inf) |
 | `--penalize-nl` | penalize newline tokens (default: false) |


### PR DESCRIPTION
* fix: set default RNG seed info in README to be random (`-1`)
* fix: changed format for `--seed` that it prints signed (`-1`)

[RNG seed (LLAMA_DEFAULT_SEED)](https://github.com/d-kleine/llama.cpp/blob/c6f4c22dcd562eb93d811073576a97d91bd3b261/common/arg.cpp#L914)

[#define LLAMA_DEFAULT_SEED 0xFFFFFFFF](https://github.com/d-kleine/llama.cpp/blob/c6f4c22dcd562eb93d811073576a97d91bd3b261/include/llama.h#L34)

`0xFFFFFFFF` equals `-1`

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
