### PR TITLE
llama: fix -fa auto for multiple GPUs

### DIFF
--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -196,7 +196,8 @@ public:
     ggml_status graph_compute(ggml_cgraph * gf, bool batched);
 
     // reserve a graph with a dummy ubatch of the specified size
-    ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx);
+    // optionally allocate the graph so that tensor backend assignments can be retrieved
+    ggml_cgraph * graph_reserve(uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool alloc = false);
 
 private:
     llm_graph_params graph_params(


### PR DESCRIPTION
Fixes `-fa auto` for multiple GPUs, the problem is that the same compute graph is being passed to `ggml_backend_sched` twice, see https://github.com/ggml-org/llama.cpp/pull/15434#issuecomment-3239630372 . This PR extends `llama_context::graph_reserve` with a flag `alloc` so that the graph is only used once.