### PR TITLE
grammars: upgrade to llguidance 0.7.10

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -114,8 +114,8 @@ if (LLAMA_LLGUIDANCE)
 
     ExternalProject_Add(llguidance_ext
         GIT_REPOSITORY https://github.com/guidance-ai/llguidance
-        # v0.6.12:
-        GIT_TAG ced1c9023d47ec194fa977932d35ce65c2ebfc09
+        # v0.7.10:
+        GIT_TAG 0309d2a6bf40abda35344a362edc71e06d5009f8
         PREFIX ${CMAKE_BINARY_DIR}/llguidance
         SOURCE_DIR ${LLGUIDANCE_SRC}
         BUILD_IN_SOURCE TRUE


### PR DESCRIPTION
This updates [llguidance](https://github.com/guidance-ai/llguidance) from 0.6.15 to 0.7.10, notable changes:
- `%regex { ... }` syntax in Lark allowing for [substring](https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#substring) matching (citations, code edits)
- `"x-guidance": {...}` key in JSON schema to [modify options](https://github.com/guidance-ai/llguidance/blob/main/docs/json_schema.md#whitespace-handling)
- `suffix=...` support in Lark syntax for [lazy matching](https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#lazy-lexemes) (eg., some tool calling)
- gbnf conversion fixes
- support for `rollback()` operation on grammar for spec-decoding; not used in llama.cpp for now
- a bunch of fixes and performance improvements

The PR also switches from `llg_constraint_*()` C APIs to `llg_matcher_*()`. The new APIs are simpler.

I've also added test using sampler chain.
