### PR TITLE
server: add OpenAI compatible response format for legacy /completions with b…

### DIFF
--- a/examples/server/tests/unit/test_basic.py
+++ b/examples/server/tests/unit/test_basic.py
@@ -40,9 +40,19 @@ def test_load_split_model():
     server.model_alias = "tinyllama-split"
     server.start()
     res = server.make_request("POST", "/completion", data={
-        "n_predict": 16,
+        "max_tokens": 16,
         "prompt": "Hello",
         "temperature": 0.0,
     })
     assert res.status_code == 200
-    assert match_regex("(little|girl)+", res.body["content"])
+    # Verify response structure
+    assert "id" in res.body
+    assert "object" in res.body
+    assert "created" in res.body
+    assert "model" in res.body
+    assert "choices" in res.body
+    assert isinstance(res.body["choices"], list)
+    assert len(res.body["choices"]) > 0
+    assert "text" in res.body["choices"][0]
+    # Verify the actual content
+    assert match_regex("(little|girl)+", res.body["choices"][0]["text"])

--- a/examples/server/tests/unit/test_completion.py
+++ b/examples/server/tests/unit/test_completion.py
@@ -18,13 +18,13 @@ def test_completion(prompt: str, n_predict: int, re_content: str, n_prompt: int,
     global server
     server.start()
     res = server.make_request("POST", "/completion", data={
-        "n_predict": n_predict,
+        "max_tokens": n_predict,
         "prompt": prompt,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert res.body["timings"]["prompt_n"] == n_prompt
     assert res.body["timings"]["predicted_n"] == n_predicted
-    assert res.body["truncated"] == truncated
     assert match_regex(re_content, res.body["content"])
 
 
@@ -36,16 +36,16 @@ def test_completion_stream(prompt: str, n_predict: int, re_content: str, n_promp
     global server
     server.start()
     res = server.make_stream_request("POST", "/completion", data={
-        "n_predict": n_predict,
+        "max_tokens": n_predict,
         "prompt": prompt,
         "stream": True,
+        "oai_compat": False,
     })
     content = ""
     for data in res:
         if data["stop"]:
             assert data["timings"]["prompt_n"] == n_prompt
             assert data["timings"]["predicted_n"] == n_predicted
-            assert data["truncated"] == truncated
             assert match_regex(re_content, content)
         else:
             content += data["content"]
@@ -63,6 +63,7 @@ def test_consistent_result_same_seed(n_slots: int):
             "seed": 42,
             "temperature": 1.0,
             "cache_prompt": False,  # TODO: remove this once test_cache_vs_nocache_prompt is fixed
+            "oai_compat": False,
         })
         if last_res is not None:
             assert res.body["content"] == last_res.body["content"]
@@ -81,6 +82,7 @@ def test_different_result_different_seed(n_slots: int):
             "seed": seed,
             "temperature": 1.0,
             "cache_prompt": False,  # TODO: remove this once test_cache_vs_nocache_prompt is fixed
+            "oai_compat": False,
         })
         if last_res is not None:
             assert res.body["content"] != last_res.body["content"]
@@ -100,6 +102,7 @@ def test_consistent_result_different_batch_size(n_batch: int, temperature: float
             "seed": 42,
             "temperature": temperature,
             "cache_prompt": False,  # TODO: remove this once test_cache_vs_nocache_prompt is fixed
+            "oai_compat": False,
         })
         if last_res is not None:
             assert res.body["content"] == last_res.body["content"]
@@ -115,12 +118,14 @@ def test_cache_vs_nocache_prompt():
         "seed": 42,
         "temperature": 1.0,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     res_no_cache = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",
         "seed": 42,
         "temperature": 1.0,
         "cache_prompt": False,
+        "oai_compat": False,
     })
     assert res_cache.body["content"] == res_no_cache.body["content"]
 
