### PR TITLE
Granite MoE NoPE fix

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -12218,6 +12218,9 @@ struct llm_build_granite : public llm_graph_context {
 
         // inp_pos - built only if rope enabled
         ggml_tensor * inp_pos = nullptr;
+        if (use_rope) {
+            inp_pos = build_inp_pos();
+        }
 
         auto * inp_attn = build_attn_inp_kv_unified();
 
@@ -12260,10 +12263,6 @@ struct llm_build_granite : public llm_graph_context {
                 Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
 
                 if (use_rope) {
-
-                    if (!inp_pos) {
-                        inp_pos = build_inp_pos();
-                    }
                     ggml_tensor * rope_factors = model.get_rope_factors(n_ctx_per_seq, il);
                     Qcur = ggml_rope_ext(
                             ctx0, Qcur, inp_pos, rope_factors,


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/pull/13269#discussion_r2088055810

This PR moves the `build_inp_pos` step to the top of the graph building for consistency with other models while still guarding it behind the `use_rope` check.