### PR TITLE
metal : allow ops to run concurrently

### DIFF
--- a/ggml/src/ggml-metal/CMakeLists.txt
+++ b/ggml/src/ggml-metal/CMakeLists.txt
@@ -6,6 +6,7 @@ message(STATUS "Metal framework found")
 
 ggml_add_backend_library(ggml-metal
                          ggml-metal.m
+                         ggml-metal-common.cpp
                         )
 
 target_link_libraries(ggml-metal PRIVATE

--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -1,0 +1,131 @@
+#include "ggml-metal-common.h"
+
+#include "ggml-impl.h"
+
+#include <vector>
+
+// keep this separate from the public ggml_mem_range_params
+struct ggml_mem_range {
+    uint64_t p0; // being
+    uint64_t p1; // end
+
+    enum ggml_mem_range_type pt;
+};
+
+struct ggml_mem_ranges {
+    std::vector<struct ggml_mem_range> ranges;
+
+    int debug = 0;
+};
+
+struct ggml_mem_ranges * ggml_mem_ranges_init(int debug) {
+    auto * res = new struct ggml_mem_ranges;
+
+    res->debug = debug;
+
+    return res;
+}
+
+void ggml_mem_ranges_free(struct ggml_mem_ranges * mrs) {
+    delete mrs;
+}
+
+void ggml_mem_ranges_reset(struct ggml_mem_ranges * mrs) {
+    mrs->ranges.clear();
+}
+
+bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp) {
+    mrs->ranges.push_back({
+        /*.p0 =*/ mrp.p0,
+        /*.p1 =*/ mrp.p1,
+        /*.pt =*/ mrp.pt,
+    });
+
+    return true;
+}
+
+bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    struct ggml_mem_range_params mrp = {
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+        /*.pt =*/ MEM_RANGE_TYPE_SRC,
+    };
+
+    if (mrs->debug > 2) {
+        GGML_LOG_DEBUG("%s: add src range [%lld, %lld)\n", __func__, mrp.p0, mrp.p1);
+    }
+
+    return ggml_mem_ranges_add(mrs, mrp);
+}
+
+bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    struct ggml_mem_range_params mrp = {
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+        /*.pt =*/ MEM_RANGE_TYPE_DST,
+    };
+
+    if (mrs->debug > 2) {
+        GGML_LOG_DEBUG("%s: add dst range [%lld, %lld)\n", __func__, mrp.p0, mrp.p1);
+    }
+
+    return ggml_mem_ranges_add(mrs, mrp);
+}
+
+bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp) {
+    for (size_t i = 0; i < mrs->ranges.size(); i++) {
+        if (mrp.pt == MEM_RANGE_TYPE_SRC && mrs->ranges[i].pt == MEM_RANGE_TYPE_SRC) {
+            continue;
+        }
+
+        if (mrp.p0 < mrs->ranges[i].p1 && mrp.p1 > mrs->ranges[i].p0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    struct ggml_mem_range_params mrp = {
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+        /*.pt =*/ MEM_RANGE_TYPE_SRC,
+    };
+
+    const bool res = ggml_mem_ranges_check(mrs, mrp);
+
+    if (res) {
+        if (mrs->debug > 2) {
+            GGML_LOG_DEBUG("%s: the src range [%lld, %lld) overlaps with a previous dst range\n", __func__, mrp.p0, mrp.p1);
+        }
+    }
+
+    return res;
+}
+
+bool ggml_mem_ranges_check_dst(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    struct ggml_mem_range_params mrp = {
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+        /*.pt =*/ MEM_RANGE_TYPE_DST,
+    };
+
+    const bool res = ggml_mem_ranges_check(mrs, mrp);
+
+    if (res) {
+        if (mrs->debug > 2) {
+            GGML_LOG_DEBUG("%s: the dst range [%lld, %lld) overlaps with a previous src range\n", __func__, mrp.p0, mrp.p1);
+        }
+    }
+
+    return res;
+}

--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -4,7 +4,6 @@
 
 #include <vector>
 
-// keep this separate from the public ggml_mem_range_params
 struct ggml_mem_range {
     uint64_t p0; // begin
     uint64_t p1; // end
@@ -21,6 +20,7 @@ struct ggml_mem_ranges {
 struct ggml_mem_ranges * ggml_mem_ranges_init(int debug) {
     auto * res = new ggml_mem_ranges;
 
+    res->ranges.reserve(256);
     res->debug = debug;
 
     return res;
@@ -34,7 +34,7 @@ void ggml_mem_ranges_reset(ggml_mem_ranges * mrs) {
     mrs->ranges.clear();
 }
 
-bool ggml_mem_ranges_add(ggml_mem_ranges * mrs, ggml_mem_range_params mrp) {
+static bool ggml_mem_ranges_add(ggml_mem_ranges * mrs, ggml_mem_range mrp) {
     mrs->ranges.push_back({
         /*.p0 =*/ mrp.p0,
         /*.p1 =*/ mrp.p1,
@@ -47,10 +47,22 @@ bool ggml_mem_ranges_add(ggml_mem_ranges * mrs, ggml_mem_range_params mrp) {
 bool ggml_mem_ranges_add_src(ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    ggml_mem_range_params mrp = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ MEM_RANGE_TYPE_SRC,
+    node = node->view_src ? node->view_src : node;
+
+    ggml_mem_range mrp;
+
+    if (node->buffer) {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node->data,
+            /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+            /*.pt =*/ MEM_RANGE_TYPE_SRC,
+        };
+    } else {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node,
+            /*.p1 =*/ (uint64_t) node + 1,
+            /*.pt =*/ MEM_RANGE_TYPE_SRC,
+        };
     };
 
     if (mrs->debug > 2) {
@@ -63,10 +75,22 @@ bool ggml_mem_ranges_add_src(ggml_mem_ranges * mrs, const ggml_tensor * node) {
 bool ggml_mem_ranges_add_dst(ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    ggml_mem_range_params mrp = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ MEM_RANGE_TYPE_DST,
+    node = node->view_src ? node->view_src : node;
+
+    ggml_mem_range mrp;
+
+    if (node->buffer) {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node->data,
+            /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+            /*.pt =*/ MEM_RANGE_TYPE_DST,
+        };
+    } else {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node,
+            /*.p1 =*/ (uint64_t) node + 1,
+            /*.pt =*/ MEM_RANGE_TYPE_DST,
+        };
     };
 
     if (mrs->debug > 2) {
@@ -76,13 +100,13 @@ bool ggml_mem_ranges_add_dst(ggml_mem_ranges * mrs, const ggml_tensor * node) {
     return ggml_mem_ranges_add(mrs, mrp);
 }
 
-bool ggml_mem_ranges_check(const ggml_mem_ranges * mrs, ggml_mem_range_params mrp) {
+static bool ggml_mem_ranges_check(const ggml_mem_ranges * mrs, ggml_mem_range mrp) {
     for (size_t i = 0; i < mrs->ranges.size(); i++) {
         if (mrp.pt == MEM_RANGE_TYPE_SRC && mrs->ranges[i].pt == MEM_RANGE_TYPE_SRC) {
             continue;
         }
 
-        if (mrp.p0 < mrs->ranges[i].p1 && mrp.p1 > mrs->ranges[i].p0) {
+        if (mrp.p0 < mrs->ranges[i].p1 && mrp.p1 >= mrs->ranges[i].p0) {
             return true;
         }
     }
@@ -93,10 +117,22 @@ bool ggml_mem_ranges_check(const ggml_mem_ranges * mrs, ggml_mem_range_params mr
 bool ggml_mem_ranges_check_src(const ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    ggml_mem_range_params mrp = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ MEM_RANGE_TYPE_SRC,
+    node = node->view_src ? node->view_src : node;
+
+    ggml_mem_range mrp;
+
+    if (node->buffer) {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node->data,
+            /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+            /*.pt =*/ MEM_RANGE_TYPE_SRC,
+        };
+    } else {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node,
+            /*.p1 =*/ (uint64_t) node + 1,
+            /*.pt =*/ MEM_RANGE_TYPE_SRC,
+        };
     };
 
     const bool res = ggml_mem_ranges_check(mrs, mrp);
@@ -113,11 +149,23 @@ bool ggml_mem_ranges_check_src(const ggml_mem_ranges * mrs, const ggml_tensor * 
 bool ggml_mem_ranges_check_dst(const ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    ggml_mem_range_params mrp = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ MEM_RANGE_TYPE_DST,
-    };
+    node = node->view_src ? node->view_src : node;
+
+    ggml_mem_range mrp;
+
+    if (node->buffer) {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node->data,
+            /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
+            /*.pt =*/ MEM_RANGE_TYPE_DST,
+        };
+    } else {
+        mrp = {
+            /*.p0 =*/ (uint64_t) node,
+            /*.p1 =*/ (uint64_t) node + 1,
+            /*.pt =*/ MEM_RANGE_TYPE_DST,
+        };
+    }
 
     const bool res = ggml_mem_ranges_check(mrs, mrp);
 
@@ -128,4 +176,268 @@ bool ggml_mem_ranges_check_dst(const ggml_mem_ranges * mrs, const ggml_tensor * 
     }
 
     return res;
+}
+
+// TODO: move to ggml.h?
+static bool is_empty(ggml_op op) {
+    switch (op) {
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_TRANSPOSE:
+        case GGML_OP_VIEW:
+        case GGML_OP_PERMUTE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+struct node_info {
+    ggml_tensor * node;
+
+    std::vector<const ggml_tensor *> srcs;
+    std::vector<ggml_tensor *> fused;
+
+    ggml_op op() const {
+        return node->op;
+    }
+
+    const ggml_tensor * dst() const {
+        return fused.empty() ? node : fused.back();
+    }
+
+    bool is_empty() const {
+        return ::is_empty(node->op);
+    }
+
+    void add_src(const ggml_tensor * src, bool check = false) {
+        if (!src) {
+            return;
+        }
+
+        src = src->view_src ? src->view_src : src;
+
+        if (check) {
+            for (const auto * prev : srcs) {
+                if (prev == src) {
+                    return;
+                }
+            }
+        }
+
+        srcs.push_back(src);
+    }
+
+    void add_fused(ggml_tensor * t) {
+        fused.push_back(t);
+    }
+};
+
+static std::vector<node_info> ggml_metal_graph_optimize_reorder(const std::vector<node_info> & nodes) {
+    // helper to add node src and dst ranges
+    const auto & h_add = [](ggml_mem_ranges * mrs, const node_info & node) {
+        for (const auto * src : node.srcs) {
+            ggml_mem_ranges_add_src(mrs, src);
+        }
+
+        ggml_mem_ranges_add_dst(mrs, node.dst());
+    };
+
+    // helper to check if a node ranges overlap with the existing set
+    // if they overlap, the node cannot be executed concurrently with the nodes participating in this set
+    const auto & h_overlap = [](const ggml_mem_ranges * mrs, const node_info & node) {
+        for (const auto * src : node.srcs) {
+            if (ggml_mem_ranges_check_src(mrs, src)) {
+                return true;
+            }
+        }
+
+        return ggml_mem_ranges_check_dst(mrs, node.dst());
+    };
+
+    // perform reorders only across these types of ops
+    // can be expanded when needed
+    // IMPORTANT: do not add ops such as GGML_OP_CPY or GGML_OP_SET_ROWS
+    //            the dependencies from such ops are not always represented in the graph
+    const auto & h_safe = [](ggml_op op) {
+        switch (op) {
+            case GGML_OP_MUL_MAT:
+            case GGML_OP_MUL_MAT_ID:
+            case GGML_OP_ROPE:
+            case GGML_OP_NORM:
+            case GGML_OP_RMS_NORM:
+            case GGML_OP_GROUP_NORM:
+            case GGML_OP_SUM:
+            case GGML_OP_SUM_ROWS:
+            case GGML_OP_MEAN:
+            case GGML_OP_MUL:
+            case GGML_OP_ADD:
+            case GGML_OP_SUB:
+            case GGML_OP_DIV:
+            case GGML_OP_SCALE:
+            case GGML_OP_GET_ROWS:
+            case GGML_OP_CLAMP:
+            case GGML_OP_UNARY:
+                return true;
+            default:
+                return is_empty(op);
+        }
+    };
+
+    const int n = nodes.size();
+
+    std::vector<node_info> res;
+    res.reserve(n);
+
+    std::vector<bool> used(n, false);
+
+    ggml_mem_ranges * mrs0 = ggml_mem_ranges_init(0);
+    ggml_mem_ranges * mrs1 = ggml_mem_ranges_init(0);
+
+    for (int i0 = 0; i0 < n; i0++) {
+        if (used[i0]) {
+            continue;
+        }
+
+        const auto & node0 = nodes[i0];
+
+        if (node0.is_empty()) {
+            res.push_back(node0);
+            continue;
+        }
+
+        // the node is not concurrent with the existing concurrent set, so we have to "put a barrier" (i.e reset mrs0)
+        // but before we do that, look forward for some other nodes that can be added to the concurrent set mrs0
+        if (h_overlap(mrs0, node0)) {
+            // this will hold the set of memory ranges from the nodes that haven't been processed yet
+            ggml_mem_ranges_reset(mrs1);
+
+            // initialize it with the current node
+            h_add(mrs1, node0);
+
+            for (int i1 = i0 + 1; i1 < i0 + 32 && i1 < n; i1++) {
+                if (used[i1]) {
+                    continue;
+                }
+
+                const auto & node1 = nodes[i1];
+
+                if (!h_safe(node1.op())) {
+                    break;
+                }
+
+                // to add a concurrent node, it has to:
+                //   - be empty
+                //   - be concurrent with all nodes in the existing concurrent set (mrs0)
+                //   - be concurrent with all nodes prior to it that haven't been processed yet (mrs1)
+                if ((node1.is_empty() || !h_overlap(mrs0, node1)) && !h_overlap(mrs1, node1)) {
+                    if (!node1.is_empty()) {
+                        // add the node to the existing concurrent set (i.e. reorder)
+                        h_add(mrs0, node1);
+                    }
+                    res.push_back(node1);
+                    used[i1] = true;
+                } else {
+                    // add the node to the set of nodes that haven't been processed, to prevent invalid reordering
+                    h_add(mrs1, node1);
+                }
+            }
+
+            // finalize the concurrent set and begina new one with the current node
+            ggml_mem_ranges_reset(mrs0);
+        }
+
+        {
+            h_add(mrs0, node0);
+            res.push_back(node0);
+        }
+    }
+
+    ggml_mem_ranges_free(mrs0);
+    ggml_mem_ranges_free(mrs1);
+
+    return res;
+}
+
+void ggml_metal_graph_optimize(ggml_cgraph * gf) {
+    constexpr int MAX_FUSE = 16;
+
+    const int n = gf->n_nodes;
+
+    enum ggml_op ops[MAX_FUSE];
+
+    std::vector<node_info> nodes;
+    nodes.reserve(gf->n_nodes);
+
+    // fuse nodes:
+    // we don't want to make reorders that break fusing, so we pack all fusable tensors
+    //   and perform the reorder over the fused nodes. after the reorder is done, we unfuse
+    for (int i = 0; i < n; i++) {
+        node_info node = {
+            /*.node =*/ gf->nodes[i],
+            /*.srcs =*/ {},
+            /*.fused =*/ {},
+        };
+
+        for (int j = 0; j < GGML_MAX_SRC; j++) {
+            node.add_src(gf->nodes[i]->src[j]);
+        }
+
+        // fuse only ops that start with these operations
+        // can be expanded when needed
+        if (node.op() == GGML_OP_ADD ||
+            node.op() == GGML_OP_RMS_NORM) {
+            ops[0] = node.op();
+
+            int f = i + 1;
+            while (f < n && f < i + MAX_FUSE) {
+                // conservatively allow fusing only these ops
+                // can be expanded when needed
+                if (gf->nodes[f]->op != GGML_OP_ADD &&
+                    gf->nodes[f]->op != GGML_OP_MUL &&
+                    gf->nodes[f]->op != GGML_OP_RMS_NORM) {
+                    break;
+                }
+                ops[f - i] = gf->nodes[f]->op;
+                f++;
+            }
+
+            f -= i;
+            for (; f > 1; f--) {
+                if (ggml_can_fuse(gf, i, ops, f)) {
+                    break;
+                }
+            }
+
+            // add the fused tensors into the node info so we can unfuse them later
+            for (int k = 1; k < f; k++) {
+                ++i;
+
+                // the .dst() becomes the last fused tensor
+                node.add_fused(gf->nodes[i]);
+
+                // track all sources of this fused node
+                for (int j = 0; j < GGML_MAX_SRC; j++) {
+                    node.add_src(gf->nodes[i]->src[j], true);
+                }
+            }
+        }
+
+        nodes.push_back(std::move(node));
+    }
+
+    // reorder to improve concurrency
+    nodes = ggml_metal_graph_optimize_reorder(nodes);
+
+    // unfuse
+    {
+        int j = 0;
+        for (const auto & node : nodes) {
+            gf->nodes[j++] = node.node;
+
+            for (auto * fused : node.fused) {
+                gf->nodes[j++] = fused;
+            }
+        }
+    }
 }

--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -6,35 +6,35 @@
 
 // keep this separate from the public ggml_mem_range_params
 struct ggml_mem_range {
-    uint64_t p0; // being
+    uint64_t p0; // begin
     uint64_t p1; // end
 
-    enum ggml_mem_range_type pt;
+    ggml_mem_range_type pt;
 };
 
 struct ggml_mem_ranges {
-    std::vector<struct ggml_mem_range> ranges;
+    std::vector<ggml_mem_range> ranges;
 
     int debug = 0;
 };
 
 struct ggml_mem_ranges * ggml_mem_ranges_init(int debug) {
-    auto * res = new struct ggml_mem_ranges;
+    auto * res = new ggml_mem_ranges;
 
     res->debug = debug;
 
     return res;
 }
 
-void ggml_mem_ranges_free(struct ggml_mem_ranges * mrs) {
+void ggml_mem_ranges_free(ggml_mem_ranges * mrs) {
     delete mrs;
 }
 
-void ggml_mem_ranges_reset(struct ggml_mem_ranges * mrs) {
+void ggml_mem_ranges_reset(ggml_mem_ranges * mrs) {
     mrs->ranges.clear();
 }
 
-bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp) {
+bool ggml_mem_ranges_add(ggml_mem_ranges * mrs, ggml_mem_range_params mrp) {
     mrs->ranges.push_back({
         /*.p0 =*/ mrp.p0,
         /*.p1 =*/ mrp.p1,
@@ -44,10 +44,10 @@ bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, struct ggml_mem_range_par
     return true;
 }
 
-bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+bool ggml_mem_ranges_add_src(ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct ggml_mem_range_params mrp = {
+    ggml_mem_range_params mrp = {
         /*.p0 =*/ (uint64_t) node->data,
         /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ MEM_RANGE_TYPE_SRC,
@@ -60,10 +60,10 @@ bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_ten
     return ggml_mem_ranges_add(mrs, mrp);
 }
 
-bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+bool ggml_mem_ranges_add_dst(ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct ggml_mem_range_params mrp = {
+    ggml_mem_range_params mrp = {
         /*.p0 =*/ (uint64_t) node->data,
         /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ MEM_RANGE_TYPE_DST,
@@ -76,7 +76,7 @@ bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_ten
     return ggml_mem_ranges_add(mrs, mrp);
 }
 
-bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp) {
+bool ggml_mem_ranges_check(const ggml_mem_ranges * mrs, ggml_mem_range_params mrp) {
     for (size_t i = 0; i < mrs->ranges.size(); i++) {
         if (mrp.pt == MEM_RANGE_TYPE_SRC && mrs->ranges[i].pt == MEM_RANGE_TYPE_SRC) {
             continue;
@@ -90,10 +90,10 @@ bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, struct ggml_mem_r
     return false;
 }
 
-bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+bool ggml_mem_ranges_check_src(const ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct ggml_mem_range_params mrp = {
+    ggml_mem_range_params mrp = {
         /*.p0 =*/ (uint64_t) node->data,
         /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ MEM_RANGE_TYPE_SRC,
@@ -110,10 +110,10 @@ bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct 
     return res;
 }
 
-bool ggml_mem_ranges_check_dst(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node) {
+bool ggml_mem_ranges_check_dst(const ggml_mem_ranges * mrs, const ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct ggml_mem_range_params mrp = {
+    ggml_mem_range_params mrp = {
         /*.p0 =*/ (uint64_t) node->data,
         /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ MEM_RANGE_TYPE_DST,

--- a/ggml/src/ggml-metal/ggml-metal-common.h
+++ b/ggml/src/ggml-metal/ggml-metal-common.h
@@ -8,17 +8,11 @@ extern "C" {
 #endif
 
 struct ggml_tensor;
+struct ggml_cgraph;
 
 enum ggml_mem_range_type {
     MEM_RANGE_TYPE_SRC = 0,
     MEM_RANGE_TYPE_DST = 1,
-};
-
-struct ggml_mem_range_params {
-    uint64_t p0; // being
-    uint64_t p1; // end
-
-    enum ggml_mem_range_type pt;
 };
 
 struct ggml_mem_ranges;
@@ -28,18 +22,16 @@ void ggml_mem_ranges_free(struct ggml_mem_ranges * mrs);
 
 void ggml_mem_ranges_reset(struct ggml_mem_ranges * mrs);
 
-bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp);
-
 bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
 bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
 
 // return true if:
 // - new src range overlaps with any existing dst range
 // - new dst range overlaps with any existing range (src or dst)
-bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp);
-
 bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
 bool ggml_mem_ranges_check_dst(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+
+void ggml_metal_graph_optimize(struct ggml_cgraph * gf);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-metal/ggml-metal-common.h
+++ b/ggml/src/ggml-metal/ggml-metal-common.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ggml_tensor;
+
+enum ggml_mem_range_type {
+    MEM_RANGE_TYPE_SRC = 0,
+    MEM_RANGE_TYPE_DST = 1,
+};
+
+struct ggml_mem_range_params {
+    uint64_t p0; // being
+    uint64_t p1; // end
+
+    enum ggml_mem_range_type pt;
+};
+
+struct ggml_mem_ranges;
+
+struct ggml_mem_ranges * ggml_mem_ranges_init(int debug);
+void ggml_mem_ranges_free(struct ggml_mem_ranges * mrs);
+
+void ggml_mem_ranges_reset(struct ggml_mem_ranges * mrs);
+
+bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp);
+
+bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+
+// return true if:
+// - new src range overlaps with any existing dst range
+// - new dst range overlaps with any existing range (src or dst)
+bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, struct ggml_mem_range_params mrp);
+
+bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+bool ggml_mem_ranges_check_dst(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ggml/src/ggml-metal/ggml-metal-common.h
+++ b/ggml/src/ggml-metal/ggml-metal-common.h
@@ -1,6 +1,7 @@
+// helper functions for ggml-metal that are too difficult to implement in Objective-C
+
 #pragma once
 
-#include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -15,22 +16,35 @@ enum ggml_mem_range_type {
     MEM_RANGE_TYPE_DST = 1,
 };
 
+// a helper object that can be used for reordering operations to improve concurrency
+//
+// the fundamental idea is that a set of tasks (either ggml ops, or something else) can run concurrently if they
+//   don't write to a memory that is being read by another task or written to by another task in the set
+//
+// with this structure, we can add tasks to the set, setting memory constraints. we can also check if a new task
+//   can be added to the set without violating the constraints (i.e. if it can be executed concurrently with the
+//   tasks already in the set)
+//
 struct ggml_mem_ranges;
 
 struct ggml_mem_ranges * ggml_mem_ranges_init(int debug);
 void ggml_mem_ranges_free(struct ggml_mem_ranges * mrs);
 
+// remove all ranges from the set
 void ggml_mem_ranges_reset(struct ggml_mem_ranges * mrs);
 
-bool ggml_mem_ranges_add_src(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
-bool ggml_mem_ranges_add_dst(struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+// add src or dst ranges to track
+bool ggml_mem_ranges_add(struct ggml_mem_ranges * mrs, const struct ggml_tensor * tensor);
 
-// return true if:
+// return false if:
 // - new src range overlaps with any existing dst range
 // - new dst range overlaps with any existing range (src or dst)
-bool ggml_mem_ranges_check_src(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
-bool ggml_mem_ranges_check_dst(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * node);
+bool ggml_mem_ranges_check(const struct ggml_mem_ranges * mrs, const struct ggml_tensor * tensor);
 
+// reorder the nodes in the graph to improve concurrency, while respecting fusion
+//
+// note: this implementation is generic and not specific to metal
+//       if it proves to work well, we can start using it for other backends in the future
 void ggml_metal_graph_optimize(struct ggml_cgraph * gf);
 
 #ifdef __cplusplus

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2128,13 +2128,9 @@ static bool ggml_metal_encode_mem_ranges_add_src(struct ggml_metal_encode_contex
         return true;
     }
 
-    size_t offs = 0;
-    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
-    GGML_ASSERT(id_node != nil);
-
     struct mem_range r = {
-        /*.p0 =*/ id_node.gpuAddress + offs,
-        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ 0,
     };
 
@@ -2148,13 +2144,9 @@ static bool ggml_metal_encode_mem_ranges_add_src(struct ggml_metal_encode_contex
 static bool ggml_metal_encode_mem_ranges_add_dst(struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    size_t offs = 0;
-    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
-    GGML_ASSERT(id_node != nil);
-
     struct mem_range r = {
-        /*.p0 =*/ id_node.gpuAddress + offs,
-        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ 1,
     };
 
@@ -2187,13 +2179,9 @@ static bool ggml_metal_encode_mem_ranges_check_src(const struct ggml_metal_encod
         return false;
     }
 
-    size_t offs = 0;
-    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
-    GGML_ASSERT(id_node != nil);
-
     struct mem_range r = {
-        /*.p0 =*/ id_node.gpuAddress + offs,
-        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ 0,
     };
 
@@ -2211,13 +2199,9 @@ static bool ggml_metal_encode_mem_ranges_check_src(const struct ggml_metal_encod
 static bool ggml_metal_encode_mem_ranges_check_dst(const struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    size_t offs = 0;
-    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
-    GGML_ASSERT(id_node != nil);
-
     struct mem_range r = {
-        /*.p0 =*/ id_node.gpuAddress + offs,
-        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.p0 =*/ (uint64_t) node->data,
+        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
         /*.pt =*/ 1,
     };
 

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -3,6 +3,7 @@
 #import "ggml-impl.h"
 #import "ggml-backend-impl.h"
 #import "ggml-metal-impl.h"
+#import "ggml-metal-common.h"
 
 #import <Foundation/Foundation.h>
 
@@ -2083,8 +2084,6 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
     }
 }
 
-#define MEM_RANGE_MAX 128
-
 struct ggml_metal_encode_context {
     ggml_backend_t backend;
 
@@ -2092,33 +2091,13 @@ struct ggml_metal_encode_context {
 
     struct ggml_metal_mem_pool * mem_pool;
 
-    int n_ranges;
-
-    struct mem_range {
-        uint64_t p0; // being
-        uint64_t p1; // end
-        int      pt; // type: 0 - src, 1 - dst
-    } ranges[MEM_RANGE_MAX];
-
-    int debug;
+    struct ggml_mem_ranges * mem_ranges;
 };
 
 static bool ggml_metal_encode_mem_ranges_reset(struct ggml_metal_encode_context * ctx) {
     [ctx->encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
-    ctx->n_ranges = 0;
-
-    return true;
-}
-
-static bool ggml_metal_encode_mem_ranges_add(struct ggml_metal_encode_context * ctx, struct mem_range r) {
-    if (ctx->n_ranges == MEM_RANGE_MAX) {
-        return false;
-    }
-
-    ctx->ranges[ctx->n_ranges] = r;
-
-    ctx->n_ranges++;
+    ggml_mem_ranges_reset(ctx->mem_ranges);
 
     return true;
 }
@@ -2128,50 +2107,13 @@ static bool ggml_metal_encode_mem_ranges_add_src(struct ggml_metal_encode_contex
         return true;
     }
 
-    struct mem_range r = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ 0,
-    };
-
-    if (ctx->debug > 2) {
-        GGML_LOG_DEBUG("%s: add src range [%lld, %lld)\n", __func__, r.p0, r.p1);
-    }
-
-    return ggml_metal_encode_mem_ranges_add(ctx, r);
+    return ggml_mem_ranges_add_src(ctx->mem_ranges, node);
 }
 
 static bool ggml_metal_encode_mem_ranges_add_dst(struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct mem_range r = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ 1,
-    };
-
-    if (ctx->debug > 2) {
-        GGML_LOG_DEBUG("%s: add dst range [%lld, %lld)\n", __func__, r.p0, r.p1);
-    }
-
-    return ggml_metal_encode_mem_ranges_add(ctx, r);
-}
-
-// return true if:
-// - new src range overlaps with any existing dst range
-// - new dst range overlaps with any existing range (src or dst)
-static bool ggml_metal_encode_mem_ranges_check(const struct ggml_metal_encode_context * ctx, struct mem_range r) {
-    for (int i = 0; i < ctx->n_ranges; i++) {
-        if (r.pt == 0 && ctx->ranges[i].pt == 0) {
-            continue;
-        }
-
-        if (r.p0 < ctx->ranges[i].p1 && r.p1 > ctx->ranges[i].p0) {
-            return true;
-        }
-    }
-
-    return false;
+    return ggml_mem_ranges_add_dst(ctx->mem_ranges, node);
 }
 
 static bool ggml_metal_encode_mem_ranges_check_src(const struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
@@ -2179,41 +2121,13 @@ static bool ggml_metal_encode_mem_ranges_check_src(const struct ggml_metal_encod
         return false;
     }
 
-    struct mem_range r = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ 0,
-    };
-
-    const bool res = ggml_metal_encode_mem_ranges_check(ctx, r);
-
-    if (res) {
-        if (ctx->debug > 2) {
-            GGML_LOG_DEBUG("%s: the src range [%lld, %lld) overlaps with a previous dst range\n", __func__, r.p0, r.p1);
-        }
-    }
-
-    return res;
+    return ggml_mem_ranges_check_src(ctx->mem_ranges, node);
 }
 
 static bool ggml_metal_encode_mem_ranges_check_dst(const struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
     GGML_ASSERT(node);
 
-    struct mem_range r = {
-        /*.p0 =*/ (uint64_t) node->data,
-        /*.p1 =*/ (uint64_t) node->data + ggml_nbytes(node),
-        /*.pt =*/ 1,
-    };
-
-    const bool res = ggml_metal_encode_mem_ranges_check(ctx, r);
-
-    if (res) {
-        if (ctx->debug > 2) {
-            GGML_LOG_DEBUG("%s: the dst range [%lld, %lld) overlaps with a previous src range\n", __func__, r.p0, r.p1);
-        }
-    }
-
-    return res;
+    return ggml_mem_ranges_check_dst(ctx->mem_ranges, node);
 }
 
 static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, int idx, int idx_end) {
@@ -6858,13 +6772,15 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
         const bool should_capture = ctx->capture_next_compute;
 
         struct ggml_metal_encode_context ctx_enc = {
-            /*.backend  =*/ backend,
-            /*.encoder  =*/ encoder,
-            /*.mem_pool =*/ mem_pool,
-            /*.n_ranges =*/ 0,
-            /*.ranges   =*/ { 0 },
-            /*.debug    =*/ ctx_dev->debug_graph,
+            /*.backend    =*/ backend,
+            /*.encoder    =*/ encoder,
+            /*.mem_pool   =*/ mem_pool,
+            /*.mem_ranges =*/ NULL,
         };
+
+        if (ctx_dev->use_concurrency) {
+            ctx_enc.mem_ranges = ggml_mem_ranges_init(ctx_dev->debug_graph);
+        }
 
         for (int idx = node_start; idx < node_end;) {
             if (should_capture) {
@@ -6889,6 +6805,8 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
         }
 
         [encoder endEncoding];
+
+        ggml_mem_ranges_free(ctx_enc.mem_ranges);
 
         if (cb_idx < 2 || ctx->abort_callback == NULL) {
             [cmd_buf commit];

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2071,12 +2071,71 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
     }
 }
 
-static int ggml_metal_encode_node(
-                        ggml_backend_t   backend,
-                                   int   idx,
-                                   int   idx_end,
-          id<MTLComputeCommandEncoder>   encoder,
-            struct ggml_metal_mem_pool * mem_pool) {
+#define MEM_RANGE_MAX 128
+
+struct ggml_metal_encode_context {
+    ggml_backend_t backend;
+
+    id<MTLComputeCommandEncoder> encoder;
+
+    struct ggml_metal_mem_pool * mem_pool;
+
+    int n_ranges;
+
+    struct mem_range {
+        uint64_t p0; // being
+        uint64_t p1; // end
+        int      pt; // type: 0 - src, 1 - dst
+    } ranges[MEM_RANGE_MAX];
+
+};
+
+static bool ggml_metal_encode_reset_mem_ranges(struct ggml_metal_encode_context * ctx_enc) {
+    ctx_enc->n_ranges = 0;
+
+    return true;
+}
+
+static bool ggml_metal_encode_add_mem_range(struct ggml_metal_encode_context * ctx_enc, struct mem_range r) {
+    if (ctx_enc->n_ranges == MEM_RANGE_MAX) {
+        return false;
+    }
+
+    ctx_enc->ranges[ctx_enc->n_ranges] = r;
+
+    ctx_enc->n_ranges++;
+
+    return true;
+}
+
+// check and return true:
+//  - if new range overlaps with any existing range of a different type
+//  - if we are close to running out of range cells
+static bool ggml_metal_encode_check_mem_range(struct ggml_metal_encode_context * ctx_enc, struct mem_range r) {
+    if (ctx_enc->n_ranges + 2*GGML_MAX_SRC >= MEM_RANGE_MAX) {
+        return true;
+    }
+
+    for (int i = 0; i < ctx_enc->n_ranges; i++) {
+        if (ctx_enc->ranges[i].pt == r.pt) {
+            continue;
+        }
+
+        if (r.p0 < ctx_enc->ranges[i].p1 && r.p1 > ctx_enc->ranges[i].p0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, int idx, int idx_end) {
+    ggml_backend_t backend = ctx_enc->backend;
+
+    id<MTLComputeCommandEncoder> encoder = ctx_enc->encoder;
+
+    struct ggml_metal_mem_pool * mem_pool = ctx_enc->mem_pool;
+
     struct ggml_backend_metal_context        * ctx     = backend->context;
     struct ggml_backend_metal_device_context * ctx_dev = backend->device->context;
 
@@ -2159,22 +2218,113 @@ static int ggml_metal_encode_node(
     const uint64_t nb2  =  dst ?  dst->nb[2] : 0;
     const uint64_t nb3  =  dst ?  dst->nb[3] : 0;
 
+    size_t offs_src[GGML_MAX_SRC];
+
+    id<MTLBuffer> id_src[GGML_MAX_SRC];
+
+    enum ggml_type srct[GGML_MAX_SRC];
+
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        offs_src[i] = 0;
+        id_src[i] = node->src[i] ? ggml_metal_get_buffer(node->src[i], &offs_src[i]) : nil;
+        srct[i]   = node->src[i] ? node->src[i]->type : GGML_TYPE_COUNT;
+    }
+
+    size_t offs_dst = 0;
+
+    id<MTLBuffer> id_dst = dst ? ggml_metal_get_buffer(dst, &offs_dst) : nil;
+
+    int n_fuse = 1;
+
+    // check if the current node can run concurrently with other nodes before it
+    // the condition is that:
+    //  - the current node cannot write to any previous src ranges
+    //  - the current node cannot read from any previous dst ranges
+    //
+    // if the condition is not satisfied, we put a memory barrier and clear all ranges
+    // otherwise, we add the new ranges to the encoding context and add the node for concurrent execution
+    //
+    {
+        bool is_concurrent = true;
+
+        // do not read from any previous dst ranges
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            if (id_src[i] == nil) {
+                continue;
+            }
+
+            struct mem_range r = {
+                /*.p0 =*/ id_src[i].gpuAddress + offs_src[i],
+                /*.p1 =*/ id_src[i].gpuAddress + offs_src[i] + ggml_nbytes(node->src[i]),
+                /*.pt =*/ 0,
+            };
+
+            if (ggml_metal_encode_check_mem_range(ctx_enc, r)) {
+                is_concurrent = false;
+
+                break;
+            }
+        }
+
+        // do not write to any previous src ranges
+        if (is_concurrent) {
+            struct mem_range r = {
+                /*.p0 =*/ id_dst.gpuAddress + offs_dst,
+                /*.p1 =*/ id_dst.gpuAddress + offs_dst + ggml_nbytes(dst),
+                /*.pt =*/ 1,
+            };
+
+            if (ggml_metal_encode_check_mem_range(ctx_enc, r)) {
+                is_concurrent = false;
+            }
+        }
+
+        if (!is_concurrent) {
+            ggml_metal_encode_reset_mem_ranges(ctx_enc);
+
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        }
+
+        // add new ranges
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            if (id_src[i] == nil) {
+                continue;
+            }
+
+            struct mem_range r = {
+                /*.p0 =*/ id_src[i].gpuAddress + offs_src[i],
+                /*.p1 =*/ id_src[i].gpuAddress + offs_src[i] + ggml_nbytes(node->src[i]),
+                /*.pt =*/ 0,
+            };
+
+            ggml_metal_encode_add_mem_range(ctx_enc, r);
+        }
+
+        {
+            struct mem_range r = {
+                /*.p0 =*/ id_dst.gpuAddress + offs_dst,
+                /*.p1 =*/ id_dst.gpuAddress + offs_dst + ggml_nbytes(dst),
+                /*.pt =*/ 1,
+            };
+
+            ggml_metal_encode_add_mem_range(ctx_enc, r);
+        }
+    }
+
+    // TODO: tmp shorthands - remove
+    size_t offs_src0 = offs_src[0];
+    size_t offs_src1 = offs_src[1];
+    size_t offs_src2 = offs_src[2];
+
+    id<MTLBuffer> id_src0 = id_src[0];
+    id<MTLBuffer> id_src1 = id_src[1];
+    id<MTLBuffer> id_src2 = id_src[2];
+
     const enum ggml_type src0t = src0 ? src0->type : GGML_TYPE_COUNT;
     const enum ggml_type src1t = src1 ? src1->type : GGML_TYPE_COUNT;
     const enum ggml_type src2t = src2 ? src2->type : GGML_TYPE_COUNT;
     const enum ggml_type dstt  = dst  ? dst->type  : GGML_TYPE_COUNT;
 
-    size_t offs_src0 = 0;
-    size_t offs_src1 = 0;
-    size_t offs_src2 = 0;
-    size_t offs_dst  = 0;
-
-    id<MTLBuffer> id_src0 = src0 ? ggml_metal_get_buffer(src0, &offs_src0) : nil;
-    id<MTLBuffer> id_src1 = src1 ? ggml_metal_get_buffer(src1, &offs_src1) : nil;
-    id<MTLBuffer> id_src2 = src2 ? ggml_metal_get_buffer(src2, &offs_src2) : nil;
-    id<MTLBuffer> id_dst  = dst  ? ggml_metal_get_buffer(dst,  &offs_dst)  : nil;
-
-    int n_fuse = 1;
 
 #if 0
     GGML_LOG_INFO("%s: op - %s\n", __func__, ggml_op_name(dst->op));
@@ -2533,6 +2683,8 @@ static int ggml_metal_encode_node(
                     const int nth = MIN((int) pipeline.maxTotalThreadsPerThreadgroup, ne00);
 
                     [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne02, ne03) threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
+
+                    [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
                 }
 
                 const id<MTLComputePipelineState> pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_ADD].pipeline;
@@ -4057,6 +4209,8 @@ static int ggml_metal_encode_node(
                         [encoder dispatchThreadgroups:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(ne02, 1, 1)];
                     }
 
+                    [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
                     {
                         id<MTLComputePipelineState> pipeline = nil;
 
@@ -4668,7 +4822,6 @@ static int ggml_metal_encode_node(
             } break;
         case GGML_OP_ROPE:
             {
-
                 // make sure we have one or more position id(ne10) per token(ne02)
                 GGML_ASSERT(ne10 % ne02 == 0);
                 GGML_ASSERT(ne10 >= ne02);
@@ -5447,6 +5600,8 @@ static int ggml_metal_encode_node(
                         [encoder setThreadgroupMemoryLength:smem atIndex:0];
                         [encoder dispatchThreadgroups:MTLSizeMake((ne01 + nqptg - 1)/nqptg, ne02, ne03*nwg) threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
 
+                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
                         // reduce the results from the workgroups
                         {
                             ggml_metal_kargs_flash_attn_ext_vec_reduce args0 = {
@@ -5677,7 +5832,7 @@ static int ggml_metal_encode_node(
 
                 [encoder dispatchThreadgroups:MTLSizeMake(n_tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(n_threads, 1, 1)];
             } break;
-            case GGML_OP_ARGMAX:
+        case GGML_OP_ARGMAX:
             {
                 GGML_ASSERT(src0->type == GGML_TYPE_F32);
                 GGML_ASSERT(ggml_is_contiguous_1(src0));
@@ -5707,6 +5862,27 @@ static int ggml_metal_encode_node(
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(dst->op));
                 GGML_ABORT("fatal error");
             }
+    }
+
+    // after fusing, we have to add the new destination range to the encoding context
+    if (n_fuse > 1) {
+        struct ggml_tensor * dstf = nodes[n_fuse - 1];
+
+        size_t offs_dstf = 0;
+
+        id<MTLBuffer> id_dstf = dstf ? ggml_metal_get_buffer(dstf, &offs_dstf) : nil;
+
+        struct mem_range r = {
+            /*.p0 =*/ id_dstf.gpuAddress + offs_dstf,
+            /*.p1 =*/ id_dstf.gpuAddress + offs_dstf + ggml_nbytes(dstf),
+            /*.pt =*/ 1,
+        };
+
+        if (!ggml_metal_encode_add_mem_range(ctx_enc, r)) {
+            ggml_metal_encode_reset_mem_ranges(ctx_enc);
+
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+        }
     }
 
     return n_fuse;
@@ -6578,7 +6754,7 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
 
         ggml_metal_mem_pool_reset(mem_pool);
 
-        id<MTLComputeCommandEncoder> encoder = [cmd_buf computeCommandEncoder];
+        id<MTLComputeCommandEncoder> encoder = [cmd_buf computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
 
         int node_start = 0;
         int node_end   = n_nodes_0;
@@ -6590,12 +6766,20 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
 
         const bool should_capture = ctx->capture_next_compute;
 
+        struct ggml_metal_encode_context ctx_enc = {
+            /*.backend  =*/ backend,
+            /*.encoder  =*/ encoder,
+            /*.mem_pool =*/ mem_pool,
+            /*.n_ranges =*/ 0,
+            /*.ranges   =*/ { 0 },
+        };
+
         for (int idx = node_start; idx < node_end;) {
             if (should_capture) {
                 [encoder pushDebugGroup:[NSString stringWithCString:ggml_op_desc(ggml_graph_node(ctx->gf, idx)) encoding:NSUTF8StringEncoding]];
             }
 
-            const int res = ggml_metal_encode_node(backend, idx, node_end, encoder, mem_pool);
+            const int res = ggml_metal_encode_node(&ctx_enc, idx, node_end);
             if (idx + res > node_end) {
                 GGML_ABORT("fusion error: nodes spanning multiple encoders have been fused. this indicates a bug in the fusion logic %s",
                         "https://github.com/ggml-org/llama.cpp/pull/14849");

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2100,45 +2100,136 @@ struct ggml_metal_encode_context {
         int      pt; // type: 0 - src, 1 - dst
     } ranges[MEM_RANGE_MAX];
 
+    int debug;
 };
 
-static bool ggml_metal_encode_reset_mem_ranges(struct ggml_metal_encode_context * ctx_enc) {
-    ctx_enc->n_ranges = 0;
+static bool ggml_metal_encode_mem_ranges_reset(struct ggml_metal_encode_context * ctx) {
+    [ctx->encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+    ctx->n_ranges = 0;
 
     return true;
 }
 
-static bool ggml_metal_encode_add_mem_range(struct ggml_metal_encode_context * ctx_enc, struct mem_range r) {
-    if (ctx_enc->n_ranges == MEM_RANGE_MAX) {
+static bool ggml_metal_encode_mem_ranges_add(struct ggml_metal_encode_context * ctx, struct mem_range r) {
+    if (ctx->n_ranges == MEM_RANGE_MAX) {
         return false;
     }
 
-    ctx_enc->ranges[ctx_enc->n_ranges] = r;
+    ctx->ranges[ctx->n_ranges] = r;
 
-    ctx_enc->n_ranges++;
+    ctx->n_ranges++;
 
     return true;
 }
 
-// check and return true:
-//  - if new range overlaps with any existing range of a different type
-//  - if we are close to running out of range cells
-static bool ggml_metal_encode_check_mem_range(struct ggml_metal_encode_context * ctx_enc, struct mem_range r) {
-    if (ctx_enc->n_ranges + 2*GGML_MAX_SRC >= MEM_RANGE_MAX) {
+static bool ggml_metal_encode_mem_ranges_add_src(struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
+    if (!node) {
         return true;
     }
 
-    for (int i = 0; i < ctx_enc->n_ranges; i++) {
-        if (ctx_enc->ranges[i].pt == r.pt) {
+    size_t offs = 0;
+    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
+    GGML_ASSERT(id_node != nil);
+
+    struct mem_range r = {
+        /*.p0 =*/ id_node.gpuAddress + offs,
+        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.pt =*/ 0,
+    };
+
+    if (ctx->debug > 2) {
+        GGML_LOG_DEBUG("%s: add src range [%lld, %lld)\n", __func__, r.p0, r.p1);
+    }
+
+    return ggml_metal_encode_mem_ranges_add(ctx, r);
+}
+
+static bool ggml_metal_encode_mem_ranges_add_dst(struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    size_t offs = 0;
+    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
+    GGML_ASSERT(id_node != nil);
+
+    struct mem_range r = {
+        /*.p0 =*/ id_node.gpuAddress + offs,
+        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.pt =*/ 1,
+    };
+
+    if (ctx->debug > 2) {
+        GGML_LOG_DEBUG("%s: add dst range [%lld, %lld)\n", __func__, r.p0, r.p1);
+    }
+
+    return ggml_metal_encode_mem_ranges_add(ctx, r);
+}
+
+// return true if:
+// - new src range overlaps with any existing dst range
+// - new dst range overlaps with any existing range (src or dst)
+static bool ggml_metal_encode_mem_ranges_check(const struct ggml_metal_encode_context * ctx, struct mem_range r) {
+    for (int i = 0; i < ctx->n_ranges; i++) {
+        if (r.pt == 0 && ctx->ranges[i].pt == 0) {
             continue;
         }
 
-        if (r.p0 < ctx_enc->ranges[i].p1 && r.p1 > ctx_enc->ranges[i].p0) {
+        if (r.p0 < ctx->ranges[i].p1 && r.p1 > ctx->ranges[i].p0) {
             return true;
         }
     }
 
     return false;
+}
+
+static bool ggml_metal_encode_mem_ranges_check_src(const struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
+    if (!node) {
+        return false;
+    }
+
+    size_t offs = 0;
+    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
+    GGML_ASSERT(id_node != nil);
+
+    struct mem_range r = {
+        /*.p0 =*/ id_node.gpuAddress + offs,
+        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.pt =*/ 0,
+    };
+
+    const bool res = ggml_metal_encode_mem_ranges_check(ctx, r);
+
+    if (res) {
+        if (ctx->debug > 2) {
+            GGML_LOG_DEBUG("%s: the src range [%lld, %lld) overlaps with a previous dst range\n", __func__, r.p0, r.p1);
+        }
+    }
+
+    return res;
+}
+
+static bool ggml_metal_encode_mem_ranges_check_dst(const struct ggml_metal_encode_context * ctx, const struct ggml_tensor * node) {
+    GGML_ASSERT(node);
+
+    size_t offs = 0;
+    id<MTLBuffer> id_node = ggml_metal_get_buffer(node, &offs);
+    GGML_ASSERT(id_node != nil);
+
+    struct mem_range r = {
+        /*.p0 =*/ id_node.gpuAddress + offs,
+        /*.p1 =*/ id_node.gpuAddress + offs + ggml_nbytes(node),
+        /*.pt =*/ 1,
+    };
+
+    const bool res = ggml_metal_encode_mem_ranges_check(ctx, r);
+
+    if (res) {
+        if (ctx->debug > 2) {
+            GGML_LOG_DEBUG("%s: the dst range [%lld, %lld) overlaps with a previous src range\n", __func__, r.p0, r.p1);
+        }
+    }
+
+    return res;
 }
 
 static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, int idx, int idx_end) {
@@ -2262,94 +2353,47 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
 
     int n_fuse = 1;
 
-    // check if the current node can run concurrently with other nodes before it
-    // the condition is that:
-    //  - the current node cannot write to any previous src ranges
-    //  - the current node cannot read from any previous dst ranges
-    //
-    // if the condition is not satisfied, we put a memory barrier and clear all ranges
-    // otherwise, we add the new ranges to the encoding context and add the node for concurrent execution
-    //
-    bool is_concurrent = ctx_dev->use_concurrency;
-
-    if (is_concurrent) {
-        // do not read from any previous dst ranges
-        for (int i = 0; i < GGML_MAX_SRC; i++) {
-            if (id_src[i] == nil) {
-                continue;
-            }
-
-            struct mem_range r = {
-                /*.p0 =*/ id_src[i].gpuAddress + offs_src[i],
-                /*.p1 =*/ id_src[i].gpuAddress + offs_src[i] + ggml_nbytes(node->src[i]),
-                /*.pt =*/ 0,
-            };
-
-            if (ggml_metal_encode_check_mem_range(ctx_enc, r)) {
-                is_concurrent = false;
-
-                break;
-            }
-        }
-
-        // do not write to any previous src ranges
-        if (is_concurrent) {
-            struct mem_range r = {
-                /*.p0 =*/ id_dst.gpuAddress + offs_dst,
-                /*.p1 =*/ id_dst.gpuAddress + offs_dst + ggml_nbytes(dst),
-                /*.pt =*/ 1,
-            };
-
-            if (ggml_metal_encode_check_mem_range(ctx_enc, r)) {
-                is_concurrent = false;
-            }
-        }
-
-        if (!is_concurrent) {
-            ggml_metal_encode_reset_mem_ranges(ctx_enc);
-
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-        }
-
-        // add new ranges
-        for (int i = 0; i < GGML_MAX_SRC; i++) {
-            if (id_src[i] == nil) {
-                continue;
-            }
-
-            struct mem_range r = {
-                /*.p0 =*/ id_src[i].gpuAddress + offs_src[i],
-                /*.p1 =*/ id_src[i].gpuAddress + offs_src[i] + ggml_nbytes(node->src[i]),
-                /*.pt =*/ 0,
-            };
-
-            ggml_metal_encode_add_mem_range(ctx_enc, r);
-        }
-
-        {
-            struct mem_range r = {
-                /*.p0 =*/ id_dst.gpuAddress + offs_dst,
-                /*.p1 =*/ id_dst.gpuAddress + offs_dst + ggml_nbytes(dst),
-                /*.pt =*/ 1,
-            };
-
-            ggml_metal_encode_add_mem_range(ctx_enc, r);
-        }
-    }
-
     if (ctx_dev->debug_graph > 0) {
-        GGML_LOG_INFO("%s: op - %s, concurrent = %d\n", __func__, ggml_op_name(dst->op), is_concurrent);
+        GGML_LOG_DEBUG("%s: op - %s\n", __func__, ggml_op_name(dst->op));
         if (src0) {
-            GGML_LOG_INFO("%s: src0 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src0t), ne00, ne01, ne02, ne03, nb00, nb01, nb02, nb03,
+            GGML_LOG_DEBUG("%s: src0 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src0t), ne00, ne01, ne02, ne03, nb00, nb01, nb02, nb03,
                     ggml_is_contiguous(src0), src0->name);
         }
         if (src1) {
-            GGML_LOG_INFO("%s: src1 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src1t), ne10, ne11, ne12, ne13, nb10, nb11, nb12, nb13,
+            GGML_LOG_DEBUG("%s: src1 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src1t), ne10, ne11, ne12, ne13, nb10, nb11, nb12, nb13,
                     ggml_is_contiguous(src1), src1->name);
         }
         if (dst) {
-            GGML_LOG_INFO("%s: dst  - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], 1, %s\n", __func__, ggml_type_name(dstt), ne0, ne1, ne2, ne3, nb0, nb1, nb2, nb3,
+            GGML_LOG_DEBUG("%s: dst  - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], 1, %s\n", __func__, ggml_type_name(dstt), ne0, ne1, ne2, ne3, nb0, nb1, nb2, nb3,
                     dst->name);
+        }
+    }
+
+    // check if the current node can run concurrently with other nodes before it
+    // the condition is that:
+    //  - the current node cannot write to any previous src or dst ranges
+    //  - the current node cannot read from any previous dst ranges
+    //
+    // if the condition is not satisfied, we put a memory barrier and clear all ranges
+    // otherwise, we add the new ranges to the encoding context and process the node concurrently
+    //
+    if (ctx_dev->use_concurrency) {
+        bool is_concurrent = true;
+
+        // do not read from any previous dst ranges
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_src(ctx_enc, node->src[i]);
+        }
+
+        // do not write to any previous ranges
+        is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_dst(ctx_enc, dst);
+
+        if (!is_concurrent) {
+            ggml_metal_encode_mem_ranges_reset(ctx_enc);
+        }
+
+        if (ctx_dev->debug_graph > 0) {
+            GGML_LOG_DEBUG("%s: concurrent = %d\n", __func__, is_concurrent);
         }
     }
 
@@ -2552,6 +2596,22 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                     id_dst = ggml_metal_get_buffer(nodes[n_fuse - 1], &offs_dst);
                 }
 
+                if (ctx_dev->use_concurrency && n_fuse > 1) {
+                    bool is_concurrent = true;
+
+                    // make sure that none of the fused nodes reads from a previous dst range
+                    for (int i = 1; i < n_fuse; ++i) {
+                        is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_src(ctx_enc, nodes[i]->src[1]);
+                    }
+
+                    // do not write to any previous range
+                    is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_dst(ctx_enc, nodes[n_fuse - 1]);
+
+                    if (!is_concurrent) {
+                        ggml_metal_encode_mem_ranges_reset(ctx_enc);
+                    }
+                }
+
                 [encoder setComputePipelineState:pipeline];
                 [encoder setBytes:&args length:sizeof(args) atIndex:0];
                 [encoder setBuffer:id_src0 offset:offs_src0 atIndex:1];
@@ -2696,7 +2756,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                     [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne02, ne03) threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
 
                     if (ctx_dev->use_concurrency) {
-                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                        ggml_metal_encode_mem_ranges_reset(ctx_enc);
                     }
                 }
 
@@ -4223,7 +4283,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                     }
 
                     if (ctx_dev->use_concurrency) {
-                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                        ggml_metal_encode_mem_ranges_reset(ctx_enc);
                     }
 
                     {
@@ -4694,6 +4754,22 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
 
                 if (n_fuse > 1) {
                     id_dst = ggml_metal_get_buffer(nodes[n_fuse - 1], &offs_dst);
+                }
+
+                if (ctx_dev->use_concurrency) {
+                    bool is_concurrent = true;
+
+                    // make sure that none of the fused nodes reads from a previous dst range
+                    for (int i = 1; i < n_fuse; ++i) {
+                        is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_src(ctx_enc, nodes[i]->src[1]);
+                    }
+
+                    // do not write to any previous range
+                    is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_dst(ctx_enc, nodes[n_fuse - 1]);
+
+                    if (!is_concurrent) {
+                        ggml_metal_encode_mem_ranges_reset(ctx_enc);
+                    }
                 }
 
                 id<MTLComputePipelineState> pipeline;
@@ -5616,7 +5692,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                         [encoder dispatchThreadgroups:MTLSizeMake((ne01 + nqptg - 1)/nqptg, ne02, ne03*nwg) threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
 
                         if (ctx_dev->use_concurrency) {
-                            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                            ggml_metal_encode_mem_ranges_reset(ctx_enc);
                         }
 
                         // reduce the results from the workgroups
@@ -5883,28 +5959,28 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
 
     if (ctx_dev->debug_graph > 0) {
         if (n_fuse > 1) {
-            GGML_LOG_INFO("%s: fuse: %d ops\n", __func__, n_fuse);
+            GGML_LOG_DEBUG("%s: fuse: %d ops\n", __func__, n_fuse);
         }
     }
 
-    // after fusing, we have to add the new destination range to the encoding context
-    if (ctx_dev->use_concurrency && n_fuse > 1) {
-        struct ggml_tensor * dstf = nodes[n_fuse - 1];
+    // update the mem ranges in the encoding context
+    if (ctx_dev->use_concurrency) {
+        bool ok = true;
 
-        size_t offs_dstf = 0;
+        // add new src ranges
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            ok = ok && ggml_metal_encode_mem_ranges_add_src(ctx_enc, node->src[i]);
+        }
 
-        id<MTLBuffer> id_dstf = dstf ? ggml_metal_get_buffer(dstf, &offs_dstf) : nil;
+        // add the destination range
+        ok = ok && ggml_metal_encode_mem_ranges_add_dst(ctx_enc, nodes[n_fuse - 1]);
 
-        struct mem_range r = {
-            /*.p0 =*/ id_dstf.gpuAddress + offs_dstf,
-            /*.p1 =*/ id_dstf.gpuAddress + offs_dstf + ggml_nbytes(dstf),
-            /*.pt =*/ 1,
-        };
+        if (!ok) {
+            if (ctx_dev->debug_graph > 2) {
+                GGML_LOG_DEBUG("%s: the range cache is full -> reset and put a barrier\n", __func__);
+            }
 
-        if (!ggml_metal_encode_add_mem_range(ctx_enc, r)) {
-            ggml_metal_encode_reset_mem_ranges(ctx_enc);
-
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            ggml_metal_encode_mem_ranges_reset(ctx_enc);
         }
     }
 
@@ -6803,6 +6879,7 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
             /*.mem_pool =*/ mem_pool,
             /*.n_ranges =*/ 0,
             /*.ranges   =*/ { 0 },
+            /*.debug    =*/ ctx_dev->debug_graph,
         };
 
         for (int idx = node_start; idx < node_end;) {

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -61,8 +61,10 @@ static struct ggml_backend_metal_device_context {
     bool has_bfloat;
     bool use_bfloat;
     bool use_fusion;
+    bool use_concurrency;
     bool use_shared_buffers;
 
+    int debug_graph;
     int debug_fusion;
 
     // how many times a given op was fused
@@ -83,7 +85,9 @@ static struct ggml_backend_metal_device_context {
     /*.has_bfloat              =*/ false,
     /*.use_bfloat              =*/ false,
     /*.use_fusion              =*/ true,
+    /*.use_concurrency         =*/ true,
     /*.use_shared_buffers      =*/ true,
+    /*.debug_graph             =*/ 0,
     /*.debug_fusion            =*/ 0,
     /*.fuse_cnt                =*/ { 0 },
     /*.max_size                =*/ 0,
@@ -124,7 +128,14 @@ static id<MTLDevice> ggml_backend_metal_device_acq(struct ggml_backend_metal_dev
 #else
             ctx->use_bfloat = false;
 #endif
-            ctx->use_fusion = getenv("GGML_METAL_FUSION_DISABLE") == nil;
+
+            ctx->use_fusion      = getenv("GGML_METAL_FUSION_DISABLE") == nil;
+            ctx->use_concurrency = getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;
+
+            {
+                const char * val = getenv("GGML_METAL_GRAPH_DEBUG");
+                ctx->debug_graph = val ? atoi(val) : 0;
+            }
 
             {
                 const char * val = getenv("GGML_METAL_FUSION_DEBUG");
@@ -1091,6 +1102,7 @@ static struct ggml_backend_metal_context * ggml_metal_init(ggml_backend_dev_t de
     GGML_LOG_INFO("%s: has bfloat            = %s\n", __func__, ctx_dev->has_bfloat                  ? "true" : "false");
     GGML_LOG_INFO("%s: use bfloat            = %s\n", __func__, ctx_dev->use_bfloat                  ? "true" : "false");
     GGML_LOG_INFO("%s: use fusion            = %s\n", __func__, ctx_dev->use_fusion                  ? "true" : "false");
+    GGML_LOG_INFO("%s: use concurrency       = %s\n", __func__, ctx_dev->use_concurrency             ? "true" : "false");
     GGML_LOG_INFO("%s: use shared buffers    = %s\n", __func__, ctx_dev->use_shared_buffers          ? "true" : "false");
     GGML_LOG_INFO("%s: hasUnifiedMemory      = %s\n", __func__, ctx_dev->mtl_device.hasUnifiedMemory ? "true" : "false");
 
@@ -2230,6 +2242,20 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
         srct[i]   = node->src[i] ? node->src[i]->type : GGML_TYPE_COUNT;
     }
 
+    // TODO: tmp shorthands - remove
+    size_t offs_src0 = offs_src[0];
+    size_t offs_src1 = offs_src[1];
+    size_t offs_src2 = offs_src[2];
+
+    id<MTLBuffer> id_src0 = id_src[0];
+    id<MTLBuffer> id_src1 = id_src[1];
+    id<MTLBuffer> id_src2 = id_src[2];
+
+    const enum ggml_type src0t = src0 ? src0->type : GGML_TYPE_COUNT;
+    const enum ggml_type src1t = src1 ? src1->type : GGML_TYPE_COUNT;
+    const enum ggml_type src2t = src2 ? src2->type : GGML_TYPE_COUNT;
+    const enum ggml_type dstt  = dst  ? dst->type  : GGML_TYPE_COUNT;
+
     size_t offs_dst = 0;
 
     id<MTLBuffer> id_dst = dst ? ggml_metal_get_buffer(dst, &offs_dst) : nil;
@@ -2244,9 +2270,9 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
     // if the condition is not satisfied, we put a memory barrier and clear all ranges
     // otherwise, we add the new ranges to the encoding context and add the node for concurrent execution
     //
-    {
-        bool is_concurrent = true;
+    bool is_concurrent = ctx_dev->use_concurrency;
 
+    if (is_concurrent) {
         // do not read from any previous dst ranges
         for (int i = 0; i < GGML_MAX_SRC; i++) {
             if (id_src[i] == nil) {
@@ -2311,36 +2337,21 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
         }
     }
 
-    // TODO: tmp shorthands - remove
-    size_t offs_src0 = offs_src[0];
-    size_t offs_src1 = offs_src[1];
-    size_t offs_src2 = offs_src[2];
-
-    id<MTLBuffer> id_src0 = id_src[0];
-    id<MTLBuffer> id_src1 = id_src[1];
-    id<MTLBuffer> id_src2 = id_src[2];
-
-    const enum ggml_type src0t = src0 ? src0->type : GGML_TYPE_COUNT;
-    const enum ggml_type src1t = src1 ? src1->type : GGML_TYPE_COUNT;
-    const enum ggml_type src2t = src2 ? src2->type : GGML_TYPE_COUNT;
-    const enum ggml_type dstt  = dst  ? dst->type  : GGML_TYPE_COUNT;
-
-
-#if 0
-    GGML_LOG_INFO("%s: op - %s\n", __func__, ggml_op_name(dst->op));
-    if (src0) {
-        GGML_LOG_INFO("%s: src0 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src0t), ne00, ne01, ne02, ne03, nb00, nb01, nb02, nb03,
-                ggml_is_contiguous(src0), src0->name);
+    if (ctx_dev->debug_graph > 0) {
+        GGML_LOG_INFO("%s: op - %s, concurrent = %d\n", __func__, ggml_op_name(dst->op), is_concurrent);
+        if (src0) {
+            GGML_LOG_INFO("%s: src0 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src0t), ne00, ne01, ne02, ne03, nb00, nb01, nb02, nb03,
+                    ggml_is_contiguous(src0), src0->name);
+        }
+        if (src1) {
+            GGML_LOG_INFO("%s: src1 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src1t), ne10, ne11, ne12, ne13, nb10, nb11, nb12, nb13,
+                    ggml_is_contiguous(src1), src1->name);
+        }
+        if (dst) {
+            GGML_LOG_INFO("%s: dst  - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], 1, %s\n", __func__, ggml_type_name(dstt), ne0, ne1, ne2, ne3, nb0, nb1, nb2, nb3,
+                    dst->name);
+        }
     }
-    if (src1) {
-        GGML_LOG_INFO("%s: src1 - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], %d, %s\n", __func__, ggml_type_name(src1t), ne10, ne11, ne12, ne13, nb10, nb11, nb12, nb13,
-                ggml_is_contiguous(src1), src1->name);
-    }
-    if (dst) {
-        GGML_LOG_INFO("%s: dst  - %4s [%5lld, %5lld, %5lld, %5lld] [%5lld, %5lld, %5lld, %5lld], 1, %s\n", __func__, ggml_type_name(dstt), ne0, ne1, ne2, ne3, nb0, nb1, nb2, nb3,
-                dst->name);
-    }
-#endif
 
     id<MTLDevice> device = ctx_dev->mtl_device;
 
@@ -2684,7 +2695,9 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
 
                     [encoder dispatchThreadgroups:MTLSizeMake(ne01, ne02, ne03) threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
 
-                    [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                    if (ctx_dev->use_concurrency) {
+                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                    }
                 }
 
                 const id<MTLComputePipelineState> pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_ADD].pipeline;
@@ -4209,7 +4222,9 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                         [encoder dispatchThreadgroups:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(ne02, 1, 1)];
                     }
 
-                    [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                    if (ctx_dev->use_concurrency) {
+                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                    }
 
                     {
                         id<MTLComputePipelineState> pipeline = nil;
@@ -5600,7 +5615,9 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
                         [encoder setThreadgroupMemoryLength:smem atIndex:0];
                         [encoder dispatchThreadgroups:MTLSizeMake((ne01 + nqptg - 1)/nqptg, ne02, ne03*nwg) threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
 
-                        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                        if (ctx_dev->use_concurrency) {
+                            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+                        }
 
                         // reduce the results from the workgroups
                         {
@@ -5864,8 +5881,14 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
             }
     }
 
+    if (ctx_dev->debug_graph > 0) {
+        if (n_fuse > 1) {
+            GGML_LOG_INFO("%s: fuse: %d ops\n", __func__, n_fuse);
+        }
+    }
+
     // after fusing, we have to add the new destination range to the encoding context
-    if (n_fuse > 1) {
+    if (ctx_dev->use_concurrency && n_fuse > 1) {
         struct ggml_tensor * dstf = nodes[n_fuse - 1];
 
         size_t offs_dstf = 0;
@@ -6754,7 +6777,15 @@ static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
 
         ggml_metal_mem_pool_reset(mem_pool);
 
-        id<MTLComputeCommandEncoder> encoder = [cmd_buf computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
+        id<MTLComputeCommandEncoder> encoder;
+
+        struct ggml_backend_metal_device_context * ctx_dev = backend->device->context;
+
+        if (ctx_dev->use_concurrency) {
+            encoder = [cmd_buf computeCommandEncoderWithDispatchType: MTLDispatchTypeConcurrent];
+        } else {
+            encoder = [cmd_buf computeCommandEncoder];
+        }
 
         int node_start = 0;
         int node_end   = n_nodes_0;

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2279,7 +2279,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
         }
 
         if (ctx_dev->debug_graph > 0) {
-            GGML_LOG_DEBUG("%s: op - %-12s %s\n", __func__, ggml_op_name(dst->op), is_concurrent ? "(concurrent)" : "");
+            GGML_LOG_DEBUG("%s: node[%5d] - %-12s %s\n", __func__, idx, ggml_op_name(dst->op), is_concurrent ? "(concurrent)" : "");
         }
         if (ctx_dev->debug_graph > 1) {
             if (src0) {
@@ -5848,7 +5848,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
 
     if (ctx_dev->debug_graph > 0) {
         if (n_fuse > 1) {
-            GGML_LOG_DEBUG("%s: fuse: %d ops\n", __func__, n_fuse);
+            GGML_LOG_DEBUG("%s:               fuse %d ops\n", __func__, n_fuse);
         }
     }
 

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -2284,7 +2284,7 @@ static int ggml_metal_encode_node(struct ggml_metal_encode_context * ctx_enc, in
         }
 
         // do not write to any previous ranges
-        is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_dst(ctx_enc, dst);
+        is_concurrent = is_concurrent && !ggml_metal_encode_mem_ranges_check_dst(ctx_enc, node);
 
         if (!is_concurrent) {
             ggml_metal_encode_mem_ranges_reset(ctx_enc);
@@ -5892,7 +5892,7 @@ static enum ggml_status ggml_metal_graph_compute(
     struct ggml_backend_metal_device_context * ctx_dev = backend->device->context;
 
     // number of nodes encoded by the main thread (empirically determined)
-    const int n_main = 128;
+    const int n_main = 64;
 
     // number of threads in addition to the main thread
     const int n_cb = ctx->n_cb;
@@ -6720,6 +6720,16 @@ static enum ggml_status ggml_backend_metal_graph_compute(ggml_backend_t backend,
     return ggml_metal_graph_compute(backend, cgraph);
 }
 
+static void ggml_backend_metal_graph_optimize(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
+    GGML_UNUSED(backend);
+
+    //const int64_t t_start = ggml_time_us();
+
+    ggml_metal_graph_optimize(cgraph);
+
+    //printf("%s: initial graph optimize took %.3f ms\n", __func__, (ggml_time_us() - t_start) / 1000.0);
+}
+
 static void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
     GGML_ASSERT(ggml_backend_is_metal(backend));
 
@@ -6832,7 +6842,7 @@ static struct ggml_backend_i ggml_backend_metal_i = {
     // https://developer.apple.com/documentation/metal/mtlcommandbuffer#Synchronizing-Passes-with-Events
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
-    /* .optimize_graph          = */ NULL,
+    /* .optimize_graph          = */ ggml_backend_metal_graph_optimize,
 };
 
 static ggml_guid_t ggml_backend_metal_guid(void) {


### PR DESCRIPTION
While queueing the graph nodes, keep track of the memory intervals/ranges from which we read data and to which we write data. Using this information, for the new node we can determine if it can safely run concurrently with all the concurrent ops prior to it:

- It should not read data from a memory range that a previous node is writing to
- It should not write data to a memory range for which a previous node is reading from or writing to

This feature can be disabled with `GGML_METAL_CONCURRENCY_DISABLE=1` env.

~Improvements depends on the order of the nodes in the graph. Some models do not currently allow to benefit much from this logic, but utilizing a graph optimization approach similar to https://github.com/ggml-org/llama.cpp/pull/15850 should improve things.~ Introduced logic for optimizing the graph to improve concurrency in a similar way as in #15850. The benefits are large for TG and decent for PP.

TODO:

- [x] Env to disable graph optimization
- [x] More comments about the implemented logic
- [ ] Stats?

### Example

For example, before this patch, the graph of one layer of `gpt-oss-20b` is executed like this       :

*`(concurrent)` means that the node runs in parallel with the previous one*

```
0.02.203.953 D ggml_metal_encode_node: node[  897] - ADD          
0.02.203.954 D ggml_metal_encode_node: node[  898] - RMS_NORM     
0.02.203.955 D ggml_metal_encode_node:               fuse 2 ops
0.02.203.955 D ggml_metal_encode_node: node[  900] - MUL_MAT      
0.02.203.956 D ggml_metal_encode_node: node[  901] - ADD          
0.02.203.957 D ggml_metal_encode_node: node[  903] - ROPE         
0.02.203.957 D ggml_metal_encode_node: node[  904] - MUL_MAT      (concurrent)
0.02.203.958 D ggml_metal_encode_node: node[  905] - ADD          
0.02.203.959 D ggml_metal_encode_node: node[  907] - ROPE         
0.02.203.959 D ggml_metal_encode_node: node[  908] - MUL_MAT      (concurrent)
0.02.203.960 D ggml_metal_encode_node: node[  909] - ADD          
0.02.203.961 D ggml_metal_encode_node: node[  912] - SET_ROWS     (concurrent)
0.02.203.961 D ggml_metal_encode_node: node[  914] - SET_ROWS     
0.02.203.962 D ggml_metal_encode_node: node[  921] - FLASH_ATTN_EXT 
0.02.203.966 D ggml_metal_encode_node: node[  923] - MUL_MAT      
0.02.203.966 D ggml_metal_encode_node: node[  924] - ADD          
0.02.203.968 D ggml_metal_encode_node: node[  925] - ADD          
0.02.203.968 D ggml_metal_encode_node: node[  926] - RMS_NORM     
0.02.203.969 D ggml_metal_encode_node:               fuse 2 ops
0.02.203.969 D ggml_metal_encode_node: node[  929] - MUL_MAT      
0.02.203.970 D ggml_metal_encode_node: node[  930] - ADD          
0.02.203.971 D ggml_metal_encode_node: node[  931] - ARGSORT      
0.02.203.972 D ggml_metal_encode_node: node[  933] - MUL_MAT_ID   
0.02.203.972 D ggml_metal_encode_node: node[  934] - ADD_ID       
0.02.203.973 D ggml_metal_encode_node: node[  935] - MUL_MAT_ID   (concurrent)
0.02.203.974 D ggml_metal_encode_node: node[  936] - ADD_ID       
0.02.203.974 D ggml_metal_encode_node: node[  937] - GLU          
0.02.203.975 D ggml_metal_encode_node: node[  938] - MUL_MAT_ID   
0.02.203.976 D ggml_metal_encode_node: node[  939] - ADD_ID       
0.02.203.976 D ggml_metal_encode_node: node[  941] - GET_ROWS     (concurrent)
0.02.203.977 D ggml_metal_encode_node: node[  943] - SOFT_MAX     
0.02.203.978 D ggml_metal_encode_node: node[  945] - MUL          
0.02.203.978 D ggml_metal_encode_node: node[  950] - ADD          
0.02.203.979 D ggml_metal_encode_node:               fuse 3 ops
```

After this patch, the nodes are reordered and executed like this:

```
0.02.119.870 D ggml_metal_encode_node: node[  897] - ADD          
0.02.119.871 D ggml_metal_encode_node: node[  898] - RMS_NORM     
0.02.119.872 D ggml_metal_encode_node:               fuse 2 ops
0.02.119.872 D ggml_metal_encode_node: node[  900] - MUL_MAT      
0.02.119.873 D ggml_metal_encode_node: node[  901] - MUL_MAT      (concurrent)
0.02.119.874 D ggml_metal_encode_node: node[  902] - MUL_MAT      (concurrent)
0.02.119.875 D ggml_metal_encode_node: node[  903] - ADD          
0.02.119.875 D ggml_metal_encode_node: node[  905] - ADD          (concurrent)
0.02.119.876 D ggml_metal_encode_node: node[  907] - ADD          (concurrent)
0.02.119.877 D ggml_metal_encode_node: node[  909] - ROPE         
0.02.119.877 D ggml_metal_encode_node: node[  910] - ROPE         (concurrent)
0.02.119.878 D ggml_metal_encode_node: node[  913] - SET_ROWS     
0.02.119.879 D ggml_metal_encode_node: node[  914] - SET_ROWS     (concurrent)
0.02.119.880 D ggml_metal_encode_node: node[  921] - FLASH_ATTN_EXT 
0.02.119.883 D ggml_metal_encode_node: node[  923] - MUL_MAT      
0.02.119.884 D ggml_metal_encode_node: node[  924] - ADD          
0.02.119.885 D ggml_metal_encode_node: node[  925] - ADD          
0.02.119.891 D ggml_metal_encode_node: node[  926] - RMS_NORM     
0.02.119.892 D ggml_metal_encode_node:               fuse 2 ops
0.02.119.892 D ggml_metal_encode_node: node[  929] - MUL_MAT      
0.02.119.893 D ggml_metal_encode_node: node[  930] - ADD          
0.02.119.893 D ggml_metal_encode_node: node[  931] - ARGSORT      
0.02.119.894 D ggml_metal_encode_node: node[  933] - MUL_MAT_ID   
0.02.119.894 D ggml_metal_encode_node: node[  934] - MUL_MAT_ID   (concurrent)
0.02.119.895 D ggml_metal_encode_node: node[  935] - ADD_ID       
0.02.119.896 D ggml_metal_encode_node: node[  936] - ADD_ID       (concurrent)
0.02.119.897 D ggml_metal_encode_node: node[  937] - GLU          
0.02.119.911 D ggml_metal_encode_node: node[  938] - MUL_MAT_ID   
0.02.119.915 D ggml_metal_encode_node: node[  940] - ADD_ID       
0.02.119.917 D ggml_metal_encode_node: node[  941] - GET_ROWS     (concurrent)
0.02.119.920 D ggml_metal_encode_node: node[  943] - SOFT_MAX     
0.02.119.921 D ggml_metal_encode_node: node[  945] - MUL          
0.02.119.923 D ggml_metal_encode_node: node[  950] - ADD          
0.02.119.924 D ggml_metal_encode_node:               fuse 3 ops
```

### Perf

| Model                 | Test   |   t/s master |   t/s gg/metal-concurrent-graphs |   Speedup |
|:----------------------|:-------|-------------:|---------------------------------:|----------:|
| gemma3 1B Q4_0        | pp512  |     10347.13 |                         10927.45 |      1.06 |
| gemma3 1B Q4_0        | pp2048 |     11105.25 |                         11289.86 |      1.02 |
| gemma3 1B Q4_0        | pp4096 |     11278.28 |                         11428.73 |      1.01 |
| gemma3 1B Q4_0        | tg128  |       204.67 |                           225.84 |      1.10 |
| gemma3 270M Q4_0      | pp512  |     36085.32 |                         37940.85 |      1.05 |
| gemma3 270M Q4_0      | pp2048 |     40402.50 |                         41045.04 |      1.02 |
| gemma3 270M Q4_0      | pp4096 |     42624.23 |                         43358.27 |      1.02 |
| gemma3 270M Q4_0      | tg128  |       333.98 |                           392.28 |      1.17 |
| gemma3 4B Q4_0        | pp512  |      2664.39 |                          2738.56 |      1.03 |
| gemma3 4B Q4_0        | pp2048 |      2837.75 |                          2876.11 |      1.01 |
| gemma3 4B Q4_0        | pp4096 |      2823.03 |                          2859.76 |      1.01 |
| gemma3 4B Q4_0        | tg128  |       124.45 |                           137.87 |      1.11 |
| gpt-oss 20B MXFP4 MoE | pp512  |      2262.85 |                          2303.68 |      1.02 |
| gpt-oss 20B MXFP4 MoE | pp2048 |      2660.63 |                          2661.22 |      1.00 |
| gpt-oss 20B MXFP4 MoE | pp4096 |      2653.64 |                          2662.97 |      1.00 |
| gpt-oss 20B MXFP4 MoE | tg128  |       120.91 |                           133.14 |      1.10 |
| qwen2 3B Q4_0         | pp512  |      3019.72 |                          3108.98 |      1.03 |
| qwen2 3B Q4_0         | pp2048 |      3239.79 |                          3265.49 |      1.01 |
| qwen2 3B Q4_0         | pp4096 |      3055.22 |                          3081.93 |      1.01 |
| qwen2 3B Q4_0         | tg128  |       152.27 |                           167.65 |      1.10 |
| qwen2 7B Q8_0         | pp512  |      1427.79 |                          1455.75 |      1.02 |
| qwen2 7B Q8_0         | pp2048 |      1500.79 |                          1510.12 |      1.01 |
| qwen2 7B Q8_0         | pp4096 |      1445.67 |                          1454.36 |      1.01 |
| qwen2 7B Q8_0         | tg128  |        75.93 |                            78.35 |      1.03 |
| qwen3 0.6B Q8_0       | pp512  |     13398.86 |                         13937.51 |      1.04 |
| qwen3 0.6B Q8_0       | pp2048 |     13190.99 |                         13393.04 |      1.02 |
| qwen3 0.6B Q8_0       | pp4096 |     11061.29 |                         11260.44 |      1.02 |
| qwen3 0.6B Q8_0       | tg128  |       245.57 |                           274.48 |      1.12 |
| qwen3moe 30B.A3B Q4_0 | pp512  |      2119.15 |                          2148.71 |      1.01 |
| qwen3moe 30B.A3B Q4_0 | pp2048 |      2447.42 |                          2468.89 |      1.01 |
| qwen3moe 30B.A3B Q4_0 | pp4096 |      2183.56 |                          2202.32 |      1.01 |
| qwen3moe 30B.A3B Q4_0 | tg128  |        91.51 |                           101.70 |      1.11 |
