### PR TITLE
server: document /apply-template response format

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -584,6 +584,10 @@ Uses the server's prompt template formatting functionality to convert chat messa
 
 `messages`: (Required) Chat turns in the same format as `/v1/chat/completions`.
 
+**Response format**
+
+Returns a JSON object with a field `prompt` containing a string of the input messages formatted according to the model's chat template format.
+
 ### POST `/embedding`: Generate embedding of a given text
 
 > [!IMPORTANT]


### PR DESCRIPTION
Small documentation followup to https://github.com/ggerganov/llama.cpp/pull/11489 (thanks for that PR by the way, a very nice feature addition!).

Adds the response format for the `/apply-template` route (a JSON object with field `prompt`) to the server's README.md file.