### PR TITLE
build: refine toplevel .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ poetry.toml
 # Local scripts
 /run-vim.sh
 /run-chat.sh
+
+/prebuilts


### PR DESCRIPTION
 * [x]  I have read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
 * Self-reported review complexity:
       * [x] Low
       * [ ] Medium
       * [ ] High

     

  
### PR Description
add prebuilts in  toplevel .gitignore, this addition might-be helpful for simplify build process.

