### PR TITLE
(draft) tts: Sesame support

### DIFF
--- a/examples/tts/convert_pt_to_hf.py
+++ b/examples/tts/convert_pt_to_hf.py
@@ -12,7 +12,7 @@ import re
 from safetensors.torch import save_file
 
 # default
-model_path = './model.pt';
+model_path = './model.pt'
 
 # read from CLI
 if len(sys.argv) > 1:

--- a/examples/tts/tts.cpp
+++ b/examples/tts/tts.cpp
@@ -671,7 +671,7 @@ lovely<|t_0.56|><|code_start|><|634|><|596|><|1766|><|1556|><|1306|><|1285|><|14
     {
         LOG_INF("%s: constructing prompt ..\n", __func__);
 
-        std::vector<llama_token> prompt_inp;
+        llama_tokens prompt_inp;
 
         prompt_init(prompt_inp, vocab);
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -286,6 +286,7 @@ class MODEL_ARCH(IntEnum):
     GRANITE_MOE      = auto()
     CHAMELEON        = auto()
     WAVTOKENIZER_DEC = auto()
+    MIMI_DEC         = auto()
 
 
 class MODEL_TENSOR(IntEnum):
@@ -488,6 +489,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.GRANITE_MOE:      "granitemoe",
     MODEL_ARCH.CHAMELEON:        "chameleon",
     MODEL_ARCH.WAVTOKENIZER_DEC: "wavtokenizer-dec",
+    MODEL_ARCH.MIMI_DEC:         "mimi-dec",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
@@ -626,7 +628,7 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.POSNET_ATTN_Q:             "posnet.{bid}.attn_q",
     MODEL_TENSOR.POSNET_ATTN_K:             "posnet.{bid}.attn_k",
     MODEL_TENSOR.POSNET_ATTN_V:             "posnet.{bid}.attn_v",
-    MODEL_TENSOR.POSNET_ATTN_OUT:           "posnet.{bid}.attn_output",
+    MODEL_TENSOR.POSNET_ATTN_OUT:           "posnet.{bid}.attn_output"
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -1649,6 +1651,13 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.POSNET_ATTN_K,
         MODEL_TENSOR.POSNET_ATTN_V,
         MODEL_TENSOR.POSNET_ATTN_OUT,
+    ],
+    MODEL_ARCH.MIMI_DEC: [ # TODO: check those again
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.TOKEN_EMBD_NORM,
+        MODEL_TENSOR.CONV1D,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.OUTPUT_NORM,
     ],
     # TODO
 }

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -29,6 +29,8 @@ class TensorNameMap:
             "shared",                                    # t5
             "rwkv.embeddings",                           # rwkv6
             "model.embeddings",                          # rwkv7
+            "text_embeddings",                           # csm
+            "audio_embeddings",                          # csm
         ),
 
         # Token type embeddings
@@ -66,6 +68,7 @@ class TensorNameMap:
             "output_layer",              # chatglm
             "head",                      # rwkv
             "head.out",                  # wavtokenizer
+            "audio_head",                # csm
         ),
 
         # Output norm
@@ -88,6 +91,7 @@ class TensorNameMap:
             "rwkv.ln_out",                             # rwkv6
             "model.ln_out",                            # rwkv7
             "backbone.final_layer_norm",               # wavtokenizer
+            "model.norm.scale",                        # csm
         ),
 
         # Rope frequencies
@@ -129,6 +133,7 @@ class TensorNameMap:
             "transformer.layers.{bid}.attn_norm",                   # openelm
             "rwkv.blocks.{bid}.ln1",                                # rwkv6
             "model.layers.{bid}.ln1",                               # rwkv7
+            "model.layers.{bid}.sa_norm.scale"                     # csm
         ),
 
         # Attention norm 2
@@ -168,6 +173,7 @@ class TensorNameMap:
             "model.layers.{bid}.attention.wq",                           # internlm2
             "transformer.decoder_layer.{bid}.multi_head_attention.query",# Grok
             "transformer.h.{bid}.attn.attention.q_proj",                 # exaone
+            "model.layers.{bid}.attn.q_proj"                             # csm
         ),
 
         # Attention key
@@ -182,6 +188,7 @@ class TensorNameMap:
             "model.layers.{bid}.attention.wk",                         # internlm2
             "transformer.decoder_layer.{bid}.multi_head_attention.key",# Grok
             "transformer.h.{bid}.attn.attention.k_proj",               # exaone
+            "model.layers.{bid}.attn.k_proj"                           # csm
         ),
 
         # Attention value
