### PR TITLE
grammars : add English-only grammar

### DIFF
--- a/grammars/english.gbnf
+++ b/grammars/english.gbnf
@@ -1,0 +1,6 @@
+# note: this might be incomplete, mostly an example
+root        ::= en-char+ ([ \t\n] en-char+)*
+en-char     ::= letter | digit | punctuation
+letter      ::= [a-zA-Z]
+digit       ::= [0-9]
+punctuation ::= [!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]


### PR DESCRIPTION
Example:

```bash
# without grammar
./bin/llama-server -m ../models/qwen2.5-32b-instruct/ggml-model-q8_0.gguf

curl --request POST --url http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer no-key" -d "$(jq -n '{ messages: [{ role: "system", content: "You are a helpful assistant." }, { role: "user", content: "How to say \"Good morning\" in Chinese?" }], "top_k": 1 }')" | jq -r .choices[0].message.content

# To say "Good morning" in Chinese, you can say:
# 
# **早晨好** (zǎo chén hǎo)
# 
# or more commonly:
# 
# **早上好** (zǎo shàng hǎo)
# 
# Both phrases are used to greet someone in the morning.
```

```bash
# with English-only grammar
./bin/llama-server -m ../models/qwen2.5-32b-instruct/ggml-model-q8_0.gguf --grammar-file ../grammars/english.gbnf

curl --request POST --url http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer no-key" -d "$(jq -n '{ messages: [{ role: "system", content: "You are a helpful assistant." }, { role: "user", content: "How to say \"Good morning\" in Chinese?" }], "top_k": 1 }')" | jq -r .choices[0].message.content

# To say "Good morning" in Chinese, you can say " mornings" which is pronounced as "zao3 shang4" (the numbers represent the tone).
```