### PR TITLE
Don't use a specific version for the main-cmake-pkg (CMake throws and error)

### DIFF
--- a/examples/main-cmake-pkg/CMakeLists.txt
+++ b/examples/main-cmake-pkg/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 project("llama-cli-cmake-pkg" C CXX)
 set(TARGET llama-cli-cmake-pkg)
 
-find_package(Llama 0.0.1 REQUIRED)
+find_package(Llama QUIET)
 
 # Bake common functionality in with target. Because applications
 # using the relocatable Llama package should be outside of the


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

---
Note for reviewers: do we need to check if package isn't available, and then throw error (something like this):
```cmake
if(MyPackage_FOUND)
    message(STATUS "MyPackage found!")
else()
    message(WARNING "MyPackage not found.")
endif()
```

Or just do nothing (CMake will throw an error if package is not found)? 