### PR TITLE
ci: add error handling for Python venv creation in run.sh

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -815,7 +815,10 @@ if [ -z ${GG_BUILD_LOW_PERF} ]; then
     ln -sfn ${mnt_models} ${SRC}/models-mnt
 
     # Create a fresh python3 venv and enter it
-    python3 -m venv "$MNT/venv"
+    if ! python3 -m venv "$MNT/venv"; then
+        echo "Error: Failed to create Python virtual environment at $MNT/venv."
+        exit 1
+    fi
     source "$MNT/venv/bin/activate"
 
     pip install -r ${SRC}/requirements.txt --disable-pip-version-check


### PR DESCRIPTION
I am trying to do a complete ci for my changes following [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) but it took me a while to discover that my python venv was not setup properly. I added this checking to let it fail faster to save some time for future contributors. I tested this change by remove python3.12-venv package on a Ubuntu-24.04 and here is the output:
```
┌─[±][no-throw-in-extern-c {1} ✓][root][~/llama.cpp]
└─▪ GG_BUILD_CUDA=1 sudo bash ./ci/run.sh ./tmp/results ./tmp/mnt
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.12-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.

Failing command: /root/llama.cpp/tmp/mnt/venv/bin/python3

Error: Failed to create Python virtual environment at /root/llama.cpp/tmp/mnt/venv.
```
---
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
