### PR TITLE
add GGML_USE_NUMA_MIGRATE feature to optimize cross NUMA op computation

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2276,12 +2276,18 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "- distribute: spread execution evenly over all nodes\n"
         "- isolate: only spawn threads on CPUs on the node that execution started on\n"
         "- numactl: use the CPU map provided by numactl\n"
+#ifdef GGML_USE_NUMA_MIGRATE
+        "- migrate: for affinity threads with page migration across NUMA nodes\n"
+#endif
         "if run without this previously, it is recommended to drop the system page cache before using this\n"
         "see https://github.com/ggml-org/llama.cpp/issues/1437",
         [](common_params & params, const std::string & value) {
             /**/ if (value == "distribute" || value == "") { params.numa = GGML_NUMA_STRATEGY_DISTRIBUTE; }
             else if (value == "isolate") { params.numa = GGML_NUMA_STRATEGY_ISOLATE; }
             else if (value == "numactl") { params.numa = GGML_NUMA_STRATEGY_NUMACTL; }
+#ifdef GGML_USE_NUMA_MIGRATE
+            else if (value == "migrate") { params.numa = GGML_NUMA_STRATEGY_MIGRATE; }
+#endif
             else { throw std::invalid_argument("invalid value"); }
         }
     ).set_env("LLAMA_ARG_NUMA"));

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -151,6 +151,11 @@ set(GGML_BLAS_VENDOR ${GGML_BLAS_VENDOR_DEFAULT} CACHE STRING
                                             "ggml: BLAS library vendor")
 option(GGML_LLAMAFILE                       "ggml: use LLAMAFILE"                             ${GGML_LLAMAFILE_DEFAULT})
 
+option(GGML_NUMA_MIGRATE                    "ggml: use NUMA_MIGRATE"                          OFF)
+set(GGML_NUMA_MIGRATE_NODES "2" CACHE STRING
+                                            "ggml: the number of NUMA nodes during page migration")
+option(GGML_NUMA_MIGRATE_DEBUG              "ggml: enable debugging of NUMA_MIGRATE"          OFF)
+
 option(GGML_CUDA                            "ggml: use CUDA"                                  OFF)
 option(GGML_MUSA                            "ggml: use MUSA"                                  OFF)
 option(GGML_CUDA_FORCE_MMQ                  "ggml: use mmq kernels instead of cuBLAS"         OFF)

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -348,6 +348,9 @@ extern "C" {
     // CPU buffer types are always available
     GGML_API ggml_backend_buffer_t      ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
     GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
+#ifdef GGML_USE_NUMA_MIGRATE
+    GGML_API size_t ggml_backend_get_page_size(void);
+#endif
 
 #ifdef  __cplusplus
 }

--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -28,6 +28,9 @@ extern "C" {
         GGML_NUMA_STRATEGY_ISOLATE    = 2,
         GGML_NUMA_STRATEGY_NUMACTL    = 3,
         GGML_NUMA_STRATEGY_MIRROR     = 4,
+#ifdef GGML_USE_NUMA_MIGRATE
+        GGML_NUMA_STRATEGY_MIGRATE    = 5,
+#endif
         GGML_NUMA_STRATEGY_COUNT
     };
 

