### PR TITLE
HIP: Remove GCN from list of devices that avoid MMQ

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -149,5 +149,5 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11) {
         return !fp16_mma_hardware_available(cc) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
     }
 
-    return (!GGML_CUDA_CC_IS_RDNA3(cc) && !GGML_CUDA_CC_IS_CDNA(cc) && !GGML_CUDA_CC_IS_GCN(cc)) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
+    return (!GGML_CUDA_CC_IS_RDNA3(cc) && !GGML_CUDA_CC_IS_CDNA(cc)) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
 }


### PR DESCRIPTION
My intuition was that if the rocblas path is faster on CDNA with mfma disabled, its likely also faster on GCN gpus, as these are very similar. 

After testing and discussion with @cb88 on Vega10 (GFX900) and Vega20 (GFX906) it however turns out to not be the case.
Further complicating things, the change in intended code path did not take effect until d6d24cd9ed6d0b9558643dcc28f2124bef488c52 masking the fact that this is a pessimization at first.
