### PR TITLE
ggml WebGPU: remove userdata from request adapter callback

### DIFF
--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -1150,17 +1150,16 @@ static ggml_backend_dev_t ggml_backend_webgpu_reg_get_device(ggml_backend_reg_t 
     webgpu_context ctx = reg_ctx->webgpu_ctx;
 
     wgpu::RequestAdapterOptions options = {};
-    auto                        callback =
-        [](wgpu::RequestAdapterStatus status, wgpu::Adapter adapter, const char * message, void * userdata) {
+    auto                       callback =
+        [&ctx](wgpu::RequestAdapterStatus status, wgpu::Adapter adapter, const char * message) {
             if (status != wgpu::RequestAdapterStatus::Success) {
                 GGML_LOG_ERROR("ggml_webgpu: Failed to get an adapter: %s\n", message);
                 return;
             }
-            *static_cast<wgpu::Adapter *>(userdata) = std::move(adapter);
+            ctx->adapter = std::move(adapter);
         };
-    void * userdata = &ctx->adapter;
     ctx->instance.WaitAny(
-        ctx->instance.RequestAdapter(&options, wgpu::CallbackMode::AllowSpontaneous, callback, userdata), UINT64_MAX);
+        ctx->instance.RequestAdapter(&options, wgpu::CallbackMode::AllowSpontaneous, callback), UINT64_MAX);
     GGML_ASSERT(ctx->adapter != nullptr);
 
     ctx->adapter.GetLimits(&ctx->limits);


### PR DESCRIPTION
This commit removes the `userdata` parameter from the WebGPU request adapter callback in `ggml-webgpu.cpp`. Instead, the lambda function captures the `webgpu_context` directly.

The motivation for this change is to simplify the code and improve readability.
