### PR TITLE
llama-model : support Qwen2 embedding models and pooling_mode_lasttoken

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -454,6 +454,7 @@ class ModelBase:
 
 class TextModel(ModelBase):
     model_type = ModelType.TEXT
+    hf_arch: str
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import sys
-from abc import ABC, abstractmethod
 from enum import IntEnum
 from pathlib import Path
 from hashlib import sha256
@@ -52,7 +51,7 @@ class ModelType(IntEnum):
 AnyModel = TypeVar("AnyModel", bound="type[ModelBase]")
 
 
-class ModelBase(ABC):
+class ModelBase:
     _model_classes: dict[ModelType, dict[str, type[ModelBase]]] = {
         ModelType.TEXT: {},
         ModelType.VISION: {},
@@ -136,11 +135,6 @@ class ModelBase(ABC):
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
                                            split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard)
-
-    @property
-    @abstractmethod
-    def model_type(self):
-        raise NotImplementedError
 
     @classmethod
     def add_prefix_to_filename(cls, path: Path, prefix: str) -> Path:

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -2032,6 +2032,8 @@ class PoolingType(IntEnum):
     NONE = 0
     MEAN = 1
     CLS  = 2
+    LAST = 3
+    RANK = 4
 
 
 class GGMLQuantizationType(IntEnum):

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -773,6 +773,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
             // fall through
         case LLM_ARCH_QWEN2:
             {
+                ml.get_key(LLM_KV_POOLING_TYPE, hparams.pooling_type, false);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
                 switch (hparams.n_layer) {
                     case 24: type = hparams.n_embd == 1024 ? LLM_TYPE_0_5B : LLM_TYPE_1B; break;


### PR DESCRIPTION
These changes are necessary to support nomic-embed-code, a Qwen2-7B-based embedding model for code retrieval.

Without these changes it is still possible to run the GGUFs converted using this PR, but you have to explicitly specify the pooling mode when it is loaded, e.g. `--pooling last` for llama-server.

See the model card and GGUFs here: https://huggingface.co/nomic-ai/nomic-embed-code-GGUF