### PR TITLE
llava: add performance print for gemma3 example

### DIFF
--- a/examples/llava/gemma3-cli.cpp
+++ b/examples/llava/gemma3-cli.cpp
@@ -317,6 +317,6 @@ int main(int argc, char ** argv) {
             is_first_msg = false;
         }
     }
-
+    llama_perf_context_print(ctx.lctx);
     return 0;
 }


### PR DESCRIPTION

Add the `llama_perf_context_print` function to `gemma3-cli` for easier performance measurement and to keep it consistent with the other llava examples.