### PR TITLE
OpenCL: add `mul_mat_f16_f32_image` kernel 

### DIFF
--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -105,6 +105,9 @@ set(GGML_OPENCL_KERNELS
     pad
     repeat
     mul_mat_f16_f32
+    mul_mat_f16_f32_image
+    pack_a_for_image
+    pack_b_for_image
 )
 
 foreach (K ${GGML_OPENCL_KERNELS})

--- a/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32_image.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32_image.cl
@@ -1,0 +1,61 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__constant sampler_t SAMPLER = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+__kernel void mul_mat_f16_f32_image(
+    __read_only image2d_t A_img,
+    __read_only image2d_t B_img,
+    __global float* C_buf,
+    const ulong c_offset,
+    const int M,
+    const int N,
+    const int K
+) {
+    const int n_4_idx = get_global_id(0);
+    const int m_idx = get_global_id(1);
+
+    const int n_base = n_4_idx << 2;
+
+    if (n_base >= N || m_idx >= M) {
+        return;
+    }
+
+    float4 c_vals = (float4)(0.0f);
+    const int K_4 = (K + 3) / 4;
+
+    for (int k_4_idx = 0; k_4_idx < K_4; ++k_4_idx) {
+        int k_base = k_4_idx << 2;
+
+        float4 a_vals = convert_float4(read_imageh(A_img, SAMPLER, (int2)(k_4_idx, m_idx)));
+
+        if (k_base < K) {
+            float4 b0 = convert_float4(read_imageh(B_img, SAMPLER, (int2)(n_4_idx, k_base + 0)));
+            c_vals = mad(a_vals.x, b0, c_vals);
+        }
+        if (k_base + 1 < K) {
+            float4 b1 = convert_float4(read_imageh(B_img, SAMPLER, (int2)(n_4_idx, k_base + 1)));
+            c_vals = mad(a_vals.y, b1, c_vals);
+        }
+        if (k_base + 2 < K) {
+            float4 b2 = convert_float4(read_imageh(B_img, SAMPLER, (int2)(n_4_idx, k_base + 2)));
+            c_vals = mad(a_vals.z, b2, c_vals);
+        }
+        if (k_base + 3 < K) {
+            float4 b3 = convert_float4(read_imageh(B_img, SAMPLER, (int2)(n_4_idx, k_base + 3)));
+            c_vals = mad(a_vals.w, b3, c_vals);
+        }
+    }
+
+    __global float* C = (__global float*)((__global char*)C_buf + c_offset);
+    
+    if (n_base + 3 < N) {
+        C[(n_base + 0) * M + m_idx] = c_vals.x;
+        C[(n_base + 1) * M + m_idx] = c_vals.y;
+        C[(n_base + 2) * M + m_idx] = c_vals.z;
+        C[(n_base + 3) * M + m_idx] = c_vals.w;
+    } else {
+        if (n_base < N) C[n_base * M + m_idx] = c_vals.x;
+        if (n_base + 1 < N) C[(n_base + 1) * M + m_idx] = c_vals.y;
+        if (n_base + 2 < N) C[(n_base + 2) * M + m_idx] = c_vals.z;
+    }
+}

--- a/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32_image.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32_image.cl
@@ -47,7 +47,7 @@ __kernel void mul_mat_f16_f32_image(
     }
 
     __global float* C = (__global float*)((__global char*)C_buf + c_offset);
