### PR TITLE
[CUDA backend ONLY] Use just K-cache for MLA + FA: 47% saving on KV-cache size

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1257,7 +1257,11 @@ ggml_tensor * llm_graph_context::build_attn(
     // store to KV cache
     {
         ggml_build_forward_expand(gf, kv_state->cpy_k(ctx0, k_cur, il));
-        ggml_build_forward_expand(gf, kv_state->cpy_v(ctx0, v_cur, il));
+
+        // note: MLA with flash attention now uses the last 512 elements of K-cache in place of a V-cache
+        if (!v_mla || !cparams.flash_attn) {
+            ggml_build_forward_expand(gf, kv_state->cpy_v(ctx0, v_cur, il));
+        }
     }
 
     const auto & kq_mask = inp->get_kq_mask();
@@ -1341,7 +1345,11 @@ ggml_tensor * llm_graph_context::build_attn(
     // store to KV cache
     {
         ggml_build_forward_expand(gf, kv_state->cpy_k(ctx0, k_cur, il));
-        ggml_build_forward_expand(gf, kv_state->cpy_v(ctx0, v_cur, il));
+
+        // note: MLA with flash attention now uses the last 512 elements of K-cache in place of a V-cache
+        if (!v_mla || !cparams.flash_attn) {
+            ggml_build_forward_expand(gf, kv_state->cpy_v(ctx0, v_cur, il));
+        }
     }
 
     const auto & kq_mask = is_swa ? inp->get_kq_mask_swa() : inp->get_kq_mask();


### PR DESCRIPTION
From https://github.com/ggml-org/llama.cpp/pull/13435:

> Going forward I would suggest re-writing the code in other backends as well to use only the K tensor. The KV cache size could then be reduced by ~47% by simply not allocating and filling the V cache. At least as long as FlashAttention is used this should be relatively simple. So for a first version it would I think be fine to only deduplicate K and V if FA is used. 

I've only tested this to work with https://github.com/ggml-org/llama.cpp/pull/13435 for now, but it should still work with the other backends' flash attention implementations so long as they don't assume that the V-cache they are passed is contiguous:

```cpp
    } else {
        // note: MLA with flash attention now uses the last 512 elements of K-cache in place of a V-cache
        v = ggml_view_3d(ctx0, kv_self->k_l[il],
                n_embd_head_v, n_kv, n_head_kv,
                ggml_row_size(kv_self->k_l[il]->type, n_embd_k_gqa),
                ggml_row_size(kv_self->k_l[il]->type, n_embd_head_k),
                n_embd_head_k-n_embd_head_v); // offset by n_rot elements
    }
```

The full context of 160k tokens now takes up less than 11GB:

```
llama_kv_cache_unified: kv_size = 163840, type_k = 'f16', type_v = 'f16', n_layer = 61, can_shift = 0, padding = 256
llama_kv_cache_unified:      CUDA0 KV buffer size = 10980.00 MiB
llama_kv_cache_unified: KV self size  = 10980.00 MiB, K (f16): 10980.00 MiB, V (f16):    0.00 MiB
```
! :open_mouth: 

---

I've just disabled context shifting for now, as like I said in the [other post](https://github.com/ggml-org/llama.cpp/pull/13435#issuecomment-2871863386); I'm not at all confident I can cleanly change all that is required to deal with the empty V-cache:

![image](https://github.com/user-attachments/assets/563297f9-fb62-4f4e-9a36-198d1d8e8df0)

---

I will leave it as a draft for now, as the other backends' flash attention implementations need to either:

A. Check they can work with the non-contiguous V-cache passed to them.
B. Copy @JohannesGaessler's strategy of only using the last 512 elements of the K-cache in place of the V-cache.

I think (B) is preferable, as there is likely to be some significant gains possible regarding CPU cache (re-)use, etc.