### PR TITLE
ci : continue file download with wget

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -106,7 +106,7 @@ function gg_wget {
     cd $out
 
     # should not re-download if file is the same
-    wget -nv -N $url
+    wget -nv -c -N $url
 
     cd $cwd
 }


### PR DESCRIPTION
For some reason the `-N` flag alone is not enough to prevent re-downloading the file on MacOS. Adding `-c` seems to resolve the issue.