### PR TITLE
GitHub workflow: set RPATH to "@loader_path" / "$ORIGIN" to ensure executables and dynamic libraries search for dependencies in their origin directory.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           sysctl -a
           cmake -B build \
-            -DCMAKE_BUILD_RPATH="@loader_path" \
+            -DCMAKE_INSTALL_RPATH='@loader_path' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
             -DGGML_METAL_USE_BF16=ON \
             -DGGML_METAL_EMBED_LIBRARY=ON \
@@ -103,7 +104,8 @@ jobs:
           # Metal is disabled due to intermittent failures with Github runners not having a GPU:
           # https://github.com/ggml-org/llama.cpp/actions/runs/8635935781/job/23674807267#step:5:2313
           cmake -B build \
-            -DCMAKE_BUILD_RPATH="@loader_path" \
+            -DCMAKE_INSTALL_RPATH='@loader_path' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DLLAMA_FATAL_WARNINGS=ON \
             -DGGML_METAL=OFF \
             -DGGML_RPC=ON
@@ -160,6 +162,8 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DGGML_BACKEND_DL=ON \
             -DGGML_NATIVE=OFF \
             -DGGML_CPU_ALL_VARIANTS=ON \
@@ -211,6 +215,8 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DGGML_BACKEND_DL=ON \
             -DGGML_NATIVE=OFF \
             -DGGML_CPU_ALL_VARIANTS=ON \


### PR DESCRIPTION
(Some earlier information in related pull request: #13741)

## Linux binaries
Currently the distributed Linux binaries (executables and shared libraries) default to embed an RPATH with an absolute path only relevant to the CI runner, like `/home/runner/work/llama.cpp/llama.cpp/build/bin`:

```
readelf -d llama-cli

Dynamic section at offset 0x1bcd80 contains 36 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libllama.so]
 0x0000000000000001 (NEEDED)             Shared library: [libggml.so]
 0x0000000000000001 (NEEDED)             Shared library: [libggml-base.so]
 0x0000000000000001 (NEEDED)             Shared library: [libcurl.so.4]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000001d (RUNPATH)            Library runpath: [/home/runner/work/llama.cpp/llama.cpp/build/bin:]
 ```
 
This means that the binaries can only run correctly if in the current working directory, or if on system path.

If trying to run not from the current working directory, an error occurs:
```
llama-bin/llama-cli
```
```
llama-bin/llama-cli: error while loading shared libraries: libggml.so: 
cannot open shared object file: No such file or directory
```

After adding:
```
            -DCMAKE_INSTALL_RPATH="$ORIGIN" \
            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
```

Linux binaries should include the `$ORIGIN` RPATH instead:

```
readelf -d llama-cli

Dynamic section at offset 0x196e68 contains 34 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libllama.so]
 0x0000000000000001 (NEEDED)             Shared library: [libggml.so]
 0x0000000000000001 (NEEDED)             Shared library: [libggml-base.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```

Which resolves this issue.

### Issues with Linux shared libraries

Similar issue occurs with the built shared libraries. It's difficult to use them since their search paths don't allow finding each other in the same origin directory. This resolves that as well.

## macOS binaries

For macOS, the workflow already had a related build setting:

```
            -DCMAKE_BUILD_RPATH="@loader_path" \
```
Which in practice did something similar, since no CMAKE `install` phase was likely used.

```
otool -l ./llama-cli | grep LC_RPATH -A2
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)
--
          cmd LC_RPATH
      cmdsize 64
         path /Users/runner/work/llama.cpp/llama.cpp/build/bin (offset 12)
```

It caused both the `@loader_path` and the runner absolute path to be used.

I also changed to use the same approach:
```
            -DCMAKE_INSTALL_RPATH="@loader_path" \
            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
```

Which shouldn't actually make any practical difference, except removing the absolute path.

## I can't test the workflows

I hope these changes are correct, but I can't exactly test the workflows before submitting the pull request.

## Order of command line arguments

I've put the new arguments at the top to be consistent with the order they were added in the macOS builds (in my personal builds I put them last actually). You can change the order in any way you want.