### PR TITLE
Llama server - Update doc for slot states

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -761,8 +761,16 @@ Example:
 ```
 
 Possible values for `slot[i].state` are:
-- `0`: SLOT_STATE_IDLE
-- `1`: SLOT_STATE_PROCESSING
+- `0`: SLOT_STATE_IDLE  
+  The slot is idle and ready to use.
+- `1`: SLOT_STATE_PROCESSING_PROMPT  
+  The slot is processing the input prompt tokens.
+- `2`: SLOT_STATE_DONE_PROMPT  
+  The slot has finished processing the input prompt. For embedding and rerank tasks the slot will be released soon, otherwise the slot will be used for generation.
+- `3`: SLOT_STATE_GENERATING  
+  The slot is generating output tokens.
+
+[State diagram](https://github.com/ggerganov/llama.cpp/pull/9283)
 
 ### GET `/metrics`: Prometheus compatible metrics exporter
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Updates the documentation for the `state` property of slots returned by the `/slots` endpoint of llama-server. The documentation stated that the possible values were `0` and `1` but I was getting different values which led to me to the change in #9283 

Let me know if the explanations need to be changed :)