### PR TITLE
ggml: aarch64: implement SVE kernels for q3_K_q8_K vector dot

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5094,13 +5094,13 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
     const int8_t m32 = 32;
     const int vector_length = svcntb()*8;
-    const svuint8_t m3b_sv = svdup_n_u8(0X3);
+    const svuint8_t m3b_sv = svdup_n_u8(0x3);
     const svint32_t vzero_sv = svdup_n_s32(0);
 
     const svuint8_t m0_sv = svdup_n_u8(1);
-    const svuint8_t m1_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 1);
-    const svuint8_t m2_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 2);
-    const svuint8_t m3_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 3);
+    const svuint8_t m1_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 1);
+    const svuint8_t m2_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 2);
+    const svuint8_t m3_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 3);
     svbool_t pred_s32 = svnot_b_z (svptrue_b32(), svptrue_pat_b32(SV_VL4));
 
     float sum = 0;
@@ -5194,12 +5194,12 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
                         sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[3]));
 
 
-                        if (j==0) {
+                        if (j == 0) {
                             qhbits_sv_1 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_1, 4);
                             qhbits_sv_2 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_2, 4);
                         }
 
-                    scale += 4;
+                        scale += 4;
 
                     }
 
@@ -5250,11 +5250,11 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
                         sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), scale_1);
 
 
-                        if (j==0) {
+                        if (j == 0) {
                             qhbits_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), qhbits_sv, 4);
                         }
 
-                    scale += 4;
+                        scale += 4;
 
                     }
 

--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5098,10 +5098,10 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
     const svint32_t vzero_sv = svdup_n_s32(0);
 
     const svuint8_t m0_sv = svdup_n_u8(1);
-    const svuint8_t m1_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,1);
-    const svuint8_t m2_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,2);
-    const svuint8_t m3_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,3);
-    svbool_t pred_s32 = svnot_b_z (svptrue_b32(),svptrue_pat_b32(SV_VL4));
+    const svuint8_t m1_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 1);
+    const svuint8_t m2_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 2);
+    const svuint8_t m3_sv =  svlsl_n_u8_x(svptrue_b8(), m0_sv, 3);
+    svbool_t pred_s32 = svnot_b_z (svptrue_b32(), svptrue_pat_b32(SV_VL4));
 
     float sum = 0;
 
@@ -5124,11 +5124,11 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
         for (int j = 0; j < 16; ++j) scale[j] -= m32;
 
-        switch(vector_length){
+        switch (vector_length) {
             case 128:
                 {
-                    svuint8_t qhbits_sv_1 = svld1_u8(svptrue_b8(),qh_sv);
-                    svuint8_t qhbits_sv_2 = svld1_u8(svptrue_b8(),qh_sv+16);
+                    svuint8_t qhbits_sv_1 = svld1_u8(svptrue_b8(), qh_sv);
+                    svuint8_t qhbits_sv_2 = svld1_u8(svptrue_b8(), qh_sv+16);
                     svuint8_t q3h_sv;
 
                     svint32_t sumi1_1 = svdup_n_s32(0);
@@ -5136,68 +5136,67 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
                     for (int j = 0; j < QK_K/128; ++j) {
 
-                        const svuint8_t q3bits_sv = svld1_u8(svptrue_b8(),q3_sv); q3_sv += 16;
-                        const svuint8_t q3bits_sv_1 = svld1_u8(svptrue_b8(),q3_sv); q3_sv += 16;
-                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
-                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        const svuint8_t q3bits_sv = svld1_u8(svptrue_b8(), q3_sv); q3_sv += 16;
+                        const svuint8_t q3bits_sv_1 = svld1_u8(svptrue_b8(), q3_sv); q3_sv += 16;
+                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
+                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m0_sv, qhbits_sv_1),2);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),q3bits_sv,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m0_sv, qhbits_sv_1), 2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), q3bits_sv, m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[0]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), svdup_n_s32((int32_t)scale[0]));
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m0_sv, qhbits_sv_2),2);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),q3bits_sv_1,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m0_sv, qhbits_sv_2), 2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), q3bits_sv_1, m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[1]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[1]));
 
