### PR TITLE
arg : add model catalog

### DIFF
--- a/common/catalog.h
+++ b/common/catalog.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <initializer_list>
+
+#include "common.h"
+
+struct common_catalog_entry {
+    const char * name;
+    const char * description;
+    std::initializer_list<enum llama_example> examples = {LLAMA_EXAMPLE_COMMON};
+    void (*handler)(common_params & params);
+};
+
+// This is a list of models that are available in the catalog
+// The rule for naming is: [<capability>]-<model_name>
+// The <capability> is optional, for example: "fim" or "embd"
+// The <model_name> is the name of the model, for example: "qwen-7b"
+
+// For contributors:
+// - Model MUST be hosted on hf.co/ggml-org
+// - If you want to add your model to the catalog, please open an issue, we will consider copying it to ggml-org
+// - For better user experience, we don't add models that are:
+//     - NSFW or not having NSFW safeguard
+//     - Not having an open-source license
+//     - Too old (more than 1 year old)
+//     - Having too many issues or poor quality (for ex. no chat templates, sensitive to system prompts)
+//     - Or, having too little usage (less than 1000 downloads monthly)
+
+const std::initializer_list<common_catalog_entry> model_catalog = {
+    {
+        "tts-oute",
+        "OuteTTS model",
+        {LLAMA_EXAMPLE_TTS},
+        [](common_params & params) {
+            params.model.hf_repo = "OuteAI/OuteTTS-0.2-500M-GGUF";
+            params.model.hf_file = "OuteTTS-0.2-500M-Q8_0.gguf";
+            params.vocoder.model.hf_repo = "ggml-org/WavTokenizer";
+            params.vocoder.model.hf_file = "WavTokenizer-Large-75-F16.gguf";
+        }
+    },
+    {
+        "embd-bge-small-en",
+        "bge-small-en-v1.5 text embedding model",
+        {LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/bge-small-en-v1.5-Q8_0-GGUF";
+            params.model.hf_file = "bge-small-en-v1.5-q8_0.gguf";
+            params.pooling_type = LLAMA_POOLING_TYPE_NONE;
+            params.embd_normalize = 2;
+            params.n_ctx = 512;
+            params.verbose_prompt = true;
+            params.embedding = true;
+        }
+    },
+    {
+        "embd-e5-small-en",
+        "e5-small-v2 text embedding model",
+        {LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/e5-small-v2-Q8_0-GGUF";
+            params.model.hf_file = "e5-small-v2-q8_0.gguf";
+            params.pooling_type = LLAMA_POOLING_TYPE_NONE;
+            params.embd_normalize = 2;
+            params.n_ctx = 512;
+            params.verbose_prompt = true;
+            params.embedding = true;
+        }
+    },
+    {
+        "embd-gte-small",
+        "gte-small text embedding model",
+        {LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/gte-small-Q8_0-GGUF";
+            params.model.hf_file = "gte-small-q8_0.gguf";
+            params.pooling_type = LLAMA_POOLING_TYPE_NONE;
+            params.embd_normalize = 2;
+            params.n_ctx = 512;
+            params.verbose_prompt = true;
+            params.embedding = true;
+        }
+    },
+    {
+        "fim-qwen-1.5b",
+        "Qwen 2.5 Coder 1.5B",
+        {LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF";
+            params.model.hf_file = "qwen2.5-coder-1.5b-q8_0.gguf";
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    },
+    {
+        "fim-qwen-3b",
+        "Qwen 2.5 Coder 3B (support fill-in-the-middle)",
+        {LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-3B-Q8_0-GGUF";
+            params.model.hf_file = "qwen2.5-coder-3b-q8_0.gguf";
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    },
+    {
+        "fim-qwen-7b",
+        "Qwen 2.5 Coder 7B (support fill-in-the-middle)",
+        {LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
+            params.model.hf_file = "qwen2.5-coder-7b-q8_0.gguf";
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    },
+    {
+        "fim-qwen-7b-spec",
+        "use Qwen 2.5 Coder 7B + 0.5B draft for speculative decoding (support fill-in-the-middle)",
+        {LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
+            params.model.hf_file = "qwen2.5-coder-7b-q8_0.gguf";
+            params.speculative.model.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
+            params.speculative.model.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
+            params.speculative.n_gpu_layers = 99;
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    },
+    {
+        "fim-qwen-14b-spec",
+        "use Qwen 2.5 Coder 14B + 0.5B draft for speculative decoding (support fill-in-the-middle)",
+        {LLAMA_EXAMPLE_SERVER},
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-14B-Q8_0-GGUF";
+            params.model.hf_file = "qwen2.5-coder-14b-q8_0.gguf";
+            params.speculative.model.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
+            params.speculative.model.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
+            params.speculative.n_gpu_layers = 99;
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    },
+};

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1029,19 +1029,6 @@ struct common_init_result common_init_from_params(common_params & params) {
     return iparams;
 }
 
-std::string get_model_endpoint() {
-    const char * model_endpoint_env = getenv("MODEL_ENDPOINT");
-    // We still respect the use of environment-variable "HF_ENDPOINT" for backward-compatibility.
-    const char * hf_endpoint_env = getenv("HF_ENDPOINT");
-    const char * endpoint_env = model_endpoint_env ? model_endpoint_env : hf_endpoint_env;
-    std::string model_endpoint = "https://huggingface.co/";
-    if (endpoint_env) {
-        model_endpoint = endpoint_env;
-        if (model_endpoint.back() != '/') model_endpoint += '/';
-    }
-    return model_endpoint;
-}
-
 void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora) {
     llama_clear_adapter_lora(ctx);
     for (auto & la : lora) {

--- a/common/common.h
+++ b/common/common.h
@@ -424,6 +424,25 @@ struct common_params {
 
     // common params
     std::string out_file; // output filename for all example programs
+
+    // set internally by positional argument handler
+    std::string custom_model_endpoint = ""; // custom model endpoint (e.g. for HF mirrors)
+    std::string get_model_endpoint() {
+        if (!custom_model_endpoint.empty()) {
+            return custom_model_endpoint;
+        }
+        // otherwise, we read it from the environment variable
+        const char * model_endpoint_env = getenv("MODEL_ENDPOINT");
+        // We still respect the use of environment-variable "HF_ENDPOINT" for backward-compatibility.
+        const char * hf_endpoint_env = getenv("HF_ENDPOINT");
+        const char * endpoint_env = model_endpoint_env ? model_endpoint_env : hf_endpoint_env;
+        std::string model_endpoint = "https://huggingface.co/";
+        if (endpoint_env) {
+            model_endpoint = endpoint_env;
+            if (model_endpoint.back() != '/') model_endpoint += '/';
+        }
+        return model_endpoint;
+    }
 };
 
 // call once at the start of a program if it uses libcommon
@@ -544,8 +563,6 @@ struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const cpu_p
 
 // clear LoRA adapters from context, then apply new list of adapters
 void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora);
-
-std::string                   get_model_endpoint();
 
 //
 // Batch utils


### PR DESCRIPTION
I'm drafting this PR to illustrate my idea from https://github.com/ggml-org/llama.cpp/issues/10932#issuecomment-2860458658

This is be viewed as an improvement to the existing "preset" system. The main ideas are:
1. Make a dedicated `catalog.h` file with proper guides for contributors
2. Use the catalog model name as positional arg (on top of that, we also support protocols like `hf://`, `hf-mirror://` and `ms://`)

For example:

```sh
llama-server fim-qwen-7b-spec
llama-server hf://ggml-org/gemma-3-4b-it-GGUF
llama-server ./models/local-file.gguf

# override params also work better now (both commands below work)
llama-server fim-qwen-7b-spec --temperature 0
llama-server --temperature 0 fim-qwen-7b-spec
```

WDYT @ggerganov ?