### PR TITLE
webui: prettify styling

### DIFF
--- a/tools/server/webui/index.html
+++ b/tools/server/webui/index.html
@@ -7,7 +7,8 @@
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
     <meta name="color-scheme" content="light dark" />
-    <title>🦙 llama.cpp - chat</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦙</text></svg>">
+    <title>llama.cpp</title>
   </head>
   <body>
     <div id="root"></div>

--- a/tools/server/webui/index.html
+++ b/tools/server/webui/index.html
@@ -7,7 +7,10 @@
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
     <meta name="color-scheme" content="light dark" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦙</text></svg>">
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦙</text></svg>"
+    />
     <title>llama.cpp</title>
   </head>
   <body>

--- a/tools/server/webui/src/App.tsx
+++ b/tools/server/webui/src/App.tsx
@@ -37,6 +37,7 @@ function AppLayout() {
       >
         <Header />
         <Outlet />
+        <ServerInfo />
       </main>
       {
         <SettingDialog
@@ -46,6 +47,39 @@ function AppLayout() {
       }
       <Toaster />
     </>
+  );
+}
+
+function ServerInfo() {
+  const { serverProps } = useAppContext();
+  const modalities = [];
+  if (serverProps?.modalities?.audio) {
+    modalities.push('audio');
+  }
+  if (serverProps?.modalities?.vision) {
+    modalities.push('vision');
+  }
+  return (
+    <div
+      className="sticky bottom-0 w-full pb-1 text-base-content/70 text-xs text-center"
+      tabIndex={0}
+      aria-description="Server information"
+    >
+      <span>
+        <b>Llama.cpp</b> {serverProps?.build_info}
+      </span>
+
+      <span className="sm:ml-2">
+        {modalities.length > 0 ? (
+          <>
+            <br className="sm:hidden" />
+            <b>Supported modalities:</b> {modalities.join(', ')}
+          </>
+        ) : (
+          ''
+        )}
+      </span>
+    </div>
   );
 }
 

--- a/tools/server/webui/src/App.tsx
+++ b/tools/server/webui/src/App.tsx
@@ -37,7 +37,6 @@ function AppLayout() {
       >
         <Header />
         <Outlet />
-        <ServerInfo />
       </main>
       {
         <SettingDialog
@@ -47,39 +46,6 @@ function AppLayout() {
       }
       <Toaster />
     </>
-  );
-}
-
-function ServerInfo() {
-  const { serverProps } = useAppContext();
-  const modalities = [];
-  if (serverProps?.modalities?.audio) {
-    modalities.push('audio');
-  }
-  if (serverProps?.modalities?.vision) {
-    modalities.push('vision');
-  }
-  return (
-    <div
-      className="sticky bottom-0 w-full pb-1 text-base-content/70 text-xs text-center"
-      tabIndex={0}
-      aria-description="Server information"
-    >
-      <span>
-        <b>Llama.cpp</b> {serverProps?.build_info}
-      </span>
-
-      <span className="sm:ml-2">
-        {modalities.length > 0 ? (
-          <>
-            <br className="sm:hidden" />
-            <b>Supported modalities:</b> {modalities.join(', ')}
-          </>
-        ) : (
-          ''
-        )}
-      </span>
-    </div>
   );
 }
 

--- a/tools/server/webui/src/components/ChatMessage.tsx
+++ b/tools/server/webui/src/components/ChatMessage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowPathIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ExclamationCircleIcon,
   PencilSquareIcon,
 } from '@heroicons/react/24/outline';
 import ChatInputExtraContextItem from './ChatInputExtraContextItem';
