### PR TITLE
Issues while building on AIX OS

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -476,7 +476,7 @@ struct llama_mlock::impl {
 
         char* errmsg = std::strerror(errno);
         bool suggest = (errno == ENOMEM);
-#if defined(TARGET_OS_VISION) || defined(TARGET_OS_TV)
+#if defined(TARGET_OS_VISION) || defined(TARGET_OS_TV) || defined(_AIX)
         // visionOS/tvOS dont't support RLIMIT_MEMLOCK
         // Skip resource limit checks on visionOS/tvOS
         suggest = false;


### PR DESCRIPTION
AIX doesnt support RLIMIT_MEMLOCK. Skipping resource limit checks on AIX.
