### PR TITLE
cmake : llguidance build parser library only

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -118,7 +118,7 @@ if (LLAMA_LLGUIDANCE)
         SOURCE_DIR ${LLGUIDANCE_SRC}
         BUILD_IN_SOURCE TRUE
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND cargo build --release
+        BUILD_COMMAND cargo build --release --package llguidance
         INSTALL_COMMAND ""
         BUILD_BYPRODUCTS ${LLGUIDANCE_PATH}/${LLGUIDANCE_LIB_NAME} ${LLGUIDANCE_PATH}/llguidance.h
         UPDATE_COMMAND ""


### PR DESCRIPTION
The LLGuidance repo contains a lot of stuffs, while the parser library we care about (`libllguidance.a` and `llguidance.h`) is only a small portion of it, under `parser` directory as per [project README](https://github.com/guidance-ai/llguidance/blob/v1.0.1/README.md#building), thus building the whole project when building llama.cpp is unnecessary and a waste of time and compute power. This PR instructs CMake to only build the parser library, which cuts the number of compiled Rust packages from ~300 to 75, and provides a ~40% overall build speed increase.

Tested with a GitHub Codespace with 2 vCPUs, 8GB RAM, and llama.cpp b5857 with default CMake config (`cmake . -B build -DLLAMA_LLGUIDANCE=ON && time cmake --build build -j $(nproc)`):

Before (b5857):
```
real    11m3.258s
user    17m34.982s
sys     1m11.124s
```

After (this PR):
```
real    6m38.164s
user    10m23.589s
sys     0m41.985s
```