### PR TITLE
convert : use reflinks for faster conversion

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -97,6 +97,7 @@ class ModelBase:
     is_big_endian: bool
     endianess: gguf.GGUFEndian
     use_temp_file: bool
+    use_reflinks: bool
     lazy: bool
     dry_run: bool
     hparams: dict[str, Any]
@@ -141,6 +142,7 @@ class ModelBase:
         self.is_big_endian = is_big_endian
         self.endianess = gguf.GGUFEndian.BIG if is_big_endian else gguf.GGUFEndian.LITTLE
         self.use_temp_file = use_temp_file
+        self.use_reflinks = use_reflinks
         self.lazy = not eager or (remote_hf_model_id is not None)
         self.dry_run = dry_run
         self.remote_hf_model_id = remote_hf_model_id
@@ -156,7 +158,7 @@ class ModelBase:
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
                                            split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard,
-                                           use_reflinks=use_reflinks)
+                                           use_reflinks=self.use_reflinks)
 
         # Mistral specific
         self.disable_mistral_community_chat_template = disable_mistral_community_chat_template
@@ -225,7 +227,7 @@ class ModelBase:
             logger.info(f"gguf: indexing model part '{part_name}'")
             ctx: ContextManager[Any]
             if is_safetensors:
-                ctx = cast(ContextManager[Any], gguf.utility.SafetensorsLocal(self.dir_model / part_name))
+                ctx = cast(ContextManager[Any], gguf.utility.SafetensorsLocal(self.dir_model / part_name, reflink=self.use_reflinks))
             else:
                 ctx = contextlib.nullcontext(torch.load(str(self.dir_model / part_name), map_location="cpu", mmap=True, weights_only=True))
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11,6 +11,7 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from hashlib import sha256
@@ -76,6 +77,14 @@ class ModelType(IntEnum):
 AnyModel = TypeVar("AnyModel", bound="type[ModelBase]")
 
 
+@dataclass
+class ModelTensorInfo:
+    load: Callable[[], Tensor]
+    src_type: str
+    src_qtype: gguf.GGMLQuantizationType | None = None
+    dst_qtype: gguf.GGMLQuantizationType | None = None
+
+
 class ModelBase:
     _model_classes: dict[ModelType, dict[str, type[ModelBase]]] = {
         ModelType.TEXT: {},
@@ -91,7 +100,7 @@ class ModelBase:
     lazy: bool
     dry_run: bool
     hparams: dict[str, Any]
-    model_tensors: dict[str, Callable[[], Tensor]]
+    model_tensors: dict[str, ModelTensorInfo]
     gguf_writer: gguf.GGUFWriter
     model_name: str | None
     metadata_override: Path | None
@@ -116,7 +125,8 @@ class ModelBase:
                  split_max_tensors: int = 0, split_max_size: int = 0, dry_run: bool = False,
                  small_first_shard: bool = False, hparams: dict[str, Any] | None = None, remote_hf_model_id: str | None = None,
                  disable_mistral_community_chat_template: bool = False,
-                 sentence_transformers_dense_modules: bool = False):
+                 sentence_transformers_dense_modules: bool = False,
+                 use_reflinks: bool = False):
         if type(self) is ModelBase or \
                 type(self) is TextModel or \
                 type(self) is MmprojModel:
@@ -141,22 +151,12 @@ class ModelBase:
         self.model_name = model_name
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
 
-        # Apply heuristics to figure out typical tensor encoding based on first layer tensor encoding type
-        if self.ftype == gguf.LlamaFileType.GUESSED:
-            # NOTE: can't use field "torch_dtype" in config.json, because some finetunes lie.
-            _, first_tensor = next(self.get_tensors())
-            if first_tensor.dtype == torch.float16:
-                logger.info(f"choosing --outtype f16 from first tensor type ({first_tensor.dtype})")
-                self.ftype = gguf.LlamaFileType.MOSTLY_F16
-            else:
-                logger.info(f"choosing --outtype bf16 from first tensor type ({first_tensor.dtype})")
-                self.ftype = gguf.LlamaFileType.MOSTLY_BF16
-
         self.dequant_model()
 
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
-                                           split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard)
+                                           split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard,
+                                           use_reflinks=use_reflinks)
 
         # Mistral specific
         self.disable_mistral_community_chat_template = disable_mistral_community_chat_template
@@ -175,8 +175,8 @@ class ModelBase:
             return None
         raise KeyError(f"could not find any of: {keys}")
 
-    def index_tensors(self, remote_hf_model_id: str | None = None) -> dict[str, Callable[[], Tensor]]:
-        tensors: dict[str, Callable[[], Tensor]] = {}
+    def index_tensors(self, remote_hf_model_id: str | None = None) -> dict[str, ModelTensorInfo]:
+        tensors: dict[str, ModelTensorInfo] = {}
 
         if remote_hf_model_id is not None:
             is_safetensors = True
@@ -184,7 +184,14 @@ class ModelBase:
             logger.info(f"Using remote model with HuggingFace id: {remote_hf_model_id}")
             remote_tensors = gguf.utility.SafetensorRemote.get_list_tensors_hf_model(remote_hf_model_id)
             for name, remote_tensor in remote_tensors.items():
-                tensors[name] = lambda r=remote_tensor: LazyTorchTensor.from_remote_tensor(r)
+                dtype = LazyTorchTensor._dtype_str_map[remote_tensor.dtype]
+                qtype = LazyTorchTensor._qtype_map.get(dtype)
+                tensors[name] = ModelTensorInfo(
+                    load=lambda r=remote_tensor: LazyTorchTensor.from_remote_tensor(r),
+                    src_type=str(dtype),
+                    src_qtype=qtype,
+                    dst_qtype=qtype,
+                )
 
             return tensors
 
@@ -228,18 +235,25 @@ class ModelBase:
                 for name in model_part.keys():
                     if is_safetensors:
                         data: gguf.utility.LocalTensor = model_part[name]
+                        dtype = LazyTorchTensor._dtype_str_map[data.dtype]
                         if self.lazy:
                             data_gen = lambda data=data: LazyTorchTensor.from_local_tensor(data)  # noqa: E731
                         else:
-                            dtype = LazyTorchTensor._dtype_str_map[data.dtype]
                             data_gen = lambda data=data, dtype=dtype: torch.from_numpy(data.mmap_bytes()).view(dtype).reshape(data.shape)  # noqa: E731
                     else:
                         data_torch: Tensor = model_part[name]
+                        dtype = data_torch.dtype
                         if self.lazy:
                             data_gen = lambda data=data_torch: LazyTorchTensor.from_eager(data)  # noqa: E731
                         else:
                             data_gen = lambda data=data_torch: data  # noqa: E731
-                    tensors[name] = data_gen
+                    qtype = LazyTorchTensor._qtype_map.get(dtype)
+                    tensors[name] = ModelTensorInfo(
+                        load=data_gen,
+                        src_type=str(dtype),
+                        src_qtype=qtype,
+                        dst_qtype=qtype,
+                    )
 
         # verify tensor name presence and identify potentially missing files
         if len(tensor_names_from_index) > 0:
@@ -260,7 +274,7 @@ class ModelBase:
 
     def dequant_model(self):
         tensors_to_remove: list[str] = []
