### PR TITLE
vulkan: set cmake minimum and project name in vulkan-shaders

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.19)
+project("vulkan-shaders-gen" C CXX)
+
 find_package (Threads REQUIRED)
 
 if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)


### PR DESCRIPTION
I forced the CMAKE_CROSSCOMPILING path in ggml-vulkan/CMakeLists.txt and was able to build it with these minor changes. Without them, the errors were:

```
3>CMake Warning (dev) in CMakeLists.txt:
3>  No project() command is present.  The top-level CMakeLists.txt file must
3>  contain a literal, direct call to the project() command.  Add a line of
3>  code such as
3>
3>    project(ProjectName)
3>
3>  near the top of the file, but after cmake_minimum_required().
3>
3>  CMake is pretending there is a "project(Project)" command on the first
3>  line.
3>This warning is for project developers.  Use -Wno-dev to suppress it.
3>
3>CMake Warning (dev) in CMakeLists.txt:
3>  cmake_minimum_required() should be called prior to this top-level project()
3>  call.  Please see the cmake-commands(7) manual for usage documentation of
3>  both commands.
3>This warning is for project developers.  Use -Wno-dev to suppress it.
3>
3>-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.22631.
3>CMake Error in CMakeLists.txt:
3>  No cmake_minimum_required command is present.  A line of code such as
3>
3>    cmake_minimum_required(VERSION 4.0)
3>
3>  should be added at the top of the file.  The version specified may be lower
3>  if you wish to support older CMake versions for this project.  For more
3>  information run "cmake --help-policy CMP0000".
3>
3>
3>-- Configuring incomplete, errors occurred!
```

I did this experiment with cmake 4.0.0. I didn't get these warnings/errors with the normal build, but I guess they're required when vulkan-shaders-gen is treated as an external project?

This also makes me wonder whether we really need a separate path for cross compiles, or if we could force normal builds down the ExternalProject_Add path. But I didn't attempt to do that in this change.