### PR TITLE
server: Experimental new speculative decoding algorithm 

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -155,9 +155,9 @@ llama_tokens common_speculative_gen_draft(
     const int i_start = std::max<int>(0, (int) prompt_tgt.size() - n_ctx);
 
     // Extract parameters packed in p_min (format: 0.pmin_pdecay_nmin)
-    const float p_min   = floorf(params.p_min * 100) / 100;  // First 2 decimal places
-    const float p_decay = floorf(params.p_min * 10000) / 100 - p_min;  // Next 2 decimal places
-    const int   n_min   = roundf((params.p_min * 100000) - (p_min * 100000) - (p_decay * 1000));  // Last digit
+    const float p_min   = floorf(params_p_min * 100) / 100;                           // First 2 decimal places
+    const float p_decay = floorf((params_p_min - p_min) * 10000) / 100;               // Next 2 decimal places
+    const int n_min     = floorf((params_p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
 
     printf("p_min=%f, p_decay=%f, n_min=%d\n", p_min, p_decay, n_min);
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -157,7 +157,7 @@ llama_tokens common_speculative_gen_draft(
     // Extract parameters packed in p_min (format: 0.pmin_pdecay_nmin)
     const float p_min   = floorf(params.p_min * 100) / 100;                           // First 2 decimal places
     const float p_decay = floorf((params.p_min - p_min) * 10000) / 100;               // Next 2 decimal places
-    const int n_min     = floorf((params.p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
+    const int n_min     = roundf((params.p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
 
     printf("p_min=%f, p_decay=%f, n_min=%d\n", p_min, p_decay, n_min);
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -159,7 +159,7 @@ llama_tokens common_speculative_gen_draft(
     const float p_decay = floorf((params.p_min - p_min) * 10000) / 100;               // Next 2 decimal places
     const int n_min     = roundf((params.p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
 
-    printf("p_min=%f, p_decay=%f, n_min=%d\n", p_min, p_decay, n_min);
+    LOG_DBG("%s: p_min = %f, p_decay = %f, n_min = %d\n", __func__, p_min, p_decay, n_min);
 
     // reuse as much as possible from the old draft context
     // ideally, the draft context should be as big as the target context and we will always reuse the entire prompt
@@ -277,7 +277,7 @@ llama_tokens common_speculative_gen_draft(
 
         const float threshold_p = p_min * pow(std::max((int) result.size() - std::max(n_min, 1) + 1, 1), -p_decay);
 
-        printf("sequence_p=%f, threshold_p=%f\n", sequence_p, threshold_p);
+        LOG_DBG("%s: sequence_p = %f, threshold_p = %f\n", __func__, sequence_p, threshold_p);
 
         // only collect very high-confidence draft tokens
         if (sequence_p < threshold_p) {
@@ -292,7 +292,7 @@ llama_tokens common_speculative_gen_draft(
         prompt.push_back(id);
     }
 
-    printf("result.size()=%d, sequence_p=%f\n", result.size(), sequence_p);
+    LOG_DBG("%s: n_result = %d, sequence_p = %f\n", __func__, (int) result.size(), sequence_p);
 
     return result;
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -154,7 +154,7 @@ llama_tokens common_speculative_gen_draft(
 
     const int i_start = std::max<int>(0, (int) prompt_tgt.size() - n_ctx);
 
-    // Extract parameters packed in p_min (format: 0.pmin_pdecay_nmin)
+    // Extract parameters packed in p_min (format: 0.{pmin:2}{pdecay:2}{nmin:1})
     const float p_min   = floorf(params.p_min * 100) / 100;                           // First 2 decimal places
     const float p_decay = floorf((params.p_min - p_min) * 10000) / 100;               // Next 2 decimal places
     const int n_min     = roundf((params.p_min - p_min - (p_decay / 100)) * 100000);  // Last digit

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -155,9 +155,9 @@ llama_tokens common_speculative_gen_draft(
     const int i_start = std::max<int>(0, (int) prompt_tgt.size() - n_ctx);
 
     // Extract parameters packed in p_min (format: 0.pmin_pdecay_nmin)
-    const float p_min   = floorf(params_p_min * 100) / 100;                           // First 2 decimal places
-    const float p_decay = floorf((params_p_min - p_min) * 10000) / 100;               // Next 2 decimal places
-    const int n_min     = floorf((params_p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
+    const float p_min   = floorf(params.p_min * 100) / 100;                           // First 2 decimal places
+    const float p_decay = floorf((params.p_min - p_min) * 10000) / 100;               // Next 2 decimal places
+    const int n_min     = floorf((params.p_min - p_min - (p_decay / 100)) * 100000);  // Last digit
 
     printf("p_min=%f, p_decay=%f, n_min=%d\n", p_min, p_decay, n_min);
 
@@ -275,7 +275,7 @@ llama_tokens common_speculative_gen_draft(
 
         sequence_p *= cur_p->data[0].p;
 
-        const float threshold_p = p_min * pow(std::max((int) result.size() - std::max(n_min, 1), 1), -p_decay);
+        const float threshold_p = p_min * pow(std::max((int) result.size() - std::max(n_min, 1) + 1, 1), -p_decay);
 
         printf("sequence_p=%f, threshold_p=%f\n", sequence_p, threshold_p);
 


### PR DESCRIPTION
### How to use this PR

#### 1. Edit the parameters of the `llama-batched-bench` call in the `BENCHMARK_COMMAND` command here to match how you intend to use the model, eg:

```sh
#!/bin/bash

# Evrionment variables
#export CUDA_VISIBLE_DEVICES=0

# User-defined parameters
MAX_DRAFT_BATCH_SIZE=32
NUM_SAMPLES_PER_BATCH=10

BENCHMARK_COMMAND="~/llama.cpp/build/bin/llama-batched-bench \
    --model ./qwen-2.5-coder-Q6_K.gguf \
    --n-gpu-layers 99 \
    --flash-attn"

# Temporary files
TEMP_FILE=$(mktemp)
JSONL_FILE=$(mktemp)

# Function to generate comma-separated PP and NPL lists
generate_lists() {
    local max_pp=$1
    local num_repeats=$2
    pp_list=$(seq -s ',' 1 $max_pp)
    npl_list=$(printf '1%.0s,' $(seq 1 $num_repeats) | sed 's/,$//')
}

# Function to run the benchmark
run_benchmark() {
    echo "Running benchmark..."
    $BENCHMARK_COMMAND \
        -npp "$pp_list" \
        -ntg 0 \
        -npl "$npl_list" \
        --output-format jsonl | tee "$TEMP_FILE"
}

# Function to extract and process results
process_results() {
    echo -n "Extracting results..."
    count=$(grep '^{' "$TEMP_FILE" | tail -n +2 | tee "$JSONL_FILE" | wc -l)
    echo " Done ($count results extracted)"

    echo "Processing results:"
    jq -s --raw-output '
        (map(.pp) | max) as $max_pp |
        reduce .[] as $item (
            {};
            ($item.pp | tostring) as $pp |
            .[$pp].sum = (.[$pp].sum + $item.speed) |
            .[$pp].count = (.[$pp].count + 1)
        ) |
        [range(1; $max_pp + 1) as $pp |
            (.[($pp|tostring)]).sum / .[($pp|tostring)].count
        ] as $averages |
        $averages[0] as $base |
        [1] + [$averages[1:][] | $base / . ] |
        map(. * 1000 | round | . / 1000) |
        "y_data = np.array([ " + join(", ") + " ])"
    ' "$JSONL_FILE"
}

# Main script execution
generate_lists $MAX_DRAFT_BATCH_SIZE $NUM_SAMPLES_PER_BATCH
run_benchmark
process_results

# Clean up
rm "$TEMP_FILE" "$JSONL_FILE"
```

**NOTE**: You will need the `jq` tool installed for the results processing.

**NOTE**: Not all `lama-server` parameters are available for use with `llama-batched-bench`.

#### 2. Run this and it will produce a line of python that looks like this:

```python
y_data = np.array([ 1, 0.526, 0.352, 0.269, 0.229, 0.226, 0.217, 0.209, 0.137, 0.123, 0.112, 0.103, 0.095, 0.089, 0.083, 0.078, 0.075, 0.071, 0.068, 0.064, 0.061, 0.059, 0.056, 0.054, 0.051, 0.049, 0.047, 0.046, 0.044, 0.043, 0.042, 0.04 ])
```

#### 3. Copy that line into this python program replacing the line under the `# Your data points` comment:

```python
import numpy as np
import matplotlib.pyplot as plt
from scipy.optimize import curve_fit

# Your data points
y_data = np.array([ 1, 0.526, 0.352, 0.269, 0.229, 0.226, 0.217, 0.209, 0.137, 0.123, 0.112, 0.103, 0.095, 0.089, 0.083, 0.078, 0.075, 0.071, 0.068, 0.064, 0.061, 0.059, 0.056, 0.054, 0.051, 0.049, 0.047, 0.046, 0.044, 0.043, 0.042, 0.04 ])

x_data = np.arange(len(y_data))

# Find the first value less than 1
n_skipped = 0
for i, val in enumerate(y_data):
    if val < 1:
        n_skipped = i
        break

# Get the base value (first value less than 1)
base_value = y_data[n_skipped]

# Define the power decay function using the base value
def power_decay(x, b):
    return base_value * (x + 1)**(-b)

# Adjust the data to start from the first value < 1
x_fit = x_data[n_skipped:] - n_skipped  # Shift x to start at 0
y_fit = y_data[n_skipped:]

try:
    # Fit the function
    popt_power, _ = curve_fit(power_decay, x_fit, y_fit, p0=[0.5])
    power = popt_power[0]
    
    # Calculate fitted values
    y_fitted = power_decay(x_fit, power)
    
    # Plot results
    plt.figure(figsize=(10, 6))
    plt.scatter(x_data, y_data, label='Original Data')
    plt.scatter(x_fit + n_skipped, y_fit, color='red', label='Data used for fitting')
    plt.plot(x_fit + n_skipped, y_fitted, label=f'Power fit: {base_value:.2f}*x^(-{power:.2f})')
    plt.legend()
    plt.xlabel('Drafted Tokens')
    plt.ylabel('Relative Cost')
    plt.title('Power Law Fitting')
    plt.show()
    
    # Calculate and print RMSE
    def rmse(y_true, y_pred):
        return np.sqrt(np.mean((y_true - y_pred)**2))
    
    print("RMSE for power fit:", rmse(y_fit, y_fitted))
    
    # Print the actual line and rounded version
    print(f"\nActual fit line: {base_value}*x^(-{power})")
    print(f"Rounded fit line: {base_value:.2f}*x^(-{power:.2f})")
    
    # Print suggested PR parameters for llama-server
    print("\nSuggested PR parameters for llama-server:\n")
    print(f"--draft-min {n_skipped}")
    print(f"--draft-max {len(y_data)}")
    print(f"--draft-p-min 0.{100.0*base_value:.0f}{100.0*power:.0f}{n_skipped} (NOTE: Encoded as 0.{{base}}{{power}}{{min}} for use with this PR only!)")

except Exception as e:
    print("Error during fitting:", e)
```

#### 4. Run this (eg: online here:  https://python-fiddle.com/examples/matplotlib).

and it will produce some output like this:

```
RMSE for power fit: 0.02035426400115545

Actual fit line: 0.526*x^(-0.654553089044972)
Rounded fit line: 0.53*x^(-0.65)

Suggested PR parameters for llama-server:

--draft-min 1
--draft-max 32
--draft-p-min 0.53651 (NOTE: Encoded as 0.{base}{power}{min} for use with this PR only!)
```

and a graph:

![image](https://github.com/user-attachments/assets/8e290ccb-f60b-4843-88db-304692d847e7)

#### 5. Then run your `llama-server` using the draft parameters it has generated, eg:

```sh
#!/bin/bash

host_address=192.168.1.1
port_number=8080

# Run the main command
~/llama.cpp/build/bin/llama-server \
        --host "$host_address" \
        --port "$port_number" \
        --alias "qwen-2.5-coder" \
        --chat-template chatml \
        --model ~/models/gguf/qwen-2.5-coder-Q6_K.gguf \
        --n-gpu-layers 99 \
        --flash-attn \
        --ctx_size 16384 \
        --model-draft ~/models/gguf/draft_models/Qwen2.5-Coder-DRAFT-0.6B-Q4_0.gguf \
        --top-k 1 \
        --samplers "top_k" \
        --gpu-layers-draft 99 \
        --draft-min 1 \
        --draft-max 32 \
        --draft-p-min 0.53651
```

---

### You can also manually set the parameters, eg:

` --draft-p-min` $${\color{white}0\.\color{red}53\color{lightblue}65\color{orange}1}$$

translates to use this power-law formula:

$${\color{red}0.53}$$  *  (x - $${\color{orange}1}$$)^(- $${\color{lightblue}0.65}$$)

and with the last digit set to always match your `--draft-min 1`.

**NOTE**: Don't change the `--draft-min` without also changing this last digit or the formula will be completely wrong!

So, in general you can set:

```
--draft-p-min 0.{base}{power}{min}
```

where `base` and `power` are always 2 digits and `min` is always 1 digit.

(sorry it's such a crappy way of doing this, but if this shows more promise I will add the proper command line arg(s) later...).

---

The discussion that led to the idea of this PR start here:

https://github.com/ggml-org/llama.cpp/discussions/10466#discussioncomment-13420376

and the basic idea is that the [marginal cost](https://en.wikipedia.org/wiki/Marginal_cost) of adding 1 more token to a batch goes way down as you add more and more tokens, but different models have very different cost profiles.

For example here I repeat the above for `deepseek-v3-0324`:

```
BENCHMARK_COMMAND="~/build/bin/llama-batched-bench \
    --model ./deepseek-v3-0324-Q4_K_XL.gguf \
    --n-gpu-layers 99 \
    --flash-attn \
    --numa distribute \
    --threads 80 \
    --override-tensor exps=CPU"
```

and we get a completely different set of values:

```
y_data = np.array([ 1, 1.544, 1.045, 0.823, 0.695, 0.604, 0.544, 0.494, 0.472, 0.439, 0.413, 0.391, 0.374, 0.35, 0.342, 0.33, 0.323, 0.316, 0.309, 0.301, 0.295, 0.29, 0.285, 0.281, 0.277, 0.274, 0.27, 0.268, 0.264, 0.261, 0.259, 0.257 ])
```

which give a different set of optimal values:

```
RMSE for power fit: 0.016165745898928052

Actual fit line: 0.823*x^(-0.3431006496784628)
Rounded fit line: 0.82*x^(-0.34)


Suggested PR parameters for llama-server:

--draft-min 3
--draft-max 32
--draft-p-min 0.82343 (NOTE: Encoded as 0.{base}{power}{min} for use with this PR only!)
```

![image](https://github.com/user-attachments/assets/437f0c80-818f-4ba7-bc2e-4b7ab7da8e19)

So basically drafts of less than 3 tokens always have negative expectation here!

(also note in the `qwen-2.5-coder:32b` the effect the flash attention kernels have for the small batch sizes)

---

One final thing to note is that the linked discussion shows that a rational approximation fit the data much better, but actually the power-law fit is better at modelling the marginal cost here as it tends to *under*-estimate the costs (ie: the gradient of the line is usually *steeper* than the data shows), and this in turn reduces the need to recalibrate the draft models' output.

It's also:

- Much clearer for non-technical people to see what is happening and adjust manually.
- Should fit better with the existing `--draft-p-min` if it ever makes it into the code.

---

I'm keen to get some feedback on this, as for my use cases and models; it looks to be quite a big improvement and also seems to work really well for different levels of "draftability" without the need to reload the model for refactoring tasks, etc.