### PR TITLE
ci: Enable GGML_CPU_ALL_VARIANTS for ARM

### DIFF
--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -4,8 +4,6 @@ FROM ubuntu:$UBUNTU_VERSION AS build
 
 ARG TARGETARCH
 
-ARG GGML_CPU_ARM_ARCH=armv8-a
-
 RUN apt-get update && \
     apt-get install -y build-essential git cmake libcurl4-openssl-dev
 
@@ -13,10 +11,8 @@ WORKDIR /app
 
 COPY . .
 
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DLLAMA_BUILD_TESTS=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DLLAMA_BUILD_TESTS=OFF -DGGML_CPU_ARM_ARCH=${GGML_CPU_ARM_ARCH}; \
     else \
         echo "Unsupported architecture"; \
         exit 1; \


### PR DESCRIPTION
I now have an Orion O6 which has an ARMv9.2 CPU. On this host, I booted up QEMU VMs with `-cpu host` and in it, built a Debug build with `GGML_BACKEND_DL=ON` and `GGML_CPU_ALL_VARIANTS=ON`.

I then booted up the VM repeatedly with various feature flags disabled, and observed the correct backend being loaded.

I only couldn't test SME because it was not supported by the CPU.