### PR TITLE
clip : bring back GPU support

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -4,30 +4,31 @@
 // Note: Even when using identical normalized image inputs (see normalize_image_u8_to_f32()) we have a significant difference in resulting embeddings compared to pytorch
 #include "clip.h"
 #include "ggml.h"
+#include "ggml-cpp.h"
 #include "ggml-cpu.h"
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 #include "gguf.h"
 
-//#ifdef GGML_USE_CUDA
-//#include "ggml-cuda.h"
-//#endif
-//
-//#ifdef GGML_USE_SYCL
-//#include "ggml-sycl.h"
-//#endif
-//
-//#ifdef GGML_USE_METAL
-//#include "ggml-metal.h"
-//#endif
-//
-//#ifdef GGML_USE_CANN
-//#include "ggml-cann.h"
-//#endif
-//
-//#ifdef GGML_USE_VULKAN
-//#include "ggml-vulkan.h"
-//#endif
+#ifdef GGML_USE_CUDA
+#include "ggml-cuda.h"
+#endif
+
+#ifdef GGML_USE_SYCL
+#include "ggml-sycl.h"
+#endif
+
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
+
+#ifdef GGML_USE_CANN
+#include "ggml-cann.h"
+#endif
+
+#ifdef GGML_USE_VULKAN
+#include "ggml-vulkan.h"
+#endif
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
@@ -600,18 +601,36 @@ struct clip_ctx {
     bool has_post_norm = false;
     bool has_patch_bias = false;
 
-    struct gguf_context * ctx_gguf;
-    struct ggml_context * ctx_data;
+    struct gguf_context * ctx_gguf = nullptr;
+    struct ggml_context * ctx_data = nullptr;
 
     std::vector<uint8_t> buf_compute_meta;
 
-    // memory buffers to evaluate the model
-    ggml_backend_buffer_t params_buffer  = NULL;
+    ggml_backend_t backend     = nullptr;
+    ggml_backend_t backend_cpu = nullptr;
+    ggml_backend_buffer_t buf  = nullptr;
 
-    ggml_backend_t backend       = NULL;
-    ggml_gallocr_t compute_alloc = NULL;
+    ggml_backend_sched_ptr sched;
 
     struct clip_image_size * load_image_size;
+
+    ~clip_ctx() {
+        if (ctx_data) {
+            ggml_free(ctx_data);
+        }
+        if (ctx_gguf) {
+            gguf_free(ctx_gguf);
+        }
+        if (buf) {
+            ggml_backend_buffer_free(buf);
+        }
+        if (backend) {
+            ggml_backend_free(backend);
+        }
+        if (backend_cpu) {
+            ggml_backend_free(backend_cpu);
+        }
+    }
 };
 
 static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32_batch * imgs, struct clip_image_size * load_image_size, bool is_inf = false) {
@@ -1184,6 +1203,14 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
 
 // read and create ggml_context containing the tensors and their data
 struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+    return clip_init(fname, clip_context_params{
+        /* use_gpu */   true,
+        /* verbosity */ verbosity,
+    });
+}
+
+struct clip_ctx * clip_init(const char * fname, clip_context_params ctx_params) {
+    int verbosity = ctx_params.verbosity;
     struct ggml_context * meta = NULL;
 
     struct gguf_init_params params = {
@@ -1296,35 +1323,52 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
         }
     }
 
-//#ifdef GGML_USE_CUDA
-//    new_clip->backend = ggml_backend_cuda_init(0);
-//    LOG_INF("%s: CLIP using CUDA backend\n", __func__);
-//#endif
-//
-//#ifdef GGML_USE_METAL
-//    new_clip->backend = ggml_backend_metal_init();
-//    LOG_INF("%s: CLIP using Metal backend\n", __func__);
-//#endif
-//
-//#ifdef GGML_USE_CANN
-//    new_clip->backend = ggml_backend_cann_init(0);
-//    LOG_INF("%s: CLIP using CANN backend\n", __func__);
-//#endif
-//
-//#ifdef GGML_USE_VULKAN
-//    new_clip->backend = ggml_backend_vk_init(0);
-//    LOG_INF("%s: CLIP using Vulkan backend\n", __func__);
-//#endif
-//
-//#ifdef GGML_USE_SYCL
-//    new_clip->backend = ggml_backend_sycl_init(0);
-//    LOG_INF("%s: CLIP using SYCL backend\n", __func__);
-//#endif
+    std::vector<ggml_backend_buffer_type_t> backend_buft;
+    std::vector<ggml_backend_t> backend_ptrs;
 
