### PR TITLE
vulkan: improve im2col performance

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
@@ -41,33 +41,36 @@ void main() {
     const uint ic = gl_GlobalInvocationID.z % p.IC;
 
     const uint ksize = p.OW * (p.KH > 1 ? p.KW : 1);
+    const int oh_s1 = int(oh) * p.s1;
+    const uint base_linear_idx = gidx * NUM_ITER;
     const uint src_base = ic * p.offset_delta + batch * p.batch_offset;
     const uint dst_base = ((batch * p.OH + oh) * p.OW) * p.CHW + ic * (p.KW * p.KH);
-    const int oh_s1 = int(oh) * p.s1;
-    const uint base_idx = gidx * NUM_ITER;
+
+    uint current_kx = base_linear_idx / ksize;
+    uint rem = base_linear_idx - (current_kx * ksize); // equivalent to init_val % ksize
+    uint current_ky = rem / p.OW;
+    uint current_ix = rem % p.OW;
 
     [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
-
-        const uint i = base_idx + idx;
-
-        if (i >= p.pelements) {
-            break;
+        uint linear_idx = base_linear_idx + idx;
+        if (linear_idx >= p.pelements) {
+            continue;
         }
 
-        const uint kx  = i / ksize;
-        const uint rem = i % ksize;
-        const uint ky  = rem / p.OW;
-        const uint ix  = rem % p.OW;
+        int iiw = int(current_ix) * p.s0 + int(current_kx) * p.d0 - p.p0;
+        int iih = oh_s1 + int(current_ky) * p.d1 - p.p1;
+        uint dst_offset = dst_base + current_ix * p.CHW + current_ky * p.KW + current_kx;
 
-        const int iiw = int(ix) * p.s0 + int(kx) * p.d0 - p.p0;
-        const int iih = oh_s1 + int(ky) * p.d1 - p.p1;
+        bool valid = (iih >= 0 && iih < int(p.IH) && iiw >= 0 && iiw < int(p.IW));
+        data_d[dst_offset] = D_TYPE(valid ? data_a[src_base + uint(iih) * p.IW + uint(iiw)] : 0);
 
-        const uint dst_offset = dst_base + ix * p.CHW + ky * p.KW + kx;
-
-        data_d[dst_offset] = D_TYPE((iih >= 0 && iih < int(p.IH) &&
-                                     iiw >= 0 && iiw < int(p.IW))
-                              ? data_a[src_base + uint(iih) * p.IW + uint(iiw)]
-                              : 0);
+        if (++current_ix == p.OW) {
+            current_ix = 0;
+            if (++current_ky == (ksize / p.OW)) {
+                current_ky = 0;
+                current_kx++;
+            }
+        }
     }
 
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
@@ -37,51 +37,33 @@ void main() {
     const uint gidx = gl_GlobalInvocationID.x;
 
     const uint oh = gl_GlobalInvocationID.y;
-    const uint batch = gl_GlobalInvocationID.z / p.IC;
-    const uint ic = gl_GlobalInvocationID.z % p.IC;
+    const uint batch_ic = gl_GlobalInvocationID.z;
 
-    A_TYPE values[NUM_ITER];
-    uint offset_dst[NUM_ITER];
-    [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
-        values[idx] = A_TYPE(0);
-    }
+    const uint batch = batch_ic / p.IC;
+    const uint ic = batch_ic % p.IC;
+
+    const uint ksize = p.OW * ((p.KH > 1) ? p.KW : 1);
+    const uint src_base = ic * p.offset_delta + batch * p.batch_offset;
+    const uint dst_base = ((batch * p.OH + oh) * p.OW) * p.CHW + ic * p.KW * p.KH;
 
     [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
 
         const uint i = gidx * NUM_ITER + idx;
+        if (i >= p.pelements) continue;
 
-        const uint ksize = p.OW * (p.KH > 1 ? p.KW : 1);
         const uint kx = i / ksize;
-        const uint kd = kx * ksize;
-        const uint ky = (i - kd) / p.OW;
+        const uint ky = (i % ksize) / p.OW;
         const uint ix = i % p.OW;
 
-        const uint iiw = ix * p.s0 + kx * p.d0 - p.p0;
-        const uint iih = oh * p.s1 + ky * p.d1 - p.p1;
+        const int iiw = int(ix * uint(p.s0)) + int(kx * uint(p.d0)) - p.p0;
+        const int iih = int(oh * uint(p.s1)) + int(ky * uint(p.d1)) - p.p1;
 
-        offset_dst[idx] =
-            ((batch * p.OH + oh) * p.OW + ix) * p.CHW +
-            (ic * (p.KW * p.KH) + ky * p.KW + kx);
+        const uint dst_offset = dst_base + ix * p.CHW + ky * p.KW + kx;
 
-        if (i >= p.pelements) {
-            continue;
-        }
+        const bool valid = iih >= 0 && iih < int(p.IH) && iiw >= 0 && iiw < int(p.IW);
+        const uint src_offset = src_base + uint(iih) * p.IW + uint(iiw);
 
-        if (iih < p.IH && iiw < p.IW) {
-            const uint offset_src = ic * p.offset_delta + batch * p.batch_offset;
-            values[idx] = data_a[offset_src + iih * p.IW + iiw];
-        }
-    }
-
-    [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
-
-        const uint i = gidx * NUM_ITER + idx;
-
-        if (i >= p.pelements) {
-            continue;
-        }
-
-        data_d[offset_dst[idx]] = D_TYPE(values[idx]);
+        data_d[dst_offset] = D_TYPE(valid ? data_a[src_offset] : 0.0);
     }
 
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
@@ -37,35 +37,37 @@ void main() {
     const uint gidx = gl_GlobalInvocationID.x;
 
     const uint oh = gl_GlobalInvocationID.y;
-    const uint batch_ic = gl_GlobalInvocationID.z;
+    const uint batch = gl_GlobalInvocationID.z / p.IC;
+    const uint ic = gl_GlobalInvocationID.z % p.IC;
 
-    const uint batch = batch_ic / p.IC;
-    const uint ic = batch_ic % p.IC;
-
-    const uint ksize = p.OW * ((p.KH > 1) ? p.KW : 1);
+    const uint ksize = p.OW * (p.KH > 1 ? p.KW : 1);
     const uint src_base = ic * p.offset_delta + batch * p.batch_offset;
-    const uint dst_base = ((batch * p.OH + oh) * p.OW) * p.CHW + ic * p.KW * p.KH;
+    const uint dst_base = ((batch * p.OH + oh) * p.OW) * p.CHW + ic * (p.KW * p.KH);
+    const int oh_s1 = int(oh) * p.s1;
+    const uint base_idx = gidx * NUM_ITER;
 
     [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
 
-        const uint i = gidx * NUM_ITER + idx;
+        uint i = base_idx + idx;
+
         if (i >= p.pelements) {
-            continue;
+            break;
         }
 
-        const uint kx = i / ksize;
-        const uint ky = (i % ksize) / p.OW;
-        const uint ix = i % p.OW;
+        const uint kx  = i / ksize;
+        const uint rem = i % ksize;
+        const uint ky  = rem / p.OW;
+        const uint ix  = rem % p.OW;
 
-        const int iiw = int(ix * uint(p.s0)) + int(kx * uint(p.d0)) - p.p0;
-        const int iih = int(oh * uint(p.s1)) + int(ky * uint(p.d1)) - p.p1;
+        int iiw = int(ix) * p.s0 + int(kx) * p.d0 - p.p0;
+        int iih = oh_s1 + int(ky) * p.d1 - p.p1;
 
         const uint dst_offset = dst_base + ix * p.CHW + ky * p.KW + kx;
 
-        const bool valid = iih >= 0 && iih < int(p.IH) && iiw >= 0 && iiw < int(p.IW);
-        const uint src_offset = src_base + uint(iih) * p.IW + uint(iiw);
-
-        data_d[dst_offset] = D_TYPE(valid ? data_a[src_offset] : 0.0);
+        data_d[dst_offset] = D_TYPE((iih >= 0 && iih < int(p.IH) &&
+                                     iiw >= 0 && iiw < int(p.IW))
+                              ? data_a[src_base + uint(iih) * p.IW + uint(iiw)]
+                              : 0);
     }
 
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
@@ -48,7 +48,7 @@ void main() {
 
     [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
 
-        uint i = base_idx + idx;
+        const uint i = base_idx + idx;
 
         if (i >= p.pelements) {
             break;
@@ -59,8 +59,8 @@ void main() {
         const uint ky  = rem / p.OW;
         const uint ix  = rem % p.OW;
 
-        int iiw = int(ix) * p.s0 + int(kx) * p.d0 - p.p0;
-        int iih = oh_s1 + int(ky) * p.d1 - p.p1;
+        const int iiw = int(ix) * p.s0 + int(kx) * p.d0 - p.p0;
+        const int iih = oh_s1 + int(ky) * p.d1 - p.p1;
 
         const uint dst_offset = dst_base + ix * p.CHW + ky * p.KW + kx;
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/im2col.comp
@@ -49,7 +49,9 @@ void main() {
     [[unroll]] for (uint idx = 0; idx < NUM_ITER; ++idx) {
 
         const uint i = gidx * NUM_ITER + idx;
-        if (i >= p.pelements) continue;
+        if (i >= p.pelements) {
+            continue;
+        }
 
         const uint kx = i / ksize;
         const uint ky = (i % ksize) / p.OW;


### PR DESCRIPTION
This PR tries to improve the performance of the im2col vulkan shader.
It's my first time working on a vulkan shader so any feedback is welcomed (I'm still not entirely convinced about the performance since there seems to be some small regressions).

Performance on `master`:
```
./test-backend-ops perf -o IM2COL                                                                                        0.001s 
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon RX 5700 XT (RADV NAVI10) (radv) | uma: 0 | fp16: 1 | warp size: 64 | shared memory: 65536 | matrix cores: none
Testing 2 devices

Backend 1/2: Vulkan0
  Device description: AMD Radeon RX 5700 XT (RADV NAVI10)
  Device memory: 8176 MB (8176 MB free)

  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):              13104 runs -    96.50 us/run -    10244 kB/run -  101.24 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                820 runs -  1452.41 us/run -    40964 kB/run -   26.90 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       52 runs - 118532.81 us/run -   655364 kB/run -    5.28 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                      984 runs -  1261.37 us/run -   102445 kB/run -   77.48 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       82 runs - 47492.62 us/run -   409645 kB/run -    8.24 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               4278 runs -   335.33 us/run -    23536 kB/run -   66.94 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                335 runs -  7528.33 us/run -   100208 kB/run -   12.70 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       20 runs - 254158.50 us/run -  1678448 kB/run -    6.31 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                      286 runs -  5017.27 us/run -   235365 kB/run -   44.75 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       34 runs - 244071.59 us/run -  1002085 kB/run -    3.92 GB/s
  Backend Vulkan0: OK

Backend 2/2: CPU
  Skipping CPU backend
2/2 backends passed
OK
``` 

`PR`:
```
./test-backend-ops perf -o IM2COL                                                                                        0.001s 
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon RX 5700 XT (RADV NAVI10) (radv) | uma: 0 | fp16: 1 | warp size: 64 | shared memory: 65536 | matrix cores: none
Testing 2 devices

Backend 1/2: Vulkan0
  Device description: AMD Radeon RX 5700 XT (RADV NAVI10)
  Device memory: 8176 MB (8176 MB free)

  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               9828 runs -   104.09 us/run -    10244 kB/run -   93.87 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               1640 runs -  1136.91 us/run -    40964 kB/run -   34.37 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       52 runs - 85186.02 us/run -   655364 kB/run -    7.35 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                     1312 runs -  1012.51 us/run -   102445 kB/run -   96.52 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       82 runs - 32447.41 us/run -   409645 kB/run -   12.05 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               4278 runs -   291.92 us/run -    23536 kB/run -   76.89 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                335 runs -  6894.89 us/run -   100208 kB/run -   13.86 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       20 runs - 286088.75 us/run -  1678448 kB/run -    5.61 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                      286 runs -  4790.58 us/run -   235365 kB/run -   46.87 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       34 runs - 226612.35 us/run -  1002085 kB/run -    4.22 GB/s
  Backend Vulkan0: OK

Backend 2/2: CPU
  Skipping CPU backend
2/2 backends passed
OK
``` 

`ROCm` for comparison:
```
./test-backend-ops perf -o IM2COL                                                                                        0.001s 
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 ROCm devices:
  Device 0: AMD Radeon RX 5700 XT, gfx1010:xnack- (0x1010), VMM: no, Wave Size: 32
Testing 2 devices

Backend 1/2: ROCm0
  Device description: AMD Radeon RX 5700 XT
  Device memory: 8176 MB (8092 MB free)

  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               3276 runs -   923.04 us/run -    10244 kB/run -   10.58 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                820 runs -  3359.14 us/run -    40964 kB/run -   11.63 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[3,3,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       52 runs - 58759.37 us/run -   655364 kB/run -   10.66 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                      328 runs -  9271.95 us/run -   102445 kB/run -   10.54 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[3,3,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       82 runs - 79109.07 us/run -   409645 kB/run -    4.94 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):               1426 runs -  1077.72 us/run -    23536 kB/run -   20.83 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                335 runs -  9038.40 us/run -   100208 kB/run -   10.57 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[256,256,256,1],ne_kernel=[5,5,256,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       20 runs - 160059.45 us/run -  1678448 kB/run -   10.02 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[32,32,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                      143 runs - 12785.92 us/run -   235365 kB/run -   17.56 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f32,ne_input=[64,64,2560,1],ne_kernel=[5,5,2560,1],s0=1,s1=1,p0=1,p1=1,d0=1,d1=1,is_2D=1):                       34 runs - 120635.09 us/run -  1002085 kB/run -    7.93 GB/s
  Backend ROCm0: OK

Backend 2/2: CPU
  Skipping CPU backend
2/2 backends passed
OK
``` 