### PR TITLE
Include speculative decoding stats when timings_per_token is enabled

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1453,6 +1453,15 @@ struct server_slot {
                 t_prompt_processing, n_prompt_tokens_processed, t_prompt, n_prompt_second,
                 t_token_generation, n_decoded, t_gen, n_gen_second,
                 t_prompt_processing + t_token_generation, n_prompt_tokens_processed + n_decoded);
+
+        if (n_draft_total > 0) {
+            const float draft_ratio = (float) n_draft_accepted / n_draft_total;
+            SLT_INF(*this,
+                    "\n"
+                    "draft acceptance rate = %0.5f (%5d accepted / %5d generated)\n",
+                    draft_ratio, n_draft_accepted, n_draft_total
+            );
+        }
     }
 
     json to_json() const {


### PR DESCRIPTION
New fields added to the `timings` object:

  - draft_n           : number of draft tokens generated
  - draft_n_accepted  : number of draft tokens accepted

## Sample of output 

These were done on an M1 Pro, 32GB

### Server: 
```
$ ./build/bin/llama-server --no-mmap --no-warmup \
  --model /Volumes/devdisk/llama-swap/models/Qwen2.5-7B-Instruct-Q4_K_M.gguf \
  --model-draft /Volumes/devdisk/llama-swap/models/qwen2.5-0.5b-instruct-q8_0.gguf \
  -ngl 99 -ngld 99 \
  --draft-max 16 --draft-min 4 --draft-p-min 0.4
```

### streaming off

```
$ curl -s http://localhost:8080/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{"model":"qwen","max_tokens":200, "timings_per_token":true, "messages": [{"role": "user","content": "write a story about dogs"}]}' | jq .timings

{
  "prompt_n": 1,
  "prompt_ms": 228.522,
  "prompt_per_token_ms": 228.522,
  "prompt_per_second": 4.375946298387026,
  "predicted_n": 200,
  "predicted_ms": 11082.606,
  "predicted_per_token_ms": 55.41303,
  "predicted_per_second": 18.0462970532382,
  "draft_n": 347,
  "draft_n_accepted": 65
}
```

### streaming on 

```
$ curl -sn http://localhost:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"qwen","max_tokens":200, "stream":true, "timings_per_token":true, "messages": [{"role": "user","content": "write a story about dogs"}]}' | jq -cR 'sub("^data: "; "") | fromjson? | .timings | {predicted_n, predicted_per_second, draft_n, draft_n_accepted, draft_accept_ratio: (if .draft_n > 0 then .draft_n_accepted / .draft_n else null end)}'

{"predicted_n":1,"predicted_per_second":null,"draft_n":null,"draft_n_accepted":null,"draft_accept_ratio":null}
{"predicted_n":8,"predicted_per_second":null,"draft_n":16,"draft_n_accepted":6,"draft_accept_ratio":0.375}
{"predicted_n":8,"predicted_per_second":null,"draft_n":16,"draft_n_accepted":6,"draft_accept_ratio":0.375}
{"predicted_n":8,"predicted_per_second":null,"draft_n":16,"draft_n_accepted":6,"draft_accept_ratio":0.375}
{"predicted_n":8,"predicted_per_second":null,"draft_n":16,"draft_n_accepted":6,"draft_accept_ratio":0.375}
{"predicted_n":8,"predicted_per_second":null,"draft_n":16,"draft_n_accepted":6,"draft_accept_ratio":0.375}
... 
{"predicted_n":197,"predicted_per_second":17.71554376197935,"draft_n":335,"draft_n_accepted":72,"draft_accept_ratio":0.21492537313432836}
{"predicted_n":198,"predicted_per_second":17.740989615697014,"draft_n":335,"draft_n_accepted":72,"draft_accept_ratio":0.21492537313432836}
{"predicted_n":199,"predicted_per_second":17.76501315459052,"draft_n":335,"draft_n_accepted":72,"draft_accept_ratio":0.21492537313432836}
{"predicted_n":200,"predicted_per_second":17.79046198182722,"draft_n":335,"draft_n_accepted":72,"draft_accept_ratio":0.21492537313432836}
{"predicted_n":200,"predicted_per_second":17.790439826817185,"draft_n":335,"draft_n_accepted":72,"draft_accept_ratio":0.21492537313432836}
```
