### PR TITLE
server : include scheme when printing URL

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3259,7 +3259,7 @@ int main(int argc, char ** argv) {
         ctx_server.queue_tasks.terminate();
     };
 
-    LOG_INF("%s: server is listening on %s:%d - starting the main loop\n", __func__, params.hostname.c_str(), params.port);
+    LOG_INF("%s: server is listening on http://%s:%d - starting the main loop\n", __func__, params.hostname.c_str(), params.port);
 
     ctx_server.queue_tasks.start_loop();
 


### PR DESCRIPTION
My terminal, like most modern terminals, allows you to click links to open them in the browser. To be recognized by such a terminal, the `http://` part needs to be included. So put that in the startup message so I can click it instead of needing to copy-paste.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
