### PR TITLE
common : add GLM-4.5 tool calling support

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1347,7 +1347,7 @@ static void common_chat_parse_glm_4_5(common_chat_msg_parser & builder) {
     // GLM 4.5 uses format: <tool_call>function_name\n<arg_key>key</arg_key>\n<arg_value>value</arg_value>\n</tool_call>
     static const common_regex tool_call_start("<tool_call>([^\n<]+)");
     static const common_regex arg_key_regex("<arg_key>([^<]+)</arg_key>");
-    static const common_regex arg_value_regex("<arg_value>(.*)</arg_value>");
+    static const common_regex arg_value_regex("<arg_value>(.*?)</arg_value>");
     static const common_regex tool_call_end("</tool_call>");
 
     while (auto res = builder.try_find_regex(tool_call_start)) {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1347,7 +1347,7 @@ static void common_chat_parse_glm_4_5(common_chat_msg_parser & builder) {
     // GLM 4.5 uses format: <tool_call>function_name\n<arg_key>key</arg_key>\n<arg_value>value</arg_value>\n</tool_call>
     static const common_regex tool_call_start("<tool_call>([^\n<]+)");
     static const common_regex arg_key_regex("<arg_key>([^<]+)</arg_key>");
-    static const common_regex arg_value_regex("<arg_value>([^<]*)</arg_value>");
+    static const common_regex arg_value_regex("<arg_value>(.*)</arg_value>");
     static const common_regex tool_call_end("</tool_call>");
 
     while (auto res = builder.try_find_regex(tool_call_start)) {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1330,62 +1330,196 @@ static void common_chat_parse_gpt_oss(common_chat_msg_parser & builder) {
 }
 
 static common_chat_params common_chat_params_init_glm_4_5(const common_chat_template & tmpl, const struct templates_params & inputs) {
+    LOG_INF("%s: initializing GLM-4.5 chat params\n", __func__);
     common_chat_params data;
-    data.prompt = apply(tmpl, inputs);
+    
+    // Configure template inputs
+    minja::chat_template_inputs tmpl_inputs;
+    tmpl_inputs.messages = inputs.messages;
+    tmpl_inputs.tools = inputs.tools.empty() ? json() : inputs.tools;
+    tmpl_inputs.add_generation_prompt = inputs.add_generation_prompt;
+    tmpl_inputs.extra_context = inputs.extra_context;
+    tmpl_inputs.now = inputs.now; // Use the consistent timestamp from params
+    
+    // Configure template options to disable polyfills and enforce native XML format
+    minja::chat_template_options opts;
+    opts.apply_polyfills = false; // Hard disable all polyfills
+    
+    // The prompt is generated here
+    data.prompt = tmpl.apply(tmpl_inputs, opts);
     data.format = COMMON_CHAT_FORMAT_GLM_4_5;
+    
+    data.preserved_tokens = {
+        "<|system|>", "<|assistant|>", "<|observation|>",
+        "<tool_call>", "</tool_call>", "<arg_key>", "</arg_key>", 
+        "<arg_value>", "</arg_value>", "<think>", "</think>",
+        "<tool_response>", "</tool_response>",
+    };
+    
+    // Store tools schema for type-aware parsing later
+    data.tools_schema = inputs.tools;
+    
+    LOG_INF("%s: GLM-4.5 native XML format enforced\n", __func__);
     return data;
 }
 
 static void common_chat_parse_glm_4_5(common_chat_msg_parser & builder) {
-    builder.consume_spaces();
-    builder.try_parse_reasoning("<think>", "</think>");
-    if (!builder.syntax().parse_tool_calls) {
-        builder.add_content(builder.consume_rest());
-        return;
-    }
-
-    // GLM 4.5 uses format: <tool_call>function_name\n<arg_key>key</arg_key>\n<arg_value>value</arg_value>\n</tool_call>
-    static const common_regex tool_call_start("<tool_call>([^\n<]+)");
-    static const common_regex arg_key_regex("<arg_key>([^<]+)</arg_key>");
-    static const common_regex arg_value_regex("<arg_value>([\\s\\S]*?)</arg_value>");
-    static const common_regex tool_call_end("</tool_call>");
-
-    while (auto res = builder.try_find_regex(tool_call_start)) {
-        // Move to the start of the tool call and consume it
-        builder.move_to(res->groups[0].begin);
-        builder.consume_regex(tool_call_start);
-        
-        std::string function_name = builder.str(res->groups[1]);
-        json arguments = json::object();
-        
-        builder.consume_spaces();
-        
-        // Parse all arg_key/arg_value pairs
-        while (auto key_res = builder.try_consume_regex(arg_key_regex)) {
-            std::string key = builder.str(key_res->groups[1]);
-            builder.consume_spaces();
-            
-            if (auto value_res = builder.try_consume_regex(arg_value_regex)) {
-                std::string value = builder.str(value_res->groups[1]);
-                arguments[key] = value;
-                builder.consume_spaces();
-            } else {
-                throw common_chat_msg_partial_exception("Expected <arg_value> after <arg_key>");
+    
+    auto get_expected_type = [&](const std::string& tool_name, const std::string& param_name) -> std::string {
+        // Access tools schema from builder syntax
+        const auto& tools_schema = builder.syntax().tools_schema;
+        if (tools_schema.is_array()) {
+            for (const auto& tool : tools_schema) {
+                if (tool.contains("function") && tool["function"]["name"] == tool_name) {
+                    auto params = tool["function"]["parameters"];
+                    if (params.contains("properties") && params["properties"].contains(param_name)) {
+                        return params["properties"][param_name].value("type", "string");
+                    }
+                }
             }
         }
+        return "string"; // Default fallback
+    };
+
+    auto handle_tool_call_end = [&] (common_chat_msg_parser & builder, auto end_pos) {
+        builder.move_to(end_pos);
+        builder.consume_literal("</tool_call>");
         
-        // Consume closing tag
-        builder.consume_regex(tool_call_end);
-        builder.consume_spaces();
-        
-        // Add the parsed tool call
-        if (!builder.add_tool_call(function_name, "", arguments.dump())) {
-            throw common_chat_msg_partial_exception("Failed to add GLM tool call");
+        size_t obs_pos = builder.input().find("<|observation|>", builder.pos());
+        if (obs_pos != std::string::npos) {
+            if (obs_pos > builder.pos()) {
+                std::string content = builder.input().substr(builder.pos(), obs_pos - builder.pos());
+                builder.add_content(content);
+            }
+            
+            builder.move_to(obs_pos);
+            builder.consume_literal("<|observation|>");
+        } else {
+            std::string remaining = builder.consume_rest();
+            if (!remaining.empty()) builder.add_content(remaining);
         }
+    };
+
+    builder.consume_spaces();
+    
+    builder.try_parse_reasoning("<think>", "</think>");
+    
+    size_t curr_pos = builder.pos();
+    while (builder.input().find("<tool_call>", builder.pos()) != std::string::npos) {
+        size_t tool_call_start = builder.input().find("<tool_call>", builder.pos());
+        if (tool_call_start > builder.pos()) {
+            std::string content = builder.input().substr(builder.pos(), tool_call_start - builder.pos());
+            builder.add_content(content);
+        }
+        
+        size_t tool_call_end = builder.input().find("</tool_call>", tool_call_start);
+        if (tool_call_end == std::string::npos) return;
+
+        builder.move_to(tool_call_start);
+        builder.consume_literal("<tool_call>");
+        builder.consume_spaces();
+
+        size_t arg_key_start = builder.input().find("<arg_key>", tool_call_start);
+        if (arg_key_start == std::string::npos || arg_key_start > tool_call_end) {
+            std::string function_content = builder.input().substr(builder.pos(), tool_call_end - builder.pos());
+            std::string function_name = string_strip(function_content);
+            
+            if (!builder.add_tool_call(function_name, "", "{}")) {
+                LOG_INF("%s: failed to add tool call\n", __func__);
+            }
+
+            handle_tool_call_end(builder, tool_call_end);
+
+        } else {
+            std::string function_content = builder.input().substr(builder.pos(), arg_key_start - builder.pos());
+            std::string function_name = string_strip(function_content);
+            
+            json args_json = json::object();
+            builder.move_to(arg_key_start);
+            
+            while (builder.pos() < tool_call_end && builder.input().substr(builder.pos()).find("<arg_key>") == 0) {
+                if (!builder.try_consume_literal("<arg_key>")) break;
+                
+                auto key_close = builder.try_find_literal("</arg_key>");
+                if (!key_close || key_close->groups[0].end > tool_call_end) {
+                    throw common_chat_msg_partial_exception("incomplete tool call");
+                    return;
+                }
+                
+                std::string key = string_strip(key_close->prelude);
+                
+                builder.consume_spaces();
+                
+                if (!builder.try_consume_literal("<arg_value>")) {
+                    throw common_chat_msg_partial_exception("incomplete tool call");
+                    return;
+                }
+                
+                auto value_close = builder.try_find_literal("</arg_value>");
+                if (!value_close || value_close->groups[0].end > tool_call_end) {
+                    throw common_chat_msg_partial_exception("incomplete tool call");
+                    return;
+                }
+                
+                std::string value = string_strip(value_close->prelude);
+
+                // Schema-aware type conversion
+                std::string expected_type = get_expected_type(function_name, key);
+                json parsed_value;
+
+                if (expected_type == "array" || expected_type == "object") {
+                    try {
+                        parsed_value = json::parse(value);
+                    } catch (...) {
+                        parsed_value = value;
+                    }
+                } else {
+                    // For all other types, store as string and let the unpacking logic handle it
+                    parsed_value = value;
+                }
+
+                args_json[key] = parsed_value;
+                builder.consume_spaces();
+            }
+
+            if (args_json.size() == 1) {
+                const auto key = args_json.begin().key();
+                auto& value = args_json.begin().value();
+
+                if (value.is_string()) {
+                    try {
+                        json unpacked_json = json::parse(value.get<std::string>());
+                        if (unpacked_json.is_object()) {
+                            args_json = unpacked_json;
+                        }
+                    } catch (const std::exception&) {
+                        // Not a valid JSON string, proceed as normal
+                    }
+                }
+            }
+            
+            if (!builder.add_tool_call(function_name, "", args_json.dump())) {
+                LOG_INF("%s: failed to add tool call with arguments\n", __func__);
+            } else {
+                LOG_INF("%s: successfully added tool call with arguments\n", __func__);
+            }
+
+            handle_tool_call_end(builder, tool_call_end);
+        }
+    
+        if (curr_pos == builder.pos()) {
+            // No progress made, avoid infinite loop
+            LOG_INF("%s: no progress in parsing, stopping to avoid infinite loop\n", __func__);
+            break;
+        }
+        curr_pos = builder.pos();
     }
 
-    builder.add_content(builder.consume_rest());
+    if (builder.pos() < builder.input().size()) {
+        builder.add_content(builder.consume_rest());
+    }
 }
+
 
 static common_chat_params common_chat_params_init_firefunction_v2(const common_chat_template & tmpl, const struct templates_params & inputs) {
     LOG_DBG("%s\n", __func__);

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1347,7 +1347,7 @@ static void common_chat_parse_glm_4_5(common_chat_msg_parser & builder) {
     // GLM 4.5 uses format: <tool_call>function_name\n<arg_key>key</arg_key>\n<arg_value>value</arg_value>\n</tool_call>
     static const common_regex tool_call_start("<tool_call>([^\n<]+)");
     static const common_regex arg_key_regex("<arg_key>([^<]+)</arg_key>");
-    static const common_regex arg_value_regex("<arg_value>(.*?)</arg_value>");
+    static const common_regex arg_value_regex("<arg_value>([\\s\\S]*?)</arg_value>");
     static const common_regex tool_call_end("</tool_call>");
 
     while (auto res = builder.try_find_regex(tool_call_start)) {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1337,6 +1337,7 @@ static common_chat_params common_chat_params_init_glm_4_5(const common_chat_temp
 }
 
 static void common_chat_parse_glm_4_5(common_chat_msg_parser & builder) {
+    builder.consume_spaces();
     builder.try_parse_reasoning("<think>", "</think>");
     if (!builder.syntax().parse_tool_calls) {
         builder.add_content(builder.consume_rest());
@@ -1867,7 +1868,7 @@ static common_chat_params common_chat_templates_apply_jinja(
     }
 
     // GLM 4.5: detect by <arg_key> and <arg_value> tags (check before Hermes since both use <tool_call>)
-    if (src.find("<arg_key>") != std::string::npos && src.find("<arg_value>") != std::string::npos && params.json_schema.is_null()) {
+    if (src.find("[gMASK]<sop>") != std::string::npos && src.find("<arg_key>") != std::string::npos && src.find("<arg_value>") != std::string::npos && params.json_schema.is_null()) {
         return common_chat_params_init_glm_4_5(tmpl, params);
     }
 

--- a/common/chat.h
+++ b/common/chat.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "common.h"
+#include <nlohmann/json.hpp>
 #include <functional>
 #include <chrono>
 #include <string>
@@ -142,6 +143,7 @@ struct common_chat_params {
     std::vector<common_grammar_trigger> grammar_triggers;
     std::vector<std::string>            preserved_tokens;
     std::vector<std::string>            additional_stops;
+    nlohmann::ordered_json              tools_schema = nlohmann::ordered_json();  // Schema for tools to pass to parser
 };
 
 struct common_chat_syntax {
@@ -151,6 +153,7 @@ struct common_chat_syntax {
     bool                     reasoning_in_content  = false;
     bool                     thinking_forced_open  = false;
     bool                     parse_tool_calls      = true;
+    nlohmann::ordered_json   tools_schema          = nlohmann::ordered_json();  // Schema for tools to enable type-aware parsing
 };
 
 // Check if the template supplied via "--chat-template" is supported or not. Returns true if it's valid

--- a/common/chat.h
+++ b/common/chat.h
@@ -110,6 +110,7 @@ enum common_chat_format {
     COMMON_CHAT_FORMAT_HERMES_2_PRO,
     COMMON_CHAT_FORMAT_COMMAND_R7B,
     COMMON_CHAT_FORMAT_GPT_OSS,
+    COMMON_CHAT_FORMAT_GLM_4_5,
 
     COMMON_CHAT_FORMAT_COUNT, // Not a format, just the # formats
 };

--- a/models/templates/glm_4_5.jinja
+++ b/models/templates/glm_4_5.jinja
@@ -1,0 +1,119 @@
+[gMASK]<sop>
+{%- if tools -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{{ tool | tojson }}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}
+<arg_key>{arg-key-1}</arg_key>
+<arg_value>{arg-value-1}</arg_value>
+<arg_key>{arg-key-2}</arg_key>
+<arg_value>{arg-value-2}</arg_value>
+...
+</tool_call>{%- endif -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text }}
+            {%- elif item is string -%}
+                {{- item }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1) %}
+{%- for m in messages %}
+    {%- if m.role == 'user' %}
+        {% set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{% for m in messages %}
+{%- if m.role == 'user' -%}<|user|>
+{%- set user_content = visible_text(m.content) -%}
+{{ user_content }}
+{{- '/nothink' if (enable_thinking is defined and not enable_thinking and not user_content.endswith("/nothink")) else '' -}}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set reasoning_content = '' %}
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- else %}
+    {%- if '</think>' in content %}
+        {%- set parts = content.split('</think>') -%}
+        {%- set before_first_close = parts | first -%}
+        {%- set inner_parts = before_first_close.rstrip('\n').split('<think>') -%}
+        {%- set extracted_reasoning = inner_parts | last -%}
+        {%- set reasoning_content = extracted_reasoning.lstrip('\n') -%}
+        {%- set after_last_close = parts | last -%}
+        {%- set content = after_last_close.lstrip('\n') -%}
+    {%- endif %}
+{%- endif %}
+{%- if loop.index0 > ns.last_user_index and reasoning_content -%}
+{{ '\n<think>' + reasoning_content.strip() +  '</think>'}}
+{%- else -%}
+{{ '\n<think></think>' }}
+{%- endif -%}
+{%- if content.strip() -%}
+{{ '\n' + content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc_obj = tc.function %}
+{%- else %}
+    {%- set tc_obj = tc %}
+{%- endif %}
+{{ '\n<tool_call>' + tc_obj.name }}
+{%- if tc_obj.arguments is mapping -%}
+    {%- for k, v in tc_obj.arguments.items() -%}
+
+<arg_key>{{ k }}</arg_key>
+<arg_value>{{ v | tojson if v is not string else v }}</arg_value>
+    {%- endfor -%}
+{%- else -%}
+    {#- Arguments came as string - this shouldn't happen with polyfills disabled -#}
+    {#- Output as single argument for debugging -#}
+
+<arg_key>raw_arguments</arg_key>
+<arg_value>{{ tc_obj.arguments }}</arg_value>
+{%- endif -%}
+</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+{%- if m.content is string -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' }}
+{%- endif %}
+{{- '\n<tool_response>\n' }}
+{{- m.content }}
+{{- '\n</tool_response>' }}
+{%- else -%}
+<|observation|>{% for tr in m.content %}
+
+<tool_response>
+{{ tr.output if tr.output is defined else tr }}
+</tool_response>{% endfor -%}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>
+{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    <|assistant|>{{- '\n<think></think>' if (enable_thinking is defined and not enable_thinking) else '' -}}
+{%- endif -%}

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -294,6 +294,7 @@ static void test_templates(const struct common_chat_templates * tmpls, const std
             common_chat_syntax syntax;
             syntax.format = data.params.format;
             syntax.reasoning_format = reasoning_format;
+            syntax.tools_schema = data.params.tools_schema;
             const auto msg = common_chat_parse(data.delta, /* is_partial= */ false, syntax);
             assert_msg_equals(test_message, msg);
         }

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -387,6 +387,7 @@ struct server_task {
             params.oaicompat_chat_syntax.reasoning_in_content = params.stream && (params_base.reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
             params.oaicompat_chat_syntax.thinking_forced_open = json_value(data, "thinking_forced_open", false);
             params.oaicompat_chat_syntax.parse_tool_calls = json_value(data, "parse_tool_calls", false);
+            params.oaicompat_chat_syntax.tools_schema = json_value(data, "tools_schema", nlohmann::ordered_json());
         }
 
         {

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -848,6 +848,9 @@ static json oaicompat_chat_params_parse(
         }
     }
 
+    // Store tools schema for parser
+    llama_params["tools_schema"] = chat_params.tools_schema;
+
     return llama_params;
 }
 


### PR DESCRIPTION
- Add COMMON_CHAT_FORMAT_GLM_4_5 format enum
- Implement GLM-4.5 tool call parser for <tool_call><arg_key><arg_value> format
- Add template detection based on <arg_key> and <arg_value> tags
- Fix null content handling in message parsing and serialization
- Ensure GLM-4.5 detection runs before Hermes to avoid misidentification

This enables tool calling functionality for GLM-4.5 models when using --jinja flag. The parser handles GLM-4.5's XML-like tool call format with key-value argument pairs.

Personally verified working on following applications
- Cline
- Roo Code
- Kilo Code
- Cherry Studio (MCP + Tool calling)

~~Unfortunately its not working with OpenAI API SDK because jinja requires dict parser but OpenAI requires json.~~

Now works with OpenAI SDK too.
above issue is now fixed with corrected Jinja template. The template works great with cline too. I extensively tested it.

Corrected Jinja template available at `models/templates/glm_4_5.jinja`

@ggerganov @ngxson @slaren  Please review and merge the PR. Thank you.