### PR TITLE
ggml-cpu: enable IBM NNPA Vector Intrinsics

### DIFF
--- a/docs/build-s390x.md
+++ b/docs/build-s390x.md
@@ -28,8 +28,9 @@ cmake --build build --config Release -j $(nproc)
 ```
 
 **Notes**:
-- For faster repeated compilation, install [ccache](https://ccache.dev/)
-- By default, VXE/VXE2 is enabled. To disable it (not recommended):
+
+-   For faster repeated compilation, install [ccache](https://ccache.dev/)
+-   By default, VXE/VXE2 is enabled. To disable it (not recommended):
 
     ```bash
     cmake -S . -B build             \
@@ -41,18 +42,29 @@ cmake --build build --config Release -j $(nproc)
     cmake --build build --config Release -j $(nproc)
     ```
 
-- For debug builds:
+-   By default, NNPA is enabled when available. To disable it (not recommended):
+
+    ```bash
+    cmake -S . -B build             \
+        -DCMAKE_BUILD_TYPE=Release  \
+        -DGGML_BLAS=ON              \
+        -DGGML_BLAS_VENDOR=OpenBLAS \
+        -DGGML_NNPA=OFF
+
+    cmake --build build --config Release -j $(nproc)
+    ```
+
+-   For debug builds:
 
     ```bash
     cmake -S . -B build             \
         -DCMAKE_BUILD_TYPE=Debug    \
         -DGGML_BLAS=ON              \
         -DGGML_BLAS_VENDOR=OpenBLAS
-
     cmake --build build --config Debug -j $(nproc)
     ```
 
-- For static builds, add `-DBUILD_SHARED_LIBS=OFF`:
+-   For static builds, add `-DBUILD_SHARED_LIBS=OFF`:
 
     ```bash
     cmake -S . -B build             \
