### PR TITLE
llama-run : fix context size

### DIFF
--- a/examples/run/run.cpp
+++ b/examples/run/run.cpp
@@ -83,6 +83,7 @@ class Opt {
         }
 
         ctx_params.n_batch        = context_size >= 0 ? context_size : context_size_default;
+        ctx_params.n_ctx          = ctx_params.n_batch;
         model_params.n_gpu_layers = ngl >= 0 ? ngl : ngl_default;
         temperature               = temperature >= 0 ? temperature : temperature_default;
 


### PR DESCRIPTION
Set `n_ctx` equal to `n_batch` in `Opt` class. Now context size is a more reasonable 2048.


