### PR TITLE
lasx_ext16_32: Initialize the vector

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -515,7 +515,7 @@ static __m256i lasx_ext8_16(__m128i a) {
 }
 
 static __m256i lasx_ext16_32(__m128i a) {
-    __m256i tmp1;
+    __m256i tmp1 = {0};
     tmp1 = __lasx_xvinsgr2vr_w(tmp1, __lsx_vpickve2gr_h(a, 0), 0);
     tmp1 = __lasx_xvinsgr2vr_w(tmp1, __lsx_vpickve2gr_h(a, 1), 1);
     tmp1 = __lasx_xvinsgr2vr_w(tmp1, __lsx_vpickve2gr_h(a, 2), 2);


### PR DESCRIPTION
In function 'lasx_ext16_32',
 inlined from 'ggml_vec_dot_iq3_s_q8_K' at
/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-quants.c:518:12:
 warning: 'tmp1' may be used uninitialized [-Wmaybe-uninitialized]
 518 |     tmp1 = __lasx_xvinsgr2vr_w(tmp1, __lsx_vpickve2gr_h(a, 0), 0);
     |            ^~~~~~~~~~~~~~~~~~~

*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
