### PR TITLE
convert : update Ernie 4.5 0.3B model name

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3109,7 +3109,7 @@ class LLaDAModel(TextModel):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Ernie4_5_ForCausalLM")
+@ModelBase.register("Ernie4_5_ForCausalLM", "Ernie4_5ForCausalLM")
 class Ernie4_5Model(TextModel):
     model_arch = gguf.MODEL_ARCH.ERNIE4_5
 


### PR DESCRIPTION
 Baidu Ernie 4.5 0.3B model have the name change from `Ernie4_5_ForCausalLM` to `Ernie4_5ForCausalLM`.

- https://huggingface.co/baidu/ERNIE-4.5-0.3B-PT/discussions/4
- https://huggingface.co/baidu/ERNIE-4.5-0.3B-Base-PT/discussions/4
