### PR TITLE
common : add -m to bash completion for --model [no ci]

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1106,7 +1106,7 @@ static void common_params_print_completion(common_params_context & ctx_arg) {
     printf("\"\n\n");
 
     printf("    case \"$prev\" in\n");
-    printf("        --model)\n");
+    printf("        --model|-m)\n");
     printf("            COMPREPLY=( $(compgen -f -X '!*.gguf' -- \"$cur\") $(compgen -d -- \"$cur\") )\n");
     printf("            return 0\n");
     printf("            ;;\n");


### PR DESCRIPTION
This commit updates the bash completion script to include the -m short option for the --model argument.

The motivation for this is that currently tab completion only works the full --model option, and it is nice to have it work for the short option as well.
