### PR TITLE
ci: Download SDKs in ios-xcode-build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1113,6 +1113,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup SDKs
+        run: |
+          # Install SDK
+          xcodebuild -downloadPlatform iOS
+          xcodebuild -downloadPlatform tvOS
+          xcodebuild -downloadPlatform visionOS
+
       - name: Build
         id: cmake_build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,6 +608,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup SDKs
+        run: |
+          # Install SDK
+          xcodebuild -downloadPlatform iOS
+          xcodebuild -downloadPlatform tvOS
+          xcodebuild -downloadPlatform visionOS
+
       - name: Build
         id: cmake_build
         run: |


### PR DESCRIPTION
This should fix https://github.com/ggml-org/llama.cpp/issues/15322 without affecting the XCode version and without the use of external actions, see https://github.com/actions/runner-images/issues/12541

@slaren Feel free to close this in favor of: https://github.com/ggml-org/llama.cpp/pull/15324