### PR TITLE
Fix params bug in diffusion example

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -224,7 +224,7 @@ struct common_params_diffusion {
     bool    visual_mode   = false;
 
     float   eps           = 0;        // epsilon for timesteps
-    int32_t block_length  = 32;       // block length for generation
+    int32_t block_length  = 0;        // block length for generation
 
     int32_t algorithm     = 4;        // default algorithm: low-confidence
     float   alg_temp      = 0.0f;     // algorithm temperature


### PR DESCRIPTION
This causes an assert to trigger because of default params when using `--diffusion-eps`

https://github.com/ggml-org/llama.cpp/blob/d6818d06a6237631523bc0f45d42e79482667948/examples/diffusion/diffusion-cli.cpp#L616