### PR TITLE
feat(batched): Add functionality to upload benchmark test results

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -447,6 +447,7 @@ struct common_params {
 
     // batched-bench params
     bool batched_bench_output_jsonl = false;
+    bool upload = false; // whether to upload benchmark results
 
     // common params
     std::string out_file; // output filename for all example programs


### PR DESCRIPTION
- Add the upload field in common.h to control whether to upload benchmark test results
- Implement the benchmark result saving and upload functionality in batched.cpp
- Added the --upload command-line parameter to enable the upload feature
- Add upload logic in the main function, including generating timestamp filenames, saving benchmark results, etc

For issue: https://github.com/ggml-org/llama.cpp/issues/14791
