### PR TITLE
Make Mistral community chat templates optional

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -8462,7 +8462,7 @@ class MistralModel(LlamaModel):
             if is_mistral_format:
                 err_message += (
                     " . Please pass --disable-mistral-community-chat-template argument to the CLI "
-                    "if you want to use the Mistral official `mistral-common` pre-processing library."
+                    "if you want to skip this error and use the Mistral official `mistral-common` pre-processing library."
                 )
             raise ValueError(err_message)
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -91,14 +91,14 @@ class ModelBase:
 
     # Mistral format specifics
     is_mistral_format: bool = False
-    use_mistral_community_chat_template: bool = False
+    disable_mistral_community_chat_template: bool = False
 
     def __init__(self, dir_model: Path, ftype: gguf.LlamaFileType, fname_out: Path, *, is_big_endian: bool = False,
                  use_temp_file: bool = False, eager: bool = False,
                  metadata_override: Path | None = None, model_name: str | None = None,
                  split_max_tensors: int = 0, split_max_size: int = 0, dry_run: bool = False,
                  small_first_shard: bool = False, hparams: dict[str, Any] | None = None, remote_hf_model_id: str | None = None,
-                 use_mistral_community_chat_template: bool = False):
+                 disable_mistral_community_chat_template: bool = False):
         if type(self) is ModelBase or \
                 type(self) is TextModel or \
                 type(self) is MmprojModel:
@@ -151,7 +151,7 @@ class ModelBase:
                                            split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard)
 
         # Mistral specific
-        self.use_mistral_community_chat_template = use_mistral_community_chat_template
+        self.disable_mistral_community_chat_template = disable_mistral_community_chat_template
 
     @classmethod
     def add_prefix_to_filename(cls, path: Path, prefix: str) -> Path:
@@ -2017,17 +2017,17 @@ class LlamaModel(TextModel):
 
         template_dir = Path(__file__).parent / "models/templates/"
 
-        if not self.is_mistral_format or self.use_mistral_community_chat_template:
+        if not self.is_mistral_format or not self.disable_mistral_community_chat_template:
             # Log only for Mistral format that the official tokenization and detokenization is via `mistral-common`.
             if self.is_mistral_format:
                 logger.info(
-                    "Using a Mistral community chat template. These templates are subject to errors, especially in early days or weeks after a release. "
+                    "Using a Mistral community chat template. These templates can be subject to errors in early days or weeks after a release. "
                     "The official way of using Mistral models is via `mistral-common`."
                 )
-            template = MistralModel.get_community_chat_template(vocab, template_dir)
+            template = MistralModel.get_community_chat_template(vocab, template_dir, self.is_mistral_format)
             self.gguf_writer.add_chat_template(template)
         else:
-            logger.info("Not using a Mistral community chat template. Ensure to follow the official tokenization and detokenization process via `mistral-common`.")
+            logger.info("Not using a Mistral community chat template. Ensure to perform the official tokenization and detokenization via `mistral-common`.")
 
     def set_vocab(self):
         if self.is_mistral_format:
@@ -8437,7 +8437,7 @@ class MistralModel(LlamaModel):
     undo_permute = False
 
     @staticmethod
-    def get_community_chat_template(vocab: MistralVocab, templates_dir: Path):
+    def get_community_chat_template(vocab: MistralVocab, templates_dir: Path, is_mistral_format: bool):
         assert TokenizerVersion is not None, "mistral_common is not installed"
         assert isinstance(vocab.tokenizer, (Tekkenizer, SentencePieceTokenizer)), (
             f"Expected Tekkenizer or SentencePieceTokenizer, got {type(vocab.tokenizer)}"
@@ -8458,7 +8458,13 @@ class MistralModel(LlamaModel):
         elif vocab.tokenizer.version == TokenizerVersion.v13:
             template_file = "unsloth-mistral-Devstral-Small-2507.jinja"
         else:
-            raise ValueError(f"Unknown tokenizer type: {vocab.tokenizer_type} and version {vocab.tokenizer.version}")
+            err_message = f"Unknown tokenizer type: {vocab.tokenizer_type} and version {vocab.tokenizer.version}"
+            if is_mistral_format:
+                err_message += (
+                    " . Please pass --disable-mistral-community-chat-template argument to the CLI "
+                    "if you want to use the Mistral official `mistral-common` pre-processing library."
+                )
+            raise ValueError(err_message)
 
         template_path = templates_dir / template_file
         if not template_path.exists():
@@ -8654,10 +8660,10 @@ def parse_args() -> argparse.Namespace:
         help="Whether the model is stored following the Mistral format.",
     )
     parser.add_argument(
-        "--use-mistral-community-chat-template", action="store_true",
+        "--disable-mistral-community-chat-template", action="store_true",
         help=(
-            "Whether to store in the GGUF file a Mistral community chat template for the Mistral format. These are not official templates that may contains errors, "
-            "especially in the first days or weeks after a release. The official process of tokenization and detokenization using Mistral models is via `mistral-common`."
+            "Whether to disable usage of Mistral community chat templates. If set, use the Mistral official `mistral-common` library for tokenization and detokenization of Mistral models. "
+            "This setting ensure correctness and zero-day support of tokenization for models converted from the Mistral format."
         )
     )
 
