### PR TITLE
ggml-cpu: optimise assembly calls for hsum on s390x

### DIFF
--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -944,10 +944,8 @@ static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
     for (int i = 0; i < offset; ++i) {              \
         x[i] = vec_add(x[i], x[offset + i]);        \
     }                                               \
-    res = vec_extract(x[0], 0) +                    \
-          vec_extract(x[0], 1) +                    \
-          vec_extract(x[0], 2) +                    \
-          vec_extract(x[0], 3);                     \
+    float32x4_t tmp = x[0] + vec_reve(x[0]);        \
+    res = tmp[0] + tmp[1];                          \
 }
 
 #define GGML_F32_VEC        GGML_F32x4


### PR DESCRIPTION
This pull request aims to optimise the assembly instructions for horizontal summation of vector elements on s390x.

### Before Optimisation Assembly
```asm
     vlgvf   %r1,%v24,0                                                                                                                                           
     vlgvf   %r0,%v24,1                                                                                                                                           
     vlvgf   %v0,%r1,0                                                                                                                                            
     vlvgf   %v2,%r0,0                                                                                                                                            
     aebr    %f0,%f2                                                                                                                                              
     vlgvf   %r3,%v24,2                                                                                                                                           
     vlvgf   %v4,%r3,0                                                                                                                                            
     vlgvf   %r2,%v24,3                                                                                                                                           
     vlvgf   %v6,%r2,0                                                                                                                                            
     aebr    %f0,%f4                                                                                                                                              
     aebr    %f0,%f6                                                                                                                                              
     br  %r14
```

### After Optimisation Assembly
```asm
     larl    %r1, .LCPI0_0                                                                                                                                        
     vl  %v0, 0(%r1), 3                                                                                                                                           
     vperm   %v0, %v24, %v24, %v0                                                                                                                                 
     vfasb   %v0, %v24, %v0                                                                                                                                       
     vrepf   %v1, %v0, 1                                                                                                                                          
     vfasb   %v0, %v0, %v1                                                                                                                                        
     br  %r14
```

Note: Assembly code generated will vary based on the compiler used (i.e., GCC vs. Clang).

### Verification

To ensure that this optimisation did not break anything, the optimisation has been tested on the following models:
1. IBM Granite 3.3 2B (F32, F16)
2. Kindly request additional models to be tested

> [!NOTE]
> Tests were conducted on an IBM z16 Mainframe with 2 IFLs (4 vCPUs) and 64 GB Memory on a shared R&D LPAR.

Please review this pull request and consider merging into the main repository. Thank you!