### PR TITLE
ggml: fix `GGML_UNARY_OP_NAME` order  to align with `enum ggml_unary_op`

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1091,15 +1091,15 @@ static const char * GGML_UNARY_OP_NAME[GGML_UNARY_OP_COUNT] = {
     "STEP",
     "TANH",
     "ELU",
-    "RELU",
     "SIGMOID",
     "GELU",
+    "GELU_ERF",
     "GELU_QUICK",
     "SILU",
     "HARDSWISH",
     "HARDSIGMOID",
     "EXP",
-    "GELU_ERF",
+    "RELU",
 };
 
 static_assert(GGML_UNARY_OP_COUNT == 15, "GGML_UNARY_OP_COUNT != 15");


### PR DESCRIPTION
The names order in `GGML_UNARY_OP_NAME` mismatches that in `enum ggml_unary_op`. This causes problem when unit testing a specific unary op by passing the unary op name to `test-backend-ops`.