### PR TITLE
server : add /apply-template endpoint for additional use cases of Minja functionality

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -572,6 +572,14 @@ With input 'á' (utf8 hex: C3 A1) on tinyllama/stories260k
 
 `tokens`: Set the tokens to detokenize.
 
+### POST `/apply-template`: Apply chat template to a conversation
+
+Uses the server's prompt template formatting functionality to convert chat messages to a single string expected by a chat model as input, but does not perform inference. Instead, the prompt string is returned in the `prompt` field of the JSON response. The prompt can then be modified as desired (for example, to insert "Sure!" at the beginning of the model's response) before sending to `/completion` to generate the chat response.
+
+*Options:*
+
+`messages`: (Required) Chat turns in the same format as `/v1/chat/completions`.
+
 ### POST `/embedding`: Generate embedding of a given text
 
 > [!IMPORTANT]

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -4127,8 +4127,10 @@ int main(int argc, char ** argv) {
     const auto handle_apply_template = [&ctx_server, &params, &res_ok](const httplib::Request & req, httplib::Response & res) {
         auto body = json::parse(req.body);
         const auto & chat_template = body.contains("tools") && ctx_server.chat_templates.template_tool_use ? *ctx_server.chat_templates.template_tool_use : *ctx_server.chat_templates.template_default;
-        json data = oaicompat_completion_params_parse(body, chat_template, params.use_jinja);
 
+        // format and return only the "prompt" field
+        json data = json::object();
+        data["prompt"] = oaicompat_completion_params_parse(body, chat_template, params.use_jinja)["prompt"];
         res_ok(res, data);
     };
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -4124,6 +4124,14 @@ int main(int argc, char ** argv) {
         res_ok(res, root);
     };
 
+    const auto handle_apply_template = [&ctx_server, &params, &res_ok](const httplib::Request & req, httplib::Response & res) {
+        auto body = json::parse(req.body);
+        const auto & chat_template = body.contains("tools") && ctx_server.chat_templates.template_tool_use ? *ctx_server.chat_templates.template_tool_use : *ctx_server.chat_templates.template_default;
+        json data = oaicompat_completion_params_parse(body, chat_template, params.use_jinja);
+
+        res_ok(res, data);
+    };
+
     const auto handle_embeddings = [&handle_embeddings_impl](const httplib::Request & req, httplib::Response & res) {
         handle_embeddings_impl(req, res, OAICOMPAT_TYPE_NONE);
     };
@@ -4300,6 +4308,7 @@ int main(int argc, char ** argv) {
     svr->Post("/v1/reranking",        handle_rerank);
     svr->Post("/tokenize",            handle_tokenize);
     svr->Post("/detokenize",          handle_detokenize);
+    svr->Post("/apply-template",      handle_apply_template);
     // LoRA adapters hotswap
     svr->Get ("/lora-adapters",       handle_lora_adapters_list);
     svr->Post("/lora-adapters",       handle_lora_adapters_apply);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -4127,11 +4127,9 @@ int main(int argc, char ** argv) {
     const auto handle_apply_template = [&ctx_server, &params, &res_ok](const httplib::Request & req, httplib::Response & res) {
         auto body = json::parse(req.body);
         const auto & chat_template = body.contains("tools") && ctx_server.chat_templates.template_tool_use ? *ctx_server.chat_templates.template_tool_use : *ctx_server.chat_templates.template_default;
+        json data = oaicompat_completion_params_parse(body, chat_template, params.use_jinja);
 
-        // format and return only the "prompt" field
-        json data = json::object();
-        data["prompt"] = oaicompat_completion_params_parse(body, chat_template, params.use_jinja)["prompt"];
-        res_ok(res, data);
+        res_ok(res, {{ "prompt", data.at("prompt") }});
     };
 
     const auto handle_embeddings = [&handle_embeddings_impl](const httplib::Request & req, httplib::Response & res) {

--- a/examples/server/tests/unit/test_chat_completion.py
+++ b/examples/server/tests/unit/test_chat_completion.py
@@ -126,7 +126,6 @@ def test_apply_chat_template():
     server.chat_template = "command-r"
     server.start()
     res = server.make_request("POST", "/apply-template", data={
-        "max_tokens": 8,
         "messages": [
             {"role": "system", "content": "You are a test."},
             {"role": "user", "content":"Hi there"},

--- a/examples/server/tests/unit/test_chat_completion.py
+++ b/examples/server/tests/unit/test_chat_completion.py
@@ -121,6 +121,22 @@ def test_chat_template():
     assert res.body["__verbose"]["prompt"] == "<s> <|start_header_id|>system<|end_header_id|>\n\nBook<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nWhat is the best book<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
 
 
+def test_apply_chat_template():
+    global server
+    server.chat_template = "command-r"
+    server.start()
+    res = server.make_request("POST", "/apply-template", data={
+        "max_tokens": 8,
+        "messages": [
+            {"role": "system", "content": "You are a test."},
+            {"role": "user", "content":"Hi there"},
+        ]
+    })
+    assert res.status_code == 200
+    assert "prompt" in res.body
+    assert res.body["prompt"] == "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>You are a test.<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|USER_TOKEN|>Hi there<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+
+
 @pytest.mark.parametrize("response_format,n_predicted,re_content", [
     ({"type": "json_object", "schema": {"const": "42"}}, 6, "\"42\""),
     ({"type": "json_object", "schema": {"items": [{"type": "integer"}]}}, 10, "[ -3000 ]"),


### PR DESCRIPTION
This PR adds an endpoint to examples/server, `/apply-template`, which will apply the model's chat template to the given messages, like for chat completion, but then will simply return the formatted prompt rather than running inference.

Sometimes I modify prompts after formatting them for chat interactions, especially for cases where the goal is to insert something into the beginning of the model's response. For example, the classic "Sure!" insertion to reduce refusals, or more often some partially-constructed solutions that I would like the model to finish.

Previously I have implemented chat templates for each model myself, but with the addition of some Jinja support via Minja it is very tempting to let the server do this for users instead, as it is more likely to be correct and offer good coverage of prompt templates.

This PR also adds a CI test, which I did using the Command-R template to provide some variety versus the closely related `test_chat_template` unit test (side note: I did not find `__verbose` very useful for prompt formatting use cases because it includes BOS, hence the new endpoint).