### PR TITLE
sycl: allow ggml-sycl configuration and compilation using Visual Studio project/solution

### DIFF
--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -561,7 +561,7 @@ If you want to use Intel C++ Compiler only for ggml-sycl:
 cmake -B build -G "Visual Studio 17 2022"  -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release -DSYCL_INCLUDE_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\include" -DSYCL_LIBRARY_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib"
 ```
 
-In both cases, after the Visual Studio is created open it, right click on `ggml-sycl` and open properties. In the left column open `C/C++` sub menu and select `DPC++`. In the option window on the right set `Enable SYCL offload` to `yes` and apply changes.
+In both cases, after the Visual Studio solution is created, open it, right click on `ggml-sycl` and open properties. In the left column open `C/C++` sub menu and select `DPC++`. In the option window on the right set `Enable SYCL offload` to `yes` and apply changes.
 
 Properties -> C\C++ -> DPC++ -> Enable SYCL offload(yes)
 

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -549,7 +549,7 @@ You have two options to use Visual Studio to build llama.cpp:
 
 All following commands are executed in PowerShell.
 
-###### - Open as a CMake Project
+##### - Open as a CMake Project
 
 You can use Visual Studio to open the `llama.cpp` folder directly as a CMake project. Before compiling, select one of the SYCL CMake presets:
 
@@ -564,19 +564,15 @@ You can use Visual Studio to open the `llama.cpp` folder directly as a CMake pro
     cmake --build build --config Release -j --target llama-cli
     ```
 
-###### - Generating a Visual Studio Solution
+##### - Generating a Visual Studio Solution
 
 You can use Visual Studio solution to build and work on llama.cpp on Windows. You need to convert the CMake Project into a `.sln` file.
-
-- Using Intel C++ Compiler for the Entire Project
 
 If you want to use the Intel C++ Compiler for the entire `llama.cpp` project, run the following command:
 
 ```Powershell
 cmake -B build -G "Visual Studio 17 2022" -T "Intel C++ Compiler 2025" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release
 ```
-
-- Using Intel C++ Compiler Only for ggml-sycl
 
 If you prefer to use the Intel C++ Compiler only for `ggml-sycl`, ensure that `ggml` and its backend libraries are built as shared libraries ( i.e. `-DBUILD_SHARED_LIBRARIES=ON`, this is default behaviour):
 
@@ -616,9 +612,9 @@ Once it is completed, final results will be in **build/Release/bin**
 
 - You can avoid specifying `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` in the CMake command by setting the environment variables:
 
-	- `SYCL_INCLUDE_DIR_HINT`
+    - `SYCL_INCLUDE_DIR_HINT`
 
-	- `SYCL_LIBRARY_DIR_HINT`
+    - `SYCL_LIBRARY_DIR_HINT`
 
 - Above instruction has been tested with Visual Studio 17 Community edition and oneAPI 2025.0. We expect them to work also with future version if the instructions are adapted accordingly.
 

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -504,13 +504,13 @@ You could download the release package for Windows directly, which including bin
 
 Choose one of following methods to build from source code.
 
-1. Script
+#### 1. Script
 
 ```sh
 .\examples\sycl\win-build-sycl.bat
 ```
 
-2. CMake
+#### 2. CMake
 
 On the oneAPI command line window, step into the llama.cpp main directory and run the following:
 
@@ -539,7 +539,7 @@ cmake --preset x64-windows-sycl-debug
 cmake --build build-x64-windows-sycl-debug -j --target llama-cli
 ```
 
-3. Visual Studio
+#### 3. Visual Studio
 
 You have two options to use Visual Studio to build llama.cpp:
 - As CMake Project using CMake presets.
@@ -549,7 +549,7 @@ You have two options to use Visual Studio to build llama.cpp:
 
 All following commands are executed in PowerShell.
 
-1. Open as a CMake Project
+###### - Open as a CMake Project
 
 You can use Visual Studio to open the `llama.cpp` folder directly as a CMake project. Before compiling, select one of the SYCL CMake presets:
 
@@ -564,7 +564,7 @@ You can use Visual Studio to open the `llama.cpp` folder directly as a CMake pro
     cmake --build build --config Release -j --target llama-cli
     ```
 
-2. Generating a Visual Studio Solution
+###### - Generating a Visual Studio Solution
 
 You can use Visual Studio solution to build and work on llama.cpp on Windows. You need to convert the CMake Project into a `.sln` file.
 
@@ -589,8 +589,6 @@ cmake -B build -G "Visual Studio 17 2022" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TY
 If successful the build files have been written to: *path/to/llama.cpp/build*
 Open the project file **build/llama.cpp.sln** with Visual Studio.
 
