### PR TITLE
fix: Use Q8_0 for all embedding quantizations for granite and granitemoe

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -155,7 +155,7 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
             const int64_t nx = tensor->ne[0];
             const int64_t qk_k = ggml_blck_size(new_type);
 
-            if (arch == LLM_ARCH_FALCON || nx % qk_k != 0) {
+            if (arch == LLM_ARCH_FALCON || arch == LLM_ARCH_GRANITE || arch == LLM_ARCH_GRANITE_MOE || nx % qk_k != 0) {
                 new_type = GGML_TYPE_Q8_0;
             }
             else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS ||
@@ -171,7 +171,10 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
         if (qs.params->token_embedding_type < GGML_TYPE_COUNT) {
             new_type = qs.params->token_embedding_type;
         } else {
-            if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS ||
+            if (arch == LLM_ARCH_GRANITE || arch == LLM_ARCH_GRANITE_MOE) {
+                new_type = GGML_TYPE_Q8_0;
+            }
+            else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS ||
                 ftype == LLAMA_FTYPE_MOSTLY_IQ1_S   || ftype == LLAMA_FTYPE_MOSTLY_IQ1_M) {
                 new_type = GGML_TYPE_Q2_K;
             }


### PR DESCRIPTION
## Description

At lower precision levels, the models can manifest numerical instability, especially with batch size > 1. This shows up as nondeterministic stopping when index 0 (the EOG token) has a seemingly uninitialized large value in the logits.

**NOTE**: The same behavior can be achieved by adding `--token-embedding-type Q8_0` to `llama-quantize`. The goal of this PR is to avoid needing to document this for all users that are performing their own quantization of the Granite models.

## Changes

* Add checks in `llama-quant.cpp` to always use `GGML_TYPE_Q8_0` for token embeddings.
    * The checks are in both the clause for tied embeddings and non-tied embeddings since this is a configurable parameter for these architectures

## Testing

This issue came up around the published Ollama models for `granite3.1-dense` and `granite3.1-moe`. The instability (early stopping) arose only when running multiple requests in parallel that resulted in a batch with size > 1. I used the script below to repro against both Ollama and the native `llama-server`:

<details>
<summary>parallel_repro.py</summary>

```py
#!/usr/bin/env python

import argparse
import concurrent.futures
import requests
from functools import partial


prompts = [
    "Hello world! Tell me about yourself",
    "Tell me a story about a developer and their dog",
    "Write a poem about the beauty of nature",
    "Write an email to your future self",
    "Tell me about your dreams and aspirations",
    "Write a letter to your parents",
    "Write a short story about a detective solving a murder case",
    "Write a script for a short film",
    "Write a blog post about the importance of mental health",
    "Write an essay about the history of technology",
]

def do_chat_ollama(args, prompt):
    body = {
        "model": args.model,
        "stream": False,
        "messages": [
            {
                "role": "user",
                "content": prompt,
            },
        ],
        "options": {
            "temperature": 0,
            "num_predict": args.max_t
            # "num_gpu": 39,
            # "cache_prompt": not no_cache,
        },
    }
    response = requests.post(f"{args.base_url}/api/chat", json=body)
    output = None
    done_reason = None
    if response.status_code == 200:
        j = response.json()
        output = j["message"]["content"]
        done_reason = j["done_reason"]
    else:
        print("ERROR")
        print(response.text)
    return (prompt, {"response": output, "done_reason": done_reason})


def do_chat_llamacpp(args, prompt):
    body = {
        "model": args.model,
        "stream": False,
        "messages": [
            {
                "role": "user",
                "content": prompt,
            },
        ],
        "temperature": 0,
        "max_tokens": args.max_tokens,
    }
    response = requests.post(f"{args.base_url}/v1/chat/completions", json=body)
    output = None
    done_reason = None
    if response.status_code == 200:
        j = response.json()
        output = j["choices"][0]["message"]["content"]
        done_reason = j["choices"][0]["finish_reason"]
    else:
        print("ERROR")
        print(response.text)
    return (prompt, {"response": output, "done_reason": done_reason})


def do_generate_ollama(args, prompt):
    body = {
        "model": args.model,
        "stream": False,
        "prompt": prompt,
        "options": {
            "temperature": 0,
            # "cache_prompt": not args.no_cache,
            "num_predict": args.max_tokens,
        },
    }
    response = requests.post(f"{args.base_url}/api/generate", json=body)
    output = None
    done_reason = None
    if response.status_code == 200:
        j = response.json()
        output = j["response"]
        done_reason = j["done_reason"]
    else:
        print("ERROR")
        print(response.text)
    return (prompt, {"response": output, "done_reason": done_reason})


def do_generate_llamacpp(args, prompt):
    body = {
        "model": args.model,
        "stream": False,
        "prompt": prompt,
        "temperature": 0,
        "max_tokens": args.max_tokens,
    }
    response = requests.post(f"{args.base_url}/v1/completions", json=body)
    output = None
    done_reason = None
    if response.status_code == 200:
        j = response.json()
        output = j["choices"][0]["text"]
        done_reason = j["choices"][0]["finish_reason"]
    else:
        print("ERROR")
        print(response.text)
    return (prompt, {"response": output, "done_reason": done_reason})

if __name__ == "__main__":

    parser = argparse.ArgumentParser()
    parser.add_argument("-j", "--num-threads", type=int, default=4, help="Number of concurrent threads")
    parser.add_argument("-M", "--mode", choices=["generate", "chat"], default="chat", help="Run as raw generation or chat")
    parser.add_argument("-n", "--num-prompts", type=int, default=len(prompts), help="Number of prompts to send")
    parser.add_argument("-u", "--base-url", default="http://localhost:11434", help="Base URL of the server")
    parser.add_argument("-m", "--model", default="granite3.1-dense", help="The Ollama model to run")
    parser.add_argument("-c", "--no-cache", action="store_true", help="Run with no caching")
    parser.add_argument("-s", "--server-type", choices=["ollama", "llama.cpp"], default="ollama", help="Which type of server to test against")
    parser.add_argument("-x", "--max-tokens", type=int, default=100, help="Max tokens to generate")
    args = parser.parse_args()

    if args.server_type == "ollama":
        mode_fn = do_chat_ollama if args.mode == "chat" else do_generate_ollama
    else:
        mode_fn = do_chat_llamacpp if args.mode == "chat" else do_generate_llamacpp
    doit = partial(mode_fn, args)

    with concurrent.futures.ThreadPoolExecutor(max_workers=args.num_threads) as executor:
        results = dict(executor.map(doit, prompts[:args.num_prompts]))

    for prompt, response in sorted(results.items()):
        print("------------------------")
        print("PROMPT")
        print(prompt)
        print()
        print("RESPONSE")
        print(response["response"])
        print()
        print("DONE REASON")
        print(response["done_reason"])
        print()

```
</details>

Using this script, I did the following:

```sh
# (Terminal 1) Run the model with `llama-server`
./build/bin/llama-server --model ggml-model-Q4_K_M.gguf --parallel 4 --batch-size 512 --port 8081

# (Terminal 2) Run the parallel script with -j 1 to verify expected outputs
python parallel_repro.py -u http://localhost:8081 -j 1 -n 3 -s llama.cpp -x 300

# (Terminal 2) Run the parallel script with -j 3 to check for truncated responses
python parallel_repro.py -u http://localhost:8081 -j 3 -n 3 -s llama.cpp -x 300
```

Using this, I was able to verify that without this fix, and using standard `llama-quantize <path/to/f16.gguf> Q4_K_M` reproduced the early stopping. Without this fix, but with `--token-embedding-type Q8_0`, the results were no longer truncated. With this fix, I no longer needed to add the special conversion argument.

While investigating, I tested this against a large number of out-of-the-box quantizations from Ollama ([here](https://ollama.com/library/granite3-dense/tags)) across both `granite` and `granitemoe`. I found that for both `granite` and `granitemoe`, the early stopping occurs across all quantizations below `Q8_0`. With this fix, I validated that early stopping is gone for both `granite` and `granitemoe` at `Q4_K_M`.