### PR TITLE
ci : Fix -Werror=return-type in clip.cpp so ci/run.sh can run without issue

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -3468,7 +3468,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
 
         return true;
     } else {
-        GGML_ASSERT(false && "Unknown image preprocessing type");
+        GGML_ABORT("Unknown image preprocessing type");
         return false;
     }
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -3469,7 +3469,6 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
         return true;
     } else {
         GGML_ABORT("Unknown image preprocessing type");
-        return false;
     }
 
 }

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -3467,10 +3467,11 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
         }
 
         return true;
-
+    } else {
+        GGML_ASSERT(false && "Unknown image preprocessing type");
+        return false;
     }
 
-    GGML_ASSERT(false && "Unknown image preprocessing type");
 }
 
 ggml_tensor * clip_get_newline_tensor(const struct clip_ctx * ctx) {


### PR DESCRIPTION
The CONTRIBUTING.md file suggests to run ci/run.sh before making any changes. But since that script sets `-DLLAMA_FATAL_WARNINGS` a warning from `tools/mtmd/clip.cpp`  causes the script to terminate early.  This fixes that error so that script can run

