### PR TITLE
llama-mtmd-cli: Sigint rework in mtmd vision example

### DIFF
--- a/examples/llava/mtmd-cli.cpp
+++ b/examples/llava/mtmd-cli.cpp
@@ -24,7 +24,7 @@
 #include <signal.h>
 #endif
 
-//volatile, because of signal being an interrupt
+// volatile, because of signal being an interrupt
 static volatile bool g_is_generating = false;
 static volatile bool g_is_interrupted = false;
 

--- a/examples/llava/mtmd-cli.cpp
+++ b/examples/llava/mtmd-cli.cpp
@@ -24,7 +24,9 @@
 #include <signal.h>
 #endif
 
-static bool g_is_generating = false;
+//volatile, because of signal being an interrupt
+static volatile bool g_is_generating = false;
+static volatile bool is_app_running = true;
 
 /**
  * Please note that this is NOT a production-ready stuff.
@@ -50,8 +52,10 @@ static void sigint_handler(int signo) {
             g_is_generating = false;
         } else {
             console::cleanup();
-            LOG("\nInterrupted by user\n");
-            _exit(130);
+            if(!is_app_running) {
+                _exit(1);
+            }
+            is_app_running = false;
         }
     }
 }
@@ -167,7 +171,7 @@ struct decode_embd_batch {
 static int generate_response(mtmd_cli_context & ctx, common_sampler * smpl, int n_predict) {
     llama_tokens generated_tokens;
     for (int i = 0; i < n_predict; i++) {
-        if (i > n_predict || !g_is_generating) {
+        if (i > n_predict || !g_is_generating || !is_app_running) {
             printf("\n");
             break;
         }
@@ -183,6 +187,11 @@ static int generate_response(mtmd_cli_context & ctx, common_sampler * smpl, int 
 
         printf("%s", common_token_to_piece(ctx.lctx, token_id).c_str());
         fflush(stdout);
+
+        if(!is_app_running) {
+            printf("\n");
+            break;
+        }
 
         // eval the token
         common_batch_clear(ctx.batch);
@@ -206,6 +215,7 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg, std::vect
     LOG_DBG("formatted_chat.prompt: %s\n", formatted_chat.prompt.c_str());
 
     for (auto & fname : images_fname) {
+        if(!is_app_running) return 0;
         mtmd_bitmap bitmap;
         if (mtmd_helper_bitmap_init_from_file(fname.c_str(), bitmap)) {
             LOG_ERR("Unable to load image %s\n", fname.c_str());
@@ -219,6 +229,9 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg, std::vect
     text.add_special   = add_bos;
     text.parse_special = true;
     mtmd_input_chunks chunks;
+
+    if(!is_app_running) return 0;
+
     int32_t res = mtmd_tokenize(ctx.ctx_vision.get(), chunks, text, bitmaps);
     if (res != 0) {
         LOG_ERR("Unable to tokenize prompt, res = %d\n", res);
@@ -276,6 +289,8 @@ int main(int argc, char ** argv) {
 #endif
     }
 
+    if(!is_app_running) return 130;
+
     if (is_single_turn) {
         g_is_generating = true;
         if (params.prompt.find("<__image__>") == std::string::npos) {
@@ -287,7 +302,7 @@ int main(int argc, char ** argv) {
         if (eval_message(ctx, msg, params.image, true)) {
             return 1;
         }
-        if (generate_response(ctx, smpl, n_predict)) {
+        if (is_app_running && generate_response(ctx, smpl, n_predict)) {
             return 1;
         }
 
@@ -302,12 +317,13 @@ int main(int argc, char ** argv) {
         std::vector<std::string> images_fname;
         std::string content;
 
-        while (true) {
+        while (is_app_running) {
             g_is_generating = false;
             LOG("\n> ");
             console::set_display(console::user_input);
             std::string line;
             console::readline(line, false);
+            if(!is_app_running) break;
             console::set_display(console::reset);
             line = string_strip(line);
             if (line.empty()) {
@@ -335,6 +351,7 @@ int main(int argc, char ** argv) {
             msg.role = "user";
             msg.content = content;
             int ret = eval_message(ctx, msg, images_fname, is_first_msg);
+            if(!is_app_running) break;
             if (ret == 2) {
                 // non-fatal error
                 images_fname.clear();
@@ -352,6 +369,7 @@ int main(int argc, char ** argv) {
             is_first_msg = false;
         }
     }
+    if(!is_app_running) LOG("\nInterrupted by user\n");
     llama_perf_context_print(ctx.lctx);
-    return 0;
+    return is_app_running ? 0 : 130;
 }

--- a/examples/llava/mtmd-cli.cpp
+++ b/examples/llava/mtmd-cli.cpp
@@ -302,7 +302,7 @@ int main(int argc, char ** argv) {
         if (eval_message(ctx, msg, params.image, true)) {
             return 1;
         }
-        if (g_is_interrupted && generate_response(ctx, smpl, n_predict)) {
+        if (!g_is_interrupted && generate_response(ctx, smpl, n_predict)) {
             return 1;
         }
 

--- a/examples/llava/mtmd-cli.cpp
+++ b/examples/llava/mtmd-cli.cpp
@@ -215,7 +215,6 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg, std::vect
     LOG_DBG("formatted_chat.prompt: %s\n", formatted_chat.prompt.c_str());
 
     for (auto & fname : images_fname) {
-        if (g_is_interrupted) return 0;
         mtmd_bitmap bitmap;
         if (mtmd_helper_bitmap_init_from_file(fname.c_str(), bitmap)) {
             LOG_ERR("Unable to load image %s\n", fname.c_str());


### PR DESCRIPTION
**Follow-up on the https://github.com/ggml-org/llama.cpp/pull/13043**

**Purpose**
Converted SIGINT handler to notify the main through the flag, instead of just exiting
Added the logic to interrupt the program in the predictable states

**Rationale**
Original code abruptly ends the program on sigint, without flushing stdout or printing any stats
Changed the behavior to only setting global state flags or force quit, if the application didn't respond to the flag change
State flags are volatile, due to them being changed in the interrupt and only read in the main code, which doesn't guarantee proper handling of unobserved changes in some of the compilers with enabled -O2 or higher.

**P. S.**
Making it more like it is implemented in the llama-cli example might be more preferable, but I will leave it up to you. Feel free to suggest/do any adjustments

