### PR TITLE
vulkan: optimize and reenable split_k

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_split_k_reduce.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_split_k_reduce.comp
@@ -5,7 +5,9 @@
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout (binding = 0) readonly buffer A {float data_a[];};
+layout (binding = 0) readonly buffer A4 {vec4 data_a4[];};
 layout (binding = 1) writeonly buffer D {float data_d[];};
+layout (binding = 1) writeonly buffer D4 {vec4 data_d4[];};
 
 layout (push_constant) uniform parameter {
     uint ne;
@@ -13,17 +15,34 @@ layout (push_constant) uniform parameter {
 } p;
 
 void main() {
-    const uint idx = gl_GlobalInvocationID.x;
+    // Each invocation handles four consecutive components
+    const uint idx = gl_GlobalInvocationID.x * 4;
 
     if (idx >= p.ne) {
         return;
     }
 
-    float result = 0.0f;
+    // Check if all four components are in bounds and aligned,
+    // then use vector loads
+    if (idx + 3 < p.ne && (p.ne % 4) == 0) {
+        vec4 result = vec4(0.0f);
 
-    [[unroll]] for (uint i = 0; i < p.k_num; i++) {
-        result += data_a[i * p.ne + idx];
+        [[unroll]] for (uint i = 0; i < p.k_num; i++) {
+            result += data_a4[(i * p.ne + idx) / 4];
+        }
+
+        data_d4[idx / 4] = result;
+    } else {
+        [[unroll]] for (uint j = 0; j < 4; ++j) {
+            if (idx + j < p.ne) {
+                float result = 0.0f;
+
+                [[unroll]] for (uint i = 0; i < p.k_num; i++) {
+                    result += data_a[i * p.ne + idx + j];
+                }
+
+                data_d[idx + j] = result;
+            }
+        }
     }
-
-    data_d[idx] = result;
 }


### PR DESCRIPTION
Use vector loads when possible in mul_mat_split_k_reduce. Use split_k when there aren't enough workgroups to fill the shaders.

Split out from #10206.

I did a quick touch test to verify split_k helps the non-coopmat shaders as well:

```
before:
  MUL_MAT(type_a=f32,type_b=f32,m=128,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                    426 runs -  2600.37 us/run - 469.76 MFLOP/run - 180.65 GFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=256,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                    428 runs -  2569.83 us/run - 939.52 MFLOP/run - 365.60 GFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=384,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                    426 runs -  2579.22 us/run -   1.41 GFLOP/run - 546.40 GFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=512,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                    432 runs -  2582.09 us/run -   1.88 GFLOP/run - 727.72 GFLOPS

after:
  MUL_MAT(type_a=f32,type_b=f32,m=128,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                   1704 runs -   664.08 us/run - 469.76 MFLOP/run - 707.39 GFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=256,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                   1605 runs -   656.67 us/run - 939.52 MFLOP/run -   1.43 TFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=384,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                   1562 runs -   659.93 us/run -   1.41 GFLOP/run -   2.14 TFLOPS
  MUL_MAT(type_a=f32,type_b=f32,m=512,n=128,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                   1512 runs -   678.08 us/run -   1.88 GFLOP/run -   2.77 TFLOPS
```
