### PR TITLE
context : round n_tokens to next multiple of n_seqs when reserving

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1332,7 +1332,7 @@ ggml_cgraph * llama_context::graph_reserve(uint32_t n_tokens, uint32_t n_seqs, u
     LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
 
     if (n_tokens % n_seqs != 0) {
-        n_tokens = (n_tokens / n_seqs) * n_seqs;
+        n_tokens = ((n_tokens + (n_seqs - 1)) / n_seqs) * n_seqs; // round to next multiple of n_seqs
         n_outputs = std::min(n_outputs, n_tokens);
 
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);


### PR DESCRIPTION
This fixes RWKV inference which otherwise fails when `ubatch.n_seq_tokens` is 0.

I noticed this when trying to run the command from <https://github.com/ggml-org/llama.cpp/pull/13834#discussion_r2110847307>, but with RWKV instead of Mamba.

For example, with <https://huggingface.co/latestissue/rwkv-6-finch-1b6-gguf/blob/main/rwkv-6-finch-1b6-Q4_0.gguf>

Before:
```console
$ ./bin/llama-parallel -m /path/to/rwkv-6-finch-1b6-Q4_0.gguf -np 5 -ns 8 --temp 0 --repeat-penalty 1.1 -ub 2 -pps
.../ggml/src/ggml.c:1593: GGML_ASSERT(view_src == NULL || data_size == 0 || data_size + view_offs <= ggml_nbytes(view_src)) failed
```
After:
```console
$ ./bin/llama-parallel -m /path/to/rwkv-6-finch-1b6-Q4_0.gguf -np 5 -ns 8 --temp 0 --repeat-penalty 1.1 -ub 2 -pps
(proceeds normally)
```

This has been broken since #13746 because it made the worst case `graph_reserve` use `n_seqs = cparams.n_seq_max` instead of `n_seqs = 1`.

`ubatch.n_seq_tokens` must not be 0 for RWKV, because in some views it uses `ubatch.n_seq_tokens - 1` for one of the dimensions:

<https://github.com/ggml-org/llama.cpp/blob/2e89f76b7af2c0b827be785e445f2e2b3e52e1ca/src/llama-model.cpp#L11858>

---

There will hopefully eventually be automated tests which will help detect this kind of problem, see #14139 (still in the early stages, though).

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
