### PR TITLE
llama-bench: fixed help output for `-override-tensors` to `-override-tensor`

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -374,7 +374,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -embd, --embeddings <0|1>                 (default: %s)\n",
            join(cmd_params_defaults.embeddings, ",").c_str());
     printf("  -ts, --tensor-split <ts0/ts1/..>          (default: 0)\n");
-    printf("  -ot --override-tensors <tensor name pattern>=<buffer type>;...\n");
+    printf("  -ot --override-tensor <tensor name pattern>=<buffer type>;...\n");
     printf("                                            (default: disabled)\n");
     printf("  -nopo, --no-op-offload <0|1>              (default: 0)\n");
     printf("\n");


### PR DESCRIPTION
Just fixed this help output for `llama-bench`

```
  -ot --override-tensors <tensor name pattern>=<buffer type>;...
                                            (default: disabled)
```

```
error: invalid parameter for argument: --override-tensors
```

it should be `--override-tensor` to match the rest of `llama.cpp`.