### PR TITLE
ggml-backend: backend-agnostic tensor parallelism

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -41,6 +41,7 @@ extern "C" {
     GGML_API size_t                ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type_t buft, const struct ggml_tensor * tensor);
     GGML_API bool                  ggml_backend_buft_is_host       (ggml_backend_buffer_type_t buft);
     GGML_API ggml_backend_dev_t    ggml_backend_buft_get_device    (ggml_backend_buffer_type_t buft);
+    GGML_API bool                  ggml_backend_buft_is_split      (ggml_backend_buffer_type_t buft);
 
     //
     // Backend buffer

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -758,8 +758,9 @@ bool ggml_gallocr_reserve_n(ggml_gallocr_t galloc, struct ggml_cgraph * graph, c
             }
         }
 
-        size_t cur_size = galloc->buffers[i] ? ggml_backend_buffer_get_size(galloc->buffers[i]) : 0;
-        size_t new_size = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i]);
+        // FIXME
+        size_t cur_size = (galloc->buffers[i] ? ggml_backend_buffer_get_size(galloc->buffers[i]) : 0) + 1024*1024*1024;
+        size_t new_size = (ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i])) + 1024*1024*1024;
 
         // even if there are no tensors allocated in this buffer, we still need to allocate it to initialize views
         if (new_size > cur_size || galloc->buffers[i] == NULL) {

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -758,9 +758,8 @@ bool ggml_gallocr_reserve_n(ggml_gallocr_t galloc, struct ggml_cgraph * graph, c
             }
         }
 
-        // FIXME
-        size_t cur_size = (galloc->buffers[i] ? ggml_backend_buffer_get_size(galloc->buffers[i]) : 0) + 1024*1024*1024;
-        size_t new_size = (ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i])) + 1024*1024*1024;
+        size_t cur_size = galloc->buffers[i] ? ggml_backend_buffer_get_size(galloc->buffers[i]) : 0;
+        size_t new_size = ggml_dyn_tallocr_max_size(galloc->buf_tallocs[i]);
 
         // even if there are no tensors allocated in this buffer, we still need to allocate it to initialize views
         if (new_size > cur_size || galloc->buffers[i] == NULL) {

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -26,6 +26,7 @@ extern "C" {
         size_t                (*get_alloc_size)(ggml_backend_buffer_type_t buft, const struct ggml_tensor * tensor);
         // (optional) check if tensor data is in host memory and uses standard ggml tensor layout (defaults to false)
         bool                  (*is_host)       (ggml_backend_buffer_type_t buft);
+        bool                  (*is_split)      (ggml_backend_buffer_type_t buft);
     };
 
     struct ggml_backend_buffer_type {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1423,10 +1423,6 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
     }
     sched->n_splits = splits_tp.size();
 
-    if (sched->debug) {
-        ggml_backend_sched_print_assignments(sched, graph);
-    }
-
     // swap node_backend_ids and leaf _backend_ids with prevs
     {
         int * tmp = sched->node_backend_ids;
@@ -1478,6 +1474,10 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             sched->node_backend_ids[graph_copy->n_nodes] = split->backend_id;
             graph_copy->nodes[graph_copy->n_nodes++] = split->graph.nodes[j];
         }
+    }
+
+    if (sched->debug) {
+        ggml_backend_sched_print_assignments(sched, &sched->graph);
     }
 
     if (sched->n_copies > 1) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1190,7 +1190,6 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     for (int n = 0; n < split->graph.n_nodes; n++) {
                         ggml_tensor * node_orig = graph->nodes[split->i_start + n];
                         ggml_tensor * node_sg   = split->graph.nodes[n];
-                        assert(node_orig == node_sg || split->backend_id != 0);
 
                         const size_t node_id = hash_id(node_orig);
                         assert(tensor_id_tp(node_id, split->backend_id) == nullptr);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1420,6 +1420,8 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             GGML_ASSERT(sched->splits != NULL);
         }
         sched->splits[i_split] = splits_tp[i_split];
+        fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
+            __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
     }
     sched->n_splits = splits_tp.size();
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1214,7 +1214,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     ggml_backend_sched_split split = split_main;
                     split.backend_id = i_gpu;
                     split.graph = *ggml_new_graph_custom(sched->ctx, split_main.graph.size, /*grads =*/ false);
-                    dup_graph(sched->ctx, &split_main.graph, &split.graph, /*expand =*/ false);
+                    dup_graph(sched->ctx, &split_main.graph, &split.graph, /*deep =*/ false);
                     splits_tp.push_back(split);
                 }
             }
@@ -1228,7 +1228,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 continue;
             }
 
-            const int i_gpu  = split.backend_id;
+            const int i_gpu = split.backend_id;
             for (int n = 0; n < split.graph.n_nodes; n++) {
                 ggml_tensor * dst = split.graph.nodes[n];
                 GGML_ASSERT(dst->op == GGML_OP_MUL_MAT);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1596,12 +1596,14 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         const int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
 
+        bool execute_inputs = false;
         // copy the input tensors to the split backend
         for (int j = 0; j < split->n_inputs; j++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[j]);
             struct ggml_tensor * input = split->inputs[j];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
             if (input_cpy->op != GGML_OP_NONE) {
+                execute_inputs = true;
                 continue;
             }
 
@@ -1633,7 +1635,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 }
             }
         }
