### PR TITLE
fix(server) : handling DONE message in simple chat

### DIFF
--- a/examples/server/public_simplechat/simplechat.js
+++ b/examples/server/public_simplechat/simplechat.js
@@ -407,6 +407,9 @@ class SimpleChat {
                 if (curLine.startsWith("data:")) {
                     curLine = curLine.substring(5);
                 }
+                if (curLine.trim() === "[DONE]") {
+                    break;
+                }
                 let curJson = JSON.parse(curLine);
                 console.debug("DBUG:SC:PART:Json:", curJson);
                 this.append_response(this.response_extract_stream(curJson, apiEP));


### PR DESCRIPTION
When the sever is started and you try to use the simple chat on each end of the response there is [DONE] message. It's not handled and there is a js exception:

```
SyntaxError:Unexpected token 'D', " [DONE]  " is not valid JSON
```