--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -12,6 +12,9 @@ extern "C" {
     struct ggml_cplan {
         size_t    work_size; // size of work buffer, calculated by `ggml_graph_plan()`
         uint8_t * work_data; // work buffer, to be allocated by caller before calling to `ggml_graph_compute()`
+#ifdef GGML_USE_NUMA_MIGRATE
+        uint8_t * work_data_numa[GGML_NUMA_MIGRATE_NODES];
+#endif
 
         int n_threads;
         struct ggml_threadpool * threadpool;

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -343,3 +343,27 @@ if (BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC  GGML_SHARED)
     endforeach()
 endif()
+
+if (GGML_NUMA_MIGRATE)
+    find_path(NUMA_ROOT_DIR
+        NAMES include/numa.h
+        PATHS ENV NUMA_ROOT
+        DOC "NUMA root directory")
+
+    find_library(NUMA_LIBRARY
+        NAMES numa
+        HINTS ${NUMA_ROOT_DIR}
+        DOC "NUMA library")
+
+    if (NOT NUMA_LIBRARY)
+        message(FATAL_ERROR "Could NOT find NUMA library.")
+    endif()
+
+    if (GGML_NUMA_MIGRATE_DEBUG)
+        target_compile_definitions(ggml-base PUBLIC GGML_USE_NUMA_MIGRATE GGML_NUMA_MIGRATE_NODES=${GGML_NUMA_MIGRATE_NODES} GGML_USE_NUMA_MIGRATE_DEBUG)
+    else()
+        target_compile_definitions(ggml-base PUBLIC GGML_USE_NUMA_MIGRATE GGML_NUMA_MIGRATE_NODES=${GGML_NUMA_MIGRATE_NODES})
+    endif()
+
+    target_link_libraries(ggml-base PRIVATE ${NUMA_LIBRARY})
+endif()

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -22,12 +22,51 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <numa.h>
+#include <execinfo.h>
+#include <iostream>
+#include <cstdlib>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <numa.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <numaif.h>
+#include <set>
+#include <mutex>
 
 #ifdef __APPLE__
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
 
+#ifdef GGML_USE_NUMA_MIGRATE
+class numa_migrate_mapping_cache {
+public:
+    void * addr;
+    int size;
+    numa_migrate_mapping_cache(void *addr, int size): addr(addr), size(size) { }
+
+    bool operator<(const numa_migrate_mapping_cache& other) const {
+        if (addr != other.addr) {
+            return addr < other.addr;
+        } else {
+            return size < other.size;
+        }
+    }
+
+    bool operator==(const numa_migrate_mapping_cache& other) const {
+        return (addr == other.addr && size == other.size);
+    }
+
+};
+
+static std::set<numa_migrate_mapping_cache> ggml_mapping_cache;
+static size_t ggml_backend_page_size = 0;
+static std::mutex ggml_mapping_mutex;
+#endif
 
 // backend buffer type
 
@@ -1658,6 +1697,244 @@ enum ggml_status ggml_backend_view_init(struct ggml_tensor * tensor) {
     return ggml_backend_buffer_init_tensor(tensor->buffer, tensor);
 }
 
+#ifdef GGML_USE_NUMA_MIGRATE
+#ifdef GGML_USE_NUMA_MIGRATE_DEBUG
+static int check_numa_pages_migration(void *addr, size_t total_size) {
+    if (total_size % ggml_backend_page_size != 0) {
+        return -1;
+    }
+
+    size_t offset = 0; // Offset in bytes from the start of the allocated memory
+    int num_nodes = GGML_NUMA_MIGRATE_NODES;
+
+    for (int i = 0; i < num_nodes; ++i) {
+        int target_node = i;
+        size_t size_to_migrate = total_size / num_nodes;
+
+        if (size_to_migrate > total_size - offset) {
+            GGML_LOG_ERROR(
+                "Error: Size to migrate to node %d exceeds remaining memory, "
+                "size_to_migrate: %ld, total: %ld\n",
+                target_node, size_to_migrate, total_size);
+            return -1;
+        }
+
+        size_t num_pages_to_migrate = size_to_migrate / ggml_backend_page_size;
+        if (size_to_migrate % ggml_backend_page_size != 0) {
+            GGML_LOG_WARN("Warning: Size to migrate to node %ld is not a "
+                          "multiple of page size, total: %ld size_to_migrate: "
+                          "%ld, ggml_backend_page_size: %ld.\n",
+                          target_node, total_size, size_to_migrate,
+                          ggml_backend_page_size);
+            return -1;
+        }
+
+        if (num_pages_to_migrate == 0) {
+            GGML_LOG_WARN("Warning: No pages to migrate to node %d.\n",
+                          target_node);
+            continue;
+        }
+
+        void *migrate_start_addr = (char *)addr + (i)*size_to_migrate;
+
+        int *status = (int *)malloc(num_pages_to_migrate * sizeof(int));
+        if (!status) {
+            GGML_LOG_ERROR("malloc for status failed");
+            return -1;
+        }
+        memset(status, 0, num_pages_to_migrate * sizeof(int));
+
+        int *nodes = (int *)malloc(num_pages_to_migrate * sizeof(int));
+        if (!nodes) {
+            GGML_LOG_ERROR("malloc for nodes failed");
+            return -1;
+        }
+        memset(nodes, 0, num_pages_to_migrate * sizeof(int));
+
+        void **addr_to_migrate =
+            (void **)malloc(num_pages_to_migrate * sizeof(void *));
+        for (size_t j = 0; j < num_pages_to_migrate; j++) {
+            status[j] = 0;
+            nodes[j] = i;
+            addr_to_migrate[j] = (void *)((char *)migrate_start_addr +
+                                          j * ggml_backend_page_size);
+        }
+
+        // check if pages are migrated
+        int ret = move_pages(0, num_pages_to_migrate, addr_to_migrate, NULL,
+                             status, MPOL_MF_MOVE);
+        if (ret < 0) {
+            GGML_LOG_ERROR("check pages failed");
+            free(status);
+            free(nodes);
+            return -1;
+        }
+
+        for (size_t j = 0; j < num_pages_to_migrate; ++j) {
+            if (status[j] != target_node) {
+                GGML_LOG_WARN("Warning: Page %zu migration status to node %d: "
+                              "%d, ret: %d, addr: %p\n",
+                              j, target_node, status[j], ret,
+                              addr_to_migrate[j]);
+                if (status[j] == -ENODEV) {
+                    GGML_LOG_ERROR(
+                        "   - Error: No such device (NUMA node problem)\n");
+                } else if (status[j] == -EPERM) {
+                    GGML_LOG_ERROR(
+                        "   - Error: Operation not permitted (permissions)\n");
+                } else if (status[j] == -ENOENT) {
+                    GGML_LOG_ERROR("   - Error: ENOENT\n");
+                } else if (status[j] == -EFAULT) {
+                    GGML_LOG_ERROR("   - Error: Bad address\n");
+                } else if (status[j] == -EINVAL) {
+                    GGML_LOG_ERROR("   - Error: Invalid argument\n");
+                } else if (status[j] == -ENOMEM) {
+                    GGML_LOG_ERROR("   - Error: Out of memory\n");
+                } else if (status[j] == -EACCES) {
+                    GGML_LOG_ERROR("   - Error: access\n");
+                } else if (status[j] == -ESRCH) {
+                    GGML_LOG_ERROR("   - Error: access\n");
+                } else {
+                    GGML_LOG_ERROR("   - Error: Unknown status code at j: %ld: "
+                                   "%d, total_size: %ld\n",
+                                   j, status[j], total_size);
+                }
+
+                exit(0);
+                return -1;
+            }
+        }
+
+        free(status);
+        free(nodes);
+        free(addr_to_migrate);
+
+        offset += size_to_migrate;
+    }
+
+    GGML_LOG_INFO(
+        "page migration check passed at %p, size: %ld, num nodes: %d\n", addr,
+        total_size, num_nodes);
+    return 0;
+}
+#endif
+
+// Function to migrate pages to multiple NUMA nodes.
+static int migrate_pages_multiple_nodes(void *addr, size_t total_size) {
+
+    if (total_size % ggml_backend_page_size != 0) {
+        GGML_LOG_WARN("Warning: Total size is not a multiple of page size. "
+                      "Some memory may not be migrated.\n");
+        return -1;
+    }
+
+    size_t offset = 0; // Offset in bytes from the start of the allocated memory
+    int num_nodes = GGML_NUMA_MIGRATE_NODES;
+
+    for (int i = 0; i < num_nodes; ++i) {
+        int target_node = i;
+        size_t size_to_migrate = total_size / num_nodes;
+
+        if (size_to_migrate > total_size - offset) {
+            GGML_LOG_ERROR(
+                "Error: Size to migrate to node %d exceeds remaining memory, "
+                "size_to_migrate: %ld, total: %ld\n",
+                target_node, size_to_migrate, total_size);
+            return -1;
+        }
+
+        size_t num_pages_to_migrate = size_to_migrate / ggml_backend_page_size;
+        if (size_to_migrate % ggml_backend_page_size != 0) {
+#ifdef GGML_USE_NUMA_MIGRATE_DEBUG
+            GGML_LOG_WARN("Warning: Size to migrate to node %ld is not a "
+                          "multiple of page size, total: %ld size_to_migrate: "
+                          "%ld, ggml_backend_page_size: %ld.\n",
+                          target_node, total_size, size_to_migrate,
+                          ggml_backend_page_size);
+#endif
+            return -1;
+        }
+
+        if (num_pages_to_migrate == 0) {
+            GGML_LOG_WARN("Warning: No pages to migrate to node %d.\n",
+                          target_node);
+            continue;
+        }
+
+        void *migrate_start_addr = (char *)addr + (i)*size_to_migrate;
+
+        int *status = (int *)malloc(num_pages_to_migrate * sizeof(int));
+        if (!status) {
+            GGML_LOG_ERROR("malloc for status failed");
+            return -1;
+        }
+        memset(status, 0, num_pages_to_migrate * sizeof(int));
+
+        int *nodes = (int *)malloc(num_pages_to_migrate * sizeof(int));
+        if (!nodes) {
+            GGML_LOG_ERROR("malloc for nodes failed");
+            return -1;
+        }
+        memset(nodes, 0, num_pages_to_migrate * sizeof(int));
+
+        void **addr_to_migrate =
+            (void **)malloc(num_pages_to_migrate * sizeof(void *));
+        for (size_t j = 0; j < num_pages_to_migrate; j++) {
+            status[j] = 0;
+            nodes[j] = i;
+            addr_to_migrate[j] = (void *)((char *)migrate_start_addr +
+                                          j * ggml_backend_page_size);
+        }
+
+        int ret = move_pages(0, num_pages_to_migrate, addr_to_migrate, nodes,
+                             status, MPOL_MF_MOVE);
+        if (ret < 0) {
+            GGML_LOG_ERROR("move_pages failed");
+            free(status);
+            free(nodes);
+            return -1;
+        }
+
+        free(status);
+        free(nodes);
+        free(addr_to_migrate);
+
+        offset += size_to_migrate;
+    }
+
+    return 0;
+}
+
+static void migrate_pages_with_cache(void *addr, size_t size,
+                                     bool force_memset) {
+    if (size >= GGML_NUMA_MIGRATE_NODES * ggml_backend_page_size) {
+        numa_migrate_mapping_cache current_addr(addr, size);
+        std::lock_guard<std::mutex> lock(ggml_mapping_mutex);
+        auto it = ggml_mapping_cache.find(current_addr);
+        if (it == ggml_mapping_cache.end()) {
+            GGML_ASSERT(((uint64_t)(addr) & (ggml_backend_page_size - 1)) == 0);
+            int num_pages =
+                size / ggml_backend_page_size / GGML_NUMA_MIGRATE_NODES;
+            if (num_pages && ((size % ggml_backend_page_size) == 0)) {
+                if (force_memset) {
+                    memset(addr, 0, size); // force to allocate memory
+                }
+                if (migrate_pages_multiple_nodes(addr, size) != 0) {
+                    GGML_LOG_DEBUG("Migration to multiple nodes failed, addr: "
+                                   "%p, size: %ld\n",
+                                   addr, size);
+                } else {
+#ifdef GGML_USE_NUMA_MIGRATE_DEBUG
+                    check_numa_pages_migration(addr, size);
+#endif
+                }
+                ggml_mapping_cache.insert(current_addr);
+            }
+        }
+    }
+}
+#endif
+
 enum ggml_status ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr) {
     GGML_ASSERT(tensor->buffer == NULL);
     GGML_ASSERT(tensor->data == NULL);
@@ -1668,6 +1945,11 @@ enum ggml_status ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct 
 
     tensor->buffer = buffer;
     tensor->data = addr;
+
+#ifdef GGML_USE_NUMA_MIGRATE
+    size_t size = ggml_backend_buffer_get_alloc_size(buffer, tensor);
+    migrate_pages_with_cache(tensor->data, size, true);
+#endif
     return ggml_backend_buffer_init_tensor(buffer, tensor);
 }
 
@@ -1861,16 +2143,28 @@ bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t 
 static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
     uintptr_t data = (uintptr_t)buffer->context;
 
+#ifdef GGML_USE_NUMA_MIGRATE
+    // align the buffer
+    if (data % ggml_backend_page_size != 0) {
+        data = GGML_PAD(data, ggml_backend_page_size);
+    }
+#else
     // align the buffer
     if (data % TENSOR_ALIGNMENT != 0) {
         data = GGML_PAD(data, TENSOR_ALIGNMENT);
     }
+#endif
 
     return (void *)data;
 }
 
 static void ggml_backend_cpu_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    numa_free(buffer->context, buffer->size);
