### PR TITLE
Fix: Compile failure due to Microsoft STL breaking change

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -1,5 +1,6 @@
 #include "log.h"
 
+#include <chrono>
 #include <condition_variable>
 #include <cstdarg>
 #include <cstdio>

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "llama.h"
 
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstring>

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "llama.h"
 
+#include <chrono>
 #include <algorithm>
 #include <array>
 #include <atomic>


### PR DESCRIPTION
This pull request adds #include chrono to common/log.cpp, examples/imatrix/imatrix.cpp, and examples/perplexity/perplexity.cpp.

This is necessary because Microsoft STL moved system_clock from <__msvc_chrono.hpp> to <chrono> in a recent breaking change (see [https://github.com/microsoft/STL/pull/5105]). This caused llama.cpp to fail to compile on Windows after MSVC.

This PR ensures that the necessary header is included, resolving the compilation error.