### PR TITLE
readme: Fix typo in InternVL model name

### DIFF
--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -69,9 +69,9 @@ NOTE: some models may require large context window, for example: `-c 8192`
 
 # InternVL 2.5 and 3
 (tool_name) -hf ggml-org/InternVL2_5-1B-GGUF
-(tool_name) -hf ggml-org/InternVL2_5-2B-GGUF
+(tool_name) -hf ggml-org/InternVL2_5-4B-GGUF
 (tool_name) -hf ggml-org/InternVL3-1B-Instruct-GGUF
 (tool_name) -hf ggml-org/InternVL3-2B-Instruct-GGUF
-(tool_name) -hf ggml-org/InternVL3-4B-Instruct-GGUF
+(tool_name) -hf ggml-org/InternVL3-8B-Instruct-GGUF
 (tool_name) -hf ggml-org/InternVL3-14B-Instruct-GGUF
 ```


### PR DESCRIPTION
Two InternVL model names were mispelled.

#### Old (don't exist)

* https://huggingface.co/ggml-org/InternVL2_5-2B-GGUF
* https://huggingface.co/ggml-org/InternVL3-4B-Instruct-GGUF

#### New (do exist)

* https://huggingface.co/ggml-org/InternVL2_5-4B-GGUF
* https://huggingface.co/ggml-org/InternVL3-8B-Instruct-GGUF