### PR TITLE
server : output embeddings for all tokens when pooling = none

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1780,7 +1780,9 @@ void common_embd_normalize(const float * inp, float * out, int n, int embd_norm)
             break;
         case 0: // max absolute
             for (int i = 0; i < n; i++) {
-                if (sum < std::abs(inp[i])) sum = std::abs(inp[i]);
+                if (sum < std::abs(inp[i])) {
+                    sum = std::abs(inp[i]);
+                }
             }
             sum /= 32760.0; // make an int16 range
             break;

--- a/common/common.h
+++ b/common/common.h
@@ -596,7 +596,8 @@ void common_kv_cache_dump_view_seqs(const llama_kv_cache_view & view, int row_si
 // Embedding utils
 //
 
-void common_embd_normalize(const float * inp, float * out, int n, int embd_norm = 2);
+// TODO: repace embd_norm with an enum
+void common_embd_normalize(const float * inp, float * out, int n, int embd_norm);
 
 float common_embd_similarity_cos(const float * embd1, const float * embd2, int n);
 

--- a/examples/gritlm/gritlm.cpp
+++ b/examples/gritlm/gritlm.cpp
@@ -75,7 +75,7 @@ static std::vector<std::vector<float>> encode(llama_context * ctx, const std::ve
         }
 
         std::vector<float> emb_norm(emb_unorm.size());
-        common_embd_normalize(emb_unorm.data(), emb_norm.data(), n_embd);
+        common_embd_normalize(emb_unorm.data(), emb_norm.data(), n_embd, 2);
         result.push_back(emb_norm);
 
 #ifdef GRIT_DEBUG

--- a/examples/retrieval/retrieval.cpp
+++ b/examples/retrieval/retrieval.cpp
@@ -107,7 +107,7 @@ static void batch_decode(llama_context * ctx, llama_batch & batch, float * outpu
         }
 
         float * out = output + batch.seq_id[i][0] * n_embd;
-        common_embd_normalize(embd, out, n_embd);
+        common_embd_normalize(embd, out, n_embd, 2);
     }
 }
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -795,6 +795,8 @@ See [OpenAI Embeddings API documentation](https://platform.openai.com/docs/api-r
   }'
   ```
 
+When `--pooling none` is used, the server will output an array of embeddings - one for each token in the input.
+
 ### GET `/slots`: Returns the current slots processing state
 
 > [!WARNING]

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -763,6 +763,8 @@ curl http://localhost:8080/v1/chat/completions \
 
 ### POST `/v1/embeddings`: OpenAI-compatible embeddings API
 
+This endpoint requires that the model uses a pooling different than type `none`.
+
 *Options:*
 
 See [OpenAI Embeddings API documentation](https://platform.openai.com/docs/api-reference/embeddings).
@@ -795,7 +797,45 @@ See [OpenAI Embeddings API documentation](https://platform.openai.com/docs/api-r
   }'
   ```
 
-When `--pooling none` is used, the server will output an array of embeddings - one for each token in the input.
+### POST `/embeddings`: non-OpenAI-compatible embeddings API
+
+This endpoint supports `--pooling none`. When used, the responses will contain the embeddings for all input tokens.
+Note that the response format is slightly different than `/v1/embeddings` - it does not have the `"data"` sub-tree and the
+embeddings are always returned as vector of vectors.
+
+*Options:*
+
+Same as the `/v1/embeddings` endpoint.
+
+*Examples:*
+
+Same as the `/v1/embeddings` endpoint.
+
+**Response format**
+
+```json
+[
+  {
+    "index": 0,
+    "embedding": [
+      [ ... embeddings for token 0   ... ],
+      [ ... embeddings for token 1   ... ],
+      [ ... ]
+      [ ... embeddings for token N-1 ... ],
+    ]
+  },
+  ...
+  {
+    "index": P,
+    "embedding": [
+      [ ... embeddings for token 0   ... ],
+      [ ... embeddings for token 1   ... ],
+      [ ... ]
+      [ ... embeddings for token N-1 ... ],
+    ]
+  }
+]
+```
 
 ### GET `/slots`: Returns the current slots processing state
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -763,7 +763,7 @@ curl http://localhost:8080/v1/chat/completions \
 
 ### POST `/v1/embeddings`: OpenAI-compatible embeddings API
 
-This endpoint requires that the model uses a pooling different than type `none`.
+This endpoint requires that the model uses a pooling different than type `none`. The embeddings are normalized using the Eucledian norm.
 
 *Options:*
 
