### PR TITLE
fix(vulkan): Adjust vulkan-shaders-gen build for Termux compatibility

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -51,6 +51,7 @@ if (Vulkan_FOUND)
 
     set(VULKAN_SHADER_GEN_CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
+        # CMAKE_RUNTIME_OUTPUT_DIRECTORY 这里保持原样，因为 _ggml_vk_genshaders_cmd 接下来会使用硬编码路径
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     )
 
@@ -88,7 +89,7 @@ if (Vulkan_FOUND)
     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build
-    # Posssibly relevant: https://stackoverflow.com/questions/74748276/visual-studio-no-displays-the-correct-length-of-stdvector
+    # Posssibly relevant: https://stackoverflow.com/questions/74748276/visual-studio-no-displays-the.correct-length-of-stdvector
     if (MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         add_compile_definitions(_ITERATOR_DEBUG_LEVEL=0)
     endif()
@@ -151,13 +152,18 @@ if (Vulkan_FOUND)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders
         CMAKE_ARGS ${VULKAN_SHADER_GEN_CMAKE_ARGS}
         BUILD_COMMAND ${CMAKE_COMMAND} --build . ${VULKAN_SHADER_GEN_CMAKE_BUILD_ARGS}
-        INSTALL_COMMAND ${CMAKE_COMMAND} --install .
-        INSTALL_DIR ${CMAKE_BINARY_DIR}
+        INSTALL_COMMAND "" # <-- 关键修改：强制为空命令
+        # INSTALL_DIR ${CMAKE_BINARY_DIR} # <-- 保持注释，因为 INSTALL_COMMAND 已经为空
+        BUILD_IN_SOURCE ON # <-- 保持新增
     )
-    ExternalProject_Add_StepTargets(vulkan-shaders-gen build install)
+    # 修改 ExternalProject_Add_StepTargets, 移除 'install' 目标
+    ExternalProject_Add_StepTargets(vulkan-shaders-gen build)
 
     set (_ggml_vk_host_suffix $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,.exe,>)
-    set (_ggml_vk_genshaders_cmd ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/vulkan-shaders-gen${_ggml_vk_host_suffix})
+    # 修改 _ggml_vk_genshaders_cmd 的路径，直接指向构建后的文件位置
+    # CMAKE_BINARY_DIR 是主项目的构建目录（例如 /data/data/com.termux/files/home/llama.cpp/build）
+    # bin/ 是 CMAKE_RUNTIME_OUTPUT_DIRECTORY 的默认子目录，vulkan-shaders-gen 实际链接到这里
+    set (_ggml_vk_genshaders_cmd ${CMAKE_BINARY_DIR}/bin/vulkan-shaders-gen${_ggml_vk_host_suffix})
     set (_ggml_vk_header     ${CMAKE_CURRENT_BINARY_DIR}/ggml-vulkan-shaders.hpp)
     set (_ggml_vk_source     ${CMAKE_CURRENT_BINARY_DIR}/ggml-vulkan-shaders.cpp)
     set (_ggml_vk_input_dir  ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders)
@@ -167,7 +173,8 @@ if (Vulkan_FOUND)
     set (_ggml_vk_shader_deps ${_ggml_vk_shader_deps} vulkan-shaders-gen)
 
     # Add build and install dependencies for all builds
