### PR TITLE
GGUF: backend support, fixed-width I/O, misc fixes

### DIFF
--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -1,10 +1,8 @@
 #include "ggml.h"
 
 #include <cstdio>
-#include <cinttypes>
 #include <string>
 #include <sstream>
-#include <fstream>
 #include <vector>
 
 #undef MIN
@@ -135,9 +133,11 @@ static bool gguf_ex_read_0(const std::string & fname) {
 
         for (int i = 0; i < n_tensors; ++i) {
             const char * name   = gguf_get_tensor_name  (ctx, i);
+            const size_t size   = gguf_get_tensor_size  (ctx, i);
+            // const size_t size   = 0;
             const size_t offset = gguf_get_tensor_offset(ctx, i);
 
-            printf("%s: tensor[%d]: name = %s, offset = %zu\n", __func__, i, name, offset);
+            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu\n", __func__, i, name, size, offset);
         }
     }
 
@@ -182,9 +182,11 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
 
         for (int i = 0; i < n_tensors; ++i) {
             const char * name   = gguf_get_tensor_name  (ctx, i);
+            const size_t size   = gguf_get_tensor_size  (ctx, i);
+            // const size_t size   = 0;
             const size_t offset = gguf_get_tensor_offset(ctx, i);
 
-            printf("%s: tensor[%d]: name = %s, offset = %zu\n", __func__, i, name, offset);
+            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu\n", __func__, i, name, size, offset);
         }
     }
 
@@ -199,7 +201,8 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
 
             struct ggml_tensor * cur = ggml_get_tensor(ctx_data, name);
 
-            printf("%s: tensor[%d]: n_dims = %d, name = %s, data = %p\n", __func__, i, ggml_n_dims(cur), cur->name, cur->data);
+            printf("%s: tensor[%d]: n_dims = %d, ne = (%d, %d, %d, %d) name = %s, data = %p\n",
+                __func__, i, ggml_n_dims(cur), int(cur->ne[0]), int(cur->ne[1]), int(cur->ne[2]), int(cur->ne[3]), cur->name, cur->data);
 
             // print first 10 elements
             const float * data = (const float *) cur->data;
