### PR TITLE
context : remove redundant explicit casting to the same type

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -181,7 +181,7 @@ llama_context::llama_context(
         // graph outputs buffer
         {
             // resized during inference when a batch uses more outputs
-            if ((uint32_t) output_reserve(params.n_seq_max) < params.n_seq_max) {
+            if (output_reserve(params.n_seq_max) < params.n_seq_max) {
                 throw std::runtime_error("failed to reserve initial output buffer");
             }
 


### PR DESCRIPTION
The function 'output_reserve' return type is 'uint32_t', so need to add explicit casting.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
