### PR TITLE
ggml-backend: raise GGML_MAX_SPLIT_INPUTS

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -651,7 +651,7 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #endif
 
 #ifndef GGML_SCHED_MAX_SPLIT_INPUTS
-#define GGML_SCHED_MAX_SPLIT_INPUTS GGML_MAX_SRC
+#define GGML_SCHED_MAX_SPLIT_INPUTS 30
 #endif
 
 #ifndef GGML_SCHED_MAX_COPIES


### PR DESCRIPTION
With FlashAttention enabled Gemma 3n can crash when using many GPUs due to `GGML_MAX_SPLIT_INPUTS` being too low, see https://github.com/ggml-org/llama.cpp/pull/15434#issuecomment-3243129756 . The maximum value with which I can provoke the issue is 19 when using 6 GPUs. This PR sets the value to 30 so that there is some margin above this value.