### PR TITLE
fix wrong template in GLM4-0414

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5154,7 +5154,7 @@ class Glm4Model(TextModel):
         special_vocab._set_special_token("eos", tokenizer.get_added_vocab()["<|endoftext|>"])
         special_vocab._set_special_token("eot", tokenizer.get_added_vocab()["<|user|>"])
         special_vocab._set_special_token("unk", tokenizer.get_added_vocab()["<|endoftext|>"])
-        special_vocab._set_special_token("bos", tokenizer.get_added_vocab()["[gMASK]"])
+        special_vocab._set_special_token("bos", tokenizer.get_added_vocab()["<|endoftext|>"])
         special_vocab.add_to_gguf(self.gguf_writer)
 
     def set_gguf_parameters(self):

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -122,7 +122,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
         }
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|end|>")) {
         return LLM_CHAT_TEMPLATE_PHI_3;
-    } else if (tmpl_contains("[gMASK]<sop>") && tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) { /* GLM4 0414 models */
+    } else if (tmpl_contains("[gMASK]<sop>")) {
         return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
         return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
@@ -157,8 +157,6 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("[gMASK]sop")) {
         // chatglm3-6b
         return LLM_CHAT_TEMPLATE_CHATGML_3;
-    } else if (tmpl_contains("[gMASK]<sop>")) {
-        return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains(LU8("<用户>"))) {
         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF
         return LLM_CHAT_TEMPLATE_MINICPM;

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -122,7 +122,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
         }
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|end|>")) {
         return LLM_CHAT_TEMPLATE_PHI_3;
-    } else if (tmpl_contains("[gMASK]<sop>") && tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) { /* GLM4 models */
+    } else if (tmpl_contains("[gMASK]<sop>") && tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) { /* GLM4 0414 models */
         return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
         return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
@@ -157,6 +157,8 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("[gMASK]sop")) {
         // chatglm3-6b
         return LLM_CHAT_TEMPLATE_CHATGML_3;
+    } else if (tmpl_contains("[gMASK]<sop>")) {
+        return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains(LU8("<用户>"))) {
         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF
         return LLM_CHAT_TEMPLATE_MINICPM;

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -124,8 +124,8 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
         return LLM_CHAT_TEMPLATE_PHI_3;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
         if (tmpl_contains("[gMASK]<sop>")) { /* new GLM4 0414 models */
-			return LLM_CHAT_TEMPLATE_CHATGML_4;
-		}
+            return LLM_CHAT_TEMPLATE_CHATGML_4;
+        }
         return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
     } else if (tmpl_contains("<|{{ item['role'] }}|>") && tmpl_contains("<|begin_of_image|>")) {
         return LLM_CHAT_TEMPLATE_GLMEDGE;
@@ -158,7 +158,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("[gMASK]sop")) {
         // chatglm3-6b
         return LLM_CHAT_TEMPLATE_CHATGML_3;
-    } else if (tmpl_contains("[gMASK]<sop>")) {
+    } else if (tmpl_contains("[gMASK]<sop>")) { /* old GLM4 models */
         return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains(LU8("<用户>"))) {
         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -123,6 +123,9 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|end|>")) {
         return LLM_CHAT_TEMPLATE_PHI_3;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
+        if (tmpl_contains("[gMASK]<sop>")) { /* new GLM4 0414 models */
+			return LLM_CHAT_TEMPLATE_CHATGML_4;
+		}
         return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
     } else if (tmpl_contains("<|{{ item['role'] }}|>") && tmpl_contains("<|begin_of_image|>")) {
         return LLM_CHAT_TEMPLATE_GLMEDGE;

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -122,10 +122,9 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
         }
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|end|>")) {
         return LLM_CHAT_TEMPLATE_PHI_3;
+    } else if (tmpl_contains("[gMASK]<sop>") && tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) { /* GLM4 models */
+        return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
-        if (tmpl_contains("[gMASK]<sop>")) { /* new GLM4 0414 models */
-            return LLM_CHAT_TEMPLATE_CHATGML_4;
-        }
         return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
     } else if (tmpl_contains("<|{{ item['role'] }}|>") && tmpl_contains("<|begin_of_image|>")) {
         return LLM_CHAT_TEMPLATE_GLMEDGE;
@@ -158,8 +157,6 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("[gMASK]sop")) {
         // chatglm3-6b
         return LLM_CHAT_TEMPLATE_CHATGML_3;
-    } else if (tmpl_contains("[gMASK]<sop>")) { /* old GLM4 models */
-        return LLM_CHAT_TEMPLATE_CHATGML_4;
     } else if (tmpl_contains(LU8("<用户>"))) {
         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF
         return LLM_CHAT_TEMPLATE_MINICPM;


### PR DESCRIPTION
Reopening https://github.com/ggml-org/llama.cpp/pull/13099 because I broke my repo with a wrong git command and it automatically closed the PR.



@ngxson 
- I moved the check for GLM4 above so it gets higher priority.
> Instead of changing BOS, I think what should be done is to set add_add_bos(False) to prevent tokenize function from adding BOS to the sentence

I am not sure if I can do that. add_bos_token is automatically set to false by the HF model. I am forced to set it to PAD token because otherwise it would break the jinja templating system `./llama-server --jinja`.
The jinja code ignores the add_bos_token value and removes any BOS token it encounters.

This is the relevant code block.
https://github.com/ggml-org/llama.cpp/blob/e291450b7602d7a36239e4ceeece37625f838373/common/chat.cpp#L651
If I don't set the BOS token it would break the /props endpoint

ORIGINAL:
```
GLM4-0414 models were using the wrong legacy template, leading to a missing `[gMASK]<sop>` preamble.
The old code was returning `LLM_CHAT_TEMPLATE_GLMEDGE`

As a workaround you needed to launch `llama-server` with `--chat-template chatglm4`

After the patch the gguf should be regenerated or edited manually.
```
