### PR TITLE
metal : small-batch mat-mul kernels

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -193,6 +193,30 @@ typedef struct {
 } ggml_metal_kargs_mul_mv;
 
 typedef struct {
+    int32_t  ne00;
+    int32_t  ne01;
+    int32_t  ne02;
+    uint64_t nb00;
+    uint64_t nb01;
+    uint64_t nb02;
+    uint64_t nb03;
+    int32_t  ne10;
+    int32_t  ne11;
+    int32_t  ne12;
+    uint64_t nb10;
+    uint64_t nb11;
+    uint64_t nb12;
+    uint64_t nb13;
+    int32_t  ne0;
+    int32_t  ne1;
+    int16_t  r2;
+    int16_t  r3;
+    int16_t  nsg;
+    int16_t  nxpsg;
+    int16_t  r1ptg;
+} ggml_metal_kargs_mul_mv_ext;
+
+typedef struct {
     int32_t  nei0;
     int32_t  nei1;
     uint64_t nbi1;

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -175,6 +175,30 @@ enum ggml_metal_kernel_type {
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q5_0_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q5_1_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q8_0_F32,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q2_K_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q3_K_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q4_K_F32,
@@ -699,6 +723,30 @@ static struct ggml_backend_metal_context * ggml_metal_init(ggml_backend_dev_t de
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q5_0_F32,               mul_mv_q5_0_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q5_1_F32,               mul_mv_q5_1_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q8_0_F32,               mul_mv_q8_0_f32,                has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_2,       mul_mv_ext_f16_f32_r1_2,        has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_3,       mul_mv_ext_f16_f32_r1_3,        has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_4,       mul_mv_ext_f16_f32_r1_4,        has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_5,       mul_mv_ext_f16_f32_r1_5,        has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_2,      mul_mv_ext_q4_0_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_3,      mul_mv_ext_q4_0_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_4,      mul_mv_ext_q4_0_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_5,      mul_mv_ext_q4_0_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_2,      mul_mv_ext_q4_1_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_3,      mul_mv_ext_q4_1_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_4,      mul_mv_ext_q4_1_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_5,      mul_mv_ext_q4_1_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_2,      mul_mv_ext_q5_0_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_3,      mul_mv_ext_q5_0_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_4,      mul_mv_ext_q5_0_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_5,      mul_mv_ext_q5_0_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_2,      mul_mv_ext_q5_1_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_3,      mul_mv_ext_q5_1_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_4,      mul_mv_ext_q5_1_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_5,      mul_mv_ext_q5_1_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_2,      mul_mv_ext_q8_0_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3,      mul_mv_ext_q8_0_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4,      mul_mv_ext_q8_0_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5,      mul_mv_ext_q8_0_f32_r1_5,       has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q2_K_F32,               mul_mv_q2_K_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q3_K_F32,               mul_mv_q3_K_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q4_K_F32,               mul_mv_q4_K_f32,                has_simdgroup_reduction);
@@ -1930,28 +1978,128 @@ static void ggml_metal_encode_node(
                 // to the matrix-vector kernel
                 int ne11_mm_min = 4;
 
-#if 0
-                // the numbers below are measured on M2 Ultra for 7B and 13B models
-                // these numbers do not translate to other devices or model sizes
-                // TODO: need to find a better approach
-                        if ([device.name isEqualToString:@"Apple M2 Ultra"]) {
-                            switch (src0t) {
-                                case GGML_TYPE_F16:  ne11_mm_min = 2;  break;
-                                case GGML_TYPE_Q8_0: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q2_K: ne11_mm_min = 15; break;
-                                case GGML_TYPE_Q3_K: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q4_0:
-                                case GGML_TYPE_Q4_1: ne11_mm_min = 15; break;
-                                case GGML_TYPE_Q4_K: ne11_mm_min = 11; break;
-                                case GGML_TYPE_Q5_0:                          // not tested yet
-                                case GGML_TYPE_Q5_1: ne11_mm_min = 13; break; // not tested yet
-                                case GGML_TYPE_Q5_K: ne11_mm_min = 7;  break;
-                                case GGML_TYPE_Q6_K: ne11_mm_min = 7;  break;
-                                default:             ne11_mm_min = 1;  break;
-                            }
-                        }
-#endif
+                if ((src0t == GGML_TYPE_F16  || // TODO: helper function
+                     src0t == GGML_TYPE_Q4_0 ||
+                     src0t == GGML_TYPE_Q4_1 ||
+                     src0t == GGML_TYPE_Q5_0 ||
+                     src0t == GGML_TYPE_Q5_1 ||
+                     src0t == GGML_TYPE_Q8_0
+                     ) &&
+                    src1t == GGML_TYPE_F32 &&
+                    (ne00%256 == 0) && // TODO: this can be relaxed to 128 for nxpsg == 8
+                    (ne11 >= 2 && ne11 <= 8)) {
 
+                    // TODO: determine the optimal parameters based on grid utilization
+                    const int nsg    = 2; // TODO: or 4?
+                    const int nxpsg  = ne11 < 3 ? 16 : 8;
+                    const int nypsg  = 32/nxpsg;
+                    const int r0ptg  = nypsg*nsg;
+                          int r1ptg  = 4;
+
+                    switch (ne11) {
+                        case 2:
+                            r1ptg = 2; break;
+                        case 3:
+                        case 6:
+                            r1ptg = 3; break;
+                        case 4:
+                        case 7:
+                        case 8:
+                            r1ptg = 4; break;
+                        case 5:
+                            r1ptg = 5; break;
+                    };
+
+                    assert(nxpsg   >= 8);
+                    assert(nxpsg%8 == 0);
+
+                    id<MTLComputePipelineState> pipeline = nil;
+
+                    switch (src0->type) {
+                        case GGML_TYPE_F16:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_F16_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q4_0:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_0_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q4_1:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_1_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q5_0:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_0_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q5_1:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_1_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q8_0:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        default: GGML_ABORT("not implemented");
+                    }
+
+                    ggml_metal_kargs_mul_mv_ext args = {
+                        /*.ne00  =*/ ne00,
+                        /*.ne01  =*/ ne01,
+                        /*.ne02  =*/ ne02,
+                        /*.nb00  =*/ nb00,
+                        /*.nb01  =*/ nb01,
+                        /*.nb02  =*/ nb02,
+                        /*.nb03  =*/ nb03,
+                        /*.ne10  =*/ ne10,
+                        /*.ne11  =*/ ne11,
+                        /*.ne12  =*/ ne12,
+                        /*.nb10  =*/ nb10,
+                        /*.nb11  =*/ nb11,
+                        /*.nb12  =*/ nb12,
+                        /*.nb13  =*/ nb13,
+                        /*.ne0   =*/ ne0,
+                        /*.ne1   =*/ ne1,
+                        /*.r2    =*/ r2,
+                        /*.r3    =*/ r3,
+                        /*.nsg   =*/ nsg,
+                        /*.nxpsg =*/ nxpsg,
+                        /*.r1ptg =*/ r1ptg,
+                    };
+
+                    [encoder setComputePipelineState:pipeline];
+                    [encoder setBytes:&args length:sizeof(args) atIndex:0];
+                    [encoder setBuffer:id_src0 offset:offs_src0 atIndex:1];
+                    [encoder setBuffer:id_src1 offset:offs_src1 atIndex:2];
+                    [encoder setBuffer:id_dst  offset:offs_dst  atIndex:3];
+
+                    //printf("ne01 = %lld nr0ptg = %d\n", ne01, nr0ptg);
+                    [encoder dispatchThreadgroups:MTLSizeMake((ne01 + r0ptg - 1)/r0ptg, (ne11 + r1ptg - 1)/r1ptg, ne12*ne13) threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
+                } else
                 // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
                 // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel
                 if ([device supportsFamily:MTLGPUFamilyApple7] &&

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -199,6 +199,22 @@ enum ggml_metal_kernel_type {
     GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3,
     GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4,
     GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_5,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_2,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_3,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_4,
+    GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_5,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q2_K_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q3_K_F32,
     GGML_METAL_KERNEL_TYPE_MUL_MV_Q4_K_F32,
@@ -747,6 +763,22 @@ static struct ggml_backend_metal_context * ggml_metal_init(ggml_backend_dev_t de
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3,      mul_mv_ext_q8_0_f32_r1_3,       has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4,      mul_mv_ext_q8_0_f32_r1_4,       has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5,      mul_mv_ext_q8_0_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_2,      mul_mv_ext_q4_K_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_3,      mul_mv_ext_q4_K_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_4,      mul_mv_ext_q4_K_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_5,      mul_mv_ext_q4_K_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_2,      mul_mv_ext_q5_K_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_3,      mul_mv_ext_q5_K_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_4,      mul_mv_ext_q5_K_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_5,      mul_mv_ext_q5_K_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_2,      mul_mv_ext_q6_K_f32_r1_2,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_3,      mul_mv_ext_q6_K_f32_r1_3,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_4,      mul_mv_ext_q6_K_f32_r1_4,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_5,      mul_mv_ext_q6_K_f32_r1_5,       has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_2,    mul_mv_ext_iq4_nl_f32_r1_2,     has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_3,    mul_mv_ext_iq4_nl_f32_r1_3,     has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_4,    mul_mv_ext_iq4_nl_f32_r1_4,     has_simdgroup_reduction);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_5,    mul_mv_ext_iq4_nl_f32_r1_5,     has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q2_K_F32,               mul_mv_q2_K_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q3_K_F32,               mul_mv_q3_K_f32,                has_simdgroup_reduction);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_MUL_MV_Q4_K_F32,               mul_mv_q4_K_f32,                has_simdgroup_reduction);
@@ -1978,17 +2010,28 @@ static void ggml_metal_encode_node(
                 // to the matrix-vector kernel
                 int ne11_mm_min = 4;
 
-                if ((src0t == GGML_TYPE_F16  || // TODO: helper function
-                     src0t == GGML_TYPE_Q4_0 ||
-                     src0t == GGML_TYPE_Q4_1 ||
-                     src0t == GGML_TYPE_Q5_0 ||
-                     src0t == GGML_TYPE_Q5_1 ||
-                     src0t == GGML_TYPE_Q8_0
-                     ) &&
-                    src1t == GGML_TYPE_F32 &&
-                    (ne00%256 == 0) && // TODO: this can be relaxed to 128 for nxpsg == 8
-                    (ne11 >= 2 && ne11 <= 8)) {
-
+                if (src1t == GGML_TYPE_F32 && (ne00%256 == 0) &&
+                    (
+                     (
+                      (
+                       src0t == GGML_TYPE_F16  || // TODO: helper function
+                       src0t == GGML_TYPE_Q4_0 ||
+                       src0t == GGML_TYPE_Q4_1 ||
+                       src0t == GGML_TYPE_Q5_0 ||
+                       src0t == GGML_TYPE_Q5_1 ||
+                       src0t == GGML_TYPE_Q8_0 ||
+                       src0t == GGML_TYPE_IQ4_NL ||
+                       false) && (ne11 >= 2 && ne11 <= 8)
+                     ) ||
+                     (
+                      (
+                       src0t == GGML_TYPE_Q4_K ||
+                       src0t == GGML_TYPE_Q5_K ||
+                       src0t == GGML_TYPE_Q6_K ||
+                       false) && (ne11 >= 4 && ne11 <= 12)
+                     )
+                    )
+                   ) {
                     // TODO: determine the optimal parameters based on grid utilization
                     const int nsg    = 2; // TODO: or 4?
                     const int nxpsg  = ne11 < 3 ? 16 : 8;
@@ -2009,9 +2052,6 @@ static void ggml_metal_encode_node(
                         case 5:
                             r1ptg = 5; break;
                     };
-
-                    assert(nxpsg   >= 8);
-                    assert(nxpsg%8 == 0);
 
                     id<MTLComputePipelineState> pipeline = nil;
 
@@ -2062,6 +2102,38 @@ static void ggml_metal_encode_node(
                                 case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_3].pipeline; break;
                                 case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_4].pipeline; break;
                                 case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q8_0_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q4_K:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q4_K_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q5_K:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q5_K_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_Q6_K:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_Q6_K_F32_R1_5].pipeline; break;
+                                default: GGML_ABORT("not implemented");
+                            } break;
+                        case GGML_TYPE_IQ4_NL:
+                            switch (r1ptg) {
+                                case 2: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_2].pipeline; break;
+                                case 3: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_3].pipeline; break;
+                                case 4: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_4].pipeline; break;
+                                case 5: pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_MUL_MV_EXT_IQ4_NL_F32_R1_5].pipeline; break;
                                 default: GGML_ABORT("not implemented");
                             } break;
                         default: GGML_ABORT("not implemented");

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2028,7 +2028,7 @@ static void ggml_metal_encode_node(
                        src0t == GGML_TYPE_Q4_K ||
                        src0t == GGML_TYPE_Q5_K ||
                        src0t == GGML_TYPE_Q6_K ||
-                       false) && (ne11 >= 4 && ne11 <= 12)
+                       false) && (ne11 >= 4 && ne11 <= 8)
                      )
                     )
                    ) {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -128,7 +128,7 @@ void dequantize_q4_1_t4(device const block_q4_1 * xb, short il, thread type4 & r
 }
 
 template <typename type4x4>
-void dequantize_q5_0(device const block_q5_0 *xb, short il, thread type4x4 & reg) {
+void dequantize_q5_0(device const block_q5_0 * xb, short il, thread type4x4 & reg) {
     device const uint16_t * qs = ((device const uint16_t *)xb + 3);
     const float d = xb->d;
     const float md = -16.h * xb->d;
@@ -161,14 +161,36 @@ void dequantize_q5_0(device const block_q5_0 *xb, short il, thread type4x4 & reg
 
 template <typename type4>
 void dequantize_q5_0_t4(device const block_q5_0 * xb, short il, thread type4 & reg) {
-    // TODO: implement
-    float4x4 tmp;
-    dequantize_q5_0(xb, il/4, tmp);
-    reg = tmp[il%4];
+    device const uint16_t * qs = ((device const uint16_t *)xb + 3);
+    const float d = xb->d;
+    const float md = -16.h * xb->d;
+    const ushort mask = (il/4) ? 0x00F0 : 0x000F;
+
+    const uint32_t qh = *((device const uint32_t *)xb->qh);
+
+    const int x_mv = (il/4) ? 4 : 0;
+
+    const int gh_mv = (il/4) ? 12 : 0;
+    const int gh_bk = (il/4) ?  0 : 4;
+
+    for (int ii = 0; ii < 2; ii++) {
+        int i = 2*(il%4) + ii;
+
+        // extract the 5-th bits for x0 and x1
+        const uint8_t xh_0 = ((qh >> (gh_mv + 2*i  )) << gh_bk) & 0x10;
+        const uint8_t xh_1 = ((qh >> (gh_mv + 2*i+1)) << gh_bk) & 0x10;
+
+        // combine the 4-bits from qs with the 5th bit
+        const int32_t x0 = ((((qs[i]     ) & mask) >> x_mv) | xh_0);
+        const int32_t x1 = ((((qs[i] >> 8) & mask) >> x_mv) | xh_1);
+
+        reg[2*ii + 0] = d * x0 + md;
+        reg[2*ii + 1] = d * x1 + md;
+    }
 }
 
 template <typename type4x4>
-void dequantize_q5_1(device const block_q5_1 *xb, short il, thread type4x4 & reg) {
+void dequantize_q5_1(device const block_q5_1 * xb, short il, thread type4x4 & reg) {
     device const uint16_t * qs = ((device const uint16_t *)xb + 4);
     const float d = xb->d;
     const float m = xb->m;
@@ -201,10 +223,32 @@ void dequantize_q5_1(device const block_q5_1 *xb, short il, thread type4x4 & reg
 
 template <typename type4>
 void dequantize_q5_1_t4(device const block_q5_1 * xb, short il, thread type4 & reg) {
-    // TODO: implement
-    float4x4 tmp;
-    dequantize_q5_1(xb, il/4, tmp);
-    reg = tmp[il%4];
+    device const uint16_t * qs = ((device const uint16_t *)xb + 4);
+    const float d = xb->d;
+    const float m = xb->m;
+    const ushort mask = (il/4) ? 0x00F0 : 0x000F;
+
+    const uint32_t qh = *((device const uint32_t *)xb->qh);
+
+    const int x_mv = (il/4) ? 4 : 0;
+
+    const int gh_mv = (il/4) ? 12 : 0;
+    const int gh_bk = (il/4) ?  0 : 4;
+
+    for (int ii = 0; ii < 2; ii++) {
+        int i = 2*(il%4) + ii;
+
+        // extract the 5-th bits for x0 and x1
+        const uint8_t xh_0 = ((qh >> (gh_mv + 2*i  )) << gh_bk) & 0x10;
+        const uint8_t xh_1 = ((qh >> (gh_mv + 2*i+1)) << gh_bk) & 0x10;
+
+        // combine the 4-bits from qs with the 5th bit
+        const int32_t x0 = ((((qs[i]     ) & mask) >> x_mv) | xh_0);
+        const int32_t x1 = ((((qs[i] >> 8) & mask) >> x_mv) | xh_1);
+
+        reg[2*ii + 0] = d * x0 + m;
+        reg[2*ii + 1] = d * x1 + m;
+    }
 }
 
 template <typename type4x4>
@@ -285,7 +329,7 @@ static inline uchar2 get_scale_min_k4_just2(int j, int k, device const uchar * q
 }
 
 template <typename type4x4>
-void dequantize_q4_K(device const block_q4_K *xb, short il, thread type4x4 & reg) {
+void dequantize_q4_K(device const block_q4_K * xb, short il, thread type4x4 & reg) {
     device const uchar * q = xb->qs;
 
     short is = (il/4) * 2;
@@ -297,7 +341,7 @@ void dequantize_q4_K(device const block_q4_K *xb, short il, thread type4x4 & reg
     const float dl = d * sc[0];
     const float ml = min * sc[1];
 
-    const ushort mask = il<2 ? 0x0F : 0xF0;
+    const ushort mask = il < 2 ? 0x0F : 0xF0;
     for (int i = 0; i < 16; ++i) {
         reg[i/4][i%4] = dl * (q[i] & mask) - ml;
     }
@@ -528,6 +572,19 @@ void dequantize_iq4_nl(device const block_iq4_nl * xb, short il, thread type4x4 
         reg[i][2] = d * kvalues_iq4nl_f[q8[2]];
         reg[i][3] = d * kvalues_iq4nl_f[q8[3]];
     }
+}
+
+template <typename type4>
+void dequantize_iq4_nl_t4(device const block_iq4_nl * xb, short il, thread type4 & reg) {
+    device const uint16_t * q4 = (device const uint16_t *)xb->qs;
+    const float d = xb->d;
+    uint32_t aux32;
+    thread const uint8_t * q8 = (thread const uint8_t *)&aux32;
+    aux32 = ((q4[2*(il%4)] | (q4[2*(il%4)+1] << 16)) >> 4*(il/4)) & 0x0f0f0f0f;
+    reg[0] = d * kvalues_iq4nl_f[q8[0]];
+    reg[1] = d * kvalues_iq4nl_f[q8[1]];
+    reg[2] = d * kvalues_iq4nl_f[q8[2]];
+    reg[3] = d * kvalues_iq4nl_f[q8[3]];
 }
 
 template <typename type4x4>
@@ -1813,8 +1870,8 @@ kernel void kernel_mul_mv_q8_0_f32(
     kernel_mul_mv_q8_0_f32_impl<constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, nullptr, tgpig, tiisg, sgitg);
 }
 
-template<short nxpsg, short r1ptg, typename q_t, short bp32, void (*deq_t4)(device const q_t *, short, thread float4 &) >
-void kernel_mul_mv_ext_q_f32_impl(
+template<short nxpsg, short r1ptg, typename q_t, short chpb, void (*deq_t4)(device const q_t *, short, thread float4 &) >
+void kernel_mul_mv_ext_q4_f32_impl(
         constant ggml_metal_kargs_mul_mv_ext & args,
         device const char * src0,
         device const char * src1,
@@ -1840,7 +1897,7 @@ void kernel_mul_mv_ext_q_f32_impl(
     const uint64_t offset0 = i01*args.nb01 + (i12/args.r2)*args.nb02 + (i13/args.r3)*args.nb03;
     const uint64_t offset1 = i11*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
 
-    device const q_t * xq = (i01 < args.ne01) ? (device const q_t *) (src0 + offset0) + (tx/8)*bp32 : (device const q_t *) src0;
+    device const q_t * xq = (i01 < args.ne01) ? (device const q_t *) (src0 + offset0) + tx/chpb : (device const q_t *) src0;
 
     device const float4 * y4[r1ptg];
 
@@ -1850,23 +1907,34 @@ void kernel_mul_mv_ext_q_f32_impl(
 
     float sumf[r1ptg] = { [ 0 ... r1ptg - 1 ] = 0.0f };
 
-    for (int iib = 0; (4*chpt)*(iib*nxpsg + tx) < args.ne00; ++iib) {
+    short cch = tx%chpb;
+
+    for (int ich = tx; 4*ich < args.ne00; ich += chpt*nxpsg) {
+        float4 lx[chpt];
+
 #pragma unroll(chpt)
         for (short ch = 0; ch < chpt; ++ch) {
-            float4 lx;
+            deq_t4(xq, cch, lx[ch]);
 
-            deq_t4(xq + (4*ch*nxpsg)/(32/bp32), tx%8, lx);
-
-#pragma unroll(r1ptg)
-            for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
-                sumf[ir1] += dot(lx, y4[ir1][ch*nxpsg]);
+            cch += nxpsg;
+            if (cch >= chpb) {
+                xq  += cch/chpb;
+                cch %= chpb;
             }
         }
 
-        xq += ((4*chpt)*nxpsg)/(32/bp32);
+#pragma unroll(chpt)
+        for (short ch = 0; ch < chpt; ++ch) {
+#pragma unroll(r1ptg)
+            for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
+                sumf[ir1] += dot(lx[ch], y4[ir1][ch*nxpsg]);
 
+            }
+        }
+
+#pragma unroll(r1ptg)
         for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
-            y4[ir1] += ((4*chpt)*nxpsg)/4;
+            y4[ir1] += chpt*nxpsg;
         }
     }
 
@@ -1901,8 +1969,111 @@ void kernel_mul_mv_ext_q_f32_impl(
     }
 }
 
-template<short r1ptg, typename q_t, short bp32, void (*deq_t4)(device const q_t *, short, thread float4 &)>
-kernel void kernel_mul_mv_ext_q_f32_disp(
+template<short nxpsg, short r1ptg, typename q_t, short chpb, void (*deq_t4x4)(device const q_t *, short, thread float4x4 &) >
+void kernel_mul_mv_ext_q4x4_f32_impl(
+        constant ggml_metal_kargs_mul_mv_ext & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]]) {
+    const short chpt = 1;
+
+  //const short nxpsg = (32);
+    const short nypsg = (32/nxpsg);
+
+    const short tx = tiisg%nxpsg;
+    const short ty = tiisg/nxpsg;
+
+    const int i01 = tgpig.x*(nypsg*args.nsg) + nypsg*sgitg + ty;
+    const int i11 = tgpig.y*r1ptg;
+    const int i1m = tgpig.z;
+
+    const int i12 = i1m%args.ne12;
+    const int i13 = i1m/args.ne12;
+
+    const uint64_t offset0 = i01*args.nb01 + (i12/args.r2)*args.nb02 + (i13/args.r3)*args.nb03;
+    const uint64_t offset1 = i11*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
+
+    device const q_t * xq = (i01 < args.ne01) ? (device const q_t *) (src0 + offset0) + tx/chpb : (device const q_t *) src0;
+
+    device const float4x4 * y4x4[r1ptg];
+
+    for (int ir1 = 0; ir1 < r1ptg; ++ir1) {
+        y4x4[ir1] = (i11 + ir1 < args.ne11) ? (device const float4x4 *) (src1 + offset1 + ir1*args.nb11) + tx : (device const float4x4 *) src1;
+    }
+
+    float sumf[r1ptg] = { [ 0 ... r1ptg - 1 ] = 0.0f };
+
+    short cch = tx%chpb;
+
+    for (int ich = tx; 16*ich < args.ne00; ich += chpt*nxpsg) {
+        float4x4 lx[chpt];
+
+#pragma unroll(chpt)
+        for (short ch = 0; ch < chpt; ++ch) {
+            deq_t4x4(xq, cch, lx[ch]);
+
+            cch += nxpsg;
+            if (cch >= chpb) {
+                xq  += cch/chpb;
+                cch %= chpb;
+            }
+        }
+
+#pragma unroll(chpt)
+        for (short ch = 0; ch < chpt; ++ch) {
+#pragma unroll(r1ptg)
+            for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
+                sumf[ir1] +=
+                    dot(lx[ch][0], y4x4[ir1][ch*nxpsg][0]) +
+                    dot(lx[ch][1], y4x4[ir1][ch*nxpsg][1]) +
+                    dot(lx[ch][2], y4x4[ir1][ch*nxpsg][2]) +
+                    dot(lx[ch][3], y4x4[ir1][ch*nxpsg][3]);
+
+            }
+        }
+
+#pragma unroll(r1ptg)
+        for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
+            y4x4[ir1] += chpt*nxpsg;
+        }
+    }
+
+    for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
+        if (nxpsg >= 32) {
+            sumf[ir1] += simd_shuffle_down(sumf[ir1], 16);
+        }
+        if (nxpsg >= 16) {
+            sumf[ir1] += simd_shuffle_down(sumf[ir1],  8);
+        }
+        if (nxpsg >= 8) {
+            sumf[ir1] += simd_shuffle_down(sumf[ir1],  4);
+        }
+        if (nxpsg >= 4) {
+            sumf[ir1] += simd_shuffle_down(sumf[ir1],  2);
+        }
+        if (nxpsg >= 2) {
+            sumf[ir1] += simd_shuffle_down(sumf[ir1],  1);
+        }
+
+        //sumf[ir1] = simd_sum(sumf[ir1]);
+    }
+
+    if (tx == 0) {
+        for (short ir1 = 0; ir1 < r1ptg && i11 + ir1 < args.ne11; ++ir1) {
+            device float * dst_f32 = (device float *) dst + (uint64_t)i1m*args.ne0*args.ne1 + (uint64_t)(i11 + ir1)*args.ne0;
+
+            if (i01 < args.ne01) {
+                dst_f32[i01] = sumf[ir1];
+            }
+        }
+    }
+}
+
+template<short r1ptg, typename q_t, short epb, void (*deq_t4)(device const q_t *, short, thread float4 &)>
+kernel void kernel_mul_mv_ext_q4_f32_disp(
         constant ggml_metal_kargs_mul_mv_ext & args,
         device const char * src0,
         device const char * src1,
@@ -1911,43 +2082,82 @@ kernel void kernel_mul_mv_ext_q_f32_disp(
         ushort  tiisg[[thread_index_in_simdgroup]],
         ushort  sgitg[[simdgroup_index_in_threadgroup]]) {
     switch (args.nxpsg) {
-        case 8:  kernel_mul_mv_ext_q_f32_impl<8,  r1ptg, q_t, bp32, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
-        case 16: kernel_mul_mv_ext_q_f32_impl<16, r1ptg, q_t, bp32, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
-        case 32: kernel_mul_mv_ext_q_f32_impl<32, r1ptg, q_t, bp32, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 4:  kernel_mul_mv_ext_q4_f32_impl<4,  r1ptg, q_t, epb/4, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 8:  kernel_mul_mv_ext_q4_f32_impl<8,  r1ptg, q_t, epb/4, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 16: kernel_mul_mv_ext_q4_f32_impl<16, r1ptg, q_t, epb/4, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 32: kernel_mul_mv_ext_q4_f32_impl<32, r1ptg, q_t, epb/4, deq_t4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
     }
 }
 
-typedef decltype(kernel_mul_mv_ext_q_f32_disp<2, block_q8_0, 32, dequantize_q8_0_t4>) mul_mv_ext_q_f32_t;
+template<short r1ptg, typename q_t, short epb, void (*deq_t4x4)(device const q_t *, short, thread float4x4 &)>
+kernel void kernel_mul_mv_ext_q4x4_f32_disp(
+        constant ggml_metal_kargs_mul_mv_ext & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]]) {
+    switch (args.nxpsg) {
+        case 4:  kernel_mul_mv_ext_q4x4_f32_impl<4,  r1ptg, q_t, epb/16, deq_t4x4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 8:  kernel_mul_mv_ext_q4x4_f32_impl<8,  r1ptg, q_t, epb/16, deq_t4x4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 16: kernel_mul_mv_ext_q4x4_f32_impl<16, r1ptg, q_t, epb/16, deq_t4x4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+        case 32: kernel_mul_mv_ext_q4x4_f32_impl<32, r1ptg, q_t, epb/16, deq_t4x4>(args, src0, src1, dst, tgpig, tiisg, sgitg); break;
+    }
+}
 
-template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]  kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, half4,      8, dequantize_f16_t4>;
-template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]  kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, half4,      8, dequantize_f16_t4>;
-template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]  kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, half4,      8, dequantize_f16_t4>;
-template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]  kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, half4,      8, dequantize_f16_t4>;
+typedef decltype(kernel_mul_mv_ext_q4_f32_disp  <2, block_q8_0, 32,  dequantize_q8_0_t4>) mul_mv_ext_q4_f32_t;
+typedef decltype(kernel_mul_mv_ext_q4x4_f32_disp<2, block_q4_K, 256, dequantize_q4_K>)    mul_mv_ext_q4x4_f32_t;
 
-template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, block_q4_0, 1, dequantize_q4_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_3")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, block_q4_0, 1, dequantize_q4_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_4")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, block_q4_0, 1, dequantize_q4_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_5")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, block_q4_0, 1, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, half4,        4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, half4,        4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, half4,        4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, half4,        4,  dequantize_f16_t4>;
 
