### PR TITLE
ggml: check if non-native endian model is being loaded

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -347,6 +347,12 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
     int64_t n_tensors = 0;
 
     if (ok && gr.read(ctx->version)) {
+        if ((ctx->version & 0xFFFF) == 0x0000) {
+            GGML_LOG_ERROR("%s: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
+            gguf_free(ctx);
+            return nullptr;
+        }
+
         if (ctx->version == 1) {
             GGML_LOG_ERROR("%s: GGUFv1 is no longer supported, please use a more up-to-date version\n", __func__);
             ok = false;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -351,11 +351,11 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
          * bit layout is different when reading non-native endian models.
          * assuming that the GGUF version is 3, the non-native endian model
          * would read it as 0x30000000. we can use the AND operation against
-         * the last 4 hexadecimal digit to check if the model is the same
+         * the last 4 hexadecimal digits to check if the model is the same
          * endianness as the host system.
         */
         if ((ctx->version & 0x0000FFFF) == 0x00000000) {
-            GGML_LOG_ERROR("%s: failed to load model: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
+            GGML_LOG_ERROR("%s: failed to load model: this GGUF file version %" PRIu32 " is extremely large, is there a mismatch between the host and model endianness?\n", __func__, ctx->version);
             gguf_free(ctx);
             return nullptr;
         }

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -354,13 +354,13 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
          * the last 4 hexadecimal digit to check if the model is the same
          * endianness as the host system.
         */
-        GGML_ASSERT(ctx->version > 0 && ctx->version <= 65535);
         if ((ctx->version & 0x0000FFFF) == 0x00000000) {
             GGML_LOG_ERROR("%s: failed to load model: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
             gguf_free(ctx);
             return nullptr;
         }
 
+        GGML_ASSERT(ctx->version > 0 && ctx->version <= 65535);
         if (ctx->version == 1) {
             GGML_LOG_ERROR("%s: GGUFv1 is no longer supported, please use a more up-to-date version\n", __func__);
             ok = false;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -347,7 +347,15 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
     int64_t n_tensors = 0;
 
     if (ok && gr.read(ctx->version)) {
-        if ((ctx->version & 0xFFFF) == 0x0000) {
+        /*
+         * bit layout is different when reading non-native endian models.
+         * assuming that the GGUF version is 3, the non-native endian model
+         * would read it as 0x30000000. we can use the AND operation against
+         * the last 4 hexadecimal digit to check if the model is the same
+         * endianness as the host system.
+        */
+        GGML_ASSERT(ctx->version > 0 && ctx->version <= 65535);
+        if ((ctx->version & 0x0000FFFF) == 0x00000000) {
             GGML_LOG_ERROR("%s: failed to load model: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
             gguf_free(ctx);
             return nullptr;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -348,7 +348,7 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
     if (ok && gr.read(ctx->version)) {
         if ((ctx->version & 0xFFFF) == 0x0000) {
-            GGML_LOG_ERROR("%s: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
+            GGML_LOG_ERROR("%s: failed to load model: host and model endian mismatch, please use a model compiled with the same endian as your host system\n", __func__);
             gguf_free(ctx);
             return nullptr;
         }


### PR DESCRIPTION
This PR adds more descriptive error messages for when a non-native endian model is being loaded on the host system.

### Verification
To ensure that this implementation did not break anything, this PR has been tested on the following systems:
1. IBM z15 Mainframe (16 IFLs / 160 RAIM / NOSMT / LPAR)
2. M3 MacBook Air (8 Cores / 16 GB / SMT)
3. Kindly request additional systems to be tested in this PR

| System                        | Granite 3.1 2B Instruct LE Model | Granite 3.1 2B Instruct BE Model |
|-------------------------------|----------------------------------|----------------------------------|
| IBM z15 Mainframe (BE System) | ❌ Does not load (Expected)       | ✅ Loads (Expected)               |
| M3 MacBook Air (LE System)    | ✅ Loads (Expected)               | ❌ Does not load (Expected)       |