### PR TITLE
gguf-py: correct MODEL_ARCH_NAMES qwen3moe to qwen3_moe

### DIFF
--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -532,7 +532,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.QWEN2MOE:         "qwen2moe",
     MODEL_ARCH.QWEN2VL:          "qwen2vl",
     MODEL_ARCH.QWEN3:            "qwen3",
-    MODEL_ARCH.QWEN3MOE:         "qwen3moe",
+    MODEL_ARCH.QWEN3MOE:         "qwen3_moe",
     MODEL_ARCH.PHI2:             "phi2",
     MODEL_ARCH.PHI3:             "phi3",
     MODEL_ARCH.PHIMOE:           "phimoe",


### PR DESCRIPTION
This incorrect constant causes arch mapping of ggufs to fail in vllm.

See qwen3's moe model config.json:


https://huggingface.co/Qwen/Qwen3-30B-A3B/blob/main/config.json#L18