### PR TITLE
added kalavai (external) to infrastructure list on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [GPUStack](https://github.com/gpustack/gpustack) - Manage GPU clusters for running LLMs
 - [llama_cpp_canister](https://github.com/onicai/llama_cpp_canister) - llama.cpp as a smart contract on the Internet Computer, using WebAssembly
 - [llama-swap](https://github.com/mostlygeek/llama-swap) - transparent proxy that adds automatic model switching with llama-server
+- [Kalavai](https://github.com/kalavai-net/kalavai-client) - Crowdsource end to end LLM deployment at any scale
 
 </details>
 


### PR DESCRIPTION
Added [Kalavai](https://github.com/kalavai-net/kalavai-client) to the README as an Infrastructure project that utilises llama.cpp

Kalavai uses llama.cpp as one of it's off-the-shelf supported LLM engines.

*Note: I was unsure if a PR is the best way forward for this type of request. Happy to oblige if there's an alternative process to be considered!
