### PR TITLE
SYCL: Introducing memory host pool

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -352,14 +352,12 @@ struct ggml_backend_sycl_context {
 
     ggml_sycl_pool & host_pool(int device) {
         if (host_pools[device] == nullptr) {
-            host_pools[device] = new_pool_for_host(stream(device,0), device);
+            host_pools[device] = new_pool_for_host(stream(device, 0), device);
         }
         return *host_pools[device];
     }
 
-    ggml_sycl_pool & host_pool() {
-        return host_pool(device);
-    }
+    ggml_sycl_pool & host_pool() { return host_pool(device); }
 };
 
 // common device functions

--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -333,7 +333,11 @@ struct ggml_backend_sycl_context {
     // pool
     std::unique_ptr<ggml_sycl_pool> pools[GGML_SYCL_MAX_DEVICES];
 
+    std::unique_ptr<ggml_sycl_pool> host_pools[GGML_SYCL_MAX_DEVICES];
+
     static std::unique_ptr<ggml_sycl_pool> new_pool_for_device(queue_ptr qptr, int device);
+
+    static std::unique_ptr<ggml_sycl_pool> new_pool_for_host(queue_ptr qptr, int device);
 
     ggml_sycl_pool & pool(int device) {
         if (pools[device] == nullptr) {
@@ -344,6 +348,17 @@ struct ggml_backend_sycl_context {
 
     ggml_sycl_pool & pool() {
         return pool(device);
+    }
+
+    ggml_sycl_pool & host_pool(int device) {
+        if (host_pools[device] == nullptr) {
+            host_pools[device] = new_pool_for_host(stream(device,0), device);
+        }
+        return *host_pools[device];
+    }
+
+    ggml_sycl_pool & host_pool() {
+        return host_pool(device);
     }
 };
 

--- a/ggml/src/ggml-sycl/dpct/helper.hpp
+++ b/ggml/src/ggml-sycl/dpct/helper.hpp
@@ -82,14 +82,12 @@ inline std::string get_device_backend_and_type(const sycl::device &device) {
     return device_type.str();
 }
 
-template<typename Ts>
-struct matrix_info_t
-{
+template <typename Ts> struct matrix_info_t {
     oneapi::mkl::transpose transpose_info[2];
-    Ts value_info[2];
-    std::int64_t size_info[3];
-    std::int64_t ld_info[3];
-    std::int64_t groupsize_info;
+    Ts                     value_info[2];
+    std::int64_t           size_info[3];
+    std::int64_t           ld_info[3];
+    std::int64_t           groupsize_info;
 };
 
 namespace dpct
@@ -1737,13 +1735,10 @@ namespace dpct
         };
 
         template <class Ta, class Tb, class Tc, class Ts>
-        inline void gemm_batch_impl(sycl::queue &q, oneapi::mkl::transpose a_trans,
-                                    oneapi::mkl::transpose b_trans, int m, int n, int k,
-                                    const void *alpha, const void **a, int lda,
-                                    const void **b, int ldb, const void *beta, void **c,
-                                    int ldc, int batch_size, matrix_info_t<float>* matrix_info)
-        {
-
+        inline void gemm_batch_impl(sycl::queue & q, oneapi::mkl::transpose a_trans, oneapi::mkl::transpose b_trans,
+                                    int m, int n, int k, const void * alpha, const void ** a, int lda, const void ** b,
+                                    int ldb, const void * beta, void ** c, int ldc, int batch_size,
+                                    matrix_info_t<float> * matrix_info) {
             Ts alpha_value = dpct::get_value(reinterpret_cast<const Ts *>(alpha), q);
             Ts beta_value = dpct::get_value(reinterpret_cast<const Ts *>(beta), q);
 
@@ -1763,19 +1758,18 @@ namespace dpct
             sycl::event e = oneapi::mkl::blas::column_major::gemm_batch(
                 oneapi::mkl::backend_selector<oneapi::mkl::backend::cublas>{ q }, matrix_info->transpose_info,
                 matrix_info->transpose_info + 1, matrix_info->size_info, matrix_info->size_info + 1,
-                matrix_info->size_info + 2, reinterpret_cast<Ts*>(matrix_info->value_info), reinterpret_cast<const Ta **>(a),
-                matrix_info->ld_info, reinterpret_cast<const Tb **>(b), matrix_info->ld_info + 1,
-                reinterpret_cast<Ts*>(matrix_info->value_info+1), reinterpret_cast<Tc **>(c), matrix_info->ld_info + 2, 1,
-                &(matrix_info->groupsize_info));
+                matrix_info->size_info + 2, reinterpret_cast<Ts *>(matrix_info->value_info),
+                reinterpret_cast<const Ta **>(a), matrix_info->ld_info, reinterpret_cast<const Tb **>(b),
+                matrix_info->ld_info + 1, reinterpret_cast<Ts *>(matrix_info->value_info + 1),
+                reinterpret_cast<Tc **>(c), matrix_info->ld_info + 2, 1, &(matrix_info->groupsize_info));
 #else
             sycl::event e = oneapi::mkl::blas::column_major::gemm_batch(
                 q, matrix_info->transpose_info, matrix_info->transpose_info + 1, matrix_info->size_info,
-                matrix_info->size_info + 1, matrix_info->size_info + 2, reinterpret_cast<Ts*>(matrix_info->value_info),
+                matrix_info->size_info + 1, matrix_info->size_info + 2, reinterpret_cast<Ts *>(matrix_info->value_info),
                 reinterpret_cast<const Ta **>(a), matrix_info->ld_info, reinterpret_cast<const Tb **>(b),
-                matrix_info->ld_info + 1, reinterpret_cast<Ts*>(matrix_info->value_info + 1), reinterpret_cast<Tc **>(c),
-                matrix_info->ld_info + 2, 1, &(matrix_info->groupsize_info));
+                matrix_info->ld_info + 1, reinterpret_cast<Ts *>(matrix_info->value_info + 1),
+                reinterpret_cast<Tc **>(c), matrix_info->ld_info + 2, 1, &(matrix_info->groupsize_info));
 #endif
-
         }
 
         template <class Ta, class Tb, class Tc, class Ts>
@@ -2418,15 +2412,11 @@ namespace dpct
     /// \param [in] ldc Leading dimension of C.
     /// \param [in] batch_size Specifies the number of matrix multiply operations to perform.
     /// \param [in] scaling_type Data type of the scaling factors.
-    inline void gemm_batch(sycl::queue &q, oneapi::mkl::transpose a_trans,
-                           oneapi::mkl::transpose b_trans, int m, int n, int k,
-                           const void *alpha, const void *a[],
-                           library_data_t a_type, int lda, const void *b[],
-                           library_data_t b_type, int ldb, const void *beta,
-                           void *c[], library_data_t c_type, int ldc,
-                           int batch_size, library_data_t scaling_type,
-                           matrix_info_t<float>* matrix_info)
-    {
+    inline void gemm_batch(sycl::queue & q, oneapi::mkl::transpose a_trans, oneapi::mkl::transpose b_trans, int m,
+                           int n, int k, const void * alpha, const void * a[], library_data_t a_type, int lda,
+                           const void * b[], library_data_t b_type, int ldb, const void * beta, void * c[],
+                           library_data_t c_type, int ldc, int batch_size, library_data_t scaling_type,
+                           matrix_info_t<float> * matrix_info) {
         std::uint64_t key =
             detail::get_type_combination_id(a_type, b_type, c_type, scaling_type);
         switch (key)
@@ -2435,28 +2425,24 @@ namespace dpct
             library_data_t::real_float, library_data_t::real_float,
             library_data_t::real_float, library_data_t::real_float):
         {
-            detail::gemm_batch_impl<float, float, float, float>(
-                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
-                batch_size, matrix_info);
+            detail::gemm_batch_impl<float, float, float, float>(q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb,
+                                                                beta, c, ldc, batch_size, matrix_info);
             break;
         }
         case detail::get_type_combination_id(
             library_data_t::real_double, library_data_t::real_double,
             library_data_t::real_double, library_data_t::real_double):
         {
-            detail::gemm_batch_impl<double, double, double, double>(
-                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
-                batch_size, matrix_info);
+            detail::gemm_batch_impl<double, double, double, double>(q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb,
+                                                                    beta, c, ldc, batch_size, matrix_info);
             break;
         }
         case detail::get_type_combination_id(
             library_data_t::real_half, library_data_t::real_half,
             library_data_t::real_half, library_data_t::real_half):
         {
-            detail::gemm_batch_impl<sycl::half, sycl::half, sycl::half,
-                                    sycl::half>(q, a_trans, b_trans, m, n, k, alpha,
-                                                a, lda, b, ldb, beta, c, ldc,
-                                                batch_size, matrix_info);
+            detail::gemm_batch_impl<sycl::half, sycl::half, sycl::half, sycl::half>(
+                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_size, matrix_info);
             break;
         }
 #ifdef __INTEL_MKL__
@@ -2464,19 +2450,16 @@ namespace dpct
             library_data_t::real_bfloat16, library_data_t::real_bfloat16,
             library_data_t::real_bfloat16, library_data_t::real_float):
         {
-            detail::gemm_batch_impl<oneapi::mkl::bfloat16, oneapi::mkl::bfloat16,
-                                    oneapi::mkl::bfloat16, float>(
-                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
-                batch_size, matrix_info);
+            detail::gemm_batch_impl<oneapi::mkl::bfloat16, oneapi::mkl::bfloat16, oneapi::mkl::bfloat16, float>(
+                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_size, matrix_info);
             break;
         }
         case detail::get_type_combination_id(
             library_data_t::real_bfloat16, library_data_t::real_bfloat16,
             library_data_t::real_float, library_data_t::real_float):
         {
-            detail::gemm_batch_impl<oneapi::mkl::bfloat16, oneapi::mkl::bfloat16, float,
-                                    float>(q, a_trans, b_trans, m, n, k, alpha, a, lda,
-                                           b, ldb, beta, c, ldc, batch_size, matrix_info);
+            detail::gemm_batch_impl<oneapi::mkl::bfloat16, oneapi::mkl::bfloat16, float, float>(
+                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_size, matrix_info);
             break;
         }
 #endif
@@ -2488,10 +2471,9 @@ namespace dpct
                 dpct::get_value(reinterpret_cast<const std::int32_t *>(alpha), q);
             float beta_float =
                 dpct::get_value(reinterpret_cast<const std::int32_t *>(beta), q);
-            detail::gemm_batch_impl<std::int8_t, std::int8_t, std::int32_t,
-                                    float>(q, a_trans, b_trans, m, n, k, &alpha_float,
-                                           a, lda, b, ldb, &beta_float, c, ldc,
-                                           batch_size, matrix_info);
+            detail::gemm_batch_impl<std::int8_t, std::int8_t, std::int32_t, float>(
+                q, a_trans, b_trans, m, n, k, &alpha_float, a, lda, b, ldb, &beta_float, c, ldc, batch_size,
+                matrix_info);
             break;
         }
         case detail::get_type_combination_id(
@@ -2499,8 +2481,7 @@ namespace dpct
             library_data_t::real_float, library_data_t::real_float):
         {
             detail::gemm_batch_impl<std::int8_t, std::int8_t, float, float>(
-                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
-                batch_size, matrix_info);
+                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_size, matrix_info);
             break;
         }
         case detail::get_type_combination_id(
@@ -2508,8 +2489,7 @@ namespace dpct
             library_data_t::real_float, library_data_t::real_float):
         {
             detail::gemm_batch_impl<sycl::half, sycl::half, float, float>(
-                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
-                batch_size, matrix_info);
+                q, a_trans, b_trans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_size, matrix_info);
             break;
         }
         case detail::get_type_combination_id(
@@ -2523,8 +2503,7 @@ namespace dpct
             sycl::half alpha_half(alpha_value);
             sycl::half beta_half(beta_value);
             detail::gemm_batch_impl<sycl::half, sycl::half, sycl::half, sycl::half>(
-                q, a_trans, b_trans, m, n, k, &alpha_half, a, lda, b, ldb, &beta_half, c, ldc,
-                batch_size, matrix_info);
+                q, a_trans, b_trans, m, n, k, &alpha_half, a, lda, b, ldb, &beta_half, c, ldc, batch_size, matrix_info);
             break;
         }
         default:

