### PR TITLE
Pass --keep to llama-server

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -233,6 +233,7 @@ struct server_task {
         slot_params defaults;
         defaults.sampling    = params_base.sampling;
         defaults.speculative = params_base.speculative;
+        defaults.n_keep      = params_base.n_keep;
 
         // enabling this will output extra debug information in the HTTP responses from the server
         params.verbose           = params_base.verbosity > 9;
@@ -2060,6 +2061,7 @@ struct server_context {
             SLT_INF(slot, "new slot n_ctx_slot = %d\n", slot.n_ctx);
 
             slot.params.sampling = params_base.sampling;
+            slot.params.n_keep = params_base.n_keep;
 
             slot.callback_on_release = [this](int) {
                 queue_tasks.pop_deferred_task();


### PR DESCRIPTION
This is just a super simple 2 line change to llama-server that passes the value from the --keep command line flag to the server slots as keep_n. This allows llama-server to implement StreamingLLM properly, increasing model coherency on long contexts when context shift is enabled. All proper handling for this was already in the code, merely unused, so I think this should be considered a bug fix.