### PR TITLE
`ci`: ctest --parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,11 @@ jobs:
             -DGGML_METAL_USE_BF16=ON \
             -DGGML_METAL_EMBED_LIBRARY=ON \
             -DGGML_RPC=ON
-          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          ctest -L 'main|curl' --verbose --timeout 900
+        run: ctest --parallel --test-dir build -L 'main|curl' --verbose --timeout 900
 
       - name: Determine tag name
         id: tag
@@ -138,13 +136,11 @@ jobs:
             -DLLAMA_CURL=ON \
             -DGGML_METAL=OFF \
             -DGGML_RPC=ON
-          cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --parallel --build build --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          ctest -L main --verbose --timeout 900
+        run: ctest --parallel --test-dir build -L main --verbose --timeout 900
 
       - name: Determine tag name
         id: tag
@@ -205,13 +201,11 @@ jobs:
             -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_CURL=ON \
             -DGGML_RPC=ON
-          cmake --build . --config Release -j $(nproc)
+          cmake --parallel --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          ctest -L 'main|curl' --verbose --timeout 900
+        run: ctest --parallel --test-dir build -L 'main|curl' --verbose --timeout 900
 
       - name: Test llama2c conversion
         id: llama2c_test
@@ -289,7 +283,7 @@ jobs:
             -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          cmake --build . --config ${{ matrix.build_type }} -j $(nproc)
+          cmake --parallel --build . --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Build (no OpenMP)
         id: cmake_build_no_openmp
@@ -302,13 +296,11 @@ jobs:
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
-          cmake --build . --config ${{ matrix.build_type }} -j $(nproc)
+          cmake --parallel --build . --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          ctest -L main --verbose --timeout 900
+        run: ctest --parallel --test-dir build -L main --verbose --timeout 900
 
   ubuntu-latest-cmake-rpc:
     runs-on: ubuntu-latest
@@ -339,13 +331,11 @@ jobs:
           cd build
           cmake .. \
             -DGGML_RPC=ON
-          cmake --build . --config Release -j $(nproc)
+          cmake --parallel --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          ctest -L main --verbose
+        run: ctest --parallel --test-dir build -L main --verbose
 
   ubuntu-22-cmake-vulkan:
     runs-on: ubuntu-22.04
@@ -376,14 +366,12 @@ jobs:
           cd build
           cmake .. \
             -DGGML_VULKAN=ON
-          cmake --build . --config Release -j $(nproc)
+          cmake --parallel --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
-        run: |
-          cd build
-          # This is using llvmpipe and runs slower than other backends
-          ctest -L main --verbose --timeout 1800
+        # This is using llvmpipe and runs slower than other backends
+        run: ctest --parallel --test-dir build -L main --verbose --timeout 1800
 
   ubuntu-22-cmake-hip:
     runs-on: ubuntu-22.04
@@ -412,7 +400,7 @@ jobs:
           cmake -B build -S . \
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGGML_HIP=ON
-          cmake --build build --config Release -j $(nproc)
+          cmake --parallel --build build --config Release -j $(nproc)
 
       - name: Build with legacy HIP support
         id: cmake_build_legacy_hip
@@ -421,7 +409,7 @@ jobs:
             -DCMAKE_C_COMPILER=hipcc \
             -DCMAKE_CXX_COMPILER=hipcc \
             -DGGML_HIP=ON
-          cmake --build build2 --config Release -j $(nproc)
+          cmake --parallel --build build2 --config Release -j $(nproc)
 
   ubuntu-22-cmake-musa:
     runs-on: ubuntu-22.04
@@ -449,7 +437,7 @@ jobs:
         run: |
           cmake -B build -S . \
             -DGGML_MUSA=ON
-          cmake --build build --config Release -j $(nproc)
+          cmake --parallel --build build --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl:
     runs-on: ubuntu-22.04
@@ -499,7 +487,7 @@ jobs:
             -DGGML_SYCL=ON \
             -DCMAKE_C_COMPILER=icx \
             -DCMAKE_CXX_COMPILER=icpx
-          cmake --build . --config Release -j $(nproc)
+          cmake --parallel --build . --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl-fp16:
     runs-on: ubuntu-22.04
@@ -550,7 +538,7 @@ jobs:
             -DCMAKE_C_COMPILER=icx \
             -DCMAKE_CXX_COMPILER=icpx \
             -DGGML_SYCL_F16=ON
