### PR TITLE
batched-bench : fix pp batch contents

### DIFF
--- a/tools/batched-bench/batched-bench.cpp
+++ b/tools/batched-bench/batched-bench.cpp
@@ -123,8 +123,8 @@ int main(int argc, char ** argv) {
 
                 common_batch_clear(batch);
 
-                for (int i = 0; i < pp; ++i) {
-                    for (int j = 0; j < (is_pp_shared ? 1 : pl); ++j) {
+                for (int j = 0; j < (is_pp_shared ? 1 : pl); ++j) {
+                    for (int i = 0; i < pp; ++i) {
                         common_batch_add(batch, 0, i, { j }, false);
                     }
                 }


### PR DESCRIPTION
The tool was incorrectly ordering the tokens for the prompt processing batches by interleaving the sequences like this:

```
123412341234...
```

Instead the batch should look like this:

```
1111...2222...3333...
```

This is important for correctly benchmarking some attention optimization techniques.