### PR TITLE
HIP: Add option to export kernel resource useage metrics

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -176,6 +176,7 @@ option(GGML_HIP_NO_VMM                      "ggml: do not try to use HIP VMM"   
 option(GGML_HIP_ROCWMMA_FATTN               "ggml: enable rocWMMA for FlashAttention"         OFF)
 option(GGML_HIP_FORCE_ROCWMMA_FATTN_GFX12   "ggml: enable rocWMMA FlashAttention on GFX12"    OFF)
 option(GGML_HIP_MMQ_MFMA                    "ggml: enable MFMA MMA for CDNA in MMQ"           ON)
+option(GGML_HIP_EXPORT_METRICS              "ggml: enable kernel perf metrics output"         OFF)
 option(GGML_MUSA_GRAPHS                     "ggml: use MUSA graph, experimental, unstable"    OFF)
 option(GGML_MUSA_MUDNN_COPY                 "ggml: enable muDNN for accelerated copy"         OFF)
 option(GGML_VULKAN                          "ggml: use Vulkan"                                OFF)

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -121,6 +121,10 @@ if (GGML_HIP_FORCE_ROCWMMA_FATTN_GFX12 OR ${hip_VERSION} VERSION_GREATER_EQUAL 7
     add_compile_definitions(GGML_HIP_ROCWMMA_FATTN_GFX12)
 endif()
 
+if (GGML_HIP_EXPORT_METRICS)
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -Rpass-analysis=kernel-resource-usage --save-temps")
+endif()
+
 if (NOT GGML_CUDA_FA)
     add_compile_definitions(GGML_CUDA_NO_FA)
 endif()


### PR DESCRIPTION
This adds a convenience option GGML_HIP_EXPORT_METRICS that `-Rpass-analysis=kernel-resource-usage --save-temps` to the hip compilers flags.

This causes the hip compiler to save the assembly of the compiled kernels and output resource usage to stdout:
```
fattn-vec-f32.cuh:34:1: remark: Function Name: _ZL22flash_attn_vec_ext_f32ILi128ELi8EL9ggml_type1ELS0_1ELb1EEvPKcS2_S2_S2_PKiPfP15HIP_vector_typeIfLj2EEffffjfiiiiiiiiiiiiiliiliiiiil [-Rpass-analysis=kernel-resource-usage]
   34 |                             const int32_t nb31, const int32_t nb32, const int64_t nb33) {
      | ^
fattn-vec-f32.cuh:34:1: remark:     SGPRs: 92 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     VGPRs: 63 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     AGPRs: 64 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     ScratchSize [bytes/lane]: 12 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     Dynamic Stack: False [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     Occupancy [waves/SIMD]: 4 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     SGPRs Spill: 0 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     VGPRs Spill: 14 [-Rpass-analysis=kernel-resource-usage]
fattn-vec-f32.cuh:34:1: remark:     LDS Size [bytes/block]: 10240 [-Rpass-analysis=kernel-resource-usage]
```

While the same information can also be just as well be gathered by rocprof, and these flags can just as well be added by setting them directly when invoking cmake (which is what i do atm) i would find the inclusion of the above option convenient.