### PR TITLE
cmake: Fix ggml backend dependencies and installation

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -212,6 +212,8 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
+include(GNUInstallDirs)
+
 #
 # build the library
 #
@@ -235,7 +237,6 @@ endif ()
 # install
 #
 
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # all public headers

--- a/ggml/cmake/ggml-config.cmake.in
+++ b/ggml/cmake/ggml-config.cmake.in
@@ -112,7 +112,7 @@ foreach(_ggml_backend ${GGML_AVAILABLE_BACKENDS})
 
     string(REGEX MATCH "^ggml-cpu" is_cpu_variant "${_ggml_backend}")
     if(is_cpu_variant)
-        list(APPEND GGML_CPU_INTERFACE_LINK_LIBRARIES "ggml::ggml" "ggml::ggml-base")
+        list(APPEND GGML_CPU_INTERFACE_LINK_LIBRARIES "ggml::ggml-base")
         set_target_properties(ggml::${_ggml_backend}
            PROPERTIES
                INTERFACE_LINK_LIBRARIES "${GGML_CPU_INTERFACE_LINK_LIBRARIES}")
@@ -124,7 +124,7 @@ foreach(_ggml_backend ${GGML_AVAILABLE_BACKENDS})
         endif()
 
     else()
-        list(APPEND ${_ggml_backend_pfx}_INTERFACE_LINK_LIBRARIES "ggml::ggml" "ggml::ggml-base")
+        list(APPEND ${_ggml_backend_pfx}_INTERFACE_LINK_LIBRARIES "ggml::ggml-base")
         set_target_properties(ggml::${_ggml_backend}
             PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${${_ggml_backend_pfx}_INTERFACE_LINK_LIBRARIES}")
@@ -138,6 +138,11 @@ foreach(_ggml_backend ${GGML_AVAILABLE_BACKENDS})
 
     list(APPEND _ggml_all_targets ggml::${_ggml_backend})
 endforeach()
+
+list(APPEND GGML_INTERFACE_LINK_LIBRARIES ggml::ggml-base "${_ggml_all_targets}")
+set_target_properties(ggml::ggml
+    PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${GGML_INTERFACE_LINK_LIBRARIES}")
 
 add_library(ggml::all INTERFACE IMPORTED)
 set_target_properties(ggml::all


### PR DESCRIPTION
This makes the following changes to ggml backends:

1. Fix dependencies between `ggml`, `ggml-base` and backends. Linking a static build of `libllama` using cmake is currently broken because dependencies are listed in the wrong order in linker commands. Backends should only link to `ggml-base`, and `ggml` should link to `ggml-base` and the backends.
2. Fix the installation directory of ggml backends. On Fedora (and probably some other linux distros) `libllama`, `libggml` and `libggml-base`  are installed in the `/lib64` directory, but ggml backends are installed in `/lib`. That is because ggml backends have their installation directory set before `GNUInstallDirs` is included.