### PR TITLE
context : clear sets of encoder output sequence ids before storing new values

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1153,6 +1153,7 @@ int llama_context::encode(llama_batch & inp_batch) {
         // remember the sequence ids used during the encoding - needed for cross attention later
         cross.seq_ids_enc.resize(n_tokens);
         for (int32_t i = 0; i < n_tokens; i++) {
+            cross.seq_ids_enc[i].clear();
             for (int s = 0; s < ubatch.n_seq_id[i]; s++) {
                 llama_seq_id seq_id = ubatch.seq_id[i][s];
                 cross.seq_ids_enc[i].insert(seq_id);


### PR DESCRIPTION
This PR fixes a bug that results in accumulation of sequence ids in `seq_ids_enc` vector of sets when processing batches containing multiple sequences in encoder-decoder models (T5 and family). By clearing sets before storing sequence ids of current encoder output previously stored values are removed which prevents possible accumulation of sequence ids.