### PR TITLE
HIP: Replace usage of depricated preprocessor macro __AMDGCN_WAVEFRONT_SIZE__

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -262,11 +262,11 @@ static bool cp_async_available(const int cc) {
 }
 
 static constexpr __device__ int ggml_cuda_get_physical_warp_size() {
-#if defined(GGML_USE_HIP) && defined(__HIP_PLATFORM_AMD__)
-    return __AMDGCN_WAVEFRONT_SIZE;
+#if defined(GGML_USE_HIP) && defined(__HIP_PLATFORM_AMD__) && (defined(__GFX9__) || defined(__GFX8__))
+    return 64;
 #else
     return 32;
-#endif // defined(GGML_USE_HIP) && defined(__HIP_PLATFORM_AMD__)
+#endif // defined(GGML_USE_HIP) && defined(__HIP_PLATFORM_AMD__) && (defined(__GFX9__) || defined(__GFX8__))
 }
 
 [[noreturn]]


### PR DESCRIPTION
Unfortunately AMD has decided to deprecate the `__AMDGCN_WAVEFRONT_SIZE__` macro and all methods to determine the warp size at compile time.

Officially the method we should use is to query the warp size at runtime only. This is unworkable for us as this would require us to pass the size to all our kernels as a template parameter, which would bloat compile time and binary size for no reason, as all architectures you can build hip for are currently fixed warp size, as RDNA can not be used in CU mode in hip see https://github.com/ROCm/hip/blob/4f263b6e90770c55c694af6beb0924db084b952f/include/hip/hip_runtime.h#L41

This leaves us with only the option to guess the wavefront size based on the generation of the GPU we are compiling for, which is also what has been recommended to me by an AMD engineer https://github.com/ROCm/ROCm/issues/4121#issuecomment-2741913224 and is what this pr dose.