### PR TITLE
utils : add t_max_predict_ms param to set prediction phase time limit to cli

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1775,6 +1775,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sparam());
     add_opt(common_arg(
+        {"--t-max-predict-ms"}, "MILLISECONDS",
+        string_format("time limit in ms for prediction phase; triggers if generation exceeds this time and a new-line was generated (default: %ld)", params.t_max_predict_ms),
+        [](common_params & params, const std::string & value) {
+            params.t_max_predict_ms = std::stoll(value);
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-s", "--seed"}, "SEED",
         string_format("RNG seed (default: %d, use random seed for %d)", params.sampling.seed, LLAMA_DEFAULT_SEED),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -347,6 +347,7 @@ struct common_params {
     int32_t control_vector_layer_end   = -1; // layer range for control vector
     bool    offline                    = false;
 
+    int64_t t_max_predict_ms= 0;     // max time in ms to predict after first new line (0 = unlimited)
     int32_t ppl_stride      = 0;     // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.
     int32_t ppl_output_type = 0;     // = 0 -> ppl output is as usual, = 1 -> ppl output is num_tokens, ppl, one per line
                                      //                                       (which is more convenient to use for plotting)


### PR DESCRIPTION
This is an attempt to solve my own feature request: #15654

Pretty much just tries to duplicate the same feature from sever.


But I haven't written any C++ since I did some Gamecube Homebrew alllllong time ago... so would be happy for someone who knows what they are doing to do a better job.