@@ -215,7 +218,7 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
                 const float * data = (const float *) cur->data;
                 for (int j = 0; j < ggml_nelements(cur); ++j) {
                     if (data[j] != 100 + i) {
-                        fprintf(stderr, "%s: tensor[%d]: data[%d] = %f\n", __func__, i, j, data[j]);
+                        fprintf(stderr, "%s: tensor[%d], data[%d]: found %f, expected %f\n", __func__, i, j, data[j], float(100 + i));
                         gguf_free(ctx);
                         return false;
                     }
@@ -244,6 +247,8 @@ int main(int argc, char ** argv) {
     if (argc == 4) {
         check_data = false;
     }
+
+    srand(123456);
 
     const std::string fname(argv[1]);
     const std::string mode (argv[2]);

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -2566,7 +2566,8 @@ bool clip_model_quantize(const char * fname_inp, const char * fname_out, const i
         total_size_org += orig_size;
         total_size_new += new_size;
         gguf_set_tensor_type(ctx_out, name.c_str(), new_type);
-        gguf_set_tensor_data(ctx_out, name.c_str(), new_data, new_size);
+        GGML_ASSERT(gguf_get_tensor_size(ctx_out, gguf_find_tensor(ctx_out, name.c_str())) == new_size);
+        gguf_set_tensor_data(ctx_out, name.c_str(), new_data);
         fout.write((const char *)new_data, new_size);
         size_t pad = GGML_PAD(new_size, gguf_get_alignment(ctx_out)) - new_size;
         for (size_t j = 0; j < pad; ++j) {

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2072,9 +2072,10 @@ extern "C" {
                const float * imatrix);
 
     //
-    // gguf
+    // GGUF
     //
 
+    // types that can be stored as GGUF KV data
     enum gguf_type {
         GGUF_TYPE_UINT8   = 0,
         GGUF_TYPE_INT8    = 1,
@@ -2136,41 +2137,56 @@ extern "C" {
     GGML_API const char * gguf_get_val_str (const struct gguf_context * ctx, int key_id);
     GGML_API const void * gguf_get_val_data(const struct gguf_context * ctx, int key_id);
     GGML_API int          gguf_get_arr_n   (const struct gguf_context * ctx, int key_id);
+
+    // get raw pointer to the first element of the array with the given key_id
+    // for bool arrays, note that they are always stored as int8 on all platforms (usually this makes no difference)
     GGML_API const void * gguf_get_arr_data(const struct gguf_context * ctx, int key_id);
+
+    // get ith C string from array with given key_id
     GGML_API const char * gguf_get_arr_str (const struct gguf_context * ctx, int key_id, int i);
 
     GGML_API int            gguf_get_n_tensors    (const struct gguf_context * ctx);
     GGML_API int            gguf_find_tensor      (const struct gguf_context * ctx, const char * name);
     GGML_API size_t         gguf_get_tensor_offset(const struct gguf_context * ctx, int i);
-    GGML_API char *         gguf_get_tensor_name  (const struct gguf_context * ctx, int i);
+    GGML_API const char *   gguf_get_tensor_name  (const struct gguf_context * ctx, int i);
     GGML_API enum ggml_type gguf_get_tensor_type  (const struct gguf_context * ctx, int i);
+    GGML_API size_t         gguf_get_tensor_size  (const struct gguf_context * ctx, int i);
 
     // removes key if it exists
     GGML_API void gguf_remove_key(struct gguf_context * ctx, const char * key);
 
     // overrides existing values or adds a new one
-    GGML_API void gguf_set_val_u8  (struct gguf_context * ctx, const char * key, uint8_t  val);
-    GGML_API void gguf_set_val_i8  (struct gguf_context * ctx, const char * key, int8_t   val);
-    GGML_API void gguf_set_val_u16 (struct gguf_context * ctx, const char * key, uint16_t val);
-    GGML_API void gguf_set_val_i16 (struct gguf_context * ctx, const char * key, int16_t  val);
-    GGML_API void gguf_set_val_u32 (struct gguf_context * ctx, const char * key, uint32_t val);
-    GGML_API void gguf_set_val_i32 (struct gguf_context * ctx, const char * key, int32_t  val);
-    GGML_API void gguf_set_val_f32 (struct gguf_context * ctx, const char * key, float    val);
-    GGML_API void gguf_set_val_u64 (struct gguf_context * ctx, const char * key, uint64_t val);
-    GGML_API void gguf_set_val_i64 (struct gguf_context * ctx, const char * key, int64_t  val);
-    GGML_API void gguf_set_val_f64 (struct gguf_context * ctx, const char * key, double   val);
-    GGML_API void gguf_set_val_bool(struct gguf_context * ctx, const char * key, bool     val);
+    GGML_API void gguf_set_val_u8  (struct gguf_context * ctx, const char * key, uint8_t      val);
+    GGML_API void gguf_set_val_i8  (struct gguf_context * ctx, const char * key, int8_t       val);
+    GGML_API void gguf_set_val_u16 (struct gguf_context * ctx, const char * key, uint16_t     val);
+    GGML_API void gguf_set_val_i16 (struct gguf_context * ctx, const char * key, int16_t      val);
+    GGML_API void gguf_set_val_u32 (struct gguf_context * ctx, const char * key, uint32_t     val);
+    GGML_API void gguf_set_val_i32 (struct gguf_context * ctx, const char * key, int32_t      val);
+    GGML_API void gguf_set_val_f32 (struct gguf_context * ctx, const char * key, float        val);
+    GGML_API void gguf_set_val_u64 (struct gguf_context * ctx, const char * key, uint64_t     val);
+    GGML_API void gguf_set_val_i64 (struct gguf_context * ctx, const char * key, int64_t      val);
+    GGML_API void gguf_set_val_f64 (struct gguf_context * ctx, const char * key, double       val);
+    GGML_API void gguf_set_val_bool(struct gguf_context * ctx, const char * key, bool         val);
     GGML_API void gguf_set_val_str (struct gguf_context * ctx, const char * key, const char * val);
+
+    // creates a new array with n elements of the given type and copies the corresponding number of bytes from data
     GGML_API void gguf_set_arr_data(struct gguf_context * ctx, const char * key, enum gguf_type type, const void * data, int n);
+
+    // creates a new array with n strings and copies the corresponding strings from data
     GGML_API void gguf_set_arr_str (struct gguf_context * ctx, const char * key, const char ** data, int n);
 
     // set or add KV pairs from another context
-    GGML_API void gguf_set_kv(struct gguf_context * ctx, struct gguf_context * src);
+    GGML_API void gguf_set_kv(struct gguf_context * ctx, const struct gguf_context * src);
 
     // manage tensor info
     GGML_API void gguf_add_tensor(struct gguf_context * ctx, const struct ggml_tensor * tensor);
+
+    // after changing a tensor's type, the offsets of all tensors with higher indices are recalculated
+    //   in such a way that the tensor data remains as one contiguous block (except for padding)
     GGML_API void gguf_set_tensor_type(struct gguf_context * ctx, const char * name, enum ggml_type type);
-    GGML_API void gguf_set_tensor_data(struct gguf_context * ctx, const char * name, const void * data, size_t size);
+
+    // assumes that at least gguf_get_tensor_size bytes can be read from data
+    GGML_API void gguf_set_tensor_data(struct gguf_context * ctx, const char * name, const void * data);
 
     // writing gguf files can be done in 2 ways:
     //
@@ -2195,6 +2211,8 @@ extern "C" {
 
     // get the size in bytes of the meta data (header, kv pairs, tensor info) including padding
     GGML_API size_t gguf_get_meta_size(const struct gguf_context * ctx);
+
+    // writes the meta data to pointer "data"
     GGML_API void   gguf_get_meta_data(const struct gguf_context * ctx, void * data);
 
 #ifdef  __cplusplus

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6779,8 +6779,8 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
                     ok = false;
                     break;
                 }
-                const size_t type_size = ggml_type_size(info->t.type);
-                const size_t blck_size = ggml_blck_size(info->t.type);
+                const size_t  type_size = ggml_type_size(info->t.type);
+                const int64_t blck_size = ggml_blck_size(info->t.type);
 
                 // check that row size is divisible by block size
                 if (blck_size == 0 || info->t.ne[0] % blck_size != 0) {
@@ -7350,8 +7350,8 @@ void gguf_set_tensor_type(struct gguf_context * ctx, const char * name, enum ggm
         GGML_ABORT("tensor not found");
     }
     struct ggml_tensor * tensor = &ctx->info[idx].t;
-    const size_t type_size = ggml_type_size(type);
-    const int    blck_size = ggml_blck_size(type);
+    const size_t  type_size = ggml_type_size(type);
+    const int64_t blck_size = ggml_blck_size(type);
 
     tensor->type = type;
     GGML_ASSERT(tensor->ne[0] % blck_size == 0 && "tensor row size not divisible by block size of new type");

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -19211,7 +19211,8 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
 
         // update the gguf meta data as we go
         gguf_set_tensor_type(ctx_outs[cur_split].get(), name.c_str(), new_type);
-        gguf_set_tensor_data(ctx_outs[cur_split].get(), name.c_str(), new_data, new_size);
+        GGML_ASSERT(gguf_get_tensor_size(ctx_outs[cur_split].get(), gguf_find_tensor(ctx_outs[cur_split].get(), name.c_str())) == new_size);
+        gguf_set_tensor_data(ctx_outs[cur_split].get(), name.c_str(), new_data);
 
         // write tensor data + padding
         fout.write((const char *) new_data, new_size);


### PR DESCRIPTION
This PR refactors the GGUF code. Summary of the functional changes:

* Refactor `gguf_tensor_info` to directly hold a `ggml_tensor` instead of fields duplicated from `ggml_tensor`. This enables the use of `ggml_backend_tensor_get` to write data from backends other than the CPU. The `size` field has been removed since it can be calculated from the tensor dimension and type and was therefore duplicated information.
* Use fixed-width types for storing enums and boolean KV data. On most modern platforms booleans are stored as 1 byte integers and enums as 4 byte integers. These are the types that are now used on all platforms for storing/reading/writing the data. This should make the GGUF files more portable. I don't know how to properly check that floats and doubles are portable since (from what I can tell) there isn't e.g. a single macro that I can check to assert that the data layout is compliant with IEE 754. Right now it is simply asserted that floats and doubles have the expected size when initializing the GGUF context; quite honestly, if those types are somehow implemented differently GGML is probably going to be subtly broken in dozens of other places anyways.
* On master, when calling `gguf_set_tensor_type` the GGUF context enters an inconsistent state where the sizes and offsets of the tensors don't match the tensor dimensions and types. This is only resolved with another call to `gguf_set_tensor_data` which then recalculates the offset. But there are no assertions that the tensor dimensions, types, sizes, and offsets are then actually consistent. This PR makes it so that instead the sizes and offsets are immediately recalculated after calling `gguf_set_tensor_type`. The user no longer explicitly passes a size to `gguf_set_tensor_data` but the size is instead calculated automatically.
* `gguf_get_tensor_name` now returns `const char *` instead of `char *` since the name should not be modifiable via the getter.
* New function `gguf_get_tensor_size` to assert that the buffers in user code have the expected size.
* Fixed or added detection for various memory leaks, in particular when repeatedly calling `gguf_set_array_data` with the same key.
* Stricter asserts for the data, e.g. that the row size rather than the total number of elements is divisible by the block size.

What could maybe also be done:

* Currently KV and tensor indices internally use `uint64_t` for indexing but externally they return `int`. The C standard therefore strictly speaking only guarantees ~32k usable values. Would it make sense to instead internally use `size_t` and make that the type that is being returned? The returned value upon not finding something is -1, checks against this exact value would still work, but not checks for whether the returned value is < 0.
* `gguf_get_data` returns a `void *` to the potentially internally allocated blob. I don't understand what the use case for this function is and I don't see it in use anywhere and if the goal is to calculate a pointer to the tensor data I think it would make more sense to have a dedicated function like `gguf_get_tensor_data`. At the very least I think it should return `const void *`.