### PR TITLE
llguidance : init tokenizer slices

### DIFF
--- a/common/llguidance.cpp
+++ b/common/llguidance.cpp
@@ -189,6 +189,7 @@ static LlgTokenizer * llama_sampler_llg_new_tokenizer(const llama_vocab * vocab)
         /* .tokenize_fn                        = */ llama_sampler_llg_tokenize_fn,
         /* .use_approximate_greedy_tokenize_fn = */ false,
         /* .tokenize_user_data                 = */ vocab,
+        /* .slices                             = */ nullptr,
     };
 
     char           error_buffer[1024];


### PR DESCRIPTION
Followup to #13413 which broke build due to un-inited `slices`.

Not sure if default or disabled (empty array) is preferable...