### PR TITLE
docker : add configurable port support for health checking

### DIFF
--- a/.devops/cann.Dockerfile
+++ b/.devops/cann.Dockerfile
@@ -57,7 +57,8 @@ RUN mkdir -p /app/full && \
     cp *.py /app/full/ && \
     cp -r gguf-py /app/full/ && \
     cp -r requirements /app/full/ && \
-    cp requirements.txt /app/full/
+    cp requirements.txt /app/full/ && \
+    cp .devops/healthcheck.sh /app/full/healthcheck.sh
     # If you have a tools.sh script, make sure it is copied here
     # cp .devops/tools.sh /app/full/tools.sh
 
@@ -124,7 +125,8 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
-HEALTHCHECK --interval=5m CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK --interval=5m CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]

--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -28,7 +28,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 ## Base image
 FROM ubuntu:$UBUNTU_VERSION AS base
@@ -80,9 +81,10 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -33,7 +33,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 ## Base image
 FROM ${BASE_CUDA_RUN_CONTAINER} AS base
@@ -86,9 +87,10 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]

--- a/.devops/healthcheck.sh
+++ b/.devops/healthcheck.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+curl -f "http://localhost:${LLAMA_ARG_PORT:-8080}/health"

--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -29,7 +29,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 FROM intel/oneapi-basekit:$ONEAPI_VERSION AS base
 
@@ -86,10 +87,11 @@ ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/lib/ /app
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]
 

--- a/.devops/musa.Dockerfile
+++ b/.devops/musa.Dockerfile
@@ -40,7 +40,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 ## Base image
 FROM ${BASE_MUSA_RUN_CONTAINER} AS base
@@ -93,9 +94,10 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]

--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -52,7 +52,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 ## Base image
 FROM ${BASE_ROCM_DEV_CONTAINER} AS base
@@ -105,9 +106,10 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]

--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -44,7 +44,8 @@ RUN mkdir -p /app/full \
     && cp -r gguf-py /app/full \
     && cp -r requirements /app/full \
     && cp requirements.txt /app/full \
-    && cp .devops/tools.sh /app/full/tools.sh
+    && cp .devops/tools.sh /app/full/tools.sh \
+    && cp .devops/healthcheck.sh /app/full/healthcheck.sh
 
 ## Base image
 FROM ubuntu:$UBUNTU_VERSION AS base
@@ -97,9 +98,10 @@ FROM base AS server
 ENV LLAMA_ARG_HOST=0.0.0.0
 
 COPY --from=build /app/full/llama-server /app
+COPY --from=build /app/full/healthcheck.sh /app
 
 WORKDIR /app
 
-HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+HEALTHCHECK CMD [ "/app/healthcheck.sh" ]
 
 ENTRYPOINT [ "/app/llama-server" ]


### PR DESCRIPTION
When "docker run -e LLAMA_ARG_PORT=8088", the container health status is always '(unhealthy)', since the command is fixed as "http://localhost:8080/health".

Use the enviroment value 'LLAMA_ARG_PORT' to start health checking to avoid this problem.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
