### PR TITLE
Fix includes in arg.cpp and gemma3-cli.cpp

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <climits>
 #include <cstdarg>
+#include <filesystem>
 #include <fstream>
 #include <regex>
 #include <set>

--- a/examples/llava/gemma3-cli.cpp
+++ b/examples/llava/gemma3-cli.cpp
@@ -10,7 +10,7 @@
 
 #include <vector>
 #include <limits.h>
-#include <inttypes.h>
+#include <cinttypes>
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 #include <signal.h>


### PR DESCRIPTION
Wonder how this was missed. The source [uses](https://github.com/ggml-org/llama.cpp/blob/7a84777f42a9b3ba47db5d20b7662f8ddf92f652/common/arg.cpp#L242) `filesystem`, but does not include it.