### PR TITLE
python : bump transformers version

### DIFF
--- a/requirements/requirements-convert_legacy_llama.txt
+++ b/requirements/requirements-convert_legacy_llama.txt
@@ -1,5 +1,5 @@
 numpy~=1.26.4
 sentencepiece~=0.2.0
-transformers>=4.45.1,<5.0.0
+transformers>=4.45.3,<5.0.0
 gguf>=0.1.0
 protobuf>=4.21.0,<5.0.0


### PR DESCRIPTION
As reported by @bartowski1182 ; can you check if this works on docker now?

Old package make it fails when converting qwen2.5 VL
