### PR TITLE
llama : allow other bufts when overriding to CPU, add --no-repack option

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2096,6 +2096,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_NO_KV_OFFLOAD"));
     add_opt(common_arg(
+        {"-nr", "--no-repack"},
+        "disable weight repacking",
+        [](common_params & params) {
+            params.no_extra_bufts = true;
+        }
+    ).set_env("LLAMA_ARG_NO_REPACK"));
+    add_opt(common_arg(
         {"-ctk", "--cache-type-k"}, "TYPE",
         string_format(
             "KV cache data type for K\n"

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1122,6 +1122,7 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.use_mmap        = params.use_mmap;
     mparams.use_mlock       = params.use_mlock;
     mparams.check_tensors   = params.check_tensors;
+    mparams.use_extra_bufts = !params.no_extra_bufts;
 
     if (params.kv_overrides.empty()) {
         mparams.kv_overrides = NULL;

--- a/common/common.h
+++ b/common/common.h
@@ -359,6 +359,7 @@ struct common_params {
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
+    bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
 
     bool single_turn       = false; // single turn chat conversation
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -284,10 +284,11 @@ extern "C" {
         const struct llama_model_kv_override * kv_overrides;
 
         // Keep the booleans together to avoid misalignment during copy-by-value.
-        bool vocab_only;    // only load the vocabulary, no weights
-        bool use_mmap;      // use mmap if possible
-        bool use_mlock;     // force system to keep model in RAM
-        bool check_tensors; // validate model tensor data
+        bool vocab_only;      // only load the vocabulary, no weights
+        bool use_mmap;        // use mmap if possible
+        bool use_mlock;       // force system to keep model in RAM
+        bool check_tensors;   // validate model tensor data
+        bool use_extra_bufts; // use extra buffer types (used for weight repacking)
     };
 
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations


### PR DESCRIPTION
- When using `--override-tensor` to override to the CPU, other buffer types will be considered as well. In practice, what this means is that the host buffer types will be used, which may improve performance when prompt processing is offloaded (Note that mmap needs to be disabled to use host buffers).
- Adds `--no-repack` (`-nr`) option to disable weight repacking.

`llama-bench -m Qwen3-30B-A3B-Q4_0.gguf -ot exps=CPU -n 0 -p 32,64,128,256,512,1024 -ub 1024 -mmp 0`:
| Model                 | Test   |   t/s master |   t/s sl/ot-repacking |   Speedup |
|:----------------------|:-------|-------------:|----------------------:|----------:|
| qwen3moe 30B.A3B Q4_0 | pp32   |        15.03 |                 22.62 |      1.50 |
| qwen3moe 30B.A3B Q4_0 | pp64   |        28.87 |                 45.04 |      1.56 |
| qwen3moe 30B.A3B Q4_0 | pp128  |        61.06 |                 89.35 |      1.46 |
| qwen3moe 30B.A3B Q4_0 | pp256  |       121.44 |                173.97 |      1.43 |
| qwen3moe 30B.A3B Q4_0 | pp512  |       227.41 |                309.59 |      1.36 |
| qwen3moe 30B.A3B Q4_0 | pp1024 |       421.50 |                594.32 |      1.41 |