@@ -101,27 +113,33 @@ All models need to be converted to Big-Endian. You can achieve this in three cas
     ```
 
     For example,
+
     ```bash
     python3 gguf-py/gguf/scripts/gguf_convert_endian.py granite-3.3-2b-instruct-le.f16.gguf BIG
     mv granite-3.3-2b-instruct-le.f16.gguf granite-3.3-2b-instruct-be.f16.gguf
     ```
 
     **Notes:**
+
     - The GGUF endian conversion script may not support all data types at the moment and may fail for some models/quantizations. When that happens, please try manually converting the safetensors model to GGUF Big-Endian via Step 2.
 
 ## IBM Accelerators
 
 ### 1. SIMD Acceleration
 
-Only available in IBM z15 or later system with the `-DGGML_VXE=ON` (turned on by default) compile flag. No hardware acceleration is possible with llama.cpp with older systems, such as IBM z14 or EC13. In such systems, the APIs can still run but will use a scalar implementation.
+Only available in IBM z15 or later system with the `-DGGML_VXE=ON` (turned on by default) compile flag. No hardware acceleration is possible with llama.cpp with older systems, such as IBM z14/arch12. In such systems, the APIs can still run but will use a scalar implementation.
 
-### 2. zDNN Accelerator
+### 2. NNPA Vector Intrinsics Acceleration
 
-*Only available in IBM z16 or later system. No direction at the moment.*
+Only available in IBM z16 or later system with the `-DGGML_NNPA=ON` (turned on when available) compile flag. No hardware acceleration is possible with llama.cpp with older systems, such as IBM z15/arch13. In such systems, the APIs can still run but will use a scalar implementation.
 
-### 3. Spyre Accelerator
+### 3. zDNN Accelerator
 
-*No direction at the moment.*
+_Only available in IBM z16 or later system. No direction at the moment._
+
+### 4. Spyre Accelerator
+
+_No direction at the moment._
 
 ## Performance Tuning
 
@@ -154,4 +172,3 @@ IBM VXE/VXE2 SIMD acceleration depends on the BLAS implementation. It is strongl
 2. **Other Questions**
 
     Please reach out directly to [aionz@us.ibm.com](mailto:aionz@us.ibm.com).
-

--- a/docs/build.md
+++ b/docs/build.md
@@ -557,6 +557,10 @@ ninja
 
 To read documentation for how to build on Android, [click here](./android.md)
 
+## IBM Z & LinuxONE
+
+To read documentation for how to build on IBM Z & LinuxONE, [click here](./build-s390x.md)
+
 ## Notes about GPU-accelerated backends
 
 The GPU may still be used to accelerate some parts of the computation even when using the `-ngl 0` option. You can fully disable GPU acceleration by using `--device none`.

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -131,6 +131,7 @@ option(GGML_RVV              "ggml: enable rvv"              ON)
 option(GGML_RV_ZFH           "ggml: enable riscv zfh"        OFF)
 option(GGML_XTHEADVECTOR     "ggml: enable xtheadvector"     OFF)
 option(GGML_VXE              "ggml: enable vxe"              ON)
+option(GGML_NNPA             "ggml: enable nnpa"             ON)
 
 option(GGML_CPU_ALL_VARIANTS "ggml: build all variants of the CPU backend (requires GGML_BACKEND_DL)" OFF)
 set(GGML_CPU_ARM_ARCH        "" CACHE STRING "ggml: CPU architecture for ARM")

--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -101,6 +101,7 @@ extern "C" {
     GGML_BACKEND_API int ggml_cpu_has_riscv_v    (void);
     GGML_BACKEND_API int ggml_cpu_has_vsx        (void);
     GGML_BACKEND_API int ggml_cpu_has_vxe        (void);
+    GGML_BACKEND_API int ggml_cpu_has_nnpa       (void);
     GGML_BACKEND_API int ggml_cpu_has_wasm_simd  (void);
     GGML_BACKEND_API int ggml_cpu_has_llamafile  (void);
 

--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -427,6 +427,7 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
 
         # TODO: Separation to determine activation of VX/VXE/VXE2
         if (${S390X_M} MATCHES "8561|8562")
+            set(GGML_NNPA OFF)
             message(STATUS "z15 target")
             list(APPEND ARCH_FLAGS -march=z15)
         elseif (${S390X_M} MATCHES "3931")
@@ -443,7 +444,13 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
         endif()
 
         if (GGML_VXE)
+            message(STATUS "VX/VXE/VXE2 enabled")
             list(APPEND ARCH_FLAGS -mvx -mzvector)
+        endif()
+
+        if (GGML_NNPA)
+            target_compile_definitions(${GGML_CPU_NAME} PRIVATE GGML_NNPA)
+            message(STATUS "NNPA enabled")
         endif()
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "wasm")
         message(STATUS "Wasm detected")

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -62,11 +62,17 @@ struct ggml_compute_params {
 #if defined(__s390x__) && defined(__VEC__)
 #ifndef __VXE__
 #define __VXE__
-#endif
+#endif  // __VXE__
 #ifndef __VXE2__
 #define __VXE2__
-#endif
-#endif
+#endif  // __VXE2__
+#endif  // __s390x__ && __VEC__
+
+#if defined(__s390x__) && defined(GGML_NNPA)
+#ifndef __NNPA__
+#define __NNPA__
+#endif  // __NNPA__
+#endif  // __s390x__ && GGML_NNPA
 
 #if defined(__ARM_FEATURE_SVE)
 #include <sys/prctl.h>

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,8 +3140,8 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
-        float32x4_t v_x1 = vec_xl(i + 0, x);
-        float32x4_t v_x2 = vec_xl(i + 4, x);
+        float32x4_t v_x1 = vec_ld(0, x + i + 0);
+        float32x4_t v_x2 = vec_ld(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
         vec_xst(v_dlf16, 0, (uint16_t *)(y + i));
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,10 +3140,10 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
-        int16_t tmp[8];
+        uint16_t tmp[8];
         float32x4_t v_x1 = vec_xl(0, x + i + 0);
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
-        int16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
+        uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
         vec_xst(v_dlf16, 0, tmp);
         raise(SIGINT);
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3143,6 +3143,7 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
         float32x4_t v_x1 = vec_xl(0, x + i + 0);
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
+        raise(SIGINT);
         vec_xst(v_dlf16, 0, (uint16_t *)(y + i));
     }
     // TODO: Enable bottom code once checks are done

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,10 +3140,10 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
-        uint16_t tmp[8];
+        int16_t tmp[8];
         float32x4_t v_x1 = vec_xl(0, x + i + 0);
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
-        uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
+        int16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
         vec_xst(v_dlf16, 0, tmp);
         raise(SIGINT);
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,11 +3140,12 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
+        uint16x8_t tmp[8];
         float32x4_t v_x1 = vec_xl(0, x + i + 0);
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
+        vec_xst(v_dlf16, 0, tmp);
         raise(SIGINT);
-        vec_xst(v_dlf16, 0, (uint16_t *)(y + i));
     }
     // TODO: Enable bottom code once checks are done
     // for (; i + 3 < n; i += 4) {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3143,7 +3143,7 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
         float32x4_t v_x1 = vec_xl(i + 0, x);
         float32x4_t v_x2 = vec_xl(i + 4, x);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
-        vec_xst(v_dlf16, i, (uint16_t *)y);
+        vec_xst(v_dlf16, 0, (uint16_t *)(y + i));
     }
     // TODO: Enable bottom code once checks are done
     // for (; i + 3 < n; i += 4) {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3145,7 +3145,7 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
         vec_xst(v_dlf16, 0, tmp);
-        raise(SIGINT);
+        // raise(SIGINT);
     }
     // TODO: Enable bottom code once checks are done
     // for (; i + 3 < n; i += 4) {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,8 +3140,8 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
-        float32x4_t v_x1 = vec_ld(0, x + i + 0);
-        float32x4_t v_x2 = vec_ld(0, x + i + 4);
+        float32x4_t v_x1 = vec_xl(0, x + i + 0);
+        float32x4_t v_x2 = vec_xl(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
         vec_xst(v_dlf16, 0, (uint16_t *)(y + i));
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3364,6 +3364,14 @@ int ggml_cpu_has_vxe(void) {
 #endif
 }
 
+int ggml_cpu_has_nnpa(void) {
+#if defined(GGML_NNPA)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 int ggml_cpu_has_neon(void) {
 #if defined(__ARM_ARCH) && defined(__ARM_NEON)
     return 1;

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3140,7 +3140,7 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
 
 #if defined(__NNPA__)
     for (; i + 7 < n; i += 8) {
-        uint16x8_t tmp[8];
+        uint16_t tmp[8];
         float32x4_t v_x1 = vec_xl(0, x + i + 0);
         float32x4_t v_x2 = vec_xl(0, x + i + 4);
         uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3137,6 +3137,23 @@ void ggml_cpu_fp32_to_fp16(const float * x, ggml_fp16_t * y, int64_t n) {
         _mm_storel_epi64((__m128i *)(y + i), y_vec);
     }
 #endif
+
+#if defined(__NNPA__)
+    for (; i + 7 < n; i += 8) {
+        float32x4_t v_x1 = vec_xl(i + 0, x);
+        float32x4_t v_x2 = vec_xl(i + 4, x);
+        uint16x8_t v_dlf16 = vec_round_from_fp32(v_x1, v_x2, 0);
+        vec_xst(v_dlf16, i, (uint16_t *)y);
+    }
+    // TODO: Enable bottom code once checks are done
+    // for (; i + 3 < n; i += 4) {
+    //     float32x4_t v_x = vec_xl(i, x);
+    //     float32x4_t v_zero = vec_splats(0.0f);
+    //     uint16x4_t v_dlf16 = vec_round_from_fp32(v_x, v_zero, 0);
+    //     vec_xst(v_dlf16, i, (uint16_t *)y);
+    // }
+#endif
+
     for (; i < n; ++i) {
         y[i] = GGML_FP32_TO_FP16(x[i]);
     }

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -578,6 +578,9 @@ static ggml_backend_feature * ggml_backend_cpu_get_features(ggml_backend_reg_t r
         if (ggml_cpu_has_vxe()) {
             features.push_back({ "VXE", "1" });
         }
+        if (ggml_cpu_has_nnpa()) {
+            features.push_back({ "NNPA", "1" });
+        }
         if (ggml_cpu_has_wasm_simd()) {
             features.push_back({ "WASM_SIMD", "1" });
         }

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -984,10 +984,7 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t y) {
 #ifdef __NNPA__
     float32x4_t zero = vec_splats(0.0f);
     uint16x8_t nnpa = vec_round_from_fp32(y, zero, 0);
-    x[0] = nnpa[0];
-    x[1] = nnpa[1];
-    x[2] = nnpa[2];
-    x[3] = nnpa[3];
+    x = nnpa;
 #else
     float arr[4];
 

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ggml-cpu-impl.h"
+#include <signal.h>
 
 //
 // simd mappings

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -962,7 +962,12 @@ static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
 #define GGML_F16_STEP GGML_F32_STEP
 #define GGML_F16_EPR  GGML_F32_EPR
 
-static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
+static inline float32x4_t __lzs_f16cx4_load(const ggml_fp16_t * x) {
+#ifdef __NNPA__
+    uint16x8_t tmp = vec_xl(0, (const ggml_fp16_t *)x);
+    uint16x8_t nnpa = vec_convert_from_fp16(tmp, 0);
+    return vec_extend_to_fp32_hi(nnpa, 0);
+#else
     float tmp[4];
 
     for (int i = 0; i < 4; i++) {
@@ -972,6 +977,7 @@ static inline __vector float __lzs_f16cx4_load(const ggml_fp16_t * x) {
     // note: keep type-cast here to prevent compiler bugs
     // see: https://github.com/ggml-org/llama.cpp/issues/12846
     return vec_xl(0, (const float *)(tmp));
+#endif
 }
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -988,6 +988,7 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t v_y) {
     x[1] = vec_extract(v_x, 1);
     x[2] = vec_extract(v_x, 2);
     x[3] = vec_extract(v_x, 3);
+    raise(SIGINT);
 #else
     float arr[4];
 

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -922,7 +922,7 @@ static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
 #define GGML_F32_STEP 32
 #define GGML_F32_EPR  4
 
-#define GGML_F32x4              __vector float
+#define GGML_F32x4              float32x4_t
 #define GGML_F32x4_ZERO         vec_splats(0.0f)
 #define GGML_F32x4_SET1         vec_splats
 #define GGML_F32x4_LOAD(p)      vec_xl(0, p)
@@ -980,7 +980,15 @@ static inline float32x4_t __lzs_f16cx4_load(const ggml_fp16_t * x) {
 #endif
 }
 
-static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
+static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t y) {
+#ifdef __NNPA__
+    float32x4_t zero = vec_splats(0.0f);
+    uint16x8_t nnpa = vec_round_from_fp32(y, zero, 0);
+    x[0] = nnpa[0];
+    x[1] = nnpa[1];
+    x[2] = nnpa[2];
+    x[3] = nnpa[3];
+#else
     float arr[4];
 
     // note: keep type-cast here to prevent compiler bugs
@@ -990,6 +998,7 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, __vector float y) {
     for (int i = 0; i < 4; i++) {
         x[i] = GGML_FP32_TO_FP16(arr[i]);
     }
+#endif
 }
 
 #define GGML_F16_VEC                GGML_F32x4

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -982,8 +982,8 @@ static inline float32x4_t __lzs_f16cx4_load(const ggml_fp16_t * x) {
 
 static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t v_y) {
 #ifdef __NNPA__
-    float32x4_t zero = vec_splats(0.0f);
-    uint16x8_t v_x = vec_round_from_fp32(v_y, zero, 0);
+    float32x4_t v_zero = vec_splats(0.0f);
+    uint16x8_t v_x = vec_round_from_fp32(v_y, v_zero, 0);
     x[0] = vec_extract(v_x, 0);
     x[1] = vec_extract(v_x, 1);
     x[2] = vec_extract(v_x, 2);

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -984,7 +984,10 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t y) {
 #ifdef __NNPA__
     float32x4_t zero = vec_splats(0.0f);
     uint16x8_t nnpa = vec_round_from_fp32(y, zero, 0);
-    x = nnpa;
+    x[0] = nnpa[0];
+    x[1] = nnpa[1];
+    x[2] = nnpa[2];
+    x[3] = nnpa[3];
 #else
     float arr[4];
 

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -428,17 +428,9 @@ GGML_API void ggml_aligned_free(void * ptr, size_t size);
 
     // TODO: Determine if inline assembly is faster
     static inline float ggml_compute_fp16_to_fp32(ggml_fp16_t h) {
-        float f;
-        __asm__ (
-            "vlvgp  %%v0, %1, %1\n"
-            "vreph  %%v0, %%v0, 3\n"
-            "vcnf   %%v0, %%v0, 0, 1\n"
-            "vclfnh %%v0, %%v0, 2, 0\n"
-            "ler    %0, %%f0\n" :
-            /* out */   "=f"(f) :
-            /* in */     "r"(h) :
-            /* clobber */ "v0", "f0");
-        return f;
+        uint16x8_t v_h = vec_splats(h);
+        uint16x8_t nnpa_dlf16 = vec_convert_from_fp16(v_h, 0);
+        return vec_extend_to_fp32_hi(nnpa_dlf16, 0)[0];
     }
 
     // TODO: Determine if inline assembly is faster

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -426,14 +426,12 @@ GGML_API void ggml_aligned_free(void * ptr, size_t size);
     #define GGML_FP16_TO_FP32(x) GGML_COMPUTE_FP16_TO_FP32(x)
     #define GGML_FP32_TO_FP16(x) GGML_COMPUTE_FP32_TO_FP16(x)
 
-    // TODO: Determine if inline assembly is faster
     static inline float ggml_compute_fp16_to_fp32(ggml_fp16_t h) {
         uint16x8_t v_h = vec_splats(h);
         uint16x8_t nnpa_dlf16 = vec_convert_from_fp16(v_h, 0);
         return vec_extend_to_fp32_hi(nnpa_dlf16, 0)[0];
     }
 
-    // TODO: Determine if inline assembly is faster
     static inline ggml_fp16_t ggml_compute_fp32_to_fp16(float f) {
         float32x4_t v_f = vec_splats(f);
         float32x4_t v_zero = vec_splats(0.0f);

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -428,9 +428,17 @@ GGML_API void ggml_aligned_free(void * ptr, size_t size);
 
     // TODO: Determine if inline assembly is faster
     static inline float ggml_compute_fp16_to_fp32(ggml_fp16_t h) {
-        uint16x8_t v_h = vec_splats(h);
-        uint16x8_t nnpa_dlf16 = vec_convert_from_fp16(v_h, 0);
-        return vec_extend_to_fp32_hi(nnpa_dlf16, 0)[0];
+        float f;
+        __asm__ (
+            "vlvgp  %%v0, %1, %1\n"
+            "vreph  %%v0, %%v0, 3\n"
+            "vcnf   %%v0, %%v0, 0, 1\n"
+            "vclfnh %%v0, %%v0, 2, 0\n"
+            "ler    %0, %%f0\n" :
+            /* out */   "=f"(f) :
+            /* in */     "r"(h) :
+            /* clobber */ "v0", "f0");
+        return f;
     }
 
     // TODO: Determine if inline assembly is faster


### PR DESCRIPTION
This pull request aims to enable the IBM NNPA instruction set for IBM z16 mainframes and later on the s390x platform. This code change is mainly targeted at FP16 -> FP32 or FP32 -> FP16 data conversions.

### Verification

To ensure that this implementation did not break anything, the NNPA instruction set has been tested on the following models:
* Tested IBM Granite 3.3 (F32, F16, Q4_0, Q4_1, Q3_K, Q4_K, Q5_K)
* Kindly request additional models for testing in this PR

### Performance Results

I will be using IBM Granite 3.3 for the performance tests. We notice a performance improvement of roughly 31.21% for F16 Token Generation, which is the expected outcome.

Before NNPA Instruction Set
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |       4 |           pp512 |         31.56 ± 0.23 |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |       4 |           tg128 |          1.75 ± 0.01 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |       4 |           pp512 |         30.94 ± 0.20 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |       4 |           tg128 |          1.46 ± 0.01 |

After NNPA Instruction Set
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |       4 |           pp512 |         30.56 ± 2.42 |
| granite 3B all F32             |   9.44 GiB |     2.53 B | BLAS       |       4 |           tg128 |          1.77 ± 0.01 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |       4 |           pp512 |         30.86 ± 0.23 |
| granite 3B F16                 |   4.72 GiB |     2.53 B | BLAS       |       4 |           tg128 |          2.00 ± 0.01 |

> [!NOTE]
> Tests were conducted on an IBM z16 Mainframe with 2 IFLs (4 vCores) and 64 GB Memory on z/VM (Type-2)

Please review this pull request and consider merging into the main repository. Thank you!