### PR TITLE
llama : add log about loading model tensors

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1275,6 +1275,8 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
     const bool use_mmap_buffer = true;
 
+    LLAMA_LOG_INFO("%s: loading model tensors, this can take a while... (mmap = %s)\n", __func__, use_mmap_buffer ? "true" : "false");
+
     // build a list of buffer types for the CPU and GPU devices
     pimpl->cpu_buft_list = make_cpu_buft_list(devices);
     for (auto * dev : devices) {


### PR DESCRIPTION
Minor QoL improvement - sometimes it can be confusing why it takes so long to start processing. We now print a message to explain that the model data is being loaded.

```
...
0.00.189.951 I print_info: EOG token        = 128001 '<|end_of_text|>'
0.00.189.951 I print_info: EOG token        = 128009 '<|eot_id|>'
0.00.189.952 I print_info: max token length = 256
0.00.189.952 I load_tensors: loading model tensors, this can take a while... (mmap = true)
...
```