### PR TITLE
CANN: implement LRU cache for ACL graphs in CANN backend

### DIFF
--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -314,3 +314,7 @@ Converting the matmul weight format from ND to NZ to improve performance. Enable
 ### GGML_CANN_ACL_GRAPH
 
 Operators are executed using ACL graph execution, rather than in op-by-op (eager) mode. Enabled by default.
+
+### GGML_CANN_GRAPH_CACHE_CAPACITY
+
+Maximum number of compiled CANN graphs kept in the LRU cache, default is 12. When the number of cached graphs exceeds this capacity, the least recently used graph will be evicted.

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -368,11 +368,20 @@ struct ggml_cann_graph {
  * move existing graphs to the front (most recently used), and clear the cache.
  */
 struct ggml_cann_graph_lru_cache {
-    size_t capacity = 12;  /**< Maximum number of graphs in the cache. */
+    size_t capacity;  /**< Maximum number of graphs in the cache. */
 
     std::list<std::shared_ptr<ggml_cann_graph>> cache_list; /**< List storing cached graphs. */
 
     std::shared_ptr<ggml_cann_graph> matched_graph = nullptr; /**< Pointer to a recently matched graph. */
+
+    ggml_cann_graph_lru_cache() {
+        std::string env_val = get_env("GGML_CANN_GRAPH_CACHE_CAPACITY").value_or("12");
+        try {
+            capacity = std::stoul(env_val);
+        } catch (...) {
+            capacity = 12; // fallback to default if invalid
+        }
+    }
 
     /**
      * @brief Push a new graph to the front of the cache.

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2238,7 +2238,7 @@ static bool is_cann_graph_update_required(ggml_backend_cann_context * cann_ctx, 
         if (all_match) {
             lru_cache.matched_graph = graph_ptr;
             return false;
-        } 
+        }
     }
     lru_cache.matched_graph = nullptr;
     return true;


### PR DESCRIPTION
### What does this PR do? 
implement LRU cache for ACL graphs in CANN backend.
- Introduce ggml_cann_graph_lru_cache to store multiple ggml_cann_graph objects.
- Graphs are loaded on demand and evicted using LRU policy when capacity is exceeded.
- Updated push, move_to_front, and clear methods to manage cached graphs efficiently.
- Ensures reuse of graphs, reducing graph reconstruction overhead in CANN backend.
