### PR TITLE
`chat`: improve llama 3.x handling of <|python_tag|> (+ allow --special combo)

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -51,10 +51,10 @@ bool common_chat_msg_parser::add_tool_call(const std::string & name, const std::
     result_.tool_calls.emplace_back(tool_call);
     return true;
 }
-bool common_chat_msg_parser::add_tool_call(const json & tool_call) {
+bool common_chat_msg_parser::add_tool_call(const json & tool_call, const char * arguments_name) {
     std::string name = tool_call.contains("name") ? tool_call.at("name") : "";
     std::string id = tool_call.contains("id") ? tool_call.at("id") : "";
-    std::string arguments = tool_call.contains("arguments") ? tool_call.at("arguments") : "";
+    std::string arguments = tool_call.contains(arguments_name) ? tool_call.at(arguments_name) : "";
     return add_tool_call(name, id, arguments);
 }
 

--- a/common/chat-parser.h
+++ b/common/chat-parser.h
@@ -59,7 +59,7 @@ class common_chat_msg_parser {
     bool add_tool_call(const std::string & name, const std::string & id, const std::string & arguments);
 
     // Adds a tool call using the "name", "id" and "arguments" fields of the json object
-    bool add_tool_call(const nlohmann::ordered_json & tool_call);
+    bool add_tool_call(const nlohmann::ordered_json & tool_call, const char * arguments_name = "arguments");
 
     // Adds an array of tool calls using their "name", "id" and "arguments" fields.
     bool add_tool_calls(const nlohmann::ordered_json & arr);

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1146,7 +1146,7 @@ static void common_chat_parse_llama_3_1(common_chat_msg_parser & builder, bool w
         } else if (with_builtin_tools) {
             static const common_regex function_name_regex("\\s*(\\w+)\\s*\\.\\s*call\\(");
             static const common_regex arg_name_regex("\\s*(\\w+)\\s*=\\s*");
-            
+
             auto fun_res = builder.consume_regex(function_name_regex);
             auto function_name = builder.str(fun_res.groups[1]);
 
@@ -1181,7 +1181,6 @@ static void common_chat_parse_llama_3_1(common_chat_msg_parser & builder, bool w
         }
     }
     builder.add_content(builder.consume_rest());
-
 }
 
 static common_chat_params common_chat_params_init_deepseek_r1(const common_chat_template & tmpl, const struct templates_params & inputs) {

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1062,6 +1062,18 @@ static void test_template_output_parsers() {
                 "{\"name\": \"special_function\", \"parameters\": {\"arg1\": 1}}",
                 /* is_partial= */ false,
                 {COMMON_CHAT_FORMAT_LLAMA_3_X}));
+        assert_equals(
+            message_assist_call,
+            common_chat_parse(
+                "<|python_tag|>{\"name\": \"special_function\", \"parameters\": {\"arg1\": 1}}",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_LLAMA_3_X}));
+        assert_equals(
+            message_assist_call,
+            common_chat_parse(
+                "<|python_tag|>{\"type\": \"function\", \"name\": \"special_function\", \"parameters\": {\"arg1\": 1}}",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_LLAMA_3_X}));
 
         // test_templates(tmpls.get(), end_tokens, message_assist, tools, R"(?)", /* expect_grammar_triggered= */ false);
         test_templates(tmpls.get(), end_tokens, message_assist_call_code_interpreter, llama_3_1_tools,

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1074,6 +1074,24 @@ static void test_template_output_parsers() {
                 "<|python_tag|>{\"type\": \"function\", \"name\": \"special_function\", \"parameters\": {\"arg1\": 1}}",
                 /* is_partial= */ false,
                 {COMMON_CHAT_FORMAT_LLAMA_3_X}));
+        assert_equals(
+            simple_assist_msg("{\"something\": \"else\"}"),
+            common_chat_parse(
+                "{\"something\": \"else\"}",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_LLAMA_3_X}));
+        assert_equals(
+            message_assist_empty,
+            common_chat_parse(
+                "{\"some",
+                /* is_partial= */ true,
+                {COMMON_CHAT_FORMAT_LLAMA_3_X}));
+        assert_equals(
+            message_assist_empty,
+            common_chat_parse(
+                "{\"parameters\": {\"arg1\": 1}",
+                /* is_partial= */ true,
+                {COMMON_CHAT_FORMAT_LLAMA_3_X}));
 
         // test_templates(tmpls.get(), end_tokens, message_assist, tools, R"(?)", /* expect_grammar_triggered= */ false);
         test_templates(tmpls.get(), end_tokens, message_assist_call_code_interpreter, llama_3_1_tools,


### PR DESCRIPTION
Turns out the `<|python_tag|>` was passed in cases where I thought there was just raw JSON arguments.

Fixes https://github.com/ggml-org/llama.cpp/issues/13769