### PR TITLE
CUDA: fix build error from ambiguous __half conversions in conv2d

### DIFF
--- a/ggml/src/ggml-cuda/conv2d.cu
+++ b/ggml/src/ggml-cuda/conv2d.cu
@@ -17,15 +17,6 @@ struct kernel_bounds {
     int64_t x_min, x_max;
 };
 
-template<typename T>
-__device__ __forceinline__ float to_float(const T& val) {
-    if constexpr (std::is_same_v<T, __half>) {
-        return __half2float(val);
-    } else {
-        return val;  // Assumes T is float
-    }
-}
-
 __device__ __forceinline__ int64_t max64(int64_t a, int64_t b) {
     return (a > b) ? a : b;
 }
@@ -104,7 +95,7 @@ static __global__ void conv2d_kernel(const float * __restrict__ input,
 
                 const float input_val = input[Layout::input_index(n, c_in, in_y, in_x, P)];
                 const T kernel_val = kernel[Layout::kernel_index(c_out, c_in, ky, kx, P)];
-                acc += (input_val * to_float(kernel_val));
+                acc += (input_val * ggml_cuda_cast<float, T>(kernel_val));
             }
         }
     }

--- a/ggml/src/ggml-cuda/conv2d.cu
+++ b/ggml/src/ggml-cuda/conv2d.cu
@@ -96,7 +96,7 @@ static __global__ void conv2d_kernel(const float * __restrict__ input,
 
                 const float input_val = input[Layout::input_index(n, c_in, in_y, in_x, P)];
                 const T kernel_val = kernel[Layout::kernel_index(c_out, c_in, ky, kx, P)];
-                acc += (input_val * ggml_cuda_cast<float, T>(kernel_val));
+                acc += (input_val * ggml_cuda_cast<float>(kernel_val));
             }
         }
     }

--- a/ggml/src/ggml-cuda/conv2d.cu
+++ b/ggml/src/ggml-cuda/conv2d.cu
@@ -1,4 +1,5 @@
 #include "conv2d.cuh"
+#include "convert.cuh"
 
 struct conv_params {
     const int64_t IW, IH;

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -34,6 +34,8 @@ template<typename dst_t, typename src_t>
  __host__ __device__ inline dst_t ggml_cuda_cast(src_t x) {
     if constexpr (std::is_same_v<dst_t, src_t>) {
         return x;
+    } else if constexpr (std::is_same_v<dst_t, float> && std::is_same_v<src_t, half>) {
+        return __half2float(x);
     } else if constexpr(std::is_same_v<dst_t, nv_bfloat16>) {
         return __float2bfloat16(float(x));
     } else if constexpr(std::is_same_v<src_t, nv_bfloat16>) {

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -34,8 +34,6 @@ template<typename dst_t, typename src_t>
  __host__ __device__ inline dst_t ggml_cuda_cast(src_t x) {
     if constexpr (std::is_same_v<dst_t, src_t>) {
         return x;
-    } else if constexpr (std::is_same_v<dst_t, float> && std::is_same_v<src_t, half>) {
-        return __half2float(x);
     } else if constexpr(std::is_same_v<dst_t, nv_bfloat16>) {
         return __float2bfloat16(float(x));
     } else if constexpr(std::is_same_v<src_t, nv_bfloat16>) {


### PR DESCRIPTION
Building conv2d with half precision failed because `__half` defines multiple implicit conversion operators (to float, int, short, etc.), causing ambiguous overload resolution when multiplying with float.

~~Introduce a templated `to_float` helper that explicitly converts `__half` via `__half2float`, while passing through float unchanged. Use this helper in conv2d accumulation to ensure unambiguous and correct promotion to float.~~

Use ggml_cuda_cast from convert.cuh for casting the value to float instead.

Fixes some build errors with half-precision kernels on CUDA.

