### PR TITLE
Use model->gguf_kv for loading the template instead of using the C API.

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -22652,7 +22652,7 @@ int32_t llama_chat_apply_template(
     if (tmpl == nullptr) {
         GGML_ASSERT(model != nullptr);
         // load template from model
-        std::vector<char> model_template(2048, 0); // longest known template is about 1200 bytes
+        std::vector<char> model_template(16384, 0); // longest known template is about 12792 bytes
         std::string template_key = "tokenizer.chat_template";
         int32_t res = llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
         if (res < 0) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -22651,15 +22651,15 @@ int32_t llama_chat_apply_template(
     std::string curr_tmpl(tmpl == nullptr ? "" : tmpl);
     if (tmpl == nullptr) {
         GGML_ASSERT(model != nullptr);
-        // load template from model
-        std::vector<char> model_template(16384, 0); // longest known template is about 12792 bytes
-        std::string template_key = "tokenizer.chat_template";
-        int32_t res = llama_model_meta_val_str(model, template_key.c_str(), model_template.data(), model_template.size());
-        if (res < 0) {
+
+        // load template from model, if available
+        const auto & it = model->gguf_kv.find("tokenizer.chat_template");
+        if (it != model->gguf_kv.end() && it->second.size() > 0) {
+            curr_tmpl = it->second;
+        }
+        else {
             // worst case: there is no information about template, we will use chatml by default
-            curr_tmpl = "chatml"; // see llama_chat_apply_template_internal
-        } else {
-            curr_tmpl = std::string(model_template.data(), model_template.size());
+            curr_tmpl = "chatml";  // see llama_chat_apply_template_internal
         }
     }
 


### PR DESCRIPTION
Cohere's command-r models use a rather large chat template and therefore `llama_chat_detect_template()` fails to properly detect because `<|USER_TOKEN|>` is beyond the current 2048 limit. This patch bumps the limit to 16K bytes and allows the conversation mode to work with the command-r models.