### PR TITLE
llama : auto-batch preparation

### DIFF
--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -392,7 +392,7 @@ int main(int argc, char ** argv) {
                     return 1;
                 }
 
-                LOG_ERR("%s : failed to decode the batch, retrying with n_batch = %d\n", __func__, n_batch / 2);
+                LOG_WRN("%s : failed to decode the batch, retrying with n_batch = %d\n", __func__, n_batch / 2);
 
                 n_cache_miss += 1;
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -50,8 +50,9 @@ struct llama_context {
           llama_kv_cache * get_kv_self();
     const llama_kv_cache * get_kv_self() const;
 
+    // return true of the KV cache was updated
     // TODO: remove
-    void kv_self_update();
+    bool kv_self_update();
 
     enum llama_pooling_type pooling_type() const;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1809,9 +1809,10 @@ llama_pos llama_kv_cache_unified_iswa::seq_pos_max(llama_seq_id seq_id) const {
 llama_memory_state_ptr llama_kv_cache_unified_iswa::init_batch(const llama_batch & batch, uint32_t n_ubatch, bool embd_pooled, bool logits_all) {
     GGML_UNUSED(embd_pooled);
 
-    auto sbatch = llama_sbatch(batch, hparams.n_embd, true, logits_all);
+    // TODO: if we fail with split_simple, we should attempt different splitting strategies
+    //       but to do that properly, we first have to refactor the batches to be more flexible
 
-    // TODO: if we fail with split_simple, we should attempt split_equal
+    auto sbatch = llama_sbatch(batch, hparams.n_embd, true, logits_all);
 
     std::vector<llama_ubatch> ubatches;
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3431,7 +3431,7 @@ struct server_context {
                 // retry with half the batch size to try to find a free slot in the KV cache
                 n_batch /= 2;
 
-                SRV_WRN("failed to find free space in the KV cache, retrying with smaller batch size - try increasing it via the context size or enable defragmentation, i = %d, n_batch = %d, ret = %d\n", i, n_batch, ret);
+                SRV_WRN("failed to find free space in the KV cache, retrying with smaller batch size, i = %d, n_batch = %d, ret = %d\n", i, n_batch, ret);
 
                 continue; // continue loop of n_batch
             }


### PR DESCRIPTION
target #13746 

The memory implementations now implement their respective optimal strategy for splitting the input batch into ubatches (see [llama_memory_i::init_batch()](https://github.com/ggml-org/llama.cpp/blob/a059161636ec6bc8c47a6d2d390fd7f7c65e0123/src/llama-kv-cache.h#L23-L32)). For example, the iSWA KV cache currently attempts to do a [simple split of the input batch](https://github.com/ggml-org/llama.cpp/blob/a059161636ec6bc8c47a6d2d390fd7f7c65e0123/src/llama-kv-cache.cpp#L1809-L1839). In the future, it will be updated to try different splitting strategies if the simple split fails. For example, the [batch splitting logic from `llama-server`](https://github.com/ggml-org/llama.cpp/blob/a059161636ec6bc8c47a6d2d390fd7f7c65e0123/tools/server/server.cpp#L3385-L3444) should be done as a fallback. But to implement this, we first need to refactor the `llama_sbatch` and `llama_ubatch` implementation.

<details>
<summary>outdated</summary>

This change adds logic to `llama_decode()` for retrying with smaller `n_ubatch` if we fail to fit the input batch. This logic is usually implemented in the user code, but it now comes integrated into `libllama`.

Note that the user code can still continue to do it's own batching of the input. It's just no longer really needed.

As an example, the `llama-server` is updated to no longer perform this process manually. The rest of the examples will be updated in a follow-up PRs.

This PR will be merged after #13746 

</details>

## Next PRs

- ~Remove the notion of `n_batch`. We can now always work with the full `n_ctx` and simplify the logic of splitting the input into `n_batch` sizes. (low prio)~ (not ready for this yet).
