### PR TITLE
fix(hybrid cache): Only call apply on child caches in the success state

### DIFF
--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -222,8 +222,12 @@ bool llama_memory_hybrid_context::apply() {
 
     bool res = true;
 
-    res = res & ctx_attn->apply();
-    res = res & ctx_recr->apply();
+    if (ctx_attn->get_status() == LLAMA_MEMORY_STATUS_SUCCESS) {
+        res = res & ctx_attn->apply();
+    }
+    if (ctx_recr->get_status() == LLAMA_MEMORY_STATUS_SUCCESS) {
+        res = res & ctx_recr->apply();
+    }
 
     return res;
 }


### PR DESCRIPTION
There are conditions where the two child conditions can end up with different status values based on the logic in the init_update constructor for llama_kv_cache_unified_context which can conditionally set status to either LLAMA_MEMORY_STATUS_SUCCESS or LLAMA_MEMORY_STATUS_NO_UPDATE.

See full discussion:
https://github.com/ggml-org/llama.cpp/pull/13550#issuecomment-3014200391

Branch: HybridCacheApplyLogic