### PR TITLE
fix: free meta memory in clip model loading

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1377,6 +1377,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
         new_clip->ctx_data = ggml_init(params);
         if (!new_clip->ctx_data) {
             LOG_ERR("%s: ggml_init() failed\n", __func__);
+            ggml_free(meta);
             clip_free(new_clip);
             gguf_free(ctx);
             return nullptr;
@@ -1385,6 +1386,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
         auto fin = std::ifstream(fname, std::ios::binary);
         if (!fin) {
             LOG_ERR("cannot open model file for loading tensors\n");
+            ggml_free(meta);
             clip_free(new_clip);
             gguf_free(ctx);
             return nullptr;


### PR DESCRIPTION
# Fix Memory Leak in clip.cpp

## Changes
- Added `ggml_free(meta);` in all error handling paths

## Testing
- [x] Local CI tests passed
- [x] Verified with llama-perplexity that the changes do not affect model performance
- [x] Verified with llama-bench that the changes do not affect runtime performance
- [x] Tested on:
  - macOS Ventura 13.x
  - Compiler: Apple clang version 14.0.3

## Additional Notes
- This is a pure memory management fix without any functional changes
- Changes follow the project's coding guidelines