### PR TITLE
CUDA: fix negative KV_max values in FA

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -539,10 +539,14 @@ static __global__ void flash_attn_mask_to_KV_max(
         all_inf = warp_reduce_all(all_inf);
 
         if (!all_inf) {
-            KV_max_sj += FATTN_KQ_STRIDE;
             break;
         }
     }
+
+    // If the break in the loop was not triggered, KV_max_sj is now -FATTN_KQ_STRIDE.
+    // If the break was triggered it's the lower edge of the tile with the first non-masked values.
+    // In either case, walk back the decrementation by FATTN_KQ_STRIDE.
+    KV_max_sj += FATTN_KQ_STRIDE;
 
     if (threadIdx.x != 0) {
         return;


### PR DESCRIPTION
Looking at the code I noticed that, depending on the inputs, there are scenarios where the values in `KV_max` could become negative. For this to happen there would need to be 16 consecutive tokens that are completely masked out, and the physical batch size would need to be >= 1024. I'm not sure this is going to fix https://github.com/ggml-org/llama.cpp/issues/15294 or https://github.com/ggml-org/llama.cpp/issues/15112 but it should be fixed either way since it could be causing problems in the future.