### PR TITLE
batched-bench : fix unified KV cache handling + pp timing

### DIFF
--- a/tools/batched-bench/batched-bench.cpp
+++ b/tools/batched-bench/batched-bench.cpp
@@ -124,7 +124,7 @@ int main(int argc, char ** argv) {
                 const int tg = n_tg[i_tg];
                 const int pl = n_pl[i_pl];
 
-                const int n_ctx_req = is_pp_shared ? pp + pl*tg : pl*(pp + tg);
+                const int n_ctx_req = is_pp_shared ? (params.kv_unified ? pp : pl*pp) + pl*tg : pl*(pp + tg);
 
                 if (n_ctx_req > n_kv_max) {
                     continue;
@@ -147,13 +147,22 @@ int main(int argc, char ** argv) {
                     return 1;
                 }
 
+                const auto t_pp_end = ggml_time_us();
+
                 if (is_pp_shared) {
                     for (int32_t i = 1; i < pl; ++i) {
                         llama_memory_seq_cp(mem, 0, i, -1, -1);
                     }
-                }
 
-                const auto t_pp_end = ggml_time_us();
+                    // run one dummy token to apply the memory copy
+                    common_batch_clear(batch);
+                    common_batch_add(batch, get_token_rand(), pp + 0, { 0 }, true);
+                    if (!decode_helper(ctx, batch, ctx_params.n_batch)) {
+                        LOG_ERR("%s: llama_decode() failed\n", __func__);
+                        return 1;
+                    }
+                    llama_memory_seq_rm(mem, 0, pp, -1);
+                }
 
                 const auto t_tg_start = ggml_time_us();
 

--- a/tools/batched-bench/batched-bench.cpp
+++ b/tools/batched-bench/batched-bench.cpp
@@ -154,14 +154,16 @@ int main(int argc, char ** argv) {
                         llama_memory_seq_cp(mem, 0, i, -1, -1);
                     }
 
-                    // run one dummy token to apply the memory copy
-                    common_batch_clear(batch);
-                    common_batch_add(batch, get_token_rand(), pp + 0, { 0 }, true);
-                    if (!decode_helper(ctx, batch, ctx_params.n_batch)) {
-                        LOG_ERR("%s: llama_decode() failed\n", __func__);
-                        return 1;
+                    if (!params.kv_unified) {
+                        // run one dummy token to apply the memory copy
+                        common_batch_clear(batch);
+                        common_batch_add(batch, get_token_rand(), pp + 0, { 0 }, true);
+                        if (!decode_helper(ctx, batch, ctx_params.n_batch)) {
+                            LOG_ERR("%s: llama_decode() failed\n", __func__);
+                            return 1;
+                        }
+                        llama_memory_seq_rm(mem, 0, pp, -1);
                     }
-                    llama_memory_seq_rm(mem, 0, pp, -1);
                 }
 
                 const auto t_tg_start = ggml_time_us();


### PR DESCRIPTION
- Take into account split KV cache when computing `N_KV`
- Do not measure KV cache copying when `-pps` is enabled