### PR TITLE
server: apply grammar before other samplers

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3249,7 +3249,7 @@ struct server_context {
 
                 const int tok_idx = slot.i_batch - i;
 
-                llama_token id = common_sampler_sample(slot.smpl, ctx, tok_idx);
+                llama_token id = common_sampler_sample(slot.smpl, ctx, tok_idx, true);
 
                 slot.i_batch = -1;
 
@@ -3347,7 +3347,7 @@ struct server_context {
                 llama_decode(ctx, slot.batch_spec);
 
                 // the accepted tokens from the speculation
-                const auto ids = common_sampler_sample_and_accept_n(slot.smpl, ctx, draft);
+                const auto ids = common_sampler_sample_and_accept_n(slot.smpl, ctx, draft, true);
 
                 slot.n_past    += ids.size();
                 slot.n_decoded += ids.size();


### PR DESCRIPTION
Context: I've recently started working on code for evaluating language model benchmarks such as MMLU using the llama.cpp server. The approach I'm taking is to present the model with a multiple choice question, restrict the output to exactly the given choices with a grammar, and to then retrieve the post-sampling probabilities for the choices. The individual probabilities for the choices should then add up to 1.

I noticed that with the current server code, when disabling all of the chain samplers except softmax and using a grammar, the post-sampling probabilities of the tokens allowed by the grammar don't consistently add up to 1. The reason is that tokens disallowed by the grammar can be assigned non-zero probabilities. This is because `common_sampler_sample` has a boolean parameter `grammar_first` which the server sets to false. The probabilities are then those of the softmax and they are not being recalculated when the function simply checks whether the sampled token is allowed by the grammar. On the other hand, if the token is disallowed by the grammar, then the sampling is re-run with the grammar being applied before the softmax and the token probabilities are returned correctly.

I am not at all familiar with the history of the grammar code. My assumption would be that `grammar_first` exists for optimization purposes since the grammar is comparatively slow so it is overall faster to apply it last when there are fewer viable tokens to iterate over. However, I think that the correct way to combine a grammar and other samplers is to apply the grammar first and that the current code with the grammar last distorts the distribution of tokens in a way that is not well-defined and depends on the probability of tokens that the grammar disallows in the first place. For this reason I am simply changing the server code in this PR to apply the grammar first, this fixes the immediate issue of the post-sampling probabilities being wrong. I think the implementation with the grammar last can be salvaged but it would require comparatively more effort. And if the only reason for this implementation is better performance I would suggest that I continue working on my code first to determine whether such an optimization would be worthwhile in the first place.