-        {
+        if (execute_inputs) {
             ggml_cgraph graph_inputs = {
                 /*.size             =*/ 0,
                 /*.n_nodes          =*/ split->n_inputs,

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1234,9 +1234,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 GGML_ASSERT(dst->op == GGML_OP_MUL_MAT);
                 ggml_tensor * src0 = dst->src[0];
                 ggml_tensor * src1 = dst->src[1];
-                fprintf(stderr, "%s: 025 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
-                      __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
-                      dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
+                // fprintf(stderr, "%s: 025 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
+                //       __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
+                //       dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 
                 GGML_ASSERT(src0->buffer);
                 GGML_ASSERT(ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer)));
@@ -1270,9 +1270,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 dst->nb[2] = dst->ne[1]*dst->nb[1];
                 dst->nb[3] = dst->ne[2]*dst->nb[2];
 
-                fprintf(stderr, "%s: 050 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
-                      __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
-                      dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
+                // fprintf(stderr, "%s: 050 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
+                //       __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
+                //       dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
             }
 
             for (int n = 0; n < split.graph.n_nodes; n++) {
@@ -1385,7 +1385,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                         split.inputs[n_inputs] = src;
                     }
-                    fprintf(stderr, "%s: 100 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
+                    // fprintf(stderr, "%s: 100 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
                     node->src[j] = tensor_id_copy(src_id, split.backend_id, sched->cur_copy);
                 } else if (src_backend_id != split.backend_id && !ggml_backend_sched_buffer_supported(sched, src, split.backend_id)) {
                     // create a copy of the input in the split's backend
@@ -1405,7 +1405,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                         split.inputs[n_inputs] = src;
                     }
-                    fprintf(stderr, "%s: 200 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
+                    // fprintf(stderr, "%s: 200 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
                     node->src[j] = tensor_id_copy(src_id, split.backend_id, sched->cur_copy);
                 }
             }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1171,6 +1171,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 split.backend_id = node_backend_id;
                 split.i_start = i;
                 split.n_inputs = 0;
+                split.tensor_parallel = src0_on_split_buffer;
             }
         }
         split.i_end = graph->n_nodes;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1269,8 +1269,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             }
 
             for (int n = 0; n < split.graph.n_nodes; n++) {
-                ggml_tensor * node = split.graph.nodes[n];
-                tensor_id_tp(hash_id(node), split.backend_id) = node;
+                ggml_tensor * node_orig = graph->nodes[split.i_start + n];
+                ggml_tensor * node_sg   = split.graph.nodes[n];
+                tensor_id_tp(hash_id(node_orig), split.backend_id) = node_sg;
             }
         }
     }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1329,7 +1329,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     }
                     node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
                 } else if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id) &&
-                           !ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src->buffer))) {
+                           !(src->buffer && ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src->buffer)))) {
                     // create a copy of the input in the split's backend
                     if (tensor_id_copy(src_id, cur_backend_id, 0) == nullptr) {
                         ggml_backend_t backend = sched->backends[cur_backend_id];

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1220,13 +1220,13 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", name.c_str(), i_gpu);
                     }
 
-                    fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split.backend_id);
+                    // fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split.backend_id);
                     splits_tp.push_back(split);
                 }
             }
 
             // add split on same backend last so that splits on other backends don't have to wait for it
-            fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split_main.backend_id);
+            // fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split_main.backend_id);
             splits_tp.push_back(split_main);
         }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1328,6 +1328,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                         split->inputs[n_inputs] = src;
                     }
+                    fprintf(stderr, "%s: 100 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
                     node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
                 } else if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id) &&
                            !(src->buffer && ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src->buffer)))) {
@@ -1348,6 +1349,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                         split->inputs[n_inputs] = src;
                     }
+                    fprintf(stderr, "%s: 200 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
                     node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
                 }
             }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1427,14 +1427,14 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             GGML_ASSERT(sched->splits != NULL);
         }
         sched->splits[i_split] = splits_tp[i_split];
