### PR TITLE
llamafile: support s390x SIMD instruction set

### DIFF
--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -63,14 +63,10 @@
 #define NOINLINE __attribute__((__noinline__))
 #endif
 
-#if defined(__ARM_NEON) || defined(__AVX512F__)
+#if defined(__ARM_NEON) || defined(__AVX512F__) || defined(__VXE__) || defined(__VXE2__)
 #define VECTOR_REGISTERS 32
 #else
 #define VECTOR_REGISTERS 16
-#endif
-
-#if defined(__VXE__) || defined(__VXE2__)
-#define VECTOR_REGISTERS 32
 #endif
 
 #define MM256_SET_M128I(a, b) _mm256_insertf128_si256(_mm256_castsi128_si256(b), (a), 1)

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -253,7 +253,7 @@ template <> inline float32x4_t load(const ggml_fp16_t * p) {
     float tmp[4];
 
     for (int i = 0; i < 4; i++) {
-        tmp[i] = GGML_FP16_TO_FP32(x[i]);
+        tmp[i] = GGML_FP16_TO_FP32(p[i]);
     }
 
     return vec_xl(0, (const float *)(tmp));

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3353,6 +3353,14 @@ bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t m, int64
             (const float *)B, ldb,
             (float *)C, ldc};
         return tb.matmul(m, n);
