### PR TITLE
sycl: fix docker image

### DIFF
--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -49,19 +49,23 @@ COPY --from=build /app/full /app
 
 WORKDIR /app
 
-RUN apt-get update \
-    && apt-get install -y \
-    git \
-    python3 \
-    python3-pip \
-    && pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt \
-    && apt autoremove -y \
-    && apt clean -y \
-    && rm -rf /tmp/* /var/tmp/* \
-    && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
-    && find /var/cache -type f -delete
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        python3 \
+        python3-pip \
+        python3-venv && \
+    python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install --upgrade pip setuptools wheel && \
+    pip install -r requirements.txt && \
+    apt autoremove -y && \
+    apt clean -y && \
+    rm -rf /tmp/* /var/tmp/* && \
+    find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete && \
+    find /var/cache -type f -delete
 
+ENV PATH="/opt/venv/bin:$PATH"
 
 ENTRYPOINT ["/app/tools.sh"]
 


### PR DESCRIPTION
As reported in https://github.com/ggml-org/llama.cpp/discussions/5277#discussioncomment-13374885 the SYCL docker image has been failing for a while now. The issue seems to be the externally managed python environment error in the logs: https://github.com/ggml-org/llama.cpp/actions/runs/15458334203/job/43514658105#step:8:986 which prevents installing python modules system-wide with pip. This PR fixes this issue by introducing a virtual environment in which python packages are installed.