### PR TITLE
`chat`: allow unclosed thinking tags

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -154,9 +154,10 @@ bool common_chat_msg_parser::try_parse_reasoning(const std::string & start_think
             if (!rest.empty()) {
                 handle_reasoning(rest, /* closed */ !is_partial());
             }
-            if (!syntax_.thinking_forced_open) {
-                throw common_chat_msg_partial_exception(end_think);
-            }
+            // Allow unclosed thinking tags, for now (https://github.com/ggml-org/llama.cpp/issues/13812, https://github.com/ggml-org/llama.cpp/issues/13877)
+            // if (!syntax_.thinking_forced_open) {
+            //     throw common_chat_msg_partial_exception(end_think);
+            // }
             return true;
         }
     }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1041,6 +1041,15 @@ static void test_template_output_parsers() {
                       "<tool_call>\n"
                       "{\"name\": \"python\", \"arguments\": {\"code\":\"# This is a program:\\nprint('hey')\"}}\n"
                       "</tool_call>");
+        assert_msg_equals(
+            simple_assist_msg("", /* reasoning_content= */ "<tool_call>nah uhg</tool_call>"),
+            common_chat_parse(
+                "<think><tool_call>nah uhg</tool_call>",
+                /* is_partial= */ false,
+                {
+                    /* .format = */ COMMON_CHAT_FORMAT_HERMES_2_PRO,
+                    /* .reasoning_format = */ COMMON_REASONING_FORMAT_DEEPSEEK,
+                }));
     }
     {
         auto tmpls = read_templates("models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja");


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/13812 & https://github.com/ggml-org/llama.cpp/issues/13877

Note: won't try and scavenge tool calls inside unclosed thinking tags (I've seen legit thought traces that contained mock-tool calls), although this might end up being a frequent failure mode for small Qwen3 models. Can disable thinking w/ `--reasoning-budget 0` to avoid the issue w/ these.