### PR TITLE
sycl:remove redundant memcopy in function ggml_backend_sycl_buffer_set_tensor

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -372,12 +372,9 @@ static void ggml_backend_sycl_buffer_set_tensor(ggml_backend_buffer_t buffer,
     auto stream = &(dpct::dev_mgr::instance().get_device(ctx->device).default_queue());
     SYCL_CHECK(
         CHECK_TRY_ERROR(dpct::dev_mgr::instance().get_device(ctx->device).queues_wait_and_throw()));
-    char* host_buf = (char*)malloc(size);
-    memcpy(host_buf, data, size);
     SYCL_CHECK(
-        CHECK_TRY_ERROR((*stream).memcpy((char *)tensor->data + offset, host_buf, size)
+        CHECK_TRY_ERROR((*stream).memcpy((char *)tensor->data + offset, data, size)
                              .wait()));
-    free(host_buf);
 }
 catch (sycl::exception const &exc) {
   std::cerr << exc.what() << "Exception caught at file:" << __FILE__


### PR DESCRIPTION
1.the logic here should similar to the default ggml backend or exactly same to ggml-cann(copy data from host to device), so I think this memcopy is redundant and might-be brings some overhead in this function. of course, might-be my misunderstanding if there are some special tech details in sycl's internal.
2.I think we should avoid dynamic memory allocation/free in such performance-sensitive scenario.