### PR TITLE
[SYCL] Add SYCL device and backend reg interfaces

### DIFF
--- a/ggml/include/ggml-sycl.h
+++ b/ggml/include/ggml-sycl.h
@@ -34,6 +34,8 @@ GGML_API void ggml_sycl_get_device_description(int device, char *description, si
 GGML_API int  ggml_backend_sycl_get_device_count();
 GGML_API void ggml_backend_sycl_get_device_memory(int device, size_t *free, size_t *total);
 
+GGML_API ggml_backend_reg_t ggml_backend_sycl_reg(void);
+
 // SYCL doesn't support registering host memory, keep here for reference
 // GGML_API bool ggml_backend_sycl_register_host_buffer(void * buffer, size_t size);
 // GGML_API void ggml_backend_sycl_unregister_host_buffer(void * buffer);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -546,6 +546,10 @@ void * ggml_backend_reg_get_proc_address(ggml_backend_reg_t reg, const char * na
 #include "ggml-rpc.h"
 #endif
 
+#ifdef GGML_USE_SYCL
+#include "ggml-sycl.h"
+#endif
+
 struct ggml_backend_registry {
     std::vector<ggml_backend_reg_t> backends;
     std::vector<ggml_backend_dev_t> devices;
@@ -563,10 +567,14 @@ struct ggml_backend_registry {
 #ifdef GGML_USE_RPC
         register_backend(ggml_backend_rpc_reg());
 #endif
-
+#ifdef GGML_USE_SYCL
+        register_backend(ggml_backend_sycl_reg());
+        // printf("zjy sycl ggml_backend_reg_count()=%d\n", ggml_backend_reg_count());
+#endif
         // TODO: sycl, vulkan, kompute, cann
 
         register_backend(ggml_backend_cpu_reg());
+        // printf("zjy cpu ggml_backend_reg_count()=%d\n", ggml_backend_reg_count());
     }
 
     void register_backend(ggml_backend_reg_t reg) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3416,9 +3416,7 @@ struct llama_lora_adapter {
 static int llama_get_device_count(const llama_model & model) {
     int count = (int) model.devices.size();
 
-#if defined(GGML_USE_SYCL)
-    count += ggml_backend_sycl_get_device_count();
-#elif defined(GGML_USE_VULKAN)
+#if defined(GGML_USE_VULKAN)
     count += ggml_backend_vk_get_device_count();
 #elif defined(GGML_USE_CANN)
     count += ggml_backend_cann_get_device_count();


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [x] High

This PR add SYCL device and backend reg interfaces by refer to CUDA backend: https://github.com/ggerganov/llama.cpp/commit/c83ad6d01e7b89ec71080d97c7e5db7ac1f4fda6.

It makes the SYCL backend follow the GGML backend standard interface.

1. Make the CI passed by support the new backend reg interface.
2. Print CPU info