### PR TITLE
convert : fix tensor naming conflict for llama 4 vision

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2169,6 +2169,8 @@ class Llama4VisionModel(MmprojModel):
             # process vision tensors
             if "positional_embedding_vlm" in name and ".weight" not in name:
                 name += ".weight"
+            if "multi_modal_projector.linear_1" in name:
+                return [(gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.V_MMPROJ_FC], data_torch)]
             return [(self.map_tensor_name(name), data_torch)]
         return []
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2170,6 +2170,7 @@ class Llama4VisionModel(MmprojModel):
             if "positional_embedding_vlm" in name and ".weight" not in name:
                 name += ".weight"
             if "multi_modal_projector.linear_1" in name:
+                # despite the name with number postfix, this is a single fully connected layer
                 return [(gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.V_MMPROJ_FC], data_torch)]
             return [(self.map_tensor_name(name), data_torch)]
         return []

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -902,7 +902,6 @@ class TensorNameMap:
 
         MODEL_TENSOR.V_MMPROJ_FC: (
             "model.connector.modality_projection.proj", # SmolVLM
-            "multi_modal_projector.linear_1", # llama 4
         ),
 
         MODEL_TENSOR.V_MMPROJ_MLP: (


### PR DESCRIPTION
Fix naming conflict of `multi_modal_projector.linear_*` tensor name.

Llama 4 has only one single `multi_modal_projector.linear_1` which acts as a fully connected layer.

Other models usually have 2 or 3 linear layers.

(Note: there is no bug report for this, but I just found out while looking at the code, so assume somehow this does not affect any users)