-    
+
     if (n_base + 3 < N) {
         C[(n_base + 0) * M + m_idx] = c_vals.x;
         C[(n_base + 1) * M + m_idx] = c_vals.y;

--- a/ggml/src/ggml-opencl/kernels/pack_a_for_image.cl
+++ b/ggml/src/ggml-opencl/kernels/pack_a_for_image.cl
@@ -1,0 +1,29 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__kernel void pack_a_for_image(
+    __global const half* src_a,
+    const ulong a_offset,
+    __write_only image2d_t dest_img,
+    const int M,
+    const int K
+) {
+    const int k_4_idx = get_global_id(0);
+    const int m_idx = get_global_id(1);
+
+    const int k_base = k_4_idx << 2;
+
+    if (k_base >= K || m_idx >= M) {
+        return;
+    }
+
+    __global const half* a_ptr = (__global const half*)((__global const char*)src_a + a_offset);
+    const int a_idx_base = m_idx * K + k_base;
+
+    half4 vals;
+    vals.x = a_ptr[a_idx_base];
+    vals.y = (k_base + 1 < K) ? a_ptr[a_idx_base + 1] : (half)0.0h;
+    vals.z = (k_base + 2 < K) ? a_ptr[a_idx_base + 2] : (half)0.0h;
+    vals.w = (k_base + 3 < K) ? a_ptr[a_idx_base + 3] : (half)0.0h;
+
+    write_imageh(dest_img, (int2)(k_4_idx, m_idx), vals);
+}

--- a/ggml/src/ggml-opencl/kernels/pack_b_for_image.cl
+++ b/ggml/src/ggml-opencl/kernels/pack_b_for_image.cl
@@ -1,0 +1,28 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__kernel void pack_b_for_image(
+    __global const float* src_b,
+    const ulong b_offset,
+    __write_only image2d_t dest_img,
+    const int K,
+    const int N
+) {
+    const int n_4_idx = get_global_id(0);
+    const int k_idx = get_global_id(1);
+
+    const int n_base = n_4_idx << 2;
+
+    if (n_base >= N || k_idx >= K) {
+        return;
+    }
+
+    __global const float* b_ptr = (__global const float*)((__global const char*)src_b + b_offset);
+
+    half4 vals;
+    vals.x = convert_half(b_ptr[n_base * K + k_idx]);
+    vals.y = (n_base + 1 < N) ? convert_half(b_ptr[(n_base + 1) * K + k_idx]) : (half)0.0h;
+    vals.z = (n_base + 2 < N) ? convert_half(b_ptr[(n_base + 2) * K + k_idx]) : (half)0.0h;
+    vals.w = (n_base + 3 < N) ? convert_half(b_ptr[(n_base + 3) * K + k_idx]) : (half)0.0h;
+
+    write_imageh(dest_img, (int2)(n_4_idx, k_idx), vals);
+}


### PR DESCRIPTION
This PR adds a new `mul_mat_f16_f32_image` kernel that uses `image2d_t` to take advantage of the L1 texture cache. For now, it will completely override my previous generic tiled kernel, but I think the tiled one may still be useful when targeting other vendors, as this approach is very mobile GPU-specific.

I think we could gain an additional 10% in performance by avoiding branch creation in the kernel and handling the case where K is divisible by 4 in a separate path. For now, we can keep it as is.

I will try to use a similar approach for `conv2d`, requires additional tricks tho. I think for now we're good enough for large matrix multiplies, I will next seek improvements in GEMV and cases not addressed by this kernel next

Performance on adreno 830:

| Version | m    | n   | k     | Performance |
|---------|------|-----|-------|-------------|
| Master  | 4096 | 512 | 14336 | 375 GFLOPS  |
| This PR | 4096 | 512 | 14336 | 1.27 TFLOPS |

Master: 

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 1B F16                   |   2.30 GiB |     1.24 B | OpenCL     |  99 |           pp512 |        168.17 ± 0.41 |
| llama 1B F16                   |   2.30 GiB |     1.24 B | OpenCL     |  99 |           tg128 |         22.61 ± 0.02 |

This PR: 

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 1B F16                   |   2.30 GiB |     1.24 B | OpenCL     |  99 |           pp512 |        193.79 ± 2.68|
| llama 1B F16                   |   2.30 GiB |     1.24 B | OpenCL     |  99 |           tg128 |         22.67 ± 0.04|