### PR TITLE
cmake: fix for building with no internet connection

### DIFF
--- a/examples/eval-callback/CMakeLists.txt
+++ b/examples/eval-callback/CMakeLists.txt
@@ -4,7 +4,25 @@ install(TARGETS ${TARGET} RUNTIME)
 target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
-set(TEST_TARGET test-eval-callback)
-add_test(NAME ${TEST_TARGET}
-        COMMAND llama-eval-callback --hf-repo ggml-org/models --hf-file tinyllamas/stories260K.gguf --model stories260K.gguf --prompt hello --seed 42 -ngl 0)
-set_property(TEST ${TEST_TARGET} PROPERTY LABELS eval-callback curl)
+if(MSVC)
+       execute_process(
+           COMMAND ping www.google.com -n 2
+           ERROR_QUIET
+           RESULT_VARIABLE NO_CONNECTION
+    )
+else()
+       execute_process(
+           COMMAND ping www.google.com -c 2
+           ERROR_QUIET
+           RESULT_VARIABLE NO_CONNECTION
+    )
+endif()
+
+if(NOT NO_CONNECTION EQUAL 0)
+       message(WARNING "Offline mode!")
+else()
+       set(TEST_TARGET test-eval-callback)
+       add_test(NAME ${TEST_TARGET}
+               COMMAND llama-eval-callback --hf-repo ggml-org/models --hf-file tinyllamas/stories260K.gguf --model stories260K.gguf --prompt hello --seed 42 -ngl 0)
+       set_property(TEST ${TEST_TARGET} PROPERTY LABELS eval-callback curl)
+endif()


### PR DESCRIPTION
This PR will ensure that the test for curl integration in llama.cpp is only conducted if an internet connection is available. If no internet is available, it
will simply provide a warning and not test the curl integration.

The reason for this PR is to allow all other tests to be used in environments where internet access is not available at build time without causing the tests to
fail. For example, in Fedora/RedHat package build systems like mock [1], where no internet is provided during the build process.

[1] <https://rpm-software-management.github.io/mock/>