### PR TITLE
[CANN] Fix compile error for CANN backend as get_name has been removed from ggml_backend_buffer_i

### DIFF
--- a/ggml/src/ggml-cann.cpp
+++ b/ggml/src/ggml-cann.cpp
@@ -1227,7 +1227,6 @@ static ggml_backend_buffer_t ggml_backend_cann_host_buffer_type_alloc_buffer(ggm
 
     ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(hostPtr, size);
     buffer->buft = buft;
-    buffer->iface.get_name = ggml_backend_cann_host_buffer_name;
     buffer->iface.free_buffer = ggml_backend_cann_host_buffer_free;
 
     return buffer;


### PR DESCRIPTION
Fix compile error for CANN backend as get_name has been removed from ggml_backend_buffer_i.  The issue corresponding is #10105.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High


Function is normal:
![image](https://github.com/user-attachments/assets/d29de890-4fdd-4e21-8df9-2fb2cfdebd45)
