### PR TITLE
[GGML][RPC] Support for models with non-512-aligned tensors over RPC.

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -110,10 +110,6 @@ struct rpc_msg_init_tensor_req {
     rpc_tensor tensor;
 };
 
-//struct rpc_msg_init_tensor_rsp {
-//    uint8_t result; // success/failure
-//};
-
 struct rpc_msg_alloc_buffer_req {
     uint64_t size;
 };
@@ -824,7 +820,7 @@ bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_
     ggml_tensor * tensor = deserialize_tensor(ctx, &request.tensor);
 
     if (tensor == nullptr) {
-        fprintf(stderr,"Null tensor pointer passed to server get_alloc_size function.\n");
+        GGML_LOG_ERROR("Null tensor pointer passed to server get_alloc_size function.\n");
         ggml_free(ctx);
         return false;
     }
@@ -986,7 +982,7 @@ bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
     struct ggml_context * ctx = ggml_init(params);
     ggml_tensor * tensor = deserialize_tensor(ctx, &request.tensor);
     if (tensor == nullptr) {
-        fprintf(stderr,"Null tensor pointer passed to server init_tensor function.\n");
+        GGML_LOG_ERROR("Null tensor pointer passed to server init_tensor function.\n");
         ggml_free(ctx);
         return false;
     }
@@ -996,7 +992,7 @@ bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
     if (buffer && buffer->iface.init_tensor) {
         buffer->iface.init_tensor(buffer, tensor);
     } else {
-        fprintf(stderr,"Null buffer for tensor passed to init_tensor function\n");
+        GGML_LOG_ERROR("Null buffer for tensor passed to init_tensor function\n");
     }
 
     ggml_free(ctx);

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -813,7 +813,7 @@ private:
 };
 
 bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response) {
-    ggml_backend_buffer_type_t buft; 
+    ggml_backend_buffer_type_t buft;
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -822,7 +822,7 @@ bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_
 
     struct ggml_context * ctx = ggml_init(params);
     ggml_tensor * tensor = deserialize_tensor(ctx, &request.tensor);
-    
+
     if (tensor == nullptr) {
         fprintf(stderr,"Null tensor pointer passed to server get_alloc_size function.\n");
         ggml_free(ctx);


### PR DESCRIPTION
This PR adds support for quantized tensors with sizes not divisible by 512, such as those found in quantized versions of the Qwen2.5 72B model. Please also see discussion in #10943.

### Changes
- Implemented forwarding to CUDA backend on server for `init_tensor` and `get_alloc_size` calls
- Forwarding all calls would result in unacceptable latency (tested and tok/s drops to 0.02). At the moment only calls for misaligned tensors are forwarded. There may be a better way of handling this in the future.

### Performance Impact
- Qwen2.5 72B Q4_K_M: Coherent at ~4 tokens/s over GbE with mix of GPU/RPC/CPU. (previously outputted garbage)
- Existing models (e.g. LLaMA 3.3 70B Q4_K_M): Unaffected (~7 tokens/s over GbE with GPU/RPC)

### Testing
- Perplexity validation with Tulu-3 8B:
  - Without RPC: 6.9362 ± 0.04526
  - With RPC: 6.9362 ± 0.04526 (identical results)
- test-backend-ops: Passed for supported backends
- Note: Unable to run full CI due to bandwidth limitations with model downloads
