### PR TITLE
batch : add `pad_equal` [RFC]

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1338,10 +1338,6 @@ ggml_cgraph * llama_context::graph_reserve(uint32_t n_tokens, uint32_t n_seqs, u
     // when the scheduler is reset, we cannnot reuse the old graph, so we reset the previous graph result to prevent that
     gf_res_prev->reset();
 
-    // store the n_outputs as it is, and restore it afterwards
-    // TODO: not sure if needed, might simplify in the future by removing this
-    const auto save_n_outputs = this->n_outputs;
-
     this->n_outputs = n_outputs;
 
     llama_batch_allocr balloc(model.hparams.n_pos_per_embd());
@@ -1354,8 +1350,6 @@ ggml_cgraph * llama_context::graph_reserve(uint32_t n_tokens, uint32_t n_seqs, u
     res->reset();
 
     auto * gf = model.build_graph(gparams);
-
-    this->n_outputs = save_n_outputs;
 
     // initialize scheduler with the specified graph
     if (!ggml_backend_sched_reserve(sched.get(), gf)) {


### PR DESCRIPTION
Since we now support better parallelization of the attention via "streams" (see #14363) I was planning to add an alternative approach for computing multi-sequence embeddings. However, I am starting to doubt it would have any benefit compared to the existing method, so opening this PR/discussion for feedback.

### Existing approach

Currently we put all tokens from all sequences in a single `ubatch` and process this with a masked cross-sequence attention in a single stream. For example the ubatch of 4 sequences with different lengths could looks like this:

```bash
000000000011122222222222222233333
```

### New approach

The idea that I had, which I believe other implementation also use, is to pad the sequences to an equal length:

```bash
# x is a padding token - i.e. it does not attend to nothing and is not attended by any
0000000000xxxxx
111xxxxxxxxxxxx
222222222222222
33333xxxxxxxxxx
```

We can process this batch with 4 streams in the attention.

### Observations

- The new approach _might_ be a bit more efficient, though with embeddings we usually have relatively short sequences anyway. So probably the performance would be fine either way
- The computation in the non-attention operators (FFN, norms, etc.) will increase because of the extra padding tokens
- The logic for passing the `llama_encode()` input batch would become more complicated for the user because they have to take into account the padding in order to not exceed `n_ubatch` when it is applied
- Note that the reason we cannot use the existing `split_equal()` approach is because non-causal encoding requires to process all tokens of a sequence in a single ubatch

If you have any thoughts about this let me know. For now, will probably postpone this until I'm more convinced it would be useful.