### PR TITLE
feat(amx): add --amx toggle; prefer CPU 'extra' with GPU host+mmap wh…

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2369,6 +2369,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.use_mmap = false;
         }
     ).set_env("LLAMA_ARG_NO_MMAP"));
+add_opt(common_arg(
+    {"--amx"},
+    "enable AMX-aware CPU repack when mmap is on and a GPU host buffer would be used; prefers CPU \"extra\" buffer types (e.g., AMX) for weights on CPU.",
+    [](common_params & params) {
+        params.amx_enable_mmap = true;
+    }
+));
+
     add_opt(common_arg(
         {"--numa"}, "TYPE",
         "attempt optimizations that help on some NUMA systems\n"

--- a/common/common.h
+++ b/common/common.h
@@ -391,6 +391,8 @@ struct common_params {
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
     bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
+    bool amx_enable_mmap  = false; // prefer CPU "extra" buffers when GPU host+mmap is chosen (enable AMX)
+
 
     bool single_turn       = false; // single turn chat conversation
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -296,6 +296,7 @@ extern "C" {
         bool use_mlock;       // force system to keep model in RAM
         bool check_tensors;   // validate model tensor data
         bool use_extra_bufts; // use extra buffer types (used for weight repacking)
+        bool amx_enable_mmap; // prefer CPU 'extra' buffers with GPU host+mmap (enable AMX repack on CPU)
     };
 
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations


### PR DESCRIPTION
…en enabled

- CLI/server/bench: --amx (presence=enabled) -> mparams.amx_enable_mmap
- Loader: with mmap + GPU host buft, prefer CPU 'extra' if supported (AMX repack), else fallback
- llama-bench: add --amx flag to match CLI/server behavior

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
