### PR TITLE
CUDA: fix shared memory access condition for mmv

### DIFF
--- a/ggml/src/ggml-cuda/mmv.cu
+++ b/ggml/src/ggml-cuda/mmv.cu
@@ -57,7 +57,7 @@ static __global__ void mul_mat_vec(
     if (block_size > WARP_SIZE) {
         buf_iw[tid/WARP_SIZE] = sumf;
         __syncthreads();
-        if (tid > WARP_SIZE) {
+        if (tid >= WARP_SIZE) {
             return;
         }
         sumf = buf_iw[tid];


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/issues/10739 .

The memory access condition in the mmv kernel is wrong. Only `WARP_SIZE` floats are supposed to be used so all threads with an index >= `WARP_SIZE` need to return.