### PR TITLE
`ci`: ccache for all github worfklows

### DIFF
--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -12,13 +12,16 @@ FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 ARG CUDA_DOCKER_ARCH=default
 
 RUN apt-get update && \
-    apt-get install -y build-essential cmake python3 python3-pip git libcurl4-openssl-dev libgomp1
+    apt-get install -y build-essential cmake python3 python3-pip git libcurl4-openssl-dev libgomp1 ccache
 
 WORKDIR /app
 
 COPY . .
 
-RUN if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
+RUN --mount=type=cache,target=/root/.ccache \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/cache/apt \
+    if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
     export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=${CUDA_DOCKER_ARCH}"; \
     fi && \
     cmake -B build -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DLLAMA_CURL=ON ${CMAKE_ARGS} -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined . && \

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -12,16 +12,13 @@ FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 ARG CUDA_DOCKER_ARCH=default
 
 RUN apt-get update && \
-    apt-get install -y build-essential cmake python3 python3-pip git libcurl4-openssl-dev libgomp1 ccache
+    apt-get install -y build-essential cmake python3 python3-pip git libcurl4-openssl-dev libgomp1
 
 WORKDIR /app
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.ccache \
-    --mount=type=cache,target=/var/lib/apt/lists \
-    --mount=type=cache,target=/var/cache/apt \
-    if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
+RUN if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
     export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=${CUDA_DOCKER_ARCH}"; \
     fi && \
     cmake -B build -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DLLAMA_CURL=ON ${CMAKE_ARGS} -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined . && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: macOS-latest-cmake-arm64
           evict-old-files: job
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: macOS-latest-cmake-x64
           evict-old-files: job
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-cpu-cmake
           evict-old-files: job
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-latest-cmake-sanitizer-${{ matrix.sanitizer }}
           evict-old-files: job
@@ -321,7 +321,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-latest-cmake-rpc
           evict-old-files: job
@@ -356,7 +356,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-22-cmake-vulkan
           evict-old-files: job
@@ -395,7 +395,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-22-cmake-hip
           evict-old-files: job
@@ -433,7 +433,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-22-cmake-musa
           evict-old-files: job
@@ -484,7 +484,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-22-cmake-sycl
           evict-old-files: job
@@ -534,7 +534,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ubuntu-22-cmake-sycl-fp16
           evict-old-files: job
@@ -561,7 +561,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: macOS-latest-cmake-ios
           evict-old-files: job
@@ -598,7 +598,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: macOS-latest-cmake-tvos
           evict-old-files: job
@@ -639,7 +639,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: macOS-latest-swift
           evict-old-files: job
@@ -686,7 +686,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-msys2
           evict-old-files: job
@@ -760,7 +760,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-latest-cmake-${{ matrix.build }}
           evict-old-files: job
@@ -907,7 +907,7 @@ jobs:
             fetch-depth: 0
 
         - name: ccache
-          uses: hendrikmuhs/ccache-action@v1.2.11
+          uses: hendrikmuhs/ccache-action@v1.2.16
           with:
             key: ubuntu-latest-cmake-cuda
             evict-old-files: job
@@ -946,7 +946,7 @@ jobs:
             fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-2019-cmake-cuda-${{ matrix.cuda }}
           evict-old-files: job
@@ -1092,7 +1092,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-latest-cmake-sycl
           evict-old-files: job
@@ -1161,7 +1161,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-latest-cmake-hip
           evict-old-files: job
@@ -1215,7 +1215,7 @@ jobs:
             fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-latest-cmake-hip-release
           evict-old-files: job
@@ -1318,7 +1318,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: android-build
           evict-old-files: job
@@ -1361,7 +1361,7 @@ jobs:
           fetch-depth: 0
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: release
           evict-old-files: job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: macOS-latest-cmake-arm64
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -117,8 +116,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: macOS-latest-cmake-x64
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -187,8 +185,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-cpu-cmake
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -270,8 +267,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-latest-cmake-sanitizer-${{ matrix.sanitizer }}
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -323,8 +319,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-latest-cmake-rpc
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -358,8 +353,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-22-cmake-vulkan
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -397,8 +391,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-22-cmake-hip
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -435,8 +428,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-22-cmake-musa
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -486,8 +478,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-22-cmake-sycl
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Build
         id: cmake_build
@@ -536,8 +527,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: ubuntu-22-cmake-sycl-fp16
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Build
         id: cmake_build
@@ -563,8 +553,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: macOS-latest-cmake-ios
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -600,8 +589,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: macOS-latest-cmake-tvos
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -641,8 +629,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: macOS-latest-swift
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Dependencies
         id: depends
