### PR TITLE
doc: add text-based diagram of software architecture in toplevel README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,21 +246,21 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 | [OpenCL](docs/backend/OPENCL.md) | Adreno GPU |
 
 ## Software architecture
-
 ```mermaid
 block-beta
 columns 1
 
 block:llamacpp
-   llamacpp["llama_cpp"]
-   style llamacpp fill:#3c3,color:#000,stroke:#000
+  llamacpp["llama_cpp"]
+  style llamacpp        fill:#3c3,color:#000,stroke:#000
 end
 
-block:ggml
-   ggml["GGML"]
-   style ggml     fill:#3c3,color:#000,stroke:#000
+block:ggml_backend
+ggml_backend["GGML backend subsystem"]
+  style ggml_backend    fill:#3c3,color:#000,stroke:#000
 
-   ggml_cpu["ggml-cpu"]
+block:ggmlbackends
+ ggml_cpu["ggml-cpu"]
    ggml_metal["ggml-metal"]
    ggml_sycl["ggml-sycl"]
    ggml_cuda["ggml-cuda"]
@@ -284,13 +284,31 @@ block:ggml
    style ggml_qnn       fill:#cc3,color:#000,stroke:#000
    style ggml_ane       fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
    style ggml_nnpa      fill:#cc3,color:#000,stroke:#000
+  end
 end
 
 block:ggml_pal
-   ggml_pal["GGML Platform Abstraction Layer"]
-   style ggml_pal       fill:#c33,color:#000,stroke:#000
+  ggml_pal["Platform Abstraction Layer"]
+  style ggml_pal fill:#c33,color:#000,stroke:#000
 end
 
+block:ggml_backendsubsystem
+  ggml_backendsubsystem["GGML backend subsystem"]
+  style ggml_backendsubsystem fill:#3c3,color:#000,stroke:#000
+end
+
+block:group1：2
+  columns 2
+  block:ggml_tensor
+  ggml_tensor["GGML tensor"]
+  style ggml_tensor fill:#3c3,color:#000,stroke:#000
+  end
+
+  block:ggml_cgraph
+  ggml_cgraph["GGML cgraph"]
+  style ggml_cgraph  fill:#3c3,color:#000,stroke:#000
+  end
+end
 
 block:OS
     Windows
@@ -349,6 +367,7 @@ flowchart LR
       EXIST:::EXIST ~~~ TODO:::TODO ~~~ WIP:::WIP ~~~ DONE:::DONE ~~~ NEW:::NEW
     end
 ```
