### PR TITLE
gguf-py : support lazy tensor splitting

### DIFF
--- a/gguf-py/gguf/lazy.py
+++ b/gguf-py/gguf/lazy.py
@@ -139,6 +139,15 @@ class LazyBase(ABC, metaclass=LazyMeta):
 
             if isinstance(res, cls._tensor_type):
                 return cls(meta=cls.eager_to_meta(res), args=args, kwargs=kwargs, func=fn)
+            elif isinstance(res, tuple) and all(isinstance(t, cls._tensor_type) for t in res):
+                # share the evaluation between lazy tuple elements
+                shared_args: list = [args, None]
+                def eager_tuple_element(a: list[Any], i: int = 0, /, **kw) -> LazyBase:
+                    assert len(a) == 2
+                    if a[1] is None:
+                        a[1] = fn(*a[0], **kw)
+                    return a[1][i]
+                return tuple(cls(meta=cls.eager_to_meta(res[i]), args=(shared_args, i), kwargs=kwargs, func=eager_tuple_element) for i in range(len(res)))
             else:
                 del res  # not needed
                 # non-tensor return likely relies on the contents of the args

--- a/gguf-py/gguf/lazy.py
+++ b/gguf-py/gguf/lazy.py
@@ -142,6 +142,7 @@ class LazyBase(ABC, metaclass=LazyMeta):
             elif isinstance(res, tuple) and all(isinstance(t, cls._tensor_type) for t in res):
                 # share the evaluation between lazy tuple elements
                 shared_args: list = [args, None]
+
                 def eager_tuple_element(a: list[Any], i: int = 0, /, **kw) -> LazyBase:
                     assert len(a) == 2
                     if a[1] is None:


### PR DESCRIPTION
Splitting usually involves returning tuples of tensors, which need to be handled properly to avoid early eager evaluation.

As explained in <https://github.com/ggml-org/llama.cpp/pull/12791#discussion_r2032047087>, this will likely help reducing the RAM usage when converting Llama4, since the approach in <https://github.com/ggml-org/llama.cpp/pull/12791> uses `torch.split` on the FFN projections.

# TODO:

- [x] Test conversion with Llama4 and make sure this helps with RAM usage and the output is the same
  - @bartowski1182 or @ddh0 if you have the hashes for a previous conversion of the slow-to-convert model(s) that would be helpful (although the hash may depend on the directory name of the source directory since the metadata of the model potentially includes part of it)

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
