### PR TITLE
memory : fix broken batch splits for recurrent cache

### DIFF
--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -377,12 +377,16 @@ llama_memory_context_ptr llama_memory_recurrent::init_batch(llama_batch_allocr &
                 ubatch = balloc.split_equal(n_ubatch, false);
             }
 
-            if (balloc.get_n_used() < balloc.get_n_tokens()) {
-                // failed to find a suitable split
+            if (ubatch.n_tokens == 0) {
                 break;
             }
 
             ubatches.push_back(std::move(ubatch)); // NOLINT
+        }
+
+        if (balloc.get_n_used() < balloc.get_n_tokens()) {
+            // failed to find a suitable split
+            break;
         }
 
         if (!prepare(ubatches)) {


### PR DESCRIPTION
Splits producing more than one ubatch per batch for recurrent models were broken with #14512.

This could cause SEGFAULTS and possibly other problems when using any `ubatch` size smaller than a processed batch with a recurrent model (e.g. Mamba, Mamba-2, etc.)

(I first noticed this when getting a SEGFAULT with Mamba after updating #14139 to a commit after #14512 was merged)

This fixes it by moving the completeness check after the ubatch split loop.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
