### PR TITLE
Include limits header file on AIX

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -163,6 +163,8 @@ struct common_hf_file_res {
 #   if !defined(PATH_MAX)
 #   define PATH_MAX MAX_PATH
 #   endif
+#elif defined(_AIX)
+#include <sys/limits.h>
 #else
 #include <sys/syslimits.h>
 #endif


### PR DESCRIPTION
The limits header file is present in /usr/include/sys on AIX