-          cmake --build . --config Release -j $(nproc)
+          cmake --parallel --build . --config Release -j $(nproc)
 
   macOS-latest-cmake-ios:
     runs-on: macos-latest
@@ -587,7 +575,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macOS-latest-cmake-tvos:
     runs-on: macos-latest
@@ -624,7 +612,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=tvOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macOS-latest-swift:
     runs-on: macos-latest
@@ -663,7 +651,7 @@ jobs:
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_SERVER=OFF \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
-          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu)
           sudo cmake --install . --config Release
 
       - name: xcodebuild for swift package
@@ -707,7 +695,7 @@ jobs:
         shell: msys2 {0}
         run: |
             cmake -B build
-            cmake --build build --config ${{ matrix.build }} -j $(nproc)
+            cmake --parallel --build build --config ${{ matrix.build }} -j $(nproc)
 
       - name: Clean after building using CMake
         shell: msys2 {0}
@@ -718,7 +706,7 @@ jobs:
         shell: msys2 {0}
         run: |
             cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS
-            cmake --build build --config ${{ matrix.build }} -j $(nproc)
+            cmake --parallel --build build --config ${{ matrix.build }} -j $(nproc)
 
   windows-latest-cmake:
     runs-on: windows-latest
@@ -810,7 +798,7 @@ jobs:
             -DOPENCL_HEADERS_BUILD_TESTING=OFF `
             -DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF `
             -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
-          cmake --build . --target install
+          cmake --parallel --build . --target install
           git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
           cd OpenCL-ICD-Loader
           mkdir build-arm64-release && cd build-arm64-release
@@ -818,13 +806,13 @@ jobs:
             -A arm64 `
             -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/opencl-arm64-release" `
             -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
-          cmake --build . --target install --config release
+          cmake --parallel --build . --target install --config release
 
       - name: Build
         id: cmake_build
         run: |
           cmake -S . -B build ${{ matrix.defines }}
-          cmake --build build --config Release -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --parallel --build build --config Release -j ${env:NUMBER_OF_PROCESSORS}
 
       - name: Add libopenblas.dll
         id: add_libopenblas_dll
@@ -850,9 +838,7 @@ jobs:
         id: cmake_test
         # not all machines have native AVX-512
         if: ${{ matrix.build != 'msvc-arm64' && matrix.build != 'llvm-arm64' && matrix.build != 'llvm-arm64-opencl-adreno' && matrix.build != 'kompute-x64' && matrix.build != 'vulkan-x64' && (matrix.build != 'avx512-x64' || env.HAS_AVX512F == '1') }}
-        run: |
-          cd build
-          ctest -L main -C Release --verbose --timeout 900
+        run: ctest --parallel --test-dir build -L main -C Release --verbose --timeout 900
 
       - name: Test (Intel SDE)
         id: cmake_test_sde
@@ -865,7 +851,7 @@ jobs:
           $sde = $(join-path $env:RUNNER_TEMP sde-external-${env:SDE_VERSION}-win/sde.exe)
           cd build
           $env:LLAMA_SKIP_TESTS_SLOW_ON_EMULATOR = 1
-          & $sde -future -- ctest -L main -C Release --verbose --timeout 900
+          & $sde -future -- ctest --parallel -L main -C Release --verbose --timeout 900
 
       - name: Determine tag name
         id: tag
@@ -928,7 +914,7 @@ jobs:
               -DLLAMA_FATAL_WARNINGS=ON \
               -DGGML_NATIVE=OFF \
               -DGGML_CUDA=ON
-            cmake --build build
+            cmake --parallel --build build
 
   windows-2019-cmake-cuda:
     runs-on: windows-2019
@@ -1023,8 +1009,8 @@ jobs:
             -DGGML_CUDA=ON ^
             -DGGML_RPC=ON
           set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1
-          cmake --build build --config Release -j %NINJA_JOBS% -t ggml
-          cmake --build build --config Release
+          cmake --parallel --build build --config Release -j %NINJA_JOBS% -t ggml
+          cmake --parallel --build build --config Release
 
       - name: Determine tag name
         id: tag
