### PR TITLE
server: added more docs for response_fields field

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -450,7 +450,7 @@ These words will not be included in the completion, so make sure to add them to 
 
 `post_sampling_probs`: Returns the probabilities of top `n_probs` tokens after applying sampling chain.
 
-`response_fields`: A list of response fields, for example: `"response_fields": ["content", "generation_settings/n_predict"]`. If the specified field is missing, it will simply be omitted from the response without triggering an error.
+`response_fields`: A list of response fields, for example: `"response_fields": ["content", "generation_settings/n_predict"]`. If the specified field is missing, it will simply be omitted from the response without triggering an error. Note that fields with a slash will be unnested; for example, `generation_settings/n_predict` will move the field `n_predict` from the `generation_settings` object to the root of the response and give it a new name.
 
 **Response format**
 


### PR DESCRIPTION
Per the conversation at https://github.com/ggerganov/llama.cpp/pull/10940#issuecomment-2561486415, it was decided to leave the current behavior of `response_fields` un-nesting objects with a slash.

This PR just adds a quick note to the server documentation that clarifies this behavior.
