### PR TITLE
server : fix default draft model parameters

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -697,6 +697,10 @@ struct server_context {
             params_dft.n_ctx        = params_base.speculative.n_ctx;
             params_dft.n_gpu_layers = params_base.speculative.n_gpu_layers;
 
+            // force F16 KV cache for the draft model for extra performance
+            params_dft.cache_type_k = "f16";
+            params_dft.cache_type_v = "f16";
+
             common_init_result llama_init_dft = common_init_from_params(params_dft);
 
             model_dft = llama_init_dft.model;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -694,12 +694,9 @@ struct server_context {
 
             params_dft.devices      = params_base.speculative.devices;
             params_dft.model        = params_base.speculative.model;
-            params_dft.n_ctx        = params_base.speculative.n_ctx;
+            params_dft.n_ctx        = params_base.speculative.n_ctx == 0 ? params_base.n_ctx / params_base.n_parallel : params_base.speculative.n_ctx;
             params_dft.n_gpu_layers = params_base.speculative.n_gpu_layers;
-
-            // force F16 KV cache for the draft model for extra performance
-            params_dft.cache_type_k = "f16";
-            params_dft.cache_type_v = "f16";
+            params_dft.n_parallel   = 1;
 
             common_init_result llama_init_dft = common_init_from_params(params_dft);
 
@@ -719,8 +716,14 @@ struct server_context {
                 return false;
             }
 
+            const int n_ctx_dft = llama_n_ctx(llama_init_dft.context);
+
             cparams_dft = common_context_params_to_llama(params_dft);
-            cparams_dft.n_batch = llama_n_ctx(llama_init_dft.context);
+            cparams_dft.n_batch = n_ctx_dft;
+
+            // force F16 KV cache for the draft model for extra performance
+            cparams_dft.type_k = GGML_TYPE_F16;
+            cparams_dft.type_v = GGML_TYPE_F16;
 
             // the context is not needed - we will create one for each slot
             llama_free(llama_init_dft.context);
@@ -2309,6 +2312,10 @@ struct server_context {
             // do speculative decoding
             for (auto & slot : slots) {
                 if (!slot.is_processing() || !slot.can_speculate()) {
+                    continue;
+                }
+
+                if (slot.state != SLOT_STATE_GENERATING) {
                     continue;
                 }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -719,7 +719,7 @@ struct server_context {
                 return false;
             }
 
-            cparams_dft = common_context_params_to_llama(params_base);
+            cparams_dft = common_context_params_to_llama(params_dft);
             cparams_dft.n_batch = llama_n_ctx(llama_init_dft.context);
 
             // the context is not needed - we will create one for each slot


### PR DESCRIPTION
ref #10552 

- Use F16 KV cache for the draft model
- Set draft context equal to slot context
- Do not speculate during prompt processing