### PR TITLE
llama-graph : fix text position for mrope

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -55,13 +55,15 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
     if (ubatch->pos && pos) {
         const int64_t n_tokens = ubatch->n_tokens;
 
-        if (ubatch->token && n_pos_per_embd > 1) {
-            // in case we're using M-RoPE with text tokens, convert the 1D positions to 4D
-            // the other dimensions are all 0, they are unused for text tokens
+        if (ubatch->token && n_pos_per_embd == 4) {
+            // in case we're using M-RoPE with text tokens, convert the 1D positions to 3D
+            // the other dimensions are the same, except for 4th dim which will be all 0
             std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd, 0);
             // copy the first dimension
             for (int i = 0; i < n_tokens; ++i) {
-                pos_data[i] = ubatch->pos[i];
+                pos_data[               i] = ubatch->pos[i];
+                pos_data[    n_tokens + i] = ubatch->pos[i];
+                pos_data[2 * n_tokens + i] = ubatch->pos[i];
             }
             ggml_backend_tensor_set(pos, pos_data.data(), 0, pos_data.size()*ggml_element_size(pos));
         } else {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -58,12 +58,13 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
         if (ubatch->token && n_pos_per_embd == 4) {
             // in case we're using M-RoPE with text tokens, convert the 1D positions to 4D
             // the 3 first dims are the same, and 4th dim is all 0
-            std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd, 0);
+            std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd);
             // copy the first dimension
             for (int i = 0; i < n_tokens; ++i) {
                 pos_data[               i] = ubatch->pos[i];
                 pos_data[    n_tokens + i] = ubatch->pos[i];
                 pos_data[2 * n_tokens + i] = ubatch->pos[i];
+                pos_data[3 * n_tokens + i] = 0; // 4th dim is 0
             }
             ggml_backend_tensor_set(pos, pos_data.data(), 0, pos_data.size()*ggml_element_size(pos));
         } else {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -56,8 +56,8 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
         const int64_t n_tokens = ubatch->n_tokens;
 
         if (ubatch->token && n_pos_per_embd == 4) {
-            // in case we're using M-RoPE with text tokens, convert the 1D positions to 3D
-            // the other dimensions are the same, except for 4th dim which will be all 0
+            // in case we're using M-RoPE with text tokens, convert the 1D positions to 4D
+            // the 3 first dims are the same, and 4th dim is all 0
             std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd, 0);
             // copy the first dimension
             for (int i = 0; i < n_tokens; ++i) {


### PR DESCRIPTION
Cont https://github.com/ggml-org/llama.cpp/pull/13138

I misunderstood the original code:

```cpp
        // TODO: add mrope pos ids somewhere else
        pos.resize(batch.n_tokens * 4);
        std::fill(pos.begin(), pos.end(), 0);
        for (int j = 0; j < batch.n_tokens * 3; j ++) {
            pos[j] = *st_pos_id + (j % batch.n_tokens);
        }
        batch.pos = pos.data();
```

Which means 3 first dims are the same, and 4th dim is 0, something like this:

`1234...1234...1234...0000...`

Thanks @mattjcly for spotting this!
