### PR TITLE
[Issue #12458] Temporarily Clamp inf Values in ggml-cpu.c to Prevent Garbled Output(or coredump) on RK3588

### DIFF
--- a/debug_check.gdb
+++ b/debug_check.gdb
@@ -1,0 +1,34 @@
+# 1) Set program arguments
+set args -m ~/dev/llm/DeepSeek-R1-Distill-Qwen-1.5B-Q4_0-GGUF/deepseek-r1-distill-qwen-1.5b-q4_0.gguf -b 16 -ngl 0 -c 1024 -t 4 -p "Hello"
+
+# 2) Redirect GDB output to a log file
+set logging file gdb_output.log
+set logging on
+
+# 3) Place a breakpoint at the debug_hook() function in ggml-cpu.c
+break ggml-cpu.c:debug_hook
+
+# 4) Commands to execute once the breakpoint is hit
+commands
+  # Prevent GDB from printing its usual breakpoint messages
+  silent
+
+  # (a) Exit from debug_hook() and return to its caller
+  #     This should land you at check_invalid_values() right before 'return true;'
+  finish
+
+  # (b) Now that you're in check_invalid_values(), print variables of interest
+  p *src0
+  p (*src0).data
+  x/128f (*src0).data
+
+  # (c) If you only want to trigger once, disable the breakpoint afterwards
+  disable $bpnum
+
+  # If you would rather keep hitting this breakpoint repeatedly, comment out
+  # the disable command above and uncomment the following 'continue' command:
+  # continue
+end
+
+# 5) Automatically run the program (remove or comment out if you want to run manually)
+run


### PR DESCRIPTION
# Overview
This PR introduces two changes:
  1. A function call to check_invalid_values() within ggml_graph_compute_thread() to detect inf or NaN in tensor data.
  2. A modification in ggml_compute_forward_soft_max_f32() where, if inf is detected, it is forcibly converted to FLT_MAX.

These changes serve as a temporary workaround on the RK3588 (ARM64) platform to prevent garbled text output caused by inf values in the tensors. However, it only addresses the symptoms and may increase CPU usage.

# Changes
- ggml-cpu.c:
  -   Added calls to check_invalid_values() to detect problematic data.
  -   Modified ggml_compute_forward_soft_max_f32() to clamp inf to FLT_MAX.

- debug_check.gdb:
  - Provides a GDB script that sets breakpoints in check_invalid_values().
  - Automatically prints the src0 structure and its first 128 floats whenever an inf is detected.

# How to Reproduce and Debug
1. Compile the project in Debug mode (on RK3588 or any ARM64 environment):
  ``` bash
  cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DGGML_OPENCL=ON -DGGML_VULKAN_CHECK_RESULTS=ON
  ninja
  ```
2. Edit debug_check.gdb to point to your DeepSeek R1-1.5B model file path.
3. Run GDB:
  ``` bash
  cd llama-cpp
  gdb -x debug_check.gdb ./build/bin/llama-cli
  ```
4. Once the breakpoint is hit at return true;, inspect the data:
  ``` gdb
  p *src0
  p (*src0).data
  x/128f (*src0).data
  ``` 
5. You’ll see inf values in the tensor.

# Notes
- This patch works around the immediate issue but doesn’t tackle the underlying reason why inf values appear in the first place.
- CPU overhead is increased by the additional checks/clamping.
# Related Issue
- Please see Issue #12458 for more details and discussions: https://github.com/ggml-org/llama.cpp/issues/12458

