### PR TITLE
CUDA: fix FA tg at long context for CC >= 8.9

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -623,8 +623,8 @@ static __global__ void flash_attn_combine_results(
     __builtin_assume(tid < D);
 
     extern __shared__ float2 meta[];
-    if (tid < 2*parallel_blocks) {
-        ((float *) meta)[threadIdx.x] = ((const float *)VKQ_meta) [blockIdx.z*(2*parallel_blocks) + tid];
+    for (int i = tid; i < 2*parallel_blocks; i += D) {
+        ((float *) meta)[i] = ((const float *)VKQ_meta) [blockIdx.z*(2*parallel_blocks) + i];
     }
 
     __syncthreads();


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/12816#issuecomment-2915519224 .

On master the CUDA kernel for combining FlashAttention results without stream-k implicitly assumes that the number of parallel blocks is small vs. the head size. This used to be true but after the number of parallel blocks was made variable in https://github.com/ggml-org/llama.cpp/issues/12182 there are configurations where the shared memory is not being initialized correctly. This PR fixes the issue by replacing the bad conditional statement with a loop.