### PR TITLE
ARM: Fixes and additions to CPU feature detection

### DIFF
--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -95,6 +95,7 @@ extern "C" {
     GGML_BACKEND_API int ggml_cpu_has_dotprod    (void);
     GGML_BACKEND_API int ggml_cpu_has_matmul_int8(void);
     GGML_BACKEND_API int ggml_cpu_has_sve        (void);
+    GGML_BACKEND_API int ggml_cpu_has_sve2       (void);
     GGML_BACKEND_API int ggml_cpu_get_sve_cnt    (void);  // sve vector length in bytes
     GGML_BACKEND_API int ggml_cpu_has_sme        (void);
     // other

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -729,6 +729,18 @@ static void ggml_init_arm_arch_features(void) {
     ggml_arm_arch_features.has_neon = 0;
 #endif
 
+#if defined(__ARM_FEATURE_DOTPROD)
+    ggml_arm_arch_features.has_dotprod = 1;
+#else
+    ggml_arm_arch_features.has_dotprod = 0;
+#endif
+
+#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+    ggml_arm_arch_features.has_fp16_va = 1;
+#else
+    ggml_arm_arch_features.has_fp16_va = 0;
+#endif
+
 #if defined(__ARM_FEATURE_MATMUL_INT8)
     ggml_arm_arch_features.has_i8mm = 1;
 #else

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -79,9 +79,10 @@ struct ggml_arm_arch_features_type {
     int has_fp16_va;
     int has_i8mm;
     int has_sve;
+    int has_sve2;
     int sve_cnt;
     int has_sme;
-} ggml_arm_arch_features = {-1, -1, -1, -1, -1, 0, -1};
+} ggml_arm_arch_features = {-1, -1, -1, -1, -1, -1, 0, -1};
 #endif
 
 
@@ -693,6 +694,7 @@ static void ggml_init_arm_arch_features(void) {
     ggml_arm_arch_features.has_fp16_va = !!(hwcap & HWCAP_FPHP);
     ggml_arm_arch_features.has_i8mm    = !!(hwcap2 & HWCAP2_I8MM);
     ggml_arm_arch_features.has_sve     = !!(hwcap & HWCAP_SVE);
+    ggml_arm_arch_features.has_sve2    = !!(hwcap2 & HWCAP2_SVE2);
     ggml_arm_arch_features.has_sme     = !!(hwcap2 & HWCAP2_SME);
 
 #if defined(__ARM_FEATURE_SVE)
@@ -726,8 +728,9 @@ static void ggml_init_arm_arch_features(void) {
     }
     ggml_arm_arch_features.has_sme = oldp;
 
-    ggml_arm_arch_features.has_sve = 0;
-    ggml_arm_arch_features.sve_cnt = 0;
+    ggml_arm_arch_features.has_sve  = 0;
+    ggml_arm_arch_features.has_sve2 = 0;
+    ggml_arm_arch_features.sve_cnt  = 0;
 #else
 // Run-time CPU feature detection not implemented for this platform, fallback to compile time
 #if defined(__ARM_NEON)
@@ -760,6 +763,12 @@ static void ggml_init_arm_arch_features(void) {
 #else
     ggml_arm_arch_features.has_sve = 0;
     ggml_arm_arch_features.sve_cnt = 0;
+#endif
+
+#if defined(__ARM_FEATURE_SVE2)
+    ggml_arm_arch_features.has_sve2 = 1;
+#else
+    ggml_arm_arch_features.has_sve2 = 0;
 #endif
 
 #if defined(__ARM_FEATURE_SME) || defined(__ARM_FEATURE_SME2)
@@ -3471,6 +3480,14 @@ int ggml_cpu_has_fp16_va(void) {
 int ggml_cpu_has_sve(void) {
 #if defined(__ARM_ARCH) && defined(__ARM_FEATURE_SVE)
     return ggml_arm_arch_features.has_sve;
+#else
+    return 0;
+#endif
+}
+
+int ggml_cpu_has_sve2(void) {
+#if defined(__ARM_ARCH) && defined(__ARM_FEATURE_SVE2)
+    return ggml_arm_arch_features.has_sve2;
 #else
     return 0;
 #endif

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -559,6 +559,9 @@ static ggml_backend_feature * ggml_backend_cpu_get_features(ggml_backend_reg_t r
         if (ggml_cpu_has_sve()) {
             features.push_back({ "SVE", "1" });
         }
+        if (ggml_cpu_has_sve2()) {
+            features.push_back({ "SVE2", "1" });
+        }
         if (ggml_cpu_has_dotprod()) {
             features.push_back({ "DOTPROD", "1" });
         }


### PR DESCRIPTION
Working with the ggml-cpu ARM backend, I noticed that feature detection was not entirely complete.

This improves detection for `FP16_VECTOR_ARITHMETIC`, and adds support for `SVE2`.

Note that I had no way to test the `__APPLE__` implementation for querying `FP16_VECTOR_ARITHMETIC`, I just used the sysctl name that I found in a web search.