### PR TITLE
Removed const references for simple types and structures less 16 bytes

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -376,7 +376,7 @@ static std::vector<ggml_backend_dev_t> parse_device_list(const std::string & val
     return devices;
 }
 
-static void add_rpc_devices(std::string servers) {
+static void add_rpc_devices(const std::string & servers) {
     auto rpc_servers = string_split<std::string>(servers, ',');
     if (rpc_servers.empty()) {
         throw std::invalid_argument("no RPC servers specified");

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -1153,7 +1153,7 @@ struct gguf_writer {
         buf.insert(buf.end(), val.begin(), val.end());
     }
 
-    void write(const bool & val) const {
+    void write(const bool val) const {
         const int8_t val8 = val ? 1 : 0;
         write(val8);
     }
@@ -1172,11 +1172,11 @@ struct gguf_writer {
         write(std::string(val));
     }
 
-    void write(const enum ggml_type & val) const {
+    void write(const enum ggml_type val) const {
         write(int32_t(val));
     }
 
-    void write(const enum gguf_type & val) const {
+    void write(const enum gguf_type val) const {
         write(int32_t(val));
     }
 


### PR DESCRIPTION
As a minor improvement, `std::string` is made as param by constant reference, and `probs_iterator tmp` has become constant iterator.

In general, passing simple types and objects less than 16 bytes by reference makes optimization worse by modern compiler because it strictly follows rules programmer. I don't know if this will affect -O2 and even more so -O3.

Reference: https://stackoverflow.com/a/3314034

