### PR TITLE
[server] accept requests where 'content' is missing entirely, not just null or empty

### DIFF
--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -643,6 +643,10 @@ static json oaicompat_completion_params_parse(
         throw std::runtime_error("Expected 'messages' to be an array");
     }
     for (auto & msg : messages) {
+        if (!msg.contains("content")) {
+            continue;
+        }
+
         json & content = msg.at("content");
         if (content.is_string() || content.is_null()) {
             continue;


### PR DESCRIPTION
I have encountered a problem very similar to #13471 .

That issue was fixed by allowing null or empty value for "content".

But my scenario (using pydantic-ai as a client) has requests where "content" is completely absent, in scenarios where there is a tool request.

If you look at the code for "at()" in json.hpp, you'll see it throws if the property is missing entirely.

This PR change fixed the issue for me locally.

Edit - here is an example of a message within a chat completions requests that has no content:

```
    {
      "role": "assistant",
      "tool_calls": [
        {
          "id": "qdAlNVrVB7fYP10SidYiSKx9MMbJCIb7",
          "type": "function",
          "function": {
            "name": "search_web",
            "arguments": "{\"query\":\"What is llama.cpp?\"}"
          }
        }
      ]
    }
```

looks related to #13516