### PR TITLE
main: allow preloading conversation with -p and add -st / --single-turn

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -950,6 +950,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_MAIN}));
     add_opt(common_arg(
+        {"-st", "--single-turn"},
+        "run conversation for a single turn only, then exit when done\n"
+        "will not be interactive if first turn is predefined with --prompt\n"
+        "(default: false)",
+        [](common_params & params) {
+            params.single_turn = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_MAIN}));
+    add_opt(common_arg(
         {"-i", "--interactive"},
         string_format("run in interactive mode (default: %s)", params.interactive ? "true" : "false"),
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -326,6 +326,8 @@ struct common_params {
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
 
+    bool single_turn       = false; // single turn chat conversation
+
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
     ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V
 

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -45,8 +45,8 @@ static void print_usage(int argc, char ** argv) {
     (void) argc;
 
     LOG("\nexample usage:\n");
-    LOG("\n  text generation:     %s -m your_model.gguf -p \"I believe the meaning of life is\" -n 128\n", argv[0]);
-    LOG("\n  chat (conversation): %s -m your_model.gguf -p \"You are a helpful assistant\" -cnv\n", argv[0]);
+    LOG("\n  text generation:     %s -m your_model.gguf -p \"I believe the meaning of life is\" -n 128 -no-cnv\n", argv[0]);
+    LOG("\n  chat (conversation): %s -m your_model.gguf -sys \"You are a helpful assistant\"\n", argv[0]);
     LOG("\n");
 }
 
@@ -279,11 +279,9 @@ int main(int argc, char ** argv) {
     std::string prompt;
     {
         if (params.conversation_mode && params.enable_chat_template) {
-            prompt = params.system_prompt;
-
-            if (!prompt.empty()) {
+            if (!params.system_prompt.empty()) {
                 // format the system prompt (will use template default if empty)
-                chat_add_and_format("system", prompt);
+                chat_add_and_format("system", params.system_prompt);
             }
 
             if (!params.prompt.empty()) {
@@ -293,7 +291,7 @@ int main(int argc, char ** argv) {
                 waiting_for_first_input = true;
             }
 
-            if (!prompt.empty() || !params.prompt.empty()) {
+            if (!params.system_prompt.empty() || !params.prompt.empty()) {
                 common_chat_templates_inputs inputs;
                 inputs.messages = chat_msgs;
                 inputs.add_generation_prompt = !params.prompt.empty();

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -283,14 +283,22 @@ int main(int argc, char ** argv) {
 
             if (!prompt.empty()) {
                 // format the system prompt (will use template default if empty)
-                prompt = chat_add_and_format("system", prompt);
+                chat_add_and_format("system", prompt);
             }
 
             if (!params.prompt.empty()) {
                 // format and append the user prompt
-                prompt += chat_add_and_format("user", params.prompt);
+                chat_add_and_format("user", params.prompt);
             } else {
                 waiting_for_first_input = true;
+            }
+
+            if (!prompt.empty() || !params.prompt.empty()) {
+                common_chat_templates_inputs inputs;
+                inputs.messages = chat_msgs;
+                inputs.add_generation_prompt = !params.prompt.empty();
+
+                prompt = common_chat_templates_apply(chat_templates.get(), inputs).prompt;
             }
         } else {
             // otherwise use the prompt as is

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -277,6 +277,7 @@ int main(int argc, char ** argv) {
     };
 
     {
+        const bool explicit_chat_template = params.enable_chat_template && (params.use_jinja || !params.chat_template.empty());
         std::string prompt = params.enable_chat_template ? params.system_prompt : "";
 
         if (params.enable_chat_template && !prompt.empty()) {
@@ -285,7 +286,7 @@ int main(int argc, char ** argv) {
         }
 
         if (!params.conversation_mode) {
-            if (params.enable_chat_template && !params.prompt.empty()) {
+            if (explicit_chat_template && !params.prompt.empty()) {
                 // format and append the user prompt
                 prompt += chat_add_and_format("user", params.prompt);
             } else {

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -376,17 +376,17 @@ int main(int argc, char ** argv) {
     }
 
     if (params.conversation_mode) {
-        params.interactive_first = true;
+        if (params.single_turn && !params.prompt.empty()) {
+            params.interactive = false;
+            params.interactive_first = false;
+        } else {
+            params.interactive_first = true;
+        }
     }
 
     // enable interactive mode if interactive start is specified
     if (params.interactive_first) {
         params.interactive = true;
-    }
-
-    if (params.single_turn && !params.prompt.empty()) {
-        params.interactive = false;
-        params.interactive_first = false;
     }
 
     if (params.verbose_prompt) {

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -217,8 +217,8 @@ int main(int argc, char ** argv) {
     // print chat template example in conversation mode
     if (params.conversation_mode) {
         if (params.enable_chat_template) {
-            if (!params.prompt.empty()) {
-                LOG_WRN("*** User-specified prompt in conversation mode will be ignored, did you mean to set --system-prompt (-sys) instead?\n");
+            if (!params.prompt.empty() && params.system_prompt.empty()) {
+                LOG_WRN("*** User-specified prompt will pre-start conversation, did you mean to set --system-prompt (-sys) instead?\n");
             }
 
             LOG_INF("%s: chat template example:\n%s\n", __func__, common_chat_format_example(chat_templates.get(), params.use_jinja).c_str());


### PR DESCRIPTION
Implements preloading conversation mode with `-p` and adds `-st`/`--single-turn` that limit the conversation to a single turn for one-shot instructions.