### PR TITLE
opencl: fix incorrect local_size index in profiling log

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -1024,7 +1024,7 @@ static void ggml_cl2_free(void) {
             info.cmd_complete_duration_ns/1.e6f,
             info.cmd_total_duration_ns/1.e6f,
             info.global_size[0], info.global_size[1], info.global_size[2],
-            info.local_size[0], info.local_size[2], info.local_size[2],
+            info.local_size[0], info.local_size[1], info.local_size[2],
             info.output_size[0], info.output_size[1], info.output_size[2], info.output_size[3]);
     }
     fclose(fperf);


### PR DESCRIPTION
This PR fixes a logging issue in OpenCL profiling where the local_size was printed incorrectly.

Previously, the profiling output printed local_size[2] twice and missed local_size[1]. This resulted in wrong log entries like:

```
64x1x1  → 64x1x1  → 64x1x1  → 2x1x1  → ...
```

This fix ensures correct output of all three dimensions:
local_size[0] x local_size[1] x local_size[2]