### PR TITLE
quantize: Use UINT32 if there's an INT KV override

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -585,7 +585,8 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
             if (o.tag == LLAMA_KV_OVERRIDE_TYPE_FLOAT) {
                 gguf_set_val_f32(ctx_out.get(), o.key, o.val_f64);
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_INT) {
-                gguf_set_val_i32(ctx_out.get(), o.key, o.val_i64);
+                // Setting type to UINT32. See https://github.com/ggml-org/llama.cpp/pull/14182 for context
+                gguf_set_val_u32(ctx_out.get(), o.key, (uint32_t)abs(o.val_i64));
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_BOOL) {
                 gguf_set_val_bool(ctx_out.get(), o.key, o.val_bool);
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_STR) {


### PR DESCRIPTION
When quantising models and overriding integer metadata parameters at the same time, their assigned type becomes `int` even though their original value is `unsigned int`. In certain cases this behaviour triggers an exception when loading the quantised model.

For example, using the model available [here](https://huggingface.co/eaddario/Qwen3-30B-A3B-GGUF):

1. Quantise & override: `llama-quantize --override-kv qwen3moe.expert_used_count=int:16 Qwen3-30B-A3B-BF16.gguf Qwen3-30B-A3B-Q4_K_M.gguf Q4_K_M`
2. Load model: `llama-simple -m Qwen3-30B-A3B-Q4_K_M.gguf "Hello, world!"`

Will lead to an `error loading model hyperparameters: key qwen3moe.expert_used_count has wrong type i32 but expected type u32 exception`

This PR changes the `if (params->kv_overrides)` logic in _llama-quant.cpp_ to use `uint32` if there are any `int` overrides, so that `llama-quantize --override-kv qwen3moe.expert_used_count=int:16 Qwen3-30B-A3B-BF16.gguf Qwen3-30B-A3B-Q4_K_M.gguf Q4_K_M` generates a functioning model

More context [here](https://github.com/ggml-org/llama.cpp/pull/14182)