### PR TITLE
server : disable Nagle's algorithm

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -7,6 +7,8 @@
 
 // increase max payload length to allow use of larger context size
 #define CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH 1048576
+// disable Nagle's algorithm
+#define CPPHTTPLIB_TCP_NODELAY true
 #include "httplib.h"
 
 // Change JSON_ASSERT from assert() to GGML_ASSERT:


### PR DESCRIPTION
[Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm) is notorious for affecting negatively the performance of most network applications. From quick tests, I wasn't able to measure any significant perf difference, but it's likely better to have it disabled anyway.