### PR TITLE
server: Add parse_special option to /tokenize endpoint

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -575,6 +575,8 @@ These words will not be included in the completion, so make sure to add them to 
 
 `add_special`: (Optional) Boolean indicating if special tokens, i.e. `BOS`, should be inserted.  Default: `false`
 
+`parse_special`: (Optional) Boolean indicating if special tokens should be tokenized. When `false` special tokens are treated as plaintext.  Default: `true`
+
 `with_pieces`: (Optional) Boolean indicating whether to return token pieces along with IDs.  Default: `false`
 
 **Response:**

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4516,9 +4516,10 @@ int main(int argc, char ** argv) {
         json tokens_response = json::array();
         if (body.count("content") != 0) {
             const bool add_special = json_value(body, "add_special", false);
+            const bool parse_special = json_value(body, "parse_special", true);
             const bool with_pieces = json_value(body, "with_pieces", false);
 
-            llama_tokens tokens = tokenize_mixed(ctx_server.vocab, body.at("content"), add_special, true);
+            llama_tokens tokens = tokenize_mixed(ctx_server.vocab, body.at("content"), add_special, parse_special);
 
             if (with_pieces) {
                 for (const auto& token : tokens) {


### PR DESCRIPTION
Add `parse_special` option to /tokenize endpoint. 

The `parse_special` option is explained here https://github.com/ggml-org/llama.cpp/discussions/9379.


Tested with:
`llama-server.exe --model C:\tools\llm\qwen2.5-coder-1.5b-instruct-q4_k_m.gguf  --port 8088`

New behavior when parse_special = false:
```
curl --request POST --url http://localhost:8088/tokenize --header "Content-Type: application/json" 
    --data '{"content": "<|im_start|>Hello World<|im_end|>", "with_pieces": true, "parse_special": false}'
{"tokens":[
    {"id":27,"piece":"<"},
    {"id":91,"piece":"|"},
    {"id":318,"piece":"im"},
    {"id":4906,"piece":"_start"},
    {"id":91,"piece":"|"},
    {"id":29,"piece":">"},
    {"id":9707,"piece":"Hello"},
    {"id":4337,"piece":" World"},
    {"id":27,"piece":"<"},
    {"id":91,"piece":"|"},
    {"id":318,"piece":"im"},
    {"id":6213,"piece":"_end"},
    {"id":91,"piece":"|"},
    {"id":29,"piece":">"}
]}
```

Old / default behavior (parse_special = true) is unchanged:
```
curl --request POST --url http://localhost:8088/tokenize --header "Content-Type: application/json" 
    --data '{"content": "<|im_start|>Hello World<|im_end|>", "with_pieces": true}'
{"tokens":[
    {"id":151644,"piece":"<|im_start|>"},
    {"id":9707,"piece":"Hello"},
    {"id":4337,"piece":" World"},
    {"id":151645,"piece":"<|im_end|>"}
]}
```
