### PR TITLE
vulkan: optimize coopmat2 q2_k dequant function

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs_cm2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs_cm2.comp
@@ -101,19 +101,25 @@ layout(buffer_reference, std430, buffer_reference_align = 4) buffer decodeBufQ2_
    block_q2_K block;
 };
 
+layout(buffer_reference, std430, buffer_reference_align = 16) buffer decodeBufQ2_K_packed16 {
+   block_q2_K_packed16 block;
+};
+
 float16_t dequantFuncQ2_K(const in decodeBufQ2_K bl, const in uint blockCoords[2], const in uint coordInBlock[2])
 {
+    decodeBufQ2_K_packed16 bl16 = decodeBufQ2_K_packed16(bl);
     const f16vec2 d = bl.block.d;
     const uint idx = coordInBlock[1];
-    const uint iqs = idx;
 
-    const uint qsi = (iqs / 128) * 32 + (iqs % 32);     // 0..31
-    const uint scalesi = iqs / 16;                      // 0..15
-    const uint qsshift = ((iqs % 128) / 32) * 2;        // 0,2,4,6
+    const uint scalesi = (idx & 0xF0) >> 4;             // 0..15
+    const uint qsshift = (idx & 0x60) >> 4;             // 0,2,4,6
 
-    uint32_t qs = bl.block.qs[qsi];
+    uint qs = uint32_t(bl16.block.qs[((idx & 0x80) >> 3) + ((idx & 0x1E) >> 1)]);
+    qs = (qs >> qsshift) & 0x0303;
+    qs = unpack8(qs)[idx & 1];
+
     const uint scales = bl.block.scales[scalesi];
-    float16_t ret = d.x * float16_t(scales & 0xF) * float16_t((qs >> qsshift) & 3) - d.y * float16_t(scales >> 4);
+    float16_t ret = d.x * float16_t(scales & 0xF) * float16_t(qs) - d.y * float16_t(scales >> 4);
     return ret;
 }
 


### PR DESCRIPTION
Same kind of optimization as in https://github.com/ggerganov/llama.cpp/pull/10855, just for Q2_K. I happened to be trying out a Q2_K model for stable-diffusion/flux and this makes it about 5% faster.

```
stable-diffusion:
sd --diffusion-model  models\flux\flux1-dev-Q2_K.gguf --vae models\flux\ae.safetensors --clip_l models\flux\clip_l.safetensors --t5xxl models\flux\t5xxl_fp16.safetensors -p "a lovely cat holding a sign says 'flux.cpp'" --cfg-scale 1.0 --sampling-method euler -v --diffusion-fa
coopmat2 before:
  |==================================================| 20/20 - 1.45it/s
coopmat2 after:
  |==================================================| 20/20 - 1.53it/s
coopmat2 after without --diffusion-fa:
  |==================================================| 20/20 - 1.20it/s
coopmat1 without --diffusion-fa:
  |==================================================| 20/20 - 1.08it/s
no coopmat without --diffusion-fa:
  |==================================================| 20/20 - 1.83s/it ( == 0.55it/s)

test-backend-ops:
before
  MUL_MAT(type_a=q2_K,type_b=f32,m=4096,n=512,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                 2880 runs -  1736.50 us/run -  60.13 GFLOP/run -  34.63 TFLOPS
after
  MUL_MAT(type_a=q2_K,type_b=f32,m=4096,n=512,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3]):                 3094 runs -  1616.07 us/run -  60.13 GFLOP/run -  37.21 TFLOPS
```