### PR TITLE
server : use httplib status codes

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -4321,7 +4321,6 @@ int main(int argc, char ** argv) {
             });
         }
         res_ok(res, result);
-        res.status = httplib::StatusCode::OK_200; // HTTP OK
     };
 
     const auto handle_lora_adapters_apply = [&](const httplib::Request & req, httplib::Response & res) {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3516,7 +3516,7 @@ int main(int argc, char ** argv) {
             auto tmp = string_split<std::string>(req.path, '.');
             if (req.path == "/" || tmp.back() == "html") {
                 res.set_content(reinterpret_cast<const char*>(loading_html), loading_html_len, "text/html; charset=utf-8");
-                res.status = res.status == httplib::StatusCode::ServiceUnavailable_503;
+                res.status = httplib::StatusCode::ServiceUnavailable_503;
             } else {
                 res_error(res, format_error_response("Loading model", ERROR_TYPE_UNAVAILABLE));
             }

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1051,31 +1051,31 @@ static json format_error_response(const std::string & message, const enum error_
     switch (type) {
         case ERROR_TYPE_INVALID_REQUEST:
             type_str = "invalid_request_error";
-            code = httplib::StatusCode::BadRequest_400;
+            code = 400;
             break;
         case ERROR_TYPE_AUTHENTICATION:
             type_str = "authentication_error";
-            code = httplib::StatusCode::Unauthorized_401;
+            code = 401;
             break;
         case ERROR_TYPE_NOT_FOUND:
             type_str = "not_found_error";
-            code = httplib::StatusCode::NotFound_404;
+            code = 404;
             break;
         case ERROR_TYPE_SERVER:
             type_str = "server_error";
-            code = httplib::StatusCode::InternalServerError_500;
+            code = 500;
             break;
         case ERROR_TYPE_PERMISSION:
             type_str = "permission_error";
-            code = httplib::StatusCode::Forbidden_403;
+            code = 403;
             break;
         case ERROR_TYPE_NOT_SUPPORTED:
             type_str = "not_supported_error";
-            code = httplib::StatusCode::NotImplemented_501;
+            code = 501;
             break;
         case ERROR_TYPE_UNAVAILABLE:
             type_str = "unavailable_error";
-            code = httplib::StatusCode::ServiceUnavailable_503;
+            code = 503;
             break;
     }
     return json {


### PR DESCRIPTION
This commit replaces the status code number with the httplib `StatusCode` enum values.

The motivation for this change is to make the code a little more readable.