@@ -109,7 +110,7 @@ export default function ChatMessage({
         <div
           className={classNames({
             'chat-bubble markdown': true,
-            'chat-bubble bg-transparent': !isUser,
+            'bg-transparent': !isUser,
           })}
         >
           {/* textarea for editing message */}
@@ -168,30 +169,6 @@ export default function ChatMessage({
                   </div>
                 </>
               )}
-              {/* render timings if enabled */}
-              {timings && config.showTokensPerSecond && (
-                <div className="dropdown dropdown-hover dropdown-top mt-2">
-                  <div
-                    tabIndex={0}
-                    role="button"
-                    className="cursor-pointer font-semibold text-sm opacity-60"
-                  >
-                    Speed: {timings.predicted_per_second.toFixed(1)} t/s
-                  </div>
-                  <div className="dropdown-content bg-base-100 z-10 w-64 p-2 shadow mt-4">
-                    <b>Prompt</b>
-                    <br />- Tokens: {timings.prompt_n}
-                    <br />- Time: {timings.prompt_ms} ms
-                    <br />- Speed: {timings.prompt_per_second.toFixed(1)} t/s
-                    <br />
-                    <b>Generation</b>
-                    <br />- Tokens: {timings.predicted_n}
-                    <br />- Time: {timings.predicted_ms} ms
-                    <br />- Speed: {timings.predicted_per_second.toFixed(1)} t/s
-                    <br />
-                  </div>
-                </div>
-              )}
             </>
           )}
         </div>
