### PR TITLE
[CANN] Simplify the environment variable setting for GGML_CANN_MEM_POOL and GGML_CANN_ASYNC_MODE

### DIFF
--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -286,25 +286,20 @@ Please add the **[CANN]** prefix/tag in issues/PRs titles to help the CANN-team 
 
 ### GGML_CANN_ASYNC_MODE
 
- `GGML_CANN_ASYNC_MODE` controls whether asynchronous commit mode is enabled(default closed state), which can help speed up model execution. Yes, enable, y, 1, on ,true(case insensitive) are all valid values to enable `GGML_CANN_ASYNC_MODE`, such as `export GGML_CANN_ASYNC_MODE=yEs`.
-
-
+Enables asynchronous operator submission. Disabled by default.
 
 ### GGML_CANN_MEM_POOL
 
-three cases here:
+Specifies the memory pool management strategy:
 
-- By setting `export GGML_CANN_MEM_POOL=pRio` (the value is case-insensitive), you specify the use of a priority queue-based memory pool.
+- vmm: Utilizes a virtual memory manager pool. If hardware support for VMM is unavailable, falls back to the legacy (leg) memory pool.
 
-- Legacy memory pools are enabled when VMM is not available or when `export GGML_CANN_MEM_POOL=leg` is set.
-
-- default VMM
+- prio: Employs a priority queue-based memory pool management.
+- leg: Uses a fixed-size buffer pool.
 
 ### GGML_CANN_DISABLE_BUF_POOL_CLEAN
 
-`GGML_CANN_DISABLE_BUF_POOL_CLEAN` is used to disable the buffer pool cleaning feature.
- The values **yes**, **enable**, **y**, **1**, **on**, and **true** (case-insensitive) are all valid to enable `GGML_CANN_DISABLE_BUF_POOL_CLEAN`. such as `export GGML_CANN_DISABLE_BUF_POOL_CLEAN=yEs`.
-
+Controls automatic cleanup of the memory pool. This option is only effective when using the prio or leg memory pool strategies.
 
 ## TODO
 - Support more models and data types.

