### PR TITLE
ci: use ccache on windows HIP jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1178,7 +1178,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: ${{ github.job }}
-          variant: sccache
           evict-old-files: 1d
 
       - name: Build
@@ -1186,7 +1185,6 @@ jobs:
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
-          $env:CMAKE_HIP_COMPILER_LAUNCHER=sccache
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\bin\clang++.exe" `
@@ -1214,7 +1212,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
           key: windows-latest-cmake-hip-release
-          variant: sccache
           evict-old-files: 1d
 
       - name: Install
@@ -1237,7 +1234,6 @@ jobs:
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
-          $env:CMAKE_HIP_COMPILER_LAUNCHER=sccache
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\bin\clang++.exe" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1186,6 +1186,7 @@ jobs:
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
+          $env:CMAKE_HIP_COMPILER_LAUNCHER=sccache
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\bin\clang++.exe" `
@@ -1236,6 +1237,7 @@ jobs:
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
+          $env:CMAKE_HIP_COMPILER_LAUNCHER=sccache
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\bin\clang++.exe" `

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -100,6 +100,10 @@ if (GGML_CCACHE)
             set(GGML_CCACHE_VARIANT ccache)
         else()
             set(GGML_CCACHE_VARIANT sccache)
+            if(GGML_HIP)
+                # TODO: should not be set globally
+                set(GLOBAL CMAKE_HIP_COMPILER_LAUNCHER sccache)
+            endif()
         endif()
         # TODO: should not be set globally
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${GGML_CCACHE_VARIANT}")

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -100,10 +100,6 @@ if (GGML_CCACHE)
             set(GGML_CCACHE_VARIANT ccache)
         else()
             set(GGML_CCACHE_VARIANT sccache)
-            if(GGML_HIP)
-                # TODO: should not be set globally
-                set(GLOBAL CMAKE_HIP_COMPILER_LAUNCHER sccache)
-            endif()
         endif()
         # TODO: should not be set globally
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${GGML_CCACHE_VARIANT}")


### PR DESCRIPTION
Revert windows HIP build to plain ccache, which seems to work (despite caveats about windows support for the github action).

Also tried CMAKE_HIP_COMPILER_LAUNCHER described in https://github.com/ROCm/ROCm/issues/2817, in vain.

[ref](https://github.com/ggerganov/llama.cpp/pull/11545)