### PR TITLE
CUDA: fix race condition in FA vector kernels

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f16.cuh
@@ -212,6 +212,7 @@ static __global__ void flash_attn_vec_ext_f16(
                 }
             }
             if (__all_sync(0xFFFFFFFF, skip)) {
+                __syncthreads();
                 continue;
             }
 #endif // GGML_USE_HIP

--- a/ggml/src/ggml-cuda/fattn-vec-f32.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f32.cuh
@@ -217,6 +217,7 @@ static __global__ void flash_attn_vec_ext_f32(
                 }
             }
             if (__all_sync(0xFFFFFFFF, skip)) {
+                __syncthreads();
                 continue;
             }
 #endif // GGML_USE_HIP


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/13733 .

Looking at the code I added in https://github.com/ggml-org/llama.cpp/pull/13584 again, I think I accidentally introduced a race condition. The mask is being written to shared memory anyways, so the synchronization between warps is achieved by each warp just checking all of the mask values, and then reducing `skip` within the warp. Each warp will come to the same conclusion regarding whether or not to execute the `continue`. However, warps are not guaranteed to execute the `continue` at the same time, and after they do they will write new values to `maskf_shared` which can in turn influence whether other warps will execute the `continue`, potentially causing the warps to become desynchronized.