### PR TITLE
cmake: remove shader-gen step-targets from ggml-vulkan

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -144,7 +144,14 @@ if (Vulkan_FOUND)
                    ${VULKAN_SHADER_GEN_CMAKE_ARGS}
 
         BUILD_COMMAND   ${CMAKE_COMMAND} --build   . --config $<CONFIG>
-        INSTALL_COMMAND ${CMAKE_COMMAND} --install . --config $<CONFIG>
+
+        # NOTE: When DESTDIR is set using Makefile generators and
+        # "make install" triggers the build step, vulkan-shaders-gen
+        # would be installed into the DESTDIR prefix, so it is unset
+        # to ensure that does not happen.
+
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E env --unset=DESTDIR
+                        ${CMAKE_COMMAND} --install . --config $<CONFIG>
     )
 
     set (_ggml_vk_host_suffix $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,.exe,>)

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -146,7 +146,6 @@ if (Vulkan_FOUND)
         BUILD_COMMAND   ${CMAKE_COMMAND} --build   . --config $<CONFIG>
         INSTALL_COMMAND ${CMAKE_COMMAND} --install . --config $<CONFIG>
     )
-    ExternalProject_Add_StepTargets(vulkan-shaders-gen build install)
 
     set (_ggml_vk_host_suffix $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,.exe,>)
     set (_ggml_vk_genshaders_dir "${CMAKE_BINARY_DIR}/$<CONFIG>")
@@ -172,8 +171,6 @@ if (Vulkan_FOUND)
 
         DEPENDS ${_ggml_vk_shader_files}
                 vulkan-shaders-gen
-                vulkan-shaders-gen-build
-                vulkan-shaders-gen-install
 
         COMMENT "Generate vulkan shaders"
     )


### PR DESCRIPTION
The build/install steps of vulkan-shaders-gen are an implementation detail, but they are included as dependencies for ggml-vulkan. This removes such dependency so vulkan-shaders-gen doesn't get installed with the top-level "make install".

In addition it fixes an issue when the DESTDIR is specified for a Makefile generator when "make install" triggers the build step.