-    if (!new_clip->backend) {
-        new_clip->backend = ggml_backend_cpu_init();
+    new_clip->backend_cpu = ggml_backend_cpu_init();
+
+    if (ctx_params.use_gpu) {
+#ifdef GGML_USE_CUDA
+        new_clip->backend = ggml_backend_cuda_init(0);
+        LOG_INF("%s: CLIP using CUDA backend\n", __func__);
+#endif
+
+#ifdef GGML_USE_METAL
+        new_clip->backend = ggml_backend_metal_init();
+        LOG_INF("%s: CLIP using Metal backend\n", __func__);
+#endif
+
+#ifdef GGML_USE_CANN
+        new_clip->backend = ggml_backend_cann_init(0);
+        LOG_INF("%s: CLIP using CANN backend\n", __func__);
+#endif
+
+#ifdef GGML_USE_VULKAN
+        new_clip->backend = ggml_backend_vk_init(0);
+        LOG_INF("%s: CLIP using Vulkan backend\n", __func__);
+#endif
+
+#ifdef GGML_USE_SYCL
+        new_clip->backend = ggml_backend_sycl_init(0);
+        LOG_INF("%s: CLIP using SYCL backend\n", __func__);
+#endif
+    }
+
+    if (new_clip->backend) {
+        backend_ptrs.push_back(new_clip->backend);
+        backend_buft.push_back(ggml_backend_get_default_buffer_type(new_clip->backend));
+    } else {
+        new_clip->backend = new_clip->backend_cpu;
         LOG_INF("%s: CLIP using CPU backend\n", __func__);
     }
+
+    backend_ptrs.push_back(new_clip->backend_cpu);
+    backend_buft.push_back(ggml_backend_get_default_buffer_type(new_clip->backend_cpu));
+
+    new_clip->sched.reset(
+        ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), 8192, false)
+    );
 
     // model size and capabilities
     {
@@ -1421,7 +1465,9 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
         }
 
         // alloc memory and offload data
