### PR TITLE
docs: add libcurl-dev install hint for Linux distros

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -68,6 +68,10 @@ cmake --build build --config Release
       cmake --build build-x64-windows-llvm-release
       ```
 - Curl usage is enabled by default and can be turned off with `-DLLAMA_CURL=OFF`. Otherwise you need to install development libraries for libcurl.
+  - **Debian / Ubuntu:** `sudo apt-get install libcurl4-openssl-dev`  
+    _(or `libcurl4-gnutls-dev` if you prefer GnuTLS)_
+  - **Fedora / RHEL / Rocky / Alma:** `sudo dnf install libcurl-devel`
+  - **Arch / Manjaro:** `sudo pacman -S curl`  # includes libcurl headers
 
 ## BLAS Build
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -68,8 +68,7 @@ cmake --build build --config Release
       cmake --build build-x64-windows-llvm-release
       ```
 - Curl usage is enabled by default and can be turned off with `-DLLAMA_CURL=OFF`. Otherwise you need to install development libraries for libcurl.
-  - **Debian / Ubuntu:** `sudo apt-get install libcurl4-openssl-dev`  
-    _(or `libcurl4-gnutls-dev` if you prefer GnuTLS)_
+  - **Debian / Ubuntu:** `sudo apt-get install libcurl4-openssl-dev`  # (or `libcurl4-gnutls-dev` if you prefer GnuTLS)
   - **Fedora / RHEL / Rocky / Alma:** `sudo dnf install libcurl-devel`
   - **Arch / Manjaro:** `sudo pacman -S curl`  # includes libcurl headers
 


### PR DESCRIPTION
I hit a CMake configure error: Could NOT find CURL when building on Ubuntu. The build guide mentions that curl is enabled by default and can be disabled, but doesn’t list the packages to install. This PR adds distro-specific install one-liners (Debian/Ubuntu, Fedora/RHEL, Arch) below the curl note to help first-time builders avoid the error. Tested on Ubuntu 22.04: reinstalling libcurl4-openssl-dev allowed CMake to find CURL successfully.