### PR TITLE
model : fix internvl3_5_20b gguf conversion

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -8208,7 +8208,13 @@ class GptOssModel(TextModel):
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         del bid  # unused
-
+        
+        name = name.replace("language_model.", "") # InternVL
+        
+        if name.startswith("vision_model") or name.startswith("mlp") :    
+            # skip vision tensors
+            return []
+            
         if "sinks" in name:
             name += ".weight"
 


### PR DESCRIPTION
Fixes OpenGVLab/InternVL3_5-GPT-OSS-20B-A4B-Preview conversion
since this one uses gpt oss 20b as a base

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
