### PR TITLE
graph : fix equal_seq() check

### DIFF
--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -291,6 +291,9 @@ private:
     // ref: https://github.com/ggml-org/llama.cpp/pull/14285
     bool supports_set_rows = false;
 
+    // env: LLAMA_GRAPH_REUSE_DISABLE
+    bool graph_reuse_disable = false;
+
     // perf
     mutable int64_t t_start_us  = 0;
     mutable int64_t t_load_us   = 0;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -423,7 +423,9 @@ struct llm_graph_params {
                 (!ubatch.embd  && !other.ubatch.embd)
             );
 
-        if (can_reuse_ubatch && !ubatch.equal_seqs()) {
+        // when we split the batch using "equal_seqs" we have to verify that the participating sequences are the same
+        //   the reason is because the set of attention streams would be different for different sequences
+        if (can_reuse_ubatch && ubatch.equal_seqs()) {
             if (!ubatch.data) {
                 // if the old ubatch does not own it's data, then we cannot guarantee that it is still alive, and
                 //   therefore we cannot perform the sequence id check. normally should never happen


### PR DESCRIPTION
fix #14893
cont #14482 

The check for `ubatch.equal_seqs()` was inverted.

Also add `LLAMA_GRAPH_REUSE_DISABLE` env as a debugging option for disable graph reuse logic.