### PR TITLE
common : change longest common subsequence to substring [no ci]

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1652,7 +1652,7 @@ size_t common_lcs(const llama_tokens & a, const llama_tokens & b) {
     size_t a_len = a.size();
     size_t b_len = b.size();
 
-    // initialize the maximum length of the longest common subsequence (LCS)
+    // initialize the maximum length of the longest common substring (LCS)
     size_t max_length = 0;
 
     // use two rows instead of a 2D matrix to optimize space

--- a/common/common.h
+++ b/common/common.h
@@ -562,7 +562,7 @@ void common_batch_add(
 // longest common prefix
 size_t common_lcp(const llama_tokens & a, const llama_tokens & b);
 
-// longet common subsequence
+// longest common substring
 size_t common_lcs(const llama_tokens & a, const llama_tokens & b);
 
 //

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2008,10 +2008,10 @@ struct server_context {
                     continue;
                 }
 
-                // length of the Longest Common Subsequence between the current slot's prompt and the input prompt
+                // length of the Longest Common Substring between the current slot's prompt and the input prompt
                 int cur_lcs_len = common_lcs(slot.cache_tokens, task.prompt_tokens);
 
-                // fraction of the common subsequence length compared to the current slot's prompt length
+                // fraction of the common substring length compared to the current slot's prompt length
                 float cur_similarity = static_cast<float>(cur_lcs_len) / static_cast<int>(slot.cache_tokens.size());
 
                 // select the current slot if the criteria match


### PR DESCRIPTION
This commit updates the comments in the code to reflect that the function `common_lcs()` is actually computing the length of the longest common substring between two sequences (consecutive elements), not the longest common subsequence.

The motivation for this change it to clarify the intent of the function.
