### PR TITLE
musa: override warp_size of musa device to 32

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -262,6 +262,8 @@ static ggml_cuda_device_info ggml_cuda_init() {
                       id, prop.name, prop.gcnArchName, info.devices[id].cc & 0xffff,
                       device_vmm ? "yes" : "no", prop.warpSize);
 #elif defined(GGML_USE_MUSA)
+        // FIXME: Ensure compatibility with varying warp sizes across different MUSA archs.
+        info.devices[id].warp_size = 32;
         // TODO: refine the .cc to reflect MUSA's actual CC capabilities
         info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
         info.devices[id].cc = 100*prop.major + 10*prop.minor;


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

llama.cpp's `musa` build encounters a runtime error after [commit 10f2e81](https://github.com/ggml-org/llama.cpp/commit/10f2e81809bbb69ecfe64fc8b4686285f84b0c07#diff-215515d65e174fb02240522a4bb36f5c8f974d129f7a8d1aa6026a4dbd8dff12).  

This PR resolves the issue by overriding `warp_size` of musa device to `32`.

#### Testing Done
- [x] `test-backend-ops` on MTT S80
- [x] `./build/bin/llama-cli -m ~/models/deepseek-r1_7b_q4_0.gguf -ngl 999` on MTT S80