### PR TITLE
Allow passing GGUF splits via repeated --model args

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -190,10 +190,10 @@ struct common_params_sampling {
 };
 
 struct common_params_model {
-    std::string path    = ""; // model local path                                           // NOLINT
-    std::string url     = ""; // model url to download                                      // NOLINT
-    std::string hf_repo = ""; // HF repo                                                    // NOLINT
-    std::string hf_file = ""; // HF file                                                    // NOLINT
+    std::vector<std::string> paths = {}; // model local path                                           // NOLINT
+    std::string url                = ""; // model url to download                                      // NOLINT
+    std::string hf_repo            = ""; // HF repo                                                    // NOLINT
+    std::string hf_file            = ""; // HF file                                                    // NOLINT
 };
 
 struct common_params_speculative {

--- a/examples/batched/batched.cpp
+++ b/examples/batched/batched.cpp
@@ -41,7 +41,20 @@ int main(int argc, char ** argv) {
 
     llama_model_params model_params = common_model_params_to_llama(params);
 
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), model_params);
+    llama_model * model = NULL;
+    if (params.model.paths.empty()) {
+        LOG_ERR("%s: failed to load model 'model path not specified'\n", __func__);
+        return 1;
+    } else if (params.model.paths.size() == 1) {
+        model = llama_model_load_from_file(params.model.paths[0].c_str(), model_params);
+    } else {
+        std::vector<const char *> paths;
+        paths.reserve(params.model.paths.size());
+        for (const auto & path : params.model.paths) {
+            paths.push_back(path.c_str());
+        }
+        model = llama_model_load_from_splits(paths.data(), paths.size(), model_params);
+    }
 
     if (model == NULL) {
         LOG_ERR("%s: error: unable to load model\n" , __func__);

--- a/examples/diffusion/diffusion-cli.cpp
+++ b/examples/diffusion/diffusion-cli.cpp
@@ -548,9 +548,23 @@ int main(int argc, char ** argv) {
     model_params.use_mlock          = params.use_mlock;
     model_params.check_tensors      = params.check_tensors;
 
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), model_params);
+    llama_model * model = NULL;
+    if (params.model.paths.empty()) {
+        LOG_ERR("error: failed to load model 'model path not specified'\n");
+        return 1;
+    } else if (params.model.paths.size() == 1) {
+        model = llama_model_load_from_file(params.model.paths[0].c_str(), model_params);
+    } else {
+        std::vector<const char *> paths;
+        paths.reserve(params.model.paths.size());
+        for (const auto & path : params.model.paths) {
+            paths.push_back(path.c_str());
+        }
+        model = llama_model_load_from_splits(paths.data(), paths.size(), model_params);
+    }
+
     if (!model) {
-        LOG_ERR("error: failed to load model '%s'\n", params.model.path.c_str());
+        LOG_ERR("error: failed to load model '%s'\n", params.model.paths[0].c_str());
         return 1;
     }
 

--- a/examples/gritlm/gritlm.cpp
+++ b/examples/gritlm/gritlm.cpp
@@ -168,7 +168,20 @@ int main(int argc, char * argv[]) {
 
     llama_backend_init();
 
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);
+    llama_model * model = NULL;
+    if (params.model.paths.empty()) {
+        fprintf(stderr, "failed to load model 'model path not specified'\n");
+        return 1;
+    } else if (params.model.paths.size() == 1) {
+        model = llama_model_load_from_file(params.model.paths[0].c_str(), mparams);
+    } else {
+        std::vector<const char *> paths;
+        paths.reserve(params.model.paths.size());
+        for (const auto & path : params.model.paths) {
+            paths.push_back(path.c_str());
+        }
+        model = llama_model_load_from_splits(paths.data(), paths.size(), mparams);
+    }
 
     // create generation context
     llama_context * ctx = llama_init_from_model(model, cparams);

--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -495,7 +495,7 @@ int main(int argc, char ** argv) {
         params.prompt_file = "used built-in defaults";
     }
     LOG_INF("External prompt file: \033[32m%s\033[0m\n", params.prompt_file.c_str());
