### PR TITLE
presets : add qwen3-30B-a3b FIM

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3539,6 +3539,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
 
     add_opt(common_arg(
+        {"--fim-qwen-30b-default"},
+        string_format("use default Qwen 3 Coder 30B A3B Instruct (note: can download weights from the internet)"),
+        [](common_params & params) {
+            params.model.hf_repo = "ggml-org/Qwen3-Coder-30B-A3B-Instruct-Q8_0-GGUF";
+            params.model.hf_file = "qwen3-coder-30b-a3b-instruct-q8_0.gguf";
+            params.port = 8012;
+            params.n_gpu_layers = 99;
+            params.flash_attn = true;
+            params.n_ubatch = 1024;
+            params.n_batch = 1024;
+            params.n_ctx = 0;
+            params.n_cache_reuse = 256;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+
+    add_opt(common_arg(
         { "--diffusion-steps" }, "N",
         string_format("number of diffusion steps (default: %d)", params.diffusion.steps),
         [](common_params & params, int value) { params.diffusion.steps = value; }


### PR DESCRIPTION
The `Qwen 3 Coder 30B-A3B` model seems to now perform equally fast (or even faster) than the old `Qwen 2.5 Coder 7B`. Adding preset for easy usage with `llama.vim`, `llama.vscode` and `llama.qtcreator`:

```bash
llama-server --fim-qwen-30b-default
```

Perf M2 Ultra:

| model                          |       size | backend    | n_ubatch | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------- | -------: | -: | --------------: | -------------------: |
| qwen3moe 30B.A3B Q8_0          |  30.25 GiB | Metal      |     2048 |  1 |           pp512 |      2045.19 ± 10.70 |
| qwen3moe 30B.A3B Q8_0          |  30.25 GiB | Metal      |     2048 |  1 |          pp2048 |       2272.56 ± 3.49 |
| qwen3moe 30B.A3B Q8_0          |  30.25 GiB | Metal      |     2048 |  1 |         pp16384 |       1022.81 ± 0.18 |
| qwen3moe 30B.A3B Q8_0          |  30.25 GiB | Metal      |     2048 |  1 |           tg128 |         76.31 ± 0.06 |
| qwen2 7B Q8_0                  |   7.54 GiB | Metal      |     2048 |  1 |           pp512 |       1419.54 ± 1.00 |
| qwen2 7B Q8_0                  |   7.54 GiB | Metal      |     2048 |  1 |          pp2048 |       1470.14 ± 0.30 |
| qwen2 7B Q8_0                  |   7.54 GiB | Metal      |     2048 |  1 |         pp16384 |       1037.44 ± 0.24 |
| qwen2 7B Q8_0                  |   7.54 GiB | Metal      |     2048 |  1 |           tg128 |         71.49 ± 0.04 |

build: 1bded5a3b (6299)
