### PR TITLE
CPU: Fix loongarch lsx compilation error

### DIFF
--- a/ggml/src/ggml-cpu/arch/loongarch/quants.c
+++ b/ggml/src/ggml-cpu/arch/loongarch/quants.c
@@ -105,6 +105,18 @@ static inline float hsum_float_4x4(const __m128 a, const __m128 b, const __m128 
 
     return ((v4f32)res)[0];
 }
+
+// multiply int8_t, add results pairwise twice
+static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
+    // Get absolute values of x vectors
+    const __m128i ax = __lsx_vsigncov_b(x, x);
+    // Sign the values of the y vectors
+    const __m128i sy = __lsx_vsigncov_b(x, y);
+    // Perform multiplication and create 16-bit values
+    const __m128i dot = lsx_maddubs_h(ax, sy);
+    const __m128i ones = __lsx_vreplgr2vr_h(1);
+    return lsx_madd_h(ones, dot);
+}
 #endif
 
 #if defined(__loongarch_asx)
@@ -321,18 +333,6 @@ static inline __m256i lasx_xvandi_b_bit(__m256i a, const unsigned int b) {
         case 7: return __lasx_xvandi_b(a, 1 << 7);
         default: __builtin_unreachable();
     }
-}
-
-// multiply int8_t, add results pairwise twice
-static inline __m128i mul_sum_i8_pairs(const __m128i x, const __m128i y) {
-    // Get absolute values of x vectors
-    const __m128i ax = __lsx_vsigncov_b(x, x);
-    // Sign the values of the y vectors
-    const __m128i sy = __lsx_vsigncov_b(x, y);
-    // Perform multiplication and create 16-bit values
-    const __m128i dot = lsx_maddubs_h(ax, sy);
-    const __m128i ones = __lsx_vreplgr2vr_h(1);
-    return lsx_madd_h(ones, dot);
 }
 
 // horizontally add 8 floats

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -998,9 +998,9 @@ static inline void __lasx_f32cx8_store(ggml_fp16_t * x, __m256 y) {
 #define GGML_F32_EPR  4
 
 #define GGML_F32x4         __m128
-#define GGML_F32x4_ZERO    __lsx_vldi(0)
-#define GGML_F32x4_SET1(x) __lsx_vinsgr2vr_w(__lsx_vldi(0),(x), 0)
-#define GGML_F32x4_LOAD(x) __lsx_vld((x), 0)
+#define GGML_F32x4_ZERO    (__m128)__lsx_vldi(0)
+#define GGML_F32x4_SET1(x) (__m128)__lsx_vinsgr2vr_w(__lsx_vldi(0),(x), 0)
+#define GGML_F32x4_LOAD(x) (__m128)__lsx_vld((x), 0)
 #define GGML_F32x4_STORE(x, y)   __lsx_vst(y, x, 0)
 #define GGML_F32x4_FMA(a, b, c) __lsx_vfmadd_s(b, c, a)
 #define GGML_F32x4_ADD     __lsx_vfadd_s
@@ -1022,7 +1022,7 @@ static inline void __lasx_f32cx8_store(ggml_fp16_t * x, __m256 y) {
     __m128i tmp     = __lsx_vsrli_d((__m128i) x[0], 32);                              \
     tmp             = (__m128i) __lsx_vfadd_s((__m128) tmp, x[0]);                    \
     tmp             = __lsx_vpickev_w(__lsx_vldi(0), tmp);                            \
-    const __m128 t0 = __lsx_vshuf4i_w(tmp, 0x88);                                     \
+    const __m128 t0 = (__m128)__lsx_vshuf4i_w(tmp, 0x88);                                     \
     tmp             = __lsx_vsrli_d((__m128i) t0, 32);                                \
     tmp             = (__m128i) __lsx_vfadd_s((__m128) tmp, t0);                      \
     tmp             = __lsx_vpickev_w(__lsx_vldi(0), tmp);                            \
@@ -1052,7 +1052,7 @@ static inline __m128 __lsx_f16x4_load(const ggml_fp16_t * x) {
     tmp[2] = GGML_CPU_FP16_TO_FP32(x[2]);
     tmp[3] = GGML_CPU_FP16_TO_FP32(x[3]);
 
-    return __lsx_vld(tmp, 0);
+    return (__m128)__lsx_vld(tmp, 0);
 }
 
 static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
@@ -1067,9 +1067,9 @@ static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
 }
 
 #define GGML_F32Cx4             __m128
-#define GGML_F32Cx4_ZERO        __lsx_vldi(0)
-#define GGML_F32Cx4_SET1(x)     __lsx_vinsgr2vr_w(__lsx_vldi(0),(x), 0)
-#define GGML_F32Cx4_LOAD(x)     __lsx_f16x4_load(x)
+#define GGML_F32Cx4_ZERO        (__m128)__lsx_vldi(0)
+#define GGML_F32Cx4_SET1(x)     (__m128)__lsx_vinsgr2vr_w(__lsx_vldi(0),(x), 0)
+#define GGML_F32Cx4_LOAD(x)     (__m128)__lsx_f16x4_load(x)
 #define GGML_F32Cx4_STORE(x, y) __lsx_f16x4_store(x, y)
 #define GGML_F32Cx4_FMA         GGML_F32x4_FMA
 #define GGML_F32Cx4_ADD         __lsx_vfadd_s


### PR DESCRIPTION
Using the -DGGML_LASX=OFF parameter during compilation results in the following compilation errors. This is due to some 128-SIMD code not being correctly included within the #if defined(__loongarch_asx)...#endif block, as well as missing explicit type conversions.
`在编译时使用-DGGML_LASX=OFF参数，会出现以下编译错误，这是由于部分128-simd代码没有正确包含在#if defined(__loongarch_asx)...#endif中，以及缺少一些显示的类型转换`
```
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h: In function ‘__lsx_f16x4_load’:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h:1055:12: error: incompatible types when returning type ‘__vector(2) long long int’ but ‘__m128’ {aka ‘__vector(4) float’} was expected
     return __lsx_vld(tmp, 0);
            ^~~~~~~~~
In file included from /home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/quants.c:5:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h: In function ‘__lsx_f16x4_load’:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h:1055:12: error: incompatible types when returning type ‘__vector(2) long long int’ but ‘__m128’ {aka ‘__vector(4) float’} was expected
     return __lsx_vld(tmp, 0);
            ^~~~~~~~~
In file included from /home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:14:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/vec.h: In function ‘ggml_vec_dot_f16_unroll’:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/vec.h:236:67: error: incompatible types when initializing type ‘float’ using type ‘__vector(2) long long int’
         GGML_F16_VEC sum[GGML_VEC_DOT_UNROLL][GGML_F16_ARR] = { { GGML_F16_VEC_ZERO } };
                                                                   ^~~~~~~~~~~~~~~~~
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/vec.h:255:13: error: incompatible types when initializing type ‘__m128’ {aka ‘const __vector(4) float’} using type ‘__vector(2) long long int’
             GGML_F16_VEC_REDUCE(sumf[k], sum[k]);
             ^~~~~~~~~~~~~~~~~~~
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/vec.h: In function ‘ggml_vec_mad_f32’:
/home/junchao/work/ai/llama.cpp/ggml/src/ggml-cpu/vec.h:370:27: error: incompatible types when initializing type ‘__m128’ {aka ‘__vector(4) float’} using type ‘__vector(2) long long int’
         GGML_F32_VEC vx = GGML_F32_VEC_SET1(v);
                           ^~~~~~~~~~~~~~~~~

```

- Added explicit type conversions to prevent compilation errors
- Moved functions implemented by lsx into the appropriate macros

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*