-                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
-                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m1_sv, qhbits_sv_1),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m1_sv, qhbits_sv_1), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv, 2), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[2]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), svdup_n_s32((int32_t)scale[2]));
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m1_sv, qhbits_sv_2),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m1_sv, qhbits_sv_2), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv_1, 2), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[3]));
 
 
                         scale += 4;
-                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
-                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
 
-                        q3h_sv = svbic_u8_x(svptrue_b8(),m2_sv, qhbits_sv_1);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svbic_u8_x(svptrue_b8(), m2_sv, qhbits_sv_1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv, 4), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[0]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), svdup_n_s32((int32_t)scale[0]));
 
-                        q3h_sv = svbic_u8_x(svptrue_b8(),m2_sv, qhbits_sv_2);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svbic_u8_x(svptrue_b8(), m2_sv, qhbits_sv_2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv_1, 4), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[1]));
-
-
-                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
-                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
-
-                        q3h_sv = svlsr_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m3_sv, qhbits_sv_1),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
-
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[2]));
-
-                        q3h_sv = svlsr_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m3_sv, qhbits_sv_2),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
-
-                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[1]));
 
 
-                        if(j==0)
-                        {
-                            qhbits_sv_1 = svlsr_n_u8_x(svptrue_b8(),qhbits_sv_1,4);
-                            qhbits_sv_2 = svlsr_n_u8_x(svptrue_b8(),qhbits_sv_2,4);
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(), q8_sv); q8_sv += 16;
+
+                        q3h_sv = svlsr_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m3_sv, qhbits_sv_1), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv, 6), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), svdup_n_s32((int32_t)scale[2]));
+
+                        q3h_sv = svlsr_n_u8_x(svptrue_b8(), svbic_u8_x(svptrue_b8(), m3_sv, qhbits_sv_2), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(), svreinterpret_s8_u8(svand_u8_m(svptrue_b8(), svlsr_n_u8_x(svptrue_b8(), q3bits_sv_1, 6), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[3]));
+
+
+                        if (j==0) {
+                            qhbits_sv_1 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_1, 4);
+                            qhbits_sv_2 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_2, 4);
                         }
 
                     scale += 4;
@@ -5205,11 +5204,11 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
                     }
 
                     sum += d * (svaddv_s32(svptrue_b32(), sumi1_1));
-                }break;
+                } break;
             case 256:
             case 512:
                 {
-                    svuint8_t qhbits_sv = svld1_u8(svptrue_pat_b8(SV_VL32),qh_sv);
+                    svuint8_t qhbits_sv = svld1_u8(svptrue_pat_b8(SV_VL32), qh_sv);
                     svuint8_t q3h_sv;
 
                     svint32_t sumi1_1 = svdup_n_s32(0);
@@ -5217,43 +5216,42 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
                     for (int j = 0; j < QK_K/128; ++j) {
 
-                        const svuint8_t q3bits_sv = svld1_u8(svptrue_pat_b8(SV_VL32),q3_sv); q3_sv += 32;
-                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
-                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+                        const svuint8_t q3bits_sv = svld1_u8(svptrue_pat_b8(SV_VL32), q3_sv); q3_sv += 32;
+                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32), q8_sv); q8_sv += 32;
+                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32), q8_sv); q8_sv += 32;
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m0_sv, qhbits_sv),2);
-                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),q3bits_sv,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32), svbic_u8_x(svptrue_pat_b8(SV_VL32), m0_sv, qhbits_sv), 2);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32), svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32), q3bits_sv, m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
 
-                        svint32_t scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[0]),svdup_n_s32((int32_t)scale[1]));
-                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),scale_1);
+                        svint32_t scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4), svdup_n_s32((int32_t)scale[0]), svdup_n_s32((int32_t)scale[1]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), scale_1);
 
