### PR TITLE
fix: llama_memory_seq_rm(mem, -1, ...)

### DIFF
--- a/examples/lookahead/lookahead.cpp
+++ b/examples/lookahead/lookahead.cpp
@@ -429,7 +429,7 @@ int main(int argc, char ** argv) {
 
         // KV cache management
         // if no verification token matched, we simply remove all cells from this batch -> no fragmentation
-        llama_memory_seq_rm(mem, -1, n_past, -1);
+        llama_memory_seq_rm(mem, 0, n_past, -1);
 
         if (seq_id_best != 0) {
             // if a verification token matched, we keep the best sequence and remove the rest

--- a/tools/main/main.cpp
+++ b/tools/main/main.cpp
@@ -354,7 +354,7 @@ int main(int argc, char ** argv) {
         }
 
         // remove any "future" tokens that we might have inherited from the previous session
-        llama_memory_seq_rm(mem, -1, n_matching_session_tokens, -1);
+        llama_memory_seq_rm(mem, 0, n_matching_session_tokens, -1);
     }
 
     LOG_DBG("recalculate the cached logits (check): embd_inp.size() %zu, n_matching_session_tokens %zu, embd_inp.size() %zu, session_tokens.size() %zu\n",


### PR DESCRIPTION
I believe it must be llama_memory_seq_rm(mem, 0, ...)

because of
```
llama_kv_cache_unified::seq_rm
GGML_ASSERT(seq_id >= 0 && (size_t) seq_id < seq_to_stream.size());
```
See:
https://github.com/ggml-org/llama.cpp/commit/745aa5319b9930068aff5e87cf5e9eef7227339b#r163727848