### PR TITLE
ggml-backend : make path_str compatible with C++20

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1045,3 +1045,4 @@ zrm <trustiosity.zrm@gmail.com>
 蕭澧邦 <45505768+shou692199@users.noreply.github.com>
 谢乃闻 <sienaiwun@users.noreply.github.com>
 Нияз Гарифзянов <112617865+garrnizon@users.noreply.github.com>
+Jason C.H <ctrysbita@outlook.com>

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -76,7 +76,14 @@ namespace fs = std::filesystem;
 static std::string path_str(const fs::path & path) {
     std::string u8path;
     try {
+#if defined(__cpp_lib_char8_t)
+        // C++20 and later: u8string() returns std::u8string
+        std::u8string u8str = path.u8string();
+        u8path = std::string(reinterpret_cast<const char*>(u8str.c_str()));
+#else
+        // C++17: u8string() returns std::string
         u8path = path.u8string();
+#endif
     } catch (...) {
     }
     return u8path;


### PR DESCRIPTION
#12144 breaks the compatibility with C++20

In C++20, `fs::path::u8string()` return type changed from `std::string` (C++17) to `std::u8string` (C++20+). This PR modifies the `path_str` function to use conditional compilation to detect `__cpp_lib_char8_t` (a standard feature flag introduced in C++20):
- When compiled with C++20+, convert `std::u8string` to `std::string`
- When compiled with C++17, use the returned `std::string` directly