### PR TITLE
graph : avoid huge warm-up graphs for MoE models

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1312,7 +1312,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 //
 
 uint32_t llama_context::graph_max_nodes() const {
-    return std::max<uint32_t>(1024u, 6u*model.n_tensors());
+    return std::max<uint32_t>(1024u, 8u*model.n_tensors());
 }
 
 llm_graph_result * llama_context::get_gf_res_reserve() const {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1312,7 +1312,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 //
 
 uint32_t llama_context::graph_max_nodes() const {
-    return std::max<uint32_t>(65536u, 5u*model.n_tensors());
+    return std::max<uint32_t>(1024u, 6u*model.n_tensors());
 }
 
 llm_graph_result * llama_context::get_gf_res_reserve() const {


### PR DESCRIPTION
Just hot loading the experts for matrix multiplication is enough to heat-up the caches. No need to add extra `GGML_OP_ADD` nodes for aggregating the results.