### PR TITLE
CUDA: fix bug in rms_norm fusion

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2827,7 +2827,7 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
         const ggml_tensor *add      = nullptr;
 
         if (ops.size() == 3 && ops.begin()[2] == GGML_OP_ADD) {
-            add = cgraph->nodes[node_idx+1];
+            add = cgraph->nodes[node_idx+2];
         }
 
         GGML_ASSERT(rms_norm->src[0]->type == GGML_TYPE_F32);

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -187,7 +187,7 @@ static __global__ void rms_norm_f32(const float * x, float *       dst,
             dst[col] = scale * x[col] * mul[mul_col];
         } else if constexpr (do_add) {
             const int add_col = col % add_ncols;
-            dst[col] += add[add_col];
+            dst[col] = scale * x[col] + add[add_col];
         } else {
             dst[col] = scale * x[col];
         }

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -127,6 +127,7 @@ static __global__ void rms_norm_f32(const float * x, float *       dst,
                                     const int     add_nrows          = 0,
                                     const int     add_nchannels      = 0,
                                     const int     add_nsamples       = 0) {
+
     const int nrows     = gridDim.x;
     const int nchannels = gridDim.y;
 
@@ -134,6 +135,8 @@ static __global__ void rms_norm_f32(const float * x, float *       dst,
     const int channel   = blockIdx.y;
     const int sample    = blockIdx.z;
     const int tid       = threadIdx.x;
+
+    static_assert(!do_add || do_multiply, "fusing add is not supported without multiplying");
 
     x   += sample*stride_sample + channel*stride_channel + row*stride_row;
     dst += ((sample*nchannels + channel)*nrows + row)*ncols;
@@ -185,9 +188,6 @@ static __global__ void rms_norm_f32(const float * x, float *       dst,
         } else if constexpr (do_multiply) {
             const int mul_col = col % mul_ncols;
             dst[col] = scale * x[col] * mul[mul_col];
-        } else if constexpr (do_add) {
-            const int add_col = col % add_ncols;
-            dst[col] = scale * x[col] + add[add_col];
         } else {
             dst[col] = scale * x[col];
         }


### PR DESCRIPTION
Fix bugs pointed out by @ORippler and @CISC  in #15631 

- Removed support for only having norm + add without the multiply 
- Fixed seg fault in op REPEAT because it was trying to access invalid `dst->src[I+1]`, whereas in repeat we only have 1 src
- Fixed index for add tensor when fusing ops
