### PR TITLE
convert : bailingmoe : set yarn metadata if present

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5680,7 +5680,12 @@ class BailingMoeModel(TextModel):
         rope_dim = hparams.get("head_dim") or hparams["hidden_size"] // hparams["num_attention_heads"]
 
         self.gguf_writer.add_rope_dimension_count(rope_dim)
-        self.gguf_writer.add_rope_scaling_type(gguf.RopeScalingType.NONE)
+        if (self.hparams.get("rope_scaling") or {}).get("type") == "yarn" and "factor" in self.hparams["rope_scaling"]:
+            self.gguf_writer.add_rope_scaling_type(gguf.RopeScalingType.YARN)
+            self.gguf_writer.add_rope_scaling_factor(self.hparams["rope_scaling"]["factor"])
+            self.gguf_writer.add_rope_scaling_orig_ctx_len(self.hparams["rope_scaling"]["original_max_position_embeddings"])
+        else:
+            self.gguf_writer.add_rope_scaling_type(gguf.RopeScalingType.NONE)
         self.gguf_writer.add_leading_dense_block_count(hparams["first_k_dense_replace"])
         self.gguf_writer.add_vocab_size(hparams["vocab_size"])
         self.gguf_writer.add_expert_feed_forward_length(hparams["moe_intermediate_size"])


### PR DESCRIPTION
Set YaRN metadata if present since support was [finally added](https://huggingface.co/inclusionAI/Ling-plus/commit/21743af28b9522aacb4d86db90fc8399c8a6678d) and it looks to be bog standard. Tested with Ling-Coder-lite (manually configured).

NOTE: For some reason they have not updated the config on any of their models, so you have to add/enable this yourself, can be done in one of the following ways:
- On the commandline (no changes to old GGUFs necessary):
  ```bash
  ./llama-cli -m Ling-Coder-lite.gguf -c 16384 --rope-scaling yarn --rope-scale 4
  ```
- Change `max_position_embeddings` (multiply by 4) and `rope_scaling` in config.json and reconvert:
  ```json
  {
      "factor": 4.0,
      "original_max_position_embeddings": 4096,
      "type": "yarn"
  }
  ```
- Add/change metadata to old GGUF with `gguf_editor_gui.py`
- Download [dynamically modified GGUF](https://ciscai-gguf-editor.hf.space/download/mradermacher/Ling-Coder-lite-GGUF/Ling-Coder-lite.Q8_0.gguf?add=["bailingmoe.context_length",4,16384]&add=["bailingmoe.rope.scaling.type",8,"yarn"]&add=["bailingmoe.rope.scaling.factor",6,4]&add=["bailingmoe.rope.scaling.original_context_length",4,4096]) using [gguf-editor](https://huggingface.co/spaces/CISCai/gguf-editor)