### PR TITLE
llama-run: add support for downloading models from ModelScope

### DIFF
--- a/tools/run/README.md
+++ b/tools/run/README.md
@@ -42,6 +42,8 @@ Examples:
   llama-run ollama://smollm:135m
   llama-run hf://QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q2_K.gguf
   llama-run huggingface://bartowski/SmolLM-1.7B-Instruct-v0.2-GGUF/SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf
+  llama-run ms://QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q2_K.gguf
+  llama-run modelscope://bartowski/SmolLM-1.7B-Instruct-v0.2-GGUF/SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf
   llama-run https://example.com/some-file1.gguf
   llama-run some-file2.gguf
   llama-run file://some-file3.gguf


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

To better support users in mainland China, this PR adds support for using ModelScope as a model endpoint in `llama-run`.

### Testing Done

```bash
❯ ./build/bin/llama-run modelscope://bartowski/SmolLM-1.7B-Instruct-v0.2-GGUF/SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf
 58% |█████████████████████████████████████████████████████████████                                             |  448.59 MB/ 772.71 MB   2.79 MB/s    4m 31s
❯ ./build/bin/llama-run ms://QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q2_K.gguf
 10% |██████████                                                                                                |    8.51 MB/  84.12 MB   4.79 MB/s       15s
```