### PR TITLE
Fix clang warning in gguf_check_reserved_keys

### DIFF
--- a/common/minja/minja.hpp
+++ b/common/minja/minja.hpp
@@ -240,7 +240,7 @@ public:
       auto index = key.get<int>();
       return array_->at(index < 0 ? array_->size() + index : index);
     } else if (object_) {
-      if (!key.is_hashable()) throw std::runtime_error("Unashable type: " + dump());
+      if (!key.is_hashable()) throw std::runtime_error("Unhashable type: " + dump());
       auto it = object_->find(key.primitive_);
       if (it == object_->end()) return Value();
       return it->second;
@@ -249,7 +249,7 @@ public:
   }
   void set(const Value& key, const Value& value) {
     if (!object_) throw std::runtime_error("Value is not an object: " + dump());
-    if (!key.is_hashable()) throw std::runtime_error("Unashable type: " + dump());
+    if (!key.is_hashable()) throw std::runtime_error("Unhashable type: " + dump());
     (*object_)[key.primitive_] = value;
   }
   Value call(const std::shared_ptr<Context> & context, ArgumentsValue & args) const {

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -932,6 +932,7 @@ static void gguf_check_reserved_keys(const std::string & key, const T val) {
         if constexpr (std::is_same<T, uint32_t>::value) {
             GGML_ASSERT(val > 0 && (val & (val - 1)) == 0 && GGUF_KEY_GENERAL_ALIGNMENT " must be power of 2");
         } else {
+            GGML_UNUSED(val);
             GGML_ABORT(GGUF_KEY_GENERAL_ALIGNMENT " must be type u32");
         }
     }


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

We recently enabled our in-house CI for MUSA backend, and this warning was detected in a fresh build:

```bash
[  0%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/gguf.cpp.o
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = unsigned char; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:944:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
  930 | static void gguf_check_reserved_keys(const std::string & key, const T val) {
      |                                                               ~~~~~~~~^~~
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = signed char; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:950:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = short unsigned int; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:956:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = short int; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:962:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = int; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:974:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = float; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:980:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = long unsigned int; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:986:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = long int; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:992:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = double; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:998:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = bool; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:1004:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = const char*; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:1010:38:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = const void*; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:1016:39:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp: In instantiation of ‘void gguf_check_reserved_keys(const string&, T) [with T = const char**; std::string = std::__cxx11::basic_string<char>]’:
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:1029:39:   required from here
/home/xiaodongye/ws/ggml/llama.cpp/ggml/src/gguf.cpp:930:71: warning: parameter ‘val’ set but not used [-Wunused-but-set-parameter]
```