### PR TITLE
vulkan: enumerate all non-CPU devices always, instead of only when missing a discrete GPU

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4462,12 +4462,10 @@ static void ggml_vk_instance_init() {
 
         // If no dedicated GPUs found, fall back to the first non-CPU device.
         // If only CPU devices are available, return without devices.
-        if (vk_instance.device_indices.empty()) {
-            for (size_t i = 0; i < devices.size(); i++) {
-                if (devices[i].getProperties().deviceType != vk::PhysicalDeviceType::eCpu) {
-                    vk_instance.device_indices.push_back(i);
-                    break;
-                }
+        for (size_t i = 0; i < devices.size(); i++) {
+            if (devices[i].getProperties().deviceType != vk::PhysicalDeviceType::eCpu) {
+                vk_instance.device_indices.push_back(i);
+                break;
             }
         }
 


### PR DESCRIPTION
I have a laptop with both an NVIDIA RTX 4060 and Intel Arc Integrated GPU. I was trying to benchmark performance of the integrated GPU on inference (with Vulkan), but I noticed it wasn't getting enumerated.

```
./llama-server.exe --list-devices
load_backend: loaded RPC backend from vulkan\bin\ggml-rpc.dll
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = NVIDIA GeForce RTX 4060 Laptop GPU (NVIDIA) | uma: 0 | fp16: 1 | bf16: 1 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: NV_coopmat2
load_backend: loaded Vulkan backend from vulkan\bin\ggml-vulkan.dll
load_backend: loaded CPU backend from vulkan\bin\ggml-cpu-alderlake.dll
Available devices:
  Vulkan0: NVIDIA GeForce RTX 4060 Laptop GPU (7957 MiB, 7189 MiB free)
```
So there was no way for me to pick it with --device.

As a workaround, exporting `GGML_VK_VISIBLE_DEVICES="0,1"` would let me pick the discrete GPU.

Is there any reason we only enumerate for integrated GPUs when we can't find a discrete one?
I think both should be shown to users by default, and there is no need to check vk_instance.device_indices.empty() before trying to enumerate the other sorts of GPUs the device might have.