### PR TITLE
github : add cmd line field to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
+++ b/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
@@ -71,6 +71,7 @@ body:
       label: Compile command
       description: >
         Please provide the exact command you used to compile llama.cpp. For example: `cmake -B ...`.
+        This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
+++ b/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
@@ -79,7 +79,7 @@ body:
     attributes:
       label: Relevant log output
       description: >
-          Please copy and paste any relevant log output, including the command that you entered and any generated text.
+          Please copy and paste any relevant log output, including any generated text.
           This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
+++ b/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
@@ -66,6 +66,15 @@ body:
     validations:
       required: false
   - type: textarea
+    id: command
+    attributes:
+      label: Compile command
+      description: >
+        Please provide the exact command you used to compile llama.cpp. For example: `cmake -B ...`.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
     id: logs
     attributes:
       label: Relevant log output

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -57,10 +57,10 @@ body:
     attributes:
       label: Command line
       description: >
-        Please provide the exact command you used to run llama.cpp. For example: `llama-server -m ... -c ...`, `llama-cli -m ...`, etc.
+        Please provide the exact commands you entered, if applicable. For example: `llama-server -m ... -c ...`, `llama-cli -m ...`, etc.
       render: shell
     validations:
-      required: true
+      required: false
   - type: textarea
     id: info
     attributes:

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -53,6 +53,15 @@ body:
     validations:
       required: false
   - type: textarea
+    id: command
+    attributes:
+      label: Command line
+      description: >
+        Please provide the exact command you used to run llama.cpp. For example: `llama-server -m ... -c ...`, `llama-cli -m ...`, etc.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
     id: info
     attributes:
       label: Problem description & steps to reproduce

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -58,6 +58,7 @@ body:
       label: Command line
       description: >
         Please provide the exact commands you entered, if applicable. For example: `llama-server -m ... -c ...`, `llama-cli -m ...`, etc.
+        This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -83,7 +83,7 @@ body:
     attributes:
       label: Relevant log output
       description: >
-          If applicable, please copy and paste any relevant log output, including the command that you entered and any generated text.
+          If applicable, please copy and paste any relevant log output, including any generated text.
           This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # collaborators can optionally add themselves here to indicate their availability for reviewing related PRs
 
 /ci/ @ggerganov
-/.devops/ @ngxson
+/.devops/*.Dockerfile @ngxson
 /examples/server/ @ngxson


### PR DESCRIPTION
Often than not, users don't specify command being used to run llama.cpp.

In many cases, just by looking at the command, we can already know what's going on.

Also modified `codeowners` to exclude myself from nix and rpm stuff inside devops
