### PR TITLE
cmake: fix shell command quoting in build-info script

### DIFF
--- a/cmake/build-info.cmake
+++ b/cmake/build-info.cmake
@@ -44,7 +44,7 @@ if(MSVC)
     set(BUILD_TARGET ${CMAKE_VS_PLATFORM_NAME})
 else()
     execute_process(
-        COMMAND sh -c "$@ --version | head -1" _ ${CMAKE_C_COMPILER}
+        COMMAND sh -c "\"$@\" --version | head -1" _ ${CMAKE_C_COMPILER}
         OUTPUT_VARIABLE OUT
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
A way to fix the warning that appears when building build-info on Windows (for example [here](https://github.com/ggerganov/llama.cpp/actions/runs/12863075407/job/35859025694#step:8:29) in CI). Fixed result is [here](https://github.com/Xarbirus/llama.cpp/actions/runs/12865447172/job/35866005595#step:8:28).