### PR TITLE
CUDA: fix logic for V100 + GGML_CUDA_FORCE_MMQ

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -109,9 +109,9 @@ static constexpr __device__ int get_mmq_x_max_device() {
 
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
 #ifdef GGML_CUDA_FORCE_MMQ
-    return MMQ_DP4A_MAX_BATCH_SIZE;
-#else // GGML_CUDA_FORCE_MMQ
     return 128;
+#else // GGML_CUDA_FORCE_MMQ
+    return MMQ_DP4A_MAX_BATCH_SIZE;
 #endif // GGML_CUDA_FORCE_MMQ
 #else // __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
 


### PR DESCRIPTION
Fixes https://github.com/LostRuins/koboldcpp/issues/1390 .

The logic for the combination of V100s and `GGML_CUDA_FORCE_MMQ` seems to be wrong on master. By default, when compiling without `GGML_CUDA_FORCE_MMQ`, the MMQ kernels should only be compiled for batch sizes up to `MMQ_DP4A_MAX_BATCH_SIZE` if FP16 tensor core hardware is available but int8 tensor core hardware is not (basically only V100s). Template specializations for higher batch sizes will never be used. However, the condition for this seems to have been inverted. Without `GGML_CUDA_FORCE_MMQ` unneeded template specializations were being compiled and with it the host code could attempt to run nonexistent kernels.