### PR TITLE
Fix rocWMMA build documentation

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -239,7 +239,7 @@ You can download it from your Linux distro's package manager or from here: [ROCm
 
   The rocWMMA library is included by default when installing the ROCm SDK using the `rocm` meta package provided by AMD. Alternatively, if you are not using the meta package, you can install the library using the `rocwmma-dev` or `rocwmma-devel` package, depending on your system's package manager.
 
-  As an alternative, you can manually install the library by cloning it from the official [GitHub repository](https://github.com/ROCm/rocWMMA), checkout the corresponding version tag (e.g. `rocm-6.2.4`) and set `-DCMAKE_CXX_FLAGS="-I<path/to/rocwmma>/library/include/"` in CMake. This also works under Windows despite not officially supported by AMD.
+  As an alternative, you can manually install the library by cloning it from the official [GitHub repository](https://github.com/ROCm/rocWMMA), checkout the corresponding version tag (e.g. `rocm-6.2.4`) and set `-DCMAKE_CXX_FLAGS="-I<path/to/rocwmma>/library/include/"`(for Windows, this also works under Windows despite not officially supported by AMD) `-DCMAKE_HIP_FLAGS="-I<path/to/rocwmma>/library/include/"`(for Linux) in CMake.
 
   Note that if you get the following error:
   ```


### PR DESCRIPTION
Current HIP build manual about rocWMMA actually not working under linux, so here's the fix for this.