### PR TITLE
server : fix incorrect res in validate_model_chat_template

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -655,11 +655,15 @@ struct server_context {
     }
 
     bool validate_model_chat_template() const {
-        llama_chat_message chat[] = {{"user", "test"}};
-
-        const int res = llama_chat_apply_template(model, nullptr, chat, 1, true, nullptr, 0);
-
-        return res > 0;
+        std::vector<char> model_template(2048, 0); // longest known template is about 1200 bytes
+        std::string template_key = "tokenizer.chat_template";
+        int32_t res = llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
+        if (res >= 0) {
+            llama_chat_message chat[] = {{"user", "test"}};
+            std::string tmpl = std::string(model_template.data(), model_template.size());
+            res = llama_chat_apply_template(model, tmpl.c_str(), chat, 1, true, nullptr, 0);
+        }
+        return res >= 0;
     }
 
     void init() {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -661,9 +661,10 @@ struct server_context {
         if (res >= 0) {
             llama_chat_message chat[] = {{"user", "test"}};
             std::string tmpl = std::string(model_template.data(), model_template.size());
-            res = llama_chat_apply_template(model, tmpl.c_str(), chat, 1, true, nullptr, 0);
+            int32_t chat_res = llama_chat_apply_template(model, tmpl.c_str(), chat, 1, true, nullptr, 0);
+            return chat_res > 0;
         }
-        return res >= 0;
+        return false;
     }
 
     void init() {


### PR DESCRIPTION
The `llama_chat_apply_template` will use `chatml` as a fallback, so we will never gets res < 0 for models that don't supported chat template, and the warning will never be printed.

https://github.com/ggerganov/llama.cpp/blob/54ef9cfc726a799e6f454ac22c4815d037716eda/src/llama.cpp#L21822-L21843

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
