### PR TITLE
ci : cache ROCm installation in windows-latest-cmake-hip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1081,7 +1081,16 @@ jobs:
           Invoke-WebRequest -Uri "https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe" -OutFile "${env:RUNNER_TEMP}\rocm-install.exe"
           write-host "Installing AMD HIP SDK"
           $proc = Start-Process "${env:RUNNER_TEMP}\rocm-install.exe" -ArgumentList '-install' -NoNewWindow -PassThru
-          $proc.WaitForExit(600000)
+          $completed = $proc.WaitForExit(600000)
+          if (-not $completed) {
+              Write-Error "ROCm installation timed out after 10 minutes. Killing the process"
+              $proc.Kill()
+              exit 1
+          }
+          if ($proc.ExitCode -ne 0) {
+              Write-Error "ROCm installation failed with exit code $($proc.ExitCode)"
+              exit 1
+          }
           write-host "Completed AMD HIP SDK installation"
 
       - name: Verify ROCm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1120,15 +1120,6 @@ jobs:
           CURL_PATH: ${{ steps.get_libcurl.outputs.curl_path }}
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
-
-          # Create symlink for amdhip64.dll (fix for amdgpu-arch.exe DLL naming issue)
-          $hipBinPath = "$env:HIP_PATH\bin"
-          $versionedDll = Get-ChildItem "$hipBinPath\amdhip64_*.dll" | Select-Object -First 1
-          if ($versionedDll -and -not (Test-Path "$hipBinPath\amdhip64.dll")) {
-              Write-Host "Creating symlink: amdhip64.dll -> $($versionedDll.Name)"
-              New-Item -ItemType SymbolicLink -Path "$hipBinPath\amdhip64.dll" -Target $versionedDll.FullName -Force
-          }
-
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1063,7 +1063,17 @@ jobs:
         run: |
           git clone https://github.com/rocm/rocwmma --branch rocm-6.2.4 --depth 1
 
-      - name: Install
+      - name: Cache ROCm Installation
+        id: cache-rocm
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\AMD\ROCm
+          key: rocm-6.1-${{ runner.os }}-v1
+          restore-keys: |
+            rocm-6.1-${{ runner.os }}-
+
+      - name: Install ROCm
+        if: steps.cache-rocm.outputs.cache-hit != 'true'
         id: depends
         run: |
           $ErrorActionPreference = "Stop"
@@ -1077,7 +1087,13 @@ jobs:
       - name: Verify ROCm
         id: verify
         run: |
-          & 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' --version
+          # Find and test ROCm installation
+          $clangPath = Get-ChildItem 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | Select-Object -First 1
+          if (-not $clangPath) {
+            Write-Error "ROCm installation not found"
+            exit 1
+          }
+          & $clangPath.FullName --version
 
       - name: Install ccache
         uses: ggml-org/ccache-action@v1.2.16
@@ -1096,7 +1112,7 @@ jobs:
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
 
-          # Create symlink for amdhip64.dll (fix for amdgpu-arch.exe)
+          # Create symlink for amdhip64.dll (fix for amdgpu-arch.exe DLL naming issue)
           $hipBinPath = "$env:HIP_PATH\bin"
           $versionedDll = Get-ChildItem "$hipBinPath\amdhip64_*.dll" | Select-Object -First 1
           if ($versionedDll -and -not (Test-Path "$hipBinPath\amdhip64.dll")) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1095,6 +1095,15 @@ jobs:
           CURL_PATH: ${{ steps.get_libcurl.outputs.curl_path }}
         run: |
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
+
+          # Create symlink for amdhip64.dll (fix for amdgpu-arch.exe)
+          $hipBinPath = "$env:HIP_PATH\bin"
+          $versionedDll = Get-ChildItem "$hipBinPath\amdhip64_*.dll" | Select-Object -First 1
+          if ($versionedDll -and -not (Test-Path "$hipBinPath\amdhip64.dll")) {
+              Write-Host "Creating symlink: amdhip64.dll -> $($versionedDll.Name)"
+              New-Item -ItemType SymbolicLink -Path "$hipBinPath\amdhip64.dll" -Target $versionedDll.FullName -Force
+          }
+
           $env:CMAKE_PREFIX_PATH="${env:HIP_PATH}"
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `


### PR DESCRIPTION
This commit adds caching of the ROCm installation for the windows-latest-cmake-hip job. 

The motivation for this is that the installation can sometimes hang and/or not complete properly leaving an invalid installation which later fails the build. By caching the installation hopefully we can keep a good installation available in the cache and avoid the installation step.

Refs: https://github.com/ggml-org/llama.cpp/pull/15365