### PR TITLE
CUDA: fix half2 -> half conversion for HIP

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -258,7 +258,7 @@ static __global__ void flash_attn_tile_ext_f16(
             const half val = hexp(sink - kqmax[j0/nwarps]);
             kqsum[j0/nwarps] = kqsum[j0/nwarps] * KQ_max_scale;
             if (threadIdx.x == 0) {
-                kqsum[j0/nwarps].x = __hadd(kqsum[j0/nwarps].x, val);
+                kqsum[j0/nwarps].x = __hadd(__low2half(kqsum[j0/nwarps]), val);
             }
 
 #pragma unroll


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/issues/15196 . Even if it doesn't fix the compilation, `__low2half` should be used consistently to eliminate the risk of an unexpected type conversion.