### PR TITLE
vulkan : shader development improvements

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -186,6 +186,7 @@ option(GGML_VULKAN_MEMORY_DEBUG             "ggml: enable Vulkan memory debug ou
 option(GGML_VULKAN_SHADER_DEBUG_INFO        "ggml: enable Vulkan shader debug info"           OFF)
 option(GGML_VULKAN_VALIDATE                 "ggml: enable Vulkan validation"                  OFF)
 option(GGML_VULKAN_RUN_TESTS                "ggml: run Vulkan tests"                          OFF)
+option(GGML_VULKAN_SHADER_DEV               "ggml: read shaders from disk, don't embed"       OFF)
 option(GGML_WEBGPU                          "ggml: use WebGPU"                                OFF)
 option(GGML_WEBGPU_DEBUG                    "ggml: enable WebGPU debug output"                OFF)
 option(GGML_ZDNN                            "ggml: use zDNN"                                  OFF)

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -175,12 +175,14 @@ if (Vulkan_FOUND)
                                 "${_ggml_vk_input_dir}/*.h")
 
     if(GGML_VULKAN_SHADER_DEV)
-        set(_ggml_vk_shader_dev_args --no-embed --ninja)
+        set(_ggml_vk_shader_ninja_file "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders.ninja")
+        set(_ggml_vk_shader_dev_args --no-embed --ninja ${_ggml_vk_shader_ninja_file})
     endif()
 
     add_custom_command(
         OUTPUT ${_ggml_vk_header}
                ${_ggml_vk_source}
+               ${_ggml_vk_shader_ninja_file}
 
         COMMAND ${_ggml_vk_genshaders_cmd}
             --glslc      ${Vulkan_GLSLC_EXECUTABLE}
@@ -197,6 +199,16 @@ if (Vulkan_FOUND)
 
         COMMENT "Generate vulkan shaders"
     )
+
+    if(GGML_VULKAN_SHADER_DEV)
+        add_custom_target(ggml-vulkan-shaders-build
+            DEPENDS ${_ggml_vk_shader_ninja_file}
+                    ${_ggml_vk_shader_files}
+            COMMAND ninja -f ${_ggml_vk_shader_ninja_file}
+            COMMENT "Build vulkan shaders"
+        )
+        add_dependencies(ggml-vulkan ggml-vulkan-shaders-build)
+    endif()
 
     target_sources(ggml-vulkan PRIVATE ${_ggml_vk_source} ${_ggml_vk_header})
 

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -174,6 +174,10 @@ if (Vulkan_FOUND)
               CONFIGURE_DEPENDS "${_ggml_vk_input_dir}/*.cpp"
                                 "${_ggml_vk_input_dir}/*.h")
 
+    if(GGML_VULKAN_SHADER_DEV)
+        set(_ggml_vk_shader_dev_args --no-embed --ninja)
+    endif()
+
     add_custom_command(
         OUTPUT ${_ggml_vk_header}
                ${_ggml_vk_source}
@@ -185,6 +189,7 @@ if (Vulkan_FOUND)
             --target-hpp ${_ggml_vk_header}
             --target-cpp ${_ggml_vk_source}
             --no-clean
+            ${_ggml_vk_shader_dev_args}
 
         DEPENDS ${_ggml_vk_shader_files}
                 ${_ggml_vk_shaders_gen_sources}

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -214,7 +214,7 @@ if (Vulkan_FOUND)
             DEPENDS ${_ggml_vk_output_dir}/CMakeCache.txt
                     ${_ggml_vk_shader_cmake_file}
                     ${_ggml_vk_shader_files}
-            COMMAND cmake --build ${_ggml_vk_output_dir} --target all
+            COMMAND cmake --build ${_ggml_vk_output_dir} -j ${CMAKE_BUILD_PARALLEL_LEVEL}
             COMMENT "Build vulkan shaders"
         )
     endif()

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -163,6 +163,7 @@ if (Vulkan_FOUND)
     set (_ggml_vk_source     "${CMAKE_CURRENT_BINARY_DIR}/ggml-vulkan-shaders.cpp")
     set (_ggml_vk_input_dir  "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders")
     set (_ggml_vk_output_dir "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders.spv")
+    set (_ggml_vk_shaders_gen_output ${_ggml_vk_header} ${_ggml_vk_source})
 
     file(GLOB _ggml_vk_shader_files CONFIGURE_DEPENDS "${_ggml_vk_input_dir}/*.comp")
 
@@ -175,14 +176,14 @@ if (Vulkan_FOUND)
                                 "${_ggml_vk_input_dir}/*.h")
 
     if(GGML_VULKAN_SHADER_DEV)
-        set(_ggml_vk_shader_ninja_file "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders.ninja")
-        set(_ggml_vk_shader_dev_args --no-embed --ninja ${_ggml_vk_shader_ninja_file})
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders")
+        set(_ggml_vk_shader_cmake_file "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders/CMakeLists.txt")
+        set(_ggml_vk_shader_dev_args --no-embed --cmake ${_ggml_vk_shader_cmake_file})
+        set(_ggml_vk_shaders_gen_output ${_ggml_vk_shader_cmake_file})
     endif()
 
     add_custom_command(
-        OUTPUT ${_ggml_vk_header}
-               ${_ggml_vk_source}
-               ${_ggml_vk_shader_ninja_file}
+        OUTPUT ${_ggml_vk_shaders_gen_output}
 
         COMMAND ${_ggml_vk_genshaders_cmd}
             --glslc      ${Vulkan_GLSLC_EXECUTABLE}
@@ -201,13 +202,21 @@ if (Vulkan_FOUND)
     )
 
     if(GGML_VULKAN_SHADER_DEV)
-        add_custom_target(ggml-vulkan-shaders-build
-            DEPENDS ${_ggml_vk_shader_ninja_file}
+        add_custom_command(
+            OUTPUT ${_ggml_vk_output_dir}/CMakeCache.txt
+            COMMAND cmake -S ${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders -B ${_ggml_vk_output_dir} -G ${CMAKE_GENERATOR}
+            DEPENDS ${_ggml_vk_shader_cmake_file}
+            COMMENT "Configure vulkan shaders"
+        )
+        add_custom_command(
+            OUTPUT ${_ggml_vk_header}
+                   ${_ggml_vk_source}
+            DEPENDS ${_ggml_vk_output_dir}/CMakeCache.txt
+                    ${_ggml_vk_shader_cmake_file}
                     ${_ggml_vk_shader_files}
-            COMMAND ninja -f ${_ggml_vk_shader_ninja_file}
+            COMMAND cmake --build ${_ggml_vk_output_dir} --target all
             COMMENT "Build vulkan shaders"
         )
-        add_dependencies(ggml-vulkan ggml-vulkan-shaders-build)
     endif()
 
     target_sources(ggml-vulkan PRIVATE ${_ggml_vk_source} ${_ggml_vk_header})


### PR DESCRIPTION
Adds a CMake option `GGML_VULKAN_SHADER_DEV` (default: off). If enabled, makes tweaking shaders less painful:
* reads shader SPIRV from disk instead of embedding it
* uses ninja to build shaders for incremental build & dependency tracking

So when you make a change to a shader file and build, exactly 1 glslc invocation will run, and no C++ compilation at all. This is faster by many orders of magnitude, and will no doubt enhance vulkan backend developer efficiency by a similar factor.