### PR TITLE
docs: fix broken url in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ To learn more about model quantization, [read this documentation](tools/quantize
 
     </details>
 
-[^1]: [tools/perplexity/README.md](./tools/perplexity/README.md)
+[^1]: [tools/perplexity/README.md](https://github.com/ggml-org/llama.cpp/tree/master/tools/perplexity/README.md)
 [^2]: [https://huggingface.co/docs/transformers/perplexity](https://huggingface.co/docs/transformers/perplexity)
 
 ## [`llama-bench`](tools/llama-bench)


### PR DESCRIPTION
Using the full url here gives a working result, whereas the existing url is broken.
