### PR TITLE
Fix ChatGLMModel for glm-4-9b cannot find tokenizer merges in model file

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5054,7 +5054,7 @@ class ChatGLMModel(Model):
                     toktypes.append(gguf.TokenType.NORMAL)
                 tokens.append(token)
  
-        self.gguf_writer.add_tokenizer_model("gpt2")
+        self.gguf_writer.add_tokenizer_model("llama")
         self.gguf_writer.add_tokenizer_pre(tokpre)
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_types(toktypes)

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5058,14 +5058,19 @@ class ChatGLMModel(Model):
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_types(toktypes)
         try:
+            tokenizer_file = self.dir_model / 'tokenizer.json'
+            if not tokenizer_file.is_file():  
+                raise ValueError("tokenizer.json not found")
+                  
             # for https://huggingface.co/THUDM/glm-4-9b
             special_vocab=gguf.SpecialVocab(
                 self.dir_model, 
                 load_merges=True,
                 n_vocab=vocab_size
             ) 
-            
+        
             self.gguf_writer.add_tokenizer_model("gpt2")
+                
         except Exception as e:
             logger.warning(f'Failed to load special tokens: {e}')
             # for https://huggingface.co/THUDM/glm-4-9b-hf

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -538,7 +538,7 @@ class Model:
         toktypes: list[int] = []
 
         from transformers import AutoTokenizer
-        tokenizer = AutoTokenizer.from_pretrained(self.dir_model)
+        tokenizer = AutoTokenizer.from_pretrained(self.dir_model, trust_remote_code=True)
         vocab_size = self.hparams.get("vocab_size", len(tokenizer.vocab))
         assert max(tokenizer.vocab.values()) < vocab_size
 
@@ -735,6 +735,9 @@ class Model:
         if chkhsh == "d353350c764d8c3b39c763113960e4fb4919bea5fbf208a0e3b22e8469dc7406":
             # ref: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct
             res = "llama4"
+        if chkhsh == "a1336059768a55c99a734006ffb02203cd450fed003e9a71886c88acf24fdbc2":
+            # ref: https://huggingface.co/THUDM/glm-4-9b-hf
+            res = "glm4"
         if chkhsh == "a1336059768a55c99a734006ffb02203cd450fed003e9a71886c88acf24fdbc2":
             # ref: https://huggingface.co/THUDM/glm-4-9b-hf
             res = "glm4"
@@ -5022,16 +5025,60 @@ class ChatGLMModel(Model):
 
         from transformers import AutoTokenizer
         tokenizer = AutoTokenizer.from_pretrained(dir_model, trust_remote_code=True)
-        vocab_size = hparams.get("padded_vocab_size",hparams["vocab_size"])
+        vocab_size = hparams.get("padded_vocab_size",hparams.get("vocab_size"))
         assert max(tokenizer.get_vocab().values()) < vocab_size
 
-        tokens, toktypes, tokpre = self.get_vocab_base()
-        self.gguf_writer.add_tokenizer_model("gpt2")
+        tokpre = self.get_vocab_base_pre(tokenizer)
+
+        reverse_vocab = {id_: encoded_tok for encoded_tok, id_ in tokenizer.get_vocab().items()}
+        added_vocab = tokenizer.get_added_vocab()
+
+        added_tokens_decoder = tokenizer.added_tokens_decoder
+
+        for i in range(vocab_size):
+            if i not in reverse_vocab:
+                tokens.append(f"[PAD{i}]")
+                toktypes.append(gguf.TokenType.UNUSED)
+            else:
+                token: str = reverse_vocab[i]
+                if token in added_vocab:
+                    # The tokenizer in llama.cpp assumes the CONTROL and USER_DEFINED tokens are pre-normalized.
+                    # To avoid unexpected issues - we make sure to normalize non-normalized tokens
+                    if not added_tokens_decoder[i].normalized:
+                        previous_token = token
+                        token = tokenizer.decode(tokenizer.encode(token, add_special_tokens=False))
+                        if previous_token != token:
+                            logger.info(f"{repr(previous_token)} is encoded and decoded back to {repr(token)} using AutoTokenizer")
+
+                    if added_tokens_decoder[i].special or self.does_token_look_special(token):
+                        toktypes.append(gguf.TokenType.CONTROL)
+                    else:
+                        # NOTE: this was added for Gemma.
+                        # Encoding and decoding the tokens above isn't sufficient for this case.
+                        token = token.replace(b"\xe2\x96\x81".decode("utf-8"), " ")  # pre-normalize user-defined spaces
+                        toktypes.append(gguf.TokenType.USER_DEFINED)
+                else:
+                    toktypes.append(gguf.TokenType.NORMAL)
+                tokens.append(token)
+ 
+        self.gguf_writer.add_tokenizer_model("llama")
         self.gguf_writer.add_tokenizer_pre(tokpre)
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_types(toktypes)
-        special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=True)
+  
+        special_vocab=gguf.SpecialVocab(
+            self.dir_model, 
+            load_merges=False,
+            n_vocab=vocab_size
+        )
         # only add special tokens when they were not already loaded from config.json