@@ -1187,7 +1173,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DGGML_HIP=ON `
             -DGGML_RPC=ON
-          cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --parallel --build build -j ${env:NUMBER_OF_PROCESSORS}
 
   windows-latest-cmake-hip-release:
     if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
@@ -1237,7 +1223,7 @@ jobs:
             -DAMDGPU_TARGETS=${{ matrix.gpu_target }} `
             -DGGML_HIP=ON `
             -DGGML_RPC=ON
-          cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --parallel --build build -j ${env:NUMBER_OF_PROCESSORS}
           md "build\bin\rocblas\library\"
           cp "${env:HIP_PATH}\bin\hipblas.dll" "build\bin\"
           cp "${env:HIP_PATH}\bin\rocblas.dll" "build\bin\"
@@ -1289,7 +1275,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
           sudo cmake --install . --config Release
 
       - name: xcodebuild for swift package
@@ -1634,4 +1620,4 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
               -DGGML_CANN=on \
               -DSOC_TYPE=${{ matrix.device }}
-          cmake --build build -j $(nproc)
+          cmake --parallel --build build -j $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             -DGGML_METAL_USE_BF16=ON \
             -DGGML_METAL_EMBED_LIBRARY=ON \
             -DGGML_RPC=ON
-          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test
         id: cmake_test
@@ -136,7 +136,7 @@ jobs:
             -DLLAMA_CURL=ON \
             -DGGML_METAL=OFF \
             -DGGML_RPC=ON
-          cmake --parallel --build build --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
 
       - name: Test
         id: cmake_test
@@ -201,7 +201,7 @@ jobs:
             -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_CURL=ON \
             -DGGML_RPC=ON
-          cmake --parallel --build . --config Release -j $(nproc)
+          cmake --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
@@ -283,7 +283,7 @@ jobs:
             -DLLAMA_FATAL_WARNINGS=ON \
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          cmake --parallel --build . --config ${{ matrix.build_type }} -j $(nproc)
+          cmake --build . --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Build (no OpenMP)
         id: cmake_build_no_openmp
@@ -296,7 +296,7 @@ jobs:
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
-          cmake --parallel --build . --config ${{ matrix.build_type }} -j $(nproc)
+          cmake --build . --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Test
         id: cmake_test
@@ -331,7 +331,7 @@ jobs:
           cd build
           cmake .. \
             -DGGML_RPC=ON
-          cmake --parallel --build . --config Release -j $(nproc)
+          cmake --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
@@ -366,7 +366,7 @@ jobs:
           cd build
           cmake .. \
             -DGGML_VULKAN=ON
-          cmake --parallel --build . --config Release -j $(nproc)
+          cmake --build . --config Release -j $(nproc)
 
       - name: Test
         id: cmake_test
@@ -400,7 +400,7 @@ jobs:
           cmake -B build -S . \
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGGML_HIP=ON
-          cmake --parallel --build build --config Release -j $(nproc)
+          cmake --build build --config Release -j $(nproc)
 
       - name: Build with legacy HIP support
         id: cmake_build_legacy_hip
@@ -409,7 +409,7 @@ jobs:
             -DCMAKE_C_COMPILER=hipcc \
             -DCMAKE_CXX_COMPILER=hipcc \
             -DGGML_HIP=ON
-          cmake --parallel --build build2 --config Release -j $(nproc)
+          cmake --build build2 --config Release -j $(nproc)
 
   ubuntu-22-cmake-musa:
     runs-on: ubuntu-22.04
@@ -437,7 +437,7 @@ jobs:
         run: |
           cmake -B build -S . \
             -DGGML_MUSA=ON
-          cmake --parallel --build build --config Release -j $(nproc)
+          cmake --build build --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl:
     runs-on: ubuntu-22.04
@@ -487,7 +487,7 @@ jobs:
             -DGGML_SYCL=ON \
             -DCMAKE_C_COMPILER=icx \
             -DCMAKE_CXX_COMPILER=icpx
-          cmake --parallel --build . --config Release -j $(nproc)
+          cmake --build . --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl-fp16:
     runs-on: ubuntu-22.04
@@ -538,7 +538,7 @@ jobs:
             -DCMAKE_C_COMPILER=icx \
             -DCMAKE_CXX_COMPILER=icpx \
             -DGGML_SYCL_F16=ON
-          cmake --parallel --build . --config Release -j $(nproc)
+          cmake --build . --config Release -j $(nproc)
 
   macOS-latest-cmake-ios:
     runs-on: macos-latest
@@ -575,7 +575,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macOS-latest-cmake-tvos:
     runs-on: macos-latest
@@ -612,7 +612,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=tvOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macOS-latest-swift:
     runs-on: macos-latest
@@ -651,7 +651,7 @@ jobs:
             -DLLAMA_BUILD_TESTS=OFF \
             -DLLAMA_BUILD_SERVER=OFF \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
-          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu)
+          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu)
           sudo cmake --install . --config Release
 
       - name: xcodebuild for swift package
@@ -695,7 +695,7 @@ jobs:
         shell: msys2 {0}
         run: |
             cmake -B build
-            cmake --parallel --build build --config ${{ matrix.build }} -j $(nproc)
+            cmake --build build --config ${{ matrix.build }} -j $(nproc)
 
       - name: Clean after building using CMake
         shell: msys2 {0}
@@ -706,7 +706,7 @@ jobs:
         shell: msys2 {0}
         run: |
             cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS
-            cmake --parallel --build build --config ${{ matrix.build }} -j $(nproc)
+            cmake --build build --config ${{ matrix.build }} -j $(nproc)
 
   windows-latest-cmake:
     runs-on: windows-latest
@@ -798,7 +798,7 @@ jobs:
             -DOPENCL_HEADERS_BUILD_TESTING=OFF `
             -DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF `
             -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
-          cmake --parallel --build . --target install
+          cmake --build . --target install -j
           git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
           cd OpenCL-ICD-Loader
           mkdir build-arm64-release && cd build-arm64-release
@@ -806,13 +806,13 @@ jobs:
             -A arm64 `
             -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/opencl-arm64-release" `
             -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
