### PR TITLE
SYCL: experimental gemv kernel for q4_K 

### DIFF
--- a/ggml/src/ggml-sycl/backend.hpp
+++ b/ggml/src/ggml-sycl/backend.hpp
@@ -22,6 +22,7 @@
 #include "dequantize.hpp"
 #include "dmmv.hpp"
 #include "element_wise.hpp"
+#include "exp_gemvq.hpp"
 #include "gla.hpp"
 #include "im2col.hpp"
 #include "mmq.hpp"

--- a/ggml/src/ggml-sycl/builtins.hpp
+++ b/ggml/src/ggml-sycl/builtins.hpp
@@ -27,22 +27,19 @@
     assert(0 && x);              \
     printf(x);
 
-#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
 template <class T, int N> using vector_t = T __attribute__((ext_vector_type(N)));
 #else
 template <class T, int N> using vector_t = sycl::marray<T, N>;
 #endif
 
-#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
 #    define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#    define SYCL_DEVICE_BUILTIN(x)                                                      \
-        inline x {                                                                      \
-            GGML_SYCL_UNREACHABLE("Attempting to use a device built-in in host code."); \
-        }
+#    define SYCL_DEVICE_BUILTIN(x)
 #endif
 
-#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
 #    define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL extern "C" x
 #else
 #    define SYCL_DEVICE_OCL(x)
