### PR TITLE
ggml-cpu: Fix build with sve

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5265,6 +5265,7 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
 
 #if defined(__ARM_FEATURE_SVE)
 
+    uint32_t aux[3];
     uint32_t utmp[4];
 
     const int8_t m32 = 32;
@@ -5289,7 +5290,7 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
         const int8_t  * restrict q8_sv = y[i].qs;
 
         // Set up scales
-        uint32_t * aux = &x[i].scales;
+        memcpy(aux, x[i].scales, 12);
         utmp[3] = ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4);
         utmp[2] = ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4);
         utmp[1] = (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4);

--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -5277,7 +5277,6 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * restrict s, size_t bs, const void * r
     const svuint8_t m1_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 1);
     const svuint8_t m2_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 2);
     const svuint8_t m3_sv = svlsl_n_u8_x(svptrue_b8(), m0_sv, 3);
-    svbool_t pred_s32 = svnot_b_z (svptrue_b32(), svptrue_pat_b32(SV_VL4));
 
     float sum = 0;
 


### PR DESCRIPTION
Fix build issue when __ARM_FEATURE_SVE is enabled:
```
# molly @ o6-archlinux in ~/llama.cpp/build-sve on git:master o [11:27:44] 
$ cmake --build . -j12                                                             
[  0%] Generating build details from Git
-- Found Git: /usr/bin/git (found version "2.48.1")
[  1%] Built target sha256
[  2%] Built target xxhash
[  2%] Built target sha1
[  6%] Built target ggml-base
[  6%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-quants.c.o
[  6%] Building CXX object common/CMakeFiles/build_info.dir/build-info.cpp.o
[  6%] Built target build_info
/home/molly/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-quants.c: In function ‘ggml_vec_dot_q3_K_q8_K’:
/home/molly/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-quants.c:5292:26: error: initialization of ‘uint32_t *’ {aka ‘unsigned int *’} from incompatible pointer type ‘const uint8_t (*)[12]’ {aka ‘const unsigned char (*)[12]’} [-Wincompatible-pointer-types]
 5292 |         uint32_t * aux = &x[i].scales;
      |                          ^
/home/molly/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-quants.c:5279:14: warning: unused variable ‘pred_s32’ [-Wunused-variable]
 5279 |     svbool_t pred_s32 = svnot_b_z (svptrue_b32(), svptrue_pat_b32(SV_VL4));
      |              ^~~~~~~~
make[2]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/build.make:135: ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-quants.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2179: ggml/src/CMakeFiles/ggml-cpu.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```