### PR TITLE
common: fix issue with regex_escape routine on windows

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -466,7 +466,7 @@ size_t string_find_partial_stop(const std::string_view & str, const std::string_
 
 std::string regex_escape(const std::string & s) {
     static const std::regex special_chars("[.^$|()*+?\\[\\]{}\\\\]");
-    return std::regex_replace(s, special_chars, "\\$0");
+    return std::regex_replace(s, special_chars, "\\$&");
 }
 
 std::string string_join(const std::vector<std::string> & values, const std::string & separator) {


### PR DESCRIPTION
This PR addresses the issue #14112 with the `test-chat` Mistral Nemo case failing which revealed a slight issue in the regex parsing logic when escaping [ and ] characters.