-    set(_ggml_vk_shader_deps ${_ggml_vk_shader_deps} vulkan-shaders-gen-build vulkan-shaders-gen-install)
+    # 修改 _ggml_vk_shader_deps，移除对 'vulkan-shaders-gen-install' 的依赖
+    set(_ggml_vk_shader_deps ${_ggml_vk_shader_deps} vulkan-shaders-gen-build )
 
     add_custom_command(
         OUTPUT ${_ggml_vk_header}


### PR DESCRIPTION
Okay, absolutely! Let's draft an outline for your English-language README.md or a similar document that you can put in your GitHub repository branch. This will include the performance reference table and highlight your key findings.

Here's a suggested structure and content, keeping in mind it should be in pure English:

```markdown

llama.cpp on Android (Termux) - Performance Testing on Dimensity 9300 (Mali-G720-Immortalis MC12 GPU)

This document details the process, findings, and performance benchmarks of running llama.cpp with Gemma 3 (4B & 12B, Q4_0 quantized) models on an Android device powered by the MediaTek Dimensity 9300 SoC, featuring the Mali-G720-Immortalis MC12 GPU, within the Termux CI environment.

The primary goal was to explore the feasibility and performance of different backends (CPU, Vulkan GPU) and configurations.

Environment Setup

Device: [Your Phone Model] with MediaTek Dimensity 9300

GPU: ARM Mali-G720-Immortalis MC12

Android Version: [Your Android Version]

Termux Version: Termux (CI Build - specify if this was crucial for Vulkan)

Note: The CI build of Termux was used, which might have specific capabilities for accessing the vendor's closed-source Vulkan drivers.

llama.cpp Commit: [Specify the commit hash or version of llama.cpp used]

Key Dependencies (Termux pkg install): cmake, clang, git, vulkan-loader, vulkan-headers (and any other specific Vulkan dev packages if needed for compilation)

Build Process
CPU Backend (Optimized for Arm)

Built using standard CMake commands, relying on llama.cpp's native Arm optimizations (NEON, SVE, DOTPROD, I8MM detected).

# Example CMake command for CPU build
cd ~/llama.cpp
cmake -B build-cpu
cmake --build build-cpu --config Release -j4

Vulkan GPU Backend

Built with the Vulkan backend enabled. Specific modifications to ggml/src/ggml-vulkan/CMakeLists.txt were required to successfully compile the vulkan-shaders-gen utility within the Termux environment.

Key ggml/src/ggml-vulkan/CMakeLists.txt Modifications:
(You can either paste the diff here, or link to the committed file in your branch, or summarize the changes)

# Example placeholder for your actual diff or summary
# --- a/ggml/src/ggml-vulkan/CMakeLists.txt
# +++ b/ggml/src/ggml-vulkan/CMakeLists.txt
# @@ -151,13 +152,18 @@ if (Vulkan_FOUND)
# -        INSTALL_COMMAND ${CMAKE_COMMAND} --install .
# +        INSTALL_COMMAND "" # Disabled install step for vulkan-shaders-gen
# +        BUILD_IN_SOURCE ON # Enabled in-source build for vulkan-shaders-gen
# ... (other relevant changes for shader gen path)
IGNORE_WHEN_COPYING_START
content_copy
download
Use code with caution.
Diff
IGNORE_WHEN_COPYING_END

(Explanation: These changes were necessary to prevent installation errors and ensure the vulkan-shaders-gen executable could be found and run during the main llama.cpp build process in Termux, potentially due to path or permission issues with standard ExternalProject installation steps in this environment.)

CMake command for Vulkan build:

cd ~/llama.cpp
cmake -B build-vulkan -DGGML_VULKAN=ON
cmake --build build-vulkan --config Release -j4
IGNORE_WHEN_COPYING_START
content_copy
download
Use code with caution.
Bash
IGNORE_WHEN_COPYING_END
Models Used

Gemma 3 4B IT Q4_0: gemma-3-4b-it-q4_0.gguf (approx. 2.93 GiB)

Gemma 3 12B IT Q4_0: gemma-3-12b-it-q4_0.gguf (approx. 7.51 GiB)

Testing Methodology

Tools: llama-bench for standardized benchmarks, and llama-server for interactive testing and observing performance during typical chat scenarios.

Key Parameters Varied:

Thread count (-t, -tb): Primarily 4 and 8 threads.

KV Cache Types (-ctk, -ctv): f16 (default for bench), q8_0, q5_1, iq4_nl.

GPU Layers Offloaded (-ngl): Used -ngl 99 for Vulkan to attempt offloading all layers.

Context Size (-c): Primarily 8192 for 4B model server tests, 4096 for 12B model initial tests.

Metrics Observed:

Tokens per second (t/s) for prompt processing (pp) and token generation (tg).

KV Cache memory footprint.

System UI responsiveness during llama-server operation.

Successful model loading and operation.

Performance Reference Table: Gemma 3 4B Q4_0

(t/s = tokens per second; pp = prompt processing; tg = token generation)

Backend/Config	Threads	KV Cache Type	Context (-c)	Support Status	PP (t/s)	TG (t/s)	KV Cache Size (MiB, SWA+non-SWA, approx.)	Notes
CPU (llama-bench)	8	f16 (default)	N/A	✅ Tested	89.68	9.12	N/A	Baseline CPU performance.
CPU (llama-bench)	4	f16 (default)	N/A	✅ Tested	62.53	11.56	N/A	Optimal CPU TG performance on this device. 4 threads outperform 8 threads for generation.
CPU (llama-server)	4	q8_0	8192	✅ Tested	~46.50	~10.0 - 10.5	~578	Good balance of speed and memory for server use.
CPU (llama-server)	4	q5_1	8192	✅ Tested	~47.76	~8.82	~408	Lower KV cache memory, slight speed dip vs. q8_0. Quality impact vs. q8_0 needs subjective evaluation.
Vulkan GPU (llama-server)	4	q8_0	8192	✅ Operational (Termux CI)	~10.75	~3.37 (see note)	~578 (GPU)	All layers offloaded to Mali-G720 GPU. Initial log showed ~3.37 t/s. However, subjective user experience suggests overall performance is comparable to CPU (around 8-10 t/s), not significantly faster or slower. This discrepancy warrants further investigation. GPU supports Integer Dot Product.

Note on Vulkan TG performance: The logged 3.37 t/s for a specific request might not reflect the overall sustained performance or user-perceived speed, which felt closer to the CPU's ~8-10 t/s range. This could be due to the nature of the specific test prompt, server overhead, or other factors not captured by that single log entry.

Preliminary Support: Gemma 3 12B Q4_0 (CPU)
Backend/Config	Threads	KV Cache Type	Context (-c)	Support Status	Notes
CPU (llama-server)	4	iq4_nl	4096	✅ Loaded & Ran	Successfully loaded and started the server. Extremely low KV cache footprint (~432 MiB). Performance (t/s) and output quality TBD.
Key Observations & "Counter-intuitive" Findings

Vulkan on Termux (Mali-G720) is Feasible: It's possible to compile and run llama.cpp with the Vulkan backend in Termux (CI build) on the Dimensity 9300, with full model offload to the Mali GPU. This required specific CMake modifications for vulkan-shaders-gen.

Vulkan Performance vs. CPU: Contrary to expectations of significant GPU acceleration, the Vulkan backend's performance (for 4B model, all layers offloaded) was subjectively perceived to be comparable to the optimized 4-thread CPU backend, and not demonstrably faster. Logged t/s for one Vulkan request was significantly lower than CPU, but this may not represent the full picture.

This could be attributed to: Mobile GPU architecture (Mali-G720) being less optimized for this type of GPGPU compute vs. desktop GPUs, UMA bottlenecks, Vulkan backend/shader optimizations for Mali, or high overhead of INT4/8 operations needing high occupancy/arithmetic intensity which might not be achieved. The GPU L2 cache size could also be a limiting factor.

CPU Threading Optimization: For CPU-based inference on this device, 4 threads yielded better token generation speed than 8 threads.

KV Cache Impact: Lower precision KV cache types (q8_0, q5_1, iq4_nl) significantly reduce memory footprint, enabling larger context windows, but may impact speed and output quality to varying degrees.

12B Model on Mobile CPU: It's possible to load and run a 12B Q4_0 model on this device using CPU inference with aggressive KV cache quantization (iq4_nl), though practical speed and quality remain to be thoroughly evaluated.

System Responsiveness with GPU: When the Vulkan backend fully utilized the GPU, a noticeable degradation in Android system UI responsiveness (lag, stutter) was observed. This is a critical consideration for on-device LLM usability.

Conclusions and Recommendations (for this specific device/setup)

For Best "Experience" (Speed & Responsiveness) with 4B Model:

The CPU backend with 4 threads and q8_0 KV cache currently offers the most practical balance of speed, acceptable memory usage for large contexts (e.g., 8192), and system responsiveness.

q5_1 KV cache is a good alternative for slightly lower memory if a minor speed trade-off is acceptable.

Vulkan GPU Backend:

A successful technical proof-of-concept, demonstrating full model offload.

Current performance on this Mali-G720 does not justify its use over the optimized CPU backend if speed is the primary concern, especially considering the impact on system UI.

Further investigation into llama.cpp's Vulkan shader optimizations for Mali, and potential for INT8 utilization (given int dot: 1 support), would be needed to unlock performance gains.

Running 12B Models (CPU):

Possible with iq4_nl KV cache, but expect very slow speeds. Output quality with such low-precision KV cache needs careful assessment.

LAN Server Idea: Given the system responsiveness issue with full GPU load, running llama-server on the device and accessing it from other devices on the LAN is a viable strategy to get dedicated LLM compute without impacting the primary user experience of the "server" device.

Future Exploration / Considerations

Test various -ngl (GPU layer offload) values with Vulkan to see if a hybrid CPU/GPU approach yields better performance or system responsiveness than full offload.

Thoroughly evaluate the output quality差异 (differences) between KV cache types (q8_0, q5_1, iq4_nl) for both 4B and 12B models.

Investigate if the llama.cpp Vulkan backend can be further optimized to leverage the Mali GPU's integer dot product capabilities for Q4_0/Q8_0 models more effectively.

Monitor developments in mobile GPU architectures (e.g., newer Qualcomm Adreno L2 cache designs) and llama.cpp Vulkan backend updates.

```This draft is in pure English and covers the points we discussed. You can copy and paste this into a README.md file in your `termux-vulkan-maliG720-experiments` branch on GitHub.

Before you finalize, please:

Fill in the bracketed placeholders: [Your Phone Model], [Your Android Version], [Specify the commit hash or version of llama.cpp used], and any other specific details.

Review the wording: Ensure it accurately reflects your findings and nuances. My interpretation of "Vulkan performance and CPU差不多" is crucial here. I've tried to capture that the subjective experience was similar, even if one specific log entry showed lower t/s for Vulkan. Adjust if needed.

Consider adding actual log snippets or links to them if you have them saved, especially for the Vulkan successful run and the CMakeLists.txt modifications.

"模型质量" / "Output quality": I've mentioned this نیاز (needs) subjective evaluation. You might want to add a small section with your qualitative assessment if you've done some.

This will be an excellent contribution to your repository and potentially helpful to others!