### PR TITLE
fix: llama-mmap: add include for cerrno; fixes issue #11295

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <climits>
 #include <stdexcept>
+#include <cerrno>
 
 #ifdef __has_include
     #if __has_include(<unistd.h>)


### PR DESCRIPTION
Use of `errno` in `src/llama-mmap.cpp`, causes build failures on some systems. That's because an include for `<cerrno>` is missing.

This PR addresses that.

See: #11295