### PR TITLE
llama-bench: rename DB table name from test to llama_bench

### DIFF
--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -326,7 +326,7 @@ class LlamaBenchDataSQLite3(LlamaBenchData):
 
         # Set table name and schema based on tool
         if self.tool == "llama-bench":
-            self.table_name = "test"
+            self.table_name = "llama_bench"
             db_fields = LLAMA_BENCH_DB_FIELDS
             db_types = LLAMA_BENCH_DB_TYPES
         elif self.tool == "test-backend-ops":
@@ -409,8 +409,8 @@ class LlamaBenchDataSQLite3File(LlamaBenchDataSQLite3):
 
         # Tool selection logic
         if tool is None:
-            if "test" in table_names:
-                self.table_name = "test"
+            if "llama_bench" in table_names:
+                self.table_name = "llama_bench"
                 self.tool = "llama-bench"
             elif "test_backend_ops" in table_names:
                 self.table_name = "test_backend_ops"
@@ -418,8 +418,8 @@ class LlamaBenchDataSQLite3File(LlamaBenchDataSQLite3):
             else:
                 raise RuntimeError(f"No suitable table found in database. Available tables: {table_names}")
         elif tool == "llama-bench":
-            if "test" in table_names:
-                self.table_name = "test"
+            if "llama_bench" in table_names:
+                self.table_name = "llama_bench"
                 self.tool = "llama-bench"
             else:
                 raise RuntimeError(f"Table 'test' not found for tool 'llama-bench'. Available tables: {table_names}")

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1738,7 +1738,7 @@ struct sql_printer : public printer {
 
     void print_header(const cmd_params & params) override {
         std::vector<std::string> fields = test::get_fields();
-        fprintf(fout, "CREATE TABLE IF NOT EXISTS test (\n");
+        fprintf(fout, "CREATE TABLE IF NOT EXISTS llama_bench (\n");
         for (size_t i = 0; i < fields.size(); i++) {
             fprintf(fout, "  %s %s%s\n", fields.at(i).c_str(), get_sql_field_type(fields.at(i)).c_str(),
                     i < fields.size() - 1 ? "," : "");
@@ -1749,7 +1749,7 @@ struct sql_printer : public printer {
     }
 
     void print_test(const test & t) override {
-        fprintf(fout, "INSERT INTO test (%s) ", join(test::get_fields(), ", ").c_str());
+        fprintf(fout, "INSERT INTO llama_bench (%s) ", join(test::get_fields(), ", ").c_str());
         fprintf(fout, "VALUES (");
         std::vector<std::string> values = t.get_values();
         for (size_t i = 0; i < values.size(); i++) {


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

This PR is a follow-up based on comments from @JohannesGaessler :

> I think it would be better to have a more specific name. (The table for llama-bench is just named "test", that could also be improved upon.)

<img width="657" height="299" alt="1" src="https://github.com/user-attachments/assets/52454125-bb08-4c6e-b569-8051d54c8aea" />

### Testing Done

```bash
root@ff759de5dd90:/ws# ./scripts/compare-commits.sh e1c2f3ea0 737f78c34 llama-bench -m /models/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf
 -ngl 999
+ commit1=e1c2f3ea0
+ commit2=737f78c34
+ tool=llama-bench
+ additional_args='-m /models/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf -ngl 999'
+ '[' llama-bench '!=' llama-bench ']'
+ ./scripts/compare-llama-bench.py --check
+ '[' llama-bench = llama-bench ']'
+ db_file=llama-bench.sqlite
+ target=llama-bench
+ run_args='-o sql -oe md -m /models/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf -ngl 999'
+ rm -f llama-bench.sqlite
+ '[' -n '' ']'
+ dir=build-bench
+ git checkout e1c2f3ea0
Previous HEAD position was 737f78c34 llama-bench: rename DB table name from test to llama_bench
HEAD is now at e1c2f3ea0 1
+ run
+ rm -fr build-bench
+ cmake -B build-bench -S .
++ nproc
+ cmake --build build-bench -t llama-bench -j 12
+ build-bench/bin/llama-bench -o sql -oe md -m /models/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf -ngl 999
+ sqlite3 llama-bench.sqlite
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| qwen2 7B Q4_K - Medium         |   4.36 GiB |     7.62 B | CPU        |       6 |           pp512 |         41.91 ± 1.66 |
| qwen2 7B Q4_K - Medium         |   4.36 GiB |     7.62 B | CPU        |       6 |           tg128 |         10.37 ± 0.20 |

build: e1c2f3ea0 (6055)
+ git checkout 737f78c34
Previous HEAD position was e1c2f3ea0 1
HEAD is now at 737f78c34 llama-bench: rename DB table name from test to llama_bench
+ run
+ rm -fr build-bench
+ cmake -B build-bench -S .
++ nproc
+ cmake --build build-bench -t llama-bench -j 12
+ build-bench/bin/llama-bench -o sql -oe md -m /models/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf -ngl 999
+ sqlite3 llama-bench.sqlite
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| qwen2 7B Q4_K - Medium         |   4.36 GiB |     7.62 B | CPU        |       6 |           pp512 |         41.45 ± 1.78 |
| qwen2 7B Q4_K - Medium         |   4.36 GiB |     7.62 B | CPU        |       6 |           tg128 |         10.29 ± 0.15 |

build: 737f78c34 (6054)
+ ./scripts/compare-llama-bench.py -b e1c2f3ea0 -c 737f78c34 --tool llama-bench -i llama-bench.sqlite
| CPU                                 | Model           | Test   |   t/s xd/llama_bench |   t/s 737f78c34 |   Speedup |
|:------------------------------------|:----------------|:-------|---------------------:|----------------:|----------:|
| 12th Gen Intel(R) Core(TM) i5-12400 | qwen2 7B Q4_K_M | pp512  |                41.91 |           41.45 |      0.99 |
| 12th Gen Intel(R) Core(TM) i5-12400 | qwen2 7B Q4_K_M | tg128  |                10.37 |           10.29 |      0.99 |
root@ff759de5dd90:/ws#  
```