### PR TITLE
nix: use optionalAttrs for `env` mkDerivation attrset argument

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -47,6 +47,7 @@ let
   inherit (lib)
     cmakeBool
     cmakeFeature
+    optionalAttrs
     optionals
     strings
     ;
@@ -197,7 +198,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ];
 
   # Environment variables needed for ROCm
-  env = optionals useRocm {
+  env = optionalAttrs useRocm {
     ROCM_PATH = "${rocmPackages.clr}";
     HIP_DEVICE_LIB_PATH = "${rocmPackages.rocm-device-libs}/amdgcn/bitcode";
   };


### PR DESCRIPTION
Fixes nix eval of `packages.${system}.default` with newer nixpkgs revision.

Previously eval failed with:

```
    error: expected a set but found a list: [ ]
```

`lib.optionals` is not for attrsets, `lib.optionalAttrs` is instead.