### PR TITLE
scripts : add option to compare commits in Debug

### DIFF
--- a/scripts/compare-commits.sh
+++ b/scripts/compare-commits.sh
@@ -15,22 +15,16 @@ bench_args="${@:3}"
 
 rm -f llama-bench.sqlite > /dev/null
 
-unset cmake_opts
-
 # to test a backend, call the script with the corresponding environment variable (e.g. GGML_CUDA=1 ./scripts/compare-commits.sh ...)
 if [ -n "$GGML_CUDA" ]; then
-    cmake_opts="${cmake_opts} -DGGML_CUDA=ON"
-fi
-
-if [ -n "$CMAKE_BUILD_TYPE" ]; then
-    cmake_opts="${cmake_opts} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    CMAKE_OPTS="${CMAKE_OPTS} -DGGML_CUDA=ON"
 fi
 
 dir="build-bench"
 
 function run {
     rm -fr ${dir} > /dev/null
-    cmake -B ${dir} -S . ${cmake_opts} > /dev/null
+    cmake -B ${dir} -S . ${CMAKE_OPTS} > /dev/null
     cmake --build ${dir} -t llama-bench > /dev/null
     ${dir}/bin/llama-bench -o sql -oe md $bench_args | sqlite3 llama-bench.sqlite
 }

--- a/scripts/compare-commits.sh
+++ b/scripts/compare-commits.sh
@@ -15,16 +15,22 @@ bench_args="${@:3}"
 
 rm -f llama-bench.sqlite > /dev/null
 
+unset cmake_opts
+
 # to test a backend, call the script with the corresponding environment variable (e.g. GGML_CUDA=1 ./scripts/compare-commits.sh ...)
 if [ -n "$GGML_CUDA" ]; then
-    cmake_opts="-DGGML_CUDA=ON"
+    cmake_opts="${cmake_opts} -DGGML_CUDA=ON"
+fi
+
+if [ -n "$CMAKE_BUILD_TYPE" ]; then
+    cmake_opts="${cmake_opts} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 fi
 
 dir="build-bench"
 
 function run {
     rm -fr ${dir} > /dev/null
-    cmake -B ${dir} -S . $cmake_opts > /dev/null
+    cmake -B ${dir} -S . ${cmake_opts} > /dev/null
     cmake --build ${dir} -t llama-bench > /dev/null
     ${dir}/bin/llama-bench -o sql -oe md $bench_args | sqlite3 llama-bench.sqlite
 }


### PR DESCRIPTION
Some changes like https://github.com/ggml-org/llama.cpp/pull/13706#issuecomment-2907697542 have more pronounced performance effects when running in Debug build. This PR adds an option to do that:

```bash
CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug" ./scripts/compare-commits.sh ...
```