### PR TITLE
llama : nit, DeepSeek V1 MoE is 16B and GigaChat is 20B

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1101,7 +1101,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,        hparams.expert_weights_scale);
 
                 switch (hparams.n_layer) {
-                    case 28: type = LLM_TYPE_20B; break;
+                    case 28: type = LLM_TYPE_16B; break;
                     default: type = LLM_TYPE_UNKNOWN;
                 }
             } break;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1100,8 +1100,9 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 ml.get_key(LLM_KV_EXPERT_SHARED_COUNT,         hparams.n_expert_shared);
                 ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,        hparams.expert_weights_scale);
 
-                switch (hparams.n_layer) {
-                    case 28: type = LLM_TYPE_16B; break;
+                switch (hparams.n_ff_exp) {
+                    case 1408: type = LLM_TYPE_16B; break;
+                    case 1792: type = LLM_TYPE_20B; break;
                     default: type = LLM_TYPE_UNKNOWN;
                 }
             } break;


### PR DESCRIPTION
~Unsure why it was identified as 20B, probably a mistake.~

DeepSeek V1 MoE is 16B while GigaChat is 20B.