### PR TITLE
llama : add ggml version and commit functions

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1307,6 +1307,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params &) {
             fprintf(stderr, "version: %d (%s)\n", LLAMA_BUILD_NUMBER, LLAMA_COMMIT);
             fprintf(stderr, "built with %s for %s\n", LLAMA_COMPILER, LLAMA_BUILD_TARGET);
+            fprintf(stderr, "ggml version: %s\n", llama_ggml_version());
             exit(0);
         }
     ));

--- a/include/llama.h
+++ b/include/llama.h
@@ -375,6 +375,9 @@ extern "C" {
     // lora adapter
     struct llama_adapter_lora;
 
+    LLAMA_API const char * llama_ggml_version(void);
+    LLAMA_API const char * llama_ggml_commit(void);
+
     // Helpers for getting default parameters
     // TODO: update API to start accepting pointers to params structs (https://github.com/ggml-org/llama.cpp/discussions/9172)
     LLAMA_API struct llama_model_params          llama_model_default_params(void);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -356,3 +356,11 @@ const char * llama_print_system_info(void) {
     return s.c_str();
 }
 
+const char * llama_ggml_version(void) {
+    return ggml_version();
+}
+
+const char * llama_ggml_commit(void) {
+    return ggml_commit();
+}
+


### PR DESCRIPTION
This commit adds functions that expose the ggml-version and ggml commit in llama.h.

The motivation for this is that allow users of llama.cpp to be able to get the version of ggml that is in use.

>Note: I've opened https://github.com/ggml-org/ggml/pull/1336 for the actual changes to ggml as it was easier to make the changes there and it also required an addition to the ggml/scripts directory which is not available in this repo.

Refs: https://github.com/ggml-org/ggml/issues/1333
