### PR TITLE
llama : fix build_ffn without gate

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -782,7 +782,7 @@ ggml_tensor * llm_graph_context::build_ffn(
             } break;
     }
 
-    if (type_gate == LLM_FFN_PAR) {
+    if (gate && type_gate == LLM_FFN_PAR) {
         cur = ggml_mul(ctx0, cur, tmp);
         cb(cur, "ffn_gate_par", il);
     }

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -29,7 +29,6 @@
 #include <limits>
 #include <array>
 #include <numeric>
-#include <functional>
 
 struct clip_logger_state g_logger_state = {GGML_LOG_LEVEL_CONT, clip_log_callback_default, NULL};
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 #include <array>
 #include <numeric>
+#include <functional>
 
 struct clip_logger_state g_logger_state = {GGML_LOG_LEVEL_CONT, clip_log_callback_default, NULL};
 


### PR DESCRIPTION
While porting these `build_*` function to `clip.cpp`, I came across the case of FFN **not** having gate (which is quite common in vision transformers)

The current logic in `llm_graph_context::build_ffn` kinda assumes that gate always exist (which make sense, since most - if not all - modern LLM have up/gate/down FFN). If the gate is missing, this causes the logic to calculate `cur = up_state * up_state` which results in an incorrect result.

I'm not sure if the code is intended to be written this way, but I think we should either:
- add `gate` to the check as proposed in this PR
- or, `GGML_ASSERT(gate)` to make sure the gate is always there

Please note that when porting to ViT, I only copy the case of `LLM_FFN_PAR` and not `LLM_FFN_SEQ`