### PR TITLE
test-backend-ops: enables perf/eval testing of composite ops

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -340,6 +340,10 @@ extern "C" {
 
     // Compare the output of two backends
     GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data, struct ggml_tensor * test_node);
+    GGML_API bool ggml_backend_compare_graph_backend_node(ggml_backend_t backend1, ggml_backend_t backend2,
+                                                          struct ggml_cgraph * graph1, struct ggml_cgraph * graph2,
+                                                          ggml_backend_eval_callback callback, void * user_data,
+                                                          const char * op_name_out_1, const char * op_name_out_2);
 
     // Tensor initialization
     GGML_API enum ggml_status ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1902,9 +1902,9 @@ bool ggml_backend_compare_graph_backend_node(ggml_backend_t backend1, ggml_backe
         }
     }
 
-    assert(out1 != NULL);
-    assert(out2 != NULL);
-    assert(ggml_are_same_layout(out1, out2));
+    GGML_ASSERT(out1 != NULL);
+    GGML_ASSERT(out2 != NULL);
+    GGML_ASSERT(ggml_are_same_layout(out1, out2));
 
     // compare results, calculate rms etc
     if (!callback(0, out1, out2, user_data)) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -114,6 +114,7 @@ size_t ggml_backend_buffer_get_size(ggml_backend_buffer_t buffer) {
     return buffer->size;
 }
 
+
 void * ggml_backend_buffer_get_base(ggml_backend_buffer_t buffer) {
     // get_base is optional if the buffer is zero-sized
     if (buffer->size == 0) {
@@ -1863,6 +1864,52 @@ bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t 
         }
     }
     ggml_backend_graph_copy_free(copy);
+
+    return true;
+}
+
+bool ggml_backend_compare_graph_backend_node(ggml_backend_t backend1, ggml_backend_t backend2,
+                                             struct ggml_cgraph * graph1, struct ggml_cgraph * graph2,
+                                             ggml_backend_eval_callback callback, void * user_data,
+                                             const char * op_name_out_1, const char * op_name_out_2) {
+    ggml_tensor * out1 = NULL;
+    ggml_tensor * out2 = NULL;
+
+    struct ggml_cgraph * g1 = graph1;
+    struct ggml_cgraph * g2 = graph2;
+
+    for (int i = 0; i < g1->n_nodes; i++) {
+        struct ggml_tensor * t1  = g1->nodes[i];
+        struct ggml_cgraph   g1v = ggml_graph_view(g1, i, i + 1);
+        ggml_backend_graph_compute(backend1, &g1v);
+        if (ggml_is_view_op(t1->op)) {
+            continue;
+        }
+        if (strcmp(t1->name, op_name_out_1) == 0) {
+            out1 = t1;
+        }
+    }
+
+    for (int i = 0; i < g2->n_nodes; i++) {
+        struct ggml_tensor * t2  = g2->nodes[i];
+        struct ggml_cgraph   g2v = ggml_graph_view(g2, i, i + 1);
+        ggml_backend_graph_compute(backend2, &g2v);
+        if (ggml_is_view_op(t2->op)) {
+            continue;
+        }
+        if (strcmp(t2->name, op_name_out_2) == 0) {
+            out2 = t2;
+        }
+    }
+
+    assert(out1 != NULL);
+    assert(out2 != NULL);
+    assert(ggml_are_same_layout(out1, out2));
+
+    // compare results, calculate rms etc
+    if (!callback(0, out1, out2, user_data)) {
+        return false;
+    }
 
     return true;
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1302,8 +1302,8 @@ struct test_case {
                         ggml_graph_add_node(gf, t);
                     }
                 }
-                assert(added_nodes == nodes_per_op);
-                (void) added_nodes;
+                GGML_ASSERT(added_nodes == nodes_per_op);
+                GGML_UNUSED(added_nodes);
             } else {
                 ggml_graph_add_node(gf, out);
             }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -20,7 +20,6 @@
 #include <ggml-backend.h>
 #include <ggml-cpp.h>
 
-#include <assert.h>
 #include <algorithm>
 #include <array>
 #include <cfloat>
