### PR TITLE
server : do not return error when running out of context (with ctx shift disabled)

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2251,6 +2251,14 @@ struct server_context {
             slot.has_next_token = true;
         }
 
+        // if context shifting is disabled, make sure that we don't run out of context
+        if (!params_base.ctx_shift && slot.n_past + 1 >= slot.n_ctx) {
+            slot.stop           = STOP_TYPE_LIMIT;
+            slot.has_next_token = false;
+
+            SLT_DBG(slot, "stopped due to running out of context, n_past = %d, n_ctx = %d\n", slot.n_past, slot.n_ctx);
+        }
+
         // check the limits
         if (slot.n_decoded > 0 && slot.has_next_token && !slot.has_budget(params_base)) {
             slot.stop           = STOP_TYPE_LIMIT;


### PR DESCRIPTION
Currently, when context shifting is disabled, we trigger the line of code that is not supposed to be called:

```cpp
if (!params_base.ctx_shift) {
    // this check is redundant (for good)
    // we should never get here, because generation should already stopped in process_token()
    slot.release();
    send_error(slot, "context shift is disabled", ERROR_TYPE_SERVER);
    continue;
}
```

This returns an error, which makes downstream applications unhappy.

NOTE: some variables may need to be renamed after https://github.com/ggml-org/llama.cpp/pull/13576
