### PR TITLE
make `ggml_is_view_op` public.

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -105,6 +105,8 @@ extern "C" {
     GGML_API bool ggml_backend_supports_buft(ggml_backend_t backend, ggml_backend_buffer_type_t buft);
     GGML_API bool ggml_backend_offload_op(ggml_backend_t backend, const struct ggml_tensor * op);
 
+    GGML_API bool ggml_backend_is_view_op(enum ggml_op op);
+
     // asynchronous copy
     // the copy is performed after all the currently queued operations in backend_src
     // backend_dst will wait for the copy to complete before performing other operations

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -663,6 +663,8 @@ extern "C" {
 
     GGML_API bool    ggml_is_quantized(enum ggml_type type);
 
+    GGML_API bool    ggml_is_view_op(enum ggml_op op);
+
     // TODO: temporary until model loading of ggml examples is refactored
     GGML_API enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype);
 

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -663,8 +663,6 @@ extern "C" {
 
     GGML_API bool    ggml_is_quantized(enum ggml_type type);
 
-    GGML_API bool    ggml_is_view_op(enum ggml_op op);
-
     // TODO: temporary until model loading of ggml examples is refactored
     GGML_API enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype);
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -600,7 +600,7 @@ static struct ggml_tensor * ggml_dup_tensor_layout(struct ggml_context * ctx, co
     return dup;
 }
 
-bool ggml_is_view_op(enum ggml_op op) {
+bool ggml_backend_is_view_op(enum ggml_op op) {
     return op == GGML_OP_VIEW || op == GGML_OP_RESHAPE || op == GGML_OP_PERMUTE || op == GGML_OP_TRANSPOSE;
 }
 
@@ -808,7 +808,7 @@ static void ggml_backend_sched_print_assignments(ggml_backend_sched_t sched, str
             cur_split++;
         }
         struct ggml_tensor * node = graph->nodes[i];
-        if (ggml_is_view_op(node->op)) {
+        if (ggml_backend_is_view_op(node->op)) {
             continue;
         }
         if (sched->debug > 1) {
@@ -924,7 +924,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         int cur_backend_id = -1;
         for (int i = 0; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_backend_is_view_op(node->op)) {
                 continue;
             }
             int * node_backend_id = &tensor_backend_id(node);
@@ -945,7 +945,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         int cur_backend_id = -1;
         for (int i = graph->n_nodes - 1; i >= 0; i--) {
             struct ggml_tensor * node = graph->nodes[i];
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_backend_is_view_op(node->op)) {
                 continue;
             }
             int * node_backend_id = &tensor_backend_id(node);
@@ -966,7 +966,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         int cur_backend_id = -1;
         for (int i = 0; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_backend_is_view_op(node->op)) {
                 continue;
             }
             int * node_backend_id = &tensor_backend_id(node);
@@ -982,7 +982,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         int cur_backend_id = -1;
         for (int i = graph->n_nodes - 1; i >= 0; i--) {
             struct ggml_tensor * node = graph->nodes[i];
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_backend_is_view_op(node->op)) {
                 continue;
             }
             int * node_backend_id = &tensor_backend_id(node);
@@ -1004,7 +1004,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
     // only nodes that could not be assigned during expansion due to the backend not supporting the op should be unassigned at this point
     for (int i = 0; i < graph->n_nodes; i++) {
         struct ggml_tensor * node = graph->nodes[i];
-        if (ggml_is_view_op(node->op)) {
+        if (ggml_backend_is_view_op(node->op)) {
             continue;
         }
         int * node_backend_id = &tensor_backend_id(node);
@@ -1090,7 +1090,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         int i = 0;
         for (; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
-            if (!ggml_is_view_op(node->op)) {
+            if (!ggml_backend_is_view_op(node->op)) {
                 split->backend_id = tensor_backend_id(node);
                 break;
             }
@@ -1101,7 +1101,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         for (; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
 
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_backend_is_view_op(node->op)) {
                 continue;
             }
 
@@ -1835,7 +1835,7 @@ bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t 
         ggml_backend_graph_compute(backend1, &g1v);
         ggml_backend_graph_compute(backend2, &g2v);
 
-        if (ggml_is_view_op(t1->op)) {
+        if (ggml_backend_is_view_op(t1->op)) {
             continue;
         }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -600,7 +600,7 @@ static struct ggml_tensor * ggml_dup_tensor_layout(struct ggml_context * ctx, co
     return dup;
 }
 
-static bool ggml_is_view_op(enum ggml_op op) {
+bool ggml_is_view_op(enum ggml_op op) {
     return op == GGML_OP_VIEW || op == GGML_OP_RESHAPE || op == GGML_OP_PERMUTE || op == GGML_OP_TRANSPOSE;
 }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -293,10 +293,6 @@ static bool isinf_or_max(float f) {
     return _isinf(f) || f == FLT_MAX || f == -FLT_MAX;
 }
 
-static bool ggml_is_view_op(enum ggml_op op) {
-    return op == GGML_OP_VIEW || op == GGML_OP_RESHAPE || op == GGML_OP_PERMUTE || op == GGML_OP_TRANSPOSE;
-}
-
 enum test_mode {
     MODE_TEST,
     MODE_PERF,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -668,7 +668,7 @@ struct test_case {
             return size;
         };
         for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
-            if (ggml_is_view_op(ggml_graph_node(gf, i)->op) || ggml_graph_node(gf, i) == out) {
+            if (ggml_backend_is_view_op(ggml_graph_node(gf, i)->op) || ggml_graph_node(gf, i) == out) {
                 continue;
             }
             mem += tensor_op_size(ggml_graph_node(gf, i));
@@ -1112,7 +1112,7 @@ struct test_get_rows : public test_case {
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
             if (t->type == GGML_TYPE_I32) {
-                if (ggml_is_view_op(t->op)) { continue; }
+                if (ggml_backend_is_view_op(t->op)) { continue; }
                 // rows
                 std::vector<int> data(r*b);
                 for (int i = 0; i < r*b; i++) {
@@ -1165,7 +1165,7 @@ struct test_get_rows_back : public test_case {
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
             if (t->type == GGML_TYPE_I32) {
-                if (ggml_is_view_op(t->op)) { continue; }
+                if (ggml_backend_is_view_op(t->op)) { continue; }
                 // rows
                 std::vector<int> data(r*b);
                 for (int i = 0; i < r*b; i++) {
@@ -2037,7 +2037,7 @@ struct test_mul_mat_id : public test_case {
         std::default_random_engine rng(rd());
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
             if (t->type == GGML_TYPE_I32) {
-                if (ggml_is_view_op(t->op)) { continue; }
+                if (ggml_backend_is_view_op(t->op)) { continue; }
                 // ids
                 for (int64_t r = 0; r < ggml_nrows(t); r++) {
                     std::vector<int32_t> data(t->ne[0]);


### PR DESCRIPTION
Motivation: `ggml_is_view_op` is a useful API.

### Use case 1

It is used by `test-backend-ops.cpp`.

### Use case 2

https://github.com/ggml-org/llama.cpp/blob/73e2ed3ce3492d3ed70193dd09ae8aa44779651d/src/llama.cpp#L8178-L8179

Let's say `cur` is a view operation and its source is on another backend, then this would be problematic. 
`if (ggml_backend_supports_op(backend.get(), cur) && !ggml_is_view_op(cur->op))` seems better.

By the way, PR #10825 is useful for checking (visualizing) these scenarios.

