### PR TITLE
ggml-cpu: document use of "free" memory [no ci]

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -348,8 +348,10 @@ static void ggml_backend_cpu_device_get_memory(ggml_backend_dev_t dev, size_t * 
     long pages = sysconf(_SC_PHYS_PAGES);
     long page_size = sysconf(_SC_PAGE_SIZE);
     *total = pages * page_size;
+
+    // "free" system memory is ill-defined, for practical purposes assume that all of it is free:
     *free = *total;
-#endif
+#endif // _WIN32
 
     GGML_UNUSED(dev);
 }


### PR DESCRIPTION
While working on code for retrieving and reporting the memory use of llama.cpp I've noticed that the CPU backend always reports all of its memory as being free. This was implemented in https://github.com/ggml-org/llama.cpp/pull/13304 . This behavior doesn't seem correct to me and there is no documentation indicating why this is being done so my impression is that this is a bug. This PR fetches the number of available pages to calculate the "free" memory - this tends to be an underestimation due to file caches being considered allocated memory. But I did not see any other suitable property in the `sysconf` manual.