### PR TITLE
Improve user-facing warnings for chat template and context length

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -131,7 +131,7 @@ llama_context::llama_context(
     }
 
     if (n_ctx_per_seq > hparams.n_ctx_train) {
-        LLAMA_LOG_WARN("%s: n_ctx_per_seq (%u) > n_ctx_train (%u) -- possible training context overflow\n",
+        LLAMA_LOG_WARN("%s: n_ctx_per_seq (%u) > n_ctx_train (%u) -- quality may degrade beyond training context\n",
                 __func__, n_ctx_per_seq, hparams.n_ctx_train);
     }
 

--- a/tools/main/main.cpp
+++ b/tools/main/main.cpp
@@ -217,7 +217,8 @@ int main(int argc, char ** argv) {
     if (params.conversation_mode) {
         if (params.enable_chat_template) {
             if (!params.prompt.empty() && params.system_prompt.empty()) {
-                LOG_WRN("*** User-specified prompt will pre-start conversation, did you mean to set --system-prompt (-sys) instead?\n");
+                LOG_WRN("*** Chat template is active: -p is treated as a user message (pre-starts the conversation).\n");
+                LOG_INF ("*** If you intended a system instruction, use the -sys flag (e.g., -sys \"You are a helpful assistant\").\n");
             }
 
             LOG_INF("%s: chat template example:\n%s\n", __func__, common_chat_format_example(chat_templates.get(), params.use_jinja, params.default_template_kwargs).c_str());


### PR DESCRIPTION
[perplexity_before_fix_05-09.txt](https://github.com/user-attachments/files/22179581/perplexity_before_fix_05-09.txt)
[perplexity_after_fix_05-09.txt](https://github.com/user-attachments/files/22179583/perplexity_after_fix_05-09.txt)
[benchmark_before_fix_05-09.txt](https://github.com/user-attachments/files/22179584/benchmark_before_fix_05-09.txt)
[benchmark_after_fix_05-09.txt](https://github.com/user-attachments/files/22179585/benchmark_after_fix_05-09.txt)

### Summary
Clarifies two log messages without changing behavior:

1.  When a chat template is active and -p is provided without -sys, the CLI now explains that -p is treated as a user message and points to -sys for system instructions. 
2. When n_ctx_per_seq exceeds n_ctx_train, the library warns that quality may degrade beyond the training context, replacing the less precise “training context overflow.”

    
### Motivation
Users frequently pass -p assuming it sets a system instruction when a chat template is present, then get surprised by assistant behavior. The previous warning hinted at -sys but did not explain why the surprise happens.

Separately, exceeding the model’s trained context is not a runtime overflow condition. It is a quality risk. The new wording is technically accurate and consistent with other logs that print the model’s train length.

### Local verification
- System: WSL2 Ubuntu, Intel Core Ultra 7 155H, CPU backend
- Model: tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf

### What changed (user-visible)

**CLI: tools/main/main.cpp:**
When a chat template is active, -p is treated as the first user message. The warning now states that explicitly and shows how to supply a system instruction:

- Before:

  `*** User-specified prompt will pre-start conversation, did you mean to set --system-prompt (-sys) instead?`

- after:

```
*** Chat template is active: -p is treated as a user message (pre-starts the conversation).
*** If you intended a system instruction, use the -sys flag (e.g., -sys "You are a helpful assistant").
```

**Library: src/llama-context.cpp:**
When n_ctx_per_seq > n_ctx_train, the warning now describes the expected effect:
 
-  Before:
   `n_ctx_per_seq (...) > n_ctx_train (...) -- possible training context overflow`

- After:
  `n_ctx_per_seq (...) > n_ctx_train (...) -- quality may degrade beyond training context`

No flags, defaults, or behavior changed.

### Rationale
 - Clarity in the CLI path: Explicitly naming how -p is interpreted under a chat template reduces confusion and support churn. Showing the correct flag and a concrete example gives users an immediate fix. 
- Accuracy in the library path: “Overflow” suggests a runtime error. The practical concern is quality outside the trained window. The new message reflects that and avoids any implication of a hard failure. 
    
### Behavior
- No change to defaults, sampling, performance, or numerical results. This affects logs only.

    
### Perplexity
- Before fix: PPL = 2.1489 ± 0.02867 
- After fix: PPL = 2.1489 ± 0.02867 

### llama-bench (CPU, threads = 11)

- Before fix
   - pp512: 192.64 ± 128.94 t/s
   - tg128: 43.67 ± 1.92 t/s 

-  After fix:
    - pp512: 154.62 ± 80.27 t/s
     - tg128: 45.09 ± 2.31 t/s 
    
 ### Test plan

1.  Chat template guidance
     - Run llama-cli -m <model> -p '…' with a model that has a chat template.
     - Expect the new two-line guidance and the usual printed template example.

2. Context length warning
    - Run with -c greater than n_ctx_train (for example, 4096 vs 2048).
    - Expect the new “quality may degrade beyond training context” message.
3. No regressions
    - Normal generations and interactive mode behave as before.
    - llama-perplexity and llama-bench produce results consistent with pre-change runs.

### Risks
None. Changes are limited to log text.

### Checklist
- Local builds and tests pass.
- ci/run.sh CPU suite completed successfully.
- llama-cli verified with and without a chat template.
- Context-length warning verified above the model’s n_ctx_train.
- llama-perplexity and llama-bench run before and after with comparable results.