### PR TITLE
added load_progress_callback to common_params

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1102,6 +1102,9 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
         mparams.tensor_buft_overrides = params.tensor_buft_overrides.data();
     }
 
+    mparams.progress_callback           = params.load_progress_callback;
+    mparams.progress_callback_user_data = params.load_progress_callback_user_data;
+
     return mparams;
 }
 

--- a/common/common.h
+++ b/common/common.h
@@ -428,7 +428,6 @@ struct common_params {
 
     // common params
     std::string out_file; // output filename for all example programs
-    
     // optional callback for model loading progress and cancellation:
     // called with a progress value between 0.0 and 1.0.
     // return false from callback to abort model loading or true to continue

--- a/common/common.h
+++ b/common/common.h
@@ -428,6 +428,12 @@ struct common_params {
 
     // common params
     std::string out_file; // output filename for all example programs
+    
+    // optional callback for model loading progress and cancellation:
+    // called with a progress value between 0.0 and 1.0.
+    // return false from callback to abort model loading or true to continue
+    llama_progress_callback load_progress_callback = NULL;
+    void *                  load_progress_callback_user_data = NULL;
 };
 
 // call once at the start of a program if it uses libcommon


### PR DESCRIPTION
llama internally supports load cancellation, but when using common* API it's not available from outside:
```
struct common_init_result common_init_from_params(common_params & params) {
    common_init_result iparams;
    auto mparams = common_model_params_to_llama(params);

    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams); // <<< ----
    if (model == NULL) {
        LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.path.c_str());
        return iparams;
    }
[...]
```
to allow load cancellation it needs a `progress_callback`, but it requires passing `common_params` and internally `llama_model_params` builds the object always with progress_callback as null.

this PR simply provides an opportunity to set it from outside. however I called it load_progress_callback because the callback is used during model loading. user will still need to call llama_set_abort_callback for compute cancellation, but it can be done after calling common_init_from_params().
