### PR TITLE
Re-enable upscaling of images smaller than the CLIP input size; fix MiniCPM evaluation on small bitmaps

### DIFF
--- a/examples/llava/clip.cpp
+++ b/examples/llava/clip.cpp
@@ -2561,7 +2561,7 @@ struct llava_uhd {
 
         // no pinpoints, dynamically calculate the grid size (e.g. minicpmv)
 
-        auto best_size    = get_best_resize(original_size, slice_size, patch_size, has_slices);
+        auto best_size    = get_best_resize(original_size, slice_size, patch_size, !has_slices);
         res.overview_size = best_size;
 
         if (!has_slices) {


### PR DESCRIPTION
Since commit #13011, MiniCPM models have been unable to process small images. This appears to be caused by disabling the upscaling of images smaller than the CLIP input size. This PR reintroduces that upscaling and restores full functionality for these models.

I'm attaching 2 example of small image for reference 
![10](https://github.com/user-attachments/assets/7589224c-9f88-4108-bc3c-da3ae9caf30d)
![cat0](https://github.com/user-attachments/assets/840bb6bb-7ab5-4b71-9fa6-ad195a26584a)


