### PR TITLE
ggml : fix Arm NEON feature detection

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -707,7 +707,7 @@ static void ggml_init_arm_arch_features(void) {
 #elif defined(__APPLE__)
     int oldp = 0;
     size_t size = sizeof(oldp);
-    if (sysctlbyname("hw.optional.AdvSIMD", &oldp, &size, NULL, 0) != 0) {
+    if (sysctlbyname("hw.optional.arm.AdvSIMD", &oldp, &size, NULL, 0) != 0) {
         oldp = 0;
     }
     ggml_arm_arch_features.has_neon = oldp;


### PR DESCRIPTION
While looking into #13168, I noticed that `Q4_0` repacking is no longer applied on my Mac (https://github.com/ggml-org/llama.cpp/issues/13168#issuecomment-2987487019). I traced this to incorrect `sysctl` string: `"hw.optional.arm.AdvSIMD"`.

This was like this ever since #9331. @eddnjjn Could you take a look and confirm this fix is correct.