### PR TITLE
NUMA-aware KV cache buffer type (experimental)

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -348,6 +348,7 @@ extern "C" {
     // CPU buffer types are always available
     GGML_API ggml_backend_buffer_t      ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
     GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
+    GGML_API ggml_backend_buffer_type_t ggml_backend_numa_buffer_type(void);
 
 #ifdef  __cplusplus
 }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2000,3 +2000,84 @@ ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size) 
     GGML_ASSERT((uintptr_t)ptr % TENSOR_ALIGNMENT == 0 && "buffer pointer must be aligned");
     return ggml_backend_buffer_init(ggml_backend_cpu_buffer_from_ptr_type(), ggml_backend_cpu_buffer_from_ptr_i, ptr, size);
 }
+
+// NUMA buffer interface - similar to CPU, but with pages allocated accordingly to a NUMA first-touch policy
+
+#include <sys/mman.h>
+
+static void ggml_backend_numa_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+    if (munmap((char *) buffer->context, buffer->size)) {
+        GGML_LOG_WARN("warning: munmap failed: %s\n", strerror(errno));
+    }
+}
+
+static void ggml_backend_numa_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
+    if (posix_madvise(buffer->context, buffer->size, POSIX_MADV_DONTNEED)) {
+        GGML_LOG_WARN("warning: posix_madvise(.., POSIX_MADV_DONTNEED) failed: %s\n",
+                strerror(errno));
+    }
+}
+
+static const struct ggml_backend_buffer_i ggml_backend_numa_buffer_i = {
+    /* .free_buffer     = */ ggml_backend_numa_buffer_free_buffer,
+    /* .get_base        = */ ggml_backend_cpu_buffer_get_base,
+    /* .init_tensor     = */ NULL, // no initialization required
+    /* .memset_tensor   = */ ggml_backend_cpu_buffer_memset_tensor,
+    /* .set_tensor      = */ ggml_backend_cpu_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_cpu_buffer_get_tensor,
+    /* .cpy_tensor      = */ ggml_backend_cpu_buffer_cpy_tensor,
+    /* .clear           = */ ggml_backend_numa_buffer_clear,
+    /* .reset           = */ NULL,
+};
+
+// NUMA buffer type - similar to CPU, but with pages allocated accordingly to a NUMA first-touch policy
+
+static const char * ggml_backend_numa_buffer_type_get_name(ggml_backend_buffer_type_t buft) {
+    return "NUMA";
+
+    GGML_UNUSED(buft);
+}
+
+static ggml_backend_buffer_t ggml_backend_numa_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    int flags = MAP_SHARED | MAP_ANONYMOUS;
+    void * data = mmap(NULL, size, PROT_READ|PROT_WRITE, flags, -1, 0);
+    if (data == MAP_FAILED) {
+        GGML_LOG_ERROR("%s: failed to allocate buffer of size %zu\n", __func__, size);
+        return NULL;
+    }
+    if (posix_madvise(data, size, POSIX_MADV_RANDOM)) {
+        GGML_LOG_WARN("warning: posix_madvise(.., POSIX_MADV_RANDOM) failed: %s\n",
+                strerror(errno));
+    }
+
+    return ggml_backend_buffer_init(buft, ggml_backend_numa_buffer_i, data, size);
+}
+
+static size_t ggml_backend_numa_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+    return TENSOR_ALIGNMENT;
+
+    GGML_UNUSED(buft);
+}
+
+static bool ggml_backend_numa_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
+    return true;
+
+    GGML_UNUSED(buft);
+}
+
+ggml_backend_buffer_type_t ggml_backend_numa_buffer_type(void) {
+    static struct ggml_backend_buffer_type ggml_backend_numa_buffer_type = {
+        /* .iface   = */ {
+            /* .get_name         = */ ggml_backend_numa_buffer_type_get_name,
+            /* .alloc_buffer     = */ ggml_backend_numa_buffer_type_alloc_buffer,
+            /* .get_alignment    = */ ggml_backend_numa_buffer_type_get_alignment,
+            /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
+            /* .get_alloc_size   = */ NULL, // defaults to ggml_nbytes
+            /* .is_host          = */ ggml_backend_numa_buffer_type_is_host,
+        },
+        /* .device  = */ NULL, // FIXME ggml_backend_reg_dev_get(ggml_backend_cpu_reg(), 0),
+        /* .context = */ NULL,
+    };
+
+    return &ggml_backend_numa_buffer_type;
+}

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -71,6 +71,13 @@ bool llama_kv_cache_init(
     cache.k_l.reserve(n_layer);
     cache.v_l.reserve(n_layer);
 
+    auto * reg = ggml_backend_dev_backend_reg(ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU));
+    auto * is_numa_fn = (decltype(ggml_is_numa) *) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cpu_is_numa");
+    bool is_numa = is_numa_fn();
+    if (!offload && is_numa) {
+        LLAMA_LOG_INFO("%s: NUMA usage detected, using NUMA-aware buffer for KV cache\n", __func__);
+    }
+
     for (int i = 0; i < n_layer; i++) {
         const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(i) + hparams.n_embd_k_s();
         const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(i) + hparams.n_embd_v_s();
@@ -82,7 +89,11 @@ bool llama_kv_cache_init(
             auto * dev = model.dev_layer(i);
             buft = ggml_backend_dev_buffer_type(dev);
         } else {
-            buft = ggml_backend_cpu_buffer_type();
+            if (is_numa) {
+                buft = ggml_backend_numa_buffer_type();
+            } else {
+                buft = ggml_backend_cpu_buffer_type();
+            }
         }
         ggml_context * ctx = ctx_for_buft(buft);
 


### PR DESCRIPTION
This PR contains an experimental NUMA-aware KV cache buffer implementation so that people can try it and check if it improves performance on multi-CPU systems.

IMPORTANT: this mechanism works only in conjunction with `--no-kv-offload` option

Also most likely this code won't compile on Windows, so it's not merge-ready.

The idea behind this is to allocate memory for KV buffer tensors the same way as for model tensors - that is by using mmap() function. In this case we are not mapping an existing file to memory but use a MAP_ANONYMOUS flag - you can think about it as a zeroized virtual file. The purpose is to allocate pages backing the KV cache accordingly to the first-touch policy on a NUMA node that will use the given KV cache memory fragment.

This prevents allocating the whole KV cache on a single NUMA node like it's currently done. To illustrate the problem examine this numactl --hardware output taken in the middle of loading of a very large model:

```
available: 8 nodes (0-7)
node 0 cpus: 0 1 2 3 32 33 34 35
node 0 size: 48051 MB
node 0 free: 19959 MB
node 1 cpus: 4 5 6 7 36 37 38 39
node 1 size: 48381 MB
node 1 free: 20286 MB
node 2 cpus: 8 9 10 11 40 41 42 43
node 2 size: 48381 MB
node 2 free: 20168 MB
node 3 cpus: 12 13 14 15 44 45 46 47
node 3 size: 48381 MB
node 3 free: 20425 MB
node 4 cpus: 16 17 18 19 48 49 50 51
node 4 size: 48381 MB
node 4 free: 20279 MB
node 5 cpus: 20 21 22 23 52 53 54 55
node 5 size: 48381 MB
node 5 free: 154 MB
node 6 cpus: 24 25 26 27 56 57 58 59
node 6 size: 48337 MB
node 6 free: 20392 MB
node 7 cpus: 28 29 30 31 60 61 62 63
node 7 size: 48338 MB
node 7 free: 20200 MB
```

Note that NUMA node 5 has no free memory left while other nodes still have around 20GB of free memory. In this case KV cache size was around 20GB, so it was allocated on NUMA node 5. This node has no free memory left, so CPU cores associated with this node will have to make foreign (non-local) memory accesses to use model weights that would be originally placed in memory associated with this NUMA node.

With this PR we have uniform memory usage across all NUMA nodes:

```
available: 8 nodes (0-7)
node 0 cpus: 0 1 2 3 32 33 34 35
node 0 size: 48051 MB
node 0 free: 20269 MB
node 1 cpus: 4 5 6 7 36 37 38 39
node 1 size: 48381 MB
node 1 free: 20847 MB
node 2 cpus: 8 9 10 11 40 41 42 43
node 2 size: 48381 MB
node 2 free: 20340 MB
node 3 cpus: 12 13 14 15 44 45 46 47
node 3 size: 48381 MB
node 3 free: 20751 MB
node 4 cpus: 16 17 18 19 48 49 50 51
node 4 size: 48381 MB
node 4 free: 20747 MB
node 5 cpus: 20 21 22 23 52 53 54 55
node 5 size: 48337 MB
node 5 free: 20701 MB
node 6 cpus: 24 25 26 27 56 57 58 59
node 6 size: 48381 MB
node 6 free: 20739 MB
node 7 cpus: 28 29 30 31 60 61 62 63
node 7 size: 48338 MB
node 7 free: 20495 MB
```

It would be nice if someone with a dual AMD Epyc Linux system could check if this PR makes any difference in performance. The test would be as follows:

1. As root do `echo 0 > /proc/sys/kernel/numa_balancing`
2. Run llama-bench on some large model without this PR, use `--numa distribute --no-kv-offload 1` options. Make sure the model is fully cached in memory, so it's best to run the command twice.
3. As root do `echo 3 > /proc/sys/vm/drop_caches`
4. Run llama-bench compiled with this PR applied, use the same `--numa distribute --no-kv-offload 1` options. Also run the command twice.
5. Post the outputs of the second llama-bench runs here.

Edit: tested this, found no meaningful difference in performance.