### PR TITLE
ggml : fix SSM_SCAN for n_groups > 1

### DIFF
--- a/ggml/src/ggml-cuda/ssm-scan.cu
+++ b/ggml/src/ggml-cuda/ssm-scan.cu
@@ -129,7 +129,7 @@ __global__ void __launch_bounds__(d_state, 1)
     const int head_off = ((blockIdx.x * splitH) % d_head) * sizeof(float);
     const int seq_idx = blockIdx.y;
 
-    const int group_off = (head_idx & (n_group - 1)) * d_state * sizeof(float);
+    const int group_off = (head_idx / (n_head / n_group)) * d_state * sizeof(float);
 
     const float * s0_block = (const float *) ((const char *) src0 + src6[seq_idx] * src0_nb3 + head_idx * src0_nb2 + head_off * d_state);
     const float * x_block  = (const float *) ((const char *) src1 + (seq_idx * src1_nb3) + blockIdx.x * splitH * sizeof(float));

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1983,14 +1983,15 @@ kernel void kernel_ssm_scan_f32(
     device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
     device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
     const int64_t i = i0 + i1*nc;
+    const int64_t g = ir / (nh / ng); // repeat_interleave
     float s0 = s0_buff[i];
     float s  = s_buff[i];
 
         device const float * A        = (device const float *) ((device const char *) src3 + ir*args.nb31);
         device const float * x_block  = (device const float *) ((device const char *) src1 + i1*nb10 + ir*args.nb11 + i3*args.nb13);
         device const float * dt_block = (device const float *) ((device const char *) src2 + ir*nb20 + i3*args.nb22);
-        device const float * B_block  = (device const float *) ((device const char *) src4 + (ir & (ng - 1))*args.nb41 + i3*args.nb43);
-        device const float * C_block  = (device const float *) ((device const char *) src5 + (ir & (ng - 1))*args.nb51 + i3*args.nb53);
+        device const float * B_block  = (device const float *) ((device const char *) src4 + g*args.nb41 + i3*args.nb43);
+        device const float * C_block  = (device const float *) ((device const char *) src5 + g*args.nb51 + i3*args.nb53);
         device       float * y_block  = (device       float *) ((device       char *) dst  + (i1 + ir*(nr) + i3*(n_t*nh*nr))*nb00);
 
     for (int64_t i2 = 0; i2 < n_t; ++i2) {
@@ -2098,14 +2099,15 @@ kernel void kernel_ssm_scan_f32_group(
     device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
     device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
     const int64_t i = i0 + i1*nc;
+    const int64_t g = ir / (nh / ng); // repeat_interleave
     float s0 = s0_buff[i];
     float s  = s_buff[i];
 
     device const float * A        = (device const float *) ((device const char *) src3 + ir*args.nb31); // {1, nh}
     device const float * x_block  = (device const float *) ((device const char *) src1 + i1*nb10 + ir*args.nb11 + i3*args.nb13);
     device const float * dt_block = (device const float *) ((device const char *) src2 + ir*nb20 + i3*args.nb22);
-    device const float * B_block  = (device const float *) ((device const char *) src4 + (ir & (ng - 1))*args.nb41 + i3*args.nb43);
-    device const float * C_block  = (device const float *) ((device const char *) src5 + (ir & (ng - 1))*args.nb51 + i3*args.nb53);
+    device const float * B_block  = (device const float *) ((device const char *) src4 + g*args.nb41 + i3*args.nb43);
+    device const float * C_block  = (device const float *) ((device const char *) src5 + g*args.nb51 + i3*args.nb53);
     device       float * y_block  = (device       float *) ((device       char *) dst  + (i1 + ir*(nr) + i3*(n_t*nh*nr))*nb00);
 
     for (int64_t i2 = 0; i2 < n_t; ++i2) {


### PR DESCRIPTION
This fixes a problem noticed by @gabe-l-hart in <https://github.com/ggml-org/llama.cpp/pull/15507#issuecomment-3229522604>.

The upstream implementation of the SSM scan [repeats the grouped parts of B and C](<https://github.com/state-spaces/mamba/blob/19072dca90f8ff71bc8e96967ca4e0fedc319a0a/mamba_ssm/ops/selective_scan_interface.py#L157>) like `repeat_interleave` behaves instead of like `repeat`.

Since most Mamba2 models use `n_groups == 1`, and that Mamba-Codestral-7B-v0.1 (which uses `n_groups == 8`) had a non-extreme perplexity, this was not really noticed until <https://github.com/ggml-org/llama.cpp/pull/15507>.

On CPU, this reduces the perplexity of a `Q8_0` [Mamba-Codestral-7B-v0.1](<https://huggingface.co/mistralai/Mamba-Codestral-7B-v0.1>) on the first 10 chunks of `wiki.test.raw` quite a lot:

Before:
```
[1]8.2788,[2]10.8075,[3]12.6548,[4]14.6535,[5]14.1671,[6]14.0561,[7]14.6714,[8]14.8880,[9]15.2977,[10]16.1435,
Final estimate: PPL = 16.1435 +/- 0.88152
```

After:
```
[1]5.2122,[2]6.4318,[3]7.0763,[4]8.0914,[5]8.1234,[6]8.1319,[7]8.4960,[8]8.6492,[9]8.7738,[10]9.1851,
Final estimate: PPL = 9.1851 +/- 0.46159
```

To be clear, there's **no need for reconversion** of the affected models because this is purely a problem in the `SSM_SCAN` operation.

However, if `imatrix` was used, it would make sense to recompute that.

# TODO:

- [x] Test with Metal
- [x] Test with CUDA

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
