### PR TITLE
llama : the WPM vocabs use the CLS token as BOS

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1657,7 +1657,7 @@ bool llama_token_is_control_impl(const struct llama_vocab & vocab, llama_token t
 }
 
 llama_token llama_token_bos_impl(const struct llama_vocab & vocab) {
-    return vocab.special_bos_id;
+    return vocab.type != LLAMA_VOCAB_TYPE_WPM ? vocab.special_bos_id : vocab.special_cls_id;
 }
 
 llama_token llama_token_eos_impl(const struct llama_vocab & vocab) {

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -45,7 +45,7 @@ struct llama_vocab {
     id special_unk_id  = 0;
     id special_sep_id  = LLAMA_TOKEN_NULL;
     id special_pad_id  = LLAMA_TOKEN_NULL;
-    id special_cls_id  = LLAMA_TOKEN_NULL;
+    id special_cls_id  = LLAMA_TOKEN_NULL; // TODO: revisit if this is really needed https://github.com/ggerganov/llama.cpp/pull/10930
     id special_mask_id = LLAMA_TOKEN_NULL;
 
     id linefeed_id = 13;


### PR DESCRIPTION
https://github.com/ggerganov/llama.cpp/blob/9d5c7115879fe33828edf3a1892b597b61c1cd7d/src/llama-vocab.cpp#L1529-L1535

Not sure if this separation of BOS and CLS tokens is really necessary. The alternative would be to remove the notion of CLS tokens from the codebase and work only with BOS tokens - seems much simpler. The problem would be if there are models that have both BOS and CLS tokens that are distinct?