### PR TITLE
Extend how Llama.cpp locates metal resources

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -509,30 +509,31 @@ static struct ggml_backend_metal_context * ggml_metal_init(ggml_backend_dev_t de
         NSString * path_lib = [bundle pathForResource:@"default" ofType:@"metallib"];
         if (path_lib == nil) {
             // Try to find the resource in the directory where the current binary located.
-            NSString *currentBinary = [[NSProcessInfo processInfo] arguments][0];
-            NSString *binDir = [currentBinary stringByDeletingLastPathComponent];
-            NSString *defaultMetalibPath = [NSString pathWithComponents:@[binDir, @"default.metallib"]];
-            NSDictionary *atts = [[NSFileManager defaultManager] attributesOfItemAtPath:defaultMetalibPath error:&error];
-            if (error) {
-                GGML_METAL_LOG_ERROR("%s: error: %s\n", __func__, [[error description] UTF8String]);
-                return NULL;
-            }
-            if (!atts) {
-                GGML_METAL_LOG_ERROR("%s: error: src path attribute is NULL\n", __func__);
-                return NULL;
-            }
-            if (atts[NSFileType] == NSFileTypeSymbolicLink) {
-                // Optionally, if this is a symlink, try to resolve it.
-                defaultMetalibPath = [[NSFileManager defaultManager] destinationOfSymbolicLinkAtPath:defaultMetalibPath error:&error];
-                if (error) {
-                    GGML_METAL_LOG_ERROR("%s: error: %s\n", __func__, [[error description] UTF8String]);
-                    return NULL;
+            NSString *current_binary = [[NSProcessInfo processInfo] arguments][0];
+            NSString *bin_dir = [current_binary stringByDeletingLastPathComponent];
+            NSString *default_metallib_path = [NSString pathWithComponents:@[bin_dir, @"default.metallib"]];
+            if ([[NSFileManager defaultManager] isReadableFileAtPath:default_metallib_path]) {
+                GGML_LOG_INFO("%s: found '%s'\n", __func__, [default_metallib_path UTF8String]);
+                NSDictionary *atts = [[NSFileManager defaultManager] attributesOfItemAtPath:default_metallib_path error:&error];
+                if (atts && atts[NSFileType] == NSFileTypeSymbolicLink) {
+                    // Optionally, if this is a symlink, try to resolve it.
+                    default_metallib_path = [[NSFileManager defaultManager] destinationOfSymbolicLinkAtPath:default_metallib_path error:&error];
+                    if (default_metallib_path && [default_metallib_path length] > 0 && ![[default_metallib_path substringToIndex:1] isEqualToString:@"/"]) {
+                        // It is a relative path, adding the binary directory as directory prefix.
+                        default_metallib_path = [NSString pathWithComponents:@[bin_dir, default_metallib_path]];
+                    }
+                    if (!default_metallib_path || ![[NSFileManager defaultManager] isReadableFileAtPath:default_metallib_path]) {
+                        // Link to the resource could not be resolved.
+                        default_metallib_path = nil;
+                    } else {
+                        GGML_LOG_INFO("%s: symlink resolved '%s'\n", __func__, [default_metallib_path UTF8String]);
+                    }
                 }
-                if (defaultMetalibPath && [defaultMetalibPath length] > 0 && ![[defaultMetalibPath substringToIndex:1] isEqualToString:@"/"]) {
-                    defaultMetalibPath = [NSString pathWithComponents:@[binDir, defaultMetalibPath]];
-                }
+            } else {
+                // The resource couldn't be found in the binary's directory.
+                default_metallib_path = nil;
             }
-            path_lib = defaultMetalibPath;
+            path_lib = default_metallib_path;
         }
 
         if (try_metallib && path_lib != nil) {


### PR DESCRIPTION
  * It searches the resource file in the directory where the current
    binary is located as well.
  * Resolves symbolic links.

Rationale:

When we plug this dependency into a Bazel build and run it in the
context of Bazel (e.g. testing):

  * the execution directory is often very different from where the files
    are located and no direct control over this (Bazel sandboxing),
  * the Bazel sandbox often use symbolic links to make files available.

With this patch, we can have the resource file added to the target,
can build and run tests in the context of Bazel.

*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
