### PR TITLE
clip: Fix llama-llava-clip-quantize-cli quantization error under CUDA backend

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1370,9 +1370,9 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
 }
 
 // read and create ggml_context containing the tensors and their data
-struct clip_ctx * clip_model_load(const char * fname, const int verbosity, const bool use_gpu) {
+struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
     return clip_init(fname, clip_context_params{
-        /* use_gpu */   use_gpu,
+        /* use_gpu */   true,
         /* verbosity */ verbosity,
     });
 }
@@ -2989,7 +2989,10 @@ bool clip_model_quantize(const char * fname_inp, const char * fname_out, const i
     assert(itype < GGML_TYPE_COUNT);
     ggml_type type = static_cast<ggml_type>(itype);
 
-    auto * ctx_clip = clip_model_load(fname_inp, 2, false);
+    auto * ctx_clip = clip_init(fname_inp, clip_context_params{
+        /* use_gpu */   false,
+        /* verbosity */ 2,
+    });
 
     const auto & ctx_src = ctx_clip->ctx_gguf;
     const auto & ctx_data = ctx_clip->ctx_data;

--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -1370,9 +1370,9 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
 }
 
 // read and create ggml_context containing the tensors and their data
-struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+struct clip_ctx * clip_model_load(const char * fname, const int verbosity, const bool use_gpu) {
     return clip_init(fname, clip_context_params{
-        /* use_gpu */   true,
+        /* use_gpu */   use_gpu,
         /* verbosity */ verbosity,
     });
 }
@@ -2989,7 +2989,7 @@ bool clip_model_quantize(const char * fname_inp, const char * fname_out, const i
     assert(itype < GGML_TYPE_COUNT);
     ggml_type type = static_cast<ggml_type>(itype);
 
-    auto * ctx_clip = clip_model_load(fname_inp, 2);
+    auto * ctx_clip = clip_model_load(fname_inp, 2, false);
 
     const auto & ctx_src = ctx_clip->ctx_gguf;
     const auto & ctx_data = ctx_clip->ctx_data;

--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -45,7 +45,7 @@ struct clip_context_params {
 };
 
 // deprecated, use clip_init
-CLIP_API struct clip_ctx * clip_model_load(const char * fname, const int verbosity=1, const bool use_gpu=true);
+CLIP_API struct clip_ctx * clip_model_load(const char * fname, int verbosity);
 
 CLIP_API struct clip_ctx * clip_init(const char * fname, struct clip_context_params ctx_params);
 

--- a/examples/llava/clip.h
+++ b/examples/llava/clip.h
@@ -45,7 +45,7 @@ struct clip_context_params {
 };
 
 // deprecated, use clip_init
-CLIP_API struct clip_ctx * clip_model_load(const char * fname, int verbosity);
+CLIP_API struct clip_ctx * clip_model_load(const char * fname, const int verbosity=1, const bool use_gpu=true);
 
 CLIP_API struct clip_ctx * clip_init(const char * fname, struct clip_context_params ctx_params);
 


### PR DESCRIPTION
Link to [issue 12564](https://github.com/ggml-org/llama.cpp/issues/12564). This PR provides a possible solution, which is to move all the quantization processes to the CPU backend. Since it is not a real inference process, the performance does not seem to be so sensitive.


*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
