### PR TITLE
scripts : support arbitrary input file formats in compare-llama-bench.py

### DIFF
--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -27,6 +27,7 @@ DB_FIELDS = [
     "model_type",   "model_size",   "model_n_params", "n_batch",    "n_ubatch",     "n_threads",
     "cpu_mask",     "cpu_strict",   "poll",           "type_k",     "type_v",       "n_gpu_layers",
     "split_mode",   "main_gpu",     "no_kv_offload",  "flash_attn", "tensor_split", "tensor_buft_overrides",
+    "defrag_thold",
     "use_mmap",     "embeddings",   "no_op_offload",  "n_prompt",   "n_gen",        "n_depth",
     "test_time",    "avg_ns",       "stddev_ns",      "avg_ts",     "stddev_ts",
 ]

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -32,6 +32,16 @@ DB_FIELDS = [
     "test_time",    "avg_ns",       "stddev_ns",      "avg_ts",     "stddev_ts",
 ]
 
+DB_TYPES = [
+    "TEXT",    "INTEGER", "TEXT",    "TEXT",    "TEXT",    "TEXT",
+    "TEXT",    "INTEGER", "INTEGER", "INTEGER", "INTEGER", "INTEGER",
+    "TEXT",    "INTEGER", "INTEGER", "TEXT",    "TEXT",    "INTEGER",
+    "TEXT",    "INTEGER", "INTEGER", "INTEGER", "TEXT",    "TEXT",
+    "REAL",
+    "INTEGER", "INTEGER", "INTEGER", "INTEGER", "INTEGER", "INTEGER",
+    "TEXT",    "INTEGER", "INTEGER", "REAL",    "REAL",
+]
+
 # Properties by which to differentiate results per commit:
 KEY_PROPERTIES = [
     "cpu_info", "gpu_info", "backends", "n_gpu_layers", "tensor_buft_overrides", "model_filename", "model_type",
@@ -240,7 +250,7 @@ class LlamaBenchDataSQLite3(LlamaBenchData):
         super().__init__()
         self.connection = sqlite3.connect(":memory:")
         self.cursor = self.connection.cursor()
-        self.cursor.execute(f"CREATE TABLE test({', '.join(DB_FIELDS)});")
+        self.cursor.execute(f"CREATE TABLE test({', '.join(' '.join(x) for x in zip(DB_FIELDS, DB_TYPES))});")
 
     def _builds_init(self):
         if self.connection:
@@ -354,7 +364,6 @@ class LlamaBenchDataCSV(LlamaBenchDataSQLite3):
                     if (missing_keys := self._check_keys(keys)):
                         raise RuntimeError(f"Missing required data key(s) at line {i + 1}: {', '.join(missing_keys)}")
 
-                    # FIXME: Convert float/int columns from str!
                     self.cursor.execute(f"INSERT INTO test({', '.join(parsed.keys())}) VALUES({', '.join('?' * len(parsed))});", tuple(parsed.values()))
 
         self._builds_init()

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -22,14 +22,14 @@ except ImportError as e:
 logger = logging.getLogger("compare-llama-bench")
 
 # All llama-bench SQLite3 fields
-DB_FIELDS = {
+DB_FIELDS = [
     "build_commit", "build_number", "cpu_info",       "gpu_info",   "backends",     "model_filename",
     "model_type",   "model_size",   "model_n_params", "n_batch",    "n_ubatch",     "n_threads",
     "cpu_mask",     "cpu_strict",   "poll",           "type_k",     "type_v",       "n_gpu_layers",
     "split_mode",   "main_gpu",     "no_kv_offload",  "flash_attn", "tensor_split", "tensor_buft_overrides",
     "use_mmap",     "embeddings",   "no_op_offload",  "n_prompt",   "n_gen",        "n_depth",
     "test_time",    "avg_ns",       "stddev_ns",      "avg_ts",     "stddev_ts",
-}
+]
 
 # Properties by which to differentiate results per commit:
 KEY_PROPERTIES = [
@@ -306,7 +306,7 @@ class LlamaBenchDataSQLite3_or_JSONL(LlamaBenchDataSQLite3File):
                 for i, line in enumerate(fp):
                     parsed = json.loads(line)
 
-                    for k in parsed.keys() - DB_FIELDS:
+                    for k in parsed.keys() - set(DB_FIELDS):
                         del parsed[k]
 
                     if (missing_keys := self._check_keys(parsed.keys())):
@@ -326,7 +326,7 @@ class LlamaBenchDataJSON(LlamaBenchDataSQLite3):
                 parsed = json.load(fp)
 
                 for i, entry in enumerate(parsed):
-                    for k in entry.keys() - DB_FIELDS:
+                    for k in entry.keys() - set(DB_FIELDS):
                         del entry[k]
 
                     if (missing_keys := self._check_keys(entry.keys())):
@@ -346,7 +346,7 @@ class LlamaBenchDataCSV(LlamaBenchDataSQLite3):
                 for i, parsed in enumerate(csv.DictReader(fp)):
                     keys = set(parsed.keys())
 
-                    for k in keys - DB_FIELDS:
+                    for k in keys - set(DB_FIELDS):
                         del parsed[k]
 
                     if (missing_keys := self._check_keys(keys)):

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -22,14 +22,14 @@ except ImportError as e:
 logger = logging.getLogger("compare-llama-bench")
 
 # All llama-bench SQLite3 fields
-DB_FIELDS = [
+DB_FIELDS = {
     "build_commit", "build_number", "cpu_info",       "gpu_info",   "backends",     "model_filename",
     "model_type",   "model_size",   "model_n_params", "n_batch",    "n_ubatch",     "n_threads",
     "cpu_mask",     "cpu_strict",   "poll",           "type_k",     "type_v",       "n_gpu_layers",
     "split_mode",   "main_gpu",     "no_kv_offload",  "flash_attn", "tensor_split", "tensor_buft_overrides",
     "use_mmap",     "embeddings",   "no_op_offload",  "n_prompt",   "n_gen",        "n_depth",
     "test_time",    "avg_ns",       "stddev_ns",      "avg_ts",     "stddev_ts",
-]
+}
 
 # Properties by which to differentiate results per commit:
 KEY_PROPERTIES = [
@@ -306,10 +306,8 @@ class LlamaBenchDataSQLite3_or_JSONL(LlamaBenchDataSQLite3File):
                 for i, line in enumerate(fp):
                     parsed = json.loads(line)
 
-                    if "samples_ns" in parsed:
-                        del parsed["samples_ns"]
-                    if "samples_ts" in parsed:
-                        del parsed["samples_ts"]
+                    for k in parsed.keys() - DB_FIELDS:
+                        del parsed[k]
 
                     if (missing_keys := self._check_keys(parsed.keys())):
                         raise RuntimeError(f"Missing required data key(s) at line {i + 1}: {', '.join(missing_keys)}")
@@ -328,10 +326,8 @@ class LlamaBenchDataJSON(LlamaBenchDataSQLite3):
                 parsed = json.load(fp)
 
                 for i, entry in enumerate(parsed):
-                    if "samples_ns" in entry:
-                        del entry["samples_ns"]
-                    if "samples_ts" in entry:
-                        del entry["samples_ts"]
+                    for k in entry.keys() - DB_FIELDS:
+                        del entry[k]
 
                     if (missing_keys := self._check_keys(entry.keys())):
                         raise RuntimeError(f"Missing required data key(s) at entry {i + 1}: {', '.join(missing_keys)}")
@@ -348,7 +344,12 @@ class LlamaBenchDataCSV(LlamaBenchDataSQLite3):
         for data_file in data_files:
             with open(data_file, "r", encoding="utf-8") as fp:
                 for i, parsed in enumerate(csv.DictReader(fp)):
-                    if (missing_keys := self._check_keys(set(parsed.keys()))):
+                    keys = set(parsed.keys())
+
+                    for k in keys - DB_FIELDS:
+                        del parsed[k]
+
+                    if (missing_keys := self._check_keys(keys)):
                         raise RuntimeError(f"Missing required data key(s) at line {i + 1}: {', '.join(missing_keys)}")
 
                     # FIXME: Convert float/int columns from str!

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -369,7 +369,6 @@ class LlamaBenchDataJSON(LlamaBenchDataSQLite3):
             try:
                 with open(data_file, "r", encoding="utf-8") as fp:
                     json.load(fp)
-                    continue
             except Exception as e:
                 logger.debug(f'"{data_file}" is not a valid JSON file.', exc_info=e)
                 return False
@@ -404,8 +403,8 @@ class LlamaBenchDataCSV(LlamaBenchDataSQLite3):
         for data_file in data_files:
             try:
                 with open(data_file, "r", encoding="utf-8") as fp:
-                    csv.DictReader(fp)
-                    continue
+                    for parsed in csv.DictReader(fp):
+                        break
             except Exception as e:
                 logger.debug(f'"{data_file}" is not a valid CSV file.', exc_info=e)
                 return False

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -292,6 +292,7 @@ class LlamaBenchDataSQLite3File(LlamaBenchDataSQLite3):
 
         if (connection):
             self.connected_file = True
+            self.connection.close()
             self.connection = connection
             self.cursor = cursor
             self._builds_init()


### PR DESCRIPTION
Refactored git/file handling into specialized classes to support arbitrary input file support.

The `-i`/`--input` parameter can now be invoked multiple times to load multiple files.

If only a single file is specified, attempt to load it as SQLite3, JSON, JSONL or CSV, otherwise attempt to load multiple JSON or multiple CSV files.