-        new_tensors: dict[str, Callable[[], Tensor]] = {}
+        new_tensors: dict[str, ModelTensorInfo] = {}
 
         if (quant_config := self.hparams.get("quantization_config")) and isinstance(quant_config, dict):
             quant_method = quant_config.get("quant_method")
@@ -338,7 +352,12 @@ class ModelBase:
                         weight_name = name.removesuffix("_scale")
                         w = self.model_tensors[weight_name]
                         s = self.model_tensors[name]
-                        self.model_tensors[weight_name] = lambda w=w, s=s: dequant_bitnet(w(), s())
+                        self.model_tensors[weight_name] = ModelTensorInfo(
+                            load=lambda w=w, s=s: dequant_bitnet(w.load(), s.load()),
+                            src_type="bitnet",
+                            src_qtype=gguf.GGMLQuantizationType.F32,
+                            dst_qtype=gguf.GGMLQuantizationType.TQ1_0,
+                        )
                         tensors_to_remove.append(name)
             elif quant_method == "fp8":
                 for name in self.model_tensors.keys():
@@ -346,9 +365,15 @@ class ModelBase:
                         weight_name = name.removesuffix("_scale_inv")
                         w = self.model_tensors[weight_name]
                         s = self.model_tensors[name]
-                        self.model_tensors[weight_name] = lambda w=w, s=s: dequant_simple(w(), s())
+                        self.model_tensors[weight_name] = ModelTensorInfo(
+                            load=lambda w=w, s=s: dequant_simple(w.load(), s.load()),
+                            src_type=w.src_type,
+                            src_qtype=gguf.GGMLQuantizationType.F32,
+                            dst_qtype=gguf.GGMLQuantizationType.BF16, # TODO: change to FP8 once natively supported
+                        )
                         tensors_to_remove.append(name)
             elif quant_method == "gptq":
+                bits = quant_config["bits"]
                 for name in self.model_tensors.keys():
                     if name.endswith(".qweight"):
                         base_name = name.removesuffix(".qweight")
@@ -356,10 +381,13 @@ class ModelBase:
                         qweight = self.model_tensors[base_name + ".qweight"]
                         qzeros = self.model_tensors[base_name + ".qzeros"]
                         scales = self.model_tensors[base_name + ".scales"]
