### PR TITLE
llama: enable maintaining key ordering in rules for grammar

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -391,7 +391,7 @@ class SchemaConverter {
 private:
     std::function<json(const std::string &)> _fetch_json;
     bool _dotall;
-    std::map<std::string, std::string> _rules;
+    std::unordered_map<std::string, std::string> _rules;
     std::unordered_map<std::string, json> _refs;
     std::unordered_set<std::string> _refs_being_resolved;
     std::vector<std::string> _errors;


### PR DESCRIPTION
Rules are currently sorted by key name as they're in a map. If there is a nested schema, the wrong key might get sampled first, reducing accuracy of the generation.

This PR introduces an `ordered_map` to maintain the ordering of `rules` in the `SchemaConverter`