### PR TITLE
server : pre-calculate EOG logit biases

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -177,7 +177,8 @@ struct common_params_sampling {
     std::vector<common_grammar_trigger> grammar_triggers; // optional triggers (for lazy grammars)
     std::set<llama_token>               preserved_tokens;
 
-    std::vector<llama_logit_bias> logit_bias; // logit biases to apply
+    std::vector<llama_logit_bias> logit_bias;     // logit biases to apply
+    std::vector<llama_logit_bias> logit_bias_eog; // pre-calculated logit biases for EOG tokens
 
     // print the parameters into a string
     std::string print() const;


### PR DESCRIPTION
cont #14710 

Avoid iterating the vocabulary on each request when `"ignore_eos"` parameter is set. To do this, pre-calculate the EOG tokens in advance.