### PR TITLE
Fix convert script for non-hf GLM4 checkpoints

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5015,7 +5015,7 @@ class ChatGLMModel(Model):
 
         special_vocab = gguf.SpecialVocab(self.dir_model, n_vocab=len(tokens))
         special_vocab.add_to_gguf(self.gguf_writer)
-    
+
     def set_vocab_legacy(self):
         dir_model = self.dir_model
         hparams = self.hparams
@@ -5055,7 +5055,7 @@ class ChatGLMModel(Model):
             else:
                 tokens.append(reverse_vocab[i])
                 toktypes.append(gguf.TokenType.NORMAL)
-                
+
         self.gguf_writer.add_tokenizer_model("gpt2")
         self.gguf_writer.add_tokenizer_pre('chatglm-bpe')
         self.gguf_writer.add_token_list(tokens)


### PR DESCRIPTION
In #10573, support was added for HF variants of the GLM-4-9B model.  
However, the edits to the conversion script broke the conversion for non-HF checkpoints.  
This MR simply fixes this so that the conversion script works with both.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md) 
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Current master branch:
```
~/llama.cpp# python convert_hf_to_gguf.py ../glm-4-9b
INFO:hf-to-gguf:Loading model: glm-4-9b
INFO:gguf.gguf_writer:gguf: This GGUF file is for Little Endian only
INFO:hf-to-gguf:Exporting model...
...
INFO:hf-to-gguf:Set meta model
INFO:hf-to-gguf:Set model parameters
Traceback (most recent call last):
  File "/root/llama.cpp/convert_hf_to_gguf.py", line 5666, in <module>
    main()
  File "/root/llama.cpp/convert_hf_to_gguf.py", line 5660, in main
    model_instance.write()
  File "/root/llama.cpp/convert_hf_to_gguf.py", line 459, in write
    self.prepare_metadata(vocab_only=False)
  File "/root/llama.cpp/convert_hf_to_gguf.py", line 449, in prepare_metadata
    self.set_gguf_parameters()
  File "/root/llama.cpp/convert_hf_to_gguf.py", line 5077, in set_gguf_parameters
    self.gguf_writer.add_block_count(self.hparams.get("num_layers", self.hparams["num_hidden_layers"]))
KeyError: 'num_hidden_layers'
```

After fix:
Confirmed that both `python convert_hf_to_gguf.py ../glm-4-9b` and `python convert_hf_to_gguf.py ../glm-4-9b-hf` work without issue.