### PR TITLE
chat : Avoid partial reasoning tags in response content

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -95,6 +95,13 @@ bool common_chat_msg_parser::try_consume_literal(const std::string & literal) {
     auto pos = pos_;
     for (auto i = 0u; i < literal.size(); ++i) {
         if (pos >= input_.size()) {
+            if (is_partial() && i > 0) {
+                // For partial message, whose suffix matches the literal, report
+                // that it can be consumed. We need more content to be able to
+                // tell otherwise.
+                pos_ = pos;
+                return true;
+            }
             return false;
         }
         if (input_[pos] != literal[i]) {

--- a/tests/test-chat-parser.cpp
+++ b/tests/test-chat-parser.cpp
@@ -150,6 +150,14 @@ static void test_regex() {
     common_chat_msg_parser builder("Hello,", is_partial, {});
     assert_equals(false, builder.try_consume_literal("Oh"));
   }
+  {
+    common_chat_msg_parser builder("<some>", false, {});
+    assert_equals(false, builder.try_consume_literal("<some><suffix>"));
+  }
+  {
+    common_chat_msg_parser builder("<some>", true, {});
+    assert_equals(true, builder.try_consume_literal("<some><suffix>"));
+  }
 }
 
 const std::vector<std::string> barely_healable_jsons = {


### PR DESCRIPTION
If a model uses a multi-part reasoning tag we can end up with part of the tag in the message content when using streaming mode. E.g.

    $ curl -N http://localhost:8080/v1/chat/completions -d '{
      "model": "hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl",
      "messages": [
        {"role": "user", "content": "Hello, how are you?"}
      ],
    "stream": true
    }' -H "Content-Type: application/json"
    data: {"choices":[{"finish_reason":null,"index":0,"delta":{"role":"assistant","content":null}}],"created":1754562630,"id":"chatcmpl-bJReFN26YAf6IQXxNNSWT8Rk8q0NwfDk","model":"hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl","system_fingerprint":"b1-9515c61","object":"chat.completion.chunk"}

    data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"<|channel|>"}}],"created":1754562630,"id":"chatcmpl-bJReFN26YAf6IQXxNNSWT8Rk8q0NwfDk","model":"hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl","system_fingerprint":"b1-9515c61","object":"chat.completion.chunk"}

    data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"analysis"}}],"created":1754562630,"id":"chatcmpl-bJReFN26YAf6IQXxNNSWT8Rk8q0NwfDk","model":"hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl","system_fingerprint":"b1-9515c61","object":"chat.completion.chunk"}

    data: {"choices":[{"finish_reason":null,"index":0,"delta":{"reasoning_content":"The"}}],"created":1754562630,"id":"chatcmpl-bJReFN26YAf6IQXxNNSWT8Rk8q0NwfDk","model":"hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl","system_fingerprint":"b1-9515c61","object":"chat.completion.chunk"}

    data: {"choices":[{"finish_reason":null,"index":0,"delta":{}}],"created":1754562630,"id":"chatcmpl-bJReFN26YAf6IQXxNNSWT8Rk8q0NwfDk","model":"hf.co/unsloth/gpt-oss-20b-gguf:q6_k_xl","system_fingerprint":"b1-9515c61","object":"chat.completion.chunk"}

    ...

This happens because the chat parser can't make a full match on the first parts of the reasoning tag. So, modify try_consume_literal() to speculatively consume a partially matching string in case the parser is constructed with partial set to true.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
