### PR TITLE
ggml-cpu-aarch64: Fix compilation issues

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -40,7 +40,7 @@ static_assert(sizeof(block<4, 8>) == 8 * sizeof(ggml_half) + QK8_0 * 4, "wrong b
 static_assert(sizeof(block<8, 4>) == 4 * sizeof(ggml_half) + QK8_0 * 4, "wrong block<8,4> size/padding");
 static_assert(sizeof(block<8, 8>) == 8 * sizeof(ggml_half) + QK8_0 * 8, "wrong block<8,8> size/padding");
 
-using block_q4_0x4 = block<4, 4>;
+using block_q4_0x4 = block<4, QK4_0>;
 using block_q4_0x8 = block<4, 8>;
 using block_q8_0x4 = block<8, 4>;
 using block_q8_0x8 = block<8, 8>;


### PR DESCRIPTION
In function 'block_q4_0x4 make_block_q4_0x4(block_q4_0*, unsigned int)',
 inlined from 'int repack_q4_0_to_q4_0_4_bl(ggml_tensor*, int, const void*, size_t)' at
ggml-cpu-aarch64.cpp:3614:19: warning: writing 32 bytes into a region of size 0 [-Wstringop-overflow=]
 3614 |             memcpy(&out.qs[dst_offset], &elems, sizeof(uint64_t));
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ggml-cpu-aarch64.cpp: In function 'int repack_q4_0_to_q4_0_4_bl(ggml_tensor*, int, const void*, size_t)':
ggml-cpu-aarch64.cpp:3685:20: note: at offset 72 into destination object '<anonymous>' of size 72
 3685 |             *dst++ = make_block_q4_0x4(dst_tmp, interleave_block);
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
