### PR TITLE
speculative : fix seg fault in certain cases

### DIFF
--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -331,11 +331,11 @@ int main(int argc, char ** argv) {
                         }
 
                         active_seqs.erase(s);
-                        for(int i = 0; i < n_seq_dft; i++) {
+                        for (int i = 0; i < n_seq_dft; i++) {
                             if (i == s) {
                                 continue;
                             }
-                            if (drafts[i].tokens[i_dft] == drafts[s].tokens[i_dft]) {
+                            if (drafts[i].active && drafts[i].tokens[i_dft] == drafts[s].tokens[i_dft]) {
                                 // synchronize active status for sequences with the same drafted token
                                 drafts[i].active = drafts[i].active && accept;
                                 if (!drafts[i].active) {


### PR DESCRIPTION
Fixes a crash when using tree-based speculative decoding with greedy sampling:

```bash
make -j llama-speculative && ./bin/llama-speculative -m ../models/qwen2.5-32b-coder-instruct/ggml-model-q4_0.gguf -md ../models/qwen2.5-0.5b-coder-instruct/ggml-model-q4_0.gguf --ctx-size 0 -ub 4096 -b 4096 -ngl 99 -ngld 99 -fa --draft-max 8 --draft-min 0 --draft-p-min 0.75 -c 4096 --color -p "Write a quicksort algorithm" -np 4 --top-k 1 -s 1
```