### PR TITLE
server : Add verbose output to OAI compatible chat endpoint.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -830,6 +830,11 @@ struct server_task_result_cmpl_final : server_task_result {
             ret.push_back({"timings", timings.to_json()});
         }
 
+        // extra fields for debugging purposes
+        if (verbose) {
+            ret["__verbose"] = to_json_non_oaicompat();
+        }
+
         return ret;
     }
 };


### PR DESCRIPTION
I noticed that the /chat/completions and /v1/completions endpoints do not return the "__verbose" field in the final server response when running llama-server with -lv 10 and streaming enabled. This is inconsistent with the non-streaming behaviour of those endpoints.

This pr adds verbose output to server_task_result_cmpl_final::to_json_oaicompat_chat_stream, making it conform with server_task_result_cmpl_final::to_json_oaicompat_chat, as well as the other to_json methods.

This was motivated by me wanting to know the tokens_cached in streaming mode on those endpoints. If anyone has another way of doing that, preferably without verbose mode, I'd be very interested.
