### PR TITLE
fix: use `vm_allocate` to allocate CPU backend buffer on macOS

### DIFF
--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -266,15 +266,12 @@ inline static void * ggml_aligned_malloc(size_t size) {
         case KERN_SUCCESS:
             result = 0;
             break;
-        
         case KERN_INVALID_ADDRESS:
             result = EINVAL;
             break;
-
         case KERN_NO_SPACE:
             result = ENOMEM;
             break;
-
         default:
             result = EFAULT;
             break;

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -1,25 +1,5 @@
 #pragma once
 
-#include "ggml-impl.h"
-
-#if defined(_MSC_VER) || defined(__MINGW32__)
-#include <malloc.h> // using malloc.h with MSC/MINGW
-#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
-#include <alloca.h>
-#endif
-
-#include <errno.h>
-
-#ifdef GGML_USE_CPU_HBM
-#include <hbwmalloc.h>
-#endif
-
-#if defined(__APPLE__)
-#include <unistd.h>
-#include <mach/mach.h>
-#include <TargetConditionals.h>
-#endif
-
 // ggml-backend internal header
 
 #include "ggml-backend.h"
@@ -241,72 +221,6 @@ extern "C" {
     void ggml_backend_device_register(ggml_backend_dev_t device);
     // TODO: backends can be loaded as a dynamic library, in which case it needs to export this function
     // typedef ggml_backend_register_t * (*ggml_backend_init)(void);
-
-
-    //
-    // Memory allocation
-    //
-
-#if defined(_MSC_VER) || defined(__MINGW32__)
-#define GGML_ALIGNED_MALLOC(size)       _aligned_malloc(size, GGML_MEM_ALIGN)
-#define GGML_ALIGNED_FREE(ptr, size)    _aligned_free(ptr)
-#else
-inline static void * ggml_aligned_malloc(size_t size) {
-    if (size == 0) {
-        GGML_LOG_WARN("Behavior may be unexpected when allocating 0 bytes for ggml_aligned_malloc!\n");
-        return NULL;
-    }
-    void * aligned_memory = NULL;
-#ifdef GGML_USE_CPU_HBM
-    int result = hbw_posix_memalign(&aligned_memory, 16, size);
-#elif TARGET_OS_OSX
-    kern_return_t alloc_status = vm_allocate((vm_map_t) mach_task_self(), (vm_address_t *) &aligned_memory, size, VM_FLAGS_ANYWHERE);
-    int result = EFAULT;
-    switch (alloc_status) {
-        case KERN_SUCCESS:
-            result = 0;
-            break;
-        case KERN_INVALID_ADDRESS:
-            result = EINVAL;
-            break;
-        case KERN_NO_SPACE:
-            result = ENOMEM;
-            break;
-        default:
-            result = EFAULT;
-            break;
-    }
-#elif GGML_USE_METAL
-    int result = posix_memalign(&aligned_memory, sysconf(_SC_PAGESIZE), size);
-#else
-    int result = posix_memalign(&aligned_memory, GGML_MEM_ALIGN, size);
-#endif
-    if (result != 0) {
-        // Handle allocation failure
-        const char *error_desc = "unknown allocation error";
-        switch (result) {
-            case EINVAL:
-                error_desc = "invalid alignment value";
-                break;
-            case ENOMEM:
-                error_desc = "insufficient memory";
-                break;
-        }
-        GGML_LOG_ERROR("%s: %s (attempted to allocate %6.2f MB)\n", __func__, error_desc, size/(1024.0*1024.0));
-        GGML_ABORT("fatal error");
-        return NULL;
-    }
-    return aligned_memory;
-}
-#define GGML_ALIGNED_MALLOC(size) ggml_aligned_malloc(size)
-#ifdef GGML_USE_CPU_HBM
-#define GGML_ALIGNED_FREE(ptr, size)    if(NULL != ptr) hbw_free(ptr)
-#elif TARGET_OS_OSX
-#define GGML_ALIGNED_FREE(ptr, size)    if(NULL != ptr) vm_deallocate((vm_map_t)mach_task_self(), (vm_address_t)ptr, size)
-#else
-#define GGML_ALIGNED_FREE(ptr, size)    free(ptr)
-#endif
-#endif
 
 #ifdef  __cplusplus
 }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -682,8 +682,6 @@ ggml_backend_t ggml_backend_init_best(void) {
 
 // backend CPU
 
-static const size_t TENSOR_ALIGNMENT = 32; // required for mmap as gguf only guarantees 32-byte alignment
-
 static const char * ggml_backend_cpu_buffer_get_name(ggml_backend_buffer_t buffer) {
     return "CPU";
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -702,7 +702,7 @@ static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
 }
 
 static void ggml_backend_cpu_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    GGML_ALIGNED_FREE(buffer->context, buffer->size);
+    ggml_aligned_free(buffer->context, buffer->size);
 }
 
 static void ggml_backend_cpu_buffer_memset_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
@@ -770,7 +770,7 @@ static const char * ggml_backend_cpu_buffer_type_get_name(ggml_backend_buffer_ty
 }
 
 static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    void * data = GGML_ALIGNED_MALLOC(size);
+    void * data = ggml_aligned_malloc(size);
 
     if (data == NULL) {
         GGML_LOG_ERROR("%s: failed to allocate buffer of size %zu\n", __func__, size);

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -196,6 +196,11 @@ struct ggml_cgraph {
 
 struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph, int i0, int i1);
 
+// Memory allocation
+
+void * ggml_aligned_malloc(size_t size);
+void ggml_aligned_free(void * ptr, size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -19,6 +19,9 @@ extern "C" {
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+// required for mmap as gguf only guarantees 32-byte alignment
+#define TENSOR_ALIGNMENT 32
+
 // static_assert should be a #define, but if it's not,
 // fall back to the _Static_assert C11 keyword.
 // if C99 - static_assert is noop

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -387,7 +387,7 @@ void ggml_log_callback_default(enum ggml_log_level level, const char * text, voi
 
 void * ggml_aligned_malloc(size_t size) {
 #if defined(_MSC_VER) || defined(__MINGW32__)
-    return _aligned_malloc(size, GGML_MEM_ALIGN);
+    return _aligned_malloc(size, GGUF_DEFAULT_ALIGNMENT);
 #else
     if (size == 0) {
         GGML_LOG_WARN("Behavior may be unexpected when allocating 0 bytes for ggml_aligned_malloc!\n");
@@ -416,7 +416,7 @@ void * ggml_aligned_malloc(size_t size) {
 #elif GGML_USE_METAL
     int result = posix_memalign(&aligned_memory, sysconf(_SC_PAGESIZE), size);
 #else
-    int result = posix_memalign(&aligned_memory, GGML_MEM_ALIGN, size);
+    int result = posix_memalign(&aligned_memory, GGUF_DEFAULT_ALIGNMENT, size);
 #endif
     if (result != 0) {
         // Handle allocation failure
@@ -442,11 +442,11 @@ void ggml_aligned_free(void * ptr, size_t size) {
 #if defined(_MSC_VER) || defined(__MINGW32__)
     _aligned_free(ptr);
 #elif GGML_USE_CPU_HBM
-    if(ptr != NULL) {
+    if (ptr != NULL) {
         hbw_free(ptr);
     }
 #elif TARGET_OS_OSX
-    if(ptr != NULL) {
+    if (ptr != NULL) {
         vm_deallocate((vm_map_t)mach_task_self(), (vm_address_t)ptr, size);
     }
 #else

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19554,9 +19554,10 @@ static void ggml_thread_cpumask_next(const bool * global_mask, bool * local_mask
 void ggml_threadpool_free(struct ggml_threadpool* threadpool) {
     if (!threadpool) return;
 
+    const int n_threads = threadpool->n_threads_max;
+    
 #ifndef GGML_USE_OPENMP
     struct ggml_compute_state* workers = threadpool->workers;
-    const int n_threads = threadpool->n_threads_max;
 
     ggml_mutex_lock(&threadpool->mutex);
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19577,8 +19577,7 @@ void ggml_threadpool_free(struct ggml_threadpool* threadpool) {
     ggml_cond_destroy(&threadpool->cond);
 #endif // GGML_USE_OPENMP
 
-    const size_t workers_size = sizeof(struct ggml_compute_state) * n_threads;
-    GGML_ALIGNED_FREE(threadpool->workers, workers_size);
+    GGML_ALIGNED_FREE(threadpool->workers, sizeof(struct ggml_compute_state) * n_threads);
     GGML_ALIGNED_FREE(threadpool, sizeof(struct ggml_threadpool));
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -414,8 +414,8 @@ void * ggml_aligned_malloc(size_t size) {
             break;
     }
 #elif GGML_USE_METAL
-    const auto page_size = sysconf(_SC_PAGESIZE);
-    int result = posix_memalign(&aligned_memory, MAX(TENSOR_ALIGNMENT, page_size), sysconf(_SC_PAGESIZE), size);
+    const long page_size = sysconf(_SC_PAGESIZE);
+    int result = posix_memalign(&aligned_memory, MAX(TENSOR_ALIGNMENT, page_size), size);
 #else
     int result = posix_memalign(&aligned_memory, TENSOR_ALIGNMENT, size);
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -387,7 +387,7 @@ void ggml_log_callback_default(enum ggml_log_level level, const char * text, voi
 
 void * ggml_aligned_malloc(size_t size) {
 #if defined(_MSC_VER) || defined(__MINGW32__)
-    return _aligned_malloc(size, GGUF_DEFAULT_ALIGNMENT);
+    return _aligned_malloc(size, TENSOR_ALIGNMENT);
 #else
     if (size == 0) {
         GGML_LOG_WARN("Behavior may be unexpected when allocating 0 bytes for ggml_aligned_malloc!\n");
@@ -416,7 +416,7 @@ void * ggml_aligned_malloc(size_t size) {
 #elif GGML_USE_METAL
     int result = posix_memalign(&aligned_memory, sysconf(_SC_PAGESIZE), size);
 #else
-    int result = posix_memalign(&aligned_memory, GGUF_DEFAULT_ALIGNMENT, size);
+    int result = posix_memalign(&aligned_memory, TENSOR_ALIGNMENT, size);
 #endif
     if (result != 0) {
         // Handle allocation failure

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -395,7 +395,7 @@ void * ggml_aligned_malloc(size_t size) {
     }
     void * aligned_memory = NULL;
 #ifdef GGML_USE_CPU_HBM
-    int result = hbw_posix_memalign(&aligned_memory, 16, size);
+    int result = hbw_posix_memalign(&aligned_memory, TENSOR_ALIGNMENT, size);
 #elif TARGET_OS_OSX
     kern_return_t alloc_status = vm_allocate((vm_map_t) mach_task_self(), (vm_address_t *) &aligned_memory, size, VM_FLAGS_ANYWHERE);
     int result = EFAULT;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -414,7 +414,8 @@ void * ggml_aligned_malloc(size_t size) {
             break;
     }
 #elif GGML_USE_METAL
-    int result = posix_memalign(&aligned_memory, sysconf(_SC_PAGESIZE), size);
+    const auto page_size = sysconf(_SC_PAGESIZE);
+    int result = posix_memalign(&aligned_memory, MAX(TENSOR_ALIGNMENT, page_size), sysconf(_SC_PAGESIZE), size);
 #else
     int result = posix_memalign(&aligned_memory, TENSOR_ALIGNMENT, size);
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -438,6 +438,7 @@ void * ggml_aligned_malloc(size_t size) {
 }
 
 void ggml_aligned_free(void * ptr, size_t size) {
+    GGML_UNUSED(size);
 #if defined(_MSC_VER) || defined(__MINGW32__)
     _aligned_free(ptr);
 #elif GGML_USE_CPU_HBM

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19555,7 +19555,7 @@ void ggml_threadpool_free(struct ggml_threadpool* threadpool) {
     if (!threadpool) return;
 
     const int n_threads = threadpool->n_threads_max;
-    
+
 #ifndef GGML_USE_OPENMP
     struct ggml_compute_state* workers = threadpool->workers;
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Creating a context in an Electron app using `node-llama-cpp` on macOS without Metal crashes the process with some models ([issue](https://github.com/withcatai/node-llama-cpp/issues/361)), so I've investigated what's happening and found that allocating a large memory block using `malloc` is the culprit.

For some reason, it happens only on Electron and not on Nodejs, but I couldn't figure out why.

To fix this issue, I switched to use `GGML_ALIGNED_MALLOC` instead of `malloc` in `ggml_backend_cpu_buffer_type_alloc_buffer`, and added support for `vm_allocate` in `GGML_ALIGNED_MALLOC` on macOS.