### PR TITLE
fix(ggml-sycl): add synchronization before exiting argsort kernel

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1774,7 +1774,9 @@ static void argsort_f32_i32_sycl(const float *x, int *dst, const int ncols,
     } else {
         GGML_ABORT("fatal error");
     }
-}
+
+    // Ensure all kernels finish execution before proceeding further
+    stream->wait();
 
 static void argmax_f32_i32_sycl(const float *x, int *dst, const int ncols,
                                const int nrows, queue_ptr stream) {

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1777,6 +1777,7 @@ static void argsort_f32_i32_sycl(const float *x, int *dst, const int ncols,
 
     // Ensure all kernels finish execution before proceeding further
     stream->wait();
+}
 
 static void argmax_f32_i32_sycl(const float *x, int *dst, const int ncols,
                                const int nrows, queue_ptr stream) {


### PR DESCRIPTION
- Add `stream->wait()` to ensure all kernels finish execution before proceeding
- This resolves potential race conditions in the argsort operation

Fixes: #15580 