### PR TITLE
llama: print memory breakdown on exit

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -332,7 +332,7 @@ void common_perf_print(const struct llama_context * ctx, const struct common_sam
     }
     if (ctx) {
         llama_perf_context_print(ctx);
-        llama_print_memory_breakdown(ctx);
+        llama_memory_breakdown_print(ctx);
     }
 }
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -332,6 +332,7 @@ void common_perf_print(const struct llama_context * ctx, const struct common_sam
     }
     if (ctx) {
         llama_perf_context_print(ctx);
+        llama_print_memory_breakdown(ctx);
     }
 }
 

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -314,7 +314,7 @@ extern "C" {
     GGML_API int                  ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched);
     GGML_API int                  ggml_backend_sched_get_n_copies(ggml_backend_sched_t sched);
 
-    GGML_API size_t               ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_t backend);
+    GGML_API size_t               ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft);
 
     GGML_API void                 ggml_backend_sched_set_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node, ggml_backend_t backend);
     GGML_API ggml_backend_t       ggml_backend_sched_get_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node);

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -314,7 +314,8 @@ extern "C" {
     GGML_API int                  ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched);
     GGML_API int                  ggml_backend_sched_get_n_copies(ggml_backend_sched_t sched);
 
-    GGML_API size_t               ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft);
+    GGML_API ggml_backend_buffer_type_t ggml_backend_sched_get_buffer_type(ggml_backend_sched_t sched, ggml_backend_t backend);
+    GGML_API size_t                     ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_t backend);
 
     GGML_API void                 ggml_backend_sched_set_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node, ggml_backend_t backend);
     GGML_API ggml_backend_t       ggml_backend_sched_get_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -740,15 +740,6 @@ static int ggml_backend_sched_backend_id(ggml_backend_sched_t sched, ggml_backen
     return -1;
 }
 
-static int ggml_backend_sched_buft_id(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft) {
-    for (int i = 0; i < sched->n_backends; i++) {
-        if (sched->bufts[i] == buft) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, const struct ggml_tensor * tensor, const struct ggml_tensor * op) {
     ggml_backend_buffer_t buffer = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
     if (buffer == NULL) {
@@ -1802,15 +1793,20 @@ ggml_backend_t ggml_backend_sched_get_backend(ggml_backend_sched_t sched, int i)
     return sched->backends[i];
 }
 
-size_t ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft) {
+ggml_backend_buffer_type_t ggml_backend_sched_get_buffer_type(ggml_backend_sched_t sched, ggml_backend_t backend) {
     GGML_ASSERT(sched);
-    int buft_index = ggml_backend_sched_buft_id(sched, buft);
-    if (buft_index == -1) {
-        return 0;
-    }
-    GGML_ASSERT(buft_index < sched->n_backends);
+    int backend_index = ggml_backend_sched_backend_id(sched, backend);
+    GGML_ASSERT(backend_index >= 0 && backend_index < sched->n_backends);
 
-    return ggml_gallocr_get_buffer_size(sched->galloc, buft_index);
+    return sched->bufts[backend_index];
+}
+
+size_t ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_t backend) {
+    GGML_ASSERT(sched);
+    int backend_index = ggml_backend_sched_backend_id(sched, backend);
+    GGML_ASSERT(backend_index >= 0 && backend_index < sched->n_backends);
+
+    return ggml_gallocr_get_buffer_size(sched->galloc, backend_index);
 }
 
 void ggml_backend_sched_set_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node, ggml_backend_t backend) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -740,6 +740,15 @@ static int ggml_backend_sched_backend_id(ggml_backend_sched_t sched, ggml_backen
     return -1;
 }
 
