### PR TITLE
run : avoid double tokenization

### DIFF
--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -939,17 +939,30 @@ static int apply_chat_template(const struct common_chat_templates * tmpls, Llama
 // Function to tokenize the prompt
 static int tokenize_prompt(const llama_vocab * vocab, const std::string & prompt,
                            std::vector<llama_token> & prompt_tokens, const LlamaData & llama_data) {
-    const bool is_first = llama_memory_seq_pos_max(llama_get_memory(llama_data.context.get()), 0) == 0;
-
-    const int n_prompt_tokens = -llama_tokenize(vocab, prompt.c_str(), prompt.size(), NULL, 0, is_first, true);
-    prompt_tokens.resize(n_prompt_tokens);
-    if (llama_tokenize(vocab, prompt.c_str(), prompt.size(), prompt_tokens.data(), prompt_tokens.size(), is_first,
-                       true) < 0) {
-        printe("failed to tokenize the prompt\n");
+    const bool add_special = llama_memory_seq_pos_max(llama_get_memory(llama_data.context.get()), 0) == 0;
+    int n_tokens = prompt.size() + 2 * add_special;
+    prompt_tokens.resize(n_tokens);
+    n_tokens = llama_tokenize(vocab, prompt.c_str(), prompt.size(),
+                              prompt_tokens.data(), prompt_tokens.size(),
+                              add_special, /*parse_special =*/true);
+    if (n_tokens == std::numeric_limits<int32_t>::min()) {
+        printe("tokenization failed: input too large\n");
         return -1;
     }
-
-    return n_prompt_tokens;
+    if (n_tokens < 0) {
+        prompt_tokens.resize(-n_tokens);
+        int check = llama_tokenize(vocab, prompt.c_str(), prompt.size(),
+                                   prompt_tokens.data(), prompt_tokens.size(),
+                                   add_special, /*parse_special =*/true);
+        if (check != -n_tokens) {
+            printe("failed to tokenize the prompt (size mismatch)\n");
+            return -1;
+        }
+        n_tokens = check;
+    } else {
+        prompt_tokens.resize(n_tokens);
+    }
+    return n_tokens;
 }
 
 // Check if we have enough space in the context to evaluate this batch

--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -10,7 +10,7 @@
 
 #if defined(_WIN32)
 #    ifndef NOMINMAX
-#        define NOMINMAX 
+#        define NOMINMAX
 #    endif
 #    include <windows.h>
 #    include <io.h>

--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -942,12 +942,12 @@ static int apply_chat_template(const struct common_chat_templates * tmpls, Llama
 // Function to tokenize the prompt
 static int tokenize_prompt(const llama_vocab * vocab, const std::string & prompt,
                            std::vector<llama_token> & prompt_tokens, const LlamaData & llama_data) {
-    const bool add_special = llama_memory_seq_pos_max(llama_get_memory(llama_data.context.get()), 0) == 0;
-    int n_tokens = prompt.size() + 2 * add_special;
+    const bool is_first = llama_memory_seq_pos_max(llama_get_memory(llama_data.context.get()), 0) == -1;
+    int n_tokens = prompt.size() + 2 * is_first;
     prompt_tokens.resize(n_tokens);
     n_tokens = llama_tokenize(vocab, prompt.c_str(), prompt.size(),
                               prompt_tokens.data(), prompt_tokens.size(),
-                              add_special, /*parse_special =*/true);
+                              is_first, /*parse_special =*/true);
     if (n_tokens == std::numeric_limits<int32_t>::min()) {
         printe("tokenization failed: input too large\n");
         return -1;
@@ -956,7 +956,7 @@ static int tokenize_prompt(const llama_vocab * vocab, const std::string & prompt
         prompt_tokens.resize(-n_tokens);
         int check = llama_tokenize(vocab, prompt.c_str(), prompt.size(),
                                    prompt_tokens.data(), prompt_tokens.size(),
-                                   add_special, /*parse_special =*/true);
+                                   is_first, /*parse_special =*/true);
         if (check != -n_tokens) {
             printe("failed to tokenize the prompt (size mismatch)\n");
             return -1;

--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -9,6 +9,9 @@
 #include <nlohmann/json.hpp>
 
 #if defined(_WIN32)
+#    ifndef NOMINMAX
+#        define NOMINMAX 
+#    endif
 #    include <windows.h>
 #    include <io.h>
 #else


### PR DESCRIPTION
Adopted `common_tokenize` heuristic for `llama-run` to avoid double tokenization.

_Previously, for `run/run.cpp`, `llama-run` (length probing)_:
* For callers of llama_tokenize, the `llama_token *tokens` is initialize a zero sized buffer (`std::vector<llama_token> tokens for prompt_tokens` for `llama-run`)
	1. `llama_tokenize` is called the first time, where `n_tokens_max` will be set `0` (meaning that no actual result copying for `llama_vocab::impl::tokenize` will happen), only the intended size for the returning `res` will be returned, but note here the tokenization of that input is already computed once.
	2. The `prompt_tokens` (`result`) `resize()` based on the negative length generated (or rather, probed) by the first call of `llama_tokenize`
	3. Then we called `llama_tokenize` again, this time with the resized `prompt_tokens` (as `llama_token *tokens` or the `res`), we called `llama_vocab::impl::tokenize` again with the same `prompt`, but this time with the token actually saved in `*tokens`.
