### PR TITLE
vulkan: Added GGML_VK_DEVICE{idx}_MEMORY environment variable for setting device memory to manually allocate workload.

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7952,6 +7952,16 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
 
     vk::PhysicalDevice vkdev = vk_instance.instance.enumeratePhysicalDevices()[vk_instance.device_indices[device]];
 
+    char name[48];
+    snprintf(name, sizeof(name), "GGML_VK_DEVICE%d_MEMORY", device);
+    const char* GGML_VK_DEVICE_MEMORY = getenv(name);
+
+    if(GGML_VK_DEVICE_MEMORY != nullptr){
+        *total = strtoll(GGML_VK_DEVICE_MEMORY, NULL, 10);
+        *free = *total;
+        return;
+    }
+
     vk::PhysicalDeviceMemoryProperties memprops = vkdev.getMemoryProperties();
 
     for (const vk::MemoryHeap& heap : memprops.memoryHeaps) {


### PR DESCRIPTION
Users can manually specify the memory usage of a device using the `GGML_VK_DEVICE{idx}_MEMORY` environment variable, based on their specific needs, to allocate the workload accordingly.

For example, setting `GGML_VK_DEVICE0_MEMORY=2000000000` configures 2000MB of memory on the Vulkan0 device, and correspondingly, a 2000MB workload is allocated for model computation on that device.

Especially in environments with integrated graphics, users no longer need to reboot and enter the BIOS to configure VRAM, nor do they need to worry about portions of memory allocated as VRAM being idle. By simply using the `GGML_VK_DEVICE{idx}_MEMORY` environment variable to manually configure the memory amount, this provides a significant benefit for future devices equipped with high-performance integrated graphics.

Finally, maintain the original behavior when `GGML_VK_DEVICE{idx}_MEMORY` is not set, just like `GGML_VK_VISIBLE_DEVICES`.


