### PR TITLE
vulkan: enable fp16 for gcn 3 and 4 chips

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -203,10 +203,7 @@ enum vk_device_architecture {
 };
 
 static bool is_gcn(vk_device_architecture arch) {
-    if ((arch == AMD_GCN12) || (arch == AMD_GCN34) || (arch == AMD_GCN5))
-        return true;
-    else
-        return false;
+    return (arch == AMD_GCN12) || (arch == AMD_GCN34) || (arch == AMD_GCN5);
 }
 
 static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& device) {
@@ -240,19 +237,24 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
         vk::PhysicalDeviceShaderCorePropertiesAMD shader_core_props_amd;
         vk::PhysicalDeviceShaderIntegerDotProductPropertiesKHR integer_dot_props;
         vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_size_control_props;
-        vk::PhysicalDeviceShaderFloat16Int8FeaturesKHR float16_int8_props;
 
         props2.pNext = &shader_core_props_amd;
         shader_core_props_amd.pNext = &integer_dot_props;
         integer_dot_props.pNext = &subgroup_size_control_props;
-        subgroup_size_control_props.pNext = &float16_int8_props;
 
         device.getProperties2(&props2);
+
+        vk::PhysicalDeviceFeatures2 features2;
+        vk::PhysicalDeviceShaderFloat16Int8FeaturesKHR float16_int8_features;
+
+        features2.pNext = &float16_int8_features;
+
+        device.getFeatures2(&features2);
 
         if (subgroup_size_control_props.maxSubgroupSize == 64 && subgroup_size_control_props.minSubgroupSize == 64) {
             // GCN
             if (shader_core_props_amd.sgprAllocationGranularity == 16) {
-                if (float16_int8_props.shaderFloat16) {
+                if (float16_int8_features.shaderFloat16) {
                     return vk_device_architecture::AMD_GCN5;
                 } else {
                     return vk_device_architecture::AMD_GCN34;


### PR DESCRIPTION
Basically GCN 3 and 4 chips support FP16, but it's unable to process two values at once like GCN 5 can.. Since there's *apparently* no performance benefit `shaderFloat16` is [disabled in the drivers](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4453), but the chip fully supports it and RADV is able to generate those instructions.

While the actual FMAs won't run any faster having FP16 means that I can use four times less shared memory for mul mat and save a little bit of memory bandwidth when reading the B matrix. As a result I get a little improvement in prompt processing on my RX 470.

**PR:**

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |           pp512 |        195.34 ± 0.70 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |           tg128 |         33.48 ± 0.53 |

**Master:**
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |           pp512 |        188.32 ± 0.38 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |           tg128 |         33.62 ± 0.28 |

I'm leaving this as a draft for now as it's a bit hacky and I'm not sure if the proprietary drivers support this. The good thing here though is that it'll let me work on and test the FP16 shaders using my old card.