### PR TITLE
Adding logprobs to /v1/completions

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -267,6 +267,11 @@ struct server_task {
         params.speculative.n_min = std::max(params.speculative.n_min, 2);
         params.speculative.n_max = std::max(params.speculative.n_max, 0);
 
+        // Use OpenAI API logprobs only if n_probs wasn't provided
+        if (data.contains("logprobs") && params.sampling.n_probs == defaults.sampling.n_probs){
+            params.sampling.n_probs = json_value(data, "logprobs", defaults.sampling.n_probs);
+        }
+
         if (data.contains("lora")) {
             if (data.at("lora").is_array()) {
                 params.lora = parse_lora_request(params_base.lora_adapters, data.at("lora"));


### PR DESCRIPTION
The `/v1/completions` endpoint of the server doesn't respect the `logprobs` argument when called.
The original [API from OpenAI](https://platform.openai.com/docs/api-reference/completions/create) is deprecated, but the endpoint is still used in lot of examples, and I would assume actual projects as well.

This change will allow the `logprobs` to be treated the same as `n_probs` is. 

In principle, this change would allow for `/completion` endpoint to be called with both `n_probs` and `logprobs`.
Potentially, this could cause some confusion in case the user would supply both `n_probs` and `logprobs` in the same call to the API.

It would be possible to safeguard against that eventuality, but considering the minimal impact of this behavior and that it is only possible in cases when user deliberately calls API with different parameters, I have decided against it.
This way the PR can stay as a one liner.

Documentation needs no adjustment, because it already links to OpenAI docs, implying that it behaves in essentially the same way. 

Old output example:
```
jpodivin@fedora:~/repos/llama.cpp$ curl -H "Content-Type: application/json"  -d '{"model":"gpt-3.5-turbo", "prompt": "something", "logprobs": 5, "max_tokens": 1}' http://127.0.0.1:8080/v1/completions | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   598  100   518  100    80    639     98 --:--:-- --:--:-- --:--:--   739
{
  "choices": [
    {
      "text": " Ge",
      "index": 0,
      "logprobs": null,
      "finish_reason": "length"
    }
  ],
  "created": 1737533686,
  "model": "gpt-3.5-turbo",
  "system_fingerprint": "b4501-667d7284",
  "object": "text_completion",
  "usage": {
    "completion_tokens": 1,
    "prompt_tokens": 2,
    "total_tokens": 3
  },
  "id": "chatcmpl-Xg4bq1JlcEyXkybZDrdyEyl48zv2EeyG",
  "timings": {
    "prompt_n": 2,
    "prompt_ms": 807.999,
    "prompt_per_token_ms": 403.9995,
    "prompt_per_second": 2.475250588181421,
    "predicted_n": 1,
    "predicted_ms": 0.032,
    "predicted_per_token_ms": 0.032,
    "predicted_per_second": 31250.0
  }
}
```

New output example:
```
jpodivin@fedora:~/repos/llama.cpp$ curl -H "Content-Type: application/json"  -d '{"model":"gpt-3.5-turbo", "prompt": "something", "logprobs": 5, "max_tokens": 1}' http://127.0.0.1:8080/v1/completions | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1073  100   993  100    80   2287    184 --:--:-- --:--:-- --:--:--  2466
{
  "choices": [
    {
      "text": " Ge",
      "index": 0,
      "logprobs": {
        "content": [
          {
            "id": 2404,
            "token": " Ge",
            "bytes": [
              32,
              71,
              101
            ],
            "logprob": -0.44570669531822205,
            "top_logprobs": [
              {
                "id": 2404,
                "token": "Ge",
                "bytes": [
                  71,
                  101
                ],
                "logprob": -0.44570669531822205
              },
              {
                "id": 2970,
                "token": "ge",
                "bytes": [
                  103,
                  101
                ],
                "logprob": -2.617774248123169
              },
              {
                "id": 349,
                "token": "is",
                "bytes": [
                  105,
                  115
                ],
                "logprob": -3.1366515159606934
              },
              {
                "id": 315,
                "token": "I",
                "bytes": [
                  73
                ],
                "logprob": -3.662461519241333
              },
              {
                "id": 369,
                "token": "that",
                "bytes": [
                  116,
                  104,
                  97,
                  116
                ],
                "logprob": -4.037624835968018
              }
            ]
          }
        ]
      },
      "finish_reason": "length"
    }
  ],
  "created": 1737533297,
  "model": "gpt-3.5-turbo",
  "system_fingerprint": "b4501-667d7284",
  "object": "text_completion",
  "usage": {
    "completion_tokens": 1,
    "prompt_tokens": 2,
    "total_tokens": 3
  },
  "id": "chatcmpl-LwqGCxZCuQHAfAbfmfuU8w4axsYGaRrH",
  "timings": {
    "prompt_n": 1,
    "prompt_ms": 424.499,
    "prompt_per_token_ms": 424.499,
    "prompt_per_second": 2.355718152457367,
    "predicted_n": 1,
    "predicted_ms": 7.645,
    "predicted_per_token_ms": 7.645,
    "predicted_per_second": 130.80444735120994
  }
}
```