### PR TITLE
eval-callback : stop on first NaN

### DIFF
--- a/examples/eval-callback/eval-callback.cpp
+++ b/examples/eval-callback/eval-callback.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <string>
 #include <vector>
+#include <numeric>
 
 /**
  * This the arbitrary data which will be passed to each callback.
@@ -76,6 +77,10 @@ static void ggml_print_tensor(uint8_t * data, ggml_type type, const int64_t * ne
         }
         LOG("                                     ]\n");
         LOG("                                     sum = %f\n", sum);
+    }
+
+    if (std::isnan(sum)) {
+        exit(0);
     }
 }
 

--- a/examples/eval-callback/eval-callback.cpp
+++ b/examples/eval-callback/eval-callback.cpp
@@ -79,7 +79,9 @@ static void ggml_print_tensor(uint8_t * data, ggml_type type, const int64_t * ne
         LOG("                                     sum = %f\n", sum);
     }
 
+    // TODO: make this abort configurable/optional?
     if (std::isnan(sum)) {
+        LOG_ERR("encountered NaN - aborting\n");
         exit(0);
     }
 }


### PR DESCRIPTION
Update `llama-eval-callback` to stop on first tensor with a NaN. I think this is always useful when debugging - don't see a reason not to stop.