### PR TITLE
common: compile shared lib, and export some c functions

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 set(TARGET common)
 
-add_library(${TARGET} STATIC
+add_library(${TARGET}
     arg.cpp
     arg.h
     base64.hpp
@@ -70,6 +70,8 @@ add_library(${TARGET} STATIC
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_compile_definitions(${TARGET} PRIVATE LLAMA_BUILD)
+    target_compile_definitions(${TARGET} PUBLIC  LLAMA_SHARED)
 endif()
 
 set(LLAMA_COMMON_EXTRA_LIBS build_info)

--- a/common/common.h
+++ b/common/common.h
@@ -41,6 +41,10 @@ extern char const * LLAMA_BUILD_TARGET;
 
 struct common_control_vector_load_info;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //
 // CPU utils
 //
@@ -54,8 +58,12 @@ struct cpu_params {
     uint32_t poll                        = 50;      // Polling (busywait) level (0 - no polling, 100 - mostly polling)
 };
 
-int32_t cpu_get_num_physical_cores();
-int32_t cpu_get_num_math();
+LLAMA_API int32_t cpu_get_num_physical_cores();
+LLAMA_API int32_t cpu_get_num_math();
+
+#ifdef __cplusplus
+}
+#endif
 
 //
 // Common params


### PR DESCRIPTION
Dear llama.cpp Official,

Hi, I'm writing to address this PR submission for allowing common lib to be compiled into both dynamic and static libraries, and export some c functions. In this way, we can load libcommon.so and call these functions with FFI call. For example, [llama-cpp-python](https://github.com/abetlen/llama-cpp-python) proj can call **cpu_get_num_math** function.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
