### PR TITLE
Fix GGML not compiling on macOS with GCC

### DIFF
--- a/ggml/src/ggml-blas/CMakeLists.txt
+++ b/ggml/src/ggml-blas/CMakeLists.txt
@@ -73,6 +73,10 @@ if (BLAS_FOUND)
     message(STATUS "BLAS found, Includes: ${BLAS_INCLUDE_DIRS}")
 
     target_compile_options(ggml-blas PRIVATE ${BLAS_LINKER_FLAGS})
+    # GCC on apple complains about vector conversions
+    if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(ggml-blas PRIVATE -flax-vector-conversions)
+    endif ()
 
     if (${BLAS_INCLUDE_DIRS} MATCHES "mkl" AND (${GGML_BLAS_VENDOR} MATCHES "Generic" OR ${GGML_BLAS_VENDOR} MATCHES "Intel"))
         add_compile_definitions(GGML_BLAS_USE_MKL)

--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -319,6 +319,10 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
     message(STATUS "Adding CPU backend variant ${GGML_CPU_NAME}: ${ARCH_FLAGS} ${ARCH_DEFINITIONS}")
     target_sources(${GGML_CPU_NAME} PRIVATE ${GGML_CPU_SOURCES})
     target_compile_options(${GGML_CPU_NAME} PRIVATE ${ARCH_FLAGS})
+    # GCC on apple complains about vector conversions
+    if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${GGML_CPU_NAME} PRIVATE -flax-vector-conversions)
+    endif ()
     target_compile_definitions(${GGML_CPU_NAME} PRIVATE ${ARCH_DEFINITIONS})
 
     if (GGML_BACKEND_DL)

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -206,6 +206,14 @@ static int sched_yield (void) {
 }
 #else
 
+// GCC fails to compile ggml on macos
+#if defined(__APPLE__) && !defined(__clang__)
+#undef __restrict
+#define __restrict
+#define _Nullable
+#define _Nonnull
+#endif
+
 #include <pthread.h>
 #include <stdatomic.h>
 #include <sched.h>


### PR DESCRIPTION
I have integrated the [ProstT5](https://github.com/mheinzinger/ProstT5) protein language into [Foldseek](https://github.com/steineggerlab/foldseek). Thanks a lot for the great library! I am upstreaming a few fixes for issues I found in ggml during the integration. I hope that it's okay to push the changes here and that they get synced at some point to the main ggml repo.

The first fix is compiling on MacOS with GCC. We compile our software occasionally during development with GCC on our Macs.

The main issue is that `pthread.h` includes an apple specific header `qos.h`, which uses various clang-isms that don't seem well supported on GCC. Additionally, it complains about vector conversions in an Apple header.

One thing I didn't fix here is that GGML_METAL doesn't work with GCC, since it can't really compile the objc. So to compile, one still needs to disable the Metal backend.

