### PR TITLE
mtmd: Expose helper_decode_image_chunk

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -585,21 +585,20 @@ int32_t mtmd_helper_decode_image_chunk(
         mtmd_context * ctx,
         struct llama_context * lctx,
         const mtmd_input_chunk * chunk,
-        float * embd,
+        float * encoded_embd,
         llama_pos n_past,
         llama_seq_id seq_id,
         int32_t n_batch,
         llama_pos * new_n_past) {
-
-    if (chunk->type != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+    if (mtmd_input_chunk_get_type(chunk) != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
         LOG_ERR("failed to decode image chunk: input chunk not of image type\n");
         return -1;
     }
-    if (!chunk->tokens_image) {
+    const auto image_tokens = mtmd_input_chunk_get_tokens_image(chunk);
+    if (!image_tokens) {
         LOG_ERR("failed to decode image chunk: image tokens are null\n");
         return -1;
     }
-    const auto image_tokens = chunk->tokens_image.get();
 
     int n_mmproj_embd = clip_n_mmproj_embd(ctx->ctx_clip);
     int n_pos_per_embd = mtmd_decode_use_mrope(ctx) ? 4 : 1;
@@ -607,7 +606,7 @@ int32_t mtmd_helper_decode_image_chunk(
     int32_t n_tokens = mtmd_image_tokens_get_n_tokens(image_tokens);
     int32_t i_batch = 0;
     int32_t n_img_batches = GGML_PAD(n_tokens, n_batch) / n_batch;
-    decode_embd_batch batch_embd(embd, n_tokens, n_pos_per_embd, n_mmproj_embd);
+    decode_embd_batch batch_embd(encoded_embd, n_tokens, n_pos_per_embd, n_mmproj_embd);
 
     const int nx = mtmd_image_tokens_get_nx(image_tokens);
     const int ny = mtmd_image_tokens_get_ny(image_tokens);

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -143,14 +143,12 @@ MTMD_API void               mtmd_input_chunk_free(mtmd_input_chunk * chunk);
 //
 // the instance will be constructed via mtmd_tokenize()
 // it will be freed along with mtmd_input_chunk
-MTMD_API size_t              mtmd_image_tokens_get_n_tokens (const mtmd_image_tokens * image_tokens);
-MTMD_API size_t              mtmd_image_tokens_get_nx       (const mtmd_image_tokens * image_tokens);
-MTMD_API size_t              mtmd_image_tokens_get_ny       (const mtmd_image_tokens * image_tokens);
-MTMD_API const char *        mtmd_image_tokens_get_id       (const mtmd_image_tokens * image_tokens);
+MTMD_API size_t       mtmd_image_tokens_get_n_tokens(const mtmd_image_tokens * image_tokens);
+MTMD_API size_t       mtmd_image_tokens_get_nx      (const mtmd_image_tokens * image_tokens);
+MTMD_API size_t       mtmd_image_tokens_get_ny      (const mtmd_image_tokens * image_tokens);
+MTMD_API const char * mtmd_image_tokens_get_id      (const mtmd_image_tokens * image_tokens);
 // number of temporal positions (always 1 for M-RoPE, n_tokens otherwise)
-MTMD_API llama_pos           mtmd_image_tokens_get_n_pos    (const mtmd_image_tokens * image_tokens);
-MTMD_API mtmd_image_tokens * mtmd_image_tokens_copy         (const mtmd_image_tokens * image_tokens);
-MTMD_API void                mtmd_image_tokens_free         (mtmd_image_tokens * image_tokens);
+MTMD_API llama_pos    mtmd_image_tokens_get_n_pos   (const mtmd_image_tokens * image_tokens);
 
 // tokenize an input text prompt and an image
 // the prompt must have the input image marker (default: "<__image__>") in it
@@ -179,9 +177,6 @@ MTMD_API int32_t mtmd_encode(mtmd_context * ctx,
 
 // get output embeddings from the last encode pass
 MTMD_API float * mtmd_get_output_embd(mtmd_context * ctx);
-
-// returns a copy of output embeddings from the last encode pass, of size n_embd_out
-MTMD_API float * mtmd_get_output_embd_copy(mtmd_context * ctx, size_t * n_embd_out);
 
 /////////////////////////////////////////
 
@@ -237,14 +232,15 @@ MTMD_API int32_t mtmd_helper_eval_chunk_single(mtmd_context * ctx,
                                                llama_pos * new_n_past);
 
 // helper function to decode an image whose embeddings have already been calculated
-MTMD_API int32_t mtmd_helper_decode_image(mtmd_context *ctx,
-                                          struct llama_context *lctx,
-                                          const mtmd_image_tokens *image_tokens,
-                                          float *embd,
-                                          llama_pos n_past,
-                                          llama_seq_id seq_id,
-                                          int32_t n_batch,
-                                          llama_pos *new_n_past);
+// ret 0 on success, -1 on chunk not being a valid image chunk, 1 on decode failure
+MTMD_API int32_t mtmd_helper_decode_image_chunk(mtmd_context *ctx,
+                                                struct llama_context *lctx,
+                                                const mtmd_input_chunk * chunk,
+                                                float *embd,
+                                                llama_pos n_past,
+                                                llama_seq_id seq_id,
+                                                int32_t n_batch,
+                                                llama_pos *new_n_past);
 
 /////////////////////////////////////////
 
@@ -282,11 +278,6 @@ struct mtmd_input_chunk_deleter {
     void operator()(mtmd_input_chunk * val) { mtmd_input_chunk_free(val); }
 };
 using input_chunk_ptr = std::unique_ptr<mtmd_input_chunk, mtmd_input_chunk_deleter>;
-
-struct mtmd_image_tokens_deleter {
-    void operator()(mtmd_image_tokens * val) { mtmd_image_tokens_free(val); }
-};
-using image_tokens_ptr = std::unique_ptr<mtmd_image_tokens, mtmd_image_tokens_deleter>;
 
 struct bitmap {
     bitmap_ptr ptr;

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -232,15 +232,16 @@ MTMD_API int32_t mtmd_helper_eval_chunk_single(mtmd_context * ctx,
                                                llama_pos * new_n_past);
 
 // helper function to decode an image whose embeddings have already been calculated
+// this helper will handle batching and pre/post decoding setup (for ex. gemma 3 requires non-causal attention)
 // ret 0 on success, -1 on chunk not being a valid image chunk, 1 on decode failure
-MTMD_API int32_t mtmd_helper_decode_image_chunk(mtmd_context *ctx,
-                                                struct llama_context *lctx,
+MTMD_API int32_t mtmd_helper_decode_image_chunk(mtmd_context * ctx,
+                                                struct llama_context * lctx,
                                                 const mtmd_input_chunk * chunk,
-                                                float *embd,
+                                                float * encoded_embd,
                                                 llama_pos n_past,
                                                 llama_seq_id seq_id,
                                                 int32_t n_batch,
-                                                llama_pos *new_n_past);
+                                                llama_pos * new_n_past);
 
 /////////////////////////////////////////
 


### PR DESCRIPTION
## New API
### Decoding-only helper
- `mtmd_helper_decode_image_chunk`: Split out from `mtmd_helper_eval_chunk_single`. Same logic as before, but use as a standalone function enables clients to use `mtmd_encode` at some prior time, cache these embeddings, and then send them in later to `mtmd_helper_decode_image_chunk` to decode the embeddings without having to re-encode the image (expensive)


---
Edit: removed below APIs that were in original PR
### Output embedding copy
- `mtmd_get_output_embd_copy`: Allows client to embed with `mtmd_encode`, then get a copy of the embd to hold onto past the lifetime of the embeddings within the `mtmd_context`. Useful for caching these embedings, and sending into `mtmd_helper_decode_image` later
### `mtmd_image_tokens` management functions
- `mtmd_image_tokens_copy`: Allows clients to get a copy of `mtmd_image_tokens` from `mtmd_input_chunk`, for later use to send alongside pre-computed embeddings to `mtmd_helper_decode_image`.
- `mtmd_image_tokens_free`: For use to free an `mtmd_image_tokens *`, as can be recieved from `mtmd_image_tokens_copy`
- `image_tokens_ptr`(made public, existed privately in `mtmd.cpp` before): Enables auto memory management of `mtmd_image_tokens *`

@ngxson I'm thinking that maybe there's a way to avoid the need to expose new API for `mtmd_image_tokens`, since I feel like the statement "for later use to send alongside pre-computed embeddings" about `mtmd_image_tokens_copy` could potential be weak and the API of `mtmd_helper_decode_image` could be reworked not need this object in full? But it also seemed like the simplest conversion to enable decoupled embedding + decoding