### PR TITLE
rpc : reuse compute graphs

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 #define RPC_PROTO_MAJOR_VERSION    3
-#define RPC_PROTO_MINOR_VERSION    0
+#define RPC_PROTO_MINOR_VERSION    5
 #define RPC_PROTO_PATCH_VERSION    0
 #define GGML_RPC_MAX_SERVERS       16
 


### PR DESCRIPTION
Store compute graphs on the server side and reuse them when possible. ~~Compute graphs are kept in a ring buffer with fixed size, so we can avoid serializing and deserializing the same graph every time. Add two new commands:~~
 ~~* RPC_CMD_GRAPH_COMPUTE_AND_STORE -- compute and store the graph~~
 ~~* RPC_CMD_GRAPH_RECOMPUTE -- recompute the graph with the given ID~~

~~Currently there is no good way to associate an ID with `ggml_cgraph`, so we abuse `tensor->extra` of the first node for this purpose.~~

