### PR TITLE
server : fix cache_tokens bug with no cache_prompt

### DIFF
--- a/tools/server/tests/unit/test_completion.py
+++ b/tools/server/tests/unit/test_completion.py
@@ -196,6 +196,18 @@ def test_cache_vs_nocache_prompt():
     assert res_cache.body["content"] == res_no_cache.body["content"]
 
 
+def test_nocache_long_input_prompt():
+    global server
+    server.start()
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "I believe the meaning of life is"*32,
+        "seed": 42,
+        "temperature": 1.0,
+        "cache_prompt": False,
+    })
+    assert res.status_code == 200
+
+
 def test_completion_with_tokens_input():
     global server
     server.temperature = 0.0

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -1153,7 +1153,7 @@ public:
         tokens.clear();
     }
 
-    void resize(size_t n) {
+    void keep_first(size_t n) {
         GGML_ASSERT(n <= tokens.size());
         if (has_mtmd) {
             // we throw an error if we try to remove a token in the middle of an image


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/13484

Also added a test case for it. The test case currently fails on `master`, but passed in this PR.

I also renamed function `.resize(n)` to `.keep_first(n)` to make it easier to understand
