### PR TITLE
llama-mmap: use MAP_PRIVATE instead of MAP_SHARED

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -271,7 +271,7 @@ struct llama_mmap::impl {
     impl(struct llama_file * file, size_t prefetch, bool numa) {
         size = file->size();
         int fd = file->file_id();
-        int flags = MAP_SHARED;
+        int flags = MAP_PRIVATE;
         if (numa) { prefetch = 0; }
 #ifdef __linux__
         if (posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL)) {


### PR DESCRIPTION
It is not intended to write data to the file for others to read.
