### PR TITLE
bug fix: handle saving/loading null layers in recurrent memory

### DIFF
--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -1018,7 +1018,7 @@ bool llama_memory_recurrent::state_read_data(llama_io_read_i & io, uint32_t cell
         // For each layer, read the values for each cell (transposed)
         for (uint32_t il = 0; il < n_layer; ++il) {
             // skip null layers
-            if(s_l[il] == nullptr) continue;
+            if (s_l[il] == nullptr) continue;
 
             const uint32_t n_embd_s = hparams.n_embd_s();
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -768,11 +768,8 @@ void llama_memory_recurrent::state_write_data(llama_io_write_i & io, const std::
     // Iterate and write all the keys first, each row is a cell
     // Get whole range at a time
     for (uint32_t il = 0; il < n_layer; ++il) {
-
-        if (r_l[il] == nullptr) {
-            // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
-            continue;
-        }
+        // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
+        if (r_l[il] == nullptr) continue;
 
         // Write key type
         const int32_t r_type_i = (int32_t)r_l[il]->type;
@@ -792,12 +789,8 @@ void llama_memory_recurrent::state_write_data(llama_io_write_i & io, const std::
 
     if (!s_trans) {
         for (uint32_t il = 0; il < n_layer; ++il) {
-
-            // special key to handle null layers
-            if (s_l[il] == nullptr) {
-                // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
-                continue;
-            }
+            // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
+            if (s_l[il] == nullptr) continue;
 
             // Write value type
             const int32_t s_type_i = (int32_t)s_l[il]->type;
@@ -818,11 +811,8 @@ void llama_memory_recurrent::state_write_data(llama_io_write_i & io, const std::
         // When v is transposed, we also need the element size and get the element ranges from each row
         const uint32_t mem_size = size;
         for (uint32_t il = 0; il < n_layer; ++il) {
-            // special key to handle null layers
-            if (s_l[il] == nullptr) {
-                // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
-                continue;
-            }
+            // skip null layers (read_data will handle this by checking "r_l" and "s_l" for null)
+            if (s_l[il] == nullptr) continue;
 
             const uint32_t n_embd_s = hparams.n_embd_s();
 
@@ -969,7 +959,7 @@ bool llama_memory_recurrent::state_read_data(llama_io_read_i & io, uint32_t cell
     // For each layer, read the keys for each cell, one row is one cell, read as one contiguous block
     for (uint32_t il = 0; il < n_layer; ++il) {
         // skip null layers
-        if(r_l[il] == nullptr) continue;
+        if (r_l[il] == nullptr) continue;
 
         // Read type of key
         int32_t r_type_i_ref;
@@ -998,7 +988,7 @@ bool llama_memory_recurrent::state_read_data(llama_io_read_i & io, uint32_t cell
     if (!s_trans) {
         for (uint32_t il = 0; il < n_layer; ++il) {
             // skip null layers
-            if(s_l[il] == nullptr) continue;
+            if (s_l[il] == nullptr) continue;
 
             // Read type of value
             int32_t s_type_i_ref;


### PR DESCRIPTION
Currently saving loading kv cache of recurrent memory crashes because layers can be null.

This mainly applies to the new LiquidAI/LFM2 models.

Tested with: https://huggingface.co/LiquidAI/LFM2-350M-GGUF