### PR TITLE
llama : default pooling last for qwen3

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -820,6 +820,8 @@ void llama_model::load_hparams(llama_model_loader & ml) {
         case LLM_ARCH_QWEN3:
             {
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+                hparams.pooling_type = LLAMA_POOLING_TYPE_LAST; // for embeddings model
+
                 switch (hparams.n_layer) {
                     case 28: type = hparams.n_embd == 1024 ? LLM_TYPE_0_6B : LLM_TYPE_1_7B; break;
                     case 36: type = hparams.n_embd == 2560 ? LLM_TYPE_4B : LLM_TYPE_8B; break;
@@ -830,8 +832,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
             } break;
         case LLM_ARCH_QWEN3MOE:
             {
-                ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,        hparams.n_ff_exp, false);
-
+                ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,  hparams.n_ff_exp, false);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
                 switch (hparams.n_layer) {
                     case 48: type = LLM_TYPE_30B_A3B; break;


### PR DESCRIPTION
Maybe too late to fix upstream model (one of the GGUF already set to public), so I think we can do a quick patch in llama.cpp

CC @yuhao318 do you have any visibility about why only one GGUF is public?