### PR TITLE
Move GLM4 f32 attention fix to the correct function

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1287,6 +1287,10 @@ ggml_tensor * llm_graph_context::build_attn(
 
     if (wo) {
         cur = build_lora_mm(wo, cur);
+        if (arch == LLM_ARCH_GLM4) {
+            // GLM4 seems to have numerical issues with half-precision accumulators
+            ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
+        }
     }
 
     if (wo_b) {
@@ -1367,10 +1371,6 @@ ggml_tensor * llm_graph_context::build_attn(
 
     if (wo) {
         cur = build_lora_mm(wo, cur);
-        if (arch == LLM_ARCH_GLM4) {
-            // GLM4 seems to have numerical issues with half-precision accumulators
-            ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
-        }
     }
 
     if (wo_b) {


### PR DESCRIPTION
@ggerganov You merged SWA support (#13194) 3 hours before I merged my GLM4 fix (#13639). They touched the same build_attn functions, so there should have been a merge conflict. For whatever reason, my patch was applied to the newly-created `build_attn` function with a unified_iswa kv cache, which is not used by GLM4. So it didn't work anymore. Here's the fix, moving my patch back to the unified build_attn function... I don't think I've seen something like this before, quite the coincidence.