### PR TITLE
Vulkan: fix NaN in tanh.comp with AMD proprietary driver on Windows

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/tanh.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/tanh.comp
@@ -16,6 +16,5 @@ void main() {
     if (i >= p.KX) {
         return;
     }
-    float th = tanh(data_a[i]);
-    data_d[i] = D_TYPE(th==th ? th : sign(data_a[i]));
+    data_d[i] = D_TYPE(1. - 2. / (exp(2.*data_a[i]) + 1.));
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/tanh.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/tanh.comp
@@ -16,6 +16,6 @@ void main() {
     if (i >= p.KX) {
         return;
     }
-
-    data_d[i] = D_TYPE(tanh(data_a[i]));
+    float th = tanh(data_a[i]);
+    data_d[i] = D_TYPE(th==th ? th : sign(data_a[i]));
 }


### PR DESCRIPTION
I noticed when running `test-backend-ops` that the TANH op can sometimes output NaNs with Vulkan. I didn't experience any issues because of it, but it was a simple fix, that should hopefuly not cause any noticable slowdown.

### Master:

```
> .\build\bin\Release\test-backend-ops.exe  | Select-String -Pattern "TANH"
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon RX 5700 XT (AMD proprietary driver) | uma: 0 | fp16: 1 | warp size: 64 | matrix cores: none
ggml_vulkan: Compiling shaders..........................Done!

  TANH(type=f32,ne_a=[128,2,2,2],v=0): [TANH] NaN at index 0 (Vulkan0=-nan(ind) CPU=-1.000000) FAIL
  TANH(type=f32,ne_a=[5,7,11,13],v=0): [TANH] NaN at index 2 (Vulkan0=-nan(ind) CPU=1.000000) FAIL
  TANH(type=f32,ne_a=[128,2,2,2],v=1): not supported [Vulkan0]
  TANH(type=f32,ne_a=[5,7,11,13],v=1): not supported [Vulkan0]
```

### PR:

```
>.\build\bin\Release\test-backend-ops.exe  | Select-String -Pattern "TANH"
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon RX 5700 XT (AMD proprietary driver) | uma: 0 | fp16: 1 | warp size: 64 | matrix cores: none
ggml_vulkan: Compiling shaders..........................Done!

  TANH(type=f32,ne_a=[128,2,2,2],v=0): OK
  TANH(type=f32,ne_a=[5,7,11,13],v=0): OK
  TANH(type=f32,ne_a=[128,2,2,2],v=1): not supported [Vulkan0]
  TANH(type=f32,ne_a=[5,7,11,13],v=1): not supported [Vulkan0]
```