### PR TITLE
common : suggest --jinja when autodetection fails

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1838,7 +1838,7 @@ static common_chat_params common_chat_templates_apply_legacy(
     if (res < 0) {
         // if the custom "tmpl" is not supported, we throw an error
         // this is a bit redundant (for good), since we're not sure if user validated the custom template with llama_chat_verify_template()
-        throw std::runtime_error("this custom template is not supported");
+        throw std::runtime_error("this custom template is not supported, try using --jinja");
     }
 
     // if it turns out that our buffer is too small, we resize it


### PR DESCRIPTION
In case the user does not know about the `--jinja` option and we don't support/detect the template in legacy, it's nice to be nudged in the correct direction.