### PR TITLE
Fix #11802: Compile bug - RegQueryValueExA changed to RegQueryValueEx

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -283,15 +283,15 @@ struct ggml_backend_cpu_device_context {
                         KEY_READ,
                         &hKey) == ERROR_SUCCESS) {
             DWORD cpu_brand_size = 0;
-            if (RegQueryValueEx(hKey,
-                                TEXT("ProcessorNameString"),
+            if (RegQueryValueExA(hKey,
+                                "ProcessorNameString",
                                 NULL,
                                 NULL,
                                 NULL,
                                 &cpu_brand_size) == ERROR_SUCCESS) {
                 description.resize(cpu_brand_size);
-                if (RegQueryValueEx(hKey,
-                                    TEXT("ProcessorNameString"),
+                if (RegQueryValueExA(hKey,
+                                    "ProcessorNameString",
                                     NULL,
                                     NULL,
                                     (LPBYTE)&description[0], // NOLINT

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -283,14 +283,14 @@ struct ggml_backend_cpu_device_context {
                         KEY_READ,
                         &hKey) == ERROR_SUCCESS) {
             DWORD cpu_brand_size = 0;
-            if (RegQueryValueExA(hKey,
+            if (RegQueryValueEx(hKey,
                                 TEXT("ProcessorNameString"),
                                 NULL,
                                 NULL,
                                 NULL,
                                 &cpu_brand_size) == ERROR_SUCCESS) {
                 description.resize(cpu_brand_size);
-                if (RegQueryValueExA(hKey,
+                if (RegQueryValueEx(hKey,
                                     TEXT("ProcessorNameString"),
                                     NULL,
                                     NULL,


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

fix #11802 


