### PR TITLE
llama-bench: fixed size of fields to correctly map to values

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1133,8 +1133,6 @@ struct test {
             "build_commit", "build_number", "cpu_info",       "gpu_info",   "backends",     "model_filename",
             "model_type",   "model_size",   "model_n_params", "n_batch",    "n_ubatch",     "n_threads",
             "cpu_mask",     "cpu_strict",   "poll",           "type_k",     "type_v",       "n_gpu_layers",
-            "split_mode",   "main_gpu",     "no_kv_offload",  "flash_attn", "tensor_split", "use_mmap",
-            "embeddings",   "n_prompt",     "n_gen",          "n_depth",    "test_time",    "avg_ns",
             "split_mode",   "main_gpu",     "no_kv_offload",  "flash_attn", "tensor_split", "tensor_buft_overrides",
             "use_mmap",     "embeddings",   "n_prompt",       "n_gen",      "n_depth",      "test_time",
             "avg_ns",       "stddev_ns",    "avg_ts",         "stddev_ts",


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/pull/13096 Introduced some changes to llama-bench that have been causing segfaults to the users due to an incorrect definition of the test fields (see https://github.com/ggml-org/llama.cpp/issues/13169) 

I don't have expertise here so if this it not the cause of the issue or there is a better way to do it, happy to get some feedback.

Pinging @JohannesGaessler and @slaren , since they reviewed the original PR. (@thevishalagarwal  for visibility as well) 