### PR TITLE
embedding : enable --no-warmup option

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -877,7 +877,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params) {
             params.warmup = false;
         }
-    ).set_examples({LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER}));
+    ).set_examples({LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_EMBEDDING}));
     add_opt(common_arg(
         {"--spm-infill"},
         string_format(


### PR DESCRIPTION
This commit enables the `--no-warmup` option for the llama-embeddings.

The motivation for this change is to allow the user to disable the warmup when running the the program.