@@ -799,9 +799,9 @@ See [OpenAI Embeddings API documentation](https://platform.openai.com/docs/api-r
 
 ### POST `/embeddings`: non-OpenAI-compatible embeddings API
 
-This endpoint supports `--pooling none`. When used, the responses will contain the embeddings for all input tokens.
-Note that the response format is slightly different than `/v1/embeddings` - it does not have the `"data"` sub-tree and the
-embeddings are always returned as vector of vectors.
+This endpoint supports all poolings, including `--pooling none`. When the pooling is `none`, the responses will contain the *unnormalized* embeddings for *all* input tokens. For all other pooling types, only the pooled embeddings are returned, normalized using Euclidian norm.
+
+Note that the response format of this endpoint is different from `/v1/embeddings`.
 
 *Options:*
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -744,16 +744,16 @@ struct server_task_result_embd : server_task_result {
 
     json to_json_non_oaicompat() {
         return json {
-            {"index",            index},
-            {"embedding",        embedding},
-            {"tokens_evaluated", n_tokens},
+            {"index",     index},
+            {"embedding", embedding},
         };
     }
 
     json to_json_oaicompat() {
         return json {
-            {"index",     index},
-            {"embedding", embedding[0]},
+            {"index",            index},
+            {"embedding",        embedding[0]},
+            {"tokens_evaluated", n_tokens},
         };
     }
 };

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -704,6 +704,7 @@ struct server_task_result_cmpl_partial : server_task_result {
                 {"delta",
                 json {
                     {"content", content},
+                    {"tokens",  tokens}
                 }},
             }});
         }
