### PR TITLE
vulkan : fix compile warnings on macos

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8360,7 +8360,7 @@ static void ggml_vk_rope(ggml_backend_vk_context * ctx, vk_context& subctx, cons
         (uint32_t)src0->ne[0], (uint32_t)n_dims, freq_scale, (uint32_t)src0->ne[1],
         freq_base, ext_factor, attn_factor, {corr_dims[0], corr_dims[1]}, theta_scale,
         src2 != nullptr, (uint32_t)src0->ne[2], s1, s2,
-        sections[0], sections[1], sections[2], sections[3], backprop
+        { sections[0], sections[1], sections[2], sections[3] }, backprop
     }, dryrun);
 }
 
@@ -9627,7 +9627,6 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
     default:
         std::cerr << "ggml_vulkan: Error: Missing op: " << ggml_op_name(node->op) << std::endl;
         GGML_ABORT("fatal error");
-        return false;
     }
 
     vk_context compute_ctx;
@@ -10912,7 +10911,6 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 default:
                     return false;
             }
-            break;
         case GGML_OP_GLU:
             switch (ggml_get_glu_op(op)) {
                 case GGML_GLU_OP_GEGLU:
@@ -10928,7 +10926,6 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 default:
                     return false;
             }
-            break;
         case GGML_OP_MUL_MAT:
         case GGML_OP_MUL_MAT_ID:
             {
@@ -10992,7 +10989,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 }
 
                 return true;
-            } break;
+            }
         case GGML_OP_FLASH_ATTN_EXT:
             {
                 ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
@@ -11082,7 +11079,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     default:
                         return false;
                 }
-            } break;
+            }
         case GGML_OP_SET_ROWS:
             {
                 switch (op->type) {
@@ -11099,7 +11096,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     default:
                         return false;
                 }
-            } break;
+            }
         case GGML_OP_CONT:
         case GGML_OP_CPY:
         case GGML_OP_DUP:
@@ -11151,7 +11148,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     return true;
                 }
                 return false;
-            } break;
+            }
         case GGML_OP_REPEAT:
             return ggml_type_size(op->type) == sizeof(float) && ggml_type_size(op->src[0]->type) == sizeof(float);
         case GGML_OP_REPEAT_BACK:


### PR DESCRIPTION
Minor change to eliminate some compile warnings when building With Vulkan on MacOS:

```bash
[ 19%] Building CXX object ggml/src/ggml-vulkan/CMakeFiles/ggml-vulkan.dir/ggml-vulkan.cpp.o
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:8363:9: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 8363 |         sections[0], sections[1], sections[2], sections[3], backprop
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         {                                                 }
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:9630:16: warning: 'return' will never be executed [-Wunreachable-code-return]
 9630 |         return false;
      |                ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:11154:15: warning: 'break' will never be executed [-Wunreachable-code-break]
 11154 |             } break;
       |               ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:11102:15: warning: 'break' will never be executed [-Wunreachable-code-break]
 11102 |             } break;
       |               ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:11085:15: warning: 'break' will never be executed [-Wunreachable-code-break]
 11085 |             } break;
       |               ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:10995:15: warning: 'break' will never be executed [-Wunreachable-code-break]
 10995 |             } break;
       |               ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:10931:13: warning: 'break' will never be executed [-Wunreachable-code-break]
 10931 |             break;
       |             ^~~~~
/Users/ggerganov/development/github/llama.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:10915:13: warning: 'break' will never be executed [-Wunreachable-code-break]
 10915 |             break;
       |             ^~~~~
8 warnings generated.
```