### PR TITLE
SYCL: fix rms_norm_mul_add for tensor dim not a multiple of sg_size

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4364,11 +4364,12 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
             return (op->type == GGML_TYPE_F32 && op->src[0]->type == GGML_TYPE_F32) && (op->type == op->src[0]->type);
 #endif
         case GGML_OP_NORM:
-        case GGML_OP_RMS_NORM:
             return true;
         case GGML_OP_L2_NORM:
         case GGML_OP_GROUP_NORM:
             return ggml_is_contiguous(op->src[0]);
+        case GGML_OP_RMS_NORM:
+            return ((op->src[0]->ne[0] % WARP_SIZE) == 0);
         case GGML_OP_SCALE:
             return true;
         case GGML_OP_CONT:


### PR DESCRIPTION
The original implementation unconditionally returned true for this operation, leading to a failure when the src0 tensor's columns were not a multiple of the device sub group size. This caused a GGML_ASSERT(ncols % WARP_SIZE == 0) failure in ggml-sycl/norm.cpp.

This change updates the ggml_backend_sycl_device_supports_op check to correctly return true for GGML_OP_RMS_NORM only when the ncols are a multiple of the device sg_size, ensuring the operation can be performed without error.

--

@CISC @ggerganov  Given the current situation, I think the SYCL backend will be replaced by the new ggml openVINO backend for Intel devices, so this is just adjusting and definitely not a proper fix.

Others can feel free to correct me on this. I will try to support everything other than MUL_MAT kernels until we get a definite response from the backend's original maintainers from Intel. Leaving an unmaintained backend around isn’t ideal, so this should at least prevent immediate failures.
