### PR TITLE
feat(CMakeLists): Add MSVC-specific compiler warning flags in CMake configuration

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -74,8 +74,19 @@ if (GGML_ALL_WARNINGS)
 
         add_compile_options("$<$<COMPILE_LANGUAGE:C>:${C_FLAGS};${GF_C_FLAGS}>"
                             "$<$<COMPILE_LANGUAGE:CXX>:${CXX_FLAGS};${GF_CXX_FLAGS}>")
+    elseif(MSVC)
+        # MSVC
+        list(APPEND MSVC_WARNING_FLAGS 
+            /W4       # Comprehensive warnings (similar to -Wall and some of -Wextra)
+            /we4456   # declaration hides previous local declaration
+            /we4457   # declaration hides function parameter
+            /we4458   # declaration hides class member
+            /wd4100   # unreferenced formal parameter (too noisy)
+            /wd4324   # structure was padded due to alignment specifier
+        )
+
+        add_compile_options(${MSVC_WARNING_FLAGS})
     else()
-        # todo : msvc
         set(C_FLAGS   "")
         set(CXX_FLAGS "")
     endif()

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -76,7 +76,7 @@ if (GGML_ALL_WARNINGS)
                             "$<$<COMPILE_LANGUAGE:CXX>:${CXX_FLAGS};${GF_CXX_FLAGS}>")
     elseif(MSVC)
         # MSVC
-        list(APPEND MSVC_WARNING_FLAGS 
+        list(APPEND MSVC_WARNING_FLAGS
             /W4       # Comprehensive warnings (similar to -Wall and some of -Wextra)
             /we4456   # declaration hides previous local declaration
             /we4457   # declaration hides function parameter


### PR DESCRIPTION
**Summary:**
This pull request improves the handling of MSVC compiler warning flags in the CMake build configuration. Previously, the MSVC compiler warning flags (`C_FLAGS` and `CXX_FLAGS`) were unset, resulting in limited warning coverage. This change explicitly defines and applies a comprehensive set of MSVC warnings for improved code quality and consistency.

**Key Changes:**
- Removed the placeholder comments and empty flag settings for MSVC (`C_FLAGS` and `CXX_FLAGS`).
- Introduced a dedicated list `MSVC_WARNING_FLAGS` with a clear set of warning flags:
  - `/W4`: Comprehensive warnings similar to GCC's `-Wall`.
  - Enabled critical warnings to detect potential code issues related to declaration hiding (`/we4456`, `/we4457`, `/we4458`).
  - Disabled overly verbose or less useful warnings (`/wd4100`, `/wd4324`).

**Rationale:**
- This improves the maintainability of the build process by explicitly defining relevant MSVC warnings.
- It ensures better parity with warning standards established for GCC/Clang builds.

**Testing:**
- Successfully compiled and verified locally with MSVC.
- No negative impact observed on performance benchmarks (`llama-perplexity` and `llama-bench`).

**Review Considerations:**
- Reviewers should confirm these warnings align with the project's coding standards and practices.
