### PR TITLE
vulkan: increase timeout for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,7 @@ jobs:
           cd build
           export GGML_VK_VISIBLE_DEVICES=0
           # This is using llvmpipe and runs slower than other backends
-          ctest -L main --verbose --timeout 3600
+          ctest -L main --verbose --timeout 4200
 
   ubuntu-22-cmake-hip:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Fixes #14569.

This has gotten slower recently with the additional flash attention variants. I think the crash-on-exit workaround will be available relatively soon, after that we should consider switching the Vulkan testing back to GPU.
