### PR TITLE
Update common.cpp

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -57,6 +57,7 @@
 #if defined(LLAMA_USE_CURL)
 #include <curl/curl.h>
 #include <curl/easy.h>
+#include <thread>
 #include <future>
 #endif
 


### PR DESCRIPTION
add #include <thread> as it was in earlier versions of common.cpp.  Without  this under Windows (gcc  mingw) didn't work ctl+c in cmd.

*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
