### PR TITLE
Fixes for rwkv-world template and the missing inputs.use_jinja in llama-cli

### DIFF
--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -528,12 +528,17 @@ int32_t llm_chat_apply_template(
         }
     } else if (tmpl == LLM_CHAT_TEMPLATE_RWKV_WORLD) {
         // this template requires the model to have "\n\n" as EOT token
-        for (auto message : chat) {
-            std::string role(message->role);
-            if (role == "user") {
-                ss << "User: " << message->content << "\n\nAssistant:";
-            } else {
-                ss << message->content << "\n\n";
+        for (size_t i = 0; i < chat.size(); i++) {
+            std::string role(chat[i]->role);
+            if (role == "system") {
+                ss << trim(chat[i]->content) << "\n\n";
+            } else if (role == "user") {
+                ss << "User: " << trim(chat[i]->content) << "\n\n";
+                if (i == chat.size() - 1) {
+                    ss << "Assistant:";
+                }
+            } else if (role == "assistant") {
+                ss << "Assistant: " << trim(chat[i]->content) << "\n\n";
             }
         }
     } else if (tmpl == LLM_CHAT_TEMPLATE_GRANITE) {

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -531,7 +531,7 @@ int32_t llm_chat_apply_template(
         for (size_t i = 0; i < chat.size(); i++) {
             std::string role(chat[i]->role);
             if (role == "system") {
-                ss << trim(chat[i]->content) << "\n\n";
+                ss << "System: " << trim(chat[i]->content) << "\n\n";
             } else if (role == "user") {
                 ss << "User: " << trim(chat[i]->content) << "\n\n";
                 if (i == chat.size() - 1) {

--- a/tools/main/main.cpp
+++ b/tools/main/main.cpp
@@ -292,6 +292,7 @@ int main(int argc, char ** argv) {
 
             if (!params.system_prompt.empty() || !params.prompt.empty()) {
                 common_chat_templates_inputs inputs;
+                inputs.use_jinja = g_params->use_jinja;
                 inputs.messages = chat_msgs;
                 inputs.add_generation_prompt = !params.prompt.empty();
 


### PR DESCRIPTION
- Handle the `rwkv-world` chat template better
- Fix a bug where `inputs.use_jinja` is not set according to `g_params->use_jinja` in llama-cli