### PR TITLE
server : add support for "encoding_format": "base64" to the */embeddings endpoints

### DIFF
--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -34,6 +34,7 @@ endforeach()
 add_executable(${TARGET} ${TARGET_SRCS})
 install(TARGETS ${TARGET} RUNTIME)
 
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(${TARGET} PRIVATE common ${CMAKE_THREAD_LIBS_INIT})
 
 if (LLAMA_SERVER_SSL)

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3786,6 +3786,17 @@ int main(int argc, char ** argv) {
             return;
         }
 
+        bool use_base64 = false;
+        if (body.count("encoding_format") != 0) {
+            const std::string& format = body.at("encoding_format");
+            if (format == "base64") {
+                use_base64 = true;
+            } else if (format != "float") {
+                res_error(res, format_error_response("The format to return the embeddings in. Can be either float or base64", ERROR_TYPE_INVALID_REQUEST));
+                return;
+            }
+        }
+
         std::vector<llama_tokens> tokenized_prompts = tokenize_input_prompts(ctx_server.ctx, prompt, true, true);
         for (const auto & tokens : tokenized_prompts) {
             // this check is necessary for models that do not add BOS token to the input
@@ -3837,7 +3848,7 @@ int main(int argc, char ** argv) {
         }
 
         // write JSON response
-        json root = oaicompat ? format_embeddings_response_oaicompat(body, responses) : json(responses);
+        json root = oaicompat ? format_embeddings_response_oaicompat(body, responses, use_base64) : json(responses);
         res_ok(res, root);
     };
 

--- a/examples/server/tests/unit/test_embedding.py
+++ b/examples/server/tests/unit/test_embedding.py
@@ -202,7 +202,7 @@ def test_embedding_openai_library_base64():
     server.start()
     test_input = "Test base64 embedding output"
 
-    res = server.make_request("POST", "/embeddings", data={
+    res = server.make_request("POST", "/v1/embeddings", data={
         "input": test_input,
         "encoding_format": "base64"
     })

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -3,6 +3,7 @@
 #include "common.h"
 #include "log.h"
 #include "llama.h"
+#include "common/base64.hpp"
 
 #ifndef NDEBUG
 // crash the server in debug mode, otherwise send an http 500 error
@@ -596,6 +597,8 @@ static json format_embeddings_response_oaicompat(const json & request, const jso
     int32_t n_tokens = 0;
     int i = 0;
     for (const auto & elem : embeddings) {
+        json embedding_obj;
+
         if (use_base64) {
             const auto& vec = json_value(elem, "embedding", json::array()).get<std::vector<float>>();
             const char* data_ptr = reinterpret_cast<const char*>(vec.data());


### PR DESCRIPTION
# Add base64 encoding format support for embeddings endpoints

## Overview
This PR implements support for base64 format in embedding responses, aligning with OpenAI's API functionality and improving payload efficiency.

## Changes
- Added `encoding_format` [parameter support](https://github.com/elk-cloner/llama.cpp/blob/0a753fbd1c37ad06af9ad78e278a5acbfc2d6a4e/examples/server/server.cpp#L3790) to embedding endpoints
- Implemented base64 encoding for embedding vectors [when specified](https://github.com/elk-cloner/llama.cpp/blob/c66b1a7611a90cb0bafc03f6413125a777280c8c/examples/server/utils.hpp#L595)
- Updated response handling to [support](https://github.com/elk-cloner/llama.cpp/blob/c66b1a7611a90cb0bafc03f6413125a777280c8c/examples/server/utils.hpp#L610) both float and base64 formats
- Added [tests](https://github.com/elk-cloner/llama.cpp/blob/c66b1a7611a90cb0bafc03f6413125a777280c8c/examples/server/tests/unit/test_embedding.py#L201) to verify base64 encoding functionality

## Related Issue
Closes #10887