-        fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
-            __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
-        for (int n = 0; n < sched->splits[i_split].n_inputs; n++) {
-            fprintf(stderr, "%s:   - input %d: %s\n", __func__, n, sched->splits[i_split].inputs[n]->name);
-        }
-        for (int n = 0; n < sched->splits[i_split].graph.n_nodes; n++) {
-            fprintf(stderr, "%s:   - node %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);
-        }
+        // fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
+        //     __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
+        // for (int n = 0; n < sched->splits[i_split].n_inputs; n++) {
+        //     fprintf(stderr, "%s:   - input %d: %s\n", __func__, n, sched->splits[i_split].inputs[n]->name);
+        // }
+        // for (int n = 0; n < sched->splits[i_split].graph.n_nodes; n++) {
+        //     fprintf(stderr, "%s:   - node %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);
+        // }
     }
     sched->n_splits = splits_tp.size();
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1173,6 +1173,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 {
                     const ggml_cgraph tmp = ggml_graph_view(graph, split->i_start, split->i_end);
                     if (split->tensor_parallel && split->backend_id > 0) {
+                        split->graph = *ggml_new_graph_custom(sched->ctx, tmp.size, /*grads =*/ false);
                         dup_graph(sched->ctx, &tmp, &split->graph, /*expand =*/ false);
                     } else {
                         split->graph = tmp;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1484,8 +1484,10 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             assert(graph_copy->size > (graph_copy->n_nodes + 1));
 
             struct ggml_tensor * input = split->inputs[j];
+            assert(input);
             const size_t input_id = hash_id(input);
             struct ggml_tensor * input_cpy = tensor_id_copy(input_id, split->backend_id, sched->cur_copy);
+            assert(input_cpy);
 
             // add a dependency to the input source so that it is not freed before the copy is done
             struct ggml_tensor * input_dep = ggml_view_tensor(sched->ctx, input);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -805,7 +805,7 @@ static char * fmt_size(size_t size) {
 static void ggml_backend_sched_print_assignments(ggml_backend_sched_t sched, struct ggml_cgraph * graph) {
     int cur_split = 0;
     for (int i = 0; i < graph->n_nodes; i++) {
-        if (cur_split < sched->n_splits && i == sched->splits[cur_split].i_start) {
+        while (cur_split < sched->n_splits && i >= sched->splits[cur_split].i_start) {
             ggml_backend_t split_backend = sched->backends[sched->splits[cur_split].backend_id];
             GGML_LOG_DEBUG("\n## SPLIT #%d: %s # %d inputs", cur_split, ggml_backend_name(split_backend),
                 sched->splits[cur_split].n_inputs);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1422,8 +1422,11 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         sched->splits[i_split] = splits_tp[i_split];
         fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
             __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
+        for (int n = 0; n < sched->splits[i_split].n_inputs; n++) {
+            fprintf(stderr, "%s:   - input %d: %s\n", __func__, n, sched->graph_inputs[n]->name);
+        }
         for (int n = 0; n < sched->splits[i_split].graph.n_nodes; n++) {
-            fprintf(stderr, "%s:   - %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);
+            fprintf(stderr, "%s:   - node %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);
         }
     }
     sched->n_splits = splits_tp.size();

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1173,7 +1173,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 {
                     const ggml_cgraph tmp = ggml_graph_view(graph, split->i_start, split->i_end);
                     if (split->tensor_parallel && split->backend_id > 0) {
-                        dup_graph(sched->ctx, &tmp, &split->graph);
+                        dup_graph(sched->ctx, &tmp, &split->graph, /*expand =*/ false);
                     } else {
                         split->graph = tmp;
                     }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1162,6 +1162,16 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 split.i_start = i;
                 split.n_inputs = 0;
             }
+        }
+        split.i_end = graph->n_nodes;
+        // GGML_ASSERT(!split.tensor_parallel);
+        split.graph = ggml_graph_view(graph, split.i_start, split.i_end);
+        splits_no_tp.push_back(split);
+    }
+
+    for (ggml_backend_sched_split & split : splits_no_tp) {
+        for (int i = 0; i < split.graph.n_nodes; i++) {
+            ggml_tensor * node = split.graph.nodes[i];
 
             // find inputs that are not on the same backend
             for (int j = 0; j < GGML_MAX_SRC; j++) {
@@ -1221,10 +1231,6 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 }
             }
         }
-        split.i_end = graph->n_nodes;
-        // GGML_ASSERT(!split.tensor_parallel);
-        split.graph = ggml_graph_view(graph, split.i_start, split.i_end);
-        splits_no_tp.push_back(split);
     }
 
     for (size_t i_split = 0; i_split < splits_no_tp.size(); i_split++) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1217,7 +1217,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
 
                     for (int n = 0; n < split.graph.n_nodes; n++) {
                         std::string name = split.graph.nodes[n]->name;
-                        ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", name.c_str(), i_gpu);
+                        ggml_format_name(split.graph.nodes[n], "%s#tp%d", name.c_str(), i_gpu);
                     }
 
                     // fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split.backend_id);
@@ -1261,6 +1261,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 src0 = ggml_dup_tensor_layout(sched->ctx, src0);
                 src0->data = ((void **) dst->src[0]->extra)[i_gpu]; // FIXME
                 src0->buffer = dst->src[0]->buffer;
+                ggml_format_name(src0, "%s#tp%d", dst->src[0]->name, i_gpu);
                 dst->src[0] = src0;
                 tensor_backend_id(src0) = split.backend_id;
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1116,7 +1116,8 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         for (; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
 
-            if (ggml_is_view_op(node->op) && !split.tensor_parallel) {
+            if (ggml_is_view_op(node->op)) {
+                GGML_ASSERT(!split.tensor_parallel);
                 continue;
             }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1423,7 +1423,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
             __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
         for (int n = 0; n < sched->splits[i_split].n_inputs; n++) {
-            fprintf(stderr, "%s:   - input %d: %s\n", __func__, n, sched->graph_inputs[n]->name);
+            fprintf(stderr, "%s:   - input %d: %s\n", __func__, n, sched->splits[i_split].inputs[n]->name);
         }
         for (int n = 0; n < sched->splits[i_split].graph.n_nodes; n++) {
             fprintf(stderr, "%s:   - node %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1218,13 +1218,13 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                         split.inputs[n_inputs] = src;
                     }
-                    fprintf(stderr, "%s: 200 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
+                    // fprintf(stderr, "%s: 200 replacing src%d=%s of %s\n", __func__, j, node->src[j]->name, node->name);
                     node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
                 }
             }
         }
         split.i_end = graph->n_nodes;
-        GGML_ASSERT(!split.tensor_parallel);
+        // GGML_ASSERT(!split.tensor_parallel);
         split.graph = ggml_graph_view(graph, split.i_start, split.i_end);
     }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1157,7 +1157,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             const bool src0_on_split_buffer = node->src[0] && node->src[0]->buffer &&
                 ggml_backend_buft_is_split(ggml_backend_buffer_get_type(node->src[0]->buffer));
             GGML_ASSERT(!src0_on_split_buffer || node->op == GGML_OP_MUL_MAT);
-            need_new_split = src0_on_split_buffer != split->tensor_parallel;
+            if (src0_on_split_buffer != split->tensor_parallel) {
+                need_new_split = true;
+            }
 
             if (need_new_split && !src0_on_split_buffer && split->tensor_parallel) {
                 split->i_end = i;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1188,6 +1188,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         const size_t node_id = hash_id(node_orig);
                         assert(tensor_id_tp(node_id, split->backend_id) == nullptr);
                         tensor_id_tp(node_id, split->backend_id) = node_sg;
+                        tensor_backend_id(node_sg) = split->backend_id;
                     }
 
                     const int i_gpu  = split->backend_id;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1222,11 +1222,13 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", name.c_str(), i_gpu);
                     }
 
+                    fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split.backend_id);
                     splits_tp.push_back(split);
                 }
             }
 
             // add split on same backend last so that splits on other backends don't have to wait for it
+            fprintf(stderr, "%s: 10 index=%d backend_id=%d\n", __func__, int(splits_tp.size()), split_main.backend_id);
             splits_tp.push_back(split_main);
         }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1217,7 +1217,8 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     dup_graph(sched->ctx, &split_main.graph, &split.graph, /*deep =*/ false);
 
                     for (int n = 0; n < split.graph.n_nodes; n++) {
-                        ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", split.graph.nodes[n]->name, i_gpu);
+                        std::string name = split.graph.nodes[n]->name;
+                        ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", name.c_str(), i_gpu);
                     }
 
                     splits_tp.push_back(split);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1328,7 +1328,8 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         split->inputs[n_inputs] = src;
                     }
                     node->src[j] = tensor_id_copy(src_id, cur_backend_id, sched->cur_copy);
