### PR TITLE
`sampler`: fixes trigger tokens + lazy grammars (fix typo cast from token to string)

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -384,7 +384,8 @@ struct server_task {
                             SRV_DBG("Grammar trigger token: %d (`%s`)\n", token, word.c_str());
                             common_grammar_trigger trigger;
                             trigger.type = COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN;
-                            trigger.value = (llama_token) token;
+                            trigger.value = word;
+                            trigger.token = token;
                             params.sampling.grammar_triggers.push_back(trigger);
                         } else {
                             SRV_DBG("Grammar trigger word: `%s`\n", word.c_str());

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -386,7 +386,7 @@ struct server_task {
                             trigger.type = COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN;
                             trigger.value = word;
                             trigger.token = token;
-                            params.sampling.grammar_triggers.push_back(trigger);
+                            params.sampling.grammar_triggers.push_back(std::move(trigger));
                         } else {
                             SRV_DBG("Grammar trigger word: `%s`\n", word.c_str());
                             params.sampling.grammar_triggers.push_back({COMMON_GRAMMAR_TRIGGER_TYPE_WORD, word});


### PR DESCRIPTION
Fixes regression introduced in https://github.com/ggml-org/llama.cpp/pull/12034 (which got trigger tokens to just be... ignored)

Likely fixes https://github.com/ggml-org/llama.cpp/issues/12256

Note: this is hard to test against, short of exposing the triggered status of lazy grammars all the way to the server API (maybe limiting to verbose mode)