### PR TITLE
[CANN]Support operator SIN COS ARGMAX

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -181,55 +181,6 @@ static void aclnn_add(ggml_backend_cann_context& ctx, aclTensor* acl_src0,
     ACL_CHECK(aclDestroyScalar(alpha));
 }
 
-/**
- * @brief Computes the argmax of a tensor along the specified dimension using the CANN backend.
- *
- * This function performs the argmax operation on the input tensor (`acl_src`)
- * and stores the result in the destination tensor (`acl_dst`). The argmax is
- * computed along a specified axis, and the result is the index of the maximum value
- * along that axis. The operation is performed using the CANN backend, and
- * necessary memory allocation is handled automatically.
- *
- * @param ctx The context for CANN backend operations.
- * @param acl_src The source tensor on which the argmax operation will be performed.
- * @param acl_dst The destination tensor that will hold the resulting indices.
- * @param dst The destination tensor object that stores the result after the argmax operation.
- */
-static void aclnn_argmax(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-    aclTensor* acl_dst, ggml_tensor* dst) {
-    ggml_cann_pool_alloc dst_buffer_allocator(
-        ctx.pool(), ggml_nelements(dst) * ggml_type_size(dst->type));
-    void* buffer = dst_buffer_allocator.get();
-    int64_t dst_buffer_ne[4] = {1, dst->ne[0], dst->ne[1], dst->ne[2]};
-    size_t dst_buffer_nb[GGML_MAX_DIMS];
-    dst_buffer_nb[0] = ggml_type_size(dst->type);
-    for (int i = 1; i < GGML_MAX_DIMS; i++) {
-        dst_buffer_nb[i] = dst_buffer_nb[i - 1] * dst_buffer_ne[i - 1];
-    }
-
-    aclTensor* dst_buffer_tensor =
-        ggml_cann_create_tensor(buffer,  ggml_cann_type_mapping(dst->type), ggml_type_size(dst->type),
-        dst_buffer_ne, dst_buffer_nb, 4);
-
-    uint64_t workspaceSize = 0;
-    aclOpExecutor* executor;
-    void* workspaceAddr = nullptr;
-
-
-    ACL_CHECK(aclnnArgMaxGetWorkspaceSize(acl_src, 3, true, dst_buffer_tensor,
-                     &workspaceSize, &executor));
-    if (workspaceSize > 0) {
-        ggml_cann_pool_alloc workspace_allocator(ctx.pool(), workspaceSize);
-        workspaceAddr = workspace_allocator.get();
-    }
-
-    ACL_CHECK(aclnnArgMax(workspaceAddr, workspaceSize, executor, ctx.stream()));
-
-    size_t cpy_size = ggml_nbytes(dst);
-    ACL_CHECK(aclrtMemcpyAsync(dst->data, cpy_size, buffer, cpy_size,
-        ACL_MEMCPY_DEVICE_TO_DEVICE, ctx.stream()));
-}
-
 void ggml_cann_add(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     ggml_tensor* src0 = dst->src[0];
     ggml_tensor* src1 = dst->src[1];
@@ -3500,8 +3451,22 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     ggml_tensor * src0 = dst->src[0];
 
     aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
-    aclnn_argmax(ctx, acl_src, acl_dst, dst);
+    int64_t dst_ne[3] = {dst->ne[0], dst->ne[1], dst->ne[2]};
+    size_t dst_nb[3] = {dst->nb[0], dst->ne[1], dst->nb[2]};
+    aclTensor* acl_dst = ggml_cann_create_tensor(dst, dst_ne, dst_nb, 3);
+
+    uint64_t workspaceSize = 0;
+    aclOpExecutor* executor;
+    void* workspaceAddr = nullptr;
+
+    ACL_CHECK(aclnnArgMaxGetWorkspaceSize(acl_src, 3, false, acl_dst,
+                     &workspaceSize, &executor));
+    if (workspaceSize > 0) {
+        ggml_cann_pool_alloc workspace_allocator(ctx.pool(), workspaceSize);
+        workspaceAddr = workspace_allocator.get();
+    }
+    ACL_CHECK(aclnnArgMax(workspaceAddr, workspaceSize, executor, ctx.stream()));
+
     ACL_CHECK(aclDestroyTensor(acl_src));
     ACL_CHECK(aclDestroyTensor(acl_dst));
 }

--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -3451,9 +3451,7 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     ggml_tensor * src0 = dst->src[0];
 
     aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    int64_t dst_ne[3] = {dst->ne[0], dst->ne[1], dst->ne[2]};
