### PR TITLE
cmake: Allow to configure GGML_BUILD_NUMBER with file

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -287,6 +287,15 @@ endif()
 
 # Generate version info based on git commit.
 
+# First try to get the build number from the file.
+if(NOT DEFINED GGML_BUILD_NUMBER)
+    if(EXISTS ${CMAKE_SOURCE_DIR}/.ggml_build_number)
+        file(STRINGS ${CMAKE_SOURCE_DIR}/.ggml_build_number GGML_BUILD_NUMBER)
+        # Assume the first line contains the desired version.
+        list(GET GGML_BUILD_NUMBER 0 GGML_BUILD_NUMBER)
+    endif()
+endif()
+
 if(NOT DEFINED GGML_BUILD_NUMBER)
     find_program(GIT_EXE NAMES git git.exe REQUIRED NO_CMAKE_FIND_ROOT_PATH)
     execute_process(COMMAND ${GIT_EXE} rev-list --count HEAD


### PR DESCRIPTION
This will enable llama-cpp-python to generate the file during sdist build and
include it into the final tarball. The file then will be picked up by the
package build to include the correct version, even without full git checkout
included.

Related: https://github.com/abetlen/llama-cpp-python/issues/1979