-                } else if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id)) {
+                } else if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id) &&
+                           !ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src->buffer))) {
                     // create a copy of the input in the split's backend
                     if (tensor_id_copy(src_id, cur_backend_id, 0) == nullptr) {
                         ggml_backend_t backend = sched->backends[cur_backend_id];

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1161,28 +1161,6 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 need_new_split = true;
             }
 
-            if (need_new_split && !src0_on_split_buffer && split->tensor_parallel) {
-                split->i_end = i;
-
-                // FIXME
-                const int n_gpus = sched->n_backends - 1;
-                GGML_ASSERT(split->backend_id != sched->n_backends - 1);
-                for (int j = 0; j < n_gpus; j++) {
-                    if (j == split->backend_id) {
-                        continue;
-                    }
-
-                    i_split++;
-                    if (i_split >= sched->splits_capacity) {
-                        sched->splits_capacity *= 2;
-                        sched->splits = (ggml_backend_sched_split *)
-                            realloc(sched->splits, sched->splits_capacity * sizeof(struct ggml_backend_sched_split));
-                        GGML_ASSERT(sched->splits != NULL);
-                    }
-                    sched->splits[i_split] = *split;
-                    sched->splits[i_split].backend_id = j;
-                }
-            }
             if (node_backend_id != cur_backend_id || need_new_split) {
                 split->i_end = i;
                 i_split++;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1633,6 +1633,23 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 }
             }
         }
+        {
+            ggml_cgraph graph_inputs = {
+                /*.size             =*/ 0,
+                /*.n_nodes          =*/ split->n_inputs,
+                /*.n_leafs          =*/ 0,
+                /*.nodes            =*/ split->inputs,
+                /*.grads            =*/ NULL, // gradients would need visited_hash_set
+                /*.grad_accs        =*/ NULL,
+                /*.leafs            =*/ NULL,
+                /*.visited_hash_set =*/ { 0, NULL, NULL },
+                /*.order            =*/ split->graph.order,
+            };
+            enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &graph_inputs);
+            if (ec != GGML_STATUS_SUCCESS) {
+                return ec;
+            }
+        }
 
         if (!sched->callback_eval) {
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1121,7 +1121,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         for (; i < graph->n_nodes; i++) {
             struct ggml_tensor * node = graph->nodes[i];
 
-            if (ggml_is_view_op(node->op)) {
+            if (ggml_is_view_op(node->op) && !split->tensor_parallel) {
                 continue;
             }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1215,6 +1215,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     split.backend_id = i_gpu;
                     split.graph = *ggml_new_graph_custom(sched->ctx, split_main.graph.size, /*grads =*/ false);
                     dup_graph(sched->ctx, &split_main.graph, &split.graph, /*expand =*/ false);
+                    splits_tp.push_back(split);
                 }
             }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1361,9 +1361,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         GGML_ASSERT(n_gpus == 2);
                         ggml_backend_t backend = sched->backends[split.backend_id];
 
-                        ggml_tensor * a = tensor_id_tp(src_id, 0);
-                        ggml_tensor * b = tensor_id_tp(src_id, 1);
                         for (int c = 0; c < sched->n_copies; c++) {
+                            ggml_tensor * a = tensor_id_tp(src_id, 0);
+                            ggml_tensor * b = tensor_id_tp(src_id, 1);
                             if (split.backend_id == 0) {
                                 ggml_tensor * b_copy = ggml_dup_tensor_layout(sched->ctx, b);
                                 ggml_format_name(b_copy, "%s#%s part1#%d", ggml_backend_name(backend), src->name, c);
@@ -1394,9 +1394,11 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                             const int n_inputs = split.n_inputs++;
                             GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS);
                             if (split.backend_id == 0) {
+                                ggml_tensor * b = tensor_id_tp(src_id, 1);
                                 split.inputs[n_inputs] = b;
                             } else {
                                 GGML_ASSERT(split.backend_id == 1);
+                                ggml_tensor * a = tensor_id_tp(src_id, 0);
                                 split.inputs[n_inputs] = a;
                             }
                         }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1422,6 +1422,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         sched->splits[i_split] = splits_tp[i_split];
         fprintf(stderr, "%s: split%d backend_id=%d i_start=%d i_end=%d\n",
             __func__, int(i_split), sched->splits[i_split].backend_id, sched->splits[i_split].i_start, sched->splits[i_split].i_end);
+        for (int n = 0; n < sched->splits[i_split].graph.n_nodes; n++) {
+            fprintf(stderr, "%s:   - %d: %s\n", __func__, n, sched->splits[i_split].graph.nodes[n]->name);
+        }
     }
     sched->n_splits = splits_tp.size();
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1226,6 +1226,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         split.i_end = graph->n_nodes;
         // GGML_ASSERT(!split.tensor_parallel);
         split.graph = ggml_graph_view(graph, split.i_start, split.i_end);
