### PR TITLE
ggml : do not output unprintable characters on GGUF load failure

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -335,7 +335,11 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
         for (uint32_t i = 0; i < magic.size(); i++) {
             if (magic[i] != GGUF_MAGIC[i]) {
-                GGML_LOG_ERROR("%s: invalid magic characters: '%c%c%c%c', expected 'GGUF'\n", __func__, magic[0], magic[1], magic[2], magic[3]);
+                char c0 = isprint(magic[0]) ? magic[0] : '?';
+                char c1 = isprint(magic[1]) ? magic[1] : '?';
+                char c2 = isprint(magic[2]) ? magic[2] : '?';
+                char c3 = isprint(magic[3]) ? magic[3] : '?';
+                GGML_LOG_ERROR("%s: invalid magic characters: '%c%c%c%c', expected 'GGUF'\n", __func__, c0, c1, c2, c3);
                 gguf_free(ctx);
                 return nullptr;
             }


### PR DESCRIPTION
On failure to load a GGUF the first four characters of the file will be output to the console, leading to all kinds of trouble depending on the characters.

This is especially important to resolve before starting to support GGUF for other kinds of data files, see https://github.com/ggml-org/llama.cpp/pull/9400#pullrequestreview-2955060828