### PR TITLE
fix(trim): prevent assertion failure in trim function

### DIFF
--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -16,10 +16,10 @@
 static std::string trim(const std::string & str) {
     size_t start = 0;
     size_t end = str.size();
-    while (start < end && isspace(str[start])) {
+    while (start < end && isspace(static_cast<unsigned char>(str[start]))) {
         start += 1;
     }
-    while (end > start && isspace(str[end - 1])) {
+    while (end > start && isspace(static_cast<unsigned char>(str[end - 1]))) {
         end -= 1;
     }
     return str.substr(start, end - start);


### PR DESCRIPTION
When compiling with **MSVC** in the Debug configuration, during the execution of the `llama_chat_apply_template` function, the `trim` function (located in src/llama-chat.cpp) is called for certain models (e.g., Gemma 3). If **non-ASCII characters** are present in the `const struct llama_chat_message * chat` passed to the `llama_chat_apply_template` function, the assertion within the `isspace` function in the `trim` function will trigger an **Assertion Failed error**. The error message displays the expression: **c >= -1 && c <= 255**.

To resolve this problem, I added `static_cast<unsigned char>` to the `isspace` call, ensuring that negative-valued non-ASCII characters are converted to positive values.