### PR TITLE
Add Conv2d for CPU

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -482,6 +482,7 @@ extern "C" {
         GGML_OP_CONV_TRANSPOSE_1D,
         GGML_OP_IM2COL,
         GGML_OP_IM2COL_BACK,
+        GGML_OP_CONV_2D,
         GGML_OP_CONV_2D_DW,
         GGML_OP_CONV_TRANSPOSE_2D,
         GGML_OP_POOL_1D,
@@ -1812,6 +1813,17 @@ extern "C" {
             struct ggml_tensor  * a,
             struct ggml_tensor  * b,
             int                   stride);
+
+    GGML_API struct ggml_tensor * ggml_conv_2d_direct(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,   // convolution kernel [KW, KH, IC, OC]
+            struct ggml_tensor  * b,   // input data [W, H, C, N]
+            int                   s0,  // stride dimension 0
+            int                   s1,  // stride dimension 1
+            int                   p0,  // padding dimension 0
+            int                   p1,  // padding dimension 1
+            int                   d0,  // dilation dimension 0
+            int                   d1); // dilation dimension 1
 
     enum ggml_op_pool {
         GGML_OP_POOL_MAX,

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1866,6 +1866,10 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_im2col_back_f32(params, tensor);
             } break;
+        case GGML_OP_CONV_2D:
+            {
+                ggml_compute_forward_conv_2d(params, tensor);
+            } break;
         case GGML_OP_CONV_2D_DW:
             {
                 ggml_compute_forward_conv_2d_dw(params, tensor);
@@ -2228,6 +2232,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
             } break;
         case GGML_OP_IM2COL:
         case GGML_OP_IM2COL_BACK:
+        case GGML_OP_CONV_2D:
         case GGML_OP_CONV_2D_DW:
         case GGML_OP_CONV_TRANSPOSE_1D:
         case GGML_OP_CONV_TRANSPOSE_2D:

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -687,6 +687,10 @@ static void ggml_init_arm_arch_features(void) {
 
 #endif // __ARM_ARCH
 
+void ggml_compute_forward_mul_mat(
+        const struct ggml_compute_params * params,
+              struct ggml_tensor * dst);
+
 struct ggml_tensor * ggml_new_i32(struct ggml_context * ctx, int32_t value) {
     GGML_ASSERT(!ggml_get_no_alloc(ctx));
 
@@ -1193,7 +1197,7 @@ static void ggml_compute_forward_mul_mat_one_chunk(
     }
 }
 
-static void ggml_compute_forward_mul_mat(
+void ggml_compute_forward_mul_mat(
         const struct ggml_compute_params * params,
               struct ggml_tensor * dst) {
 
@@ -2750,6 +2754,12 @@ struct ggml_cplan ggml_graph_plan(
                         } else {
                             GGML_ABORT("fatal error");
                         }
+                    } break;
+                case GGML_OP_CONV_2D:
+                    {
+                        cur = GGML_IM2COL_WORK_SIZE;
+                        //Add enough space for kernel transpose
+                        cur += sizeof(ggml_fp16_t)*node->src[1]->ne[0]*node->src[1]->ne[1]*node->src[1]->ne[2]*node->src[1]->ne[3];
                     } break;
                 case GGML_OP_CONV_TRANSPOSE_2D:
                     {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -687,10 +687,6 @@ static void ggml_init_arm_arch_features(void) {
 
 #endif // __ARM_ARCH
 
-void ggml_compute_forward_mul_mat(
-        const struct ggml_compute_params * params,
-              struct ggml_tensor * dst);
-
 struct ggml_tensor * ggml_new_i32(struct ggml_context * ctx, int32_t value) {
     GGML_ASSERT(!ggml_get_no_alloc(ctx));
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2758,8 +2758,6 @@ struct ggml_cplan ggml_graph_plan(
                 case GGML_OP_CONV_2D:
                     {
                         cur = GGML_IM2COL_WORK_SIZE;
-                        //Add enough space for kernel transpose
-                        cur += sizeof(ggml_fp16_t)*node->src[1]->ne[0]*node->src[1]->ne[1]*node->src[1]->ne[2]*node->src[1]->ne[3];
                     } break;
                 case GGML_OP_CONV_TRANSPOSE_2D:
                     {

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6592,18 +6592,21 @@ static void ggml_call_mul_mat(
 
 // ggml_compute_forward_conv_2d
 
-static void ggml_compute_forward_conv_2d_f32(const ggml_compute_params * params,
-                                       ggml_tensor        * dst) {
-
-    const ggml_tensor * src    = dst->src[1];      // [W H C_in N]
-    const ggml_tensor * kernel = dst->src[0];      // [W H C_in C_out]
+static void ggml_compute_forward_conv_2d_f32(
+        const ggml_compute_params * params,
+        const ggml_tensor * kernel,  // [KW, KH, IC, OC] - fp32
+        const ggml_tensor * src,     // [W, H, C, N]
+        ggml_tensor * dst) {         // [OW, OH, OC, N]
 
     GGML_ASSERT(ggml_is_contiguous(kernel));
+    GGML_ASSERT(kernel->type == GGML_TYPE_F32);
 
-    const int32_t stride_x = dst->op_params[0];
-    const int32_t stride_y = dst->op_params[1];
-    const int32_t pad_x    = dst->op_params[2];
-    const int32_t pad_y    = dst->op_params[3];
+    const int32_t stride_x   = dst->op_params[0];
+    const int32_t stride_y   = dst->op_params[1];
+    const int32_t pad_x      = dst->op_params[2];
+    const int32_t pad_y      = dst->op_params[3];
+    const int32_t dilation_x = dst->op_params[4];
+    const int32_t dilation_y = dst->op_params[5];
 
     const int64_t c_in  = src->ne[2];
     const int64_t c_out = kernel->ne[3];
@@ -6616,168 +6619,88 @@ static void ggml_compute_forward_conv_2d_f32(const ggml_compute_params * params,
     const int64_t dst_w = dst->ne[0];
     const int64_t dst_h = dst->ne[1];
 
-
-    float * src_data = (float *) src->data;
-    float * knl_data = (float *) kernel->data;
-    float * dst_data = (      float *) dst->data;
-
+    float * src_data = (float*) src->data;
+    float * knl_data = (float*) kernel->data;
+    float * dst_data = (float*) dst->data;
 
     const int64_t knl_n           = knl_w * knl_h * c_in;
     const int64_t patch_total     = dst->ne[3] * dst_w * dst_h;
-    
 
-    
-    const int64_t space_per_patch = knl_n * sizeof(float) + patch_total * c_out * sizeof(float);
-
-    const int64_t batch_size = params->wsize / space_per_patch;
+    const int64_t space_per_patch   = knl_n * sizeof(float) + c_out * sizeof(float);
+    const int64_t batch_size        = params->wsize / space_per_patch;
     const int64_t patches_per_batch = batch_size > 8 ? (batch_size / 8) * 8 : batch_size;
-    const int64_t batch_n = (patch_total + patches_per_batch - 1) / patches_per_batch;
-
+    const int64_t batch_n           = (patch_total + patches_per_batch - 1) / patches_per_batch;
 
     GGML_ASSERT(patches_per_batch > 0 && batch_size >= 1);
 
-    float * tmp = (float *) params->wdata;          // per-thread scratch
+    float * tmp = (float *) params->wdata;
 
     for (int64_t batch_i = 0; batch_i < batch_n; ++batch_i) {
 
         const int64_t patch_start_batch = batch_i * patches_per_batch;
         const int64_t patch_end_batch   = std::min(patch_start_batch + patches_per_batch,
                                               patch_total);
-        const int64_t patch_n = patch_end_batch - patch_start_batch;
+        const int64_t patch_n           = patch_end_batch - patch_start_batch;
 
-        const int64_t patch_per_thread =
-            (patch_n + params->nth - 1) / params->nth;
-        const int64_t patch_start = patch_start_batch +
-                                    params->ith * patch_per_thread;
-        const int64_t patch_end   = std::min(patch_start + patch_per_thread,
-                                        patch_end_batch);
+        const int64_t patch_per_thread  = (patch_n + params->nth - 1) / params->nth;
+        const int64_t patch_start       = patch_start_batch + params->ith * patch_per_thread;
+        const int64_t patch_end         = std::min(patch_start + patch_per_thread,patch_end_batch);
 
         //im2col for a patch
         for (int64_t p = patch_start; p < patch_end; ++p) {
-            const int64_t  b     =  p / (dst_w * dst_h);
-            const int64_t  dy    = (p / dst_w) % dst_h;
-            const int64_t  dx    =  p % dst_w;
+            const int64_t  batch_n     =  p / (dst_w * dst_h);
+            const int64_t  src_x       = (p / dst_w) % dst_h;
+            const int64_t  src_y       =  p % dst_w;
 
-            const float  * src_base = (const float *)((char *)src_data + b * src->nb[3]);
-            float        * out_row = tmp + (p % patches_per_batch) * knl_n;
+            float * src_base = (float *)((char *)src_data + batch_n * src->nb[3]);
+            float * dst_row  = tmp + (p % patches_per_batch) * knl_n;
 
-            // Extract patch in IC,KH,KW order (same as im2col)
             for (int64_t ic = 0; ic < c_in; ++ic) {
                 for (int64_t ky = 0; ky < knl_h; ++ky) {
                     for (int64_t kx = 0; kx < knl_w; ++kx) {
-                        const int64_t sy = dy * stride_y + ky - pad_y;
-                        const int64_t sx = dx * stride_x + kx - pad_x;
-                        
+                        const int64_t sy = src_x * stride_y + ky * dilation_y - pad_y;
+                        const int64_t sx = src_y * stride_x + kx * dilation_x - pad_x;
+
                         int64_t dst_idx = ic * (knl_h * knl_w) + ky * knl_w + kx;
-                        
+
                         if (sy < 0 || sy >= src_h || sx < 0 || sx >= src_w) {
-                            out_row[dst_idx] = 0.0f;
+                            dst_row[dst_idx] = 0.0f;
                         } else {
-                            float * src_ptr = (float *)((char *)src_base + 
-                                sx * src->nb[0] + sy * src->nb[1] + ic * src->nb[2]);
-                            out_row[dst_idx] = *src_ptr;
+                            float * src_ptr = (float *)((char *)src_base + sx * src->nb[0] + sy * src->nb[1] + ic * src->nb[2]);
+                            dst_row[dst_idx] = *src_ptr;
                         }
                     }
                 }
             }
         }   // patches handled by this thread
 
-        ggml_barrier(params->threadpool);   // wait for all threads
+        ggml_barrier(params->threadpool);
 
-        //GEMM output is patch_n * cout 
         float * gemm_output = tmp + patches_per_batch * knl_n;
-        
+
         // GEMM: patches[patch_n, knl_n] × kernel[knl_n, c_out] = output[patch_n, c_out]
         ggml_call_mul_mat(params, patch_n, c_out, knl_n,
                             tmp, knl_data, gemm_output);
-        
-        // Barrier to ensure GEMM completes before permutation
+
         ggml_barrier(params->threadpool);
-        
-        // Distribute permutation work across threads
+
+
+        //permute back [OC, N, OH, OW] to [N, OC, OH, OW]
         const int64_t permute_per_thread = (patch_n + params->nth - 1) / params->nth;
         const int64_t permute_start = params->ith * permute_per_thread;
         const int64_t permute_end = std::min(permute_start + permute_per_thread, patch_n);
-        
-        // Each thread handles part of the permutation from [patch_n, c_out] to WHCN layout
+
         for (int64_t i = permute_start; i < permute_end; ++i) {
-            const int64_t p = patch_start_batch + i;
-            const int64_t b  = p / (dst_w * dst_h);         // batch index
-            const int64_t dy = (p / dst_w) % dst_h;         // height index  
-            const int64_t dx = p % dst_w;                   // width index
-            
-            // Copy all channels for this spatial position
+            const int64_t p       = patch_start_batch + i;
+            const int64_t batch_n = p / (dst_w * dst_h);
+            const int64_t dst_y   = (p / dst_w) % dst_h;
+            const int64_t dst_x   = p % dst_w;
+
             for (int64_t oc = 0; oc < c_out; ++oc) {
                 const float value = gemm_output[i * c_out + oc];
                 // Write to WHCN layout: dst[w, h, c, n]
-                float * dst_ptr = (float *)((char *)dst_data + 
-                    dx * dst->nb[0] + dy * dst->nb[1] + oc * dst->nb[2] + b * dst->nb[3]);
+                float * dst_ptr = (float *)((char *)dst_data + dst_x * dst->nb[0] + dst_y * dst->nb[1] + oc * dst->nb[2] + batch_n * dst->nb[3]);
                 *dst_ptr = value;
-            }
-        }
-    }
-}
-
-static void ggml_compute_forward_conv_2d_f16(
-        const ggml_compute_params * params,
-        const ggml_tensor * kernel,  // [KW, KH, IC, OC]
-        const ggml_tensor * src,     // [W, H, C, N]
-        ggml_tensor * dst) {         // [OW, OH, OC, N]
-
-    const int32_t s0 = ggml_get_op_params_i32(dst, 0);
-    const int32_t s1 = ggml_get_op_params_i32(dst, 1);
-    const int32_t p0 = ggml_get_op_params_i32(dst, 2);
-    const int32_t p1 = ggml_get_op_params_i32(dst, 3);
-    const int32_t d0 = ggml_get_op_params_i32(dst, 4);
-    const int32_t d1 = ggml_get_op_params_i32(dst, 5);
-
-    const int64_t OW = dst->ne[0];
-    const int64_t OH = dst->ne[1];
-    const int64_t OC = dst->ne[2];
-    const int64_t N  = dst->ne[3];
-
-    const int64_t IW = src->ne[0];
-    const int64_t IH = src->ne[1];
-    const int64_t IC = src->ne[2];
-
-    const int64_t KW = kernel->ne[0];
-    const int64_t KH = kernel->ne[1];
-
-    const ggml_fp16_t * kernel_data = (const ggml_fp16_t *)kernel->data;
-    const ggml_fp16_t * src_data    = (const ggml_fp16_t *)src->data;
-    ggml_fp16_t       * dst_data    = (ggml_fp16_t       *)dst->data;
-
-    const int64_t rows_total = OH * N;
-    const int64_t rows_per_thread = (rows_total + params->nth - 1) / params->nth;
-    const int64_t row_start = params->ith * rows_per_thread;
-    const int64_t row_end = MIN(row_start + rows_per_thread, rows_total);
-
-    for (int64_t row = row_start; row < row_end; ++row) {
-        const int64_t oh = row % OH;
-        const int64_t n  = row / OH;
-        const ggml_fp16_t * src_batch = src_data + n * IW * IH * IC;
-
-        for (int64_t ow = 0; ow < OW; ++ow) {
-            for (int64_t oc = 0; oc < OC; ++oc) {
-                float sum = 0.0f;
-                const ggml_fp16_t * kernel_channel = kernel_data + oc * KW * KH * IC;
-                for (int64_t kh = 0; kh < KH; ++kh) {
-                    const int64_t ih = oh * s1 - p1 + kh * d1;
-                    if (ih < 0 || ih >= IH) continue;
-
-                    for (int64_t kw = 0; kw < KW; ++kw) {
-                        const int64_t iw = ow * s0 - p0 + kw * d0;
-                        if (iw < 0 || iw >= IW) continue;
-
-                        for (int64_t ic = 0; ic < IC; ++ic) {
-                            const ggml_fp16_t * kernel_ptr = kernel_channel + (kh * KW + kw) + ic * KW * KH;
-                            const ggml_fp16_t * src_ptr = src_batch + (ih * IW + iw) + ic * IW * IH;
-                            sum += GGML_FP16_TO_FP32(*kernel_ptr) * GGML_FP16_TO_FP32(*src_ptr);
-                        }
-                    }
-                }
-
-                dst_data[((n * OC + oc) * OH + oh) * OW + ow] = GGML_FP32_TO_FP16(sum);
             }
         }
     }
@@ -6790,19 +6713,10 @@ void ggml_compute_forward_conv_2d(
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
 
-    switch (src0->type) {
-        case GGML_TYPE_F16:
-            {
-                ggml_compute_forward_conv_2d_f16(params, src0, src1, dst);
-            } break;
-        case GGML_TYPE_F32:
-            {
-                ggml_compute_forward_conv_2d_f32(params, dst);
-            } break;
-        default:
-            {
-                GGML_ABORT("fatal error");
-            }
+    if (src0->type == GGML_TYPE_F16) {
+        GGML_ASSERT(false && "F16 not supported yet");
+    } else {
+        ggml_compute_forward_conv_2d_f32(params, src0, src1, dst);
     }
 }
 

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6645,7 +6645,7 @@ static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params
 
         const int64_t patch_per_thread  = (patch_n + params->nth - 1) / params->nth;
         const int64_t patch_start       = patch_start_batch + params->ith * patch_per_thread;
-        const int64_t patch_end         = std::min(patch_start + patch_per_thread,patch_end_batch);
+        const int64_t patch_end         = std::min(patch_start + patch_per_thread, patch_end_batch);
 
         //im2col for a patch
         for (int64_t p = patch_start; p < patch_end; ++p) {
@@ -6686,6 +6686,8 @@ static void ggml_compute_forward_conv_2d_impl(const ggml_compute_params * params
         ggml_barrier(params->threadpool);
 
         float * gemm_output = (float *) ((char *) tmp + patches_per_batch * knl_n * traits->type_size);
+
+        GGML_ASSERT(gemm_output + patch_n * c_out <= (float*)tmp + params->wsize);
 
         // GEMM: patches[patch_n, knl_n] × kernel[knl_n, c_out] = output[patch_n, c_out]
         ggml_call_mul_mat(kernel_type, params, patch_n, c_out, knl_n, tmp, knl_data, gemm_output);

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6545,6 +6545,163 @@ void ggml_compute_forward_im2col_back_f32(
     }
 }
 
+// ggml_compute_forward_conv_2d
+
+static void ggml_compute_forward_conv_2d_f32(
+        const ggml_compute_params * params,
+        const ggml_tensor * kernel,  // [KW, KH, IC, OC]
+        const ggml_tensor * src,     // [W, H, C, N]
+        ggml_tensor * dst) {         // [OW, OH, OC, N]
+
+    const int32_t s0 = ggml_get_op_params_i32(dst, 0);
+    const int32_t s1 = ggml_get_op_params_i32(dst, 1);
+    const int32_t p0 = ggml_get_op_params_i32(dst, 2);
+    const int32_t p1 = ggml_get_op_params_i32(dst, 3);
+    const int32_t d0 = ggml_get_op_params_i32(dst, 4);
+    const int32_t d1 = ggml_get_op_params_i32(dst, 5);
+
+    const int64_t OW = dst->ne[0];
+    const int64_t OH = dst->ne[1];
+    const int64_t OC = dst->ne[2];
+    const int64_t N  = dst->ne[3];
+
+    const int64_t IW = src->ne[0];
+    const int64_t IH = src->ne[1];
+    const int64_t IC = src->ne[2];
+
+    const int64_t KW = kernel->ne[0];
+    const int64_t KH = kernel->ne[1];
+
+    const float * kernel_data = (const float *)kernel->data;
+    const float * src_data    = (const float *)src->data;
+    float       * dst_data    = (float       *)dst->data;
+
+    const int64_t rows_total = OH * N;
+    const int64_t rows_per_thread = (rows_total + params->nth - 1) / params->nth;
+    const int64_t row_start = params->ith * rows_per_thread;
+    const int64_t row_end = MIN(row_start + rows_per_thread, rows_total);
+
+    for (int64_t row = row_start; row < row_end; ++row) {
+        const int64_t oh = row % OH;
+        const int64_t n  = row / OH;
+        const float * src_batch = src_data + n * IW * IH * IC;
+
+        for (int64_t ow = 0; ow < OW; ++ow) {
+            for (int64_t oc = 0; oc < OC; ++oc) {
+                float sum = 0.0f;
+                const float * kernel_channel = kernel_data + oc * KW * KH * IC;
+
+                for (int64_t kh = 0; kh < KH; ++kh) {
+                    const int64_t ih = oh * s1 - p1 + kh * d1;
+                    if (ih < 0 || ih >= IH) continue;
+
+                    for (int64_t kw = 0; kw < KW; ++kw) {
+                        const int64_t iw = ow * s0 - p0 + kw * d0;
+                        if (iw < 0 || iw >= IW) continue;
+
+                        #pragma omp simd
+                        for (int64_t ic = 0; ic < IC; ++ic) {
+                            const float * kernel_ptr = kernel_channel + (kh * KW + kw) + ic * KW * KH;
+                            const float * src_ptr = src_batch + (ih * IW + iw) + ic * IW * IH;
+                            sum += (*kernel_ptr) * (*src_ptr);
+                        }
+                    }
+                }
+
+                dst_data[((n * OC + oc) * OH + oh) * OW + ow] = sum;
+            }
+        }
+    }
+}
+
+static void ggml_compute_forward_conv_2d_f16(
+        const ggml_compute_params * params,
+        const ggml_tensor * kernel,  // [KW, KH, IC, OC]
+        const ggml_tensor * src,     // [W, H, C, N]
+        ggml_tensor * dst) {         // [OW, OH, OC, N]
+
+    const int32_t s0 = ggml_get_op_params_i32(dst, 0);
+    const int32_t s1 = ggml_get_op_params_i32(dst, 1);
+    const int32_t p0 = ggml_get_op_params_i32(dst, 2);
+    const int32_t p1 = ggml_get_op_params_i32(dst, 3);
+    const int32_t d0 = ggml_get_op_params_i32(dst, 4);
+    const int32_t d1 = ggml_get_op_params_i32(dst, 5);
+
+    const int64_t OW = dst->ne[0];
+    const int64_t OH = dst->ne[1];
+    const int64_t OC = dst->ne[2];
+    const int64_t N  = dst->ne[3];
+
+    const int64_t IW = src->ne[0];
+    const int64_t IH = src->ne[1];
+    const int64_t IC = src->ne[2];
+
+    const int64_t KW = kernel->ne[0];
+    const int64_t KH = kernel->ne[1];
+
+    const ggml_fp16_t * kernel_data = (const ggml_fp16_t *)kernel->data;
+    const ggml_fp16_t * src_data    = (const ggml_fp16_t *)src->data;
+    ggml_fp16_t       * dst_data    = (ggml_fp16_t       *)dst->data;
+
+    const int64_t rows_total = OH * N;
+    const int64_t rows_per_thread = (rows_total + params->nth - 1) / params->nth;
+    const int64_t row_start = params->ith * rows_per_thread;
+    const int64_t row_end = MIN(row_start + rows_per_thread, rows_total);
+
+    for (int64_t row = row_start; row < row_end; ++row) {
+        const int64_t oh = row % OH;
+        const int64_t n  = row / OH;
+        const ggml_fp16_t * src_batch = src_data + n * IW * IH * IC;
+
+        for (int64_t ow = 0; ow < OW; ++ow) {
+            for (int64_t oc = 0; oc < OC; ++oc) {
+                float sum = 0.0f;
+                const ggml_fp16_t * kernel_channel = kernel_data + oc * KW * KH * IC;
+                for (int64_t kh = 0; kh < KH; ++kh) {
+                    const int64_t ih = oh * s1 - p1 + kh * d1;
+                    if (ih < 0 || ih >= IH) continue;
+
+                    for (int64_t kw = 0; kw < KW; ++kw) {
+                        const int64_t iw = ow * s0 - p0 + kw * d0;
+                        if (iw < 0 || iw >= IW) continue;
+
+                        for (int64_t ic = 0; ic < IC; ++ic) {
+                            const ggml_fp16_t * kernel_ptr = kernel_channel + (kh * KW + kw) + ic * KW * KH;
+                            const ggml_fp16_t * src_ptr = src_batch + (ih * IW + iw) + ic * IW * IH;
+                            sum += GGML_FP16_TO_FP32(*kernel_ptr) * GGML_FP16_TO_FP32(*src_ptr);
+                        }
+                    }
+                }
+
+                dst_data[((n * OC + oc) * OH + oh) * OW + ow] = GGML_FP32_TO_FP16(sum);
+            }
+        }
+    }
+}
+
+void ggml_compute_forward_conv_2d(
+        const ggml_compute_params * params,
+        ggml_tensor * dst) {
+
+    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor * src1 = dst->src[1];
+
+    switch (src0->type) {
+        case GGML_TYPE_F16:
+            {
+                ggml_compute_forward_conv_2d_f16(params, src0, src1, dst);
+            } break;
+        case GGML_TYPE_F32:
+            {
+                ggml_compute_forward_conv_2d_f32(params, src0, src1, dst);
+            } break;
+        default:
+            {
+                GGML_ABORT("fatal error");
+            }
+    }
+}
+
 // ggml_compute_forward_conv_transpose_2d
 
 void ggml_compute_forward_conv_transpose_2d(

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -3,6 +3,7 @@
 #include "ggml-cpu.h"
 #include "ggml-impl.h"
 #include "binary-ops.h"
+#include "ggml.h"
 #include "unary-ops.h"
 #include "vec.h"
 
@@ -6545,70 +6546,173 @@ void ggml_compute_forward_im2col_back_f32(
     }
 }
 
+static void ggml_call_mul_mat(
+    const ggml_compute_params * params,
+    int64_t m, int64_t n, int64_t k,
+    void * a, void * b, void * c) {
+
+    struct ggml_tensor src1 = {};
+    src1.ne[0] = k;
+    src1.ne[1] = m;
+    src1.ne[2] = 1;
+    src1.ne[3] = 1;
+    src1.nb[0] = sizeof(float);
+    src1.nb[1] = k * sizeof(float);
+    src1.nb[2] = src1.nb[1];
+    src1.nb[3] = src1.nb[2];
+    src1.data  = a;
+
+    struct ggml_tensor src0 = {};
+    src0.ne[0] = k;
+    src0.ne[1] = n;
+    src0.ne[2] = 1;
+    src0.ne[3] = 1;
+    src0.nb[0] = sizeof(float);
+    src0.nb[1] = k * sizeof(float);
+    src0.nb[2] = src0.nb[1];
+    src0.nb[3] = src0.nb[2];
+    src0.data  = b;
+
+    struct ggml_tensor dst = {};
+    dst.ne[0] = n;
+    dst.ne[1] = m;
+    dst.ne[2] = 1;
+    dst.ne[3] = 1;
+    dst.nb[0] = sizeof(float);
+    dst.nb[1] = n * sizeof(float);
+    dst.nb[2] = dst.nb[1];
+    dst.nb[3] = dst.nb[2];
+    dst.data  = c;
+    dst.src[0] = &src0;
+    dst.src[1] = &src1;
+
+    ggml_compute_forward_mul_mat(params, &dst);
+}
+
+
 // ggml_compute_forward_conv_2d
 
-static void ggml_compute_forward_conv_2d_f32(
-        const ggml_compute_params * params,
-        const ggml_tensor * kernel,  // [KW, KH, IC, OC]
-        const ggml_tensor * src,     // [W, H, C, N]
-        ggml_tensor * dst) {         // [OW, OH, OC, N]
+static void ggml_compute_forward_conv_2d_f32(const ggml_compute_params * params,
+                                       ggml_tensor        * dst) {
 
-    const int32_t s0 = ggml_get_op_params_i32(dst, 0);
-    const int32_t s1 = ggml_get_op_params_i32(dst, 1);
-    const int32_t p0 = ggml_get_op_params_i32(dst, 2);
-    const int32_t p1 = ggml_get_op_params_i32(dst, 3);
-    const int32_t d0 = ggml_get_op_params_i32(dst, 4);
-    const int32_t d1 = ggml_get_op_params_i32(dst, 5);
+    const ggml_tensor * src    = dst->src[1];      // [W H C_in N]
+    const ggml_tensor * kernel = dst->src[0];      // [W H C_in C_out]
 
-    const int64_t OW = dst->ne[0];
-    const int64_t OH = dst->ne[1];
-    const int64_t OC = dst->ne[2];
-    const int64_t N  = dst->ne[3];
+    GGML_ASSERT(ggml_is_contiguous(kernel));
 
-    const int64_t IW = src->ne[0];
-    const int64_t IH = src->ne[1];
-    const int64_t IC = src->ne[2];
+    const int32_t stride_x = dst->op_params[0];
+    const int32_t stride_y = dst->op_params[1];
+    const int32_t pad_x    = dst->op_params[2];
+    const int32_t pad_y    = dst->op_params[3];
 
-    const int64_t KW = kernel->ne[0];
-    const int64_t KH = kernel->ne[1];
+    const int64_t c_in  = src->ne[2];
+    const int64_t c_out = kernel->ne[3];
+    GGML_ASSERT(c_in == kernel->ne[2]);
 
-    const float * kernel_data = (const float *)kernel->data;
-    const float * src_data    = (const float *)src->data;
-    float       * dst_data    = (float       *)dst->data;
+    const int64_t src_w = src->ne[0];
+    const int64_t src_h = src->ne[1];
+    const int64_t knl_w = kernel->ne[0];
+    const int64_t knl_h = kernel->ne[1];
+    const int64_t dst_w = dst->ne[0];
+    const int64_t dst_h = dst->ne[1];
 
-    const int64_t rows_total = OH * N;
-    const int64_t rows_per_thread = (rows_total + params->nth - 1) / params->nth;
-    const int64_t row_start = params->ith * rows_per_thread;
-    const int64_t row_end = MIN(row_start + rows_per_thread, rows_total);
 
-    for (int64_t row = row_start; row < row_end; ++row) {
-        const int64_t oh = row % OH;
-        const int64_t n  = row / OH;
-        const float * src_batch = src_data + n * IW * IH * IC;
+    float * src_data = (float *) src->data;
+    float * knl_data = (float *) kernel->data;
+    float * dst_data = (      float *) dst->data;
 
-        for (int64_t ow = 0; ow < OW; ++ow) {
-            for (int64_t oc = 0; oc < OC; ++oc) {
-                float sum = 0.0f;
-                const float * kernel_channel = kernel_data + oc * KW * KH * IC;
 
-                for (int64_t kh = 0; kh < KH; ++kh) {
-                    const int64_t ih = oh * s1 - p1 + kh * d1;
-                    if (ih < 0 || ih >= IH) continue;
+    const int64_t knl_n           = knl_w * knl_h * c_in;
+    const int64_t patch_total     = dst->ne[3] * dst_w * dst_h;
+    
 
-                    for (int64_t kw = 0; kw < KW; ++kw) {
-                        const int64_t iw = ow * s0 - p0 + kw * d0;
-                        if (iw < 0 || iw >= IW) continue;
+    
+    const int64_t space_per_patch = knl_n * sizeof(float) + patch_total * c_out * sizeof(float);
 
-                        #pragma omp simd
-                        for (int64_t ic = 0; ic < IC; ++ic) {
-                            const float * kernel_ptr = kernel_channel + (kh * KW + kw) + ic * KW * KH;
-                            const float * src_ptr = src_batch + (ih * IW + iw) + ic * IW * IH;
-                            sum += (*kernel_ptr) * (*src_ptr);
+    const int64_t batch_size = params->wsize / space_per_patch;
+    const int64_t patches_per_batch = batch_size > 8 ? (batch_size / 8) * 8 : batch_size;
+    const int64_t batch_n = (patch_total + patches_per_batch - 1) / patches_per_batch;
+
+
+    GGML_ASSERT(patches_per_batch > 0 && batch_size >= 1);
+
+    float * tmp = (float *) params->wdata;          // per-thread scratch
+
+    for (int64_t batch_i = 0; batch_i < batch_n; ++batch_i) {
+
+        const int64_t patch_start_batch = batch_i * patches_per_batch;
+        const int64_t patch_end_batch   = std::min(patch_start_batch + patches_per_batch,
+                                              patch_total);
+        const int64_t patch_n = patch_end_batch - patch_start_batch;
+
+        const int64_t patch_per_thread =
+            (patch_n + params->nth - 1) / params->nth;
+        const int64_t patch_start = patch_start_batch +
+                                    params->ith * patch_per_thread;
+        const int64_t patch_end   = std::min(patch_start + patch_per_thread,
+                                        patch_end_batch);
+
+        //im2col for a patch
+        for (int64_t p = patch_start; p < patch_end; ++p) {
+            const int64_t  b     =  p / (dst_w * dst_h);
+            const int64_t  dy    = (p / dst_w) % dst_h;
+            const int64_t  dx    =  p % dst_w;
+
+            const float  * src_base = (const float *)((char *)src_data + b * src->nb[3]);
+            float        * out_row = tmp + (p % patches_per_batch) * knl_n;
+
+            // Extract patch in IC,KH,KW order (same as im2col)
+            for (int64_t ic = 0; ic < c_in; ++ic) {
+                for (int64_t ky = 0; ky < knl_h; ++ky) {
+                    for (int64_t kx = 0; kx < knl_w; ++kx) {
+                        const int64_t sy = dy * stride_y + ky - pad_y;
+                        const int64_t sx = dx * stride_x + kx - pad_x;
+                        
+                        int64_t dst_idx = ic * (knl_h * knl_w) + ky * knl_w + kx;
+                        
+                        if (sy < 0 || sy >= src_h || sx < 0 || sx >= src_w) {
+                            out_row[dst_idx] = 0.0f;
+                        } else {
+                            float * src_ptr = (float *)((char *)src_base + 
+                                sx * src->nb[0] + sy * src->nb[1] + ic * src->nb[2]);
+                            out_row[dst_idx] = *src_ptr;
                         }
                     }
                 }
+            }
+        }   // patches handled by this thread
 
-                dst_data[((n * OC + oc) * OH + oh) * OW + ow] = sum;
+        ggml_barrier(params->threadpool);   // wait for all threads
+
+        //GEMM output is patch_n * cout 
+        float * gemm_output = tmp + patches_per_batch * knl_n;
+        
+        // GEMM: patches[patch_n, knl_n] × kernel[knl_n, c_out] = output[patch_n, c_out]
+        ggml_call_mul_mat(params, patch_n, c_out, knl_n,
+                            tmp, knl_data, gemm_output);
+        
+        // Barrier to ensure GEMM completes before permutation
+        ggml_barrier(params->threadpool);
+        
+        // Distribute permutation work across threads
+        const int64_t permute_per_thread = (patch_n + params->nth - 1) / params->nth;
+        const int64_t permute_start = params->ith * permute_per_thread;
+        const int64_t permute_end = std::min(permute_start + permute_per_thread, patch_n);
+        
+        // Each thread handles part of the permutation from [patch_n, c_out] to WHCN layout
+        for (int64_t i = permute_start; i < permute_end; ++i) {
+            const int64_t p = patch_start_batch + i;
+            const int64_t b  = p / (dst_w * dst_h);         // batch index
+            const int64_t dy = (p / dst_w) % dst_h;         // height index  
+            const int64_t dx = p % dst_w;                   // width index
+            
+            // Copy all channels for this spatial position
+            for (int64_t oc = 0; oc < c_out; ++oc) {
+                const float value = gemm_output[i * c_out + oc];
+                // Write to WHCN layout: dst[w, h, c, n]
+                float * dst_ptr = (float *)((char *)dst_data + 
+                    dx * dst->nb[0] + dy * dst->nb[1] + oc * dst->nb[2] + b * dst->nb[3]);
+                *dst_ptr = value;
             }
         }
     }
@@ -6693,7 +6797,7 @@ void ggml_compute_forward_conv_2d(
             } break;
         case GGML_TYPE_F32:
             {
-                ggml_compute_forward_conv_2d_f32(params, src0, src1, dst);
+                ggml_compute_forward_conv_2d_f32(params, dst);
             } break;
         default:
             {

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -20,6 +20,9 @@
 
 static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 
+// Work buffer size for im2col operations in CONV2D
+#define GGML_IM2COL_WORK_SIZE (16 * 1024 * 1024)  // 16MB work buffer
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -108,6 +111,7 @@ void ggml_compute_forward_custom(const struct ggml_compute_params * params, stru
 void ggml_compute_forward_cross_entropy_loss(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_cross_entropy_loss_back(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_opt_step_adamw(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_mul_mat(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -21,7 +21,7 @@
 static const size_t CACHE_LINE_SIZE_F32 = CACHE_LINE_SIZE/sizeof(float);
 
 // Work buffer size for im2col operations in CONV2D
-#define GGML_IM2COL_WORK_SIZE (16 * 1024 * 1024)  // 16MB work buffer
+#define GGML_IM2COL_WORK_SIZE (16 * 1024 * 1024)
 
 #ifdef __cplusplus
 extern "C" {

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -65,6 +65,7 @@ void ggml_compute_forward_clamp(const struct ggml_compute_params * params, struc
 void ggml_compute_forward_conv_transpose_1d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_im2col(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_im2col_back_f32(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_conv_2d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_conv_transpose_2d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_conv_2d_dw(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_pool_1d(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4306,7 +4306,7 @@ struct ggml_tensor * ggml_conv_2d_direct(
         int                   d1) {// dilation dimension 1
 
     GGML_ASSERT(a->ne[2] == b->ne[2]);
-    GGML_ASSERT(a->type == b->type);
+    //GGML_ASSERT(a->type == b->type);
 
     int64_t ne[4];
     ne[0] = ggml_calc_conv_output_size(b->ne[0], a->ne[0], s0, p0, d0);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -945,6 +945,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "CONV_TRANSPOSE_1D",
     "IM2COL",
     "IM2COL_BACK",
+    "CONV_2D",
     "CONV_2D_DW",
     "CONV_TRANSPOSE_2D",
     "POOL_1D",

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -987,7 +987,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "GLU",
 };
 
-static_assert(GGML_OP_COUNT == 85, "GGML_OP_COUNT != 85");
+static_assert(GGML_OP_COUNT == 86, "GGML_OP_COUNT != 86");
 
 static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "none",
@@ -1087,7 +1087,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "glu(x)",
 };
 
-static_assert(GGML_OP_COUNT == 85, "GGML_OP_COUNT != 85");
+static_assert(GGML_OP_COUNT == 86, "GGML_OP_COUNT != 86");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,6 +195,7 @@ endif()
 # llama_build_and_test(test-opt.cpp) # SLOW
 llama_build_and_test(test-gguf.cpp)
 llama_build_and_test(test-backend-ops.cpp)
+llama_build_and_test(test_conv2d_comparison.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
 llama_build_and_test(test-autorelease.cpp        LABEL "model")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,7 +195,6 @@ endif()
 # llama_build_and_test(test-opt.cpp) # SLOW
 llama_build_and_test(test-gguf.cpp)
 llama_build_and_test(test-backend-ops.cpp)
-llama_build_and_test(test_conv2d_comparison.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
 llama_build_and_test(test-autorelease.cpp        LABEL "model")


### PR DESCRIPTION
Follow up #14320, added a tilled Im2col + GEMM approach for kernels upon @Acly's excellent suggestion. This is inspired from his branch which does the CHWN conv, this one does the WHCN one, which is a bit different. ~~Only works for F32~~, but sizeable speedups. I will work on the f16 version as well, but putting this up for review
<details>
  <summary> Performance </summary>

| Input Size | Kernel | Config | IM2COL (ms) | SIMD (ms) | Speedup | Match | Type |
|------------|--------|--------|-------------|-----------|---------|-------|------|
| 224x224x3 | 7x7x3→64 | s2 p3 | 11.988 |  8.594 |  1.39x SIMD | ✅ | F32 |
| 56x56x64 | 1x1x64→64 | s1 p0 |  1.491 |  1.149 |  1.30x SIMD | ✅ | F32 |
| 56x56x64 | 3x3x64→64 | s1 p1 |  6.683 |  3.417 |  1.96x SIMD | ✅ | F32 |
| 56x56x64 | 1x1x64→256 | s1 p0 |  4.056 |  1.672 |  2.43x SIMD | ✅ | F32 |
| 28x28x256 | 1x1x256→128 | s1 p0 |  1.162 |  0.865 |  1.34x SIMD | ✅ | F32 |
| 28x28x128 | 3x3x128→128 | s1 p1 |  3.376 |  1.403 |  2.41x SIMD | ✅ | F32 |
| 28x28x128 | 1x1x128→512 | s1 p0 |  2.010 |  1.407 |  1.43x SIMD | ✅ | F32 |
| 14x14x512 | 1x1x512→256 | s1 p0 |  0.699 |  0.482 |  1.45x SIMD | ✅ | F32 |
| 14x14x256 | 3x3x256→256 | s1 p1 |  2.260 |  1.043 |  2.17x SIMD | ✅ | F32 |
| 14x14x256 | 1x1x256→1024 | s1 p0 |  1.347 |  1.099 |  1.23x SIMD | ✅ | F32 |
| 7x7x1024 | 1x1x1024→512 | s1 p0 |  0.654 |  0.369 |  1.77x SIMD | ✅ | F32 |
| 7x7x512 | 3x3x512→512 | s1 p1 |  2.564 |  1.044 |  2.46x SIMD | ✅ | F32 |
| 7x7x512 | 1x1x512→2048 | s1 p0 |  1.612 |  0.855 |  1.89x SIMD | ✅ | F32 |
| 224x224x3 | 3x3x3→64 | s1 p1 | 23.499 | 25.072 |  0.97 SIMD | ✅ | F32 |
| 224x224x16 | 3x3x16→64 | s1 p1 | 34.263 | 24.667 |  1.39x SIMD | ✅ | F32 |
| 112x112x64 | 3x3x64→128 | s1 p1 | 30.443 | 15.720 |  1.94x SIMD | ✅ | F32 |
| 112x112x16 | 3x3x16→16 | s1 p1 |  7.382 |  1.543 |  4.78x SIMD | ✅ | F32 |
| 56x56x128 | 3x3x128→256 | s1 p1 | 18.871 |  8.376 |  2.25x SIMD | ✅ | F32 |
| 56x56x256 | 3x3x256→256 | s1 p1 | 34.579 | 16.293 |  2.12x SIMD | ✅ | F32 |
| 28x28x256 | 3x3x256→512 | s1 p1 | 13.815 |  9.819 |  1.41x SIMD | ✅ | F32 |
| 28x28x512 | 3x3x512→512 | s1 p1 | 26.577 | 15.285 |  1.74x SIMD | ✅ | F32 |
| 112x112x32 | 3x3x32→32 | s1 p1 | 12.815 |  4.811 |  2.66x SIMD | ✅ | F32 |
| 112x112x32 | 1x1x32→64 | s1 p0 |  4.261 |  2.128 |  2.00x SIMD | ✅ | F32 |
| 56x56x64 | 1x1x64→128 | s1 p0 |  2.268 |  1.243 |  1.82x SIMD | ✅ | F32 |
| 28x28x128 | 1x1x128→256 | s1 p0 |  1.241 |  0.969 |  1.28x SIMD | ✅ | F32 |
| 224x224x3 | 3x3x3→32 | s2 p1 |  3.636 |  2.232 |  1.63x SIMD | ✅ | F32 |
| 112x112x16 | 3x3x16→96 | s1 p1 | 11.007 |  4.500 |  2.45x SIMD | ✅ | F32 |
| 112x112x24 | 1x1x24→14 | s1 p0 |  1.897 |  0.997 |  1.90x SIMD | ✅ | F32 |
| 56x56x40 | 1x1x40→24 | s1 p0 |  0.676 |  0.287 |  2.36x SIMD | ✅ | F32 |
| 56x56x96 | 7x7x96→96 | s1 p3 | 52.281 | 20.812 |  2.51x SIMD | ✅ | F32 |
| 28x28x192 | 7x7x192→192 | s1 p3 | 28.765 | 12.747 |  2.26x SIMD | ✅ | F32 |
| 14x14x384 | 7x7x384→384 | s1 p3 | 20.449 | 11.509 |  1.78x SIMD | ✅ | F32 |
| 224x224x3 | 3x3x3→64 | s1 p1 | 110.537 | 78.612 |  1.41x SIMD | ✅ | F32 |
| 56x56x64 | 3x3x64→64 | s1 p1 | 26.656 |  8.599 |  3.10x SIMD | ✅ | F32 |
| 28x28x128 | 1x1x128→64 | s1 p0 |  3.096 |  0.831 |  3.73x SIMD | ✅ | F32 |
| 512x512x3 | 3x3x3→1 | s1 p0 | 22.431 |  8.468 |  2.65x SIMD | ✅ | F32 |
| 256x512x3 | 3x3x3→9 | s1 p0 | 16.887 |  9.996 |  1.69x SIMD | ✅ | F32 |
| 896x896x1 | 3x3x1→1 | s1 p0 | 32.143 | 11.903 |  2.70x SIMD | ✅ | F32 |
| 224x224x3 | 3x3x3→768 | s1 p1 | 218.972 | 201.482 |  1.09x SIMD | ✅ | F32 | 
</details>

EDIT: added f16 version also