### PR TITLE
Ignore invalid UTF-8 input in the BPE tokenizer

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -618,7 +618,14 @@ std::vector<uint32_t> unicode_cpts_from_utf8(const std::string & utf8) {
     result.reserve(utf8.size());
     size_t offset = 0;
     while (offset < utf8.size()) {
-        result.push_back(unicode_cpt_from_utf8(utf8, offset));
+        try {
+            result.push_back(unicode_cpt_from_utf8(utf8, offset));
+        }
+        catch (const std::invalid_argument & /*ex*/) {
+            // Silently ignore invalid UTF-8 input to avoid leaking the exception beyond llama_tokenize
+            ++offset;
+            result.emplace_back(0xFFFD); // replacement character
+        }
     }
     return result;
 }


### PR DESCRIPTION
This fixes `llama_tokenize` throwing an exception across the C API boundary or libllama's module boundary (the caller's C++ runtime might be incompatible, similarly to #11727!) by silently inserting `U+FFFD`(s) (Unicode replacement character) until the next valid codepoint can be found.

```cpp
llama_tokenize(vocab, "\xE2\x80", 2, nullptr, 0, false, false);

// terminate called after throwing an instance of 'std::invalid_argument'
//   what():  invalid character
```

```
#7  __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7ffff7876d90 <typeinfo for std::invalid_argument>, dest=0x7ffff76c5b30 <std::invalid_argument::~invalid_argument()>)
#8  unicode_cpt_from_utf8 (utf8=<incomplete sequence \342\200>, offset=@0x7fffffffd520: 0)
#9  unicode_cpts_from_utf8 (utf8=<incomplete sequence \342\200>)
#10 unicode_regex_split (text=<incomplete sequence \342\200>, regex_exprs=std::vector of length 1, capacity 1 = {...})
#11 llm_tokenizer_bpe_session::tokenize (this=0x7fffffffdab0, text=<incomplete sequence \342\200>, output=std::vector of length 0, capacity 0)
#12 llama_vocab::impl::tokenize (this=0x55555557c5b0, raw_text=<incomplete sequence \342\200>, add_special=false, parse_special=false)
#13 llama_vocab::tokenize (this=0x555556081440, raw_text=<incomplete sequence \342\200>, add_special=false, parse_special=false)
#14 llama_vocab::tokenize (this=0x555556081440, text=0x555555559074 <incomplete sequence \342\200>, text_len=2, tokens=0x0, n_tokens_max=0, add_special=false, parse_special=false)
#15 llama_tokenize (vocab=0x555556081440, text=0x555555559074 <incomplete sequence \342\200>, text_len=2, tokens=0x0, n_tokens_max=0, add_special=false, parse_special=false)
```

Non-C++ callers cannot reasonably catch that, C++ callers across the DLL boundary might invoke undefined behavior, and the documentation doesn't state that the input must be fully valid UTF-8 or else face unavoidable `std::terminate()`.

Returning a proper error code might be desirable, however `llama_tokenize` already assigns meaning to all return values.

Other areas of llama.cpp already behave similarly when encountering invalid input:
https://github.com/ggerganov/llama.cpp/blob/b7552cfcbc7defccd8bdefd0a7b9c47d145ed3d7/src/llama-vocab.cpp#L1041-L1048
