### PR TITLE
Add explanation to --no-mmap in llama server

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -69,7 +69,7 @@ The project is under active development, and we are [looking for feedback and co
 | `-dt, --defrag-thold N` | KV cache defragmentation threshold (default: 0.1, < 0 - disabled)<br/>(env: LLAMA_ARG_DEFRAG_THOLD) |
 | `-np, --parallel N` | number of parallel sequences to decode (default: 1)<br/>(env: LLAMA_ARG_N_PARALLEL) |
 | `--mlock` | force system to keep model in RAM rather than swapping or compressing<br/>(env: LLAMA_ARG_MLOCK) |
-| `--no-mmap` | do not memory-map model (slower load but may reduce pageouts if not using mlock)<br/>(env: LLAMA_ARG_NO_MMAP) |
+| `--no-mmap` | do not memory-map model (slower load but may reduce pageouts if not using mlock; if all layers are offloaded to a GPU and RAM < VRAM, this actually makes loading faster)<br/>(env: LLAMA_ARG_NO_MMAP) |
 | `--numa TYPE` | attempt optimizations that help on some NUMA systems<br/>- distribute: spread execution evenly over all nodes<br/>- isolate: only spawn threads on CPUs on the node that execution started on<br/>- numactl: use the CPU map provided by numactl<br/>if run without this previously, it is recommended to drop the system page cache before using this<br/>see https://github.com/ggml-org/llama.cpp/issues/1437<br/>(env: LLAMA_ARG_NUMA) |
 | `-dev, --device <dev1,dev2,..>` | comma-separated list of devices to use for offloading (none = don't offload)<br/>use --list-devices to see a list of available devices<br/>(env: LLAMA_ARG_DEVICE) |
 | `--list-devices` | print list of available devices and exit |


### PR DESCRIPTION
mmap actually slows down data loading if all layers are offloaded to the GPU and VRAM < RAM. I tested this using an A100 and Gemma3, and these are the results:

| RAM | mmap | load time |
| ---- | --------- | --------- 
| 40GB | no |  14.3s |
| 40GB | yes | 33.677s |
| 8GB | no |  14.490s |
| 8GB | yes |  1.07m |