### PR TITLE
musa: fix failures in test-backend-ops for mul_mat_id op

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -316,7 +316,7 @@ static bool ampere_mma_available(const int cc) {
 }
 
 static bool cp_async_available(const int cc) {
-    return cc < GGML_CUDA_CC_OFFSET_AMD && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_AMPERE;
+    return GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_AMPERE;
 }
 
 static constexpr __device__ int ggml_cuda_get_physical_warp_size() {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -312,7 +312,7 @@ static bool turing_mma_available(const int cc) {
 }
 
 static bool ampere_mma_available(const int cc) {
-    return cc < GGML_CUDA_CC_OFFSET_AMD && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_AMPERE;
+    return GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_AMPERE;
 }
 
 static bool cp_async_available(const int cc) {


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

Ref: https://github.com/ggml-org/llama.cpp/pull/15131

### Testing Done

ToT:

```
root@xiaodongye-s80:/ws# ./build/bin/test-backend-ops  | grep FAIL
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 MUSA devices:
  Device 0: MTT S80, compute capability 2.1, VMM: yes
[MUL_MAT_ID] NMSE = 0.473073968 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=4,n_used=1,b=0,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 0.602911949 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=4,n_used=1,b=1,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 0.801315053 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=4,n_used=2,b=0,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 2.501388765 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=4,n_used=2,b=1,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 1.142949490 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=1,b=0,m=512,n=129,k=256): FAIL
[MUL_MAT_ID] NMSE = 0.820664836 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=1,b=1,m=512,n=129,k=256): FAIL
[MUL_MAT_ID] NMSE = 0.730463410 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=2,b=0,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 1.249068448 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=2,b=1,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 1.097372514 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=4,b=0,m=512,n=32,k=256): FAIL
[MUL_MAT_ID] NMSE = 0.734338886 > 0.000500000   MUL_MAT_ID(type_a=f32,type_b=f32,n_mats=8,n_used=4,b=1,m=512,n=32,k=256): FAIL
  Backend MUSA0: FAIL
FAIL
```

With this fix:

```
root@xiaodongye-s80:/ws# ./build/bin/test-backend-ops | grep FAIL
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 MUSA devices:
  Device 0: MTT S80, compute capability 2.1, VMM: yes
```