-template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_2")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, block_q4_1, 1, dequantize_q4_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_3")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, block_q4_1, 1, dequantize_q4_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_4")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, block_q4_1, 1, dequantize_q4_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_5")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, block_q4_1, 1, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q4_0,   32, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q4_0,   32, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q4_0,   32, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q4_0,   32, dequantize_q4_0_t4>;
 
-template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_2")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, block_q5_0, 1, dequantize_q5_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_3")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, block_q5_0, 1, dequantize_q5_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_4")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, block_q5_0, 1, dequantize_q5_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_5")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, block_q5_0, 1, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q4_1,   32, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q4_1,   32, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q4_1,   32, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q4_1,   32, dequantize_q4_1_t4>;
 
-template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_2")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, block_q5_1, 1, dequantize_q5_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_3")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, block_q5_1, 1, dequantize_q5_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_4")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, block_q5_1, 1, dequantize_q5_1_t4>;
-template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_5")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, block_q5_1, 1, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q5_0,   32, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q5_0,   32, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q5_0,   32, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q5_0,   32, dequantize_q5_0_t4>;
 
-template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<2, block_q8_0, 1, dequantize_q8_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<3, block_q8_0, 1, dequantize_q8_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<4, block_q8_0, 1, dequantize_q8_0_t4>;
-template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]] kernel mul_mv_ext_q_f32_t kernel_mul_mv_ext_q_f32_disp<5, block_q8_0, 1, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q5_1,   32, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q5_1,   32, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q5_1,   32, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q5_1,   32, dequantize_q5_1_t4>;
+
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q8_0,   32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0,   32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0,   32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0,   32, dequantize_q8_0_t4>;
+
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+
+template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_q4_K, 256, dequantize_q4_K>;
+template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_q4_K, 256, dequantize_q4_K>;
+template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_q4_K, 256, dequantize_q4_K>;
+template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_q4_K, 256, dequantize_q4_K>;
+
+template [[host_name("kernel_mul_mv_ext_q5_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_q5_K, 256, dequantize_q5_K>;
+template [[host_name("kernel_mul_mv_ext_q5_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_q5_K, 256, dequantize_q5_K>;
+template [[host_name("kernel_mul_mv_ext_q5_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_q5_K, 256, dequantize_q5_K>;
+template [[host_name("kernel_mul_mv_ext_q5_K_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_q5_K, 256, dequantize_q5_K>;
+
+template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_q6_K, 256, dequantize_q6_K>;
+template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_q6_K, 256, dequantize_q6_K>;
+template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_q6_K, 256, dequantize_q6_K>;
+template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_q6_K, 256, dequantize_q6_K>;
 
 #define N_MV_T_T 4
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3572,6 +3572,15 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 4));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 128, 4));
 
+    for (int i = 1; i < 64; ++i) {
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16,  GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_1, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_1, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+    }
+
 #if 1
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32, GGML_TYPE_F16}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3573,12 +3573,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 128, 4));
 
     for (int i = 1; i < 64; ++i) {
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16,  GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_1, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_1, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
-        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16,    GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_1,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_0,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_1,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_K,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q5_K,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q6_K,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_IQ4_NL, GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
     }
 
 #if 1

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3572,7 +3572,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 4));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 128, 4));
 
-    for (int i = 1; i < 64; ++i) {
+    for (int i = 1; i < 9; ++i) {
         test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16,    GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
         test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));
         test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_1,   GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));