@@ -4042,7 +4041,7 @@ struct test_conv_2d_im2col : public test_case {
     // IM2COL -> MUL_MM graph will be built.
 
     virtual std::string op_desc(ggml_tensor * t) override {
-        (void) t;
+        GGML_UNUSED(t);
         return std::string("CONV_2D_IM2COL");
     }
 
@@ -4220,7 +4219,7 @@ struct test_conv_2d_compare : public test_case_compare {
     std::string output_name_2 = "out";
 
     virtual std::string op_desc(ggml_tensor * t) override {
-        (void) t;
+        GGML_UNUSED(t);
         return std::string("CONV_2D_COMPARE");
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1303,6 +1303,7 @@ struct test_case {
                     }
                 }
                 assert(added_nodes == nodes_per_op);
+                (void) added_nodes;
             } else {
                 ggml_graph_add_node(gf, out);
             }
@@ -1713,7 +1714,7 @@ struct test_case_compare : public test_case {
 
     std::string vars() override { return "(" + case1->vars() + "),(" + case2->vars() + ")"; }
 
-    ggml_tensor * build_graph(ggml_context * ctx) {
+    ggml_tensor * build_graph(ggml_context * ctx) override {
         GGML_UNUSED(ctx);
         return nullptr;
     }
@@ -1761,7 +1762,7 @@ struct test_case_compare : public test_case {
     }
 
     // Compares the output of the actual graph to the output of the reference
-    bool eval(ggml_backend_t backend1, ggml_backend_t backend2, const char * op_name,
+    bool eval_compare(ggml_backend_t backend1, ggml_backend_t backend2, const char * op_name,
               std::vector<std::pair<std::string, std::string>> input_names, std::string output_name_1,
               std::string output_name_2, printer * output_printer) {
         mode = MODE_TEST;
@@ -4045,7 +4046,7 @@ struct test_conv_2d_im2col : public test_case {
         return std::string("CONV_2D_IM2COL");
     }
 
-    bool run_whole_graph() { return false; }
+    bool run_whole_graph() override { return false; }
 
     std::string vars() override {
         return VARS_TO_STR9(ne_input, ne_kernel, stride0, stride1, padding0, padding1, dilation0, dilation1, cwhn);
@@ -4228,7 +4229,7 @@ struct test_conv_2d_compare : public test_case_compare {
 
     bool eval(ggml_backend_t backend1, ggml_backend_t backend2, const char * op_name,
               printer * output_printer) override {
-        return test_case_compare::eval(backend1, backend2, op_name, input_names, output_name_1, output_name_2,
+        return test_case_compare::eval_compare(backend1, backend2, op_name, input_names, output_name_1, output_name_2,
                                        output_printer);
     }
 };

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -38,6 +38,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <map>
 
 static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float max = 1.0f) {
     size_t nels = ggml_nelements(tensor);
@@ -5531,7 +5532,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     }
 
     // extra tests for im2col 2D
-    test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {12, 12, 1, 32}, {3, 4, 1, 32}, 1, 1, 1, 1, 1, 1, true));
+    test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {12, 12, 1, 32}, {3, 3, 1, 32}, 1, 1, 1, 1, 1, 1, true));
     test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {12, 12, 2, 32}, {3, 3, 2, 32}, 1, 1, 1, 1, 1, 1, true));
     test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {12, 12, 1, 1024}, {3, 3, 1, 1024}, 1, 1, 1, 1, 1, 1, true));
     test_cases.emplace_back(new test_im2col(GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_F16, {12, 12, 2, 1024}, {3, 3, 2, 1024}, 1, 1, 1, 1, 1, 1, true));
@@ -5575,16 +5576,27 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     };
 
     for (auto act_case : cases) {
-        test_cases.emplace_back(new test_conv_2d(
-            { act_case[iwh_idx], act_case[iwh_idx], act_case[Cin_idx], act_case[B_idx] },
-            { act_case[kwh_idx], act_case[kwh_idx], act_case[Cin_idx], act_case[Cout_idx] }, 1, 1, 0, 0, 1, 1, false));
-        test_cases.emplace_back(new test_conv_2d_im2col(
-            { act_case[iwh_idx], act_case[iwh_idx], act_case[Cin_idx], act_case[B_idx] },
-            { act_case[kwh_idx], act_case[kwh_idx], act_case[Cin_idx], act_case[Cout_idx] }, 1, 1, 0, 0, 1, 1, false));
         test_cases.emplace_back(
+            new test_conv_2d({ act_case[iwh_idx], act_case[iwh_idx], act_case[Cin_idx], act_case[B_idx] },
+                             { act_case[kwh_idx], act_case[kwh_idx], act_case[Cin_idx], act_case[Cout_idx] },
+                             1,
+                             1,
+                             0,
+                             0,
+                             1,
+                             1,
+                             false));
+        /*
+        // Example test for testing a composite op
+            test_cases.emplace_back(new test_conv_2d_im2col(
+            { act_case[iwh_idx], act_case[iwh_idx], act_case[Cin_idx], act_case[B_idx] },
+            { act_case[kwh_idx], act_case[kwh_idx], act_case[Cin_idx], act_case[Cout_idx] }, 1, 1, 0, 0, 1, 1, false));
+        // Example test for testing a regular op against a composite op
+            test_cases.emplace_back(
             new test_conv_2d_compare({ act_case[iwh_idx], act_case[iwh_idx], act_case[Cin_idx], act_case[B_idx] },
                                      { act_case[kwh_idx], act_case[kwh_idx], act_case[Cin_idx], act_case[Cout_idx] }, 1,
                                      1, 0, 0, 1, 1, false, true));
+        */
     }
 #endif
 
