### PR TITLE
cuda : avoid cuGetErrorString when not needed

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -168,7 +168,7 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
 
 #define CUBLAS_CHECK(err) CUDA_CHECK_GEN(err, CUBLAS_STATUS_SUCCESS, cublas_get_error_str)
 
-#if !defined(GGML_USE_HIP)
+#if !defined(GGML_USE_HIP) && !defined(GGML_CUDA_NO_VMM)
 static const char * cu_get_error_str(CUresult err) {
     const char * err_str;
     cuGetErrorString(err, &err_str);


### PR DESCRIPTION
ref #13788

Not sure if this is correct, but without this patch I cannot build the project with `VMM = OFF` in `Debug` mode:

```bash
cmake -B build-cuda-no-vmm -DGGML_CUDA=ON -DGGML_CUDA_NO_VMM=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build-cuda-no-vmm -j
```

Output:
```
...

/usr/bin/ld: ../../bin/libggml-cuda.so: undefined reference to `cuGetErrorString'
collect2: error: ld returned 1 exit status
gmake[2]: *** [examples/gguf/CMakeFiles/llama-gguf.dir/build.make:101: bin/llama-gguf] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2968: examples/gguf/CMakeFiles/llama-gguf.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: ../../bin/libggml-cuda.so: undefined reference to `cuGetErrorString'
collect2: error: ld returned 1 exit status
gmake[2]: *** [examples/gguf-hash/CMakeFiles/llama-gguf-hash.dir/build.make:107: bin/llama-gguf-hash] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2861: examples/gguf-hash/CMakeFiles/llama-gguf-hash.dir/all] Error 2
[ 48%] Linking CXX static library libmtmd_audio.a
[ 48%] Built target mtmd_audio
[ 48%] Linking CXX shared library ../bin/libllama.so
[ 48%] Built target llama
gmake: *** [Makefile:146: all] Error 2
```

Note that it builds without this patch in `Release`.