### PR TITLE
Update build.yml for Windows Vulkan builder to use Vulkan 1.4.304 SDK…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -774,7 +774,7 @@ jobs:
     env:
       OPENBLAS_VERSION: 0.3.23
       SDE_VERSION: 9.33.0-2024-01-07
-      VULKAN_VERSION: 1.3.261.1
+      VULKAN_VERSION: 1.4.304.1
 
     strategy:
       matrix:


### PR DESCRIPTION
Hi,
it's  for VK_NV_cooperative_matrix2 support..

detail:
fixes: https://github.com/ggml-org/llama.cpp/issues/12294
