### PR TITLE
docs: Fix server API key doc for /props (move it to /health)

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -370,6 +370,8 @@ node index.js
 
 ### GET `/health`: Returns heath check result
 
+This endpoint is public (no API key check).
+
 **Response format**
 
 - HTTP status code 503
@@ -708,7 +710,7 @@ If the tokens are missing, then the extra context is simply prefixed at the star
 
 ### **GET** `/props`: Get server global properties.
 
-This endpoint is public (no API key check). By default, it is read-only. To make POST request to change global properties, you need to start server with `--props`
+By default, it is read-only. To make POST request to change global properties, you need to start server with `--props`
 
 **Response format**
 


### PR DESCRIPTION
I noticed that the llama-server [README](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#get-props-get-server-global-properties) alleges that `/props` has "no API key check". However, it does. For example:

```bash
./llama-server -m Qwen3-0.6B-Q8_0.gguf --api-key abc123
curl http://localhost:8080/props
```
Result:
```json
{"error":{"code":401,"message":"Invalid API Key","type":"authentication_error"}}
```
c.f. adding `-H 'Authorization: Bearer abc123'` to `curl` which then works.

Conversely, the `/health` endpoint does not require an API key, which is not noted in the docs, but which was helpful (for me) to know. So I moved that sentence of the docs in this PR.