### PR TITLE
server : add more clean up when cancel_tasks is called

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1428,6 +1428,10 @@ struct server_queue {
         } else {
             queue_tasks.push_back(std::move(task));
         }
+        // if this is cancel task make sure to clean up pending tasks
+        if (task.type == SERVER_TASK_TYPE_CANCEL) {
+            cleanup_pending_task(task.id_target);
+        }
         condition_tasks.notify_one();
         return task.id;
     }
@@ -1444,6 +1448,10 @@ struct server_queue {
                 queue_tasks.push_front(std::move(task));
             } else {
                 queue_tasks.push_back(std::move(task));
+            }
+            // if this is cancel task make sure to clean up pending tasks
+            if (task.type == SERVER_TASK_TYPE_CANCEL) {
+                cleanup_pending_task(task.id_target);
             }
         }
         condition_tasks.notify_one();
@@ -1539,6 +1547,23 @@ struct server_queue {
             }
         }
     }
+
+private:
+    void cleanup_pending_task(int id_task) {
+        // no need lock because this is called exclusively by post()
+        for (size_t i = 0; i < queue_tasks.size(); i++) {
+            if (queue_tasks[i].id == id_task) {
+                queue_tasks.erase(queue_tasks.begin() + i);
+                break;
+            }
+        }
+        for (size_t i = 0; i < queue_tasks_deferred.size(); i++) {
+            if (queue_tasks_deferred[i].id == id_task) {
+                queue_tasks_deferred.erase(queue_tasks_deferred.begin() + i);
+                break;
+            }
+        }
+    }
 };
 
 struct server_response {
@@ -1574,6 +1599,13 @@ struct server_response {
 
         std::unique_lock<std::mutex> lock(mutex_results);
         waiting_task_ids.erase(id_task);
+        // make sure to clean up all pending results
+        for (size_t i = 0; i < queue_results.size(); i++) {
+            if (queue_results[i]->id == id_task) {
+                queue_results.erase(queue_results.begin() + i);
+                i--;
+            }
+        }
     }
 
     void remove_waiting_task_ids(const std::unordered_set<int> & id_tasks) {
@@ -1593,7 +1625,7 @@ struct server_response {
                 return !queue_results.empty();
             });
 
-            for (int i = 0; i < (int) queue_results.size(); i++) {
+            for (size_t i = 0; i < queue_results.size(); i++) {
                 if (id_tasks.find(queue_results[i]->id) != id_tasks.end()) {
                     server_task_result_ptr res = std::move(queue_results[i]);
                     queue_results.erase(queue_results.begin() + i);
@@ -1610,10 +1642,8 @@ struct server_response {
     server_task_result_ptr recv_with_timeout(const std::unordered_set<int> & id_tasks, int timeout) {
         while (true) {
             std::unique_lock<std::mutex> lock(mutex_results);
-            bool cr_res = condition_results.wait_for(lock, std::chrono::seconds(timeout), [&]{
-                return !queue_results.empty();
-            });
-            if (!cr_res) {
+            std::cv_status cr_res = condition_results.wait_for(lock, std::chrono::seconds(timeout));
+            if (cr_res == std::cv_status::timeout) {
                 return nullptr;
             }
 
@@ -2368,8 +2398,8 @@ struct server_context {
 
             server_task task(SERVER_TASK_TYPE_CANCEL);
             task.id_target = id_task;
-            cancel_tasks.push_back(task);
             queue_results.remove_waiting_task_id(id_task);
+            cancel_tasks.push_back(task);
         }
         // push to beginning of the queue, so it has highest priority
         queue_tasks.post(cancel_tasks, true);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1642,10 +1642,6 @@ struct server_response {
     server_task_result_ptr recv_with_timeout(const std::unordered_set<int> & id_tasks, int timeout) {
         while (true) {
             std::unique_lock<std::mutex> lock(mutex_results);
-            std::cv_status cr_res = condition_results.wait_for(lock, std::chrono::seconds(timeout));
-            if (cr_res == std::cv_status::timeout) {
-                return nullptr;
-            }
 
             for (int i = 0; i < (int) queue_results.size(); i++) {
                 if (id_tasks.find(queue_results[i]->id) != id_tasks.end()) {
@@ -1653,6 +1649,11 @@ struct server_response {
                     queue_results.erase(queue_results.begin() + i);
                     return res;
                 }
+            }
+
+            std::cv_status cr_res = condition_results.wait_for(lock, std::chrono::seconds(timeout));
+            if (cr_res == std::cv_status::timeout) {
+                return nullptr;
             }
         }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1554,8 +1554,12 @@ private:
         auto rm_func = [id_task](const server_task & task) {
             return task.id_target == id_task;
         };
-        std::remove_if(queue_tasks.begin(),          queue_tasks.end(),          rm_func);
-        std::remove_if(queue_tasks_deferred.begin(), queue_tasks_deferred.end(), rm_func);
+        queue_tasks.erase(
+            std::remove_if(queue_tasks.begin(),          queue_tasks.end(),          rm_func),
+            queue_tasks.end());
+        queue_tasks_deferred.erase(
+            std::remove_if(queue_tasks_deferred.begin(), queue_tasks_deferred.end(), rm_func),
+            queue_tasks_deferred.end());
     }
 };
 
@@ -1593,13 +1597,11 @@ struct server_response {
         std::unique_lock<std::mutex> lock(mutex_results);
         waiting_task_ids.erase(id_task);
         // make sure to clean up all pending results
-        std::remove_if(
-            queue_results.begin(),
-            queue_results.end(),
-            [id_task](const server_task_result_ptr & res) {
+        queue_results.erase(
+            std::remove_if(queue_results.begin(), queue_results.end(), [id_task](const server_task_result_ptr & res) {
                 return res->id == id_task;
-            }
-        );
+            }),
+            queue_results.end());
     }
 
     void remove_waiting_task_ids(const std::unordered_set<int> & id_tasks) {


### PR DESCRIPTION
This PR fixes an edge case where multiple requests are sent to the server at once, get queued and not yet processed, but `cancel_tasks` fail to clean them up.

Also fix a small issue with `condition_results.wait_for`, where it returns the value of `pred()` instead of timeout state (aka `std::cv_status::timeout`). See the docs [here](https://en.cppreference.com/w/cpp/thread/condition_variable/wait_for).
