### PR TITLE
model : add text-only support for Kimi-VL

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -6059,6 +6059,7 @@ class DeepseekModel(TextModel):
 
 @ModelBase.register("DeepseekV2ForCausalLM")
 @ModelBase.register("DeepseekV3ForCausalLM")
+@ModelBase.register("KimiVLForConditionalGeneration")
 class DeepseekV2Model(TextModel):
     model_arch = gguf.MODEL_ARCH.DEEPSEEK2
 
@@ -6161,6 +6162,13 @@ class DeepseekV2Model(TextModel):
     _experts: list[dict[str, Tensor]] | None = None
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # skip vision tensors and remove "language_model." for Kimi-VL
+        if "vision_tower" in name or "multi_modal_projector" in name:
+            return []
+
+        if name.startswith("language_model."):
+            name = name.replace("language_model.", "")
+
         # rename e_score_correction_bias tensors
         if name.endswith("e_score_correction_bias"):
             name = name.replace("e_score_correction_bias", "e_score_correction.bias")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -6113,19 +6113,6 @@ class DeepseekV2Model(TextModel):
             self.gguf_writer.add_token_merges(merges)
 
             special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=False)
-
-            # fix for Kimi-VL: Use <|im_end|> as EOS token instead of [EOS]
-            # This ensures text generation stops correctly at sentence boundaries, rather than at commas (which would happen with wrong EOS token)
-            if self.hf_arch == "KimiVLForConditionalGeneration":
-                im_end_id = None
-                for i, token in enumerate(tokens):
-                    if token == "<|im_end|>":
-                        im_end_id = i
-                        break
-                if im_end_id is not None:
-                    logger.info(f"Kimi-VL: Overriding EOS token from {special_vocab.special_token_ids.get('eos', 'N/A')} to <|im_end|> (ID: {im_end_id})")
-                    special_vocab.special_token_ids["eos"] = im_end_id
-
             special_vocab.add_to_gguf(self.gguf_writer)
         else:
             raise NotImplementedError(f"Deepseek pre-tokenizer {tokpre!r} is not supported yet!")

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -312,7 +312,11 @@ class SpecialVocab:
         with open(config_file, encoding = 'utf-8') as f:
             config = json.load(f)
         for typ in self.special_token_types:
-            self._set_special_token(typ, config.get(f'{typ}_token_id'))
+            token_id = config.get(f'{typ}_token_id')
+            # If not found at root, check in text_config (for multimodal models like Kimi-VL)
+            if token_id is None and 'text_config' in config:
+                token_id = config['text_config'].get(f'{typ}_token_id')
+            self._set_special_token(typ, token_id)
         return True
 
 


### PR DESCRIPTION
The text model portion of moonshotai/Kimi-VL-A3B-Instruct is functionally identical to moonshotai/Moonlight-16B-A3B-Instruct, but there is an error in the model's config files. The Kimi-VL models should be using token "<|im_end|>" as their EOS token, not  "[EOS]". Without this fix, generation was stopping after any comma "," and I'm not really sure why.

Just wanted to get this merged before I really start working on getting the vision portion working.
