### PR TITLE
grammar: handle misplaced special regex chars [*+?]

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -483,7 +483,8 @@ private:
                     seq.emplace_back("|", false);
                     i++;
                 } else if (c == '*' || c == '+' || c == '?') {
-                    seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
+                    if (!seq.empty())
+                        seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
                     i++;
                 } else if (c == '{') {
                     std::string curly_brackets = std::string(1, c);


### PR DESCRIPTION
Don't try to access the previous element of a regex seq if the vector is empty.  Prevents segment violation failures for regexes like `^?[0-9]$` and `^(?:a|b)$`.

Fixes: #13390