### PR TITLE
SYCL: Set the SYCL_PROGRAM_COMPILE_OPTIONS env variable in the CI

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -59,6 +59,8 @@ if [ ! -z ${GG_BUILD_SYCL} ]; then
     export ONEAPI_DEVICE_SELECTOR="level_zero:0"
     # Enable sysman for correct memory reporting
     export ZES_ENABLE_SYSMAN=1
+    # to circumvent precision issues on CPY operations
+    export SYCL_PROGRAM_COMPILE_OPTIONS="-cl-fp32-correctly-rounded-divide-sqrt"
     CMAKE_EXTRA="${CMAKE_EXTRA} -DGGML_SYCL=1 -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DGGML_SYCL_F16=ON"
 fi
 

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -302,6 +302,10 @@ cmake -B build -DGGML_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -
 cmake --build build --config Release -j -v
 ```
 
+It is possible to come across some precision issues when running tests that stem from using faster
+instructions, which can be circumvented by setting the environment variable `SYCL_PROGRAM_COMPILE_OPTIONS`
+as `-cl-fp32-correctly-rounded-divide-sqrt`
+
 #### Nvidia GPU
 
 The SYCL backend depends on [oneMath](https://github.com/uxlfoundation/oneMath) for Nvidia and AMD devices.
@@ -321,6 +325,9 @@ cmake -B build -DGGML_SYCL=ON -DGGML_SYCL_TARGET=NVIDIA -DGGML_SYCL_DEVICE_ARCH=
 # build all binary
 cmake --build build --config Release -j -v
 ```
+
+It is possible to come across some precision issues when running tests that stem from using faster
+instructions, which can be circumvented by passing the `-fno-fast-math` flag to the compiler.
 
 #### AMD GPU
 


### PR DESCRIPTION
The CPY operation tests occasionally fail on both nvptx and intel targets of the SYCL backend, which stem from using lesser precise instructions. Setting the environment `SYCL_PROGRAM_COMPILE_OPTION` to `-cl-fp32-correctly-rounded-divide-sqrt` resolves this issue. On the nvptx backends, passing `-fno-fast-math` resolves the same. 

This PR adds the environment variables, and conveys the same via the SYCL.md file.