### PR TITLE
CUDA: fix FA logic for PTX 7.0 and CC >= 7.5

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -310,7 +310,7 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     }
 
     // The MMA implementation needs Turing or newer, use the old WMMA code for Volta:
-    if (cc == GGML_CUDA_CC_VOLTA) {
+    if (fp16_mma_available(cc) && !new_mma_available(cc)) {
         ggml_cuda_flash_attn_ext_wmma_f16(ctx, dst);
         return;
     }


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/pull/12187 .

The problem is as far as I can tell the explicit check against CC 7.0. However, if on a GPU with CC >= 7.5 the highest available PTX is 7.0 then the WMMA implementation should also be used.