### PR TITLE
llama-bench : skip repeated values in consecutive lines

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1095,6 +1095,8 @@ struct jsonl_printer : public printer {
 struct markdown_printer : public printer {
     std::vector<std::string> fields;
 
+    std::vector<std::string> prev_values;
+
     static int get_field_width(const std::string & field) {
         if (field == "model") {
             return -30;
@@ -1242,8 +1244,10 @@ struct markdown_printer : public printer {
 
     void print_test(const test & t) override {
         std::map<std::string, std::string> vmap = t.get_map();
+        std::vector<std::string> values;
 
         fprintf(fout, "|");
+        size_t i = 0;
         for (const auto & field : fields) {
             std::string value;
             char buf[128];
@@ -1292,9 +1296,20 @@ struct markdown_printer : public printer {
                 // HACK: the utf-8 character is 2 bytes
                 width += 1;
             }
+            values.push_back(value);
+
+            if (prev_values.size() > i && prev_values.at(i) == value) {
+                value = "";
+            }
+
+
             fprintf(fout, " %*s |", width, value.c_str());
+
+            i++;
         }
         fprintf(fout, "\n");
+
+        prev_values = std::move(values);
     }
 
     void print_footer() override {


### PR DESCRIPTION
The goal is to improve readability of the markdown output by skipping repeated column values. Not sure if it is actually better.

For example:
```
./llama-bench -fa 0,1 -p 128,512 -m models/7B/ggml-model-f16.gguf -m models/7B/ggml-model-Q4_0.gguf
```

| model                          |       size |     params | backend    | ngl | fa |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | ------------: | -------------------: |
| llama 7B F16                   |  12.55 GiB |     6.74 B | CUDA       |  99 |  0 |         pp128 |      4258.54 ± 11.35 |
|                                |            |            |            |     |    |         pp512 |      5613.05 ± 15.36 |
|                                |            |            |            |     |    |         tg128 |         60.14 ± 0.04 |
|                                |            |            |            |     |  1 |         pp128 |       4376.25 ± 7.00 |
|                                |            |            |            |     |    |         pp512 |      6078.50 ± 11.93 |
|                                |            |            |            |     |    |         tg128 |         61.07 ± 0.35 |
| llama 7B Q4_0                  |   3.56 GiB |            |            |     |  0 |         pp128 |      4925.08 ± 13.67 |
|                                |            |            |            |     |    |         pp512 |       5894.38 ± 5.63 |
|                                |            |            |            |     |    |         tg128 |        161.10 ± 0.30 |
|                                |            |            |            |     |  1 |         pp128 |       5076.93 ± 6.05 |
|                                |            |            |            |     |    |         pp512 |       6422.28 ± 5.30 |
|                                |            |            |            |     |    |         tg128 |        167.63 ± 0.55 |