### PR TITLE
llama: fix deprecation message: vocabable -> vocab

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -961,7 +961,7 @@ extern "C" {
     LLAMA_API llama_token llama_vocab_fim_rep(const struct llama_vocab * vocab);
     LLAMA_API llama_token llama_vocab_fim_sep(const struct llama_vocab * vocab);
 
-    DEPRECATED(LLAMA_API const char * llama_token_get_text(const struct llama_vocab * vocab, llama_token token), "use llama_vocabable_get_text instead");
+    DEPRECATED(LLAMA_API const char * llama_token_get_text(const struct llama_vocab * vocab, llama_token token), "use llama_vocab_get_text instead");
     DEPRECATED(LLAMA_API float llama_token_get_score(const struct llama_vocab * vocab, llama_token token), "use llama_vocab_get_score instead");
     DEPRECATED(LLAMA_API enum llama_token_attr llama_token_get_attr(const struct llama_vocab * vocab, llama_token token), "use llama_vocab_get_attr instead");
     DEPRECATED(LLAMA_API bool llama_token_is_eog(const struct llama_vocab * vocab, llama_token token), "use llama_vocab_is_eog instead");


### PR DESCRIPTION
Fixes a mispelled deprecation message that was added in afa8a9ec9b520137bbd1ca6838cda93ee39baf20.

The message is supposed to refer to https://github.com/ggerganov/llama.cpp/blob/7a689c415e2aecea1a5ae438542afeaf69815d52/include/llama.h#L934