### PR TITLE
tokenize : escape the prompt

### DIFF
--- a/examples/tokenize/tokenize.cpp
+++ b/examples/tokenize/tokenize.cpp
@@ -31,6 +31,7 @@ static void print_usage_information(const char * argv0) {
     printf("    -p PROMPT, --prompt PROMPT           read prompt from the argument.\n");
     printf("    --stdin                              read prompt from standard input.\n");
     printf("    --no-bos                             do not ever add a BOS token to the prompt, even if normally the model uses a BOS token.\n");
+    printf("    --no-escape                          do not escape input (such as \\n, \\t, etc.).\n");
     printf("    --no-parse-special                   do not parse control tokens.\n");
     printf("    --log-disable                        disable logs. Makes stderr quiet when loading the model.\n");
     printf("    --show-count                         print the total number of tokens.\n");

--- a/examples/tokenize/tokenize.cpp
+++ b/examples/tokenize/tokenize.cpp
@@ -198,6 +198,7 @@ int main(int raw_argc, char ** raw_argv) {
     // variables where to put any arguments we see.
     bool printing_ids = false;
     bool no_bos = false;
+    bool no_escape = false;
     bool no_parse_special = false;
     bool disable_logging = false;
     bool show_token_count = false;
@@ -232,6 +233,9 @@ int main(int raw_argc, char ** raw_argv) {
         }
         else if (arg == "--no-bos") {
             no_bos = true;
+        }
+        else if (arg == "--no-escape") {
+            no_escape = true;
         }
         else if (arg == "--no-parse-special") {
             no_parse_special = true;
@@ -363,6 +367,11 @@ int main(int raw_argc, char ** raw_argv) {
     const bool model_wants_add_bos = llama_add_bos_token(model);
     const bool add_bos = model_wants_add_bos && !no_bos;
     const bool parse_special = !no_parse_special;
+    const bool escape = !no_escape;
+
+    if (escape) {
+        string_process_escapes(prompt);
+    }
 
     std::vector<llama_token> tokens;
     tokens = common_tokenize(model, prompt, add_bos, parse_special);


### PR DESCRIPTION
fix #11054

### Escape

```bash
make -j && ./bin/llama-tokenize -m ../models/llama-8b-v3-instruct/ggml-model-q4_0.gguf -p "<|im_start|>user\nhello who are you?<|im_end|>\n<|im_start|>assistant\n"

128000 -> '<|begin_of_text|>'
    27 -> '<'
    91 -> '|'
   318 -> 'im'
  5011 -> '_start'
    91 -> '|'
    29 -> '>'
   882 -> 'user'
   198 -> '
'
 15339 -> 'hello'
   889 -> ' who'
   527 -> ' are'
   499 -> ' you'
 76514 -> '?<'
    91 -> '|'
   318 -> 'im'
  6345 -> '_end'
    91 -> '|'
   397 -> '>
'
    27 -> '<'
    91 -> '|'
   318 -> 'im'
  5011 -> '_start'
    91 -> '|'
    29 -> '>'
 78191 -> 'assistant'
   198 -> '
'
```

### No escape

```bash
make -j && ./bin/llama-tokenize -m ../models/llama-8b-v3-instruct/ggml-model-q4_0.gguf -p "<|im_start|>user\nhello who are you?<|im_end|>\n<|im_start|>assistant\n" --no-escape

128000 -> '<|begin_of_text|>'
    27 -> '<'
    91 -> '|'
   318 -> 'im'
  5011 -> '_start'
    91 -> '|'
    29 -> '>'
   882 -> 'user'
  1734 -> '\n'
 15339 -> 'hello'
   889 -> ' who'
   527 -> ' are'
   499 -> ' you'
 76514 -> '?<'
    91 -> '|'
   318 -> 'im'
  6345 -> '_end'
    91 -> '|'
  8616 -> '>\'
    77 -> 'n'
    27 -> '<'
    91 -> '|'
   318 -> 'im'
  5011 -> '_start'
    91 -> '|'
    29 -> '>'
 78191 -> 'assistant'
  1734 -> '\n'
```