### PR TITLE
docker: allow installing pip packages system-wide

### DIFF
--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -55,8 +55,9 @@ RUN apt-get update \
     git \
     python3 \
     python3-pip \
-    && pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt \
+    python3-wheel \
+    && pip install --break-system-packages --upgrade setuptools \
+    && pip install --break-system-packages -r requirements.txt \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \


### PR DESCRIPTION
This will allow installing pip packages system-wide in the python libraries install step. Ubuntu 24.04 has a version of python that includes https://peps.python.org/pep-0668/#keep-the-marker-file-in-container-images which caused the error mentioned in https://github.com/ggerganov/llama.cpp/pull/11422#issuecomment-2614545545
The same install logic is already applied in the rocm image: https://github.com/ggerganov/llama.cpp/blob/master/.devops/rocm.Dockerfile#L83-L84