### PR TITLE
SYCL: set extras only on GGML_TYPE_Q4_0

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -333,10 +333,11 @@ ggml_backend_sycl_buffer_init_tensor(ggml_backend_buffer_t buffer,
         assert(tensor->view_src->buffer->buft == buffer->buft);
         return GGML_STATUS_SUCCESS;
     }
-
-    ggml_tensor_extra_gpu * extra = new ggml_tensor_extra_gpu{};
-    tensor->extra = extra;
-    ctx->tensor_extras.push_back(extra); //used to release it when destroy ctx.
+    if (tensor->type == GGML_TYPE_Q4_0) {
+        ggml_tensor_extra_gpu * extra = new ggml_tensor_extra_gpu{};
+        tensor->extra                 = extra;
+        ctx->tensor_extras.push_back(extra);  //used to release it when destroy ctx.
+    }
 
     if (ggml_is_quantized(tensor->type)) {
         // initialize padding to 0 to avoid possible NaN values


### PR DESCRIPTION
Commit 08d5986290cc42d2c52739e046642b8252f97e4b implemented optimization of Q4_0 tensors on intel GPUs by opting to reorder the Q4 block to separate quantized weights and dequantize scaler.

However, since this commit required setting extras in init_tensor function, this commit did not check if the tensor type is indeed of Q4_0, which resulted in memory leak.

This change adds a condition to prevent memory leak.


ps. This is not a permanent solution. We should remove setting extras inside init_tensor function.


Tested with both non Q4_0 and Q4_0 models.
