### PR TITLE
CUDA: print CUDART_VERSION on init

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -194,6 +194,9 @@ static ggml_cuda_device_info ggml_cuda_init() {
     GGML_ASSERT(info.device_count <= GGML_CUDA_MAX_DEVICES);
 
     int64_t total_vram = 0;
+#ifdef CUDART_VERSION
+    GGML_LOG_INFO("%s: Compiled with CUDART_VERSION=%d\n", __func__, CUDART_VERSION);
+#endif //CUDART_VERSION
 #ifdef GGML_CUDA_FORCE_MMQ
     GGML_LOG_INFO("%s: GGML_CUDA_FORCE_MMQ:    yes\n", __func__);
 #else


### PR DESCRIPTION
This PR makes it so that `CUDART_VERSION` is printed in `ggml_cuda_init` if applicable. This information can be useful for debugging issues and I think it's easier to print it than to make users fill out issue templates. 