### PR TITLE
Note about necessity of having libcurl installed for standard build

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -63,6 +63,7 @@ cmake --build build --config Release
       cmake --preset x64-windows-llvm-release
       cmake --build build-x64-windows-llvm-release
       ```
+- Curl usage is enabled by default and can be turned off with `-DLLAMA_CURL=OFF`. Otherwise you need to install development libraries for libcurl.
 
 ## BLAS Build
 


### PR DESCRIPTION
Since https://github.com/ggml-org/llama.cpp/commit/bd3f59f81289b920bcc597a208c14f55e39ed37e the basic build requires installation of curl development files, for example from the `libcurl4-openssl-dev` package for Ubuntu.

This PR simply adds note of the change in behavior and how can you revert to the previous state of affairs. 