### PR TITLE
server : add n_indent parameter for line indentation requirement

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -333,6 +333,8 @@ node index.js
 
     `n_predict`: Set the maximum number of tokens to predict when generating text. **Note:** May exceed the set limit slightly if the last token is a partial multibyte character. When 0, no tokens will be generated but the prompt is evaluated into the cache. Default: `-1`, where `-1` is infinity.
 
+    `n_indent`: Specify the minimum line indentation for the generated text in number of whitespace characters. Useful for code completion tasks. Default: `0`
+
     `n_keep`: Specify the number of tokens from the prompt to retain when the context size is exceeded and tokens need to be discarded. The number excludes the BOS token.
     By default, this value is set to `0`, meaning no tokens are kept. Use `-1` to retain all tokens from the prompt.
 


### PR DESCRIPTION
target #9924 

`/infill` requests can now pass the `"n_indent": int` parameter to require that each new generated line has an indentation of at least `n_indent` whitespaces. This is useful for code completion tasks, where we want to generate code in the current local scope.

## Before

<img width="1447" alt="n_indent-before" src="https://github.com/user-attachments/assets/e3f7b38e-caaa-4592-be95-315f0499b5a1">

## After

<img width="1396" alt="n_indent-after" src="https://github.com/user-attachments/assets/7174d9a2-6c60-4374-a0ff-29ec9ff39af7">
