### PR TITLE
gguf-py : add Numpy MXFP4 de/quantization support

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -288,7 +288,7 @@ void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RE
             }
         }
 
-        const uint8_t e = (uint8_t) (floorf(log2f(amax)) - 2 + 127);
+        const uint8_t e = amax > 0.0f ? (uint8_t) (floorf(log2f(amax)) - 2 + 127) : 0;
 
         const float d = GGML_E8M0_TO_FP32_HALF(e);
 


### PR DESCRIPTION
MXFP4 support was added in #15091, but Python-based (de)quantization is missing, which this should fix.

Other change: I've removed the FMA workaround for `Q4_0` and `Q5_0` quantization functions, since the C versions don't use FMA since a while ago (not sure exactly when). 

All correctness tests pass.

```console
$ python3 gguf-py/tests/test_quants.py --type MXFP4
INFO:test-quants:Testing MXFP4
DEBUG:test-quants:Quantizing to MXFP4 with Python
DEBUG:test-quants:Quantizing to MXFP4 with C
INFO:test-quants:Quantization to MXFP4 matches exactly ✅
DEBUG:test-quants:Dequantizing from MXFP4 with Python
DEBUG:test-quants:Dequantizing from MXFP4 with C
INFO:test-quants:Dequantization from MXFP4 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as MXFP4 with Python
gguf-py/gguf/quants.py:704: RuntimeWarning: overflow encountered in multiply
  return (d * qs.astype(np.float32))
DEBUG:test-quants:Dequantizing random f16 data as MXFP4 with C
INFO:test-quants:Dequantization from random f16 data as MXFP4 matches exactly ✅
```

Note that there's a RuntimeWarning from Numpy above, but the equality check still passes. The warning is likely caused by invalid E8M0 values from the random data which is dequantized in that test.

<details><summary>Full test results</summary>

