### PR TITLE
Bump LLGuidance git tag so it compiles on GCC15

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -121,8 +121,8 @@ if (LLAMA_LLGUIDANCE)
 
     ExternalProject_Add(llguidance_ext
         GIT_REPOSITORY https://github.com/guidance-ai/llguidance
-        # v0.7.19 (+ fancy-regex build fix):
-        GIT_TAG b59f98f85269892a7de3d3641ad155366f13daa6
+        # v0.7.20 (+ fix to build on GCC 15):
+        GIT_TAG b5b8b64dba11c4e4ee6b1d1450d3a3ae279891e8
         PREFIX ${CMAKE_BINARY_DIR}/llguidance
         SOURCE_DIR ${LLGUIDANCE_SRC}
         BUILD_IN_SOURCE TRUE


### PR DESCRIPTION
This is a small change to the common CMakeLists.txt that simply bumps the llguidance git tag to version 7.20. Without this llama cpp will fail to compile on GCC15 if building llguidance as onig_sys rust repo is deprecated. See the issue below.

https://github.com/guidance-ai/llguidance/issues/173#issuecomment-2885265499