### PR TITLE
cpu_pnp_strategy changes

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -565,6 +565,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
+       { "-CPnP", "--cpu-pnp-strategy" }, "N",
+        string_format("set CPU PnP strategy : 0-disabled, 1-efficiency (default: %d)\n", params.cpuparams.cpu_pnp_strategy),
+        [](common_params& params, int strategy) {
+           if (strategy < 0 || strategy > 1) {
+                throw std::invalid_argument("invalid value");
+            }
+            params.cpuparams.cpu_pnp_strategy = (enum ggml_cpu_pnp_strategy)strategy;
+        }
+    ));
+    add_opt(common_arg(
+       { "-CPnPb", "--cpu-pnp-strategy-batch" }, "N",
+        string_format("set CPU PnP strategy batch  : 0-disabled, 1-efficiency (default: %d)\n", params.cpuparams.cpu_pnp_strategy),
+        [](common_params& params, int strategy) {
+           if (strategy < 0 || strategy > 1) {
+                throw std::invalid_argument("invalid value");
+            }
+            params.cpuparams_batch.cpu_pnp_strategy = (enum ggml_cpu_pnp_strategy)strategy;
+        }
+    ));
+    add_opt(common_arg(
         {"--poll"}, "<0...100>",
         string_format("use polling level to wait for work (0 - no polling, default: %u)\n", (unsigned) params.cpuparams.poll),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <bitset>
 
 #ifdef _WIN32
 #define DIRECTORY_SEPARATOR '\\'
@@ -45,11 +46,22 @@ struct common_control_vector_load_info;
 // CPU utils
 //
 
+struct cpu_info {
+    bool is_hybrid  =  false;
+    int num_logical_cores = 0;
+    int num_physical_cores = 0;
+    int num_p_cores = 0;
+    int num_e_cores = 0;
+    std::bitset<GGML_MAX_N_THREADS> e_core_affinity_mask;
+    std::bitset<GGML_MAX_N_THREADS> p_core_affinity_mask;
+};
+
 struct cpu_params {
     int      n_threads                   = -1;
     bool     cpumask[GGML_MAX_N_THREADS] = {false}; // CPU affinity mask.
     bool     mask_valid                  = false;   // Default: any CPU
     enum ggml_sched_priority  priority   = GGML_SCHED_PRIO_NORMAL;  // Scheduling prio : (0 - normal, 1 - medium, 2 - high, 3 - realtime)
+    enum ggml_cpu_pnp_strategy cpu_pnp_strategy = GGML_CPU_PNP_STRATEGY_DISABLED; // CPU power and performance strategy
     bool     strict_cpu                  = false;   // Use strict CPU placement
     uint32_t poll                        = 50;      // Polling (busywait) level (0 - no polling, 100 - mostly polling)
 };

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2169,6 +2169,11 @@ extern "C" {
         GGML_SCHED_PRIO_REALTIME
     };
 
+    enum ggml_cpu_pnp_strategy {
+        GGML_CPU_PNP_STRATEGY_DISABLED,
+        GGML_CPU_PNP_STRATEGY_EFFICIENCY
+    };
+
     // threadpool params
     // Use ggml_threadpool_params_default() or ggml_threadpool_params_init() to populate the defaults
     struct ggml_threadpool_params {


### PR DESCRIPTION
This change is to provide ability to specify CPU power and performance strategy. Based on strategy core mask is calculated automatically and affinity is applied to target specific cores. Right now, only efficiency strategy is enabled, which target e-cores on hybrid CPU.