### PR TITLE
server : add VSCode's Github Copilot Chat support

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3907,6 +3907,21 @@ int main(int argc, char ** argv) {
         res_ok(res, {{ "success", true }});
     };
 
+    const auto handle_api = [&ctx_server, &res_ok](const httplib::Request &, httplib::Response & res) {
+        json data = {
+            {
+                "template", common_chat_templates_source(ctx_server.chat_templates.get()),
+            },
+            {
+                "model_info", {
+                    { "llama.context_length", ctx_server.slots.back().n_ctx, },
+                }
+            },
+        };
+
+        res_ok(res, data);
+    };
+
     // handle completion-like requests (completion, chat, infill)
     // we can optionally provide a custom format for partial results and final results
     const auto handle_completions_impl = [&ctx_server, &res_error, &res_ok](
@@ -4471,6 +4486,7 @@ int main(int argc, char ** argv) {
     svr->Get ("/metrics",             handle_metrics);
     svr->Get ("/props",               handle_props);
     svr->Post("/props",               handle_props_change);
+    svr->Post("/api/show",            handle_api);
     svr->Get ("/models",              handle_models); // public endpoint (no API key check)
     svr->Get ("/v1/models",           handle_models); // public endpoint (no API key check)
     svr->Post("/completion",          handle_completions); // legacy

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -3907,7 +3907,7 @@ int main(int argc, char ** argv) {
         res_ok(res, {{ "success", true }});
     };
 
-    const auto handle_api = [&ctx_server, &res_ok](const httplib::Request &, httplib::Response & res) {
+    const auto handle_api_show = [&ctx_server, &res_ok](const httplib::Request &, httplib::Response & res) {
         json data = {
             {
                 "template", common_chat_templates_source(ctx_server.chat_templates.get()),
@@ -4486,7 +4486,7 @@ int main(int argc, char ** argv) {
     svr->Get ("/metrics",             handle_metrics);
     svr->Get ("/props",               handle_props);
     svr->Post("/props",               handle_props_change);
-    svr->Post("/api/show",            handle_api);
+    svr->Post("/api/show",            handle_api_show);
     svr->Get ("/models",              handle_models); // public endpoint (no API key check)
     svr->Get ("/v1/models",           handle_models); // public endpoint (no API key check)
     svr->Post("/completion",          handle_completions); // legacy


### PR DESCRIPTION
## Overview

VSCode recently added support to use local models with Github Copilot Chat:

https://code.visualstudio.com/updates/v1_99#_bring-your-own-key-byok-preview

This PR adds compatibility of `llama-server` with this feature.

## Usage

- Start a `llama-server` on port 11434 with an instruct model of your choice. For example, using `Qwen 2.5 Coder Instruct 3B`:

  ```bash
  # downloads ~3GB of data

  llama-server \
      -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF \
      --port 11434 -fa -ngl 99 -c 0
  ```

- In VSCode -> Chat -> Manage models -> select "Ollama" (not sure why it is called like this):

  ![image](https://github.com/user-attachments/assets/003f408c-333b-4f18-b4c5-6c0ecfe01597)

- Select the available model from the list and click "OK":

  ![image](https://github.com/user-attachments/assets/ddd13f2e-6016-4752-a5a8-84c9efe0a8d6)

- Enjoy local AI assistance using vanilla `llama.cpp`:

  ![image](https://github.com/user-attachments/assets/8c41b10c-4892-4fad-9b43-8643fb8839c0)

- Advanced context reuse for faster prompt reprocessing can be enabled by adding `--cache-reuse 256` to the `llama-server` command

- Speculative decoding is also supported. Simply start the `llama-server` like this for example:

  ```bash
  llama-server \
      -m  ./models/qwen2.5-32b-coder-instruct/ggml-model-q8_0.gguf \
      -md ./models/qwen2.5-1.5b-coder-instruct/ggml-model-q4_0.gguf \
      --port 11434 -fa -ngl 99 -ngld 99 -c 0 --cache-reuse 256
  ```