### PR TITLE
llama : adds llama-grammar memoization stacks (#4218)

### DIFF
--- a/examples/gbnf-validator/gbnf-validator.cpp
+++ b/examples/gbnf-validator/gbnf-validator.cpp
@@ -13,9 +13,9 @@ static bool llama_grammar_validate(struct llama_grammar * grammar, const std::st
 
     const llama_grammar_rules  & rules      = llama_grammar_get_rules (grammar);
           llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
+          llama_grammar_stacks_cache & stacks_cache = llama_grammar_get_stacks_cache(grammar);
 
     size_t pos = 0;
-    llama_grammar_stacks_cache stacks_cache;
     for (const auto & cpt : cpts) {
         const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
 

--- a/examples/gbnf-validator/gbnf-validator.cpp
+++ b/examples/gbnf-validator/gbnf-validator.cpp
@@ -11,20 +11,15 @@
 static bool llama_grammar_validate(struct llama_grammar * grammar, const std::string & input_str, size_t & error_pos, std::string & error_msg) {
     const auto cpts = unicode_cpts_from_utf8(input_str);
 
-    const llama_grammar_rules  & rules      = llama_grammar_get_rules (grammar);
-          llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
-          llama_grammar_stacks_cache & stacks_cache = llama_grammar_get_stacks_cache(grammar);
+    auto & stacks_cur = llama_grammar_get_stacks(grammar);
 
     size_t pos = 0;
     for (const auto & cpt : cpts) {
-        const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
-
-        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur, stacks_cache);
+        llama_grammar_accept(grammar, cpt);
 
         if (stacks_cur.empty()) {
             error_pos = pos;
             error_msg = "Unexpected character '" + unicode_cpt_to_utf8(cpt) + "'";
-            stacks_cur = stacks_prev;
             return false;
         }
         ++pos;
@@ -83,7 +78,8 @@ int main(int argc, char** argv) {
 
     llama_grammar * grammar = llama_grammar_init_impl(nullptr, grammar_str.c_str(), "root");
     if (grammar == nullptr) {
-        throw std::runtime_error("Failed to initialize llama_grammar");
+        fprintf(stdout, "Failed to initialize llama_grammar\n");
+        return 1;
     }
     // Read the input file
     std::string input_str;

--- a/examples/gbnf-validator/gbnf-validator.cpp
+++ b/examples/gbnf-validator/gbnf-validator.cpp
@@ -15,10 +15,11 @@ static bool llama_grammar_validate(struct llama_grammar * grammar, const std::st
           llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
 
     size_t pos = 0;
+    llama_grammar_stacks_cache stacks_cache;
     for (const auto & cpt : cpts) {
         const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
 
-        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur);
+        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur, stacks_cache);
 
         if (stacks_cur.empty()) {
             error_pos = pos;

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -764,7 +764,7 @@ static void llama_grammar_advance_stack_memo(
     if (it != stacks_cache.end()) {
            advanced_stacks = it->second;
     } else {
-        // Advance stacks with memorization
+        // Advance stacks with memoization
         llama_grammar_advance_stack_memo_impl(rules, stack, advanced_stacks, stacks_cache);
         stacks_cache.insert(make_pair(stack, advanced_stacks));
     }

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -684,7 +684,7 @@ static bool llama_grammar_match_partial_char(
 
 // transforms a grammar pushdown stack into N possible stacks, all ending
 // at a character range (terminal element)
-// additionally memorizes the stack to its possible stacks by mapping
+// additionally memoizes the stack to its possible stacks by mapping
 // < llama_grammar_stack, llama_grammar_stacks >
 
 static void llama_grammar_advance_stack_memo(

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -917,6 +917,10 @@ llama_grammar_stacks & llama_grammar_get_stacks(struct llama_grammar * grammar) 
     return grammar->stacks;
 }
 
+llama_grammar_stacks_cache & llama_grammar_get_stacks_cache(struct llama_grammar * grammar) {
+    return grammar->stacks_cache;
+}
+
 void llama_grammar_accept(
         const llama_grammar_rules  & rules,
         const llama_grammar_stacks & stacks,
@@ -1058,7 +1062,7 @@ struct llama_grammar * llama_grammar_init_impl(
     // Important: vec_rules has to be moved here, not copied, because stacks contains
     // pointers to elements of vec_rules. If vec_rules were copied into llama_grammar
     // then the pointers would be invalidated when the local vec_rules goes out of scope.
-    return new llama_grammar { vocab, std::move(vec_rules), std::move(stacks), {}, };
+    return new llama_grammar { vocab, std::move(vec_rules), std::move(stacks), {}, std::move(stacks_cache), };
 }
 
 struct llama_grammar * llama_grammar_init_impl(const struct llama_vocab * vocab, const char * grammar_str, const char * grammar_root) {
@@ -1137,7 +1141,7 @@ struct llama_grammar * llama_grammar_init_impl(const struct llama_vocab * vocab,
     // Important: vec_rules has to be moved here, not copied, because stacks contains
     // pointers to elements of vec_rules. If vec_rules were copied into llama_grammar
     // then the pointers would be invalidated when the local vec_rules goes out of scope.
-    return new llama_grammar { vocab, std::move(vec_rules), std::move(stacks), {}, };
+    return new llama_grammar { vocab, std::move(vec_rules), std::move(stacks), {}, std::move(stacks_cache), };
 }
 
 void llama_grammar_free_impl(struct llama_grammar * grammar) {
@@ -1225,10 +1229,9 @@ void llama_grammar_accept_impl(struct llama_grammar & grammar, llama_token token
     const auto & code_points = decoded.first;
 
     llama_grammar_stacks stacks_new;
-    llama_grammar_stacks_cache stacks_cache;
 
     for (auto it = code_points.begin(), end = code_points.end() - 1; it != end; ++it) {
-        llama_grammar_accept(grammar.rules, grammar.stacks, *it, stacks_new, stacks_cache);
+        llama_grammar_accept(grammar.rules, grammar.stacks, *it, stacks_new, grammar.stacks_cache);
         grammar.stacks = std::move(stacks_new);
     }
 

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -71,20 +71,15 @@ struct VectorPointerHash {
 
 using llama_grammar_stacks_cache = std::unordered_map<llama_grammar_stack, llama_grammar_stacks, VectorPointerHash>;
 
+// TODO: remove, needed for tests atm
 const llama_grammar_rules  & llama_grammar_get_rules (const struct llama_grammar * grammar);
       llama_grammar_stacks & llama_grammar_get_stacks(      struct llama_grammar * grammar);
-      llama_grammar_stacks_cache & llama_grammar_get_stacks_cache(      struct llama_grammar * grammar);
 
 // takes a set of possible pushdown stacks on a grammar, which are required to
 // be positioned at a character range (see `llama_grammar_advance_stack`), and
 // produces the N possible stacks if the given char is accepted at those
 // positions
-void llama_grammar_accept(
-        const llama_grammar_rules  & rules,
-        const llama_grammar_stacks & stacks,
-                          uint32_t   chr,
-              llama_grammar_stacks & stacks_new,
-              llama_grammar_stacks_cache & stacks_cache);
+void llama_grammar_accept(struct llama_grammar * grammar, uint32_t chr);
 
 std::vector<llama_grammar_candidate> llama_grammar_reject_candidates_for_stack(
         const llama_grammar_rules      & rules,
@@ -128,10 +123,11 @@ struct llama_grammar {
     const llama_grammar_rules  rules;  // TODO: shared ptr
           llama_grammar_stacks stacks;
 
-    // buffer for partially generated UTF-8 sequence from accepted tokens
-    llama_partial_utf8 partial_utf8;
     // cache N possible stacks from a stack
     llama_grammar_stacks_cache stacks_cache;
+
+    // buffer for partially generated UTF-8 sequence from accepted tokens
+    llama_partial_utf8 partial_utf8;
 };
 
 //

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -59,9 +59,6 @@ using llama_grammar_rules      = std::vector<llama_grammar_rule>;
 using llama_grammar_stacks     = std::vector<llama_grammar_stack>;
 using llama_grammar_candidates = std::vector<llama_grammar_candidate>;
 
-const llama_grammar_rules  & llama_grammar_get_rules (const struct llama_grammar * grammar);
-      llama_grammar_stacks & llama_grammar_get_stacks(      struct llama_grammar * grammar);
-
 struct VectorPointerHash {
     size_t operator()(const llama_grammar_stack & v) const {
         size_t seed = v.size();
@@ -73,6 +70,10 @@ struct VectorPointerHash {
 };
 
 using llama_grammar_stacks_cache = std::unordered_map<llama_grammar_stack, llama_grammar_stacks, VectorPointerHash>;
+
+const llama_grammar_rules  & llama_grammar_get_rules (const struct llama_grammar * grammar);
+      llama_grammar_stacks & llama_grammar_get_stacks(      struct llama_grammar * grammar);
+      llama_grammar_stacks_cache & llama_grammar_get_stacks_cache(      struct llama_grammar * grammar);
 
 // takes a set of possible pushdown stacks on a grammar, which are required to
 // be positioned at a character range (see `llama_grammar_advance_stack`), and
@@ -129,6 +130,8 @@ struct llama_grammar {
 
     // buffer for partially generated UTF-8 sequence from accepted tokens
     llama_partial_utf8 partial_utf8;
+    // cache N possible stacks from a stack
+    llama_grammar_stacks_cache stacks_cache;
 };
 
 //

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -34,8 +34,8 @@ static bool match_string(const std::string & input, llama_grammar * grammar) {
 
     const llama_grammar_rules  & rules      = llama_grammar_get_rules (grammar);
           llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
+          llama_grammar_stacks_cache & stacks_cache = llama_grammar_get_stacks_cache(grammar);
 
-    llama_grammar_stacks_cache stacks_cache;
     for (const auto & cpt : cpts) {
         const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
 

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -32,14 +32,10 @@ static bool test_build_grammar_fails(const std::string & grammar_str) {
 static bool match_string(const std::string & input, llama_grammar * grammar) {
     const auto cpts = unicode_cpts_from_utf8(input);
 
-    const llama_grammar_rules  & rules      = llama_grammar_get_rules (grammar);
-          llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
-          llama_grammar_stacks_cache & stacks_cache = llama_grammar_get_stacks_cache(grammar);
+    auto & stacks_cur = llama_grammar_get_stacks(grammar);
 
     for (const auto & cpt : cpts) {
-        const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
-
-        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur, stacks_cache);
+        llama_grammar_accept(grammar, cpt);
 
         if (stacks_cur.empty()) {
             // no stacks means that the grammar failed to match at this point
@@ -64,7 +60,7 @@ static void test(const std::string & test_desc, const std::string & grammar_str,
     auto * grammar = build_grammar(grammar_str);
 
     // Save the original grammar stacks so that we can reset after every new string we want to test
-    const llama_grammar_stacks stacks_org = llama_grammar_get_stacks(grammar);
+    const llama_grammar_stacks stacks_org = llama_grammar_get_stacks(grammar); // copy
 
     llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
 

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -35,10 +35,11 @@ static bool match_string(const std::string & input, llama_grammar * grammar) {
     const llama_grammar_rules  & rules      = llama_grammar_get_rules (grammar);
           llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
 
+    llama_grammar_stacks_cache stacks_cache;
     for (const auto & cpt : cpts) {
         const llama_grammar_stacks stacks_prev = llama_grammar_get_stacks(grammar); // copy
 
-        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur);
+        llama_grammar_accept(rules, stacks_prev, cpt, stacks_cur, stacks_cache);
 
         if (stacks_cur.empty()) {
             // no stacks means that the grammar failed to match at this point

--- a/tests/test-llama-grammar.cpp
+++ b/tests/test-llama-grammar.cpp
@@ -113,12 +113,10 @@ int main()
         }
     }
 
-    llama_grammar * grammar = NULL;
     std::vector<const llama_grammar_element *> grammar_rules(parsed_grammar.c_rules());
 
-    grammar = llama_grammar_init_impl(nullptr, grammar_rules.data(), grammar_rules.size(), parsed_grammar.symbol_ids.at("root"));
-    if (grammar == nullptr)
-    {
+    llama_grammar * grammar = llama_grammar_init_impl(nullptr, grammar_rules.data(), grammar_rules.size(), parsed_grammar.symbol_ids.at("root"));
+    if (grammar == nullptr) {
         throw std::runtime_error("Failed to initialize llama_grammar");
     }
 


### PR DESCRIPTION
I brought back @HanClinto idea on [memoize](https://github.com/ggerganov/llama.cpp/issues/4218#issuecomment-2053470658). You might have forgotten to add the` <stack, stacks>` pair in the `llama_grammar_stacks_cache.`

Here is a helpful case of memoization to avoid exponential increments on the stacks.

Grammar
```
root ::= digit ((letter (letter (letter (letter (letter)?)?)?)?)? digit )*
digit ::= [0-9]
letter ::= mega-rule-a | mega-rule-b
mega-rule-b ::= l-b  | l-ba
mega-rule-a ::= l-a | l-ab | l-aa | l-aaa | l-aaaa | l-aaaaa | l-aaaaaa | l-aaaaaaa | l-aaaaaaaa | l-aaaaaaaaa | l-aaaaaaaa | l-aaaaaaaaa | l-aaaaaaaaaa
l-a ::= "a"
l-b ::= "b"
l-ab ::= "ab"
l-ba ::= "ba"
l-aa ::= "aa"
l-aaa ::= "aaa"
l-aaaa ::= "aaaa"
l-aaaaa ::= "aaaaa"
l-aaaaaa ::= "aaaaaa"
l-aaaaaaa ::= "aaaaaaa"
l-aaaaaaaa ::= "aaaaaaaa"
l-aaaaaaaaa ::= "aaaaaaaaa"
l-aaaaaaaaaa ::= "a"+
```
[long_test.txt](https://github.com/user-attachments/files/17336355/long_test.txt)

Current llama-gbnf-validator profiling:
![current-validator](https://github.com/user-attachments/assets/52cab284-5ba3-41df-af2f-cc5c8f35ca84)

Memoization llama-gbnf-validator profiling:
![using-memoization](https://github.com/user-attachments/assets/23e521c5-e169-43f2-864a-60463a86ec16)

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
