### PR TITLE
ci : pin nodejs to 22.11.0

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -79,7 +79,7 @@ jobs:
       # Setup nodejs (to be used for verifying bundled index.html)
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '22.11.0'
 
       - name: Verify bundled index.html
         id: verify_server_index_html


### PR DESCRIPTION
Fix a problem where `llama-server` CI randomly fails due to some jobs being run with nodejs 22.11.0, while the other run 22.12.0

Example: https://github.com/ggerganov/llama.cpp/actions/runs/12267038747

Upstream issue: https://github.com/nodejs/node/issues/56155