### PR TITLE
llama : Fix GGML API compatibility issues

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1350,7 +1350,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--prio"}, "N",
         string_format("set process/thread priority : low(-1), normal(0), medium(1), high(2), realtime(3) (default: %d)\n", params.cpuparams.priority),
         [](common_params & params, int prio) {
-            if (prio < GGML_SCHED_PRIO_LOW || prio > GGML_SCHED_PRIO_REALTIME) {
+            if (prio < GGML_SCHED_PRIO_NORMAL || prio > GGML_SCHED_PRIO_REALTIME) {
                 throw std::invalid_argument("invalid value");
             }
             params.cpuparams.priority = (enum ggml_sched_priority) prio;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -203,7 +203,6 @@ bool set_process_priority(enum ggml_sched_priority prio) {
 
     DWORD p = NORMAL_PRIORITY_CLASS;
     switch (prio) {
-        case GGML_SCHED_PRIO_LOW:      p = BELOW_NORMAL_PRIORITY_CLASS; break;
         case GGML_SCHED_PRIO_NORMAL:   p = NORMAL_PRIORITY_CLASS;       break;
         case GGML_SCHED_PRIO_MEDIUM:   p = ABOVE_NORMAL_PRIORITY_CLASS; break;
         case GGML_SCHED_PRIO_HIGH:     p = HIGH_PRIORITY_CLASS;         break;
@@ -229,7 +228,6 @@ bool set_process_priority(enum ggml_sched_priority prio) {
 
     int p = 0;
     switch (prio) {
-        case GGML_SCHED_PRIO_LOW:      p =  5;  break;
         case GGML_SCHED_PRIO_NORMAL:   p =  0;  break;
         case GGML_SCHED_PRIO_MEDIUM:   p = -5;  break;
         case GGML_SCHED_PRIO_HIGH:     p = -10; break;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -770,7 +770,8 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
 
     if (weight_before_ffn) {
         // repeat cur to [n_embd, n_expert_used, n_tokens]
-        ggml_tensor * repeated = ggml_repeat_4d(ctx0, cur, n_embd, n_expert_used, n_tokens, 1);
+        ggml_tensor * target_shape = ggml_new_tensor_4d(ctx0, cur->type, n_embd, n_expert_used, n_tokens, 1);
+        ggml_tensor * repeated = ggml_repeat(ctx0, cur, target_shape);
         cur = ggml_mul(ctx0, repeated, weights);
         cb(cur, "ffn_moe_weighted", il);
     }


### PR DESCRIPTION
This PR addresses compatibility issues with the GGML API by removing references to non-existent constants and updating deprecated function calls.

Changes:
- Remove references to non-existent GGML_SCHED_PRIO_LOW
- Replace ggml_repeat_4d with ggml_repeat + ggml_new_tensor_4d

These changes ensure compatibility with the current GGML API and resolve build/runtime issues.