### PR TITLE
fix: resolve unsigned integer initialization warnings in gguf.cpp

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -273,7 +273,7 @@ struct gguf_reader {
     }
 
     bool read(std::string & dst) const {
-        uint64_t size = -1;
+        uint64_t size = 0;
         if (!read(size)) {
             return false;
         }
@@ -523,7 +523,7 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
         // tensor shape
         {
-            uint32_t n_dims = -1;
+            uint32_t n_dims = 0;
             ok = ok && gr.read(n_dims);
             if (n_dims > GGML_MAX_DIMS) {
                 GGML_LOG_ERROR("%s: tensor '%s' has invalid number of dimensions: %" PRIu32 " > %" PRIu32 "\n",


### PR DESCRIPTION
Fix warnings caused by initializing unsigned integers (`uint32_t n_dims` and `uint64_t size`) with negative values.

- Changed `uint32_t n_dims = -1` to `0` in tensor shape parsing.
- Changed `uint64_t size = -1` to `0` in string reading logic.

These values are overwritten by subsequent `gr.read(...)` calls, so using `0` as an initial placeholder eliminates unsigned integer underflow warnings without affecting runtime behavior.