### PR TITLE
Refactor: Merge build_moe_ffn_from_probs function into build_moe_ffn

### DIFF
--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -626,19 +626,8 @@ struct llm_graph_context {
                     bool   scale_w,
                    float   w_scale,
             llama_expert_gating_func_type gating_op,
-                     int   il) const;
-
-    ggml_tensor * build_moe_ffn_from_probs(
-             ggml_tensor * cur,
-             ggml_tensor * probs,
-             ggml_tensor * up_exps,
-             ggml_tensor * gate_exps,
-             ggml_tensor * down_exps,
-             ggml_tensor * exp_probs_b,
-                 int64_t   n_expert,
-                 int64_t   n_expert_used,
-            llama_expert_gating_func_type gating_op,
-                     int   il) const;
+                     int   il,
+             ggml_tensor * probs_in = nullptr) const;
 
     //
     // inputs

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -17158,10 +17158,18 @@ struct llm_build_smallthinker : public llm_graph_context{
             cur = build_norm(ffn_inp, model.layers[il].ffn_norm, NULL, LLM_NORM_RMS, il);
             cb(cur, "ffn_norm", il);
 
-            ggml_tensor * ffn_out = build_moe_ffn_from_probs(cur, probs, model.layers[il].ffn_up_exps,
-                                                model.layers[il].ffn_gate_exps, model.layers[il].ffn_down_exps,
-                                                nullptr, n_expert, n_expert_used,
-                                                static_cast<llama_expert_gating_func_type>(hparams.expert_gating_func), il);
+            ggml_tensor * ffn_out =
+                build_moe_ffn(cur,
+                        nullptr,
+                        model.layers[il].ffn_up_exps,
+                        model.layers[il].ffn_gate_exps,
+                        model.layers[il].ffn_down_exps,
+                        nullptr,
+                        n_expert, n_expert_used,
+                        LLM_FFN_RELU, true,
+                        false, 0.0,
+                        static_cast<llama_expert_gating_func_type>(hparams.expert_gating_func),
+                        il, probs);
 
             cb(ffn_out, "ffn_out", il);
             cur = ffn_out;


### PR DESCRIPTION
This PR resolves the code duplication discussed in Issue #14920 by merging the `build_moe_ffn_from_probs` function into the primary `build_moe_ffn` function.

### Description

Following the plan outlined in the issue, the unified `build_moe_ffn` function now accepts an optional `ggml_tensor *probs_in` parameter (defaulting to `nullptr`). This parameter acts as a "toggle" to control the logic path:

- If `probs_in` is provided, the function uses it directly, skipping the internal logits and probability calculations. This path is used by SmallThinker models where the MoE router is placed before the attention block.
- If `probs_in` is `nullptr`, the function maintains its original behavior, making it backward-compatible with existing MoE models.

Additionally, to fully support the SmallThinker model within this unified function, support for the ReLU activation function has been introduced.

The now-redundant `build_moe_ffn_from_probs` function has been removed. 

### Testing

I have performed basic inference tests on the following MoE models to ensure that the refactoring has not introduced any regressions:

- **SmallThinker-21BA3B-Instruct** (The new logic path)
- **Qwen3-30B-A3B** (The original logic path)

Both models appear to function correctly and produce coherent output.

Fixes #14920