### PR TITLE
docs: utilize the forward slash (/) as the path separator for Unix-li…

### DIFF
--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -37,7 +37,7 @@ Once downloaded, place your model in the models folder in llama.cpp.
 
 ##### Infinite text from a starting prompt (you can use `Ctrl-C` to stop it):
 ```bash
-./llama-cli -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
+./llama-cli -m models/gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 ```
 
 ### Windows:


### PR DESCRIPTION
utilize the forward slash (/) as the path separator for Unix-like systems.