### PR TITLE
simple-chat : fix context-exceeded condition

### DIFF
--- a/examples/simple-chat/simple-chat.cpp
+++ b/examples/simple-chat/simple-chat.cpp
@@ -114,14 +114,15 @@ int main(int argc, char ** argv) {
             // check if we have enough space in the context to evaluate this batch
             int n_ctx = llama_n_ctx(ctx);
             int n_ctx_used = llama_memory_seq_pos_max(llama_get_memory(ctx), 0);
-            if (n_ctx_used + batch.n_tokens > n_ctx) {
+            if (n_ctx_used + batch.n_tokens >= n_ctx) {
                 printf("\033[0m\n");
                 fprintf(stderr, "context size exceeded\n");
                 exit(0);
             }
 
-            if (llama_decode(ctx, batch)) {
-                GGML_ABORT("failed to decode\n");
+            int ret = llama_decode(ctx, batch);
+            if (ret != 0) {
+                GGML_ABORT("failed to decode, ret = %d\n", ret);
             }
 
             // sample the next token

--- a/examples/simple-chat/simple-chat.cpp
+++ b/examples/simple-chat/simple-chat.cpp
@@ -113,8 +113,8 @@ int main(int argc, char ** argv) {
         while (true) {
             // check if we have enough space in the context to evaluate this batch
             int n_ctx = llama_n_ctx(ctx);
-            int n_ctx_used = llama_memory_seq_pos_max(llama_get_memory(ctx), 0);
-            if (n_ctx_used + batch.n_tokens >= n_ctx) {
+            int n_ctx_used = llama_memory_seq_pos_max(llama_get_memory(ctx), 0) + 1;
+            if (n_ctx_used + batch.n_tokens > n_ctx) {
                 printf("\033[0m\n");
                 fprintf(stderr, "context size exceeded\n");
                 exit(0);


### PR DESCRIPTION
fix #14487

Fix off-by-one error. New behavior after the fix:

```bash
make -j && ./bin/llama-simple-chat -m ../models/gemma-3-1b-it/ggml-model-q8_0.gguf -c 128

> Tell me a long story
Okay, here’s a long story, aiming for a bit of depth and emotional resonance. It’s a bit sprawling, so buckle up! It’s titled “The Cartographer’s Echo.”
---
The salt spray stung Elias’s face as he adjusted the compass, the needle spinning wildly in the grey, relentless wind. He was perched on the crumbling cliffs of Aethelgard, a tiny, forgotten village clinging to the edge of the Whispering Sea, a place time seemed to have deliberately abandoned. He’d inherited the cartography shop
context size exceeded
```