### PR TITLE
Disable KV cache shifting automatically for unsupported models

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -889,7 +889,7 @@ struct common_init_result common_init_from_params(common_params & params) {
     }
 
     if (params.ctx_shift && !llama_kv_cache_can_shift(lctx)) {
-        LOG_WRN("%s: KV cache shifting is not supported for this model, disabling KV cache shifting'\n", __func__);
+        LOG_WRN("%s: KV cache shifting is not supported for this model, disabling KV cache shifting\n", __func__);
         params.ctx_shift = false;
     }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -889,9 +889,8 @@ struct common_init_result common_init_from_params(common_params & params) {
     }
 
     if (params.ctx_shift && !llama_kv_cache_can_shift(lctx)) {
-        LOG_ERR("%s: KV cache shifting is not supported for this model (--no-context-shift to disable)'\n", __func__);
-        llama_free_model(model);
-        return iparams;
+        LOG_WRN("%s: KV cache shifting is not supported for this model, disabling KV cache shifting'\n", __func__);
+        params.ctx_shift = false;
     }
 
     if (!params.control_vectors.empty()) {


### PR DESCRIPTION
Disable KV cache shifting automatically for unsupported models instead of exiting directly.

This makes it easier for models that doesn't support KV cache shifting.
Currently in arg.cpp `--no-context-shift` is only enabled in `LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY`. As a result, for example, using `llama-parallel` with recurrent models will fail with message indicating that context-shift is not supported. But `--no-context-shift` isn't an available parameter for llama-parallel.