### PR TITLE
fix(log): prevent system info string accumulation across calls in `llama_print_system_info()`

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -12458,6 +12458,8 @@ int llama_split_prefix(char * dest, size_t maxlen, const char * split_path, int 
 
 const char * llama_print_system_info(void) {
     static std::string s;
+    s.clear(); // Clear the string, since it's static, otherwise it will accumulate data from previous calls.
+
 
     for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
         auto * reg = ggml_backend_reg_get(i);


### PR DESCRIPTION
This PR fixes a minor issue where the static string in `llama_print_system_info()` would accumulate data across multiple function calls, by adding `s.clear()` at the start of the function. 
