### PR TITLE
CUDA: fix misaligned synchronization in FA

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -895,6 +895,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             float2 * dstk_fixup_meta = dstk_fixup + (gridDim.x + blockIdx.x)*ncols;
             dstk_fixup_meta[(threadIdx.y/np)*cols_per_warp + threadIdx.x] = make_float2(KQ_cmn, KQ_crs);
         }
+    } else if (np > 1) {
+        // Warps with threadIdx.y % np == 0 execute a __syncthreads() in the if branch.
+        // Therefore, all other warps also need to execute a __syncthreads().
+        // Otherwise the points at which warps synchronize with each other would become misaligned.
+        __syncthreads();
     }
 
 #pragma unroll


### PR DESCRIPTION
See discussion following https://github.com/ggml-org/llama.cpp/issues/13430#issuecomment-2869309424 .

I added a `__syncthreads` instruction in https://github.com/ggml-org/llama.cpp/pull/13438 to fix a race condition. However, this instruction is for some kernel configuration only executed for part of the warps so the points at which warps wait for each other become misaligned. On a sufficiently long context this then causes incorrect results.