-                        new_tensors[base_name + ".weight"] = (
-                            lambda g=g_idx, z=qzeros, w=qweight, s=scales: dequant_gptq(
-                                g(), w(), z(), s()
-                            )
+                        new_tensors[base_name + ".weight"] = ModelTensorInfo(
+                            load=lambda g=g_idx, z=qzeros, w=qweight, s=scales: dequant_gptq(
+                                g.load(), w.load(), z.load(), s.load()
+                            ),
+                            src_type=f"GPTQ-{bits}bit",
+                            src_qtype=gguf.GGMLQuantizationType.F32,
+                            dst_qtype=gguf.GGMLQuantizationType.Q8_0 if bits == 8 else gguf.GGMLQuantizationType.Q4_1,
                         )
                         tensors_to_remove += [
                             base_name + n
@@ -381,8 +409,8 @@ class ModelBase:
             self.model_tensors[name] = value
 
     def get_tensors(self) -> Iterator[tuple[str, Tensor]]:
-        for name, gen in self.model_tensors.items():
-            yield name, gen()
+        for name, t in self.model_tensors.items():
+            yield name, t.load()
 
     def format_tensor_name(self, key: gguf.MODEL_TENSOR, bid: int | None = None, suffix: str = ".weight") -> str:
         if key not in gguf.MODEL_TENSORS[self.model_arch]:
@@ -437,10 +465,12 @@ class ModelBase:
             if name.endswith((".attention.masked_bias", ".attention.bias", ".rotary_emb.inv_freq")):
                 continue
 
-            old_dtype = data_torch.dtype
+            tensor_info = self.model_tensors.get(name)
+            old_dtype: str = tensor_info.src_type if tensor_info is not None else str(data_torch.dtype)
 
             # convert any unsupported data types to float32
-            if data_torch.dtype not in (torch.float16, torch.float32):
+            # TODO: handle pre-quantized tensors for repacking
+            if data_torch.dtype not in (torch.float16, torch.bfloat16, torch.float32):
                 data_torch = data_torch.to(torch.float32)
 
             # use the first number-like part of the tensor name as the block id
@@ -451,8 +481,16 @@ class ModelBase:
                     break
 
             for new_name, data_torch in (self.modify_tensors(data_torch, name, bid)):
-                # TODO: why do we squeeze here?
-                # data = data_torch.squeeze().numpy()
+                old_qtype = LazyTorchTensor._qtype_map[data_torch.dtype]
+
+                # workaround BF16 not being supported by Numpy
+                if data_torch.dtype == torch.bfloat16:
+                    data_torch = data_torch.view(torch.uint8)
+
+                # if data ends up empty, it means data_torch was a scalar tensor -> restore
+                if len(data_torch.shape) == 0:
+                    data_torch = data_torch.reshape(1)
+
                 data = data_torch.numpy()
 
                 n_dims = len(data.shape)
@@ -523,15 +561,23 @@ class ModelBase:
                         data_qtype = gguf.GGMLQuantizationType.TQ1_0
                     elif self.ftype == gguf.LlamaFileType.MOSTLY_TQ2_0:
                         data_qtype = gguf.GGMLQuantizationType.TQ2_0
+                    elif self.ftype == gguf.LlamaFileType.GUESSED:
+                        data_qtype = old_qtype if tensor_info is None or tensor_info.dst_qtype is None else tensor_info.dst_qtype
                     else:
                         raise ValueError(f"Unknown file type: {self.ftype.name}")
 
-                try:
-                    data = gguf.quants.quantize(data, data_qtype)
-                except gguf.QuantError as e:
-                    logger.warning("%s, %s", e, "falling back to F16")
-                    data_qtype = gguf.GGMLQuantizationType.F16
-                    data = gguf.quants.quantize(data, data_qtype)
+                if old_qtype != data_qtype:
+                    if old_qtype not in (
+                        gguf.GGMLQuantizationType.F32,
+                        gguf.GGMLQuantizationType.F16,
+                    ):
+                        data = gguf.quants.dequantize(data, old_qtype)
+                    try:
+                        data = gguf.quants.quantize(data, data_qtype)
+                    except gguf.QuantError as e:
+                        logger.warning("%s, %s", e, "falling back to F16")
+                        data_qtype = gguf.GGMLQuantizationType.F16
+                        data = gguf.quants.quantize(data, data_qtype)
 
                 shape = gguf.quant_shape_from_byte_shape(data.shape, data_qtype) if data.dtype == np.uint8 else data.shape
 
@@ -679,8 +725,24 @@ class TextModel(ModelBase):
         super().prepare_metadata(vocab_only=vocab_only)
 
         total_params = self.gguf_writer.get_total_parameter_count()[0]
+
+        # Apply heuristics to figure out typical tensor encoding based on first layer tensor encoding type
+        # TODO: get type name from `quantization_config` field when present?
+        if self.ftype == gguf.LlamaFileType.GUESSED:
+            # NOTE: can't use field "torch_dtype" in config.json, because some finetunes lie.
+            _, first_tensor = next(self.get_tensors())
+            logger.info(f"first tensor type is {first_tensor.dtype}")
+            if first_tensor.dtype == torch.float16:
+                ftype = gguf.LlamaFileType.MOSTLY_F16
+            elif first_tensor.dtype == torch.bfloat16:
+                ftype = gguf.LlamaFileType.MOSTLY_BF16
+            else:
+                ftype = gguf.LlamaFileType.ALL_F32
+        else:
+            ftype = self.ftype
+
         # Extract the encoding scheme from the file type name. e.g. 'gguf.LlamaFileType.MOSTLY_Q8_0' --> 'Q8_0'
-        output_type: str = self.ftype.name.partition("_")[2]
+        output_type: str = ftype.name.partition("_")[2]
 
         # Filename Output
         if self.fname_out.is_dir():
@@ -9982,12 +10044,20 @@ class LazyTorchTensor(gguf.LazyBase):
         "F8_E5M2": torch.float8_e5m2,
     }
 
+    _qtype_map: dict[torch.dtype, gguf.GGMLQuantizationType] = {
+        torch.float64: gguf.GGMLQuantizationType.F64,
+        torch.float32: gguf.GGMLQuantizationType.F32,
+        torch.float16: gguf.GGMLQuantizationType.F16,
+        torch.bfloat16: gguf.GGMLQuantizationType.BF16,
+    }
+
     def numpy(self) -> gguf.LazyNumpyTensor:
         dtype = self._dtype_map[self.dtype]
         return gguf.LazyNumpyTensor(
             meta=gguf.LazyNumpyTensor.meta_with_dtype_and_shape(dtype, self.shape),
             args=(self,),
-            func=(lambda s: s.numpy())
+            func=(lambda s: s.numpy()),
+            ranges=self._ranges
         )
 
     @classmethod
@@ -10008,7 +10078,7 @@ class LazyTorchTensor(gguf.LazyBase):
             return torch.from_numpy(tensor.mmap_bytes()).view(dtype).reshape(tensor.shape)
         dtype = cls._dtype_str_map[t.dtype]
         shape = t.shape
-        lazy = cls(meta=cls.meta_with_dtype_and_shape(dtype, shape), args=(t,), func=lambda r: load_tensor(r))
+        lazy = cls(meta=cls.meta_with_dtype_and_shape(dtype, shape), args=(t,), func=lambda r: load_tensor(r), ranges=(t.data_range,))
         return cast(torch.Tensor, lazy)
 
     @classmethod
@@ -10029,7 +10099,27 @@ class LazyTorchTensor(gguf.LazyBase):
         if func is torch.Tensor.numpy:
             return args[0].numpy()
 
-        return cls._wrap_fn(func)(*args, **kwargs)
+        result = cls._wrap_fn(func)(*args, **kwargs)
+
+        def get_dim(index: int, key: str = "dim", default: int = 0, args=args, kwargs=kwargs) -> int:
+            # TODO: handle negative dim
+            if len(args) > index:
+                return args[index]
+            else:
+                return kwargs.get(key, default)
+
+        # Track file ranges
+        # TODO: handle tensor splits (with torch.split, torch.chunk, and torch.__getitem__)
+        if isinstance(result, LazyTorchTensor):
+            if isinstance(args[0], LazyTorchTensor):
+                if func is torch.Tensor.to and not isinstance(args[1], torch.dtype):
+                    result._ranges = args[0]._ranges
+            if func is torch.stack and get_dim(1) == 0:
+                if all(isinstance(t, LazyTorchTensor) and len(t._ranges) > 0 for t in args[0]):
+                    # collect ranges of all stacked tensors
+                    result._ranges = tuple(r for t in args[0] for r in t._ranges)
+
+        return result
 
 
 def parse_args() -> argparse.Namespace:
@@ -10044,8 +10134,8 @@ def parse_args() -> argparse.Namespace:
         help="path to write to; default: based on input. {ftype} will be replaced by the outtype.",
     )
     parser.add_argument(
-        "--outtype", type=str, choices=["f32", "f16", "bf16", "q8_0", "tq1_0", "tq2_0", "auto"], default="f16",
-        help="output format - use f32 for float32, f16 for float16, bf16 for bfloat16, q8_0 for Q8_0, tq1_0 or tq2_0 for ternary, and auto for the highest-fidelity 16-bit float type depending on the first loaded tensor type",
+        "--outtype", type=str, choices=["f32", "f16", "bf16", "q8_0", "tq1_0", "tq2_0", "auto"], default="auto",
+        help="output format - use f32 for float32, f16 for float16, bf16 for bfloat16, q8_0 for Q8_0, tq1_0 or tq2_0 for ternary, and auto for mostly unchanged types",
     )
     parser.add_argument(
         "--bigendian", action="store_true",
@@ -10063,6 +10153,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-lazy", action="store_true",
         help="use more RAM by computing all outputs before writing (use in case lazy evaluation is broken)",
+    )
+    parser.add_argument(
+        "--reflink", action="store_true",
+        help="(Experimental) Use copy-on-write reflinks when possible (e.g. on BTRFS, XFS, ZFS, etc.). File alignment and padding will differ compared to not using this option. Should be very fast when source model layout is compatible enough.",
     )
     parser.add_argument(
         "--model-name", type=str, default=None,
@@ -10258,7 +10352,8 @@ def main() -> None:
                                      split_max_size=split_str_to_n_bytes(args.split_max_size), dry_run=args.dry_run,
                                      small_first_shard=args.no_tensor_first_split,
                                      remote_hf_model_id=hf_repo_id, disable_mistral_community_chat_template=disable_mistral_community_chat_template,
-                                     sentence_transformers_dense_modules=args.sentence_transformers_dense_modules
+                                     sentence_transformers_dense_modules=args.sentence_transformers_dense_modules,
+                                     use_reflinks=args.reflink,
                                      )
 
         if args.vocab_only:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -485,7 +485,9 @@ class ModelBase:
 
                 # workaround BF16 not being supported by Numpy
                 if data_torch.dtype == torch.bfloat16:
-                    data_torch = data_torch.view(torch.uint8)
+                    # Need a contiguous last dimension otherwise byte view doesn't work
+                    # (problem can be reproduced with DeepSeek-V2-Lite-Chat)
+                    data_torch = data_torch.contiguous().view(torch.uint8)
 
                 # if data ends up empty, it means data_torch was a scalar tensor -> restore
                 if len(data_torch.shape) == 0:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -399,11 +399,13 @@ class ModelBase:
                         weight_name = name.removesuffix("_scale_inv")
                         w = self.model_tensors[weight_name]
                         s = self.model_tensors[name]
+                        # TODO: change to FP8 once natively supported
+                        auto_qtype = s.auto_qtype if s.auto_qtype is not gguf.GGMLQuantizationType.F32 else gguf.GGMLQuantizationType.BF16
                         self.model_tensors[weight_name] = ModelTensorInfo(
                             load=lambda w=w, s=s: dequant_simple(w.load(), s.load()),
                             size=w.size,
                             src_type=w.src_type,
-                            auto_qtype=gguf.GGMLQuantizationType.BF16, # TODO: change to FP8 once natively supported
+                            auto_qtype=auto_qtype,
                         )
                         tensors_to_remove.append(name)
             elif quant_method == "gptq":

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -82,8 +82,7 @@ class ModelTensorInfo:
     load: Callable[[], Tensor]
     size: int  # in elements
     src_type: str
