### PR TITLE
ggml : update ggml_backend_cpu_device_supports_op

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2968,12 +2968,8 @@ static void ggml_compute_forward_dup_f16(
                         id += ne00 * (ne01 - ir1);
                     }
                 }
-            } else if (ggml_get_type_traits_cpu(dst->type)->from_float || ggml_get_type_traits(dst->type)->from_float_ref) {
-                ggml_from_float_t quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
-                if (!quantize_row_q) {
-                    quantize_row_q = ggml_get_type_traits(dst->type)->from_float_ref;
-                }
-
+            } else if (ggml_get_type_traits_cpu(dst->type)->from_float) {
+                ggml_from_float_t const quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
                 float * src0_f32 = (float *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
                 size_t id = 0;
@@ -3569,11 +3565,8 @@ static void ggml_compute_forward_dup_f32(
                         id += rs * (ne01 - ir1);
                     }
                 }
-            } else if (ggml_get_type_traits_cpu(dst->type)->from_float || ggml_get_type_traits(dst->type)->from_float_ref) {
-                ggml_from_float_t quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
-                if (!quantize_row_q) {
-                    quantize_row_q = ggml_get_type_traits(dst->type)->from_float_ref;
-                }
+            } else if (ggml_get_type_traits_cpu(dst->type)->from_float) {
+                ggml_from_float_t const quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
 
                 size_t id = 0;
                 size_t rs = nb0 * (ne00 / ggml_blck_size(dst->type));

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2968,8 +2968,12 @@ static void ggml_compute_forward_dup_f16(
                         id += ne00 * (ne01 - ir1);
                     }
                 }
-            } else if (ggml_get_type_traits_cpu(dst->type)->from_float) {
-                ggml_from_float_t const quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
+            } else if (ggml_get_type_traits_cpu(dst->type)->from_float || ggml_get_type_traits(dst->type)->from_float_ref) {
+                ggml_from_float_t quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
+                if (!quantize_row_q) {
+                    quantize_row_q = ggml_get_type_traits(dst->type)->from_float_ref;
+                }
+
                 float * src0_f32 = (float *) params->wdata + (ne00 + CACHE_LINE_SIZE_F32) * ith;
 
                 size_t id = 0;
@@ -3565,8 +3569,11 @@ static void ggml_compute_forward_dup_f32(
                         id += rs * (ne01 - ir1);
                     }
                 }
-            } else if (ggml_get_type_traits_cpu(dst->type)->from_float) {
-                ggml_from_float_t const quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
+            } else if (ggml_get_type_traits_cpu(dst->type)->from_float || ggml_get_type_traits(dst->type)->from_float_ref) {
+                ggml_from_float_t quantize_row_q = ggml_get_type_traits_cpu(dst->type)->from_float;
+                if (!quantize_row_q) {
+                    quantize_row_q = ggml_get_type_traits(dst->type)->from_float_ref;
+                }
 
                 size_t id = 0;
                 size_t rs = nb0 * (ne00 / ggml_blck_size(dst->type));

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -394,8 +394,11 @@ static bool ggml_backend_cpu_device_supports_op(ggml_backend_dev_t dev, const st
     switch (op->op) {
         case GGML_OP_CPY:
             return
+                op->type != GGML_TYPE_IQ3_XXS &&
+                op->type != GGML_TYPE_IQ3_S   &&
                 op->type != GGML_TYPE_IQ2_XXS &&
                 op->type != GGML_TYPE_IQ2_XS  &&
+                op->type != GGML_TYPE_IQ2_S   &&
                 op->type != GGML_TYPE_IQ1_S   &&
                 op->type != GGML_TYPE_IQ1_M; // missing type_traits.from_float
         case GGML_OP_MUL_MAT:

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3549,9 +3549,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     for (ggml_type type_src : {GGML_TYPE_F16, GGML_TYPE_F32}) {
         for (ggml_type type_dst : all_types) {
-            if (type_dst == GGML_TYPE_IQ2_S || type_dst == GGML_TYPE_IQ3_XXS || type_dst == GGML_TYPE_IQ3_S) {
-                continue;
-            }
             test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 4, 4, 4}));
             test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 2, 3, 4}, {0, 2, 1, 3})); // cpy by rows
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3549,9 +3549,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     for (ggml_type type_src : {GGML_TYPE_F16, GGML_TYPE_F32}) {
         for (ggml_type type_dst : all_types) {
-            //if (type_dst == GGML_TYPE_IQ2_S || type_dst == GGML_TYPE_IQ3_XXS || type_dst == GGML_TYPE_IQ3_S) {
-            //    continue;
-            //}
+            if (type_dst == GGML_TYPE_IQ2_S || type_dst == GGML_TYPE_IQ3_XXS || type_dst == GGML_TYPE_IQ3_S) {
+                continue;
+            }
             test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 4, 4, 4}));
             test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 2, 3, 4}, {0, 2, 1, 3})); // cpy by rows
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3549,8 +3549,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     for (ggml_type type_src : {GGML_TYPE_F16, GGML_TYPE_F32}) {
         for (ggml_type type_dst : all_types) {
-           test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 4, 4, 4}));
-           test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 2, 3, 4}, {0, 2, 1, 3})); // cpy by rows
+            //if (type_dst == GGML_TYPE_IQ2_S || type_dst == GGML_TYPE_IQ3_XXS || type_dst == GGML_TYPE_IQ3_S) {
+            //    continue;
+            //}
+            test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 4, 4, 4}));
+            test_cases.emplace_back(new test_cpy(type_src, type_dst, {256, 2, 3, 4}, {0, 2, 1, 3})); // cpy by rows
         }
     }
     for (ggml_type type_src : {GGML_TYPE_F16, GGML_TYPE_F32}) {


### PR DESCRIPTION
This fixes the following failures:

```bash
./build/bin/test-backend-ops -b CPU -o CPY

  CPY(type_src=f16,type_dst=q6_K,ne=[256,4,4,4],permute=[0,0,0,0]): OK
  CPY(type_src=f16,type_dst=q6_K,ne=[256,2,3,4],permute=[0,2,1,3]): OK
  CPY(type_src=f16,type_dst=iq2_xxs,ne=[256,4,4,4],permute=[0,0,0,0]): not supported [CPU] not supported [CPU] 
  CPY(type_src=f16,type_dst=iq2_xxs,ne=[256,2,3,4],permute=[0,2,1,3]): not supported [CPU] not supported [CPU] 
  CPY(type_src=f16,type_dst=iq2_xs,ne=[256,4,4,4],permute=[0,0,0,0]): not supported [CPU] not supported [CPU] 
  CPY(type_src=f16,type_dst=iq2_xs,ne=[256,2,3,4],permute=[0,2,1,3]): not supported [CPU] not supported [CPU] 
  CPY(type_src=f16,type_dst=iq2_s,ne=[256,4,4,4],permute=[0,0,0,0]): /llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal error
/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: /llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal error
/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal errorfatal error/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: 
/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal error/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal error
/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2996: fatal errorAbort trap: 6
```