### PR TITLE
tests: disable GGUF test for bad value size

### DIFF
--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -634,7 +634,7 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
 
         HANDCRAFTED_KV_BAD_KEY_SIZE,
         HANDCRAFTED_KV_BAD_TYPE,
-        HANDCRAFTED_KV_BAD_VALUE_SIZE,
+        // HANDCRAFTED_KV_BAD_VALUE_SIZE, // FIXME sanitizer limit
         // HANDCRAFTED_FILE_TYPE_DUPLICATE_KEY, // FIXME
         HANDCRAFTED_KV_SUCCESS,
 


### PR DESCRIPTION
See https://github.com/ggerganov/llama.cpp/pull/10830#issuecomment-2550751581 .

This PR makes the test failure with a bad value size deterministic (as in independent of the seed). The way this test causes a failure is not really well-defined since it just writes a random wrong number of wrong, random bytes to the file. So depending on the RNG you can get a random, uncaught failure in a `calloc` call. This PR makes the test failure deterministic to prevent false positives in the CI until I have the C++ refactor ready.

@ggerganov where in llama.cpp is the sanitizer logic defined? I usually use Valgrind for my local development but I'd like to assert that there aren't any more random failures with the method used in the CI.