### PR TITLE
security : add note about RPC and server functionality

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,9 @@ To protect sensitive data from potential leaks or unauthorized access, it is cru
 ### Untrusted environments or networks
 
 If you can't run your models in a secure and isolated environment or if it must be exposed to an untrusted network, make sure to take the following security precautions:
-* Confirm the hash of any downloaded artifact (e.g. pre-trained model weights) matches a known-good value
+* Confirm the hash of any downloaded artifact (e.g. pre-trained model weights) matches a known-good value.
 * Encrypt your data if sending it over the network.
+* Do not use the RPC backend and [rpc-server](https://github.com/ggml-org/llama.cpp/tree/master/examples/rpc) functionality.
 
 ### Multi-Tenant environments
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,9 +40,9 @@ To protect sensitive data from potential leaks or unauthorized access, it is cru
 ### Untrusted environments or networks
 
 If you can't run your models in a secure and isolated environment or if it must be exposed to an untrusted network, make sure to take the following security precautions:
+* Do not use the RPC backend, [rpc-server](https://github.com/ggml-org/llama.cpp/tree/master/examples/rpc) and [llama-server](https://github.com/ggml-org/llama.cpp/tree/master/examples/server) functionality (see https://github.com/ggml-org/llama.cpp/pull/13061).
 * Confirm the hash of any downloaded artifact (e.g. pre-trained model weights) matches a known-good value.
 * Encrypt your data if sending it over the network.
-* Do not use the RPC backend and [rpc-server](https://github.com/ggml-org/llama.cpp/tree/master/examples/rpc) functionality.
 
 ### Multi-Tenant environments
 


### PR DESCRIPTION
We are generally aware that the RPC backend and `rpc-server` are vulnerable to all sorts of attack vectors. At some point we added a notice in the README to avoid usage of the RPC functionality in sensitive environments: https://github.com/ggml-org/llama.cpp/tree/master/examples/rpc

However, we keep receiving security advisories about the RPC backend that we don't have the capacity to act upon privately. It makes more sense for the time being to resolve such vulnerabilities publicly, so that the community can help in the process.

With this change to the security policy, we categorize such issues as known vulnerabilities and recommend to skip the advisory process. My suggestion is this to be in effect until we feel more confident about the security of the RPC implementation.