### PR TITLE
ggml: optimize some vec dot functions for LoongArch ASX

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -691,13 +691,8 @@ static inline __m256 mul_sum_us8_pairs_float(const __m256i ax, const __m256i sy)
 
 // multiply int8_t, add results pairwise twice and return as float vector
 static inline __m256 mul_sum_i8_pairs_float(const __m256i x, const __m256i y) {
-
-    // Get absolute values of x vectors
-    const __m256i ax = __lasx_xvsigncov_b(x, x);
-    // Sign the values of the y vectors
-    const __m256i sy = __lasx_xvsigncov_b(x, y);
-
-    return mul_sum_us8_pairs_float(ax, sy);
+    const __m256i dot = lasx_madd_h_b(x, y);
+    return sum_i16_pairs_float(dot);
 }
 
 static inline __m128i packNibbles( __m256i bytes ) {


### PR DESCRIPTION
* ggml : optimize ggml_vec_dot_iq4_xs_q8_K for LoongArch ASX

* ggml : optimize mul_sum_i8_pairs_float for LoongArch ASX

* ggml : optimize ggml_vec_dot_q2_K_q8_K for LoongArch ASX

* ggml : optimize ggml_vec_dot_q5_K_q8_K for LoongArch ASX

* ggml : optimize ggml_vec_dot_q6_K_q8_K for LoongArch ASX

* ggml : optimize ggml_vec_dot_q4_K_q8_K for LoongArch ASX

* ggml : optimize ggml_vec_dot_q3_K_q8_K for LoongArch ASX