### PR TITLE
In streaming output mode, the content in delta is missing from the second to last data #11746

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -797,7 +797,7 @@ struct server_task_result_cmpl_final : server_task_result {
         json choice = json {
             {"finish_reason", finish_reason},
             {"index", 0},
-            {"delta", json::object()}
+            {"delta", json {{"content", ""},}}
         };
 
         json ret = json {


### PR DESCRIPTION
In streaming output mode, the content in delta is missing from the second to last data #11746

My solution is to add a default value to the output content

*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
