### PR TITLE
gguf-py : Fix disconnect-before-connect crash on Kubuntu

### DIFF
--- a/gguf-py/gguf/scripts/gguf_editor_gui.py
+++ b/gguf-py/gguf/scripts/gguf_editor_gui.py
@@ -823,6 +823,7 @@ class GGUFEditorWindow(QMainWindow):
         self.modified = False
         self.metadata_changes = {}  # Store changes to apply when saving
         self.metadata_to_remove = set()  # Store keys to remove when saving
+        self.on_metadata_changed_is_connected = False
 
         self.setup_ui()
 
@@ -941,9 +942,11 @@ class GGUFEditorWindow(QMainWindow):
             return
 
         # Disconnect to prevent triggering during loading
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore')
-            self.metadata_table.itemChanged.disconnect(self.on_metadata_changed)
+        if self.on_metadata_changed_is_connected:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore')
+                self.metadata_table.itemChanged.disconnect(self.on_metadata_changed)
+            self.on_metadata_changed_is_connected = False
 
         for i, (key, field) in enumerate(self.reader.fields.items()):
             self.metadata_table.insertRow(i)
@@ -1021,6 +1024,7 @@ class GGUFEditorWindow(QMainWindow):
 
         # Reconnect after loading
         self.metadata_table.itemChanged.connect(self.on_metadata_changed)
+        self.on_metadata_changed_is_connected = True
 
     def extract_array_values(self, field: ReaderField) -> list:
         """Extract all values from an array field."""


### PR DESCRIPTION
This fixes the crash upon load with venvs created with `--system-site-packages` to use `python3-pyside6.qtwidgets=python3-pyside6.qtwidgets=6.6.2-4` from Kubuntu 24.10. Using system Qt is not merely æsthetic; I need Qt to use KDE's file picker so that hidden folders are openable. For users on other platforms, this doesn't change anything or just improves correctness.

# Before

```console
$ gguf-editor-gui
Traceback (most recent call last):
  File "/home/home/CLionProjects/llamacpprocm/gguf-py/gguf/scripts/gguf_editor_gui.py", line 913, in load_file
    self.load_metadata()
  File "/home/home/CLionProjects/llamacpprocm/gguf-py/gguf/scripts/gguf_editor_gui.py", line 948, in load_metadata
    self.metadata_table.itemChanged.disconnect(self.on_metadata_changed)
RuntimeError: Failed to disconnect (<bound method GGUFEditorWindow.on_metadata_changed of <gguf.scripts.gguf_editor_gui.GGUFEditorWindow(0x3fe2f560) at 0x7f5754e84480>>) from signal "itemChanged(QTableWidgetItem*)".
```

# After

I was able to view `gemma-3-4b-it-Q4_K_M.gguf` successfully.