### PR TITLE
vulkan: fix coopmat shader generation when cross-compiling

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -32,9 +32,11 @@ if (Vulkan_FOUND)
 
     if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
         message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat is supported by glslc")
     else()
         message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
         add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat is supported by glslc")
     endif()
 
     # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
@@ -46,9 +48,11 @@ if (Vulkan_FOUND)
 
     if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
         message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat2 is supported by glslc")
     else()
         message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
         add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat2 is supported by glslc")
     endif()
 
     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
@@ -119,6 +123,8 @@ if (Vulkan_FOUND)
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders
             CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${HOST_CMAKE_TOOLCHAIN_FILE}
                     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
+                    -DGGML_VULKAN_COOPMAT_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}
+                    -DGGML_VULKAN_COOPMAT2_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}
             BUILD_COMMAND ${CMAKE_COMMAND} --build .
             INSTALL_COMMAND ${CMAKE_COMMAND} --install .
             INSTALL_DIR ${CMAKE_BINARY_DIR}

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -23,36 +23,40 @@ if (Vulkan_FOUND)
                              ../../include/ggml-vulkan.h
                             )
 
-    # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
+    if(NOT DEFINED GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
 
-    if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
-        message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
-        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat is supported by glslc")
-    else()
-        message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
-        add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat is supported by glslc")
+        if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
+            message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat is supported by glslc")
+        else()
+            message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
+            add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat is supported by glslc")
+        endif()
     endif()
 
-    # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
+    if(NOT DEFINED GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+        # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
 
-    if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
-        message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
-        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat2 is supported by glslc")
-    else()
-        message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
-        add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
-        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat2 is supported by glslc")
+        if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
+            message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Whether coopmat2 is supported by glslc")
+        else()
+            message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
+            add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Whether coopmat2 is supported by glslc")
+        endif()
     endif()
 
     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,5 +1,11 @@
 find_package (Threads REQUIRED)
 
+if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+	add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+endif()
+if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+	add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+endif()
 set(TARGET vulkan-shaders-gen)
 add_executable(${TARGET} vulkan-shaders-gen.cpp)
 install(TARGETS ${TARGET} RUNTIME)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_package (Threads REQUIRED)
 
 if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-	add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+    add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
 endif()
 if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
-	add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+    add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
 endif()
 set(TARGET vulkan-shaders-gen)
 add_executable(${TARGET} vulkan-shaders-gen.cpp)


### PR DESCRIPTION
Previously the status of coopmat{,2} support isn't passed to the vulkan-shaders-gen project building on the host, which leads to build failure because of the cross-compiling code expecting coopmat{,2} shaders that didn't get generated.

Fix this by passing the coopmat{,2} support status to vulkan-shaders subproject.

Tested by building with a glslc w/ coopmat and w/o coopmat2 both natively and cross-compiling (to RISC-V).
