### PR TITLE
server : PoC implementation of "interim" server

### DIFF
--- a/common/arg.h
+++ b/common/arg.h
@@ -80,6 +80,9 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
 common_params_context common_params_parser_init(common_params & params, llama_example ex, void(*print_usage)(int, char **) = nullptr);
 bool common_has_curl();
 
+// handle model and download
+void common_params_handle_models(enum llama_example cur_ex, common_params & params);
+
 struct common_remote_params {
     std::vector<std::string> headers;
     long timeout = 0; // CURLOPT_TIMEOUT, in seconds ; 0 means no timeout

--- a/common/common.h
+++ b/common/common.h
@@ -23,8 +23,6 @@
     fprintf(stderr, "%s: built with %s for %s\n", __func__, LLAMA_COMPILER, LLAMA_BUILD_TARGET);    \
 } while(0)
 
-#define DEFAULT_MODEL_PATH "models/7B/ggml-model-f16.gguf"
-
 struct common_adapter_lora_info {
     std::string path;
     float scale;


### PR DESCRIPTION
This PR acts as a PoC to illustrate my idea in https://github.com/ggml-org/llama.cpp/issues/13367

The way it works is to spawn an "interim" server that exposes `/load` endpoint.

For example:

```sh
# run server without specifying model
llama-server

# then, load it via API
curl --header "Content-Type: application/json" \
  --request POST \
  --data '{"hf_repo": "ggml-org/gemma-3-4b-it-GGUF"}' \
  http://localhost:8080/load
```

The implementation separates `run_interim_server` and `run_main_server` because the `run_main_server` can be converted to creating a child process, though I'm not sure if this is preferable way to go.

WDYT about this approach @ggerganov @slaren ?