### PR TITLE
server: Fix the status of finish_reason if the stream value is False

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -662,8 +662,8 @@ static json oaicompat_completion_params_parse(
 }
 
 static json format_final_response_oaicompat(const json & request, const json & result, const std::string & completion_id, bool streaming = false, bool verbose = false) {
-    bool stopped_word        = result.count("stopped_word") != 0;
-    bool stopped_eos         = json_value(result, "stopped_eos", false);
+    bool stopped_word        = json_value(result, "stopped_word", false);
+    bool stopped_eos         = json_value(result, "stopped_eos",  false);
     int num_tokens_predicted = json_value(result, "tokens_predicted", 0);
     int num_prompt_tokens    = json_value(result, "tokens_evaluated", 0);
     std::string content      = json_value(result, "content", std::string(""));


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

"finish_reason" returns "stop" in all cases because the "stop_word" value is always "True" when using "stream false mode" in /chat/completions API.

So modify the "stopped_word" value so that "length" can also be returned.

Thanks.