### PR TITLE
llama-chat : fix multiple system messages for gemma, orion

### DIFF
--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -331,7 +331,7 @@ int32_t llm_chat_apply_template(
             std::string role(message->role);
             if (role == "system") {
                 // there is no system message for gemma, but we will merge it with user prompt, so nothing is broken
-                system_prompt = trim(message->content);
+                system_prompt += trim(message->content);
                 continue;
             }
             // in gemma, "assistant" is "model"
@@ -353,7 +353,7 @@ int32_t llm_chat_apply_template(
             std::string role(message->role);
             if (role == "system") {
                 // there is no system message support, we will merge it with user prompt
-                system_prompt = message->content;
+                system_prompt += message->content;
                 continue;
             } else if (role == "user") {
                 ss << "Human: ";


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/14151

---

Important: this won't work with jinja template, because jinja only allow 0 or 1 system message at the **beginning** of the conversation:

<img width="704" alt="image" src="https://github.com/user-attachments/assets/200b07f1-584c-4295-8366-f887199e6cac" />

