### PR TITLE
build: update Makefile comments for C++ version change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ endif
 # Compile flags
 #
 
-# keep standard at C11 and C++11
+# keep standard at C11 and C++17
 MK_CPPFLAGS  = -Iggml/include -Iggml/src -Iinclude -Isrc -Icommon -DGGML_USE_CPU
 MK_CFLAGS    = -std=c11   -fPIC
 MK_CXXFLAGS  = -std=c++17 -fPIC


### PR DESCRIPTION
Coomit [7cc2d2](https://github.com/ggerganov/llama.cpp/commit/7cc2d2c88908fc92b97b28acafb82f7d6e425b85) changed the compiler flags but didn't update the comment. 

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
