### PR TITLE
webui: add missing messages in export (#13552)

### DIFF
--- a/tools/server/webui/src/components/Sidebar.tsx
+++ b/tools/server/webui/src/components/Sidebar.tsx
@@ -149,14 +149,16 @@ export default function Sidebar() {
                       navigate('/');
                     }
                   }}
-                  onDownload={() => {
+                  onDownload={async () => {
                     if (isGenerating(conv.id)) {
                       toast.error(
                         'Cannot download conversation while generating'
                       );
                       return;
                     }
-                    const conversationJson = JSON.stringify(conv, null, 2);
+                    const msgs = await StorageUtils.getMessages(conv.id);
+                    const dict = { conv: conv, messages: msgs };
+                    const conversationJson = JSON.stringify(dict, null, 2);
                     const blob = new Blob([conversationJson], {
                       type: 'application/json',
                     });


### PR DESCRIPTION
This fix restores the messages that have been missing from the web UI's JSON export for the past few weeks; see also #13552.
