### PR TITLE
Update README.md for tts example to use afplay on MacOS

### DIFF
--- a/examples/tts/README.md
+++ b/examples/tts/README.md
@@ -77,6 +77,10 @@ play the audio:
 ```console
 $ aplay output.wav
 ```
+On macOS, use:
+```console
+$ afplay output.wav
+```
 
 ### Running the example with llama-server
 Running this example with `llama-server` is also possible and requires two


### PR DESCRIPTION
aplay does not automatically installed in MacOS, update the doc to use afplay on MacOS