+        splits_no_tp.push_back(split);
     }
 
     for (size_t i_split = 0; i_split < splits_no_tp.size(); i_split++) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1232,6 +1232,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 GGML_ASSERT(dst->op == GGML_OP_MUL_MAT);
                 ggml_tensor * src0 = dst->src[0];
                 ggml_tensor * src1 = dst->src[1];
+                fprintf(stderr, "%s: 025 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
+                      __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
+                      dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 
                 GGML_ASSERT(src0->buffer);
                 GGML_ASSERT(ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer)));
@@ -1258,6 +1261,10 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 dst->nb[1] = ggml_row_size(dst->type, dst->ne[0]);
                 dst->nb[2] = dst->ne[1]*dst->nb[1];
                 dst->nb[3] = dst->ne[2]*dst->nb[2];
+
+                fprintf(stderr, "%s: 050 src0={%ld, %ld, %ld, %ld} src1={%ld, %ld, %ld, %ld} dst={%ld, %ld, %ld, %ld}\n",
+                      __func__, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
+                      dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
             }
 
             for (int n = 0; n < split.graph.n_nodes; n++) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1250,11 +1250,16 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 GGML_ASSERT(ne01 == ne0);
                 GGML_ASSERT(ne01 % n_gpus == 0);
 
+                GGML_ASSERT(src0->op == GGML_OP_NONE);
+                src0 = ggml_dup_tensor_layout(sched->ctx, src0);
+                src0->data = ((void **) dst->src[0]->extra)[i_gpu]; // FIXME
+                dst->src[0] = src0;
+                tensor_backend_id(src0) = split.backend_id;
+
                 const int64_t row_low  = ne01 *  i_gpu   /n_gpus;
                 const int64_t row_high = ne01 * (i_gpu+1)/n_gpus;
                 const int64_t row_diff = row_high - row_low;
 
-                src0->data  = ((void **) src0->extra)[i_gpu];
                 src0->ne[1] = row_diff;
                 src0->nb[2] = src0->ne[1]*src0->nb[1];
                 src0->nb[3] = src0->ne[2]*src0->nb[2];

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1385,7 +1385,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                             }
                             ggml_tensor * concat = ggml_concat(sched->ctx, a, b, /*dim =*/ 0);
 
-                            ggml_format_name(concat, "%s#%s concat#%d", ggml_backend_name(backend), src->name, c);
+                            ggml_format_name(concat, "%s#%s cc#%d", ggml_backend_name(backend), src->name, c);
                             tensor_id_copy(src_id, split.backend_id, c) = concat;
                         }
                         const int n_inputs = split.n_inputs++;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1273,6 +1273,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 ggml_tensor * node_orig = graph->nodes[split.i_start + n];
                 ggml_tensor * node_sg   = split.graph.nodes[n];
                 tensor_id_tp(hash_id(node_orig), split.backend_id) = node_sg;
+                tensor_backend_id(node_sg) = split.backend_id;
             }
         }
     }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1456,10 +1456,10 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             graph_copy->nodes[graph_copy->n_nodes++] = input_cpy;
         }
 
-        for (int j = split->i_start; j < split->i_end; j++) {
+        for (int j = 0; j < split->graph.n_nodes; j++) {
             assert(graph_copy->size > graph_copy->n_nodes);
-            sched->node_backend_ids[graph_copy->n_nodes] = tensor_backend_id(graph->nodes[j]);
-            graph_copy->nodes[graph_copy->n_nodes++] = graph->nodes[j];
+            sched->node_backend_ids[graph_copy->n_nodes] = split->backend_id;
+            graph_copy->nodes[graph_copy->n_nodes++] = split->graph.nodes[j];
         }
     }
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1253,6 +1253,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 GGML_ASSERT(src0->op == GGML_OP_NONE);
                 src0 = ggml_dup_tensor_layout(sched->ctx, src0);
                 src0->data = ((void **) dst->src[0]->extra)[i_gpu]; // FIXME
+                src0->buffer = dst->src[0]->buffer;
                 dst->src[0] = src0;
                 tensor_backend_id(src0) = split.backend_id;
 

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1215,6 +1215,11 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     split.backend_id = i_gpu;
                     split.graph = *ggml_new_graph_custom(sched->ctx, split_main.graph.size, /*grads =*/ false);
                     dup_graph(sched->ctx, &split_main.graph, &split.graph, /*deep =*/ false);
+
+                    for (int n = 0; n < split.graph.n_nodes; n++) {
+                        ggml_format_name(split.graph.nodes[n], "%s (parallel %d)", split.graph.nodes[n]->name, i_gpu);
+                    }
+
                     splits_tp.push_back(split);
                 }
             }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1277,8 +1277,8 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         sched->graph.size = graph_size;
         sched->graph.nodes = (ggml_tensor **) realloc(sched->graph.nodes, graph_size * sizeof(struct ggml_tensor *));
         sched->graph.leafs = (ggml_tensor **) realloc(sched->graph.leafs, graph_size * sizeof(struct ggml_tensor *));
-        GGML_ASSERT(sched->graph.nodes != nullptr);
-        GGML_ASSERT(sched->graph.leafs != nullptr);
+        GGML_ASSERT(sched->graph.nodes != NULL);
+        GGML_ASSERT(sched->graph.leafs != NULL);
     }
     sched->graph.n_nodes = 0;
     sched->graph.n_leafs = 0;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1416,14 +1416,17 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 GGML_ASSERT(j1 > j0);
 
                 if (split_src0) {
-                    GGML_ASSERT(j1 == j0 + 1);
-                    GGML_ASSERT(false);
-                } else {
+                    j1--;
+                }
+                if (j1 > j0) {
                     struct ggml_cgraph gv = ggml_graph_view(&split->graph, j0, j1);
                     enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv);
                     if (ec != GGML_STATUS_SUCCESS) {
                         return ec;
                     }
