### PR TITLE
ggml : allow CUDA graphs when using pipeline parallelism

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1598,6 +1598,9 @@ void ggml_backend_sched_synchronize(ggml_backend_sched_t sched) {
     for (int i = 0; i < sched->n_backends; i++) {
         ggml_backend_synchronize(sched->backends[i]);
     }
+    // reset the current copy to 0 so that the graphs will be similar during generation
+    // necessary for CUDA graphs
+    sched->cur_copy = 0;
 }
 
 void ggml_backend_sched_set_eval_callback(ggml_backend_sched_t sched, ggml_backend_sched_eval_callback callback, void * user_data) {


### PR DESCRIPTION
Due to changes in the graph in each evaluation when pipeline parallelism is enabled, CUDA graphs could not be used. This change ensures that during generation the graphs will not change, allowing the use of CUDA graphs when pipeline parallelism is enabled.

Fixes #13751