### PR TITLE
chat : fix kimi-k2 chat template

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1934,12 +1934,6 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
         }
     },
     {
-        LLM_ARCH_UNKNOWN,
-        {
-            { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
-        },
-    },
-    {
         LLM_ARCH_DREAM,
         {
             { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
@@ -1954,6 +1948,12 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
             { LLM_TENSOR_FFN_GATE,        "blk.%d.ffn_gate" },
             { LLM_TENSOR_FFN_DOWN,        "blk.%d.ffn_down" },
             { LLM_TENSOR_FFN_UP,          "blk.%d.ffn_up" },
+        },
+    },
+    {
+        LLM_ARCH_UNKNOWN,
+        {
+            { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
         },
     },
 };

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -718,10 +718,9 @@ int32_t llm_chat_apply_template(
             }
 
             ss << message->content << "<|im_end|>";
-
-            if (add_ass) {
-                ss << "<|im_assistant|>assistant<|im_middle|>";
-            }
+        }
+        if (add_ass) {
+            ss << "<|im_assistant|>assistant<|im_middle|>";
         }
     } else {
         // template not supported


### PR DESCRIPTION
Fix a mistake in kimi k2 chat template, the `add_ass` was put inside the the loop, which cause the formatted text to have assistant prompt in the wrong places

Also fix a wrong code ordering in `llama-arch.cpp`
