### PR TITLE
ggml : rpc replace reallocation to reuse vector

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -481,15 +481,16 @@ static void ggml_backend_rpc_buffer_init_tensor(ggml_backend_buffer_t buffer, gg
 }
 
 static void ggml_backend_rpc_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    static std::vector<uint8_t> input{};
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     // input serialization format: | rpc_tensor | offset (8 bytes) | data (size bytes) |
     size_t input_size = sizeof(rpc_tensor) + sizeof(uint64_t) + size;
-    std::vector<uint8_t> input(input_size, 0);
+    input.resize(input_size);
     rpc_tensor rpc_tensor = serialize_tensor(tensor);
     memcpy(input.data(), &rpc_tensor, sizeof(rpc_tensor));
     memcpy(input.data() + sizeof(rpc_tensor), &offset, sizeof(offset));
     memcpy(input.data() + sizeof(rpc_tensor) + sizeof(offset), data, size);
-    bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR, input.data(), input.size(), nullptr, 0);
+    bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR, input.data(), input_size, nullptr, 0);
     GGML_ASSERT(status);
 }
 
@@ -1148,6 +1149,8 @@ rpc_server::~rpc_server() {
 }
 
 static void rpc_serve_client(ggml_backend_t backend, sockfd_t sockfd, size_t free_mem, size_t total_mem) {
+    std::vector<uint8_t> set_tensor_vec;
+    set_tensor_vec.reserve(100);
     rpc_server server(backend);
     while (true) {
         uint8_t cmd;
@@ -1247,11 +1250,10 @@ static void rpc_serve_client(ggml_backend_t backend, sockfd_t sockfd, size_t fre
                 break;
             }
             case RPC_CMD_SET_TENSOR: {
-                std::vector<uint8_t> input;
-                if (!recv_msg(sockfd, input)) {
+                if (!recv_msg(sockfd, set_tensor_vec)) {
                     return;
                 }
-                if (!server.set_tensor(input)) {
+                if (!server.set_tensor(set_tensor_vec)) {
                     return;
                 }
                 if (!send_msg(sockfd, nullptr, 0)) {


### PR DESCRIPTION
Good afternoon! I've found a way to optimize tensor transmission a bit further. 
The improvement is approximately -10% in terms of time and -20% according to the profiler. The changes are still in draft form, as I'm unsure how much to allocate initially for the vector.
Perhaps we could extract the "maximum tensor size" from somewhere if it's not too large, or set a constant value—just not as a hardcoded magic number like I used for now (I picked one arbitrarily). I believe the changes are clear to everyone: there won't be any reallocation, whereas previously we were simply calling resize on an empty vector in the recv_msg function.
Also, i go doing experiments with batching sending))
@rgerganov This change is very minor, sorry for bothering you over such a small thing. On one hand, if I create a draft MR, it might go unnoticed. On the other hand, if I open it for merging, someone might accidentally merge my arbitrary constant.
Alse i see warn msg in rpc-server "check_node_graph_compatibility_and_refresh_copy_ops: disabling CUDA graphs due to batch size > 1 [ffn_inp-0] [5120 2 1 1]" what is it? 