### PR TITLE
webui: save model name with conversation history (#13570)

### DIFF
--- a/tools/server/webui/src/components/ChatMessage.tsx
+++ b/tools/server/webui/src/components/ChatMessage.tsx
@@ -37,7 +37,7 @@ export default function ChatMessage({
   onChangeSibling(sibling: Message['id']): void;
   isPending?: boolean;
 }) {
-  const { viewingChat, config } = useAppContext();
+  const { viewingChat, config, serverProps } = useAppContext();
   const [editingContent, setEditingContent] = useState<string | null>(null);
   const timings = useMemo(
     () =>
@@ -189,11 +189,18 @@ export default function ChatMessage({
                   </div>
                 </div>
               )}
+              
+              {/* Show model name only after AI messages */}
+              {msg.role === 'assistant' && serverProps?.model_path && (
+                <div className="text-xs opacity-50 mt-2">
+                  {serverProps.model_path.split(/(\\|\/)/).pop()}
+                </div>
+              )}
             </>
           )}
         </div>
       </div>
-
+        
       {/* actions for each message */}
       {msg.content !== null && (
         <div

--- a/tools/server/webui/src/utils/app.context.tsx
+++ b/tools/server/webui/src/utils/app.context.tsx
@@ -305,8 +305,10 @@ export const AppContextProvider = ({
     if (isGenerating(convId ?? '') || content.trim().length === 0) return false;
 
     if (convId === null || convId.length === 0 || leafNodeId === null) {
+      const modelName = serverProps?.model_path?.split(/(\\|\/)/).pop();
       const conv = await StorageUtils.createConversation(
-        content.substring(0, 256)
+        content.substring(0, 256),
+        modelName
       );
       convId = conv.id;
       leafNodeId = conv.currNode;

--- a/tools/server/webui/src/utils/storage.ts
+++ b/tools/server/webui/src/utils/storage.ts
@@ -25,8 +25,14 @@ const db = new Dexie('LlamacppWebui') as Dexie & {
 
 // https://dexie.org/docs/Version/Version.stores()
 db.version(1).stores({
-  // Unlike SQL, you don’t need to specify all properties but only the one you wish to index.
+  // Unlike SQL, you don't need to specify all properties but only the one you wish to index.
   conversations: '&id, lastModified',
+  messages: '&id, convId, [convId+id], timestamp',
+});
+
+db.version(2).stores({
+  // Version 2: Added modelName field to conversations
+  conversations: '&id, lastModified, modelName',
   messages: '&id, convId, [convId+id], timestamp',
 });
 
@@ -93,7 +99,10 @@ const StorageUtils = {
   /**
    * create a new conversation with a default root node
    */
-  async createConversation(name: string): Promise<Conversation> {
+  async createConversation(
+    name: string,
+    modelName?: string
+  ): Promise<Conversation> {
     const now = Date.now();
     const msgId = now;
     const conv: Conversation = {
@@ -101,6 +110,7 @@ const StorageUtils = {
       lastModified: now,
       currNode: msgId,
       name,
+      modelName,
     };
     await db.conversations.add(conv);
     // create a root node

--- a/tools/server/webui/src/utils/types.ts
+++ b/tools/server/webui/src/utils/types.ts
@@ -103,6 +103,7 @@ export interface Conversation {
   lastModified: number; // timestamp from Date.now()
   currNode: Message['id']; // the current message node being viewed
   name: string;
+  modelName?: string; // optional model name extracted from serverProps
 }
 
 export interface ViewingChat {


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

added the support for model name in AI chat message as requested. 
![image](https://github.com/user-attachments/assets/6fbeff00-2476-498d-a863-0bc03b14139f)

It saves the model in local index.db as well as shown in below image
![image](https://github.com/user-attachments/assets/f2115e1b-91bf-4e9e-9b0c-fe5faece6848)

