### PR TITLE
blas build: use configuration from pkg_check_modules(DepBLAS openblas) and alike

### DIFF
--- a/ggml/src/ggml-blas/CMakeLists.txt
+++ b/ggml/src/ggml-blas/CMakeLists.txt
@@ -54,6 +54,8 @@ if (BLAS_FOUND)
         endif()
         if (DepBLAS_FOUND)
             set(BLAS_INCLUDE_DIRS ${DepBLAS_INCLUDE_DIRS})
+            set(BLAS_LIBRARIES ${DepBLAS_LIBRARIES})
+            set(BLAS_LINKER_FLAGS ${DepBLAS_LINKER_FLAGS})
         else()
             message(WARNING "BLAS_INCLUDE_DIRS neither been provided nor been automatically"
             " detected by pkgconfig, trying to find cblas.h from possible paths...")


### PR DESCRIPTION
Hi. On my system (a gentoo), cmake build process with OpenBLAS or BLIS fails because linker options like `-openblas` or `-lblis` are missing.

With BLIS:
```
$ cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=FLAME -DBUILD_NUMBER=1 && cmake --build build --config Release -v
...
[ 26%] Linking CXX executable ../bin/test-tokenizer-0
cd llama.cpp/build/tests && /usr/bin/cmake -E cmake_link_script CMakeFiles/test-tokenizer-0.dir/link.txt --verbose=1
/usr/bin/c++ -O3 -DNDEBUG "CMakeFiles/test-tokenizer-0.dir/test-tokenizer-0.cpp.o" -o ../bin/test-tokenizer-0  -Wl,-rpath,llama.cpp/build/bin: ../common/libcommon.a ../bin/libllama.so ../bin/libggml.so ../bin/libggml-cpu.so ../bin/libggml-blas.so ../bin/libggml-base.so
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: ../bin/libggml-blas.so: undefined reference to `bli_thread_set_num_threads'
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: ../bin/libggml-blas.so: undefined reference to `cblas_sgemm'
collect2: error: ld returned 1 exit status
gmake[2]: *** [tests/CMakeFiles/test-tokenizer-0.dir/build.make:103: bin/test-tokenizer-0] Error 1
gmake[2]: Leaving directory 'llama.cpp/build'
gmake[1]: *** [CMakeFiles/Makefile2:1906: tests/CMakeFiles/test-tokenizer-0.dir/all] Error 2
gmake[1]: Leaving directory 'llama.cpp/build'
gmake: *** [Makefile:146: all] Error 2
```
or with OpenBLAS:
```
$ cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DBUILD_NUMBER=1 && cmake --build build --config Release -v
[ 26%] Linking CXX executable ../bin/test-tokenizer-0
cd llama.cpp/build/tests && /usr/bin/cmake -E cmake_link_script CMakeFiles/test-tokenizer-0.dir/link.txt --verbose=1
/usr/bin/c++ -O3 -DNDEBUG "CMakeFiles/test-tokenizer-0.dir/test-tokenizer-0.cpp.o" -o ../bin/test-tokenizer-0  -Wl,-rpath,llama.cpp/build/bin: ../common/libcommon.a ../bin/libllama.so ../bin/libggml.so ../bin/libggml-cpu.so ../bin/libggml-blas.so ../bin/libggml-base.so
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: ../bin/libggml-blas.so: undefined reference to `openblas_set_num_threads'
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: ../bin/libggml-blas.so: undefined reference to `cblas_sgemm'
collect2: error: ld returned 1 exit status
gmake[2]: *** [tests/CMakeFiles/test-tokenizer-0.dir/build.make:103: bin/test-tokenizer-0] Error 1
gmake[2]: Leaving directory 'llama.cpp/build'
gmake[1]: *** [CMakeFiles/Makefile2:1906: tests/CMakeFiles/test-tokenizer-0.dir/all] Error 2
gmake[1]: Leaving directory 'llama.cpp/build'
gmake: *** [Makefile:146: all] Error 2
```

The problem seems to be quite basic: the build process is not using `DepBLAS_LIBRARIES` and `DepBLAS_LINKER_FLAGS` that come from `pkg_check_modules(DepBLAS openblas)` or similar. So I added a couple of lines to fix it. I'm not sure that this is the right fix, and I don't know cmake, but it seems sensible.

P.S.: Edited because at first I was wrong
P.P.S.: Added the error output so people who have the same problem are more likely to find it