### PR TITLE
SYCL: Disable mul_mat kernels for noncontiguous tensor b

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3873,6 +3873,9 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
                 if (a->ne[3] != b->ne[3]) {
                     return false;
                 }
+                if (!ggml_is_contiguous(b)) {
+                    return false;
+                }
                 ggml_type a_type = a->type;
                 if (a_type == GGML_TYPE_IQ4_NL  || a_type == GGML_TYPE_IQ4_XS ||
                     a_type == GGML_TYPE_IQ3_XXS || a_type == GGML_TYPE_IQ3_S  ||


### PR DESCRIPTION
Tests for non contiguous tensor b was added in b0ecbd434be024c06bf547491be444ed92e1123e which the kernels doesn't seem to support.

Disable it for now until we work on a fix.