### PR TITLE
ggml: introduce GGML_NUMA_MIGRATE to optimize cross NUMA op computation

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2280,12 +2280,18 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "- distribute: spread execution evenly over all nodes\n"
         "- isolate: only spawn threads on CPUs on the node that execution started on\n"
         "- numactl: use the CPU map provided by numactl\n"
+#ifdef GGML_USE_NUMA_MIGRATE
+        "- migrate: for affinity threads with page migration across NUMA nodes\n"
+#endif
         "if run without this previously, it is recommended to drop the system page cache before using this\n"
         "see https://github.com/ggml-org/llama.cpp/issues/1437",
         [](common_params & params, const std::string & value) {
             /**/ if (value == "distribute" || value == "") { params.numa = GGML_NUMA_STRATEGY_DISTRIBUTE; }
             else if (value == "isolate") { params.numa = GGML_NUMA_STRATEGY_ISOLATE; }
             else if (value == "numactl") { params.numa = GGML_NUMA_STRATEGY_NUMACTL; }
+#ifdef GGML_USE_NUMA_MIGRATE
+            else if (value == "migrate") { params.numa = GGML_NUMA_STRATEGY_MIGRATE; }
+#endif
             else { throw std::invalid_argument("invalid value"); }
         }
     ).set_env("LLAMA_ARG_NUMA"));

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -152,6 +152,11 @@ set(GGML_BLAS_VENDOR ${GGML_BLAS_VENDOR_DEFAULT} CACHE STRING
                                             "ggml: BLAS library vendor")
 option(GGML_LLAMAFILE                       "ggml: use LLAMAFILE"                             ${GGML_LLAMAFILE_DEFAULT})
 
