### PR TITLE
llama : print hint when loading a model when no backends are loaded

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -140,7 +140,7 @@ static struct llama_model * llama_model_load_from_file_impl(
         struct llama_model_params params) {
     ggml_time_init();
 
-    if (ggml_backend_reg_count() == 0) {
+    if (!params.vocab_only && ggml_backend_reg_count() == 0) {
         LLAMA_LOG_ERROR("%s: no backends are loaded. hint: use ggml_backend_load() or ggml_backend_load_all() to load a backend before calling this function\n", __func__);
         return nullptr;
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -140,6 +140,11 @@ static struct llama_model * llama_model_load_from_file_impl(
         struct llama_model_params params) {
     ggml_time_init();
 
+    if (ggml_backend_reg_count() == 0) {
+        LLAMA_LOG_ERROR("%s: no backends are loaded. hint: use ggml_backend_load() or ggml_backend_load_all() to load a backend before calling this function\n", __func__);
+        return nullptr;
+    }
+
     unsigned cur_percentage = 0;
     if (params.progress_callback == NULL) {
         params.progress_callback_user_data = &cur_percentage;


### PR DESCRIPTION
Some of the releases are now built with dynamically loadable backends, which requires loading the backends before calling llama.cpp. To ease the transition, this change instructs users to call `ggml_backend_load()` or `ggml_backend_load_all()` to load a backend when trying to load a model while there are no backends loaded.