### PR TITLE
cmake: refined conditions for math library linking on windows

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -322,7 +322,7 @@ target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
 find_library(MATH_LIBRARY m)
 if (MATH_LIBRARY)
-    if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
+    if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC" OR DEFINED ENV{ONEAPI_ROOT}))
         target_link_libraries(ggml-base PRIVATE m)
     endif()
 endif()


### PR DESCRIPTION
I encountered some problems when building llama.cpp on windows (for x64 and arm64) on a system where **MSVC** (with **clang**) and **mingw** are installed at the same time.

It seems to me that the condition for adding MATH_LIBRARY to the build is not quite correct. MATH_LIBRARY should not be added if
- **Intel oneAPI** is already used (since these libraries include optimized math libraries and tools)
- or the **MSVC** compiler is used

An important addition - in case **clang** is used in the **MSVC** pipeline, we should not add the library (condition `CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"` was added for this). At the same time, when building with **mingw**, the library can be added.

I think this would also be a solution to [this](https://github.com/ggerganov/llama.cpp/issues/9908) issue (if it hadn't closed).