-    LOG_INF("Model and path used:  \033[32m%s\033[0m\n\n", params.model.path.c_str());
+    LOG_INF("Model and path used:  \033[32m%s\033[0m\n\n", params.model.paths[0].c_str());
 
     LOG_INF("Total prompt tokens: %6d, speed: %5.2f t/s\n", n_total_prompt, (double) (n_total_prompt              ) / (t_main_end - t_main_start) * 1e6);
     LOG_INF("Total gen tokens:    %6d, speed: %5.2f t/s\n", n_total_gen,    (double) (n_total_gen                 ) / (t_main_end - t_main_start) * 1e6);

--- a/examples/passkey/passkey.cpp
+++ b/examples/passkey/passkey.cpp
@@ -64,7 +64,20 @@ int main(int argc, char ** argv) {
 
     llama_model_params model_params = common_model_params_to_llama(params);
 
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), model_params);
+    llama_model * model;
+    if (params.model.paths.empty()) {
+        LOG_ERR("%s: failed to load model 'model path not specified'\n", __func__);
+        return 1;
+    } else if (params.model.paths.size() == 1) {
+        model = llama_model_load_from_file(params.model.paths[0].c_str(), model_params);
+    } else {
+        std::vector<const char *> paths;
+        paths.reserve(params.model.paths.size());
+        for (const auto & path : params.model.paths) {
+            paths.push_back(path.c_str());
+        }
+        model = llama_model_load_from_splits(paths.data(), paths.size(), model_params);
+    }
 
     if (model == NULL) {
         LOG_ERR("%s: unable to load model\n" , __func__);

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -24,7 +24,7 @@ int main(int argc, char ** argv) {
 
     common_init();
 
-    if (params.speculative.model.path.empty()) {
+    if (params.speculative.model.paths.empty()) {
         LOG_ERR("%s: --model-draft is required\n", __func__);
         return 1;
     }
@@ -67,7 +67,7 @@ int main(int argc, char ** argv) {
     ctx_dft   = llama_init_dft.context.get();
 
     if (!common_speculative_are_compatible(ctx_tgt, ctx_dft)) {
-        LOG_INF("the draft model '%s' is not compatible with the target model '%s'. tokens will be translated between the draft and target models.\n", params.speculative.model.path.c_str(), params.model.path.c_str());
+        LOG_INF("the draft model '%s' is not compatible with the target model '%s'. tokens will be translated between the draft and target models.\n", params.speculative.model.paths[0].c_str(), params.model.paths[0].c_str());
     }
 
     // Tokenize the prompt

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -46,7 +46,7 @@ int main(int argc, char ** argv) {
 
     common_init();
 
-    if (params.speculative.model.path.empty()) {
+    if (params.speculative.model.paths.empty()) {
         LOG_ERR("%s: --model-draft is required\n", __func__);
         return 1;
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -258,6 +258,7 @@ struct llama_model * llama_model_load_from_splits(
         return nullptr;
     }
     for (size_t i = 0; i < n_paths; ++i) {
+        LLAMA_LOG_INFO("%s: splits[%zu] = '%s'\n", __func__, i, paths[i]);
         splits.push_back(paths[i]);
     }
     return llama_model_load_from_file_impl(splits.front(), splits, params);

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -77,7 +77,7 @@ int main(void) {
 
     argv = {"binary_name", "-m", "model_file.gguf"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
-    assert(params.model.path == "model_file.gguf");
+    assert(params.model.paths[0] == "model_file.gguf");
 
     argv = {"binary_name", "-t", "1234"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
@@ -89,7 +89,7 @@ int main(void) {
 
     argv = {"binary_name", "-m", "abc.gguf", "--predict", "6789", "--batch-size", "9090"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
-    assert(params.model.path == "abc.gguf");
+    assert(params.model.paths[0] == "abc.gguf");
     assert(params.n_predict == 6789);
     assert(params.n_batch == 9090);
 
@@ -112,7 +112,7 @@ int main(void) {
     setenv("LLAMA_ARG_THREADS", "1010", true);
     argv = {"binary_name"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
-    assert(params.model.path == "blah.gguf");
+    assert(params.model.paths[0] == "blah.gguf");
     assert(params.cpuparams.n_threads == 1010);
 
 
@@ -122,7 +122,7 @@ int main(void) {
     setenv("LLAMA_ARG_THREADS", "1010", true);
     argv = {"binary_name", "-m", "overwritten.gguf"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
-    assert(params.model.path == "overwritten.gguf");
+    assert(params.model.paths[0] == "overwritten.gguf");
     assert(params.cpuparams.n_threads == 1010);
 #endif // _WIN32
 

--- a/tests/test-thread-safety.cpp
+++ b/tests/test-thread-safety.cpp
@@ -66,9 +66,23 @@ int main(int argc, char ** argv) {
             mparams.split_mode = LLAMA_SPLIT_MODE_LAYER;;
         }
 
-        llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);
+        llama_model * model = NULL;
+        if (params.model.paths.empty()) {
+            LOG_ERR("%s: failed to load model 'model path not specified'\n", __func__);
+            return 1;
+        } else if (params.model.paths.size() == 1) {
+            model = llama_model_load_from_file(params.model.paths[0].c_str(), mparams);
+        } else {
+            std::vector<const char *> paths;
+            paths.reserve(params.model.paths.size());
+            for (const auto & path : params.model.paths) {
+                paths.push_back(path.c_str());
+            }
+            model = llama_model_load_from_splits(paths.data(), paths.size(), mparams);
+        }
+
         if (model == NULL) {
-            LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.path.c_str());
+            LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.paths[0].c_str());
             return 1;
         }
 

--- a/tools/batched-bench/batched-bench.cpp
+++ b/tools/batched-bench/batched-bench.cpp
@@ -38,7 +38,20 @@ int main(int argc, char ** argv) {
 
     llama_model_params model_params = common_model_params_to_llama(params);
 
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), model_params);
+    llama_model * model = NULL;
+    if (params.model.paths.empty()) {
+        fprintf(stderr, "%s: failed to load model 'model path not specified'\n", __func__);
+        return 1;
+    } else if (params.model.paths.size() == 1) {
+        model = llama_model_load_from_file(params.model.paths[0].c_str(), model_params);
+    } else {
+        std::vector<const char *> paths;
+        paths.reserve(params.model.paths.size());
+        for (const auto & path : params.model.paths) {
+            paths.push_back(path.c_str());
+        }
+        model = llama_model_load_from_splits(paths.data(), paths.size(), model_params);
+    }
 
     if (model == NULL) {
         fprintf(stderr , "%s: error: unable to load model\n" , __func__);

--- a/tools/export-lora/export-lora.cpp
+++ b/tools/export-lora/export-lora.cpp
@@ -419,9 +419,14 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    if (params.model.paths.size() != 1) {
+        fprintf(stderr, "exactly one model path needs to be specified, got %zu\n", params.model.paths.size());
+        exit(EXIT_FAILURE);
+    }
+
     g_verbose = (params.verbosity > 1);
     try {
-        lora_merge_ctx ctx(params.model.path, params.lora_adapters, params.out_file, params.cpuparams.n_threads);
+        lora_merge_ctx ctx(params.model.paths[0], params.lora_adapters, params.out_file, params.cpuparams.n_threads);
         ctx.run_merge();
     } catch (const std::exception & err) {
         fprintf(stderr, "%s\n", err.what());

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -126,7 +126,7 @@ struct mtmd_cli_context {
     }
 
     void init_vision_context(common_params & params) {
-        const char * clip_path = params.mmproj.path.c_str();
+        const char * clip_path = params.mmproj.paths[0].c_str();
         mtmd_context_params mparams = mtmd_context_params_default();
         mparams.use_gpu = params.mmproj_use_gpu;
         mparams.print_timings = true;
@@ -257,14 +257,20 @@ int main(int argc, char ** argv) {
 
     common_init();
 
-    if (params.mmproj.path.empty()) {
+    if (params.mmproj.paths.empty()) {
         show_additional_info(argc, argv);
         LOG_ERR("ERR: Missing --mmproj argument\n");
         return 1;
     }
 
+    if (params.mmproj.paths.size() == 1) {
+        show_additional_info(argc, argv);
+        LOG_ERR("ERR: Only one --mmproj argument is supported\n");
+        return 1;
+    }
+
     mtmd_cli_context ctx(params);
-    LOG("%s: loading model: %s\n", __func__, params.model.path.c_str());
+    LOG("%s: loading model: %s\n", __func__, params.model.paths[0].c_str());
 
     bool is_single_turn = !params.prompt.empty() && !params.image.empty();
 


### PR DESCRIPTION
In case a segmented GGUF file does not follow the specified naming convention, it will not be possible to load it. So, modify the argument parser to allow repeated --model args to be specified on the CLI, and in such case assume those are GGUF splits given in order.