+static int ggml_backend_sched_buft_id(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft) {
+    for (int i = 0; i < sched->n_backends; i++) {
+        if (sched->bufts[i] == buft) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, const struct ggml_tensor * tensor, const struct ggml_tensor * op) {
     ggml_backend_buffer_t buffer = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
     if (buffer == NULL) {
@@ -1793,12 +1802,15 @@ ggml_backend_t ggml_backend_sched_get_backend(ggml_backend_sched_t sched, int i)
     return sched->backends[i];
 }
 
-size_t ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_t backend) {
+size_t ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_buffer_type_t buft) {
     GGML_ASSERT(sched);
-    int backend_index = ggml_backend_sched_backend_id(sched, backend);
-    GGML_ASSERT(backend_index >= 0 && backend_index < sched->n_backends);
+    int buft_index = ggml_backend_sched_buft_id(sched, buft);
+    if (buft_index == -1) {
+        return 0;
+    }
+    GGML_ASSERT(buft_index < sched->n_backends);
 
-    return ggml_gallocr_get_buffer_size(sched->galloc, backend_index);
+    return ggml_gallocr_get_buffer_size(sched->galloc, buft_index);
 }
 
 void ggml_backend_sched_set_tensor_backend(ggml_backend_sched_t sched, struct ggml_tensor * node, ggml_backend_t backend) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1334,7 +1334,7 @@ extern "C" {
 
     struct llama_perf_context_data {
         // ms == milliseconds
-        double t_start_ms;  // time needed for startup
+        double t_start_ms;  // absolute start time
         double t_load_ms;   // time needed for loading the model
         double t_p_eval_ms; // time needed for processing the prompt
         double t_eval_ms;   // time needed for generating tokens
@@ -1359,33 +1359,8 @@ extern "C" {
     LLAMA_API void                           llama_perf_sampler_print(const struct llama_sampler * chain);
     LLAMA_API void                           llama_perf_sampler_reset(      struct llama_sampler * chain);
 
-    //
-    // backend utils
-    //
-
-    LLAMA_API size_t llama_backend_count(const struct llama_context * ctx);
-
-    struct llama_backend_info_data {
-        const char * name;
-
-        struct {
-            const char * name;
-            const char * description;
-
-            // device memory is in bytes
-            size_t memory_total;             // total memory as reported by the device
-            size_t memory_free;              // free memory as reported by the device
-            size_t memory_used_self;         // sum of model, context, and compute
-            size_t memory_used_self_model;   // memory allocated for the model
-            size_t memory_used_self_context; // memory allocated for the context
-            size_t memory_used_self_compute; // memory allocated for temporary compute buffers
-            size_t memory_used_unaccounted;  // memory with unknown use, e.g. drivers or other programs, total - (free + self)
-        } device;
-    };
-
-    LLAMA_API struct llama_backend_info_data llama_backend_info(const struct llama_context * ctx, size_t index);
-
-    LLAMA_API void llama_print_memory_breakdown(const struct llama_context * ctx);
+    // print a breakdown of per-device memory use via LLAMA_LOG:
+    LLAMA_API void llama_memory_breakdown_print(const struct llama_context * ctx);
 
     //
     // training

--- a/include/llama.h
+++ b/include/llama.h
@@ -1329,24 +1329,25 @@ extern "C" {
     //
     // Performance utils
     //
-    // NOTE: Used by llama.cpp examples, avoid using in third-party apps. Instead, do your own performance measurements.
+    // NOTE: Used by llama.cpp examples/tools, avoid using in third-party apps. Instead, do your own performance measurements.
     //
 
     struct llama_perf_context_data {
-        double t_start_ms;
-        double t_load_ms;
-        double t_p_eval_ms;
-        double t_eval_ms;
+        // ms == milliseconds
+        double t_start_ms;  // time needed for startup
+        double t_load_ms;   // time needed for loading the model
+        double t_p_eval_ms; // time needed for processing the prompt
+        double t_eval_ms;   // time needed for generating tokens
 
-        int32_t n_p_eval;
-        int32_t n_eval;
-        int32_t n_reused; // number of times a ggml compute graph had been reused
+        int32_t n_p_eval;   // number of prompt tokens
+        int32_t n_eval;     // number of generated tokens
+        int32_t n_reused;   // number of times a ggml compute graph had been reused
     };
 
     struct llama_perf_sampler_data {
-        double t_sample_ms;
+        double t_sample_ms; // time needed for sampling in ms
 
-        int32_t n_sample;
+        int32_t n_sample;   // number of sampled tokens
     };
 
     LLAMA_API struct llama_perf_context_data llama_perf_context      (const struct llama_context * ctx);
@@ -1357,6 +1358,34 @@ extern "C" {
     LLAMA_API struct llama_perf_sampler_data llama_perf_sampler      (const struct llama_sampler * chain);
     LLAMA_API void                           llama_perf_sampler_print(const struct llama_sampler * chain);
     LLAMA_API void                           llama_perf_sampler_reset(      struct llama_sampler * chain);
+
+    //
+    // backend utils
+    //
+
+    LLAMA_API size_t llama_backend_count(const struct llama_context * ctx);
+
+    struct llama_backend_info_data {
+        const char * name;
+
+        struct {
+            const char * name;
+            const char * description;
+
+            // device memory is in bytes
+            size_t memory_total;             // total memory as reported by the device
+            size_t memory_free;              // free memory as reported by the device
+            size_t memory_used_self;         // sum of model, context, and compute
+            size_t memory_used_self_model;   // memory allocated for the model
+            size_t memory_used_self_context; // memory allocated for the context
+            size_t memory_used_self_compute; // memory allocated for temporary compute buffers
+            size_t memory_used_unaccounted;  // memory with unknown use, e.g. drivers or other programs, total - (free + self)
+        } device;
+    };
+
+    LLAMA_API struct llama_backend_info_data llama_backend_info(const struct llama_context * ctx, size_t index);
+
+    LLAMA_API void llama_print_memory_breakdown(const struct llama_context * ctx);
 
     //
     // training

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -23,9 +23,9 @@ struct llama_memory_context_i;
 
 // "memory" as in physical memory for a buffer type, in bytes
 struct llama_memory_breakdown_data {
-    size_t model;   // memory allocated for the model
-    size_t context; // memory allocated for the context
-    size_t compute; // memory allocated for temporary compute buffers
+    size_t model   = 0; // memory allocated for the model
+    size_t context = 0; // memory allocated for the context
+    size_t compute = 0; // memory allocated for temporary compute buffers
 };
 
 struct llama_context {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -144,6 +144,9 @@ struct llama_context {
     llama_perf_context_data perf_get_data() const;
     void perf_reset();
 
+    size_t                  backend_count() const;
+    llama_backend_info_data backend_info(size_t index) const;
+
     //
     // training
     //

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -17,8 +17,16 @@ class llama_batch_allocr;
 class llama_io_read_i;
 class llama_io_write_i;
 
+// "memory" as in abstract memory for the context
 struct llama_memory_i;
 struct llama_memory_context_i;
+
+// "memory" as in physical memory for a buffer type, in bytes
+struct llama_memory_breakdown_data {
+    size_t model;   // memory allocated for the model
+    size_t context; // memory allocated for the context
+    size_t compute; // memory allocated for temporary compute buffers
+};
 
 struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
@@ -144,8 +152,7 @@ struct llama_context {
     llama_perf_context_data perf_get_data() const;
     void perf_reset();
 
-    size_t                  backend_count() const;
-    llama_backend_info_data backend_info(size_t index) const;
+    std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> memory_breakdown() const;
 
     //
     // training

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -113,6 +113,10 @@ llama_pos llama_kv_cache_iswa::seq_pos_max(llama_seq_id seq_id) const {
     return kv_swa->seq_pos_max(seq_id);
 }
 
+size_t llama_kv_cache_iswa::memory_use(ggml_backend_dev_t dev) const {
+    return kv_base->memory_use(dev) + kv_swa->memory_use(dev);
+}
+
 llama_memory_context_ptr llama_kv_cache_iswa::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {
     GGML_UNUSED(embd_all);
 

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -113,8 +113,12 @@ llama_pos llama_kv_cache_iswa::seq_pos_max(llama_seq_id seq_id) const {
     return kv_swa->seq_pos_max(seq_id);
 }
 
-size_t llama_kv_cache_iswa::memory_use(ggml_backend_buffer_type_t buft) const {
-    return kv_base->memory_use(buft) + kv_swa->memory_use(buft);
+std::map<ggml_backend_buffer_type_t, size_t> llama_kv_cache_iswa::memory_breakdown() const {
+    std::map<ggml_backend_buffer_type_t, size_t> mb = kv_base->memory_breakdown();
+    for (const auto & buft_size : kv_swa->memory_breakdown()) {
+        mb[buft_size.first] += buft_size.second;
+    }
+    return mb;
 }
 
 llama_memory_context_ptr llama_kv_cache_iswa::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -113,8 +113,8 @@ llama_pos llama_kv_cache_iswa::seq_pos_max(llama_seq_id seq_id) const {
     return kv_swa->seq_pos_max(seq_id);
 }
 
-size_t llama_kv_cache_iswa::memory_use(ggml_backend_dev_t dev) const {
-    return kv_base->memory_use(dev) + kv_swa->memory_use(dev);
+size_t llama_kv_cache_iswa::memory_use(ggml_backend_buffer_type_t buft) const {
+    return kv_base->memory_use(buft) + kv_swa->memory_use(buft);
 }
 
 llama_memory_context_ptr llama_kv_cache_iswa::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -56,7 +56,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_dev_t dev) const override;
+    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
 
     // state write/load
 

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -56,6 +56,8 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
+    size_t memory_use(ggml_backend_dev_t dev) const override;
+
     // state write/load
 
     void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) const override;

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -56,7 +56,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
+    std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 
     // state write/load
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -473,15 +473,12 @@ llama_pos llama_kv_cache::seq_pos_max(llama_seq_id seq_id) const {
     return cells.seq_pos_max(seq_id);
 }
 
-size_t llama_kv_cache::memory_use(ggml_backend_buffer_type_t buft) const {
-    size_t n_bytes = 0;
+std::map<ggml_backend_buffer_type_t, size_t> llama_kv_cache::memory_breakdown() const {
+    std::map<ggml_backend_buffer_type_t, size_t> ret;
     for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
-        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
-            continue;
-        }
-        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+        ret[ggml_backend_buffer_get_type(buf_ptr.get())] += ggml_backend_buffer_get_size(buf_ptr.get());
     }
-    return n_bytes;
+    return ret;
 }
 
 llama_memory_context_ptr llama_kv_cache::init_batch(

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -473,13 +473,10 @@ llama_pos llama_kv_cache::seq_pos_max(llama_seq_id seq_id) const {
     return cells.seq_pos_max(seq_id);
 }
 
-size_t llama_kv_cache::memory_use(ggml_backend_dev_t dev) const {
-    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
-
+size_t llama_kv_cache::memory_use(ggml_backend_buffer_type_t buft) const {
     size_t n_bytes = 0;
     for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
-        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
-        if (buft != buft_dev) {
+        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
             continue;
         }
         n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -473,6 +473,20 @@ llama_pos llama_kv_cache::seq_pos_max(llama_seq_id seq_id) const {
     return cells.seq_pos_max(seq_id);
 }
 
+size_t llama_kv_cache::memory_use(ggml_backend_dev_t dev) const {
+    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
+
+    size_t n_bytes = 0;
+    for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
+        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
+        if (buft != buft_dev) {
+            continue;
+        }
+        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+    }
+    return n_bytes;
+}
+
 llama_memory_context_ptr llama_kv_cache::init_batch(
             llama_batch_allocr & balloc,
             uint32_t n_ubatch,

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -121,7 +121,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
+    std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 
     // state write/load
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -121,6 +121,8 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
+    size_t memory_use(ggml_backend_dev_t dev) const override;
+
     // state write/load
 
     void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) const override;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -121,7 +121,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_dev_t dev) const override;
+    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
 
     // state write/load
 

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -166,8 +166,8 @@ llama_pos llama_memory_hybrid::seq_pos_max(llama_seq_id seq_id) const {
     return std::min(mem_attn->seq_pos_max(seq_id), mem_recr->seq_pos_max(seq_id));
 }
 
-size_t llama_memory_hybrid::memory_use(ggml_backend_dev_t dev) const {
-    return mem_attn->memory_use(dev) + mem_recr->memory_use(dev);
+size_t llama_memory_hybrid::memory_use(ggml_backend_buffer_type_t buft) const {
+    return mem_attn->memory_use(buft) + mem_recr->memory_use(buft);
 }
 
 void llama_memory_hybrid::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -166,6 +166,10 @@ llama_pos llama_memory_hybrid::seq_pos_max(llama_seq_id seq_id) const {
     return std::min(mem_attn->seq_pos_max(seq_id), mem_recr->seq_pos_max(seq_id));
 }
 
+size_t llama_memory_hybrid::memory_use(ggml_backend_dev_t dev) const {
+    return mem_attn->memory_use(dev) + mem_recr->memory_use(dev);
+}
+
 void llama_memory_hybrid::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
     GGML_UNUSED(flags);
 

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -166,8 +166,12 @@ llama_pos llama_memory_hybrid::seq_pos_max(llama_seq_id seq_id) const {
     return std::min(mem_attn->seq_pos_max(seq_id), mem_recr->seq_pos_max(seq_id));
 }
 
-size_t llama_memory_hybrid::memory_use(ggml_backend_buffer_type_t buft) const {
-    return mem_attn->memory_use(buft) + mem_recr->memory_use(buft);
+std::map<ggml_backend_buffer_type_t, size_t> llama_memory_hybrid::memory_breakdown() const {
+    std::map<ggml_backend_buffer_type_t, size_t> mb = mem_attn->memory_breakdown();
+    for (const auto & buft_size : mem_recr->memory_breakdown()) {
+        mb[buft_size.first] += buft_size.second;
+    }
+    return mb;
 }
 
 void llama_memory_hybrid::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -68,6 +68,8 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
+    size_t memory_use(ggml_backend_dev_t dev) const override;
+
     // state write/load
 
     void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) const override;

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -68,7 +68,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_dev_t dev) const override;
+    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
 
     // state write/load
 

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -68,7 +68,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
+    std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 
     // state write/load
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -359,13 +359,10 @@ llama_pos llama_memory_recurrent::seq_pos_max(llama_seq_id seq_id) const {
     return result;
 }
 
-size_t llama_memory_recurrent::memory_use(ggml_backend_dev_t dev) const {
-    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
-
+size_t llama_memory_recurrent::memory_use(ggml_backend_buffer_type_t buft) const {
     size_t n_bytes = 0;
     for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
-        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
-        if (buft != buft_dev) {
+        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
             continue;
         }
         n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -1,5 +1,6 @@
 #include "llama-memory-recurrent.h"
 
+#include "ggml-alloc.h"
 #include "llama-impl.h"
 #include "llama-io.h"
 #include "llama-batch.h"
@@ -359,15 +360,12 @@ llama_pos llama_memory_recurrent::seq_pos_max(llama_seq_id seq_id) const {
     return result;
 }
 
-size_t llama_memory_recurrent::memory_use(ggml_backend_buffer_type_t buft) const {
-    size_t n_bytes = 0;
+std::map<ggml_backend_buffer_type_t, size_t> llama_memory_recurrent::memory_breakdown() const {
+    std::map<ggml_backend_buffer_type_t, size_t> ret;
     for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
-        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
-            continue;
-        }
-        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+        ret[ggml_backend_buffer_get_type(buf_ptr.get())] += ggml_backend_buffer_get_size(buf_ptr.get());
     }
-    return n_bytes;
+    return ret;
 }
 
 llama_memory_context_ptr llama_memory_recurrent::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -359,6 +359,20 @@ llama_pos llama_memory_recurrent::seq_pos_max(llama_seq_id seq_id) const {
     return result;
 }
 
+size_t llama_memory_recurrent::memory_use(ggml_backend_dev_t dev) const {
+    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
+
+    size_t n_bytes = 0;
+    for (const ggml_backend_buffer_ptr & buf_ptr : bufs) {
+        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
+        if (buft != buft_dev) {
+            continue;
+        }
+        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+    }
+    return n_bytes;
+}
+
 llama_memory_context_ptr llama_memory_recurrent::init_batch(llama_batch_allocr & balloc, uint32_t n_ubatch, bool embd_all) {
     do {
         balloc.split_reset();

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -1,6 +1,5 @@
 #include "llama-memory-recurrent.h"
 
-#include "ggml-alloc.h"
 #include "llama-impl.h"
 #include "llama-io.h"
 #include "llama-batch.h"

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -50,6 +50,8 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
+    size_t memory_use(ggml_backend_dev_t dev) const override;
+
     bool prepare(const std::vector<llama_ubatch> & ubatches);
 
     // find a contiguous slot of memory cells and emplace the ubatch there

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -4,6 +4,7 @@
 #include "llama-graph.h"
 #include "llama-memory.h"
 
+#include <map>
 #include <set>
 #include <vector>
 
@@ -50,7 +51,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
+    std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 
     bool prepare(const std::vector<llama_ubatch> & ubatches);
 

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -50,7 +50,7 @@ public:
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
 
-    size_t memory_use(ggml_backend_dev_t dev) const override;
+    size_t memory_use(ggml_backend_buffer_type_t buft) const override;
 
     bool prepare(const std::vector<llama_ubatch> & ubatches);
 

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -108,6 +108,8 @@ struct llama_memory_i {
     virtual llama_pos seq_pos_min(llama_seq_id seq_id) const = 0;
     virtual llama_pos seq_pos_max(llama_seq_id seq_id) const = 0;
 
+    virtual size_t memory_use(ggml_backend_dev_t dev) const = 0;
+
     //
     // state write/read
     //

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -2,6 +2,7 @@
 
 #include "llama.h"
 
+#include <map>
 #include <memory>
 #include <functional>
 
@@ -108,7 +109,7 @@ struct llama_memory_i {
     virtual llama_pos seq_pos_min(llama_seq_id seq_id) const = 0;
     virtual llama_pos seq_pos_max(llama_seq_id seq_id) const = 0;
 
-    virtual size_t memory_use(ggml_backend_buffer_type_t buft) const = 0;
+    virtual std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const = 0;
 
     //
     // state write/read

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -108,7 +108,7 @@ struct llama_memory_i {
     virtual llama_pos seq_pos_min(llama_seq_id seq_id) const = 0;
     virtual llama_pos seq_pos_max(llama_seq_id seq_id) const = 0;
 
-    virtual size_t memory_use(ggml_backend_dev_t dev) const = 0;
+    virtual size_t memory_use(ggml_backend_buffer_type_t buft) const = 0;
 
     //
     // state write/read

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -5903,13 +5903,10 @@ size_t llama_model::n_devices() const {
     return devices.size();
 }
 
-size_t llama_model::memory_use(ggml_backend_dev_t dev) const {
-    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
-
+size_t llama_model::memory_use(ggml_backend_buffer_type_t buft) const {
     size_t n_bytes = 0;
     for (const ggml_backend_buffer_ptr & buf_ptr : pimpl->bufs) {
-        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
-        if (buft != buft_dev) {
+        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
             continue;
         }
         n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -5903,15 +5903,12 @@ size_t llama_model::n_devices() const {
     return devices.size();
 }
 
-size_t llama_model::memory_use(ggml_backend_buffer_type_t buft) const {
-    size_t n_bytes = 0;
+std::map<ggml_backend_buffer_type_t, size_t> llama_model::memory_breakdown() const {
+    std::map<ggml_backend_buffer_type_t, size_t> ret;
     for (const ggml_backend_buffer_ptr & buf_ptr : pimpl->bufs) {
-        if (ggml_backend_buffer_get_type(buf_ptr.get()) != buft) {
-            continue;
-        }
-        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+        ret[ggml_backend_buffer_get_type(buf_ptr.get())] += ggml_backend_buffer_get_size(buf_ptr.get());
     }
-    return n_bytes;
+    return ret;
 }
 
 uint64_t llama_model::n_elements() const {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -5903,6 +5903,20 @@ size_t llama_model::n_devices() const {
     return devices.size();
 }
 
+size_t llama_model::memory_use(ggml_backend_dev_t dev) const {
+    ggml_backend_buffer_type_t buft_dev = ggml_backend_dev_buffer_type(dev);
+
+    size_t n_bytes = 0;
+    for (const ggml_backend_buffer_ptr & buf_ptr : pimpl->bufs) {
+        ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buf_ptr.get());
+        if (buft != buft_dev) {
+            continue;
+        }
+        n_bytes += ggml_backend_buffer_get_size(buf_ptr.get());
+    }
+    return n_bytes;
+}
+
 uint64_t llama_model::n_elements() const {
     return pimpl->n_elements;
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -452,7 +452,7 @@ struct llama_model {
     size_t size() const; // file size
     size_t n_tensors() const;
     size_t n_devices() const;
-    size_t memory_use(ggml_backend_dev_t dev) const;
+    size_t memory_use(ggml_backend_buffer_type_t buft) const;
 
     // total number of parameters in the model
     uint64_t n_elements() const;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -449,9 +449,10 @@ struct llama_model {
 
     std::string desc() const;
 
-    size_t size() const;
+    size_t size() const; // file size
     size_t n_tensors() const;
     size_t n_devices() const;
+    size_t memory_use(ggml_backend_dev_t dev) const;
 
     // total number of parameters in the model
     uint64_t n_elements() const;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -7,6 +7,7 @@
 #include "llama-memory.h"
 #include "llama-vocab.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -452,7 +453,8 @@ struct llama_model {
     size_t size() const; // file size
     size_t n_tensors() const;
     size_t n_devices() const;
-    size_t memory_use(ggml_backend_buffer_type_t buft) const;
+
+    std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const;
 
     // total number of parameters in the model
     uint64_t n_elements() const;

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2812,8 +2812,9 @@ struct clip_model_loader {
         ggml_backend_sched_reserve(ctx_clip.sched.get(), gf);
 
         for (size_t i = 0; i < ctx_clip.backend_ptrs.size(); ++i) {
+            ggml_backend_t backend = ctx_clip.backend_ptrs[i];
             ggml_backend_buffer_type_t buft = ctx_clip.backend_buft[i];
-            size_t size = ggml_backend_sched_get_buffer_size(ctx_clip.sched.get(), buft);
+            size_t size = ggml_backend_sched_get_buffer_size(ctx_clip.sched.get(), backend);
             if (size > 1) {
                 LOG_INF("%s: %10s compute buffer size = %8.2f MiB\n", __func__,
                         ggml_backend_buft_name(buft),

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2812,9 +2812,8 @@ struct clip_model_loader {
         ggml_backend_sched_reserve(ctx_clip.sched.get(), gf);
 
         for (size_t i = 0; i < ctx_clip.backend_ptrs.size(); ++i) {
-            ggml_backend_t backend = ctx_clip.backend_ptrs[i];
             ggml_backend_buffer_type_t buft = ctx_clip.backend_buft[i];
-            size_t size = ggml_backend_sched_get_buffer_size(ctx_clip.sched.get(), backend);
+            size_t size = ggml_backend_sched_get_buffer_size(ctx_clip.sched.get(), buft);
             if (size > 1) {
                 LOG_INF("%s: %10s compute buffer size = %8.2f MiB\n", __func__,
                         ggml_backend_buft_name(buft),

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -2060,6 +2060,7 @@ int main(int argc, char ** argv) {
 
     LOG("\n");
     llama_perf_context_print(ctx);
+    llama_memory_breakdown_print(ctx);
 
     llama_backend_free();
 


### PR DESCRIPTION
This PR makes it so that on exit a breakdown of the memory use is printed. For example:

```
llama_print_memory_breakdown: memory breakdown:      total   free     self   model   context   compute    unaccounted
llama_print_memory_breakdown:   - CUDA0 (RTX 4090):  24080 = 9436 + (14193 = 13169 +      38 +     985) +         451
llama_print_memory_breakdown:   - CUDA1 (RTX 4090):  24080 = 9868 + (13756 = 13169 +      38 +     548) +         456
llama_print_memory_breakdown:   - CUDA2 (RTX 4090):  24080 = 9868 + (13756 = 13169 +      38 +     548) +         456
llama_print_memory_breakdown:   - CPU (EPYC 7742):  515628              72 =     0 +      57 +      15
```

Explanation:

```
size_t memory_total;             // total memory as reported by the device
size_t memory_free;              // free memory as reported by the device
size_t memory_used_self;         // sum of model, context, and compute
size_t memory_used_self_model;   // memory allocated for the model
size_t memory_used_self_context; // memory allocated for the context
size_t memory_used_self_compute; // memory allocated for temporary compute buffers
size_t memory_used_unaccounted;  // memory with unknown use, e.g. drivers or other programs, total - (free + self)
```

The intended immediate use is to make it easier to efficiently distribute models across devices. I also intend to re-use this code to determine automatically which parts of the model to put on which device for optimal performance. Long-term I would also want to expose this information via the HTTP server to establish a Pareto frontier of quality vs. memory use for different quantizations of different models.

Open problems:

* I added a function `llama_print_memory_breakdown` to the llama API which produces the above table on the console. Internally this function uses another new function `llama_backend_info` which returns a struct with information about the backends used by a `llama_context`. I'm not sure whether the latter should be part of the public API, and if yes, in what form.
* I added methods like `llama_model::memory_use(ggml_backend_dev_t dev)` which return the memory used on a specified device. But I'm not sure whether the device is the correct argument type here. Would it make more sense to pass a `ggml_backend_buffer_type_t`? In particular, I think this is the only correct way to handle e.g. `CUDA_Host` buffers.
* The memory for e.g. the CUDA pools is currently under "unaccounted", but it should be under "compute". Currently it is not possible for llama.cpp to retrieve this information. I think it would make sense to extend the ggml backend interface with a function that returns the total amount of device memory allocated by the backend.
* I'm not sure what to show, if anything, for the CPU. "Free" memory in this context does not have a clear-cut definition so I'm only showing total memory and memory that is definitely allocated for the CPU backend.