### PR TITLE
`ci`: fix certificate revocation error failures on windows workers (WIP)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1095,6 +1095,7 @@ jobs:
         with:
           fetch-depth: 0
 
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,7 +693,10 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Install Deps
+      - name: Check curl version BEFORE
+        run: curl --version
+
+      - name: Install Choco Deps
         run: |
           choco install curl
 
@@ -776,7 +779,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Deps
+      - name: Check curl version BEFORE
+        run: curl --version
+
+      - name: Install Choco Deps
         run: |
           choco install ninja curl
 
@@ -964,7 +970,10 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Install Deps
+      - name: Check curl version BEFORE
+        run: curl --version
+
+      - name: Install Choco Deps
         run: |
           choco install ninja curl
 
@@ -1109,7 +1118,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Deps
+      - name: Check curl version BEFORE
+        run: curl --version
+
+      - name: Install Choco Deps
         run: |
           choco install curl
 
@@ -1236,7 +1248,10 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Install Deps
+      - name: Check curl version BEFORE
+        run: curl --version
+
+      - name: Install Choco Deps
         run: |
           choco install curl
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,6 +693,14 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
+      - name: Install Deps
+        run: |
+          choco install curl
+
+      - name: Check curl version
+        run: |
+          curl --version
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -768,6 +776,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Deps
+        run: |
+          choco install ninja curl
+
+      - name: Check curl version
+        run: |
+          curl --version
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -802,11 +818,6 @@ jobs:
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
-
-      - name: Install Ninja
-        id: install_ninja
-        run: |
-          choco install ninja
 
       - name: Install OpenCL Headers and Libs
         id: install_opencl
@@ -953,6 +964,14 @@ jobs:
         with:
             fetch-depth: 0
 
+      - name: Install Deps
+        run: |
+          choco install ninja curl
+
+      - name: Check curl version
+        run: |
+          curl --version
+
       - name: Install ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -1015,11 +1034,6 @@ jobs:
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V12_4=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Install Ninja
-        id: install_ninja
-        run: |
-          choco install ninja
 
       - name: Build
         id: cmake_build
@@ -1094,6 +1108,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install Deps
+        run: |
+          choco install curl
+
+      - name: Check curl version
+        run: |
+          curl --version
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
@@ -1213,6 +1235,14 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-depth: 0
+
+      - name: Install Deps
+        run: |
+          choco install curl
+
+      - name: Check curl version
+        run: |
+          curl --version
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,17 +693,6 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Check curl version BEFORE
-        run: curl --version
-
-      - name: Install Choco Deps
-        run: |
-          choco install curl
-
-      - name: Check curl version
-        run: |
-          curl --version
-
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -779,17 +768,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check curl version BEFORE
-        run: curl --version
-
-      - name: Install Choco Deps
-        run: |
-          choco install ninja curl
-
-      - name: Check curl version
-        run: |
-          curl --version
-
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -824,6 +802,11 @@ jobs:
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
+
+      - name: Install Ninja
+        id: install_ninja
+        run: |
+          choco install ninja
 
       - name: Install OpenCL Headers and Libs
         id: install_opencl
@@ -970,17 +953,6 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Check curl version BEFORE
-        run: curl --version
-
-      - name: Install Choco Deps
-        run: |
-          choco install ninja curl
-
-      - name: Check curl version
-        run: |
-          curl --version
-
       - name: Install ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
         with:
@@ -1043,6 +1015,11 @@ jobs:
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V12_4=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Install Ninja
+        id: install_ninja
+        run: |
+          choco install ninja
 
       - name: Build
         id: cmake_build
@@ -1117,17 +1094,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Check curl version BEFORE
-        run: curl --version
-
-      - name: Install Choco Deps
-        run: |
-          choco install curl
-
-      - name: Check curl version
-        run: |
-          curl --version
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16
@@ -1247,17 +1213,6 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-depth: 0
-
-      - name: Check curl version BEFORE
-        run: curl --version
-
-      - name: Install Choco Deps
-        run: |
-          choco install curl
-
-      - name: Check curl version
-        run: |
-          curl --version
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.16


### PR DESCRIPTION
We've had high rates of failures on windows w/ `curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE (0x80092013) - The revocation function was unable to check revocation because the revocation server was offline.` ([ref](https://github.com/ggerganov/llama.cpp/pull/11516#issuecomment-2645764587)).

[example failed run](https://github.com/ggerganov/llama.cpp/actions/runs/13214491900/job/36892126894)

<details><summary>Show error trace</summary>

```
"C:\Program Files\Git\bin\sh.exe" -xc "curl -L 'https://github.com/mozilla/sccache/releases/download/v0.7.6/sccache-v0.7.6-x86_64-pc-windows-msvc.tar.gz' | tar xzf - -O --wildcards '*/sccache.exe' > 'C:\Users\runneradmin\.cargo\bin\sccache.exe'"
  + curl -L https://github.com/mozilla/sccache/releases/download/v0.7.6/sccache-v0.7.6-x86_64-pc-windows-msvc.tar.gz
  + tar xzf - -O --wildcards '*/sccache.exe'
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE (0x80092013) - The revocation function was unable to check revocation because the revocation server was offline.
  
  gzip: stdin: unexpected end of file
  tar: Child returned status 1
  tar: Error is not recoverable: exiting now
  Error: Restoring cache failed: Error: The process 'C:\Program Files\Git\bin\sh.exe' failed with exit code 2
```

</details>

SSL certificate revocation on windows seems to be stricter (at least w/ the schannel layer), cf. https://github.com/curl/curl/issues/12239#issuecomment-2141986111), with these failures possibly a transient flare on Github's Windows workers (https://github.com/mamba-org/mamba/issues/3346#issuecomment-2641767075.

Possible options being evaluated:

- Install a different version of curl before running the action maybe (one NOT using schannel in its SSL layer)
- Disable ccache on windows (short term)
- Request ccache-action to support setting curl's [--ssl-revoke-best-effort](https://curl.se/docs/manpage.html#--ssl-revoke-best-effort) flag (or even [--ssl-no-revoke](https://curl.se/docs/manpage.html#--ssl-no-revoke)) (filed https://github.com/hendrikmuhs/ccache-action/issues/287 )
