### PR TITLE
graph : fix assert in memory-less build_attn

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1376,7 +1376,7 @@ ggml_tensor * llm_graph_context::build_attn(
 
     // [TAG_NO_CACHE_PAD]
     // TODO: if ubatch.equal_seqs() == true, we can split the three tensors below into ubatch.n_seqs_unq streams
-    assert(!ubatch.equal_seqs());
+    assert(!ubatch.equal_seqs() || (k_cur->ne[3] == 1 && k_cur->ne[3] == ubatch.n_seqs_unq));
 
     ggml_tensor * q = q_cur;
     ggml_tensor * k = k_cur;


### PR DESCRIPTION
cont #15586 

This assert will be removed after the TODOs with tag `[TAG_NO_CACHE_PAD]` from #14363 are completed. For now guarantee that we are not calling this path with `equal_seqs && n_seqs_unq > 1`, which is guaranteed in the `encode()` method of `llama_context`:

https://github.com/ggml-org/llama.cpp/blob/dc7e58d2b0f392e5cb69d7bd5bd50aa0f441d685/src/llama-context.cpp#L780-L784

