### PR TITLE
fix typo: `n_ctx_pre_seq` -> `n_ctx_per_seq`

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -114,7 +114,7 @@ llama_context::llama_context(
     }
 
     if (n_ctx_per_seq > hparams.n_ctx_train) {
-        LLAMA_LOG_WARN("%s: n_ctx_pre_seq (%u) > n_ctx_train (%u) -- possible training context overflow\n",
+        LLAMA_LOG_WARN("%s: n_ctx_per_seq (%u) > n_ctx_train (%u) -- possible training context overflow\n",
                 __func__, n_ctx_per_seq, hparams.n_ctx_train);
     }
 


### PR DESCRIPTION
Fixed a typo in src/llama-context.cpp:117: `n_ctx_pre_seq` --> `n_ctx_per_seq`