### PR TITLE
server : fix incoming tasks not process in order (#15008)

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1729,7 +1729,7 @@ struct server_queue {
     void pop_deferred_task() {
         std::unique_lock<std::mutex> lock(mutex_tasks);
         if (!queue_tasks_deferred.empty()) {
-            queue_tasks.emplace_back(std::move(queue_tasks_deferred.front()));
+            queue_tasks.emplace_front(std::move(queue_tasks_deferred.front()));
             queue_tasks_deferred.pop_front();
         }
         condition_tasks.notify_one();


### PR DESCRIPTION
With 3+ concurrent requests sending back-to-back tasks, one (or more if you add more concurrent requests) get stuck in the deferred queue almost until you stop sending new requests.

When a previous task is completed and pop_deferred_task is called there is already a newly received task in queue_tasks so the task poped from queue_tasks_deferred queue will be second in queue_tasks so it will later deferred again (as last) in queue_tasks_deferred queue.
In this PR we change it so that poped task is at front of queue_tasks_deferred so will be the one executed next.