### PR TITLE
ggml: fixes #12846 compilation error

### DIFF
--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -851,12 +851,16 @@ static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
         tmp[i] = GGML_FP16_TO_FP32(x[i]);
     }
 
+    // TODO: change to const pointer instead (see #12846)
+    // this is only a workaround to the compile error but its unreadable
     return vec_xl(0, &(tmp[0]));
 }
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
     float arr[4];
 
+    // TODO: change to const pointer instead (see #12846)
+    // this is only a workaround to the compile error but its unreadable
     vec_xst(y, 0, &(arr[0]));
 
     for (int i = 0; i < 4; i++) {

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -851,13 +851,13 @@ static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
         tmp[i] = GGML_FP16_TO_FP32(x[i]);
     }
 
-    return vec_xl(0, tmp);
+    return vec_xl(0, &(tmp[0]));
 }
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
     float arr[4];
 
-    vec_xst(y, 0, arr);
+    vec_xst(y, 0, &(arr[0]));
 
     for (int i = 0; i < 4; i++) {
         x[i] = GGML_FP32_TO_FP16(arr[i]);

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -851,17 +851,15 @@ static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
         tmp[i] = GGML_FP16_TO_FP32(x[i]);
     }
 
-    // TODO: change to const pointer instead (see #12846)
-    // this is only a workaround to the compile error but its unreadable
-    return vec_xl(0, &(tmp[0]));
+    // note: keep type-cast here to prevent compiler bugs (see #12846)
+    return vec_xl(0, (const float *)(tmp));
 }
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
     float arr[4];
 
-    // TODO: change to const pointer instead (see #12846)
-    // this is only a workaround to the compile error but its unreadable
-    vec_xst(y, 0, &(arr[0]));
+    // note: keep type-cast here to prevent compiler bugs (see #12846)
+    vec_xst(y, 0, (float *)(arr));
 
     for (int i = 0; i < 4; i++) {
         x[i] = GGML_FP32_TO_FP16(arr[i]);

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -851,14 +851,16 @@ static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
         tmp[i] = GGML_FP16_TO_FP32(x[i]);
     }
 
-    // note: keep type-cast here to prevent compiler bugs (see #12846)
+    // note: keep type-cast here to prevent compiler bugs
+    // see: https://github.com/ggml-org/llama.cpp/issues/12846
     return vec_xl(0, (const float *)(tmp));
 }
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
     float arr[4];
 
-    // note: keep type-cast here to prevent compiler bugs (see #12846)
+    // note: keep type-cast here to prevent compiler bugs
+    // see: https://github.com/ggml-org/llama.cpp/issues/12846
     vec_xst(y, 0, (float *)(arr));
 
     for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
Fixes the compilation error introduced in 995083e4ed24933e6a289472f9de0f0b53ca5eca for s390x platform. Please refer to #12846 for more information.

cc: @AlekseiNikiforovIBM 