### PR TITLE
model : gpt-oss simulate think tags when reasoning

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2339,13 +2339,6 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             }
         }
 
-        // @ngxson : quick hack for gpt-oss, always render these tokens
-        for (const auto & t : token_to_id) {
-            if (t.first == "<|channel|>" || t.first == "<|message|>" || t.first == "<|start|>") {
-                id_to_token[t.second].attr = LLAMA_TOKEN_ATTR_USER_DEFINED;
-            }
-        }
-
         // sanity checks
         if (special_eos_id != LLAMA_TOKEN_NULL && special_eog_ids.count(special_eos_id) == 0) {
             special_eog_ids.insert(special_eos_id);

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2339,6 +2339,13 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             }
         }
 
+        // @ngxson : quick hack for gpt-oss, always render these tokens
+        for (const auto & t : token_to_id) {
+            if (t.first == "<|channel|>" || t.first == "<|message|>" || t.first == "<|start|>") {
+                id_to_token[t.second].attr = LLAMA_TOKEN_ATTR_USER_DEFINED;
+            }
+        }
+
         // sanity checks
         if (special_eos_id != LLAMA_TOKEN_NULL && special_eog_ids.count(special_eos_id) == 0) {
             special_eog_ids.insert(special_eos_id);


### PR DESCRIPTION
Problem: the current implementation generates `<|channel|>analysis<|message|>...`  in the output and clients send it back verbatim. This causes an exception in the official gpt-oss jinja chat templates.

This PR parses out the reasoning and does one of the following:
- `reasoning_format = auto` - send it in the `reasoning_content` field.
- `reasoning_format = none` - wrap it in `<think></think>`, sent to the `content` field to avoid exceptions.

Additionally, it parses out any `final` channels. It does not yet support tool use. More comprehensive parsing is being worked on #15181.

@ggerganov @ngxson 