### PR TITLE
CMake: fix typo in comment [no ci]

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CUDAToolkit_FOUND)
         # 60     == P100, FP16 CUDA intrinsics
         # 61     == Pascal, __dp4a instruction (per-byte integer dot product)
         # 70     == V100, FP16 tensor cores
-        # 75     == Turing, int6 tensor cores
+        # 75     == Turing, int8 tensor cores
         if (GGML_NATIVE AND CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.6")
             set(CMAKE_CUDA_ARCHITECTURES "native")
         elseif(GGML_CUDA_F16 OR GGML_CUDA_DMMV_F16)


### PR DESCRIPTION
Fixes a typo in a comment, no functional changes.