### PR TITLE
Vulkan: Destroy Vulkan instance on exit

### DIFF
--- a/ggml/include/ggml-vulkan.h
+++ b/ggml/include/ggml-vulkan.h
@@ -11,6 +11,7 @@ extern "C" {
 #define GGML_VK_MAX_DEVICES 16
 
 GGML_BACKEND_API void ggml_vk_instance_init(void);
+GGML_BACKEND_API void ggml_vk_instance_unload(void);
 
 // backend API
 GGML_BACKEND_API ggml_backend_t ggml_backend_vk_init(size_t dev_num);


### PR DESCRIPTION
This seems to fix the Nvidia driver segfault on exit (#10528). If someone can reproduce it reliably, please test if this resolves it.

It's a little more hacky than I had hoped, but I couldn't think of a better way to check when the instance can be destroyed.

Basically the backend is now counting backend contexts and backend (device) buffer allocations and when a backend or buffer is destroyed checks whether any are left. If not, it destroys the instance. This seems to happen early enough that it avoids the issue with the Nvidia driver. Usually it should happen on a backend unload or model unload, depending on which happens last.

Let me know if you see any issues, I had to touch a lot of code to remove references to the devices that would prevent them and thus the instance from being destroyed.