--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -8,6 +8,7 @@
  - [DataType Supports](#datatype-supports)
  - [Docker](#docker)
  - [Linux](#linux)
+ - [Environment variable setup](#environment-variable-setup)
  - [TODO](#todo)
 
 
@@ -279,6 +280,30 @@ cmake --build build --config release
 
 ### **GitHub contribution**:
 Please add the **[CANN]** prefix/tag in issues/PRs titles to help the CANN-team check/address them without delay.
+
+
+## Environment variable setup
+
+### GGML_CANN_ASYNC_MODE
+
+ `GGML_CANN_ASYNC_MODE` controls whether asynchronous commit mode is enabled(default closed state), which can help speed up model execution. Yes, enable, y, 1, on ,true(case insensitive) are all valid values to enable `GGML_CANN_ASYNC_MODE`, such as `export GGML_CANN_ASYNC_MODE=yEs`.
+
+
+
+### GGML_CANN_MEM_POOL
+
+three cases here:
+
+- By setting `export GGML_CANN_MEM_POOL=pRio` (the value is case-insensitive), you specify the use of a priority queue-based memory pool.
+
+- Legacy memory pools are enabled when VMM is not available or when `export GGML_CANN_MEM_POOL=leg` is set.
+
+- default VMM
+
+### GGML_CANN_DISABLE_BUF_POOL_CLEAN
+
+`GGML_CANN_DISABLE_BUF_POOL_CLEAN` is used to disable the buffer pool cleaning feature.
+ The values **yes**, **enable**, **y**, **1**, **on**, and **true** (case-insensitive) are all valid to enable `GGML_CANN_DISABLE_BUF_POOL_CLEAN`. such as `export GGML_CANN_DISABLE_BUF_POOL_CLEAN=yEs`.
 
 
 ## TODO

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -359,10 +359,10 @@ struct ggml_backend_cann_context {
         description = aclrtGetSocName();
 
         std::string value = to_lower_case(getenv("GGML_CANN_ASYNC_MODE"));
-        std::set<std::string> valid_values = {"on", "1", "yes", "enable"};
+        std::set<std::string> valid_values = {"on", "1", "yes", "y", "enable"};
         async_mode = valid_values.find(value) != valid_values.end();
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
-            device, async_mode ? "ON" : "OFF");
+            device, async_mode ? "ON" : "OFF");git 
     }
 
     /**

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -362,7 +362,7 @@ struct ggml_backend_cann_context {
         std::set<std::string> valid_values = {"on", "1", "yes", "y", "enable"};
         async_mode = valid_values.find(value) != valid_values.end();
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
-            device, async_mode ? "ON" : "OFF");git 
+            device, async_mode ? "ON" : "OFF");
     }
 
     /**

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -361,7 +361,7 @@ struct ggml_backend_cann_context {
 
         bool async_mode = parse_bool(get_env("GGML_CANN_ASYNC_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
-            device, async_mode ? "ON" : "OFF"); 
+            device, async_mode ? "ON" : "OFF");
     }
 
     /**

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -37,7 +37,7 @@
 #include <thread>
 #include <unistd.h>
 #include <functional>
-#include <set>
+#include <optional>
 
 #include "../include/ggml-cann.h"
 #include "../include/ggml.h"
@@ -104,7 +104,8 @@ const ggml_cann_device_info& ggml_cann_info();
 void ggml_cann_set_device(int32_t device);
 int32_t ggml_cann_get_device();
 
-static std::string to_lower_case(const char* env_var);
+std::optional<std::string> get_env(const std::string& name);
+bool parse_bool(const std::string& value);
 
 /**
  * @brief Abstract base class for memory pools used by CANN.
@@ -358,11 +359,9 @@ struct ggml_backend_cann_context {
         ggml_cann_set_device(device);
         description = aclrtGetSocName();
 
-        std::string value = to_lower_case(getenv("GGML_CANN_ASYNC_MODE"));
-        std::set<std::string> valid_values = {"on", "1", "yes", "y", "enable"};
-        async_mode = valid_values.find(value) != valid_values.end();
+        bool async_mode = parse_bool(get_env("GGML_CANN_ASYNC_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
-            device, async_mode ? "ON" : "OFF");
+            device, async_mode ? "ON" : "OFF"); 
     }
 
     /**

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -37,6 +37,7 @@
 #include <thread>
 #include <unistd.h>
 #include <functional>
+#include <set>
 
 #include "../include/ggml-cann.h"
 #include "../include/ggml.h"
@@ -102,6 +103,8 @@ const ggml_cann_device_info& ggml_cann_info();
 
 void ggml_cann_set_device(int32_t device);
 int32_t ggml_cann_get_device();
+
+static std::string to_lower_case(const char* env_var);
 
 /**
  * @brief Abstract base class for memory pools used by CANN.
@@ -354,7 +357,10 @@ struct ggml_backend_cann_context {
         : device(device), name("CANN" + std::to_string(device)), task_queue(1024, device) {
         ggml_cann_set_device(device);
         description = aclrtGetSocName();
-        async_mode = (getenv("GGML_CANN_ASYNC_MODE") != nullptr);
+
+        std::string value = to_lower_case(getenv("GGML_CANN_ASYNC_MODE"));
+        std::set<std::string> valid_values = {"on", "1", "yes", "enable"};
+        async_mode = valid_values.find(value) != valid_values.end();
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
             device, async_mode ? "ON" : "OFF");
     }

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -93,6 +93,18 @@ int32_t ggml_cann_get_device() {
 }
 
 /**
+ * @brief Convert the value obtained from getenv to a lowercase std::string.
+ *
+ * @param env_var C-style string(char*)
+ * @return A string of type std::stringD.
+ */
+static std::string to_lower_case(const char* env_var){
+    std::string mem_pool_type(env_var ? env_var : "");
+    std::transform(mem_pool_type.begin(), mem_pool_type.end(), mem_pool_type.begin(), ::tolower);
+    return mem_pool_type;
+}
+
+/**
  * @brief Initialize the CANN device information.
  *
  * This function initializes the CANN device information by obtaining the
@@ -731,8 +743,7 @@ struct ggml_cann_pool_vmm : public ggml_cann_pool {
 std::unique_ptr<ggml_cann_pool> ggml_backend_cann_context::new_pool_for_device(
     int device) {
     const char* env_var = getenv("GGML_CANN_MEM_POOL");
-    std::string mem_pool_type(env_var ? env_var : "");
-    std::transform(mem_pool_type.begin(), mem_pool_type.end(), mem_pool_type.begin(), ::tolower);
+    std::string mem_pool_type = to_lower_case(env_var);
 
     if (mem_pool_type == "prio") {
         GGML_LOG_INFO("%s: device %d use buffer pool with priority queue\n", __func__, device);

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -31,7 +31,7 @@
 #include <mutex>
 #include <queue>
 #include <chrono>
-#include <set>
+#include <unordered_set>
 #include <optional>
 
 #include "ggml-impl.h"
@@ -101,17 +101,17 @@ int32_t ggml_cann_get_device() {
 std::optional<std::string> get_env(const std::string& name) {
     const char* val = std::getenv(name.c_str());
     if (!val) return std::nullopt;
-    return std::string(val);
+    std::string res = std::string(val);
+    std::transform(res.begin(), res.end(), res.begin(), ::tolower);
+    return res;
 }
 
 /**
  * @brief Verify whether the environment variable is a valid value.
  */
 bool parse_bool(const std::string& value) {
-    std::string res = value;
-    std::transform(res.begin(), res.end(), res.begin(), ::tolower);
-    std::set<std::string> valid_values = {"on", "1", "yes", "y", "enable", "true"};
-    return valid_values.find(res) != valid_values.end();
+    std::unordered_set<std::string> valid_values = {"on", "1", "yes", "y", "enable", "true"};
+    return valid_values.find(value) != valid_values.end();
 }
 
 /**
@@ -753,7 +753,6 @@ struct ggml_cann_pool_vmm : public ggml_cann_pool {
 std::unique_ptr<ggml_cann_pool> ggml_backend_cann_context::new_pool_for_device(
     int device) {
     std::string mem_pool_type = get_env("GGML_CANN_MEM_POOL").value_or("");
-    std::transform(mem_pool_type.begin(), mem_pool_type.end(), mem_pool_type.begin(), ::tolower);
 
     if (mem_pool_type == "prio") {
         GGML_LOG_INFO("%s: device %d use buffer pool with priority queue\n", __func__, device);

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -96,7 +96,7 @@ int32_t ggml_cann_get_device() {
  * @brief Convert the value obtained from getenv to a lowercase std::string.
  *
  * @param env_var C-style string(char*)
- * @return A string of type std::stringD.
+ * @return A string of type std::string.
  */
 static std::string to_lower_case(const char* env_var){
     std::string mem_pool_type(env_var ? env_var : "");


### PR DESCRIPTION
This PR simplifies the environment variable setup for GGML_CANN_MEM_POOL and GGML_CANN_ASYNC_MODE.

GGML_CANN_MEM_POOL:

- default VMM 
- By setting `export GGML_CANN_MEM_POOL="pRio"` (the value is case-insensitive), you specify the use of a priority queue-based memory pool.
- `export GGML_CANN_MEM_POOL="leg"` or, if VMM is unavailable, the legacy buffer pool will be enabled.

GGML_CANN_ASYNC_MODE:
- Yes, enable, y, 1, on ,true(case insensitive) are all valid values to enable GGML_CANN_ASYNC_MODE, such as `export GGML_CANN_ASYNC_MODE=yEs`.
