### PR TITLE
tool-call: fix type promotion typo causing crashes w/ --jinja w/o tools

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -968,7 +968,7 @@ static common_chat_params common_chat_params_init_without_tools(const common_cha
         }
         data.grammar = json_schema_to_grammar(inputs.json_schema);
     } else {
-        data.grammar = inputs.grammar.empty();
+        data.grammar = inputs.grammar;
     }
     return data;
 }


### PR DESCRIPTION
Fixes (at least part of) https://github.com/ggerganov/llama.cpp/issues/11866

Somehow [a bool can be assigned to an std::string](https://stackoverflow.com/questions/9670854/assigning-true-false-to-stdstring-whats-going-on) 🤯: new fear unlocked 😅

This introduced different levels of soft or hard crashes as the grammar string got a true / (byte 1) then... something random / platform specific.

Seems different compilers have different levels of letting this through:

`bug.cc`

```c++
// g++ -Wall -Wextra -Wpedantic bug.cc -o out
#include <string>
int main() {
  std::string s;
  // s = false; // this is caught by Apple clang version 15.0.0 but not GCC 14
  s = s.empty(); // caught by neither, even w/ -Wall -Wextra -Wpedantic 
}
```