### PR TITLE
readme : add link to Autopen under UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [ramalama](https://github.com/containers/ramalama) (MIT)
 - [semperai/amica](https://github.com/semperai/amica) (MIT)
 - [withcatai/catai](https://github.com/withcatai/catai) (MIT)
+- [Autopen](https://github.com/blackhole89/autopen) (GPL)
 
 </details>
 


### PR DESCRIPTION
Sorry that after all the months of AWOL this triviality is all I come back with, but I'd be grateful if my little project could be added to the README list.

[Autopen](https://github.com/blackhole89/autopen) is a graphical text editor that uses llama.cpp to tokenize the buffer on the fly, score the buffer, visualise token logits and allow you to switch back and forth between different possible completions at any point. There's a demo video [here](https://www.youtube.com/watch?v=GXWZPpVI0zU). I hope the criteria for inclusion are met, as I'm stating the dependency prominently.

(I think I might also have found some subtle issues (of numerical stability, snapshot save/restore, and/or the CUDA kernels) in the process of working on it, where different sequences of decode calls that *should* give identical results don't, but I'm still working on isolating the exact conditions in a way that is actionable.)