### PR TITLE
server : add try..catch to places not covered by set_exception_handler

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3353,14 +3353,12 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
         return;
     }
 
-    try {
-        LOG_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
+    // reminder: this function is not covered by httplib's exception handler; if someone does more complicated stuff, think about wrapping it in try-catch
 
-        LOG_DBG("request:  %s\n", req.body.c_str());
-        LOG_DBG("response: %s\n", res.body.c_str());
-    } catch (const std::exception & e) {
-        LOG_ERR("failed to log request/response: %s\n", e.what());
-    }
+    LOG_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
+
+    LOG_DBG("request:  %s\n", req.body.c_str());
+    LOG_DBG("response: %s\n", res.body.c_str());
 }
 
 std::function<void(int)> shutdown_handler;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3353,10 +3353,14 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
         return;
     }
 
-    LOG_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
+    try {
+        LOG_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
 
-    LOG_DBG("request:  %s\n", req.body.c_str());
-    LOG_DBG("response: %s\n", res.body.c_str());
+        LOG_DBG("request:  %s\n", req.body.c_str());
+        LOG_DBG("response: %s\n", res.body.c_str());
+    } catch (const std::exception & e) {
+        LOG_ERR("failed to log request/response: %s\n", e.what());
+    }
 }
 
 std::function<void(int)> shutdown_handler;
@@ -3439,9 +3443,13 @@ int main(int argc, char ** argv) {
             message = "Unknown Exception";
         }
 
-        json formatted_error = format_error_response(message, ERROR_TYPE_SERVER);
-        LOG_WRN("got exception: %s\n", formatted_error.dump().c_str());
-        res_error(res, formatted_error);
+        try {
+            json formatted_error = format_error_response(message, ERROR_TYPE_SERVER);
+            LOG_WRN("got exception: %s\n", formatted_error.dump().c_str());
+            res_error(res, formatted_error);
+        } catch (const std::exception & e) {
+            LOG_ERR("got another exception: %s | while hanlding exception: %s\n", e.what(), message.c_str());
+        }
     });
 
     svr->set_error_handler([&res_error](const httplib::Request &, httplib::Response & res) {


### PR DESCRIPTION
For httplib, the exceptions inside `set_exception_handler` and `set_logger` are not being handled
