### PR TITLE
metadata: use char* under the hood to avoid conversion round trips

### DIFF
--- a/examples/cvector-generator/cvector-generator.cpp
+++ b/examples/cvector-generator/cvector-generator.cpp
@@ -422,8 +422,7 @@ int main(int argc, char ** argv) {
     int n_layers = llama_n_layer(model);
     int n_embd = llama_n_embd(model);
     // get model hint param (a.k.a model arch name)
-    char model_hint[128];
-    llama_model_meta_val_str(model, "general.architecture", model_hint, 128);
+    const char* model_hint = llama_model_meta_val_str(model, "general.architecture");
 
     // init train_context
     train_context ctx_train(n_embd, n_layers);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -663,14 +663,13 @@ struct server_context {
     bool validate_model_chat_template() const {
         std::vector<char> model_template(2048, 0); // longest known template is about 1200 bytes
         std::string template_key = "tokenizer.chat_template";
-        int32_t res = llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
-        if (res >= 0) {
-            llama_chat_message chat[] = {{"user", "test"}};
-            std::string tmpl = std::string(model_template.data(), model_template.size());
-            int32_t chat_res = llama_chat_apply_template(model, tmpl.c_str(), chat, 1, true, nullptr, 0);
-            return chat_res > 0;
+        const char* tmpl = llama_model_meta_val_str(model, template_key.c_str());
+        if (tmpl == NULL) {
+            return false;
         }
-        return false;
+        llama_chat_message chat[] = {{"user", "test"}};
+        int32_t chat_res = llama_chat_apply_template(model, tmpl, chat, 1, true, nullptr, 0);
+        return chat_res > 0;
     }
 
     void init() {

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -336,15 +336,8 @@ inline std::string format_chat(const struct llama_model * model, const std::stri
 
 static std::string llama_get_chat_template(const struct llama_model * model) {
     std::string template_key = "tokenizer.chat_template";
-    // call with NULL buffer to get the total size of the string
-    int32_t res = llama_model_meta_val_str(model, template_key.c_str(), NULL, 0);
-    if (res < 0) {
-        return "";
-    } else {
-        std::vector<char> model_template(res, 0);
-        llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
-        return std::string(model_template.data(), model_template.size());
-    }
+    const char* tmpl = llama_model_meta_val_str(model, template_key.c_str());
+    return tmpl ? tmpl : "";
 }
 
 //

--- a/include/llama.h
+++ b/include/llama.h
@@ -449,12 +449,11 @@ extern "C" {
     LLAMA_API float llama_rope_freq_scale_train(const struct llama_model * model);
 
     // Functions to access the model's GGUF metadata scalar values
-    // - The functions return the length of the string on success, or -1 on failure
-    // - The output string is always null-terminated and cleared on failure
+    // - The functions return a const char* of the value on success, and NULL on failure.
     // - GGUF array values are not supported by these functions
 
     // Get metadata value as a string by key name
-    LLAMA_API int32_t llama_model_meta_val_str(const struct llama_model * model, const char * key, char * buf, size_t buf_size);
+    LLAMA_API const char* llama_model_meta_val_str(const struct llama_model * model, const char * key);
 
     // Get the number of metadata key/value pairs
     LLAMA_API int32_t llama_model_meta_count(const struct llama_model * model);
@@ -463,7 +462,7 @@ extern "C" {
     LLAMA_API int32_t llama_model_meta_key_by_index(const struct llama_model * model, int32_t i, char * buf, size_t buf_size);
 
     // Get metadata value as a string by index
-    LLAMA_API int32_t llama_model_meta_val_str_by_index(const struct llama_model * model, int32_t i, char * buf, size_t buf_size);
+    LLAMA_API const char* llama_model_meta_val_str_by_index(const struct llama_model * model, int32_t i);
 
     // Get a string describing the model type
     LLAMA_API int32_t llama_model_desc(const struct llama_model * model, char * buf, size_t buf_size);


### PR DESCRIPTION
This replaces #10424 and removes the need for deallocation.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
