### PR TITLE
ci(intel): venv for python & pip installation for intel docker

### DIFF
--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /app
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN apt-get update \
-    && apt-get install -y python3 python3-pip python3-venv \
+    && apt-get install -y git python3 python3-pip python3-venv \
     && python3 -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip setuptools wheel \
     && pip install -r requirements.txt \

--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -49,11 +49,12 @@ COPY --from=build /app/full /app
 
 WORKDIR /app
 
+# PEP 668 are in effect, pip should be run within virtualenv instead
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN apt-get update \
-    && apt-get install -y \
-    git \
-    python3 \
-    python3-pip \
+    && apt-get install -y python3 python3-pip python3-venv \
+    && python3 -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip setuptools wheel \
     && pip install -r requirements.txt \
     && apt autoremove -y \
@@ -61,7 +62,6 @@ RUN apt-get update \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
-
 
 ENTRYPOINT ["/app/tools.sh"]
 
@@ -88,4 +88,3 @@ WORKDIR /app
 HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
 
 ENTRYPOINT [ "/app/llama-server" ]
-


### PR DESCRIPTION
Solve this kind of issue that clogged the CI docker build: https://github.com/ggml-org/llama.cpp/actions/runs/15339094371/job/43161788866

Upgrading intel basekit (which upgrade to Ubuntu 24.04) impose [PEP 668](https://peps.python.org/pep-0668/), which call for python and pip isolation

This PR solve this by creating `venv` and set as default `PATH` for `python3` and `pip` commands