### PR TITLE
ggml: load all backends from a user-provided search path

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -228,6 +228,7 @@ extern "C" {
     GGML_API void               ggml_backend_unload(ggml_backend_reg_t reg);
     // Load all known backends from dynamic libraries
     GGML_API void               ggml_backend_load_all(void);
+    GGML_API void               ggml_backend_load_all_in_search_path(const char * search_path);
 
     //
     // Backend scheduler

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -228,7 +228,7 @@ extern "C" {
     GGML_API void               ggml_backend_unload(ggml_backend_reg_t reg);
     // Load all known backends from dynamic libraries
     GGML_API void               ggml_backend_load_all(void);
-    GGML_API void               ggml_backend_load_all_from_path(const char * search_path);
+    GGML_API void               ggml_backend_load_all_from_path(const char * dir_path);
 
     //
     // Backend scheduler

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -228,7 +228,7 @@ extern "C" {
     GGML_API void               ggml_backend_unload(ggml_backend_reg_t reg);
     // Load all known backends from dynamic libraries
     GGML_API void               ggml_backend_load_all(void);
-    GGML_API void               ggml_backend_load_all_in_search_path(const char * search_path);
+    GGML_API void               ggml_backend_load_all_from_path(const char * search_path);
 
     //
     // Backend scheduler

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -519,10 +519,10 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
 }
 
 void ggml_backend_load_all() {
-    ggml_backend_load_all_in_search_path(NULL);
+    ggml_backend_load_all_from_path(NULL);
 }
 
-void ggml_backend_load_all_in_search_path(const char * search_path) {
+void ggml_backend_load_all_from_path(const char * search_path) {
 #ifdef NDEBUG
     bool silent = true;
 #else

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -519,7 +519,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
 }
 
 void ggml_backend_load_all() {
-    ggml_backend_load_all_from_path(NULL);
+    ggml_backend_load_all_from_path(nullptr);
 }
 
 void ggml_backend_load_all_from_path(const char * dir_path) {

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -458,7 +458,11 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
         search_paths.push_back("./");
         search_paths.push_back(get_executable_path());
     } else {
+#if defined(_WIN32)
+        search_paths.push_back(std::string(user_search_path) + "\\");
+#else
         search_paths.push_back(std::string(user_search_path) + "/");
+#endif
     }
 
     int best_score = 0;

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -522,22 +522,22 @@ void ggml_backend_load_all() {
     ggml_backend_load_all_from_path(NULL);
 }
 
-void ggml_backend_load_all_from_path(const char * search_path) {
+void ggml_backend_load_all_from_path(const char * dir_path) {
 #ifdef NDEBUG
     bool silent = true;
 #else
     bool silent = false;
 #endif
 
-    ggml_backend_load_best("blas", silent, search_path);
-    ggml_backend_load_best("cann", silent, search_path);
-    ggml_backend_load_best("cuda", silent, search_path);
-    ggml_backend_load_best("hip", silent, search_path);
-    ggml_backend_load_best("kompute", silent, search_path);
-    ggml_backend_load_best("metal", silent, search_path);
-    ggml_backend_load_best("rpc", silent, search_path);
-    ggml_backend_load_best("sycl", silent, search_path);
-    ggml_backend_load_best("vulkan", silent, search_path);
-    ggml_backend_load_best("musa", silent, search_path);
-    ggml_backend_load_best("cpu", silent, search_path);
+    ggml_backend_load_best("blas", silent, dir_path);
+    ggml_backend_load_best("cann", silent, dir_path);
+    ggml_backend_load_best("cuda", silent, dir_path);
+    ggml_backend_load_best("hip", silent, dir_path);
+    ggml_backend_load_best("kompute", silent, dir_path);
+    ggml_backend_load_best("metal", silent, dir_path);
+    ggml_backend_load_best("rpc", silent, dir_path);
+    ggml_backend_load_best("sycl", silent, dir_path);
+    ggml_backend_load_best("vulkan", silent, dir_path);
+    ggml_backend_load_best("musa", silent, dir_path);
+    ggml_backend_load_best("cpu", silent, dir_path);
 }

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -454,7 +454,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
      // TODO: search system paths
     std::string file_prefix = backend_filename_prefix() + name + "-";
     std::vector<std::string> search_paths;
-    if (user_search_path == NULL) {
+    if (user_search_path == nullptr) {
         search_paths.push_back("./");
         search_paths.push_back(get_executable_path());
     } else {

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -449,11 +449,17 @@ static std::string backend_filename_suffix() {
 #endif
 }
 
-static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent) {
+static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent, const char * user_search_path) {
     // enumerate all the files that match [lib]ggml-name-*.[so|dll] in the search paths
      // TODO: search system paths
-    std::vector<std::string> search_paths = { "./", get_executable_path() };
     std::string file_prefix = backend_filename_prefix() + name + "-";
+    std::vector<std::string> search_paths;
+    if (user_search_path == NULL) {
+        search_paths.push_back("./");
+        search_paths.push_back(get_executable_path());
+    } else {
+        search_paths.push_back(std::string(user_search_path) + "/");
+    }
 
     int best_score = 0;
     std::string best_path;
@@ -509,21 +515,25 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent)
 }
 
 void ggml_backend_load_all() {
+    ggml_backend_load_all_in_search_path(NULL);
+}
+
+void ggml_backend_load_all_in_search_path(const char * search_path) {
 #ifdef NDEBUG
     bool silent = true;
 #else
     bool silent = false;
 #endif
 
-    ggml_backend_load_best("blas", silent);
-    ggml_backend_load_best("cann", silent);
-    ggml_backend_load_best("cuda", silent);
-    ggml_backend_load_best("hip", silent);
-    ggml_backend_load_best("kompute", silent);
-    ggml_backend_load_best("metal", silent);
-    ggml_backend_load_best("rpc", silent);
-    ggml_backend_load_best("sycl", silent);
-    ggml_backend_load_best("vulkan", silent);
-    ggml_backend_load_best("musa", silent);
-    ggml_backend_load_best("cpu", silent);
+    ggml_backend_load_best("blas", silent, search_path);
+    ggml_backend_load_best("cann", silent, search_path);
+    ggml_backend_load_best("cuda", silent, search_path);
+    ggml_backend_load_best("hip", silent, search_path);
+    ggml_backend_load_best("kompute", silent, search_path);
+    ggml_backend_load_best("metal", silent, search_path);
+    ggml_backend_load_best("rpc", silent, search_path);
+    ggml_backend_load_best("sycl", silent, search_path);
+    ggml_backend_load_best("vulkan", silent, search_path);
+    ggml_backend_load_best("musa", silent, search_path);
+    ggml_backend_load_best("cpu", silent, search_path);
 }


### PR DESCRIPTION
This PR makes it possible to load all backends from a given search path instead of the default search paths.