--- a/ggml/src/ggml-sycl/dpct/helper.hpp
+++ b/ggml/src/ggml-sycl/dpct/helper.hpp
@@ -18,15 +18,8 @@
 #include <syclcompat/math.hpp>
 #include <oneapi/mkl.hpp>
 #include <map>
-#include <cassert>
 
-#include "ggml-sycl.h"
 #include "ggml.h"
-
-#include "ggml-backend.h"
-#include "ggml-backend-impl.h"
-#include "ggml-alloc.h"
-#include "ggml-impl.h"
 
 #if defined(__linux__)
 #include <sys/mman.h>

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -37,7 +37,6 @@
 #include "ggml-backend-impl.h"
 
 #include "ggml-sycl/backend.hpp"
-#include "ggml-sycl/dpct/helper.hpp"
 #include "ggml-sycl/presets.hpp"
 #include "ggml-sycl/gemm.hpp"
 
@@ -3486,7 +3485,7 @@ static void ggml_sycl_mul_mat_batched_sycl(ggml_backend_sycl_context & ctx,
             (const void **)(ptrs_src.get() + 1 * ne23),
             dpct::library_data_t::real_half, nb11 / nb10, beta,
             (void **)(ptrs_dst.get() + 0 * ne23), cu_data_type, ne01, ne23,
-            cu_compute_type, (matrix_info_t<float>*)matrix_info.get())));
+            cu_compute_type, matrix_info.get())));
     }
 }
 catch (sycl::exception const &exc) {

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1207,7 +1207,6 @@ struct ggml_sycl_pool_host : public ggml_sycl_pool {
     void * alloc(size_t size, size_t * actual_size) override {
         if (counter == MAX_POOL_SIZE) {
             ggml_sycl_buffer b               = buffer_pool[0];
-            size_t           look_ahead_size = (size_t) (1.05 * size);
             void *           ptr             = b.ptr;
             *actual_size                     = b.size;
             counter                          = 1;

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1226,7 +1226,7 @@ struct ggml_sycl_pool_host : public ggml_sycl_pool {
             *actual_size = size;
             counter      = counter + 1;
             return ptr;
-        } else if (b.ptr != nullptr) {
+        } else {
             ++counter;
             b.size = size;
             return b.ptr;

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1175,8 +1175,8 @@ struct ggml_sycl_pool_leg : public ggml_sycl_pool {
 
 struct ggml_sycl_pool_host : public ggml_sycl_pool {
 
-    int device;
     queue_ptr qptr;
+    int device;
 
     inline static int counter{0};
     struct ggml_sycl_buffer {
@@ -1189,10 +1189,7 @@ struct ggml_sycl_pool_host : public ggml_sycl_pool {
     std::vector<ggml_sycl_buffer> buffer_pool = std::vector<ggml_sycl_buffer>(MAX_POOL_SIZE);
     size_t pool_size = 0;
 
-    explicit ggml_sycl_pool_host(queue_ptr qptr_, int device_) :
-        qptr(qptr_),
-        device(device_) {
-    }
+    explicit ggml_sycl_pool_host(queue_ptr qptr_, int device_) : qptr(qptr_), device(device_) {}
 
     ~ggml_sycl_pool_host() {
         for (int i = 0; i < MAX_POOL_SIZE; ++i) {


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
 - Self-reported review complexity:
     - [x] Low
     - [ ] Medium
     - [ ] High

This patch adds a host memory pool dedicated to `matrix_info_t`. This struct is used when calling `gemm_batch_impl` and right now forces an `host_task` synchronization to free memory. After this patch it is not necessary anymore. The pool ensures that the memory will be usable long enough to call the kernel and it will be freed at the end of the program. 

Pool's design is naive and right now usable only with above reported type, further improvement are possible but not necessary at the moment.

Full test pass on A100 and Intel PVC.
Benchmark results for NVIDIA:

### FP32
**Current**

| model                          |       size |     params | backend    | ngl | threads |    sm | mmap |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | ----: | ---: | ------------: | -------------------: |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        759.05 ± 4.70 |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         89.10 ± 0.16 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |         72.93 ± 0.31 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         18.17 ± 0.02 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        743.26 ± 1.85 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         91.47 ± 0.07 |

build: a29f0870 (4473)

**This patch**


| model                          |       size |     params | backend    | ngl | threads |    sm | mmap |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | ----: | ---: | ------------: | -------------------: |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        969.44 ± 7.14 |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         89.98 ± 0.18 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        104.87 ± 0.21 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         18.27 ± 0.01 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        957.31 ± 2.29 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         92.51 ± 0.05 |

build: e878c29a (4476)

### FP16

**Current**


| model                          |       size |     params | backend    | ngl | threads |    sm | mmap |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | ----: | ---: | ------------: | -------------------: |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |      5557.98 ± 18.23 |
| llama 8B Q8_0                  |   7.95 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         88.98 ± 0.19 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |        694.68 ± 1.90 |
| llama 70B Q4_K - Small         |  37.57 GiB |    70.55 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         18.15 ± 0.02 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         pp512 |      5375.49 ± 23.61 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | SYCL       |  99 |       8 |  none |    0 |         tg128 |         91.56 ± 0.06 |

build: a29f0870 (4473)

**This patch**


| model                  |      size |  params | backend | ngl | threads |   sm | mmap |  test |             t/s |
| ---------------------- | --------: | ------: | ------- | --: | ------: | ---: | ---: | ----: | --------------: |
| llama 8B Q8_0          |  7.95 GiB |  8.03 B | SYCL    |  99 |       8 | none |    0 | pp512 | 5606.51 ± 79.11 |
| llama 8B Q8_0          |  7.95 GiB |  8.03 B | SYCL    |  99 |       8 | none |    0 | tg128 |    87.32 ± 6.34 |
| llama 70B Q4_K - Small | 37.57 GiB | 70.55 B | SYCL    |  99 |       8 | none |    0 | pp512 |   707.81 ± 3.43 |
| llama 70B Q4_K - Small | 37.57 GiB | 70.55 B | SYCL    |  99 |       8 | none |    0 | tg128 |    18.35 ± 0.06 |
| llama 8B Q4_K - Medium |  4.58 GiB |  8.03 B | SYCL    |  99 |       8 | none |    0 | pp512 | 5404.64 ± 16.42 |
| llama 8B Q4_K - Medium |  4.58 GiB |  8.03 B | SYCL    |  99 |       8 | none |    0 | tg128 |    92.62 ± 0.07 |

build: e878c29a (4476)