+#else
     ggml_aligned_free(buffer->context, buffer->size);
+#endif
+
 }
 
 static void ggml_backend_cpu_buffer_memset_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
@@ -1939,8 +2233,22 @@ static const char * ggml_backend_cpu_buffer_type_get_name(ggml_backend_buffer_ty
     GGML_UNUSED(buft);
 }
 
+#ifdef GGML_USE_NUMA_MIGRATE
+size_t ggml_backend_get_page_size(void) {
+    if (ggml_backend_page_size == 0) {
+        ggml_backend_page_size = sysconf(_SC_PAGE_SIZE);
+    }
+    return ggml_backend_page_size;
+}
+#endif
+
 static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    ggml_backend_get_page_size();
+    void * data = numa_alloc_onnode(size, 0);
+#else
     void * data = ggml_aligned_malloc(size);
+#endif
 
     if (data == NULL) {
         GGML_LOG_ERROR("%s: failed to allocate buffer of size %zu\n", __func__, size);
@@ -1951,7 +2259,11 @@ static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_back
 }
 
 static size_t ggml_backend_cpu_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/ggml/src/ggml-cpu/amx/amx.cpp
+++ b/ggml/src/ggml-cpu/amx/amx.cpp
@@ -133,7 +133,11 @@ static ggml_backend_buffer_t ggml_backend_amx_buffer_type_alloc_buffer(ggml_back
 }
 
 static size_t ggml_backend_amx_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -15,6 +15,7 @@
 #include <cfloat>
 #include <cstdlib> // for qsort
 #include <cstdio>  // for GGML_ASSERT
