### PR TITLE
Changes to CMakePresets.json to add ninja clang target on windows

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,7 +11,6 @@
             "CMAKE_INSTALL_RPATH": "$ORIGIN;$ORIGIN/.."
         }
     },
-
     {
         "name": "sycl-base",
         "hidden": true,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,10 +87,10 @@
     { "name": "x64-windows-msvc-release", "inherits": [ "base", "reldbg" ] },
     { "name": "x64-windows-msvc+static-release", "inherits": [ "base", "reldbg", "static" ] },
 
-    { "name": "x64-windows-ninja-debug"  , "inherits": [ "clang-ninja", "debug"   ] },
-    { "name": "x64-windows-ninja-reldbg", "inherits": [ "clang-ninja", "reldbg" ] },
-    { "name": "x64-windows-ninja-release", "inherits": [ "clang-ninja", "release" ] },
-    { "name": "x64-windows-ninja+static-release", "inherits": [ "clang-ninja", "reldbg", "static" ] },
+    { "name": "x64-windows-llvm-debug"  , "inherits": [ "clang-ninja", "debug"   ] },
+    { "name": "x64-windows-llvm-reldbg", "inherits": [ "clang-ninja", "reldbg" ] },
+    { "name": "x64-windows-llvm-release", "inherits": [ "clang-ninja", "release" ] },
+    { "name": "x64-windows-llvm+static-release", "inherits": [ "clang-ninja", "reldbg", "static" ] },
 
     { "name": "x64-windows-sycl-debug", "inherits": [ "sycl-base", "debug" ] },
     { "name": "x64-windows-sycl-debug-f16", "inherits": [ "sycl-base", "debug", "sycl_f16" ] },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,6 +87,11 @@
     { "name": "x64-windows-msvc-release", "inherits": [ "base", "reldbg" ] },
     { "name": "x64-windows-msvc+static-release", "inherits": [ "base", "reldbg", "static" ] },
 
+    { "name": "x64-windows-ninja-debug"  , "inherits": [ "clang-ninja", "debug"   ] },
+    { "name": "x64-windows-ninja-reldbg", "inherits": [ "clang-ninja", "reldbg" ] },
+    { "name": "x64-windows-ninja-release", "inherits": [ "clang-ninja", "release" ] },
+    { "name": "x64-windows-ninja+static-release", "inherits": [ "clang-ninja", "reldbg", "static" ] },
+
     { "name": "x64-windows-sycl-debug", "inherits": [ "sycl-base", "debug" ] },
     { "name": "x64-windows-sycl-debug-f16", "inherits": [ "sycl-base", "debug", "sycl_f16" ] },
     { "name": "x64-windows-sycl-release", "inherits": [ "sycl-base", "release" ] },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,18 +11,6 @@
             "CMAKE_INSTALL_RPATH": "$ORIGIN;$ORIGIN/.."
         }
     },
