### PR TITLE
CUDA: fix typo in FlashAttention code

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1246,7 +1246,7 @@ static __global__ void flash_attn_ext_f16(
         NO_DEVICE_CODE;
         return;
     }
-#endif __CUDA_ARCH__ == GGML_CUDA_CC_TURING
+#endif // __CUDA_ARCH__ == GGML_CUDA_CC_TURING
 
     static_assert(!mla || DKQ >= DV, "MLA needs DKQ >= DV");
 


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/pull/13306#issuecomment-2922675815 .

To my knowledge this should not make a difference but I think we should fix it regardless.