### PR TITLE
llama : fix non-causal mask for gemma 3

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1317,8 +1317,8 @@ int llama_context::decode(llama_batch & inp_batch) {
             n_outputs = n_outputs_new;
         }
 
-        // non-causal masks do not use the KV cache
-        if (hparams.causal_attn) {
+        // find KV slot
+        {
             kv_self_update();
 
             // if we have enough unused cells before the current head ->


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/12433

Related to this comment: https://github.com/ggml-org/llama.cpp/pull/12181#issuecomment-2720808102

---

For example, provided that we have a cache of 10 tokens, 3 tokens already inside the cache and we are about to process 4 more tokens

Causal mask (with `llama_set_causal_attn(true)`):

```
xxxx------
xxxxx-----
xxxxxx----
xxxxxxx---
```

For gemma 3, what we want is (with `llama_set_causal_attn(false)`):

```
xxxxxxx---
xxxxxxx---
xxxxxxx---
xxxxxxx---
```

---

To visualize the mask, insert the code below inside `llm_graph_input_attn_kv_unified::set_input()`:

```cpp
printf("\n\n\n\n");
printf("self_kq_mask.shape %lld, %lld\n", self_kq_mask->ne[0], self_kq_mask->ne[1]);
printf("n_tokens: %lld, n_kv: %lld\n", n_tokens, n_kv);
for (int row = 0; row < n_row; row++) {
    for (int i = 0; i < std::min(max_tok_display, (int)self_kq_mask->ne[0]); i++) {
        printf(data[row*self_kq_mask->ne[0] + i] == 0.0f ? "x" : ".");
    }
    printf("\n");
}
printf("\n\n\n\n"); // GGML_ABORT("test");
```