### PR TITLE
Use string_view::find() to search for tokenization to speed up

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2220,13 +2220,11 @@ void llama_vocab::impl::tokenizer_st_partition(std::forward_list<fragment_buffer
                     // find the first occurrence of a given special token in this fragment
                     //  passing offset argument only limit the "search area" but match coordinates
                     //  are still relative to the source full raw_text
-                    auto match = raw_text.find(text, raw_text_base_offset);
+                    //  string_view begins at pos 0 for the same reason
+                    auto match = std::string_view(raw_text.data(), raw_text_base_offset + raw_text_base_length).find(text, raw_text_base_offset);
 
                     // no occurrences found, stop processing this fragment for a given special token
                     if (match == std::string::npos) break;
-
-                    // check if match is within bounds of offset <-> length
-                    if (match + text.length() > raw_text_base_offset + raw_text_base_length) break;
 
 #ifdef PRETOKENIZERDEBUG
                     LLAMA_LOG_WARN("FF: (%ld %ld %ld) '%s'\n", raw_text->length(), raw_text_base_offset, raw_text_base_length, raw_text->substr(raw_text_base_offset, raw_text_base_length).c_str());


### PR DESCRIPTION
The old implementation using `std::string::find()` consumes a lot of time if the string is very long, because it searches beyond the fragment range, looking up for tokens after the fragment end (and later drop the match result if it is beyond the range).

_O(n)_ wasted.

**Furthermore, a long string produces more fragments and for each fragment, then a token is searched again and again in the fragments**, i.e. It searches within `[offset1, end) [offset2, end) [offset3, end) ...` where _offsetn_ is the _nth_ of the fragments.

So actually _O(n^2)_ wasted.

Hope this pic helps understand the issue more easily.
![image](https://github.com/user-attachments/assets/5fa1fd5d-0ac7-4355-bc0e-0c6eefd2250d)


By limiting the search area (esp. the end) using `std::string_view::find()`, we can avoid such unnecessary looking up.

This PR contains the minimal code change to solve the performance pitfall, to at least make it work.
Maybe someone should refactor the whole fragment stuff with `std::string_view` for code readability in the future.