+#include <numa.h>
 
 #include "ggml-cpu-aarch64.h"
 
@@ -6094,7 +6095,12 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
         GGML_ASSERT(ggml_n_dims(op->src[0]) == 2);
         // GGML_ASSERT(ggml_n_dims(op->src[1]) == 2);
 
+#ifdef GGML_USE_NUMA_MIGRATE
+        int node_id = numa_node_of_cpu(ith);
+        char *       wdata = static_cast<char *>(params->wdata_numa[node_id]);
+#else
         char *       wdata = static_cast<char *>(params->wdata);
+#endif
         const size_t nbw1  = ggml_row_size(PARAM_TYPE, ne10);
 
         assert(params->wsize >= nbw1 * ne11);
@@ -6102,18 +6108,32 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
         const ggml_from_float_t from_float = ggml_get_type_traits_cpu(PARAM_TYPE)->from_float;
 
         int64_t i11_processed = 0;
-        for (int64_t i11 = ith * 4; i11 < ne11 - ne11 % 4; i11 += nth * 4) {
+#ifdef GGML_USE_NUMA_MIGRATE
+        int round_cnts = ggml_cores_per_numa();
+        int start_id = ith - round_cnts * node_id;
+        if (round_cnts == 0) {
+            round_cnts = nth;
+            start_id = ith;
+        }
+#else
+        int round_cnts = nth;
+        int start_id = ith;
+#endif
+        for (int64_t i11 = start_id * 4; i11 < ne11 - ne11 % 4; i11 += round_cnts * 4) {
             ggml_quantize_mat_t<INTER_SIZE, PARAM_TYPE>((float *) ((char *) src1->data + i11 * nb11), (void *) (wdata + i11 * nbw1), 4, ne10);
         }
 
         i11_processed = ne11 - ne11 % 4;
-        for (int64_t i11 = i11_processed + ith; i11 < ne11; i11 += nth) {
+        for (int64_t i11 = i11_processed + start_id; i11 < ne11; i11 += round_cnts) {
             from_float((float *) ((char *) src1->data + i11 * nb11), (void *) (wdata + i11 * nbw1), ne10);
         }
 
+#ifdef GGML_USE_NUMA_MIGRATE
+        ggml_barrier_numa_aware(params->threadpool, ith, GGML_BARRIER_NODE_LAST);
+#else
         ggml_barrier(params->threadpool);
+#endif
 
-        const void * src1_wdata      = params->wdata;
         const size_t src1_col_stride = ggml_row_size(PARAM_TYPE, ne10);
         int64_t      src0_start      = (ith * ne01) / nth;
         int64_t      src0_end        = ((ith + 1) * ne01) / nth;
@@ -6128,13 +6148,13 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             gemm<BLOC_TYPE, INTER_SIZE, NB_COLS, PARAM_TYPE>(ne00,
                     (float *) ((char *) dst->data) + src0_start, ne01,
                     (const char *) src0->data + src0_start * nb01,
-                    (const char *) src1_wdata, ne11 - ne11 % 4, src0_end - src0_start);
+                    (const char *) wdata, ne11 - ne11 % 4, src0_end - src0_start);
         }
         for (int iter = ne11 - ne11 % 4; iter < ne11; iter++) {
             gemv<BLOC_TYPE, INTER_SIZE, NB_COLS, PARAM_TYPE>(ne00,
                     (float *) ((char *) dst->data + (iter * nb1)) + src0_start, ne01,
                     (const char *) src0->data + src0_start * nb01,
-                    (const char *) src1_wdata + (src1_col_stride * iter), 1,
+                    (const char *) wdata + (src1_col_stride * iter), 1,
                     src0_end - src0_start);
         }
     }

