### PR TITLE
server: higher timeout for tests

### DIFF
--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -26,10 +26,7 @@ from re import RegexFlag
 import wget
 
 
-DEFAULT_HTTP_TIMEOUT = 12
-
-if "LLAMA_SANITIZE" in os.environ or "GITHUB_ACTION" in os.environ:
-    DEFAULT_HTTP_TIMEOUT = 30
+DEFAULT_HTTP_TIMEOUT = 30
 
 
 class ServerResponse:


### PR DESCRIPTION
When I tried running the server tests locally they would fail because the server would try downloading the test models but be unable to finish the download for TinyStories 15m in the 12 second timeout window. This PR increases the timeout to 30 seconds.