### PR TITLE
Correctly identify LF token for GPT-2 style BPE tokenizer

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1687,7 +1687,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         GGML_ASSERT(!ids.empty() && "model vocab missing newline token");
         linefeed_id = ids[0];
     } else {
-        const std::vector<int> ids = tokenize("\xC4\x8A", false); // U+010A
+        const std::vector<int> ids = tokenize("\n", false);
 
         //GGML_ASSERT(!ids.empty() && "model vocab missing newline token");
         if (ids.empty()) {


### PR DESCRIPTION
This fix makes the reported linefeed token for models such as Llama-3 and Qwen consistent with what other sources say (verified with https://huggingface.co/spaces/Xenova/the-tokenizer-playground).

This bug is unlikely to have any impact on current llama.cpp functionality, because the `llama_vocab_nl()` API function is never called. However, the incorrect token IDs appear to have caused some confusion, e.g. here: https://www.reddit.com/r/LocalLLaMA/comments/1cpv7np/why_does_llama3_use_lf_token_128_%C3%A4.

The change is necessary because the `llama_vocab::impl::tokenize()` method takes the original orthography in UTF-8 as input, rather than the modified internal representation of the BPE vocabulary (U+010A for "\n"), which is only created in `unicode_byte_to_utf8_map()`.

This leads to the correct tokens IDs being shown in the trace:

# Before

Llama-3:
	`print_info: LF token         = 128 'Ä'`
Qwen:
	`print_info: LF token         = 148848 'ÄĬ'`

# After

Llama-3:
	`print_info: LF token         = 198 'Ċ'`
Qwen2:
	`print_info: LF token         = 198 'Ċ`