@@ -92,7 +89,7 @@ SYCL_DEVICE_BUILTIN(sycl::vector_types::ushort16 __builtin_IB_subgroup_block_rea
 SYCL_DEVICE_BUILTIN(uint32_t __builtin_IB_subgroup_block_read_flat_u32_m1k16v1(
     intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
 
-SYCL_EXTERNAL extern "C" int __builtin_IB_dp4a_ss(int c, int a, int b) __attribute__((const));
+SYCL_DEVICE_BUILTIN(int __builtin_IB_dp4a_ss(int c, int a, int b) __attribute__((const)));
 
 #pragma clang diagnostic pop
 
@@ -104,8 +101,17 @@ template <> struct XeSubgroup2DBlockLoad<2, 16, 1, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<uint16_t *>(dstPointer) = __builtin_IB_subgroup_block_read_flat_u16_m1k16v1(
             (intptr_t) (srcBasePointer), memoryWidth - 1, memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 
@@ -113,9 +119,18 @@ template <> struct XeSubgroup2DBlockLoad<2, 16, 2, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<sycl::vector_types::ushort2 *>(dstPointer) =
             __builtin_IB_subgroup_block_read_flat_u16_m2k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
                                                               memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 
@@ -123,9 +138,18 @@ template <> struct XeSubgroup2DBlockLoad<2, 16, 4, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<sycl::vector_types::ushort4 *>(dstPointer) =
             __builtin_IB_subgroup_block_read_flat_u16_m4k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
                                                               memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 
@@ -133,9 +157,18 @@ template <> struct XeSubgroup2DBlockLoad<2, 16, 8, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<sycl::vector_types::ushort8 *>(dstPointer) =
             __builtin_IB_subgroup_block_read_flat_u16_m8k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
                                                               memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 
@@ -143,9 +176,18 @@ template <> struct XeSubgroup2DBlockLoad<2, 16, 16, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<sycl::vector_types::ushort16 *>(dstPointer) =
             __builtin_IB_subgroup_block_read_flat_u16_m16k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
                                                                memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 
@@ -153,8 +195,17 @@ template <> struct XeSubgroup2DBlockLoad<4, 16, 1, 1> {
     template <typename T>
     __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
                                     coord_t coordinate, T * dstPointer) {
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
         *reinterpret_cast<uint32_t *>(dstPointer) = __builtin_IB_subgroup_block_read_flat_u32_m1k16v1(
             reinterpret_cast<long>(srcBasePointer), memoryWidth - 1, memoryHeight - 1, memoryPitch - 1, coordinate);
+#else
+       (void)srcBasePointer;
+       (void)memoryWidth;
+       (void)memoryHeight;
+       (void)memoryPitch;
+       (void)coordinate;
+       (void)dstPointer;
+#endif
     }
 };
 

--- a/ggml/src/ggml-sycl/builtins.hpp
+++ b/ggml/src/ggml-sycl/builtins.hpp
@@ -1,0 +1,161 @@
+/***************************************************************************
+ *
+ *  Copyright (C) 2025 Codeplay Software Ltd.
+ *  Copyright (C) 2025 Intel Corporation
+ *
+ *  MIT License
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  builtins.hpp
+ *
+ *  Description:
+ *     Intel builtin specifics
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/marray.hpp>
+
+#include "ggml-sycl/dpct/helper.hpp"
+
+#define GGML_SYCL_UNREACHABLE(x) \
+    assert(0 && x);              \
+    printf(x);
+
+#ifdef __SYCL_DEVICE_ONLY__
+template <class T, int N> using vector_t = T __attribute__((ext_vector_type(N)));
+#else
+template <class T, int N> using vector_t = sycl::marray<T, N>;
+#endif
+
+#ifdef __SYCL_DEVICE_ONLY__
+#    define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
+#else
+#    define SYCL_DEVICE_BUILTIN(x)                                                      \
+        inline x {                                                                      \
+            GGML_SYCL_UNREACHABLE("Attempting to use a device built-in in host code."); \
+        }
+#endif
+
+#ifdef __SYCL_DEVICE_ONLY__
+#    define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL extern "C" x
+#else
+#    define SYCL_DEVICE_OCL(x)
+#endif
+
+namespace sycl::vector_types {
+
+using ushort2  = vector_t<uint16_t, 2>;
+using ushort4  = vector_t<uint16_t, 4>;
+using ushort8  = vector_t<uint16_t, 8>;
+using ushort16 = vector_t<uint16_t, 16>;
+
+using uint16_t2  = vector_t<uint16_t, 2>;
+using uint16_t4  = vector_t<uint16_t, 4>;
+using uint16_t8  = vector_t<uint16_t, 8>;
+using uint16_t16 = vector_t<uint16_t, 16>;
+
+using uint32_t2  = vector_t<uint32_t, 2>;
+using uint32_t8  = vector_t<uint32_t, 8>;
+using uint32_t16 = vector_t<uint32_t, 16>;
+using uint32_t32 = vector_t<uint32_t, 32>;
+
+using int32_t2 = vector_t<int32_t, 2>;
+}  // namespace sycl::vector_types
+
+using coord_t = sycl::vector_types::int32_t2;
+
+namespace sycl::detail {
+
+// Avoid compilation warnings in the host side
+// These are expected to be unused
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wreturn-type"
+
+SYCL_DEVICE_BUILTIN(uint16_t __builtin_IB_subgroup_block_read_flat_u16_m1k16v1(intptr_t baseoffset, int width_minus_one,
+                                                                               int height_minus_one,
+                                                                               int pitch_minus_one, coord_t coord));
+SYCL_DEVICE_BUILTIN(sycl::vector_types::ushort2 __builtin_IB_subgroup_block_read_flat_u16_m2k16v1(
+    intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
+SYCL_DEVICE_BUILTIN(sycl::vector_types::ushort4 __builtin_IB_subgroup_block_read_flat_u16_m4k16v1(
+    intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
+SYCL_DEVICE_BUILTIN(sycl::vector_types::ushort8 __builtin_IB_subgroup_block_read_flat_u16_m8k16v1(
+    intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
+SYCL_DEVICE_BUILTIN(sycl::vector_types::ushort16 __builtin_IB_subgroup_block_read_flat_u16_m16k16v1(
+    intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
+SYCL_DEVICE_BUILTIN(uint32_t __builtin_IB_subgroup_block_read_flat_u32_m1k16v1(
+    intptr_t baseoffset, int width_minus_one, int height_minus_one, int pitch_minus_one, coord_t coord));
+
+SYCL_EXTERNAL extern "C" int __builtin_IB_dp4a_ss(int c, int a, int b) __attribute__((const));
+
+#pragma clang diagnostic pop
+
+template <int ElementSize, int BlockWidth, int BlockHeight, int BlockCount> struct XeSubgroup2DBlockLoad {
+    static_assert(false, "Unsupported 2D Block Load Configuration.");
+};
+
+template <> struct XeSubgroup2DBlockLoad<2, 16, 1, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<uint16_t *>(dstPointer) = __builtin_IB_subgroup_block_read_flat_u16_m1k16v1(
+            (intptr_t) (srcBasePointer), memoryWidth - 1, memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+template <> struct XeSubgroup2DBlockLoad<2, 16, 2, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<sycl::vector_types::ushort2 *>(dstPointer) =
+            __builtin_IB_subgroup_block_read_flat_u16_m2k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
+                                                              memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+template <> struct XeSubgroup2DBlockLoad<2, 16, 4, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<sycl::vector_types::ushort4 *>(dstPointer) =
+            __builtin_IB_subgroup_block_read_flat_u16_m4k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
+                                                              memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+template <> struct XeSubgroup2DBlockLoad<2, 16, 8, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<sycl::vector_types::ushort8 *>(dstPointer) =
+            __builtin_IB_subgroup_block_read_flat_u16_m8k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
+                                                              memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+template <> struct XeSubgroup2DBlockLoad<2, 16, 16, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<sycl::vector_types::ushort16 *>(dstPointer) =
+            __builtin_IB_subgroup_block_read_flat_u16_m16k16v1((intptr_t) (srcBasePointer), memoryWidth - 1,
+                                                               memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+template <> struct XeSubgroup2DBlockLoad<4, 16, 1, 1> {
+    template <typename T>
+    __dpct_inline__ void operator()(const void * srcBasePointer, int memoryWidth, int memoryHeight, int memoryPitch,
+                                    coord_t coordinate, T * dstPointer) {
+        *reinterpret_cast<uint32_t *>(dstPointer) = __builtin_IB_subgroup_block_read_flat_u32_m1k16v1(
+            reinterpret_cast<long>(srcBasePointer), memoryWidth - 1, memoryHeight - 1, memoryPitch - 1, coordinate);
+    }
+};
+
+}  // namespace sycl::detail

--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -45,6 +45,8 @@ void ggml_sycl_host_free(void* ptr);
 extern int g_ggml_sycl_debug;
 extern int g_ggml_sycl_disable_optimize;
 extern int g_ggml_sycl_prioritize_dmmv;
+extern int g_ggml_sycl_use_exp_gemvq;
+extern int g_ggml_sycl_exp_gemvq_tile_height;
 
 #if defined(__clang__) && __has_builtin(__builtin_expect)
 // Hint the optimizer to pipeline the more likely following instruction in branches
@@ -556,6 +558,11 @@ struct scope_op_debug_print {
   private:
     std::string_view func;
     std::string_view func_suffix;
+};
+
+enum class reorder_kind_t {
+    SOA = 0,
+    LINEAR_BLOCK_LOAD = 1,
 };
 
 #endif // GGML_SYCL_COMMON_HPP

--- a/ggml/src/ggml-sycl/exp_gemvq.hpp
+++ b/ggml/src/ggml-sycl/exp_gemvq.hpp
@@ -1,0 +1,28 @@
+/***************************************************************************
+ *
+ *  Copyright (C) 2025 Codeplay Software Ltd.
+ *  Copyright (C) 2025 Intel Corporation
+ *
+ *  MIT License
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  exp_gemvq.hpp
+ *
+ *  Description:
+ *     Exp gemv public API
+ **************************************************************************/
+
+#pragma once
+
+#include "dpct/helper.hpp"
+
+void ggml_sycl_op_mul_mat_exp_gemvq(ggml_backend_sycl_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
+                                    ggml_tensor * dst, const char * src0_dd_i, const float * src1_ddf_i,
+                                    const char * src1_ddq_i, float * dst_dd_i, const int64_t row_low,
+                                    const int64_t row_high, const int64_t src1_ncols,
+                                    const int64_t src1_padded_col_size, const dpct::queue_ptr & stream);

--- a/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
+++ b/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
@@ -182,10 +182,12 @@ __dpct_inline__ static void q4_K_q8_1_tiled_gemvq(
                     decode_chunk_scales(chunk_idx, scales, &sc_m[2 * i]);
                 }
 
+#if defined(__SYCL_DEVICE_ONLY__) && !defined(__NVPTX__)
                 const int32_t q4_val = unpack_q4_tile(q4_tile[i]);
                 const int32_t q8_val = static_cast<int32_t>(q8_tile);
                 dot1[i]              = sycl::detail::__builtin_IB_dp4a_ss(dot1[i], q4_val, q8_val);
                 dot2[i]              = sycl::detail::__builtin_IB_dp4a_ss(dot2[i], 0x01010101, q8_val);
+#endif
             }
         }
 

--- a/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
+++ b/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
@@ -1,0 +1,282 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  MIT License
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  gemvq_q4_k_q8_1.cpp
+ *
+ *  Description:
+ *    Exp gemv for llama.cpp's q4_K X q8_1 quantized types
+ *    Expected GEMV Layout: nrows x ncols : ncols x 1;
+ **************************************************************************/
+
+#include <sycl/sycl.hpp>
+
+#include "dpct/helper.hpp"
+#include "ggml-sycl/builtins.hpp"
+#include "ggml-sycl/common.hpp"
+#include "ggml.h"
+#include "quants.hpp"
+
+template <int ElementSize, int Cols, int Rows, int Values> struct BlockLayout {
+    static constexpr int element_size = ElementSize;
+    static constexpr int cols         = Cols;
+    static constexpr int rows         = Rows;
+    static constexpr int values       = Values;
+};
+
+template <typename block_q_t, typename block_layout, typename T>
+static __dpct_inline__ void get_quant_tile(const void * weights, size_t ncols, size_t nrows, coord_t coord, T * tile) {
+#ifdef __SYCL_DEVICE_ONLY__
+    using namespace sycl::detail;
+    // Width is expected in bytes. Quants are packed in bytes, 1 col == 1 nibble (q4_K)
+    size_t width = ncols / (block_q_t::traits::qr);
+    XeSubgroup2DBlockLoad<block_layout::element_size, block_layout::cols, block_layout::rows, block_layout::values>()(
+        weights, width, nrows, width, coord, tile);
+#else
+    (void) weights;
+    (void) nrows;
+    (void) ncols;
+    (void) coord;
+    (void) tile;
+    GGML_ABORT("Host code should not get here");
+#endif
+}
+
+template <int tile_height> struct BlockLoadType {};
+
+template <> struct BlockLoadType<1> {
+    using T = uint16_t[1];
+};
+
+template <> struct BlockLoadType<2> {
+    using T = sycl::vector_types::uint16_t2;
+};
+
+template <> struct BlockLoadType<4> {
+    using T = sycl::vector_types::uint16_t4;
+};
+
+template <> struct BlockLoadType<8> {
+    using T = sycl::vector_types::uint16_t8;
+};
+
+template <> struct BlockLoadType<16> {
+    using T = sycl::vector_types::uint16_t16;
+};
+
+template <int tile_height> using block_load_t = typename BlockLoadType<tile_height>::T;
+
+template <int tile_height> struct LayoutTraits {
+    // Block Load
+    static constexpr int bytes   = 2;
+    static constexpr int rows    = tile_height;
+    static constexpr int columns = 16;
+    static constexpr int values  = 1;
+
+    using QK_Layout = BlockLayout<bytes, columns, rows, values>;
+    using Q8_Layout = BlockLayout<2 * bytes, columns, 1, values>;
+    using QK_tile_t = block_load_t<tile_height>;
+
+    // Tiled GemV traits
+    static constexpr size_t coord_stride = columns;
+
+    template <size_t prefetch_pipeline> static constexpr size_t prefetch_offset = coord_stride * prefetch_pipeline;
+
+    template <typename block_q_t> __dpct_inline__ static size_t coord_range(size_t ncols) {
+        return ncols / (QK_Layout::element_size * block_q_t::traits::qr);
+    }
+};
+
+__dpct_inline__ static int32_t unpack_q4_tile(uint16_t q4_tile) {
+    return ((q4_tile >> 12) & 0x0F) << 16 | ((q4_tile >> 8) & 0x0F) << 24 | ((q4_tile >> 4) & 0x0F) |
+           (q4_tile & 0x0F) << 8;
+}
+
+// NOTE: Branchless approach gives better performance
+static __dpct_inline__ void decode_chunk_scales(int chunk_idx, const uint8_t * scales, uint8_t * sc_m) {
+    // chunk_idx < 4
+    uint16_t val_a = *reinterpret_cast<const uint16_t *>(&scales[2 * chunk_idx]) & 0x3f3f;
+
+    // chunk_idx >= 4
+    uint16_t hbits = *reinterpret_cast<const uint16_t *>(&scales[(chunk_idx - 4) * 2]);
+    uint8_t  b0    = ((hbits & 0x00c0) >> 2) | (scales[chunk_idx + 4] & 0x0f);
+    uint8_t  b1    = ((hbits & 0xc000) >> 10) | ((scales[chunk_idx + 4] >> 4) & 0x0f);
+    uint16_t val_b = static_cast<uint16_t>(b0) | (static_cast<uint16_t>(b1) << 8);
+
+    uint32_t mask                       = -(chunk_idx < 4);
+    *reinterpret_cast<uint16_t *>(sc_m) = (val_a & mask) | (val_b & ~mask);
+}
+
+static __dpct_inline__ void decode_superblock_scale(const uint8_t * weights_ptr, size_t offset, sycl::float2 * dm4f) {
+    const ggml_half2 * dm4 = reinterpret_cast<const ggml_half2 *>(weights_ptr + offset);
+    *dm4f                  = dm4->convert<float, sycl::rounding_mode::automatic>();
+}
+
+template <typename Traits, size_t prefetch_pipeline>
+__dpct_inline__ static void q4_K_q8_1_tiled_gemvq(
+    const void * weights, const void * input, float * dst, const size_t ncols, const size_t nrows,
+    const sycl::nd_item<1> & it) {
+    using block_q_t  = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q4_K>;
+    using block_q8_t = ggml_sycl_reordered::block_q_t<GGML_TYPE_Q8_1>;
+
+    using bl_layout                     = typename Traits::QK_Layout;
+    using q8_layout                     = typename Traits::Q8_Layout;
+    using q4_tile_t                     = typename Traits::QK_tile_t;
+    constexpr size_t coord_stride       = Traits::coord_stride;
+    constexpr int    tile_height        = Traits::rows;
+    constexpr size_t sblock_coord_width = (block_q_t::traits::qk / block_q_t::traits::qr) / Traits::bytes;
+
+    // Since local_range = WARP_RANGE
+    size_t       coord_range    = Traits::template coord_range<block_q_t>(ncols);
+    const int    workgroup_id   = it.get_group_linear_id();
+    auto         local_id       = it.get_local_linear_id();    // subgroup local id = workgroup local id
+    const size_t tile_row_begin = tile_height * workgroup_id;  // NOTE: only supports a single sg per wg
+    const int    blocks_per_row = ncols / block_q_t::traits::qk;
+
+    const uint8_t *               weights_ptr = static_cast<const uint8_t *>(weights);
+    sycl::vec<float, tile_height> partial_sums{ 0 };
+
+    // INFO: Current blockloads grabs entire superblock every 4 iterations
+    for (size_t tile_coord_begin = 0; tile_coord_begin < coord_range; tile_coord_begin += sblock_coord_width) {
+        const int          chunk_idx      = local_id / 2;
+        const int          superblock_idx = tile_coord_begin / 64;
+        const int          q8_block_idx   = superblock_idx * 8 + chunk_idx;
+        const uint         q8_dm_offset   = block_q8_t::get_d_offset(1, ncols, q8_block_idx).first;
+        const ggml_half2 * q8_dm =
+            reinterpret_cast<const ggml_half2 *>(reinterpret_cast<const uint8_t *>(input) + q8_dm_offset);
+        const float d8 = static_cast<float>(q8_dm->x());
+
+        int32_t      dot1[tile_height] = { 0 };
+        int32_t      dot2[tile_height] = { 0 };
+        uint8_t      sc_m[2 * tile_height];
+        sycl::float2 dm4f[tile_height];
+
+#pragma unroll(sblock_coord_width / Traits::columns)
+        for (size_t w = 0; w < sblock_coord_width / Traits::columns; w++) {
+            q4_tile_t q4_tile;
+            uint      q8_tile;
+
+            const int  w_coord  = tile_coord_begin + coord_stride * w;
+            const auto q4_coord = coord_t{ w_coord, tile_row_begin };
+            get_quant_tile<block_q_t, bl_layout>(weights, ncols, nrows, q4_coord, &q4_tile);
+
+            const auto q8_coord = coord_t{ w_coord, 0 };
+            get_quant_tile<block_q8_t, q8_layout>(input, ncols, 1, q8_coord, &q8_tile);
+
+#pragma unroll(tile_height)
+            for (size_t i = 0; i < tile_height; i++) {
+                const size_t    q4_k_block_idx = (tile_row_begin + i) * blocks_per_row + superblock_idx;
+                const auto      scs_offsets    = block_q_t::get_d_offset(nrows, ncols, q4_k_block_idx);
+                const uint8_t * scales         = weights_ptr + scs_offsets.first;
+
+                if (!w) {
+                    decode_superblock_scale(weights_ptr, scs_offsets.second, &dm4f[i]);
+                    decode_chunk_scales(chunk_idx, scales, &sc_m[2 * i]);
+                }
+
+                const int32_t q4_val = unpack_q4_tile(q4_tile[i]);
+                const int32_t q8_val = static_cast<int32_t>(q8_tile);
+                dot1[i]              = sycl::detail::__builtin_IB_dp4a_ss(dot1[i], q4_val, q8_val);
+                dot2[i]              = sycl::detail::__builtin_IB_dp4a_ss(dot2[i], 0x01010101, q8_val);
+            }
+        }
+
+#pragma unroll(tile_height)
+        for (size_t i = 0; i < tile_height; i++) {
+            partial_sums[i] +=
+                dm4f[i].x() * d8 * (dot1[i] * sc_m[2 * i]) - dm4f[i].y() * d8 * (dot2[i] * sc_m[2 * i + 1]);
+        }
+    }
+
+#pragma unroll(tile_height)
+    for (size_t i = 0; i < tile_height; i++) {
+        partial_sums[i] = sycl::reduce_over_group(it.get_sub_group(), partial_sums[i], std::plus<>());
+    }
+
+    // INFO: Seems equivalent to the for loop using only the leader
+    if (local_id < tile_height) {
+        dst[tile_row_begin + local_id] = partial_sums[local_id];
+    }
+}
+
+template <typename Traits, size_t prefetch_pipeline>
+void launch_q4_K_q8_1_tiled_gemvq(sycl::queue * stream, const void * vx, const void * vy, float * dst, size_t ncols,
+                                 size_t nrows, sycl::nd_range<1> launch_range) {
+    stream->submit([=](sycl::handler & cgh) {
+        cgh.parallel_for(launch_range, [=](sycl::nd_item<1> nd_item) [[sycl::reqd_sub_group_size(WARP_SIZE)]] {
+            q4_K_q8_1_tiled_gemvq<Traits, prefetch_pipeline>(vx, vy, dst, ncols, nrows, nd_item);
+        });
+    });
+}
+
+static void mul_mat_q4_K_q8_1_exp_gemvq(const void * vx, const void * vy, float * dst, const size_t ncols,
+                                        const size_t nrows, dpct::queue_ptr stream) {
+    GGML_ASSERT(ncols % QK_K == 0);
+
+    int tile_height = g_ggml_sycl_exp_gemvq_tile_height;
+    GGML_ASSERT(nrows % tile_height == 0);
+
+    constexpr size_t prefetch_pipeline = 0;
+
+    const sycl::range<1> global_size(nrows * WARP_SIZE / tile_height);
+    const sycl::range<1> wg_size(WARP_SIZE);
+
+    if (tile_height == 16) {
+        launch_q4_K_q8_1_tiled_gemvq<LayoutTraits<16>, prefetch_pipeline>(stream, vx, vy, dst, ncols, nrows,
+                                                                         sycl::nd_range<1>(global_size, wg_size));
+    } else if (tile_height == 8) {
+        launch_q4_K_q8_1_tiled_gemvq<LayoutTraits<8>, prefetch_pipeline>(stream, vx, vy, dst, ncols, nrows,
+                                                                        sycl::nd_range<1>(global_size, wg_size));
+    } else if (tile_height == 4) {
+        launch_q4_K_q8_1_tiled_gemvq<LayoutTraits<4>, prefetch_pipeline>(stream, vx, vy, dst, ncols, nrows,
+                                                                        sycl::nd_range<1>(global_size, wg_size));
+    } else if (tile_height == 2) {
+        launch_q4_K_q8_1_tiled_gemvq<LayoutTraits<2>, prefetch_pipeline>(stream, vx, vy, dst, ncols, nrows,
+                                                                        sycl::nd_range<1>(global_size, wg_size));
+    } else if (tile_height == 1) {
+        launch_q4_K_q8_1_tiled_gemvq<LayoutTraits<1>, prefetch_pipeline>(stream, vx, vy, dst, ncols, nrows,
+                                                                        sycl::nd_range<1>(global_size, wg_size));
+    } else {
+        GGML_ABORT("unsupported tile height");
+    }
+}
+
+void ggml_sycl_op_mul_mat_exp_gemvq(ggml_backend_sycl_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
+                                   ggml_tensor * dst, const char * src0_dd_i, const float * src1_ddf_i,
+                                   const char * src1_ddq_i, float * dst_dd_i, const int64_t row_low,
+                                   const int64_t row_high, const int64_t src1_ncols, const int64_t src1_padded_col_size,
+                                   const dpct::queue_ptr & stream) {
+    constexpr size_t q8_1_ts = sizeof(block_q8_1);
+    constexpr size_t q8_1_bs = QK8_1;
+
+    const int64_t ne10 = src1->ne[0];
+    GGML_ASSERT(ne10 % q8_1_bs == 0);
+
+    const int64_t ne00     = src0->ne[0];
+    const int64_t row_diff = row_high - row_low;
+
+    for (int i = 0; i < src1_ncols; i++) {
+        const size_t src1_ddq_i_offset = i * src1_padded_col_size * q8_1_ts / q8_1_bs;
+        const char * src1_ddq_i_bs     = src1_ddq_i + src1_ddq_i_offset;
+        float *      dst_dd_i_bs       = dst_dd_i + i * dst->ne[0];
+        switch (src0->type) {
+            case GGML_TYPE_Q4_K:
+                mul_mat_q4_K_q8_1_exp_gemvq(src0_dd_i, src1_ddq_i_bs, dst_dd_i_bs, ne00, row_diff, stream);
+                break;
+            default:
+                GGML_ABORT("Unsupported quantization reached in exp_gemvq");
+        }
+    }
+    GGML_UNUSED(src1);
+    GGML_UNUSED(dst);
+    GGML_UNUSED(src1_ddf_i);
+    GGML_UNUSED(ctx);
+}

--- a/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
+++ b/ggml/src/ggml-sycl/gemv_q4_k_q8_1.cpp
@@ -149,7 +149,7 @@ __dpct_inline__ static void q4_K_q8_1_tiled_gemvq(
         const int          chunk_idx      = local_id / 2;
         const int          superblock_idx = tile_coord_begin / 64;
         const int          q8_block_idx   = superblock_idx * 8 + chunk_idx;
-        const uint         q8_dm_offset   = block_q8_t::get_d_offset(1, ncols, q8_block_idx).first;
+        const int          q8_dm_offset   = block_q8_t::get_d_offset(1, ncols, q8_block_idx).first;
         const ggml_half2 * q8_dm =
             reinterpret_cast<const ggml_half2 *>(reinterpret_cast<const uint8_t *>(input) + q8_dm_offset);
         const float d8 = static_cast<float>(q8_dm->x());
@@ -162,7 +162,7 @@ __dpct_inline__ static void q4_K_q8_1_tiled_gemvq(
 #pragma unroll(sblock_coord_width / Traits::columns)
         for (size_t w = 0; w < sblock_coord_width / Traits::columns; w++) {
             q4_tile_t q4_tile;
-            uint      q8_tile;
+            uint32_t  q8_tile;
 
             const int  w_coord  = tile_coord_begin + coord_stride * w;
             const auto q4_coord = coord_t{ w_coord, tile_row_begin };

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -2708,9 +2708,9 @@ static void ggml_sycl_mul_mat_batched_sycl(ggml_backend_sycl_context & ctx, cons
                                                 " : converting src1 to fp16");
 
         // iterate tensor dims and find the slowest moving dim and stride
-        int64_t last_dim=0;
-        int64_t last_str=0;
-        int64_t largest_str=0;
+        size_t last_dim = 0;
+        size_t last_str = 0;
+        size_t largest_str = 0;
         for(int i = 0; i< 4; i++){
             // last stride is always the largest
             if(src1->nb[i] == largest_str){
@@ -2784,7 +2784,7 @@ static void ggml_sycl_mul_mat_batched_sycl(ggml_backend_sycl_context & ctx, cons
             auto launch_gemm_for_batches = [&ctx, queue](const sycl::half *src0,
                                                 const sycl::half *src1, float *dst,
                                                 int64_t a0, int64_t a1, int64_t batcha,
-                                                int64_t b0, int64_t b1, int64_t batchb,
+                                                int64_t /* b0 */, int64_t b1, int64_t batchb,
                                                 int64_t sa0, int64_t sa1, int64_t sa2,
                                                 int64_t sb0, int64_t sb1, int64_t sb2,
                                                 int64_t sd2) {

--- a/ggml/src/ggml-sycl/quants.hpp
+++ b/ggml/src/ggml-sycl/quants.hpp
@@ -58,6 +58,24 @@ template <> struct block_q_t<GGML_TYPE_Q4_0> {
     static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
 };
 
+template <> struct block_q_t<GGML_TYPE_Q8_1> {
+    struct traits {
+        static constexpr uint32_t qk = QK8_1;
+        static constexpr uint32_t qi = QI8_1;
+        static constexpr uint32_t qr = QR8_1;
+    };
+
+    static constexpr std::pair<int, int> get_block_offset(const int block_index) {
+        return { block_index * (traits::qk / traits::qr), 0 };
+    }
+
+    static constexpr std::pair<int, int> get_d_offset(int nrows, int ncols, const int block_index) {
+        return { (ncols / traits::qr * nrows) + block_index * sizeof(ggml_half2), 0 };
+    }
+
+    static constexpr int block_to_q8_1_ratio() { return traits::qk / QK8_1; }
+};
+
 template <> struct block_q_t<GGML_TYPE_Q4_K> {
     struct traits {
         static constexpr uint32_t qk       = QK_K;


### PR DESCRIPTION
This PR introduces an experimental gemv kernel (exp_gemvq) that restructures the layout of q4_K blocks for improved performance on Intel GPUs. It yields significantly better kernel performance on phi3.
However, this change causes notable regressions on llama2. I haven't checked the performance on bigger models.
End-to-end perf is equivalent to MMVQ in tested q4_K models.

| model                    |  test |     MMVQ  t/s |     Tiled t/s |
| ------------------------ | ----: | ------------: | ------------: |
| qwen2 1.5B Q4_K - Medium | tg128 | 124.70 ± 1.62 | 125.17 ± 1.25 |
| llama 7B Q4_K - Medium   | tg128 |  56.21 ± 0.25 |  56.92 ± 0.12 |
| gemma2 2B Q4_K - Medium  | tg128 |  95.18 ± 1.27 |  92.21 ± 2.96 |
| llama 8B Q4_K - Medium   | tg128 |  70.51 ± 0.83 |  51.68 ± 0.43 |
| phi3 3B Q4_K - Medium    | tg128 |  50.42 ± 0.32 |  70.04 ± 0.64 |

The numbers above are from an Intel Arc B580. In Lunar lake integrated GPUs there is no change in the performance.

The new codepath is controlled using the env var GGML_SYCL_USE_EXP_GEMVQ (default 0).
Tiling is configurable via GGML_SYCL_EXP_GEMVQ_TILE_HEIGHT (default 4).

Key changes:

- The block layout is reordered to better suit Intel block load intrinsics by interleaving weights in each block.
- Thanks to the new layout, reuse of scales is maximized per thread due to the interleaved memory layout, which essentially minimizes the number of multiplications needed in the vecdot (kinda lilke what MMVQ does with vdr set to 2, but with an entire block).

Due to the regressions observed, the feature is opt-in and marked experimental.
There is also another thing to discuss, which is the use of Intel specific instrinsics in the code directly. These functionalities yield performance but are not available through SYCL directly, it's not the best solution, but I think it's good for what we have.

Here is the isolated kernel performance, benchmarked using test-backend-ops perf mode:

<details><summary>Details</summary>
<p>

#MMVQ
```
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              22152 runs -    92.82 us/run - 117.44 MFLOP/run -   1.27 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=7168,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):               42575 runs -    47.98 us/run -  58.72 MFLOP/run -   1.22 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=4096,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):               68563 runs -    30.07 us/run -  33.55 MFLOP/run -   1.12 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=2048,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              107298 runs -    18.68 us/run -  16.78 MFLOP/run - 898.07 GFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=1024,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              163840 runs -    12.66 us/run -   8.39 MFLOP/run - 662.77 GFLOPS
```

#EXP GEMV
#GGML_SYCL_GEMV_TILE_HEIGHT=4
```
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=14336,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              23856 runs -    84.87 us/run - 117.44 MFLOP/run -   1.38 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=7168,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):               59605 runs -    34.17 us/run -  58.72 MFLOP/run -   1.72 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=4096,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):               92411 runs -    21.76 us/run -  33.55 MFLOP/run -   1.54 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=2048,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              149025 runs -    13.68 us/run -  16.78 MFLOP/run -   1.23 TFLOPS
MUL_MAT(type_a=q4_K,type_b=f32,m=4096,n=1,k=1024,bs=[1,1],nr=[1,1],per=[0,1,2,3],v=0):              204800 runs -     9.91 us/run -   8.39 MFLOP/run - 846.82 GFLOPS
```

</p>
</details> 

The kernel requires more work to address the regressions observed in llama. We may have other issues in the backend since the increase of performance is not translating to actual tokens/s. 

