### PR TITLE
llama : correct rms norm for llama 4

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4440,8 +4440,8 @@ struct llm_build_llama : public llm_graph_context {
 
                 if (arch == LLM_ARCH_LLAMA4 && use_rope && hparams.use_kq_norm) {
                     // Llama4TextL2Norm
-                    Qcur = ggml_rms_norm(ctx0, Qcur, 1e-6);
-                    Kcur = ggml_rms_norm(ctx0, Kcur, 1e-6);
+                    Qcur = ggml_rms_norm(ctx0, Qcur, hparams.f_norm_rms_eps);
+                    Kcur = ggml_rms_norm(ctx0, Kcur, hparams.f_norm_rms_eps);
                     cb(Qcur, "Qcur_normed", il);
                     cb(Kcur, "Kcur_normed", il);
                 }


### PR DESCRIPTION
Adapt to match this commit in transformers library: https://github.com/huggingface/transformers/commit/10144ff116497878d1d82aabf0a84c16944786f1

Thanks @danielhanchen and @ArthurZucker for noticing this