### PR TITLE
lora : error message if new token is added in the adapter

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -348,6 +348,9 @@ if __name__ == '__main__':
                         if ".base_layer.weight" in name:
                             continue
                         logger.error(f"Unexpected name '{name}': Not a lora_A or lora_B tensor")
+                        if ".embed_tokens.weight" in name or ".lm_head.weight" in name:
+                            logger.error("Embeddings is present in the adapter. This can be due to new tokens added during fine tuning")
+                            logger.error("Hint: if you are using TRL, make sure not to call setup_chat_format()")
                         sys.exit(1)
 
                     if base_name in tensor_map:


### PR DESCRIPTION
Related to #9778

Explanation from TRL team member:

> There can be situations where PEFT will automatically save the embedding layer when it detects that it has been changed (e.g. new tokens being added). However, this should save the full embedding layer, not lora_A and lora_B.

In llama.cpp, we simply can't support this case because it will break adapter hot-reload (cannot switch `lm_head` or `embd_tokens` at runtime). Also, if multiple adapters each has its own set of additional token, we can't mix and match these adapters together.

## Solution

When fine-tuning your model using TRL, please make sure:
- Not to add any token
- Not to call `setup_chat_format()`

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
