### PR TITLE
sycl: Bump oneMath commit

### DIFF
--- a/ggml/src/ggml-sycl/CMakeLists.txt
+++ b/ggml/src/ggml-sycl/CMakeLists.txt
@@ -142,7 +142,7 @@ else()
         FetchContent_Declare(
             ONEMATH
             GIT_REPOSITORY https://github.com/uxlfoundation/oneMath.git
-            GIT_TAG c255b1b4c41e2ee3059455c1f96a965d6a62568a
+            GIT_TAG 8efe85f5aaebb37f1d8c503b7af66315feabf142
         )
         FetchContent_MakeAvailable(ONEMATH)
         # Create alias to match with find_package targets name


### PR DESCRIPTION
Update oneMath commit to merged PR https://github.com/uxlfoundation/oneMath/pull/669 which adds SYCL-Graph support for recording CUDA BLAS commands.

With this change the `MUL_MAT` tests now pass on DPC++ CUDA backends with SYCL-Graph enabled. Prior to this change, an error would be thrown.

```
$ GGML_SYCL_DISABLE_GRAPH=0 ./bin/test-backend-ops -b SYCL0 -o MUL_MAT
...
MUL_MAT(type_a=f16,type_b=f32,m=16,n=1,k=256,bs=[1,1],nr=[2,1],per=[0,1,2,3],v=0): <CUDA>[ERROR]:
UR CUDA ERROR:
        Value:           700
        Name:            CUDA_ERROR_ILLEGAL_ADDRESS
        Description:     an illegal memory access was encountered
        Function:        wait
        Source Location: $HOME/dpcpp/unified-runtime/source/adapters/cuda/event.cpp:116

cuda backend failed with error: 2147483646 (UR_RESULT_ERROR_UNKNOWN)
Exception caught at file:/home/ewan/Development/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp, line:3937, func:operator()
SYCL error: CHECK_TRY_ERROR((stream)->wait()): Exception caught in this line of code.
  in function ggml_backend_sycl_synchronize at /home/ewan/Development/llama.cpp/ggml/src/ggml-sycl/ggml-sycl.cpp:3937
/home/ewan/Development/llama.cpp/ggml/src/ggml-sycl/../ggml-sycl/common.hpp:126: SYCL error
```