### PR TITLE
common : fix incorrect print of non-ascii characters in the logging

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -558,13 +558,6 @@ std::string string_from(const struct llama_context * ctx, const std::vector<llam
 
         auto detokenized = common_token_to_piece(ctx, token);
 
-        detokenized.erase(
-            std::remove_if(
-                detokenized.begin(),
-                detokenized.end(),
-                [](const unsigned char c) { return !std::isprint(c); }),
-            detokenized.end());
-
         buf << "'" << detokenized << "'"
             << ":" << std::to_string(token);
     }
@@ -588,13 +581,6 @@ std::string string_from(const struct llama_context * ctx, const struct llama_bat
         }
 
         auto detokenized = common_token_to_piece(ctx, batch.token[i]);
-
-        detokenized.erase(
-                std::remove_if(
-                    detokenized.begin(),
-                    detokenized.end(),
-                    [](const unsigned char c) { return !std::isprint(c); }),
-                detokenized.end());
 
         buf << "\n"          << std::to_string(i)
             << ", token '"   << detokenized << "'"


### PR DESCRIPTION
While I was debugging our Hunyun models, I found that non-ascii characters had been displayed incorrectly in the logging.

For example,
```
tokenize the prompt
prompt: ""
tokens: [ '<?hy_begin?of?sentence?>':120000 ]     <--- the bos of Hunyuan model, which used non-ascii chars, had been displayed incorrectly

...

我eval: [ '?':564 ]
n_past = 29
n_remain: -30
应该eval: [ '?该':3165 ]          <---- The Chinese characters had been also dumped incorrectly
n_past = 30
n_remain: -31
保持eval: [ '??':3674 ]
n_past = 31
n_remain: -32
友好eval: [ '?好':28753 ]
n_past = 32
n_remain: -33
。eval: [ '?':292 ]
n_past = 33
n_remain: -34
接下来eval: [ '???':7764 ]
```

The reason is that erasing the chars which are `!std::isprint` in the `detokenized` string leads to the problem for non-ascii characters. 

After this patch, the non-ascii characters can be print correctly.
```
tokenize the prompt
prompt: ""
tokens: [ '<｜hy_begin▁of▁sentence｜>':120000 ]

...

我eval: [ '我':564 ]
n_past = 34
n_remain: -35
应该eval: [ '应该':3165 ]
n_past = 35
n_remain: -36
保持eval: [ '保持':3674 ]
n_past = 36
n_remain: -37
友好eval: [ '友好':28753 ]
n_past = 37
n_remain: -38
，eval: [ '，':270 ]
n_past = 38
n_remain: -39
回应eval: [ '回应':25417 ]
```
