### PR TITLE
Prefilling assistant message in openai compatible API

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -642,8 +642,14 @@ static json oaicompat_completion_params_parse(
         throw std::runtime_error("Cannot use custom grammar constraints with tools.");
     }
 
+    /* sanity check, max one assistant message at the end of the list */
+    bool last_message_is_assistant = inputs.messages.size() > 0 && inputs.messages.back().role == "assistant";
+    if (last_message_is_assistant && inputs.messages.size() >= 2 && inputs.messages[inputs.messages.size()-2].role == "assistant") {
+        throw std::runtime_error("Cannot have 2 or more assistant messages at the end of the list.");
+    }
+
     /* Prefill assistant message support */
-    bool prefill_assistant_message = inputs.messages.size() > 0 && inputs.messages.back().role == "assistant";
+    bool prefill_assistant_message = last_message_is_assistant;
     common_chat_msg last_message;
     if (prefill_assistant_message) {
         last_message = inputs.messages.back();

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -642,8 +642,25 @@ static json oaicompat_completion_params_parse(
         throw std::runtime_error("Cannot use custom grammar constraints with tools.");
     }
 
+    /* Prefill assistant message support */
+    bool prefill_assistant_message = inputs.messages.size() > 0 && inputs.messages[inputs.messages.size()-1].role == "assistant";
+    common_chat_msg last_message;
+    if (prefill_assistant_message)
+    {
+    	last_message = inputs.messages.back();
+        inputs.messages.pop_back();
+        inputs.extract_reasoning = false;
+        inputs.add_generation_prompt = true;
+    }
+
     // Apply chat template to the list of messages
     auto chat_params = common_chat_templates_apply(tmpls, inputs);
+
+    /* Append assistant prefilled message */
+    if (prefill_assistant_message)
+    {
+         chat_params.prompt += last_message.content;
+    }
 
     llama_params["chat_format"]      = static_cast<int>(chat_params.format);
     llama_params["prompt"]           = chat_params.prompt;

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -643,7 +643,7 @@ static json oaicompat_completion_params_parse(
     }
 
     /* Prefill assistant message support */
-    bool prefill_assistant_message = inputs.messages.size() > 0 && inputs.messages[inputs.messages.size()-1].role == "assistant";
+    bool prefill_assistant_message = inputs.messages.size() > 0 && inputs.messages.back().role == "assistant";
     common_chat_msg last_message;
     if (prefill_assistant_message) {
         last_message = inputs.messages.back();

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -647,7 +647,7 @@ static json oaicompat_completion_params_parse(
     common_chat_msg last_message;
     if (prefill_assistant_message)
     {
-    	last_message = inputs.messages.back();
+        last_message = inputs.messages.back();
         inputs.messages.pop_back();
         inputs.extract_reasoning = false;
         inputs.add_generation_prompt = true;

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -645,8 +645,7 @@ static json oaicompat_completion_params_parse(
     /* Prefill assistant message support */
     bool prefill_assistant_message = inputs.messages.size() > 0 && inputs.messages[inputs.messages.size()-1].role == "assistant";
     common_chat_msg last_message;
-    if (prefill_assistant_message)
-    {
+    if (prefill_assistant_message) {
         last_message = inputs.messages.back();
         inputs.messages.pop_back();
         inputs.extract_reasoning = false;
@@ -657,8 +656,7 @@ static json oaicompat_completion_params_parse(
     auto chat_params = common_chat_templates_apply(tmpls, inputs);
 
     /* Append assistant prefilled message */
-    if (prefill_assistant_message)
-    {
+    if (prefill_assistant_message) {
          chat_params.prompt += last_message.content;
     }
 

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -642,7 +642,8 @@ static json oaicompat_completion_params_parse(
         throw std::runtime_error("Cannot use custom grammar constraints with tools.");
     }
 
-    /* Prefill assistant message support */
+    // if the assistant message appears at the end of list, we do not add end-of-turn token
+    // for ex. this can be useful to modify the reasoning process in reasoning models
     bool prefill_assistant_message = !inputs.messages.empty() && inputs.messages.back().role == "assistant";
     common_chat_msg last_message;
     if (prefill_assistant_message) {

--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -642,18 +642,18 @@ static json oaicompat_completion_params_parse(
         throw std::runtime_error("Cannot use custom grammar constraints with tools.");
     }
 
-    /* sanity check, max one assistant message at the end of the list */
-    bool last_message_is_assistant = inputs.messages.size() > 0 && inputs.messages.back().role == "assistant";
-    if (last_message_is_assistant && inputs.messages.size() >= 2 && inputs.messages[inputs.messages.size()-2].role == "assistant") {
-        throw std::runtime_error("Cannot have 2 or more assistant messages at the end of the list.");
-    }
-
     /* Prefill assistant message support */
-    bool prefill_assistant_message = last_message_is_assistant;
+    bool prefill_assistant_message = !inputs.messages.empty() && inputs.messages.back().role == "assistant";
     common_chat_msg last_message;
     if (prefill_assistant_message) {
         last_message = inputs.messages.back();
         inputs.messages.pop_back();
+
+        /* sanity check, max one assistant message at the end of the list */
+        if (!inputs.messages.empty() && inputs.messages.back().role == "assistant"){
+            throw std::runtime_error("Cannot have 2 or more assistant messages at the end of the list.");
+        }
+
         inputs.extract_reasoning = false;
         inputs.add_generation_prompt = true;
     }


### PR DESCRIPTION
This adds support for prefilling assistant response (or its thought process) using the OpenAI compatible API.

The feature is used for example by Claude.

It can be tested using open-webui or with the following curl command:
```
curl http://localhost:8080/apply-template \
-H "Content-Type: application/json" \
-H "Authorization: Bearer no-key" \
-d '{
"model": "gpt-3.5-turbo",
"messages": [
 {
    "role": "system",
    "content": "SYSTEM"
 },
 {
    "role": "user",
    "content": "USERMESSAGE"
 },
 {
    "role": "assistant",
    "content": "ASSISTANT"
 }
]
}'
```

**Example advanced scenario**: time limit for the thinking process
- launch a reasoning model and stop its thought early
- append `</think>` to its partial response
- prefill the response and let it continue generating tokens