-    src_qtype: gguf.GGMLQuantizationType | None = None
-    dst_qtype: gguf.GGMLQuantizationType | None = None
+    auto_qtype: gguf.GGMLQuantizationType | None = None
 
 
 class ModelBase:
@@ -162,17 +161,17 @@ class ModelBase:
             # find out the most common type
             hist: dict[gguf.GGMLQuantizationType, int] = {}
             for t in self.model_tensors.values():
-                if t.dst_qtype is not None:
-                    if t.dst_qtype not in hist:
-                        hist[t.dst_qtype] = 0
-                    hist[t.dst_qtype] += t.size
+                if t.auto_qtype is not None:
+                    if t.auto_qtype not in hist:
+                        hist[t.auto_qtype] = 0
+                    hist[t.auto_qtype] += t.size
             max_qtype = gguf.GGMLQuantizationType.F32
             max_size = 0
             for qtype, size in hist.items():
                 if size > max_size:
                     max_qtype = qtype
                     max_size = size
-            # TODO: add more type if they're used as dst_qtypes
+            # TODO: add more type if they're used as auto_qtype
             if max_qtype == gguf.GGMLQuantizationType.F32:
                 self.ftype = gguf.LlamaFileType.ALL_F32
             elif max_qtype == gguf.GGMLQuantizationType.F16:
@@ -223,8 +222,7 @@ class ModelBase:
                     load=lambda r=remote_tensor: LazyTorchTensor.from_remote_tensor(r),
                     size=math.prod(remote_tensor.shape),
                     src_type=str(dtype),
-                    src_qtype=qtype,
-                    dst_qtype=qtype,
+                    auto_qtype=qtype,
                 )
 
             return tensors
@@ -288,8 +286,7 @@ class ModelBase:
                         load=data_gen,
                         size=size,
                         src_type=str(dtype),
-                        src_qtype=qtype,
-                        dst_qtype=qtype,
+                        auto_qtype=qtype,
                     )
 
         # verify tensor name presence and identify potentially missing files
@@ -393,8 +390,7 @@ class ModelBase:
                             load=lambda w=w, s=s: dequant_bitnet(w.load(), s.load()),
                             size=w.size,
                             src_type="bitnet",
-                            src_qtype=gguf.GGMLQuantizationType.F32,
-                            dst_qtype=gguf.GGMLQuantizationType.TQ1_0,
+                            auto_qtype=gguf.GGMLQuantizationType.TQ1_0,
                         )
                         tensors_to_remove.append(name)
             elif quant_method == "fp8":
@@ -407,8 +403,7 @@ class ModelBase:
                             load=lambda w=w, s=s: dequant_simple(w.load(), s.load()),
                             size=w.size,
                             src_type=w.src_type,
-                            src_qtype=gguf.GGMLQuantizationType.F32,
-                            dst_qtype=gguf.GGMLQuantizationType.BF16, # TODO: change to FP8 once natively supported
+                            auto_qtype=gguf.GGMLQuantizationType.BF16, # TODO: change to FP8 once natively supported
                         )
                         tensors_to_remove.append(name)
             elif quant_method == "gptq":
@@ -426,8 +421,7 @@ class ModelBase:
                             ),
                             size=qweight.size,  # TODO: use more accurate value
                             src_type=f"GPTQ-{bits}bit",
-                            src_qtype=gguf.GGMLQuantizationType.F32,
-                            dst_qtype=gguf.GGMLQuantizationType.Q8_0 if bits == 8 else gguf.GGMLQuantizationType.Q4_1,
+                            auto_qtype=gguf.GGMLQuantizationType.Q8_0 if bits == 8 else gguf.GGMLQuantizationType.Q4_1,
                         )
                         tensors_to_remove += [
                             base_name + n
@@ -592,7 +586,7 @@ class ModelBase:
                 # No override (data_qtype is False), or wants to be quantized (data_qtype is True)
                 if isinstance(data_qtype, bool):
                     if self.ftype_guessed:
-                        data_qtype = old_qtype if tensor_info is None or tensor_info.dst_qtype is None else tensor_info.dst_qtype
+                        data_qtype = old_qtype if tensor_info is None or tensor_info.auto_qtype is None else tensor_info.auto_qtype
                     elif self.ftype == gguf.LlamaFileType.ALL_F32:
                         data_qtype = gguf.GGMLQuantizationType.F32
                     elif self.ftype == gguf.LlamaFileType.MOSTLY_F16:
@@ -10084,7 +10078,7 @@ class LazyTorchTensor(gguf.LazyBase):
             meta=gguf.LazyNumpyTensor.meta_with_dtype_and_shape(dtype, self.shape),
             args=(self,),
             func=(lambda s: s.numpy()),
-            ranges=self._ranges
+            ranges=self._ranges,
         )
 
     @classmethod

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -80,6 +80,7 @@ AnyModel = TypeVar("AnyModel", bound="type[ModelBase]")
 @dataclass
 class ModelTensorInfo:
     load: Callable[[], Tensor]
+    size: int  # in elements
     src_type: str
     src_qtype: gguf.GGMLQuantizationType | None = None
     dst_qtype: gguf.GGMLQuantizationType | None = None
@@ -93,6 +94,7 @@ class ModelBase:
 
     dir_model: Path
     ftype: gguf.LlamaFileType
+    ftype_guessed: bool
     fname_out: Path
     is_big_endian: bool
     endianess: gguf.GGUFEndian
@@ -138,6 +140,7 @@ class ModelBase:
 
         self.dir_model = dir_model
         self.ftype = ftype
+        self.ftype_guessed = ftype == gguf.LlamaFileType.GUESSED
         self.fname_out = fname_out
         self.is_big_endian = is_big_endian
         self.endianess = gguf.GGUFEndian.BIG if is_big_endian else gguf.GGUFEndian.LITTLE
@@ -154,6 +157,34 @@ class ModelBase:
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
 
         self.dequant_model()
