### PR TITLE
cuda: fix build warnings in set-rows.cu (unused variable)

### DIFF
--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -3,7 +3,10 @@
 typedef void (*set_rows_kernel_t)(const char * src, char * dst);
 
 template<typename src_t, typename dst_t>
-__device__ void set_rows_1(const src_t * src_f, dst_t * dst_f) {}
+__device__ void set_rows_1(const src_t * src_f, dst_t * dst_f) {
+    GGML_UNUSED(src_f);
+    GGML_UNUSED(dst_f);
+}
 
 template<>
 __device__ __forceinline__ void set_rows_1<float, half>(const float * src_f, half * dst_h) {
@@ -53,6 +56,9 @@ static __global__ void k_set_rows(
     const src_t* src_elem = src0_row + i00;
     dst_t* dst_elem = dst_row_ptr + i00;
     set_rows_1(src_elem, dst_elem);
+
+    GGML_UNUSED(ne10);
+    GGML_UNUSED(ne13);
 }
 
 template<typename src_t, typename dst_t>


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

```bash
/ws/ggml/src/ggml-cuda/set-rows.cu:6:42: warning: unused parameter 'src_f' [-Wunused-parameter]
__device__ void set_rows_1(const src_t * src_f, dst_t * dst_f) {}
                                         ^
/ws/ggml/src/ggml-cuda/set-rows.cu:6:57: warning: unused parameter 'dst_f' [-Wunused-parameter]
__device__ void set_rows_1(const src_t * src_f, dst_t * dst_f) {}
                                                        ^
/ws/ggml/src/ggml-cuda/set-rows.cu:27:23: warning: unused parameter 'ne10' [-Wunused-parameter]
        const int64_t ne10, const int64_t ne11, const int64_t ne12, const int64_t ne13,
                      ^
/ws/ggml/src/ggml-cuda/set-rows.cu:27:83: warning: unused parameter 'ne13' [-Wunused-parameter]
        const int64_t ne10, const int64_t ne11, const int64_t ne12, const int64_t ne13,
                                                                                  ^
```