@@ -5615,7 +5627,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                         test_cases.emplace_back(test_case_conv_2d);
                                         auto test_case_conv_2d_im2col = new test_conv_2d_im2col(
                                             { W, H, Cin, 2 }, { KW, KH, Cin, Cout }, s0, s1, p0, p1, d0, d1, false);
-                                        test_cases.emplace_back(test_case_conv_2d_im2col);
+                                        //test_cases.emplace_back(test_case_conv_2d_im2col);
                                         //test_cases.emplace_back(new test_conv_2d_compare(test_case_conv_2d, test_case_conv_2d_im2col);
                                     }
                                 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4091,7 +4091,7 @@ struct test_conv_2d_im2col : public test_case {
         dilation1(dilation1),
         cwhn(cwhn) {}
 
-    std::vector<std::string> get_input_names() { return { "kernel", "input" }; }
+    std::vector<std::string> get_input_names() override { return { "kernel", "input" }; }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         //printf("Building conv_2d_im2col graph...\n");
@@ -4180,7 +4180,7 @@ struct test_conv_2d : public test_case {
         dilation1(dilation1),
         cwhn(cwhn) {}
 
-    std::vector<std::string> get_input_names() { return { "kernel", "input" }; }
+    std::vector<std::string> get_input_names() override { return { "kernel", "input" }; }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         //printf("Building conv_2d graph...\n");

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -5625,8 +5625,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                         auto test_case_conv_2d = new test_conv_2d(
                                             { W, H, Cin, 2 }, { KW, KH, Cin, Cout }, s0, s1, p0, p1, d0, d1, false);
                                         test_cases.emplace_back(test_case_conv_2d);
-                                        auto test_case_conv_2d_im2col = new test_conv_2d_im2col(
-                                            { W, H, Cin, 2 }, { KW, KH, Cin, Cout }, s0, s1, p0, p1, d0, d1, false);
+                                        //auto test_case_conv_2d_im2col = new test_conv_2d_im2col(
+                                        //    { W, H, Cin, 2 }, { KW, KH, Cin, Cout }, s0, s1, p0, p1, d0, d1, false);
                                         //test_cases.emplace_back(test_case_conv_2d_im2col);
                                         //test_cases.emplace_back(new test_conv_2d_compare(test_case_conv_2d, test_case_conv_2d_im2col);
                                     }


### PR DESCRIPTION
This patch adds support for testing computation graphs "composite ops" in ```test-backend-ops```. 

This is useful 
* when measuring the performance gains of fused ops compared to indirect implementations,
* in op development to check the correctness if the implementation of the op under development does not exist yet  on CPU but it's equivalent computation graph can be built by combining existing ops forming a composite op.

Currently out of the tree code is used to test the correctness (https://github.com/ggml-org/llama.cpp/pull/14316 or https://github.com/ggml-org/llama.cpp/pull/14316) or non-standardized out-of-tree vibe coded standalone gists added to test the performance in https://github.com/ggml-org/llama.cpp/pull/14388#issuecomment-3019402862.

In particular, this PR enables 
* comparing the output of computation graphs when executed on backend1 vs backend2, 
* comparing the output of a computation graph to the output of a regular op or even comparing two composite ops if it makes sense,
* performance testing of computation graphs.

An example is when we compare the output of ```CONV_2D``` (direct conv implementation) with the ```ggml_conv_2d``` (indirect conv implementation as the latter contains im2col followed by a mul_mat in the resulting graph).

**To test output of an op against a graph**, the user needs to add a test case for the graph and the actual op, then they need  to subclass a `test_case_compare : public test_case` that accepts the two test cases in the constructor. The tensor name  assignment should be defined in ```test_case_compare``` to let the ```eval()``` function know how to copy the inputs between the two graphs before execution. The output nodes will then be compared after execution.

**When testing the perf of a graph**, the ```get_input_names``` of ```test_case``` should be overwritten to return the name of the input tensors that will be used by ```eval_perf``` to know which nodes should be duplicated. The default implementation returns an empty list and ```eval_perf``` assumes that the graph tests a regular op containing only the input nodes connected to a single output node doing the actual calculation, so only the output will be duplicated in this case.