### PR TITLE
ci: add bash script to check if llama-impl.h was included erroneously

### DIFF
--- a/.github/workflows/precompile-checks.yml
+++ b/.github/workflows/precompile-checks.yml
@@ -1,0 +1,21 @@
+name: Precompile Checks
+
+on:
+  push:
+    branches:
+      - master
+    paths: ['**/*.c', '**/*.cpp']
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: ['**/*.c', '**/*.cpp']
+
+jobs:
+  precompile-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Forbidden Includes Check
+        run: bash scripts/precompile-checks.sh

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ifdef GGML_VULKAN
 	BUILD_TARGETS += vulkan-shaders-gen
 endif
 
-default: $(BUILD_TARGETS) $(LEGACY_TARGETS_BUILD)
+default: precompile_checks $(BUILD_TARGETS) $(LEGACY_TARGETS_BUILD)
 
 test: $(TEST_TARGETS)
 	@failures=0; \
@@ -247,6 +247,10 @@ test: $(TEST_TARGETS)
 	@echo 'All tests passed.'
 
 all: $(BUILD_TARGETS) $(TEST_TARGETS) $(LEGACY_TARGETS_BUILD)
+
+# Run the forbidden includes check before every build
+precompile_checks:
+	@bash ./scripts/precompile-checks.sh
 
 ifdef RISCV_CROSS_COMPILE
 CC	:= riscv64-unknown-linux-gnu-gcc

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ifdef GGML_VULKAN
 	BUILD_TARGETS += vulkan-shaders-gen
 endif
 
-default: precompile_checks $(BUILD_TARGETS) $(LEGACY_TARGETS_BUILD)
+default: $(BUILD_TARGETS) $(LEGACY_TARGETS_BUILD)
 
 test: $(TEST_TARGETS)
 	@failures=0; \
@@ -247,10 +247,6 @@ test: $(TEST_TARGETS)
 	@echo 'All tests passed.'
 
 all: $(BUILD_TARGETS) $(TEST_TARGETS) $(LEGACY_TARGETS_BUILD)
-
-# Run the forbidden includes check before every build
-precompile_checks:
-	@bash ./scripts/precompile-checks.sh
 
 ifdef RISCV_CROSS_COMPILE
 CC	:= riscv64-unknown-linux-gnu-gcc

--- a/scripts/precompile-checks.sh
+++ b/scripts/precompile-checks.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This runs some pre compilation sanity checks that certain project rules and guidelines are kept
+# This will not contain any signifiant logic, but mostly just obvious and easily greppable checks
+
+ERROR_FOUND=0
+
+
+## START OF INCLUDES EXCLUDED FROM EXAMPLES FOLDER ##
+SRC_DIR="./examples"
+FORBIDDEN_HEADERS=("llama-impl.h")
+echo "🔍 Scanning for forbidden includes in $SRC_DIR..."
+for HEADER in "${FORBIDDEN_HEADERS[@]}"; do
+  MATCHES=$(grep -rn --include=\*.{c,cpp} "#include \"$HEADER\"" "$SRC_DIR" 2>/dev/null)
+
+  if [[ -n "$MATCHES" ]]; then
+    echo "❌ Forbidden include detected: $HEADER"
+    echo "$MATCHES" | while IFS=: read -r FILE LINE _; do
+      echo "::error file=$FILE,line=$LINE::Forbidden include: $HEADER in $FILE at line $LINE"
+    done
+    ERROR_FOUND=1
+  fi
+
+done
+## END OF INCLUDES EXCLUDED FROM EXAMPLES FOLDER ##
+
+
+if [[ "$ERROR_FOUND" -eq 1 ]]; then
+  echo "❌ Forbidden includes found. Please remove!"
+  exit 1
+else
+  echo "✅ No forbidden includes found."
+fi

--- a/scripts/precompile-checks.sh
+++ b/scripts/precompile-checks.sh
@@ -11,23 +11,23 @@ SRC_DIR="./examples"
 FORBIDDEN_HEADERS=("llama-impl.h")
 echo "🔍 Scanning for forbidden includes in $SRC_DIR..."
 for HEADER in "${FORBIDDEN_HEADERS[@]}"; do
-  MATCHES=$(grep -rn --include=\*.{c,cpp} "#include \"$HEADER\"" "$SRC_DIR" 2>/dev/null)
+    MATCHES=$(grep -rn --include=\*.{c,cpp} "#include \"$HEADER\"" "$SRC_DIR" 2>/dev/null)
 
-  if [[ -n "$MATCHES" ]]; then
-    echo "❌ Forbidden include detected: $HEADER"
-    echo "$MATCHES" | while IFS=: read -r FILE LINE _; do
-      echo "::error file=$FILE,line=$LINE::Forbidden include: $HEADER in $FILE at line $LINE"
-    done
-    ERROR_FOUND=1
-  fi
+    if [[ -n "$MATCHES" ]]; then
+        echo "❌ Forbidden include detected: $HEADER"
+        echo "$MATCHES" | while IFS=: read -r FILE LINE _; do
+            echo "::error file=$FILE,line=$LINE::Forbidden include: $HEADER in $FILE at line $LINE"
+        done
+        ERROR_FOUND=1
+    fi
 
 done
 ## END OF INCLUDES EXCLUDED FROM EXAMPLES FOLDER ##
 
 
 if [[ "$ERROR_FOUND" -eq 1 ]]; then
-  echo "❌ Forbidden includes found. Please remove!"
-  exit 1
+    echo "❌ Forbidden includes found. Please remove!"
+    exit 1
 else
-  echo "✅ No forbidden includes found."
+    echo "✅ No forbidden includes found."
 fi


### PR DESCRIPTION
This PR will add some automation to checks against certain includes.

Unsure how to add to make, so the client side checks is only for makefile for now.

This rule is based on  Ggerganov's directive in https://github.com/ggerganov/llama.cpp/pull/11596#pullrequestreview-2589222357