@@ -8766,7 +8772,7 @@ def main() -> None:
             fname_out = ModelBase.add_prefix_to_filename(fname_out, "mmproj-")
 
     is_mistral_format = args.mistral_format
-    use_mistral_community_chat_template = args.use_mistral_community_chat_template
+    disable_mistral_community_chat_template = args.disable_mistral_community_chat_template
 
     with torch.inference_mode():
         output_type = ftype_map[args.outtype]
@@ -8793,7 +8799,7 @@ def main() -> None:
                                      split_max_tensors=args.split_max_tensors,
                                      split_max_size=split_str_to_n_bytes(args.split_max_size), dry_run=args.dry_run,
                                      small_first_shard=args.no_tensor_first_split,
-                                     remote_hf_model_id=hf_repo_id, use_mistral_community_chat_template=use_mistral_community_chat_template
+                                     remote_hf_model_id=hf_repo_id, disable_mistral_community_chat_template=disable_mistral_community_chat_template
                                      )
 
         if args.vocab_only:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2022,12 +2022,12 @@ class LlamaModel(TextModel):
             if self.is_mistral_format:
                 logger.info(
                     "Using a Mistral community chat template. These templates can be subject to errors in early days or weeks after a release. "
-                    "The official way of using Mistral models is via `mistral-common`."
+                    "Mistral recommends to use `mistral-common` to perform tokenization and detokenization."
                 )
             template = MistralModel.get_community_chat_template(vocab, template_dir, self.is_mistral_format)
             self.gguf_writer.add_chat_template(template)
         else:
-            logger.info("Not using a Mistral community chat template. Ensure to perform the official tokenization and detokenization via `mistral-common`.")
+            logger.info("Not using a Mistral community chat template. Ensure to perform the tokenization and detokenization via `mistral-common`.")
 
     def set_vocab(self):
         if self.is_mistral_format:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -8663,7 +8663,7 @@ def parse_args() -> argparse.Namespace:
         "--disable-mistral-community-chat-template", action="store_true",
         help=(
             "Whether to disable usage of Mistral community chat templates. If set, use the Mistral official `mistral-common` library for tokenization and detokenization of Mistral models. "
-            "This setting ensure correctness and zero-day support of tokenization for models converted from the Mistral format."
+            "Using `mistral-common` ensure correctness and zero-day support of tokenization for models converted from the Mistral format but requires to manually setup the tokenization server."
         )
     )
 


### PR DESCRIPTION
Hi, we'd like to make the community chat templates optional for the Mistral format after its support thanks to https://github.com/ggml-org/llama.cpp/pull/14737.

This is mainly due to two issues:
1. Community chat templates can contain errors in the first days/weeks after a release. Making it clear to the users and proposing an alternative would be a good add.  Indeed, at Mistral we officially recommend to use `mistral-common` to handle tokenization and detokenization. 
2. For future releases, the tokenization version might not be supported by llama.cpp on day-0. Making the chat templates optional allows the community to convert the models without meeting an error.

As jinja templates can be overridden by llama.cpp when serving, this doesn't prevent users to either convert again when a template is released or simply passing the template to the CLI.

Happy to know your thoughts about it and address the different issues you might have.