### PR TITLE
CANN: Support eager execution mode under ACL graph compilation

### DIFF
--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -314,3 +314,7 @@ Controls automatic cleanup of the memory pool. This option is only effective whe
 
 Converting the matmul weight format from ND to NZ can significantly improve performance on the 310I DUO NPU.
 
+### GGML_CANN_EAGER_MODE
+
+Enabling eager execution mode will bypass ACL graph execution and submit operators directly.  
+This is useful for debugging or scenarios where graph building overhead is undesirable.

--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -316,5 +316,5 @@ Converting the matmul weight format from ND to NZ can significantly improve perf
 
 ### GGML_CANN_EAGER_MODE
 
-Enabling eager execution mode will bypass ACL graph execution and submit operators directly.  
+Enabling eager execution mode will bypass ACL graph execution and submit operators directly.
 This is useful for debugging or scenarios where graph building overhead is undesirable.

--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -314,7 +314,7 @@ Controls automatic cleanup of the memory pool. This option is only effective whe
 
 Converting the matmul weight format from ND to NZ can significantly improve performance on the 310I DUO NPU.
 
-### GGML_CANN_EAGER_MODE
+### GGML_CANN_DISABLE_ACL_GRAPH
 
-Enabling eager execution mode will bypass ACL graph execution and submit operators directly.
-This is useful for debugging or scenarios where graph building overhead is undesirable.
+When this variable is set, ACL graph execution is disabled and operators are executed in an op-by-op (eager) mode.
+This mode is mainly intended for debugging or for cases where the overhead of graph construction and execution is not desirable.

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -395,16 +395,15 @@ struct ggml_backend_cann_context {
 #ifdef USE_ACL_GRAPH
     /// Cached CANN ACL graph used for executing the current ggml computation graph.
     std::unique_ptr<ggml_cann_graph> cann_graph;
+    bool acl_graph_mode = true;
 #endif
     cann_task_queue task_queue;
     bool async_mode;
-    bool eager_mode; // not use acl graph
     // Rope Cache
     ggml_cann_rope_cache rope_cache;
     // Constant Pool
     ggml_cann_tensor_cache rms_norm_one_tensor_cache;
     ggml_cann_tensor_cache rms_norm_zero_tensor_cache;
-
 
     aclrtStream streams[GGML_CANN_MAX_STREAMS] = {nullptr}; /**< Array of streams for the device. */
 
@@ -420,10 +419,13 @@ struct ggml_backend_cann_context {
         async_mode = parse_bool(get_env("GGML_CANN_ASYNC_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
             device, async_mode ? "ON" : "OFF");
-
-        eager_mode = parse_bool(get_env("GGML_CANN_EAGER_MODE").value_or(""));
-        GGML_LOG_INFO("%s: device %d eager execution mode is %s (acl graph disabled)\n",
-              __func__, device, eager_mode ? "ON" : "OFF");
+#ifdef USE_ACL_GRAPH
+        acl_graph_mode = !(parse_bool(get_env("GGML_CANN_DISABLE_ACL_GRAPH").value_or("")));
+        GGML_LOG_INFO("%s: device %d execution mode is %s (%s)\n",
+              __func__, device,
+              acl_graph_mode ? "GRAPH" : "EAGER",
+              acl_graph_mode ? "acl graph enabled" : "acl graph disabled");
+#endif
     }
 
     /**

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -420,7 +420,7 @@ struct ggml_backend_cann_context {
         async_mode = parse_bool(get_env("GGML_CANN_ASYNC_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
             device, async_mode ? "ON" : "OFF");
-        
+
         eager_mode = parse_bool(get_env("GGML_CANN_EAGER_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d eager execution mode is %s (acl graph disabled)\n",
               __func__, device, eager_mode ? "ON" : "OFF");

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -398,6 +398,7 @@ struct ggml_backend_cann_context {
 #endif
     cann_task_queue task_queue;
     bool async_mode;
+    bool eager_mode; // not use acl graph
     // Rope Cache
     ggml_cann_rope_cache rope_cache;
     // Constant Pool
@@ -419,6 +420,10 @@ struct ggml_backend_cann_context {
         async_mode = parse_bool(get_env("GGML_CANN_ASYNC_MODE").value_or(""));
         GGML_LOG_INFO("%s: device %d async operator submission is %s\n", __func__,
             device, async_mode ? "ON" : "OFF");
+        
+        eager_mode = parse_bool(get_env("GGML_CANN_EAGER_MODE").value_or(""));
+        GGML_LOG_INFO("%s: device %d eager execution mode is %s (acl graph disabled)\n",
+              __func__, device, eager_mode ? "ON" : "OFF");
     }
 
     /**

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2252,6 +2252,10 @@ static enum ggml_status ggml_backend_cann_graph_compute(
     bool use_cann_graph = true;
     bool cann_graph_update_required = false;
 
+    if (cann_ctx->eager_mode) {
+        use_cann_graph = false;
+    }
+
     if (use_cann_graph) {
         if (cann_ctx->cann_graph == nullptr) {
             cann_ctx->cann_graph.reset(new ggml_cann_graph());

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2252,7 +2252,7 @@ static enum ggml_status ggml_backend_cann_graph_compute(
     bool use_cann_graph = true;
     bool cann_graph_update_required = false;
 
-    if (cann_ctx->eager_mode) {
+    if (!cann_ctx->acl_graph_mode) {
         use_cann_graph = false;
     }
 


### PR DESCRIPTION
Add support for running operators in eager mode while ACL graph compilation is enabled. This allows bypassing graph execution and directly submitting ops, which is useful for debugging and reducing graph build overhead in certain scenarios.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
