### PR TITLE
CUDA: fix compilation with GGML_CUDA_F16

### DIFF
--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -31,8 +31,8 @@ static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __
     dequantize_kernel(vx, ib, iqs, v);
 
     const int64_t iy0 = ((i03*ne02 + i02)*ne01 + i01)*ne00 + iybs + iqs;
-    y[iy0 + 0]        = v.x;
-    y[iy0 + y_offset] = v.y;
+    y[iy0 + 0]        = float(v.x);
+    y[iy0 + y_offset] = float(v.y);
 }
 
 template <bool need_check>


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/14834 .

Quite frankly we should be removing `GGML_CUDA_F16` and make decisions regarding whether or not to use FP16 arithmetic based on the hardware.