@@ -140,6 +145,7 @@ def test_completion_with_tokens_input():
     # single completion
     res = server.make_request("POST", "/completion", data={
         "prompt": tokens,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert type(res.body["content"]) == str
@@ -147,6 +153,7 @@ def test_completion_with_tokens_input():
     # batch completion
     res = server.make_request("POST", "/completion", data={
         "prompt": [tokens, tokens],
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert type(res.body) == list
@@ -156,6 +163,7 @@ def test_completion_with_tokens_input():
     # mixed string and tokens
     res = server.make_request("POST", "/completion", data={
         "prompt": [tokens, prompt_str],
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert type(res.body) == list
@@ -165,6 +173,7 @@ def test_completion_with_tokens_input():
     # mixed string and tokens in one sequence
     res = server.make_request("POST", "/completion", data={
         "prompt": [1, 2, 3, 4, 5, 6, prompt_str, 7, 8, 9, 10, prompt_str],
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert type(res.body["content"]) == str
@@ -208,6 +217,7 @@ def test_completion_parallel_slots(n_slots: int, n_requests: int):
             "prompt": prompt,
             "seed": 42,
             "temperature": 1.0,
+            "oai_compat": False,
         })))
     tasks.append((check_slots_status, ()))
     results = parallel_function_calls(tasks)
@@ -221,3 +231,122 @@ def test_completion_parallel_slots(n_slots: int, n_requests: int):
         assert len(res.body["content"]) > 10
         # FIXME: the result is not deterministic when using other slot than slot 0
         # assert match_regex(re_content, res.body["content"])
+
+# OpenAI legacy completion endpoint tests
+@pytest.mark.parametrize("prompt,n_predict,expected_text,n_prompt,n_predicted", [
+    ("I believe the meaning of life is", 8, "going to bed", 18, 8),
+    ("Write a joke about", 16, "Why did the AI", 14, 16),
+])
+def test_completion_openai(prompt: str, n_predict: int, expected_text: str, n_prompt: int, n_predicted: int):
+    global server
+    server.start()
+    
+    # Test non-streaming response
+    res = server.make_request("POST", "/completions", data={
+        "model": "local-model",
+        "prompt": prompt,
+        "max_tokens": n_predict,
+        "logprobs": 3,
+        "echo": True
+    })
+    
+    assert res.status_code == 200
+    assert res.body["object"] == "text_completion"
+    assert isinstance(res.body["id"], str)
+    assert isinstance(res.body["created"], int)
+    assert res.body["model"] == "local-model"
+    
+    # Check choices array
+    assert len(res.body["choices"]) == 1
+    choice = res.body["choices"][0]
+    assert choice["index"] == 0
+    assert isinstance(choice["text"], str)
+    assert choice["finish_reason"] in ["stop", "length"]
+    
+    # Check logprobs
+    assert choice["logprobs"] is not None
+    assert "tokens" in choice["logprobs"]
+    assert "token_logprobs" in choice["logprobs"]
+    assert "top_logprobs" in choice["logprobs"]
+    assert len(choice["logprobs"]["top_logprobs"]) == len(choice["logprobs"]["tokens"])
+    
+    # Check usage statistics
+    assert "usage" in res.body
+    assert res.body["usage"]["prompt_tokens"] == n_prompt
+    assert res.body["usage"]["completion_tokens"] == n_predicted
+    assert res.body["usage"]["total_tokens"] == n_prompt + n_predicted
+
+@pytest.mark.parametrize("prompt,n_predict,expected_text,n_prompt,n_predicted", [
+    ("I believe the meaning of life is", 8, "going to bed", 18, 8),
+    ("Write a joke about", 16, "Why did the AI", 14, 16),
+])
+def test_completion_openai_stream(prompt: str, n_predict: int, expected_text: str, n_prompt: int, n_predicted: int):
+    global server
+    server.start()
+    
+    res = server.make_stream_request("POST", "/v1/completions", data={
+        "prompt": prompt,
+        "max_tokens": n_predict,
+        "stream": True,
+    })
+    
+    collected_text = ""
+    is_first_chunk = True
+    for data in res:
+        assert "id" in data
+        assert data["object"] == "text_completion"
+        assert isinstance(data["created"], int)
+        
+        assert len(data["choices"]) == 1
+        choice = data["choices"][0]
+        assert choice["index"] == 0
+        assert isinstance(choice["text"], str)
+        collected_text += choice["text"]
+        
+        if is_first_chunk:
+            # First chunk should have model info
+            is_first_chunk = False
+        
+        if choice["finish_reason"] is not None:
+            # This is the last chunk
+            assert choice["finish_reason"] in ["stop", "length"]
+            assert "usage" in data
+            assert data["usage"]["prompt_tokens"] == n_prompt
+            assert data["usage"]["completion_tokens"] == n_predicted
+            assert data["usage"]["total_tokens"] == n_prompt + n_predicted
+
+@pytest.mark.parametrize("prompt,n_predict,expected_text,n_prompt,n_predicted", [
+    ("I believe the meaning of life is", 8, "going to bed", 18, 8),
+    ("Write a joke about", 16, "Why did the AI", 14, 16),
+])
+def test_completion_openai_no_logprobs(prompt: str, n_predict: int, expected_text: str, n_prompt: int, n_predicted: int):
+    global server
+    server.start()
+    
+    # Test non-streaming response
+    res = server.make_request("POST", "/completions", data={
+        "prompt": prompt,
+        "max_tokens": n_predict,
+        "echo": True
+    })
+    
+    assert res.status_code == 200
+    assert res.body["object"] == "text_completion"
+    assert isinstance(res.body["id"], str)
+    assert isinstance(res.body["created"], int)
+    
+    # Check choices array
+    assert len(res.body["choices"]) == 1
+    choice = res.body["choices"][0]
+    assert choice["index"] == 0
+    assert isinstance(choice["text"], str)
+    assert choice["finish_reason"] in ["stop", "length"]
+    
+    # Verify logprobs is None when not requested
+    assert choice["logprobs"] is None
+    
+    # Check usage statistics
+    assert "usage" in res.body
+    assert res.body["usage"]["prompt_tokens"] == n_prompt
+    assert res.body["usage"]["completion_tokens"] == n_predicted
+    assert res.body["usage"]["total_tokens"] == n_prompt + n_predicted

--- a/examples/server/tests/unit/test_ctx_shift.py
+++ b/examples/server/tests/unit/test_ctx_shift.py
@@ -29,6 +29,7 @@ def test_ctx_shift_enabled():
     res = server.make_request("POST", "/completion", data={
         "n_predict": 64,
         "prompt": LONG_TEXT,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert res.body["timings"]["prompt_n"] == 109
@@ -48,6 +49,7 @@ def test_ctx_shift_disabled_short_prompt(n_predict: int, n_token_output: int, tr
     res = server.make_request("POST", "/completion", data={
         "n_predict": n_predict,
         "prompt": "Hi how are you",
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert res.body["timings"]["predicted_n"] == n_token_output
@@ -61,6 +63,7 @@ def test_ctx_shift_disabled_long_prompt():
     res = server.make_request("POST", "/completion", data={
         "n_predict": 64,
         "prompt": LONG_TEXT,
+        "oai_compat": False,
     })
     assert res.status_code != 200
     assert "error" in res.body

--- a/examples/server/tests/unit/test_lora.py
+++ b/examples/server/tests/unit/test_lora.py
@@ -36,6 +36,7 @@ def test_lora(scale: float, re_content: str):
     assert res_lora_control.status_code == 200
     res = server.make_request("POST", "/completion", data={
         "prompt": "Look in thy glass",
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex(re_content, res.body["content"])

--- a/examples/server/tests/unit/test_security.py
+++ b/examples/server/tests/unit/test_security.py
@@ -41,6 +41,7 @@ def test_correct_api_key():
     server.start()
     res = server.make_request("POST", "/completions", data={
         "prompt": "I believe the meaning of life is",
+        "oai_compat": False,
     }, headers={
         "Authorization": f"Bearer {TEST_API_KEY}",
     })

--- a/examples/server/tests/unit/test_slot_save.py
+++ b/examples/server/tests/unit/test_slot_save.py
@@ -20,6 +20,7 @@ def test_slot_save_restore():
         "prompt": "What is the capital of France?",
         "id_slot": 1,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex("(Whiskers|Flana)+", res.body["content"])
@@ -37,6 +38,7 @@ def test_slot_save_restore():
         "prompt": "What is the capital of Germany?",
         "id_slot": 1,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex("(Jack|said)+", res.body["content"])
@@ -54,6 +56,7 @@ def test_slot_save_restore():
         "prompt": "What is the capital of Germany?",
         "id_slot": 0,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex("(Jack|said)+", res.body["content"])
@@ -64,6 +67,7 @@ def test_slot_save_restore():
         "prompt": "What is the capital of Germany?",
         "id_slot": 1,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex("(Jack|said)+", res.body["content"])
@@ -78,6 +82,7 @@ def test_slot_erase():
         "prompt": "What is the capital of France?",
         "id_slot": 1,
         "cache_prompt": True,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     assert match_regex("(Whiskers|Flana)+", res.body["content"])
@@ -94,5 +99,5 @@ def test_slot_erase():
         "cache_prompt": True,
     })
     assert res.status_code == 200
-    assert match_regex("(Whiskers|Flana)+", res.body["content"])
+    assert match_regex("(Whiskers|Flana)+", res.body["choices"][0]["text"])
     assert res.body["timings"]["prompt_n"] == 21  # all tokens are processed

--- a/examples/server/tests/unit/test_speculative.py
+++ b/examples/server/tests/unit/test_speculative.py
@@ -37,6 +37,7 @@ def test_with_and_without_draft():
         "prompt": "I believe the meaning of life is",
         "temperature": 0.0,
         "top_k": 1,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     content_no_draft = res.body["content"]
@@ -49,6 +50,7 @@ def test_with_and_without_draft():
         "prompt": "I believe the meaning of life is",
         "temperature": 0.0,
         "top_k": 1,
+        "oai_compat": False,
     })
     assert res.status_code == 200
     content_draft = res.body["content"]
@@ -75,6 +77,7 @@ def test_different_draft_min_draft_max():
             "prompt": "I believe the meaning of life is",
             "temperature": 0.0,
             "top_k": 1,
+            "oai_compat": False,
         })
         assert res.status_code == 200
         if last_content is not None:
@@ -96,6 +99,7 @@ def test_multi_requests_parallel(n_slots: int, n_requests: int):
             "prompt": "I believe the meaning of life is",
             "temperature": 0.0,
             "top_k": 1,
+            "oai_compat": False,
         })))
     results = parallel_function_calls(tasks)
     for res in results:


### PR DESCRIPTION
This is based of a previous [PR](https://github.com/ggerganov/llama.cpp/pull/10627)

However, @ngxson seems to be working refactoring the server.cpp to prevent use of JSON as stated [here](https://github.com/ggerganov/llama.cpp/pull/10643) so I don't expect is to be merged easily. However, might be of use to someone else.

Support for full (almost) OpenAI API response format for the legacy completion related endpoints (including when logprobs is specified)

When `oai_compat` is set to `True` in the request (as suggested by @ngxson, the old response format is used (check tests)

[HELM benchmarks from CRFM](https://crfm.stanford.edu/helm/lite/latest/#/leaderboard) have support for a OpenAI compatible API server that uses this endpoint, this enables testing differently quantized models for degradation against this benchmark. Tested it on a QwQ Preview 32B GGUF Q4_K_M to evaluate the model against other frontier models. I've described that [here](https://github.com/stanford-crfm/helm/issues/3141)
