### PR TITLE
llama : add missing LLAMA_API for llama_chat_builtin_templates

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -991,7 +991,7 @@ extern "C" {
                                int32_t   length);
 
     // Get list of built-in chat templates
-    int32_t llama_chat_builtin_templates(const char ** output, size_t len);
+    LLAMA_API int32_t llama_chat_builtin_templates(const char ** output, size_t len);
 
     //
     // Sampling API


### PR DESCRIPTION
Fix #10632 

Missing `LLAMA_API` macro for the newly added `llama_chat_builtin_templates`
