### PR TITLE
convert : BailingMoE : avoid setting rope_dim to 0

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5146,7 +5146,7 @@ class BailingMoeModel(Model):
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
         hparams = self.hparams
-        if "head_dim" in hparams:
+        if hparams.get("head_dim"):
             rope_dim = hparams["head_dim"]
         else:
             rope_dim = hparams["hidden_size"] // hparams["num_attention_heads"]


### PR DESCRIPTION
The Ling-lite-base model has `head_dim` set to 0:
https://huggingface.co/inclusionAI/Ling-lite-base/blob/main/config.json#L44

@bartowski1182 @nicoboss