-        new_clip->params_buffer = ggml_backend_alloc_ctx_tensors(new_clip->ctx_data, new_clip->backend);
+        ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(new_clip->backend);
+        new_clip->buf = ggml_backend_alloc_ctx_tensors_from_buft(new_clip->ctx_data, buft);
+        ggml_backend_buffer_set_usage(new_clip->buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
         for (int i = 0; i < n_tensors; ++i) {
             const char * name = gguf_get_tensor_name(ctx, i);
             struct ggml_tensor * cur = ggml_get_tensor(new_clip->ctx_data, name);
@@ -1434,7 +1480,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
                 return nullptr;
             }
             int num_bytes = ggml_nbytes(cur);
-            if (ggml_backend_buffer_is_host(new_clip->params_buffer)) {
+            if (ggml_backend_buft_is_host(buft)) {
                 // for the CPU and Metal backend, we can read directly into the tensor
                 fin.read(reinterpret_cast<char *>(cur->data), num_bytes);
             } else {
@@ -1720,14 +1766,21 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
     // measure mem requirement and allocate
     {
         new_clip->buf_compute_meta.resize(GGML_DEFAULT_GRAPH_SIZE * ggml_tensor_overhead() + ggml_graph_overhead());
-        new_clip->compute_alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(new_clip->backend));
         clip_image_f32_batch batch;
         batch.size = 1;
         batch.data = nullptr;
         ggml_cgraph * gf = clip_image_build_graph(new_clip, &batch, nullptr, false);
-        ggml_gallocr_reserve(new_clip->compute_alloc, gf);
-        size_t compute_memory_buffer_size = ggml_gallocr_get_buffer_size(new_clip->compute_alloc, 0);
-        LOG_INF("%s: compute allocated memory: %.2f MB\n", __func__, compute_memory_buffer_size /1024.0/1024.0);
+        ggml_backend_sched_reserve(new_clip->sched.get(), gf);
+        for (size_t i = 0; i < backend_ptrs.size(); ++i) {
+            ggml_backend_t backend = backend_ptrs[i];
+            ggml_backend_buffer_type_t buft = backend_buft[i];
+            size_t size = ggml_backend_sched_get_buffer_size(new_clip->sched.get(), backend);
+            if (size > 1) {
+                LOG_INF("%s: %10s compute buffer size = %8.2f MiB\n", __func__,
+                        ggml_backend_buft_name(buft),
+                        size / 1024.0 / 1024.0);
+            }
+        }
     }
 
     return new_clip;
@@ -2408,12 +2461,6 @@ ggml_tensor * clip_get_newline_tensor(const struct clip_ctx * ctx) {
 }
 
 void clip_free(clip_ctx * ctx) {
-    ggml_free(ctx->ctx_data);
-    gguf_free(ctx->ctx_gguf);
-
-    ggml_backend_buffer_free(ctx->params_buffer);
-    ggml_backend_free(ctx->backend);
-    ggml_gallocr_free(ctx->compute_alloc);
     delete ctx;
 }
 
@@ -2609,8 +2656,9 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
     }
 
     // build the inference graph
+    ggml_backend_sched_reset(ctx->sched.get());
     ggml_cgraph * gf = clip_image_build_graph(ctx, imgs, ctx->load_image_size, true);
-    ggml_gallocr_alloc_graph(ctx->compute_alloc, gf);
+    ggml_backend_sched_alloc_graph(ctx->sched.get(), gf);
 
     // set inputs
     const auto & model = ctx->vision_model;
@@ -2775,11 +2823,13 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
         }
     }
 
-    if (ggml_backend_is_cpu(ctx->backend)) {
-        ggml_backend_cpu_set_n_threads(ctx->backend, n_threads);
-    }
+    ggml_backend_cpu_set_n_threads(ctx->backend_cpu, n_threads);
 
-    ggml_backend_graph_compute(ctx->backend, gf);
+    auto status = ggml_backend_sched_graph_compute(ctx->sched.get(), gf);
+    if (status != GGML_STATUS_SUCCESS) {
+        LOG_ERR("%s: ggml_backend_sched_graph_compute failed with error %d\n", __func__, status);
+        return false;
+    }
 
     // the last node is the embedding tensor
     struct ggml_tensor * embeddings = ggml_graph_node(gf, -1);

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -627,7 +627,7 @@ struct clip_ctx {
         if (backend) {
             ggml_backend_free(backend);
         }
-        if (backend_cpu) {
+        if (backend_cpu && backend_cpu != backend) {
             ggml_backend_free(backend_cpu);
         }
     }

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1209,7 +1209,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
     });
 }
 
