### PR TITLE
CANN: Support ext_factor in rope

### DIFF
--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2401,14 +2401,8 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
         }
         case GGML_OP_ROPE: {
             // TODO: with ops-test v == 1
-            float ext_factor = 0.0f;
-            memcpy(&ext_factor, (const float *) op->op_params + 7, sizeof(float));
             // TODO: n_dims <= ne0
             if (op->src[0]->ne[0] != op->op_params[1]) {
-                return false;
-            }
-            // TODO: ext_factor != 0
-            if (ext_factor != 0) {
                 return false;
             }
 
@@ -2420,9 +2414,6 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
                 return false;
             }
 
-            if(!ggml_is_contiguous(op->src[0])){
-                return false;
-            }
             return true;
         }
         case GGML_OP_UPSCALE: {
@@ -2521,13 +2512,6 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
             }
             if (op->src[1]->ne[0] != op->src[2]->ne[0]) {
                 // different head sizes of K and V are not supported yet
-                return false;
-            }
-            if (op->src[0]->ne[0] == 192) {
-                return false;
-            }
-            if (op->src[0]->ne[0] == 576) {
-                // DeepSeek MLA
                 return false;
             }
             if (op->src[0]->ne[0] % 16 != 0) {


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

./bin/test-backend-ops -b CANN0 -o ROPE
Testing 3 devices
Backend 1/3: CANN0
  Device description: Ascend910B4
  Device memory: 30196 MB (29802 MB free)
  11837/11837 tests passed
  Backend CANN0: OK
Backend 2/3: CANN1
  Skipping
Backend 3/3: CPU
  Skipping
3/3 backends passed
OK

Test it with DeepSeek-V2-Lite
```
llama_perf_sampler_print:    sampling time =     150.96 ms /   810 runs   (    0.19 ms per token,  5365.73 tokens per second)
llama_perf_context_print:        load time =   20965.59 ms
llama_perf_context_print: prompt eval time =     247.80 ms /    17 tokens (   14.58 ms per token,    68.60 tokens per second)
llama_perf_context_print:        eval time =   18359.62 ms /   792 runs   (   23.18 ms per token,    43.14 tokens per second)
llama_perf_context_print:       total time =   19236.89 ms /   809 tokens
llama_perf_context_print:    graphs reused =        789
```