### PR TITLE
musa: fix build warnings

### DIFF
--- a/ggml/src/ggml-cuda/binbcast.cu
+++ b/ggml/src/ggml-cuda/binbcast.cu
@@ -54,7 +54,7 @@ static __global__ void k_bin_bcast(const src0_t *         src0,
     const uint32_t i2  = fastdiv((blockDim.z * blockIdx.z + threadIdx.z), ne3);
     const uint32_t i3  = (blockDim.z * blockIdx.z + threadIdx.z) - (i2 * ne3.z);
 
-    if (i0s >= ne0 || i1 >= ne1 || i2 >= ne2 || i3 >= ne3.z) {
+    if (i0s >= (uint32_t)ne0 || i1 >= (uint32_t)ne1 || i2 >= (uint32_t)ne2 || i3 >= ne3.z) {
         return;
     }
 

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -81,7 +81,7 @@ static __global__ void mmq_ids_helper(
 #pragma unroll
             for (int offset = neu_padded; offset < warp_size; offset += neu_padded) {
                 const int tmp = __shfl_up_sync(0xFFFFFFFF, it_compact_add_self, offset, warp_size);
-                if (threadIdx.x >= offset) {
+                if (threadIdx.x >= static_cast<unsigned int>(offset)) {
                     it_compact_add_lower += tmp;
                 }
             }
@@ -110,7 +110,7 @@ static __global__ void mmq_ids_helper(
 
     expert_bounds[expert] = nex_prev;
 
-    if (expert < gridDim.x - 1) {
+    if (expert < static_cast<int>(gridDim.x) - 1) {
         return;
     }
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -220,7 +220,7 @@ static __global__ void mul_mat_vec_q(
             tmp[j][i] = warp_reduce_sum<warp_size>(tmp[j][i]);
         }
 
-        if (threadIdx.x < rows_per_cuda_block && (rows_per_cuda_block == 1 || row0 + int(threadIdx.x) < stride_col_dst)) {
+        if (threadIdx.x < rows_per_cuda_block && (rows_per_cuda_block == 1 || uint32_t(row0 + threadIdx.x) < stride_col_dst)) {
             dst[j*stride_col_dst + threadIdx.x] = tmp[j][threadIdx.x];
         }
     }

--- a/ggml/src/ggml-cuda/pad_reflect_1d.cu
+++ b/ggml/src/ggml-cuda/pad_reflect_1d.cu
@@ -51,6 +51,8 @@ static __global__ __launch_bounds__(CUDA_PAD_REFLECT_1D_BLOCK_SIZE, 1) void
     }
     const float value               = *(const float *) (src0_ptr + src_idx * nb00);
     *(float *) (dst_ptr + i0 * nb0) = value;
+
+    GGML_UNUSED(p1);
 }
 
 void ggml_cuda_op_pad_reflect_1d(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

### Testing Done

```bash 
❯ docker exec -it yeahdongcn bash
root@xiaodongye-s80:/ws# rm -rf ./build
root@xiaodongye-s80:/ws# cmake -B build -DGGML_MUSA=ON 
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMAKE_BUILD_TYPE=Release
-- Found Git: /usr/bin/git (found version "2.34.1") 
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- ccache found, compilation results will be cached. Disable with GGML_CCACHE=OFF.
-- CMAKE_SYSTEM_PROCESSOR: x86_64
-- GGML_SYSTEM_ARCH: x86
-- Including CPU backend
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- x86 detected
-- Adding CPU backend variant ggml-cpu: -march=native 
-- Found MUSAToolkit: /usr/local/musa/include  
-- MUSA Toolkit found
-- Using MUSA architectures: 21;22;31
-- Including MUSA backend
-- ggml version: 0.9.0-dev
-- ggml commit:  1f3217767
-- Found CURL: /usr/lib/x86_64-linux-gnu/libcurl.so (found version "7.81.0")  
-- Configuring done
-- Generating done
-- Build files have been written to: /ws/build
root@xiaodongye-s80:/ws# cmake --build build -j $(nproc) --config Release                       
[  0%] Building C object examples/gguf-hash/CMakeFiles/sha256.dir/deps/sha256/sha256.c.o
[  1%] Building C object examples/gguf-hash/CMakeFiles/sha1.dir/deps/sha1/sha1.c.o
[  1%] Building CXX object common/CMakeFiles/build_info.dir/build-info.cpp.o
[  2%] Building C object examples/gguf-hash/CMakeFiles/xxhash.dir/deps/xxhash/xxhash.c.o
[  3%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml.c.o
[  4%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-alloc.c.o
[  4%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-backend.cpp.o
[  4%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml.cpp.o
[  4%] Building CXX object tools/mtmd/CMakeFiles/llama-llava-cli.dir/deprecation-warning.cpp.o
[  4%] Building CXX object tools/mtmd/CMakeFiles/llama-gemma3-cli.dir/deprecation-warning.cpp.o
[  4%] Building CXX object tools/mtmd/CMakeFiles/llama-qwen2vl-cli.dir/deprecation-warning.cpp.o
[  4%] Building CXX object tools/mtmd/CMakeFiles/llama-minicpmv-cli.dir/deprecation-warning.cpp.o
[  4%] Built target sha1
[  4%] Built target sha256
[  4%] Built target xxhash
[  4%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-opt.cpp.o
[  4%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-threading.cpp.o
[  4%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-quants.c.o
[  4%] Built target build_info
[  5%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/gguf.cpp.o
[  6%] Linking CXX executable ../../bin/llama-llava-cli
[  7%] Linking CXX executable ../../bin/llama-minicpmv-cli
[  7%] Linking CXX executable ../../bin/llama-gemma3-cli
[  8%] Linking CXX executable ../../bin/llama-qwen2vl-cli
[  8%] Built target llama-gemma3-cli
[  8%] Built target llama-minicpmv-cli
[  8%] Built target llama-qwen2vl-cli
[  8%] Built target llama-llava-cli
[  8%] Linking CXX shared library ../../bin/libggml-base.so
[  8%] Built target ggml-base
[  9%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/repack.cpp.o
[  9%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.c.o
[  9%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.cpp.o
[  9%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/mmq.cpp.o
[  9%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/hbm.cpp.o
[  9%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/quants.c.o
[ 10%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/traits.cpp.o
[ 10%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/amx.cpp.o
[ 11%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/binary-ops.cpp.o
[ 11%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/unary-ops.cpp.o
[ 11%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/vec.cpp.o
[ 11%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/acc.cu.o
[ 11%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ops.cpp.o
[ 12%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/llamafile/sgemm.cpp.o
[ 12%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/x86/quants.c.o
[ 12%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/add-id.cu.o
[ 12%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/x86/repack.cpp.o
[ 13%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/argmax.cu.o
[ 13%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/arange.cu.o
[ 13%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/argsort.cu.o
[ 13%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/binbcast.cu.o
[ 14%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/clamp.cu.o
[ 14%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/concat.cu.o
[ 14%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/conv-transpose-1d.cu.o
[ 14%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/conv2d-dw.cu.o
[ 15%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/conv2d-transpose.cu.o
[ 16%] Linking CXX shared library ../../bin/libggml-cpu.so
[ 16%] Built target ggml-cpu
[ 16%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/conv2d.cu.o
[ 16%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/convert.cu.o
[ 17%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/count-equal.cu.o
[ 17%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/cpy.cu.o
[ 17%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/cross-entropy-loss.cu.o
[ 18%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/diagmask.cu.o
[ 18%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/fattn-tile.cu.o
[ 18%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/fattn-wmma-f16.cu.o
[ 18%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/fattn.cu.o
[ 19%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/getrows.cu.o
[ 19%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/ggml-cuda.cu.o
[ 19%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/gla.cu.o
[ 20%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/im2col.cu.o
[ 20%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/mean.cu.o
[ 20%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/mmf.cu.o
[ 20%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/mmq.cu.o
[ 21%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/mmvf.cu.o
[ 21%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/mmvq.cu.o
[ 21%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/norm.cu.o
[ 22%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/opt-step-adamw.cu.o
[ 22%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/opt-step-sgd.cu.o
[ 22%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/out-prod.cu.o
[ 22%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/pad.cu.o
[ 23%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/pad_reflect_1d.cu.o
[ 23%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/pool2d.cu.o
[ 23%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/quantize.cu.o
[ 24%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/roll.cu.o
[ 24%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/rope.cu.o
[ 24%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/scale.cu.o
[ 24%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/set-rows.cu.o
[ 25%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/softcap.cu.o
[ 25%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/softmax.cu.o
[ 25%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/ssm-conv.cu.o
[ 26%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/ssm-scan.cu.o
[ 26%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/sum.cu.o
[ 26%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/sumrows.cu.o
[ 26%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/tsembd.cu.o
[ 27%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/unary.cu.o
[ 27%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/upscale.cu.o
[ 27%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/wkv.cu.o
[ 28%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_1-ncols2_16.cu.o
[ 28%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_1-ncols2_8.cu.o
[ 28%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_16-ncols2_1.cu.o
[ 28%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_16-ncols2_2.cu.o
[ 29%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_16-ncols2_4.cu.o
[ 29%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_2-ncols2_16.cu.o
[ 29%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_2-ncols2_4.cu.o
[ 30%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_2-ncols2_8.cu.o
[ 30%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_32-ncols2_1.cu.o
[ 30%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_32-ncols2_2.cu.o
[ 30%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_4-ncols2_16.cu.o
[ 31%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_4-ncols2_2.cu.o
[ 31%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_4-ncols2_4.cu.o
[ 31%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_4-ncols2_8.cu.o
[ 32%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_64-ncols2_1.cu.o
[ 32%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_8-ncols2_1.cu.o
[ 32%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_8-ncols2_2.cu.o
[ 32%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_8-ncols2_4.cu.o
[ 33%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-mma-f16-instance-ncols1_8-ncols2_8.cu.o
[ 33%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq1_s.cu.o
[ 33%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq2_s.cu.o
[ 34%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq2_xs.cu.o
[ 34%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq2_xxs.cu.o
[ 34%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq3_s.cu.o
[ 35%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq3_xxs.cu.o
[ 35%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq4_nl.cu.o
[ 35%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-iq4_xs.cu.o
[ 35%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-mxfp4.cu.o
[ 36%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q2_k.cu.o
[ 36%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q3_k.cu.o
[ 36%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q4_0.cu.o
[ 37%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q4_1.cu.o
[ 37%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q4_k.cu.o
[ 37%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q5_0.cu.o
[ 37%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q5_1.cu.o
[ 38%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q5_k.cu.o
[ 38%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q6_k.cu.o
[ 38%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/mmq-instance-q8_0.cu.o
[ 39%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f16-instance-hs128-q4_0-q4_0.cu.o
[ 39%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f32-instance-hs128-q4_0-q4_0.cu.o
[ 39%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f16-instance-hs128-q8_0-q8_0.cu.o
[ 39%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f32-instance-hs128-q8_0-q8_0.cu.o
[ 40%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f16-instance-hs128-f16-f16.cu.o
[ 40%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f16-instance-hs256-f16-f16.cu.o
[ 40%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f16-instance-hs64-f16-f16.cu.o
[ 41%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f32-instance-hs128-f16-f16.cu.o
[ 41%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f32-instance-hs256-f16-f16.cu.o
[ 41%] Building CXX object ggml/src/ggml-musa/CMakeFiles/ggml-musa.dir/__/ggml-cuda/template-instances/fattn-vec-f32-instance-hs64-f16-f16.cu.o
[ 41%] Linking CXX shared library ../../../bin/libggml-musa.so
[ 41%] Built target ggml-musa
[ 41%] Building CXX object ggml/src/CMakeFiles/ggml.dir/ggml-backend-reg.cpp.o
[ 41%] Linking CXX shared library ../../bin/libggml.so
[ 41%] Built target ggml
[ 41%] Building CXX object src/CMakeFiles/llama.dir/llama-adapter.cpp.o
[ 42%] Building CXX object src/CMakeFiles/llama.dir/llama-batch.cpp.o
[ 43%] Building CXX object examples/gguf-hash/CMakeFiles/llama-gguf-hash.dir/gguf-hash.cpp.o
[ 43%] Building CXX object examples/gguf/CMakeFiles/llama-gguf.dir/gguf.cpp.o
[ 44%] Building CXX object src/CMakeFiles/llama.dir/llama.cpp.o
[ 44%] Building CXX object src/CMakeFiles/llama.dir/llama-arch.cpp.o
[ 44%] Building CXX object src/CMakeFiles/llama.dir/llama-chat.cpp.o
[ 44%] Building CXX object src/CMakeFiles/llama.dir/llama-cparams.cpp.o
[ 44%] Building CXX object src/CMakeFiles/llama.dir/llama-context.cpp.o
[ 45%] Building CXX object src/CMakeFiles/llama.dir/llama-grammar.cpp.o
[ 45%] Building CXX object src/CMakeFiles/llama.dir/llama-graph.cpp.o
[ 45%] Building CXX object src/CMakeFiles/llama.dir/llama-hparams.cpp.o
[ 45%] Linking CXX executable ../../bin/llama-gguf
[ 46%] Building CXX object src/CMakeFiles/llama.dir/llama-impl.cpp.o
[ 46%] Linking CXX executable ../../bin/llama-gguf-hash
[ 46%] Building CXX object src/CMakeFiles/llama.dir/llama-io.cpp.o
[ 46%] Building CXX object src/CMakeFiles/llama.dir/llama-kv-cache.cpp.o
[ 47%] Building CXX object src/CMakeFiles/llama.dir/llama-memory.cpp.o
[ 47%] Building CXX object src/CMakeFiles/llama.dir/llama-kv-cache-iswa.cpp.o
[ 47%] Building CXX object src/CMakeFiles/llama.dir/llama-memory-hybrid.cpp.o
[ 47%] Building CXX object src/CMakeFiles/llama.dir/llama-memory-recurrent.cpp.o
[ 48%] Building CXX object src/CMakeFiles/llama.dir/llama-mmap.cpp.o
[ 48%] Building CXX object src/CMakeFiles/llama.dir/llama-model-loader.cpp.o
[ 48%] Building CXX object src/CMakeFiles/llama.dir/llama-model-saver.cpp.o
[ 48%] Building CXX object src/CMakeFiles/llama.dir/llama-model.cpp.o
[ 49%] Building CXX object src/CMakeFiles/llama.dir/llama-sampling.cpp.o
[ 49%] Building CXX object src/CMakeFiles/llama.dir/llama-quant.cpp.o
[ 49%] Building CXX object src/CMakeFiles/llama.dir/llama-vocab.cpp.o
[ 50%] Building CXX object src/CMakeFiles/llama.dir/unicode.cpp.o
[ 50%] Building CXX object src/CMakeFiles/llama.dir/unicode-data.cpp.o
[ 50%] Linking CXX shared library ../bin/libllama.so
[ 50%] Built target llama-gguf
[ 50%] Built target llama-gguf-hash
[ 50%] Built target llama
[ 50%] Building CXX object tools/mtmd/CMakeFiles/mtmd.dir/mtmd-audio.cpp.o
[ 50%] Building CXX object tools/mtmd/CMakeFiles/mtmd.dir/mtmd.cpp.o
[ 50%] Building CXX object examples/simple/CMakeFiles/llama-simple.dir/simple.cpp.o
[ 51%] Building C object tests/CMakeFiles/test-c.dir/test-c.c.o
[ 52%] Building CXX object tools/mtmd/CMakeFiles/mtmd.dir/clip.cpp.o
[ 52%] Building CXX object common/CMakeFiles/common.dir/arg.cpp.o
[ 53%] Building CXX object common/CMakeFiles/common.dir/chat.cpp.o
[ 53%] Building CXX object common/CMakeFiles/common.dir/common.cpp.o
[ 54%] Building CXX object examples/simple-chat/CMakeFiles/llama-simple-chat.dir/simple-chat.cpp.o
[ 55%] Building CXX object common/CMakeFiles/common.dir/json-partial.cpp.o
[ 55%] Building CXX object common/CMakeFiles/common.dir/chat-parser.cpp.o
[ 55%] Building CXX object common/CMakeFiles/common.dir/console.cpp.o
[ 55%] Linking CXX executable ../../bin/llama-simple
[ 55%] Linking C executable ../bin/test-c
[ 55%] Linking CXX executable ../../bin/llama-simple-chat
[ 55%] Building CXX object common/CMakeFiles/common.dir/llguidance.cpp.o
[ 55%] Building CXX object common/CMakeFiles/common.dir/json-schema-to-grammar.cpp.o
[ 55%] Building CXX object tools/mtmd/CMakeFiles/mtmd.dir/mtmd-helper.cpp.o
[ 55%] Building CXX object common/CMakeFiles/common.dir/log.cpp.o
[ 56%] Building CXX object common/CMakeFiles/common.dir/ngram-cache.cpp.o
[ 57%] Building CXX object common/CMakeFiles/common.dir/speculative.cpp.o
[ 57%] Building CXX object common/CMakeFiles/common.dir/sampling.cpp.o
[ 57%] Building CXX object common/CMakeFiles/common.dir/regex-partial.cpp.o
[ 57%] Linking CXX shared library ../../bin/libmtmd.so
[ 57%] Built target test-c
[ 57%] Linking CXX static library libcommon.a
[ 57%] Built target mtmd
[ 57%] Built target common
[ 58%] Building CXX object tests/CMakeFiles/test-tokenizer-0.dir/test-tokenizer-0.cpp.o
[ 58%] Building CXX object tests/CMakeFiles/test-sampling.dir/test-sampling.cpp.o
[ 59%] Building CXX object tests/CMakeFiles/test-llama-grammar.dir/test-llama-grammar.cpp.o
[ 59%] Building CXX object tests/CMakeFiles/test-grammar-integration.dir/test-grammar-integration.cpp.o
[ 59%] Building CXX object tests/CMakeFiles/test-grammar-parser.dir/test-grammar-parser.cpp.o
[ 59%] Building CXX object tests/CMakeFiles/test-json-schema-to-grammar.dir/test-json-schema-to-grammar.cpp.o
[ 59%] Building CXX object tests/CMakeFiles/test-chat.dir/test-chat.cpp.o
[ 60%] Building CXX object tests/CMakeFiles/test-quantize-stats.dir/test-quantize-stats.cpp.o
[ 60%] Building CXX object tests/CMakeFiles/test-tokenizer-1-bpe.dir/test-tokenizer-1-bpe.cpp.o
[ 61%] Building CXX object tests/CMakeFiles/test-gbnf-validator.dir/test-gbnf-validator.cpp.o
[ 61%] Building CXX object tests/CMakeFiles/test-sampling.dir/get-model.cpp.o
[ 61%] Linking CXX executable ../bin/test-tokenizer-0
[ 61%] Building CXX object tests/CMakeFiles/test-llama-grammar.dir/get-model.cpp.o
[ 62%] Building CXX object tests/CMakeFiles/test-grammar-parser.dir/get-model.cpp.o
[ 62%] Building CXX object tests/CMakeFiles/test-grammar-integration.dir/get-model.cpp.o
[ 62%] Built target llama-simple
[ 62%] Building CXX object tests/CMakeFiles/test-json-schema-to-grammar.dir/get-model.cpp.o
[ 62%] Linking CXX executable ../bin/test-quantize-stats
[ 62%] Linking CXX executable ../bin/test-gbnf-validator
[ 62%] Building CXX object tests/CMakeFiles/test-chat.dir/get-model.cpp.o
[ 63%] Linking CXX executable ../bin/test-tokenizer-1-bpe
[ 64%] Linking CXX executable ../bin/test-grammar-parser
[ 65%] Linking CXX executable ../bin/test-sampling
[ 65%] Built target llama-simple-chat
[ 65%] Linking CXX executable ../bin/test-grammar-integration
[ 65%] Linking CXX executable ../bin/test-llama-grammar
[ 65%] Linking CXX executable ../bin/test-json-schema-to-grammar
[ 66%] Linking CXX executable ../bin/test-chat
[ 66%] Building CXX object tests/CMakeFiles/test-tokenizer-1-spm.dir/test-tokenizer-1-spm.cpp.o
[ 66%] Linking CXX executable ../bin/test-tokenizer-1-spm
[ 66%] Building CXX object tests/CMakeFiles/test-chat-parser.dir/test-chat-parser.cpp.o
[ 66%] Building CXX object tests/CMakeFiles/test-chat-parser.dir/get-model.cpp.o
[ 67%] Linking CXX executable ../bin/test-chat-parser
[ 67%] Built target test-gbnf-validator
[ 67%] Built target test-tokenizer-0
[ 67%] Built target test-llama-grammar
[ 67%] Built target test-grammar-parser
[ 67%] Built target test-sampling
[ 68%] Building CXX object tests/CMakeFiles/test-log.dir/test-log.cpp.o
[ 68%] Built target test-quantize-stats
[ 68%] Built target test-tokenizer-1-bpe
[ 68%] Building CXX object tests/CMakeFiles/test-chat-template.dir/test-chat-template.cpp.o
[ 68%] Built target test-grammar-integration
[ 68%] Building CXX object tests/CMakeFiles/test-json-partial.dir/test-json-partial.cpp.o
[ 68%] Built target test-tokenizer-1-spm
[ 68%] Building CXX object tests/CMakeFiles/test-regex-partial.dir/test-regex-partial.cpp.o
[ 68%] Building CXX object tests/CMakeFiles/test-json-partial.dir/get-model.cpp.o
[ 68%] Building CXX object tests/CMakeFiles/test-log.dir/get-model.cpp.o
[ 69%] Building CXX object tests/CMakeFiles/test-regex-partial.dir/get-model.cpp.o
[ 69%] Building CXX object tests/CMakeFiles/test-arg-parser.dir/test-arg-parser.cpp.o
[ 69%] Building CXX object tests/CMakeFiles/test-thread-safety.dir/test-thread-safety.cpp.o
[ 69%] Building CXX object tests/CMakeFiles/test-chat-template.dir/get-model.cpp.o
[ 69%] Linking CXX executable ../bin/test-log
[ 70%] Linking CXX executable ../bin/test-json-partial
[ 70%] Linking CXX executable ../bin/test-regex-partial
[ 70%] Building CXX object tests/CMakeFiles/test-thread-safety.dir/get-model.cpp.o
[ 70%] Built target test-json-schema-to-grammar
[ 70%] Building CXX object tests/CMakeFiles/test-opt.dir/test-opt.cpp.o
[ 70%] Building CXX object tests/CMakeFiles/test-opt.dir/get-model.cpp.o
[ 70%] Building CXX object tests/CMakeFiles/test-arg-parser.dir/get-model.cpp.o
[ 70%] Linking CXX executable ../bin/test-chat-template
[ 70%] Built target test-chat
[ 70%] Linking CXX executable ../bin/test-thread-safety
[ 70%] Building CXX object tests/CMakeFiles/test-gguf.dir/test-gguf.cpp.o
[ 71%] Linking CXX executable ../bin/test-arg-parser
[ 71%] Building CXX object tests/CMakeFiles/test-backend-ops.dir/test-backend-ops.cpp.o
[ 71%] Building CXX object tests/CMakeFiles/test-model-load-cancel.dir/test-model-load-cancel.cpp.o
[ 72%] Building CXX object tests/CMakeFiles/test-model-load-cancel.dir/get-model.cpp.o
[ 73%] Linking CXX executable ../bin/test-opt
[ 74%] Building CXX object tests/CMakeFiles/test-gguf.dir/get-model.cpp.o
[ 74%] Linking CXX executable ../bin/test-model-load-cancel
[ 74%] Linking CXX executable ../bin/test-gguf
[ 74%] Building CXX object tests/CMakeFiles/test-backend-ops.dir/get-model.cpp.o
[ 74%] Building CXX object tests/CMakeFiles/test-autorelease.dir/test-autorelease.cpp.o
[ 74%] Built target test-chat-parser
[ 74%] Linking CXX executable ../bin/test-backend-ops
[ 74%] Building CXX object tests/CMakeFiles/test-autorelease.dir/get-model.cpp.o
[ 74%] Built target test-log
[ 75%] Building CXX object tests/CMakeFiles/test-barrier.dir/test-barrier.cpp.o
[ 76%] Linking CXX executable ../bin/test-autorelease
[ 76%] Built target test-json-partial
[ 76%] Building CXX object tests/CMakeFiles/test-quantize-fns.dir/test-quantize-fns.cpp.o
[ 76%] Building CXX object tests/CMakeFiles/test-barrier.dir/get-model.cpp.o
[ 76%] Linking CXX executable ../bin/test-barrier
[ 76%] Building CXX object tests/CMakeFiles/test-quantize-perf.dir/test-quantize-perf.cpp.o
[ 76%] Building CXX object tests/CMakeFiles/test-quantize-fns.dir/get-model.cpp.o
[ 77%] Linking CXX executable ../bin/test-quantize-fns
[ 77%] Building CXX object tests/CMakeFiles/test-quantize-perf.dir/get-model.cpp.o
[ 77%] Linking CXX executable ../bin/test-quantize-perf
[ 77%] Built target test-regex-partial
[ 77%] Built target test-opt
[ 77%] Built target test-model-load-cancel
[ 77%] Building CXX object tests/CMakeFiles/test-rope.dir/test-rope.cpp.o
[ 77%] Built target test-gguf
[ 77%] Building C object tests/CMakeFiles/test-mtmd-c-api.dir/test-mtmd-c-api.c.o
[ 77%] Built target test-barrier
[ 77%] Built target test-chat-template
[ 77%] Building CXX object tests/CMakeFiles/test-rope.dir/get-model.cpp.o
[ 77%] Building CXX object examples/batched/CMakeFiles/llama-batched.dir/batched.cpp.o
[ 78%] Building CXX object tests/CMakeFiles/test-mtmd-c-api.dir/get-model.cpp.o
[ 79%] Linking CXX executable ../bin/test-rope
[ 79%] Built target test-quantize-fns
[ 80%] Building CXX object examples/embedding/CMakeFiles/llama-embedding.dir/embedding.cpp.o
[ 80%] Linking CXX executable ../bin/test-mtmd-c-api
[ 80%] Building CXX object examples/eval-callback/CMakeFiles/llama-eval-callback.dir/eval-callback.cpp.o
[ 80%] Building CXX object examples/lookahead/CMakeFiles/llama-lookahead.dir/lookahead.cpp.o
[ 81%] Linking CXX executable ../../bin/llama-batched
[ 81%] Building CXX object examples/lookup/CMakeFiles/llama-lookup.dir/lookup.cpp.o
[ 81%] Linking CXX executable ../../bin/llama-embedding
[ 81%] Built target test-backend-ops
[ 81%] Linking CXX executable ../../bin/llama-eval-callback
[ 82%] Linking CXX executable ../../bin/llama-lookahead
[ 82%] Linking CXX executable ../../bin/llama-lookup
[ 82%] Built target test-autorelease
[ 82%] Built target test-quantize-perf
[ 83%] Building CXX object examples/lookup/CMakeFiles/llama-lookup-create.dir/lookup-create.cpp.o
[ 83%] Linking CXX executable ../../bin/llama-lookup-create
[ 83%] Building CXX object examples/lookup/CMakeFiles/llama-lookup-merge.dir/lookup-merge.cpp.o
[ 83%] Built target test-thread-safety
[ 84%] Building CXX object examples/lookup/CMakeFiles/llama-lookup-stats.dir/lookup-stats.cpp.o
[ 84%] Linking CXX executable ../../bin/llama-lookup-merge
[ 84%] Built target test-arg-parser
[ 84%] Linking CXX executable ../../bin/llama-lookup-stats
[ 84%] Building CXX object examples/parallel/CMakeFiles/llama-parallel.dir/parallel.cpp.o
[ 84%] Built target test-rope
[ 85%] Linking CXX executable ../../bin/llama-parallel
[ 85%] Building CXX object examples/retrieval/CMakeFiles/llama-retrieval.dir/retrieval.cpp.o
[ 85%] Building CXX object examples/passkey/CMakeFiles/llama-passkey.dir/passkey.cpp.o
[ 85%] Linking CXX executable ../../bin/llama-retrieval
[ 85%] Linking CXX executable ../../bin/llama-passkey
[ 85%] Built target llama-lookup-merge
[ 85%] Built target test-mtmd-c-api
[ 85%] Building CXX object examples/save-load-state/CMakeFiles/llama-save-load-state.dir/save-load-state.cpp.o
[ 85%] Building CXX object examples/speculative/CMakeFiles/llama-speculative.dir/speculative.cpp.o
[ 86%] Linking CXX executable ../../bin/llama-save-load-state
[ 87%] Linking CXX executable ../../bin/llama-speculative
[ 87%] Built target llama-embedding
[ 87%] Built target llama-eval-callback
[ 87%] Built target llama-lookahead
[ 87%] Building CXX object examples/speculative-simple/CMakeFiles/llama-speculative-simple.dir/speculative-simple.cpp.o
[ 87%] Building CXX object examples/gen-docs/CMakeFiles/llama-gen-docs.dir/gen-docs.cpp.o
[ 87%] Built target llama-batched
[ 87%] Built target llama-lookup-create
[ 87%] Built target llama-lookup
[ 87%] Building CXX object examples/training/CMakeFiles/llama-finetune.dir/finetune.cpp.o
[ 87%] Linking CXX executable ../../bin/llama-speculative-simple
[ 87%] Building CXX object examples/model-conversion/CMakeFiles/llama-logits.dir/logits.cpp.o
[ 87%] Building CXX object examples/diffusion/CMakeFiles/llama-diffusion-cli.dir/diffusion-cli.cpp.o
[ 88%] Linking CXX executable ../../bin/llama-gen-docs
[ 88%] Built target llama-lookup-stats
[ 89%] Linking CXX executable ../../bin/llama-finetune
[ 89%] Building CXX object examples/convert-llama2c-to-ggml/CMakeFiles/llama-convert-llama2c-to-ggml.dir/convert-llama2c-to-ggml.cpp.o
[ 89%] Linking CXX executable ../../bin/llama-logits
[ 89%] Linking CXX executable ../../bin/llama-diffusion-cli
[ 89%] Linking CXX executable ../../bin/llama-convert-llama2c-to-ggml
[ 90%] Building CXX object pocs/vdot/CMakeFiles/llama-vdot.dir/vdot.cpp.o
[ 90%] Built target llama-parallel
[ 90%] Linking CXX executable ../../bin/llama-vdot
[ 90%] Building CXX object pocs/vdot/CMakeFiles/llama-q8dot.dir/q8dot.cpp.o
[ 90%] Built target llama-retrieval
[ 90%] Linking CXX executable ../../bin/llama-q8dot
[ 90%] Built target llama-passkey
[ 90%] Building CXX object tools/batched-bench/CMakeFiles/llama-batched-bench.dir/batched-bench.cpp.o
[ 90%] Built target llama-save-load-state
[ 90%] Linking CXX executable ../../bin/llama-batched-bench
[ 90%] Building CXX object tools/gguf-split/CMakeFiles/llama-gguf-split.dir/gguf-split.cpp.o
[ 90%] Built target llama-vdot
[ 91%] Building CXX object tools/imatrix/CMakeFiles/llama-imatrix.dir/imatrix.cpp.o
[ 91%] Linking CXX executable ../../bin/llama-gguf-split
[ 91%] Built target llama-speculative
[ 92%] Building CXX object tools/llama-bench/CMakeFiles/llama-bench.dir/llama-bench.cpp.o
[ 92%] Built target llama-q8dot
[ 92%] Built target llama-logits
[ 92%] Linking CXX executable ../../bin/llama-imatrix
[ 92%] Building CXX object tools/main/CMakeFiles/llama-cli.dir/main.cpp.o
[ 92%] Linking CXX executable ../../bin/llama-bench
[ 93%] Building CXX object tools/perplexity/CMakeFiles/llama-perplexity.dir/perplexity.cpp.o
[ 93%] Built target llama-convert-llama2c-to-ggml
[ 94%] Building CXX object tools/quantize/CMakeFiles/llama-quantize.dir/quantize.cpp.o
[ 95%] Linking CXX executable ../../bin/llama-cli
[ 95%] Generating loading.html.hpp
[ 95%] Linking CXX executable ../../bin/llama-perplexity
[ 95%] Linking CXX executable ../../bin/llama-quantize
[ 95%] Generating index.html.gz.hpp
[ 95%] Built target llama-speculative-simple
[ 95%] Built target llama-gen-docs
[ 95%] Built target llama-diffusion-cli
[ 96%] Building CXX object tools/run/CMakeFiles/llama-run.dir/run.cpp.o
[ 96%] Building CXX object tools/tokenize/CMakeFiles/llama-tokenize.dir/tokenize.cpp.o
[ 96%] Built target llama-finetune
[ 96%] Building CXX object tools/tts/CMakeFiles/llama-tts.dir/tts.cpp.o
[ 97%] Linking CXX executable ../../bin/llama-tokenize
[ 97%] Built target llama-gguf-split
[ 97%] Building CXX object tools/mtmd/CMakeFiles/llama-mtmd-cli.dir/mtmd-cli.cpp.o
[ 97%] Building CXX object tools/run/CMakeFiles/llama-run.dir/linenoise.cpp/linenoise.cpp.o
[ 97%] Linking CXX executable ../../bin/llama-tts
[ 97%] Linking CXX executable ../../bin/llama-mtmd-cli
[ 97%] Building CXX object tools/cvector-generator/CMakeFiles/llama-cvector-generator.dir/cvector-generator.cpp.o
[ 97%] Linking CXX executable ../../bin/llama-run
[ 97%] Built target llama-bench
[ 98%] Linking CXX executable ../../bin/llama-cvector-generator
[ 99%] Building CXX object tools/export-lora/CMakeFiles/llama-export-lora.dir/export-lora.cpp.o
[ 99%] Built target llama-quantize
[ 99%] Linking CXX executable ../../bin/llama-export-lora
[ 99%] Built target llama-batched-bench
[ 99%] Built target llama-imatrix
[ 99%] Built target llama-tokenize
[ 99%] Built target llama-cli
[ 99%] Built target llama-perplexity
[ 99%] Built target llama-mtmd-cli
[ 99%] Built target llama-run
[ 99%] Built target llama-tts
[ 99%] Built target llama-export-lora
[ 99%] Built target llama-cvector-generator
[100%] Building CXX object tools/server/CMakeFiles/llama-server.dir/server.cpp.o
[100%] Linking CXX executable ../../bin/llama-server
[100%] Built target llama-server
root@xiaodongye-s80:/ws# 
```