-                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m1_sv, qhbits_sv),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32), svbic_u8_x(svptrue_pat_b8(SV_VL32), m1_sv, qhbits_sv), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32), svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32), svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), q3bits_sv, 2), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[2]),svdup_n_s32((int32_t)scale[3]));
-                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),scale_1);
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4), svdup_n_s32((int32_t)scale[2]), svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), scale_1);
 
                         scale += 4;
-                        q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
-                        q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32), q8_sv); q8_sv += 32;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32), q8_sv); q8_sv += 32;
 
-                        q3h_sv = svbic_u8_x(svptrue_pat_b8(SV_VL32),m2_sv, qhbits_sv);
-                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svbic_u8_x(svptrue_pat_b8(SV_VL32), m2_sv, qhbits_sv);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32), svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32), svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), q3bits_sv, 4), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[0]),svdup_n_s32((int32_t)scale[1]));
-                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),scale_1);
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4), svdup_n_s32((int32_t)scale[0]), svdup_n_s32((int32_t)scale[1]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1), scale_1);
 
-                        q3h_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m3_sv, qhbits_sv),1);
-                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+                        q3h_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), svbic_u8_x(svptrue_pat_b8(SV_VL32), m3_sv, qhbits_sv), 1);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32), svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32), svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), q3bits_sv, 6), m3b_sv)), svreinterpret_s8_u8(q3h_sv));
 
-                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[2]),svdup_n_s32((int32_t)scale[3]));
-                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),scale_1);
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4), svdup_n_s32((int32_t)scale[2]), svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), scale_1);
 
 
-                        if(j==0)
-                        {
-                            qhbits_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),qhbits_sv,4);
+                        if (j==0) {
+                            qhbits_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), qhbits_sv, 4);
                         }
 
                     scale += 4;
@@ -5261,10 +5259,10 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
                     }
 
                     sum += d * (svaddv_s32(svptrue_pat_b32(SV_VL8), sumi1_1));
-                }break;
+                } break;
             default:
-            assert(false && "Unsupported vector length");
-            break;
+                assert(false && "Unsupported vector length");
+                break;
         }
     }
     *s = sum;

--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5193,14 +5193,12 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
                         sumi1_1 = svmla_s32_m(svptrue_b32(), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), svdup_n_s32((int32_t)scale[3]));
 
-
                         if (j == 0) {
                             qhbits_sv_1 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_1, 4);
                             qhbits_sv_2 = svlsr_n_u8_x(svptrue_b8(), qhbits_sv_2, 4);
                         }
 
                         scale += 4;
-
                     }
 
                     sum += d * (svaddv_s32(svptrue_b32(), sumi1_1));
@@ -5249,13 +5247,11 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
                         scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4), svdup_n_s32((int32_t)scale[2]), svdup_n_s32((int32_t)scale[3]));
                         sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8), sumi1_1, svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2), scale_1);
 
-
                         if (j == 0) {
                             qhbits_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32), qhbits_sv, 4);
                         }
 
                         scale += 4;
-
                     }
 
                     sum += d * (svaddv_s32(svptrue_pat_b32(SV_VL8), sumi1_1));

--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5114,7 +5114,7 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
         const int8_t  * restrict q8_sv = y[i].qs;
 
         // Set up scales
-        uint32_t *aux = &x[i].scales;
+        uint32_t * aux = &x[i].scales;
         utmp[3] = ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4);
         utmp[2] = ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4);
         utmp[1] = (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4);

--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5088,7 +5088,188 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
     const int nb = n / QK_K;
 
