### PR TITLE
CUDA: fix race condition in MMQ stream-k fixup

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2958,6 +2958,7 @@ static __global__ void mul_mat_q_stream_k_fixup(
     for (int j = threadIdx.y*WARP_SIZE + threadIdx.x; j < mmq_x; j += nwarps*WARP_SIZE) {
         ids_dst_shared[j] = ids_dst[col_low + j];
     }
+    __syncthreads();
 
     const int offset_dst = it*mmq_y;
     dst += offset_dst;


### PR DESCRIPTION
Follow-up to https://github.com/ggml-org/llama.cpp/pull/13294 . I forgot that the stream-k fixup would suffer from the same problem.