### PR TITLE
common: Ensure libcommon.so is build if BUILD_SHARED_LIBS=ON (#13156)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(TARGET common)
 
-add_library(${TARGET} STATIC
+add_library(${TARGET}
     arg.cpp
     arg.h
     base64.hpp


### PR DESCRIPTION
Ensures BUILD_SHARED_LIBS=ON creates shared libraries that contain functions from /common (currently always static). Resolves #13156 