### PR TITLE
llava : add struct for FFI bindgen

### DIFF
--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -74,8 +74,10 @@ CLIP_API void clip_image_f32_free(struct clip_image_f32 * img);
 CLIP_API void clip_image_u8_batch_free (struct clip_image_u8_batch  * batch);
 CLIP_API void clip_image_f32_batch_free(struct clip_image_f32_batch * batch);
 
-/** build image from pixels decoded by other libraries instead of stb_image.h for better performance. The memory layout is RGBRGBRGB..., input buffer length must be 3*nx*ny bytes */
-CLIP_API void clip_build_img_from_pixels(const unsigned char * rgb_pixels, int nx, int ny, clip_image_u8 * img);
+/** build image from pixels decoded by other libraries instead of stb_image.h for better performance. 
+ * The memory layout is RGBRGBRGB..., input buffer length must be 3*nx*ny bytes 
+ */
+CLIP_API void clip_build_img_from_pixels(const unsigned char * rgb_pixels, int nx, int ny, struct clip_image_u8 * img);
 
 CLIP_API bool clip_image_load_from_file(const char * fname, struct clip_image_u8 * img);
 

--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -74,8 +74,9 @@ CLIP_API void clip_image_f32_free(struct clip_image_f32 * img);
 CLIP_API void clip_image_u8_batch_free (struct clip_image_u8_batch  * batch);
 CLIP_API void clip_image_f32_batch_free(struct clip_image_f32_batch * batch);
 
-/** build image from pixels decoded by other libraries instead of stb_image.h for better performance. 
- * The memory layout is RGBRGBRGB..., input buffer length must be 3*nx*ny bytes 
+/**
+ * Build image from pixels decoded by other libraries instead of stb_image.h for better performance.
+ * The memory layout is RGBRGBRGB..., input buffer length must be 3*nx*ny bytes
  */
 CLIP_API void clip_build_img_from_pixels(const unsigned char * rgb_pixels, int nx, int ny, struct clip_image_u8 * img);
 


### PR DESCRIPTION
Rust bindgen failed to generate bindings: ClangDiagnostic("./llama.cpp/examples/llava/clip.h:78:92: error: must use 'struct' tag to refer to type 'clip_image_u8'\n")
