### PR TITLE
bug fix: convert-hf-to-gguf plamo2 add chat-template

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3598,6 +3598,9 @@ class Plamo2Model(TextModel):
 
         self.gguf_writer.add_add_space_prefix(False)
 
+        special_vocab = gguf.SpecialVocab(self.dir_model, n_vocab=len(tokens))
+        special_vocab.add_to_gguf(self.gguf_writer)
+
     def set_gguf_parameters(self):
         hparams = self.hparams
         block_count = hparams["num_hidden_layers"]


### PR DESCRIPTION
plamo2: missing SpecialVocab.add_to_gguf call caused chat_template to be dropped; add it.