### PR TITLE
gguf-py : fix Qwen3-Embedding eos token

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -199,10 +199,10 @@ class SpecialVocab:
                                 special_eos = special_last
                             elif special_last != special_eos:
                                 if 'eot' not in self.special_token_types:
-                                    self.special_token_types = self.special_token_types + ('eot', )
+                                    self.special_token_types = tuple(self.special_token_types) + ('eot', )
                                     tokenizer_config['eot_token'] = special_eos
                                 elif 'eom' not in self.special_token_types:
-                                    self.special_token_types = self.special_token_types + ('eom', )
+                                    self.special_token_types = tuple(self.special_token_types) + ('eom', )
                                     tokenizer_config['eom_token'] = special_eos
                                 else:
                                     logger.warning(f'Overriding special token {special_eos!r} with {special_last!r} without EOT/EOM fallback!')

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -205,7 +205,7 @@ class SpecialVocab:
                                     self.special_token_types = tuple(self.special_token_types) + ('eom', )
                                     tokenizer_config['eom_token'] = special_eos
                                 else:
-                                    logger.warning(f'Overriding special token {special_eos!r} with {special_last!r} without EOT/EOM fallback!')
+                                    logger.warning(f'Overriding EOS token {special_eos!r} with {special_last!r} without EOT/EOM fallback!')
                                 tokenizer_config['eos_token'] = special_eos = special_last
                             self.add_special_token['eos'] = True if special_last == special_eos else False
                             if special_last != special_eos:

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -197,6 +197,16 @@ class SpecialVocab:
                         if special_last := tmpl_single[-1].get('SpecialToken', {}).get('id'):
                             if not tokenizer_config:
                                 special_eos = special_last
+                            elif special_last != special_eos:
+                                if 'eot' not in self.special_token_types:
+                                    self.special_token_types = self.special_token_types + ('eot', )
+                                    tokenizer_config['eot_token'] = special_eos
+                                elif 'eom' not in self.special_token_types:
+                                    self.special_token_types = self.special_token_types + ('eom', )
+                                    tokenizer_config['eom_token'] = special_eos
+                                else:
+                                    logger.warning(f'Overriding special token {special_eos!r} with {special_last!r} without EOT/EOM fallback!')
+                                tokenizer_config['eos_token'] = special_eos = special_last
                             self.add_special_token['eos'] = True if special_last == special_eos else False
                             if special_last != special_eos:
                                 logger.warning(f'Unknown trailing special token {special_last!r} in TemplateProcessing<single>')


### PR DESCRIPTION
Qwen3-Embedding sets a different EOS token than defined in `tokenizer_config.json` using `TemplateProcessing`, so we override that if detected (and try to shift EOS onto EOT/EOM just in case).