### PR DESCRIPTION
Improve Metal performance for small batch sizes (<= 8)

```bash
make -j && ./bin/llama-bench -m ../models/qwen2.5-3b-coder/ggml-model-q4_0.gguf -m ../models/qwen2.5-3b-coder/ggml-model-q4_1.gguf -m ../models/qwen2.5-3b-coder/ggml-model-q4_k.gguf -m ../models/qwen2.5-3b-coder/ggml-model-q5_k.gguf -m ../models/qwen2.5-3b-coder/ggml-model-q6_k.gguf -m ../models/qwen2.5-3b-coder/ggml-model-iq4_nl.gguf -m ../models/qwen2.5-3b-coder/ggml-model-q8_0.gguf -m ../models/qwen2.5-3b-coder/ggml-model-f16.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q4_0.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q4_1.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q4_k.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q5_k.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q6_k.gguf -m ../models/qwen2.5-7b-coder/ggml-model-iq4_nl.gguf -m ../models/qwen2.5-7b-coder/ggml-model-q8_0.gguf -m ../models/qwen2.5-7b-coder/ggml-model-f16.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q4_0.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q4_1.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q4_k.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q5_k.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q6_k.gguf -m ../models/qwen2.5-14b-coder/ggml-model-iq4_nl.gguf -m ../models/qwen2.5-14b-coder/ggml-model-q8_0.gguf -m ../models/qwen2.5-14b-coder/ggml-model-f16.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q4_0.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q4_1.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q4_k.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q5_k.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q6_k.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-iq4_nl.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q8_0.gguf -m ../models/qwen2.5-32b-coder-instruct/ggml-model-f16.gguf -p 1,2,3,4,5,6,7,8 -n 0 -fa 1 -t 1
```

