### PR TITLE
ggml : fix possible buffer use after free in sched reserve

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2299,12 +2299,13 @@ bool ggml_backend_sched_reserve(ggml_backend_sched_t sched, struct ggml_cgraph *
 
     ggml_backend_sched_split_graph(sched, measure_graph);
 
+    ggml_backend_sched_synchronize(sched);
+
     if (!ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids)) {
         return false;
     }
 
     ggml_backend_sched_reset(sched);
-    ggml_backend_sched_synchronize(sched);
 
     return true;
 }


### PR DESCRIPTION
`ggml_gallocr_reserve_n` may reallocate the compute buffers, so any pending operations must be completed first with a call to `ggml_backend_sched_synchronize`.

Fixes #9928