### PR TITLE
vulkan : update ggml_vk_instance_validation_ext_available

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -12210,7 +12210,7 @@ static bool ggml_vk_instance_validation_ext_available() {
         }
     }
 
-    std::cerr << "ggml_vulkan: WARNING: Instance extension VK_EXT_validation_features not found." << std::endl;
+    std::cerr << "ggml_vulkan: WARNING: Validation layer or layer extension VK_EXT_validation_features not found." << std::endl;
 #endif
     return false;
 }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -12200,17 +12200,15 @@ static bool ggml_vk_instance_validation_ext_available() {
 #ifdef GGML_VULKAN_VALIDATE
     // Check if validation layer provides the extension
     const std::string layer_name = "VK_LAYER_KHRONOS_validation";
-    try {
-        for (const auto& layer : vk::enumerateInstanceLayerProperties()) {
-            if (layer_name == layer.layerName.data()) {
-                for (const auto& ext : vk::enumerateInstanceExtensionProperties(layer_name)) {
-                    if (strcmp("VK_EXT_validation_features", ext.extensionName.data()) == 0) {
-                        return true;
-                    }
+    for (const auto& layer : vk::enumerateInstanceLayerProperties()) {
+        if (layer_name == layer.layerName.data()) {
+            for (const auto& ext : vk::enumerateInstanceExtensionProperties(layer_name)) {
+                if (strcmp("VK_EXT_validation_features", ext.extensionName.data()) == 0) {
+                    return true;
                 }
             }
         }
-    } catch (...) { /* It's alright if the layer is not present */ }
+    }
 
     std::cerr << "ggml_vulkan: WARNING: Instance extension VK_EXT_validation_features not found." << std::endl;
 #endif

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4267,7 +4267,7 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     }
 }
 
-static bool ggml_vk_instance_validation_ext_available(const std::vector<vk::ExtensionProperties>& instance_extensions);
+static bool ggml_vk_instance_validation_ext_available();
 static bool ggml_vk_instance_portability_enumeration_ext_available(const std::vector<vk::ExtensionProperties>& instance_extensions);
 
 static bool ggml_vk_instance_debug_utils_ext_available(const std::vector<vk::ExtensionProperties> & instance_extensions);
@@ -4288,7 +4288,7 @@ static void ggml_vk_instance_init() {
     vk::ApplicationInfo app_info{ "ggml-vulkan", 1, nullptr, 0, api_version };
 
     const std::vector<vk::ExtensionProperties> instance_extensions = vk::enumerateInstanceExtensionProperties();
-    const bool validation_ext = ggml_vk_instance_validation_ext_available(instance_extensions);
+    const bool validation_ext = ggml_vk_instance_validation_ext_available();
 #ifdef __APPLE__
     const bool portability_enumeration_ext = ggml_vk_instance_portability_enumeration_ext_available(instance_extensions);
 #endif
@@ -12196,22 +12196,25 @@ ggml_backend_reg_t ggml_backend_vk_reg() {
 }
 
 // Extension availability
-static bool ggml_vk_instance_validation_ext_available(const std::vector<vk::ExtensionProperties>& instance_extensions) {
+static bool ggml_vk_instance_validation_ext_available() {
 #ifdef GGML_VULKAN_VALIDATE
-    bool portability_enumeration_ext = false;
-    // Check for portability enumeration extension for MoltenVK support
-    for (const auto& properties : instance_extensions) {
-        if (strcmp("VK_KHR_portability_enumeration", properties.extensionName) == 0) {
-            return true;
+    // Check if validation layer provides the extension
+    const std::string layer_name = "VK_LAYER_KHRONOS_validation";
+    try {
+        for (const auto& layer : vk::enumerateInstanceLayerProperties()) {
+            if (layer_name == layer.layerName.data()) {
+                for (const auto& ext : vk::enumerateInstanceExtensionProperties(layer_name)) {
+                    if (strcmp("VK_EXT_validation_features", ext.extensionName.data()) == 0) {
+                        return true;
+                    }
+                }
+            }
         }
-    }
-    if (!portability_enumeration_ext) {
-        std::cerr << "ggml_vulkan: WARNING: Instance extension VK_KHR_portability_enumeration not found." << std::endl;
-    }
+    } catch (...) { /* It's alright if the layer is not present */ }
+
+    std::cerr << "ggml_vulkan: WARNING: Instance extension VK_EXT_validation_features not found." << std::endl;
 #endif
     return false;
-
-    UNUSED(instance_extensions);
 }
 static bool ggml_vk_instance_portability_enumeration_ext_available(const std::vector<vk::ExtensionProperties>& instance_extensions) {
 #ifdef __APPLE__


### PR DESCRIPTION
This commit updates ggml_vk_instance_validation_ext_available() to check for VK_EXT_validation_features instead of
VK_KHR_portability_enumeration.

Based on how the returned boolean is used later in the code (to enable both the validation layer and the VK_EXT_validation_features extension), it appears the function may have been intended to check for the validation layer features extension. 

----

This is my first look at the Vulkan backend and I might be way off here...but the thing that caught my attention was the similarity between these functions [ggml_vk_instance_validation_ext_available](https://github.com/ggml-org/llama.cpp/blob/81017865ee444cf49ce0136f2be1e41a0270ff91/ggml/src/ggml-vulkan/ggml-vulkan.cpp#L12001-L12017) and
 [ggml_vk_instance_portability_enumeration_ext_available](https://github.com/ggml-org/llama.cpp/blob/81017865ee444cf49ce0136f2be1e41a0270ff91/ggml/src/ggml-vulkan/ggml-vulkan.cpp#L12018-L12034).