### PR TITLE
convert : fix rwkv bos/eos token

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1044,6 +1044,10 @@ class TextModel(ModelBase):
         special_vocab.chat_template = "rwkv-world"
         # hack: Add '\n\n' as the EOT token to make it chat normally
         special_vocab._set_special_token("eot", 261)
+        # hack: Override these as they have already been set (incorrectly)
+        special_vocab.special_token_ids["bos"] = 0
+        special_vocab.special_token_ids["eos"] = 0
+
         special_vocab.add_to_gguf(self.gguf_writer)
 
     def _set_vocab_builtin(self, model_name: Literal["gpt-neox", "llama-spm"], vocab_size: int):


### PR DESCRIPTION
SpecialVocab gets the token IDs from `config.json`, but they are overridden to 0 in [hf_rwkv_tokenizer.py](https://huggingface.co/fla-hub/rwkv7-2.9B-world/blob/main/hf_rwkv_tokenizer.py#L166) since they all share the same [value](https://huggingface.co/fla-hub/rwkv7-2.9B-world/blob/main/special_tokens_map.json) (except eos_token, but that's [incorrect](https://huggingface.co/fla-hub/rwkv7-2.9B-world/discussions/3#6836b8155e0917e677cc72c5) and we use `eot_token` here).

cc/ @MollySophia