### PR TITLE
llama: fix (non hf) glm4 models

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7217,7 +7217,7 @@ struct llm_build_context {
                 struct ggml_tensor * Qcur = nullptr;
                 struct ggml_tensor * Kcur = nullptr;
                 struct ggml_tensor * Vcur = nullptr;
-                if (model.type == LLM_TYPE_1_5B || model.type == LLM_TYPE_4B || model.type == LLM_TYPE_9B) {
+                if (model.layers[il].wqkv == nullptr) {
                     Qcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wq, cur);
                     if (model.layers[il].bq) {
                         Qcur = ggml_add(ctx0, Qcur, model.layers[il].bq);


### PR DESCRIPTION
fixes segfault when running old (non hf) glm4 models
e.g. https://huggingface.co/THUDM/glm-4-9b-chat

fixes: #11651 

fixes inconsistency with:
https://github.com/ggerganov/llama.cpp/blob/9f4cc8f8d310b13ab3fc93a9be81b1d1376a7fa6/src/llama-model.cpp#L3086-L3088