### PR TITLE
Help msg about context shift is incorrect

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1532,7 +1532,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_MAIN, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY}).set_env("LLAMA_ARG_NO_CONTEXT_SHIFT"));
     add_opt(common_arg(
         {"--context-shift"},
-        string_format("enables context shift on infinite text generation (default: %s)", params.ctx_shift ? "disabled" : "enabled"),
+        string_format("enables context shift on infinite text generation (default: %s)", params.ctx_shift ? "enabled" : "disabled"),
         [](common_params & params) {
             params.ctx_shift = true;
         }

--- a/common/common.h
+++ b/common/common.h
@@ -375,7 +375,7 @@ struct common_params {
     bool cont_batching     = true;  // insert new sequences for decoding on-the-fly
     bool flash_attn        = false; // flash attention
     bool no_perf           = false; // disable performance metrics
-    bool ctx_shift         = false;  // context shift on inifinite text generation
+    bool ctx_shift         = false;  // context shift on infinite text generation
     bool swa_full          = false; // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
     bool kv_unified        = false; // enable unified KV cache
 


### PR DESCRIPTION
Help msg about context shift is incorrect

After https://github.com/ggml-org/llama.cpp/pull/15416 , context shift had been disabled by default.
However, the help msg is incorrect.

For example, if we run `llama-cli -h`
```
--no-context-shift                      disables context shift on infinite text generation (default: enabled)
                                        (env: LLAMA_ARG_NO_CONTEXT_SHIFT)
--context-shift                         enables context shift on infinite text generation (default: enabled)
                                        (env: LLAMA_ARG_CONTEXT_SHIFT)
```

After this patch, it would be 
```
--no-context-shift                      disables context shift on infinite text generation (default: enabled)
                                        (env: LLAMA_ARG_NO_CONTEXT_SHIFT)
--context-shift                         enables context shift on infinite text generation (default: disabled)
                                        (env: LLAMA_ARG_CONTEXT_SHIFT)
```

The patch also fixes a typo about `ctx_shift` (inifinite --> infinite).