+                }
+                if (split_src0) {
+                    GGML_ASSERT(false);
                 }
 
                 j0 = j1;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -77,6 +77,10 @@ ggml_backend_dev_t ggml_backend_buft_get_device(ggml_backend_buffer_type_t buft)
     return buft->device;
 }
 
+bool ggml_backend_buft_is_split(ggml_backend_buffer_type_t buft) {
+    return buft->iface.is_split && buft->iface.is_split(buft);
+}
+
 // backend buffer
 
 ggml_backend_buffer_t ggml_backend_buffer_init(
@@ -1971,6 +1975,7 @@ ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void) {
             /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
             /* .get_alloc_size   = */ NULL, // defaults to ggml_nbytes
             /* .is_host          = */ ggml_backend_cpu_buffer_type_is_host,
+            /* .is_split         = */ NULL,
         },
         /* .device  = */ NULL, // FIXME ggml_backend_reg_dev_get(ggml_backend_cpu_reg(), 0),
         /* .context = */ NULL,
@@ -1994,6 +1999,7 @@ static ggml_backend_buffer_type_t ggml_backend_cpu_buffer_from_ptr_type(void) {
             /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
             /* .get_alloc_size   = */ NULL, // defaults to ggml_nbytes
             /* .is_host          = */ ggml_backend_cpu_buffer_type_is_host,
+            /* .is_split         = */ NULL,
         },
         /* .device  = */ NULL, // FIXME ggml_backend_reg_dev_get(ggml_backend_cpu_reg(), 0),
         /* .context = */ NULL,

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1401,37 +1401,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
-        constexpr bool tp = true;
-
-        if (tp) {
-            for (int j0 = 0; j0 < split->graph.n_nodes;) {
-                bool split_src0 = false;
-
-                int j1 = j0;
-                for (;!split_src0 && j1 < split->graph.n_nodes; ++j1) {
-                    struct ggml_tensor * dst  = split->graph.nodes[j1];
-                    struct ggml_tensor * src0 = dst->src[0];
-                    split_src0 = src0 && ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer));
-                }
-                GGML_ASSERT(j1 > j0);
-
-                if (split_src0) {
-                    j1--;
-                }
-                if (j1 > j0) {
-                    struct ggml_cgraph gv = ggml_graph_view(&split->graph, j0, j1);
-                    enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv);
-                    if (ec != GGML_STATUS_SUCCESS) {
-                        return ec;
-                    }
-                }
-                if (split_src0) {
-                    GGML_ASSERT(false);
-                }
-
-                j0 = j1;
-            }
-        } else if (!sched->callback_eval) {
+        if (!sched->callback_eval) {
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph);
             if (ec != GGML_STATUS_SUCCESS) {
                 return ec;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1408,7 +1408,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 bool split_src0 = false;
 
                 int j1 = j0;
-                for (;j1 < split->graph.n_nodes; ++j1) {
+                for (;!split_src0 && j1 < split->graph.n_nodes; ++j1) {
                     struct ggml_tensor * dst  = split->graph.nodes[j1];
                     struct ggml_tensor * src0 = dst->src[0];
                     split_src0 = src0 && ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer));

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1401,7 +1401,29 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
-        if (!sched->callback_eval) {
+        constexpr bool tp = true;
+
+        if (tp) {
+            for (int j0 = 0; j0 < split->graph.n_nodes; j0++) {
+                struct ggml_tensor * dst  = split->graph.nodes[j0];
+                struct ggml_tensor * src0 = dst->src[0];
+                bool split_src0 = src0 && ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer));
+                int j1 = j0;
+
+                while (j1 < split->graph.n_nodes - 1 && !split_src0) {
+                    dst = split->graph.nodes[++j1];
+                    split_src0 = ggml_backend_buft_is_split(ggml_backend_buffer_get_type(src0->buffer));
+                }
+
+                struct ggml_cgraph gv = ggml_graph_view(&split->graph, j0, j1 + 1);
+                enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv);
+                if (ec != GGML_STATUS_SUCCESS) {
+                    return ec;
+                }
+
+                j0 = j1;
+            }
+        } else if (!sched->callback_eval) {
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph);
             if (ec != GGML_STATUS_SUCCESS) {
                 return ec;

--- a/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -6422,6 +6422,7 @@ ggml_backend_buffer_type_t ggml_backend_cpu_aarch64_buffer_type(void) {
                            /* .get_max_size     = */ nullptr,  // defaults to SIZE_MAX
                            /* .get_alloc_size   = */ nullptr,  // defaults to ggml_nbytes
                            /* .is_host          = */ nullptr,
+                           /* .is_split         = */ nullptr,
                            },
         /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_cpu_reg(), 0),
         /* .context = */ new ggml::cpu::aarch64::extra_buffer_type(),

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2656,7 +2656,8 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
                 }
 
 #ifndef NDEBUG
