### PR TITLE
llama : use n_swa + n_ubatch cells for SWA cache

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -366,6 +366,8 @@ extern "C" {
         bool no_perf;     // measure performance timings
         bool op_offload;  // offload host tensor operations to device
         bool swa_full;    // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+                          // NOTE: setting to false when n_seq_max > 1 can cause bad performance in some cases
+                          //       ref: https://github.com/ggml-org/llama.cpp/pull/13845#issuecomment-2924800573
     };
 
     // model quantization parameters

--- a/include/llama.h
+++ b/include/llama.h
@@ -502,6 +502,7 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);
 
     // Get the model's RoPE frequency scaling factor
     LLAMA_API float llama_model_rope_freq_scale_train(const struct llama_model * model);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -123,6 +123,11 @@ llama_context::llama_context(
                 __func__, n_ctx_per_seq, hparams.n_ctx_train);
     }
 
+    if (!params.swa_full && cparams.n_seq_max > 1) {
+        LLAMA_LOG_WARN("%s: requested n_seq_max (%u) > 1, but swa_full is not enabled -- performance may be degraded: %s\n",
+                __func__, cparams.n_seq_max, "https://github.com/ggml-org/llama.cpp/pull/13845#issuecomment-2924800573");
+    }
+
     if (!hparams.vocab_only) {
         // GPU backends
         for (auto * dev : model.devices) {

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1731,14 +1731,14 @@ llama_kv_cache_unified_iswa::llama_kv_cache_unified_iswa(
                      bool   swa_full,
                  uint32_t   kv_size,
                  uint32_t   n_seq_max,
-                 uint32_t   n_batch,
+                 uint32_t   n_ubatch,
                  uint32_t   n_pad) : hparams(model.hparams) {
     llama_kv_cache_unified::layer_filter_cb filter_base = [&](int32_t il) { return !model.hparams.is_swa(il); };
     llama_kv_cache_unified::layer_filter_cb filter_swa  = [&](int32_t il) { return  model.hparams.is_swa(il); };
 
     const uint32_t size_base = kv_size;
 
-    uint32_t size_swa = std::min(size_base, GGML_PAD(hparams.n_swa*n_seq_max + n_batch, n_pad));
+    uint32_t size_swa = std::min(size_base, GGML_PAD(hparams.n_swa*n_seq_max + n_ubatch, n_pad));
 
     // when using full-size SWA cache, we set the SWA cache size to be equal to the base cache size
     if (swa_full) {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -339,7 +339,7 @@ public:
                          bool   swa_full,
                      uint32_t   kv_size,
                      uint32_t   n_seq_max,
-                     uint32_t   n_batch,
+                     uint32_t   n_ubatch,
                      uint32_t   n_pad);
 
     ~llama_kv_cache_unified_iswa() = default;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -13230,7 +13230,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             params.swa_full,
                             cparams.n_ctx,
                             cparams.n_seq_max,
-                            cparams.n_batch,
+                            cparams.n_ubatch,
                             padding);
                 } else {
                     GGML_ASSERT(!hparams.is_swa_any());
@@ -13591,6 +13591,10 @@ int32_t llama_model_n_head(const llama_model * model) {
 
 int32_t llama_model_n_head_kv(const llama_model * model) {
     return model->hparams.n_head_kv();
+}
+
+int32_t llama_model_n_swa(const llama_model * model) {
+    return model->hparams.n_swa;
 }
 
 // deprecated


### PR DESCRIPTION
target #13845

### Overview

- [x] SWA cache now uses less memory
- [x] Enable SWA speculative decoding
- [x] Allow short SWA rollbacks (avoids cache recalculations caused by whitespace truncation of the last response)

```bash
./scripts/compare-commits.sh master gg/swa-optimize -m models/gemma-3-4b/ggml-model-q8_0.gguf -d 8192 -p 0 -b 512,1024,2048,4096,8192 -n 32 -fa 0,1 -t 1
```

| Model          |   Batch size | FA   | Test       |   t/s master |   t/s gg/swa-optimize |   Speedup |
|:---------------|-------------:|:-----------------|:-----------|-------------:|----------------------:|----------:|
| gemma3 4B Q8_0 |          512 | No               | tg32@d8192 |        75.63 |                 75.83 |      1.00 |
| gemma3 4B Q8_0 |          512 | Yes              | tg32@d8192 |        75.12 |                 75.13 |      1.00 |
| gemma3 4B Q8_0 |         1024 | No               | tg32@d8192 |        73.68 |                 76.03 |      1.03 |
| gemma3 4B Q8_0 |         1024 | Yes              | tg32@d8192 |        74.94 |                 75.15 |      1.00 |
| gemma3 4B Q8_0 |         2048 | No               | tg32@d8192 |        69.73 |                 75.92 |      1.09 |
| gemma3 4B Q8_0 |         2048 | Yes              | tg32@d8192 |        74.62 |                 75.14 |      1.01 |
| gemma3 4B Q8_0 |         4096 | No               | tg32@d8192 |        62.43 |                 75.92 |      1.22 |
| gemma3 4B Q8_0 |         4096 | Yes              | tg32@d8192 |        74.39 |                 75.15 |      1.01 |
| gemma3 4B Q8_0 |         8192 | No               | tg32@d8192 |        54.37 |                 76.00 |      1.40 |
| gemma3 4B Q8_0 |         8192 | Yes              | tg32@d8192 |        73.25 |                 75.11 |      1.03 |
