### PR TITLE
llama: automatically set runtime parameters such as --n-gpu-layers to fit VRAM

### DIFF
--- a/ggml/include/ggml-alloc.h
+++ b/ggml/include/ggml-alloc.h
@@ -9,6 +9,7 @@ extern "C" {
 typedef struct ggml_backend_buffer_type * ggml_backend_buffer_type_t;
 typedef struct      ggml_backend_buffer * ggml_backend_buffer_t;
 typedef struct             ggml_backend * ggml_backend_t;
+typedef struct      ggml_backend_device * ggml_backend_dev_t;
 
 // Tensor allocator
 struct ggml_tallocr {
@@ -58,16 +59,19 @@ GGML_API bool ggml_gallocr_reserve_n(
     ggml_gallocr_t galloc,
     struct ggml_cgraph * graph,
     const int * node_buffer_ids,
-    const int * leaf_buffer_ids);
+    const int * leaf_buffer_ids,
+    bool dry_run);
 
 // automatic reallocation if the topology changes when using a single buffer
 // returns false if using multiple buffers and a re-allocation is needed (call ggml_gallocr_reserve_n first to set the node buffers)
 GGML_API bool ggml_gallocr_alloc_graph(ggml_gallocr_t galloc, struct ggml_cgraph * graph);
 
 GGML_API size_t ggml_gallocr_get_buffer_size(ggml_gallocr_t galloc, int buffer_id);
+size_t ggml_gallocr_get_max_size(ggml_gallocr_t galloc, ggml_backend_dev_t dev);
 
 // Utils
 // Create a buffer and allocate all the tensors in a ggml_context
+GGML_API size_t                       ggml_backend_alloc_ctx_tensors_from_buft_size(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
 GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
 GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors(struct ggml_context * ctx, ggml_backend_t backend);
 

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -293,6 +293,7 @@ extern "C" {
     GGML_API void                 ggml_backend_sched_free(ggml_backend_sched_t sched);
 
     // Initialize backend buffers from a measure graph
+    GGML_API void                 ggml_backend_sched_reserve_size(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph, size_t * sizes); // result per backend is written to sizes
     GGML_API bool                 ggml_backend_sched_reserve(ggml_backend_sched_t sched, struct ggml_cgraph * measure_graph); // returns success
 
     GGML_API int                  ggml_backend_sched_get_n_backends(ggml_backend_sched_t sched);

--- a/include/llama.h
+++ b/include/llama.h
@@ -414,6 +414,13 @@ extern "C" {
     LLAMA_API struct llama_sampler_chain_params  llama_sampler_chain_default_params(void);
     LLAMA_API struct llama_model_quantize_params llama_model_quantize_default_params(void);
 
+    // returns success
+    LLAMA_API bool llama_expected_memory_use(
+                             const char * path_model,
+              struct llama_model_params   mparams,
+            struct llama_context_params   cparams,
+                                 size_t * nbytes_expect);
+
     // Initialize the llama + ggml backend
     // If numa is true, use NUMA optimizations
     // Call once at the start of the program

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -24,7 +24,8 @@ struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
             const llama_model & model,
-                  llama_context_params params);
+                  llama_context_params params,
+                  bool dry_run);
 
     ~llama_context();
 
@@ -45,6 +46,8 @@ struct llama_context {
 
     uint32_t n_threads()       const;
     uint32_t n_threads_batch() const;
+
+    size_t total_size(ggml_backend_dev_t dev = nullptr) const;
 
     llama_memory_t get_memory() const;
 
@@ -104,6 +107,8 @@ struct llama_context {
 
     int encode(llama_batch & inp_batch);
     int decode(llama_batch & inp_batch);
+
+    size_t get_expected_max_size(ggml_backend_dev_t dev) const;
 
     //
     // state save/load
@@ -197,7 +202,7 @@ public:
     ggml_status graph_compute(ggml_cgraph * gf, bool batched);
 
     // reserve a graph with a dummy ubatch of the specified size
-    ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_state_i * mstate);
+    ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_state_i * mstate, bool dry_run);
 
 private:
     llm_graph_result_ptr graph_build(
@@ -255,6 +260,7 @@ private:
 
     ggml_backend_t backend_cpu = nullptr;
     std::vector<ggml_backend_ptr> backends;
+    std::vector<size_t> backends_exp_max_size;
 
     ggml_context_ptr ctx_compute;
 

--- a/src/llama-impl.h
+++ b/src/llama-impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ggml.h" // for ggml_log_level
+#include "ggml-cpp.h"
 
 #include <string>
 #include <vector>
@@ -14,6 +15,11 @@
 #else
 #    define LLAMA_ATTRIBUTE_FORMAT(...)
 #endif
+
+struct llama_context;
+struct llama_model;
+struct llama_context_params;
+llama_context * llama_init_from_model_impl(llama_model * model, llama_context_params params, bool dry_run);
 
 //
 // logging
@@ -59,3 +65,9 @@ std::string llama_format_tensor_shape(const std::vector<int64_t> & ne);
 std::string llama_format_tensor_shape(const struct ggml_tensor * t);
 
 std::string gguf_kv_to_str(const struct gguf_context * ctx_gguf, int i);
+
+// calculate the total number of bytes needed to allocate a vector of ggml contexts
+// skips ggml contexts without ggml_backend buffers (dummy buffers are ok)
+// assumes that all tensors in a context are on the same buffer
+// if the optional device dev is set, return the number of bytes needed on that device only
+size_t ctxs_total_size(const std::vector<ggml_context_ptr> & ctxs, ggml_backend_dev_t dev = nullptr);

--- a/src/llama-kv-cache-recurrent.h
+++ b/src/llama-kv-cache-recurrent.h
@@ -21,7 +21,8 @@ public:
                     ggml_type   type_v,
                          bool   offload,
                      uint32_t   kv_size,
-                     uint32_t   n_seq_max);
+                     uint32_t   n_seq_max,
+                         bool   dry_run);
 
     ~llama_kv_cache_recurrent() = default;
 
@@ -49,6 +50,8 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+
+    size_t total_size(ggml_backend_dev_t dev = nullptr) const override;
 
     bool prepare(const std::vector<llama_ubatch> & ubatches);
 
@@ -107,8 +110,6 @@ private:
 
     std::vector<ggml_context_ptr>        ctxs;
     std::vector<ggml_backend_buffer_ptr> bufs;
-
-    size_t total_size() const;
 
     size_t size_k_bytes() const;
     size_t size_v_bytes() const;

--- a/src/llama-kv-cache-unified-iswa.h
+++ b/src/llama-kv-cache-unified-iswa.h
@@ -23,7 +23,8 @@ public:
                      uint32_t   kv_size,
                      uint32_t   n_seq_max,
                      uint32_t   n_ubatch,
-                     uint32_t   n_pad);
+                     uint32_t   n_pad,
+                         bool   dry_run);
 
     ~llama_kv_cache_unified_iswa() = default;
 
