### PR TITLE
Optimize l2_norm_f32 op with SIMD

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -4321,7 +4321,6 @@ static void ggml_compute_forward_l2_norm_f32(
     const ggml_tensor * src0 = dst->src[0];
 
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
-
     GGML_ASSERT(src0->nb[0] == sizeof(float));
 
     const int ith = params->ith;
@@ -4331,26 +4330,21 @@ static void ggml_compute_forward_l2_norm_f32(
 
     float eps;
     memcpy(&eps, dst->op_params, sizeof(float));
-
     GGML_ASSERT(eps >= 0.0f);
 
-    // TODO: optimize
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
+
                 const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                float * y = (float *) ((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3);
 
-                ggml_float sum = 0.0;
-                for (int64_t i00 = 0; i00 < ne00; i00++) {
-                    sum += (ggml_float)(x[i00] * x[i00]);
-                }
+                float sum = 0.0f;
+                ggml_vec_dot_f32(ne00, &sum, 0, x, 0, x, 0, 1);
 
-                float * y = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
+                const float scale = 1.0f / fmaxf(sqrtf(sum), eps);
 
-                memcpy(y, x, ne00 * sizeof(float));
-
-                const float scale = 1.0f/fmaxf(sqrtf(sum), eps);
-
+                ggml_vec_cpy_f32(ne00, y, x);
                 ggml_vec_scale_f32(ne00, y, scale);
             }
         }


### PR DESCRIPTION
I added an optimized version of ggml_compute_forward_l2_norm_f32 op in ops.cpp. 

I replaced naive scalar loop with ggml_vec* operations based on SIMD.

- Passed all test-backend-ops test -o L2_NORM -b CPU
- Verifed correctness
- Benchmarked perfomance and got 6% more time efficiency on function

###
I hope this helps^)