### PR TITLE
Fix backend search path

### DIFF
--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -495,7 +495,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
     if (user_search_path == nullptr) {
         // default search paths: executable directory, current directory
         search_paths.push_back(get_executable_path());
-        search_paths.push_back(fs::current_path());
+        search_paths.push_back(fs::current_path() / "");
     } else {
         search_paths.push_back(user_search_path);
     }

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -488,7 +488,7 @@ static fs::path backend_filename_extension() {
 static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent, const char * user_search_path) {
     // enumerate all the files that match [lib]ggml-name-*.[so|dll] in the search paths
     const fs::path name_path = fs::u8path(name);
-    const fs::path file_prefix = backend_filename_prefix() / name_path / fs::u8path("-");
+    const fs::path file_prefix = backend_filename_prefix().native() + name_path.native() + fs::u8path("-").native();
     const fs::path file_extension = backend_filename_extension();
 
     std::vector<fs::path> search_paths;
@@ -543,7 +543,7 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
     if (best_score == 0) {
         // try to load the base backend
         for (const auto & search_path : search_paths) {
-            fs::path filename = backend_filename_prefix() / name_path / backend_filename_extension();
+            fs::path filename = backend_filename_prefix().native() + name_path.native() + backend_filename_extension().native();
             fs::path path = search_path / filename;
             if (fs::exists(path)) {
                 return get_reg().load_backend(path, silent);


### PR DESCRIPTION
`std::filesystem::current_path()` returns path without '/', leading to `path` error when trying to load the base backend.

I provide a simple example to demonstrate.

```
lin@amx:~/bs$ touch test.txt
lin@amx:~/bs$ cat error.cpp
#include <filesystem>
#include <iostream>
namespace fs = std::filesystem;
 
int main()
{
    fs::path search_path = fs::current_path();
    fs::path filename = "test.txt";
    fs::path path = search_path.native() + filename.native();
    if (fs::exists(path)) {
        std::cout << "File exists." << std::endl;
    } else {
        std::cout << "File does not exist." << std::endl;
    }
}
lin@amx:~/bs$ g++ error.cpp --std=c++17
lin@amx:~/bs$ ./a.out 
File does not exist.
lin@amx:~/bs$ diff error.cpp correct.cpp 
7c7
<     fs::path search_path = fs::current_path();
---
>     fs::path search_path = fs::current_path() / "";
lin@amx:~/bs$ g++ correct.cpp --std=c++17
lin@amx:~/bs$ ./a.out 
File exists.
```

Refenence: https://en.cppreference.com/w/cpp/filesystem/current_path