### PR TITLE
cpu: Update RISC-V condition to require GCC version 14 or higher

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-quants.c
+++ b/ggml/src/ggml-cpu/ggml-cpu-quants.c
@@ -3121,7 +3121,7 @@ void ggml_vec_dot_q5_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
     }
 
     sumf = hsum_float_8(acc);
-#elif defined(__riscv_v)
+#elif defined(__riscv_v) && (__GNUC__ >= 14)
     size_t vl;
     size_t vlenb = __riscv_vlenb();
 
@@ -3460,7 +3460,7 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const voi
     }
 
     sumf = hsum_float_8(acc) + summs;
-#elif defined(__riscv_v)
+#elif defined(__riscv_v) && (__GNUC__ >= 14)
     size_t vl;
     size_t vlenb = __riscv_vlenb();
 


### PR DESCRIPTION
This pull request includes a minor update to the `ggml-cpu-quants.c` file. The changes ensure compatibility with GCC version 14 or higher for RISC-V vector intrinsics.

Compatibility update:

* [`ggml/src/ggml-cpu/ggml-cpu-quants.c`](diffhunk://#diff-2fe6a0c5c19ec624a453d7ad59b4e8fdfe8e3527c19c1b5b44a297a370d661c6L3124-R3124): Modified conditional compilation checks to require GCC version 14 or higher when using RISC-V vector intrinsics in the `ggml_vec_dot_q5_0_q8_0` and `ggml_vec_dot_q5_1_q8_1` functions.

