### PR TITLE
convert : force setting sliding_window from original config

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5128,6 +5128,20 @@ class EmbeddingGemma(Gemma3Model):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
+
+        # Override the sliding window size as it gets adjusted by the Gemma3TextConfig
+        # constructor. We want to use the value from the original model's config.json.
+        with open(self.dir_model / "config.json", "r", encoding="utf-8") as f:
+            config = json.load(f)
+            orig_sliding_window = config.get("sliding_window")
+            if orig_sliding_window is None:
+                raise ValueError("sliding_window not found in model config - this is required for the model")
+
+            logger.info(f"Using original sliding_window from config: {orig_sliding_window} "
+                        f"instead of {self.hparams['sliding_window']}"
+            )
+            self.gguf_writer.add_sliding_window(orig_sliding_window)
+
         self._try_set_pooling_type()
 
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5138,8 +5138,7 @@ class EmbeddingGemma(Gemma3Model):
                 raise ValueError("sliding_window not found in model config - this is required for the model")
 
             logger.info(f"Using original sliding_window from config: {orig_sliding_window} "
-                        f"instead of {self.hparams['sliding_window']}"
-            )
+                        f"instead of {self.hparams['sliding_window']}")
             self.gguf_writer.add_sliding_window(orig_sliding_window)
 
         self._try_set_pooling_type()

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5131,6 +5131,7 @@ class EmbeddingGemma(Gemma3Model):
 
         # Override the sliding window size as it gets adjusted by the Gemma3TextConfig
         # constructor. We want to use the value from the original model's config.json.
+        # ref: https://github.com/huggingface/transformers/pull/40700
         with open(self.dir_model / "config.json", "r", encoding="utf-8") as f:
             config = json.load(f)
             orig_sliding_window = config.get("sliding_window")


### PR DESCRIPTION
This commit modifies the set_gguf_parameters method for EmbeddingGemma so that it reads the sliding_window parameter from the original model config.json and uses that value.

The motivation for this change is that the Gemma3TextConfig constructor adjusts the sliding_window value, which can lead to inconsistencies when converting models as we expects this value to match the original model's configuration.

Refs: https://github.com/huggingface/transformers/blob/bb45d3631ec7026db04a77d33a52b31766372160/src/transformers/models/gemma3/configuration_gemma3.py#L230
