### PR TITLE
server : update prompt on slot restore

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1778,6 +1778,9 @@ struct server_context {
                     }
                     slot->cache_tokens.resize(token_count);
 
+                    // TODO: maybe detokenize the slot->cache_tokens instead?
+                    slot->prompt = string_format("[restored %d tokens from file]", (int) token_count);
+
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
 


### PR DESCRIPTION
ref https://github.com/ggerganov/llama.cpp/discussions/9781

The `slot.prompt` field is not being updated after restoring a slot state from a file. Since we don't store the original jsonic representation of the prompt, we simply set it to a descriptive message in order to not confuse the reported state of the slot.

Another option might be to detokenize the restored tokens. Not sure if worth it.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
