### PR TITLE
server: bench: minor fixes

### DIFF
--- a/examples/server/bench/README.md
+++ b/examples/server/bench/README.md
@@ -6,10 +6,10 @@ Benchmark is using [k6](https://k6.io/).
 
 SSE is not supported by default in k6, you have to build k6 with the [xk6-sse](https://github.com/phymbert/xk6-sse) extension.
 
-Example:
+Example (assuming golang >= 1.21 is installed):
 ```shell
 go install go.k6.io/xk6/cmd/xk6@latest
-xk6 build master \
+$GOPATH/bin/xk6 build master \
 --with github.com/phymbert/xk6-sse
 ```
 
@@ -33,7 +33,7 @@ The server must answer OAI Chat completion requests on `http://localhost:8080/v1
 
 Example:
 ```shell
-server --host localhost --port 8080 \
+llama-server --host localhost --port 8080 \
   --model ggml-model-q4_0.gguf \
   --cont-batching \
   --metrics \

--- a/examples/server/bench/bench.py
+++ b/examples/server/bench/bench.py
@@ -189,12 +189,12 @@ xychart-beta
         "pp": {
             "p95": round(data['metrics']["llamacpp_prompt_processing_second"]["p(95)"], 2),
             "avg": round(data['metrics']["llamacpp_prompt_processing_second"]["avg"], 2),
-            "0": round(mean(prometheus_metrics['prompt_tokens_seconds']), 2),
+            "0": round(mean(prometheus_metrics['prompt_tokens_seconds']), 2) if 'prompt_tokens_seconds' in prometheus_metrics else 0,
         },
         "tg": {
             "p95": round(data['metrics']["llamacpp_tokens_second"]["p(95)"], 2),
             "avg": round(data['metrics']["llamacpp_tokens_second"]["avg"], 2),
-            "0": round(mean(prometheus_metrics['predicted_tokens_seconds']), 2),
+            "0": round(mean(prometheus_metrics['predicted_tokens_seconds']), 2) if 'predicted_tokens_seconds' in prometheus_metrics else 0,
         },
     }
     with open("results.github.env", 'a') as github_env:
@@ -234,7 +234,7 @@ def start_server(args):
     server_process = start_server_background(args)
 
     attempts = 0
-    max_attempts = 20
+    max_attempts = 600
     if 'GITHUB_ACTIONS' in os.environ:
         max_attempts *= 2
 
@@ -245,7 +245,15 @@ def start_server(args):
         print(f"bench:     waiting for server to start ...")
         time.sleep(0.5)
 
-    print("bench: server started.")
+    attempts = 0
+    while not is_server_ready(args.host, args.port):
+        attempts += 1
+        if attempts > max_attempts:
+            assert False, "server not ready"
+        print(f"bench:     waiting for server to be ready ...")
+        time.sleep(0.5)
+
+    print("bench: server started and ready.")
     return server_process
 
 
@@ -258,11 +266,6 @@ def start_server_background(args):
         '--host', args.host,
         '--port', args.port,
     ]
-    model_file = args.model_path_prefix + os.path.sep + args.hf_file
-    model_dir  = os.path.dirname(model_file)
-    if not os.path.exists(model_dir):
-        os.makedirs(model_dir)
-    server_args.extend(['--model', model_file])
     server_args.extend(['--hf-repo', args.hf_repo])
     server_args.extend(['--hf-file', args.hf_file])
     server_args.extend(['--n-gpu-layers', args.n_gpu_layers])
@@ -304,6 +307,12 @@ def is_server_listening(server_fqdn, server_port):
         if _is_server_listening:
             print(f"server is listening on {server_fqdn}:{server_port}...")
         return _is_server_listening
+
+
+def is_server_ready(server_fqdn, server_port):
+    url = f"http://{server_fqdn}:{server_port}/health"
+    response = requests.get(url)
+    return response.status_code == 200
 
 
 def escape_metric_name(metric_name):

--- a/examples/server/bench/bench.py
+++ b/examples/server/bench/bench.py
@@ -214,11 +214,14 @@ def start_benchmark(args):
     k6_args = [
         'run', args.scenario,
         '--no-color',
+        '--no-connection-reuse',
+        '--no-vu-connection-reuse',
     ]
     k6_args.extend(['--duration', args.duration])
     k6_args.extend(['--iterations', args.n_prompts])
     k6_args.extend(['--vus', args.parallel])
     k6_args.extend(['--summary-export', 'k6-results.json'])
