### PR TITLE
server: enable token array inputs for OAI API

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4249,9 +4249,6 @@ int main(int argc, char ** argv) {
 
             // process prompt
             std::vector<server_tokens> inputs;
-            if (oaicompat && !prompt.is_string()) {
-                throw std::runtime_error("prompt must be a string");
-            }
 
             if (oaicompat && has_mtmd) {
                 // multimodal


### PR DESCRIPTION
According to the [OpenAI documentation](https://platform.openai.com/docs/api-reference/completions/create#completions_create-prompt) formatting the prompt as an array of tokens is supported. However, the llama.cpp server raises an error if you provide such input. I assume the reason is that the interpretation of tokens depends on the model so this would not be "OpenAI compatible" either way. However, I have a use case where I need such inputs. This PR simply removes the error in the llama.cpp server. I don't think this would cause issues but my understanding of the server code is also relatively poor.

I'm currently working on benchmarking llama.cpp vs. vllm. Both projects provide an OAI-compatible API. So I want to make `scripts/server-bench.py` use the OAI-compatible API instead of the llama.cpp-specific API in order to use the exact same code for benchmarking either project. Under these circumstances I want to be able to send prompts of an exact length (in tokens) while at the same time the interpretations of those prompts as text are irrelevant.

 