### PR TITLE
gguf-py: Improve `GGUFReader` read-only mode performance

### DIFF
--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -95,6 +95,7 @@ class GGUFReader:
         offs = 0
 
         # Check for GGUF magic
+        self.data.seek(offs)
         if struct.unpack("<I", self.data.read(4))[0] != GGUF_MAGIC:
             raise ValueError('GGUF magic invalid')
         offs += 4

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -203,9 +203,9 @@ class GGUFReader:
         # Handle arrays.
         if gtype == GGUFValueType.ARRAY:
             raw_itype = self._get(offs, np.uint32)
-            offs += int(raw_itype.nbytes)
+            offs = self.data.tell()
             alen = self._get(offs, np.uint64)
-            offs += int(alen.nbytes)
+            offs = self.data.tell()
             aparts: list[npt.NDArray[Any]] = [raw_itype, alen]
             data_idxs: list[int] = []
             for idx in range(alen[0]):

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -89,8 +89,9 @@ class GGUFReader:
 
     def __init__(self, path: os.PathLike[str] | str, mode: Literal['r', 'r+', 'c'] = 'r'):
         file_mode = "rb" if mode == 'r' else 'rb+'
+        self.mode = mode
         self.data = open(path, mode=file_mode)
-        self.mmap = np.memmap(self.data, mode = mode)
+        self.mmap = np.memmap(path, mode = mode)
         offs = 0
 
         # Check for GGUF magic
@@ -150,10 +151,11 @@ class GGUFReader:
         itemsize = np.dtype(dtype).itemsize
         if not lazy:
             self.data.seek(offset)
-            return (
+            data = (
                 np.frombuffer(self.data.read(itemsize * count), dtype = dtype, count = count)
                 .newbyteorder(override_order or self.byte_order)
             )
+            return data if self.mode == 'r' else data.copy()
         else:
             return (
                 self.mmap[offset:offset + itemsize * count]

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -152,10 +152,10 @@ class GGUFReader:
     ) -> npt.NDArray[Any]:
         count = int(count)
         itemsize = np.dtype(dtype).itemsize
-        new_offset = offset + itemsize * count
-        self.data.seek(new_offset)
+        end_offs = offset + itemsize * count
+        self.data.seek(end_offs)
         return (
-            self.mmap[offset:new_offset]
+            self.mmap[offset:end_offs]
             .view(dtype = dtype)[:count]
             .newbyteorder(override_order or self.byte_order)
         )

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -88,8 +88,9 @@ class GGUFReader:
     }
 
     def __init__(self, path: os.PathLike[str] | str, mode: Literal['r', 'r+', 'c'] = 'r'):
-        self.data = open(path, mode="rb")
-        self.mmap = np.memmap(path, mode = mode)
+        file_mode = "rb" if mode == 'r' else 'rb+'
+        self.data = open(path, mode=file_mode)
+        self.mmap = np.memmap(self.data, mode = mode)
         offs = 0
 
         # Check for GGUF magic
@@ -129,7 +130,7 @@ class GGUFReader:
         if padding != 0:
             offs += self.alignment - padding
         self.data_offset = offs
-        # self._build_tensors(offs, tensors_fields)
+        self._build_tensors(offs, tensors_fields)
         self.data.close()
 
     _DT = TypeVar('_DT', bound = npt.DTypeLike)

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import logging
 import os
-import mmap
 import struct
 from collections import OrderedDict
 from typing import Any, Literal, NamedTuple, TypeVar, Union
@@ -133,7 +132,7 @@ class GGUFReader:
             offs += self.alignment - padding
         self.data_offset = offs
         self._build_tensors(offs, tensors_fields)
-    
+
     def __del__(self) -> None:
         self.data.close()
 
@@ -174,7 +173,7 @@ class GGUFReader:
     def _get_str(self, offset: int, return_size=False) -> tuple[npt.NDArray[np.uint64], npt.NDArray[np.uint8]]:
         self.data.seek(offset)
         slen = struct.unpack('<Q', self.data.read(8))
-        sdata = struct.unpack('<'+'B'*slen[0], self.data.read(1*slen[0]))
+        sdata = struct.unpack('<' + 'B' * slen[0], self.data.read(slen[0]))
         output = (slen, sdata)
         if return_size:
             output += (8 + slen[0],)


### PR DESCRIPTION
This PR aims to optimize the `GGUFReader` read-only performance with following modifications:
- Using native python file I/O to build fields instead of memmap array.
- Optimize `_get_str` and `_get` function in read-only mode with `np.from_buffer`.
- Avoid calculating offsets from array with creating intermediate data, using `tell` from native python I/O file to update offsets instead.

**Performance Comparison**

<details>

<summary> Benchmark script </summary>

```python3
#!/usr/bin/env python3
import logging
import sys
import time
from pathlib import Path
import psutil
from gguf.gguf_reader import GGUFReader

logger = logging.getLogger("reader")

sys.path.insert(0, str(Path(__file__).parent.parent))


def read_gguf_file(gguf_file_path):
    """
    Reads and prints key-value pairs and tensor information from a GGUF file in an improved format.

    Parameters:
    - gguf_file_path: Path to the GGUF file.
    """

    time0 = time.time()
    ram_init1 = psutil.virtual_memory()[2]
    ram_init2 = psutil.virtual_memory()[3]/1000000000

    reader = GGUFReader(gguf_file_path)

    # List all key-value pairs in a columnized format
    print("Key-Value Pairs:") # noqa: NP100
    max_key_length = max(len(key) for key in reader.fields.keys())
    for key, field in reader.fields.items():
        value = field.parts[field.data[0]]
        print(f"{key:{max_key_length}} : {value}") # noqa: NP100
    print("----") # noqa: NP100

    # List all tensors
    print("Tensors:") # noqa: NP100
    tensor_info_format = "{:<30} | Shape: {:<15} | Size: {:<12} | Quantization: {}"
    print(tensor_info_format.format("Tensor Name", "Shape", "Size", "Quantization")) # noqa: NP100
    print("-" * 80) # noqa: NP100
    for tensor in reader.tensors:
        shape_str = "x".join(map(str, tensor.shape))
        size_str = str(tensor.n_elements)
        quantization_str = tensor.tensor_type.name
        print(tensor_info_format.format(tensor.name, shape_str, size_str, quantization_str)) # noqa: NP100

    print('Time (s):', time.time() - time0)
    print('RAM memory % used:', psutil.virtual_memory()[2] - ram_init1)
    print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000 - ram_init2)


if __name__ == '__main__':
    if len(sys.argv) < 2:
        logger.info("Usage: reader.py <path_to_gguf_file>")
        sys.exit(1)
    gguf_file_path = sys.argv[1]
    read_gguf_file(gguf_file_path)
```

</details>


<details>
<summary>Comparison Results</summary>

File: [qwen2-0_5b-instruct-q2_k.gguf](https://huggingface.co/Qwen/Qwen2-0.5B-Instruct-GGUF/resolve/main/qwen2-0_5b-instruct-q2_k.gguf)
CPU: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
RAM: 16GB

**Master**
```text
Time (s): 12.987974643707275
RAM memory % used: 1.7999999999999972
RAM Used (GB): 0.31249203199999975
```

**This PR**
```text
Time (s): 4.433131456375122
RAM memory % used: 0.7999999999999972
RAM Used (GB): 0.1335459839999995
```
</details>



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
