### PR TITLE
sycl: Add reorder to Q6_K mmvq implementation

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3106,7 +3106,6 @@ static void reorder_qw_q6_k(uint8_t * data_device, size_t size, size_t offset, d
 
     auto *       ql_ptr     = data_device;
     auto *       qh_ptr     = ql_ptr + (QK_K / 2) * nblocks;
-    // scales are after all quants' bits so adding both to get correct offset
     auto *       scales_ptr = qh_ptr + (QK_K / 4) * nblocks;
     sycl::half * dm_ptr     = (sycl::half *) (scales_ptr + (QK_K / 16) * nblocks);
 

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -354,7 +354,8 @@ ggml_backend_sycl_buffer_init_tensor(ggml_backend_buffer_t buffer,
         assert(tensor->view_src->buffer->buft == buffer->buft);
         return GGML_STATUS_SUCCESS;
     }
-    if ((tensor->type == GGML_TYPE_Q4_0 || tensor->type == GGML_TYPE_Q4_K) && !g_ggml_sycl_disable_optimize) {
+    if ((tensor->type == GGML_TYPE_Q4_0 || tensor->type == GGML_TYPE_Q4_K || tensor->type == GGML_TYPE_Q6_K) &&
+        !g_ggml_sycl_disable_optimize) {
         ggml_tensor_extra_gpu * extra = new ggml_tensor_extra_gpu{};
         tensor->extra                 = extra;
         ctx->tensor_extras.push_back(extra);  //used to release it when destroy ctx.
@@ -2989,6 +2990,7 @@ inline bool ggml_sycl_supports_reorder_mul_mat_sycl(enum ggml_type type) {
         case GGML_TYPE_Q4_0:
             return true;
         case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q6_K:
             return !g_ggml_sycl_prioritize_dmmv;
         default:
             return false;
@@ -3008,6 +3010,7 @@ inline bool ggml_sycl_supports_reorder_mmvq(enum ggml_type type) {
     switch (type) {
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q6_K:
             return true;
         default:
             return false;
@@ -3092,6 +3095,51 @@ static void reorder_qw_q4_k(uint8_t * data_device, size_t size, size_t offset, d
     sycl::free(tmp_buf, *stream);
 }
 
+static void reorder_qw_q6_k(uint8_t * data_device, size_t size, size_t offset, dpct::queue_ptr stream) {
+    GGML_ASSERT(size % sizeof(block_q6_K) == 0);
+    GGML_ASSERT(offset % sizeof(block_q6_K) == 0);
+
+    const int nblocks = size / sizeof(block_q6_K);
+
+    auto * tmp_buf = sycl::malloc_shared<uint8_t>(size, *stream);
+    SYCL_CHECK(CHECK_TRY_ERROR((*stream).memcpy(tmp_buf, data_device, size).wait()));
+
+    auto *       ql_ptr     = data_device;
+    auto *       qh_ptr     = ql_ptr + (QK_K / 2) * nblocks;
+    // scales are after all quants' bits so adding both to get correct offset
+    auto *       scales_ptr = qh_ptr + (QK_K / 4) * nblocks;
+    sycl::half * dm_ptr     = (sycl::half *) (scales_ptr + (QK_K / 16) * nblocks);
+
+    stream
+        ->parallel_for(nblocks,
+                       [=](auto i) {
+                           const block_q6_K * x  = (const block_q6_K *) tmp_buf;
+                           const int          ib = i;
+
+                           const uint8_t * ql              = x[ib].ql;
+                           const uint8_t * qh              = x[ib].qh;
+                           uint8_t *       base_ql_ptr     = ql_ptr + (QK_K / 2) * ib;
+                           uint8_t *       base_qh_ptr     = qh_ptr + (QK_K / 4) * ib;
+                           uint8_t *       base_scales_ptr = scales_ptr + (QK_K / 16) * ib;
+
+                           for (int j = 0; j < QK_K / 2; ++j) {
+                               base_ql_ptr[j] = ql[j];
+                           }
+                           for (int j = 0; j < QK_K / 4; ++j) {
+                               base_qh_ptr[j] = qh[j];
+                           }
+
+                           for (int j = 0; j < QK_K / 16; ++j) {
+                               base_scales_ptr[j] = x[ib].scales[j];
+                           }
+
+                           dm_ptr[ib] = x[ib].d;
+                       })
+        .wait_and_throw();
+
+    sycl::free(tmp_buf, *stream);
+}
+
 static void reorder_qw(const ggml_tensor * src0, dpct::queue_ptr stream) {
     uint8_t * data_device = (uint8_t *) src0->data;
     size_t ncols = src0->ne[0];
@@ -3104,6 +3152,9 @@ static void reorder_qw(const ggml_tensor * src0, dpct::queue_ptr stream) {
             break;
         case GGML_TYPE_Q4_K:
             reorder_qw_q4_k(data_device, size, 0, stream);
+            break;
+        case GGML_TYPE_Q6_K:
+            reorder_qw_q6_k(data_device, size, 0, stream);
             break;
         default:
             GGML_ABORT("reorder_qw() called with unsupported type");

--- a/ggml/src/ggml-sycl/mmvq.cpp
+++ b/ggml/src/ggml-sycl/mmvq.cpp
@@ -33,9 +33,8 @@ static void mul_mat_vec_q_reorder(const void * __restrict__ vx, const void * __r
     for (int i = sg.get_local_linear_id() / block_elements_per_subgroup; i < blocks_per_row; i += blocks_per_subgroup) {
         const int ibx       = row * blocks_per_row + i;  // x block index
         // TODO: Generalize offsets, right now only works for quantizations that don't split high and low bits
-        const int bx_offset = block_type::get_block_offset(ibx);
-        const int d_offset  = block_type::get_d_offset(nrows, ncols, ibx);
-
+        const auto         bx_offset      = block_type::get_block_offset(ibx, nblocks);
+        const auto         d_offset       = block_type::get_d_offset(nrows, ncols, ibx);
         // Y block index that aligns with ibx
         const int iby = i * block_type::block_to_q8_1_ratio();
         const int8_t* q8_1_quant_ptr = (const int8_t*)vy + iby * QK8_1;
@@ -785,6 +784,24 @@ static void mul_mat_vec_q5_K_q8_1_sycl(const void *vx, const void *vy,
     }
 }
 
+static void reorder_mul_mat_vec_q6_k_q8_1_sycl(const void * vx, const void * vy, float * dst, const int ncols,
+                                               const int nrows, dpct::queue_ptr stream) {
+    GGML_ASSERT(ncols % QK_K == 0);
+    const int        block_num_y   = ceil_div(nrows, GGML_SYCL_MMV_Y);
+    constexpr size_t num_subgroups = 16;
+    GGML_ASSERT(block_num_y % num_subgroups == 0);
+
+    const sycl::range<3> global_size(1, GGML_SYCL_MMV_Y, block_num_y * WARP_SIZE);
+    const sycl::range<3> workgroup_size(1, GGML_SYCL_MMV_Y, num_subgroups * WARP_SIZE);
+
+    stream->submit([&](sycl::handler & cgh) {
+        cgh.parallel_for(sycl::nd_range<3>(global_size, workgroup_size),
+                         [=](sycl::nd_item<3> nd_item) [[sycl::reqd_sub_group_size(WARP_SIZE)]] {
+                             mul_mat_vec_q_reorder<reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K>>(vx, vy, dst, ncols, nrows,
+                                                                                           nd_item);
+                         });
+    });
+}
 static void mul_mat_vec_q6_K_q8_1_sycl(const void *vx, const void *vy,
                                        float *dst, const int ncols,
                                        const int nrows,
@@ -1070,7 +1087,14 @@ void ggml_sycl_op_mul_mat_vec_q(ggml_backend_sycl_context & ctx, const ggml_tens
                 mul_mat_vec_q5_K_q8_1_sycl(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);
                 break;
             case GGML_TYPE_Q6_K:
-                mul_mat_vec_q6_K_q8_1_sycl(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);
+                if ((ggml_tensor_extra_gpu *) dst->src[0]->extra &&
+                    ((ggml_tensor_extra_gpu *) dst->src[0]->extra)->optimized_feature.reorder) {
+                    GGML_SYCL_DEBUG("Calling reorder_mul_mat_vec_q6_k_q8_1_sycl\n");
+                    reorder_mul_mat_vec_q6_k_q8_1_sycl(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);
+                } else {
+                    GGML_SYCL_DEBUG("Calling mul_mat_vec_q6_k_q8_1_sycl\n");
+                    mul_mat_vec_q6_K_q8_1_sycl(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);
+                }
                 break;
             case GGML_TYPE_IQ1_S:
                 mul_mat_vec_iq1_s_q8_1_sycl(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);

--- a/ggml/src/ggml-sycl/mmvq.cpp
+++ b/ggml/src/ggml-sycl/mmvq.cpp
@@ -31,7 +31,7 @@ static void mul_mat_vec_q_reorder(const void * __restrict__ vx, const void * __r
 
     float partial_sum = 0.0f;
     for (int i = sg.get_local_linear_id() / block_elements_per_subgroup; i < blocks_per_row; i += blocks_per_subgroup) {
-        const int ibx       = row * blocks_per_row + i;  // x block index
+        const int ibx = row * blocks_per_row + i;  // x block index
 
         const auto         bx_offset      = block_type::get_block_offset(ibx, nblocks);
         const auto         d_offset       = block_type::get_d_offset(nrows, ncols, ibx);
@@ -45,7 +45,7 @@ static void mul_mat_vec_q_reorder(const void * __restrict__ vx, const void * __r
             // x block quant index when casting the quants to int
             const int iqs = elem + block_traits::vdr_mmvq * (sg.get_local_linear_id() % block_elements_per_subgroup);
 
-            partial_sum += reorder_vec_dot_q_sycl()(vx, bx_offset, d_offset, q8_1_quant_ptr, q8_1_ds_ptr, iqs, nblocks);
+            partial_sum += reorder_vec_dot_q_sycl()(vx, bx_offset, d_offset, q8_1_quant_ptr, q8_1_ds_ptr, iqs);
         }
     }
 

--- a/ggml/src/ggml-sycl/mmvq.cpp
+++ b/ggml/src/ggml-sycl/mmvq.cpp
@@ -32,7 +32,7 @@ static void mul_mat_vec_q_reorder(const void * __restrict__ vx, const void * __r
     float partial_sum = 0.0f;
     for (int i = sg.get_local_linear_id() / block_elements_per_subgroup; i < blocks_per_row; i += blocks_per_subgroup) {
         const int ibx       = row * blocks_per_row + i;  // x block index
-        // TODO: Generalize offsets, right now only works for quantizations that don't split high and low bits
+
         const auto         bx_offset      = block_type::get_block_offset(ibx, nblocks);
         const auto         d_offset       = block_type::get_d_offset(nrows, ncols, ibx);
         // Y block index that aligns with ibx

--- a/ggml/src/ggml-sycl/quants.hpp
+++ b/ggml/src/ggml-sycl/quants.hpp
@@ -72,14 +72,13 @@ template <> struct block_q_t<GGML_TYPE_Q4_K> {
 
     static constexpr std::pair<int, int> get_d_offset(int nrows, int ncols, const int block_index) {
         auto nblocks = (nrows * (ncols / traits::qk));
-        return { (nblocks * QK_K / 2) + (nblocks * K_SCALE_SIZE) + (block_index * sizeof(ggml_half2)), 0 };
+        return { nblocks * (QK_K / 2),
+                 (nblocks * QK_K / 2) + (nblocks * K_SCALE_SIZE) + (block_index * sizeof(ggml_half2)) };
     }
 
     static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
 
     constexpr size_t get_total_qs_bytes(int nblocks) { return nblocks * QK_K / 2; }
-
-    constexpr int get_dm_offset(int nblocks) { return get_total_qs_bytes(nblocks) + nblocks * K_SCALE_SIZE; }
 };
 
 template <> struct block_q_t<GGML_TYPE_Q6_K> {

--- a/ggml/src/ggml-sycl/quants.hpp
+++ b/ggml/src/ggml-sycl/quants.hpp
@@ -14,11 +14,12 @@
 #ifndef GGML_SYCL_QUANTS_HPP
 #define GGML_SYCL_QUANTS_HPP
 
+#include <utility>
+
 #include "ggml-common.h"
 #include "ggml.h"
 
 namespace ggml_sycl_reordered {
-
 
 // The reordered block moves quants (qs) and  scales(d) to two
 // uniform regions of memory that is contiguous in the same tensor.
@@ -31,7 +32,6 @@ namespace ggml_sycl_reordered {
 // Aligment relies on the allocated size of qs
 
 template <ggml_type type> struct block_q_t;
-
 
 // qk number of weights / quants in a block
 // qr number of weights in a byte (described as 'before dequantization')
@@ -47,10 +47,12 @@ template <> struct block_q_t<GGML_TYPE_Q4_0> {
         static constexpr uint32_t vdr_mmvq = 2;
     };
 
-    static constexpr int get_block_offset(const int block_index) { return block_index * (traits::qk / traits::qr); }
+    static constexpr std::pair<int, int> get_block_offset(const int block_index, const int /* nblocks */) {
+        return { block_index * (traits::qk / traits::qr), 0 };
+    }
 
-    static constexpr int get_d_offset(int nrows, int ncols, const int block_index) {
-        return (ncols / traits::qr * nrows) + block_index * sizeof(ggml_half);
+    static constexpr std::pair<int, int> get_d_offset(int nrows, int ncols, const int block_index) {
+        return { (ncols / traits::qr * nrows) + block_index * sizeof(ggml_half), 0 };
     }
 
     static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
@@ -64,20 +66,47 @@ template <> struct block_q_t<GGML_TYPE_Q4_K> {
         static constexpr uint32_t vdr_mmvq = 2;
     };
 
-    static constexpr int get_block_offset(const int block_index) { return block_index * (traits::qk / traits::qr); }
+    static constexpr std::pair<int, int> get_block_offset(const int block_index, const int /* nblocks */) {
+        return { block_index * (traits::qk / traits::qr), 0 };
+    }
 
-    static constexpr int get_d_offset(int nrows, int ncols, const int block_index) {
+    static constexpr std::pair<int, int> get_d_offset(int nrows, int ncols, const int block_index) {
         auto nblocks = (nrows * (ncols / traits::qk));
-        return (nblocks * QK_K / 2) + (nblocks * K_SCALE_SIZE) + (block_index * sizeof(ggml_half2));
+        return { (nblocks * QK_K / 2) + (nblocks * K_SCALE_SIZE) + (block_index * sizeof(ggml_half2)), 0 };
     }
 
     static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
 
     constexpr size_t get_total_qs_bytes(int nblocks) { return nblocks * QK_K / 2; }
 
-    constexpr size_t get_dm_offset(int nblocks) { return get_total_qs_bytes(nblocks) + nblocks * K_SCALE_SIZE; }
+    constexpr int get_dm_offset(int nblocks) { return get_total_qs_bytes(nblocks) + nblocks * K_SCALE_SIZE; }
 };
 
+template <> struct block_q_t<GGML_TYPE_Q6_K> {
+    struct traits {
+        static constexpr uint32_t qk       = QK_K;
+        static constexpr uint32_t qi       = QI6_K;
+        static constexpr uint32_t qr       = QR6_K;
+        static constexpr uint32_t vdr_mmvq = 1;
+    };
+
+    static constexpr std::pair<int, int> get_block_offset(const int block_index, const int n_blocks) {
+        auto low_bits_index  = block_index * (traits::qk / traits::qr);
+        // the index of high bits it's after all low bits
+        auto high_bits_index = n_blocks * (QK_K / 2) + (block_index * (QK_K / 4));
+        return { low_bits_index, high_bits_index };
+    }
+
+    static constexpr std::pair<int, int> get_d_offset(int nrows, int ncols, const int block_index) {
+        auto nblocks        = (nrows * (ncols / traits::qk));
+        auto total_qs_bytes = nblocks * (QK_K / 2) + nblocks * (QK_K / 4);
+        auto block_scales   = total_qs_bytes + block_index * (QK_K / 16);
+        auto sb_scale       = total_qs_bytes + nblocks * (QK_K / 16);
+        return { block_scales, sb_scale };
+    }
+
+    static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
+};
 }  // namespace ggml_sycl_reordered
 
 #endif  // GGML_SYCL_QUANTS_HPP

--- a/ggml/src/ggml-sycl/vecdotq.hpp
+++ b/ggml/src/ggml-sycl/vecdotq.hpp
@@ -286,7 +286,7 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q4_0> {
 
     __dpct_inline__ float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
                                      const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr,
-                                     const sycl::half2 * q8_1_ds, const int & iqs, int /* nblocks */) {
+                                     const sycl::half2 * q8_1_ds, const int & iqs) {
         const uint8_t * bq4_0 = static_cast<const uint8_t *>(vbq) + ibx_offset.first;
         const ggml_half d = *(reinterpret_cast<const ggml_half *>(static_cast<const uint8_t *>(vbq) + d_offset.first));
         int             v[q4_0_traits::vdr_mmvq];
@@ -349,14 +349,13 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q4_K> {
 
     __dpct_inline__ float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
                                      const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr,
-                                     const sycl::half2 * q8_1_ds, const int & iqs, int nblocks) {
+                                     const sycl::half2 * q8_1_ds, const int & iqs) {
         const int ib = ibx_offset.first / (QK_K / 2);
 
         const uint8_t *    base           = static_cast<const uint8_t *>(vbq);
         const uint8_t *    qs             = base + ibx_offset.first;
-        const int          total_qs_bytes = nblocks * (QK_K / 2);
-        const uint8_t *    scs            = base + total_qs_bytes + ib * K_SCALE_SIZE;
-        const ggml_half2 * dms            = reinterpret_cast<const ggml_half2 *>(base + d_offset.first);
+        const uint8_t *    scs            = base + d_offset.first + ib * K_SCALE_SIZE;
+        const ggml_half2 * dms            = reinterpret_cast<const ggml_half2 *>(base + d_offset.second);
 
         const int        bq8_offset = QR4_K * ((iqs / 2) / (QI8_1 / 2));
         const int *      q4         = (const int *) (qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
@@ -427,7 +426,7 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K> {
 
     float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
                      const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr, const sycl::half2 * q8_1_ds,
-                     const int & iqs, int /* nblocks */) {
+                     const int & iqs) {
         const int ib = ibx_offset.first / (QK_K / 2);
 
         const uint8_t *   base   = static_cast<const uint8_t *>(vbq);

--- a/ggml/src/ggml-sycl/vecdotq.hpp
+++ b/ggml/src/ggml-sycl/vecdotq.hpp
@@ -402,7 +402,7 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K> {
     using q6_k_block  = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q6_K>;
     using q6_k_traits = typename q6_k_block::traits;
 
-    __dpct_inline__ float vec_dot_q6_K_q8_1_impl_mmvq(const int & vl, const int & vh, const int * __restrict__ u,
+    __dpct_inline__ float vec_dot_q6_K_q8_1_impl_mmvq(const int vl, const int vh, const int * __restrict__ u,
                                                       const int8_t * __restrict__ scales, const float d,
                                                       const float * __restrict__ d8) {
         float sumf = 0.0f;
@@ -424,9 +424,9 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K> {
         return d * sumf;
     }
 
-    float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
+    __dpct_inline__ float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
                      const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr, const sycl::half2 * q8_1_ds,
-                     const int & iqs) {
+                     const int iqs) {
         const int ib = ibx_offset.first / (QK_K / 2);
 
         const uint8_t *   base   = static_cast<const uint8_t *>(vbq);

--- a/ggml/src/ggml-sycl/vecdotq.hpp
+++ b/ggml/src/ggml-sycl/vecdotq.hpp
@@ -284,10 +284,11 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q4_0> {
         return d4 * (sumi * ds8f.x() - (8 * q4_0_traits::vdr_mmvq / q4_0_traits::qi) * ds8f.y());
     }
 
-    __dpct_inline__ float operator()(const void * __restrict__ vbq, const int ibx_offset, const int d_offset,
-                     const int8_t* q8_1_quant_ptr, const sycl::half2* q8_1_ds, const int & iqs, int /* nblocks */) {
-        const uint8_t * bq4_0 = static_cast<const uint8_t *>(vbq) + ibx_offset;
-        const ggml_half d     = *(reinterpret_cast<const ggml_half *>(static_cast<const uint8_t *>(vbq) + d_offset));
+    __dpct_inline__ float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
+                                     const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr,
+                                     const sycl::half2 * q8_1_ds, const int & iqs, int /* nblocks */) {
+        const uint8_t * bq4_0 = static_cast<const uint8_t *>(vbq) + ibx_offset.first;
+        const ggml_half d = *(reinterpret_cast<const ggml_half *>(static_cast<const uint8_t *>(vbq) + d_offset.first));
         int             v[q4_0_traits::vdr_mmvq];
         int             u[2 * q4_0_traits::vdr_mmvq];
 
@@ -346,15 +347,16 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q4_K> {
     using q4_k_block  = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q4_K>;
     using q4_k_traits = typename q4_k_block::traits;
 
-    float operator()(const void * __restrict__ vbq, const int ibx_offset, const int d_offset,
-                     const int8_t* q8_1_quant_ptr, const sycl::half2* q8_1_ds, const int & iqs, int nblocks) {
-        const int ib = ibx_offset / (QK_K / 2);
+    __dpct_inline__ float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
+                                     const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr,
+                                     const sycl::half2 * q8_1_ds, const int & iqs, int nblocks) {
+        const int ib = ibx_offset.first / (QK_K / 2);
 
         const uint8_t *    base           = static_cast<const uint8_t *>(vbq);
-        const uint8_t *    qs             = base + ibx_offset;
+        const uint8_t *    qs             = base + ibx_offset.first;
         const int          total_qs_bytes = nblocks * (QK_K / 2);
         const uint8_t *    scs            = base + total_qs_bytes + ib * K_SCALE_SIZE;
-        const ggml_half2 * dms            = reinterpret_cast<const ggml_half2 *>(base + d_offset);
+        const ggml_half2 * dms            = reinterpret_cast<const ggml_half2 *>(base + d_offset.first);
 
         const int        bq8_offset = QR4_K * ((iqs / 2) / (QI8_1 / 2));
         const int *      q4         = (const int *) (qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
@@ -395,6 +397,67 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q4_K> {
     }
 };
 
+template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K> {
+    static constexpr ggml_type gtype = GGML_TYPE_Q6_K;
+
+    using q6_k_block  = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q6_K>;
+    using q6_k_traits = typename q6_k_block::traits;
+
+    // contiguous v/x values
+    __dpct_inline__ float vec_dot_q6_K_q8_1_impl_mmvq(const int & vl, const int & vh, const int * __restrict__ u,
+                                                      const int8_t * __restrict__ scales, const float d,
+                                                      const float * __restrict__ d8) {
+        float sumf = 0.0f;
+
+#pragma unroll
+        for (int i = 0; i < QR6_K; ++i) {
+            const int sc = scales[4 * i];
+
+            const int vil = (vl >> (4 * i)) & 0x0F0F0F0F;
+
+            const int vih = ((vh >> (4 * i)) << 4) & 0x30303030;
+
+            const int vi = dpct::vectorized_binary<sycl::char4>((vil | vih), 0x20202020,
+                                                                dpct::sub_sat());  // vi = (vil | vih) - 32
+
+            sumf += d8[i] * (dpct::dp4a(vi, u[i], 0) * sc);                        // SIMD dot product
+        }
+
+        return d * sumf;
+    }
+
+    float operator()(const void * __restrict__ vbq, const std::pair<int, int> ibx_offset,
+                     const std::pair<int, int> d_offset, const int8_t * q8_1_quant_ptr, const sycl::half2 * q8_1_ds,
+                     const int & iqs, int /* nblocks */) {
+        const int ib = ibx_offset.first / (QK_K / 2);
+
+        const uint8_t *   base   = static_cast<const uint8_t *>(vbq);
+        const uint8_t *   ql     = base + ibx_offset.first;
+        const uint8_t *   qh     = base + ibx_offset.second;
+        const int8_t *    scales = reinterpret_cast<const int8_t *>(base + d_offset.first);
+        const ggml_half * d      = (const ggml_half *) (base + d_offset.second) + ib;
+
+        const int bq8_offset   = 2 * QR6_K * (iqs / (QI6_K / 2)) + (iqs % (QI6_K / 2)) / (QI6_K / 4);
+        const int scale_offset = (QI6_K / 4) * (iqs / (QI6_K / 2)) + (iqs % (QI6_K / 2)) / (QI6_K / 8);
+        const int vh_shift     = 2 * ((iqs % (QI6_K / 2)) / (QI6_K / 4));
+
+        const int vl = get_int_from_uint8(ql, iqs);
+        const int vh = get_int_from_uint8(qh, (QI6_K / 4) * (iqs / (QI6_K / 2)) + iqs % (QI6_K / 4)) >> vh_shift;
+
+        const int8_t * scs = scales + scale_offset;
+
+        int   u[QR6_K];
+        float d8[QR6_K];
+
+#pragma unroll
+        for (int i = 0; i < QR6_K; ++i) {
+            u[i] = get_int_from_int8_aligned(q8_1_quant_ptr + (bq8_offset + 2 * i) * QK8_1, iqs % QI8_1);
+            const sycl::half2 ds_values = *(q8_1_ds + bq8_offset + 2 * i);
+            d8[i]                       = ds_values[0];
+        }
+        return vec_dot_q6_K_q8_1_impl_mmvq(vl, vh, u, scs, *d, d8);
+    }
+};
 #define VDR_Q4_0_Q8_1_MMVQ 2
 #define VDR_Q4_0_Q8_1_MMQ  4
 

--- a/ggml/src/ggml-sycl/vecdotq.hpp
+++ b/ggml/src/ggml-sycl/vecdotq.hpp
@@ -403,7 +403,6 @@ template <> struct reorder_vec_dot_q_sycl<GGML_TYPE_Q6_K> {
     using q6_k_block  = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q6_K>;
     using q6_k_traits = typename q6_k_block::traits;
 
-    // contiguous v/x values
     __dpct_inline__ float vec_dot_q6_K_q8_1_impl_mmvq(const int & vl, const int & vh, const int * __restrict__ u,
                                                       const int8_t * __restrict__ scales, const float d,
                                                       const float * __restrict__ d8) {


### PR DESCRIPTION
This PR implements quants reordering for mmvq for Q6_K quantization following the work done for Q4_0 and Q4_K.
These changes give good results on BMG and do not detriment performance on other GPUs.

### Performance impact

All numbers taken with `GGML_SYCL_DISABLE_OPT=0` . 

#### Battlemage B580

| model                    |        size |  params | backend | ngl |   sm | mmap |  test |   this PR         t/s |  master(26b79b6cb)      t/s |
| ------------------------ | ----------: | ------: | ------- | --: | ---: | ---: | ----: | --------------: | ---------------: |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | none |    0 | pp512 | 7421.88 ± 40.31 | 7303.25 ± 190.33 |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | none |    0 | tg128 |   134.93 ± 4.28 |    132.17 ± 7.13 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | none |    0 | pp512 | 7508.23 ± 12.32 |  7543.68 ± 52.94 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | none |    0 | tg128 |   124.74 ± 2.57 |    117.75 ± 2.95 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | none |    0 | pp512 |  2164.47 ± 3.86 |   2156.43 ± 4.42 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | none |    0 | tg128 |    65.13 ± 0.55 |     65.65 ± 0.38 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | none |    0 | pp512 |  2206.63 ± 4.49 |   2202.15 ± 5.80 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | none |    0 | tg128 |    55.04 ± 0.19 |     52.57 ± 0.23 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | none |    0 | pp512 | 5722.94 ± 33.50 |  5688.02 ± 29.39 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | none |    0 | tg128 |    93.32 ± 2.52 |     88.34 ± 2.42 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | none |    0 | pp512 |  3043.55 ± 8.11 |   3047.39 ± 6.17 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | none |    0 | tg128 |    95.46 ± 2.23 |     95.79 ± 2.39 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | none |    0 | pp512 |  3140.52 ± 6.44 |   3154.81 ± 5.22 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | none |    0 | tg128 |    72.71 ± 0.89 |     69.35 ± 0.16 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | none |    0 | pp512 |  1472.53 ± 4.66 |   1468.04 ± 0.47 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | none |    0 | tg128 |    23.48 ± 0.03 |     20.30 ± 0.05 |

#### Lunar Lake

| model                    |        size |  params | backend | ngl |  test |    this PR         t/s |        master(26b79b6cb)      t/s |
| ------------------------ | ----------: | ------: | ------- | --: | ----: | --------------: | --------------: |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | pp512 | 1559.52 ± 38.29 | 1761.94 ± 15.09 |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | tg128 |    58.17 ± 0.59 |    56.42 ± 0.42 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | pp512 | 1775.38 ± 37.60 | 1675.54 ± 32.04 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | tg128 |    42.21 ± 0.19 |    39.81 ± 0.65 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | pp512 |   391.97 ± 4.96 |   433.80 ± 1.21 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | tg128 |    21.61 ± 0.51 |    20.38 ± 0.61 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | pp512 |   492.83 ± 0.55 |   488.92 ± 1.28 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | tg128 |    15.86 ± 0.24 |    14.98 ± 0.16 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | pp512 |  985.69 ± 62.63 |  990.18 ± 10.61 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | tg128 |    29.24 ± 0.15 |    27.48 ± 0.25 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | pp512 |   674.42 ± 0.61 |   665.08 ± 3.18 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | tg128 |    34.34 ± 0.09 |    33.52 ± 0.11 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | pp512 |   743.15 ± 1.86 |   737.78 ± 2.94 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | tg128 |    22.53 ± 0.48 |    22.17 ± 0.30 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | pp512 |  301.50 ± 14.06 |   302.83 ± 1.09 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | tg128 |     7.72 ± 0.05 |     6.06 ± 0.02 |
| llama 8B Q4_K - Medium   |    4.58 GiB |  8.03 B | SYCL    |  99 | pp512 |   411.81 ± 4.68 |   418.31 ± 5.50 |
| llama 8B Q4_K - Medium   |    4.58 GiB |  8.03 B | SYCL    |  99 | tg128 |    14.46 ± 0.06 |    13.40 ± 0.09 |

#### Intel Arc A770

| model                    |        size |  params | backend | ngl |   sm | mmap |  test |            t/s |     master(26b79b6cb)       t/s |
| ------------------------ | ----------: | ------: | ------- | --: | ---: | ---: | ----: | -------------: | -------------: |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | none |    0 | pp512 | 4456.48 ± 8.69 | 4433.16 ± 9.59 |
| qwen2 1.5B Q4_0          | 1013.62 MiB |  1.78 B | SYCL    |  99 | none |    0 | tg128 |   45.60 ± 0.21 |   44.82 ± 0.24 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | none |    0 | pp512 | 4499.64 ± 3.28 | 4460.18 ± 5.36 |
| qwen2 1.5B Q4_K - Medium |    1.04 GiB |  1.78 B | SYCL    |  99 | none |    0 | tg128 |   44.60 ± 0.16 |   43.98 ± 0.14 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | none |    0 | pp512 | 1716.17 ± 1.29 | 1707.70 ± 1.18 |
| llama 7B Q4_0            |    3.57 GiB |  6.74 B | SYCL    |  99 | none |    0 | tg128 |   34.40 ± 0.03 |   34.06 ± 0.02 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | none |    0 | pp512 | 1732.65 ± 2.73 | 1723.82 ± 1.31 |
| llama 7B Q4_K - Medium   |    3.80 GiB |  6.74 B | SYCL    |  99 | none |    0 | tg128 |   32.60 ± 0.27 |   31.71 ± 0.27 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | none |    0 | pp512 | 3661.03 ± 6.91 | 3632.01 ± 6.45 |
| gemma2 2B Q4_K - Medium  |    1.59 GiB |  2.61 B | SYCL    |  99 | none |    0 | tg128 |   39.20 ± 0.31 |   38.16 ± 0.36 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | none |    0 | pp512 | 2464.93 ± 2.58 | 2445.01 ± 2.54 |
| phi3 3B Q4_0             |    2.03 GiB |  3.82 B | SYCL    |  99 | none |    0 | tg128 |   39.98 ± 0.01 |   39.41 ± 0.33 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | none |    0 | pp512 | 2513.13 ± 2.47 | 2492.01 ± 1.80 |
| phi3 3B Q4_K - Medium    |    2.23 GiB |  3.82 B | SYCL    |  99 | none |    0 | tg128 |   34.50 ± 0.30 |   34.14 ± 0.02 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | none |    0 | pp512 | 1031.68 ± 1.04 | 1024.74 ± 1.07 |
| llama 34B Q6_K           |    8.20 GiB | 10.73 B | SYCL    |  99 | none |    0 | tg128 |   17.33 ± 0.11 |   15.12 ± 0.16 |
