### PR TITLE
sycl : offload of get_rows set to false

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4486,7 +4486,7 @@ static bool ggml_backend_sycl_device_supports_buft(ggml_backend_dev_t dev, ggml_
 static int64_t get_op_batch_size(const ggml_tensor * op) {
     switch (op->op) {
         case GGML_OP_GET_ROWS:
-            return op->ne[1]; // this will increse the speed of prefill in test
+            return 0;
         case GGML_OP_MUL_MAT:
             return op->ne[1];
         case GGML_OP_MUL_MAT_ID:


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

----

#10133 changes changed get_rows from false to true. I've detected a big regression for  quantizations that support get_rows (llama3 Q8_0 for example).

@uniartisan Could you share more information of the device you used for offloading (where you saw increased performance)? Or did this just improve testing?

An example of regression:

| model                          |       size |     params | backend    | ngl |    sm | mmap |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ----: | ---: | ------------: | -------------------: |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |  none |    0 |         pp512 |      1340.34 ± 21.74 |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |  none |    0 |         tg128 |         88.64 ± 0.05 |

build: fab5d30f (4143)

With this revert:

| model                          |       size |     params | backend    | ngl |    sm | mmap |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ----: | ---: | ------------: | -------------------: |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |  none |    0 |         pp512 |      5777.93 ± 26.32 |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |  none |    0 |         tg128 |         89.31 ± 0.03 |

build: f4c4ce37

