### PR TITLE
server : add condition for grammar

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -650,16 +650,18 @@ static json oaicompat_completion_params_parse(
 
         llama_params["chat_format"] = static_cast<int>(chat_params.format);
         llama_params["prompt"] = chat_params.prompt;
-        llama_params["grammar"] = chat_params.grammar;
-        llama_params["grammar_lazy"] = chat_params.grammar_lazy;
-        auto grammar_triggers = json::array();
-        for (const auto & trigger : chat_params.grammar_triggers) {
-            grammar_triggers.push_back({
-                {"word", trigger.word},
-                {"at_start", trigger.at_start},
-            });
+        if (inputs.json_schema == nullptr) {
+            llama_params["grammar"] = chat_params.grammar;
+            llama_params["grammar_lazy"] = chat_params.grammar_lazy;
+            auto grammar_triggers = json::array();
+            for (const auto & trigger : chat_params.grammar_triggers) {
+                grammar_triggers.push_back({
+                    {"word", trigger.word},
+                    {"at_start", trigger.at_start},
+                });
+            }
+            llama_params["grammar_triggers"] = grammar_triggers;
         }
-        llama_params["grammar_triggers"] = grammar_triggers;
         llama_params["preserved_tokens"] = chat_params.preserved_tokens;
         for (const auto & stop : chat_params.additional_stops) {
             llama_params["stop"].push_back(stop);


### PR DESCRIPTION
This commit adds a condition to check if the json_schema is null before adding the grammar and grammar_triggers to the llama_params.

The motivation of this is to prevent the server from throwing an exeption as the request will have both a json_schema and a grammar field.

Resolves: https://github.com/ggerganov/llama.cpp/issues/11847