+#elif defined(__VXE__) || defined(__VXE2__)
+        if (n < 4)
+            return false;
+        tinyBLAS<4, float32x4_t, float32x4_t, float, float, float> tb{ params,
+            k, (const float *)A, lda,
+            (const float *)B, ldb,
+            (float *)C, ldc};
+        return tb.matmul(m, n);
 #elif defined(__MMA__)
         if (k % 8)
             return false;

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -250,7 +250,13 @@ template <> inline float32x4_t load(const ggml_fp16_t *p) {
 
 #if defined(__VXE__) || defined(__VXE2__)
 template <> inline float32x4_t load(const ggml_fp16_t * p) {
-    return vec_xl(0, p);
+    float tmp[4];
+
+    for (int i = 0; i < 4; i++) {
+        tmp[i] = GGML_FP16_TO_FP32(x[i]);
+    }
+
+    return vec_xl(0, (const float *)(tmp));
 }
 template <> inline float32x4_t load(const float * p) {
     return vec_xl(0, p);

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3458,10 +3458,12 @@ bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t m, int64
             return tb.matmul(m, n);
         }
 #elif defined(__VXE__) || defined(__VXE2__)
-        if (Btype == GGML_TYPE_F32) {
-            tinyBLAS<4, float32x4_t, float32x4_t, ggml_fp16_t, float, float> tb{ params,
+        if (n < 4)
+            return false;
+        if (Btype == GGML_TYPE_FP16) {
+            tinyBLAS<4, float32x4_t, float32x4_t, ggml_fp16_t, ggml_fp16_t, float> tb{ params,
                 k, (const ggml_fp16_t *)A, lda,
-                (const float *)B, ldb,
+                (const ggml_fp16_t *)B, ldb,
                 (float *)C, ldc};
             return tb.matmul(m, n);
         }

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3460,7 +3460,7 @@ bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t m, int64
 #elif defined(__VXE__) || defined(__VXE2__)
         if (n < 4)
             return false;
-        if (Btype == GGML_TYPE_FP16) {
+        if (Btype == GGML_TYPE_F16) {
             tinyBLAS<4, float32x4_t, float32x4_t, ggml_fp16_t, ggml_fp16_t, float> tb{ params,
                 k, (const ggml_fp16_t *)A, lda,
                 (const ggml_fp16_t *)B, ldb,

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3448,6 +3448,14 @@ bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t m, int64
                 (float *)C, ldc};
             return tb.matmul(m, n);
         }
+#elif defined(__VXE__) || defined(__VXE2__)
+        if (Btype == GGML_TYPE_F32) {
+            tinyBLAS<4, float32x4_t, float32x4_t, ggml_fp16_t, float, float> tb{ params,
+                k, (const ggml_fp16_t *)A, lda,
+                (const float *)B, ldb,
+                (float *)C, ldc};
+            return tb.matmul(m, n);
+        }
 #endif
         return false;
     }

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -249,6 +249,9 @@ template <> inline float32x4_t load(const ggml_fp16_t *p) {
 #endif // __ARM_NEON
 
 #if defined(__VXE__) || defined(__VXE2__)
+template <> inline float32x4_t load(const ggml_fp16_t * p) {
+    return vec_xl(0, p);
+}
 template <> inline float32x4_t load(const float * p) {
     return vec_xl(0, p);
 }

--- a/ggml/src/ggml-cpu/llamafile/sgemm.h
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.h
@@ -14,48 +14,6 @@ bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t, int64_t
                      const void *, int64_t, const void *, int64_t, void *, int64_t,
                      int, int, int);
 
-#if defined(__VXE__) || defined(__VXE2__)
-#define vec_neg(a)    (-(a))                // Vector Negate
-#define vec_add(a, b) ((a) + (b))           // Vector Add
-#define vec_sub(a, b) ((a) - (b))           // Vector Subtract
-#define vec_mul(a, b) ((a) * (b))           // Vector Multiply
-#define vec_div(a, b) ((a) / (b))           // Vector Divide
-#define vec_sl(a, b)  ((a) << (b))          // Vector Shift Left
-#define vec_sra(a, b) ((a) >> (b))          // Vector Shift Right
-#define vec_sr(a, b)  ((a) >> (b))          // Vector Shift Right Algebraic
-#define vec_slo(a, b) vec_slb(a, (b) << 64) // Vector Shift Left by Octet
-#define vec_sro(a, b) vec_srb(a, (b) << 64) // Vector Shift Right by Octet
-
-#ifndef vec_and
-#define vec_and(a, b) ((a) & (b)) // Vector AND
-#endif
-
-#ifndef vec_or
-#define vec_or(a, b)  ((a) | (b)) // Vector OR
-#endif
-
-#ifndef vec_xor
-#define vec_xor(a, b) ((a) ^ (b)) // Vector XOR
-#endif
-
-typedef signed   char char8x16_t  __attribute__((vector_size(16)));
-typedef unsigned char uchar8x16_t __attribute__((vector_size(16)));
-
-typedef int8_t  int8x16_t __attribute__((vector_size(16)));
-typedef int16_t int16x8_t __attribute__((vector_size(16)));
-typedef int32_t int32x4_t __attribute__((vector_size(16)));
-
-typedef uint8_t  uint8x16_t __attribute__((vector_size(16)));
-typedef uint16_t uint16x8_t __attribute__((vector_size(16)));
-typedef uint32_t uint32x4_t __attribute__((vector_size(16)));
-
-typedef float  float32x4_t  __attribute__((vector_size(16)));
-typedef double double64x2_t __attribute__((vector_size(16)));
-
-typedef signed   long long long64x2_t  __attribute__((vector_size(16)));
-typedef unsigned long long ulong64x2_t __attribute__((vector_size(16)));
-#endif  // defined(__VXE__) || defined(__VXE2__)
-
 #ifdef __cplusplus
 }
 #endif

--- a/ggml/src/ggml-cpu/llamafile/sgemm.h
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.h
@@ -1,6 +1,11 @@
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
+
+#if defined(__VXE__) || defined(__VXE2__)
+#include <vecintrin.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,6 +13,48 @@ extern "C" {
 bool llamafile_sgemm(const struct ggml_compute_params * params, int64_t, int64_t, int64_t,
                      const void *, int64_t, const void *, int64_t, void *, int64_t,
                      int, int, int);
+
+#if defined(__VXE__) || defined(__VXE2__)
+#define vec_neg(a)    (-(a))                // Vector Negate
+#define vec_add(a, b) ((a) + (b))           // Vector Add
+#define vec_sub(a, b) ((a) - (b))           // Vector Subtract
+#define vec_mul(a, b) ((a) * (b))           // Vector Multiply
+#define vec_div(a, b) ((a) / (b))           // Vector Divide
+#define vec_sl(a, b)  ((a) << (b))          // Vector Shift Left
+#define vec_sra(a, b) ((a) >> (b))          // Vector Shift Right
+#define vec_sr(a, b)  ((a) >> (b))          // Vector Shift Right Algebraic
+#define vec_slo(a, b) vec_slb(a, (b) << 64) // Vector Shift Left by Octet
+#define vec_sro(a, b) vec_srb(a, (b) << 64) // Vector Shift Right by Octet
+
+#ifndef vec_and
+#define vec_and(a, b) ((a) & (b)) // Vector AND
+#endif
+
+#ifndef vec_or
+#define vec_or(a, b)  ((a) | (b)) // Vector OR
+#endif
+
+#ifndef vec_xor
+#define vec_xor(a, b) ((a) ^ (b)) // Vector XOR
+#endif
+
+typedef signed   char char8x16_t  __attribute__((vector_size(16)));
+typedef unsigned char uchar8x16_t __attribute__((vector_size(16)));
+
+typedef int8_t  int8x16_t __attribute__((vector_size(16)));
+typedef int16_t int16x8_t __attribute__((vector_size(16)));
+typedef int32_t int32x4_t __attribute__((vector_size(16)));
+
+typedef uint8_t  uint8x16_t __attribute__((vector_size(16)));
+typedef uint16_t uint16x8_t __attribute__((vector_size(16)));
+typedef uint32_t uint32x4_t __attribute__((vector_size(16)));
+
+typedef float  float32x4_t  __attribute__((vector_size(16)));
+typedef double double64x2_t __attribute__((vector_size(16)));
+
+typedef signed   long long long64x2_t  __attribute__((vector_size(16)));
+typedef unsigned long long ulong64x2_t __attribute__((vector_size(16)));
+#endif  // defined(__VXE__) || defined(__VXE2__)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request aims to integrate the SIMD instruction set into Llamafile for the s390x platform.

At current, only F32 and F16 data types are activated. Quantised data types are WIP and will not be part of this PR.

### Verification

To ensure that this implementation did not break anything, the SIMD instruction set has been tested on the following models:
* Tested IBM Granite 3.3 (F32, F16, Q4_0, Q4_1, Q8_0, Q3_K, Q4_K, Q5_K, Q6_K, IQ4_NL, IQ4_XS)
* Kindly request additional models for testing in this PR

### Performance Results

I will be using IBM Granite 3.3 for the performance tests. We notice an average of 8.14% performance improvement in Prompt Processing.

Before Llamafile SIMD Instruction Set

| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |      16 |           pp512 |         57.45 ± 0.28 |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |      16 |           tg128 |          2.33 ± 0.09 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |      16 |           pp512 |         56.54 ± 0.37 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |      16 |           tg128 |          4.19 ± 0.31 |

After Llamafile SIMD Instruction Set

| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |      16 |           pp512 |         62.33 ± 0.45 |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |      16 |           tg128 |          2.34 ± 0.04 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |      16 |           pp512 |         61.98 ± 0.10 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |      16 |           tg128 |          4.46 ± 0.14 |

> [!NOTE]
> Tests were conducted on an IBM z15 Mainframe with 16 IFLs (cores) and 160 GB Memory on a shared R&D LPAR.

Please review this pull request and consider merging into the main repository. Thank you!