@@ -688,8 +675,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-msys2
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Setup ${{ matrix.sys }}
         uses: msys2/setup-msys2@v2
@@ -762,8 +748,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-latest-cmake-${{ matrix.build }}
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Clone Kompute submodule
         id: clone_kompute
@@ -909,8 +894,7 @@ jobs:
         - name: ccache
           uses: hendrikmuhs/ccache-action@v1.2.16
           with:
-            key: ubuntu-latest-cmake-cuda
-            evict-old-files: job
+            evict-old-files: 1d
 
         - name: Install dependencies
           env:
@@ -948,8 +932,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-2019-cmake-cuda-${{ matrix.cuda }}
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Install Cuda Toolkit 11.7
         if: ${{ matrix.cuda == '11.7' }}
@@ -1094,8 +1077,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-latest-cmake-sycl
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Install
         run:  |
@@ -1163,8 +1145,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-latest-cmake-hip
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Install
         id: depends
@@ -1217,8 +1198,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-latest-cmake-hip-release
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Install
         id: depends
@@ -1320,8 +1300,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: android-build
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -1363,8 +1342,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: release
-          evict-old-files: job
+          evict-old-files: 1d
 
       - name: Determine tag name
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -900,8 +900,8 @@ jobs:
           env:
             DEBIAN_FRONTEND: noninteractive
           run: |
-            apt update
-            apt install -y cmake build-essential ninja-build libcurl4-openssl-dev libgomp1 git
+              apt update
+              apt install -y cmake build-essential ninja-build libgomp1 git
 
         - name: Build with CMake
           run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: macOS-latest-cmake-arm64
           evict-old-files: 1d
 
       - name: Dependencies
@@ -116,6 +117,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: macOS-latest-cmake-x64
           evict-old-files: 1d
 
       - name: Dependencies
@@ -185,6 +187,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-cpu-cmake
           evict-old-files: 1d
 
       - name: Dependencies
@@ -267,6 +270,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-latest-cmake-sanitizer-${{ matrix.sanitizer }}
           evict-old-files: 1d
 
       - name: Dependencies
@@ -319,6 +323,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-latest-cmake-rpc
           evict-old-files: 1d
 
       - name: Dependencies
@@ -353,6 +358,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-22-cmake-vulkan
           evict-old-files: 1d
 
       - name: Dependencies
@@ -391,6 +397,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-22-cmake-hip
           evict-old-files: 1d
 
       - name: Dependencies
@@ -428,6 +435,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-22-cmake-musa
           evict-old-files: 1d
 
       - name: Dependencies
@@ -478,6 +486,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-22-cmake-sycl
           evict-old-files: 1d
 
       - name: Build
@@ -527,6 +536,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: ubuntu-22-cmake-sycl-fp16
           evict-old-files: 1d
 
       - name: Build
@@ -553,6 +563,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: macOS-latest-cmake-ios
           evict-old-files: 1d
 
       - name: Dependencies
@@ -589,6 +600,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: macOS-latest-cmake-tvos
           evict-old-files: 1d
 
       - name: Dependencies
@@ -629,6 +641,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: macOS-latest-swift
           evict-old-files: 1d
 
       - name: Dependencies
@@ -675,6 +688,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-msys2
           evict-old-files: 1d
 
       - name: Setup ${{ matrix.sys }}
@@ -748,6 +762,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-latest-cmake-${{ matrix.build }}
           evict-old-files: 1d
 
       - name: Clone Kompute submodule
@@ -894,6 +909,7 @@ jobs:
         - name: ccache
           uses: hendrikmuhs/ccache-action@v1.2.16
           with:
+            key: ubuntu-latest-cmake-cuda
             evict-old-files: 1d
 
         - name: Install dependencies
@@ -932,6 +948,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-2019-cmake-cuda-${{ matrix.cuda }}
           evict-old-files: 1d
 
       - name: Install Cuda Toolkit 11.7
@@ -1077,6 +1094,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-latest-cmake-sycl
           evict-old-files: 1d
 
       - name: Install
@@ -1145,6 +1163,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-latest-cmake-hip
           evict-old-files: 1d
 
       - name: Install
@@ -1198,6 +1217,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: windows-latest-cmake-hip-release
           evict-old-files: 1d
 
       - name: Install
@@ -1300,6 +1320,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: android-build
           evict-old-files: 1d
 
       - name: Set up JDK
@@ -1342,6 +1363,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
+          key: release
           evict-old-files: 1d
 
       - name: Determine tag name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,17 +394,17 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.16
