### PR TITLE
vulkan: Optimize soft_max

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -388,6 +388,7 @@ struct vk_op_soft_max_push_constants {
     float m0;
     float m1;
     uint32_t n_head_log2;
+    uint32_t nrows_x;
 };
 
 struct vk_op_argsort_push_constants {
@@ -1496,8 +1497,8 @@ static void ggml_vk_load_shaders(vk_device& device) {
 
     ggml_vk_create_pipeline(device, device->pipeline_diag_mask_inf_f32, "diag_mask_inf_f32", diag_mask_inf_f32_len, diag_mask_inf_f32_data, "main", 2, sizeof(vk_op_diag_mask_push_constants), {512, 1, 1}, {}, 1);
 
-    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32, "soft_max_f32", soft_max_f32_len, soft_max_f32_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, {}, 1);
-    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32_f16, "soft_max_f32_f16", soft_max_f32_f16_len, soft_max_f32_f16_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32, "soft_max_f32", soft_max_f32_len, soft_max_f32_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { device->subgroup_size }, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32_f16, "soft_max_f32_f16", soft_max_f32_f16_len, soft_max_f32_f16_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { device->subgroup_size }, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_rope_norm_f32, "rope_norm_f32", rope_norm_f32_len, rope_norm_f32_data, "main", 4, sizeof(vk_op_rope_push_constants), {1, 512, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_rope_norm_f16, "rope_norm_f16", rope_norm_f16_len, rope_norm_f16_data, "main", 4, sizeof(vk_op_rope_push_constants), {1, 512, 1}, {}, 1);
@@ -4581,6 +4582,7 @@ static void ggml_vk_soft_max(ggml_backend_vk_context * ctx, vk_context& subctx, 
         scale, max_bias,
         m0, m1,
         n_head_log2,
+        nrows_x,
     }, dryrun);
 }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -218,6 +218,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_tanh_f32;
     vk_pipeline pipeline_diag_mask_inf_f32;
     vk_pipeline pipeline_soft_max_f32, pipeline_soft_max_f32_f16;
+    vk_pipeline pipeline_soft_max_f32_wg512, pipeline_soft_max_f32_f16_wg512;
     vk_pipeline pipeline_rope_norm_f32, pipeline_rope_norm_f16;
     vk_pipeline pipeline_rope_neox_f32, pipeline_rope_neox_f16;
     vk_pipeline pipeline_argsort_f32;
