### PR TITLE
add easy-llama Python bindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 <details>
 <summary>Bindings</summary>
 
+- Python: [ddh0/easy-llama](https://github.com/ddh0/easy-llama)
 - Python: [abetlen/llama-cpp-python](https://github.com/abetlen/llama-cpp-python)
 - Go: [go-skynet/go-llama.cpp](https://github.com/go-skynet/go-llama.cpp)
 - Node.js: [withcatai/node-llama-cpp](https://github.com/withcatai/node-llama-cpp)


### PR DESCRIPTION
The Python bindings `llama-cpp-python` have become less frequently updated over time, my project `easy-llama` is more up-to-date. This PR adds `easy-llama` to the list of bindings in the README. It does not remove `llama-cpp-python`.