+option(GGML_NUMA_MIGRATE                    "ggml: use NUMA_MIGRATE"                          OFF)
+set(GGML_NUMA_MIGRATE_NODES "2" CACHE STRING
+                                            "ggml: the number of NUMA nodes during page migration")
+option(GGML_NUMA_MIGRATE_DEBUG              "ggml: enable debugging of NUMA_MIGRATE"          OFF)
+
 option(GGML_CUDA                            "ggml: use CUDA"                                  OFF)
 option(GGML_MUSA                            "ggml: use MUSA"                                  OFF)
 option(GGML_CUDA_FORCE_MMQ                  "ggml: use mmq kernels instead of cuBLAS"         OFF)

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -350,6 +350,8 @@ extern "C" {
     GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
 #ifdef GGML_USE_NUMA_MIGRATE
     GGML_API size_t ggml_backend_get_page_size(void);
+    GGML_API int ggml_backend_get_node_id(int index);
+    GGML_API void ggml_backend_init_node_id(void);
 #endif
 
 #ifdef  __cplusplus

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -348,6 +348,9 @@ extern "C" {
     // CPU buffer types are always available
     GGML_API ggml_backend_buffer_t      ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
     GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
+#ifdef GGML_USE_NUMA_MIGRATE
+    GGML_API size_t ggml_backend_get_page_size(void);
+#endif
 
 #ifdef  __cplusplus
 }

--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -12,6 +12,9 @@ extern "C" {
     struct ggml_cplan {
         size_t    work_size; // size of work buffer, calculated by `ggml_graph_plan()`
         uint8_t * work_data; // work buffer, to be allocated by caller before calling to `ggml_graph_compute()`
+#ifdef GGML_USE_NUMA_MIGRATE
+        uint8_t * work_data_numa[GGML_NUMA_MIGRATE_NODES];
+#endif
 
         int n_threads;
         struct ggml_threadpool * threadpool;
@@ -28,6 +31,9 @@ extern "C" {
         GGML_NUMA_STRATEGY_ISOLATE    = 2,
         GGML_NUMA_STRATEGY_NUMACTL    = 3,
         GGML_NUMA_STRATEGY_MIRROR     = 4,
+#ifdef GGML_USE_NUMA_MIGRATE
+        GGML_NUMA_STRATEGY_MIGRATE    = 5,
+#endif
         GGML_NUMA_STRATEGY_COUNT
     };
 

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -381,3 +381,27 @@ if (BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC  GGML_SHARED)
     endforeach()
 endif()
+
+if (GGML_NUMA_MIGRATE)
+    find_path(NUMA_ROOT_DIR
+        NAMES include/numa.h
+        PATHS ENV NUMA_ROOT
+        DOC "NUMA root directory")
+
+    find_library(NUMA_LIBRARY
+        NAMES numa
+        HINTS ${NUMA_ROOT_DIR}
+        DOC "NUMA library")
+
+    if (NOT NUMA_LIBRARY)
+        message(FATAL_ERROR "Could NOT find NUMA library.")
+    endif()
+
+    if (GGML_NUMA_MIGRATE_DEBUG)
+        target_compile_definitions(ggml-base PUBLIC GGML_USE_NUMA_MIGRATE GGML_NUMA_MIGRATE_NODES=${GGML_NUMA_MIGRATE_NODES} GGML_USE_NUMA_MIGRATE_DEBUG)
+    else()
+        target_compile_definitions(ggml-base PUBLIC GGML_USE_NUMA_MIGRATE GGML_NUMA_MIGRATE_NODES=${GGML_NUMA_MIGRATE_NODES})
+    endif()
+
+    target_link_libraries(ggml-base PRIVATE ${NUMA_LIBRARY})
+endif()

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1922,6 +1922,7 @@ static void migrate_pages_with_cache(void *addr, size_t size,
     if (size >= GGML_NUMA_MIGRATE_NODES * ggml_backend_page_size) {
         numa_migrate_mapping_cache current_addr(addr, size);
         std::lock_guard<std::mutex> lock(ggml_mapping_mutex);
+        ggml_backend_init_node_id();
         auto it = ggml_mapping_cache.find(current_addr);
         if (it == ggml_mapping_cache.end()) {
             GGML_ASSERT(((uint64_t)(addr) & (ggml_backend_page_size - 1)) == 0);

--- a/ggml/src/ggml-cpu/amx/amx.cpp
+++ b/ggml/src/ggml-cpu/amx/amx.cpp
@@ -133,7 +133,11 @@ static ggml_backend_buffer_t ggml_backend_amx_buffer_type_alloc_buffer(ggml_back
 }
 
 static size_t ggml_backend_amx_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -515,6 +515,7 @@ enum ggml_barrier_node_index {
 void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
 int ggml_cores_per_numa(int ith);
 int ggml_get_node_from_cpu(int ith);
+int ggml_get_start_id_in_node(int ith);
 #endif
 
 void ggml_threadpool_chunk_set(struct ggml_threadpool * tp, int value);

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -22,6 +22,9 @@ struct ggml_compute_params {
     // work buffer for all threads
     size_t wsize;
     void * wdata;
+#ifdef GGML_USE_NUMA_MIGRATE
+    void * wdata_numa[GGML_NUMA_MIGRATE_NODES];
+#endif
 
     struct ggml_threadpool * threadpool;
 };
@@ -502,6 +505,17 @@ static __m256 __lasx_xvreplfr2vr_s(const float val) {
 
 // TODO: move to ggml-threading
 void ggml_barrier(struct ggml_threadpool * tp);
+#ifdef GGML_USE_NUMA_MIGRATE
+enum ggml_barrier_node_index {
+    GGML_BARRIER_NODE_PING = 0,
+    GGML_BARRIER_NODE_PONG = 1,
+    GGML_BARRIER_NODE_LAST = 2,
+    GGML_BARRIER_NODE_CNTS = 3
+};
+void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
+int ggml_cores_per_numa(void);
+int ggml_get_node_from_cpu(int cpu);
+#endif
 
 void ggml_threadpool_chunk_set(struct ggml_threadpool * tp, int value);
 int  ggml_threadpool_chunk_add(struct ggml_threadpool * tp, int value);

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -513,8 +513,8 @@ enum ggml_barrier_node_index {
     GGML_BARRIER_NODE_CNTS = 3
 };
 void ggml_barrier_numa_aware(struct ggml_threadpool * tp, int ith, int node_n);
-int ggml_cores_per_numa(void);
-int ggml_get_node_from_cpu(int cpu);
+int ggml_cores_per_numa(int ith);
+int ggml_get_node_from_cpu(int ith);
 #endif
 
 void ggml_threadpool_chunk_set(struct ggml_threadpool * tp, int value);

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -176,7 +176,7 @@ static enum ggml_status ggml_backend_cpu_graph_compute(ggml_backend_t backend, s
 
 #ifdef GGML_USE_NUMA_MIGRATE
         for (int i = 0; i < GGML_NUMA_MIGRATE_NODES; i++) {
-            cpu_ctx->work_data_numa[i] = (uint8_t *)numa_alloc_onnode(cplan.work_size, i);
+            cpu_ctx->work_data_numa[i] = (uint8_t *)numa_alloc_onnode(cplan.work_size, ggml_backend_get_node_id(i));
             if (cpu_ctx->work_data_numa[i] == NULL) {
                 cpu_ctx->work_size = 0;
                 return GGML_STATUS_ALLOC_FAILED;

--- a/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
+++ b/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
@@ -413,7 +413,11 @@ static ggml_backend_buffer_t ggml_backend_cpu_kleidiai_buffer_type_alloc_buffer(
 }
 
 static size_t ggml_backend_cpu_kleidiai_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+#ifdef GGML_USE_NUMA_MIGRATE
+    return ggml_backend_get_page_size();
+#else
     return TENSOR_ALIGNMENT;
+#endif
 
     GGML_UNUSED(buft);
 }

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1250,11 +1250,8 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
         int64_t i11_processed = 0;
 #ifdef GGML_USE_NUMA_MIGRATE
         int round_cnts = ggml_cores_per_numa(ith);
-        int start_id = ith - round_cnts * node_id;
-        if (round_cnts == 0) {
-            round_cnts = nth;
-            start_id = ith;
-        }
+        assert(round_cnts);
+        int start_id = ggml_get_start_id_in_node(ith);
 #else
         int round_cnts = nth;
         int start_id = ith;

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1249,7 +1249,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
 
         int64_t i11_processed = 0;
 #ifdef GGML_USE_NUMA_MIGRATE
-        int round_cnts = ggml_cores_per_numa();
+        int round_cnts = ggml_cores_per_numa(ith);
         int start_id = ith - round_cnts * node_id;
         if (round_cnts == 0) {
             round_cnts = nth;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -711,6 +711,10 @@ llama_model_loader::llama_model_loader(
         use_mmap = false;
     }
 
+#ifdef GGML_USE_NUMA_MIGRATE
+    use_mmap = false;
+#endif
+
     this->use_mmap = use_mmap;
     this->check_tensors = check_tensors;
 }

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -312,7 +312,12 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("\n");
     printf("options:\n");
     printf("  -h, --help\n");
+#ifdef GGML_USE_NUMA_MIGRATE
+    printf("  --numa <distribute|isolate|numactl|migrate>\n");
+    printf("                                            numa mode (default: disabled)\n");
+#else
     printf("  --numa <distribute|isolate|numactl>       numa mode (default: disabled)\n");
+#endif
     printf("  -r, --repetitions <n>                     number of times to repeat each test (default: %d)\n",
            cmd_params_defaults.reps);
     printf("  --prio <-1|0|1|2|3>                          process/thread priority (default: %d)\n",
@@ -628,6 +633,10 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                     params.numa = GGML_NUMA_STRATEGY_ISOLATE;
                 } else if (value == "numactl") {
                     params.numa = GGML_NUMA_STRATEGY_NUMACTL;
+#ifdef GGML_USE_NUMA_MIGRATE
+                } else if (value == "migrate") {
+                    params.numa = GGML_NUMA_STRATEGY_MIGRATE;
+#endif
                 } else {
                     invalid_param = true;
                     break;


### PR DESCRIPTION
This PR adds GGML_NUMA_MIGRATE feature to optimize cross NUMA op computation as the cross-NUMA memory access would be the bottleneck if spawning threads across NUMA nodes:

1. optimize the ggml_barrier() for cross NUMA case by adding ggml_barrier_numa_aware()
2. add build option GGML_NUMA_MIGRATE to enable the feature
3. add option --numa migrate if GGML_NUMA_MIGRATE is enabled, which would migrate pages across NUMA nodes so that mul_mat op would only do the computation in local numa part of tensor data src0 and dst according to the ith, cores would be set affinity with the option. also src1 data will quantized into the local numa wdata.

With the feature, tested on NeoVerse N2 with multiple NUMA nodes (with 64 cores per NUMA node), there's obvious performance improvements with running llama3 model, see test results as below:

# bench Test Results
## Base data
running command:
```
numactl -m 0 -N 0 $LLAMA/build/bin/llama-bench -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -r 1 -t 64 -p 512 -n 128
```
results:
```
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      64 |           pp512 |        505.06 ± 0.00 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      64 |           tg128 |         25.43 ± 0.00 |
 
build: e434e691 (5686)

```

## Result with the feature
running command:
```
numactl -m 0,1 -N 0,1 $LLAMA/build/bin/llama-bench -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -r 1 -t 128 -p 512 -n 128 --numa migrate
```
results:
```
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |     128 |           pp512 |        761.85 ± 0.00 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |     128 |           tg128 |         33.76 ± 0.00 |
 
build: e434e691 (5686) 

```

improvement:
```

TC | Base | OPT | Uplift
-- | -- | -- | --
pp512 | 505.06 | 761.85 | 50.8%
tg128 | 25.43 | 33.76 | 32.7%


```


# batched bench Test Results
## Base data
running command:
```
  numactl -m 0 -N 0 $LLAMA/build/bin/llama-batched-bench -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -c 8192 -b 4096 -ub 512 -npp 128 -ntg 128 -npl 1,4,8,16,32 -t 64 --cache-type-k q8_0 --cache-type-v q8_0 -fa

```
results:
```
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.268 |   477.19 |    5.047 |    25.36 |    5.315 |    48.17 |
|   128 |    128 |    4 |   1024 |    0.940 |   544.73 |    5.721 |    89.50 |    6.661 |   153.74 |
|   128 |    128 |    8 |   2048 |    1.839 |   556.85 |    8.108 |   126.29 |    9.947 |   205.88 |
|   128 |    128 |   16 |   4096 |    3.689 |   555.11 |    8.973 |   228.23 |   12.663 |   323.47 |
|   128 |    128 |   32 |   8192 |    7.475 |   547.94 |   14.847 |   275.89 |   22.322 |   366.99 |


```

## Result with the feature
running command:
```
numactl -m 0,1 -N 0,1 $LLAMA/build/bin/llama-batched-bench -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -c 8192 -b 4096 -ub 512 -npp 128 -ntg 128 -npl 1,4,8,16,32 -t 128 --numa migrate --cache-type-k q8_0 --cache-type-v q8_0  -fa
```
results:
```
|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   128 |    128 |    1 |    256 |    0.165 |   777.10 |    3.628 |    35.28 |    3.793 |    67.49 |
|   128 |    128 |    4 |   1024 |    0.556 |   921.39 |    4.312 |   118.73 |    4.868 |   210.35 |
|   128 |    128 |    8 |   2048 |    1.057 |   968.92 |    5.529 |   185.20 |    6.586 |   310.96 |
|   128 |    128 |   16 |   4096 |    2.133 |   960.04 |    6.414 |   319.30 |    8.547 |   479.22 |
|   128 |    128 |   32 |   8192 |    4.311 |   950.20 |   10.013 |   409.07 |   14.324 |   571.92 |

```

improvement:
```
B | Base | OPT | Uplift
-- | -- | -- | --
1 | 25.36 | 35.28 | 39.1%
4 | 89.5 | 118.73 | 32.6%
8 | 126.29 | 185.2 | 46.6%
16 | 228.23 | 319.30 | 39.9%
32 | 275.89 | 409.07 | 48.2%
```


Tested perplexity, there's no regression with the feature:
```
$ numactl -m 0,1 -N 0,1 $LLAMA/build/bin/llama-perplexity -m ./models/Meta-Llama-3-8B-Instruct.Q4_0.gguf -f $LLAMA/wikitext-2-raw/wiki.test.raw -t 128 --numa migrate

Final estimate: PPL = 8.7547 +/- 0.06483


```
# Enablement
The feature is disabled by default, this is the guidances to enable the feature:
1. enable DGGML_NUMA_MIGRATE during cmake
```
$ cmake -B build -DGGML_NUMA_MIGRATE=ON
```
2. add --numa migrate option when running, and set thread numbers according to the number of numa nodes (which is 2 nodes by default which is the best trade-off number during the NeoVerse N2 platform in test, could be changed by setting GGML_NUMA_MIGRATE_NODES build option, it's also better to bind  llama to numa node 0 and 1 through numactl -m 0,1 -N 0,1).