```console
$ python3 gguf-py/tests/test_quants.py
INFO:test-quants:Testing F16
DEBUG:test-quants:Quantizing to F16 with Python
DEBUG:test-quants:Quantizing to F16 with C
INFO:test-quants:Quantization to F16 matches exactly ✅
DEBUG:test-quants:Dequantizing from F16 with Python
DEBUG:test-quants:Dequantizing from F16 with C
INFO:test-quants:Dequantization from F16 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as F16 with Python
DEBUG:test-quants:Dequantizing random f16 data as F16 with C
INFO:test-quants:Dequantization from random f16 data as F16 matches exactly ✅
INFO:test-quants:Testing BF16
DEBUG:test-quants:Quantizing to BF16 with Python
DEBUG:test-quants:Quantizing to BF16 with C
INFO:test-quants:Quantization to BF16 matches exactly ✅
DEBUG:test-quants:Dequantizing from BF16 with Python
DEBUG:test-quants:Dequantizing from BF16 with C
INFO:test-quants:Dequantization from BF16 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as BF16 with Python
DEBUG:test-quants:Dequantizing random f16 data as BF16 with C
INFO:test-quants:Dequantization from random f16 data as BF16 matches exactly ✅
INFO:test-quants:Testing Q4_0
DEBUG:test-quants:Quantizing to Q4_0 with Python
DEBUG:test-quants:Quantizing to Q4_0 with C
INFO:test-quants:Quantization to Q4_0 matches exactly ✅
DEBUG:test-quants:Dequantizing from Q4_0 with Python
DEBUG:test-quants:Dequantizing from Q4_0 with C
INFO:test-quants:Dequantization from Q4_0 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q4_0 with Python
DEBUG:test-quants:Dequantizing random f16 data as Q4_0 with C
INFO:test-quants:Dequantization from random f16 data as Q4_0 matches exactly ✅
INFO:test-quants:Testing Q4_1
DEBUG:test-quants:Quantizing to Q4_1 with Python
DEBUG:test-quants:Quantizing to Q4_1 with C
INFO:test-quants:Quantization to Q4_1 matches exactly ✅
DEBUG:test-quants:Dequantizing from Q4_1 with Python
DEBUG:test-quants:Dequantizing from Q4_1 with C
INFO:test-quants:Dequantization from Q4_1 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q4_1 with Python
DEBUG:test-quants:Dequantizing random f16 data as Q4_1 with C
INFO:test-quants:Dequantization from random f16 data as Q4_1 matches exactly ✅
INFO:test-quants:Testing Q5_0
DEBUG:test-quants:Quantizing to Q5_0 with Python
DEBUG:test-quants:Quantizing to Q5_0 with C
INFO:test-quants:Quantization to Q5_0 matches exactly ✅
DEBUG:test-quants:Dequantizing from Q5_0 with Python
DEBUG:test-quants:Dequantizing from Q5_0 with C
INFO:test-quants:Dequantization from Q5_0 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q5_0 with Python
DEBUG:test-quants:Dequantizing random f16 data as Q5_0 with C
INFO:test-quants:Dequantization from random f16 data as Q5_0 matches exactly ✅
INFO:test-quants:Testing Q5_1
DEBUG:test-quants:Quantizing to Q5_1 with Python
DEBUG:test-quants:Quantizing to Q5_1 with C
INFO:test-quants:Quantization to Q5_1 matches exactly ✅
DEBUG:test-quants:Dequantizing from Q5_1 with Python
DEBUG:test-quants:Dequantizing from Q5_1 with C
INFO:test-quants:Dequantization from Q5_1 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q5_1 with Python
DEBUG:test-quants:Dequantizing random f16 data as Q5_1 with C
INFO:test-quants:Dequantization from random f16 data as Q5_1 matches exactly ✅
INFO:test-quants:Testing Q8_0
DEBUG:test-quants:Quantizing to Q8_0 with Python
DEBUG:test-quants:Quantizing to Q8_0 with C
INFO:test-quants:Quantization to Q8_0 matches exactly ✅
DEBUG:test-quants:Dequantizing from Q8_0 with Python
DEBUG:test-quants:Dequantizing from Q8_0 with C
INFO:test-quants:Dequantization from Q8_0 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q8_0 with Python
DEBUG:test-quants:Dequantizing random f16 data as Q8_0 with C
INFO:test-quants:Dequantization from random f16 data as Q8_0 matches exactly ✅
INFO:test-quants:Testing Q2_K
DEBUG:test-quants:Quantizing to Q2_K with C
DEBUG:test-quants:Dequantizing from Q2_K with Python
DEBUG:test-quants:Dequantizing from Q2_K with C
INFO:test-quants:Dequantization from Q2_K matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q2_K with Python
DEBUG:test-quants:Dequantizing random f16 data as Q2_K with C
INFO:test-quants:Dequantization from random f16 data as Q2_K matches exactly ✅
INFO:test-quants:Testing Q3_K
DEBUG:test-quants:Quantizing to Q3_K with C
DEBUG:test-quants:Dequantizing from Q3_K with Python
DEBUG:test-quants:Dequantizing from Q3_K with C
INFO:test-quants:Dequantization from Q3_K matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q3_K with Python
DEBUG:test-quants:Dequantizing random f16 data as Q3_K with C
INFO:test-quants:Dequantization from random f16 data as Q3_K matches exactly ✅
INFO:test-quants:Testing Q4_K
DEBUG:test-quants:Quantizing to Q4_K with C
DEBUG:test-quants:Dequantizing from Q4_K with Python
DEBUG:test-quants:Dequantizing from Q4_K with C
INFO:test-quants:Dequantization from Q4_K matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q4_K with Python
DEBUG:test-quants:Dequantizing random f16 data as Q4_K with C
INFO:test-quants:Dequantization from random f16 data as Q4_K matches exactly ✅
INFO:test-quants:Testing Q5_K
DEBUG:test-quants:Quantizing to Q5_K with C
DEBUG:test-quants:Dequantizing from Q5_K with Python
DEBUG:test-quants:Dequantizing from Q5_K with C
INFO:test-quants:Dequantization from Q5_K matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q5_K with Python
DEBUG:test-quants:Dequantizing random f16 data as Q5_K with C
INFO:test-quants:Dequantization from random f16 data as Q5_K matches exactly ✅
INFO:test-quants:Testing Q6_K
DEBUG:test-quants:Quantizing to Q6_K with C
DEBUG:test-quants:Dequantizing from Q6_K with Python
DEBUG:test-quants:Dequantizing from Q6_K with C
INFO:test-quants:Dequantization from Q6_K matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as Q6_K with Python
DEBUG:test-quants:Dequantizing random f16 data as Q6_K with C
INFO:test-quants:Dequantization from random f16 data as Q6_K matches exactly ✅
INFO:test-quants:Testing TQ1_0
DEBUG:test-quants:Quantizing to TQ1_0 with Python
DEBUG:test-quants:Quantizing to TQ1_0 with C
INFO:test-quants:Quantization to TQ1_0 matches exactly ✅
DEBUG:test-quants:Dequantizing from TQ1_0 with Python
DEBUG:test-quants:Dequantizing from TQ1_0 with C
INFO:test-quants:Dequantization from TQ1_0 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as TQ1_0 with Python
DEBUG:test-quants:Dequantizing random f16 data as TQ1_0 with C
INFO:test-quants:Dequantization from random f16 data as TQ1_0 matches exactly ✅
INFO:test-quants:Testing TQ2_0
DEBUG:test-quants:Quantizing to TQ2_0 with Python
DEBUG:test-quants:Quantizing to TQ2_0 with C
INFO:test-quants:Quantization to TQ2_0 matches exactly ✅
DEBUG:test-quants:Dequantizing from TQ2_0 with Python
DEBUG:test-quants:Dequantizing from TQ2_0 with C
INFO:test-quants:Dequantization from TQ2_0 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as TQ2_0 with Python
DEBUG:test-quants:Dequantizing random f16 data as TQ2_0 with C
INFO:test-quants:Dequantization from random f16 data as TQ2_0 matches exactly ✅
INFO:test-quants:Testing MXFP4
DEBUG:test-quants:Quantizing to MXFP4 with Python
DEBUG:test-quants:Quantizing to MXFP4 with C
INFO:test-quants:Quantization to MXFP4 matches exactly ✅
DEBUG:test-quants:Dequantizing from MXFP4 with Python
DEBUG:test-quants:Dequantizing from MXFP4 with C
INFO:test-quants:Dequantization from MXFP4 matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as MXFP4 with Python
gguf-py/gguf/quants.py:704: RuntimeWarning: overflow encountered in multiply
  return (d * qs.astype(np.float32))
DEBUG:test-quants:Dequantizing random f16 data as MXFP4 with C
INFO:test-quants:Dequantization from random f16 data as MXFP4 matches exactly ✅
INFO:test-quants:Testing IQ2_XXS
DEBUG:test-quants:Quantizing to IQ2_XXS with C
DEBUG:test-quants:Dequantizing from IQ2_XXS with Python
DEBUG:test-quants:Dequantizing from IQ2_XXS with C
INFO:test-quants:Dequantization from IQ2_XXS matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ2_XXS with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ2_XXS with C
INFO:test-quants:Dequantization from random f16 data as IQ2_XXS matches exactly ✅
INFO:test-quants:Testing IQ2_XS
DEBUG:test-quants:Quantizing to IQ2_XS with C
DEBUG:test-quants:Dequantizing from IQ2_XS with Python
DEBUG:test-quants:Dequantizing from IQ2_XS with C
INFO:test-quants:Dequantization from IQ2_XS matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ2_XS with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ2_XS with C
INFO:test-quants:Dequantization from random f16 data as IQ2_XS matches exactly ✅
INFO:test-quants:Testing IQ2_S
DEBUG:test-quants:Quantizing to IQ2_S with C
DEBUG:test-quants:Dequantizing from IQ2_S with Python
DEBUG:test-quants:Dequantizing from IQ2_S with C
INFO:test-quants:Dequantization from IQ2_S matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ2_S with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ2_S with C
INFO:test-quants:Dequantization from random f16 data as IQ2_S matches exactly ✅
INFO:test-quants:Testing IQ3_XXS
DEBUG:test-quants:Quantizing to IQ3_XXS with C
DEBUG:test-quants:Dequantizing from IQ3_XXS with Python
DEBUG:test-quants:Dequantizing from IQ3_XXS with C
INFO:test-quants:Dequantization from IQ3_XXS matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ3_XXS with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ3_XXS with C
INFO:test-quants:Dequantization from random f16 data as IQ3_XXS matches exactly ✅
INFO:test-quants:Testing IQ3_S
DEBUG:test-quants:Quantizing to IQ3_S with C
DEBUG:test-quants:Dequantizing from IQ3_S with Python
DEBUG:test-quants:Dequantizing from IQ3_S with C
INFO:test-quants:Dequantization from IQ3_S matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ3_S with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ3_S with C
INFO:test-quants:Dequantization from random f16 data as IQ3_S matches exactly ✅
INFO:test-quants:Testing IQ1_S
DEBUG:test-quants:Quantizing to IQ1_S with C
DEBUG:test-quants:Dequantizing from IQ1_S with Python
DEBUG:test-quants:Dequantizing from IQ1_S with C
INFO:test-quants:Dequantization from IQ1_S matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ1_S with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ1_S with C
INFO:test-quants:Dequantization from random f16 data as IQ1_S matches exactly ✅
INFO:test-quants:Testing IQ1_M
DEBUG:test-quants:Quantizing to IQ1_M with C
DEBUG:test-quants:Dequantizing from IQ1_M with Python
DEBUG:test-quants:Dequantizing from IQ1_M with C
INFO:test-quants:Dequantization from IQ1_M matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ1_M with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ1_M with C
INFO:test-quants:Dequantization from random f16 data as IQ1_M matches exactly ✅
INFO:test-quants:Testing IQ4_NL
DEBUG:test-quants:Quantizing to IQ4_NL with C
DEBUG:test-quants:Dequantizing from IQ4_NL with Python
DEBUG:test-quants:Dequantizing from IQ4_NL with C
INFO:test-quants:Dequantization from IQ4_NL matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ4_NL with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ4_NL with C
INFO:test-quants:Dequantization from random f16 data as IQ4_NL matches exactly ✅
INFO:test-quants:Testing IQ4_XS
DEBUG:test-quants:Quantizing to IQ4_XS with C
DEBUG:test-quants:Dequantizing from IQ4_XS with Python
DEBUG:test-quants:Dequantizing from IQ4_XS with C
INFO:test-quants:Dequantization from IQ4_XS matches exactly ✅
DEBUG:test-quants:Dequantizing random f16 data as IQ4_XS with Python
DEBUG:test-quants:Dequantizing random f16 data as IQ4_XS with C
INFO:test-quants:Dequantization from random f16 data as IQ4_XS matches exactly ✅
```
</details>

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
