### PR TITLE
llama-tts : avoid crashes related to bad model file paths

### DIFF
--- a/examples/tts/tts.cpp
+++ b/examples/tts/tts.cpp
@@ -571,6 +571,10 @@ int main(int argc, char ** argv) {
     model_ttc = llama_init_ttc.model.get();
     ctx_ttc   = llama_init_ttc.context.get();
 
+    if (model_ttc == nullptr || ctx_ttc == nullptr) {
+        return ENOENT;
+    }
+
     const llama_vocab * vocab = llama_model_get_vocab(model_ttc);
 
     // TODO: refactor in a common struct
@@ -585,6 +589,10 @@ int main(int argc, char ** argv) {
 
     model_cts = llama_init_cts.model.get();
     ctx_cts   = llama_init_cts.context.get();
+
+    if (model_cts == nullptr || ctx_cts == nullptr) {
+        return ENOENT;
+    }
 
     std::vector<common_sampler *> smpl(n_parallel);
     for (int i = 0; i < n_parallel; ++i) {


### PR DESCRIPTION
llama--tts crashes when the user provides bad cmdline model paths. In these cases the pointer check prevents both the sigsev and useless runtime.
