### PR TITLE
Fix ggml-cuda using a driver symbol in NO_VMM mode

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -108,7 +108,7 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
 
 #define CUBLAS_CHECK(err) CUDA_CHECK_GEN(err, CUBLAS_STATUS_SUCCESS, cublas_get_error_str)
 
-#if !defined(GGML_USE_HIP)
+#if !defined(GGML_USE_HIP) && !defined(GGML_CUDA_NO_VMM)
 static const char * cu_get_error_str(CUresult err) {
     const char * err_str;
     cuGetErrorString(err, &err_str);


### PR DESCRIPTION
I have integrated the [ProstT5](https://github.com/mheinzinger/ProstT5) protein language into [Foldseek](https://github.com/steineggerlab/foldseek). Thanks a lot for the great library! I am upstreaming a few fixes for issues I found in ggml during the integration. I hope that it's okay to push the changes here and that they get synced at some point to the main ggml repo.

This fix should be simple. `cuGetErrorString` uses the driver API and should not be available if GGML_CUDA_NO_VMM is set.