### PR TITLE
server : only attempt to enable thinking if using jinja

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2313,7 +2313,7 @@ struct server_context {
         // thinking is enabled if:
         // 1. It's not explicitly disabled (reasoning_budget == 0)
         // 2. The chat template supports it
-        const bool enable_thinking = params_base.reasoning_budget != 0 && common_chat_templates_support_enable_thinking(chat_templates.get());
+        const bool enable_thinking = params_base.use_jinja && params_base.reasoning_budget != 0 && common_chat_templates_support_enable_thinking(chat_templates.get());
         SRV_INF("Enable thinking? %d\n", enable_thinking);
 
         oai_parser_opt = {


### PR DESCRIPTION
Avoids crash introduced in #15404 when not using `--jinja`, but `minja` can't parse the chat template. Will still refuse to start when using `--jinja`, but this is expected behavior.

Fixes #15930