### PR TITLE
delete buffer clear as suggested

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1536,8 +1536,6 @@ int32_t llama_context::output_reserve(int32_t n_outputs) {
     // set all ids as invalid (negative)
     std::fill(output_ids.begin(), output_ids.end(), -1);
 
-    ggml_backend_buffer_clear(buf_output.get(), 0);
-
     this->n_outputs     = 0;
     this->n_outputs_max = n_outputs_max;
 


### PR DESCRIPTION
As discussed in https://github.com/ggml-org/llama.cpp/pull/13002,  ggml_backend_buffer_clear is deleted.