### PR TITLE
Support start strings, the opposite of stop tokens.

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2850,10 +2850,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MAIN}).set_env("LLAMA_ARG_THINK"));
     add_opt(common_arg(
         {"--start-string"}, "STRING",
-        "Start outputting tokens only when the start string has been reached",
+        "Start outputting tokens only when at least one start string has been reached. Can be set multiple times.",
         [](common_params & params, const std::string & value) {
-            params.start_strings.resize(1);
-            params.start_strings[0] = value;
+            params.start_strings.push_back(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_START_STRING"));
     add_opt(common_arg(

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2849,6 +2849,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MAIN}).set_env("LLAMA_ARG_THINK"));
     add_opt(common_arg(
+        {"--start-string"}, "STRING",
+        "Start outputting tokens only when the start string has been reached",
+        [](common_params & params, const std::string & value) {
+            params.start_strings.resize(1);
+            params.start_strings[0] = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_START_STRING"));
+    add_opt(common_arg(
         {"--chat-template"}, "JINJA_TEMPLATE",
         string_format(
             "set custom jinja chat template (default: template taken from model's metadata)\n"

--- a/common/common.h
+++ b/common/common.h
@@ -366,6 +366,7 @@ struct common_params {
     bool use_jinja = false;                                                                                 // NOLINT
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
+    std::vector<std::string> start_strings;
 
     std::vector<std::string> api_keys;
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -160,6 +160,7 @@ The project is under active development, and we are [looking for feedback and co
 | `--props` | enable changing global properties via POST /props (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_PROPS) |
 | `--no-slots` | disables slots monitoring endpoint<br/>(env: LLAMA_ARG_NO_ENDPOINT_SLOTS) |
 | `--slot-save-path PATH` | path to save slot kv cache (default: disabled) |
+| `--start-string STRING` | The response is not sent to client until one start string is reached. Can be set multiple times |
 | `--chat-template JINJA_TEMPLATE` | set custom jinja chat template (default: template taken from model's metadata)<br/>if suffix/prefix are specified, template will be disabled<br/>list of built-in templates:<br/>chatglm3, chatglm4, chatml, command-r, deepseek, deepseek2, exaone3, gemma, granite, llama2, llama2-sys, llama2-sys-bos, llama2-sys-strip, llama3, minicpm, mistral-v1, mistral-v3, mistral-v3-tekken, mistral-v7, monarch, openchat, orion, phi3, rwkv-world, vicuna, vicuna-orca, zephyr<br/>(env: LLAMA_ARG_CHAT_TEMPLATE) |
 | `-sps, --slot-prompt-similarity SIMILARITY` | how much the prompt of a request must match the prompt of a slot in order to use that slot (default: 0.50, 0.0 = disabled)<br/> |
 | `--lora-init-without-apply` | load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: disabled) |

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -391,6 +391,9 @@ By default, this value is set to `0`, meaning no tokens are kept. Use `-1` to re
 
 `stream`: Allows receiving each predicted token in real-time instead of waiting for the completion to finish (uses a different response format). To enable this, set to `true`.
 
+`start_strings`: Specify a JSON array of starting strings.
+The output of the model is discarded until the first start string is reached, the matching string is not included in the completion. Default: `[]`
+
 `stop`: Specify a JSON array of stopping strings.
 These words will not be included in the completion, so make sure to add them to the prompt for the next iteration. Default: `[]`
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -248,7 +248,7 @@ struct server_task {
       //params.t_max_prompt_ms  = json_value(data, "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement
         params.t_max_predict_ms = json_value(data, "t_max_predict_ms",   defaults.t_max_predict_ms);
         params.response_fields  = json_value(data, "response_fields",   std::vector<std::string>());
-        
+
         params.sampling.top_k              = json_value(data, "top_k",              defaults.sampling.top_k);
         params.sampling.top_p              = json_value(data, "top_p",              defaults.sampling.top_p);
         params.sampling.min_p              = json_value(data, "min_p",              defaults.sampling.min_p);
@@ -288,7 +288,7 @@ struct server_task {
         for (auto start_string: params.start_strings) {
             params.start_string_max_len = std::max(params.start_string_max_len, start_string.size());
         }
-        
+
 
         // Use OpenAI API logprobs only if n_probs wasn't provided
         if (data.contains("logprobs") && params.sampling.n_probs == defaults.sampling.n_probs){

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2201,13 +2201,14 @@ struct server_context {
         // check if there is incomplete UTF-8 character at the end
         bool incomplete = validate_utf8(slot.generated_text) < slot.generated_text.size();
 
-        // search stop word and delete it
+
         if (!incomplete) {
             size_t pos = std::min(slot.n_sent_text, slot.generated_text.size());
 
             const std::string str_test = slot.generated_text.substr(pos);
             bool send_text = true;
 
+            // Handle the start strings
             if (!slot.start_string_found && slot.has_next_token && !slot.params.start_strings.empty()) {
                 size_t max_start_string_size = slot.params.start_string_max_len;
                 size_t search_len = max_start_string_size + token_str.size();
@@ -2231,6 +2232,7 @@ struct server_context {
                 }
             }
 
+            // search stop word and delete it
             size_t stop_pos = slot.find_stopping_strings(str_test, token_str.size(), true);
             if (stop_pos != std::string::npos) {
                 slot.generated_text.erase(

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2199,7 +2199,7 @@ struct server_context {
 
             if(slot.n_sent_text == 0 && slot.has_next_token && !slot.params.start_strings.empty())
             {
-                size_t max_start_string_size = 0;           
+                size_t max_start_string_size = 0;
                 for(auto start_string: slot.params.start_strings)
                 {
                     max_start_string_size = std::max(max_start_string_size, start_string.size());
@@ -2218,12 +2218,12 @@ struct server_context {
                 {
                     found_pos = slot.generated_text.find(start_string,search_pos);
                     if(found_pos != slot.generated_text.npos) {
-                        found = true; 
+                        found = true;
                         found_string = start_string;
                         break;
                     }
                 }
-                
+
                 if(found && slot.generated_text.size() > (found_pos + found_string.size()) ) {
                     slot.generated_text.erase(
                         slot.generated_text.begin(),

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2217,11 +2217,11 @@ struct server_context {
                 search_pos = slot.generated_text.size() - search_len;
             }
 
-            std::pair<size_t, int> search_result = find_first_substring(slot.generated_text,slot.params.start_strings, search_pos);
+            std::pair<size_t, std::string> search_result = find_first_substring(slot.generated_text,slot.params.start_strings, search_pos);
             bool start_string_found = search_result.first != std::string::npos;
             if (start_string_found) {
                 auto found_pos = search_result.first;
-                std::string found_string = slot.params.start_strings[search_result.second];
+                std::string found_string = search_result.second;
                 slot.generated_text.erase(
                     slot.generated_text.begin(),
                     slot.generated_text.begin() + found_pos + found_string.size());

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2197,30 +2197,30 @@ struct server_context {
             const std::string str_test = slot.generated_text.substr(pos);
             bool send_text = true;
 
-            if(slot.n_sent_text == 0 && slot.has_next_token && !slot.params.start_strings.empty()) {
+            if (slot.n_sent_text == 0 && slot.has_next_token && !slot.params.start_strings.empty()) {
                 size_t max_start_string_size = 0;
-                for(auto start_string: slot.params.start_strings) {
+                for (auto start_string: slot.params.start_strings) {
                     max_start_string_size = std::max(max_start_string_size, start_string.size());
                 }
                 size_t search_len = max_start_string_size + token_str.size();
                 size_t search_pos = 0;
-                if(slot.generated_text.size() > search_len) {
+                if (slot.generated_text.size() > search_len) {
                     search_pos = slot.generated_text.size() - search_len;
                 }
 
                 auto found_pos = slot.generated_text.npos;
                 bool found = false;
                 std::string found_string;
-                for(auto start_string: slot.params.start_strings) {
+                for (auto start_string: slot.params.start_strings) {
                     found_pos = slot.generated_text.find(start_string,search_pos);
-                    if(found_pos != slot.generated_text.npos) {
+                    if (found_pos != slot.generated_text.npos) {
                         found = true;
                         found_string = start_string;
                         break;
                     }
                 }
 
-                if(found && slot.generated_text.size() > (found_pos + found_string.size()) ) {
+                if (found && slot.generated_text.size() > (found_pos + found_string.size()) ) {
                     slot.generated_text.erase(
                         slot.generated_text.begin(),
                         slot.generated_text.begin() + found_pos + found_string.size());

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2196,7 +2196,6 @@ struct server_context {
         if (slot.params.return_tokens) {
             slot.generated_tokens.push_back(result.tok);
         }
-        
 
         // SECTION: compute conditions on generated tokens so far
 
@@ -2250,6 +2249,7 @@ struct server_context {
             }
         }
 
+        // @ngxson all the other stop reasons should be in this function
         if(full_stop_reached)
         {
             slot.stop           = STOP_TYPE_WORD;
@@ -2257,6 +2257,7 @@ struct server_context {
             SLT_DBG(slot, "stopped by word, n_decoded = %d, n_predict = %d\n", slot.n_decoded, slot.params.n_predict);
         }
 
+        // hold the output if we are not ready
         if(partial_stop_reached || start_string_missing)
         {
             result.text_to_send = "";
@@ -2269,8 +2270,10 @@ struct server_context {
             slot.n_sent_text += result.text_to_send.size();
         }
 
+        // @ngxson: add the token and its probabilities even if not valid utf8 data
         slot.add_token(result);
 
+        // @ngxson: we also avoid outputting the final token if it's entirely a stop word
         if (slot.params.stream && !result.text_to_send.empty()) {
             send_partial_response(slot, result);
         }

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2216,19 +2216,12 @@ struct server_context {
                     search_pos = slot.generated_text.size() - search_len;
                 }
 
-                auto found_pos = slot.generated_text.npos;
-                bool found = false;
-                std::string found_string;
-                for (auto start_string: slot.params.start_strings) {
-                    found_pos = slot.generated_text.find(start_string,search_pos);
-                    if (found_pos != slot.generated_text.npos) {
-                        found = true;
-                        found_string = start_string;
-                        break;
-                    }
-                }
+                std::pair<size_t, int> search_result = find_first_substring(slot.generated_text,slot.params.start_strings, search_pos);
+                bool found = search_result.first != std::string::npos;
 
-                if (found && slot.generated_text.size() > (found_pos + found_string.size()) ) {
+                if (found) {
+                    auto found_pos = search_result.first;
+                    std::string found_string = slot.params.start_strings[search_result.second];
                     slot.generated_text.erase(
                         slot.generated_text.begin(),
                         slot.generated_text.begin() + found_pos + found_string.size());

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2197,25 +2197,21 @@ struct server_context {
             const std::string str_test = slot.generated_text.substr(pos);
             bool send_text = true;
 
-            if(slot.n_sent_text == 0 && slot.has_next_token && !slot.params.start_strings.empty())
-            {
+            if(slot.n_sent_text == 0 && slot.has_next_token && !slot.params.start_strings.empty()) {
                 size_t max_start_string_size = 0;
-                for(auto start_string: slot.params.start_strings)
-                {
+                for(auto start_string: slot.params.start_strings) {
                     max_start_string_size = std::max(max_start_string_size, start_string.size());
                 }
                 size_t search_len = max_start_string_size + token_str.size();
                 size_t search_pos = 0;
-                if(slot.generated_text.size() > search_len)
-                {
+                if(slot.generated_text.size() > search_len) {
                     search_pos = slot.generated_text.size() - search_len;
                 }
 
                 auto found_pos = slot.generated_text.npos;
                 bool found = false;
                 std::string found_string;
-                for(auto start_string: slot.params.start_strings)
-                {
+                for(auto start_string: slot.params.start_strings) {
                     found_pos = slot.generated_text.find(start_string,search_pos);
                     if(found_pos != slot.generated_text.npos) {
                         found = true;

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -88,6 +88,7 @@ class ServerProcess:
     chat_template: str | None = None
     chat_template_file: str | None = None
     server_path: str | None = None
+    start_string: str | None = None
 
     # session variables
     process: subprocess.Popen | None = None
@@ -194,6 +195,8 @@ class ServerProcess:
             server_args.extend(["--chat-template", self.chat_template])
         if self.chat_template_file:
             server_args.extend(["--chat-template-file", self.chat_template_file])
+        if self.start_string:
+            server_args.extend(["--start_string", self.start_string])
 
         args = [str(arg) for arg in [server_path, *server_args]]
         print(f"tests: starting server with: {' '.join(args)}")

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -498,10 +498,10 @@ static std::pair<size_t, int> find_first_substring(const std::string &haystack, 
 
     for (unsigned int i = 0; i < needles.size(); ++i) {
         const std::string & start_string = needles[i];
-        found_pos = haystack.find(start_string,search_pos);
-        if (found_pos != std::string::npos) {
+        auto needle_pos = haystack.find(start_string,search_pos);
+        if (needle_pos != std::string::npos && (found_pos == std::string::npos || needle_pos < found_pos) ) {
+            found_pos = needle_pos;
             found_idx = i;
-            break;
         }
     }
 

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -491,21 +491,21 @@ static size_t find_partial_stop_string(const std::string &stop, const std::strin
 
 /* returns a pair containing the position and index of first element found.
    returns npos and -1 if not found */
-static std::pair<size_t, int> find_first_substring(const std::string &haystack, const std::vector<std::string> & needles, size_t search_pos = 0)
+static std::pair<size_t, std::string> find_first_substring(const std::string &haystack, const std::vector<std::string> & needles, size_t search_pos = 0)
 {
     size_t found_pos  = std::string::npos;
-    int    found_idx = -1;
+    std::string    found_str = "";
 
     for (unsigned int i = 0; i < needles.size(); ++i) {
         const std::string & start_string = needles[i];
         auto needle_pos = haystack.find(start_string,search_pos);
         if (needle_pos != std::string::npos && (found_pos == std::string::npos || needle_pos < found_pos) ) {
             found_pos = needle_pos;
-            found_idx = i;
+            found_str = start_string;
         }
     }
 
-    return std::pair<size_t, int>(found_pos,found_idx);
+    return std::pair<size_t, std::string>(found_pos,found_str);
 }
 
 // TODO: reuse llama_detokenize

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -489,6 +489,25 @@ static size_t find_partial_stop_string(const std::string &stop, const std::strin
     return std::string::npos;
 }
 
+/* returns a pair containing the position and index of first element found.
+   returns npos and -1 if not found */
+static std::pair<size_t, int> find_first_substring(const std::string &haystack, const std::vector<std::string> & needles, size_t search_pos = 0)
+{
+    size_t found_pos  = std::string::npos;
+    int    found_idx = -1;
+
+    for (unsigned int i = 0; i < needles.size(); ++i) {
+        const std::string & start_string = needles[i];
+        found_pos = haystack.find(start_string,search_pos);
+        if (found_pos != std::string::npos) {
+            found_idx = i;
+            break;
+        }
+    }
+
+    return std::pair<size_t, int>(found_pos,found_idx);
+}
+
 // TODO: reuse llama_detokenize
 template <class Iter>
 static std::string tokens_to_str(llama_context * ctx, Iter begin, Iter end) {


### PR DESCRIPTION
This allows setting one or multiple start strings that behave the opposite of stop tokens.
The output is discarded until a start string is reached, then it is sent to client as usual even in streaming mode.
If no start string is found, the entire generated text is sent to client at the end of generation.

Use case:
- Support for broken clients that don't behave well with reasoning models (github copilot) while still allowing the model to perform its reasoning. Example: set start string to `"</think>`

From command line: `llama-server --start-string "</think>" --start-string "</thinking>"`

From client:
```
curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen3-8B",
  "messages": [
    {"role": "user", "content": "Hi"}
  ],
  "start_strings": ["</think>","</thinking>"]
}'
```