### PR TITLE
build: fix build error when build source code on Windows

### DIFF
--- a/examples/export-lora/export-lora.cpp
+++ b/examples/export-lora/export-lora.cpp
@@ -148,7 +148,7 @@ struct lora_merge_ctx {
 
         ctx_out = gguf_init_empty();
         struct ggml_init_params params = {
-            /*.mem_size   =*/ gguf_get_n_tensors(base_model.ctx_gguf)*ggml_tensor_overhead(),
+            /*.mem_size   =*/ static_cast<size_t>(gguf_get_n_tensors(base_model.ctx_gguf)*ggml_tensor_overhead()),
             /*.mem_buffer =*/ NULL,
             /*.no_alloc   =*/ true,
         };


### PR DESCRIPTION
I know nothing about Windows programming, but it seems there is a minor build error when build latest source code on Windows after verified twice:

![Screenshot from 2025-03-03 13-19-00](https://github.com/user-attachments/assets/235d781d-1f04-464b-87eb-1445d00ce5ce)

pls help to close this PR accordingly if this is a misunderstanding, thanks.