### PR TITLE
MODEL_TENSOR.SSM_DT_NORM has defined twice

### DIFF
--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -615,6 +615,11 @@ class TensorNameMap:
             "model.layers.layers.{bid}.mixer.dt_proj",  # plamo2
         ),
 
+        MODEL_TENSOR.SSM_DT_NORM: (
+            "model.layers.layers.{bid}.mixer.dt_norm.weight",  # plamo2
+            "model.layers.{bid}.mamba.dt_layernorm",  # jamba
+        ),
+
         MODEL_TENSOR.SSM_A: (
             "model.layers.{bid}.A_log",               # mamba-hf
             "backbone.layers.{bid}.mixer.A_log",      # mamba
@@ -639,11 +644,6 @@ class TensorNameMap:
             "backbone.layers.{bid}.mixer.D",      # mamba
             "model.layers.{bid}.mamba.D",         # jamba falcon-h1 granite-hybrid
             "model.layers.layers.{bid}.mixer.D",  # plamo2
-        ),
-
-        MODEL_TENSOR.SSM_DT_NORM: (
-            "model.layers.layers.{bid}.mixer.dt_norm.weight",  # plamo2
-            "model.layers.{bid}.mamba.dt_layernorm",  # jamba
         ),
 
         MODEL_TENSOR.SSM_NORM: (

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -615,10 +615,6 @@ class TensorNameMap:
             "model.layers.layers.{bid}.mixer.dt_proj",  # plamo2
         ),
 
-        MODEL_TENSOR.SSM_DT_NORM: (
-            "model.layers.{bid}.mamba.dt_layernorm",  # jamba
-        ),
-
         MODEL_TENSOR.SSM_A: (
             "model.layers.{bid}.A_log",               # mamba-hf
             "backbone.layers.{bid}.mixer.A_log",      # mamba
@@ -647,6 +643,7 @@ class TensorNameMap:
 
         MODEL_TENSOR.SSM_DT_NORM: (
             "model.layers.layers.{bid}.mixer.dt_norm.weight",  # plamo2
+            "model.layers.{bid}.mamba.dt_layernorm",  # jamba
         ),
 
         MODEL_TENSOR.SSM_NORM: (


### PR DESCRIPTION
MODEL_TENSOR.SSM_DT_NORM has defined twice

  1. Line 618-620 (correct for Jamba):
```
  MODEL_TENSOR.SSM_DT_NORM: (
      "model.layers.{bid}.mamba.dt_layernorm",  # jamba
  ),
```
  2. Lines 648-650 (for plamo2, overwrites the first):
```
  MODEL_TENSOR.SSM_DT_NORM: (
      "model.layers.layers.{bid}.mixer.dt_norm.weight",  # plamo2
  ),
```
This has blocked the quantization of ai21labs/AI21-Jamba-Mini-1.7 

"architectures": [
    "JambaForCausalLM"
  ],

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
