### PR TITLE
graph : simplify attn input build for unified KV cache

### DIFF
--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -509,9 +509,7 @@ struct llm_graph_context {
                   float   kq_scale,
                     int   il) const;
 
-    llm_graph_input_attn_kv_unified * build_attn_inp_kv_unified(
-            bool causal,
-            bool swa) const;
+    llm_graph_input_attn_kv_unified * build_attn_inp_kv_unified() const;
 
     ggml_tensor * build_attn(
             llm_graph_input_attn_kv_unified * inp,


### PR DESCRIPTION
fix #12380 

The `llm_graph_context::build_attn_inp_kv_unified` used to take 2 redundant arguments: wether the attention is causal and wether SWA is enabled. The `causal` is always `true` when using a KV cache, while the `swa` can be deduced from the `hparams`.