### PR TITLE
[CANN] Add the n_graph_splits performance metric to llama-bench.

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -883,7 +883,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
 static std::string get_modelfile_name(const std::string & path_str) {
     namespace fs = std::filesystem;
     fs::path path = path_str;
-    
+
     return path.filename();
 }
 

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -874,18 +874,6 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
 
     return instances;
 }
-/**
- * @brief Remove the input model path information and keep only the model name.
- *
- * @param path The input model path information.
- * @return Full name of the model.
- */
-static std::string get_modelfile_name(const std::string & path_str) {
-    namespace fs = std::filesystem;
-    fs::path path = path_str;
-
-    return path.filename();
-}
 
 struct test {
     static const std::string build_commit;
@@ -922,7 +910,7 @@ struct test {
         cpu_info(get_cpu_info()),
         gpu_info(get_gpu_info()) {
 
-        model_filename = get_modelfile_name(inst.model);
+        model_filename = inst.model;
         char buf[128];
         llama_model_desc(lmodel, buf, sizeof(buf));
         model_type     = buf;

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -22,6 +22,7 @@
 #include "ggml.h"
 #include "llama.h"
 #include "llama-context.h"
+#include <filesystem>
 
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN
@@ -879,14 +880,11 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
  * @param path The input model path information.
  * @return Full name of the model.
  */
-static std::string get_modelfile_name(const std::string & path) {
-    size_t index = path.find_last_of('/');
-    if (index != std::string::npos) {
-        std::string filename = path.substr(index + 1);
-        return filename;
-    } else {
-        return path;
-    }
+static std::string get_modelfile_name(const std::string & path_str) {
+    namespace fs = std::filesystem;
+    fs::path path = path_str;
+    
+    return path.filename();
 }
 
 struct test {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2216,6 +2216,13 @@ void llama_context::perf_reset() {
     t_p_eval_us = n_p_eval = 0;
 }
 
+/**
+ * @brief Get the number of graph splits.
+ */
+int llama_context::get_graph_splits() const{
+    return ggml_backend_sched_get_n_splits(sched.get());
+}
+
 //
 // interface implementation
 //

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -127,7 +127,7 @@ struct llama_context {
 
     llama_perf_context_data perf_get_data() const;
     void perf_reset();
-    
+
     int get_graph_splits() const;
 
 private:

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -127,6 +127,8 @@ struct llama_context {
 
     llama_perf_context_data perf_get_data() const;
     void perf_reset();
+    
+    int get_graph_splits() const;
 
 private:
     //


### PR DESCRIPTION
llama-bench is an excellent model testing tool. This PR adds the n_graph_splits (graph partition count) parameter to the output of llama-bench. This parameter provides a more intuitive way to assess how well the hardware backend supports the model, helping developers improve model support. 

Here is a comparison of the results with `-o json`.
### Before
```
[
  {
    "build_commit": "12b17501",
    "build_number": 5145,
    "cpu_info": "CPU",
    "gpu_info": "Ascend910B3",
    "backends": "CANN",
    "model_filename": "/home/models/qwen2.5:0.5b-instruct-fp16",
    "model_type": "qwen2 1B F16",
    "model_size": 988208640,
    "model_n_params": 494032768,
    "n_batch": 2048,
    "n_ubatch": 512,
    "n_threads": 192,
    "cpu_mask": "0x0",
    "cpu_strict": false,
    "poll": 50,
    "type_k": "f16",
    "type_v": "f16",
    "n_gpu_layers": 32,
    "split_mode": "layer",
    "main_gpu": 0,
    "no_kv_offload": false,
    "flash_attn": false,
    "tensor_split": "0.00",
    "use_mmap": true,
    "embeddings": false,
    "n_prompt": 0,
    "n_gen": 128,
    "test_time": "2025-04-17T08:51:41Z",
    "avg_ns": 2099229836,
    "stddev_ns": 28969817,
    "avg_ts": 60.984063,
    "stddev_ts": 0.844204,
    "samples_ns": [ 2067742567, 2068888383, 2113888137, 2130481700, 2115148394 ],
    "samples_ts": [ 61.9033, 61.869, 60.5519, 60.0803, 60.5158 ]
  }
]

```

### After

```
[
  {
    "build_commit": "12790280",
    "build_number": 5155,
    "cpu_info": "CPU",
    "gpu_info": "Ascend910B3",
    "backends": "CANN",
    "model_filename": "/home/models/qwen2.5:0.5b-instruct-fp16",
    "n_graph_splits": 2,
    "model_type": "qwen2 1B F16",
    "model_size": 988208640,
    "model_n_params": 494032768,
    "n_batch": 2048,
    "n_ubatch": 512,
    "n_threads": 192,
    "cpu_mask": "0x0",
    "cpu_strict": false,
    "poll": 50,
    "type_k": "f16",
    "type_v": "f16",
    "n_gpu_layers": 32,
    "split_mode": "layer",
    "main_gpu": 0,
    "no_kv_offload": false,
    "flash_attn": false,
    "tensor_split": "0.00",
    "use_mmap": true,
    "embeddings": false,
    "n_prompt": 0,
    "n_gen": 128,
    "test_time": "2025-04-18T02:21:20Z",
    "avg_ns": 2988958856,
    "stddev_ns": 86828048,
    "avg_ts": 42.853434,
    "stddev_ts": 1.254731,
    "samples_ns": [ 2890490934, 2900927646, 3036466484, 3038520785, 3078388432 ],
    "samples_ts": [ 44.2831, 44.1238, 42.1543, 42.1258, 41.5802 ]
  }
]
```
