### PR TITLE
CUDA: return -1 for nonexistent compiled arch

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -107,9 +107,9 @@ constexpr bool ggml_cuda_has_arch(const int arch) {
     return ggml_cuda_has_arch_impl(arch, __CUDA_ARCH_LIST__);
 }
 
-constexpr int ggml_cuda_highest_compiled_arch_impl(const int arch, const int cur) {
+constexpr int ggml_cuda_highest_compiled_arch_impl(const int /*arch*/, const int cur) {
     if (cur == 0) {
-        GGML_ABORT("ggml was not compiled with any CUDA arch <= %d", arch);
+        return -1;
     }
     return cur;
 }


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/15584 .

Simply return -1 for the "highest compiled arch" of a GPU architecture that the code was not compiled for, handling of this case is then the responsibility of the caller.