### PR TITLE
test: convert test-grammar-integration.cpp to UTF-8-BOM encoding

### DIFF
--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -1,4 +1,4 @@
-#ifdef NDEBUG
+﻿#ifdef NDEBUG
 #undef NDEBUG
 #endif
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

This commit fix `error C2001: newline in constant` when building with MSVC.