### PR TITLE
docs: update link to ramalama on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ To learn more about model quantization, [read this documentation](examples/quant
 
     </details>
 
-[^3]: [https://github.com/containers/ramalama](RamaLama)
+[^3]: [https://github.com/containers/ramalama](https://github.com/containers/ramalama)
 
 ## [`llama-simple`](examples/simple)
 


### PR DESCRIPTION
docs: update link to ramalama on readme

Link goes to https://github.com/ggerganov/RamaLama which does not exist.

Updated the reference to correctly to go to
https://github.com/containers/ramalama

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
