### PR TITLE
opencl: remove a self-referential macro

### DIFF
--- a/ggml/src/ggml-opencl/kernels/ggml-opencl_mm.cl
+++ b/ggml/src/ggml-opencl/kernels/ggml-opencl_mm.cl
@@ -847,8 +847,6 @@ float qcom_sub_group_reduce_add(float sum) {
     return sum;
 }
 #define sub_group_reduce_add qcom_sub_group_reduce_add
-#else
-#define sub_group_reduce_add sub_group_reduce_add
 #endif
 
 #undef THREADS_PER_BLK


### PR DESCRIPTION
PoCL fails to compile due to a self-referential macro in ggml-opencl_mm.cl (`#define sub_group_reduce_add
sub_group_reduce_add`) on some devices:

```
error: /home/linehill/.cache/pocl/kcache/tempfile_qlSuTg.cl:1048:11 <Spelling=/home/linehill/.cache/pocl/kcache/tempfile_qlSuTg.cl:851:30>: use of undeclared identifier 'sub_group_reduce_add'
...
```

