### PR TITLE
server: add `--lora-layer-range START END` to match existing `--control-vector-layer-range START END`

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2473,6 +2473,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
     ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}));
     add_opt(common_arg(
+        {"--lora-layer-range"}, "START", "END",
+        "layer range to apply the lora(s) to, start and end inclusive",
+        [](common_params & params, const std::string & start, const std::string & end) {
+            params.lora_layer_start = std::stoi(start);
+            params.lora_layer_end = std::stoi(end);
+        }
+    ));
+    add_opt(common_arg(
         {"--control-vector"}, "FNAME",
         "add a control vector\nnote: this argument can be repeated to add multiple control vectors",
         [](common_params & params, const std::string & value) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -988,7 +988,7 @@ struct common_init_result common_init_from_params(common_params & params) {
 
         for (auto & la : params.lora_adapters) {
             llama_adapter_lora_ptr lora;
-            lora.reset(llama_adapter_lora_init(model, la.path.c_str()));
+            lora.reset(llama_adapter_lora_init(model, la.path.c_str(), params.lora_layer_start, params.lora_layer_end));
             if (lora == nullptr) {
                 LOG_ERR("%s: failed to apply lora adapter '%s'\n", __func__, la.path.c_str());
                 llama_free(lctx);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -983,8 +983,8 @@ struct common_init_result common_init_from_params(common_params & params) {
 
     // load and optionally apply lora adapters
     if (!params.lora_adapters.empty()) {
-        if (params.lora_layer_start <= 0) params.lora_layer_start = 1;
-        if (params.lora_layer_end   <= 0) params.lora_layer_end   = llama_model_n_layer(model);
+        if (params.lora_layer_start < 0) params.lora_layer_start = 0;
+        if (params.lora_layer_end   < 0) params.lora_layer_end   = llama_model_n_layer(model);
 
         for (auto & la : params.lora_adapters) {
             llama_adapter_lora_ptr lora;

--- a/common/common.h
+++ b/common/common.h
@@ -296,6 +296,8 @@ struct common_params {
     int32_t verbosity                  = 0;
     int32_t control_vector_layer_start = -1; // layer range for control vector
     int32_t control_vector_layer_end   = -1; // layer range for control vector
+    int32_t lora_layer_start           = -1; // layer range for lora
+    int32_t lora_layer_end             = -1; // layer range for lora
     bool    offline                    = false;
 
     int32_t ppl_stride      = 0;     // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.

--- a/include/llama.h
+++ b/include/llama.h
@@ -544,9 +544,12 @@ extern "C" {
     //
 
     // Load a LoRA adapter from file
+    // il_start and il_end are the layer range the lora should apply to (both inclusive)
     LLAMA_API struct llama_adapter_lora * llama_adapter_lora_init(
             struct llama_model * model,
-            const char * path_lora);
+                    const char * path_lora,
+                       int32_t   il_start,
+                       int32_t   il_end);
 
     // Manually free a LoRA adapter
     // Note: loaded adapters will be free when the associated model is deleted

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -82,6 +82,7 @@ The project is under active development, and we are [looking for feedback and co
 | `--override-kv KEY=TYPE:VALUE` | advanced option to override model metadata by key. may be specified multiple times.<br/>types: int, float, bool, str. example: --override-kv tokenizer.ggml.add_bos_token=bool:false |
 | `--lora FNAME` | path to LoRA adapter (can be repeated to use multiple adapters) |
 | `--lora-scaled FNAME SCALE` | path to LoRA adapter with user defined scaling (can be repeated to use multiple adapters) |
+| `--lora-layer-range START END` | layer range to apply the LoRA(s) to, start and end inclusive |
 | `--control-vector FNAME` | add a control vector<br/>note: this argument can be repeated to add multiple control vectors |
 | `--control-vector-scaled FNAME SCALE` | add a control vector with user defined scaling SCALE<br/>note: this argument can be repeated to add multiple scaled control vectors |
 | `--control-vector-layer-range START END` | layer range to apply the control vector(s) to, start and end inclusive |


### PR DESCRIPTION
This just adds the equivalent option for LoRAs as already existed for Control Vectors, eg:

Using `--lora-layer-range 0 59` on a LoRA with 64 pairs of `A`/`B` tensors:

```
llama_adapter_lora_init_impl: loading lora adapter from 'qwq-32b-writer-lora-F32.gguf' ...
llama_adapter_lora_init_impl: Metal_Mapped LoRA buffer size =   120.00 MiB
llama_adapter_lora_init_impl: loaded 120 tensors from lora file
```

It does change the function signature of `llama_adapter_lora_init`:

```cpp
    // Load a LoRA adapter from file
    // il_start and il_end are the layer range the lora should apply to (both inclusive)
    LLAMA_API struct llama_adapter_lora * llama_adapter_lora_init(
            struct llama_model * model,
                    const char * path_lora,
                       int32_t   il_start,
                       int32_t   il_end);
```

but it is only called from `common.cpp` here:

```cpp
    // load and optionally apply lora adapters
    if (!params.lora_adapters.empty()) {
        if (params.lora_layer_start < 0) params.lora_layer_start = 0;
        if (params.lora_layer_end   < 0) params.lora_layer_end   = llama_model_n_layer(model);

        for (auto & la : params.lora_adapters) {
            llama_adapter_lora_ptr lora;
            lora.reset(llama_adapter_lora_init(model, la.path.c_str(), params.lora_layer_start, params.lora_layer_end));
            if (lora == nullptr) {
                LOG_ERR("%s: failed to apply lora adapter '%s'\n", __func__, la.path.c_str());
                llama_free(lctx);
                llama_model_free(model);
                return iparams;
            }

            la.ptr = lora.get();
            iparams.lora.emplace_back(std::move(lora)); // copy to list of loaded adapters
        }
    }
```

(just something to be aware of if any other external tool uses this as an API call, etc)