### PR TITLE
common: Add missing va_end

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -206,6 +206,7 @@ public:
                 vsnprintf(entry.msg.data(), entry.msg.size(), ss.str().c_str(), args_copy);
             }
 #endif
+            va_end(args_copy);
         }
 
         entry.level = level;


### PR DESCRIPTION
The va_copy man page states that va_end must be called to revert whatever the copy did. For some implementations, not calling va_end has no consequences. For others it could leak memory.
