### PR TITLE
ggml: offload the entire cgraph to a specified backend

### DIFF
--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -114,6 +114,8 @@ extern "C" {
         void (*event_record)(ggml_backend_t backend, ggml_backend_event_t event);
         // wait for an event on on a different stream
         void (*event_wait)  (ggml_backend_t backend, ggml_backend_event_t event);
+
+        enum ggml_status          (*graph_compute_entire)     (ggml_backend_t backend, struct ggml_cgraph * cgraph);
     };
 
     struct ggml_backend {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1577,6 +1577,19 @@ enum ggml_status ggml_backend_sched_graph_compute(ggml_backend_sched_t sched, st
 }
 
 enum ggml_status ggml_backend_sched_graph_compute_async(ggml_backend_sched_t sched, struct ggml_cgraph * graph) {
+    ggml_backend_t prefer_backend = nullptr;
+    for (size_t idx = 0; idx < GGML_SCHED_MAX_BACKENDS; idx++) {
+        prefer_backend = sched->backends[idx];
+        if (nullptr != prefer_backend) {
+            if (ggml_backend_dev_type(prefer_backend->device) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+                continue;
+            } else {
+                if (nullptr != prefer_backend->iface.graph_compute_entire) {
+                    return prefer_backend->iface.graph_compute_entire(prefer_backend, graph);
+                }
+            }
+        }
+    }
     if (!sched->is_reset && !sched->is_alloc) {
         ggml_backend_sched_reset(sched);
     }

--- a/ggml/src/ggml-blas/ggml-blas.cpp
+++ b/ggml/src/ggml-blas/ggml-blas.cpp
@@ -270,6 +270,7 @@ static struct ggml_backend_i blas_backend_i = {
     /* .graph_compute           = */ ggml_backend_blas_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_blas_guid(void) {

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1897,6 +1897,7 @@ static const ggml_backend_i ggml_backend_cann_interface = {
     /* .graph_compute           = */ ggml_backend_cann_graph_compute,
     /* .event_record            = */ ggml_backend_cann_event_record,
     /* .event_wait              = */ ggml_backend_cann_event_wait,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 /**

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -182,6 +182,7 @@ static const struct ggml_backend_i ggml_backend_cpu_i = {
     /* .graph_compute           = */ ggml_backend_cpu_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_cpu_guid(void) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2816,6 +2816,7 @@ static const ggml_backend_i ggml_backend_cuda_interface = {
     /* .graph_compute           = */ ggml_backend_cuda_graph_compute,
     /* .event_record            = */ ggml_backend_cuda_event_record,
     /* .event_wait              = */ ggml_backend_cuda_event_wait,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_cuda_guid() {

--- a/ggml/src/ggml-kompute/ggml-kompute.cpp
+++ b/ggml/src/ggml-kompute/ggml-kompute.cpp
@@ -2058,6 +2058,7 @@ static struct ggml_backend_i kompute_backend_i = {
     /* .graph_compute           = */ ggml_backend_kompute_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_kompute_guid() {

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -4806,6 +4806,7 @@ static struct ggml_backend_i ggml_backend_metal_i = {
     /* .graph_compute           = */ ggml_backend_metal_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_metal_guid(void) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -1167,6 +1167,7 @@ static ggml_backend_i ggml_backend_opencl_i = {
     /* .graph_compute           = */ ggml_backend_opencl_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 ggml_backend_t ggml_backend_opencl_init(void) {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -697,6 +697,7 @@ static ggml_backend_i ggml_backend_rpc_interface = {
     /* .graph_compute           = */ ggml_backend_rpc_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint) {

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3749,6 +3749,7 @@ static ggml_backend_i ggml_backend_sycl_interface = {
     /* .graph_compute           = */ ggml_backend_sycl_graph_compute,
     /* .event_record            = */ ggml_backend_sycl_event_record,
     /* .event_wait              = */ ggml_backend_sycl_event_wait,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_sycl_guid() {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8332,6 +8332,7 @@ static ggml_backend_i ggml_backend_vk_interface = {
     /* .graph_compute           = */ ggml_backend_vk_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_compute_entire    = */ NULL,
 };
 
 static ggml_guid_t ggml_backend_vk_guid() {


### PR DESCRIPTION
this PR provide a concise approach to offload the entire ggml's cgraph to a specified backend and no side-effect to the all existing backends.

this PR **has [verified in my forked llama.cpp project](https://github.com/kantv-ai/ggml-qnn/commit/7eab1265c53bdc5dd55c75af4bc5259602b95765) and it works fine as expected**. 
```
3-12 12:29:31.568 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4722]: qnn device 2(QNN-NPU)
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4723]: cgraph->n_nodes 846
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op inp_embd (GET_ROWS)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op norm-0 (RMS_NORM)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op attn_norm-0 (MUL)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Qcur-0 (MUL_MAT)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Qcur-0 (ADD)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Qcur-0 (reshaped) (RESHAPE)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Qcur-0 (ROPE)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Kcur-0 (MUL_MAT)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Kcur-0 (ADD)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Kcur-0 (reshaped) (RESHAPE)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Kcur-0 (ROPE)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Vcur-0 (MUL_MAT)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Vcur-0 (ADD)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op k_cache_view-0 (VIEW)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op k_cache_view-0 (copy of Kcur-0) (CPY)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op Vcur-0 (transposed) (TRANSPOSE)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op v_cache_view-0 (VIEW)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op v_cache_view-0 (copy of Vcur-0 (transposed)) (CPY)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op v-0 (VIEW)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4728]: ggmlqnn_graph_compute: op k-0 (VIEW)
03-12 12:29:31.569 13867 13867 I ggml-qnn: 
03-12 12:29:31.569 13867 13867 I ggml-qnn: [ggmlqnn_graph_compute, 4758]: the second inference approach "mapping 


```

this feature would be very helpful for a WIP PR: mapping entire ggml cgraph to the QNN graph although it seems it's a bad news for my formal third PR:https://github.com/ggml-org/llama.cpp/pull/12326, it doesn't matter 🤗 and I'd like to see success of similar PR from others in this great tech community although that implementation hide so much tech details and much complicated encapsulation.

I personally hope this PR can be helpful for that WIP PR because I already have no positive attention to Qualcomm's ggml-qnn backend since 03/12/2025(03/29 might-be a better date because it seems I was back to github and this great tech community since 01/29/2024, that's enough).

<!--
in the fact, as I said some weeks ago: the second technical approach of ggml-qnn can be also implemented in my PR without much complicated encapsulation(the difference is that: everyone can understand tech details easily and quickly and no beautiful class diagram or PPT in my PR) and I really have no intention of getting involved in a meaningless competition between me and other CN programmer in this non-CN tech community because I already experienced similar scenarios too much and I never do that or I tried to never do that and I personally think all of these behaviors(stop others and fight others and  win others) which can be seen everywhere in CN is totally meaningless: you will have nothing even you win all other people at the moment.

I personally hope this PR can be helpful for some WIP PRs because I already have no positive attention to Qualcomm's ggml-qnn backend since 03/12/2025(03/29 might-be a better date because it seems I was back to github and this great non-CN tech community since 01/29/2024 after I suddenly heard DeepSeek-R1 brought a wake-up call to the US, that's enough) and I'd like to see other's success although that implementation hide so much tech details.of course, as a highly-skilled Linux programmer, I clearly know some non-tech factors and we must face the reality: I closed my github because too much unpleasant experience in my formal personal second PR although I always think I'm an open-minded programmer, ok, that's' enough.
-->

this feature will/might brings some unexpected help for Intel's sycl or Huawei's cann backend which similar to the second tech approach in a WIP Qualcomm's ggml-qnn backend, many advanced or state-of-the-art AI technologies can be imported to this great project.

relative tech details can be found at: https://github.com/ggml-org/llama.cpp/pull/12326#issuecomment-2713353334

@slaren, could you help to review this PR? it will very helpful for a WIP PR(mapping entire ggml cgraph to a Qualcomm's QNN NPU backend then the specified backend can do some special hardware-dependent optimizations). the function name or function position might be not inappropriate, I'll adjust  it accordingly as your review comments.
