### PR TITLE
fix A800 not supper 'movmatrix' module

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -47,6 +47,7 @@
 #define GGML_CUDA_CC_TURING     750
 #define GGML_CUDA_CC_AMPERE     800
 #define GGML_CUDA_CC_OFFSET_AMD 0x1000000
+#define GGML_CUDA_CC_HOPPER     900
 
 // GCN/CNDA, wave size is 64
 #define GGML_CUDA_CC_GCN4       (GGML_CUDA_CC_OFFSET_AMD + 0x803)  // Tonga, Fiji, Polaris, minimum for fast fp16

--- a/ggml/src/ggml-cuda/mma.cuh
+++ b/ggml/src/ggml-cuda/mma.cuh
@@ -16,7 +16,7 @@
 #include "common.cuh"
 
 
-#if CUDART_VERSION >= 11080
+#if (CUDART_VERSION >= 11080) && (__CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER)
 
 static __device__ __forceinline__ int ggml_cuda_movmatrix(const int x) {
     int ret = 0;


### PR DESCRIPTION
FIX : Compile bug: ptxas fatal : Ptx assembly aborted due to errors #11750 


compute capability  in the Ampere architecture  not use movmatrix.
@JohannesGaessler
@SilentGrn