### PR TITLE
llama : fix progress dots

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9446,8 +9446,8 @@ static struct llama_model * llama_model_load_from_file_impl(
         };
     }
 
-    llama_model * model = new llama_model(params);    
-    
+    llama_model * model = new llama_model(params);
+
     // create list of devices to use with this model
     if (params.devices) {
         for (ggml_backend_dev_t * dev = params.devices; *dev; ++dev) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9428,7 +9428,6 @@ static struct llama_model * llama_model_load_from_file_impl(
         struct llama_model_params params) {
     ggml_time_init();
 
-    llama_model * model = new llama_model(params);
 
     unsigned cur_percentage = 0;
     if (params.progress_callback == NULL) {
@@ -9447,6 +9446,8 @@ static struct llama_model * llama_model_load_from_file_impl(
         };
     }
 
+    llama_model * model = new llama_model(params);    
+    
     // create list of devices to use with this model
     if (params.devices) {
         for (ggml_backend_dev_t * dev = params.devices; *dev; ++dev) {


### PR DESCRIPTION
The progress dots were not displayed during model loading in the new version, and this fix restores the expected behavior.
```
load_tensors:      Vulkan0 model buffer size =  4306.97 MiB
load_tensors:   CPU_Mapped model buffer size =  6828.77 MiB
llama_init_from_model: n_seq_max     = 1
llama_init_from_model: n_ctx         = 4096
llama_init_from_model: n_ctx_per_seq = 4096
```
Fixed the progress dot display during model loading. ilke this 
```
load_tensors:      Vulkan0 model buffer size =  4306.97 MiB
load_tensors:   CPU_Mapped model buffer size =  6828.77 MiB
...................................................................................................
llama_init_from_model: n_seq_max     = 1
llama_init_from_model: n_ctx         = 4096
llama_init_from_model: n_ctx_per_seq = 4096
```


*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
