### PR TITLE
ggml-cpu : set openmp wait time if not set

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3486,8 +3486,15 @@ void ggml_cpu_init(void) {
             GGML_PRINT_DEBUG("%s: GELU, Quick GELU, SILU and EXP tables initialized in %f ms\n", __func__, (t_end - t_start)/1000.0);
 
 #ifdef GGML_USE_OPENMP
-            if (!getenv("OMP_WAIT_POLICY")) {
-                putenv("OMP_WAIT_POLICY=active");
+            //if (!getenv("OMP_WAIT_POLICY")) {
+            //    // set the wait policy to active, so that OpenMP threads don't sleep
+            //    putenv("OMP_WAIT_POLICY=active");
+            //}
+
+            if (!getenv("KMP_BLOCKTIME")) {
+                // set the time to wait before sleeping a thread
+                // this is less aggressive than setting the wait policy to active, but should achieve similar results in most cases
+                putenv("KMP_BLOCKTIME=200"); // 200ms
             }
 #endif
         }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3484,6 +3484,12 @@ void ggml_cpu_init(void) {
             const uint64_t t_end = ggml_time_us(); UNUSED(t_end);
 
             GGML_PRINT_DEBUG("%s: GELU, Quick GELU, SILU and EXP tables initialized in %f ms\n", __func__, (t_end - t_start)/1000.0);
+
+#ifdef GGML_USE_OPENMP
+            if (!getenv("OMP_WAIT_POLICY")) {
+                putenv("OMP_WAIT_POLICY=active");
+            }
+#endif
         }
 
 #if defined(__ARM_ARCH)


### PR DESCRIPTION
~Sets the OpenMP wait policy to `active` if not set~. On some implementations this can significantly increase performance when using OpenMP.

Edit: changed to setting the thread block time instead, otherwise threads will continue spinning indefinitely. This is not a standard OpenMP setting, but it works in clang/windows. In my system setting it to 200ms results in the same performance as `active` wait policy.