### PR TITLE
server : add handle_slot_type lambda

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3738,7 +3738,11 @@ int main(int argc, char ** argv) {
             return;
         }
         GGML_ASSERT(result.get() != nullptr);
-        GGML_ASSERT(result.get()->get_server_task_type() == type);
+        if (type == SERVER_TASK_TYPE_SLOT_RESTORE) {
+            GGML_ASSERT(result.get()->get_server_task_type() == SERVER_TASK_TYPE_SLOT_SAVE);
+        } else {
+            GGML_ASSERT(result.get()->get_server_task_type() == type);
+        }
         res_ok(res, result->to_json());
     };
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2794,7 +2794,7 @@ struct server_context {
                 {
                     // do nothing
                     GGML_ASSERT(false && "Invalid task.type (SERVER_TASK_TYPE_NONE)\n");
-                } break;
+                }
         }
     }
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -798,7 +798,7 @@ struct server_task_result_cmpl_final : server_task_result {
         return ret;
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_COMPLETION;
     }
 };
@@ -970,7 +970,7 @@ struct server_task_result_cmpl_partial : server_task_result {
         return std::vector<json>({ret});
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_NONE;
     }
 };
@@ -1009,7 +1009,7 @@ struct server_task_result_embd : server_task_result {
         };
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_EMBEDDING;
     }
 };
@@ -1032,7 +1032,7 @@ struct server_task_result_rerank : server_task_result {
         };
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_RERANK;
     }
 };
@@ -1091,7 +1091,7 @@ struct server_task_result_error : server_task_result {
         return format_error_response(err_msg, err_type);
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_NONE;
     }
 };
@@ -1151,7 +1151,7 @@ struct server_task_result_metrics : server_task_result {
         };
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_METRICS;
     }
 };
@@ -1188,7 +1188,7 @@ struct server_task_result_slot_save_load : server_task_result {
         }
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_SLOT_SAVE;
     }
 };
@@ -1203,7 +1203,7 @@ struct server_task_result_slot_erase : server_task_result {
         };
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_SLOT_ERASE;
     }
 };
@@ -1213,7 +1213,7 @@ struct server_task_result_apply_lora : server_task_result {
         return json {{ "success", true }};
     }
 
-    server_task_type get_server_task_type() {
+    server_task_type get_server_task_type() override {
         return SERVER_TASK_TYPE_NONE;
     }
 };

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3665,7 +3665,7 @@ int main(int argc, char ** argv) {
         res.status = 200; // HTTP OK
     };
 
-    const auto handle_slot_type = [&ctx_server, &res_error, &res_ok, &params](const httplib::Request & req,
+    const auto handle_slot_impl = [&ctx_server, &res_error, &res_ok, &params](const httplib::Request & req,
             httplib::Response & res, int id_slot, server_task_type type) {
         json request_data = json::parse(req.body);
         std::string filename = request_data.at("filename");
@@ -3698,12 +3698,12 @@ int main(int argc, char ** argv) {
         res_ok(res, result->to_json());
     };
 
-    const auto handle_slots_save = [&handle_slot_type](const httplib::Request & req, httplib::Response & res, int id_slot) {
-        handle_slot_type(req, res, id_slot, SERVER_TASK_TYPE_SLOT_SAVE);
+    const auto handle_slots_save = [&handle_slot_impl](const httplib::Request & req, httplib::Response & res, int id_slot) {
+        handle_slot_impl(req, res, id_slot, SERVER_TASK_TYPE_SLOT_SAVE);
     };
 
-    const auto handle_slots_restore = [&handle_slot_type](const httplib::Request & req, httplib::Response & res, int id_slot) {
-        handle_slot_type(req, res, id_slot, SERVER_TASK_TYPE_SLOT_RESTORE);
+    const auto handle_slots_restore = [&handle_slot_impl](const httplib::Request & req, httplib::Response & res, int id_slot) {
+        handle_slot_impl(req, res, id_slot, SERVER_TASK_TYPE_SLOT_RESTORE);
     };
 
     const auto handle_slots_erase = [&ctx_server, &res_error, &res_ok](const httplib::Request & /* req */, httplib::Response & res, int id_slot) {


### PR DESCRIPTION
This commit adds a lambda function by extracting the common code for saving and restoring slots.

The motivation for this change is to reduce code duplication between the current two lambda expressions/functions.
