### PR TITLE
sycl: Remove not needed copy f16->f32 for dnnl mul mat

### DIFF
--- a/ggml/src/ggml-sycl/gemm.hpp
+++ b/ggml/src/ggml-sycl/gemm.hpp
@@ -65,6 +65,9 @@ public:
 
         dnnl::primitive_attr primitive_attr;
         primitive_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+#ifdef GGML_SYCL_F16
+        primitive_attr.set_fpmath_mode(dnnl::fpmath_mode::f16);
+#endif
 
         auto a_mem = dnnl::memory(a_in_md, eng, const_cast<void*>(a));
         auto b_mem = dnnl::memory(b_in_md, eng, const_cast<void*>(b));


### PR DESCRIPTION
PR proposes when `GGML_SYCL_F16=ON` to allow oneDNN to handle conversion and outputting of mul_mat into f32 and enabling fpmathmode to `f16`.

The current approach uses the memory pool to pass a f16 `dst` for the oneDNN matmul and a `cpy` from f16 to the actual f32 output `dst_dd_i`
Example of performance difference observed: 

### Lunar Lake

current approach:
model | size | params | backend | ngl | threads | test | t/s
-- | -- | -- | -- | -- | -- | -- | --
qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | 8 | pp512 | 1475.42 ± 43.91
qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | 8 | tg128 | 37.46 ± 0.38

proposed changes:
model | size | params | backend | ngl | threads | test | t/s
-- | -- | -- | -- | -- | -- | -- | --
qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | 8 | pp512 | 1566.90 ± 26.33
qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | 8 | tg128 | 37.66 ± 0.49

### Battlemage

current approach:
| model | size | params | backend | ngl | test | t/s |
| --- | --- | --- | --- | --- | --- | --- |
| qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | pp512 | 7424.59 ± 15.58 |
| qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | tg128 | 99.61 ± 2.09 |

proposed changes:
| model | size | params | backend | ngl | test | t/s |
| --- | --- | --- | --- | --- | --- | --- |
| qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | pp512 | 8148.99 ± 35.10 |
| qwen2 1.5B Q4_0 | 1013.62 MiB | 1.78 B | SYCL | 99 | tg128 | 100.62 ± 2.05 |