-                assert(node->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device));
+                assert(node->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device) ||
+                        ggml_backend_buft_is_cuda_split(node->buffer->buft));
                 for (int j = 0; j < GGML_MAX_SRC; j++) {
                     if (node->src[j] != nullptr) {
                         assert(node->src[j]->buffer);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2656,8 +2656,7 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
                 }
 
 #ifndef NDEBUG
-                assert(node->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device) ||
-                        ggml_backend_buft_is_cuda_split(node->buffer->buft));
+                assert(node->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device));
                 for (int j = 0; j < GGML_MAX_SRC; j++) {
                     if (node->src[j] != nullptr) {
                         assert(node->src[j]->buffer);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1912,7 +1912,7 @@ static void ggml_cuda_mul_mat_batched_cublas(ggml_backend_cuda_context & ctx, co
 }
 
 static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    const bool split = ggml_backend_buft_is_cuda_split(src0->buffer->buft);
+    const bool split = false && ggml_backend_buft_is_cuda_split(src0->buffer->buft);
 
     // If src0 is a temporary compute buffer it may have some padding that needs to be cleared for mul_mat_vec_q or mul_mat_q.
     // But if src0 is also a view of another tensor then this cannot be done safely because it may overwrite valid tensor data.
@@ -2129,7 +2129,7 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
 
 static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct ggml_tensor * dst) {
     // why is this here instead of mul_mat?
-    if (dst->src[0] != nullptr && ggml_backend_buft_is_cuda_split(dst->src[0]->buffer->buft)) {
+    if (false && dst->src[0] != nullptr && ggml_backend_buft_is_cuda_split(dst->src[0]->buffer->buft)) {
         ggml_cuda_set_peer_access(dst->src[1]->ne[1], ctx.device);
     }
 
@@ -2997,7 +2997,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 struct ggml_tensor * b = op->src[1];
                 // for small weight matrices the active device can end up without any rows, don't use row split in those cases
                 // this avoids some edge cases (and the performance would not be good anyways)
-                if (a->buffer && ggml_backend_buft_is_cuda_split(a->buffer->buft)) {
+                if (false && a->buffer && ggml_backend_buft_is_cuda_split(a->buffer->buft)) {
                     ggml_backend_cuda_split_buffer_type_context * buft_ctx = (ggml_backend_cuda_split_buffer_type_context *) a->buffer->buft->context;
                     int64_t row_low;
                     int64_t row_high;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -689,6 +689,8 @@ static size_t ggml_backend_cuda_buffer_type_get_alloc_size(ggml_backend_buffer_t
     GGML_UNUSED(buft);
 }
 
+static bool ggml_backend_buft_is_cuda_split(ggml_backend_buffer_type_t buft);
+
 static const ggml_backend_buffer_type_i ggml_backend_cuda_buffer_type_interface = {
     /* .get_name         = */ ggml_backend_cuda_buffer_type_get_name,
     /* .alloc_buffer     = */ ggml_backend_cuda_buffer_type_alloc_buffer,
@@ -696,6 +698,7 @@ static const ggml_backend_buffer_type_i ggml_backend_cuda_buffer_type_interface 
     /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
     /* .get_alloc_size   = */ ggml_backend_cuda_buffer_type_get_alloc_size,
     /* .is_host          = */ NULL,
+    /* .is_split         = */ ggml_backend_buft_is_cuda_split,
 };
 
 ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device) {
@@ -1013,6 +1016,7 @@ static const ggml_backend_buffer_type_i ggml_backend_cuda_split_buffer_type_inte
     /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
     /* .get_alloc_size   = */ ggml_backend_cuda_split_buffer_type_get_alloc_size,
     /* .is_host          = */ ggml_backend_cuda_split_buffer_type_is_host,
+    /* .is_split         = */ ggml_backend_buft_is_cuda_split,
 };
 
 ggml_backend_buffer_type_t ggml_backend_cuda_split_buffer_type(int main_device, const float * tensor_split) {
@@ -1111,6 +1115,7 @@ ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type() {
             /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
             /* .get_alloc_size   = */ ggml_backend_cpu_buffer_type()->iface.get_alloc_size,
             /* .is_host          = */ ggml_backend_cpu_buffer_type()->iface.is_host,
+            /* .is_split         = */ NULL,
         },
         /* .device   = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), 0),
         /* .context  = */ nullptr,

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -629,6 +629,11 @@ static ggml_tensor * map_tensor(std::map<ggml_tensor *, ggml_tensor *> & tensor_
         for (int i = 0; i < GGML_MAX_SRC; i++) {
             new_tensor->src[i] = map_tensor(tensor_map, ctx, tensor->src[i], deep);
         }
+    } else {
+        new_tensor->view_src = tensor->view_src;
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            new_tensor->src[i] = tensor->src[i];
+        }
     }
 
     return new_tensor;

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -678,7 +678,7 @@ void ggml_opt_alloc(ggml_opt_context_t opt_ctx, bool backward) {
         opt_ctx->ctx_copy = ggml_init(params);
 
         opt_ctx->allocated_graph_copy = ggml_new_graph_custom(opt_ctx->ctx_copy, graph->size, /*grads =*/ true);
-        dup_graph(opt_ctx->ctx_copy, graph, opt_ctx->allocated_graph_copy, /*expand =*/ true);
+        dup_graph(opt_ctx->ctx_copy, graph, opt_ctx->allocated_graph_copy, /*deep =*/ true);
     } else {
         opt_ctx->allocated_graph_copy = graph;
     }

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -678,7 +678,7 @@ void ggml_opt_alloc(ggml_opt_context_t opt_ctx, bool backward) {
         opt_ctx->ctx_copy = ggml_init(params);
 
         opt_ctx->allocated_graph_copy = ggml_new_graph_custom(opt_ctx->ctx_copy, graph->size, /*grads =*/ true);
-        dup_graph(opt_ctx->ctx_copy, graph, opt_ctx->allocated_graph_copy);
+        dup_graph(opt_ctx->ctx_copy, graph, opt_ctx->allocated_graph_copy, /*expand =*/ true);
     } else {
         opt_ctx->allocated_graph_copy = graph;
     }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1714,6 +1714,7 @@ struct ggml_tensor * ggml_set_name(struct ggml_tensor * tensor, const char * nam
 struct ggml_tensor * ggml_format_name(struct ggml_tensor * tensor, const char * fmt, ...) {
     va_list args;
     va_start(args, fmt);
+    assert(tensor->name != fmt);
     vsnprintf(tensor->name, sizeof(tensor->name), fmt, args);
     va_end(args);
     return tensor;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -221,7 +221,7 @@ llama_context::llama_context(
         bool pipeline_parallel =
             model.n_devices() > 1 &&
             model.params.n_gpu_layers > (int) model.hparams.n_layer &&
-            model.params.split_mode == LLAMA_SPLIT_MODE_LAYER &&
+            (model.params.split_mode == LLAMA_SPLIT_MODE_LAYER || model.params.split_mode == LLAMA_SPLIT_MODE_ROW) &&
             cparams.offload_kqv &&
             !model.has_tensor_overrides();
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4705,6 +4705,7 @@ struct llm_build_llama : public llm_graph_context {
         cur = build_lora_mm(model.output, cur);
 
         cb(cur, "result_output", -1);
+        cur = ggml_scale(ctx0, cur, 1.0f);
         res->t_logits = cur;
 
         ggml_build_forward_expand(gf, cur);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4705,7 +4705,7 @@ struct llm_build_llama : public llm_graph_context {
         cur = build_lora_mm(model.output, cur);
 
         cb(cur, "result_output", -1);
-        cur = ggml_scale(ctx0, cur, 1.0f);
+        cur = ggml_scale(ctx0, cur, 1.0f); // FIXME
         res->t_logits = cur;
 
         ggml_build_forward_expand(gf, cur);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4570,6 +4570,9 @@ struct llm_build_llama : public llm_graph_context {
                 Qcur = ggml_scale(ctx0, Qcur, 1.0f);
                 Kcur = ggml_scale(ctx0, Kcur, 1.0f);
                 Vcur = ggml_scale(ctx0, Vcur, 1.0f);
+                cb(Qcur, "QcurFIXME", il);
+                cb(Kcur, "KcurFIXME", il);
+                cb(Vcur, "VcurFIXME", il);
 
                 Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
                 Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4566,6 +4566,11 @@ struct llm_build_llama : public llm_graph_context {
                     cb(Vcur, "Vcur", il);
                 }
 
+                // FIXME
+                Qcur = ggml_scale(ctx0, Qcur, 1.0f);
+                Kcur = ggml_scale(ctx0, Kcur, 1.0f);
+                Vcur = ggml_scale(ctx0, Vcur, 1.0f);
+
                 Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
                 Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
                 Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);


### PR DESCRIPTION
I'm currently working on support for backend-agnostic tensor parallelism. I've progressed to the point where I have a working prototype (that only works for 2 GPUs and has bad performance). I'm making this PR in order to get early feedback regarding the way I would implement it, input from @slaren in particular would be appreciated. Specifically I would:

1. Add a backend-agnostic interface for split buffers to `ggml-backend.cpp` to e.g. check whether a buffer is split, which backends are associated with it if it is, and to retrieve the effective tensor for a given backend. I think this can be done without any backend-specific code. The input would be multiple backend buffers, when allocating a tensor on the split buffer this would be translated to allocating slices of the tensor on the underlying backend buffers.
2. Refactor the code for `ggml_backend_sched` to revolve more around splits instead of the nodes from the original graph. Without tensor parallelism there will be effectively no change because the splits just contain all nodes from the original graph in sequential order. So the same results should be achieved by iterating over splits vs. iterating over nodes.
3. When using tensor parallelism, split the graph at additional points and duplicate the splits in such a way that some operations can run in parallel across multiple backends. The existing code for pipeline parallelism can be re-used to handle the scheduling, data transfer, and synchronization. To combine the results from multiple backends the current solution is to copy the partial results from other backends and to then use `GGML_CONCAT` to combine them into a tensor that contains the correct data. For this I extended the functionality of `ggml_backend_sched_split::inputs`. Tensors with `GGML_OP_NONE` use the existing code to retrieve data from other backends. Tensors with other ops are executed prior to the actual nodes from the split.
4. Extend the logic for split tensors to cover not just a split by dimension 1 but of the other dimensions + mirrored data as well. It will be not just weights that can be split but nodes as well. Define a function similar to the `_supports_op` functions to determine the state of split tensors after some op given the states of the inputs. If an op cannot be meaningfully executed in parallel, synchronize the nodes as a fallback. This should ensure that correct results can always be produced, but with bad performance if the correct transformation logic is not defined. For the attention I think the graph should be split by dimension 2, for the FFN part I think it should be dimension 1 -> dimension 0 -> mirrored. In total there would need to be 4 synchronizations per layer.

Going forward, since `ggml_backend_sched` is a critical component I would first make a separate PR to refactor it slightly so that it's easier to assert that no changes are being made for use without tensor parallelism. The approach I have in this PR is to first split the graph and to create a vector of sequential splits `splits_no_tp` where splits that need tensor parallelism are marked. Then in a second pass a vector `splits_tp` is created where tensor parallel splits are duplicated. Only after this are inputs being assigned. Finally, the vector `splits_tp` is copied to `ggml_backend_sched::splits`. So in effect I have split the 5th pass over the graph nodes into 2 passes where I can duplicate the tensor parallel splits inbetween. I used vectors because it made the implementation the easiest, but it should be possible to do the same thing with one more allocation like `ggml_backend_sched::splits` that grows dynamically when needed. I assume the reason a vector is not used in the current code for `ggml_backend_sched::splits` is to assert that the memory is never reallocated when repeatedly changing the number of splits.

For the main PR the goal would be to get an implementation that is at least as fast as the current CUDA code for `--split-mode row` but does not need code specific to the CUDA backend. This then makes it possible to remove `ggml_cuda_op_mul_mat` without loss of functionality.