### PR TITLE
llama : print size and type of overridden tensors

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1651,8 +1651,11 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                 for (const auto * overrides = ml.tensor_buft_overrides; overrides->pattern != nullptr; ++overrides) {
                     std::regex pattern(overrides->pattern);
                     if (std::regex_search(tensor_name, pattern)) {
-                        LLAMA_LOG_DEBUG("tensor %s buffer type overriden to %s\n", tensor_name.c_str(), ggml_backend_buft_name(overrides->buft));
                         buft = overrides->buft;
+                        LLAMA_LOG_DEBUG("tensor %s (%zu MiB %s) buffer type overridden to %s\n",
+                                tensor_name.c_str(),
+                                ggml_nbytes(t_meta) / 1024 / 1024, ggml_type_name(t_meta->type),
+                                ggml_backend_buft_name(buft));
                         break;
                     }
                 }


### PR DESCRIPTION
Small QoL improvement. Example output:
```
tensor blk.10.exp_probs_b.bias (0 MiB f32) buffer type overridden to CPU
tensor blk.10.ffn_gate_exps.weight (700 MiB iq1_s) buffer type overridden to CPU
tensor blk.10.ffn_down_exps.weight (700 MiB iq1_s) buffer type overridden to CPU
tensor blk.10.ffn_up_exps.weight (700 MiB iq1_s) buffer type overridden to CPU
tensor blk.10.ffn_gate_shexp.weight (9 MiB q5_K) buffer type overridden to CPU
tensor blk.10.ffn_down_shexp.weight (11 MiB q6_K) buffer type overridden to CPU
tensor blk.10.ffn_up_shexp.weight (9 MiB q5_K) buffer type overridden to CPU
```