### PR TITLE
ggml : add ggml_mul_mat_id_set_prec and use in llama.cpp

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -1301,7 +1301,7 @@ extern "C" {
             struct ggml_tensor  * b);
 
     // change the precision of a matrix multiplication
-    // set to GGML_PREC_F32 for higher precision (useful for phi-2)
+    // set to GGML_PREC_F32 for higher precision
     GGML_API void ggml_mul_mat_set_prec(
             struct ggml_tensor * a,
             enum ggml_prec       prec);
@@ -1312,6 +1312,12 @@ extern "C" {
             struct ggml_tensor  * as,
             struct ggml_tensor  * b,
             struct ggml_tensor  * ids);
+
+    // change the precision of an indirect matrix multiplication
+    // set to GGML_PREC_F32 for higher precision
+    GGML_API void ggml_mul_mat_id_set_prec(
+            struct ggml_tensor * a,
+            enum ggml_prec       prec);
 
     // A: m columns, n rows,
     // B: p columns, n rows,

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4657,8 +4657,7 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
             return nullptr;
     }
 
-    // XXX TODO 'prec' is not actually allowed in mul_mat_id.
-    bool prefer_fp16acc = ctx->device->fp16 /*&& prec == GGML_PREC_DEFAULT*/;
+    bool prefer_fp16acc = ctx->device->fp16 && prec == GGML_PREC_DEFAULT;
     bool support_fp16acc = ctx->device->pipeline_dequant_mul_mat_mat_id[src0_type].f16acc != nullptr;
     bool support_fp32acc = ctx->device->pipeline_dequant_mul_mat_mat_id[src0_type].f32acc != nullptr;
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3081,6 +3081,16 @@ struct ggml_tensor * ggml_mul_mat_id(
     return result;
 }
 
+void ggml_mul_mat_id_set_prec(
+        struct ggml_tensor * a,
+        enum ggml_prec       prec) {
+    GGML_ASSERT(a->op == GGML_OP_MUL_MAT_ID);
+
+    const int32_t prec_i32 = (int32_t) prec;
+
+    ggml_set_op_params_i32(a, 0, prec_i32);
+}
+
 // ggml_out_prod
 
 static inline bool ggml_can_out_prod(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -589,13 +589,15 @@ struct llm_graph_context {
     // do mat_mul, while optionally apply lora
     ggml_tensor * build_lora_mm(
               ggml_tensor * w,
-              ggml_tensor * cur) const;
+              ggml_tensor * cur,
+                ggml_prec   prec = GGML_PREC_DEFAULT) const;
 
     // do mat_mul_id, while optionally apply lora
     ggml_tensor * build_lora_mm_id(
               ggml_tensor * w,   // ggml_tensor * as
               ggml_tensor * cur, // ggml_tensor * b
-              ggml_tensor * ids) const;
+              ggml_tensor * ids,
+                ggml_prec   prec = GGML_PREC_DEFAULT) const;
 
     ggml_tensor * build_norm(
              ggml_tensor * cur,


### PR DESCRIPTION
fix #15274, #15517, #15516

Force F32 accumulators for attention and ffn output matrix multiplications.