-        with:
-          key: ubuntu-22-cmake-hip
-          evict-old-files: 1d
-
       - name: Dependencies
         id: depends
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential git cmake rocblas-dev hipblas-dev
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.16
+        with:
+          key: ubuntu-22-cmake-hip
+          evict-old-files: 1d
 
       - name: Build with native CMake HIP support
         id: cmake_build
@@ -432,17 +432,17 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.16
-        with:
-          key: ubuntu-22-cmake-musa
-          evict-old-files: 1d
-
       - name: Dependencies
         id: depends
         run: |
           apt-get update
           apt-get install -y build-essential git cmake libcurl4-openssl-dev
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.16
+        with:
+          key: ubuntu-22-cmake-musa
+          evict-old-files: 1d
 
       - name: Build with native CMake MUSA support
         id: cmake_build
@@ -906,18 +906,18 @@ jobs:
           with:
             fetch-depth: 0
 
-        - name: ccache
-          uses: hendrikmuhs/ccache-action@v1.2.16
-          with:
-            key: ubuntu-latest-cmake-cuda
-            evict-old-files: 1d
-
         - name: Install dependencies
           env:
             DEBIAN_FRONTEND: noninteractive
           run: |
               apt update
               apt install -y cmake build-essential ninja-build libgomp1 git
+
+        - name: ccache
+          uses: hendrikmuhs/ccache-action@v1.2.16
+          with:
+            key: ubuntu-latest-cmake-cuda
+            evict-old-files: 1d
 
         - name: Build with CMake
           run: |
@@ -945,10 +945,10 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: ccache
+      - name: Install ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
-          key: windows-2019-cmake-cuda-${{ matrix.cuda }}
+          key: ${{ github.job }}-${{ matrix.cuda }}-${{ matrix.build }}
           evict-old-files: 1d
 
       - name: Install Cuda Toolkit 11.7
@@ -1006,11 +1006,6 @@ jobs:
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V12_4=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Install ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}-${{ matrix.cuda }}-${{ matrix.build }}
 
       - name: Install Ninja
         id: install_ninja
@@ -1160,12 +1155,6 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.16
-        with:
-          key: windows-latest-cmake-hip
-          evict-old-files: 1d
-
       - name: Install
         id: depends
         run: |
@@ -1182,9 +1171,10 @@ jobs:
           & 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' --version
 
       - name: Install ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ${{ github.job }}
+          evict-old-files: 1d
 
       - name: Build
         id: cmake_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: macOS-latest-cmake-arm64
+
       - name: Dependencies
         id: depends
         continue-on-error: true
@@ -108,6 +113,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: macOS-latest-cmake-x64
+
       - name: Dependencies
         id: depends
         continue-on-error: true
@@ -171,6 +181,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-cpu-cmake
 
       - name: Dependencies
         id: depends
@@ -249,6 +264,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-latest-cmake-sanitizer-${{ matrix.sanitizer }}
+
       - name: Dependencies
         id: depends
         run: |
@@ -296,6 +316,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-latest-cmake-rpc
+
       - name: Dependencies
         id: depends
         run: |
@@ -324,6 +349,11 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-22-cmake-vulkan
 
       - name: Dependencies
         id: depends
@@ -358,6 +388,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-22-cmake-hip
+
       - name: Dependencies
         id: depends
         run: |
@@ -389,6 +424,11 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-22-cmake-musa
 
       - name: Dependencies
         id: depends
@@ -435,6 +475,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-22-cmake-sycl
+
       - name: Build
         id: cmake_build
         run: |
@@ -479,6 +524,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: ubuntu-22-cmake-sycl-fp16
+
       - name: Build
         id: cmake_build
         run: |
@@ -499,6 +549,11 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: macOS-latest-cmake-ios
 
       - name: Dependencies
         id: depends
@@ -530,6 +585,11 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: macOS-latest-cmake-tvos
 
       - name: Dependencies
         id: depends
@@ -565,6 +625,11 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: macOS-latest-swift
 
       - name: Dependencies
         id: depends
@@ -606,6 +671,11 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v4
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-msys2
 
       - name: Setup ${{ matrix.sys }}
         uses: msys2/setup-msys2@v2
@@ -674,6 +744,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-latest-cmake-${{ matrix.build }}
 
       - name: Clone Kompute submodule
         id: clone_kompute
@@ -813,13 +888,20 @@ jobs:
         - name: Clone
           id: checkout
           uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: ccache
+          uses: hendrikmuhs/ccache-action@v1.2.11
+          with:
+            key: ubuntu-latest-cmake-cuda
 
         - name: Install dependencies
           env:
             DEBIAN_FRONTEND: noninteractive
           run: |
