### PR TITLE
clang-tidy : disable warning about missing math parenthesis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >
     -readability-magic-numbers,
     -readability-uppercase-literal-suffix,
     -readability-simplify-boolean-expr,
+    -readability-math-missing-parentheses,
     clang-analyzer-*,
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     performance-*,


### PR DESCRIPTION
Should we disable this warning:

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/cd5c42b0-de33-4b8a-aad3-14b3b742e4ef" />

