### PR TITLE
examples : support encoder-decoder models in the simple example

### DIFF
--- a/examples/simple/simple.cpp
+++ b/examples/simple/simple.cpp
@@ -145,6 +145,20 @@ int main(int argc, char ** argv) {
 
     llama_batch batch = llama_batch_get_one(prompt_tokens.data(), prompt_tokens.size());
 
+    if (llama_model_has_encoder(model)) {
+        if (llama_encode(ctx, batch)) {
+            fprintf(stderr, "%s : failed to eval\n", __func__);
+            return 1;
+        }
+
+        llama_token decoder_start_token_id = llama_model_decoder_start_token(model);
+        if (decoder_start_token_id == LLAMA_TOKEN_NULL) {
+            decoder_start_token_id = llama_vocab_bos(vocab);
+        }
+
+        batch = llama_batch_get_one(&decoder_start_token_id, 1);
+    }
+
     // main loop
 
     const auto t_main_start = ggml_time_us();


### PR DESCRIPTION
I'd like to add support of encoder-decoder models in the simple example.
I believe it will help people who would like to build apps with encoder-decoder (e.g., T5) models based on llama.cpp.
Thanks.