-              apt update
-              apt install -y cmake build-essential ninja-build libgomp1 git
+            apt update
+            apt install -y cmake build-essential ninja-build libcurl4-openssl-dev libgomp1 git
 
         - name: Build with CMake
           run: |
@@ -1231,6 +1313,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: release
 
       - name: Determine tag name
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: macOS-latest-cmake-arm64
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -117,6 +118,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: macOS-latest-cmake-x64
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -186,6 +188,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-cpu-cmake
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -268,6 +271,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-latest-cmake-sanitizer-${{ matrix.sanitizer }}
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -320,6 +324,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-latest-cmake-rpc
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -354,6 +359,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-22-cmake-vulkan
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -392,6 +398,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-22-cmake-hip
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -429,6 +436,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-22-cmake-musa
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -479,6 +487,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-22-cmake-sycl
+          evict-old-files: job
 
       - name: Build
         id: cmake_build
@@ -528,6 +537,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ubuntu-22-cmake-sycl-fp16
+          evict-old-files: job
 
       - name: Build
         id: cmake_build
@@ -554,6 +564,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: macOS-latest-cmake-ios
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -590,6 +601,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: macOS-latest-cmake-tvos
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -630,6 +642,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: macOS-latest-swift
+          evict-old-files: job
 
       - name: Dependencies
         id: depends
@@ -676,6 +689,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: windows-msys2
+          evict-old-files: job
 
       - name: Setup ${{ matrix.sys }}
         uses: msys2/setup-msys2@v2
@@ -749,6 +763,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: windows-latest-cmake-${{ matrix.build }}
+          evict-old-files: job
 
       - name: Clone Kompute submodule
         id: clone_kompute
@@ -895,6 +910,7 @@ jobs:
           uses: hendrikmuhs/ccache-action@v1.2.11
           with:
             key: ubuntu-latest-cmake-cuda
+            evict-old-files: job
 
         - name: Install dependencies
           env:
@@ -928,6 +944,12 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-2019-cmake-cuda-${{ matrix.cuda }}
+          evict-old-files: job
 
       - name: Install Cuda Toolkit 11.7
         if: ${{ matrix.cuda == '11.7' }}
@@ -1069,6 +1091,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-latest-cmake-sycl
+          evict-old-files: job
+
       - name: Install
         run:  |
           scripts/install-oneapi.bat $WINDOWS_BASEKIT_URL $WINDOWS_DPCPP_MKL
@@ -1132,6 +1160,12 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-latest-cmake-hip
+          evict-old-files: job
+
       - name: Install
         id: depends
         run: |
@@ -1179,6 +1213,12 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: windows-latest-cmake-hip-release
+          evict-old-files: job
 
       - name: Install
         id: depends
@@ -1277,6 +1317,12 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          key: android-build
+          evict-old-files: job
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -1318,6 +1364,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: release
+          evict-old-files: job
 
       - name: Determine tag name
         id: tag


### PR DESCRIPTION
Use https://github.com/hendrikmuhs/ccache-action in all our ci jobs (was already used for cuda / hip jobs)

Example:
- Before:
  - [macOS-latest-cmake-x64 succeeded in 9m 57s](https://github.com/ggerganov/llama.cpp/actions/runs/13056681895/job/36429379026?pr=11516) (build = 5min15s)
  - [ubuntu-cpu-cmake succeeded in 5m 16s](https://github.com/ggerganov/llama.cpp/actions/runs/13056681895/job/36429381426?pr=11516) (build = 2min13s)
- After: 
  - [macOS-latest-cmake-x64 succeeded in 5m 2s](https://github.com/ggerganov/llama.cpp/actions/runs/13057192915/job/36431228984?pr=11516) (**build = 20s**)
  - [ubuntu-cpu-cmake succeeded in 3m 11s](https://github.com/ggerganov/llama.cpp/actions/runs/13057192915/job/36431231267?pr=11516) (**build = 7s**)

Notes:
- Default seems to be using single cache (~~Looks like each job gets its own cache by default.~~)
- May need sccache tweak on Windows?
- ~~May need to share caches between compatible jobs (assuming we can serialize them by group, as concurrent ccache updates are likely counter-productive) if hitting cache limits~~ (update: don’t think there are compatible builds between jobs)
- Expiring files unused in caches for more than 1d w/ https://github.com/hendrikmuhs/ccache-action/pull/270 (cf. @slaren's suggestion below); hopefully will allow decent cross-PR caching (TBC in real life)