<details>
<summary>M2 Ultra</summary>

| model            |       size | backend    | fa |          test |                  t/s |                  t/s | speedup |
| ---------------- | ---------: | ---------- | -: | ------------: | -------------------: | -------------------: | ------: |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp1 |        103.51 ± 0.44 |        101.58 ± 3.72 |    0.98 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp2 |        148.82 ± 4.18 |        141.95 ± 4.29 |    0.95 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp3 |        181.31 ± 2.40 |        173.71 ± 4.32 |    0.96 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp4 |        195.01 ± 5.86 |        201.25 ± 1.53 |    1.03 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp5 |         91.39 ± 0.28 |        209.06 ± 4.30 |    2.29 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp6 |        110.09 ± 1.10 |        223.83 ± 3.34 |    2.03 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp7 |        128.26 ± 1.98 |        229.85 ± 4.12 |    1.79 |
| qwen2 7B Q4_0    |   4.12 GiB | Metal,BLAS |  1 |           pp8 |        144.31 ± 1.91 |        260.05 ± 3.82 |    1.80 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp1 |        100.27 ± 0.40 |         98.12 ± 2.25 |    0.98 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp2 |        150.89 ± 1.07 |        145.80 ± 0.34 |    0.97 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp3 |        184.53 ± 0.53 |        177.67 ± 2.02 |    0.96 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp4 |        198.12 ± 0.45 |        205.09 ± 0.89 |    1.04 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp5 |         93.77 ± 0.07 |        215.70 ± 1.41 |    2.30 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp6 |        112.26 ± 0.16 |        229.39 ± 1.35 |    2.04 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp7 |        130.85 ± 0.10 |        235.22 ± 1.83 |    1.80 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp8 |        149.93 ± 0.15 |        269.63 ± 1.84 |    1.80 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp1 |         91.69 ± 1.38 |         86.70 ± 2.47 |    0.95 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp2 |        122.44 ± 0.16 |        121.30 ± 1.36 |    0.99 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp3 |        142.49 ± 0.17 |        141.52 ± 0.76 |    0.99 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp4 |        151.12 ± 0.22 |        156.37 ± 1.58 |    1.03 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp5 |         79.39 ± 0.04 |        177.85 ± 1.30 |    2.24 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp6 |         95.17 ± 0.25 |        179.18 ± 1.31 |    1.88 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp7 |        111.06 ± 0.34 |        175.66 ± 1.04 |    1.58 |
| qwen2 7B Q4_K    |   4.36 GiB | Metal,BLAS |  1 |           pp8 |        126.79 ± 0.12 |        198.07 ± 1.00 |    1.56 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp1 |         72.53 ± 0.23 |         69.08 ± 2.89 |    0.95 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp2 |         93.73 ± 0.28 |         92.89 ± 0.93 |    0.99 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp3 |        104.63 ± 0.26 |        103.75 ± 0.60 |    0.99 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp4 |        108.82 ± 0.17 |        146.24 ± 0.52 |    1.34 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp5 |         73.65 ± 0.09 |        167.83 ± 0.84 |    2.28 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp6 |         88.14 ± 0.14 |        165.03 ± 0.61 |    1.87 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp7 |        102.66 ± 0.12 |        162.18 ± 0.68 |    1.58 |
| qwen2 7B Q5_K    |   5.07 GiB | Metal,BLAS |  1 |           pp8 |        117.24 ± 0.15 |        182.82 ± 0.85 |    1.56 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp1 |         78.30 ± 0.16 |         76.63 ± 2.31 |    0.98 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp2 |        101.74 ± 0.13 |        101.38 ± 1.12 |    1.00 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp3 |        114.76 ± 0.23 |        113.90 ± 0.71 |    0.99 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp4 |        118.91 ± 0.09 |        153.46 ± 1.50 |    1.29 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp5 |         75.34 ± 0.05 |        172.64 ± 0.95 |    2.29 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp6 |         90.45 ± 0.20 |        170.42 ± 0.99 |    1.88 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp7 |        105.34 ± 0.18 |        168.04 ± 0.97 |    1.60 |
| qwen2 7B Q6_K    |   5.82 GiB | Metal,BLAS |  1 |           pp8 |        120.47 ± 0.14 |        186.88 ± 0.66 |    1.55 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp1 |         87.77 ± 0.42 |         84.21 ± 1.19 |    0.96 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp2 |        112.54 ± 0.15 |        124.63 ± 1.17 |    1.11 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp3 |        130.12 ± 0.40 |        141.64 ± 0.74 |    1.09 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp4 |        139.27 ± 0.45 |        158.47 ± 1.28 |    1.14 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp5 |         81.86 ± 0.15 |        185.89 ± 0.69 |    2.27 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp6 |         97.98 ± 0.11 |        182.10 ± 0.21 |    1.86 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp7 |        113.93 ± 0.08 |        178.31 ± 0.21 |    1.57 |
| qwen2 7B IQ4_NL  |   4.15 GiB | Metal,BLAS |  1 |           pp8 |        130.36 ± 0.46 |        205.57 ± 0.37 |    1.58 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp1 |         69.44 ± 1.83 |         70.41 ± 0.45 |    1.01 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp2 |         96.25 ± 2.72 |        126.66 ± 0.20 |    1.32 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp3 |        111.80 ± 2.43 |        163.08 ± 0.68 |    1.46 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp4 |        118.85 ± 0.49 |        200.40 ± 0.41 |    1.69 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp5 |         89.39 ± 0.62 |        207.24 ± 0.26 |    2.32 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp6 |        107.13 ± 0.62 |        210.91 ± 0.39 |    1.97 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp7 |        124.46 ± 1.41 |        229.20 ± 0.05 |    1.84 |
| qwen2 7B Q8_0    |   7.54 GiB | Metal,BLAS |  1 |           pp8 |        142.26 ± 1.47 |        260.76 ± 0.27 |    1.83 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp1 |         39.48 ± 0.55 |         39.50 ± 0.67 |    1.00 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp2 |         49.12 ± 0.69 |         83.67 ± 1.24 |    1.70 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp3 |         52.16 ± 0.34 |        117.29 ± 2.09 |    2.25 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp4 |         60.95 ± 0.43 |        149.43 ± 2.68 |    2.45 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp5 |         90.45 ± 0.11 |        174.40 ± 3.87 |    1.93 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp6 |        108.13 ± 0.28 |        150.62 ± 3.31 |    1.39 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp7 |        125.99 ± 1.45 |        170.60 ± 3.20 |    1.35 |
| qwen2 7B F16     |  14.19 GiB | Metal,BLAS |  1 |           pp8 |        143.42 ± 2.57 |        193.36 ± 3.40 |    1.35 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp1 |         55.74 ± 0.18 |         55.56 ± 0.18 |    1.00 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp2 |         81.41 ± 0.11 |         76.23 ± 0.17 |    0.94 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp3 |         99.10 ± 0.15 |         96.47 ± 0.24 |    0.97 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp4 |        106.32 ± 0.08 |        112.64 ± 0.36 |    1.06 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp5 |         48.50 ± 0.06 |        116.69 ± 0.11 |    2.41 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp6 |         58.17 ± 0.17 |        125.42 ± 0.17 |    2.16 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp7 |         67.79 ± 0.16 |        128.60 ± 0.12 |    1.90 |
| qwen2 14B Q4_0   |   7.93 GiB | Metal,BLAS |  1 |           pp8 |         77.46 ± 0.22 |        146.78 ± 0.17 |    1.89 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp1 |        100.01 ± 0.31 |         99.96 ± 0.51 |    1.00 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp2 |        150.73 ± 0.50 |        146.20 ± 0.33 |    0.97 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp3 |        184.06 ± 0.62 |        178.79 ± 0.29 |    0.97 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp4 |        198.40 ± 0.43 |        206.25 ± 0.51 |    1.04 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp5 |         94.08 ± 0.06 |        217.42 ± 0.88 |    2.31 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp6 |        112.73 ± 0.06 |        230.23 ± 0.53 |    2.04 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp7 |        130.81 ± 0.05 |        236.16 ± 0.16 |    1.81 |
| qwen2 7B Q4_1    |   4.53 GiB | Metal,BLAS |  1 |           pp8 |        149.56 ± 0.14 |        270.31 ± 0.35 |    1.81 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp1 |         49.75 ± 0.79 |         49.94 ± 0.19 |    1.00 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp2 |         67.93 ± 0.15 |         67.93 ± 0.15 |    1.00 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp3 |         78.51 ± 0.16 |         78.38 ± 0.14 |    1.00 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp4 |         83.13 ± 0.42 |         82.00 ± 0.12 |    0.99 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp5 |         40.19 ± 0.13 |         89.64 ± 0.04 |    2.23 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp6 |         48.05 ± 0.04 |         95.06 ± 0.13 |    1.98 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp7 |         55.96 ± 0.06 |         90.80 ± 0.07 |    1.62 |
| qwen2 14B Q4_K   |   8.37 GiB | Metal,BLAS |  1 |           pp8 |         63.98 ± 0.06 |        101.02 ± 0.17 |    1.58 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp1 |         40.31 ± 0.42 |         40.25 ± 0.20 |    1.00 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp2 |         52.07 ± 0.04 |         51.84 ± 0.14 |    1.00 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp3 |         56.94 ± 0.34 |         56.77 ± 0.35 |    1.00 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp4 |         58.97 ± 0.08 |         77.26 ± 0.12 |    1.31 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp5 |         36.78 ± 0.06 |         86.95 ± 0.09 |    2.36 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp6 |         44.11 ± 0.10 |         88.79 ± 0.22 |    2.01 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp7 |         51.27 ± 0.07 |         86.39 ± 0.16 |    1.69 |
| qwen2 14B Q5_K   |   9.78 GiB | Metal,BLAS |  1 |           pp8 |         58.59 ± 0.05 |         97.49 ± 0.10 |    1.66 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp1 |         42.24 ± 0.17 |         42.06 ± 0.15 |    1.00 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp2 |         52.53 ± 0.03 |         52.47 ± 0.12 |    1.00 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp3 |         57.91 ± 0.04 |         57.70 ± 0.04 |    1.00 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp4 |         59.81 ± 0.08 |         79.01 ± 0.09 |    1.32 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp5 |         38.59 ± 0.01 |         87.93 ± 0.10 |    2.28 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp6 |         46.36 ± 0.10 |         91.72 ± 0.29 |    1.98 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp7 |         53.99 ± 0.14 |         88.80 ± 0.15 |    1.64 |
| qwen2 14B Q6_K   |  11.29 GiB | Metal,BLAS |  1 |           pp8 |         61.65 ± 0.10 |         97.00 ± 0.24 |    1.57 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp1 |         43.42 ± 0.15 |         43.43 ± 0.08 |    1.00 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp2 |         59.08 ± 0.12 |         64.13 ± 0.11 |    1.09 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp3 |         67.03 ± 0.07 |         73.73 ± 0.17 |    1.10 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp4 |         71.00 ± 0.18 |         82.61 ± 0.29 |    1.16 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp5 |         42.53 ± 0.06 |         97.26 ± 0.15 |    2.29 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp6 |         50.93 ± 0.06 |         92.80 ± 0.28 |    1.82 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp7 |         59.31 ± 0.12 |         88.06 ± 0.49 |    1.48 |
| qwen2 14B IQ4_NL |   8.01 GiB | Metal,BLAS |  1 |           pp8 |         67.61 ± 0.03 |        100.83 ± 0.58 |    1.49 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp1 |         35.42 ± 0.65 |         35.47 ± 0.43 |    1.00 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp2 |         48.77 ± 0.65 |         66.12 ± 0.27 |    1.36 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp3 |         54.75 ± 0.47 |         86.90 ± 0.78 |    1.59 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp4 |         57.09 ± 0.09 |        105.82 ± 1.47 |    1.85 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp5 |         44.95 ± 0.11 |        109.84 ± 1.94 |    2.44 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp6 |         53.93 ± 0.45 |        109.45 ± 0.98 |    2.03 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp7 |         62.50 ± 0.20 |        118.56 ± 1.76 |    1.90 |
| qwen2 14B Q8_0   |  14.62 GiB | Metal,BLAS |  1 |           pp8 |         71.09 ± 0.24 |        133.41 ± 1.53 |    1.88 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp1 |         21.04 ± 0.10 |         21.07 ± 0.07 |    1.00 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp2 |         25.01 ± 0.05 |         43.02 ± 0.41 |    1.72 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp3 |         27.19 ± 0.04 |         60.72 ± 0.20 |    2.23 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp4 |         32.91 ± 0.05 |         74.23 ± 2.22 |    2.26 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp5 |         48.01 ± 0.31 |         89.55 ± 0.49 |    1.87 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp6 |         57.61 ± 0.53 |         75.01 ± 0.49 |    1.30 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp7 |         66.53 ± 0.14 |         85.14 ± 0.65 |    1.28 |
| qwen2 14B F16    |  27.51 GiB | Metal,BLAS |  1 |           pp8 |         76.36 ± 0.63 |         97.31 ± 0.97 |    1.27 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp1 |         29.25 ± 0.05 |         29.20 ± 0.06 |    1.00 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp2 |         37.11 ± 0.07 |         37.93 ± 0.05 |    1.02 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp3 |         42.27 ± 0.03 |         50.55 ± 0.04 |    1.20 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp4 |         44.16 ± 0.08 |         58.00 ± 0.08 |    1.31 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp5 |         25.01 ± 0.03 |         60.65 ± 0.05 |    2.43 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp6 |         29.97 ± 0.03 |         60.26 ± 0.11 |    2.01 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp7 |         34.86 ± 0.01 |         60.86 ± 0.05 |    1.75 |
| qwen2 32B Q4_0   |  17.35 GiB | Metal,BLAS |  1 |           pp8 |         39.79 ± 0.02 |         69.41 ± 0.09 |    1.74 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp1 |         27.03 ± 0.06 |         27.03 ± 0.06 |    1.00 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp2 |         34.15 ± 0.05 |         37.19 ± 0.04 |    1.09 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp3 |         38.02 ± 0.03 |         49.71 ± 0.22 |    1.31 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp4 |         39.36 ± 0.03 |         57.54 ± 0.11 |    1.46 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp5 |         24.96 ± 0.04 |         59.83 ± 0.07 |    2.40 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp6 |         29.96 ± 0.05 |         59.29 ± 0.01 |    1.98 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp7 |         34.83 ± 0.05 |         59.96 ± 0.12 |    1.72 |
| qwen2 32B Q4_1   |  19.22 GiB | Metal,BLAS |  1 |           pp8 |         39.83 ± 0.04 |         68.54 ± 0.08 |    1.72 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp1 |         25.89 ± 0.06 |         25.94 ± 0.06 |    1.00 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp2 |         32.06 ± 0.06 |         32.00 ± 0.03 |    1.00 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp3 |         35.42 ± 0.11 |         35.34 ± 0.05 |    1.00 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp4 |         36.82 ± 0.02 |         42.05 ± 0.05 |    1.14 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp5 |         20.64 ± 0.03 |         46.80 ± 0.07 |    2.27 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp6 |         24.79 ± 0.04 |         45.84 ± 0.05 |    1.85 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp7 |         28.85 ± 0.05 |         42.90 ± 0.04 |    1.49 |
| qwen2 32B Q4_K   |  18.48 GiB | Metal,BLAS |  1 |           pp8 |         32.92 ± 0.08 |         48.09 ± 0.13 |    1.46 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp1 |         20.66 ± 0.13 |         20.51 ± 0.02 |    0.99 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp2 |         24.03 ± 0.01 |         24.05 ± 0.02 |    1.00 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp3 |         25.49 ± 0.04 |         25.48 ± 0.02 |    1.00 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp4 |         26.06 ± 0.02 |         39.32 ± 0.12 |    1.51 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp5 |         18.89 ± 0.05 |         44.53 ± 0.04 |    2.36 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp6 |         22.64 ± 0.05 |         42.35 ± 0.02 |    1.87 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp7 |         26.33 ± 0.02 |         40.34 ± 0.12 |    1.53 |
| qwen2 32B Q5_K   |  21.66 GiB | Metal,BLAS |  1 |           pp8 |         30.10 ± 0.04 |         45.64 ± 0.10 |    1.52 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp1 |         20.55 ± 0.03 |         20.54 ± 0.04 |    1.00 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp2 |         23.18 ± 0.01 |         23.16 ± 0.02 |    1.00 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp3 |         24.45 ± 0.03 |         24.41 ± 0.01 |    1.00 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp4 |         24.86 ± 0.03 |         40.36 ± 0.04 |    1.62 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp5 |         19.61 ± 0.03 |         44.46 ± 0.03 |    2.27 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp6 |         23.52 ± 0.05 |         43.93 ± 0.02 |    1.87 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp7 |         27.37 ± 0.02 |         42.27 ± 0.03 |    1.54 |
| qwen2 32B Q6_K   |  25.03 GiB | Metal,BLAS |  1 |           pp8 |         31.28 ± 0.03 |         46.69 ± 0.05 |    1.49 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp1 |         22.45 ± 0.06 |         22.56 ± 0.07 |    1.00 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp2 |         28.20 ± 0.02 |         31.86 ± 0.08 |    1.13 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp3 |         30.84 ± 0.01 |         37.83 ± 0.12 |    1.23 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp4 |         32.05 ± 0.04 |         41.81 ± 0.05 |    1.30 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp5 |         22.18 ± 0.04 |         49.22 ± 0.07 |    2.22 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp6 |         26.55 ± 0.04 |         44.49 ± 0.16 |    1.68 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp7 |         30.90 ± 0.02 |         37.65 ± 0.12 |    1.22 |
| qwen2 32B IQ4_NL |  17.53 GiB | Metal,BLAS |  1 |           pp8 |         35.24 ± 0.03 |         43.38 ± 0.30 |    1.23 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp1 |         17.84 ± 0.08 |         17.85 ± 0.05 |    1.00 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp2 |         21.15 ± 0.02 |         32.86 ± 0.02 |    1.55 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp3 |         22.40 ± 0.01 |         45.93 ± 0.09 |    2.05 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp4 |         22.84 ± 0.02 |         55.71 ± 0.07 |    2.44 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp5 |         23.98 ± 0.02 |         57.98 ± 0.07 |    2.42 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp6 |         28.76 ± 0.04 |         53.49 ± 0.04 |    1.86 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp7 |         33.45 ± 0.02 |         57.51 ± 0.12 |    1.72 |
| qwen2 32B Q8_0   |  32.42 GiB | Metal,BLAS |  1 |           pp8 |         38.24 ± 0.06 |         65.18 ± 0.10 |    1.70 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp1 |          9.76 ± 0.06 |          9.73 ± 0.04 |    1.00 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp2 |         11.14 ± 0.01 |         20.23 ± 0.04 |    1.82 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp3 |         11.75 ± 0.01 |         29.31 ± 0.05 |    2.49 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp4 |         14.26 ± 0.02 |         37.59 ± 0.32 |    2.64 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp5 |         26.38 ± 0.11 |         45.37 ± 0.31 |    1.72 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp6 |         31.58 ± 0.11 |         34.41 ± 0.18 |    1.09 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp7 |         36.69 ± 0.14 |         39.02 ± 0.07 |    1.06 |
| qwen2 32B F16    |  61.03 GiB | Metal,BLAS |  1 |           pp8 |         41.82 ± 0.10 |         44.55 ± 0.10 |    1.07 |

