### PR TITLE
[backend](cuda): faster uncontiguous concat

### DIFF
--- a/ggml/src/ggml-cuda/concat.cu
+++ b/ggml/src/ggml-cuda/concat.cu
@@ -124,6 +124,8 @@ static __global__ void __launch_bounds__(CUDA_CONCAT_BLOCK_SIZE)
           uint64_t   nb1,
           uint64_t   nb2,
           uint64_t   nb3){
+    static_assert(dim >= 0 && dim <= 3);
+
     const int64_t i3 = blockIdx.z;
     const int64_t i2 = blockIdx.y;
     const int64_t i1 = blockIdx.x;
@@ -134,13 +136,13 @@ static __global__ void __launch_bounds__(CUDA_CONCAT_BLOCK_SIZE)
         if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
             x = (const float *)(src0 + (i3       )*nb03 + (i2       )*nb02 + (i1       )*nb01 + (i0       )*nb00);
         } else {
-            if /*constexpr*/ (dim == 0) {
+            if constexpr (dim == 0) {
                 x = (const float *) (src1 + i3 * nb13 + i2 * nb12 + i1 * nb11 + (i0 - ne00) * nb10);
-            } else if (dim == 1) {
+            } else if constexpr (dim == 1) {
                 x = (const float *) (src1 + i3 * nb13 + i2 * nb12 + (i1 - ne01) * nb11 + i0 * nb10);
-            } else if (dim == 2) {
+            } else if constexpr (dim == 2) {
                 x = (const float *) (src1 + i3 * nb13 + (i2 - ne02) * nb12 + i1 * nb11 + i0 * nb10);
-            } else if (dim == 3) {
+            } else if constexpr (dim == 3) {
                 x = (const float *) (src1 + (i3 - ne03) * nb13 + i2 * nb12 + i1 * nb11 + i0 * nb10);
             }
         }

--- a/ggml/src/ggml-cuda/concat.cu
+++ b/ggml/src/ggml-cuda/concat.cu
@@ -188,37 +188,33 @@ void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         }
     } else {
         dim3 grid_dim(dst->ne[1], dst->ne[2], dst->ne[3]);
+        auto launch_kernel = [&](auto dim) {
+            concat_f32_non_cont<dim><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
+                (const char *) src0->data, (const char *) src1->data, (char *) dst->data,
+                src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3],
+                src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3],
+                src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
+                src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
+                dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
+                dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+        };
         switch (dim) {
             case 0:
-                concat_f32_non_cont<0><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
-                    (const char *) src0->data, (const char *) src1->data, (char *) dst->data, src0->ne[0], src0->ne[1],
-                    src0->ne[2], src0->ne[3], src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3], src1->ne[0],
-                    src1->ne[1], src1->ne[2], src1->ne[3], src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
-                    dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+                launch_kernel(std::integral_constant<int, 0>{});
                 break;
             case 1:
-                concat_f32_non_cont<1><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
-                    (const char *) src0->data, (const char *) src1->data, (char *) dst->data, src0->ne[0], src0->ne[1],
-                    src0->ne[2], src0->ne[3], src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3], src1->ne[0],
-                    src1->ne[1], src1->ne[2], src1->ne[3], src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
-                    dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+                launch_kernel(std::integral_constant<int, 1>{});
                 break;
             case 2:
-                concat_f32_non_cont<2><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
-                    (const char *) src0->data, (const char *) src1->data, (char *) dst->data, src0->ne[0], src0->ne[1],
-                    src0->ne[2], src0->ne[3], src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3], src1->ne[0],
-                    src1->ne[1], src1->ne[2], src1->ne[3], src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
-                    dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+                launch_kernel(std::integral_constant<int, 2>{});
                 break;
             case 3:
-                concat_f32_non_cont<3><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
-                    (const char *) src0->data, (const char *) src1->data, (char *) dst->data, src0->ne[0], src0->ne[1],
-                    src0->ne[2], src0->ne[3], src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3], src1->ne[0],
-                    src1->ne[1], src1->ne[2], src1->ne[3], src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
-                    dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+                launch_kernel(std::integral_constant<int, 3>{});
                 break;
             default:
+                GGML_ABORT("Invalid dim: %d", dim);
                 break;
         }
+    }
     }
 }

--- a/ggml/src/ggml-cuda/concat.cu
+++ b/ggml/src/ggml-cuda/concat.cu
@@ -216,5 +216,4 @@ void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
                 break;
         }
     }
-    }
 }


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

Faster implementation of uncontiguous concat on cuda.
1. the Debug and Release build ci test is passed.
2. test-backend-op is passed, I also add one performance test, but since it may not be a real example,  I just post the result in the experiment.
3. the first uncontiguous concat kernel in deepseek-v2 is faster than master. However, the total performence is lower than master, which makes me a little confused. Due to variations in the running results of llama bench, anybody can run test and discuss the result.

**Performance experiment：**
**back-end-ops:**

test case
`test_cases.emplace_back(new test_concat(GGML_TYPE_F32, {512, 1024, 5, 1}, 1024, 0, 1));`

my implementation:
```
Backend 1/2: CUDA0
  Device description: NVIDIA GeForce RTX 3060 Laptop GPU
  Device memory: 6143 MB (5122 MB free)

  CONCAT(type=f32,ne_a=[512,1024,5,1],ne_b_d=1024,dim=0,v=1):                   5004 runs -   211.03 us/run -   120830 kB/run -  546.04 GB/s
  Backend CUDA0: OK
```

master:
```
  Device 0: NVIDIA GeForce RTX 3060 Laptop GPU, compute capability 8.6, VMM: yes
Testing 2 devices

Backend 1/2: CUDA0
  Device description: NVIDIA GeForce RTX 3060 Laptop GPU
  Device memory: 6143 MB (5122 MB free)

  CONCAT(type=f32,ne_a=[512,1024,5,1],ne_b_d=1024,dim=0,v=1):                   3336 runs -   322.92 us/run -   120830 kB/run -  356.84 GB/s
  Backend CUDA0: OK
``` 

**llama-bench:**

command：
`~/program/forked/llama.cpp/build/bin$ ./llama-bench -m ~/program/forked/DeepSeek-V2-Lite-Chat.IQ1_S.gguf`

**the first uncontiguous concat kernel：**
my implementation:
![image](https://github.com/user-attachments/assets/82b1a9bd-0695-442c-9f58-3d133b2e246b)

master:
![image](https://github.com/user-attachments/assets/1adf0e50-0d26-4d4e-859f-d6dcba3625d5)

**the overall result:**
my implementation:
| model                          |       size |     params | backend    | ngl |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | -------------------: |
| deepseek2 16B IQ1_S - 1.5625 bpw |   4.65 GiB |    15.71 B | CUDA       |  99 |         pp512 |        768.63 ± 8.81 |
| deepseek2 16B IQ1_S - 1.5625 bpw |   4.65 GiB |    15.71 B | CUDA       |  99 |         tg128 |         21.84 ± 3.75 |


master:
| model                          |       size |     params | backend    | ngl |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | -------------------: |
| deepseek2 16B IQ1_S - 1.5625 bpw |   4.65 GiB |    15.71 B | CUDA       |  99 |         pp512 |        804.11 ± 4.73 |
| deepseek2 16B IQ1_S - 1.5625 bpw |   4.65 GiB |    15.71 B | CUDA       |  99 |         tg128 |         20.92 ± 3.66 |