-    {
-        "name":  "clang-ninja",
-        "hidden": true,
-        "generator":   "Ninja",
-        "binaryDir":   "${sourceDir}/build-${presetName}",
-        "cacheVariables": {
-            "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-            "CMAKE_C_COMPILER":"clang.exe",
-            "CMAKE_CXX_COMPILER":"clang++.exe",
-            "CMAKE_INSTALL_RPATH": "$ORIGIN;$ORIGIN/.."
-        }
-    },
 
     {
         "name": "sycl-base",
@@ -43,6 +31,13 @@
     { "name": "static",   "hidden": true, "cacheVariables": { "GGML_STATIC":      "ON" } },
     { "name": "sycl_f16", "hidden": true, "cacheVariables": { "GGML_SYCL_F16":    "ON" } },
     { "name": "vulkan",   "hidden": true, "cacheVariables": { "GGML_VULKAN":      "ON" } },
+
+    {
+        "name": "x64-windows-llvm", "hidden": true,
+        "cacheVariables": {
+            "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/x64-windows-llvm.cmake"
+        }
+    },
 
     {
         "name": "arm64-windows-msvc", "hidden": true,
@@ -83,14 +78,14 @@
     { "name": "arm64-windows-msvc-release", "inherits": [ "base", "arm64-windows-msvc",  "reldbg" ] },
     { "name": "arm64-windows-msvc+static-release", "inherits": [ "base", "arm64-windows-msvc",  "reldbg", "static" ] },
 
+    { "name": "x64-windows-llvm-debug", "inherits": [ "base", "x64-windows-llvm", "debug" ] },
+    { "name": "x64-windows-llvm-release", "inherits": [ "base", "x64-windows-llvm", "release" ] },
+    { "name": "x64-windows-llvm-reldbg", "inherits": [ "base", "x64-windows-llvm", "reldbg" ] },
+    { "name": "x64-windows-llvm+static-release", "inherits": [ "base", "x64-windows-llvm", "reldbg", "static" ] },
+
     { "name": "x64-windows-msvc-debug", "inherits": [ "base", "debug" ] },
     { "name": "x64-windows-msvc-release", "inherits": [ "base", "reldbg" ] },
     { "name": "x64-windows-msvc+static-release", "inherits": [ "base", "reldbg", "static" ] },
-
-    { "name": "x64-windows-llvm-debug"  , "inherits": [ "clang-ninja", "debug"   ] },
-    { "name": "x64-windows-llvm-reldbg", "inherits": [ "clang-ninja", "reldbg" ] },
-    { "name": "x64-windows-llvm-release", "inherits": [ "clang-ninja", "release" ] },
-    { "name": "x64-windows-llvm+static-release", "inherits": [ "clang-ninja", "reldbg", "static" ] },
 
     { "name": "x64-windows-sycl-debug", "inherits": [ "sycl-base", "debug" ] },
     { "name": "x64-windows-sycl-debug-f16", "inherits": [ "sycl-base", "debug", "sycl_f16" ] },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,6 +12,19 @@
         }
     },
     {
+        "name":  "clang-ninja",
+        "hidden": true,
+        "generator":   "Ninja",
+        "binaryDir":   "${sourceDir}/build-${presetName}",
+        "cacheVariables": {
+            "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+            "CMAKE_C_COMPILER":"clang.exe",
+            "CMAKE_CXX_COMPILER":"clang++.exe",
+            "CMAKE_INSTALL_RPATH": "$ORIGIN;$ORIGIN/.."
+        }
+    },
+
+    {
         "name": "sycl-base",
         "hidden": true,
         "generator": "Ninja",

--- a/cmake/x64-windows-llvm.cmake
+++ b/cmake/x64-windows-llvm.cmake
@@ -1,0 +1,11 @@
+set( CMAKE_SYSTEM_NAME Windows )
+set( CMAKE_SYSTEM_PROCESSOR x86_64 )
+
+set( CMAKE_C_COMPILER    clang )
+set( CMAKE_CXX_COMPILER  clang++ )
+
+set( arch_c_flags "-march=native" )
+
+set( CMAKE_C_FLAGS_INIT   "${arch_c_flags}" )
+set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags}" )
+

--- a/docs/build.md
+++ b/docs/build.md
@@ -61,7 +61,7 @@ cmake --build build --config Release
       -set path:set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64
       ```bash
       cmake --preset x64-windows-llvm-release
-      cmake --build build-x64-windows-ninja-release
+      cmake --build build-x64-windows-llvm-release
       ```
 
 ## BLAS Build