build: 991f8aabe (4239)

</details>

<details>
<summary>M1 Pro</summary>

| model           |       size |  backend    | fa |          test |                  t/s |                  t/s | speedup |
| --------------- | ---------: |  ---------- | -: | ------------: | -------------------: | -------------------: | ------: |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp1 |         71.88 ± 0.91 |         72.07 ± 0.73 |  1.00   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp1 |         72.24 ± 0.12 |         71.35 ± 2.35 |  0.99   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp2 |         94.02 ± 0.08 |         89.35 ± 0.26 |  0.95   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp3 |        103.71 ± 0.12 |        125.13 ± 0.14 |  1.21   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp4 |        110.12 ± 0.06 |        140.56 ± 0.14 |  1.28   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp5 |         83.42 ± 0.07 |        155.18 ± 0.18 |  1.86   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp6 |         99.85 ± 0.04 |        151.34 ± 0.11 |  1.52   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp7 |        116.20 ± 0.04 |        145.15 ± 0.09 |  1.25   |
| llama 3B Q4_0   |   1.78 GiB |  Metal,BLAS |  1 |           pp8 |        132.87 ± 0.07 |        164.57 ± 0.07 |  1.24   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp1 |         61.36 ± 0.10 |         61.34 ± 0.16 |  1.00   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp1 |         61.41 ± 0.10 |         61.43 ± 0.19 |  1.00   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp2 |         73.71 ± 0.92 |         74.27 ± 0.12 |  1.01   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp3 |         79.77 ± 0.11 |         79.91 ± 0.05 |  1.00   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp4 |         83.43 ± 0.04 |        105.77 ± 0.12 |  1.27   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp5 |         71.31 ± 0.08 |        110.56 ± 0.11 |  1.55   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp6 |         85.53 ± 0.03 |        107.73 ± 0.09 |  1.26   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp7 |         99.54 ± 0.08 |        110.39 ± 0.10 |  1.11   |
| llama 3B Q4_K   |   1.87 GiB |  Metal,BLAS |  1 |           pp8 |        113.82 ± 0.07 |        122.02 ± 0.14 |  1.07   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp1 |         46.28 ± 0.13 |         46.03 ± 0.32 |  0.99   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp1 |         46.33 ± 0.08 |         45.26 ± 0.78 |  0.98   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp2 |         60.96 ± 0.08 |         76.28 ± 0.10 |  1.25   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp3 |         67.21 ± 0.03 |        114.75 ± 0.31 |  1.71   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp4 |         71.15 ± 0.07 |        135.15 ± 0.34 |  1.90   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp5 |         82.02 ± 0.02 |        149.47 ± 0.15 |  1.82   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp6 |         98.18 ± 0.07 |        137.05 ± 0.07 |  1.40   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp7 |        114.26 ± 0.03 |        139.25 ± 0.14 |  1.22   |
| llama 3B Q8_0   |   3.18 GiB |  Metal,BLAS |  1 |           pp8 |        130.61 ± 0.05 |        153.15 ± 0.99 |  1.17   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp1 |         40.60 ± 0.05 |         39.92 ± 0.22 |  0.98   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp1 |         40.50 ± 0.26 |         40.00 ± 0.45 |  0.99   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp2 |         47.66 ± 0.56 |         44.10 ± 0.13 |  0.93   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp3 |         49.87 ± 0.41 |         66.90 ± 0.30 |  1.34   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp4 |         51.91 ± 0.16 |         71.58 ± 0.26 |  1.38   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp5 |         41.91 ± 0.07 |         77.09 ± 0.26 |  1.84   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp6 |         50.22 ± 0.15 |         73.08 ± 0.19 |  1.46   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp7 |         58.22 ± 0.38 |         68.96 ± 0.14 |  1.18   |
| llama 7B Q4_0   |   3.56 GiB |  Metal,BLAS |  1 |           pp8 |         66.55 ± 0.23 |         77.88 ± 0.17 |  1.17   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp1 |         33.15 ± 0.18 |         33.16 ± 0.19 |  1.00   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp1 |         33.14 ± 0.19 |         33.18 ± 0.19 |  1.00   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp2 |         36.75 ± 0.13 |         36.75 ± 0.12 |  1.00   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp3 |         38.25 ± 0.12 |         38.26 ± 0.11 |  1.00   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp4 |         39.18 ± 0.09 |         52.31 ± 0.15 |  1.34   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp5 |         36.56 ± 0.01 |         54.24 ± 0.12 |  1.48   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp6 |         43.78 ± 0.01 |         52.56 ± 0.04 |  1.20   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp7 |         50.95 ± 0.09 |         52.13 ± 0.08 |  1.02   |
| llama 7B Q4_K   |   3.80 GiB |  Metal,BLAS |  1 |           pp8 |         58.25 ± 0.01 |         58.03 ± 0.12 |  1.00   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp1 |         23.74 ± 0.11 |         23.75 ± 0.10 |  1.00   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp1 |         23.77 ± 0.10 |         23.76 ± 0.10 |  1.00   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp2 |         26.14 ± 0.02 |         37.02 ± 0.12 |  1.42   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp3 |         27.29 ± 0.04 |         58.21 ± 0.22 |  2.13   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp4 |         27.92 ± 0.03 |         66.85 ± 0.20 |  2.39   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp5 |         41.06 ± 0.03 |         72.93 ± 0.21 |  1.78   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp6 |         49.16 ± 0.18 |         63.97 ± 0.19 |  1.30   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp7 |         56.99 ± 0.15 |         64.78 ± 0.19 |  1.14   |
| llama 7B Q8_0   |   6.67 GiB |  Metal,BLAS |  1 |           pp8 |         65.09 ± 0.17 |         71.21 ± 0.15 |  1.09   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp1 |         21.82 ± 0.03 |         21.83 ± 0.04 |  1.00   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp1 |         21.83 ± 0.02 |         21.85 ± 0.01 |  1.00   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp2 |         24.47 ± 0.02 |         22.65 ± 0.01 |  0.93   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp3 |         25.54 ± 0.01 |         35.48 ± 0.02 |  1.39   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp4 |         25.96 ± 0.04 |         37.49 ± 0.04 |  1.44   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp5 |         22.53 ± 0.01 |         41.14 ± 0.05 |  1.83   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp6 |         27.02 ± 0.01 |         37.65 ± 0.05 |  1.39   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp7 |         31.50 ± 0.01 |         35.59 ± 0.01 |  1.13   |
| llama 13B Q4_0  |   6.86 GiB |  Metal,BLAS |  1 |           pp8 |         35.94 ± 0.03 |         40.10 ± 0.03 |  1.12   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp1 |         17.75 ± 0.02 |         17.68 ± 0.03 |  1.00   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp1 |         17.76 ± 0.02 |         17.69 ± 0.05 |  1.00   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp2 |         19.17 ± 0.02 |         19.11 ± 0.02 |  1.00   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp3 |         19.76 ± 0.03 |         19.72 ± 0.02 |  1.00   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp4 |         20.01 ± 0.01 |         27.45 ± 0.02 |  1.37   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp5 |         19.28 ± 0.01 |         28.70 ± 0.03 |  1.49   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp6 |         23.10 ± 0.02 |         27.31 ± 0.00 |  1.18   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp7 |         26.91 ± 0.01 |         26.84 ± 0.01 |  1.00   |
| llama 13B Q4_K  |   7.33 GiB |  Metal,BLAS |  1 |           pp8 |         30.72 ± 0.01 |         29.84 ± 0.02 |  0.97   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp1 |         12.49 ± 0.03 |         12.48 ± 0.02 |  1.00   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp1 |         12.48 ± 0.04 |         12.49 ± 0.02 |  1.00   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp2 |         13.58 ± 0.02 |         19.03 ± 0.02 |  1.40   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp3 |         14.02 ± 0.01 |         31.95 ± 0.04 |  2.28   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp4 |         14.21 ± 0.01 |         34.42 ± 0.08 |  2.42   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp5 |         22.25 ± 0.02 |         37.49 ± 0.02 |  1.68   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp6 |         26.66 ± 0.02 |         33.12 ± 0.04 |  1.24   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp7 |         31.07 ± 0.02 |         33.16 ± 0.03 |  1.07   |
| llama 13B Q8_0  |  12.88 GiB |  Metal,BLAS |  1 |           pp8 |         35.45 ± 0.03 |         36.25 ± 0.04 |  1.02   |

build: 64ed2091 (4240)

</details>
