### PR TITLE
gguf-py : avoid requiring PySide6 for packaged scripts

### DIFF
--- a/gguf-py/gguf/scripts/__init__.py
+++ b/gguf-py/gguf/scripts/__init__.py
@@ -1,7 +1,0 @@
-# pyright: reportUnusedImport=false
-
-from .gguf_convert_endian import main as gguf_convert_endian_entrypoint
-from .gguf_dump import main as gguf_dump_entrypoint
-from .gguf_set_metadata import main as gguf_set_metadata_entrypoint
-from .gguf_new_metadata import main as gguf_new_metadata_entrypoint
-from .gguf_editor_gui import main as gguf_editor_gui_entrypoint

--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.16.2"
+version = "0.16.3"
 description = "Read and write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [
@@ -36,8 +36,8 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-gguf-convert-endian = "gguf.scripts:gguf_convert_endian_entrypoint"
-gguf-dump = "gguf.scripts:gguf_dump_entrypoint"
-gguf-set-metadata = "gguf.scripts:gguf_set_metadata_entrypoint"
-gguf-new-metadata = "gguf.scripts:gguf_new_metadata_entrypoint"
-gguf-editor-gui = "gguf.scripts:gguf_editor_gui_entrypoint"
+gguf-convert-endian = "gguf.scripts.gguf_convert_endian:main"
+gguf-dump = "gguf.scripts.gguf_dump:main"
+gguf-set-metadata = "gguf.scripts.gguf_set_metadata:main"
+gguf-new-metadata = "gguf.scripts.gguf_new_metadata:main"
+gguf-editor-gui = "gguf.scripts.gguf_editor_gui:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,5 +40,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 llama-convert-hf-to-gguf = "convert_hf_to_gguf:main"
+llama-convert-lora-to-gguf = "convert_lora_to_gguf:main"
 llama-convert-llama-ggml-to-gguf = "convert_llama_ggml_to_gguf:main"
 llama-ggml-vk-generate-shaders = "ggml_vk_generate_shaders:main"


### PR DESCRIPTION
I'm using Nix devShells for my development, most often with `nix develop .#default-extra`.

# Problem

I wanted to use `gguf-dump` with some model using the wrapper which that devShell puts in the `$PATH`, and was greeted with

```console
$ gguf-dump --help
Traceback (most recent call last):
  File "/nix/store/l06dc60pbanrbm5ksvf0wh3n2q9blw4z-python3.12-gguf-0.0.0/bin/.gguf-dump-wrapped", line 6, in <module>
    from gguf.scripts import gguf_dump_entrypoint
  File "/nix/store/l06dc60pbanrbm5ksvf0wh3n2q9blw4z-python3.12-gguf-0.0.0/lib/python3.12/site-packages/gguf/scripts/__init__.py", line 9, in <module>
    from .gguf_editor_gui import main as gguf_editor_gui_entrypoint
  File "/nix/store/l06dc60pbanrbm5ksvf0wh3n2q9blw4z-python3.12-gguf-0.0.0/lib/python3.12/site-packages/gguf/scripts/gguf_editor_gui.py", line 15, in <module>
    from PySide6.QtWidgets import (
ModuleNotFoundError: No module named 'PySide6'
```

That should not be a fatal error, since `gguf-dump` doesn't require that module.

This is a problem likely introduced in #12930.

**Note that this problem *also* happens when using `pip install gguf` in a venv.**

# Changes

- Remove `gguf-py/gguf/scripts/__init__.py` and directly refer to the `main` functions of the scripts as their entrypoint in `pyproject.toml` (as suggested in <https://github.com/ggml-org/llama.cpp/pull/13036#issuecomment-2818129809>)
  - `__init__.py` can be safely removed from that directory since <https://peps.python.org/pep-0420/> (Python 3.3). (and it's not really imported anywhere anymore anyway)
- ~~Add `pyside6` to the python dependencies included in `*-extra` devShells~~
  - ~~Its transitive dependencies are quite big, though (300 MB compressed). Hopefully that is fine with others who use the `*-extra` devShells~~
- ~~Update flake.lock~~
  - ~~Because the version which is used by `gguf_editor_gui` is `^6.9`, and `6.9.0` is relatively recent (and not in the previous version of nixpkgs in `flake.lock`)~~

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
