### PR TITLE
fix compile bug when the BASE_CUDA_DEV_CONTAINER is based on Ubuntu 2…

### DIFF
--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -60,8 +60,7 @@ RUN apt-get update \
     git \
     python3 \
     python3-pip \
-    && pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt \
+    && pip install --break-system-packages -r requirements.txt \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \


### PR DESCRIPTION
…4.04

fixes #15004

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