+   
+        #TODO In llama.cpp, special tokens are mapped one-to-one between a token and a coordinate. However, in reality, a transformer might associate a special token like eos_token_id with multiple tokens.
+        #     Currently, llama.cpp only supports a one-to-one mapping.
+        #     This can lead to an issue where the model fails to terminate properly.
+        #     I'm still unclear about how llama.cpp handles special_token and what the exact call chain is!
+        special_vocab._set_special_token("eos", tokenizer.get_added_vocab()["<|observation|>"])
+        special_vocab._set_special_token("eos", tokenizer.get_added_vocab()["<|user|>"])
         special_vocab._set_special_token("eos", tokenizer.get_added_vocab()["<|endoftext|>"])
         special_vocab._set_special_token("eot", tokenizer.get_added_vocab()["<|user|>"])
         # this one is usually not in config.json anyway
@@ -5045,7 +5092,7 @@ class ChatGLMModel(Model):
         self.gguf_writer.add_context_length(self.hparams.get("seq_length", n_embed))
         self.gguf_writer.add_embedding_length(n_embed)
         self.gguf_writer.add_feed_forward_length(self.hparams.get("ffn_hidden_size", self.hparams.get("intermediate_size", 4 * n_embed)))
-        self.gguf_writer.add_block_count(self.hparams.get("num_layers", self.hparams["num_hidden_layers"]))
+        self.gguf_writer.add_block_count(self.hparams.get("num_layers", self.hparams.get("num_hidden_layers")))
         self.gguf_writer.add_head_count(n_head)
         self.gguf_writer.add_head_count_kv(n_head_kv)
         self.gguf_writer.add_layer_norm_rms_eps(self.hparams.get("layernorm_epsilon",1e-5))


### PR DESCRIPTION
 ###  Fix: Resolved "Cannot find tokenizer merges in model file" Issue

This PR addresses the tokenizer merge issue (`cannot find tokenizer merges in model file`) when loading certain models, especially those converted from HuggingFace. The solution is based on insights from the following discussions and PRs:

- https://github.com/ggml-org/llama.cpp/issues/9692  
- https://github.com/unslothai/unsloth/issues/1065  
- https://github.com/ggml-org/llama.cpp/pull/9696  

###   Verification Steps

**1. Build**

```bash
cmake llama.cpp -B llama.cpp/build \
  -DBUILD_SHARED_LIBS=OFF \
  -DGGML_CUDA=ON \
  -DLLAMA_CURL=ON \
  -DCMAKE_C_COMPILER=gcc-13 \
  -DCMAKE_CXX_COMPILER=g++-13 \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.1/bin/nvcc

cmake --build llama.cpp/build --config Release -j --clean-first --target llama-quantize llama-cli llama-gguf-split
```

**2. Convert HF Weights**

```bash
python convert_hf_to_gguf.py THUDM/glm-4-9b \
  --outfile glm-4-9b.gguf \
  --outtype q8_0
```

**3. Run Inference**

```bash
./llama-cli -m /mnt/ceph/develop/jiawei/model_checkpoint/glm-4-9b.gguf -ngl 200000 -p "你好啊"
```

---

###  Known Issue

Refer to: https://github.com/ggml-org/llama.cpp/discussions/7441

In `llama.cpp`, special tokens (e.g., `eos_token_id`) are currently mapped one-to-one (token → ID). However, in actual transformer models, these tokens might correspond to multiple tokens or require multi-token representations.

This mismatch can cause issues where the model doesn't terminate generation correctly.

The exact handling logic and call chain for `special_token` in `llama.cpp` remains unclear and might require further investigation.

You can see a temporary workaround here. https://github.com/ggml-org/llama.cpp/issues/9606
 