### PR TITLE
mtmd : add hard limit on image resolution for qwen2vl / qwen2.5vl

### DIFF
--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -92,6 +92,9 @@
 #define TN_GLM_ADAPTER_GATE     "adapter.linear.gate.%s"
 #define TN_GLM_ADAPTER_D_4H_2_H "adapter.linear.dense_4h_to_h.%s"
 
+// align x to upper multiply of n
+#define CLIP_ALIGN(x, n) ((((x) + (n) - 1) / (n)) * (n))
+
 enum projector_type {
     PROJECTOR_TYPE_MLP,
     PROJECTOR_TYPE_MLP_NORM,

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -92,7 +92,7 @@
 #define TN_GLM_ADAPTER_GATE     "adapter.linear.gate.%s"
 #define TN_GLM_ADAPTER_D_4H_2_H "adapter.linear.dense_4h_to_h.%s"
 
-// align x to upper multiply of n
+// align x to upper multiple of n
 #define CLIP_ALIGN(x, n) ((((x) + (n) - 1) / (n)) * (n))
 
 enum projector_type {


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/13414

Models accepting dynamic resolution (Pixtral / Mistral Small / Qwen VL), we want to:
- Have a max resolution. If image is bigger than the max res, it will be downscaled
- Do a warm up with a more reasonable resolution instead of the max res, otherwise many users will get OOM (tbh I'm not quite sure if this is the best solution, but let's try this and also add a custom `max_image_size` in the future)
- Resize the image to a multiple of `patch_size` (or in the case of Qwen VL, must be `patch_size * 2`)

Btw @ggerganov while working on this, I realized that `GGML_PAD` only works with ~~multiple~~ power of 2, is this expected?
