### PR TITLE
Guard ThreadPowerThrottling for non-MSVC builds

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2429,6 +2429,8 @@ static bool ggml_thread_apply_priority(int32_t prio) {
         // Newer Windows 11 versions aggresively park (offline) CPU cores and often place
         // all our threads onto the first 4 cores which results in terrible performance with
         // n_threads > 4
+        #if defined(_MSC_VER)
+
         #if _WIN32_WINNT >= 0x0602
         THREAD_POWER_THROTTLING_STATE t;
         ZeroMemory(&t, sizeof(t));
@@ -2440,6 +2442,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
             GGML_LOG_DEBUG("failed to disable thread power throttling %d : (%d)\n", prio, (int) GetLastError());
             return false;
         }
+        #endif
         #endif
     }
 


### PR DESCRIPTION
Title: Guard ThreadPowerThrottling block for non-MSVC compilers

Description:
This patch wraps the ThreadPowerThrottling block in `ggml-cpu.c` with an
MSVC-only preprocessor guard so MinGW/GCC builds don't attempt to compile
Windows SDK-only types (e.g. THREAD_POWER_THROTTLING_STATE).

Patch snippet (apply inside `llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c` where the
ThreadPowerThrottling block appears):

    /* Guard MSVC-only ThreadPowerThrottling block so MinGW/GCC do not compile
       Windows SDK-only types. */
    #if defined(_MSC_VER)
    #if _WIN32_WINNT >= 0x0602
        /* existing ThreadPowerThrottling code that references
           THREAD_POWER_THROTTLING_STATE and related symbols */
    #endif
    #endif // defined(_MSC_VER)

Notes:
- This change keeps the existing _WIN32_WINNT guard and only adds a
  surrounding #if defined(_MSC_VER) so non-MSVC compilers skip the block.
- It is intentionally minimal and should be safe for MSVC builds.

Suggested PR title:
  Guard ThreadPowerThrottling block in ggml-cpu.c for non-MSVC compilers

Suggested PR description:
  The ThreadPowerThrottling block references Windows SDK-only types which
  cause MinGW/GCC builds to fail with unknown type errors. This change adds
  an MSVC-only guard so that MinGW/GCC skip the block. MSVC builds are
  unaffected.
