### PR TITLE
gguf-split now respects dry-run option

### DIFF
--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -408,8 +408,6 @@ static void gguf_merge(const split_params & split_params) {
         exit(EXIT_FAILURE);
     }
 
-    std::ofstream fout(split_params.output.c_str(), std::ios::binary);
-    fout.exceptions(std::ofstream::failbit); // fail fast on write errors
 
     auto * ctx_out = gguf_init_empty();
 
@@ -452,8 +450,7 @@ static void gguf_merge(const split_params & split_params) {
                         LLM_KV_SPLIT_COUNT);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);
-                fout.close();
+                gguf_free(ctx_out);                
                 exit(EXIT_FAILURE);
             }
 
@@ -465,8 +462,7 @@ static void gguf_merge(const split_params & split_params) {
                         n_split);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);
-                fout.close();
+                gguf_free(ctx_out);                
                 exit(EXIT_FAILURE);
             }
 
@@ -478,8 +474,7 @@ static void gguf_merge(const split_params & split_params) {
                         split_path, i_split, n_split);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);
-                fout.close();
+                gguf_free(ctx_out);                
                 exit(EXIT_FAILURE);
             }
 
@@ -500,9 +495,11 @@ static void gguf_merge(const split_params & split_params) {
 
         fprintf(stderr, "\033[3Ddone\n");
     }
-
-    // placeholder for the meta data
-    {
+    std::ofstream fout;
+    if (!split_params.dry_run) {
+        fout.open(split_params.output.c_str(), std::ios::binary);
+        fout.exceptions(std::ofstream::failbit); // fail fast on write errors
+        // placeholder for the meta data
         auto meta_size = gguf_get_meta_size(ctx_out);
         ::zeros(fout, meta_size);
     }
@@ -518,7 +515,9 @@ static void gguf_merge(const split_params & split_params) {
                 ggml_free(ctx_metas[i]);
             }
             gguf_free(ctx_out);
-            fout.close();
+            if (!split_params.dry_run) {
+                fout.close();
+            }            
             exit(EXIT_FAILURE);
         }
         fprintf(stderr, "%s: writing tensors %s ...", __func__, split_path);
@@ -540,10 +539,11 @@ static void gguf_merge(const split_params & split_params) {
             auto offset = gguf_get_data_offset(ctx_gguf) + gguf_get_tensor_offset(ctx_gguf, i_tensor);
             f_input.seekg(offset);
             f_input.read((char *)read_data.data(), n_bytes);
-
-            // write tensor data + padding
-            fout.write((const char *)read_data.data(), n_bytes);
-            zeros(fout, GGML_PAD(n_bytes, GGUF_DEFAULT_ALIGNMENT) - n_bytes);
+            if (!split_params.dry_run) {
+                // write tensor data + padding
+                fout.write((const char *)read_data.data(), n_bytes);
+                zeros(fout, GGML_PAD(n_bytes, GGUF_DEFAULT_ALIGNMENT) - n_bytes);
+            }
         }
 
         gguf_free(ctx_gguf);
@@ -552,16 +552,15 @@ static void gguf_merge(const split_params & split_params) {
         fprintf(stderr, "\033[3Ddone\n");
     }
 
-    {
+    if (!split_params.dry_run) {
         // go back to beginning of file and write the updated metadata
         fout.seekp(0);
         std::vector<uint8_t> data(gguf_get_meta_size(ctx_out));
         gguf_get_meta_data(ctx_out, data.data());
         fout.write((const char *)data.data(), data.size());
-
-        fout.close();
-        gguf_free(ctx_out);
+        fout.close();        
     }
+    gguf_free(ctx_out);
 
     fprintf(stderr, "%s: %s merged from %d split with %d tensors.\n",
             __func__, split_params.output.c_str(), n_split, total_tensors);

--- a/examples/gguf-split/gguf-split.cpp
+++ b/examples/gguf-split/gguf-split.cpp
@@ -450,7 +450,7 @@ static void gguf_merge(const split_params & split_params) {
                         LLM_KV_SPLIT_COUNT);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);                
+                gguf_free(ctx_out);
                 exit(EXIT_FAILURE);
             }
 
@@ -462,7 +462,7 @@ static void gguf_merge(const split_params & split_params) {
                         n_split);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);                
+                gguf_free(ctx_out);
                 exit(EXIT_FAILURE);
             }
 
@@ -474,7 +474,7 @@ static void gguf_merge(const split_params & split_params) {
                         split_path, i_split, n_split);
                 gguf_free(ctx_gguf);
                 ggml_free(ctx_meta);
-                gguf_free(ctx_out);                
+                gguf_free(ctx_out);
                 exit(EXIT_FAILURE);
             }
 
@@ -517,7 +517,7 @@ static void gguf_merge(const split_params & split_params) {
             gguf_free(ctx_out);
             if (!split_params.dry_run) {
                 fout.close();
-            }            
+            }
             exit(EXIT_FAILURE);
         }
         fprintf(stderr, "%s: writing tensors %s ...", __func__, split_path);
@@ -558,7 +558,7 @@ static void gguf_merge(const split_params & split_params) {
         std::vector<uint8_t> data(gguf_get_meta_size(ctx_out));
         gguf_get_meta_data(ctx_out, data.data());
         fout.write((const char *)data.data(), data.size());
-        fout.close();        
+        fout.close();
     }
     gguf_free(ctx_out);
 


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
examples/gguf-split now respects "dry-run" option for merge operation just like split operation.
