### PR TITLE
vulkan: fix assertion when qy_needs_dequant

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4192,7 +4192,7 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
     }
     if (qy_needs_dequant) {
         d_Y = ctx->prealloc_y;
-        GGML_ASSERT(d_Y->size >= y_sz * ne02 * ne03);
+        GGML_ASSERT(d_Y->size >= y_sz * ne12 * ne13);
     } else {
         d_Y = d_Qy;
         y_buf_offset = qy_buf_offset;
@@ -4769,7 +4769,7 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     }
     if (qy_needs_dequant) {
         d_Y = ctx->prealloc_y;
-        GGML_ASSERT(d_Y->size >= y_sz * ne02 * ne03);
+        GGML_ASSERT(d_Y->size >= y_sz * ne12 * ne13);
     } else {
         d_Y = d_Qy;
         y_buf_offset = qy_buf_offset;


### PR DESCRIPTION
Looks like a copy/paste bug from qx_needs_dequant.

```
llama-cli -no-cnv -p "Write a function in C to compute the fibonacci sequence" -ngl 99 -m C:\models\Moonlight-16B-A3B-Instruct-Q4_K_M.gguf
...
C:\github\jeffbolznv\llama.cpp\ggml\src\ggml-vulkan\ggml-vulkan.cpp:4772: GGML_ASSERT(d_Y->size >= y_sz * ne02 * ne03) failed
```



