### PR TITLE
Nix portability improvements

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -150,7 +150,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     [
       cmake
       ninja
-      pkg-config
       git
     ]
     ++ optionals useCuda [
@@ -171,6 +170,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ++ optionals useVulkan vulkanBuildInputs
     ++ optionals enableCurl [ curl ];
 
+  propagatedNativeBuildInputs = [ pkg-config ];
+
+  propagatedBuildInputs =
+    optionals useBlas [ blas ];
+
   cmakeFlags =
     [
       (cmakeBool "LLAMA_BUILD_SERVER" true)
@@ -184,6 +188,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       (cmakeBool "GGML_METAL" useMetalKit)
       (cmakeBool "GGML_VULKAN" useVulkan)
       (cmakeBool "GGML_STATIC" enableStatic)
+      (cmakeBool "BLA_PREFER_PKGCONFIG" true)
     ]
     ++ optionals useCuda [
       (

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -202,6 +202,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       (cmakeBool "LLAMA_BUILD_EXAMPLES" buildExamples)
       (cmakeBool "LLAMA_BUILD_SERVER" buildServer)
       (cmakeBool "BLA_PREFER_PKGCONFIG" true)
+      (cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;test-eval-callback") # Uses Internet
     ]
     ++ optionals useCuda [
       (
@@ -232,6 +233,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/include
     cp $src/include/llama.h $out/include/
   '';
+
+  doCheck = true;
 
   meta = {
     # Configurations we don't want even the CI to evaluate. Results in the

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -188,7 +188,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   cmakeFlags =
     [
       (cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
-      (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
       (cmakeBool "LLAMA_CURL" enableCurl)
       (cmakeBool "GGML_NATIVE" false)
       (cmakeBool "GGML_BLAS" useBlas)

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -107,6 +107,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp${pnameSuffix}";
   version = llamaVersion;
 
+  outputs = [ "out" "lib" "dev" ];
+
   # Note: none of the files discarded here are visible in the sandbox or
   # affect the output hash. This also means they can be modified without
   # triggering a rebuild.

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -254,6 +254,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       philiptaron
       SomeoneSerge
+      hacker1024
     ];
 
     # Extend `badPlatforms` instead

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -96,10 +96,13 @@ let
     rocblas
   ];
 
+  vulkanNativeBuildInputs = [
+    shaderc
+  ];
+
   vulkanBuildInputs = [
     vulkan-headers
     vulkan-loader
-    shaderc
   ];
 in
 
@@ -155,6 +158,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
       autoAddDriverRunpath
     ]
+    ++ optionals useVulkan vulkanNativeBuildInputs
     ++ optionals (effectiveStdenv.hostPlatform.isGnu && enableStatic) [ glibc.static ]
     ++ optionals (effectiveStdenv.isDarwin && useMetalKit && precompileMetalShaders) [ xcrunHost ];
 

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -13,6 +13,7 @@
   cudaPackages,
   autoAddDriverRunpath,
   darwin,
+  llvmPackages,
   rocmPackages,
   vulkan-headers,
   vulkan-loader,
@@ -34,6 +35,7 @@
   rocmGpuTargets ? builtins.concatStringsSep ";" rocmPackages.clr.gpuTargets,
   enableCurl ? true,
   useVulkan ? false,
+  useOpenMP ? false,
   llamaVersion ? "0.0.0", # Arbitrary version, substituted by the flake
 
   # It's necessary to consistently use backendStdenv when building with CUDA support,
@@ -173,7 +175,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   propagatedNativeBuildInputs = [ pkg-config ];
 
   propagatedBuildInputs =
-    optionals useBlas [ blas ];
+    optionals useBlas [ blas ]
+    ++ optionals useOpenMP [ llvmPackages.openmp ];
 
   cmakeFlags =
     [
@@ -187,6 +190,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       (cmakeBool "GGML_HIP" useRocm)
       (cmakeBool "GGML_METAL" useMetalKit)
       (cmakeBool "GGML_VULKAN" useVulkan)
+      (cmakeBool "GGML_OPENMP" useOpenMP)
       (cmakeBool "GGML_STATIC" enableStatic)
       (cmakeBool "BLA_PREFER_PKGCONFIG" true)
     ]

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ poetry.toml
 
 # Nix
 /result
+/result-*
 
 # Test binaries
 /tests/test-backend-ops

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -213,7 +213,7 @@ add_library(ggml
 
 target_link_libraries(ggml PUBLIC ggml-base)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(ggml PRIVATE dl stdc++fs)
 endif()
 


### PR DESCRIPTION
This MR updates the Nix package in the interest of improving portability (in regards to cross-compilation and other libcs).

Changes:

- Use a multi-output derivation to reduce runtime closure sizes
- Move dependencies into the `native`/`propagated` `buildInput` sets where appropriate
- Do not link `stdc++fs` on platforms that do not support it
- Allow setting `LLAMA_BUILD_*` options through Nix
- Enable tests in the Nix build
- Add myself as a Nix package maintainer

Tested platforms:
- GCC/glibc on `x86_64` for `x86_64`
- LLVM/glibc on `x86_64` for `x86_64`
- GCC/glibc on `x86_64` for `aarch64`
- GCC/musl on `x86_64` for static `aarch64`