### PR TITLE
clang-tidy : disable bugprone-branch-clone

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
     -bugprone-implicit-widening-of-multiplication-result,
     -bugprone-misplaced-widening-cast,
     -bugprone-narrowing-conversions,
+    -bugprone-branch-clone,
     readability-*,
     -readability-avoid-unconditional-preprocessor-if,
     -readability-function-cognitive-complexity,


### PR DESCRIPTION
This warning does not seem very useful and it floods the editor with warnings in most `switch` statements:

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/bb33a8b8-83b6-4743-b3a5-d855b5165204" />