+
+        if self.ftype == gguf.LlamaFileType.GUESSED:
+            # find out the most common type
+            hist: dict[gguf.GGMLQuantizationType, int] = {}
+            for t in self.model_tensors.values():
+                if t.dst_qtype is not None:
+                    if t.dst_qtype not in hist:
+                        hist[t.dst_qtype] = 0
+                    hist[t.dst_qtype] += t.size
+            max_qtype = gguf.GGMLQuantizationType.F32
+            max_size = 0
+            for qtype, size in hist.items():
+                if size > max_size:
+                    max_qtype = qtype
+                    max_size = size
+            # TODO: add more type if they're used as dst_qtypes
+            if max_qtype == gguf.GGMLQuantizationType.F32:
+                self.ftype = gguf.LlamaFileType.ALL_F32
+            elif max_qtype == gguf.GGMLQuantizationType.F16:
+                self.ftype = gguf.LlamaFileType.MOSTLY_F16
+            elif max_qtype == gguf.GGMLQuantizationType.BF16:
+                self.ftype = gguf.LlamaFileType.MOSTLY_BF16
+            elif max_qtype == gguf.GGMLQuantizationType.Q8_0:
+                self.ftype = gguf.LlamaFileType.MOSTLY_Q8_0
+            elif max_qtype == gguf.GGMLQuantizationType.Q4_1:
+                self.ftype = gguf.LlamaFileType.MOSTLY_Q4_1
+            elif max_qtype == gguf.GGMLQuantizationType.TQ1_0:
+                self.ftype = gguf.LlamaFileType.MOSTLY_TQ1_0
 
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
@@ -190,6 +221,7 @@ class ModelBase:
                 qtype = LazyTorchTensor._qtype_map.get(dtype)
                 tensors[name] = ModelTensorInfo(
                     load=lambda r=remote_tensor: LazyTorchTensor.from_remote_tensor(r),
+                    size=math.prod(remote_tensor.shape),
                     src_type=str(dtype),
                     src_qtype=qtype,
                     dst_qtype=qtype,
@@ -238,12 +270,14 @@ class ModelBase:
                     if is_safetensors:
                         data: gguf.utility.LocalTensor = model_part[name]
                         dtype = LazyTorchTensor._dtype_str_map[data.dtype]
+                        size = math.prod(data.shape)
                         if self.lazy:
                             data_gen = lambda data=data: LazyTorchTensor.from_local_tensor(data)  # noqa: E731
                         else:
                             data_gen = lambda data=data, dtype=dtype: torch.from_numpy(data.mmap_bytes()).view(dtype).reshape(data.shape)  # noqa: E731
                     else:
                         data_torch: Tensor = model_part[name]
+                        size = data_torch.numel()
                         dtype = data_torch.dtype
                         if self.lazy:
                             data_gen = lambda data=data_torch: LazyTorchTensor.from_eager(data)  # noqa: E731
@@ -252,6 +286,7 @@ class ModelBase:
                     qtype = LazyTorchTensor._qtype_map.get(dtype)
                     tensors[name] = ModelTensorInfo(
                         load=data_gen,
+                        size=size,
                         src_type=str(dtype),
                         src_qtype=qtype,
                         dst_qtype=qtype,
@@ -356,6 +391,7 @@ class ModelBase:
                         s = self.model_tensors[name]
                         self.model_tensors[weight_name] = ModelTensorInfo(
                             load=lambda w=w, s=s: dequant_bitnet(w.load(), s.load()),
+                            size=w.size,
                             src_type="bitnet",
                             src_qtype=gguf.GGMLQuantizationType.F32,
                             dst_qtype=gguf.GGMLQuantizationType.TQ1_0,
@@ -369,6 +405,7 @@ class ModelBase:
                         s = self.model_tensors[name]
                         self.model_tensors[weight_name] = ModelTensorInfo(
                             load=lambda w=w, s=s: dequant_simple(w.load(), s.load()),
+                            size=w.size,
                             src_type=w.src_type,
                             src_qtype=gguf.GGMLQuantizationType.F32,
                             dst_qtype=gguf.GGMLQuantizationType.BF16, # TODO: change to FP8 once natively supported
@@ -387,6 +424,7 @@ class ModelBase:
                             load=lambda g=g_idx, z=qzeros, w=qweight, s=scales: dequant_gptq(
                                 g.load(), w.load(), z.load(), s.load()
                             ),
+                            size=qweight.size,  # TODO: use more accurate value
                             src_type=f"GPTQ-{bits}bit",
                             src_qtype=gguf.GGMLQuantizationType.F32,
                             dst_qtype=gguf.GGMLQuantizationType.Q8_0 if bits == 8 else gguf.GGMLQuantizationType.Q4_1,
@@ -553,7 +591,9 @@ class ModelBase:
 
                 # No override (data_qtype is False), or wants to be quantized (data_qtype is True)
                 if isinstance(data_qtype, bool):
-                    if self.ftype == gguf.LlamaFileType.ALL_F32:
+                    if self.ftype_guessed:
+                        data_qtype = old_qtype if tensor_info is None or tensor_info.dst_qtype is None else tensor_info.dst_qtype
+                    elif self.ftype == gguf.LlamaFileType.ALL_F32:
                         data_qtype = gguf.GGMLQuantizationType.F32
                     elif self.ftype == gguf.LlamaFileType.MOSTLY_F16:
                         data_qtype = gguf.GGMLQuantizationType.F16
@@ -565,8 +605,6 @@ class ModelBase:
                         data_qtype = gguf.GGMLQuantizationType.TQ1_0
                     elif self.ftype == gguf.LlamaFileType.MOSTLY_TQ2_0:
                         data_qtype = gguf.GGMLQuantizationType.TQ2_0
-                    elif self.ftype == gguf.LlamaFileType.GUESSED:
-                        data_qtype = old_qtype if tensor_info is None or tensor_info.dst_qtype is None else tensor_info.dst_qtype
                     else:
                         raise ValueError(f"Unknown file type: {self.ftype.name}")
 
@@ -730,23 +768,8 @@ class TextModel(ModelBase):
 
         total_params = self.gguf_writer.get_total_parameter_count()[0]
 
-        # Apply heuristics to figure out typical tensor encoding based on first layer tensor encoding type
-        # TODO: get type name from `quantization_config` field when present?
-        if self.ftype == gguf.LlamaFileType.GUESSED:
-            # NOTE: can't use field "torch_dtype" in config.json, because some finetunes lie.
-            _, first_tensor = next(self.get_tensors())
-            logger.info(f"first tensor type is {first_tensor.dtype}")
-            if first_tensor.dtype == torch.float16:
-                ftype = gguf.LlamaFileType.MOSTLY_F16
-            elif first_tensor.dtype == torch.bfloat16:
-                ftype = gguf.LlamaFileType.MOSTLY_BF16
-            else:
-                ftype = gguf.LlamaFileType.ALL_F32
-        else:
-            ftype = self.ftype
-
         # Extract the encoding scheme from the file type name. e.g. 'gguf.LlamaFileType.MOSTLY_Q8_0' --> 'Q8_0'
-        output_type: str = ftype.name.partition("_")[2]
+        output_type: str = self.ftype.name.partition("_")[2]
 
         # Filename Output
         if self.fname_out.is_dir():

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4770,7 +4770,7 @@ class Plamo2Model(TextModel):
         del bid  # unused
 
         if name.endswith(".A_log"):
-            data_torch = -torch.exp(data_torch)
+            data_torch = -torch.exp(data_torch.float())
         elif name.endswith(".dt_bias"):
             name = name.rpartition(".dt_bias")[0] + ".dt_proj.bias"
         elif name.endswith(".dt_norm_weight"):
@@ -6294,7 +6294,7 @@ class MambaModel(TextModel):
 
         if name.endswith(".A_log"):
             logger.debug("A_log --> A ==> " + new_name)
-            data_torch = -torch.exp(data_torch)
+            data_torch = -torch.exp(data_torch.float())
 
         # [4 1 8192 1] -> [4 8192 1 1]
         if self.match_model_tensor_name(new_name, gguf.MODEL_TENSOR.SSM_CONV1D, bid):
@@ -6399,7 +6399,7 @@ class Mamba2Model(TextModel):
 
         if name.endswith(".A_log"):
             logger.debug("A_log --> A ==> " + new_name)
-            data_torch = -torch.exp(data_torch)
+            data_torch = -torch.exp(data_torch.float())
 
         yield (new_name, data_torch)
 
@@ -6499,7 +6499,7 @@ class JambaModel(TextModel):
 
         if name.endswith(".A_log"):
             logger.debug("A_log --> A ==> " + new_name)
-            data_torch = -torch.exp(data_torch)
+            data_torch = -torch.exp(data_torch.float())
 
         yield (new_name, data_torch)
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -761,7 +761,6 @@ class TextModel(ModelBase):
         super().prepare_metadata(vocab_only=vocab_only)
 
         total_params = self.gguf_writer.get_total_parameter_count()[0]
-
         # Extract the encoding scheme from the file type name. e.g. 'gguf.LlamaFileType.MOSTLY_Q8_0' --> 'Q8_0'
         output_type: str = self.ftype.name.partition("_")[2]
 

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -42,8 +42,8 @@ void ggml_print_backtrace(void);
 #    define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-// required for mmap as gguf only guarantees 32-byte alignment
-#define TENSOR_ALIGNMENT 32
+// required for mmap as gguf converted with reflinks from safetensors only guarantees 8-byte alignment
+#define TENSOR_ALIGNMENT 8
 
 // static_assert should be a #define, but if it's not,
 // fall back to the _Static_assert C11 keyword.

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -624,7 +624,7 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
         ctx->size = 0;
         for (size_t i = 0; i < ctx->info.size(); ++i) {
             const gguf_tensor_info & ti = ctx->info[i];
-            // alignment offset is only necessary for GGUF converted with reflinks
+            // alignment offset only exists for GGUF converted with reflinks
             const size_t align_offset = ti.offset % ctx->alignment;
             if (ti.offset - align_offset != ctx->size) {
                 GGML_LOG_ERROR("%s: tensor '%s' has offset %" PRIu64 ", expected %zu\n",

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -624,6 +624,8 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
         ctx->size = 0;
         for (size_t i = 0; i < ctx->info.size(); ++i) {
             const gguf_tensor_info & ti = ctx->info[i];
+            // HACK: bypass the continuity check
+            ctx->size = ti.offset;
             if (ti.offset != ctx->size) {
                 GGML_LOG_ERROR("%s: tensor '%s' has offset %" PRIu64 ", expected %zu\n",
                     __func__, ti.t.name, ti.offset, ctx->size);

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -201,7 +201,7 @@ class GGUFWriter:
         assert len(filenames) == len(self.tensors)
         for name, tensors in zip(filenames, self.tensors):
             total_size = sum(ti.nbytes for ti in tensors.values())
-            reflinkable_size = count_reflinkable_size(ti.tensor for ti in tensors.values()) if self.use_reflinks else 0
+            reflinkable_size = count_reflinkable_size((name, ti.tensor) for name, ti in tensors.items()) if self.use_reflinks else 0
             logger.info(f"{name}: n_tensors = {len(tensors)}, total_size = {GGUFWriter.format_n_bytes_to_str(total_size)}{', reflinked = ' + GGUFWriter.format_n_bytes_to_str(total_size - reflinkable_size) if self.use_reflinks else ''}")
 
         if self.dry_run:

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -93,7 +93,7 @@ class GGUFWriter:
         self.arch = arch
         self.endianess = endianess
         self.data_alignment = GGUF_DEFAULT_ALIGNMENT
-        self.use_reflinks = use_reflinks and hasattr(os, "copy_file_range")
+        self.use_reflinks = use_reflinks
         self.use_temp_file = False if self.use_reflinks else use_temp_file
         self.temp_file = None
         self.tensors = [{}]

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -30,7 +30,7 @@ from .constants import (
 )
 
 from .quants import quant_shape_from_byte_shape
-from .utility import LocalTensorRange, best_alignment_offset, copy_tensor_ranges
+from .utility import LocalTensorRange, best_alignment_offset, reflink_tensor_ranges
 
 logger = logging.getLogger(__name__)
 
@@ -470,7 +470,7 @@ class GGUFWriter:
                     if self.use_reflinks and len(ranges := getattr(ti.tensor, "_ranges", ())) > 0:
                         logger.debug(f"using reflinks for {name}")
                         start_offset = fout.tell()
-                        copy_tensor_ranges(fout, ranges, self.data_alignment)
+                        reflink_tensor_ranges(fout, ranges, self.data_alignment)
                         self.write_padding(fout, fout.tell() - start_offset)
                     else:
                         ti.tensor.tofile(fout)

--- a/gguf-py/gguf/lazy.py
+++ b/gguf-py/gguf/lazy.py
@@ -21,7 +21,7 @@ class LazyMeta(ABCMeta):
                 return type(self)._wrap_fn(
                     (lambda s, *args, **kwargs: getattr(s, name)(*args, **kwargs)),
                     use_self=self,
-                    data_noop=name in ("view", "reshape", "squeeze", "unsqueeze"),
+                    data_noop=name in ("view", "reshape", "squeeze", "unsqueeze", "contiguous"),
                 )
             elif isinstance(meta_attr, self._tensor_type):
                 # e.g. self.T with torch.Tensor should still be wrapped

--- a/gguf-py/gguf/lazy.py
+++ b/gguf-py/gguf/lazy.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 from abc import ABC, ABCMeta, abstractmethod
 
-from io import BufferedWriter
-import logging
-from typing import Any, Callable
+from io import BufferedReader, BufferedWriter
+from pathlib import Path
+from typing import Any, Callable, Iterable
 
+import logging
 import numpy as np
+import os
+import shutil
+
 from numpy.typing import DTypeLike
-from .utility import LocalTensorRange, copy_tensor_ranges
+
+from .utility import LocalTensorRange
 
 
 logger = logging.getLogger(__name__)
@@ -210,6 +215,7 @@ class LazyNumpyTensor(LazyBase):
     _tensor_type = np.ndarray
 
     shape: tuple[int, ...]  # Makes the type checker happy in quants.py
+    nbytes: int
 
     @classmethod
     def meta_with_dtype_and_shape(cls, dtype: DTypeLike, shape: tuple[int, ...]) -> np.ndarray[Any, Any]:
@@ -227,9 +233,140 @@ class LazyNumpyTensor(LazyBase):
 
     def tofile(self, fid, *args, **kwargs):
         if isinstance(fid, BufferedWriter) and len(self._ranges) > 0:
-            return copy_tensor_ranges(fid, self._ranges)
+            return copy_tensor_ranges(self, fid)
         else:
             eager = LazyNumpyTensor.to_eager(self)
             return eager.tofile(fid, *args, **kwargs)
 
     # TODO: __array_function__
+
+
+# For aligning blocks when reflinking
+def best_extra_offset(t: np.ndarray | LazyNumpyTensor | None, current_offset: int) -> int:
+    if not isinstance(t, LazyNumpyTensor):
+        # no file ranges, no need for an offset
+        return 0
+
+    ranges = t._ranges
+
+    histogram: dict[int, int] = {}
+
+    max_block_size = 0
+    for r in ranges:
+        # Ensure minimal alignment is 8 bytes (common with safetensors)
+        # and that the block size is valid
+        if r.offset % 8 == 0 and r.block_size > 0:
+            align_offset = r.offset % r.block_size
+            if align_offset not in histogram:
+                histogram[align_offset] = 0
+            histogram[align_offset] += r.size
+            if r.block_size > max_block_size:
+                max_block_size = r.block_size
+
+    best_offset = 0
+    best_size = 0
+    for offset, size in histogram.items():
+        if size > best_size:
+            best_size = size
+            best_offset = offset
+
+    if max_block_size > 0:
+        # the offset needs to be aligned properly
+        # or else there's probably a block size mismatch
+        assert current_offset % max_block_size == 0, current_offset % max_block_size
+
+    return best_offset
+
+
+def count_reflinkable_size(tensors: Iterable[np.ndarray | LazyNumpyTensor | None]) -> int:
+    if not hasattr(os, "copy_file_range"):
+        return 0
+
+    size = 0
+    for t in tensors:
+        if isinstance(t, LazyNumpyTensor) and len(t._ranges) > 0:
+            align_offset = best_extra_offset(t, 0)
+            for range in t._ranges:
+                if range.block_size > 0 and range.offset % range.block_size == align_offset:
+                    size += range.size
+    return size
+
+
+# Copy tensor ranges using os.copy_file_range with aligned offsets and sizes
+# to make it more likely that copy-on-write is used where possible.
+# Block alignment is necessary for BTRFS and XFS (and likely for ZFS too).
+#
+# Falls back to shutil.copyfileobj when os.copy_file_range is not present.
+def copy_tensor_ranges(t: LazyNumpyTensor, fout: BufferedWriter):
+    ranges = t._ranges
+    assert len(ranges) > 0
+    dst_offset = fout.tell()
+    extra_offset = best_extra_offset(t, dst_offset)
+
+    if extra_offset > 0:
+        # initial padding
+        fout.write(b"\x00" * extra_offset)
+
+    dst_offset += extra_offset
+    start_offset = dst_offset
+
+    src_files: dict[Path, BufferedReader] = {}
+    for r in ranges:
+        if r.filename not in src_files:
+            src_files[r.filename] = open(r.filename, "rb")
+
+    has_copy_file_range = hasattr(os, "copy_file_range")
+
+    for i, r in enumerate(ranges):
+        src = src_files[r.filename]
+        if has_copy_file_range:
+            if r.block_size > 0 and (r.offset % r.block_size) == (start_offset % r.block_size):
+                # Attempting to align copies for reflinking
+
+                # Block  0,      1,      2,      3,      4,
+                # |___0000|0000000|0001111|1111111|111____|
+                #
+                # 1. block 0 is partially overwritten with contents from range[0]
+                # 2. blocks 1 and 2 are copied from range[0] using os.copy_file_range
+                # 3. block 2 is partially overwritten with contents from range[1]
+                # 4. blocks 3 and 4 are copied from range[1] using os.copy_file_range
+                # (repeated for further ranges)
+                if dst_offset % r.block_size == 0:
+                    extra_size = 0
+                else:
+                    extra_size = r.block_size - (dst_offset % r.block_size)
+                    extra_size = min(extra_size, r.size)
+                    src.seek(r.offset)
+                    buf = src.read(extra_size)
+                    fout.seek(dst_offset)
+                    fout.write(buf)
+                    dst_offset += extra_size
+                    if extra_size == r.size:
+                        continue
+
+                assert dst_offset % r.block_size == 0, dst_offset % r.block_size
+
+                offset_src = r.offset + extra_size
+                offset_src_end = r.offset + r.size
+                if offset_src_end % r.block_size != 0:
+                    offset_src_end += r.block_size - (offset_src_end % r.block_size)
+                size = offset_src_end - offset_src
+                os.copy_file_range(src.fileno(), fout.fileno(), size, offset_src, dst_offset)
+                dst_offset += r.size - extra_size
+            else:
+                if r.block_size > 0:
+                    logger.debug(f"misaligned for reflinking, falling back to copy ({i}/{len(ranges)})")
+                # not trying to use reflinks, but still using os.copy_file_range for speed
+                os.copy_file_range(src.fileno(), fout.fileno(), r.size, r.offset, dst_offset)
+                dst_offset += r.size
+        else:
+            # not using reflinks, fallback when os.copy_file_range is not supported
+            src.seek(r.offset)
+            fout.seek(dst_offset)
+            shutil.copyfileobj(src, fout, r.size)
+            dst_offset += r.size
+
+    for f in src_files.values():
+        f.close()
+
+    fout.seek(dst_offset)

--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from io import BufferedReader, BufferedWriter
 from pathlib import Path
 from typing import Literal
 
 import os
 import json
-import shutil
 import logging
 import numpy as np
 
@@ -285,115 +283,6 @@ class LocalTensorRange:
     block_size: int
     offset: int
     size: int
-
-
-def best_extra_offset(ranges: tuple[LocalTensorRange, ...], current_offset: int) -> int:
-    hist: dict[int, int] = {}
-
-    max_block_size = 0
-    for r in ranges:
-        # Ensure minimal alignment is 8 bytes (common with safetensors)
-        # and that the block size is valid
-        if r.offset % 8 == 0 and r.block_size > 0:
-            align_offset = r.offset % r.block_size
-            if align_offset not in hist:
-                hist[align_offset] = 0
-            hist[align_offset] += r.size
-            if r.block_size > max_block_size:
-                max_block_size = r.block_size
-
-    best_offset = 0
-    best_size = 0
-    for offset, size in hist.items():
-        if size > best_size:
-            best_size = size
-            best_offset = offset
-
-    if max_block_size > 0:
-        # the offset needs to be aligned properly
-        # or else there's probably a block size mismatch
-        assert current_offset % max_block_size == 0, current_offset % max_block_size
-
-    return best_offset
-
-
-# Copy tensor ranges using os.copy_file_range with aligned offsets and sizes
-# to make it more likely that copy-on-write is used where possible.
-# Block alignment is necessary for BTRFS and XFS (and likely for ZFS too).
-#
-# Falls back to shutil.copyfileobj when os.copy_file_range is not present.
-def copy_tensor_ranges(fout: BufferedWriter, ranges: tuple[LocalTensorRange, ...]):
-    assert len(ranges) > 0
-    dst_offset = fout.tell()
-    extra_offset = best_extra_offset(ranges, dst_offset)
-
-    if extra_offset > 0:
-        # initial padding
-        fout.write(b"\x00" * extra_offset)
-
-    dst_offset += extra_offset
-    start_offset = dst_offset
-
-    src_files: dict[Path, BufferedReader] = {}
-    for r in ranges:
-        if r.filename not in src_files:
-            src_files[r.filename] = open(r.filename, "rb")
-
-    has_copy_file_range = hasattr(os, "copy_file_range")
-
-    for i, r in enumerate(ranges):
-        src = src_files[r.filename]
-        if has_copy_file_range:
-            if r.block_size > 0 and (r.offset % r.block_size) == (start_offset % r.block_size):
-                # Attempting to align copies for reflinking
-
-                # Block  0,      1,      2,      3,      4,
-                # |___0000|0000000|0001111|1111111|111____|
-                #
-                # 1. block 0 is partially overwritten with contents from range[0]
-                # 2. blocks 1 and 2 are copied from range[0] using os.copy_file_range
-                # 3. block 2 is partially overwritten with contents from range[1]
-                # 4. blocks 3 and 4 are copied from range[1] using os.copy_file_range
-                # (repeated for further ranges)
-                if dst_offset % r.block_size == 0:
-                    extra_size = 0
-                else:
-                    extra_size = r.block_size - (dst_offset % r.block_size)
-                    extra_size = min(extra_size, r.size)
-                    src.seek(r.offset)
-                    buf = src.read(extra_size)
-                    fout.seek(dst_offset)
-                    fout.write(buf)
-                    dst_offset += extra_size
-                    if extra_size == r.size:
-                        continue
-
-                assert dst_offset % r.block_size == 0, dst_offset % r.block_size
-
-                offset_src = r.offset + extra_size
-                offset_src_end = r.offset + r.size
-                if offset_src_end % r.block_size != 0:
-                    offset_src_end += r.block_size - (offset_src_end % r.block_size)
-                size = offset_src_end - offset_src
-                os.copy_file_range(src.fileno(), fout.fileno(), size, offset_src, dst_offset)
-                dst_offset += r.size - extra_size
-            else:
-                if r.block_size > 0:
-                    logger.debug(f"misaligned for reflinking, falling back to copy ({i}/{len(ranges)})")
-                # not trying to use reflinks, but still using os.copy_file_range for speed
-                os.copy_file_range(src.fileno(), fout.fileno(), r.size, r.offset, dst_offset)
-                dst_offset += r.size
-        else:
-            # not using reflinks, fallback when os.copy_file_range is not supported
-            src.seek(r.offset)
-            fout.seek(dst_offset)
-            shutil.copyfileobj(src, fout, r.size)
-            dst_offset += r.size
-
-    for f in src_files.values():
-        f.close()
-
-    fout.seek(dst_offset)
 
 
 @dataclass

--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -303,6 +303,7 @@ def best_alignment_offset(ranges: tuple[LocalTensorRange, ...], alignment: int):
             best_offset = offset
     return best_offset
 
+
 # (assuming this is only called where os.copy_file_range is present)
 #
 # Copy tensor ranges using os.copy_file_range with aligned offsets and sizes


### PR DESCRIPTION
(targets #15667 because file ranges are required)

This adds a `--reflink` option to `convert_hf_to_gguf.py` to allow using Copy-On-Write features on some filesystems (BTRFS, XFS, and likely ZFS).

For the models where it works, it makes conversion extremely fast, and saves quite a lot of disk space (because most of the resulting model shares extents with the source safetensors files).

With `--verbose` there is additional logging for when reflinking falls back to a copy because of misalignment.

> [!WARNING]
>
> This is experimental; The models produced with the `--reflink` option can have incompatible alignment with what current mainline `llama.cpp` expect. 
> It might also produce broken models in some cases. Further testing is needed.

# Results

Using `--reflink` with `convert_hf_to_gguf.py` will show the size after reflinking in the writing plan. This also works with `--dry-run`. Note that if the underlying filesystem or platform doesn't support reflinks, it will fallback to direct copies, but the size will still show as if reflinking was supported, even though it's not.

|Model|Size|Unique size with `--reflink`| % of original size |
|-----|----|-----------------------|--------------------|
|<https://huggingface.co/allenai/OLMo-2-0325-32B-Instruct>| 64.5 GB | 4.2 MB | 0.0065 % |
|<https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2>| 17.8 GB | 229.0 MB | 1.27 % |
|<https://huggingface.co/meta-llama/Llama-3.2-1B> | 2.5 GB | 168.0 MB | 6.72 % |
|<https://huggingface.co/mistralai/Mistral-7B-v0.1> | 14.5 GB | 1.3 GB | 8.97 % |
|<https://huggingface.co/bigscience/bloom-560m>| 1.1 GB | 152.3 MB | 13.8 % |
|<https://huggingface.co/TheDrummer/GLM-Steam-106B-A12B-v1>| 221.0 GB | 40.6 GB | 18.4 % |
|<https://huggingface.co/ai21labs/AI21-Jamba-Mini-1.7> | 103.2 GB | 26.3 GB | 25.5 % |


Some models are *very* easily reflinkable (e.g. `OLMo-2-0325-32B-Instruct`), while some are not (TODO: add more examples of poorly reflinkable models).
Generally, dense models which have no or very minimal tensor transformations in their `modify_tensors` part of the conversion should reflink really well.
For MoE models which require expert tensor stacking (e.g. Jamba, GLM-4.5-Air, etc.), part of the model is not reflinkable because of incompatible alignment of the stacked tensor parts. This is inevitable, and the best that can be done is to pick the most common alignment out of the stacked parts, and copy what can't be reflinked.
The other case when something isn't reflinkable is where file-range tracking isn't implemented, like permutes (which is used for some of the Attention tensors of Mistral-7B-v0.1) and splitting (which is used for Bloom).
And of course the 1D F32 tensors (e.g. the norms) aren't reflinked because they have a different type than the source file.

# Why this shouldn't be possible

My first iteration of this used plain `os.copy_file_range` and directly gave it the file offsets. This did not work (`compsize` showed no significant sharing), because apparently the COW filesystems require the blocks to be aligned (for BOTH the source and the destination), or else no reflink will be made.

From <https://manpages.debian.org/trixie/manpages-dev/FICLONERANGE.2const.en.html#EINVAL>:

> Disk filesystems generally require the offset and length arguments to be aligned to the fundamental block size.

# Why this is possible

It's possible to "cheat" so that the block alignment offset of the destination file matches the source file. Obviously, this means a model converted with `--reflink` will not have the same alignment as one converted without `--reflink`.

This is only possible because of `general.alignment` which affects the alignment of the start of the data offsets. Otherwise aligning filesystem block offsets would be much more complicated, because the offsets would depend on the size of the metadata (which the offsets are part of). Technically, this is also possible the other way around, because `safetensors` format allows arbitrary padding for the metadata (which can be made aligned), but it would require a custom writer, and this is out of scope of this PR, only a fun fact.

I've also made `BF16` not round-trip to `F32` for easier file-range tracking, and made `--outtype auto` attempt to preserve the source types instead of guessing from the first tensor.

`--outtype auto` is the new default, because it's likely what most people expect when converting a model without specifying the type.

## What works and what doesn't

File ranges are tracked for very simple operations, like type-views, reshapes, and stacking.

It's not yet implemented for tensor splits, but could be.

Fallback to a non-direct copy without reflinks is implemented and should be relatively robust.

For some models, not all the ranges of a stacked tensor can be copied with the same block alignment offset. In that case, the best one is used, but that means up to half of the stacked tensor is copied without reflink sharing.

Permutes, transposes, and similar are not supported (and probably won't be), and fallback to not tracking the file ranges.

Notably, GPT-OSS has transposed MoE tensors in its BF16 version, and so **it doesn't really benefit from reflinks**.

# TODO

- [ ] Test for correctness
  - [x] <https://huggingface.co/SpectraSuite/TriLM_3.9B_Unpacked> (F16 model, minimal transformations)
  - [x] <https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2> (BF16 model)
  - [x] <https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite-Chat> (BF16 MoE model with expert stacking)
  - [ ] (very small model)
- [x] Test on BTRFS
  - Data is shared according to `compsize /path/to/model.gguf /path/to/model_dir`
- [ ] Test on ZFS
  - Does it work? Most resources online aren't clear about whether recent ZFS on Linux works with `os.copy_file_range`.
- [ ] Test on XFS
- [ ] Test on overlayfs (in docker/podman?)
- [ ] Maybe track tensor splits
- [ ] Figure out whether changing `TENSOR_ALIGNMENT` to 8 causes problems in backends which use that constant (`cpu`, `repack`, `amx`, `kleidiai`)
- [x] Cleaner handling of non-continuity in GGUF loading (to fix the gguf tests)
- [ ] Test sharded reflinked model
- [ ] Test pre-quantized conversion for regressions, and also the types in the logs

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
