### PR TITLE
cmake: don't fail on `GGML_CPU=OFF`

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -308,7 +308,7 @@ if (GGML_CPU_ALL_VARIANTS)
         # MSVC doesn't support AMX
         ggml_add_cpu_backend_variant(sapphirerapids AVX F16C AVX2 FMA AVX512 AVX512_VBMI AVX512_VNNI AVX512_BF16 AMX_TILE AMX_INT8)
     endif()
-else ()
+elseif (GGML_CPU)
     ggml_add_cpu_backend_variant_impl("")
 endif()
 


### PR DESCRIPTION
This fixes an issue where ggml would fail to build if `GGML_CPU` was set to `OFF`. A cpu enabled build is still necessary to build the examples, but this allows the llama library itself to be built without the cpu backend.