### PR TITLE
`ci`: fix openEuler ci env that lacks ostringstream::str

### DIFF
--- a/common/minja.hpp
+++ b/common/minja.hpp
@@ -824,7 +824,7 @@ public:
     LoopControlType control_type;
     LoopControlException(const std::string & message, LoopControlType control_type) : std::runtime_error(message), control_type(control_type) {}
     LoopControlException(LoopControlType control_type)
-      : std::runtime_error((std::ostringstream() << (control_type == LoopControlType::Continue ? "continue" : "break") << " outside of a loop").str()),
+      : std::runtime_error((control_type == LoopControlType::Continue ? "continue" : "break") + std::string(" outside of a loop")),
         control_type(control_type) {}
 };
 


### PR DESCRIPTION
[Example failure](https://github.com/ggerganov/llama.cpp/actions/runs/13091253346/job/36528139797)

Broken by https://github.com/ggerganov/llama.cpp/pull/11574 (~~not sure how I missed the presubmit~~ job requires `Ascend NPU` label on PRs to run)