### PR TITLE
ggml : add pointer to attach user data

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -623,9 +623,10 @@ extern "C" {
 
         char name[GGML_MAX_NAME];
 
-        void * extra; // extra things e.g. for ggml-cuda.cu
+        void * extra; // extra things for the backend e.g. for ggml-cuda.cu
+        void * user; // extra things for the user e.g. for python or node bindings
 
-        char padding[8];
+        char padding[0];
     };
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);


### PR DESCRIPTION
I am working on node bindings for ggml and need a way to attach user data to a tensor object. Right now there is an extra pointer, but that's utilized by backends.