### PR TITLE
llama : remove llm_graph_input_one

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -354,13 +354,6 @@ void llm_graph_input_mem_hybrid::set_input(const llama_ubatch * ubatch) {
     }
 }
 
-void llm_graph_input_one::set_input(const llama_ubatch * ubatch) {
-    GGML_UNUSED(ubatch);
-    GGML_ASSERT(one && ggml_nelements(one) == 1);
-    float f_one = 1.0f;
-    ggml_backend_tensor_set(one, &f_one, 0, sizeof(float));
-}
-
 //
 // llm_graph_context
 //

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -352,17 +352,6 @@ public:
     const llama_memory_hybrid_context * mctx;
 };
 
-// TODO: remove this when ggml_scale_add is implemented
-class llm_graph_input_one : public llm_graph_input_i {
-public:
-    llm_graph_input_one() {}
-    virtual ~llm_graph_input_one() = default;
-
-    void set_input(const llama_ubatch * ubatch) override;
-
-    ggml_tensor * one = nullptr; // F32
-};
-
 //
 // llm_graph_result
 //

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -9382,8 +9382,6 @@ struct llm_build_gemma3n_iswa : public llm_graph_context {
     const int     n_layer_sparsity = 10; // number of layers using activation sparsity
     const float   f_sparsity_std_mul = 1.6448533535003662f; // std_multiplier = normal_dist.icdf(0.95)
 
-    ggml_tensor * one; // containing single element 1.0f
-
     llm_build_gemma3n_iswa(const llama_model & model, const llm_graph_params & params, ggml_cgraph * gf)
             : llm_graph_context(params),
               model(model),
@@ -9394,14 +9392,6 @@ struct llm_build_gemma3n_iswa : public llm_graph_context {
               i_altup_act(model.hparams.i_altup_act) {
         ggml_tensor * cur;
         ggml_tensor * inpL;
-
-        // TODO: remove this when ggml_scale_add is implemented
-        one = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, 1);
-        {
-            auto inp = std::make_unique<llm_graph_input_one>();
-            inp->one = one;
-            res->add_input(std::move(inp));
-        }
 
         inpL = build_inp_embd(model.tok_embd);
 
@@ -9792,7 +9782,7 @@ struct llm_build_gemma3n_iswa : public llm_graph_context {
         cb(innovation, "innovation", il);
 
         ggml_tensor * all_coefs = build_lora_mm(model.layers[il].altup_correct_coef, modalities); // [n_altup, n_tokens]
-        all_coefs = ggml_add(ctx0, all_coefs, one);
+        all_coefs = ggml_scale_bias(ctx0, all_coefs, 1.0f, 1.0f); // + 1.0
         cb(all_coefs, "all_coefs", il);
         all_coefs = ggml_cont(ctx0, ggml_transpose(ctx0, all_coefs)); // [n_tokens, n_altup]
         all_coefs = ggml_reshape_3d(ctx0, all_coefs, 1, n_tokens, n_altup); // [1, n_tokens, n_altup]


### PR DESCRIPTION
Cont https://github.com/ggml-org/llama.cpp/pull/14417

Remove the `llm_graph_input_one` for gemma 3n

---

Perplexity test:

master:

```
perplexity: 6.78 seconds per pass - ETA 0.33 minutes
[1]16.8513,[2]13.7903,[3]15.0428,
Final estimate: PPL = 15.0428 +/- 0.72134
```

PR:

```
perplexity: 6.02 seconds per pass - ETA 0.30 minutes
[1]16.8513,[2]13.7903,[3]15.0428,
Final estimate: PPL = 15.0428 +/- 0.72134
```
