### PR TITLE
Add the <|tool_call|> formatting to the granite template

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -21799,8 +21799,11 @@ static int32_t llama_chat_apply_template_internal(
         // IBM Granite template
         for (const auto & message : chat) {
             std::string role(message->role);
-            ss << "<|start_of_role|>" << role << "<|end_of_role|>"
-               << message->content << "<|end_of_text|>\n";
+            ss << "<|start_of_role|>" << role << "<|end_of_role|>";
+            if (role == "assistant_tool_call") {
+                ss << "<|tool_call|>";
+            }
+            ss << message->content << "<|end_of_text|>\n";
         }
         if (add_ass) {
             ss << "<|start_of_role|>assistant<|end_of_role|>\n";


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High


## Description

This is a small tweak on top of https://github.com/ggerganov/llama.cpp/pull/10013 (thanks @arch-btw for adding the template originally!) to include the `<|tool_call|>` tag that should be inserted when the model responds with a role of `assistant_tool_call`.