### PR TITLE
add --rpc-layers flag to explicitly set RPC layers

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1490,6 +1490,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_N_GPU_LAYERS"));
     add_opt(common_arg(
+        {"-nrl", "--rpc-layers", "--n-rpc-layers"}, "N",
+        "number of layers to store on remote RPC devices",
+        [](common_params & params, int value) {
+            params.n_rpc_layers = value;
+        }
+    ).set_env("LLAMA_ARG_N_RPC_LAYERS"));
+    add_opt(common_arg(
         {"-sm", "--split-mode"}, "{none,layer,row}",
         "how to split the model across multiple GPUs, one of:\n"
         "- none: use one GPU only\n"

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1086,6 +1086,9 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     if (params.n_gpu_layers != -1) {
         mparams.n_gpu_layers = params.n_gpu_layers;
     }
+    if (params.n_rpc_layers != -1) {
+        mparams.n_rpc_layers = params.n_rpc_layers;
+    }
     mparams.main_gpu        = params.main_gpu;
     mparams.split_mode      = params.split_mode;
     mparams.tensor_split    = params.tensor_split;

--- a/common/common.h
+++ b/common/common.h
@@ -217,6 +217,7 @@ struct common_params {
     std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
 
     int32_t n_gpu_layers      = -1;  // number of layers to store in VRAM (-1 - use default)
+    int32_t n_rpc_layers      = -1;  // number of layers to store on RPC devices (-1 - use default)
     int32_t main_gpu          = 0;   // the GPU that is used for scratch and small tensors
     float   tensor_split[128] = {0}; // how split tensors should be distributed across GPUs
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -280,6 +280,7 @@ extern "C" {
         ggml_backend_dev_t * devices;
 
         int32_t n_gpu_layers; // number of layers to store in VRAM
+        int32_t n_rpc_layers; // number of layers to delegate to RPC connected devices
         enum llama_split_mode split_mode; // how to split the model across multiple GPUs
 
         // the GPU that is used for the entire model when split_mode is LLAMA_SPLIT_MODE_NONE


### PR DESCRIPTION
The current setup does not allow for very precise control of how many layers to put on the local GPUs vs the remote RPC connected server(s). This adds an additional `--rpc-layers` flag (`-nrl`) which allows the user to explicitly set the number of layers to offload to RPC end.