-- Configuring SYCL Offload in Visual Studio
-
 Once the Visual Studio solution is created, follow these steps:
 
 1. Open the solution in Visual Studio.
@@ -609,8 +607,6 @@ Once the Visual Studio solution is created, follow these steps:
 ```
 Properties -> C/C++ -> DPC++ -> Enable SYCL Offload (Yes)
 ```
-
-- Build
 
 Now, you can build `llama.cpp` with the SYCL backend as a Visual Studio project.
 To do it from menu: `Build -> Build Solution`.

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -545,6 +545,10 @@ You have two options to use Visual Studio to build llama.cpp:
 - As CMake Project using CMake presets.
 - Creating a Visual Studio solution to handle the project.
 
+**Note**:
+
+All following commands are executed in PowerShell.
+
 1. Open as a CMake Project
 
 You can use Visual Studio to open the `llama.cpp` folder directly as a CMake project. Before compiling, select one of the SYCL CMake presets:
@@ -600,7 +604,7 @@ Once the Visual Studio solution is created, follow these steps:
 5. Apply the changes and save.
 
 
-### Navigation Path:
+*Navigation Path:*
 
 ```
 Properties -> C/C++ -> DPC++ -> Enable SYCL Offload (Yes)

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -568,7 +568,7 @@ Properties -> C\C++ -> DPC++ -> Enable SYCL offload(yes)
 Now you can build llama.cpp with SYCL backend as a Visual Studio project.
 
 *Notes:*
-- you can avoid to specify `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` if set the two env vars `SYCL_INCLUDE_DIR_HINT` and `SYCL_LIBRARY_DIR_HINT`.
+- you can avoid specifying `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` by setting the two environment variables `SYCL_INCLUDE_DIR_HINT` and `SYCL_LIBRARY_DIR_HINT`.
 
 ### III. Run the inference
 

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -541,34 +541,86 @@ cmake --build build-x64-windows-sycl-debug -j --target llama-cli
 
 3. Visual Studio
 
-You can use Visual Studio to open llama.cpp folder as a CMake project. Choose the sycl CMake presets (`x64-windows-sycl-release` or `x64-windows-sycl-debug`) before you compile the project.
+You have two options to use Visual Studio to build llama.cpp:
+- As CMake Project using CMake presets.
+- Creating a Visual Studio solution to handle the project.
+
+1. Open as a CMake Project
+
+You can use Visual Studio to open the `llama.cpp` folder directly as a CMake project. Before compiling, select one of the SYCL CMake presets:
+
+- `x64-windows-sycl-release`
+
+- `x64-windows-sycl-debug`
 
 *Notes:*
+- For a minimal experimental setup, you can build only the inference executable using:
 
-- In case of a minimal experimental setup, the user can build the inference executable only through `cmake --build build --config Release -j --target llama-cli`.
+    ```Powershell
+    cmake --build build --config Release -j --target llama-cli
+    ```
 
-4. Visual Studio Project
+2. Generating a Visual Studio Solution
 
-You can use Visual Studio projects to build and work on llama.cpp on Windows. You need to convert the CMake Project into a `.sln` file.
+You can use Visual Studio solution to build and work on llama.cpp on Windows. You need to convert the CMake Project into a `.sln` file.
 
-If you want to use Intel C++ compiler for the entire llama.cpp project:
-```
+- Using Intel C++ Compiler for the Entire Project
+
+If you want to use the Intel C++ Compiler for the entire `llama.cpp` project, run the following command:
+
+```Powershell
 cmake -B build -G "Visual Studio 17 2022" -T "Intel C++ Compiler 2025" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release
 ```
 
-If you want, you can use Intel C++ Compiler only for ggml-sycl, but `ggml` and its backend libraries *must* be build as shared libraries(i.e. `-DBUILD_SHARED_LIBRARIES=ON`):
+- Using Intel C++ Compiler Only for ggml-sycl
+
+If you prefer to use the Intel C++ Compiler only for `ggml-sycl`, ensure that `ggml` and its backend libraries are built as shared libraries ( i.e. `-DBUILD_SHARED_LIBRARIES=ON`, this is default behaviour):
+
+```Powershell
+cmake -B build -G "Visual Studio 17 2022" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release \
+      -DSYCL_INCLUDE_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\include" \
+      -DSYCL_LIBRARY_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib"
 ```
