### PR TITLE
CUDA: Prefer vector flash decoding kernel for Gemma models

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -299,7 +299,7 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     const bool gqa_opt_applies = ((Q->ne[2] / K->ne[2]) % 2 == 0) && mask; // The mma-based kernels have GQA-specific optimizations
     const bool mma_needs_data_conversion = K->type != GGML_TYPE_F16 || V->type != GGML_TYPE_F16;
     const bool mma_faster_for_bs1 = new_mma_available(cc) && gqa_opt_applies && cc < GGML_CUDA_CC_ADA_LOVELACE && !mma_needs_data_conversion;
-    const bool can_use_vector_kernel = (Q->ne[0] % (2*warp_size) == 0) && (Q->ne[0] <= 256);
+    const bool can_use_vector_kernel = Q->ne[0] % (2*warp_size) == 0;
     if (Q->ne[1] == 1 && can_use_vector_kernel && !mma_faster_for_bs1) {
         if (prec == GGML_PREC_DEFAULT) {
             ggml_cuda_flash_attn_ext_vec_f16(ctx, dst);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -299,7 +299,7 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     const bool gqa_opt_applies = ((Q->ne[2] / K->ne[2]) % 2 == 0) && mask; // The mma-based kernels have GQA-specific optimizations
     const bool mma_needs_data_conversion = K->type != GGML_TYPE_F16 || V->type != GGML_TYPE_F16;
     const bool mma_faster_for_bs1 = new_mma_available(cc) && gqa_opt_applies && cc < GGML_CUDA_CC_ADA_LOVELACE && !mma_needs_data_conversion;
-    const bool can_use_vector_kernel = (Q->ne[0] % (2*warp_size) == 0) && (prec == GGML_PREC_DEFAULT || Q->ne[0] <= 128);
+    const bool can_use_vector_kernel = (Q->ne[0] % (2*warp_size) == 0) && (Q->ne[0] <= 256);
     if (Q->ne[1] == 1 && can_use_vector_kernel && !mma_faster_for_bs1) {
         if (prec == GGML_PREC_DEFAULT) {
             ggml_cuda_flash_attn_ext_vec_f16(ctx, dst);


### PR DESCRIPTION
Vector flash decoding kernel was not being picked for models with head dimension 256. Gemma models are in this category. Removing this limit improves e2e performance by up to 12% in gen phase throughput for Gemma models.

**Performance:**

RTX 4090, CUDA 12.8, Master vs PR

  | ISL | OSL | Master: Gen phase tok/sec | PR: Gen phase tok/sec | Speed-up
-- | -- | -- | -- | -- | --
gemma3 1B Q4_K - Medium | 10 | 200 | 318.6111 | 333.6684 | 1.047259
  | 100 | 200 | 309.473 | 328.0762 | 1.060113
  | 1000 | 200 | 284.6962 | 319.3516 | 1.121728
  | 10000 | 200 | 183.7296 | 206.1121 | 1.121823
  |   |   |   |   |  
gemma3 4B Q4_K - Medium |   |   |   |   |  
  | 10 | 200 | 175.7797 | 184.4036 | 1.049061
  | 100 | 200 | 174.9861 | 181.8483 | 1.039215
  | 1000 | 200 | 165.9151 | 175.7443 | 1.059242
  | 10000 | 200 | 120.0141 | 126.6009 | 1.054884
  |   |   |   |   |  
gemma3 12B Q4_K - Medium |   |   |   |   |  
  | 10 | 200 | 83.11534 | 85.4468 | 1.028051
  | 100 | 200 | 82.62634 | 84.6703 | 1.024737
  | 1000 | 200 | 80.07223 | 81.96644 | 1.023656
  | 10000 | 200 | 56.99771 | 59.67587 | 1.046987
