### PR TITLE
model card yaml tab->2xspace

### DIFF
--- a/gguf-py/gguf/metadata.py
+++ b/gguf-py/gguf/metadata.py
@@ -144,6 +144,10 @@ class Metadata:
         # Quick hack to fix the Norway problem
         # https://hitchdev.com/strictyaml/why/implicit-typing-removed/
         yaml_content = yaml_content.replace("- no\n", "- \"no\"\n")
+        # yaml should use 2 spaces insted of tab
+        # this issue has came up with the Qwen/Qwen3-235B-A22B-Instruct-2507 model card
+        #    (I've also sent a pr tp fix the modelcard too)
+        yaml_content = yaml_content.replace("\t", "  ")
 
         if yaml_content:
             data = yaml.safe_load(yaml_content)


### PR DESCRIPTION
Issue to fix:

```
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 2, column 20:
    license: apache-2.0	
```

caused by Qwen/Qwen3-235B-A22B-Instruct-2507 model card had spaces

yaml should use 2 spaces instead of tab.

Tested locally

(Note: I've also sent a PR to fix the model card too)
