### PR TITLE
mtmd-helper : bug fix to token batching in mtmd

### DIFF
--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -231,12 +231,13 @@ int32_t mtmd_helper_eval_chunk_single(mtmd_context * ctx,
         while (i < n_tokens) { // split into batches
             text_batch.n_tokens = 0; // clear the batch
             for (; i < n_tokens && text_batch.n_tokens < n_batch; i++) {
+                text_batch.token   [text_batch.n_tokens]    = tokens[i];
+                text_batch.pos     [text_batch.n_tokens]    = n_past++;
+                text_batch.n_seq_id[text_batch.n_tokens]    = 1;
+                text_batch.seq_id  [text_batch.n_tokens][0] = seq_id;
+                text_batch.logits  [text_batch.n_tokens]    = false;
+
                 text_batch.n_tokens++;
-                text_batch.token   [i]    = tokens[i];
-                text_batch.pos     [i]    = n_past++;
-                text_batch.n_seq_id[i]    = 1;
-                text_batch.seq_id  [i][0] = seq_id;
-                text_batch.logits  [i]    = false;
             }
             bool is_last_token = (i == n_tokens);
             if (logits_last && is_last_token) {

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -231,11 +231,12 @@ int32_t mtmd_helper_eval_chunk_single(mtmd_context * ctx,
         while (i < n_tokens) { // split into batches
             text_batch.n_tokens = 0; // clear the batch
             for (; i < n_tokens && text_batch.n_tokens < n_batch; i++) {
-                text_batch.token   [text_batch.n_tokens]    = tokens[i];
-                text_batch.pos     [text_batch.n_tokens]    = n_past++;
-                text_batch.n_seq_id[text_batch.n_tokens]    = 1;
-                text_batch.seq_id  [text_batch.n_tokens][0] = seq_id;
-                text_batch.logits  [text_batch.n_tokens]    = false;
+                int32_t j = text_batch.n_tokens;
+                text_batch.token   [j]    = tokens[i];
+                text_batch.pos     [j]    = n_past++;
+                text_batch.n_seq_id[j]    = 1;
+                text_batch.seq_id  [j][0] = seq_id;
+                text_batch.logits  [j]    = false;
 
                 text_batch.n_tokens++;
             }


### PR DESCRIPTION
From my understanding, we should be setting each field in the tokens batch using the current `text_batch.n_tokens` counter, instead of the outer `i` counter.

If the outer `n_tokens` > `n_batch`, the original code gives a segmentation fault because each batch is only initialised with `n_batch` number of spaces, but `i` will increase to the number of overall `n_tokens`.