### PR TITLE
CUDA: Fix new mma detection for Turing cards with Volta PTX

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -244,7 +244,8 @@ static bool fp16_mma_hardware_available(const int cc) {
 
 // Volta technically had FP16 tensor cores but they work very differently compared to Turing and later.
 static bool new_mma_available(const int cc) {
-    return cc < GGML_CUDA_CC_OFFSET_AMD && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_TURING;
+    return cc < GGML_CUDA_CC_OFFSET_AMD && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA &&
+        cc >= GGML_CUDA_CC_TURING;
 }
 
 static bool cp_async_available(const int cc) {


### PR DESCRIPTION
We are seeing that [this change](https://github.com/ggml-org/llama.cpp/pull/11775/files#diff-ebbf9a2188dbcb76b611de6660ddcfec3f9c030ab272aaa59785149f6197c65cL176-R231) incorrectly disabled flash attention for Turing cards (cc=75) when llama.cpp was compiled for Volta cards only (cc=70). To fix, check that we have compiled for Volta or greater, and that the card is Turing or greater. If there is a better way to fix, please do advise.

To reproduce the breakage on the current build, compile with architecture `70` and without architecture `75`, and generate with flash attention on a Turing card.