### PR TITLE
rpc: fix register position

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1303,10 +1303,12 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
     const int act_gpu_layers = devices.empty() ? 0 : std::min(n_gpu_layers, (int)n_layer + 1);
     auto get_layer_buft_list = [&](int il) -> llama_model::impl::layer_dev {
         if (il < i_gpu_start || (il - i_gpu_start) >= act_gpu_layers) {
+            LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s\n", il, ggml_backend_dev_name(cpu_dev));
             return {cpu_dev, &pimpl->cpu_buft_list};
         }
         const int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin();
         auto * dev = devices.at(layer_gpu);
+        LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s\n", il, ggml_backend_dev_name(dev));
         return {dev, &pimpl->gpu_buft_list.at(dev)};
     };
 


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

PR https://github.com/ggerganov/llama.cpp/pull/11262 reverted the changes introduced by PR https://github.com/ggerganov/llama.cpp/pull/9296, changed the output layer assigned device to the remote RPC server.

this PR will keep assigning the output layer to the local device.

`-m ../Qwen/Qwen2.5-0.5B-Instruct-GGUF/qwen2.5-0.5b-instruct-fp16.gguf --tensor-split 1,9 --rpc 127.0.0.1:50052`

#### current

```
load_tensors: layer   0 assigned to device Metal
load_tensors: layer   1 assigned to device Metal
load_tensors: layer   2 assigned to device Metal
load_tensors: layer   3 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   4 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   5 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   6 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   7 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   8 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   9 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  10 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  11 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  12 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  13 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  14 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  15 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  16 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  17 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  18 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  19 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  20 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  21 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  22 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  23 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer  24 assigned to device RPC[127.0.0.1:50052]
```

#### after this pr

```
load_tensors: layer   0 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   1 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   2 assigned to device RPC[127.0.0.1:50052]
load_tensors: layer   3 assigned to device Metal
load_tensors: layer   4 assigned to device Metal
load_tensors: layer   5 assigned to device Metal
load_tensors: layer   6 assigned to device Metal
load_tensors: layer   7 assigned to device Metal
load_tensors: layer   8 assigned to device Metal
load_tensors: layer   9 assigned to device Metal
load_tensors: layer  10 assigned to device Metal
load_tensors: layer  11 assigned to device Metal
load_tensors: layer  12 assigned to device Metal
load_tensors: layer  13 assigned to device Metal
load_tensors: layer  14 assigned to device Metal
load_tensors: layer  15 assigned to device Metal
load_tensors: layer  16 assigned to device Metal
load_tensors: layer  17 assigned to device Metal
load_tensors: layer  18 assigned to device Metal
load_tensors: layer  19 assigned to device Metal
load_tensors: layer  20 assigned to device Metal
load_tensors: layer  21 assigned to device Metal
load_tensors: layer  22 assigned to device Metal
load_tensors: layer  23 assigned to device Metal
load_tensors: layer  24 assigned to device Metal
```

