### PR TITLE
CUDA: larger SRAM reads for tile FA, AMD FP16 dot

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -555,7 +555,7 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const float2 v
 }
 
 static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const half2 v, const half2 u) {
-#if defined(GGML_USE_HIP) && (defined(RDNA2)  || defined(RDNA3) || defined(RDNA4) || defined(GCN) || defined(CDNA))
+#if defined(GGML_USE_HIP) && (defined(RDNA2) || defined(RDNA3) || defined(RDNA4) || defined(__gfx906__) || defined(CDNA))
     asm volatile("v_dot2_f32_f16 %0, %1, %2, %0" : "+v"(acc) : "v"(v), "v"(u));
 #else
 #ifdef FAST_FP16_AVAILABLE
@@ -567,7 +567,7 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const half2 v,
     acc += tmpv.x * tmpu.x;
     acc += tmpv.y * tmpu.y;
 #endif // FAST_FP16_AVAILABLE
-#endif // defined(GGML_USE_HIP) && defined(GCN)
+#endif // defined(GGML_USE_HIP) && (defined(RDNA2)  || defined(RDNA3) || defined(RDNA4) || defined(GCN5) || defined(CDNA))
 }
 
 // Aligned memory transfers of 8/16 bytes can be faster than 2 transfers with 4 bytes, especially on AMD.

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -162,6 +162,14 @@
 #define GCN
 #endif
 
+#if defined(__gfx900__) || defined(__gfx906__)
+#define GCN5
+#endif
+
+#if defined(__gfx803__)
+#define GCN4
+#endif
+
 #if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx942__)
 #define CDNA // For the entire family
 #endif


### PR DESCRIPTION
See https://github.com/iacopPBK/llama.cpp-gfx906 . AMD GPUs support reads of up to 16 bytes from SRAM. This PR extends the tile FlashAttention CUDA kernel with support for reads of 8 or 16 bytes. The FP32 -> FP16 type conversion is also done prior to writing the data to SRAM to reduce I/O further.

I also checked the AMD ISA documentation for `v_dot2_f32_f16` support and adjusted the code paths accordingly; it seems to be available everywhere except for RDNA 1.

<details>
<summary>Performance changes</summary>

| GPU           | Model           |     Microbatch size | Test      |     t/s master |     t/s 5bae9f9ef |     Speedup |
| :------------ | :-------------- | ------------------: | :-------- | -------------: | ----------------: | ----------: |
| MI50          | gemma 2B Q4_0   |                  16 | pp16384   |         629.54 |            716.54 |        1.14 |
| MI50          | gemma 2B Q4_0   |                  32 | pp16384   |         728.28 |            911.94 |        1.25 |
| MI50          | gemma 2B Q4_0   |                 512 | pp16384   |        1412.40 |           2141.40 |        1.52 |
| MI50          | llama 1B Q4_0   |                  16 | pp16384   |         927.48 |            998.83 |        1.08 |
| MI50          | llama 1B Q4_0   |                  32 | pp16384   |        1189.48 |           1338.73 |        1.13 |
| MI50          | llama 1B Q4_0   |                 512 | pp16384   |        2278.02 |           2898.30 |        1.27 |
| MI50          | llama 8B Q4_0   |                  16 | pp16384   |         277.56 |            294.46 |        1.06 |
| MI50          | llama 8B Q4_0   |                  32 | pp16384   |         334.59 |            366.55 |        1.10 |
| MI50          | llama 8B Q4_0   |                 512 | pp16384   |         508.27 |            606.21 |        1.19 |
| RX 6800       | gemma 2B Q4_0   |                  16 | pp16384   |         399.91 |            636.85 |        1.59 |
| RX 6800       | gemma 2B Q4_0   |                  32 | pp16384   |         313.91 |            992.28 |        3.16 |
| RX 6800       | gemma 2B Q4_0   |                 512 | pp16384   |         568.27 |           1897.49 |        3.34 |
| RX 6800       | llama 1B Q4_0   |                  16 | pp16384   |         644.87 |            903.19 |        1.40 |
| RX 6800       | llama 1B Q4_0   |                  32 | pp16384   |         658.72 |           1336.48 |        2.03 |
| RX 6800       | llama 1B Q4_0   |                 512 | pp16384   |         897.77 |           2301.67 |        2.56 |
| RX 6800       | llama 8B Q4_0   |                  16 | pp16384   |         172.06 |            234.54 |        1.36 |
| RX 6800       | llama 8B Q4_0   |                  32 | pp16384   |         174.27 |            328.20 |        1.88 |
| RX 6800       | llama 8B Q4_0   |                 512 | pp16384   |         231.13 |            530.74 |        2.30 |

</details>