### PR TITLE
scripts: added inline script metadata per PEP 723

### DIFF
--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "GitPython",
+#   "tabulate",
+# ]
+# ///
 
 import logging
 import argparse

--- a/scripts/gen-unicode-data.py
+++ b/scripts/gen-unicode-data.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#   "requests",
+# ]
+# ///
+
 from __future__ import annotations
 
 import array

--- a/scripts/get_chat_template.py
+++ b/scripts/get_chat_template.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# /// script
+# dependencies = [
+#   "huggingface_hub",
+#   "requests",
+# ]
+# ///
+
 '''
   Fetches the Jinja chat template of a HuggingFace model.
   If a model has multiple chat templates, you can specify the variant name.


### PR DESCRIPTION
## Motivation
In October 2023, PEP 723 introduced an official specification for inline script metadata: https://packaging.python.org/en/latest/specifications/inline-script-metadata/

Inline script metadata allows compatible tools to discover the dependencies of a given script without needing to parse any `requirements.txt` or `pyproject.toml`.

For example, the `uv` tool [supports this](https://docs.astral.sh/uv/guides/scripts/), which means you can just run `uv run ./script.py` and it will automatically parse the metadata and create a temporary virtual environment.

Because inline metadata is just a comment, it's fully backwards-compatible; tools that don't use it will just ignore it.

## Changes

This PR adds inline metadata to the Python scripts in the `scripts/` directory, such that they can be directly run with compatible tools.

Example (note that I wasn't in a virtual environment and my global Python packages remained untouched):
```bash
❯ uv run ./scripts/get_chat_template.py CohereForAI/c4ai-command-r7b-12-2024 tool_use
Reading inline script metadata from `scripts/get_chat_template.py`
Installed 12 packages in 8ms
# ... output of script as normal ...
```