### PR TITLE
docs: remove link for llama-cli function calling

### DIFF
--- a/docs/function-calling.md
+++ b/docs/function-calling.md
@@ -2,7 +2,6 @@
 
 [chat.h](../common/chat.h) (https://github.com/ggml-org/llama.cpp/pull/9639) adds support for [OpenAI-style function calling](https://platform.openai.com/docs/guides/function-calling) and is used in:
 - `llama-server` when started w/ `--jinja` flag
-- `llama-cli` (WIP: https://github.com/ggml-org/llama.cpp/pull/11556)
 
 ## Universal support w/ Native & Generic handlers
 


### PR DESCRIPTION
Remove PR #11556 from documentation as it is closed as not planned.