### PR TITLE
Add support for Microsoft Phi-4 model 

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2129,6 +2129,9 @@ class Phi3MiniModel(Model):
     model_arch = gguf.MODEL_ARCH.PHI3
 
     def set_vocab(self):
+        if self.metadata.name == "Phi 4":
+            return self._set_vocab_gpt2()
+
         from sentencepiece import SentencePieceProcessor
 
         tokenizer_path = self.dir_model / 'tokenizer.model'
@@ -2245,7 +2248,8 @@ class Phi3MiniModel(Model):
         self.gguf_writer.add_rope_dimension_count(rope_dims)
         self.gguf_writer.add_rope_freq_base(self.find_hparam(["rope_theta"]))
         self.gguf_writer.add_file_type(self.ftype)
-        self.gguf_writer.add_sliding_window(self.find_hparam(["sliding_window"]))
+        if self.metadata.name != "Phi 4":
+            self.gguf_writer.add_sliding_window(self.find_hparam(["sliding_window"]))
 
     def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
         n_embd = self.find_hparam(["hidden_size", "n_embd"])

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2254,9 +2254,11 @@ class Phi3MiniModel(Model):
         self.gguf_writer.add_rope_dimension_count(rope_dims)
         self.gguf_writer.add_rope_freq_base(self.find_hparam(["rope_theta"]))
         self.gguf_writer.add_file_type(self.ftype)
-        # handle null value of sliding_window (Phi-4 model)
-        if (sliding_window := self.hparams.get("sliding_window")) is not None:
-            self.gguf_writer.add_sliding_window(sliding_window)
+        sliding_window = self.hparams.get("sliding_window")
+        # use zero value of sliding_window to distinguish Phi-4 from other PHI3 models
+        if sliding_window is None:
+            sliding_window = 0
+        self.gguf_writer.add_sliding_window(sliding_window)
 
     def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
         n_embd = self.find_hparam(["hidden_size", "n_embd"])

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5807,7 +5807,7 @@ static void llm_load_hparams(
                     hparams.n_swa = 131072;
                 }
                 bool found_swa = ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
-                if (!found_swa && hparams.n_swa == 0 && model.name != "Phi 4") {
+                if (!found_swa && hparams.n_swa == 0) {
                     throw std::runtime_error("invalid value for sliding_window");
                 }
             } break;
@@ -12840,7 +12840,7 @@ struct llm_build_context {
 
         // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
         struct ggml_tensor * KQ_mask = nullptr;
-        if (model.name == "Phi 4") {
+        if (hparams.n_swa == 0) {
             // Phi-4 doesn't use sliding window attention
             KQ_mask = build_inp_KQ_mask();
         } else {


### PR DESCRIPTION
This PR adds support for Microsoft Phi-4 model. Fixes #10814.

Current solution is to:

- Use tokenizer_class value from tokenizer_config.json as a condition to use GPT2 vocab during model conversion.
- Store explicit 0 value of `sliding_window` hparam if it's null. This allows the old Phi-3 `n_swa` validation logic to work without any changes. If `n_swa` is 0 a regular KQ mask is used instead of sliding window KQ mask in `build_phi3()`.

~A model name value from general.name ("Phi 4") was used to trigger behavior specific to Phi-4 model:~

~1. Using GPT2 vocab during model conversion~
~2. Ignoring `sliding_window` hparam during model conversion~
~3. Skipping sliding window length value check (`n_swa == 0`) in `build_phi3()`~
~4. Creating regular KQ mask instead of sliding window KQ mask in `build_phi3()`~

~Let me know if there is any better way to differentiate Phi 4 from other models based on PHI3 architecture.~