### PR TITLE
llama : (proposal) implement cpp-first library `llama-cpp.h`

### DIFF
--- a/include/llama-cpp.h
+++ b/include/llama-cpp.h
@@ -5,8 +5,11 @@
 #endif
 
 #include <memory>
+#include <string>
 
 #include "llama.h"
+
+namespace llama_cpp {
 
 struct llama_model_deleter {
     void operator()(llama_model * model) { llama_free_model(model); }
@@ -20,6 +23,44 @@ struct llama_sampler_deleter {
     void operator()(llama_sampler * sampler) { llama_sampler_free(sampler); }
 };
 
-typedef std::unique_ptr<llama_model, llama_model_deleter> llama_model_ptr;
-typedef std::unique_ptr<llama_context, llama_context_deleter> llama_context_ptr;
-typedef std::unique_ptr<llama_sampler, llama_sampler_deleter> llama_sampler_ptr;
+typedef std::unique_ptr<llama_model, llama_model_deleter>     model;
+typedef std::unique_ptr<llama_context, llama_context_deleter> context;
+typedef std::unique_ptr<llama_sampler, llama_sampler_deleter> sampler;
+
+inline model load_model_from_file(const std::string & path_model, llama_model_params params) {
+    return model(llama_load_model_from_file(path_model.c_str(), params));
+}
+
+inline context new_context_with_model(const model & model, llama_context_params params) {
+    return context(llama_new_context_with_model(model.get(), params));
+}
+
+inline sampler sampler_chain_init(llama_sampler_chain_params params) {
+    return sampler(llama_sampler_chain_init(params));
+}
+
+std::vector<llama_token> tokenize(
+        const llama_cpp::model & model,
+             const std::string & raw_text,
+                          bool   add_special,
+                          bool   parse_special = false);
+
+std::string token_to_piece(
+      const llama_cpp::model & model,
+                 llama_token   token,
+                     int32_t   lstrip,
+                        bool   special);
+
+std::string detokenize(
+            const llama_cpp::model & model,
+    const std::vector<llama_token> & tokens,
+                              bool   remove_special,
+                              bool   unparse_special);
+
+std::string chat_apply_template(
+                   const llama_cpp::model & model,
+                        const std::string & tmpl,
+    const std::vector<llama_chat_message> & chat,
+                                     bool   add_ass);
+
+} // namespace llama_cpp

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1,3 +1,4 @@
+#include "llama-cpp.h"
 #include "llama-impl.h"
 #include "llama-vocab.h"
 #include "llama-sampling.h"
@@ -21818,6 +21819,14 @@ int32_t llama_tokenize(
     return llama_tokenize_impl(model->vocab, text, text_len, tokens, n_tokens_max, add_special, parse_special);
 }
 
+std::vector<llama_token> llama_cpp::tokenize(
+        const llama_cpp::model & model,
+             const std::string & raw_text,
+                          bool   add_special,
+                          bool   parse_special) {
+    return llama_tokenize_internal(model->vocab, raw_text, add_special, parse_special);
+}
+
 int32_t llama_token_to_piece(
     const struct llama_model * model,
                  llama_token   token,
@@ -21826,6 +21835,23 @@ int32_t llama_token_to_piece(
                      int32_t   lstrip,
                         bool   special) {
     return llama_token_to_piece_impl(model->vocab, token, buf, length, lstrip, special);
+}
+
+std::string llama_cpp::token_to_piece(
+      const llama_cpp::model & model,
+                 llama_token   token,
+                     int32_t   lstrip,
+                        bool   special) {
+    std::vector<char> buf(64);
+    int32_t n = llama_token_to_piece_impl(model->vocab, token, buf.data(), buf.size(), lstrip, special);
+    if (n > (int32_t) buf.size()) {
+        buf.resize(n);
+        llama_token_to_piece_impl(model->vocab, token, buf.data(), buf.size(), lstrip, special);
+    } else if (n < 0) {
+        // TODO: make special type of expection here
+        throw std::runtime_error("failed to convert token to piece");
+    }
+    return std::string(buf.data(), n);
 }
 
 int32_t llama_detokenize(
@@ -21837,6 +21863,23 @@ int32_t llama_detokenize(
                         bool   remove_special,
                         bool   unparse_special) {
     return llama_detokenize_impl(model->vocab, tokens, n_tokens, text, text_len_max, remove_special, unparse_special);
+}
+
+std::string llama_cpp::detokenize(
+            const llama_cpp::model & model,
+    const std::vector<llama_token> & tokens,
+                              bool   remove_special,
+                              bool   unparse_special) {
+    std::vector<char> buf(1024);
+    int32_t n = llama_detokenize_impl(model->vocab, tokens.data(), tokens.size(), buf.data(), buf.size(), remove_special, unparse_special);
+    if (n > (int32_t) buf.size()) {
+        buf.resize(n);
+        llama_detokenize_impl(model->vocab, tokens.data(), tokens.size(), buf.data(), buf.size(), remove_special, unparse_special);
+    } else if (n < 0) {
+        // TODO: make special type of expection here
+        throw std::runtime_error("failed to detokenize");
+    }
+    return std::string(buf.data(), n);
 }
 
 //
@@ -22170,6 +22213,24 @@ int32_t llama_chat_apply_template(
         strncpy(buf, formatted_chat.c_str(), length);
     }
     return res;
+}
+
+std::string llama_cpp::chat_apply_template(
+                   const llama_cpp::model & model,
+                        const std::string & tmpl,
+    const std::vector<llama_chat_message> & chat,
+                                     bool   add_ass) {
+    std::vector<char> buf;
+    const char * tmpl_c = tmpl.empty() ? nullptr : tmpl.c_str();
+    int32_t n = llama_chat_apply_template(model.get(), tmpl_c, chat.data(), chat.size(), add_ass, buf.data(), buf.size());
+    if (n > (int32_t) buf.size()) {
+        buf.resize(n);
+        llama_chat_apply_template(model.get(), tmpl_c, chat.data(), chat.size(), add_ass, buf.data(), buf.size());
+    } else if (n < 0) {
+        // TODO: make special type of expection here
+        throw std::runtime_error("failed to format chat template");
+    }
+    return std::string(buf.data(), n);
 }
 
 //


### PR DESCRIPTION
## Motivation

I was re-thinking about the idea of llamax (#5215) today. While we're still far from having llamax, to get there, we need to have a step-by-step plan.

Currently, one of the main challenge for developers who want to adopt llama.cpp is that we don't have cpp functions exposed in `llama.h` (ref: [this discussion](https://github.com/ggerganov/llama.cpp/discussions/8074#discussioncomment-11073246))

I think it would be nice to take this as the first step toward llamax. We should firstly have a library that uses cpp types like `std::string` and `std::vector`, instead of passing c-pointer.

## Implementation

The `llama-cpp.h` seems to be a good starting point. It's already use by one single example (`llama-run`), so could be used as a WIP for now.

My implementation in this PR is **very draft and mostly for demo purpose**.

The final goal is to have all functions being "cpp-first", then having c-only `llama.h` as their wrapper (NOTE: this is reverse to what we do with `common`. Currently, the cpp `common` is wrapper for c functions in `llama.h`)

I'm opening this proposal for discussion, kindly invite @slaren and @ggerganov to join in.

Thank you.

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