@@ -1003,6 +1004,7 @@ struct server_slot {
         n_prompt_tokens    = 0;
         last_nl_pos        = 0;
         generated_text     = "";
+        generated_tokens   = {};
         has_new_line       = false;
         truncated          = false;
         stop               = STOP_TYPE_NONE;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -704,7 +704,6 @@ struct server_task_result_cmpl_partial : server_task_result {
                 {"delta",
                 json {
                     {"content", content},
-                    {"tokens",  tokens}
                 }},
             }});
         }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -736,7 +736,7 @@ struct server_task_result_embd : server_task_result {
     }
 
     virtual json to_json() override {
-        if (embedding.size() == 1){
+        if (embedding.size() == 1) {
             // to be OAI compatible
             return json {
                 {"index",     index},

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2059,8 +2059,14 @@ struct server_context {
                 continue;
             }
 
-            common_embd_normalize(embd, embd_res.data(), n_embd);
-            res->embedding.push_back(embd_res);
+            // normalize only when there is pooling
+            // TODO: configurable
+            if (llama_pooling_type(slot.ctx) != LLAMA_POOLING_TYPE_NONE) {
+                common_embd_normalize(embd, embd_res.data(), n_embd, 2);
+                res->embedding.push_back(embd_res);
+            } else {
+                res->embedding.push_back({ embd, embd + n_embd });
+            }
         }
 
         SLT_DBG(slot, "%s", "sending embeddings\n");

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1018,7 +1018,6 @@ struct server_slot {
         n_prompt_tokens    = 0;
         last_nl_pos        = 0;
         generated_text     = "";
-        generated_tokens   = {};
         has_new_line       = false;
         truncated          = false;
         stop               = STOP_TYPE_NONE;
@@ -3733,7 +3732,7 @@ int main(int argc, char ** argv) {
                 task.prompt_tokens = std::move(tokenized_prompts[i]);
 
                 // OAI-compat
-                task.params.oaicompat = oaicompat;;
+                task.params.oaicompat = oaicompat;
 
                 tasks.push_back(task);
             }

--- a/examples/server/tests/unit/test_embedding.py
+++ b/examples/server/tests/unit/test_embedding.py
@@ -74,6 +74,18 @@ def test_embedding_mixed_input(content, is_multi_prompt: bool):
         assert len(res.body['embedding']) > 1
 
 
+def test_embedding_pooling_none():
+    server = ServerPreset.bert_bge_small(pooling = 'none')
+    server.start()
+    res = server.make_request("POST", "/embeddings", data={
+        "input": "hello hello hello",
+    })
+    assert res.status_code == 200
+    assert len(res.body['data']) == 1
+    assert 'embedding' in res.body['data'][0]
+    assert len(res.body['data'][0]['embedding']) == 3
+
+
 def test_embedding_openai_library_single():
     global server
     server.start()

--- a/examples/server/tests/unit/test_embedding.py
+++ b/examples/server/tests/unit/test_embedding.py
@@ -87,6 +87,10 @@ def test_embedding_pooling_none():
     assert 'embedding' in res.body[0]
     assert len(res.body[0]['embedding']) == 3
 
+    # make sure embedding vector is not normalized
+    for x in res.body[0]['embedding']:
+        assert abs(sum([x ** 2 for x in x]) - 1) > EPSILON
+
 
 def test_embedding_pooling_none_oai():
     global server
@@ -95,6 +99,7 @@ def test_embedding_pooling_none_oai():
     res = server.make_request("POST", "/v1/embeddings", data={
         "input": "hello hello hello",
     })
+
     # /v1/embeddings does not support pooling type 'none'
     assert res.status_code == 400
 

--- a/examples/server/tests/unit/test_embedding.py
+++ b/examples/server/tests/unit/test_embedding.py
@@ -14,6 +14,7 @@ def create_server():
 
 def test_embedding_single():
     global server
+    server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
         "input": "I believe the meaning of life is",
@@ -29,6 +30,7 @@ def test_embedding_single():
 
 def test_embedding_multiple():
     global server
+    server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
         "input": [
@@ -75,7 +77,8 @@ def test_embedding_mixed_input(content, is_multi_prompt: bool):
 
 
 def test_embedding_pooling_none():
-    server = ServerPreset.bert_bge_small(pooling = 'none')
+    global server
+    server.pooling = 'none'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
         "input": "hello hello hello",
@@ -88,6 +91,7 @@ def test_embedding_pooling_none():
 
 def test_embedding_openai_library_single():
     global server
+    server.pooling = 'last'
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}")
     res = client.embeddings.create(model="text-embedding-3-small", input="I believe the meaning of life is")
@@ -97,6 +101,7 @@ def test_embedding_openai_library_single():
 
 def test_embedding_openai_library_multiple():
     global server
+    server.pooling = 'last'
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}")
     res = client.embeddings.create(model="text-embedding-3-small", input=[
@@ -112,6 +117,7 @@ def test_embedding_openai_library_multiple():
 
 def test_embedding_error_prompt_too_long():
     global server
+    server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
         "input": "This is a test " * 512,
@@ -121,6 +127,7 @@ def test_embedding_error_prompt_too_long():
 
 
 def test_same_prompt_give_same_result():
+    server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
         "input": [

--- a/examples/server/tests/utils.py
+++ b/examples/server/tests/utils.py
@@ -65,6 +65,7 @@ class ServerProcess:
     server_reranking: bool | None = False
     server_metrics: bool | None = False
     server_slots: bool | None = False
+    pooling: str | None = None
     draft: int | None = None
     api_key: str | None = None
     response_format: str | None = None
@@ -132,6 +133,8 @@ class ServerProcess:
             server_args.append("--metrics")
         if self.server_slots:
             server_args.append("--slots")
+        if self.pooling:
+            server_args.extend(["--pooling", self.pooling])
         if self.model_alias:
             server_args.extend(["--alias", self.model_alias])
         if self.n_ctx:
@@ -272,7 +275,7 @@ class ServerPreset:
         return server
 
     @staticmethod
-    def bert_bge_small() -> ServerProcess:
+    def bert_bge_small(pooling = 'last') -> ServerProcess:
         server = ServerProcess()
         server.model_hf_repo = "ggml-org/models"
         server.model_hf_file = "bert-bge-small/ggml-model-f16.gguf"
@@ -283,6 +286,7 @@ class ServerPreset:
         server.n_slots = 2
         server.seed = 42
         server.server_embeddings = True
+        server.pooling = pooling
         return server
 
     @staticmethod

--- a/examples/server/tests/utils.py
+++ b/examples/server/tests/utils.py
@@ -275,7 +275,7 @@ class ServerPreset:
         return server
 
     @staticmethod
-    def bert_bge_small(pooling = 'last') -> ServerProcess:
+    def bert_bge_small() -> ServerProcess:
         server = ServerProcess()
         server.model_hf_repo = "ggml-org/models"
         server.model_hf_file = "bert-bge-small/ggml-model-f16.gguf"
@@ -286,7 +286,6 @@ class ServerPreset:
         server.n_slots = 2
         server.seed = 42
         server.server_embeddings = True
-        server.pooling = pooling
         return server
 
     @staticmethod


### PR DESCRIPTION
When using an embedding model with pooling type `none`, the `/embeddings` endpoint will now output a vector of unnormalized embedding vectors - one for each input token. The `/v1/embeddings` OAI-compatible endpoint does not support this and will return an error when trying to use a model with pooling type `none`.

### API Changes

- The `/embedding` endpoint now returns a vector of embedding vectors. See the server readme for more information.

TODO: implement `"encoding_format": "base64"` to reduce the output size of this endpoint.