### PR TITLE
ggml : do not abort when ggml_aligned_malloc fails

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -798,7 +798,7 @@ static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_back
     void * data = ggml_aligned_malloc(size);
 
     if (data == NULL) {
-        GGML_LOG_ERROR("%s: failed to allocate buffer of size %zu\n", __func__, size);
+        GGML_LOG_ERROR("%s: failed to allocate buffer of size %.2f MiB\n", __func__, size / 1024.0 / 1024.0);
         return NULL;
     }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -433,7 +433,6 @@ void * ggml_aligned_malloc(size_t size) {
                 break;
         }
         GGML_LOG_ERROR("%s: %s (attempted to allocate %6.2f MB)\n", __func__, error_desc, size/(1024.0*1024.0));
-        GGML_ABORT("fatal error");
         return NULL;
     }
     return aligned_memory;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -19520,6 +19520,7 @@ struct llama_context * llama_new_context_with_model(
 
         if (!llama_kv_cache_init(ctx->kv_self, ctx, type_k, type_v, kv_size, cparams.offload_kqv)) {
             LLAMA_LOG_ERROR("%s: llama_kv_cache_init() failed for self-attention cache\n", __func__);
+            LLAMA_LOG_ERROR("%s: suggestion: try using a smaller context size (-c command line option or llama_context_params.n_ctx)\n", __func__);
             llama_free(ctx);
             return nullptr;
         }


### PR DESCRIPTION
The change to use `ggml_aligned_malloc` in ggml-backend also caused it to crash the application when the memory allocation fails, which is not intended.

Additionally, added a suggestion to reduce the ctx size when kv initialization fails in llama.cpp.