-    size_t dst_nb[3] = {dst->nb[0], dst->ne[1], dst->nb[2]};
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst, dst_ne, dst_nb, 3);
+    aclTensor* acl_dst = ggml_cann_create_tensor(dst, dst->ne, dst->nb, 3);
 
     uint64_t workspaceSize = 0;
     aclOpExecutor* executor;

--- a/ggml/src/ggml-cann/aclnn_ops.h
+++ b/ggml/src/ggml-cann/aclnn_ops.h
@@ -484,6 +484,47 @@ void ggml_cann_mul_mat(ggml_backend_cann_context& ctx, ggml_tensor* dst);
  */
 void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst);
 
+/**
+ * @brief   Computes the index of the maximum value along the specified dimension
+ *          of a ggml tensor using the CANN backend.
+ *
+ * @details This function performs an argmax operation on the input tensor.
+ *          It finds the index of the maximum value along the specified axis
+ *          and stores these indices in the destination tensor `dst`. The
+ *          operation is executed using the CANN backend for optimized performance.
+ *
+ * @param ctx The CANN context used for operations.
+ * @param dst The destination tensor where the indices of the maximum values will be stored.
+ *            dst->op is `GGML_OP_ARGMAX`.
+ */
+void ggml_cann_argmax(ggml_backend_cann_context& ctx, ggml_tensor* dst);
+
+/**
+ * @brief   Computes the cosine of each element in a ggml tensor using the CANN backend.
+ *
+ * @details This function applies the cosine function element-wise to the input tensor.
+ *          The computed cosine values are stored in the destination tensor `dst`.
+ *          The operation is optimized using the CANN backend for improved performance.
+ *
+ * @param ctx The CANN context used for operations.
+ * @param dst The destination tensor where the cosine values will be stored.
+ *            dst->op is `GGML_OP_COS`.
+ */
+void ggml_cann_cos(ggml_backend_cann_context& ctx, ggml_tensor* dst);
+
+/**
+ * @brief   Computes the sine of each element in a ggml tensor using the CANN backend.
+ *
+ * @details This function applies the sine function element-wise to the input tensor.
+ *          The computed sine values are stored in the destination tensor `dst`.
+ *          The operation is optimized using the CANN backend for improved performance.
+ *
+ * @param ctx The CANN context used for operations.
+ * @param dst The destination tensor where the sine values will be stored.
+ *            dst->op is `GGML_OP_SIN`.
+ */
+void ggml_cann_sin(ggml_backend_cann_context& ctx, ggml_tensor* dst);
+
 template <aclnnStatus getWorkspaceSize(const aclTensor*, const aclTensor*,
                                        aclTensor*, uint64_t*, aclOpExecutor**),
           aclnnStatus execute(void*, uint64_t, aclOpExecutor*, aclrtStream)>

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1420,6 +1420,15 @@ static bool ggml_cann_compute_forward(ggml_backend_cann_context& ctx,
         case GGML_OP_ARGSORT:
             ggml_cann_argsort(ctx, dst);
             break;
+        case GGML_OP_ARGMAX:
+            ggml_cann_argmax(ctx, dst);
+            break;
+        case GGML_OP_COS:
+            ggml_cann_cos(ctx, dst);
+            break;
+        case GGML_OP_SIN:
+            ggml_cann_sin(ctx, dst);
+            break;
         default:
             return false;
     }
@@ -1794,6 +1803,9 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
         case GGML_OP_ARANGE:
         case GGML_OP_TIMESTEP_EMBEDDING:
         case GGML_OP_LEAKY_RELU:
+        case GGML_OP_ARGMAX:
+        case GGML_OP_COS:
+        case GGML_OP_SIN:
             return true;
         default:
             return false;


### PR DESCRIPTION
### Why is this PR needed?

Optimize the `sin` ,  `cos`,  `argmax` operator in the CANN backend with the aclnn acceleration library.

### Test

```
  # SIN
  SIN(type=f16,ne=[10,2,2,2]): OK
  SIN(type=f32,ne=[10,2,2,2]): OK
  5294/5294 tests passed
  Backend CANN0: OK
  
  # COS
  COS(type=f16,ne=[10,2,2,2]): OK
  COS(type=f32,ne=[10,2,2,2]): OK
  5294/5294 tests passed
  Backend CANN0: OK
  
  #ARGMAX
  ARGMAX(type=f32,ne=[32,1,1,1]): OK
  ARGMAX(type=f32,ne=[100,10,1,1]): OK
  ARGMAX(type=f32,ne=[1024,10,1,1]): OK
  ARGMAX(type=f32,ne=[1024,12,1,1]): OK
  ARGMAX(type=f32,ne=[2000,10,1,1]): OK
  ARGMAX(type=f32,ne=[5438,3,1,1]): OK
  5294/5294 tests passed
  Backend CANN0: OK
```

