### PR TITLE
mtmd : use RMS norm for InternVL 3 38B and 78B mmproj

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -879,9 +879,15 @@ struct clip_graph {
         // add CLS token
         inp = ggml_concat(ctx0, inp, model.class_embedding, 1);
 
+        // The larger models use a different ViT, which uses RMS norm instead of layer norm
+        // ref: https://github.com/ggml-org/llama.cpp/pull/13443#issuecomment-2869786188
+        norm_type norm_t = (hparams.n_embd == 3200 && hparams.n_layer == 45)
+            ? NORM_TYPE_RMS // 6B ViT (Used by InternVL 2.5/3 - 26B, 38B, 78B)
+            : NORM_TYPE_NORMAL; // 300M ViT (Used by all smaller InternVL models)
+
         ggml_tensor * cur = build_vit(
                                 inp, n_pos,
-                                NORM_TYPE_NORMAL,
+                                norm_t,
                                 hparams.ffn_op,
                                 model.position_embeddings,
                                 nullptr);


### PR DESCRIPTION
Follow-up to https://github.com/ggml-org/llama.cpp/pull/13443 - in my original PR I was only checking the config file for the actual ViT and failed to realize the norm type was also different, since it wasn't included in that specific config. See referenced PR for more information.

Due to the norm type not being stored in the gguf metadata, we check the hidden size and block count instead.

<details>

<summary>Quick test</summary>

Before (topk=1, greedy sampling, black and white image)

![before](https://github.com/user-attachments/assets/4a341225-a76e-4b3a-9373-db92efc2de6a)

After (topk=1, greedy sampling, same image)

![after](https://github.com/user-attachments/assets/7f9dbafd-f09e-4f78-8473-3d4484ce68b1)

</details>