### PR TITLE
fix: ggml: make GGML compatible with vulkan v1.2.162

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ option(LLAMA_BUILD_SERVER   "llama: build server example" ${LLAMA_STANDALONE})
 # 3rd party libs
 option(LLAMA_CURL "llama: use libcurl to download model from an URL" OFF)
 
+option(GGML_VULKAN_V1_2_162 "llama: make GGML compatible with vulkan v1.2.162" OFF)
+if (GGML_VULKAN_V1_2_162 AND GGML_VULKAN)
+    add_definitions(-DGGML_VULKAN_V1_2_162)
+endif()
+
 # Required for relocatable CMake package
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-info.cmake)
 


### PR DESCRIPTION
Add the option GGML_VULKAN_V1_2_162 to make GGML
compatible with vulkan v1.2.162.
This option is OFF by default.

vulkan-header: v1.2.162
https://github.com/KhronosGroup/Vulkan-Headers/tree/v1.2.162



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
