### PR TITLE
llava: fixes #12863 v.head.ffn_up.bias byteswap on BE systems

### DIFF
--- a/examples/llava/convert_image_encoder_to_gguf.py
+++ b/examples/llava/convert_image_encoder_to_gguf.py
@@ -365,7 +365,7 @@ if has_llava_projector:
 
         # byteswaps v.head.ffn_up.bias for big-endian systems
         # see: https://github.com/ggml-org/llama.cpp/issues/12863
-        if name == "v.head.ffn_up.bias" and arg.bigendian:
+        if name == "v.head.ffn_up.bias" and args.bigendian:
             data = data.byteswap(inplace=True)
 
         fout.add_tensor(name, data)

--- a/examples/llava/convert_image_encoder_to_gguf.py
+++ b/examples/llava/convert_image_encoder_to_gguf.py
@@ -363,6 +363,11 @@ if has_llava_projector:
         else:
             data = data.squeeze().numpy().astype(np.float32)
 
+        # byteswaps v.head.ffn_up.bias for big-endian systems
+        # see: https://github.com/ggml-org/llama.cpp/issues/12863
+        if name == "v.head.ffn_up.bias" and arg.bigendian:
+            data = data.byteswap(inplace=True)
+
         fout.add_tensor(name, data)
 
     print("Projector tensors added\n")


### PR DESCRIPTION
This PR fixes the erroneous byteswap for `v.head.ffn_up.bias` tensor for Big-Endian systems. Please refer to #12863 for more information.

I have verified this change on both Little-Endian and Big-Endian systems and it is working as intended. For reference these are the test machines:
1. Little-Endian: MacBook Air M3
2. Big-Endian: IBM z15 Mainframe