--- a/docs/build.md
+++ b/docs/build.md
@@ -57,6 +57,13 @@ cmake --build build --config Release
     ```
     Building for arm64 can also be done with the MSVC compiler with the build-arm64-windows-MSVC preset, or the standard CMake build instructions. However, note that the MSVC compiler does not support inline ARM assembly code, used e.g. for the accelerated Q4_0_4_8 CPU kernels.
 
+    For building with ninja generator and clang compiler as default:
+      -set path:set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64
+      ```bash
+      cmake --preset x64-windows-ninja-release
+      cmake --build build-x64-windows-ninja-release
+      ```
+
 ## BLAS Build
 
 Building the program with BLAS support may lead to some performance improvements in prompt processing using batch sizes higher than 32 (the default is 512). Using BLAS doesn't affect the generation performance. There are currently several different BLAS implementations available for build and use:

--- a/docs/build.md
+++ b/docs/build.md
@@ -60,7 +60,7 @@ cmake --build build --config Release
     For building with ninja generator and clang compiler as default:
       -set path:set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64
       ```bash
-      cmake --preset x64-windows-ninja-release
+      cmake --preset x64-windows-llvm-release
       cmake --build build-x64-windows-ninja-release
       ```
 


### PR DESCRIPTION
This PR adds changes to CMakePresets.json to add a ninja clang target on windows. This will help users to build llama.cpp with clang and ninja dependencies, with relative ease. The additional dependencies are listed in build.md

Build commands : 

        cmake --preset x64-windows-ninja-release
        cmake --build build-x64-windows-ninja-release

Experiments were conducted to test llama.cpp with MSVC (Visual Studio Generator), Clang (Ninja) and Clang-Cl (Visual Studio Generator) and to compare the performance

Best performance was seen among the three for clang with ninja generator

**Ninja Generator, Clang.exe/Clang++.exe (17.0.3)**

- Clang.exe and clang++.exe are obtained from the same path as clang-cl - C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin
- CMAKE Command : cmake -G "Ninja" -S . -B Windows-build/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang.exe -DCMAKE_CXX_COMPILER=clang++.exe
- Ninja path : C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe and version (1.11.0)
- Additional library depedencies are resolved with : set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64 before cmake and build

Both the clang builds are done without the openmp dependencies

The tests were conducted in AMD Raphael 7600X which supports the following flags (The same were kept on in our windows tests) : 
AVX = 1 | AVX_VNNI = 0 | AVX2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1 | FMA = 1 | NEON = 0 | SVE = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | SSSE3 = 1 | VSX = 0 | MATMUL_INT8 = 0 | LLAMAFILE = 1|

**Prompt Processing** 

| model| Compiler/Generator| size| params | backend | threads | test | t/s | speedup | Commit id |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |------------- | ------------- | ------------- |
| llama 7B Q4_0 | MSVC Compiler/ VS Generator | 3.56 GiB | 6.74 B | CPU | 6 | pp 512 |  48.14  ±  0.67 | | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484) |
| llama 7B Q4_0 | clang-cl.exe/ VS Generator | 3.56 GiB | 6.74 B | CPU | 6 | pp 512 |  50.23 ± 0.91 | 4.33% | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484)  |
| llama 7B Q4_0 | clang.exe/ Ninja Generator  | 3.56 GiB | 6.74 B | CPU | 6 | pp 512 | 55.69 ± 0.71 | 15.68% | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484) |

**Text Generation** 

| model| Compiler/Generator| size| params | backend | threads | test | t/s | speedup | Commit id |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |------------- | ------------- | ------------- |
| llama 7B Q4_0 | MSVC Compiler/ VS Generator | 3.56 GiB | 6.74 B | CPU | 6 | tg 128 |  14.8 ± 0.01 | | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484) |
| llama 7B Q4_0 | clang-cl.exe/ VS Generator | 3.56 GiB | 6.74 B | CPU | 6 | tg 128 |  14.95 ± 0.02 | 1.00% | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484)  |
| llama 7B Q4_0 | clang.exe/ Ninja Generator | 3.56 GiB | 6.74 B | CPU | 6 | tg 128 | 14.95 ± 0.02 | 1.00% | [231f936](https://github.com/ggerganov/llama.cpp/commit/231f9360d94446cd083b6b116f63991b1328c484) |

OS : Windows

Tests done with [Meta Llama2 7B model](https://huggingface.co/meta-llama/Llama-2-7b) 
