### PR TITLE
llama : add nvidia nemotron chat template (not-working due to bad tokenizer)

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -21752,6 +21752,21 @@ static int32_t llama_chat_apply_template_internal(
         if (add_ass) {
             ss << "[|assistant|]";
         }
+    } else if (tmpl == "nemotron" || (tmpl_contains("<extra_id_0>System") && tmpl_contains("<extra_id_1>User"))) {
+        // nvidia/Mistral-NeMo-Minitron-8B-Instruct
+        for (auto message : chat) {
+            std::string role(message->role);
+            if (role == "system") {
+                ss << "<extra_id_0>System\n" << trim(message->content) << "\n\n";
+            } else if (role == "user") {
+                ss << "<extra_id_1>User\n" << trim(message->content) << "\n\n";
+            } else if (role == "assistant") {
+                ss << "<extra_id_1>Assistant\n" << trim(message->content) << "\n\n";
+            }
+        }
+        if (add_ass) {
+            ss << "<extra_id_1>Assistant\n";
+        }
     } else {
         // template not supported
         return -1;

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -65,6 +65,8 @@ int main(void) {
         u8"{% for message in messages %}{% if message['role'] == 'user' %}{{'<用户>' + message['content'].strip() + '<AI>'}}{% else %}{{message['content'].strip()}}{% endif %}{% endfor %}",
         // DeepSeek-V2
         "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}{{ 'User: ' + message['content'] + '\n\n' }}{% elif message['role'] == 'assistant' %}{{ 'Assistant: ' + message['content'] + eos_token }}{% elif message['role'] == 'system' %}{{ message['content'] + '\n\n' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}",
+        // nvidia/Mistral-NeMo-Minitron-8B-Instruct
+        "{{'<extra_id_0>System'}}{% for message in messages %}{% if message['role'] == 'system' %}{{'\n' + message['content'].strip()}}{% endif %}{% endfor %}{{'\n'}}{% for message in messages %}{% if message['role'] == 'user' %}{{ '\n<extra_id_1>User\n' + message['content'].strip() + '\n<extra_id_1>Assistant\n' }}{% elif message['role'] == 'assistant' %}{{ message['content'].strip() }}{% endif %}{% endfor %}",    
     };
     std::vector<std::string> expected_output = {
         // teknium/OpenHermes-2.5-Mistral-7B
@@ -109,6 +111,8 @@ int main(void) {
         u8"You are a helpful assistant<用户>Hello<AI>Hi there<用户>Who are you<AI>I am an assistant<用户>Another question<AI>",
         // DeepSeek-V2
         u8"You are a helpful assistant\n\nUser: Hello\n\nAssistant: Hi there<｜end▁of▁sentence｜>User: Who are you\n\nAssistant:    I am an assistant   <｜end▁of▁sentence｜>User: Another question\n\nAssistant:",
+        // nvidia/Mistral-NeMo-Minitron-8B-Instruct
+        "<extra_id_0>System\nYou are a helpful assistant\n\n<extra_id_1>User\nHello\n\n<extra_id_1>Assistant\nHi there\n\n<extra_id_1>User\nWho are you\n\n<extra_id_1>Assistant\nI am an assistant\n\n<extra_id_1>User\nAnother question\n\n<extra_id_1>Assistant\n",
     };
     std::vector<char> formatted_chat(1024);
     int32_t res;


### PR DESCRIPTION
This is mostly a demo, I have no intent to merge now.

The current problem is that the model [nvidia/Mistral-NeMo-Minitron-8B-Instruct](https://huggingface.co/nvidia/Mistral-NeMo-Minitron-8B-Instruct) does have the correct token `<extra_id_0>` and `<extra_id_1>` in the vocabulary, so it's just won't work as a chat model (yes, @NVIDIA , please fix it)

Fix #9864

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
