### PR TITLE
server : remove CPPHTTPLIB_NO_EXCEPTIONS define

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -5,10 +5,6 @@
 #include "llama.h"
 #include "common/base64.hpp"
 
-#ifndef NDEBUG
-// crash the server in debug mode, otherwise send an http 500 error
-#define CPPHTTPLIB_NO_EXCEPTIONS 1
-#endif
 // increase max payload length to allow use of larger context size
 #define CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH 1048576
 #include "httplib.h"


### PR DESCRIPTION
This commit removes the `CPPHTTPLIB_NO_EXCEPTIONS` define from the server code.

The motivation for this is that when using a debug build the server would crash when an exception was throws and terminate the server process, as it was unhandled. When `CPPHTTPLIB_NO_EXCEPTIONS` is set cpp_httplib will not call the exception handler, which would normally return a 500 error to the client. This caused tests to fail when using a debug build.

Fixes: https://github.com/ggerganov/llama.cpp/issues/11613
