### PR TITLE
memory : handle kv_unified for hybrid models

### DIFF
--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -25,6 +25,7 @@ llama_memory_hybrid::llama_memory_hybrid(
                          /* common */
              uint32_t    n_seq_max,
                  bool    offload,
+                 bool    unified,
                          /* layer filters */
       layer_filter_cb && filter_attn,
       layer_filter_cb && filter_recr) :
@@ -38,7 +39,7 @@ llama_memory_hybrid::llama_memory_hybrid(
         type_v,
         v_trans,
         offload,
-        1,
+        unified,
         kv_size,
         n_seq_max,
         n_pad,

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -39,6 +39,7 @@ public:
                              /* common */
                  uint32_t    n_seq_max,
                      bool    offload,
+                     bool    unified,
                              /* layer filters */
           layer_filter_cb && filter_attn = nullptr,
           layer_filter_cb && filter_recr = nullptr);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -17598,6 +17598,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                         /* recurrent_kv_size */ std::max((uint32_t) 1, cparams.n_seq_max),
                         /* n_seq_max         */ cparams.n_seq_max,
                         /* offload           */ cparams.offload_kqv,
+                        /* unified           */ cparams.kv_unified,
                         /* filter_attn       */ (arch == LLM_ARCH_FALCON_H1) ? [&](int32_t) { return true; } : (llama_memory_hybrid::layer_filter_cb)nullptr,
                         /* filter_recr       */ (arch == LLM_ARCH_FALCON_H1) ? [&](int32_t) { return true; } : (llama_memory_hybrid::layer_filter_cb)nullptr);
                 } else {


### PR DESCRIPTION
Follow-up from #14725, which didn't really fix the underlying problem of not considering `cparams.kv_unified`.

Since #14959, inference with hybrid models has been broken (except when using `-kvu`), due to hybrid memory not passing `cparams.kv_unified` properly.

Reproduction of the problem: attempt to run `llama-perplexity` with any hybrid model.

```console
$ ./bin/llama-perplexity -f /workspace/wikitext-2-raw/wiki.test.raw -m /workspace/gguf/LFM2-350M-BF16.gguf --chunks 10
```

On `master`, this fails with an assertion
```
/workspace/llama.cpp/ggml/src/ggml.c:3740: GGML_ASSERT(mask->ne[1] >= a->ne[1]) failed
```

With this PR, this is no longer a problem. I've tested this with <https://huggingface.co/LiquidAI/LFM2-350M>.

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
