### PR TITLE
metal : add memory pool for temp allocs

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -473,16 +473,19 @@ enum ggml_metal_kernel_type {
 //
 
 struct ggml_metal_heap {
-    int n_unused; // number of times the heap was unused
+    // number of times the heap was unused
+    int n_unused;
 
-    int64_t n_alloc; // total number of buffer allocations in this heap across all computes
+    // total number of buffer allocations in this heap across all computes
+    int64_t n_alloc;
 
     // current offset in the heap - we reset this after each node in order to reuse the memory
     size_t offs;
 
+    // the currently allocated MTLBuffer objects in this heap
     id<MTLHeap> obj;
 
-    NSMutableArray * bufs; // the currently allocated MTLBuffer objects in this heap
+    NSMutableArray * bufs;
 };
 
 static struct ggml_metal_heap * ggml_metal_heap_init(id<MTLDevice> device, size_t size) {
@@ -586,7 +589,7 @@ static void ggml_metal_mem_pool_free(struct ggml_metal_mem_pool * mem_pool) {
     size_t size_cur = 0;
 
     for (ggml_metal_heap_ptr * ptr in mem_pool->heaps) {
-        GGML_LOG_DEBUG("%s:   heap: %p\n",               __func__, (void *) ptr.data);
+        GGML_LOG_DEBUG("%s:   heap: %p\n",                __func__, (void *) ptr.data);
         GGML_LOG_DEBUG("%s:     n_alloc:  %" PRId64 "\n", __func__, ptr.data->n_alloc);
         GGML_LOG_DEBUG("%s:     n_unused: %d\n",          __func__, ptr.data->n_unused);
         GGML_LOG_DEBUG("%s:     size:     %.2f MiB\n",    __func__, [ptr.data->obj size] / 1024.0 / 1024.0);


### PR DESCRIPTION
ref https://github.com/ggml-org/ggml/pull/1152#issuecomment-2789063791

The goal is to introduce a mechanism that allows to allocate temporary buffers in the Metal backend that can be used to store intermediate results. This is needed for some composite operations (like convolution represented by `im2col` + `mul_mat`) or for rearranging or padding data on the fly. This is similar to the `ggml_cuda_pool_alloc` functionality in the CUDA backend.

For testing, currently using the `SOFT_MAX` operation by introducing an intermediate step of copying the input data to an intermediate buffer and then running the softmax kernel on that intermediate buffer (instead of on the input one). 

```bash
make -j && MTL_DEBUG_LAYER=1 ./bin/test-backend-ops -b Metal -o SOFT_MAX
```

TODO:

- [x] Figure out how to create [MTLHeap](https://developer.apple.com/documentation/metal/mtlheap) and allocate buffers from it
- [x] How to release the buffers
- [x] Create per-command-buffer heaps
- [x] How to dynamically resize the heap based on the memory need of the graph
- [x] Start using [MTLHeapTypePlacement](https://developer.apple.com/documentation/metal/mtlheaptype/placement?language=objc) to be able to reuse heap memory from previous nodes
- [x] Un-encode the failed encoder - how? Maybe recreate the command buffer?
- [x] Check for memory leaks
- [x] Try to allocate the `MTLHeap`s dynamically in order to avoid the extra loop over the nodes.
- [x] Add comments

Next PRs:

- Use this new functionality to add F16 x F16 `MUL_MAT` support by casting `src1` from F32 to F16
- Implement `im2col` + `mul_mat` for `GGML_OP_CONV_XXX`