### PR TITLE
Mtmd: add a way to select device for vision encoder

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -367,8 +367,8 @@ struct clip_ctx {
     std::vector<ggml_backend_t> backend_ptrs;
     std::vector<ggml_backend_buffer_type_t> backend_buft;
 
-    ggml_backend_t backend;
-    ggml_backend_t backend_cpu;
+    ggml_backend_t backend = nullptr;
+    ggml_backend_t backend_cpu = nullptr;
     ggml_backend_buffer_ptr buf;
 
     int max_nodes = 8192;
@@ -384,7 +384,6 @@ struct clip_ctx {
         if (!backend_cpu) {
             throw std::runtime_error("failed to initialize CPU backend");
         }
-        backend = nullptr;
         if (ctx_params.use_gpu) {
             auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
             if (backend_name != nullptr) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -385,12 +385,12 @@ struct clip_ctx {
             throw std::runtime_error("failed to initialize CPU backend");
         }
         backend = nullptr;
-        if(ctx_params.use_gpu) {
+        if (ctx_params.use_gpu) {
             auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
-            if(backend_name != nullptr) {
+            if (backend_name != nullptr) {
                 backend = ggml_backend_init_by_name(backend_name, nullptr);
             }
-            if(!backend){
+            if (!backend) {
                 backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
             }
         }

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -385,14 +385,14 @@ struct clip_ctx {
             throw std::runtime_error("failed to initialize CPU backend");
         }
         backend = nullptr;
-        auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
-        if(backend_name != nullptr && ctx_params.use_gpu) {
-            backend = ggml_backend_init_by_name(backend_name, nullptr);
-        }
-        if(!backend){
-            backend = ctx_params.use_gpu
-                        ? ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr)
-                        : nullptr;
+        if(ctx_params.use_gpu) {
+            auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
+            if(backend_name != nullptr) {
+                backend = ggml_backend_init_by_name(backend_name, nullptr);
+            }
+            if(!backend){
+                backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
+            }
         }
 
         if (backend) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -389,6 +389,9 @@ struct clip_ctx {
             auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
             if (backend_name != nullptr) {
                 backend = ggml_backend_init_by_name(backend_name, nullptr);
+                if (!backend) {
+                    LOG_WRN("%s: Warning: Failed to initialize \"%s\" backend, falling back to default GPU backend\n", __func__, backend_name);
+                }
             }
             if (!backend) {
                 backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -384,9 +384,16 @@ struct clip_ctx {
         if (!backend_cpu) {
             throw std::runtime_error("failed to initialize CPU backend");
         }
-        backend = ctx_params.use_gpu
-                    ? ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr)
-                    : nullptr;
+        backend = nullptr;
+        auto backend_name = std::getenv("MTMD_BACKEND_DEVICE");
+        if(backend_name != nullptr && ctx_params.use_gpu) {
+            backend = ggml_backend_init_by_name(backend_name, nullptr);
+        }
+        if(!backend){
+            backend = ctx_params.use_gpu
+                        ? ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr)
+                        : nullptr;
+        }
 
         if (backend) {
             LOG_INF("%s: CLIP using %s backend\n", __func__, ggml_backend_name(backend));


### PR DESCRIPTION
Adds a way to chose which backend device to use for Clip/vision encoder by setting the `MTMD_BACKEND_DEVICE` env variable to the device name.