-struct clip_ctx * clip_init(const char * fname, clip_context_params ctx_params) {
+struct clip_ctx * clip_init(const char * fname, struct clip_context_params ctx_params) {
     int verbosity = ctx_params.verbosity;
     struct ggml_context * meta = NULL;
 

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -10,26 +10,6 @@
 #include "ggml-backend.h"
 #include "gguf.h"
 
-#ifdef GGML_USE_CUDA
-#include "ggml-cuda.h"
-#endif
-
-#ifdef GGML_USE_SYCL
-#include "ggml-sycl.h"
-#endif
-
-#ifdef GGML_USE_METAL
-#include "ggml-metal.h"
-#endif
-
-#ifdef GGML_USE_CANN
-#include "ggml-cann.h"
-#endif
-
-#ifdef GGML_USE_VULKAN
-#include "ggml-vulkan.h"
-#endif
-
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -641,19 +621,11 @@ struct clip_ctx {
     }
 
     ~clip_ctx() {
-        if (ctx_data) {
-            ggml_free(ctx_data);
-        }
-        if (ctx_gguf) {
-            gguf_free(ctx_gguf);
-        }
-        if (buf) {
-            ggml_backend_buffer_free(buf);
-        }
-        if (backend) {
-            ggml_backend_free(backend);
-        }
-        if (backend_cpu && backend_cpu != backend) {
+        ggml_free(ctx_data);
+        gguf_free(ctx_gguf);
+        ggml_backend_buffer_free(buf);
+        ggml_backend_free(backend);
+        if (backend_cpu != backend) {
             ggml_backend_free(backend_cpu);
         }
     }

--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -47,7 +47,7 @@ struct clip_context_params {
 // deprecated, use clip_init
 CLIP_API struct clip_ctx * clip_model_load(const char * fname, int verbosity);
 
-CLIP_API struct clip_ctx * clip_init(const char * fname, clip_context_params ctx_params);
+CLIP_API struct clip_ctx * clip_init(const char * fname, struct clip_context_params ctx_params);
 
 CLIP_API void clip_free(struct clip_ctx * ctx);
 

--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -39,8 +39,15 @@ struct clip_image_f32_batch {
     size_t size;
 };
 
-CLIP_API struct clip_ctx * clip_model_load    (const char * fname, int verbosity);
-CLIP_API struct clip_ctx * clip_model_load_cpu(const char * fname, int verbosity);
+struct clip_context_params {
+    bool use_gpu;
+    int verbosity;
+};
+
+// deprecated, use clip_init
+CLIP_API struct clip_ctx * clip_model_load(const char * fname, int verbosity);
+
+CLIP_API struct clip_ctx * clip_init(const char * fname, clip_context_params ctx_params);
 
 CLIP_API void clip_free(struct clip_ctx * ctx);
 

--- a/examples/llava/minicpmv-cli.cpp
+++ b/examples/llava/minicpmv-cli.cpp
@@ -86,7 +86,11 @@ static struct clip_ctx * clip_init_context(common_params * params) {
     if (prompt.empty()) {
         prompt = "describe the image in detail.";
     }
-    auto * ctx_clip = clip_model_load(clip_path, /*verbosity=*/ 1);
+    struct clip_context_params clip_params = {
+        /* use_gpu */   params->n_gpu_layers != 0,
+        /* verbosity */ params->verbosity,
+    };
+    auto * ctx_clip = clip_init(clip_path, clip_params);
     return ctx_clip;
 }
 


### PR DESCRIPTION
## Motivation

Fix #11322

While waiting for https://github.com/ggml-org/llama.cpp/pull/11292 , I think it will be beneficial to look back at the `clip` and `llava` implementation and improve them a bit, as many downstream projects are depending on this.

Some of my ideas:
1. Format the code to make it looks nicer
2. Use more STL and cpp features to ease the memory management
3. Optimize the speed

So in this PR, I target the point (2) and (3) in my list above.

Please note that this implementation may not be perfect. My knowledge about ggml's `sched` is quite outdated, so the current status of this PR is "just work".

## How to test this

Download the GGUF from https://huggingface.co/openbmb/MiniCPM-V-2_6-gguf (download text model + mmproj)

```sh
cmake --build build -j --target llama-minicpmv-cli

./build/bin/llama-minicpmv-cli -m ../models/minicpmv-Q2_K.gguf --mmproj ../models/minicpmv-mmproj.gguf --image ../models/bliss.png -p "what do you see?"
```

If you see `CLIP using Metal backend`, that means it's good:

```
clip_init: CLIP using Metal backend
...
clip_init:      Metal compute buffer size =   102.80 MiB
clip_init:        CPU compute buffer size =    16.30 MiB
...
encode_image_with_clip: step 1 of 1 encoded in  1120.92 ms
encode_image_with_clip: all 1 segments encoded in  1120.95 ms
encode_image_with_clip: load_image_size 300 241
encode_image_with_clip: image embedding created: 64 tokens
```

To disable GPU, set `-ngl 0`, output will be:

```
clip_init: CLIP using CPU backend
...
clip_init:        CPU compute buffer size =   102.80 MiB
...
encode_image_with_clip: step 1 of 1 encoded in  6653.19 ms
encode_image_with_clip: all 1 segments encoded in  6653.21 ms
encode_image_with_clip: load_image_size 300 241
encode_image_with_clip: image embedding created: 64 tokens
```

Note: this is only tested on Metal