-#ifdef __ARM_NEON
+#if defined(__ARM_FEATURE_SVE)
+
+    uint32_t utmp[4];
+
+    const int8_t m32 = 32;
+    const int vector_length = svcntb()*8;
+    const svuint8_t m3b_sv = svdup_n_u8(0X3);
+    const svint32_t vzero_sv = svdup_n_s32(0);
+
+    const svuint8_t m0_sv = svdup_n_u8(1);
+    const svuint8_t m1_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,1);
+    const svuint8_t m2_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,2);
+    const svuint8_t m3_sv =  svlsl_n_u8_x(svptrue_b8(),m0_sv,3);
+    svbool_t pred_s32 = svnot_b_z (svptrue_b32(),svptrue_pat_b32(SV_VL4));
+
+    float sum = 0;
+
+    for (int i = 0; i < nb; ++i) {
+
+        const float d = y[i].d * GGML_FP16_TO_FP32(x[i].d);
+
+        const uint8_t * restrict q3_sv = x[i].qs;
+        const uint8_t * restrict qh_sv = x[i].hmask;
+        const int8_t  * restrict q8_sv = y[i].qs;
+
+        // Set up scales
+        uint32_t *aux = &x[i].scales;
+        utmp[3] = ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4);
+        utmp[2] = ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4);
+        utmp[1] = (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4);
+        utmp[0] = (aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4);
+
+        int8_t * scale = (int8_t *)utmp;
+
+        for (int j = 0; j < 16; ++j) scale[j] -= m32;
+
+        switch(vector_length){
+            case 128:
+                {
+                    svuint8_t qhbits_sv_1 = svld1_u8(svptrue_b8(),qh_sv);
+                    svuint8_t qhbits_sv_2 = svld1_u8(svptrue_b8(),qh_sv+16);
+                    svuint8_t q3h_sv;
+
+                    svint32_t sumi1_1 = svdup_n_s32(0);
+                    svint8_t q3bytes_sv;
+
+                    for (int j = 0; j < QK_K/128; ++j) {
+
+                        const svuint8_t q3bits_sv = svld1_u8(svptrue_b8(),q3_sv); q3_sv += 16;
+                        const svuint8_t q3bits_sv_1 = svld1_u8(svptrue_b8(),q3_sv); q3_sv += 16;
+                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m0_sv, qhbits_sv_1),2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),q3bits_sv,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[0]));
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m0_sv, qhbits_sv_2),2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),q3bits_sv_1,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[1]));
+
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m1_sv, qhbits_sv_1),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[2]));
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m1_sv, qhbits_sv_2),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[3]));
+
+
+                        scale += 4;
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+
+                        q3h_sv = svbic_u8_x(svptrue_b8(),m2_sv, qhbits_sv_1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[0]));
+
+                        q3h_sv = svbic_u8_x(svptrue_b8(),m2_sv, qhbits_sv_2);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[1]));
+
+
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_b8(),q8_sv); q8_sv += 16;
+
+                        q3h_sv = svlsr_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m3_sv, qhbits_sv_1),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),svdup_n_s32((int32_t)scale[2]));
+
+                        q3h_sv = svlsr_n_u8_x(svptrue_b8(),svbic_u8_x(svptrue_b8(),m3_sv, qhbits_sv_2),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_b8(),svreinterpret_s8_u8(svand_u8_m(svptrue_b8(),svlsr_n_u8_x(svptrue_b8(),q3bits_sv_1,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        sumi1_1 = svmla_s32_m(svptrue_b32(),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),svdup_n_s32((int32_t)scale[3]));
+
+
+                        if(j==0)
+                        {
+                            qhbits_sv_1 = svlsr_n_u8_x(svptrue_b8(),qhbits_sv_1,4);
+                            qhbits_sv_2 = svlsr_n_u8_x(svptrue_b8(),qhbits_sv_2,4);
+                        }
+
+                    scale += 4;
+
+                    }
+
+                    sum += d * (svaddv_s32(svptrue_b32(), sumi1_1));
+                }break;
+            case 256:
+            case 512:
+                {
+                    svuint8_t qhbits_sv = svld1_u8(svptrue_pat_b8(SV_VL32),qh_sv);
+                    svuint8_t q3h_sv;
+
+                    svint32_t sumi1_1 = svdup_n_s32(0);
+                    svint8_t q3bytes_sv;
+
+                    for (int j = 0; j < QK_K/128; ++j) {
+
+                        const svuint8_t q3bits_sv = svld1_u8(svptrue_pat_b8(SV_VL32),q3_sv); q3_sv += 32;
+                        svint8_t q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+                        svint8_t q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m0_sv, qhbits_sv),2);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),q3bits_sv,m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+
+                        svint32_t scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[0]),svdup_n_s32((int32_t)scale[1]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),scale_1);
+
+                        q3h_sv = svlsl_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m1_sv, qhbits_sv),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,2),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[2]),svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),scale_1);
+
+                        scale += 4;
+                        q8bytes_1_sv_1 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+                        q8bytes_1_sv_2 = svld1_s8(svptrue_pat_b8(SV_VL32),q8_sv); q8_sv += 32;
+
+                        q3h_sv = svbic_u8_x(svptrue_pat_b8(SV_VL32),m2_sv, qhbits_sv);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,4),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[0]),svdup_n_s32((int32_t)scale[1]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_1),scale_1);
+
+                        q3h_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),svbic_u8_x(svptrue_pat_b8(SV_VL32),m3_sv, qhbits_sv),1);
+                        q3bytes_sv = svsub_s8_x(svptrue_pat_b8(SV_VL32),svreinterpret_s8_u8(svand_u8_m(svptrue_pat_b8(SV_VL32),svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),q3bits_sv,6),m3b_sv)), svreinterpret_s8_u8(q3h_sv));
+
+                        scale_1 = svsel_s32(svptrue_pat_b32(SV_VL4),svdup_n_s32((int32_t)scale[2]),svdup_n_s32((int32_t)scale[3]));
+                        sumi1_1 = svmla_s32_m(svptrue_pat_b32(SV_VL8),sumi1_1,svdot_s32(vzero_sv, q3bytes_sv, q8bytes_1_sv_2),scale_1);
+
+
+                        if(j==0)
+                        {
+                            qhbits_sv = svlsr_n_u8_x(svptrue_pat_b8(SV_VL32),qhbits_sv,4);
+                        }
+
+                    scale += 4;
+
+                    }
+
+                    sum += d * (svaddv_s32(svptrue_pat_b32(SV_VL8), sumi1_1));
+                }break;
+            default:
+            assert(false && "Unsupported vector length");
+            break;
+        }
+    }
+    *s = sum;
+
+#elif __ARM_NEON
 
     uint32_t aux[3];
     uint32_t utmp[4];


