### PR TITLE
graph : use F32 accumulators for gpt-oss

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1566,6 +1566,11 @@ ggml_tensor * llm_graph_context::build_attn_with_sinks(
 
     if (wo) {
         cur = build_lora_mm(wo, cur);
+        if (arch == LLM_ARCH_OPENAI_MOE) {
+            // similar the original build_attn
+            // TODO: this is tmp until we refactor and remove the build_attn_with_sinks() path
+            ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
+        }
     }
 
     if (wo_b) {


### PR DESCRIPTION
ref #15274

Request F32 accumulators for the attention output multiplication. This is similar to the existing hint for GLM models in `llm_graph_context::build_attn()`:

https://github.com/ggml-org/llama.cpp/blob/810b9fc8b99dd55517a3e94c6dee29748d482559/src/llama-graph.cpp#L1474-L1482

Here we add the same hint for the new `llm_graph_context::built_attn_with_sinks()`:

https://github.com/ggml-org/llama.cpp/blob/810b9fc8b99dd55517a3e94c6dee29748d482559/src/llama-graph.h#L734-L738

This `build_attn_with_sinks()` path currently exists temporary and will eventually be merged in the `llm_graph_context::build_attn()`.
