### PR TITLE
fix: Vulkan shader gen binary path when not cross compiling

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -83,7 +83,7 @@ if (Vulkan_FOUND)
 
     file(GLOB _ggml_vk_shader_deps "${_ggml_vk_input_dir}/*.comp")
 
-    if (NOT CMAKE_CROSSCOMPILING)
+    if (CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)
         set(_ggml_vk_genshaders_cmd "$<TARGET_FILE_DIR:vulkan-shaders-gen>/${_ggml_vk_genshaders_cmd}")
     endif ()
 


### PR DESCRIPTION
Fixes https://github.com/ggerganov/llama.cpp/pull/11096#issuecomment-2578573275.
