### PR TITLE
ggml-vulkan: remove unused find_program(glslc)

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,8 +1,4 @@
 find_package (Threads REQUIRED)
-find_program(GLSLC_EXECUTABLE glslc)
-if(NOT GLSLC_EXECUTABLE)
-    message(FATAL_ERROR "glslc not found.")
-endif()
 
 set(TARGET vulkan-shaders-gen)
 add_executable(${TARGET} vulkan-shaders-gen.cpp)


### PR DESCRIPTION
It's unused and already found by FindVulkan.cmake in the parent CMakeLists.
Also having this find_program here directly prevents usage of hit variables like VULKAN_ROOT which are used by FindVulkan (`find_package(Vulkan)`)