### PR TITLE
llava : fix memory leaks in minicpmv

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1927,6 +1927,7 @@ static std::vector<std::vector<clip_image_u8 *>> uhd_slice_image(const clip_imag
                 images[images.size()-1].push_back(patch);
             }
         }
+        delete refine_image;
     }
     return images;
 }
@@ -1965,6 +1966,16 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, cli
                 clip_image_f32_free(res);
             }
         }
+        for (size_t i = 0; i < imgs.size(); ++i) {
+            for (size_t j = 0; j < imgs[i].size(); ++j) {
+                if (imgs[i][j] != nullptr) {
+                    imgs[i][j]->buf.clear();
+                    delete imgs[i][j];
+                }
+            }
+            imgs[i].clear();
+        }
+        imgs.clear();
         return true;
     }
 

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1969,13 +1969,10 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, cli
         for (size_t i = 0; i < imgs.size(); ++i) {
             for (size_t j = 0; j < imgs[i].size(); ++j) {
                 if (imgs[i][j] != nullptr) {
-                    imgs[i][j]->buf.clear();
                     delete imgs[i][j];
                 }
             }
-            imgs[i].clear();
         }
-        imgs.clear();
         return true;
     }
 

--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -298,6 +298,9 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
         load_image_size->height = img->ny;
         clip_add_load_image_size(ctx_clip, load_image_size);
         LOG_INF("%s: load_image_size %d %d\n", __func__, load_image_size->width, load_image_size->height);
+        delete[] img_res_v.data;
+        img_res_v.size = 0;
+        img_res_v.data = nullptr;
     }
     else if (strcmp(mm_patch_merge_type, "spatial_unpad") != 0) {
         // flat / default llava-1.5 type embedding


### PR DESCRIPTION
I found that the code I previously implemented might have memory leaks. It would be difficult to detect this problem if I just executed the code once, but this bug was discovered by supporting the sever mode. 
This pr is used to fix all known memory leak issues. After relatively long sever mode testing, it was determined that minicpmv had no other memory leak problems.