### PR DESCRIPTION
This PR introduces support for SVE (Scalable Vector Extensions) kernels for the q3_K_q8_K vector dot on the Arm architecture. A similar proposal for SVE support is made in PR https://github.com/ggerganov/llama.cpp/pull/7433 and https://github.com/ggml-org/llama.cpp/pull/11227. 

This PR contains the SVE implementation of the vector dot used to compute the Q3_K quantization.
By running a Q3_K quantized model of mistral-7b-v01, on Graviton 3 (Perf 01 XL), Accuracy and Performance are measured. 

Performance
-------------------------------------------------------------------------------------------------------------------------------------------
The performance enhancement with this PR (SVE) is ~ x1.02 to x1.15 faster than the NEON implementation. 


- Decoding Throughput (TPOT) 

| Threads | NEON (original) | This PR(SVE)|Ratio |
|----------|----------|----------|----------|
| 2| 4.21 | 4.86 |1.15 |
| 4| 8.26 | 9.37 |1.13 | 
| 8| 15.90 | 17.49 |1.10 |
| 16| 29.09 | 31.05 |1.06 |
| 32| 42.59 | 43.80 |1.03 |
| 48| 48.36 | 49.41 |1.02 |

The command used to measure the performance is
```
./llama-bench  -m ${PATH_TO_MODEL} -n 0 -n 16 -p 64 -t 2,4,8,16,32,48
```

Perplexity 
----------------------------------------------------------------------------------------------------------------------------------------
I also verified that perplexity matches between the NEON and SVE Implementation.

| NEON (original) | SVE (this PR) | 
|----------|----------|
| 2.9394 +/- 0.35779| 2.9394 +/- 0.35779|