### PR TITLE
metal : reorder write loop in mul mat kernel + style

### DIFF
--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -6317,8 +6317,8 @@ kernel void kernel_mul_mm(device const  uchar * src0,
     const uint im = tgpig.z;
 
     // if this block is of 64x32 shape or smaller
-    short n_rows = (ne0 - r0 * BLOCK_SIZE_M < BLOCK_SIZE_M) ? (ne0 - r0 * BLOCK_SIZE_M) : BLOCK_SIZE_M;
-    short n_cols = (ne1 - r1 * BLOCK_SIZE_N < BLOCK_SIZE_N) ? (ne1 - r1 * BLOCK_SIZE_N) : BLOCK_SIZE_N;
+    short n_rows = (ne0 - r0*BLOCK_SIZE_M < BLOCK_SIZE_M) ? (ne0 - r0*BLOCK_SIZE_M) : BLOCK_SIZE_M;
+    short n_cols = (ne1 - r1*BLOCK_SIZE_N < BLOCK_SIZE_N) ? (ne1 - r1*BLOCK_SIZE_N) : BLOCK_SIZE_N;
 
     // a thread shouldn't load data outside of the matrix
     short thread_row = ((short)tiitg/THREAD_PER_ROW) < n_rows ? ((short)tiitg/THREAD_PER_ROW) : n_rows - 1;
@@ -6326,9 +6326,10 @@ kernel void kernel_mul_mm(device const  uchar * src0,
 
     simdgroup_T8x8     ma[4];
     simdgroup_float8x8 mb[2];
-    simdgroup_float8x8 c_res[8];
-    for (int i = 0; i < 8; i++){
-        c_res[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    simdgroup_float8x8 mc[8];
+
+    for (short i = 0; i < 8; i++){
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
     }
 
     short il = (tiitg % THREAD_PER_ROW);
@@ -6339,7 +6340,7 @@ kernel void kernel_mul_mm(device const  uchar * src0,
     uint   offset0 = (i12/r2)*nb02 + (i13/r3)*nb03;
     ushort offset1 = il/nl;
 
-    device const block_q * x = (device const block_q *)(src0 + (r0 * BLOCK_SIZE_M + thread_row) * nb01 + offset0) + offset1;
+    device const block_q * x = (device const block_q *)(src0 + (r0*BLOCK_SIZE_M + thread_row)*nb01 + offset0) + offset1;
     device const float   * y = (device const float   *)(src1
         + nb13 * i13
         + nb12 * i12
@@ -6353,13 +6354,13 @@ kernel void kernel_mul_mm(device const  uchar * src0,
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         #pragma unroll(16)
-        for (int i = 0; i < 16; i++) {
-            *(sa + SG_MAT_SIZE * ((tiitg / THREAD_PER_ROW / 8) \
-            +                     (tiitg % THREAD_PER_ROW) * 16 + (i / 8) * 8) \
-            +                     (tiitg / THREAD_PER_ROW) % 8  + (i & 7) * 8) = temp_a[i/4][i%4];
+        for (short i = 0; i < 16; i++) {
+            *(sa + SG_MAT_SIZE * ((tiitg/THREAD_PER_ROW/8) \
+            +                     (tiitg%THREAD_PER_ROW)*16 + (i/8)*8) \
+            +                     (tiitg/THREAD_PER_ROW)%8  + (i&7)*8) = temp_a[i/4][i%4];
         }
 
-        *(threadgroup float2x4 *)(sb + (tiitg % THREAD_PER_COL) * 8 * 32 + 8 * (tiitg / THREAD_PER_COL)) = *((device float2x4 *)y);
+        *(threadgroup float2x4 *)(sb + (tiitg % THREAD_PER_COL)*8*32 + 8*(tiitg/THREAD_PER_COL)) = *((device float2x4 *) y);
 
         il = (il + 2 < nl) ? il + 2 : il % 2;
         x  = (il < 2) ? x + (2+nl-1)/nl : x;
@@ -6368,27 +6369,27 @@ kernel void kernel_mul_mm(device const  uchar * src0,
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
         // load matrices from threadgroup memory and conduct outer products
-        threadgroup T     * lsma = (sa + THREAD_MAT_M * SG_MAT_SIZE * (sgitg % 2));
-        threadgroup float * lsmb = (sb + THREAD_MAT_N * SG_MAT_SIZE * (sgitg / 2));
+        threadgroup T     * lsma = (sa + THREAD_MAT_M*SG_MAT_SIZE*(sgitg%2));
+        threadgroup float * lsmb = (sb + THREAD_MAT_N*SG_MAT_SIZE*(sgitg/2));
 
         #pragma unroll(4)
-        for (int ik = 0; ik < BLOCK_SIZE_K / 8; ik++) {
+        for (short ik = 0; ik < BLOCK_SIZE_K / 8; ik++) {
             #pragma unroll(4)
-            for (int i = 0; i < 4; i++) {
-                simdgroup_load(ma[i],lsma + SG_MAT_SIZE * i);
+            for (short i = 0; i < 4; i++) {
+                simdgroup_load(ma[i], lsma + SG_MAT_SIZE * i);
             }
             simdgroup_barrier(mem_flags::mem_none);
             #pragma unroll(2)
-            for (int i = 0; i < 2; i++) {
-                simdgroup_load(mb[i],lsmb + SG_MAT_SIZE * i);
+            for (short i = 0; i < 2; i++) {
+                simdgroup_load(mb[i], lsmb + SG_MAT_SIZE * i);
             }
 
-            lsma += BLOCK_SIZE_M / SG_MAT_ROW * SG_MAT_SIZE;
-            lsmb += BLOCK_SIZE_N / SG_MAT_ROW * SG_MAT_SIZE;
+            lsma += BLOCK_SIZE_M/SG_MAT_ROW * SG_MAT_SIZE;
+            lsmb += BLOCK_SIZE_N/SG_MAT_ROW * SG_MAT_SIZE;
 
             #pragma unroll(8)
-            for (int i = 0; i < 8; i++){
-                simdgroup_multiply_accumulate(c_res[i], mb[i/4], ma[i%4], c_res[i]);
+            for (short i = 0; i < 8; i++){
+                simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
             }
         }
     }
@@ -6396,16 +6397,16 @@ kernel void kernel_mul_mm(device const  uchar * src0,
     if ((r0 + 1) * BLOCK_SIZE_M <= ne0 && (r1 + 1) * BLOCK_SIZE_N <= ne1) {
         device float * C = dst + (BLOCK_SIZE_M * r0 + 32 * (sgitg &  1)) \
                                + (BLOCK_SIZE_N * r1 + 16 * (sgitg >> 1)) * ne0 + im*ne1*ne0;
-        for (int i = 0; i < 8; i++) {
-            simdgroup_store(c_res[i], C + 8 * (i%4) + 8 * ne0 * (i/4), ne0);
+        for (short i = 0; i < 8; i++) {
+            simdgroup_store(mc[i], C + 8 * (i%4) + 8 * ne0 * (i/4), ne0);
         }
     } else {
         // block is smaller than 64x32, we should avoid writing data outside of the matrix
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        threadgroup float * temp_str = ((threadgroup float *)shared_memory) \
-                                      + 32 * (sgitg&1) + (16 * (sgitg>>1)) * BLOCK_SIZE_M;
-        for (int i = 0; i < 8; i++) {
-            simdgroup_store(c_res[i], temp_str + 8 * (i%4) + 8 * BLOCK_SIZE_M * (i/4), BLOCK_SIZE_M);
+        threadgroup float * temp_str = ((threadgroup float *) shared_memory) \
+                                      + 32 * (sgitg&1) + (16 * (sgitg>>1))*BLOCK_SIZE_M;
+        for (short i = 0; i < 8; i++) {
+            simdgroup_store(mc[i], temp_str + 8*(i%4) + 8*BLOCK_SIZE_M*(i/4), BLOCK_SIZE_M);
         }
 
         threadgroup_barrier(mem_flags::mem_threadgroup);


### PR DESCRIPTION
Minor optimization for `BS>1` by writing the results using `float4` instead of `float`.

```bash
./scripts/compare-commits.sh master gg/metal-mul-mat-write-opt -m ./models/llama-3.2-3b-instruct/ggml-model-q4_0.gguf -m ./models/llama-3.1-8b/ggml-model-q4_k.gguf -m models/llama-3.2-1b-instruct/ggml-model-q8_0.gguf -m models/qwen2.5-7b-coder/ggml-model-q8_0.gguf -m models/qwen2.5-1.5b-coder/ggml-model-f16.gguf -fa 1 -p 511,512,1,2,3,4,5,6,7,8 -n 128
```

| CPU      | Model           | Test   |   t/s master |   t/s gg/metal-mul-mat-write-opt |   Speedup |
|:---------|:----------------|:-------|-------------:|---------------------------------:|----------:|
| M2 Ultra | llama 1B Q8_0   | pp1    |       232.67 |                           230.65 |      0.99 |
| M2 Ultra | llama 1B Q8_0   | pp2    |       125.45 |                           133.59 |      1.06 |
| M2 Ultra | llama 1B Q8_0   | pp3    |       188.18 |                           198.16 |      1.05 |
| M2 Ultra | llama 1B Q8_0   | pp4    |       250.57 |                           265.69 |      1.06 |
| M2 Ultra | llama 1B Q8_0   | pp5    |       313.60 |                           331.30 |      1.06 |
| M2 Ultra | llama 1B Q8_0   | pp6    |       376.26 |                           397.60 |      1.06 |
| M2 Ultra | llama 1B Q8_0   | pp7    |       434.15 |                           460.83 |      1.06 |
| M2 Ultra | llama 1B Q8_0   | pp8    |       496.23 |                           531.32 |      1.07 |
| M2 Ultra | llama 1B Q8_0   | pp511  |      7650.92 |                          7744.50 |      1.01 |
| M2 Ultra | llama 1B Q8_0   | pp512  |      7791.42 |                          7801.47 |      1.00 |
| M2 Ultra | llama 1B Q8_0   | tg128  |       230.77 |                           231.00 |      1.00 |
| M2 Ultra | llama 3B Q4_0   | pp1    |       155.76 |                           155.40 |      1.00 |
| M2 Ultra | llama 3B Q4_0   | pp2    |        61.35 |                            64.07 |      1.04 |
| M2 Ultra | llama 3B Q4_0   | pp3    |        91.48 |                            95.32 |      1.04 |
| M2 Ultra | llama 3B Q4_0   | pp4    |       118.39 |                           124.69 |      1.05 |
| M2 Ultra | llama 3B Q4_0   | pp5    |       147.37 |                           155.11 |      1.05 |
| M2 Ultra | llama 3B Q4_0   | pp6    |       177.50 |                           185.52 |      1.05 |
| M2 Ultra | llama 3B Q4_0   | pp7    |       205.60 |                           215.63 |      1.05 |
| M2 Ultra | llama 3B Q4_0   | pp8    |       234.92 |                           247.89 |      1.06 |
| M2 Ultra | llama 3B Q4_0   | pp511  |      2863.44 |                          2962.87 |      1.03 |
| M2 Ultra | llama 3B Q4_0   | pp512  |      2908.56 |                          2988.59 |      1.03 |
| M2 Ultra | llama 3B Q4_0   | tg128  |       155.74 |                           155.60 |      1.00 |
| M2 Ultra | llama 8B Q4_K_M | pp1    |        85.79 |                            85.90 |      1.00 |
| M2 Ultra | llama 8B Q4_K_M | pp2    |        28.87 |                            29.79 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp3    |        43.22 |                            44.40 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp4    |        56.79 |                            58.38 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp5    |        71.16 |                            72.81 |      1.02 |
| M2 Ultra | llama 8B Q4_K_M | pp6    |        85.22 |                            87.56 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp7    |        98.90 |                           101.67 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp8    |       113.33 |                           116.40 |      1.03 |
| M2 Ultra | llama 8B Q4_K_M | pp511  |      1114.44 |                          1118.62 |      1.00 |
| M2 Ultra | llama 8B Q4_K_M | pp512  |      1128.36 |                          1124.39 |      1.00 |
| M2 Ultra | llama 8B Q4_K_M | tg128  |        85.86 |                            85.52 |      1.00 |
| M2 Ultra | qwen2 1.5B F16  | pp1    |       112.38 |                           112.68 |      1.00 |
| M2 Ultra | qwen2 1.5B F16  | pp2    |        81.90 |                            88.56 |      1.08 |
| M2 Ultra | qwen2 1.5B F16  | pp3    |       122.75 |                           130.37 |      1.06 |
| M2 Ultra | qwen2 1.5B F16  | pp4    |       158.62 |                           169.50 |      1.07 |
| M2 Ultra | qwen2 1.5B F16  | pp5    |       197.93 |                           212.72 |      1.07 |
| M2 Ultra | qwen2 1.5B F16  | pp6    |       241.20 |                           255.49 |      1.06 |
| M2 Ultra | qwen2 1.5B F16  | pp7    |       280.54 |                           298.75 |      1.06 |
| M2 Ultra | qwen2 1.5B F16  | pp8    |       321.05 |                           336.54 |      1.05 |
| M2 Ultra | qwen2 1.5B F16  | pp511  |      6035.39 |                          6208.76 |      1.03 |
| M2 Ultra | qwen2 1.5B F16  | pp512  |      6251.98 |                          6257.90 |      1.00 |
| M2 Ultra | qwen2 1.5B F16  | tg128  |       110.76 |                           110.69 |      1.00 |
| M2 Ultra | qwen2 7B Q8_0   | pp1    |        67.37 |                            68.35 |      1.01 |
| M2 Ultra | qwen2 7B Q8_0   | pp2    |        35.29 |                            36.57 |      1.04 |
| M2 Ultra | qwen2 7B Q8_0   | pp3    |        53.36 |                            54.62 |      1.02 |
| M2 Ultra | qwen2 7B Q8_0   | pp4    |        69.73 |                            71.91 |      1.03 |
| M2 Ultra | qwen2 7B Q8_0   | pp5    |        86.87 |                            89.66 |      1.03 |
| M2 Ultra | qwen2 7B Q8_0   | pp6    |       104.37 |                           107.63 |      1.03 |
| M2 Ultra | qwen2 7B Q8_0   | pp7    |       121.80 |                           125.39 |      1.03 |
| M2 Ultra | qwen2 7B Q8_0   | pp8    |       139.49 |                           143.51 |      1.03 |
| M2 Ultra | qwen2 7B Q8_0   | pp511  |      1347.18 |                          1355.80 |      1.01 |
| M2 Ultra | qwen2 7B Q8_0   | pp512  |      1358.74 |                          1360.51 |      1.00 |
| M2 Ultra | qwen2 7B Q8_0   | tg128  |        67.48 |                            67.62 |      1.00 |
