### PR TITLE
server : bugfix - stop server from sending empty json during oai chat completions

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3454,8 +3454,10 @@ int main(int argc, char ** argv) {
                     json res_json = result->to_json();
                     if (res_json.is_array()) {
                         for (const auto & res : res_json) {
-                            if (!server_sent_event(sink, "data", res)) {
-                                return false;
+                            if (!res.empty()) {
+                                if (!server_sent_event(sink, "data", res)) {
+                                    return false;
+                                }
                             }
                         }
                         return true;


### PR DESCRIPTION
Since #10643, the webui crashes when the model finished generating a response:
![llama_crash](https://github.com/user-attachments/assets/11abcfe6-7561-46e9-b31d-e8911794ece3)
Upon investigation, I found that it was because an empty json object is sent from the server before the on_complete json is sent:
```
$ curl http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "stream": true,
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'

...

data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"?"}}],"created":1733515737,"id":"chatcmpl-LtMeOt2U3SPq40U172bsTkOzMiL8X4xC","model":"gpt-3.5-turbo-0613","object":"chat.completion.chunk"}

data: {}

data: {"choices":[{"finish_reason":"stop","index":0,"delta":{}}],"created":1733515738,"id":"chatcmpl-LtMeOt2U3SPq40U172bsTkOzMiL8X4xC","model":"gpt-3.5-turbo-0613","object":"chat.completion.chunk","timings":{"prompt_n":1,"prompt_ms":67.807,"prompt_per_token_ms":67.807,"prompt_per_second":14.747739908858966,"predicted_n":25,"predicted_ms":1543.024,"predicted_per_token_ms":61.72096,"predicted_per_second":16.20195149265339},"usage":{"completion_tokens":25,"prompt_tokens":23,"total_tokens":48}}

data: [DONE]
```

I made a change such that the server skips sending any empty json objects returned from the completion results stream.