-          cmake --parallel --build . --target install --config release
+          cmake --build . --target install --config release -j
 
       - name: Build
         id: cmake_build
         run: |
           cmake -S . -B build ${{ matrix.defines }}
-          cmake --parallel --build build --config Release -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --build build --config Release -j ${env:NUMBER_OF_PROCESSORS}
 
       - name: Add libopenblas.dll
         id: add_libopenblas_dll
@@ -914,7 +914,7 @@ jobs:
               -DLLAMA_FATAL_WARNINGS=ON \
               -DGGML_NATIVE=OFF \
               -DGGML_CUDA=ON
-            cmake --parallel --build build
+            cmake --build build
 
   windows-2019-cmake-cuda:
     runs-on: windows-2019
@@ -1009,8 +1009,8 @@ jobs:
             -DGGML_CUDA=ON ^
             -DGGML_RPC=ON
           set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1
-          cmake --parallel --build build --config Release -j %NINJA_JOBS% -t ggml
-          cmake --parallel --build build --config Release
+          cmake --build build --config Release -j %NINJA_JOBS% -t ggml
+          cmake --build build --config Release
 
       - name: Determine tag name
         id: tag
@@ -1173,7 +1173,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DGGML_HIP=ON `
             -DGGML_RPC=ON
-          cmake --parallel --build build -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
 
   windows-latest-cmake-hip-release:
     if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
@@ -1223,7 +1223,7 @@ jobs:
             -DAMDGPU_TARGETS=${{ matrix.gpu_target }} `
             -DGGML_HIP=ON `
             -DGGML_RPC=ON
-          cmake --parallel --build build -j ${env:NUMBER_OF_PROCESSORS}
+          cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
           md "build\bin\rocblas\library\"
           cp "${env:HIP_PATH}\bin\hipblas.dll" "build\bin\"
           cp "${env:HIP_PATH}\bin\rocblas.dll" "build\bin\"
@@ -1275,7 +1275,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=ggml
-          cmake --parallel --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
+          cmake --build . --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
           sudo cmake --install . --config Release
 
       - name: xcodebuild for swift package
@@ -1620,4 +1620,4 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
               -DGGML_CANN=on \
               -DSOC_TYPE=${{ matrix.device }}
-          cmake --parallel --build build -j $(nproc)
+          cmake --build build -j $(nproc)


### PR DESCRIPTION
DRAFT: unclear if useful at all

*Edit*: doesn't look beneficial at all ([parallel ctest run](https://github.com/ggerganov/llama.cpp/actions/runs/13074611705?pr=11546) vs. [other run](https://github.com/ggerganov/llama.cpp/actions/runs/13074180257?pr=11545)), even for the jobs that do run ctests (not that many anyway), so canning this.

Trying to use some of those sweet [github runner cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), now that ci time is dominated by tests for some jobs (since https://github.com/ggerganov/llama.cpp/pull/11516)

Note: server tests are trickier to parallelize, will need distinct ports + something like `pytest-xdist` or `pytest-parallel`, and parallel server might compete for compute and RAM anyway, esp. for the slow tests