@@ -53,6 +54,8 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+
+    size_t total_size(ggml_backend_dev_t dev = nullptr) const override;
 
     // state write/load
 

--- a/src/llama-kv-cache-unified.h
+++ b/src/llama-kv-cache-unified.h
@@ -48,7 +48,8 @@ public:
                      uint32_t    n_seq_max,
                      uint32_t    n_pad,
                      uint32_t    n_swa,
-               llama_swa_type    swa_type);
+               llama_swa_type    swa_type,
+                         bool    dry_run);
 
     ~llama_kv_cache_unified() = default;
 
@@ -78,6 +79,8 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+
+    size_t total_size(ggml_backend_dev_t dev = nullptr) const override;
 
     // state write/load
 
@@ -172,8 +175,6 @@ private:
 
     // return non-empty vector if cells have been moved
     defrag_info defrag_prepare(int32_t n_max_nodes) const;
-
-    size_t total_size() const;
 
     size_t size_k_bytes() const;
     size_t size_v_bytes() const;

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -108,6 +108,12 @@ struct llama_memory_i {
 
     virtual void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1) const = 0;
     virtual void state_read (llama_io_read_i  & io, llama_seq_id seq_id = -1) = 0;
+
+    //
+    // TODO
+    //
+
+    virtual size_t total_size(ggml_backend_dev_t dev) const = 0;
 };
 
 using llama_memory_ptr = std::unique_ptr<llama_memory_i>;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -376,7 +376,7 @@ struct llama_model {
     void load_arch   (llama_model_loader & ml);
     void load_hparams(llama_model_loader & ml);
     void load_vocab  (llama_model_loader & ml);
-    bool load_tensors(llama_model_loader & ml); // returns false if cancelled by progress_callback
+    bool load_tensors(llama_model_loader & ml, bool dry_run); // returns false if cancelled by progress_callback
 
     std::string arch_name() const;
     std::string type_name() const;
@@ -386,6 +386,8 @@ struct llama_model {
     size_t size() const;
     size_t n_tensors() const;
     size_t n_devices() const;
+
+    size_t total_size(ggml_backend_dev_t dev = nullptr) const;
 
     // total number of parameters in the model
     uint64_t n_elements() const;
@@ -408,7 +410,7 @@ struct llama_model {
 
     // note: can mutate `cparams`
     // TODO: move this to new llm_arch_model_i interface
-    llama_memory_i * create_memory(const llama_memory_params & params, llama_cparams & cparams) const;
+    llama_memory_i * create_memory(const llama_memory_params & params, llama_cparams & cparams, bool dry_run) const;
 
     // TODO: move this to new llm_arch_model_i interface
     llm_graph_result_ptr build_graph(


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/issues/13860 .

This PR aims to add code for setting runtime parameters such as the number of GPU layers automatically given the available memory. As of right now only the number of GPU layers is being adjusted and this is done unconditionally. Implementation details:

* The llama.cpp API is extended with a function `llama_expected_memory_use` to retrieve the expected memory use per device without doing any actual allocations. A function `common_fit_to_free_memory` in `common.cpp` then repeatedly tries configurations of runtime parameters until the allocation would fit in free memory (plus some margin). I think the code for determining the optimal parameters should work in such a way that only parameters that the user does not explicitly set are modified. To me the most natural way to do this would be in `common.cpp` though it could also be done in `llama.cpp`.
* The constructors for `llama_model` and `llama_context` are extended with a flag `dry_run` which, when set, prevents the allocation of memory during initialization. `dry_run` cannot be set by user code.
* `llama_model` has been extended with a method `total_size` that returns the size of the weights.
* `llama_context` has been extended with a method `total_size` that internally calls the same method on the memory, thus returning the size of the KV cache.
* Added a new function `ggml_backend_alloc_ctx_tensors_from_buft_size` which returns the amount of memory that would be needed for a call to `ggml_backend_alloc_ctx_tensors_from_buft`. Both functions internally use the same code but a new flag `dry_run` controls whether the memory is actually being allocated.
* Because the `dry_run` flag in `llama_model` and `llama_context` results in the creation of dummy backend buffers with size 0, `ggml_backend_buffer_get_size` cannot be used to retrieve the expected memory use in `total_size`. Instead `ggml_backend_alloc_ctx_tensors_from_buft_size` is used. This makes the corresponding methods for the memory awkward: right now they retrieve the expected memory use of the KV cache even if actual, physical buffers have been allocated. I'm not sure what the best course of action here is; maybe use the expected size with `dry_run` and the actually allocated size without `dry_run` and assert consistency in debug mode?
* `llama_context` has a new vector `backends_exp_max_size` to store the expected max. memory use given the worst-case compute graphs that are already being pre-allocated on master. If `dry_run` is set a new function `ggml_backend_sched_reserve_size` is used to retrieve the expected allocation size of the scheduler instead of an actual call to `ggml_backend_sched_reserve`. Independently of the automatic determination of runtime parameters, I think it would be useful to track the max. expected memory use of the scheduler and to assert that it was not exceeded in the destructor of `llama_context`.
* `ggml_backend_sched_reserve_size` calls `ggml_gallocr_reserve_n` with a new flag `dry_run` and afterwards calls a new function `ggml_gallocr_get_max_size` to retrieve the max. sizes of the internally stored `ggml_dyn_tallocr`s.
* The functions/methods to retrieve the expected memory use generally take an argument of type `ggml_backend_dev_t` to filter the memory use by. I'm not sure whether I should be filtering by `ggml_backend_buffer_type_t` instead.
* I'm not sure about the correct use of `llama_context::backends` vs. `llama_context::backend_ptrs`.
* I'm not sure about the naming of the new functionality in general (e.g. "dry_run" vs. "dry_alloc" or whether the same name with "_size" appended is intuitive).
* After I did the implementation I noticed that there is a flag `vocab_only` which does very similar things to `dry_run`. Maybe we should unify the logic using an enum?

For the finished PR I envision the following behavior:

* Check whether the model with max. GPU layers fits in VRAM, simply return if yes.
* Try cutting down the context to leave room for at least 32k or the length of the prompt, whichever is higher. Keep the reduced context size.
* Try reducing the physical batch size. Reset to original batch size if unsuccessful.
* For a non-MoE model, try reducing the number of GPU layers.
* For a MoE model, try only dense weights in VRAM. If successful, try adding MoE weights to VRAM. If not, try reducing dense weights in VRAM.
* For a multi GPU setup the above logic should also work by employing standard numerical optimization techniques. It will require additional test allocations but those seem to be sufficiently fast.