### PR TITLE
common: Include torch package for s390x

### DIFF
--- a/requirements/requirements-convert_hf_to_gguf.txt
+++ b/requirements/requirements-convert_hf_to_gguf.txt
@@ -1,3 +1,5 @@
 -r ./requirements-convert_legacy_llama.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
+# torch s390x packages can only be found from nightly builds
+--extra-index-url https://download.pytorch.org/whl/nightly
 torch~=2.2.1

--- a/requirements/requirements-convert_hf_to_gguf.txt
+++ b/requirements/requirements-convert_hf_to_gguf.txt
@@ -1,5 +1,7 @@
 -r ./requirements-convert_legacy_llama.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
+torch~=2.2.1; platform_machine != "s390x"
+
 # torch s390x packages can only be found from nightly builds
 --extra-index-url https://download.pytorch.org/whl/nightly
-torch~=2.2.1
+torch>=0.0.0.dev0; platform_machine == "s390x"

--- a/requirements/requirements-convert_hf_to_gguf_update.txt
+++ b/requirements/requirements-convert_hf_to_gguf_update.txt
@@ -1,3 +1,5 @@
 -r ./requirements-convert_legacy_llama.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
+# torch s390x packages can only be found from nightly builds
+--extra-index-url https://download.pytorch.org/whl/nightly
 torch~=2.2.1

--- a/requirements/requirements-convert_hf_to_gguf_update.txt
+++ b/requirements/requirements-convert_hf_to_gguf_update.txt
@@ -1,5 +1,7 @@
 -r ./requirements-convert_legacy_llama.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
+torch~=2.2.1; platform_machine != "s390x"
+
 # torch s390x packages can only be found from nightly builds
 --extra-index-url https://download.pytorch.org/whl/nightly
-torch~=2.2.1
+torch>=0.0.0.dev0; platform_machine == "s390x"

--- a/requirements/requirements-convert_lora_to_gguf.txt
+++ b/requirements/requirements-convert_lora_to_gguf.txt
@@ -1,2 +1,4 @@
 -r ./requirements-convert_hf_to_gguf.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
+# torch s390x packages can only be found from nightly builds
+--extra-index-url https://download.pytorch.org/whl/nightly


### PR DESCRIPTION
This pull request introduces the `torch` package into `requirements.txt` for the s390x architecture.

### Problem
At current, the `torch` package for the s390x architecture cannot be found on PyTorch's stable build; only the nightly builds include wheels for s390x.

As a result, trying to install packages using the `requirements.txt` would fail. Otherwise, conda would have to be used to resolve the `torch` dependency issue.

Additionally, going the conda route would require further manual patches as documented in my blog here: https://medium.com/@taronaeo/running-any-llm-on-mainframes-s390x-d5acc56ea649#:~:text=Step%205%3A%20Install%20Required%20Python%20Packages

### Resolution
This PR segregates the `torch~=2.2.1` requirement from all other platforms by using the requirement specifiers and only installs `torch` from the nightly build for the s390x architecture.

This effectively removes the friction of installing packages from `requirements.txt` on the s390x architecture.

### Verification
To ensure that this PR did not break anything, the `pip3 install -r requirements.txt` command has been tested on the following machines:
* Tested on IBM z15 Mainframe
* Tested on M3 MacBook Air
* Kindly request additional architectures to be tested

> [!NOTE]  
> Tests were conducted on an IBM z15 Mainframe with 16 IFLs (cores) and 160 GB Memory on an LPAR.

Please review this pull request and consider merging into the main repository. Thank you!