### PR TITLE
server : adjust prompt similarity thold + add logs

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -452,7 +452,7 @@ struct common_params {
 
     std::string slot_save_path;
 
-    float slot_prompt_similarity = 0.5f;
+    float slot_prompt_similarity = 0.1f;
 
     // batched-bench params
     bool is_pp_shared = false;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2372,7 +2372,7 @@ struct server_context {
             }
 
             if (ret != nullptr) {
-                SLT_DBG(*ret, "selected slot by lcs similarity, lcs_len = %d, similarity = %f\n", lcs_len, similarity);
+                SLT_INF(*ret, "selected slot by lcs similarity, lcs_len = %d, similarity = %.3f (> %.3f thold)\n", lcs_len, similarity, slot_prompt_similarity);
             }
         }
 
@@ -2394,7 +2394,7 @@ struct server_context {
             }
 
             if (ret != nullptr) {
-                SLT_DBG(*ret, "selected slot by lru, t_last = %" PRId64 "\n", t_last);
+                SLT_INF(*ret, "selected slot by LRU, t_last = %" PRId64 "\n", t_last);
             }
         }
 


### PR DESCRIPTION
fix #15894

The default prompt similarity threshold for reusing server slots is arguably too high (`0.5` on `master`). Reduce it to `0.1`. Also add a couple of logs to make the decisions about selecting a slot more clear.