-cmake -B build -G "Visual Studio 17 2022"  -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release -DSYCL_INCLUDE_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\include" -DSYCL_LIBRARY_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib"
+
+If successful the build files have been written to: *path/to/llama.cpp/build*
+Open the project file **build/llama.cpp.sln** with Visual Studio.
+
+- Configuring SYCL Offload in Visual Studio
+
+Once the Visual Studio solution is created, follow these steps:
+
+1. Open the solution in Visual Studio.
+
+2. Right-click on `ggml-sycl` and select **Properties**.
+
+3. In the left column, expand **C/C++** and select **DPC++**.
+
+4. In the right panel, find **Enable SYCL Offload** and set it to `Yes`.
+
+5. Apply the changes and save.
+
+
+### Navigation Path:
+
+```
+Properties -> C/C++ -> DPC++ -> Enable SYCL Offload (Yes)
 ```
 
-In both cases, after the Visual Studio solution is created, open it, right click on `ggml-sycl` and open properties. In the left column open `C/C++` sub menu and select `DPC++`. In the option window on the right set `Enable SYCL offload` to `yes` and apply changes.
+- Build
 
-Properties -> C\C++ -> DPC++ -> Enable SYCL offload(yes)
+Now, you can build `llama.cpp` with the SYCL backend as a Visual Studio project.
+To do it from menu: `Build -> Build Solution`.
+Once it is completed, final results will be in **build/Release/bin**
 
-Now you can build llama.cpp with SYCL backend as a Visual Studio project.
+*Additional Note*
 
-*Notes:*
-- you can avoid specifying `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` by setting the two environment variables `SYCL_INCLUDE_DIR_HINT` and `SYCL_LIBRARY_DIR_HINT`.
+- You can avoid specifying `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` in the CMake command by setting the environment variables:
+
+	- `SYCL_INCLUDE_DIR_HINT`
+
+	- `SYCL_LIBRARY_DIR_HINT`
+
+- Above instruction has been tested with Visual Studio 17 Community edition and oneAPI 2025.0. We expect them to work also with future version if the instructions are adapted accordingly.
 
 ### III. Run the inference
 

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -556,7 +556,7 @@ If you want to use Intel C++ compiler for the entire llama.cpp project:
 cmake -B build -G "Visual Studio 17 2022" -T "Intel C++ Compiler 2025" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release
 ```
 
-If you want to use Intel C++ Compiler only for ggml-sycl:
+If you want, you can use Intel C++ Compiler only for ggml-sycl, but `ggml` and its backend libraries *must* be build as shared libraries(i.e. `-DBUILD_SHARED_LIBRARIES=ON`):
 ```
 cmake -B build -G "Visual Studio 17 2022"  -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release -DSYCL_INCLUDE_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\include" -DSYCL_LIBRARY_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib"
 ```

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -468,6 +468,12 @@ b. Enable oneAPI running environment:
 "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" intel64
 ```
 
+- if you are using Powershell, enable the runtime environment with the following:
+
+```
+cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'
+```
+
 c. Verify installation
 
 In the oneAPI command line, run the following to print the available SYCL devices:
@@ -540,6 +546,29 @@ You can use Visual Studio to open llama.cpp folder as a CMake project. Choose th
 *Notes:*
 
 - In case of a minimal experimental setup, the user can build the inference executable only through `cmake --build build --config Release -j --target llama-cli`.
+
+4. Visual Studio Project
+
+You can use Visual Studio projects to build and work on llama.cpp on Windows. You need to convert the CMake Project into a `.sln` file.
+
+If you want to use Intel C++ compiler for the entire llama.cpp project:
+```
+cmake -B build -G "Visual Studio 17 2022" -T "Intel C++ Compiler 2025" -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release
+```
+
+If you want to use Intel C++ Compiler only for ggml-sycl:
+```
+cmake -B build -G "Visual Studio 17 2022"  -A x64 -DGGML_SYCL=ON -DCMAKE_BUILD_TYPE=Release -DSYCL_INCLUDE_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\include" -DSYCL_LIBRARY_DIR="C:\Program Files (x86)\Intel\oneAPI\compiler\latest\lib"
+```
+
+In both cases, after the Visual Studio is created open it, right click on `ggml-sycl` and open properties. In the left column open `C/C++` sub menu and select `DPC++`. In the option window on the right set `Enable SYCL offload` to `yes` and apply changes.
+
+Properties -> C\C++ -> DPC++ -> Enable SYCL offload(yes)
+
+Now you can build llama.cpp with SYCL backend as a Visual Studio project.
+
+*Notes:*
+- you can avoid to specify `SYCL_INCLUDE_DIR` and `SYCL_LIBRARY_DIR` if set the two env vars `SYCL_INCLUDE_DIR_HINT` and `SYCL_LIBRARY_DIR_HINT`.
 
 ### III. Run the inference
 

