### PR TITLE
fix: ensure proper cleanup of img_res_v.data in all code paths

### DIFF
--- a/examples/llava/llava.cpp
+++ b/examples/llava/llava.cpp
@@ -282,6 +282,7 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
 
             if (!encoded) {
                 LOG_ERR("Unable to encode image - spatial_unpad - subimage %d of %d\n", (int) i+1, (int) img_res_v.size);
+                delete[] img_res_v.data;  // 添加内存释放
                 return false;
             }
             const int64_t t_img_enc_steop_batch_us = ggml_time_us();
@@ -322,6 +323,7 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
         *n_img_pos = (pos * pos + 2);
         if (!encoded){
             LOG_ERR("Unable to encode image \n");
+            delete[] img_res_v.data;  // 添加内存释放
             return false;
         }
     }
@@ -346,6 +348,7 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
             const bool encoded = clip_image_encode(ctx_clip, n_threads, &img_res_v.data[i], image_embd_v[i]); // image data is in 3x336x336 format and will be converted to 336x336x3 inside
             if (!encoded) {
                 LOG_ERR("Unable to encode image - spatial_unpad - subimage %d of %d\n", (int) i+1, (int) img_res_v.size);
+                delete[] img_res_v.data;  // 添加内存释放
                 return false;
             }
         }


### PR DESCRIPTION
# Fix Memory Leak in llava.cpp

## Issue Description
Found possible memory leaks in `encode_image_with_clip` function where `img_res_v.data` is not properly freed in certain error paths. When image encoding fails, some code paths do not properly release the allocated memory.

## Changes
- Added `delete[] img_res_v.data` in all error handling paths
- Ensured proper memory cleanup in the following scenarios:
  - When minicpmv/qwen2vl encoding fails
  - When glm encoding fails
  - When spatial_unpad encoding fails

## Testing
- [x] Local CI tests passed
- [x] Verified with llama-perplexity that the changes do not affect model performance
- [x] Verified with llama-bench that the changes do not affect runtime performance
- [x] Tested on:
  - macOS Ventura 13.x
  - Compiler: Apple clang version 14.0.3

## Additional Notes
- This is a pure memory management fix without any functional changes
- Changes follow the project's coding guidelines