@@ -201,7 +178,7 @@ export default function ChatMessage({
       {msg.content !== null && (
         <div
           className={classNames({
-            'flex items-center gap-2 mx-4 mt-2 mb-2': true,
+            'flex items-center gap-2 mx-4 mb-2': true,
             'flex-row-reverse': msg.role === 'user',
           })}
         >
@@ -262,6 +239,41 @@ export default function ChatMessage({
                   tooltipsContent="Regenerate response"
                 >
                   <ArrowPathIcon className="h-4 w-4" />
+                </BtnWithTooltips>
+              )}
+
+              {/* render timings if enabled */}
+              {timings && config.showTokensPerSecond && (
+                <BtnWithTooltips
+                  className="btn-mini w-8 h-8"
+                  tooltipsContent="Performance"
+                >
+                  <div className="dropdown dropdown-hover dropdown-top">
+                    <ExclamationCircleIcon className="h-4 w-4" />
+
+                    <div
+                      tabIndex={0}
+                      className="dropdown-content rounded-box bg-base-100 z-10 w-48 px-4 py-2 shadow mt-4 text-sm text-left"
+                    >
+                      <b>Prompt Processing</b>
+                      <ul className="list-inside list-disc">
+                        <li>Tokens: {timings.prompt_n}</li>
+                        <li>Time: {timings.prompt_ms} ms</li>
+                        <li>
+                          Speed: {timings.prompt_per_second.toFixed(1)} t/s
+                        </li>
+                      </ul>
+                      <br />
+                      <b>Generation</b>
+                      <ul className="list-inside list-disc">
+                        <li>Tokens: {timings.predicted_n}</li>
+                        <li>Time: {timings.predicted_ms} ms</li>
+                        <li>
+                          Speed: {timings.predicted_per_second.toFixed(1)} t/s
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
                 </BtnWithTooltips>
               )}
             </>

--- a/tools/server/webui/src/components/ChatScreen.tsx
+++ b/tools/server/webui/src/components/ChatScreen.tsx
@@ -296,7 +296,7 @@ function ChatInput({
       role="group"
       aria-label="Chat input"
       className={classNames({
-        'flex items-end pt-8 pb-1 sticky bottom-0 bg-base-100': true,
+        'flex flex-col items-end pt-8 sticky bottom-0 bg-base-100': true,
         'opacity-50': isDrag, // simply visual feedback to inform user that the file will be accepted
       })}
     >
@@ -423,6 +423,40 @@ function ChatInput({
           </div>
         )}
       </Dropzone>
+      <ServerInfo />
+    </div>
+  );
+}
+
+function ServerInfo() {
+  const { serverProps } = useAppContext();
+  const modalities = [];
+  if (serverProps?.modalities?.audio) {
+    modalities.push('audio');
+  }
+  if (serverProps?.modalities?.vision) {
+    modalities.push('vision');
+  }
+  return (
+    <div
+      className="sticky bottom-0 w-full pt-1 pb-1 text-base-content/70 text-xs text-center"
+      tabIndex={0}
+      aria-description="Server information"
+    >
+      <span>
+        <b>Llama.cpp</b> {serverProps?.build_info}
+      </span>
+
+      <span className="sm:ml-2">
+        {modalities.length > 0 ? (
+          <>
+            <br className="sm:hidden" />
+            <b>Supported modalities:</b> {modalities.join(', ')}
+          </>
+        ) : (
+          ''
+        )}
+      </span>
     </div>
   );
 }

--- a/tools/server/webui/src/components/ChatScreen.tsx
+++ b/tools/server/webui/src/components/ChatScreen.tsx
@@ -231,29 +231,31 @@ export default function ChatScreen() {
           flex: !hasCanvas,
         })}
       >
-        {/* chat messages */}
-        <div id="messages-list" className="grow" ref={msgListRef}>
-          <div className="mt-auto flex flex-col items-center">
-            {/* placeholder to shift the message to the bottom */}
-            {viewingChat ? (
-              ''
-            ) : (
-              <div className="mb-4">Send a message to start</div>
-            )}
+        {/* placeholder to shift the message to the bottom */}
+        {!viewingChat && (
+          <div className="grow flex flex-col items-center justify-center ">
+            <b className="text-4xl">Nice to see you.</b>
+            <small>how can I help you today?</small>
           </div>
-          {[...messages, ...pendingMsgDisplay].map((msg) => (
-            <ChatMessage
-              key={msg.msg.id}
-              msg={msg.msg}
-              siblingLeafNodeIds={msg.siblingLeafNodeIds}
-              siblingCurrIdx={msg.siblingCurrIdx}
-              onRegenerateMessage={handleRegenerateMessage}
-              onEditMessage={handleEditMessage}
-              onChangeSibling={setCurrNodeId}
-              isPending={msg.isPending}
-            />
-          ))}
-        </div>
+        )}
+
+        {/* chat messages */}
+        {viewingChat && (
+          <div id="messages-list" className="grow" ref={msgListRef}>
+            {[...messages, ...pendingMsgDisplay].map((msg) => (
+              <ChatMessage
+                key={msg.msg.id}
+                msg={msg.msg}
+                siblingLeafNodeIds={msg.siblingLeafNodeIds}
+                siblingCurrIdx={msg.siblingCurrIdx}
+                onRegenerateMessage={handleRegenerateMessage}
+                onEditMessage={handleEditMessage}
+                onChangeSibling={setCurrNodeId}
+                isPending={msg.isPending}
+              />
+            ))}
+          </div>
+        )}
 
         {/* chat input */}
         <ChatInput

--- a/tools/server/webui/src/components/ChatScreen.tsx
+++ b/tools/server/webui/src/components/ChatScreen.tsx
@@ -238,10 +238,7 @@ export default function ChatScreen() {
             {viewingChat ? (
               ''
             ) : (
-              <>
-                <div className="mb-4">Send a message to start</div>
-                <ServerInfo />
-              </>
+              <div className="mb-4">Send a message to start</div>
             )}
           </div>
           {[...messages, ...pendingMsgDisplay].map((msg) => (
@@ -276,41 +273,6 @@ export default function ChatScreen() {
   );
 }
 
-function ServerInfo() {
-  const { serverProps } = useAppContext();
-  const modalities = [];
-  if (serverProps?.modalities?.audio) {
-    modalities.push('audio');
-  }
-  if (serverProps?.modalities?.vision) {
-    modalities.push('vision');
-  }
-  return (
-    <div
-      className="card card-sm shadow-sm border-1 border-base-content/20 text-base-content/70 mb-6"
-      tabIndex={0}
-      aria-description="Server information"
-    >
-      <div className="card-body">
-        <b>Server Info</b>
-        <p>
-          <b>Model</b>: {serverProps?.model_path?.split(/(\\|\/)/).pop()}
-          <br />
-          <b>Build</b>: {serverProps?.build_info}
-          <br />
-          {modalities.length > 0 ? (
-            <>
-              <b>Supported modalities:</b> {modalities.join(', ')}
-            </>
-          ) : (
-            ''
-          )}
-        </p>
-      </div>
-    </div>
-  );
-}
-
 function ChatInput({
   textarea,
   extraContext,
@@ -332,7 +294,7 @@ function ChatInput({
       role="group"
       aria-label="Chat input"
       className={classNames({
-        'flex items-end pt-8 pb-6 sticky bottom-0 bg-base-100': true,
+        'flex items-end pt-8 pb-1 sticky bottom-0 bg-base-100': true,
         'opacity-50': isDrag, // simply visual feedback to inform user that the file will be accepted
       })}
     >

--- a/tools/server/webui/src/components/ChatScreen.tsx
+++ b/tools/server/webui/src/components/ChatScreen.tsx
@@ -348,7 +348,7 @@ function ChatInput({
       >
         {({ getRootProps, getInputProps }) => (
           <div
-            className="flex flex-col rounded-xl border-1 border-base-content/30 p-3 w-full"
+            className="flex flex-col rounded-xl w-full"
             // when a file is pasted to the input, we handle it here
             // if a text is pasted, and if it is long text, we will convert it to a file
             onPasteCapture={(e: ClipboardEvent<HTMLInputElement>) => {
@@ -390,11 +390,11 @@ function ChatInput({
               />
             )}
 
-            <div className="flex flex-row w-full">
+            <div className="bg-base-200 border-1 border-base-content/30 rounded-lg p-2 flex flex-col">
               <textarea
                 // Default (mobile): Enable vertical resize, overflow auto for scrolling if needed
                 // Large screens (lg:): Disable manual resize, apply max-height for autosize limit
-                className="text-md outline-none border-none w-full resize-vertical lg:resize-none lg:max-h-48 lg:overflow-y-auto" // Adjust lg:max-h-48 as needed (e.g., lg:max-h-60)
+                className="w-full focus:outline-none px-2 border-none focus:ring-0 resize-none"
                 placeholder="Type a message (Shift+Enter to add a new line)"
                 ref={textarea.ref}
                 onInput={textarea.onInput} // Hook's input handler (will only resize height on lg+ screens)
@@ -413,42 +413,47 @@ function ChatInput({
               ></textarea>
 
               {/* buttons area */}
-              <div className="flex flex-row gap-2 ml-2">
-                <label
-                  htmlFor="file-upload"
-                  className={classNames({
-                    'btn w-8 h-8 p-0 rounded-full': true,
-                    'btn-disabled': isGenerating,
-                  })}
-                  aria-label="Upload file"
-                  tabIndex={0}
-                  role="button"
-                >
-                  <PaperClipIcon className="h-5 w-5" />
-                </label>
-                <input
-                  id="file-upload"
-                  type="file"
-                  disabled={isGenerating}
-                  {...getInputProps()}
-                  hidden
-                />
-                {isGenerating ? (
-                  <button
-                    className="btn btn-neutral w-8 h-8 p-0 rounded-full"
-                    onClick={onStop}
+              <div className="flex items-center justify-between mt-2">
+                <div className="flex items-center">
+                  <label
+                    htmlFor="file-upload"
+                    className={classNames({
+                      'btn w-8 h-8 p-0 rounded-full': true,
+                      'btn-disabled': isGenerating,
+                    })}
+                    aria-label="Upload file"
+                    tabIndex={0}
+                    role="button"
                   >
-                    <StopIcon className="h-5 w-5" />
-                  </button>
-                ) : (
-                  <button
-                    className="btn btn-primary w-8 h-8 p-0 rounded-full"
-                    onClick={onSend}
-                    aria-label="Send message"
-                  >
-                    <ArrowUpIcon className="h-5 w-5" />
-                  </button>
-                )}
+                    <PaperClipIcon className="h-5 w-5" />
+                  </label>
+                  <input
+                    id="file-upload"
+                    type="file"
+                    disabled={isGenerating}
+                    {...getInputProps()}
+                    hidden
+                  />
+                </div>
+
+                <div className="flex items-center">
+                  {isGenerating ? (
+                    <button
+                      className="btn btn-neutral w-8 h-8 p-0 rounded-full"
+                      onClick={onStop}
+                    >
+                      <StopIcon className="h-5 w-5" />
+                    </button>
+                  ) : (
+                    <button
+                      className="btn btn-primary w-8 h-8 p-0 rounded-full"
+                      onClick={onSend}
+                      aria-label="Send message"
+                    >
+                      <ArrowUpIcon className="h-5 w-5" />
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/tools/server/webui/src/components/Header.tsx
+++ b/tools/server/webui/src/components/Header.tsx
@@ -28,7 +28,7 @@ export default function Header() {
   }, [selectedTheme]);
 
   return (
-    <div className="flex flex-row items-center pt-2 pb-2 sticky top-0 z-10 bg-base-100 border-b border-base-content/10">
+    <div className="flex flex-row items-center py-2 sticky top-0 z-10 bg-base-100 border-b border-base-content/10">
       {/* open sidebar button */}
       <label
         htmlFor="toggle-drawer"
@@ -38,7 +38,7 @@ export default function Header() {
       </label>
 
       {/* model information*/}
-      <div className="grow ml-2 px-1 sm:px-4 py-0 sm:py-2">
+      <div className="grow ml-2 px-1 sm:px-4 py-0">
         <b>
           {serverProps?.model_alias ||
             serverProps?.model_path
@@ -55,7 +55,10 @@ export default function Header() {
           data-tip="Settings"
           onClick={() => setShowSettings(true)}
         >
-          <button className="btn w-8 h-8 p-0 rounded-full" aria-hidden={true}>
+          <button
+            className="btn btn-ghost w-8 h-8 p-0 rounded-full"
+            aria-hidden={true}
+          >
             {/* settings button */}
             <Cog8ToothIcon className="w-5 h-5" />
           </button>
@@ -67,7 +70,7 @@ export default function Header() {
             <div
               tabIndex={0}
               role="button"
-              className="btn m-1 w-8 h-8 p-0 rounded-full"
+              className="btn btn-ghost m-1 w-8 h-8 p-0 rounded-full"
             >
               <MoonIcon className="w-5 h-5" />
             </div>

--- a/tools/server/webui/src/components/Header.tsx
+++ b/tools/server/webui/src/components/Header.tsx
@@ -12,7 +12,7 @@ import {
 
 export default function Header() {
   const [selectedTheme, setSelectedTheme] = useState(StorageUtils.getTheme());
-  const { setShowSettings } = useAppContext();
+  const { serverProps, setShowSettings } = useAppContext();
 
   const setTheme = (theme: string) => {
     StorageUtils.setTheme(theme);
@@ -28,13 +28,25 @@ export default function Header() {
   }, [selectedTheme]);
 
   return (
-    <div className="flex flex-row items-center pt-6 pb-6 sticky top-0 z-10 bg-base-100">
+    <div className="flex flex-row items-center pt-2 pb-2 sticky top-0 z-10 bg-base-100 border-b border-base-content/10">
       {/* open sidebar button */}
-      <label htmlFor="toggle-drawer" className="btn btn-ghost lg:hidden">
+      <label
+        htmlFor="toggle-drawer"
+        className="btn btn-ghost w-8 h-8 p-0 lg:hidden"
+      >
         <Bars3Icon className="h-5 w-5" />
       </label>
 
-      <div className="grow text-2xl font-bold ml-2">llama.cpp</div>
+      {/* model information*/}
+      <div className="grow ml-2 px-1 sm:px-4 py-0 sm:py-2">
+        <b>
+          {serverProps?.model_alias ||
+            serverProps?.model_path
+              ?.split(/(\\|\/)/)
+              .pop()
+              ?.replace(/\.\w+$/, '')}
+        </b>
+      </div>
 
       {/* action buttons (top right) */}
       <div className="flex items-center">
@@ -43,7 +55,7 @@ export default function Header() {
           data-tip="Settings"
           onClick={() => setShowSettings(true)}
         >
-          <button className="btn" aria-hidden={true}>
+          <button className="btn w-8 h-8 p-0 rounded-full" aria-hidden={true}>
             {/* settings button */}
             <Cog8ToothIcon className="w-5 h-5" />
           </button>
@@ -52,7 +64,11 @@ export default function Header() {
         {/* theme controller is copied from https://daisyui.com/components/theme-controller/ */}
         <div className="tooltip tooltip-bottom" data-tip="Themes">
           <div className="dropdown dropdown-end dropdown-bottom">
-            <div tabIndex={0} role="button" className="btn m-1">
+            <div
+              tabIndex={0}
+              role="button"
+              className="btn m-1 w-8 h-8 p-0 rounded-full"
+            >
               <MoonIcon className="w-5 h-5" />
             </div>
             <ul

--- a/tools/server/webui/src/components/Header.tsx
+++ b/tools/server/webui/src/components/Header.tsx
@@ -38,7 +38,7 @@ export default function Header() {
       </label>
 
       {/* model information*/}
-      <div className="grow ml-2 px-1 sm:px-4 py-0">
+      <div className="grow text-nowrap overflow-hidden truncate ml-2 px-1 sm:px-4 py-0">
         <b>
           {serverProps?.model_alias ||
             serverProps?.model_path

--- a/tools/server/webui/src/components/Header.tsx
+++ b/tools/server/webui/src/components/Header.tsx
@@ -44,7 +44,7 @@ export default function Header() {
             serverProps?.model_path
               ?.split(/(\\|\/)/)
               .pop()
-              ?.replace(/\.\w+$/, '')}
+              ?.replace(/[-](?:[IQ]+[0-9]+[_\d\w]+)(?:\.[a-z]+)?$/, '')}
         </b>
       </div>
 

--- a/tools/server/webui/src/components/Header.tsx
+++ b/tools/server/webui/src/components/Header.tsx
@@ -4,11 +4,7 @@ import { useAppContext } from '../utils/app.context';
 import { classNames } from '../utils/misc';
 import daisyuiThemes from 'daisyui/theme/object';
 import { THEMES } from '../Config';
-import {
-  Cog8ToothIcon,
-  MoonIcon,
-  Bars3Icon,
-} from '@heroicons/react/24/outline';
+import { Cog8ToothIcon, Bars3Icon } from '@heroicons/react/24/outline';
 
 export default function Header() {
   const [selectedTheme, setSelectedTheme] = useState(StorageUtils.getTheme());
@@ -72,34 +68,50 @@ export default function Header() {
               role="button"
               className="btn btn-ghost m-1 w-8 h-8 p-0 rounded-full"
             >
-              <MoonIcon className="w-5 h-5" />
+              <div className="bg-base-100 grid shrink-0 grid-cols-2 gap-1 rounded-md p-1 shadow-sm">
+                <div className="bg-base-content size-1 rounded-full"></div>{' '}
+                <div className="bg-primary size-1 rounded-full"></div>{' '}
+                <div className="bg-secondary size-1 rounded-full"></div>{' '}
+                <div className="bg-accent size-1 rounded-full"></div>
+              </div>
             </div>
             <ul
               tabIndex={0}
-              className="dropdown-content bg-base-300 rounded-box z-[1] w-52 p-2 shadow-2xl h-80 overflow-y-auto"
+              className="dropdown-content rounded-box z-[1] w-50 p-2 shadow-2xl h-80 text-sm overflow-y-auto"
             >
               <li>
                 <button
                   className={classNames({
-                    'btn btn-sm btn-block btn-ghost justify-start': true,
+                    'flex gap-3 p-2 btn btn-sm btn-ghost': true,
                     'btn-active': selectedTheme === 'auto',
                   })}
                   onClick={() => setTheme('auto')}
                 >
-                  auto
+                  <div className="w-32 ml-6 pl-1 truncate text-left">auto</div>
                 </button>
               </li>
               {THEMES.map((theme) => (
                 <li key={theme}>
-                  <input
-                    type="radio"
-                    name="theme-dropdown"
-                    className="theme-controller btn btn-sm btn-block btn-ghost justify-start"
-                    aria-label={theme}
-                    value={theme}
-                    checked={selectedTheme === theme}
-                    onChange={(e) => e.target.checked && setTheme(theme)}
-                  />
+                  <button
+                    className={classNames({
+                      'flex gap-3 p-2 btn btn-sm btn-ghost': true,
+                      'btn-active': selectedTheme === theme,
+                    })}
+                    data-set-theme={theme}
+                    data-act-class="[&amp;_svg]:visible"
+                    onClick={() => setTheme(theme)}
+                  >
+                    <div
+                      data-theme={theme}
+                      className="bg-base-100 grid shrink-0 grid-cols-2 gap-0.5 rounded-md p-1 shadow-sm"
+                    >
+                      <div className="bg-base-content size-1 rounded-full"></div>{' '}
+                      <div className="bg-primary size-1 rounded-full"></div>{' '}
+                      <div className="bg-secondary size-1 rounded-full"></div>{' '}
+                      <div className="bg-accent size-1 rounded-full"></div>
+                    </div>
+                    <div className="w-32 truncate text-left">{theme}</div>
+                  </button>
                 </li>
               ))}
             </ul>

--- a/tools/server/webui/src/components/SettingDialog.tsx
+++ b/tools/server/webui/src/components/SettingDialog.tsx
@@ -341,7 +341,7 @@ export default function SettingDialog({
       className={classNames({ modal: true, 'modal-open': show })}
       aria-label="Settings dialog"
     >
-      <div className="modal-box w-11/12 max-w-3xl">
+      <div className="modal-box w-11/12 max-w-4xl">
         <h3 className="text-lg font-bold mb-6">Settings</h3>
         <div className="flex flex-col md:flex-row h-[calc(90vh-12rem)]">
           {/* Left panel, showing sections - Desktop version */}

--- a/tools/server/webui/src/components/Sidebar.tsx
+++ b/tools/server/webui/src/components/Sidebar.tsx
@@ -228,12 +228,13 @@ function ConversationItem({
       >
         {conv.name}
       </button>
+
       <div tabIndex={0} className="dropdown dropdown-end h-5">
         <BtnWithTooltips
           // on mobile, we always show the ellipsis icon
           // on desktop, we only show it when the user hovers over the conversation item
           // we use opacity instead of hidden to avoid layout shift
-          className="cursor-pointer opacity-100 md:opacity-0 group-hover:opacity-100"
+          className="cursor-pointer opacity-100 xl:opacity-20 group-hover:opacity-100"
           onClick={() => {}}
           tooltipsContent="More"
         >

--- a/tools/server/webui/src/components/Sidebar.tsx
+++ b/tools/server/webui/src/components/Sidebar.tsx
@@ -75,36 +75,33 @@ export default function Sidebar() {
           Skip to main content
         </a>
 
-        <div className="flex flex-col bg-base-200 min-h-full max-w-64 py-4 px-4">
-          <div className="flex flex-row items-center justify-between mb-4 mt-4">
-            <h2 className="font-bold ml-4" role="heading">
-              Conversations
-            </h2>
-
+        <div className="flex flex-col bg-base-200 min-h-full max-w-64 pb-4 px-4">
+          <div className="flex flex-row items-center justify-between leading-10 py-2 border-b border-base-content/10">
             {/* close sidebar button */}
+            <label className="w-8 h-8 p-0 max-lg:hidden"></label>
             <label
               htmlFor="toggle-drawer"
-              className="btn btn-ghost lg:hidden"
+              className="btn btn-ghost w-8 h-8 p-0 rounded-full lg:hidden"
               aria-label="Close sidebar"
               role="button"
               tabIndex={0}
             >
               <XMarkIcon className="w-5 h-5" />
             </label>
-          </div>
 
-          {/* new conversation button */}
-          <button
-            className={classNames({
-              'btn btn-ghost justify-start px-2': true,
-              'btn-soft': !currConv,
-            })}
-            onClick={() => navigate('/')}
-            aria-label="New conversation"
-          >
-            <PencilSquareIcon className="w-5 h-5" />
-            New conversation
-          </button>
+            <h2 className="font-bold" role="heading">
+              Conversations
+            </h2>
+
+            {/* new conversation button */}
+            <button
+              className="btn btn-ghost w-8 h-8 p-0 rounded-full"
+              onClick={() => navigate('/')}
+              aria-label="New conversation"
+            >
+              <PencilSquareIcon className="w-5 h-5" />
+            </button>
+          </div>
 
           {/* list of conversations */}
           {groupedConv.map((group, i) => (

--- a/tools/server/webui/src/components/Sidebar.tsx
+++ b/tools/server/webui/src/components/Sidebar.tsx
@@ -110,7 +110,7 @@ export default function Sidebar() {
               {group.title ? (
                 // we use btn class here to make sure that the padding/margin are aligned with the other items
                 <b
-                  className="btn btn-ghost btn-xs bg-none btn-disabled block text-xs text-base-content text-start px-2 mb-0 mt-6 font-bold"
+                  className="btn btn-ghost btn-xs bg-none btn-disabled block text-xs text-base-content text-start px-2 mb-0 mt-6 font-bold opacity-50"
                   role="note"
                   aria-description={group.title}
                   tabIndex={0}
@@ -287,6 +287,9 @@ export function groupConversationsByDate(
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // Start of today
 
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
   const sevenDaysAgo = new Date(today);
   sevenDaysAgo.setDate(today.getDate() - 7);
 
@@ -295,6 +298,7 @@ export function groupConversationsByDate(
 
   const groups: { [key: string]: Conversation[] } = {
     Today: [],
+    Yesterday: [],
     'Previous 7 Days': [],
     'Previous 30 Days': [],
   };
@@ -311,6 +315,8 @@ export function groupConversationsByDate(
 
     if (convDate >= today) {
       groups['Today'].push(conv);
+    } else if (convDate >= yesterday) {
+      groups['Yesterday'].push(conv);
     } else if (convDate >= sevenDaysAgo) {
       groups['Previous 7 Days'].push(conv);
     } else if (convDate >= thirtyDaysAgo) {
@@ -332,6 +338,13 @@ export function groupConversationsByDate(
     result.push({
       title: undefined, // no title for Today
       conversations: groups['Today'],
+    });
+  }
+
+  if (groups['Yesterday'].length > 0) {
+    result.push({
+      title: 'Yesterday',
+      conversations: groups['Yesterday'],
     });
   }
 

--- a/tools/server/webui/src/components/Sidebar.tsx
+++ b/tools/server/webui/src/components/Sidebar.tsx
@@ -75,7 +75,7 @@ export default function Sidebar() {
           Skip to main content
         </a>
 
-        <div className="flex flex-col bg-base-200 min-h-full max-w-64 pb-4 px-4">
+        <div className="flex flex-col bg-base-200 min-h-full max-w-full pb-4 px-4">
           <div className="flex flex-row items-center justify-between leading-10 py-2 border-b border-base-content/10">
             {/* close sidebar button */}
             <label className="w-8 h-8 p-0 max-lg:hidden"></label>

--- a/tools/server/webui/src/utils/common.tsx
+++ b/tools/server/webui/src/utils/common.tsx
@@ -46,7 +46,7 @@ export function BtnWithTooltips({
   disabled,
 }: {
   className?: string;
-  onClick: () => void;
+  onClick?: () => void;
   onMouseLeave?: () => void;
   children: React.ReactNode;
   tooltipsContent: string;

--- a/tools/server/webui/src/utils/types.ts
+++ b/tools/server/webui/src/utils/types.ts
@@ -128,6 +128,7 @@ export type CanvasData = CanvasPyInterpreter;
 // a non-complete list of props, only contains the ones we need
 export interface LlamaCppServerProps {
   build_info: string;
+  model_alias: string;
   model_path: string;
   n_ctx: number;
   modalities?: {


### PR DESCRIPTION
An attempt to make llama.cpp WebUI a little bit gathered. I really hope that people will stop looking for an alternatives for chat ui.

What have been done:
- [x] ChatInput is re-worked, icons are placed on the row below text.
- [x] Favicon is set to llama emoji now!
- [x] Header buttons are styled to be in sync with other UI.
- [x] Model name is moved to the header.
- [x] Server information is placed on the bottom.
- [x] Hello message is changed to be more user friendly.
- [x] Settings dialog width is a little bit increased on the desktop.
- [x] Fixed an issue with the Sidebar width on the iPad Pro.
- [x] Fixed an issue when Conversation dropdown button was not visible.
- [x] Add Yesterday message group.
- [x] Added previews for DaisyUI themes in theme selection dropdown.

Screenshots:
<img width="2560" height="1315" alt="Main view" src="https://github.com/user-attachments/assets/62bc29f9-96f4-4a52-b609-4f16b2de1394" />

<img width="249" height="395" alt="DaisyUI previews" src="https://github.com/user-attachments/assets/c3861d0b-97e2-4fe5-83c9-627d8d294b2d" />
