### PR TITLE
llama : return mistral-v7-tekken as default template only

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -14377,7 +14377,7 @@ const char * llama_model_chat_template(const llama_model * model, const char * n
         // do not extend this list unless absolutely necessary
         // Mistral-Small-2503 does not have built-in chat template
         llama_vocab_pre_type pre_type = model->vocab.get_pre_type();
-        if (pre_type == LLAMA_VOCAB_PRE_TYPE_TEKKEN && model->layers.size() == 40) {
+        if (!name && pre_type == LLAMA_VOCAB_PRE_TYPE_TEKKEN && model->layers.size() == 40) {
             return "mistral-v7-tekken";
         }
 


### PR DESCRIPTION
Do not return `mistral-v7-tekken` when `common_chat_templates_init` asks for `tool_use` template.

Fixes #14383
Adresses https://github.com/ggml-org/llama.cpp/pull/14148#discussion_r2144626716