--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -6096,7 +6096,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
         // GGML_ASSERT(ggml_n_dims(op->src[1]) == 2);
 
 #ifdef GGML_USE_NUMA_MIGRATE
-        int node_id = numa_node_of_cpu(ith);
+        int node_id = ggml_get_node_from_cpu(ith);
         char *       wdata = static_cast<char *>(params->wdata_numa[node_id]);
 #else
         char *       wdata = static_cast<char *>(params->wdata);

--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -6111,7 +6111,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             from_float((float *) ((char *) src1->data + i11 * nb11), (void *) (wdata + i11 * nbw1), ne10);
         }
 
-        ggml_barrier_numa_aware(params->threadpool, ith, GGML_BARRIER_NODE_LAST);
+        ggml_barrier(params->threadpool);
 
         const void * src1_wdata      = params->wdata;
         const size_t src1_col_stride = ggml_row_size(PARAM_TYPE, ne10);
@@ -6219,7 +6219,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             }
         }
 
-        ggml_barrier_numa_aware(params->threadpool, ith, GGML_BARRIER_NODE_LAST);
+        ggml_barrier(params->threadpool);
 
         // compute each matrix multiplication in sequence
         for (int cur_a = 0; cur_a < n_as; ++cur_a) {

--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -6111,7 +6111,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             from_float((float *) ((char *) src1->data + i11 * nb11), (void *) (wdata + i11 * nbw1), ne10);
         }
 
