### PR TITLE
Fix: flush partial stop string when <EOG> is reached in /completion endpoint in streaming mode

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2839,7 +2839,7 @@ struct server_context {
                     slot.generated_text.begin() + pos + stop_pos,
                     slot.generated_text.end());
                 pos = std::min(slot.n_sent_text, slot.generated_text.size());
-            } else if (slot.has_next_token) {
+            } else if (slot.has_next_token && !llama_vocab_is_eog(vocab, result.tok) ) {
                 stop_pos = slot.find_stopping_strings(str_test, token_str.size(), false);
                 send_text = stop_pos == std::string::npos;
             }


### PR DESCRIPTION
In the `/completion` endpoint the server correctly holds the partial stop string until a decision can be made.

If EOG is reached and a stop string was not found, then the generated content should be flushed to the user.

To reproduce:
query: `Repeat exactly the following text: UNO DUE TRE`
stop:  `["TRE\nAAAAAAAA"]`
stream: `True`

Previous result:
`UNO DUE`

After this PR:
`UNO DUE TRE`

Note:
The openAI compatible api has the opposite problem, the partial stop string is always flushed even if the full stop string is found.
This is not addressed in this PR
