### PR TITLE
server: handle n_predict==2 error

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -243,6 +243,8 @@ struct server_slot {
 
         if (params.n_predict != -1) {
             n_remaining = params.n_predict - n_decoded;
+        } else if (global_params.n_predict == -2) {
+            n_remaining = n_ctx - n_past;
         } else if (global_params.n_predict != -1) {
             n_remaining = global_params.n_predict - n_decoded;
         }


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

maybe fix: https://github.com/ggerganov/llama.cpp/issues/9933
