### PR TITLE
docs: add s390x build documentation

### DIFF
--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This build documentation is specific only to IBM Z & LinuxONE mainframes (s390x). You can find the build documentation for other architectures: [build.md](docs/build.md).
+
 # Build llama.cpp locally (for s390x)
 
 The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](include/llama.h).
@@ -26,12 +29,24 @@ cmake --build build --config Release -j $(nproc)
 
 **Notes**:
 - For faster repeated compilation, install [ccache](https://ccache.dev/)
+- By default, VXE/VXE2 is enabled. To disable it (not recommended):
+
+    ```bash
+    cmake -S . -B build             \
+        -DCMAKE_BUILD_TYPE=Release  \
+        -DGGML_BLAS=ON              \
+        -DGGML_BLAS_VENDOR=OpenBLAS \
+        -DGGML_VXE=OFF
+    
+    cmake --build build --config Release -j $(nproc)
+    ```
+
 - For debug builds:
 
     ```bash
-    cmake -S . -B build \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -DGGML_BLAS=ON \
+    cmake -S . -B build             \
+        -DCMAKE_BUILD_TYPE=Debug    \
+        -DGGML_BLAS=ON              \
         -DGGML_BLAS_VENDOR=OpenBLAS
 
     cmake --build build --config Debug -j $(nproc)
@@ -48,5 +63,51 @@ cmake --build build --config Release -j $(nproc)
 
     cmake --build build --config Release -j $(nproc)
     ```
+
+## Getting GGUF Models
+
+In order to run GGUF models, the model needs to be converted to Big-Endian. You can achieve this in three cases:
+
+1. Use pre-converted models verified for use on IBM Z & LinuxONE (easiest)
+
+You can find popular models pre-converted and verified at [s390x Ready Models](hf.co/collections/taronaeo/s390x-ready-models-672765393af438d0ccb72a08).
+
+These models and their respective tokenizers are verified to run correctly on IBM Z & LinuxONE.
+
+2. Convert safetensors model to GGUF Big-Endian directly (recommended)
+
+```bash
+python3 convert_hf_to_gguf.py \
+    --outfile model-name-be.f16.gguf \
+    --outtype f16 \
+    --bigendian \
+    model-directory/
+```
+
+For example,
+
+```bash
+python3 convert_hf_to_gguf.py \
+    --outfile granite-3.3-2b-instruct-be.f16.gguf \
+    --outtype f16 \
+    --bigendian \
+    granite-3.3-2b-instruct/
+```
+
+3. Convert existing GGUF Little-Endian model to Big-Endian
+
+```bash
+python3 gguf-py/gguf/scripts/gguf_convert_endian.py model-name.f16.gguf BIG
+```
+
+For example,
+```bash
+python3 gguf-py/gguf/scripts/gguf_convert_endian.py granite-3.3-2b-instruct-le.f16.gguf BIG
+mv granite-3.3-2b-instruct-le.f16.gguf granite-3.3-2b-instruct-be.f16.gguf
+```
+
+**Notes:**
+- The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
+
 
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -68,13 +68,13 @@ cmake --build build --config Release -j $(nproc)
 
 All models need to be converted to Big-Endian. You can achieve this in three cases:
 
-1. Use pre-converted models verified for use on IBM Z & LinuxONE (easiest)
+1. **Use pre-converted models verified for use on IBM Z & LinuxONE (easiest)**
 
     You can find popular models pre-converted and verified at [s390x Ready Models](hf.co/collections/taronaeo/s390x-ready-models-672765393af438d0ccb72a08).
 
     These models and their respective tokenizers are verified to run correctly on IBM Z & LinuxONE.
 
-2. Convert safetensors model to GGUF Big-Endian directly (recommended)
+2. **Convert safetensors model to GGUF Big-Endian directly (recommended)**
 
     ```bash
     python3 convert_hf_to_gguf.py \
@@ -94,7 +94,7 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
         granite-3.3-2b-instruct/
     ```
 
-3. Convert existing GGUF Little-Endian model to Big-Endian
+3. **Convert existing GGUF Little-Endian model to Big-Endian**
 
     ```bash
     python3 gguf-py/gguf/scripts/gguf_convert_endian.py model-name.f16.gguf BIG
@@ -109,5 +109,33 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
     **Notes:**
     - The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
 
+## IBM zDNN Accelerator
 
+*No direction at the moment.*
+
+## IBM Spyre Accelerator
+
+*No direction at the moment.*
+
+## Performance Optimization
+
+### Virtualization Setup
+
+We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
+
+Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
+
+### IFL (Core) Count
+
+We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
+
+Note: IFL count does not equate to vCPU count.
+
+### SMT vs NOSMT (Simultaneous Multithreading)
+
+We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
+
+### BLAS vs NOBLAS
+
+We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -113,7 +113,7 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ### 1. SIMD Acceleration
 
-Only available in IBM z15 or later system with the `-DGGML_VXE=ON` (turned on by default). No hardware acceleration is possible with llama.cpp with older systems, such as IBM z14 or EC13. In such systems, the APIs can still run but will use a scalar implementation.
+Only available in IBM z15 or later system with the `-DGGML_VXE=ON` (turned on by default) compile flag. No hardware acceleration is possible with llama.cpp with older systems, such as IBM z14 or EC13. In such systems, the APIs can still run but will use a scalar implementation.
 
 ### 2. zDNN Accelerator
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -109,13 +109,15 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
     **Notes:**
     - The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
 
-## IBM zDNN Accelerator
+## IBM Accelerators
 
-*Only available in IBM z16 and onwards. No direction at the moment.*
+### 1. IBM zDNN Accelerator
 
-## IBM Spyre Accelerator
+    *Only available in IBM z16 and onwards. No direction at the moment.*
 
-*No direction at the moment.*
+### 2. IBM Spyre Accelerator
+
+    *No direction at the moment.*
 
 ## Performance Tuning
 
@@ -139,7 +141,7 @@ We strongly recommend disabling SMT via the kernel boot parameters as it negativ
 
 We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
 
-## Issues Related to IBM Z & LinuxONE
+## Getting Help on IBM Z & LinuxONE
 
 1. **Bugs, Feature Requests**
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
-> This build documentation is specific only to IBM Z & LinuxONE mainframes (s390x). You can find the build documentation for other architectures: [build.md](docs/build.md).
+> This build documentation is specific only to IBM Z & LinuxONE mainframes (s390x). You can find the build documentation for other architectures: [build.md](build.md).
 
 # Build llama.cpp locally (for s390x)
 
-The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](include/llama.h).
+The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](//include/llama.h).
 
 The project also includes many example programs and tools using the `llama` library. The examples range from simple, minimal code snippets to sophisticated sub-projects such as an OpenAI-compatible HTTP server.
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -3,7 +3,7 @@
 
 # Build llama.cpp locally (for s390x)
 
-The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](//include/llama.h).
+The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](../include/llama.h).
 
 The project also includes many example programs and tools using the `llama` library. The examples range from simple, minimal code snippets to sophisticated sub-projects such as an OpenAI-compatible HTTP server.
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -113,11 +113,11 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ### 1. IBM zDNN Accelerator
 
-    *Only available in IBM z16 and onwards. No direction at the moment.*
+*Only available in IBM z16 and onwards. No direction at the moment.*
 
 ### 2. IBM Spyre Accelerator
 
-    *No direction at the moment.*
+*No direction at the moment.*
 
 ## Performance Tuning
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -111,31 +111,31 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ## IBM zDNN Accelerator
 
-*No direction at the moment.*
+*Only available in IBM z16 and onwards. No direction at the moment.*
 
 ## IBM Spyre Accelerator
 
 *No direction at the moment.*
 
-## Performance Optimization
+## Performance Tuning
 
-### Virtualization Setup
+### 1. Virtualization Setup
 
-We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
+    We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
+    
+    Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
 
-Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
+### 2. IFL (Core) Count
 
-### IFL (Core) Count
+    We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
+    
+    Note: IFL count does not equate to vCPU count.
 
-We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
+### 3. SMT vs NOSMT (Simultaneous Multithreading)
 
-Note: IFL count does not equate to vCPU count.
+    We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
 
-### SMT vs NOSMT (Simultaneous Multithreading)
+### 4. BLAS vs NOBLAS
 
-We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
-
-### BLAS vs NOBLAS
-
-We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
+    We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -1,0 +1,52 @@
+# Build llama.cpp locally (for s390x)
+
+The main product of this project is the `llama` library. Its C-style interface can be found in [include/llama.h](include/llama.h).
+
+The project also includes many example programs and tools using the `llama` library. The examples range from simple, minimal code snippets to sophisticated sub-projects such as an OpenAI-compatible HTTP server.
+
+**To get the code:**
+
+```bash
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
+```
+
+## CPU Build with BLAS
+
+Building llama.cpp with BLAS support is highly recommended as it has shown to provide performance improvements.
+
+```bash
+cmake -S . -B build             \
+    -DCMAKE_BUILD_TYPE=Release  \
+    -DGGML_BLAS=ON              \
+    -DGGML_BLAS_VENDOR=OpenBLAS
+
+cmake --build build --config Release -j $(nproc)
+```
+
+**Notes**:
+- For faster repeated compilation, install [ccache](https://ccache.dev/)
+- For debug builds:
+
+    ```bash
+    cmake -S . -B build \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DGGML_BLAS=ON \
+        -DGGML_BLAS_VENDOR=OpenBLAS
+
+    cmake --build build --config Debug -j $(nproc)
+    ```
+
+- For static builds, add `-DBUILD_SHARED_LIBS=OFF`:
+
+    ```bash
+    cmake -S . -B build             \
+        -DCMAKE_BUILD_TYPE=Release  \
+        -DGGML_BLAS=ON              \
+        -DGGML_BLAS_VENDOR=OpenBLAS \
+        -DBUILD_SHARED_LIBS=OFF
+
+    cmake --build build --config Release -j $(nproc)
+    ```
+
+

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -111,11 +111,15 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ## IBM Accelerators
 
-### 1. zDNN Accelerator
+### 1. SIMD Acceleration
 
-*Only available in IBM z16 and onwards. No direction at the moment.*
+Only available in IBM z15 or later system with the `-DGGML_VXE=ON` (turned on by default). No hardware acceleration is possible with llama.cpp with older systems, such as IBM z14 or EC13. In such systems, the APIs can still run but will use a scalar implementation.
 
-### 2. Spyre Accelerator
+### 2. zDNN Accelerator
+
+*Only available in IBM z16 or later system. No direction at the moment.*
+
+### 3. Spyre Accelerator
 
 *No direction at the moment.*
 
@@ -123,23 +127,23 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ### 1. Virtualization Setup
 
-We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
+It is strongly recommended to use only LPAR (Type-1) virtualization to get the most performance.
 
 Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
 
 ### 2. IFL (Core) Count
 
-We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
+It is recommended to allocate a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
 
 Note: IFL count does not equate to vCPU count.
 
 ### 3. SMT vs NOSMT (Simultaneous Multithreading)
 
-We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
+It is strongly recommended to disable SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
 
 ### 4. BLAS vs NOBLAS
 
-We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
+IBM VXE/VXE2 SIMD acceleration depends on the BLAS implementation. It is strongly recommended to use BLAS.
 
 ## Getting Help on IBM Z & LinuxONE
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -111,11 +111,11 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ## IBM Accelerators
 
-### 1. IBM zDNN Accelerator
+### 1. zDNN Accelerator
 
 *Only available in IBM z16 and onwards. No direction at the moment.*
 
-### 2. IBM Spyre Accelerator
+### 2. Spyre Accelerator
 
 *No direction at the moment.*
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -66,48 +66,48 @@ cmake --build build --config Release -j $(nproc)
 
 ## Getting GGUF Models
 
-In order to run GGUF models, the model needs to be converted to Big-Endian. You can achieve this in three cases:
+All models need to be converted to Big-Endian. You can achieve this in three cases:
 
 1. Use pre-converted models verified for use on IBM Z & LinuxONE (easiest)
 
-You can find popular models pre-converted and verified at [s390x Ready Models](hf.co/collections/taronaeo/s390x-ready-models-672765393af438d0ccb72a08).
+    You can find popular models pre-converted and verified at [s390x Ready Models](hf.co/collections/taronaeo/s390x-ready-models-672765393af438d0ccb72a08).
 
-These models and their respective tokenizers are verified to run correctly on IBM Z & LinuxONE.
+    These models and their respective tokenizers are verified to run correctly on IBM Z & LinuxONE.
 
 2. Convert safetensors model to GGUF Big-Endian directly (recommended)
 
-```bash
-python3 convert_hf_to_gguf.py \
-    --outfile model-name-be.f16.gguf \
-    --outtype f16 \
-    --bigendian \
-    model-directory/
-```
+    ```bash
+    python3 convert_hf_to_gguf.py \
+        --outfile model-name-be.f16.gguf \
+        --outtype f16 \
+        --bigendian \
+        model-directory/
+    ```
 
-For example,
-
-```bash
-python3 convert_hf_to_gguf.py \
-    --outfile granite-3.3-2b-instruct-be.f16.gguf \
-    --outtype f16 \
-    --bigendian \
-    granite-3.3-2b-instruct/
-```
+    For example,
+    
+    ```bash
+    python3 convert_hf_to_gguf.py \
+        --outfile granite-3.3-2b-instruct-be.f16.gguf \
+        --outtype f16 \
+        --bigendian \
+        granite-3.3-2b-instruct/
+    ```
 
 3. Convert existing GGUF Little-Endian model to Big-Endian
 
-```bash
-python3 gguf-py/gguf/scripts/gguf_convert_endian.py model-name.f16.gguf BIG
-```
-
-For example,
-```bash
-python3 gguf-py/gguf/scripts/gguf_convert_endian.py granite-3.3-2b-instruct-le.f16.gguf BIG
-mv granite-3.3-2b-instruct-le.f16.gguf granite-3.3-2b-instruct-be.f16.gguf
-```
-
-**Notes:**
-- The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
+    ```bash
+    python3 gguf-py/gguf/scripts/gguf_convert_endian.py model-name.f16.gguf BIG
+    ```
+    
+    For example,
+    ```bash
+    python3 gguf-py/gguf/scripts/gguf_convert_endian.py granite-3.3-2b-instruct-le.f16.gguf BIG
+    mv granite-3.3-2b-instruct-le.f16.gguf granite-3.3-2b-instruct-be.f16.gguf
+    ```
+    
+    **Notes:**
+    - The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
 
 
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -139,3 +139,13 @@ We strongly recommend disabling SMT via the kernel boot parameters as it negativ
 
 We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
 
+## Issues Related to IBM Z & LinuxONE
+
+1. **Bugs, Feature Requests**
+
+    Please file an issue in llama.cpp and ensure that the title contains "s390x".
+
+2. **Other Questions**
+
+    Please reach out directly to [aionz@us.ibm.com](mailto:aionz@us.ibm.com).
+

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -121,21 +121,21 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
 
 ### 1. Virtualization Setup
 
-    We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
-    
-    Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
+We strongly recommend using only LPAR (Type-1) virtualization to get the most performance.
+
+Note: Type-2 virtualization is not supported at the moment, while you can get it running, the performance will not be the best.
 
 ### 2. IFL (Core) Count
 
-    We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
-    
-    Note: IFL count does not equate to vCPU count.
+We recommend a minimum of 8 shared IFLs assigned to the LPAR. Increasing the IFL count past 8 shared IFLs will only improve Prompt Processing performance but not Token Generation.
+
+Note: IFL count does not equate to vCPU count.
 
 ### 3. SMT vs NOSMT (Simultaneous Multithreading)
 
-    We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
+We strongly recommend disabling SMT via the kernel boot parameters as it negatively affects performance. Please refer to your Linux distribution's guide on disabling SMT via kernel boot parameters.
 
 ### 4. BLAS vs NOBLAS
 
-    We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
+We strongly recommend using BLAS for llama.cpp as there are no custom kernels for s390x for llama.cpp at the moment.
 

--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -37,7 +37,7 @@ cmake --build build --config Release -j $(nproc)
         -DGGML_BLAS=ON              \
         -DGGML_BLAS_VENDOR=OpenBLAS \
         -DGGML_VXE=OFF
-    
+
     cmake --build build --config Release -j $(nproc)
     ```
 
@@ -85,7 +85,7 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
     ```
 
     For example,
-    
+
     ```bash
     python3 convert_hf_to_gguf.py \
         --outfile granite-3.3-2b-instruct-be.f16.gguf \
@@ -99,13 +99,13 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
     ```bash
     python3 gguf-py/gguf/scripts/gguf_convert_endian.py model-name.f16.gguf BIG
     ```
-    
+
     For example,
     ```bash
     python3 gguf-py/gguf/scripts/gguf_convert_endian.py granite-3.3-2b-instruct-le.f16.gguf BIG
     mv granite-3.3-2b-instruct-le.f16.gguf granite-3.3-2b-instruct-be.f16.gguf
     ```
-    
+
     **Notes:**
     - The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
 


### PR DESCRIPTION
This PR includes the s390x specific build documentation. I've decided to separate it from the default `build.md` because we're a big-endian architecture that need more documentation to get up and running.

Feel free to let me know if there are other ways to approach this documentation.

Please review this pull request and consider merging into the main repository. Thank you!

