### PR TITLE
server : passthrough the /models endpoint during loading

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1040,7 +1040,7 @@ To know the `id` of the adapter, use GET `/lora-adapters`
 
 Returns information about the loaded model. See [OpenAI Models API documentation](https://platform.openai.com/docs/api-reference/models).
 
-The returned list always has one single element.
+The returned list always has one single element. The `meta` field can be `null` (for example, while the model is still loading).
 
 By default, model `id` field is the path to model file, specified via `-m`. You can set a custom value for model `id` field via `--alias` argument. For example, `--alias gpt-4o-mini`.
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4368,7 +4368,7 @@ int main(int argc, char ** argv) {
 
     const auto handle_models = [&params, &ctx_server, &state, &res_ok](const httplib::Request &, httplib::Response & res) {
         server_state current_state = state.load();
-        std::string model_meta;
+        json model_meta = nullptr;
         if (current_state == SERVER_STATE_READY) {
             model_meta = ctx_server.model_meta();
         }

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3705,6 +3705,9 @@ int main(int argc, char ** argv) {
             if (req.path == "/" || tmp.back() == "html") {
                 res.set_content(reinterpret_cast<const char*>(loading_html), loading_html_len, "text/html; charset=utf-8");
                 res.status = 503;
+            } else if (req.path == "/models" || req.path == "/v1/models") {
+                // allow the models endpoint to be accessed during loading
+                return true;
             } else {
                 res_error(res, format_error_response("Loading model", ERROR_TYPE_UNAVAILABLE));
             }
@@ -4363,7 +4366,13 @@ int main(int argc, char ** argv) {
         res_ok(res, {{ "prompt", std::move(data.at("prompt")) }});
     };
 
-    const auto handle_models = [&params, &ctx_server, &res_ok](const httplib::Request &, httplib::Response & res) {
+    const auto handle_models = [&params, &ctx_server, &state, &res_ok](const httplib::Request &, httplib::Response & res) {
+        server_state current_state = state.load();
+        std::string model_meta;
+        if (current_state == SERVER_STATE_READY) {
+            model_meta = ctx_server.model_meta();
+        }
+
         json models = {
             {"object", "list"},
             {"data", {
@@ -4372,7 +4381,7 @@ int main(int argc, char ** argv) {
                     {"object",   "model"},
                     {"created",  std::time(0)},
                     {"owned_by", "llamacpp"},
-                    {"meta",     ctx_server.model_meta()}
+                    {"meta",     model_meta},
                 },
              }}
         };


### PR DESCRIPTION
Certain 3rd-party applications could use the information about the model currently being loaded. This change allows the `/models` and `/v1/models` endpoints to passthrough.

@ngxson Not sure if this is the correct way to do this, so suggestions are welcome.

cc @astoilkov