### PR TITLE
CANN: Disable acl_graph for prefill stage

### DIFF
--- a/docs/backend/CANN.md
+++ b/docs/backend/CANN.md
@@ -318,3 +318,7 @@ Operators are executed using ACL graph execution, rather than in op-by-op (eager
 ### GGML_CANN_GRAPH_CACHE_CAPACITY
 
 Maximum number of compiled CANN graphs kept in the LRU cache, default is 12. When the number of cached graphs exceeds this capacity, the least recently used graph will be evicted.
+
+### GGML_CANN_PREFILL_USE_GRAPH
+
+Enable ACL graph execution during the prefill stage, default is false. This option is only effective when FA is enabled.


### PR DESCRIPTION
Since the prefill length is not fixed, graphs constructed for the prefill stage cannot be reused. For this reason, ACL graph execution is disabled by default during prefill.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
