### PR TITLE
clip : cap max image size 1024 for qwen vl model

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1909,16 +1909,20 @@ struct clip_model_loader {
                     } break;
                 case PROJECTOR_TYPE_QWEN2VL:
                     {
-                        // max image size = sqrt(max_pixels)
-                        // https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct/blob/main/preprocessor_config.json
-                        hparams.image_size = 3584;
+                        // max image size = sqrt(max_pixels) = 3584
+                        // ref: https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct/blob/main/preprocessor_config.json
+                        // however, the model use unreasonable memory past 1024 size, we force it to 1024 otherwise it's unusable
+                        // ref: https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct/discussions/10
+                        hparams.image_size = 1024;
                         hparams.warmup_image_size = hparams.patch_size * 8;
                     } break;
                 case PROJECTOR_TYPE_QWEN25VL:
                     {
                         // max image size = sqrt(max_pixels)
                         // https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/blob/main/preprocessor_config.json
-                        hparams.image_size = 3584;
+                        // however, the model use unreasonable memory past 1024 size, we force it to 1024 otherwise it's unusable
+                        // ref: https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct/discussions/10
+                        hparams.image_size = 1024;
                         hparams.warmup_image_size = hparams.patch_size * 8;
                         get_u32(KEY_WIN_ATTN_PATTERN, hparams.n_wa_pattern);
                     } break;


### PR DESCRIPTION
Fix #13445 #13467

An image of size 2592x1944 equivalents to over 20k tokens, which is an unreasonable amount of computation (equivalent to 41GB of VRAM)

And turns out, the problem is not isolated to llama.cpp, someone already discuss about this using HF implementation: https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct/discussions/10

The solution is to cap image size to maximum 1024x1024, which brings down the max memory usage to 1830M

We maybe able to use less memory with flash attn, but given recent discussion about why it's not enabled by default on text model, I'm not sure what's the risk of adding flash attn to vision support. WDYT @ggerganov ?
