### PR TITLE
Allow s390x to load little endian models unmodified

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1418,8 +1418,9 @@ struct llama_model * common_load_model_from_url(
     int n_split = 0;
     {
         struct gguf_init_params gguf_params = {
-            /*.no_alloc = */ true,
-            /*.ctx      = */ NULL,
+            /*.no_alloc           = */ true,
+            /*.ctx                = */ NULL,
+            /*.allow_byteswapping = */ true,
         };
         auto * ctx_gguf = gguf_init_from_file(local_path.c_str(), gguf_params);
         if (!ctx_gguf) {
@@ -2063,8 +2064,9 @@ static common_control_vector_data common_control_vector_load_one(const common_co
 
     ggml_context * ctx = nullptr;
     struct gguf_init_params meta_gguf_params = {
-        /* .no_alloc = */ false,
-        /* .ctx      = */ &ctx,
+        /* .no_alloc           = */ false,
+        /* .ctx                = */ &ctx,
+        /* .allow_byteswapping = */ true,
     };
     struct gguf_context * ctx_gguf = gguf_init_from_file(load_info.fname.c_str(), meta_gguf_params);
     if (!ctx_gguf) {

--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -533,8 +533,9 @@ static void load_vocab(const char * filename, const Config * config, struct my_l
         struct ggml_context * ctx_data = NULL;
 
         struct gguf_init_params params = {
-            /*.no_alloc = */ false,
-            /*.ctx      = */ &ctx_data,
+            /*.no_alloc           = */ false,
+            /*.ctx                = */ &ctx_data,
+            /*.allow_byteswapping = */ true,
         };
 
         struct gguf_context * ctx = gguf_init_from_file(filename, params);

--- a/examples/export-lora/export-lora.cpp
+++ b/examples/export-lora/export-lora.cpp
@@ -48,8 +48,9 @@ static std::string ggml_ne_string(const ggml_tensor * t) {
 
 static struct gguf_context * load_gguf(std::string & fname, struct ggml_context ** ctx_ggml) {
     struct gguf_init_params params = {
-        /*.no_alloc = */ true,
-        /*.ctx      = */ ctx_ggml,
+        /*.no_alloc           = */ true,
+        /*.ctx                = */ ctx_ggml,
+        /*.allow_byteswapping = */ true,
     };
     struct gguf_context * ctx_gguf = gguf_init_from_file(fname.c_str(), params);
     if (!ctx_gguf) {

--- a/examples/gguf-hash/gguf-hash.cpp
+++ b/examples/gguf-hash/gguf-hash.cpp
@@ -288,8 +288,9 @@ static hash_exit_code_t gguf_hash(const hash_params & hash_params) {
     struct ggml_context * ctx_data = NULL;
 
     struct gguf_init_params params = {
-        /*.no_alloc = */ false,
-        /*.ctx      = */ &ctx_data,
+        /*.no_alloc           = */ false,
+        /*.ctx                = */ &ctx_data,
+        /*.allow_byteswapping = */ true,
     };
 
     // xxh64 init

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -372,8 +372,9 @@ static void gguf_split(const split_params & split_params) {
     struct ggml_context * ctx_meta = NULL;
 
     struct gguf_init_params params = {
-        /*.no_alloc = */ true,
-        /*.ctx      = */ &ctx_meta,
+        /*.no_alloc           = */ true,
+        /*.ctx                = */ &ctx_meta,
+        /*.allow_byteswapping = */ true,
     };
 
     std::ifstream f_input(split_params.input.c_str(), std::ios::binary);
@@ -437,8 +438,9 @@ static void gguf_merge(const split_params & split_params) {
         struct ggml_context * ctx_meta = NULL;
 
         struct gguf_init_params params = {
-            /*.no_alloc = */ true,
-            /*.ctx      = */ &ctx_meta,
+            /*.no_alloc           = */ true,
+            /*.ctx                = */ &ctx_meta,
+            /*.allow_byteswapping = */ true,
         };
 
         if (i_split > 0) {

--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -85,8 +85,9 @@ static bool gguf_ex_write(const std::string & fname) {
 // just read tensor info
 static bool gguf_ex_read_0(const std::string & fname) {
     struct gguf_init_params params = {
-        /*.no_alloc = */ false,
-        /*.ctx      = */ NULL,
+        /*.no_alloc           = */ false,
+        /*.ctx                = */ NULL,
+        /*.allow_byteswapping = */ true,
     };
 
     struct gguf_context * ctx = gguf_init_from_file(fname.c_str(), params);
@@ -151,8 +152,9 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
     struct ggml_context * ctx_data = NULL;
 
     struct gguf_init_params params = {
-        /*.no_alloc = */ false,
-        /*.ctx      = */ &ctx_data,
+        /*.no_alloc           = */ false,
+        /*.ctx                = */ &ctx_data,
+        /*.allow_byteswapping = */ true,
     };
 
     struct gguf_context * ctx = gguf_init_from_file(fname.c_str(), params);

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1122,8 +1122,9 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
     struct ggml_context * meta = NULL;
 
     struct gguf_init_params params = {
-        /*.no_alloc = */ true,
-        /*.ctx      = */ &meta,
+        /*.no_alloc           = */ true,
+        /*.ctx                = */ &meta,
+        /*.allow_byteswapping = */ true,
     };
 
     struct gguf_context * ctx = gguf_init_from_file(fname, params);

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2144,7 +2144,7 @@ extern "C" {
 #endif
     typedef void (*ggml_to_float_t)  (const void  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
     typedef void (*ggml_from_float_t)(const float * GGML_RESTRICT x, void  * GGML_RESTRICT y, int64_t k);
-    typedef void (*ggml_byteswap_t) (        void * GGML_RESTRICT buffer, size_t elements);
+    typedef void (*ggml_byteswap_t)  (      void  * GGML_RESTRICT buffer, size_t elements);
 
     struct ggml_type_traits {
         const char             * type_name;

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2144,6 +2144,7 @@ extern "C" {
 #endif
     typedef void (*ggml_to_float_t)  (const void  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
     typedef void (*ggml_from_float_t)(const float * GGML_RESTRICT x, void  * GGML_RESTRICT y, int64_t k);
+    typedef void (*ggml_byteswap_t) (        void * GGML_RESTRICT buffer, size_t elements);
 
     struct ggml_type_traits {
         const char             * type_name;
@@ -2153,6 +2154,7 @@ extern "C" {
         bool                     is_quantized;
         ggml_to_float_t          to_float;
         ggml_from_float_t        from_float_ref;
+        ggml_byteswap_t          byteswap;
     };
 
     GGML_API const struct ggml_type_traits * ggml_get_type_traits(enum ggml_type type);

--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -74,6 +74,8 @@ extern "C" {
 
         // if not NULL, create a ggml_context and allocate the tensor data in it
         struct ggml_context ** ctx;
+
+        bool allow_byteswapping;
     };
 
     GGML_API struct gguf_context * gguf_init_empty(void);

--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -197,6 +197,9 @@ extern "C" {
     // writes the meta data to pointer "data"
     GGML_API void   gguf_get_meta_data(const struct gguf_context * ctx, void * data);
 
+    // returns true if gguf file needs byteswapping when reading. byteswapping for writing not implemented
+    GGML_API bool gguf_needs_byteswap(const struct gguf_context * ctx);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -46,9 +46,9 @@
 
 // endianness conversion
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define convert_from_le16(x)
-#define convert_from_le32(x)
-#define convert_from_le64(x)
+#define convert_from_le16(x) UNUSED(x)
+#define convert_from_le32(x) UNUSED(x)
+#define convert_from_le64(x) UNUSED(x)
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 static inline void convert_from_le16(void * value) {
     *((uint16_t*)value) = le16toh(*((uint16_t*)value));

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -36,35 +36,6 @@
 #include <syscall.h>
 #endif
 
-#if defined(__gnu_linux__)
-#include <endian.h>
-#else
-#define le64toh(x) (x)
-#define le32toh(x) (x)
-#define le16toh(x) (x)
-#endif
-
-// endianness conversion
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define convert_from_le16(x) UNUSED(x)
-#define convert_from_le32(x) UNUSED(x)
-#define convert_from_le64(x) UNUSED(x)
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-static inline void convert_from_le16(void * value) {
-    *((uint16_t*)value) = le16toh(*((uint16_t*)value));
-}
-
-static inline void convert_from_le32(void * value) {
-    *((uint32_t*)value) = le32toh(*((uint32_t*)value));
-}
-
-static inline void convert_from_le64(void * value) {
-    *((uint64_t*)value) = le64toh(*((uint64_t*)value));
-}
-#else
-#error Unexpected or undefined __BYTE_ORDER__
-#endif
-
 #if defined(__APPLE__)
 #include <unistd.h>
 #include <mach/mach.h>
@@ -6593,113 +6564,113 @@ bool ggml_threadpool_params_match(const struct ggml_threadpool_params * p0, cons
 static void ggml_byteswap_i16(void * restrict buffer, size_t elements) {
     uint16_t *data_ptr = (uint16_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(data_ptr + i);
+        ggml_convert_from_le16(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_i32(void * restrict buffer, size_t elements) {
     uint32_t *data_ptr = (uint32_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le32(data_ptr + i);
+        ggml_convert_from_le32(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_i64(void * restrict buffer, size_t elements) {
     uint64_t *data_ptr = (uint64_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le64(data_ptr + i);
+        ggml_convert_from_le64(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_q4_0(void * restrict buffer, size_t elements) {
     block_q4_0 *data_ptr = (block_q4_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q4_1(void * restrict buffer, size_t elements) {
     block_q4_1 *data_ptr = (block_q4_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].m));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].m));
     }
 }
 
 static void ggml_byteswap_q5_0(void * restrict buffer, size_t elements) {
     block_q5_0 *data_ptr = (block_q5_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q5_1(void * restrict buffer, size_t elements) {
     block_q5_1 *data_ptr = (block_q5_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].m));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].m));
     }
 }
 
 static void ggml_byteswap_q8_0(void * restrict buffer, size_t elements) {
     block_q8_0 *data_ptr = (block_q8_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q8_1(void * restrict buffer, size_t elements) {
     block_q8_1 *data_ptr = (block_q8_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].s));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].s));
     }
 }
 
 static void ggml_byteswap_q2_k(void * restrict buffer, size_t elements) {
     block_q2_K *data_ptr = (block_q2_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].dmin));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q3_k(void * restrict buffer, size_t elements) {
     block_q3_K *data_ptr = (block_q3_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q4_k(void * restrict buffer, size_t elements) {
     block_q4_K *data_ptr = (block_q4_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].dmin));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q5_k(void * restrict buffer, size_t elements) {
     block_q5_K *data_ptr = (block_q5_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].dmin));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q6_k(void * restrict buffer, size_t elements) {
     block_q6_K *data_ptr = (block_q6_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq2_xxs(void * restrict buffer, size_t elements) {
     block_iq2_xxs *data_ptr = (block_iq2_xxs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/8; ++j) {
-            convert_from_le16(&(data_ptr[i].qs[j]));
+            ggml_convert_from_le16(&(data_ptr[i].qs[j]));
         }
     }
 }
@@ -6707,9 +6678,9 @@ static void ggml_byteswap_iq2_xxs(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq2_xs(void * restrict buffer, size_t elements) {
     block_iq2_xs *data_ptr = (block_iq2_xs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/8; ++j) {
-            convert_from_le16(&(data_ptr[i].qs[j]));
+            ggml_convert_from_le16(&(data_ptr[i].qs[j]));
         }
     }
 }
@@ -6717,30 +6688,30 @@ static void ggml_byteswap_iq2_xs(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq3_xxs(void * restrict buffer, size_t elements) {
     block_iq3_xxs *data_ptr = (block_iq3_xxs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq3_s(void * restrict buffer, size_t elements) {
     block_iq3_s *data_ptr = (block_iq3_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq2_s(void * restrict buffer, size_t elements) {
     block_iq2_s *data_ptr = (block_iq2_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq1_s(void * restrict buffer, size_t elements) {
     block_iq1_s *data_ptr = (block_iq1_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/32; ++j) {
-            convert_from_le16(&(data_ptr[i].qh[j]));
+            ggml_convert_from_le16(&(data_ptr[i].qh[j]));
         }
     }
 }
@@ -6748,24 +6719,24 @@ static void ggml_byteswap_iq1_s(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq4_nl(void * restrict buffer, size_t elements) {
     block_iq4_nl *data_ptr = (block_iq4_nl*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq4_xs(void * restrict buffer, size_t elements) {
     block_iq4_xs *data_ptr = (block_iq4_xs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
-        convert_from_le16(&(data_ptr[i].scales_h));
+        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].scales_h));
     }
 }
 
 static void ggml_byteswap_q8_k(void * restrict buffer, size_t elements) {
     block_q8_K *data_ptr = (block_q8_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le32(&(data_ptr[i].d));
+        ggml_convert_from_le32(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/16; ++j) {
-            convert_from_le16(&(data_ptr[i].bsums[j]));
+            ggml_convert_from_le16(&(data_ptr[i].bsums[j]));
         }
     }
 }
@@ -6791,13 +6762,13 @@ static void ggml_byteswap_q4_0_8x8(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_tq1_0(void * restrict buffer, size_t elements) {
     block_tq1_0 *data_ptr = (block_tq1_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_tq2_0(void * restrict buffer, size_t elements) {
     block_tq2_0 *data_ptr = (block_tq2_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        convert_from_le16(&(data_ptr[i].d));
+        ggml_convert_from_le16(&(data_ptr[i].d));
     }
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6742,19 +6742,19 @@ static void ggml_byteswap_q8_k(void * restrict buffer, size_t elements) {
 }
 
 static void ggml_byteswap_q4_0_4x4(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
+    GGML_ASSERT(false && "function ggml_byteswap_q4_0_4x4 is not implemented yet");
     UNUSED(buffer);
     UNUSED(elements);
 }
 
 static void ggml_byteswap_q4_0_4x8(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
+    GGML_ASSERT(false && "function ggml_byteswap_q4_0_4x8 is not implemented yet");
     UNUSED(buffer);
     UNUSED(elements);
 }
 
 static void ggml_byteswap_q4_0_8x8(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
+    GGML_ASSERT(false && "function ggml_byteswap_q4_0_8x8 is not implemented yet");
     UNUSED(buffer);
     UNUSED(elements);
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -51,24 +51,15 @@
 #define convert_from_le64(x)
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 static inline void convert_from_le16(void * value) {
-    uint16_t temp;
-    memcpy(&temp, value, sizeof(uint16_t));
-    temp = le16toh(temp);
-    memcpy(value, &temp, sizeof(uint16_t));
+    *((uint16_t*)value) = le16toh(*((uint16_t*)value));
 }
 
 static inline void convert_from_le32(void * value) {
-    uint32_t temp;
-    memcpy(&temp, value, sizeof(uint32_t));
-    temp = le32toh(temp);
-    memcpy(value, &temp, sizeof(uint32_t));
+    *((uint32_t*)value) = le32toh(*((uint32_t*)value));
 }
 
 static inline void convert_from_le64(void * value) {
-    uint64_t temp;
-    memcpy(&temp, value, sizeof(uint64_t));
-    temp = le64toh(temp);
-    memcpy(value, &temp, sizeof(uint64_t));
+    *((uint64_t*)value) = le64toh(*((uint64_t*)value));
 }
 #else
 #error Unexpected or undefined __BYTE_ORDER__

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6564,113 +6564,113 @@ bool ggml_threadpool_params_match(const struct ggml_threadpool_params * p0, cons
 static void ggml_byteswap_i16(void * restrict buffer, size_t elements) {
     uint16_t *data_ptr = (uint16_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(data_ptr + i);
+        ggml_bswap16(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_i32(void * restrict buffer, size_t elements) {
     uint32_t *data_ptr = (uint32_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le32(data_ptr + i);
+        ggml_bswap32(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_i64(void * restrict buffer, size_t elements) {
     uint64_t *data_ptr = (uint64_t*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le64(data_ptr + i);
+        ggml_bswap64(data_ptr + i);
     }
 }
 
 static void ggml_byteswap_q4_0(void * restrict buffer, size_t elements) {
     block_q4_0 *data_ptr = (block_q4_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q4_1(void * restrict buffer, size_t elements) {
     block_q4_1 *data_ptr = (block_q4_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].m));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].m));
     }
 }
 
 static void ggml_byteswap_q5_0(void * restrict buffer, size_t elements) {
     block_q5_0 *data_ptr = (block_q5_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q5_1(void * restrict buffer, size_t elements) {
     block_q5_1 *data_ptr = (block_q5_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].m));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].m));
     }
 }
 
 static void ggml_byteswap_q8_0(void * restrict buffer, size_t elements) {
     block_q8_0 *data_ptr = (block_q8_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q8_1(void * restrict buffer, size_t elements) {
     block_q8_1 *data_ptr = (block_q8_1*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].s));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].s));
     }
 }
 
 static void ggml_byteswap_q2_k(void * restrict buffer, size_t elements) {
     block_q2_K *data_ptr = (block_q2_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].dmin));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q3_k(void * restrict buffer, size_t elements) {
     block_q3_K *data_ptr = (block_q3_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_q4_k(void * restrict buffer, size_t elements) {
     block_q4_K *data_ptr = (block_q4_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].dmin));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q5_k(void * restrict buffer, size_t elements) {
     block_q5_K *data_ptr = (block_q5_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].dmin));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].dmin));
     }
 }
 
 static void ggml_byteswap_q6_k(void * restrict buffer, size_t elements) {
     block_q6_K *data_ptr = (block_q6_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq2_xxs(void * restrict buffer, size_t elements) {
     block_iq2_xxs *data_ptr = (block_iq2_xxs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/8; ++j) {
-            ggml_convert_from_le16(&(data_ptr[i].qs[j]));
+            ggml_bswap16(&(data_ptr[i].qs[j]));
         }
     }
 }
@@ -6678,9 +6678,9 @@ static void ggml_byteswap_iq2_xxs(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq2_xs(void * restrict buffer, size_t elements) {
     block_iq2_xs *data_ptr = (block_iq2_xs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/8; ++j) {
-            ggml_convert_from_le16(&(data_ptr[i].qs[j]));
+            ggml_bswap16(&(data_ptr[i].qs[j]));
         }
     }
 }
@@ -6688,30 +6688,30 @@ static void ggml_byteswap_iq2_xs(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq3_xxs(void * restrict buffer, size_t elements) {
     block_iq3_xxs *data_ptr = (block_iq3_xxs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq3_s(void * restrict buffer, size_t elements) {
     block_iq3_s *data_ptr = (block_iq3_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq2_s(void * restrict buffer, size_t elements) {
     block_iq2_s *data_ptr = (block_iq2_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq1_s(void * restrict buffer, size_t elements) {
     block_iq1_s *data_ptr = (block_iq1_s*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/32; ++j) {
-            ggml_convert_from_le16(&(data_ptr[i].qh[j]));
+            ggml_bswap16(&(data_ptr[i].qh[j]));
         }
     }
 }
@@ -6719,24 +6719,24 @@ static void ggml_byteswap_iq1_s(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_iq4_nl(void * restrict buffer, size_t elements) {
     block_iq4_nl *data_ptr = (block_iq4_nl*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_iq4_xs(void * restrict buffer, size_t elements) {
     block_iq4_xs *data_ptr = (block_iq4_xs*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
-        ggml_convert_from_le16(&(data_ptr[i].scales_h));
+        ggml_bswap16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].scales_h));
     }
 }
 
 static void ggml_byteswap_q8_k(void * restrict buffer, size_t elements) {
     block_q8_K *data_ptr = (block_q8_K*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le32(&(data_ptr[i].d));
+        ggml_bswap32(&(data_ptr[i].d));
         for (size_t j = 0; j < QK_K/16; ++j) {
-            ggml_convert_from_le16(&(data_ptr[i].bsums[j]));
+            ggml_bswap16(&(data_ptr[i].bsums[j]));
         }
     }
 }
@@ -6762,13 +6762,13 @@ static void ggml_byteswap_q4_0_8x8(void * restrict buffer, size_t elements) {
 static void ggml_byteswap_tq1_0(void * restrict buffer, size_t elements) {
     block_tq1_0 *data_ptr = (block_tq1_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }
 
 static void ggml_byteswap_tq2_0(void * restrict buffer, size_t elements) {
     block_tq2_0 *data_ptr = (block_tq2_0*) buffer;
     for (size_t i = 0; i < elements; ++i) {
-        ggml_convert_from_le16(&(data_ptr[i].d));
+        ggml_bswap16(&(data_ptr[i].d));
     }
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -625,6 +625,8 @@ static void ggml_byteswap_q8_k    (void * restrict buffer, size_t elements);
 static void ggml_byteswap_q4_0_4x4(void * restrict buffer, size_t elements);
 static void ggml_byteswap_q4_0_4x8(void * restrict buffer, size_t elements);
 static void ggml_byteswap_q4_0_8x8(void * restrict buffer, size_t elements);
+static void ggml_byteswap_tq1_0   (void * restrict buffer, size_t elements);
+static void ggml_byteswap_tq2_0   (void * restrict buffer, size_t elements);
 
 static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
     [GGML_TYPE_I8] = {
@@ -911,6 +913,7 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .is_quantized             = true,
         .to_float                 = (ggml_to_float_t) dequantize_row_tq1_0,
         .from_float_ref           = (ggml_from_float_t) quantize_row_tq1_0_ref,
+        .byteswap                 = ggml_byteswap_tq1_0,
     },
     [GGML_TYPE_TQ2_0] = {
         .type_name                = "tq2_0",
@@ -919,6 +922,7 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .is_quantized             = true,
         .to_float                 = (ggml_to_float_t) dequantize_row_tq2_0,
         .from_float_ref           = (ggml_from_float_t) quantize_row_tq2_0_ref,
+        .byteswap                 = ggml_byteswap_tq2_0,
     },
     [36] = { // GGML_TYPE_IQ4_NL_4_4
         .type_name                = "TYPE_IQ4_NL_4_4 REMOVED, use IQ4_NL with runtime repacking",
@@ -6791,4 +6795,18 @@ static void ggml_byteswap_q4_0_8x8(void * restrict buffer, size_t elements) {
     GGML_ASSERT(false && "byteswap function not implemented yet");
     UNUSED(buffer);
     UNUSED(elements);
+}
+
+static void ggml_byteswap_tq1_0(void * restrict buffer, size_t elements) {
+    block_tq1_0 *data_ptr = (block_tq1_0*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
+}
+
+static void ggml_byteswap_tq2_0(void * restrict buffer, size_t elements) {
+    block_tq2_0 *data_ptr = (block_tq2_0*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -619,7 +619,6 @@ static void ggml_byteswap_iq3_xxs (void * restrict buffer, size_t elements);
 static void ggml_byteswap_iq3_s   (void * restrict buffer, size_t elements);
 static void ggml_byteswap_iq2_s   (void * restrict buffer, size_t elements);
 static void ggml_byteswap_iq1_s   (void * restrict buffer, size_t elements);
-static void ggml_byteswap_iq1_m   (void * restrict buffer, size_t elements);
 static void ggml_byteswap_iq4_nl  (void * restrict buffer, size_t elements);
 static void ggml_byteswap_iq4_xs  (void * restrict buffer, size_t elements);
 static void ggml_byteswap_q8_k    (void * restrict buffer, size_t elements);
@@ -849,7 +848,6 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .is_quantized             = true,
         .to_float                 = (ggml_to_float_t) dequantize_row_iq1_m,
         .from_float_ref           = NULL,
-        .byteswap                 = ggml_byteswap_iq1_m,
     },
     [GGML_TYPE_IQ4_NL] = {
         .type_name                = "iq4_nl",
@@ -6619,51 +6617,63 @@ static void ggml_byteswap_i64(void * restrict buffer, size_t elements) {
 }
 
 static void ggml_byteswap_q4_0(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q4_0 *data_ptr = (block_q4_0*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_q4_1(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q4_1 *data_ptr = (block_q4_1*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].m));
+    }
 }
 
 static void ggml_byteswap_q5_0(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q5_0 *data_ptr = (block_q5_0*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_q5_1(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q5_1 *data_ptr = (block_q5_1*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].m));
+    }
 }
 
 static void ggml_byteswap_q8_0(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q8_0 *data_ptr = (block_q8_0*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_q8_1(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q8_1 *data_ptr = (block_q8_1*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].s));
+    }
 }
 
 static void ggml_byteswap_q2_k(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q2_K *data_ptr = (block_q2_K*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].dmin));
+    }
 }
 
 static void ggml_byteswap_q3_k(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q3_K *data_ptr = (block_q3_K*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_q4_k(void * restrict buffer, size_t elements) {
@@ -6675,9 +6685,11 @@ static void ggml_byteswap_q4_k(void * restrict buffer, size_t elements) {
 }
 
 static void ggml_byteswap_q5_k(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q5_K *data_ptr = (block_q5_K*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].dmin));
+    }
 }
 
 static void ggml_byteswap_q6_k(void * restrict buffer, size_t elements) {
@@ -6688,63 +6700,79 @@ static void ggml_byteswap_q6_k(void * restrict buffer, size_t elements) {
 }
 
 static void ggml_byteswap_iq2_xxs(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq2_xxs *data_ptr = (block_iq2_xxs*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        for (size_t j = 0; j < QK_K/8; ++j) {
+            convert_from_le16(&(data_ptr[i].qs[j]));
+        }
+    }
 }
 
 static void ggml_byteswap_iq2_xs(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq2_xs *data_ptr = (block_iq2_xs*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        for (size_t j = 0; j < QK_K/8; ++j) {
+            convert_from_le16(&(data_ptr[i].qs[j]));
+        }
+    }
 }
 
 static void ggml_byteswap_iq3_xxs(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq3_xxs *data_ptr = (block_iq3_xxs*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_iq3_s(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq3_s *data_ptr = (block_iq3_s*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_iq2_s(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq2_s *data_ptr = (block_iq2_s*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_iq1_s(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
-}
-
-static void ggml_byteswap_iq1_m(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq1_s *data_ptr = (block_iq1_s*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        for (size_t j = 0; j < QK_K/32; ++j) {
+            convert_from_le16(&(data_ptr[i].qh[j]));
+        }
+    }
 }
 
 static void ggml_byteswap_iq4_nl(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq4_nl *data_ptr = (block_iq4_nl*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+    }
 }
 
 static void ggml_byteswap_iq4_xs(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_iq4_xs *data_ptr = (block_iq4_xs*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le16(&(data_ptr[i].d));
+        convert_from_le16(&(data_ptr[i].scales_h));
+    }
 }
 
 static void ggml_byteswap_q8_k(void * restrict buffer, size_t elements) {
-    GGML_ASSERT(false && "byteswap function not implemented yet");
-    UNUSED(buffer);
-    UNUSED(elements);
+    block_q8_K *data_ptr = (block_q8_K*) buffer;
+    for (size_t i = 0; i < elements; ++i) {
+        convert_from_le32(&(data_ptr[i].d));
+        for (size_t j = 0; j < QK_K/16; ++j) {
+            convert_from_le16(&(data_ptr[i].bsums[j]));
+        }
+    }
 }
 
 static void ggml_byteswap_q4_0_4x4(void * restrict buffer, size_t elements) {

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -353,7 +353,7 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
     int64_t n_tensors = 0;
 
     if (ok && gr.read(ctx->version)) {
-        if (((ctx->version & 0x0000FFFF) == 0) && ((ctx->version & 0xFFFF0000) != 0)) {
+        if ((params.allow_byteswapping) && ((ctx->version & 0x0000FFFF) == 0) && ((ctx->version & 0xFFFF0000) != 0)) {
             // most likely different endianness, do byteswapping
             gr.do_byteswap = true;
             ctx->needs_byteswap = true;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -25,7 +25,7 @@
 
 // endianness conversion
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define convert_from_le(x)
+#define convert_from_le(x) (void)(x)
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #include <type_traits>
 

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -36,26 +36,17 @@ static inline void convert_from_le(T * /*value*/)
 
 template <typename T, std::enable_if_t<sizeof(T) == 2, int> = 0>
 static inline void convert_from_le(T * value) {
-    uint16_t temp;
-    memcpy(&temp, value, sizeof(uint16_t));
-    temp = le16toh(temp);
-    memcpy(value, &temp, sizeof(uint16_t));
+    *((uint16_t*)value) = le16toh(*((uint16_t*)value));
 }
 
 template <typename T, std::enable_if_t<sizeof(T) == 4, int> = 0>
 static inline void convert_from_le(T * value) {
-    uint32_t temp;
-    memcpy(&temp, value, sizeof(uint32_t));
-    temp = le32toh(temp);
-    memcpy(value, &temp, sizeof(uint32_t));
+    *((uint32_t*)value) = le32toh(*((uint32_t*)value));
 }
 
 template <typename T, std::enable_if_t<sizeof(T) == 8, int> = 0>
 static inline void convert_from_le(T * value) {
-    uint64_t temp;
-    memcpy(&temp, value, sizeof(uint64_t));
-    temp = le64toh(temp);
-    memcpy(value, &temp, sizeof(uint64_t));
+    *((uint64_t*)value) = le64toh(*((uint64_t*)value));
 }
 #else
 #error Unexpected or undefined __BYTE_ORDER__

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -15,43 +15,6 @@
 #include <string>
 #include <vector>
 
-#if defined(__gnu_linux__)
-#include <endian.h>
-#else
-#define le64toh(x) (x)
-#define le32toh(x) (x)
-#define le16toh(x) (x)
-#endif
-
-// endianness conversion
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define convert_from_le(x) (void)(x)
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#include <type_traits>
-
-template <typename T, std::enable_if_t<sizeof(T) == 1, int> = 0>
-static inline void convert_from_le(T * /*value*/)
-{
-}
-
-template <typename T, std::enable_if_t<sizeof(T) == 2, int> = 0>
-static inline void convert_from_le(T * value) {
-    *((uint16_t*)value) = le16toh(*((uint16_t*)value));
-}
-
-template <typename T, std::enable_if_t<sizeof(T) == 4, int> = 0>
-static inline void convert_from_le(T * value) {
-    *((uint32_t*)value) = le32toh(*((uint32_t*)value));
-}
-
-template <typename T, std::enable_if_t<sizeof(T) == 8, int> = 0>
-static inline void convert_from_le(T * value) {
-    *((uint64_t*)value) = le64toh(*((uint64_t*)value));
-}
-#else
-#error Unexpected or undefined __BYTE_ORDER__
-#endif
-
 template <typename T>
 struct type_to_gguf_type;
 
@@ -261,7 +224,7 @@ struct gguf_reader {
     template <typename T>
     bool read(T & dst) const {
         auto res = fread(&dst, 1, sizeof(dst), file);
-        convert_from_le(&dst);
+        ggml_convert_from_le(&dst);
         return res == sizeof(dst);
     }
 

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -15,6 +15,52 @@
 #include <string>
 #include <vector>
 
+#if defined(__gnu_linux__)
+#include <endian.h>
+#else
+#define le64toh(x) (x)
+#define le32toh(x) (x)
+#define le16toh(x) (x)
+#endif
+
+// endianness conversion
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define convert_from_le(x)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#include <type_traits>
+
+template <typename T, std::enable_if_t<sizeof(T) == 1, int> = 0>
+static inline void convert_from_le(T * /*value*/)
+{
+}
+
+template <typename T, std::enable_if_t<sizeof(T) == 2, int> = 0>
+static inline void convert_from_le(T * value) {
+    uint16_t temp;
+    memcpy(&temp, value, sizeof(uint16_t));
+    temp = le16toh(temp);
+    memcpy(value, &temp, sizeof(uint16_t));
+}
+
+template <typename T, std::enable_if_t<sizeof(T) == 4, int> = 0>
+static inline void convert_from_le(T * value) {
+    uint32_t temp;
+    memcpy(&temp, value, sizeof(uint32_t));
+    temp = le32toh(temp);
+    memcpy(value, &temp, sizeof(uint32_t));
+}
+
+template <typename T, std::enable_if_t<sizeof(T) == 8, int> = 0>
+static inline void convert_from_le(T * value) {
+    uint64_t temp;
+    memcpy(&temp, value, sizeof(uint64_t));
+    temp = le64toh(temp);
+    memcpy(value, &temp, sizeof(uint64_t));
+}
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
+
 template <typename T>
 struct type_to_gguf_type;
 
@@ -223,7 +269,9 @@ struct gguf_reader {
 
     template <typename T>
     bool read(T & dst) const {
-        return fread(&dst, 1, sizeof(dst), file) == sizeof(dst);
+        auto res = fread(&dst, 1, sizeof(dst), file);
+        convert_from_le(&dst);
+        return res == sizeof(dst);
     }
 
     template <typename T>

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import struct
+import sys
 import tempfile
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -451,6 +452,12 @@ class GGUFWriter:
                 for ti in tensors.values():
                     assert ti.tensor is not None  # can only iterate once over the tensors
                     assert ti.tensor.nbytes == ti.nbytes
+
+                    if (self.endianess == GGUFEndian.BIG and sys.byteorder == 'little') or \
+                       (self.endianess == GGUFEndian.LITTLE and sys.byteorder == 'big'):
+                        # ti.tensor.byteswap(inplace=True) just didn't work here
+                        ti.tensor = ti.tensor.byteswap()
+
                     ti.tensor.tofile(fout)
                     if shard_bar is not None:
                         shard_bar.update(ti.nbytes)

--- a/src/llama-adapter.cpp
+++ b/src/llama-adapter.cpp
@@ -151,8 +151,9 @@ static void llama_adapter_lora_init_impl(struct llama_model & model, const char 
 
     ggml_context * ctx_init;
     struct gguf_init_params meta_gguf_params = {
-        /* .no_alloc = */ true,
-        /* .ctx      = */ &ctx_init,
+        /* .no_alloc           = */ true,
+        /* .ctx                = */ &ctx_init,
+        /* .allow_byteswapping = */ true,
     };
 
     gguf_context_ptr ctx_gguf { gguf_init_from_file(path_lora, meta_gguf_params) };

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -460,8 +460,9 @@ llama_model_loader::llama_model_loader(
     // Load the main GGUF
     struct ggml_context * ctx = NULL;
     struct gguf_init_params params = {
-        /*.no_alloc = */ true,
-        /*.ctx      = */ &ctx,
+        /*.no_alloc           = */ true,
+        /*.ctx                = */ &ctx,
+        /*.allow_byteswapping = */ true,
     };
 
     meta.reset(gguf_init_from_file(fname.c_str(), params));
@@ -520,8 +521,9 @@ llama_model_loader::llama_model_loader(
             const char * fname_split = splits[idx].c_str();
 
             struct gguf_init_params split_params = {
-                /*.no_alloc = */ true,
-                /*.ctx      = */ &ctx,
+                /*.no_alloc           = */ true,
+                /*.ctx                = */ &ctx,
+                /*.allow_byteswapping = */ true,
             };
             gguf_context_ptr ctx_gguf { gguf_init_from_file(fname_split, split_params) };
             if (!ctx_gguf) {

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1030,7 +1030,7 @@ bool llama_model_loader::load_all_data(
                 if (byteswap != nullptr) {
                     byteswap(cur->data, ggml_nelements(cur) / ggml_blck_size(cur->type));
                 }
-#endif
+#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
                 if (check_tensors) {
                     validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
@@ -1066,7 +1066,7 @@ bool llama_model_loader::load_all_data(
                     if (byteswap != nullptr) {
                         byteswap(read_buf.data(), read_buf.size() / ggml_blck_size(cur->type));
                     }
-#endif
+#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
                     ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
                     if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -679,6 +679,9 @@ llama_model_loader::llama_model_loader(
     if (!llama_mmap::SUPPORTED) {
         LLAMA_LOG_WARN("%s: mmap is not supported on this platform\n", __func__);
         use_mmap = false;
+    } else if (gguf_needs_byteswap(meta.get())) {
+        LLAMA_LOG_WARN("%s: gguf file needs byteswapping, mmap is disabled. This may impact performance.\n", __func__);
+        use_mmap = false;
     }
 
     this->use_mmap = use_mmap;
@@ -869,6 +872,13 @@ void llama_model_loader::load_data_for(struct ggml_tensor * cur) const {
         const auto & file = files.at(w.idx);
         file->seek(w.offs, SEEK_SET);
         file->read_raw(cur->data, ggml_nbytes(cur));
+
+        if (gguf_needs_byteswap(meta.get())) {
+            auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
+            if (byteswap != nullptr) {
+                byteswap(cur->data, ggml_nelements(cur) / ggml_blck_size(cur->type));
+            }
+        }
     }
 
     if (check_tensors && !ggml_validate_row_data(cur->type, cur->data, ggml_nbytes(cur))) {
@@ -1025,12 +1035,12 @@ bool llama_model_loader::load_all_data(
                 file->seek(weight->offs, SEEK_SET);
                 file->read_raw(cur->data, n_size);
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-                auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
-                if (byteswap != nullptr) {
-                    byteswap(cur->data, ggml_nelements(cur) / ggml_blck_size(cur->type));
+                if (gguf_needs_byteswap(meta.get())) {
+                    auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
+                    if (byteswap != nullptr) {
+                        byteswap(cur->data, ggml_nelements(cur) / ggml_blck_size(cur->type));
+                    }
                 }
-#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
                 if (check_tensors) {
                     validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
@@ -1044,11 +1054,22 @@ bool llama_model_loader::load_all_data(
 
                     size_t bytes_read = 0;
 
+                    // for byteswapping purposes ensure that there is whole number of elements in buffer
+                    const size_t buf_size_aligned = gguf_needs_byteswap(meta.get()) ? buffer_size - (buffer_size % ggml_blck_size(cur->type)) : buffer_size;
+
                     while (bytes_read < n_size) {
-                        size_t read_iteration = std::min<size_t>(buffer_size, n_size - bytes_read);
+                        size_t read_iteration = std::min<size_t>(buf_size_aligned, n_size - bytes_read);
 
                         ggml_backend_event_synchronize(events[buffer_idx]);
                         file->read_raw(host_ptrs[buffer_idx], read_iteration);
+
+                        if (gguf_needs_byteswap(meta.get())) {
+                            auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
+                            if (byteswap != nullptr) {
+                                byteswap(host_ptrs[buffer_idx], read_iteration / ggml_blck_size(cur->type));
+                            }
+                        }
+
                         ggml_backend_tensor_set_async(upload_backend, cur, host_ptrs[buffer_idx], bytes_read, read_iteration);
                         ggml_backend_event_record(events[buffer_idx], upload_backend);
 
@@ -1061,12 +1082,12 @@ bool llama_model_loader::load_all_data(
                     file->seek(weight->offs, SEEK_SET);
                     file->read_raw(read_buf.data(), n_size);
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-                    auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
-                    if (byteswap != nullptr) {
-                        byteswap(read_buf.data(), read_buf.size() / ggml_blck_size(cur->type));
+                    if (gguf_needs_byteswap(meta.get())) {
+                        auto byteswap = ggml_get_type_traits(cur->type)->byteswap;
+                        if (byteswap != nullptr) {
+                            byteswap(read_buf.data(), read_buf.size() / ggml_blck_size(cur->type));
+                        }
                     }
-#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
                     ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
                     if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -15,6 +15,10 @@ struct unicode_cpt_flags {
         SYMBOL          = 0x0040,  // regex: \p{S}
         CONTROL         = 0x0080,  // regex: \p{C}
         MASK_CATEGORIES = 0x00FF,
+        WHITESPACE      = 0x0100,
+        LOWERCASE       = 0x0200,
+        UPPERCASE       = 0x0400,
+        NFD             = 0x0800,
     };
 
     // codepoint type
@@ -34,11 +38,49 @@ struct unicode_cpt_flags {
 
     // decode from uint16
     inline unicode_cpt_flags(const uint16_t flags = 0) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
         *reinterpret_cast<uint16_t*>(this) = flags;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        is_undefined   = (flags & UNDEFINED)   ? 1 : 0;
+        is_number      = (flags & NUMBER)      ? 1 : 0;
+        is_letter      = (flags & LETTER)      ? 1 : 0;
+        is_separator   = (flags & SEPARATOR)   ? 1 : 0;
+        is_accent_mark = (flags & ACCENT_MARK) ? 1 : 0;
+        is_punctuation = (flags & PUNCTUATION) ? 1 : 0;
+        is_symbol      = (flags & SYMBOL)      ? 1 : 0;
+        is_control     = (flags & CONTROL)     ? 1 : 0;
+        is_whitespace  = (flags & WHITESPACE)  ? 1 : 0;
+        is_lowercase   = (flags & LOWERCASE)   ? 1 : 0;
+        is_uppercase   = (flags & UPPERCASE)   ? 1 : 0;
+        is_nfd         = (flags & NFD)         ? 1 : 0;
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
     }
 
     inline uint16_t as_uint() const {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
         return *reinterpret_cast<const uint16_t*>(this);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        uint16_t result =
+              is_undefined   * UNDEFINED
+            + is_number      * NUMBER
+            + is_letter      * LETTER
+            + is_separator   * SEPARATOR
+            + is_accent_mark * ACCENT_MARK
+            + is_punctuation * PUNCTUATION
+            + is_symbol      * SYMBOL
+            + is_control     * CONTROL
+            + is_whitespace  * WHITESPACE
+            + is_lowercase   * LOWERCASE
+            + is_uppercase   * UPPERCASE
+            + is_nfd         * NFD
+            ;
+
+        return result;
+#else
+#error Unexpected or undefined __BYTE_ORDER__
+#endif
     }
 
     inline uint16_t category_flag() const {

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -53,9 +53,9 @@ struct unicode_cpt_flags {
         is_lowercase   = (flags & LOWERCASE)   ? 1 : 0;
         is_uppercase   = (flags & UPPERCASE)   ? 1 : 0;
         is_nfd         = (flags & NFD)         ? 1 : 0;
-#else
+#else // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #error Unexpected or undefined __BYTE_ORDER__
-#endif
+#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     }
 
     inline uint16_t as_uint() const {
@@ -78,9 +78,9 @@ struct unicode_cpt_flags {
             ;
 
         return result;
-#else
+#else // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #error Unexpected or undefined __BYTE_ORDER__
-#endif
+#endif // __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     }
 
     inline uint16_t category_flag() const {

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -707,8 +707,9 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
 
         struct ggml_context * ctx = nullptr;
         struct gguf_init_params gguf_params = {
-            /*no_alloc =*/ false,
-            /*ctx      =*/ hft >= offset_has_data ? &ctx : nullptr,
+            /*no_alloc           =*/ false,
+            /*ctx                =*/ hft >= offset_has_data ? &ctx : nullptr,
+            /*allow_byteswapping =*/ true,
         };
 
         struct gguf_context * gguf_ctx = gguf_init_from_file_impl(file, gguf_params);
@@ -1103,8 +1104,9 @@ static std::pair<int, int> test_roundtrip(ggml_backend_dev_t dev, const unsigned
 
     struct ggml_context * ctx_1 = nullptr;
     struct gguf_init_params gguf_params = {
-        /*no_alloc =*/ false,
-        /*ctx      =*/ only_meta ? nullptr : &ctx_1,
+        /*no_alloc           =*/ false,
+        /*ctx                =*/ only_meta ? nullptr : &ctx_1,
+        /*allow_byteswapping =*/ true,
     };
     struct gguf_context * gguf_ctx_1 = gguf_init_from_file_impl(file, gguf_params);
 


### PR DESCRIPTION
Allow loading little endian models on big endian systems.
This would allow using any models downloaded via ollama unmodified.