### PR TITLE
server: support add_generation_prompt query param

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -598,7 +598,7 @@ static json oaicompat_completion_params_parse(
     inputs.tool_choice           = common_chat_tool_choice_parse_oaicompat(json_value(body, "tool_choice", std::string("auto")));
     inputs.json_schema           = json_schema.is_null() ? "" : json_schema.dump();
     inputs.grammar               = grammar;
-    inputs.add_generation_prompt = true;
+    inputs.add_generation_prompt = json_value(body, "add_generation_prompt", true);
     inputs.use_jinja             = use_jinja;
     inputs.parallel_tool_calls   = json_value(body, "parallel_tool_calls", false);
     inputs.extract_reasoning     = reasoning_format != COMMON_REASONING_FORMAT_NONE;


### PR DESCRIPTION
While this isn't part of OpenAI's API, it is part of vLLM and very useful w/ the `/apply-template` endpoint

(I'm using it in this [PR for Cline's support of llama.cpp](https://github.com/cline/cline/pull/1946) to compute the tool call examples used in the system prompt)