### PR TITLE
vocab : prevent tokenizer overflow

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1284,6 +1284,9 @@ std::vector<llama_token> common_tokenize(
     int n_tokens = text.length() + 2 * add_special;
     std::vector<llama_token> result(n_tokens);
     n_tokens = llama_tokenize(vocab, text.data(), text.length(), result.data(), result.size(), add_special, parse_special);
+    if (n_tokens == std::numeric_limits<int32_t>::min()) {
+        throw std::runtime_error("Tokenization failed: input text too large, tokenization result exceeds int32_t limit");
+    }
     if (n_tokens < 0) {
         result.resize(-n_tokens);
         int check = llama_tokenize(vocab, text.data(), text.length(), result.data(), result.size(), add_special, parse_special);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1087,6 +1087,7 @@ extern "C" {
     /// @param tokens The tokens pointer must be large enough to hold the resulting tokens.
     /// @return Returns the number of tokens on success, no more than n_tokens_max
     /// @return Returns a negative number on failure - the number of tokens that would have been returned
+    /// @return Returns INT32_MIN on overflow (e.g., tokenization result size exceeds int32_t limit)
     /// @param add_special Allow to add BOS and EOS tokens if model is configured to do so.
     /// @param parse_special Allow tokenizing special and/or control tokens which otherwise are not exposed and treated
     ///                      as plaintext. Does not insert a leading space.

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3061,7 +3061,8 @@ int32_t llama_vocab::tokenize(
                         bool   parse_special) const {
     auto res = tokenize(std::string(text, text_len), add_special, parse_special);
     if (res.size() >= static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
-        GGML_ABORT("tokenization result size %zu exceeds int32_t limit", res.size());
+        LLAMA_LOG_ERROR("%s: tokenization result size %zu exceeds int32_t limit\n", __func__, res.size());
+        return -1;
     }
     
     if (n_tokens_max < (int) res.size()) {

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3060,6 +3060,10 @@ int32_t llama_vocab::tokenize(
                         bool   add_special,
                         bool   parse_special) const {
     auto res = tokenize(std::string(text, text_len), add_special, parse_special);
+    if (res.size() >= static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+        GGML_ABORT("tokenization result size %zu exceeds int32_t limit", res.size());
+    }
+    
     if (n_tokens_max < (int) res.size()) {
         // LLAMA_LOG_ERROR("%s: too many tokens\n", __func__);
         return -((int) res.size());

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3062,7 +3062,7 @@ int32_t llama_vocab::tokenize(
     auto res = tokenize(std::string(text, text_len), add_special, parse_special);
     if (res.size() >= static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
         LLAMA_LOG_ERROR("%s: tokenization result size %zu exceeds int32_t limit\n", __func__, res.size());
-        return -1;
+        return std::numeric_limits<int32_t>::min();
     }
     
     if (n_tokens_max < (int) res.size()) {


### PR DESCRIPTION
Check and prevent silent overflows when `res.size()` size exceeds `int32_t::max`.
* Adds explicit check in `llama_vocab::tokenize` and returns `INT32_MIN` if the `result.size()`
cannot be safely represented. Upstream callers (e.g., common_tokenize) now throw an 
exception when `INT32_MIN` is returned.
* Updates API doc in `llama.h` to document the new overflow return behavior.