### PR TITLE
Fix "<|channel|>analysis" appearing when chatting via llama-server API

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1318,7 +1318,7 @@ static common_chat_params common_chat_params_init_gpt_oss(const common_chat_temp
 }
 static void common_chat_parse_gpt_oss(common_chat_msg_parser & builder) {
     // TODO @ngxson : this won't work with --special enabled, we should fix that
-    builder.try_parse_reasoning("<|channel|>analysis<|message|>", "<|start|>assistant<|channel|>final<|message|>");
+    builder.try_parse_reasoning("<|message|>", "<|start|>assistant<|channel|>final<|message|>");
     if (!builder.syntax().parse_tool_calls) {
         builder.add_content(builder.consume_rest());
         return;


### PR DESCRIPTION
TBH I'm not sure if this is the correct fix, but it seems to work fine locally if I also patch the jinja2 template (https://huggingface.co/ggml-org/gpt-oss-120b-GGUF) with this:

```diff
--- gpt-oss.j2	2025-08-06 10:59:18
+++ gpt-oss.j2  2025-08-06 11:00:43
@@ -303,5 +303,5 @@

 {#- Generation prompt #}
 {%- if add_generation_prompt -%}
-<|start|>assistant
+<|start|>assistant<|channel|>analysis
 {%- endif -%}
```

This might be a partial fix for #15110