### PR TITLE
vulkan: readd GGML_VULKAN_PERF

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -839,7 +839,7 @@ public:
             for (const auto& time : t.second) {
                 total += time;
             }
-            std::cerr << t.first << ": " << t.second.size() << " x " << (total / t.second.size() / 1000.0) << " ms" << std::endl;
+            std::cerr << t.first << ": " << t.second.size() << " x " << (total / t.second.size() / 1000.0) << " us" << std::endl;
         }
 
         timings.clear();


### PR DESCRIPTION
This readds the GGML_VULKAN_PERF feature after it got removed in #9118. It's set up to submit the ops individually like GGML_VULKAN_CHECK_RESULTS (I think I did that right).

```
./bin/llama-bench -m llama-2-7b.Q4_0.gguf -r 1 -p 512 -n 2
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon RX 470 Graphics (RADV POLARIS10) (radv) | uma: 0 | fp16: 0 | warp size: 64 | shared memory: 65536 | int dot: 0 | matrix cores: none
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
----------------
Vulkan Timings:
ADD: 64 x 263.644 ms
CONT: 32 x 211.384 ms
CPY: 64 x 1339.26 ms
GET_ROWS: 2 x 87.714 ms
MUL: 97 x 438.105 ms
MUL_MAT m=11008 n=512 k=4096: 62 x 14361.3 ms
MUL_MAT m=128 n=512 k=512: 32 x 2424.7 ms
MUL_MAT m=4096 n=512 k=11008: 31 x 15690.5 ms
MUL_MAT m=4096 n=512 k=4096: 128 x 6855.94 ms
MUL_MAT m=512 n=512 k=128: 32 x 2358.41 ms
MUL_MAT_VEC m=11008 k=4096: 2 x 200.069 ms
MUL_MAT_VEC m=32000 k=4096: 1 x 727.618 ms
MUL_MAT_VEC m=4096 k=11008: 1 x 211.537 ms
RMS_NORM: 65 x 214.698 ms
ROPE: 64 x 362.017 ms
SILU: 32 x 330.783 ms
SOFT_MAX: 32 x 870.034 ms
----------------
Vulkan Timings:
ADD: 64 x 277.48 ms
CONT: 32 x 253.444 ms
CPY: 64 x 1323.65 ms
GET_ROWS: 2 x 69.106 ms
MUL: 97 x 441.004 ms
MUL_MAT m=11008 n=512 k=4096: 62 x 14390.8 ms
MUL_MAT m=128 n=512 k=512: 32 x 2845.28 ms
MUL_MAT m=4096 n=512 k=11008: 31 x 16561.4 ms
MUL_MAT m=4096 n=512 k=4096: 128 x 7122.14 ms
MUL_MAT m=512 n=512 k=128: 32 x 2458.84 ms
MUL_MAT_VEC m=11008 k=4096: 2 x 186.524 ms
MUL_MAT_VEC m=32000 k=4096: 1 x 702.008 ms
MUL_MAT_VEC m=4096 k=11008: 1 x 198.647 ms
RMS_NORM: 65 x 212.158 ms
ROPE: 64 x 303.754 ms
SILU: 32 x 311.434 ms
SOFT_MAX: 32 x 1235.61 ms
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |           pp512 |        187.09 ± 0.00 |
----------------
Vulkan Timings:
ADD: 64 x 36.659 ms
CONT: 32 x 35.54 ms
CPY: 64 x 35.763 ms
GET_ROWS: 2 x 33.407 ms
MUL: 97 x 37.877 ms
MUL_MAT_VEC m=11008 k=4096: 64 x 180.476 ms
MUL_MAT_VEC m=128 k=32: 32 x 50.035 ms
MUL_MAT_VEC m=32 k=128: 32 x 39.315 ms
MUL_MAT_VEC m=32000 k=4096: 1 x 666.888 ms
MUL_MAT_VEC m=4096 k=11008: 32 x 191.914 ms
MUL_MAT_VEC m=4096 k=4096: 128 x 96.082 ms
RMS_NORM: 65 x 46.071 ms
ROPE: 64 x 37.849 ms
SILU: 32 x 34.388 ms
SOFT_MAX: 32 x 35.824 ms
----------------
Vulkan Timings:
ADD: 64 x 39.125 ms
CONT: 32 x 36.44 ms
CPY: 64 x 35.159 ms
GET_ROWS: 2 x 33.951 ms
MUL: 97 x 35.89 ms
MUL_MAT_VEC m=11008 k=4096: 64 x 179.759 ms
MUL_MAT_VEC m=128 k=32: 32 x 56.564 ms
MUL_MAT_VEC m=32 k=128: 32 x 37.74 ms
MUL_MAT_VEC m=32000 k=4096: 1 x 664.134 ms
MUL_MAT_VEC m=4096 k=11008: 32 x 191.265 ms
MUL_MAT_VEC m=4096 k=4096: 128 x 95.2 ms
RMS_NORM: 65 x 43.697 ms
ROPE: 64 x 36.036 ms
SILU: 32 x 34.948 ms
SOFT_MAX: 32 x 36.142 ms
----------------
Vulkan Timings:
ADD: 64 x 38.788 ms
CONT: 32 x 36.099 ms
CPY: 64 x 37.976 ms
GET_ROWS: 2 x 33.572 ms
MUL: 97 x 40.582 ms
MUL_MAT_VEC m=11008 k=4096: 64 x 181.708 ms
MUL_MAT_VEC m=128 k=32: 32 x 50.636 ms
MUL_MAT_VEC m=32 k=128: 32 x 40.164 ms
MUL_MAT_VEC m=32000 k=4096: 1 x 666.921 ms
MUL_MAT_VEC m=4096 k=11008: 32 x 198.705 ms
MUL_MAT_VEC m=4096 k=4096: 128 x 97.665 ms
RMS_NORM: 65 x 46.091 ms
ROPE: 64 x 41.26 ms
SILU: 32 x 42.978 ms
SOFT_MAX: 32 x 36.567 ms
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  99 |             tg2 |         17.35 ± 0.00 |

build: 596669e3 (5471)
```

The tests are passing with GGML_VULKAN_PERF turned on.