@@ -195,6 +202,7 @@ class TensorNameMap:
             "model.layers.{bid}.attention.wv",                           # internlm2
             "transformer.decoder_layer.{bid}.multi_head_attention.value",# Grok
             "transformer.h.{bid}.attn.attention.v_proj",                 # exaone
+            "model.layers.{bid}.attn.v_proj"                             # csm
         ),
 
         # Attention output
@@ -221,6 +229,7 @@ class TensorNameMap:
             "encoder.layers.{bid}.self_attention.dense",                    # chatglm
             "transformer.layers.{bid}.attn.out_proj",                       # openelm
             "transformer.h.{bid}.attn.attention.out_proj",                  # exaone
+            "model.layers.{bid}.attn.output_proj"                           # csm
         ),
 
         # Attention output norm
@@ -258,6 +267,7 @@ class TensorNameMap:
             "transformer.decoder_layer.{bid}.rms_norm_2",                    # Grok
             "encoder.layers.{bid}.post_attention_layernorm",                 # chatglm
             "transformer.layers.{bid}.ffn_norm",                             # openelm
+            "model.layers.{bid}.mlp_norm.scale"                              # csm
         ),
 
         # Post feed-forward norm
@@ -314,6 +324,7 @@ class TensorNameMap:
             "model.layers.{bid}.residual_mlp.w3",                     # arctic
             "encoder.layers.{bid}.mlp.dense_h_to_4h",                 # chatglm
             "transformer.h.{bid}.mlp.c_fc_1",                         # exaone
+            "model.layers.{bid}.mlp.w3",                              # csm
         ),
 
         MODEL_TENSOR.FFN_UP_EXP: (
@@ -347,6 +358,7 @@ class TensorNameMap:
             "transformer.h.{bid}.mlp.linear_1",           # refact
             "model.layers.{bid}.residual_mlp.w1",         # arctic
             "transformer.h.{bid}.mlp.c_fc_0",             # exaone
+            "model.layers.{bid}.mlp.w1"                   # csm
         ),
 
         MODEL_TENSOR.FFN_GATE_EXP: (
@@ -388,6 +400,7 @@ class TensorNameMap:
             "encoder.layer.{bid}.mlp.down_layer",                     # jina-bert-v2
             "encoder.layers.{bid}.mlp.dense_4h_to_h",                 # chatglm
             "model.layers.h.{bid}.mlp.c_proj",                        # exaone
+            "model.layers.{bid}.mlp.w2",                              # csm
         ),
 
         MODEL_TENSOR.FFN_DOWN_EXP: (

--- a/split_hf.py
+++ b/split_hf.py
@@ -1,0 +1,18 @@
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+safetensors_path = "my-models/csm/model.safetensors"
+
+# Open the original SafeTensors file
+with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+    tensors = {key: f.get_tensor(key) for key in f.keys()}
+
+# Identify tensors belonging to each model
+backbone_tensors = {k.replace("backbone.", "model."): v for k, v in tensors.items() if any(x in k for x in ["backbone.", "text_"])}
+decoder_tensors = {k.replace("decoder.", "model."): v for k, v in tensors.items() if any(x in k for x in ["decoder.", "audio_", "projection.", "codebook0_head."])}
+
+save_file(backbone_tensors, "backbone.safetensors")
+print(f"Saved backbone model with {len(backbone_tensors)} tensors.")
+
+save_file(decoder_tensors, "decoder.safetensors")
+print(f"Saved decoder model with {len(decoder_tensors)} tensors.")


### PR DESCRIPTION
I've started a draft for sesame support. For now I only translated the safetensor models to gguf, so the next steps are to start implementing them. Not entirely sure if I've translated them 100% correctly, but will check them in the process and fix it.
I also had to add some properties to the safetensor config file:
```
{
    "architectures": [
        "LlamaForCausalLM"
    ],
    "n_layers": 128,
    "num_hidden_layers": 128,
    "n_layer": 128,
    "num_layers": 128,
    "num_attention_heads": 128,
^added
------------------------------------
    "backbone_flavor": "llama-1B",
    "decoder_flavor": "llama-100M",
    "text_vocab_size": 128256,
    "audio_vocab_size": 2051,
    "audio_num_codebooks": 32
}

```

Since they have 2 models in the `model.safetensor` I split them and then run convert_to_gguf
```
python3 split_hf.py

python3 convert_hf_to_gguf.py my-models/csm/backbone --outfile my-models/csm/gguf/csm-backbone-1B-f16.gguf --outtype f16
 
python3 convert_hf_to_gguf.py my-models/csm/decoder --outfile my-models/csm/gguf/csm-decoder-1B-f16.gguf --outtype f16
```