### PR TITLE
build: add /bigobj to MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 if (MSVC)
     add_compile_options("$<$<COMPILE_LANGUAGE:C>:/utf-8>")
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
+    add_compile_options(/bigobj)
 endif()
 
 #


### PR DESCRIPTION
I've recently started getting an error in the msvc debug build:

6>C:\github\jeffbolznv\llama.cpp\examples\server\server.cpp : fatal  error C1128: number of sections exceeded object file format limit: compile with /bigobj

The build works with this option added.