### PR TITLE
Vulkan: Fix Deepseek V2 inference by making `ggml_vk_op_supports_incontiguous(GGML_OP_RMS_NORM)` return `true`

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6006,6 +6006,7 @@ static bool ggml_vk_op_supports_incontiguous(ggml_op op) {
     case GGML_OP_REPEAT:
     case GGML_OP_REPEAT_BACK:
     case GGML_OP_ROPE:
+    case GGML_OP_RMS_NORM:
         return true;
     default:
         return false;


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/12956

It seems to work perfectly fine so far, but i don't really know what I'm doing, so maybe it's actually not supported and this is breaking something else.

(Also maybe the same should be done for `GGML_OP_RMS_NORM_BACK`?)