-        ggml_barrier(params->threadpool);
+        ggml_barrier_numa_aware(params->threadpool, ith, GGML_BARRIER_NODE_LAST);
 
         const void * src1_wdata      = params->wdata;
         const size_t src1_col_stride = ggml_row_size(PARAM_TYPE, ne10);
@@ -6219,7 +6219,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             }
         }
 
-        ggml_barrier(params->threadpool);
+        ggml_barrier_numa_aware(params->threadpool, ith, GGML_BARRIER_NODE_LAST);
 
         // compute each matrix multiplication in sequence
         for (int cur_a = 0; cur_a < n_as; ++cur_a) {
@@ -6359,7 +6359,11 @@ static ggml_backend_buffer_t ggml_backend_cpu_aarch64_buffer_type_alloc_buffer(g
 }
 
 static size_t ggml_backend_cpu_aarch64_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -506,6 +506,8 @@ static __m256 __lasx_xvreplfr2vr_s(const float val) {
 
 // TODO: move to ggml-threading
 void ggml_barrier(struct ggml_threadpool * tp);
+#define GGML_BARRIER_NODE_LAST      -1
+void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -506,7 +506,11 @@ static __m256 __lasx_xvreplfr2vr_s(const float val) {
 
 // TODO: move to ggml-threading
 void ggml_barrier(struct ggml_threadpool * tp);
-#define GGML_BARRIER_NODE_LAST      -1
+enum ggml_barrier_node_index {
+    GGML_BARRIER_NODE_PING = 0,
+    GGML_BARRIER_NODE_PONG = 1,
+    GGML_BARRIER_NODE_LAST = 2,
+};
 void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
 
 #ifdef __cplusplus

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -513,10 +513,12 @@ enum ggml_barrier_node_index {
     GGML_BARRIER_NODE_PING = 0,
     GGML_BARRIER_NODE_PONG = 1,
     GGML_BARRIER_NODE_LAST = 2,
+    GGML_BARRIER_NODE_CNTS = 3
 };
 void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
 #ifdef GGML_USE_NUMA_MIGRATE
 int ggml_cores_per_numa(void);
+int ggml_get_node_from_cpu(int cpu);
 #endif
 
 #ifdef __cplusplus

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -22,6 +22,9 @@ struct ggml_compute_params {
     // work buffer for all threads
     size_t wsize;
     void * wdata;
+#ifdef GGML_USE_NUMA_MIGRATE
+    void * wdata_numa[GGML_NUMA_MIGRATE_NODES];
+#endif
 
     struct ggml_threadpool * threadpool;
 };
@@ -512,6 +515,9 @@ enum ggml_barrier_node_index {
     GGML_BARRIER_NODE_LAST = 2,
 };
 void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
+#ifdef GGML_USE_NUMA_MIGRATE
+int ggml_cores_per_numa(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -593,7 +593,7 @@ void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n) {
     int cores_per_numa = g_state.numa.nodes[0].n_cpus;
     int numa_nodes = n_threads / cores_per_numa;
     int remaining_cores = n_threads % cores_per_numa;
-    if (numa_nodes <= 1 || remaining_cores) {
+    if ((numa_nodes != GGML_NUMA_MIGRATE_NODES) || remaining_cores) {
         ggml_barrier(tp);
         return;
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <string>
 #include <vector>
+#include <numa.h>
 
 #ifdef GGML_USE_CPU_HBM
 #    include "ggml-cpu-hbm.h"
@@ -87,6 +88,9 @@ struct ggml_backend_cpu_context {
     ggml_threadpool_t   threadpool;
 
     uint8_t *           work_data;
+#ifdef GGML_USE_NUMA_MIGRATE
+    uint8_t *           work_data_numa[GGML_NUMA_MIGRATE_NODES];
+#endif
     size_t              work_size;
 
     ggml_abort_callback abort_callback;
@@ -102,6 +106,11 @@ static const char * ggml_backend_cpu_get_name(ggml_backend_t backend) {
 static void ggml_backend_cpu_free(ggml_backend_t backend) {
     struct ggml_backend_cpu_context * cpu_ctx = (struct ggml_backend_cpu_context *)backend->context;
     delete[] cpu_ctx->work_data;
+#ifdef GGML_USE_NUMA_MIGRATE
+    for (int i = 0; i < GGML_NUMA_MIGRATE_NODES; i++) {
+        numa_free(cpu_ctx->work_data_numa[i], cpu_ctx->work_size);
+    }
+#endif
     delete cpu_ctx;
     delete backend;
 }
@@ -162,9 +171,24 @@ static enum ggml_status ggml_backend_cpu_graph_compute(ggml_backend_t backend, s
             cpu_ctx->work_size = 0;
             return GGML_STATUS_ALLOC_FAILED;
         }
+
+#ifdef GGML_USE_NUMA_MIGRATE
+        for (int i = 0; i < GGML_NUMA_MIGRATE_NODES; i++) {
+            cpu_ctx->work_data_numa[i] = (uint8_t *)numa_alloc_onnode(cplan.work_size, i);
+            if (cpu_ctx->work_data_numa[i] == NULL) {
+                cpu_ctx->work_size = 0;
+                return GGML_STATUS_ALLOC_FAILED;
+            }
+         }
+#endif
         cpu_ctx->work_size = cplan.work_size;
     }
     cplan.work_data = (uint8_t *)cpu_ctx->work_data;
+#ifdef GGML_USE_NUMA_MIGRATE
+    for (int i = 0; i < GGML_NUMA_MIGRATE_NODES; i++) {
+        cplan.work_data_numa[i] = (uint8_t *)(cpu_ctx->work_data_numa[i]);
+    }
+#endif
 
     cplan.abort_callback      = cpu_ctx->abort_callback;
     cplan.abort_callback_data = cpu_ctx->abort_callback_data;
@@ -205,6 +229,11 @@ ggml_backend_t ggml_backend_cpu_init(void) {
     ctx->n_threads           = GGML_DEFAULT_N_THREADS;
     ctx->threadpool          = NULL;
     ctx->work_data           = NULL;
+#ifdef GGML_USE_NUMA_MIGRATE
+    for (int i = 0; i < GGML_NUMA_MIGRATE_NODES; i++) {
+        ctx->work_data_numa[i]    = NULL;
+    }
+#endif
     ctx->work_size           = 0;
     ctx->abort_callback      = NULL;
     ctx->abort_callback_data = NULL;

--- a/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
+++ b/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
@@ -413,7 +413,11 @@ static ggml_backend_buffer_t ggml_backend_cpu_kleidiai_buffer_type_alloc_buffer(
 }
 
 static size_t ggml_backend_cpu_kleidiai_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -686,6 +686,10 @@ llama_model_loader::llama_model_loader(
         use_mmap = false;
     }
 
+#ifdef GGML_USE_NUMA_MIGRATE
+    use_mmap = false;
+#endif
+
     this->use_mmap = use_mmap;
     this->check_tensors = check_tensors;
 }

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -312,7 +312,12 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("\n");
     printf("options:\n");
     printf("  -h, --help\n");
+#ifdef GGML_USE_NUMA_MIGRATE
+    printf("  --numa <distribute|isolate|numactl|migrate>\n");
+    printf("                                            numa mode (default: disabled)\n");
+#else
     printf("  --numa <distribute|isolate|numactl>       numa mode (default: disabled)\n");
+#endif
     printf("  -r, --repetitions <n>                     number of times to repeat each test (default: %d)\n",
            cmd_params_defaults.reps);
     printf("  --prio <0|1|2|3>                          process/thread priority (default: %d)\n",
@@ -628,6 +633,10 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                     params.numa = GGML_NUMA_STRATEGY_ISOLATE;
                 } else if (value == "numactl") {
                     params.numa = GGML_NUMA_STRATEGY_NUMACTL;
+#ifdef GGML_USE_NUMA_MIGRATE
+                } else if (value == "migrate") {
+                    params.numa = GGML_NUMA_STRATEGY_MIGRATE;
+#endif
                 } else {
                     invalid_param = true;
                     break;


### PR DESCRIPTION
This PR adds GGML_USE_NUMA_MIGRATE feature to optimize cross NUMA op computation as the cross-NUMA memory access would be the bottleneck if spawning threads across NUMA nodes:

1. optimize the ggml_barrier() for cross NUMA case by adding ggml_barrier_numa_aware(), currently enabled for aarch64 forward_mul_mat()
2. add build option GGML_USE_NUMA_MIGRATE to enable the feature
3. add option --numa migrate if GGML_USE_NUMA_MIGRATE is enabled, which would migrate pages across NUMA nodes so that mul_mat op would only do the computation in local numa part of tensor data src0 and dst according to the ith, cores would be set affinity with the option.

# Test Results
With the feature, tested on NeoVerse N2 with multiple NUMA nodes (with 64 cores per NUMA node), see performance improvements with running llama3 model.
## Base data
running command:
```
$ numactl -m 0 -N 0 $LLAMA/build/bin/llama-batched-bench -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -c 4096 -b 2048 -ub 512 -npp 128 -ntg 128 -npl 1,4,8,16 -t 64
```
results:
```
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.286 |   447.56 |    5.119 |    25.01 |    5.405 |    47.37 |
|   128 |    128 |    4 |   1024 |    1.391 |   368.03 |    6.025 |    84.98 |    7.416 |   138.08 |
|   128 |    128 |    8 |   2048 |    2.925 |   350.03 |    8.641 |   118.51 |   11.566 |   177.07 |
|   128 |    128 |   16 |   4096 |    6.853 |   298.83 |   11.240 |   182.21 |   18.093 |   226.38 |

```

## Result with the feature
running command:
```
$ ./llama-batched-bench -m $MODEL_DIR/$MODEL -c 4096 -b 2048 -ub 512 -npp 128 -ntg 128 -npl 1,2,4,8,16 -t 128 --cache-type-k q8_0 --cache-type-v q8_0 -fa --numa migrate
```
results:
```
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.291 |   439.45 |    4.186 |    30.58 |    4.477 |    57.18 |
|   128 |    128 |    4 |   1024 |    1.458 |   351.08 |    5.909 |    86.65 |    7.367 |   139.00 |
|   128 |    128 |    8 |   2048 |    2.943 |   347.95 |    7.499 |   136.55 |   10.442 |   196.13 |
|   128 |    128 |   16 |   4096 |    7.738 |   264.68 |   10.933 |   187.33 |   18.670 |   219.39 |

```
For example, there's S_TG t/s 22% performance improvement with B=1, slightly S_PP t/s drop (1.8%), overall 20.7% S T/s improvement.

Tested perplexity, there's no regression with the feature:
```
$ numactl -m 0,1 -N 0,1 $LLAMA/build/bin/llama-perplexity -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -f $LLAMA/wikitext-2-raw/wiki.test.raw -t 128 --numa migrate
Final estimate: PPL = 8.7538 +/- 0.06481

```
# Enablement
The feature is disabled by default, this is the guidances to enable the feature:
1. enable DGGML_NUMA_MIGRATE during cmake
```
$ cmake -B build -DGGML_NUMA_MIGRATE=ON
```
2. add --numa migrate option when running, and set thread numbers according to the number of numa nodes (which is 2 nodes by default which is the best trade-off number during the NeoVerse N2 platform in test, could be changed by setting GGML_NUMA_MIGRATE_NODES build option, it's also better to bind  llama to numa node 0 and 1 through numactl -m 0,1 -N 0,1).

