### PR TITLE
bug-fix: snprintf prints NULL in place of the last character

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -341,9 +341,9 @@ static std::string llama_get_chat_template(const struct llama_model * model) {
     if (res < 0) {
         return "";
     } else {
-        std::vector<char> model_template(res, 0);
+        std::vector<char> model_template(res + 1, 0);
         llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
-        return std::string(model_template.data(), model_template.size());
+        return std::string(model_template.data(), model_template.size() - 1);
     }
 }
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -451,6 +451,7 @@ extern "C" {
     // Functions to access the model's GGUF metadata scalar values
     // - The functions return the length of the string on success, or -1 on failure
     // - The output string is always null-terminated and cleared on failure
+    // - When retrieving a string, an extra byte must be allocated to account for the null terminator
     // - GGUF array values are not supported by these functions
 
     // Get metadata value as a string by key name


### PR DESCRIPTION
We need to give snprintf enough space to print the last character **and** the `null` character, thus we allocate one extra byte and then ignore it when converting to std::string.

```C++
char buf[5];
snprintf(buf, 5, "hello");
printf("%s", buf); // -> hell\0
```

Because of this, when copying the C string into the `std::string`, we get a `\u0000` at the end of it, [which can cause issues](https://github.com/SillyTavern/SillyTavern/blob/4214c9d8940ac34ee866d87dbb342d39083a8a79/src/endpoints/backends/text-completions.js#L256-L259).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
