### PR TITLE
docs: Fix HIP (née hipBLAS) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 | [SYCL](docs/backend/SYCL.md) | Intel and Nvidia GPU |
 | [MUSA](docs/build.md#musa) | Moore Threads MTT GPU |
 | [CUDA](docs/build.md#cuda) | Nvidia GPU |
-| [hipBLAS](docs/build.md#hipblas) | AMD GPU |
+| [HIP](docs/build.md#hip) | AMD GPU |
 | [Vulkan](docs/build.md#vulkan) | GPU |
 | [CANN](docs/build.md#cann) | Ascend NPU |
 


### PR DESCRIPTION
Related to #10524 / be0e350c references to hipBLAS have been removed across the repository.  This fixes the link from the repositories `README.md`.