### PR TITLE
llama : expose C API to get layer device type

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -481,6 +481,7 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_ctx_train(const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_embd     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_dev_layer  (const struct llama_model * model, int32_t il);
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -19192,6 +19192,11 @@ int32_t llama_model_n_layer(const llama_model * model) {
     return model->hparams.n_layer;
 }
 
+int32_t llama_model_dev_layer(const llama_model * model, int32_t il) {
+    ggml_backend_dev_t dev = model->dev_layer(il);
+    return static_cast<int32_t>(ggml_backend_dev_type(dev));
+}
+
 int32_t llama_model_n_head(const llama_model * model) {
     return model->hparams.n_head();
 }


### PR DESCRIPTION
llama : expose C API to get layer device type

Adds `llama_model_dev_layer(model, il)` to retrieve the backend device type (CPU, GPU, ACCEL) for a given layer. This allows consumers (e.g. Python bindings) to inspect layer placement without exposing internal structures.

Implements an `int32_t`-based interface matching the pattern of existing public API functions such as `llama_model_n_layer`.

Notes:

- Follows naming convention: llama_model_dev_layer
- Pure C-compatible API (int32_t return)
- No changes to third-party deps, no extra headers
- Scoped, focused, standalone change
- Adheres to existing formatting and structure
- Useful for inspection/debugging/perf profiling via bindings