### PR TITLE
Vulkan: Default to 1GB allocations instead of 4GB to avoid fragmentation and driver issues

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2512,13 +2512,9 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         if (GGML_VK_SUBALLOCATION_BLOCK_SIZE != nullptr) {
             device->suballocation_block_size = std::stoul(GGML_VK_SUBALLOCATION_BLOCK_SIZE);
-#if defined(_WIN32)
-        } else if (device->vendor_id == VK_VENDOR_ID_NVIDIA) {
+        } else {
             // Limit batching of allocations to 1GB by default to avoid fragmentation issues
             device->suballocation_block_size = 1024*1024*1024;
-#endif
-        } else {
-            device->suballocation_block_size = device->max_memory_allocation_size;
         }
         device->suballocation_block_size = std::min(device->suballocation_block_size, device->max_memory_allocation_size);
 


### PR DESCRIPTION
Extend the changes done in #11551 to all cases to avoid driver allocation issues that keep coming up. On some drivers allocations fail for other reasons than fragmentation, despite being below the size limit. Some examples in #5441. This should fix that.

I couldn't reproduce performance differences I saw in the previous PR, so it might just have been noise. Sorry about that @jeffbolznv 