@@ -1498,7 +1499,9 @@ static void ggml_vk_load_shaders(vk_device& device) {
     ggml_vk_create_pipeline(device, device->pipeline_diag_mask_inf_f32, "diag_mask_inf_f32", diag_mask_inf_f32_len, diag_mask_inf_f32_data, "main", 2, sizeof(vk_op_diag_mask_push_constants), {512, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32, "soft_max_f32", soft_max_f32_len, soft_max_f32_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { device->subgroup_size }, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32_wg512, "soft_max_f32_wg512", soft_max_f32_len, soft_max_f32_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { 512 }, 1);
     ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32_f16, "soft_max_f32_f16", soft_max_f32_f16_len, soft_max_f32_f16_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { device->subgroup_size }, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_soft_max_f32_f16_wg512, "soft_max_f32_f16_wg512", soft_max_f32_f16_len, soft_max_f32_f16_data, "main", 3, sizeof(vk_op_soft_max_push_constants), {1, 1, 1}, { 512 }, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_rope_norm_f32, "rope_norm_f32", rope_norm_f32_len, rope_norm_f32_data, "main", 4, sizeof(vk_op_rope_push_constants), {1, 512, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_rope_norm_f16, "rope_norm_f16", rope_norm_f16_len, rope_norm_f16_data, "main", 4, sizeof(vk_op_rope_push_constants), {1, 512, 1}, {}, 1);
@@ -3933,10 +3936,10 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
         GGML_ASSERT(!src1 || src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16);
 
         if (src0->type == GGML_TYPE_F32 && (src1 == nullptr || src1->type == GGML_TYPE_F32) && dst->type == GGML_TYPE_F32) {
-            return ctx->device->pipeline_soft_max_f32;
+            return src0->ne[0] > 1024 ? ctx->device->pipeline_soft_max_f32_wg512 : ctx->device->pipeline_soft_max_f32;
         }
         if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F32) {
-            return ctx->device->pipeline_soft_max_f32_f16;
+            return src0->ne[0] > 1024 ? ctx->device->pipeline_soft_max_f32_f16_wg512 : ctx->device->pipeline_soft_max_f32_f16;
         }
         return nullptr;
     case GGML_OP_ROPE:

--- a/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
@@ -1,6 +1,7 @@
 #version 450
 
-#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_control_flow_attributes : enable
 
 layout (push_constant) uniform parameter
 {
@@ -11,14 +12,13 @@ layout (push_constant) uniform parameter
     float m0;
     float m1;
     uint n_head_log2;
+    uint nrows_x;
 } p;
 
 #include "types.comp"
 
-#extension GL_EXT_control_flow_attributes : enable
-#define BLOCK_SIZE 512
-
-layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+layout(constant_id = 0) const uint BLOCK_SIZE = 32;
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 layout (binding = 0) readonly buffer X {A_TYPE data_a[];};
 layout (binding = 1) readonly buffer Y {B_TYPE data_b[];};
@@ -26,10 +26,17 @@ layout (binding = 2) buffer D {D_TYPE data_d[];};
 
 shared FLOAT_TYPE vals[BLOCK_SIZE];
 
-void main() {
+// num_iters is the number of BLOCK_SIZE loop iterations we need to iterate
+// over all the columns. The main function tries to pass a constant here,
+// as if it were a template function, to allow unrolling.
+void soft_max(uint num_iters) {
     const uint tid = gl_LocalInvocationID.x;
     const uint rowx = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
     const uint rowy = rowx % p.KY;
+
+    if (rowx >= p.nrows_x) {
+        return;
+    }
 
     float slope = 1.0f;
 
@@ -46,19 +53,37 @@ void main() {
     // Find max
     FLOAT_TYPE max_val = uintBitsToFloat(0xFF800000);
 
-    [[unroll]] for (uint col0 = 0; col0 < p.KX; col0 += BLOCK_SIZE) {
+    // Cache values while we compute the max, so we don't need to read them
+    // again when we're ready to compute exp(x-max).
+    const uint DATA_CACHE_SIZE = 16;
+    FLOAT_TYPE data_cache[DATA_CACHE_SIZE];
+
+    [[unroll]] for (uint col0 = 0, idx = 0; idx < num_iters; col0 += BLOCK_SIZE, ++idx) {
         const uint col = col0 + tid;
 
-        if (col >= p.KX) {
-            break;
+        FLOAT_TYPE a = FLOAT_TYPE(0);
+        if (col < p.KX) {
+            a = data_a[rowx * p.KX + col];
         }
 
-        max_val = max(max_val, FLOAT_TYPE(data_a[rowx * p.KX + col]) * p.scale + (p.KY > 0 ? slope * FLOAT_TYPE(data_b[rowy * p.KX + col]) : FLOAT_TYPE(0.0f)));
-    }
-    vals[tid] = max_val;
+        FLOAT_TYPE b = FLOAT_TYPE(0);
+        if (p.KY > 0 && col < p.KX) {
+            b = data_b[rowy * p.KX + col];
+        }
 
+        FLOAT_TYPE v = a * p.scale + slope * b;
+
+        max_val = max(max_val, v);
+
+        if (idx < DATA_CACHE_SIZE) {
+            data_cache[idx] = v;
+        }
+    }
+
+    // reduce across the workgroup
+    vals[tid] = max_val;
     barrier();
-    [[unroll]] for (int s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
         if (tid < s) {
             vals[tid] = max(vals[tid], vals[tid + s]);
         }
@@ -68,39 +93,89 @@ void main() {
     max_val = vals[0];
     barrier();
 
-    // Sum up values
-    vals[tid] = FLOAT_TYPE(0.0f);
+    FLOAT_TYPE sum = FLOAT_TYPE(0.0f);
 
-    [[unroll]] for (uint col0 = 0; col0 < p.KX; col0 += BLOCK_SIZE) {
+    // Compute sum{exp(x - max)}
+    [[unroll]] for (uint col0 = 0, idx = 0; idx < num_iters; col0 += BLOCK_SIZE, ++idx) {
         const uint col = col0 + tid;
 
         if (col >= p.KX) {
             break;
         }
 
+        // compute exp(a*scale+b*slope), add it to sum, and cache the new value
+        // in data_cache if possible.
         const uint i = rowx * p.KX + col;
-        const FLOAT_TYPE val = exp(FLOAT_TYPE(data_a[i]) * p.scale + (p.KY > 0 ? slope * FLOAT_TYPE(data_b[rowy * p.KX + col]) : FLOAT_TYPE(0.0f)) - max_val);
-        vals[tid] += val;
-        data_d[i] = D_TYPE(val);
+        FLOAT_TYPE val;
+        if (idx < DATA_CACHE_SIZE) {
+            val = exp(data_cache[idx] - max_val);
+        } else {
+            val = exp(FLOAT_TYPE(data_a[i]) * p.scale + (p.KY > 0 ? slope * FLOAT_TYPE(data_b[rowy * p.KX + col]) : FLOAT_TYPE(0.0f)) - max_val);
+        }
+        sum += val;
+        if (idx < DATA_CACHE_SIZE) {
+            data_cache[idx] = val;
+        } else {
+            data_d[i] = D_TYPE(val);
+        }
     }
 
+    // reduce across the workgroup
+    vals[tid] = sum;
     barrier();
-    [[unroll]] for (int s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
         if (tid < s) {
             vals[tid] += vals[tid + s];
         }
         barrier();
     }
+    sum = vals[0];
 
-    const D_TYPE divisor = D_TYPE(vals[0]);
+    FLOAT_TYPE rcpdivisor = 1.0/sum;
 
-    [[unroll]] for (uint col0 = 0; col0 < p.KX; col0 += BLOCK_SIZE) {
+    [[unroll]] for (uint col0 = 0, idx = 0; idx < num_iters; col0 += BLOCK_SIZE, ++idx) {
         const uint col = col0 + tid;
 
         if (col >= p.KX) {
-            break;
+            continue;
         }
 
-        data_d[rowx*p.KX + col] /= divisor;
+        if (idx < DATA_CACHE_SIZE) {
+            data_d[rowx*p.KX + col] = D_TYPE(data_cache[idx] * rcpdivisor);
+        } else {
+            data_d[rowx*p.KX + col] *= D_TYPE(rcpdivisor);
+        }
+    }
+}
+
+void main() {
+    // instantiate the soft_max function for several different
+    // dimensions, to allow loop unrolling
+    uint num_blocks = (p.KX + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    switch (num_blocks) {
+    case 1:
+        soft_max(1);
+        break;
+    case 2:
+        soft_max(2);
+        break;
+    case 3:
+        soft_max(3);
+        break;
+    case 4:
+        soft_max(4);
+        break;
+    case 5:
+    case 6:
+    case 7:
+    case 8:
+        soft_max(8);
+        break;
+    case 16:
+        soft_max(16);
+        break;
+    default:
+        soft_max(num_blocks);
+        break;
     }
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
@@ -152,30 +152,21 @@ void main() {
     // instantiate the soft_max function for several different
     // dimensions, to allow loop unrolling
     uint num_blocks = (p.KX + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    switch (num_blocks) {
-    case 1:
-        soft_max(1);
-        break;
-    case 2:
-        soft_max(2);
-        break;
-    case 3:
-        soft_max(3);
-        break;
-    case 4:
-        soft_max(4);
-        break;
-    case 5:
-    case 6:
-    case 7:
-    case 8:
-        soft_max(8);
-        break;
-    case 16:
-        soft_max(16);
-        break;
-    default:
+    if (num_blocks > 32) {
         soft_max(num_blocks);
-        break;
+    } else if (num_blocks > 16) {
+        soft_max(32);
+    } else if (num_blocks > 8) {
+        soft_max(16);
+    } else if (num_blocks > 4) {
+        soft_max(8);
+    } else if (num_blocks == 4) {
+        soft_max(4);
+    } else if (num_blocks == 3) {
+        soft_max(3);
+    } else if (num_blocks == 2) {
+        soft_max(2);
+    } else if (num_blocks == 1) {
+        soft_max(1);
     }
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3790,6 +3790,14 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
 
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_F16, {512, 3072, 1, 1}));
 
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {4096, 4096, 5, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {77, 4096, 5, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {1024, 1024, 10, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {77, 1024, 10, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {256, 256, 20, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {64, 64, 20, 1}, false, 1.0f, 0.0f));
+    test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {77, 64, 20, 1}, false, 1.0f, 0.0f));
+
     for (int bs : {1, 512}) {
         for (ggml_type type_a : all_types) {
             for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
Large soft_max could already saturate memory, but small/medium sizes were pretty slow. The bulk of the gains for them comes from using a smaller workgroup size, and making the workgroup size match the subgroup size also makes the barriers much cheaper.

Cache some values in locals to avoid refetching/recomputing. And stamp out a few "template instantiations" so smaller cases will fully unroll.

Add a missing early return for OOB rows. This happens when there are more than 512 rows and the dispatch is 512 x H.

These sizes I benchmarked came from a stable diffusion network I was looking at a while back.

```
Before:
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                 728 runs -  1472.19 us/run -   655360 kB/run -  428.62 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                  5448 runs -   351.30 us/run -    12320 kB/run -   33.45 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):               4510 runs -   238.39 us/run -    81920 kB/run -  328.11 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):                10896 runs -   177.49 us/run -     6160 kB/run -   33.10 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=0,scale=1.000000,max_bias=0.000000):                13108 runs -    92.21 us/run -    10240 kB/run -  105.92 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                  40955 runs -    29.06 us/run -      640 kB/run -   21.00 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                  40955 runs -    28.83 us/run -      770 kB/run -   25.47 GB/s
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                 470 runs -  2164.47 us/run -   720896 kB/run -  320.70 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                  4952 runs -   349.47 us/run -    13552 kB/run -   36.99 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):               4301 runs -   247.73 us/run -    86016 kB/run -  331.54 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):                10376 runs -   176.68 us/run -     6468 kB/run -   34.92 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=1,scale=1.000000,max_bias=0.000000):                12788 runs -    92.78 us/run -    10496 kB/run -  107.91 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                  40955 runs -    28.73 us/run -      656 kB/run -   21.78 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                  40955 runs -    28.92 us/run -      789 kB/run -   26.02 GB/s
  
After:
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                 676 runs -  1558.61 us/run -   655360 kB/run -  404.85 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                 46308 runs -    21.79 us/run -    12320 kB/run -  539.30 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):               5330 runs -   198.13 us/run -    81920 kB/run -  394.80 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):                81720 runs -    12.47 us/run -     6160 kB/run -  471.09 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=0,scale=1.000000,max_bias=0.000000):               108141 runs -     9.40 us/run -    10240 kB/run - 1038.94 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                 270303 runs -     3.71 us/run -      640 kB/run -  164.51 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                 278494 runs -     3.68 us/run -      770 kB/run -  199.55 GB/s
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                 376 runs -  2963.52 us/run -   720896 kB/run -  234.23 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                 49520 runs -    21.00 us/run -    13552 kB/run -  615.68 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):               5083 runs -   204.13 us/run -    86016 kB/run -  402.34 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):                88196 runs -    12.03 us/run -     6468 kB/run -  513.00 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=1,scale=1.000000,max_bias=0.000000):               102304 runs -    10.00 us/run -    10496 kB/run - 1001.46 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                 278494 runs -     3.61 us/run -      656 kB/run -  173.13 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                 270303 runs -     3.75 us/run -      789 kB/run -  200.55 GB/s
  
CUDA:
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                 676 runs -  1491.82 us/run -   655360 kB/run -  422.98 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=0,scale=1.000000,max_bias=0.000000):                 21792 runs -    46.83 us/run -    12320 kB/run -  250.96 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):               3280 runs -   333.83 us/run -    81920 kB/run -  234.31 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=0,scale=1.000000,max_bias=0.000000):                43584 runs -    24.65 us/run -     6160 kB/run -  238.38 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=0,scale=1.000000,max_bias=0.000000):                42601 runs -    25.40 us/run -    10240 kB/run -  384.60 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                 311258 runs -     3.27 us/run -      640 kB/run -  186.94 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=0,scale=1.000000,max_bias=0.000000):                 229348 runs -     4.44 us/run -      770 kB/run -  165.44 GB/s
  SOFT_MAX(type=f32,ne=[4096,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                 470 runs -  2208.65 us/run -   720896 kB/run -  314.29 GB/s
  SOFT_MAX(type=f32,ne=[77,4096,5,1],mask=1,scale=1.000000,max_bias=0.000000):                 22284 runs -    48.65 us/run -    13552 kB/run -  265.73 GB/s
  SOFT_MAX(type=f32,ne=[1024,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):               3128 runs -   338.29 us/run -    86016 kB/run -  242.78 GB/s
  SOFT_MAX(type=f32,ne=[77,1024,10,1],mask=1,scale=1.000000,max_bias=0.000000):                41504 runs -    25.95 us/run -     6468 kB/run -  237.73 GB/s
  SOFT_MAX(type=f32,ne=[256,256,20,1],mask=1,scale=1.000000,max_bias=0.000000):                41561 runs -    25.66 us/run -    10496 kB/run -  390.13 GB/s
  SOFT_MAX(type=f32,ne=[64,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                 311258 runs -     3.25 us/run -      656 kB/run -  192.73 GB/s
  SOFT_MAX(type=f32,ne=[77,64,20,1],mask=1,scale=1.000000,max_bias=0.000000):                 221157 runs -     4.66 us/run -      789 kB/run -  161.51 GB/s
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
