### PR TITLE
docs: update HOWTO‑add‑model.md for ModelBase and new model classes

### DIFF
--- a/docs/development/HOWTO-add-model.md
+++ b/docs/development/HOWTO-add-model.md
@@ -23,11 +23,19 @@ The convert script reads the model configuration, tokenizer, tensor names+data a
 
 The required steps to implement for an HF model are:
 
-1. Define the model `Model.register` annotation in a new `Model` subclass, example:
+1. Define the model `ModelBase.register` annotation in a new `TextModel` or `MmprojModel` subclass, example:
 
 ```python
-@Model.register("MyModelForCausalLM")
-class MyModel(Model):
+@ModelBase.register("MyModelForCausalLM")
+class MyModel(TextModel):
+    model_arch = gguf.MODEL_ARCH.MYMODEL
+```
+
+or
+
+```python
+@ModelBase.register("MyModelForConditionalGeneration")
+class MyModel(MmprojModel):
     model_arch = gguf.MODEL_ARCH.MYMODEL
 ```
 
@@ -75,9 +83,10 @@ block_mappings_cfg: dict[MODEL_TENSOR, tuple[str, ...]] = {
 `transformer.blocks.{bid}.norm_1` will be mapped to `blk.{bid}.attn_norm` in GGUF.
 
 Depending on the model configuration, tokenizer, code and tensors layout, you will have to override:
-- `Model#set_gguf_parameters`
-- `Model#set_vocab`
-- `Model#write_tensors`
+- `TextModel#set_gguf_parameters`
+- `MmprojModel#set_gguf_parameters`
+- `ModelBase#set_vocab`
+- `ModelBase#modify_tensors`
 
 NOTE: Tensor names must end with `.weight` or `.bias` suffixes, that is the convention and several tools like `quantize` expect this to proceed the weights.
 


### PR DESCRIPTION
Hello llama.cpp team,

While working through the `docs/development/HOWTO‑add‑model.md` guide to add a new model, I noticed that the example still uses `@Model.register("MyModelForCausalLM")` and `class MyModel(Model)`. 

In #13023, the model base class was renamed from `Model` to `ModelBase`, and more recently, `TextModel` and `MmprojModel` were introduced. Following the current documentation now leads to an `AttributeError`.

This PR updates the example to use `@ModelBase.register("MyModelForCausalLM")` and `class MyModel(ModelBase)`, bringing the documentation back in line with the current code. 

Because `TextModel` and `MmprojModel` were added, some of the methods that need to be overridden in a new model class have also changed — this PR does not address those changes. 

If you guys don't mind. I plan to submit a follow‑up PR that updates the override instructions accordingly.

It’s a small fix that should prevent confusion for new contributors, and I intend to continue improving the HOWTO in subsequent PRs. Thank you for your time and consideration.