+    k6_args.extend(['--out', 'csv=k6-results.csv'])
     args = f"SERVER_BENCH_N_PROMPTS={args.n_prompts} SERVER_BENCH_MAX_PROMPT_TOKENS={args.max_prompt_tokens} SERVER_BENCH_MAX_CONTEXT={args.max_tokens} "
     args = args + ' '.join([str(arg) for arg in [k6_path, *k6_args]])
     print(f"bench: starting k6 with: {args}")


### PR DESCRIPTION
### Context

After a nice exchange with @ngxson, this is a minor change to the current server bench framework in order to refresh it a bit. Although the target would be to replace k6/xk6-sse with something like [Locust](https://github.com/locustio/locust) (to be assessed) , python based.

#### Changes
- support openAI streaming standard output with [DONE]\n\n
- export k6 raw results in csv
- fix too many tcp idle connection in tcp_wait
- add metric time to emit first token
- wait for the server to be ready in the CI script


### Tests (phi2 on RTX 3050)

```shell
LLAMA_SERVER_BIN_PATH=../../../cmake-build-debug/bin/llama-server python bench.py \
              --runner-label local \
              --name local \
              --branch `git rev-parse --abbrev-ref HEAD` \
              --commit `git rev-parse HEAD` \
              --scenario script.js \
              --duration 5m \
              --hf-repo ggml-org/models	 \
              --hf-file phi-2/ggml-model-q4_0.gguf \
              --model-path-prefix models \
              --parallel 4 \
              -ngl 33 \
              --batch-size 2048 \
              --ubatch-size	256 \
              --ctx-size 4096 \
              --n-prompts 200 \
              --max-prompt-tokens 256 \
              --max-tokens 256
```

Results:

```
srv  update_slots: all slots are idle
request: POST /v1/chat/completions 127.0.0.1 200

     ✓ success completion

     checks.....................................: 100.00% 165 out of 165
     data_received..............................: 4.5 MB  15 kB/s
     data_sent..................................: 96 kB   306 B/s
     dropped_iterations.........................: 35      0.111853/s
     http_req_duration..........................: avg=7.1s       min=794.72ms   med=4.13s      max=30.06s     p(90)=17.87s     p(95)=26.41s    
     http_req_sending...........................: avg=4.82ms     min=2.38ms     med=3.71ms     max=22.05ms    p(90)=7.24ms     p(95)=11.5ms    
     http_reqs..................................: 165     0.527306/s
     iteration_duration.........................: avg=7.4s       min=1.09s      med=4.43s      max=30.36s     p(90)=18.17s     p(95)=26.71s    
     iterations.................................: 165     0.527306/s
     llamacpp_completion_tokens.................: avg=126.915152 min=12         med=73         max=512        p(90)=327.6      p(95)=462.2     
     llamacpp_completion_tokens_total_counter...: 20941   66.923093/s
     llamacpp_completions_stop_rate.............: 95.75%  158 out of 165
   ✓ llamacpp_completions_truncated_rate........: 4.24%   7 out of 165
     llamacpp_emit_first_token_second...........: avg=0.161764   min=0.081      med=0.135      max=0.673      p(90)=0.2592     p(95)=0.3168    
     llamacpp_prompt_processing_second..........: avg=575.677944 min=100.149477 med=575.471698 max=877.862595 p(90)=724.111718 p(95)=761.987131
     llamacpp_prompt_tokens.....................: avg=91.824242  min=57         med=71         max=473        p(90)=148        p(95)=215.6     
     llamacpp_prompt_tokens_total_counter.......: 15151   48.419454/s
     llamacpp_tokens_second.....................: avg=18.933054  min=16.649324  med=18.722467  max=22.551929  p(90)=20.668266  p(95)=21.073767 
     sse_event..................................: 21270   67.974509/s
     vus........................................: 1       min=1          max=4
     vus_max....................................: 4       min=4          max=4


running (5m12.9s), 0/4 VUs, 165 complete and 0 interrupted iterations
default ✗ [==============================>-------] 4 VUs  5m12.9s/5m0s  165/200 shared iters
bench: shutting down server pid=7822 ...
```