### PR TITLE
server: Fixed speculative decoding stats to use `#accepted \ #tested` rather than `#accepted \ #drafted`

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3556,15 +3556,15 @@ struct server_context {
                 const llama_tokens & cached_text_tokens = slot.cache_tokens.get_text_tokens();
                 llama_tokens draft = common_speculative_gen_draft(slot.spec, params_spec, cached_text_tokens, id);
 
-                // keep track of total number of tokens generated in the draft
-                slot.n_draft_total += draft.size();
-
                 // ignore small drafts
                 if (slot.params.speculative.n_min > (int) draft.size()) {
                     SLT_DBG(slot, "ignoring small draft: %d < %d\n", (int) draft.size(), slot.params.speculative.n_min);
 
                     continue;
                 }
+
+                // keep track of total number of drafted tokens tested
+                slot.n_draft_total += draft.size();
 
                 // construct the speculation batch
                 common_batch_clear(slot.batch_spec);
@@ -3584,7 +3584,7 @@ struct server_context {
                 slot.n_past    += ids.size();
                 slot.n_decoded += ids.size();
 
-                // update how many tokens out of draft was accepted
+                // update how many tokens out of those tested were accepted
                 slot.n_draft_accepted += ids.size() - 1;
 
                 slot.cache_tokens.push_back(id);


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/14048

The existing printout of "draft acceptance rate" is misleading, as it is counting those tokens that were skipped due to the `--draft-min` setting:

```cpp
                // keep track of total number of tokens generated in the draft
                slot.n_draft_total += draft.size();

                // ignore small drafts
                if (slot.params.speculative.n_min > (int) draft.size()) {
                    SLT_DBG(slot, "ignoring small draft: %d < %d\n", (int) draft.size(), slot.params.speculative.n_min);

                    continue;
                }
```

This PR just moves the count increment to after this test so that "draft acceptance rate" becomes `#accepted \ #tested` rather than `#accepted \ #drafted`.

As I said ion the other thread, we could add a separate `#accepted \ #drafted` stat, but this too would be misleading as there is code in `speculative.cpp` to reuse the drafted tokens...