--- a/ggml/src/ggml-sycl/CMakeLists.txt
+++ b/ggml/src/ggml-sycl/CMakeLists.txt
@@ -27,6 +27,15 @@ file(GLOB   GGML_HEADERS_SYCL "*.hpp")
 file(GLOB   GGML_SOURCES_SYCL "*.cpp")
 target_sources(ggml-sycl PRIVATE ${GGML_HEADERS_SYCL} ${GGML_SOURCES_SYCL})
 
+if (WIN32)
+    # To generate a Visual Studio solution, using Intel C++ Compiler for ggml-sycl is mandatory
+    if( ${CMAKE_GENERATOR} MATCHES "Visual Studio" AND NOT (${CMAKE_GENERATOR_TOOLSET} MATCHES "Intel C"))
+        set_target_properties(ggml-sycl PROPERTIES VS_PLATFORM_TOOLSET "Intel C++ Compiler 2025")
+        set(CMAKE_CXX_COMPILER "icx")
+        set(CMAKE_CXX_COMPILER_ID "IntelLLVM")
+    endif()
+endif()
+
 find_package(IntelSYCL)
 if (IntelSYCL_FOUND)
     # Use oneAPI CMake when possible
@@ -95,19 +104,10 @@ if (GGML_SYCL_GRAPH)
     target_compile_definitions(ggml-sycl PRIVATE GGML_SYCL_GRAPH)
 endif()
 
-if (WIN32)
-    if( ${CMAKE_GENERATOR} MATCHES "Visual Studio" AND NOT (${CMAKE_GENERATOR_TOOLSET} MATCHES "Intel C"))
-        set_target_properties(ggml-sycl PROPERTIES VS_PLATFORM_TOOLSET "Intel C++ Compiler 2025")
-        set(CMAKE_CXX_COMPILER "icx")
-        set(CMAKE_CXX_COMPILER_ID "IntelLLVM")
-    endif()
-endif()
-
 # Link against Intel oneMKL or oneMath
 if (GGML_SYCL_TARGET STREQUAL "INTEL")
     # Intel devices use Intel oneMKL directly instead of oneMath to avoid the limitation of linking Intel oneMKL statically
     # See https://github.com/uxlfoundation/oneMath/issues/654
-    find_package(IntelSYCL REQUIRED)
     find_package(MKL REQUIRED)
     target_link_libraries(ggml-sycl PRIVATE MKL::MKL_SYCL::BLAS)
     target_compile_definitions(ggml-sycl PRIVATE GGML_SYCL_USE_INTEL_ONEMKL)

--- a/ggml/src/ggml-sycl/CMakeLists.txt
+++ b/ggml/src/ggml-sycl/CMakeLists.txt
@@ -95,10 +95,19 @@ if (GGML_SYCL_GRAPH)
     target_compile_definitions(ggml-sycl PRIVATE GGML_SYCL_GRAPH)
 endif()
 
+if (WIN32)
+    if( ${CMAKE_GENERATOR} MATCHES "Visual Studio" AND NOT (${CMAKE_GENERATOR_TOOLSET} MATCHES "Intel C"))
+        set_target_properties(ggml-sycl PROPERTIES VS_PLATFORM_TOOLSET "Intel C++ Compiler 2025")
+        set(CMAKE_CXX_COMPILER "icx")
+        set(CMAKE_CXX_COMPILER_ID "IntelLLVM")
+    endif()
+endif()
+
 # Link against Intel oneMKL or oneMath
 if (GGML_SYCL_TARGET STREQUAL "INTEL")
     # Intel devices use Intel oneMKL directly instead of oneMath to avoid the limitation of linking Intel oneMKL statically
     # See https://github.com/uxlfoundation/oneMath/issues/654
+    find_package(IntelSYCL REQUIRED)
     find_package(MKL REQUIRED)
     target_link_libraries(ggml-sycl PRIVATE MKL::MKL_SYCL::BLAS)
     target_compile_definitions(ggml-sycl PRIVATE GGML_SYCL_USE_INTEL_ONEMKL)


### PR DESCRIPTION
This PR enable the possibility of compiling and using llama.cpp with ggml-sycl backend as Visual Studio Project/Solution on windows.
The changes don't interfere with anything but the solution generation for ggml-sycl.
The user can decide which compiler wants to use for the rest of llama.cpp, while `ggml-sycl` will always be compiled using the Intel official compiler.

Tested current and new configurations on Windows 10 and Intel Arc B580
 