### PR TITLE
CMake Bugfix: Windows ggml find_package fix in llama-config.cmake.in file

### DIFF
--- a/cmake/llama-config.cmake.in
+++ b/cmake/llama-config.cmake.in
@@ -9,7 +9,7 @@ set_and_check(LLAMA_INCLUDE_DIR "@PACKAGE_LLAMA_INCLUDE_INSTALL_DIR@")
 set_and_check(LLAMA_LIB_DIR     "@PACKAGE_LLAMA_LIB_INSTALL_DIR@")
 set_and_check(LLAMA_BIN_DIR     "@PACKAGE_LLAMA_BIN_INSTALL_DIR@")
 
-find_package(ggml REQUIRED)
+find_package(ggml REQUIRED HINTS ${LLAMA_LIB_DIR}/cmake)
 
 find_library(llama_LIBRARY llama
     REQUIRED


### PR DESCRIPTION
Review Complexity: Easy

## Problem

In llama-config.cmake.in file, we are looking for the ggml cmake config file through find_package function in CMake which works normal in UNIX file architecture since cmake looks for config modules under `lib/cmake` directories.

However in Windows, since the library is installed under `C:\Program Files\llama.cpp` or `C:\Program Files (x86)\llama.cpp` folder, CMake looks for config modules based off of the names of the folders under the program files directory and it can't find the ggml library since it is not installed as an individual project on its own.

## Fix

Adding a lookup hint location where the llama-config.cmake and ggml-config.cmake file reside together.
