### PR TITLE
Add top-nsigma sampler to help globally.

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1830,7 +1830,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, const std::string & value) {
             params.sampling.top_n_sigma = std::stof(value);
         }
-    ).set_examples({LLAMA_EXAMPLE_MAIN}).set_sparam());
+    ).set_sparam());
     add_opt(common_arg(
         {"--xtc-probability"}, "N",
         string_format("xtc probability (default: %.1f, 0.0 = disabled)", (double)params.sampling.xtc_probability),


### PR DESCRIPTION
Fixes #15423.
