### PR TITLE
sampling : add adaptive temperature sampler

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1073,6 +1073,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sparam());
     add_opt(common_arg(
+        {"--temp-adaptive"},
+        "ignore arguments for temp and dynatemp, and automatically set temperature based on entropy",
+        [](common_params & params) {
+            params.sparams.temp_adaptive = true;
+        }
+    ).set_sparam());
+    add_opt(common_arg(
         {"--mirostat"}, "N",
         string_format("use Mirostat sampling.\nTop K, Nucleus, Tail Free and Locally Typical samplers are ignored if used.\n"
         "(default: %d, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)", params.sparams.mirostat),

--- a/common/common.h
+++ b/common/common.h
@@ -132,6 +132,7 @@ struct common_sampler_params {
     bool    penalize_nl        = false; // consider newlines as a repeatable token
     bool    ignore_eos         = false;
     bool    no_perf            = false; // disable performance metrics
+    bool    temp_adaptive      = false; // enables automatic adaptive setting of temperature
 
     std::vector<std::string> dry_sequence_breakers = {"\n", ":", "\"", "*"};     // default sequence breakers for DRY
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -812,6 +812,7 @@ struct server_context {
         slot.sparams.tfs_z              = json_value(data, "tfs_z",              default_sparams.tfs_z);
         slot.sparams.typ_p              = json_value(data, "typical_p",          default_sparams.typ_p);
         slot.sparams.temp               = json_value(data, "temperature",        default_sparams.temp);
+        slot.sparams.temp_adaptive      = json_value(data, "temp_adaptive",      default_sparams.temp_adaptive);
         slot.sparams.dynatemp_range     = json_value(data, "dynatemp_range",     default_sparams.dynatemp_range);
         slot.sparams.dynatemp_exponent  = json_value(data, "dynatemp_exponent",  default_sparams.dynatemp_exponent);
         slot.sparams.penalty_last_n     = json_value(data, "repeat_last_n",      default_sparams.penalty_last_n);
@@ -1142,6 +1143,7 @@ struct server_context {
             {"seed",                      slot.sparams.seed},
             {"seed_cur",                  slot.smpl ? common_sampler_get_seed(slot.smpl) : 0},
             {"temperature",               slot.sparams.temp},
+            {"temp_adaptive",             slot.sparams.temp_adaptive},
             {"dynatemp_range",            slot.sparams.dynatemp_range},
             {"dynatemp_exponent",         slot.sparams.dynatemp_exponent},
             {"top_k",                     slot.sparams.top_k},

--- a/include/llama.h
+++ b/include/llama.h
@@ -1099,6 +1099,9 @@ extern "C" {
     /// @details Dynamic temperature implementation (a.k.a. entropy) described in the paper https://arxiv.org/abs/2309.02772.
     LLAMA_API struct llama_sampler * llama_sampler_init_temp_ext   (float   t, float   delta, float exponent);
 
+    /// @details Adaptive temperature implementation described in the paper https://arxiv.org/abs/2410.01104.
+    LLAMA_API struct llama_sampler * llama_sampler_init_temp_adaptive   (void);
+
     /// @details XTC sampler as described in https://github.com/oobabooga/text-generation-webui/pull/6335
     LLAMA_API struct llama_sampler * llama_sampler_init_xtc        (float   p, float   t,     size_t min_keep, uint32_t seed);
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -1099,16 +1099,16 @@ static void llama_sampler_temp_adaptive_apply(struct llama_sampler * /*smpl*/, l
 
     // calculate beta
     float beta = 0.0f;
-    if (entropy > 0.5) { // don't overcorrect low-entropy heads
-        beta = -0.037 * powf(entropy, 4)
-             +  0.481 * powf(entropy, 3)
-             + -2.3   * powf(entropy, 2)
-             +  4.917 *      entropy
-             + -1.791;
+    if (entropy > 0.5f) { // don't overcorrect low-entropy heads
+        beta = -0.037f * powf(entropy, 4)
+             +  0.481f * powf(entropy, 3)
+             + -2.300f * powf(entropy, 2)
+             +  4.917f *      entropy
+             + -1.791f;
         // never increase entropy
-        beta = (beta < 1.0) ? 1.0 : beta;
+        beta = (beta < 1.0f) ? 1.0f : beta;
     } else {
-        beta = 1.0;
+        beta = 1.0f;
     }
 
     // beta = 1 / temp

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -72,6 +72,17 @@ static void test_temp(const std::vector<float> & probs, const std::vector<float>
     tester.check();
 }
 
+static void test_temp_adaptive(const std::vector<float> & probs, const std::vector<float> & probs_expected) {
+    sampler_tester tester(probs, probs_expected);
+
+    DUMP(&tester.cur_p);
+    tester.apply(llama_sampler_init_temp_adaptive());
+    tester.apply(llama_sampler_init_dist(0));
+    DUMP(&tester.cur_p);
+
+    tester.check();
+}
+
 static void test_temp_ext(const std::vector<float> & probs, const std::vector<float> & probs_expected, float temp, float delta, float exponent) {
     sampler_tester tester(probs, probs_expected);
 
@@ -311,7 +322,10 @@ int main(void) {
     ggml_time_init();
 
     test_temp({0.1f, 0.2f, 0.3f, 0.4f}, {0.4f, 0.3f, 0.2f, 0.1f}, 1.0f);
-    test_temp({0.1f, 0.2f, 0.3f, 0.4f}, {1.0f, 0.0f, 0.0f, 0.0f}, 0.0f);
+    test_temp({0.4f, 0.3f, 0.2f, 0.1f}, {1.0f, 0.0f, 0.0f, 0.0f}, 0.0f);
+
+    test_temp_adaptive({0.1f, 0.2f, 0.3f, 0.4f}, {0.488836, 0.304651, 0.156445, 0.050068});
+    test_temp_adaptive({0.7f, 0.1f, 0.1f, 0.1f}, {0.764643, 0.078452, 0.078452, 0.078452});
 
     test_temp_ext({0.1f, 0.2f, 0.3f, 0.4f}, {0.4f, 0.3f, 0.2f, 0.1f}, 1.0f, 0.0f, 1.0f);
     test_temp_ext({0.1f, 0.2f, 0.3f, 0.4f}, {1.0f, 0.0f, 0.0f, 0.0f}, 0.0f, 0.0f, 1.0f);


### PR DESCRIPTION
Adaptive temperature sampling from Google DeepMind's "[softmax is not enough (for sharp out-of-distribution)](https://arxiv.org/abs/2410.01104)"

Adds new `--temp-adaptive` argument. This will cause llama.cpp to ignore the `temp`, `dynatemp-range`, and `dynatemp-exp` settings. Instead, the temperature is calculated based on an entropy calculation.

[
    <img
        src="https://github.com/user-attachments/assets/389de1e1-e921-46eb-acbb-57abc3727888" 
        width=65%
        title="Polynomial Graph"
        alt="Polynomial Graph"
    />
](https://github.com/user-attachments/assets/389de1e1-e921-46eb-acbb-57abc3727888)

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Executed CI locally, all tests passed.