### PR TITLE
gguf/utility: return full content on size < 0

### DIFF
--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -231,7 +231,7 @@ class SafetensorRemote:
         response.raise_for_status()
 
         # Get raw byte data
-        return response.content[:size]
+        return response.content[:size] if size > -1 else response.content
 
     @classmethod
     def check_file_exist(cls, url: str) -> bool:

--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -231,7 +231,7 @@ class SafetensorRemote:
         response.raise_for_status()
 
         # Get raw byte data
-        return response.content[:size] if size > -1 else response.content
+        return response.content[slice(size if size > -1 else None)]
 
     @classmethod
     def check_file_exist(cls, url: str) -> bool:


### PR DESCRIPTION
`response.content[:-1]` truncates the last byte which can break `model_index.json` reading for `--remote` converts