### PR TITLE
Force FP32 compute in GLM4 FFN Down

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1245,37 +1245,19 @@ static void ggml_cuda_op_mul_mat_cublas(
         }
         const half * src1_ptr = src1->type == GGML_TYPE_F16 ? (const half *) src1_ddf_i : src1_as_f16.get();
 
+        const float alpha = 1.0f;
+        const float beta = 0.0f;
+
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
+        CUBLAS_CHECK(
+            cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
+                    row_diff, src1_ncols, ne10,
+                    &alpha, src0_ptr,  CUDA_R_16F, ne00,
+                            src1_ptr,  CUDA_R_16F, ne10,
+                    &beta,   dst_dd_i, CUDA_R_32F, ldc,
+                    CUBLAS_COMPUTE_32F,
+                    CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
-        if (GGML_CUDA_CC_IS_CDNA(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
-            const float alpha = 1.0f;
-            const float beta = 0.0f;
-            CUBLAS_CHECK(
-                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
-                        row_diff, src1_ncols, ne10,
-                        &alpha, src0_ptr,  CUDA_R_16F, ne00,
-                                src1_ptr,  CUDA_R_16F, ne10,
-                        &beta,   dst_dd_i, CUDA_R_32F, ldc,
-                        CUBLAS_COMPUTE_32F,
-                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-        } else {
-            ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
-
-            const half alpha_f16 = 1.0f;
-            const half beta_f16 = 0.0f;
-
-            CUBLAS_CHECK(
-                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
-                        row_diff, src1_ncols, ne10,
-                        &alpha_f16, src0_ptr,      CUDA_R_16F, ne00,
-                                    src1_ptr,      CUDA_R_16F, ne10,
-                        &beta_f16,  dst_f16.get(), CUDA_R_16F, ldc,
-                        CUBLAS_COMPUTE_16F,
-                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-
-            const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_F16);
-            to_fp32_cuda(dst_f16.get(), dst_dd_i, row_diff*src1_ncols, stream);
-        }
     } else {
         ggml_cuda_pool_alloc<float> src0_ddq_as_f32(ctx.pool(id));
         ggml_cuda_pool_alloc<float> src1_ddq_as_f32(ctx.pool(id));

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -804,7 +804,7 @@ ggml_tensor * llm_graph_context::build_ffn(
     if (down) {
         cur = build_lora_mm(down, cur);
         if (arch == LLM_ARCH_GLM4) {
-            // GLM4 seems to have precision issues in F16
+            // GLM4 seems to have numerical issues with half-precision accumulators
             ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
         }
     }

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -803,6 +803,10 @@ ggml_tensor * llm_graph_context::build_ffn(
 
     if (down) {
         cur = build_lora_mm(down, cur);
+        if (arch == LLM_ARCH_GLM4) {
+            // GLM4 seems to have precision issues in F16
+            ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
+        }
     }
 
     if (down_b) {


### PR DESCRIPTION
See discussion in https://github.com/ggml-org/llama.cpp/issues/12946 - the new GLM4 models seems to have issues with FP16 matmul. Should be reproducible with `GGML_CUDA_FORCE_CUBLAS=1` on any card that supports FP16.

Based on the comment for `GGML_CUDA_FORCE_MMQ` in [docs/build.md](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#performance-tuning), this would most likely affect V100, CDNA and RDNA3+, though I only have a Volta card to test on. Unsure if anything else ever hits this specific branch of the code.

Seems like it largely affects prompt processing speed (compute bound), but unsure if there's a better way to fix this specific code path other than adding more checks.

Master:
| model                          |       size |     params | backend    | ngl |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | -------------------: |
| glm4 32B Q6_K                  |  24.88 GiB |    32.57 B | CUDA       |  99 |         pp512 |        606.64 ± 5.58 |
| glm4 32B Q6_K                  |  24.88 GiB |    32.57 B | CUDA       |  99 |         tg128 |         15.89 ± 0.07 |
| llama 13B Q8_0                 |  12.12 GiB |    12.25 B | CUDA       |  99 |         pp512 |      1661.09 ± 80.06 |
| llama 13B Q8_0                 |  12.12 GiB |    12.25 B | CUDA       |  99 |         tg128 |         49.13 ± 0.03 |

PR:
| model                          |       size |     params | backend    | ngl |          test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------: | -------------------: |
| glm4 32B Q6_K                  |  24.88 GiB |    32.57 B | CUDA       |  99 |         pp512 |        513.01 ± 7.13 |
| glm4 32B Q6_K                  |  24.88 GiB |    32.57 B | CUDA       |  99 |         tg128 |         16.05 ± 0.19 |
| llama 13B Q8_0                 |  12.12 GiB |    12.25 B | CUDA       |  99 |         pp512 |      1575.93 ± 65.59 |
| llama 13B Q8_0                 |  12.12 GiB |    12.25 B | CUDA       |  99 |         tg128 |         49.48 ± 0.13 |

(Also ran `test-backend-ops`, seems ok)
