### PR TITLE
tools : fix invalid free()

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1862,7 +1862,7 @@ struct server_context {
 
     llama_context_params cparams_dft;
 
-    llama_batch batch;
+    llama_batch batch = {};
 
     bool clean_kv_cache = true;
     bool add_bos_token  = true;
@@ -1884,8 +1884,6 @@ struct server_context {
 
     common_chat_templates_ptr chat_templates;
 
-    server_context() : batch({}) {
-    }
     ~server_context() {
         mtmd_free(mctx);
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1884,6 +1884,8 @@ struct server_context {
 
     common_chat_templates_ptr chat_templates;
 
+    server_context() : batch({}) {
+    }
     ~server_context() {
         mtmd_free(mctx);
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1884,8 +1884,7 @@ struct server_context {
 
     common_chat_templates_ptr chat_templates;
 
-    server_context() : batch({}) {
-    }
+    server_context() : batch({}) {}
     ~server_context() {
         mtmd_free(mctx);
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1862,7 +1862,7 @@ struct server_context {
 
     llama_context_params cparams_dft;
 
-    llama_batch batch = {};
+    llama_batch batch {};
 
     bool clean_kv_cache = true;
     bool add_bos_token  = true;


### PR DESCRIPTION
Added a constructor to server_context that initializes server_context::batch, preventing the destructor's call to llama_batch_free() from causing an invalid free().

Ran into this when bind() failed.

<img width="397" alt="llamacpp1" src="https://github.com/user-attachments/assets/036a0353-aadb-40df-9938-175183268c75" />
<img width="421" alt="llamacpp2" src="https://github.com/user-attachments/assets/019e8192-4785-47ca-befe-5636892966ff" />