+
 
 ## Building the project
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,111 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 | [CANN](docs/build.md#cann) | Ascend NPU |
 | [OpenCL](docs/backend/OPENCL.md) | Adreno GPU |
 
+## Software architecture
+
+```mermaid
+block-beta
+columns 1
+
+block:llamacpp
+   llamacpp["llama_cpp"]
+   style llamacpp fill:#3c3,color:#000,stroke:#000
+end
+
+block:ggml
+   ggml["GGML"]
+   style ggml     fill:#3c3,color:#000,stroke:#000
+
+   ggml_cpu["ggml-cpu"]
+   ggml_metal["ggml-metal"]
+   ggml_sycl["ggml-sycl"]
+   ggml_cuda["ggml-cuda"]
+   ggml_hip["ggml-hip"]
+   ggml_vulkan["ggml-vulkan"]
+   ggml_cann["ggml-cann"]
+   ggml_opencl["ggml-opencl"]
+   ggml_qnn["ggml-qnn"]
+   ggml_nnpa["ggml-nnpa"]
+   ggml_ane["ggml-ane"]
+
+   style ggml_cpu       fill:#888,color:#000,stroke:#000
+   style ggml_metal     fill:#888,color:#000,stroke:#000
+   style ggml_sycl      fill:#888,color:#000,stroke:#000
+   style ggml_cuda      fill:#888,color:#000,stroke:#000
+   style ggml_hip       fill:#888,color:#000,stroke:#000
+   style ggml_vulkan    fill:#888,color:#000,stroke:#000
+   style ggml_cann      fill:#888,color:#000,stroke:#000
+
+   style ggml_opencl    fill:#cc3,color:#000,stroke:#000
+   style ggml_qnn       fill:#cc3,color:#000,stroke:#000
+   style ggml_ane       fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+   style ggml_nnpa      fill:#cc3,color:#000,stroke:#000
+end
+
+block:ggml_pal
+   ggml_pal["GGML Platform Abstraction Layer"]
+   style ggml_pal       fill:#c33,color:#000,stroke:#000
+end
+
+
+block:OS
+    Windows
+    Linux
+    Android
+    QNX
+    IBM_z/OS
+end
+
+block:hardware_vendors
+    Intel
+    AMD
+    Apple
+    Nvidia
+    Huawei
+    Loongson
+    Qualcomm
+    IBM
+
+    ggml_metal  --> Apple
+    ggml_cuda   --> Nvidia
+    ggml_hip    --> AMD
+    ggml_cann   --> Huawei
+    ggml_sycl   --> Intel
+    ggml_opencl --> Qualcomm
+    ggml_qnn    --> Qualcomm
+    ggml_ane    --> Apple
+    ggml_nnpa   --> IBM
+end
+
+block:hardware_types
+    CPU
+    GPU
+    NPU
+end
+
+block:hardware_archs
+    x86
+    arm
+    risc
+    dsp
+    loongson
+end
+```
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false, 'nodeSpacing': 30, 'rankSpacing': 30}} }%%
+flowchart LR
+    classDef EXIST fill:#888,color:#000,stroke:#000
+    classDef DONE fill:#3c3,color:#000,stroke:#000
+    classDef WIP fill:#cc3,color:#000,stroke:#000
+    classDef TODO fill:#c33,color:#000,stroke:#000
+    classDef NEW fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    subgraph Legend
+      direction LR
+      EXIST:::EXIST ~~~ TODO:::TODO ~~~ WIP:::WIP ~~~ DONE:::DONE ~~~ NEW:::NEW
+    end
+```
+
 ## Building the project
 
 The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](include/llama.h).

--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ block:OS
     Linux
     Android
     QNX
-    IBM_z/OS
 end
 
 block:hardware_vendors

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ block:ggmlbackends
    ggml_vulkan["ggml-vulkan"]
    ggml_cann["ggml-cann"]
    ggml_opencl["ggml-opencl"]
-   ggml_qnn["ggml-qnn"]
+   ggml_hexagon["ggml-hexagon"]
    ggml_nnpa["ggml-nnpa"]
    ggml_ane["ggml-ane"]
 
@@ -281,7 +281,7 @@ block:ggmlbackends
    style ggml_cann      fill:#888,color:#000,stroke:#000
 
    style ggml_opencl    fill:#cc3,color:#000,stroke:#000
-   style ggml_qnn       fill:#cc3,color:#000,stroke:#000
+   style ggml_hexagon       fill:#cc3,color:#000,stroke:#000
    style ggml_ane       fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
    style ggml_nnpa      fill:#cc3,color:#000,stroke:#000
   end
@@ -333,7 +333,7 @@ block:hardware_vendors
     ggml_cann   --> Huawei
     ggml_sycl   --> Intel
     ggml_opencl --> Qualcomm
-    ggml_qnn    --> Qualcomm
+    ggml_hexagon    --> Qualcomm
     ggml_ane    --> Apple
     ggml_nnpa   --> IBM
 end


### PR DESCRIPTION
 this PR add text-based diagram of high-level software architecture in toplevel README.md, it will provide a high level comprehension for llama.cpp beginner. from this simple diagram, 
- we can clearly see that the ggml machine learning library/framework is a really compact & <ins>**concise**</ins> machine learning library/framework! 
- we can clearly see what we can do/contribute for this project with our expertise.
- propose PAL(ggml-pal) in toplevel README.md, this difficult and performance-sensitive work can be done by the original authors or other domain experts. this idea comes from my effort on [https://github.com/ggml-org/llama.cpp/pull/12049 since 04/2024](https://github.com/ggml-org/llama.cpp/pull/12326). in the fact, this is not original idea because this idea can be found at Qualcomm's QNN SDK and Google's Android OS or some commercial massive complicated software in embedded system.
![Screenshot from 2025-03-22 14-17-13](https://github.com/user-attachments/assets/df1801c8-082d-4116-9028-0a4cbc86bfc7)



