### PR TITLE
scripts: corrected encoding when getting chat template (#11866)

### DIFF
--- a/scripts/get_chat_template.py
+++ b/scripts/get_chat_template.py
@@ -21,7 +21,7 @@ def get_chat_template(model_id, variant=None):
         # Use huggingface_hub library if available.
         # Allows access to gated models if the user has access and ran `huggingface-cli login`.
         from huggingface_hub import hf_hub_download
-        with open(hf_hub_download(repo_id=model_id, filename="tokenizer_config.json")) as f:
+        with open(hf_hub_download(repo_id=model_id, filename="tokenizer_config.json"), encoding="utf-8") as f:
             config_str = f.read()
     except ImportError:
         import requests


### PR DESCRIPTION
JSON files must be UTF-8 encoded, see [8.1 in RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-8.1).