### PR TITLE
gguf-py: handle numpy 2.0 byte-ordering changes

### DIFF
--- a/gguf-py/gguf/scripts/gguf_dump.py
+++ b/gguf-py/gguf/scripts/gguf_dump.py
@@ -21,7 +21,9 @@ logger = logging.getLogger("gguf-dump")
 
 
 def get_file_host_endian(reader: GGUFReader) -> tuple[str, str]:
-    host_endian = 'LITTLE' if np.uint32(1) == np.uint32(1).newbyteorder("<") else 'BIG'
+    host_val = np.array(1, dtype=np.uint32)
+    little_val = host_val.view(host_val.dtype.newbyteorder("<"))
+    host_endian = "LITTLE" if host_val.item() == little_val.item() else "BIG"
     if reader.byte_order == 'S':
         file_endian = 'BIG' if host_endian == 'LITTLE' else 'LITTLE'
     else:


### PR DESCRIPTION
this commit fixes this error:
```python
Traceback (most recent call last):
  File "/home/poweruser/python-goddamn-venv/bin/gguf-dump", line 8, in <module>
    sys.exit(gguf_dump_entrypoint())
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/poweruser/python-goddamn-venv/lib/python3.12/site-packages/gguf/scripts/gguf_dump.py", line 450, in main
    dump_metadata(reader, args)
  File "/home/poweruser/python-goddamn-venv/lib/python3.12/site-packages/gguf/scripts/gguf_dump.py", line 35, in dump_metadata
    host_endian, file_endian = get_file_host_endian(reader)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/poweruser/python-goddamn-venv/lib/python3.12/site-packages/gguf/scripts/gguf_dump.py", line 24, in get_file_host_endian
    host_endian = 'LITTLE' if np.uint32(1) == np.uint32(1).newbyteorder("<") else 'BIG'
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: newbyteorder was removed from scalar types in NumPy 2.0. Use sc.view(sc.dtype.newbyteorder(order)) instead.
```