### PR TITLE
CUDA: skip masked KV slices for all FA kernels

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -429,6 +429,20 @@ static __global__ void reduce_rows_f32(const float * x, float * dst, const int n
 }
 
 template<int width = WARP_SIZE>
+static __device__ __forceinline__ int warp_reduce_all(int x) {
+#ifdef GGML_USE_HIP
+#pragma unroll
+    for (int offset = width/2; offset > 0; offset >>= 1) {
+        x = x && __shfl_xor_sync(0xffffffff, x, offset, width);
+    }
+    return x;
+#else
+    static_assert(width == WARP_SIZE, "width != WARP_SIZE not implemented");
+    return __all_sync(0xffffffff, x);
+#endif // GGML_USE_HIP
+}
+
+template<int width = WARP_SIZE>
 static __device__ __forceinline__ float warp_reduce_max(float x) {
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -15,6 +15,7 @@ typedef void (* fattn_kernel_t)(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -500,6 +501,55 @@ constexpr __device__ dequantize_1_f32_t get_dequantize_1_f32(ggml_type type_V) {
         nullptr;
 }
 
+template <int ncols1>
+__launch_bounds__(FATTN_KQ_STRIDE/2, 1)
+static __global__ void flash_attn_mask_to_KV_max(
+        const half2 * __restrict__ mask, int * __restrict__ KV_max, const int ne30, const int s31, const int s33) {
+    const int ne31     = gridDim.x;
+    const int tid      = threadIdx.x;
+    const int sequence = blockIdx.y;
+    const int jt       = blockIdx.x;
+
+    mask += sequence*s33 + jt*ncols1*s31;
+
+    __shared__ int buf_iw[WARP_SIZE];
+    if (tid < WARP_SIZE) {
+        buf_iw[tid] = 1;
+    }
+    __syncthreads();
+
+    int KV_max_sj = (ne30 - 1) * FATTN_KQ_STRIDE;
+    for (; KV_max_sj >= 0; KV_max_sj -= FATTN_KQ_STRIDE) {
+        int all_inf = 1;
+
+#pragma unroll
+        for (int j = 0; j < ncols1; ++j) {
+            const float2 tmp = __half22float2(mask[j*s31 + KV_max_sj/2 + tid]);
+            all_inf = all_inf && int(isinf(tmp.x)) && int(isinf(tmp.y));
+        }
+
+        all_inf = warp_reduce_all(all_inf);
+        if (tid % WARP_SIZE == 0) {
+            buf_iw[tid / WARP_SIZE] = all_inf;
+        }
+        __syncthreads();
+        all_inf = buf_iw[tid % WARP_SIZE];
+        __syncthreads();
+        all_inf = warp_reduce_all(all_inf);
+
+        if (!all_inf) {
+            KV_max_sj += FATTN_KQ_STRIDE;
+            break;
+        }
+    }
+
+    if (threadIdx.x != 0) {
+        return;
+    }
+
+    KV_max[sequence*ne31 + jt] = KV_max_sj;
+}
+
 template<int D, int ncols1, int ncols2> // D == head size
 __launch_bounds__(D, 1)
 static __global__ void flash_attn_stream_k_fixup(
@@ -711,6 +761,7 @@ void launch_fattn(
 
     ggml_cuda_pool_alloc<half>   K_f16(pool);
     ggml_cuda_pool_alloc<half>   V_f16(pool);
+    ggml_cuda_pool_alloc<int>    KV_max(pool);
     ggml_cuda_pool_alloc<float>  dst_tmp(pool);
     ggml_cuda_pool_alloc<float2> dst_tmp_meta(pool);
 
@@ -779,10 +830,29 @@ void launch_fattn(
         V_data = (char *) V_f16.ptr;
     }
 
-    int parallel_blocks = 1;
-
     const int ntiles_x = ((Q->ne[1] + ncols1 - 1) / ncols1);
     const int ntiles_total = ntiles_x * (Q->ne[2] / ncols2) * Q->ne[3];
+
+    // Optional optimization where the mask is scanned to determine whether part of the calculation can be skipped.
+    // Only worth the overhead if there is at lease one FATTN_KQ_STRIDE x FATTN_KQ_STRIDE square to be skipped or
+    //     multiple sequences of possibly different lengths.
+    if (mask && (Q->ne[1] >= 1024 || Q->ne[3] > 1)) {
+        const int s31 = mask->nb[1] / sizeof(half2);
+        const int s33 = mask->nb[3] / sizeof(half2);
+
+        const dim3 blocks_num_KV_max(ntiles_x, Q->ne[3], 1);
+        const dim3 block_dim_KV_max(FATTN_KQ_STRIDE/2, 1, 1);
+
+        const int ne_KV_max = blocks_num_KV_max.x*blocks_num_KV_max.y;
+        const int iter_k = K->ne[1] / FATTN_KQ_STRIDE;
+
+        KV_max.alloc(ne_KV_max);
+        flash_attn_mask_to_KV_max<ncols1><<<blocks_num_KV_max, block_dim_KV_max, 0, main_stream>>>
+            ((const half2 *) mask->data, KV_max.ptr, iter_k, s31, s33);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    int parallel_blocks = 1;
 
     const dim3 block_dim(warp_size, nwarps, 1);
     int max_blocks_per_sm = 1; // Max. number of active blocks limited by occupancy.
@@ -870,6 +940,7 @@ void launch_fattn(
         K_data,
         V_data,
         mask ? ((const char *) mask->data) : nullptr,
+        KV_max.ptr,
         !stream_k && parallel_blocks > 1 ? dst_tmp.ptr : (float *) KQV->data, dst_tmp_meta.ptr,
         scale, max_bias, m0, m1, n_head_log2, logit_softcap,
         Q->ne[0], Q->ne[1], Q->ne[2], Q->ne[3], Q->nb[1], Q->nb[2], Q->nb[3],

--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -13,6 +13,7 @@ static __global__ void flash_attn_tile_ext_f16(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -90,7 +91,8 @@ static __global__ void flash_attn_tile_ext_f16(
 
     __syncthreads();
 
-    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE_TILE_F16; k_VKQ_0 < ne11; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE_TILE_F16) {
+    const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
+    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE_TILE_F16; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE_TILE_F16) {
         // Calculate KQ tile and keep track of new maximum KQ values:
 
         half kqmax_new[ncols/nwarps];

--- a/ggml/src/ggml-cuda/fattn-tile-f32.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f32.cu
@@ -13,6 +13,7 @@ static __global__ void flash_attn_tile_ext_f32(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -99,7 +100,8 @@ static __global__ void flash_attn_tile_ext_f32(
 
     __syncthreads();
 
-    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE_TILE_F32; k_VKQ_0 < ne11; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE_TILE_F32) {
+    const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
+    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE_TILE_F32; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE_TILE_F32) {
         // Calculate KQ tile and keep track of new maximum KQ values:
 
         float kqmax_new[ncols/nwarps];

--- a/ggml/src/ggml-cuda/fattn-vec-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f16.cuh
@@ -10,6 +10,7 @@ static __global__ void flash_attn_vec_ext_f16(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -171,10 +172,11 @@ static __global__ void flash_attn_vec_ext_f16(
 
     half2 VKQ[ncols] = {{0.0f, 0.0f}};
 
+    const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
     K     += blockIdx.y*D * nb11;
     V     += blockIdx.y*D * nb21;
     maskh += blockIdx.y*D;
-    for (int k_VKQ_0 = blockIdx.y*D; k_VKQ_0 < ne11; k_VKQ_0 += gridDim.y*D,
+    for (int k_VKQ_0 = blockIdx.y*D; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*D,
              // Increment pointers after each loop:
              K += gridDim.y*D*nb11, V += gridDim.y*D*nb21, maskh += gridDim.y*D) {
 
@@ -185,29 +187,7 @@ static __global__ void flash_attn_vec_ext_f16(
             for (int j = 0; j < ncols; ++j) {
                 maskh_shared[j*D + tid] = slopeh*maskh[j*ne11 + tid];
             }
-
             __syncthreads();
-
-            // When using multiple parallel sequences in llama.cpp, some KV slices can be fully masked out.
-            // In such cases, skip the KV slice.
-            // On AMD __all_sync would not work correctly because it assumes a warp size of 64.
-#ifndef GGML_USE_HIP
-            bool skip = true;
-#pragma unroll
-            for (int j = 0; j < ncols; ++j) {
-#pragma unroll
-                for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
-                    const int i = i0 + threadIdx.x;
-
-                    const float2 tmp = __half22float2(((const half2 *) maskh_shared)[j*(D/2) + i]);
-                    skip = skip && isinf(tmp.x) && isinf(tmp.y);
-                }
-            }
-            if (__all_sync(0xFFFFFFFF, skip)) {
-                __syncthreads();
-                continue;
-            }
-#endif // GGML_USE_HIP
         }
 
         // For unknown reasons using a half array of size 1 for kqmax_new causes a performance regression,

--- a/ggml/src/ggml-cuda/fattn-vec-f32.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f32.cuh
@@ -10,6 +10,7 @@ static __global__ void flash_attn_vec_ext_f32(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -177,10 +178,11 @@ static __global__ void flash_attn_vec_ext_f32(
 
     float VKQ[ncols] = {0.0f};
 
+    const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
     K     += blockIdx.y*D * nb11;
     V     += blockIdx.y*D * nb21;
     maskh += blockIdx.y*D;
-    for (int k_VKQ_0 = blockIdx.y*D; k_VKQ_0 < ne11; k_VKQ_0 += gridDim.y*D,
+    for (int k_VKQ_0 = blockIdx.y*D; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*D,
              // Increment pointers after each loop:
              K += gridDim.y*D*nb11, V += gridDim.y*D*nb21, maskh += gridDim.y*D) {
 
@@ -191,28 +193,7 @@ static __global__ void flash_attn_vec_ext_f32(
             for (int j = 0; j < ncols; ++j) {
                 maskf_shared[j*D + tid] = slope*__half2float(maskh[j*ne11 + tid]);
             }
-
             __syncthreads();
-
-            // When using multiple parallel sequences in llama.cpp, some KV slices can be fully masked out.
-            // In such cases, skip the KV slice.
-            // On AMD __all_sync would not work correctly because it assumes a warp size of 64.
-#ifndef GGML_USE_HIP
-            bool skip = true;
-#pragma unroll
-            for (int j = 0; j < ncols; ++j) {
-#pragma unroll
-                for (int i0 = 0; i0 < D; i0 += WARP_SIZE) {
-                    const int i = i0 + threadIdx.x;
-
-                    skip = skip && isinf(maskf_shared[j*D + i]);
-                }
-            }
-            if (__all_sync(0xFFFFFFFF, skip)) {
-                __syncthreads();
-                continue;
-            }
-#endif // GGML_USE_HIP
         }
 
         float kqmax_new_arr[ncols];

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cu
@@ -29,6 +29,7 @@ static __global__ void flash_attn_ext_f16(
         const char * __restrict__ K,
         const char * __restrict__ V,
         const char * __restrict__ mask,
+        const int  * __restrict__ KV_max,
         float      * __restrict__ dst,
         float2     * __restrict__ dst_meta,
         const float scale,
@@ -165,7 +166,8 @@ static __global__ void flash_attn_ext_f16(
     __syncthreads();
 
     // Iterate over ne11 == previous tokens:
-    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE; k_VKQ_0 < ne11; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE) {
+    const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
+    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE) {
         // Calculate tile of KQ:
 #pragma unroll
         for (int i_KQ_0 = 0; i_KQ_0 < FATTN_KQ_STRIDE; i_KQ_0 += KQ_stride_tc) {

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -315,7 +315,8 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
 
     const bool gqa_opt_applies = ((Q->ne[2] / K->ne[2]) % 2 == 0) && mask; // The mma-based kernels have GQA-specific optimizations
     const bool mma_needs_data_conversion = K->type != GGML_TYPE_F16 || V->type != GGML_TYPE_F16;
-    const bool mma_faster_for_bs1 = new_mma_available(cc) && gqa_opt_applies && cc < GGML_CUDA_CC_ADA_LOVELACE && !mma_needs_data_conversion;
+    const bool mma_faster_for_bs1 = new_mma_available(cc) && gqa_opt_applies &&
+        (Q->ne[3] > 1 || cc < GGML_CUDA_CC_ADA_LOVELACE) && !mma_needs_data_conversion;
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % (2*warp_size) == 0;
     if (Q->ne[1] == 1 && can_use_vector_kernel && !mma_faster_for_bs1) {
         if (prec == GGML_PREC_DEFAULT) {


### PR DESCRIPTION
This PR adds support for skipping fully masked out KV slices for all CUDA FlashAttention kernels. The main benefit is higher batched server throughput with `LLAMA_SET_ROWS` but it also makes prompt processing with batch sizes >= 1024 a bit faster. The implementation works by checking how many values at the end of the KV cache in dimension 1 are fully masked out with `-inf` with an auxiliary kernel (overhead <1% end-to-end). This then provides an upper limit for the iteration of the FA kernels over the KV cache, allowing them to skip the fully masked out section with minimal changes. This of course assumes that there are no significant regions that should be skipped other than at the end - I think with the SWA rework there aren't any but please correct me if I'm wrong. It would in principle be possible to pre-compute the max. extents of the KV cache in CPU code but I don't think it would be worth the additional complexity.

I tried variants which also skipped loading the mask if it's all zero or which reweighted the workloads per SM to match the sequence lengths but I was not able to get meaningful performance gains.

To measure the performance difference vs. master I used `server-bench.py` with commands like this:

```
export np=2000
LLAMA_ARG_N_PARALLEL=32 LLAMA_ARG_CTX_SIZE=700000 LLAMA_ARG_MODEL=/opt/models/llama_3.2_instruct-1b-q4_k_m.gguf python3 server-bench.py --path_server /home/johannesg/Projects/llama.cpp/build/bin/llama-server --n_prompt 1000 --prompt_source rng-0-19000 --n_predict_min $(($np/2)) --n_predict $(($np*3/2))
```

(not the exact commands, there are some changes that I will still need to upstream). For the hardware I used 6x RTX 4090s with their frequencies limited to 1350 MHz. The GPUs ran 6 parallel benchmarks for each combination of setup and mean prediction length, I then did a linear regression with a quadratic model to isolate the part of the runtime that scales with the mean prediction length. With 32 parallel slots the end-to-end speedup for the range I looked at is up to 1.15, asymptotically it's something like 1.25. The speedup comes from the mma kernels scaling better with large workloads. Skipping masked out KV slices and using the mma kernel instead of the vector kernel seem to be of about equal importance.

<details>
<summary>Server performance plot</summary>

<img width="1647" height="1083" alt="Figure_1" src="https://github.com/user-attachments/assets/6f9516e3-95cf-414b-bab5-a3051ccc89e6" />

</details>

<details>
<summary>pp8192 t/s numbers</summary>

| GPU        | Model           |     Microbatch size | Test     |     t/s master |     t/s ddede2c32 |     Speedup |
| :--------- | :-------------- | ------------------: | :------- | -------------: | ----------------: | ----------: |
| P40        | llama 8B Q4_0   |                   1 | pp8192   |          46.42 |             46.33 |        1.00 |
| P40        | llama 8B Q4_0   |                   2 | pp8192   |          81.40 |             81.32 |        1.00 |
| P40        | llama 8B Q4_0   |                   4 | pp8192   |         103.14 |            103.07 |        1.00 |
| P40        | llama 8B Q4_0   |                   8 | pp8192   |         114.72 |            113.11 |        0.99 |
| P40        | llama 8B Q4_0   |                  16 | pp8192   |         326.02 |            325.81 |        1.00 |
| P40        | llama 8B Q4_0   |                  32 | pp8192   |         458.74 |            458.53 |        1.00 |
| P40        | llama 8B Q4_0   |                  64 | pp8192   |         519.93 |            517.83 |        1.00 |
| P40        | llama 8B Q4_0   |                 128 | pp8192   |         563.78 |            561.29 |        1.00 |
| P40        | llama 8B Q4_0   |                 256 | pp8192   |         595.52 |            594.80 |        1.00 |
| P40        | llama 8B Q4_0   |                 512 | pp8192   |         606.82 |            604.50 |        1.00 |
| P40        | llama 8B Q4_0   |                1024 | pp8192   |         601.37 |            617.57 |        1.03 |
| P40        | llama 8B Q4_0   |                2048 | pp8192   |         579.87 |            621.40 |        1.07 |
| P40        | llama 8B Q4_0   |                4096 | pp8192   |         566.37 |            622.50 |        1.10 |
| P40        | llama 8B Q4_0   |                8192 | pp8192   |         579.64 |            617.56 |        1.07 |
| RTX 4090   | llama 8B Q4_0   |                   1 | pp8192   |         167.71 |            168.13 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                   2 | pp8192   |         303.63 |            302.71 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                   4 | pp8192   |         593.33 |            590.97 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                   8 | pp8192   |        1006.47 |           1004.24 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                  16 | pp8192   |        1692.53 |           1687.89 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                  32 | pp8192   |        3093.43 |           3107.36 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                  64 | pp8192   |        5417.20 |           5416.87 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                 128 | pp8192   |        7988.06 |           7988.70 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                 256 | pp8192   |       10329.99 |          10342.08 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                 512 | pp8192   |       11552.18 |          11570.88 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                1024 | pp8192   |       11772.45 |          11830.59 |        1.00 |
| RTX 4090   | llama 8B Q4_0   |                2048 | pp8192   |       11416.92 |          11534.25 |        1.01 |
| RTX 4090   | llama 8B Q4_0   |                4096 | pp8192   |       11400.16 |          11559.12 |        1.01 |
| RTX 4090   | llama 8B Q4_0   |                8192 | pp8192   |       11402.69 |          11592.19 |        1.02 |
| RX 6800    | llama 8B Q4_0   |                   1 | pp8192   |          46.40 |             45.48 |        0.98 |
| RX 6800    | llama 8B Q4_0   |                   2 | pp8192   |          67.43 |             67.47 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                   4 | pp8192   |          73.61 |             73.48 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                   8 | pp8192   |          75.18 |             75.20 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                  16 | pp8192   |          93.02 |             93.03 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                  32 | pp8192   |         115.83 |            116.52 |        1.01 |
| RX 6800    | llama 8B Q4_0   |                  64 | pp8192   |         126.99 |            127.33 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                 128 | pp8192   |         153.67 |            153.98 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                 256 | pp8192   |         160.67 |            160.94 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                 512 | pp8192   |         157.56 |            157.98 |        1.00 |
| RX 6800    | llama 8B Q4_0   |                1024 | pp8192   |         146.14 |            157.55 |        1.08 |
| RX 6800    | llama 8B Q4_0   |                2048 | pp8192   |         132.32 |            155.34 |        1.17 |
| RX 6800    | llama 8B Q4_0   |                4096 | pp8192   |         132.32 |            155.52 |        1.18 |
| RX 6800    | llama 8B Q4_0   |                8192 | pp8192   |         132.41 |            155.55 |        1.17 |

</details>
