### PR TITLE
server: add assistant prefill to webui

### DIFF
--- a/tools/server/webui/src/Config.ts
+++ b/tools/server/webui/src/Config.ts
@@ -13,6 +13,7 @@ export const CONFIG_DEFAULT = {
   // Do not use nested objects, keep it single level. Prefix the key if you need to group them.
   apiKey: '',
   systemMessage: '',
+  assistantPrefill: '',
   showTokensPerSecond: false,
   showThoughtInProgress: false,
   excludeThoughtOnReq: true,
@@ -45,6 +46,7 @@ export const CONFIG_DEFAULT = {
 export const CONFIG_INFO: Record<string, string> = {
   apiKey: 'Set the API Key if you are using --api-key option for the server.',
   systemMessage: 'The starting message that defines how model should behave.',
+  assistantPrefill: 'Text to start the model response with.',
   pasteLongTextToFileLen:
     'On pasting long text, it will be converted to a file. You can control the file length by setting the value of this parameter. Value 0 means disable.',
   samplers:

--- a/tools/server/webui/src/components/SettingDialog.tsx
+++ b/tools/server/webui/src/components/SettingDialog.tsx
@@ -93,6 +93,11 @@ const SETTING_SECTIONS: SettingSection[] = [
         label: 'System Message (will be disabled if left empty)',
         key: 'systemMessage',
       },
+      {
+        type: SettingInputType.LONG_INPUT,
+        label: 'Model response prefill',
+        key: 'assistantPrefill',
+      },
       ...BASIC_KEYS.map(
         (key) =>
           ({
@@ -478,12 +483,12 @@ function SettingsModalLongInput({
   return (
     <label className="form-control">
       <div className="label inline text-sm">{label || configKey}</div>
-      <textarea
+      <div><textarea
         className="textarea textarea-bordered h-24 mb-2"
         placeholder={`Default: ${CONFIG_DEFAULT[configKey] || 'none'}`}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-      />
+      /></div>
     </label>
   );
 }

--- a/tools/server/webui/src/utils/app.context.tsx
+++ b/tools/server/webui/src/utils/app.context.tsx
@@ -185,7 +185,7 @@ export const AppContextProvider = ({
       type: 'text',
       timestamp: pendingId,
       role: 'assistant',
-      content: null,
+      content: config.assistantPrefill,
       parent: leafNodeId,
       children: [],
     };
@@ -201,6 +201,9 @@ export const AppContextProvider = ({
       ];
       if (config.excludeThoughtOnReq) {
         messages = filterThoughtFromMsgs(messages);
+      }
+      if (config.assistantPrefill.length !== 0) {
+          messages.push({ role: 'assistant', content: config.assistantPrefill })
       }
       if (isDev) console.log({ messages });
 


### PR DESCRIPTION
The goal of this PR is to add the ability to set an assistant prefill via the llama.cpp server webui. I am not knowledgeable at all when it comes to webdev so any help would be appreciated. The current state is that the prefill seems to work correctly for basic usage.

Current issues:

* If the server is started with `--no-prefill-assistant` the webui doesn't work properly. I think the correct behavior would not to use the prefill and to display this in the settings menu. However, the server does not expose this information.
* If the server is running a reasoning model, the prefill does not seem to be used. I think the correct behavior would be to apply the prefill to the reasoning.
* According to `npm audit` the packages should be updated due to vulnerabilities. Should this be done in this PR?