### PR TITLE
server : update auto gen files comments [no ci]

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -236,9 +236,13 @@ npm i
 # to run the dev server
 npm run dev
 
-# to build the public/index.html
+# to build the public/index.html.gz
 npm run build
 ```
+After `public/index.html.gz` has been generated we need to generate the c++
+headers (like build/examples/server/index.html.gz.hpp) that will be included
+by server.cpp. This is done by building `llama-server` as described in the
+[build](#build) section above.
 
 NOTE: if you are using the vite dev server, you can change the API base URL to llama.cpp. To do that, run this code snippet in browser's console:
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -14,9 +14,7 @@
 // mime type for sending response
 #define MIMETYPE_JSON "application/json; charset=utf-8"
 
-// auto generated files
-// $ npm run build --prefix examples/server/webui (updates examples/server/public/index.html.gz)
-// $ cmake --build build --target llama-server    (generates build/examples/server/index.html.gz.hpp)
+// auto generated files (see README.md for details)
 #include "index.html.gz.hpp"
 #include "loading.html.hpp"
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -14,7 +14,7 @@
 // mime type for sending response
 #define MIMETYPE_JSON "application/json; charset=utf-8"
 
-// auto generated files update by:
+// auto generated files
 // $ npm run build --prefix examples/server/webui (updates examples/server/public/index.html.gz)
 // $ cmake --build build --target llama-server    (generates build/examples/server/index.html.gz.hpp)
 #include "index.html.gz.hpp"

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -14,7 +14,9 @@
 // mime type for sending response
 #define MIMETYPE_JSON "application/json; charset=utf-8"
 
-// auto generated files (update with ./deps.sh)
+// auto generated files update by:
+// $ npm run build --prefix examples/server/webui (updates examples/server/public/index.html.gz)
+// $ cmake --build build --target llama-server    (generates build/examples/server/index.html.gz.hpp)
 #include "index.html.gz.hpp"
 #include "loading.html.hpp"
 


### PR DESCRIPTION
This commit updates the 'auto generated files' comments in server.cpp and removes `deps.sh` from the comment.

The motivation for this change is that `deps.sh` was removed in Commit 91c36c269bca75b2d08119c653512cd20b4ea2ba ("server : (web ui) Various improvements, now use vite as bundler (#10599)").
