### PR TITLE
arg : no n_predict = -2 for examples except for main and infill

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -764,7 +764,11 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_env("LLAMA_ARG_CTX_SIZE"));
     add_opt(common_arg(
         {"-n", "--predict", "--n-predict"}, "N",
-        string_format("number of tokens to predict (default: %d, -1 = infinity, -2 = until context filled)", params.n_predict),
+        string_format(
+            ex == LLAMA_EXAMPLE_MAIN || ex == LLAMA_EXAMPLE_INFILL
+                ? "number of tokens to predict (default: %d, -1 = infinity, -2 = until context filled)"
+                : "number of tokens to predict (default: %d, -1 = infinity)",
+            params.n_predict),
         [](common_params & params, int value) {
             params.n_predict = value;
         }


### PR DESCRIPTION
Supersede #12347 and #12323

Close #12264

I checked the code base and turns out `n_predict` is only support on `main.cpp` and `infill.cpp`

For server, use `--no-context-shift` to do the same thing, so it doesn't make sense to add `n_predict == -2` support to server (which turns out to be quite messy)
