### PR TITLE
CUDA/HIP: ssm-scan: switch from shared memory to reisters, fixes indexing problem on warp64 devices

### DIFF
--- a/ggml/src/ggml-cuda/ssm-scan.cu
+++ b/ggml/src/ggml-cuda/ssm-scan.cu
@@ -25,7 +25,6 @@ __global__ void __launch_bounds__(splitD, 2)
     const int stride_s0 = src0_nb2 / sizeof(float);
     const int stride_x  = src1_nb2 / sizeof(float);
     const int stride_dt = src2_nb1 / sizeof(float);
-    const int stride_A  = src3_nb1 / sizeof(float);
     const int stride_B  = src4_nb2 / sizeof(float);
     const int stride_C  = src5_nb2 / sizeof(float);
     const int stride_s  = stride_s0;


### PR DESCRIPTION
After upgrading llvm, ssm_scan_f32 is failing again on warp64 devices.

Taking another closer look at the code, i dont get how this could have possibly ever worked. I also dont get what 
https://github.com/ggml-org/llama.cpp/blob/fd1234cb468935ea087d6929b2487926c3afff4b/ggml/src/ggml-cuda/ssm-scan.cu#L52 the ternary is trying to achieve here at all as its not avoiding a bank conflict, like the comment seams to suggest might have been the intent.

Further, given the kernel is restricted to N == 16 anyhow (but if you where to invoke it with N != 16 it simply do sent load the data from global memory into shared memory, and works on it uninitialized, huh?) i dont understand why we are bothering with loading from global memory into shared memory at all here as loading directly into registers makes the kernel use just 63 vector registers at N == 16 and we are not shearing any data.

As far as i know GCN/CDNA is the most register starved of all modern architectures and even there we have 256 64 wide vector registers resulting in an occupancy of 4 there.

So thats what this pr dose.