### PR TITLE
[WIP] Rpc split row

### DIFF
--- a/ggml/include/ggml-metal.h
+++ b/ggml/include/ggml-metal.h
@@ -51,6 +51,8 @@ GGML_BACKEND_API void ggml_backend_metal_set_abort_callback(ggml_backend_t backe
 
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void);
 
+GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_metal_split_buffer_type(int main_device, const float * tensor_split);
+
 // helper to check if the device supports a specific family
 // ideally, the user code should be doing these checks
 // ref: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -762,7 +762,7 @@ static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, co
     return -1;
 }
 
-#if 0
+#if 1
 #define GGML_SCHED_MAX_SPLITS_DEBUG 4096
 static char causes[GGML_DEFAULT_GRAPH_SIZE*16 + GGML_SCHED_MAX_SPLITS_DEBUG*GGML_SCHED_MAX_SPLIT_INPUTS][128]; // debug only
 #define SET_CAUSE(node, ...) sprintf(causes[hash_id(node)], __VA_ARGS__)

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -533,7 +533,8 @@ bool ggml_backend_dev_supports_op(ggml_backend_dev_t device, const struct ggml_t
 
 bool ggml_backend_dev_supports_buft(ggml_backend_dev_t device, ggml_backend_buffer_type_t buft) {
     GGML_ASSERT(device);
-    return device->iface.supports_buft(device, buft);
+    bool res = device->iface.supports_buft(device, buft);
+    return res;
 }
 
 bool ggml_backend_dev_offload_op(ggml_backend_dev_t device, const struct ggml_tensor * op) {

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -14,7 +14,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 // max memory buffers that can be mapped to the device
-#define GGML_METAL_MAX_BUFFERS 128
+#define GGML_METAL_MAX_BUFFERS 32
 
 // max number of MTLCommandBuffer used to submit a graph for processing
 #define GGML_METAL_MAX_COMMAND_BUFFERS 8

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -8,6 +8,13 @@
 
 #import <Metal/Metal.h>
 
+#ifdef __cplusplus
+#include <array>
+#include <map>
+#include <mutex>
+#include <vector>
+#endif
+
 #undef MIN
 #undef MAX
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -1697,6 +1704,12 @@ struct ggml_backend_metal_buffer_context {
     // optional MTLResidencySet
     id rset;
 };
+
+// Helper function to calculate tensor size for split buffers
+static size_t ggml_nbytes_split(const struct ggml_tensor * tensor, int nrows_split) {
+    // Calculate the size based on the number of rows in the split
+    return nrows_split * ggml_row_size(tensor->type, tensor->ne[0]);
+}
 
 // rset init
 static bool ggml_backend_metal_buffer_rset_init(
@@ -6579,6 +6592,9 @@ static struct ggml_backend_feature * ggml_backend_metal_get_features(ggml_backen
 }
 
 static void * ggml_backend_metal_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+    if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
+        return (void *)ggml_backend_metal_split_buffer_type;
+    }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_metal_get_features;
     }
@@ -6597,6 +6613,333 @@ static struct ggml_backend_reg_i ggml_backend_metal_reg_i = {
 // called upon program exit
 static void ggml_metal_cleanup(void) {
     ggml_backend_metal_device_rel(&g_ggml_ctx_dev_main);
+}
+
+//
+// Metal split buffer implementation
+//
+
+#ifdef __cplusplus
+
+#define MATRIX_ROW_PADDING 512 // As defined in CUDA implementation
+
+// Metal equivalent of ggml_tensor_extra_gpu
+struct ggml_tensor_extra_metal {
+    // Metal buffers for each device (Metal only supports one device in current implementation)
+    // But we'll keep the array structure for consistency with CUDA
+    id<MTLBuffer> data_device[1];  // Metal only supports one device currently
+};
+
+// Buffer type context
+struct ggml_backend_metal_split_buffer_type_context {
+    int main_device;
+    std::array<float, 1> tensor_split;  // Metal only supports one device, but keeping array for API consistency
+    std::string name;
+};
+
+// Buffer context
+struct ggml_backend_metal_split_buffer_context {
+    ~ggml_backend_metal_split_buffer_context() {
+        for (ggml_tensor_extra_metal * extra : tensor_extras) {
+            // Clean up Metal buffers
+            if (extra->data_device[0] != nullptr) {
+                [extra->data_device[0] release];
+            }
+            delete extra;
+        }
+    }
+    
+    std::vector<ggml_tensor_extra_metal *> tensor_extras;
+};
+
+// Helper function to calculate tensor size for split buffers
+static size_t ggml_nbytes_split(const struct ggml_tensor * tensor, int nrows_split) {
+    // Calculate the size based on the number of rows in the split
+    return nrows_split * ggml_row_size(tensor->type, tensor->ne[0]);
+}
+
+// Tensor split calculation
+static void get_row_split(int64_t * row_low, int64_t * row_high, const ggml_tensor * tensor, const std::array<float, 1> & tensor_split, int id) {
+    // For Metal, we only have one device, so all rows go to device 0
+    if (id == 0) {
+        *row_low = 0;
+        *row_high = tensor->ne[1];
+    } else {
+        *row_low = 0;
+        *row_high = 0;
+    }
+    
+    GGML_UNUSED(tensor_split);
+}
+
+// Buffer free function
+static void ggml_backend_metal_split_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
+    delete ctx;
+}
+
+// Buffer get base function
+static void * ggml_backend_metal_split_buffer_get_base(ggml_backend_buffer_t buffer) {
+    // The pointers are stored in the tensor extras, this is just a dummy address
+    return (void *)0x1000;
+    
+    GGML_UNUSED(buffer);
+}
+
+// Buffer init tensor function
+static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
+    GGML_ASSERT(tensor->view_src == nullptr); // views of split tensors are not supported
+    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
+
+    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
+    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+
+    const int64_t ne0 = tensor->ne[0];
+
+    ggml_tensor_extra_metal * extra = new ggml_tensor_extra_metal{};
+    ctx->tensor_extras.push_back(extra);
+
+    // For Metal, we only have one device
+    int id = 0;
+    int64_t row_low, row_high;
+    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
+
+    int64_t nrows_split = row_high - row_low;
+    if (nrows_split == 0) {
+        tensor->extra = extra;
+        return GGML_STATUS_SUCCESS;
+    }
+
+    size_t size = ggml_nbytes_split(tensor, nrows_split);
+    const size_t original_size = size;
+
+    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
+    if (ne0 % MATRIX_ROW_PADDING != 0) {
+        size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
+    }
+
+    // Get Metal device context
+    struct ggml_backend_metal_device_context * ctx_dev = (struct ggml_backend_metal_device_context *)buffer->buft->device->context;
+    id<MTLDevice> device = ctx_dev->mtl_device;
+
+    // Allocate Metal buffer
+    extra->data_device[id] = [device newBufferWithLength:size options:MTLResourceStorageModePrivate];
+    
+    // Initialize buffer with zeros
+    memset([extra->data_device[id] contents], 0, size);
+
+    tensor->extra = extra;
+    return GGML_STATUS_SUCCESS;
+}
+
+// Buffer set tensor function
+static void ggml_backend_metal_split_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    // Split tensors must always be set in their entirety at once
+    GGML_ASSERT(offset == 0);
+    GGML_ASSERT(size == ggml_nbytes(tensor));
+    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
+
+    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+
+    const int64_t ne0 = tensor->ne[0];
+    const size_t nb1 = tensor->nb[1];
+    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
+
+    // For Metal, we only have one device
+    int id = 0;
+    int64_t row_low, row_high;
+    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
+
+    int64_t nrows_split = row_high - row_low;
+    if (nrows_split == 0) {
+        return;
+    }
+
+    const size_t offset_split = row_low * nb1;
+    size_t alloc_size = ggml_nbytes_split(tensor, nrows_split);
+    const size_t original_size = alloc_size;
+
+    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
+    if (ne0 % MATRIX_ROW_PADDING != 0) {
+        alloc_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
+    }
+
+    const char * buf_host = (const char *)data + offset_split;
+    
+    // Copy data to Metal buffer
+    memcpy([extra->data_device[id] contents], buf_host, original_size);
+}
+
+// Buffer get tensor function
+static void ggml_backend_metal_split_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    // Split tensors must always be retrieved in their entirety at once
+    GGML_ASSERT(offset == 0);
+    GGML_ASSERT(size == ggml_nbytes(tensor));
+    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
+
+    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+
+    const int64_t ne0 = tensor->ne[0];
+    const size_t nb1 = tensor->nb[1];
+    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
+
+    // For Metal, we only have one device
+    int id = 0;
+    int64_t row_low, row_high;
+    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
+
+    int64_t nrows_split = row_high - row_low;
+    if (nrows_split == 0) {
+        return;
+    }
+
+    const size_t offset_split = row_low * nb1;
+    size_t alloc_size = ggml_nbytes_split(tensor, nrows_split);
+    const size_t original_size = alloc_size;
+
+    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
+    if (ne0 % MATRIX_ROW_PADDING != 0) {
+        alloc_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
+    }
+
+    char * buf_host = (char *)data + offset_split;
+    
+    // Copy data from Metal buffer
+    memcpy(buf_host, [extra->data_device[id] contents], original_size);
+}
+
+// Buffer clear function
+static void ggml_backend_metal_split_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
+    GGML_UNUSED(buffer);
+    GGML_UNUSED(value);
+    // Not implemented for split buffers
+}
+
+// Buffer interface
+static const ggml_backend_buffer_i ggml_backend_metal_split_buffer_interface = {
+    /* .free_buffer     = */ ggml_backend_metal_split_buffer_free_buffer,
+    /* .get_base        = */ ggml_backend_metal_split_buffer_get_base,
+    /* .init_tensor     = */ ggml_backend_metal_split_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
+    /* .set_tensor      = */ ggml_backend_metal_split_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_metal_split_buffer_get_tensor,
+    /* .cpy_tensor      = */ NULL,
+    /* .clear           = */ ggml_backend_metal_split_buffer_clear,
+    /* .reset           = */ NULL,
+};
+
+// Buffer type interface functions
+static const char * ggml_backend_metal_split_buffer_type_get_name(ggml_backend_buffer_type_t buft) {
+    ggml_backend_metal_split_buffer_type_context * ctx = (ggml_backend_metal_split_buffer_type_context *)buft->context;
+    return ctx->name.c_str();
+}
+
+static bool ggml_backend_buft_is_metal_split(ggml_backend_buffer_type_t buft) {
+    return buft->iface.get_name == ggml_backend_metal_split_buffer_type_get_name;
+}
+
+static ggml_backend_buffer_t ggml_backend_metal_split_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    // Since we don't know the exact split after rounding, we cannot allocate the device buffers at this point
+    // Instead, we allocate them for each tensor separately in init_tensor
+    // However, the size still represents the maximum cumulative size of all the device buffers after the tensors are allocated,
+    // as returned by get_alloc_size. This limit is enforced during tensor allocation by ggml-alloc, so it must be correct.
+    ggml_backend_metal_split_buffer_context * ctx = new ggml_backend_metal_split_buffer_context();
+
+    return ggml_backend_buffer_init(buft, ggml_backend_metal_split_buffer_interface, ctx, size);
+}
+
+static size_t ggml_backend_metal_split_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+    return 128;
+    
+    GGML_UNUSED(buft);
+}
+
+static size_t ggml_backend_metal_split_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft, const ggml_tensor * tensor) {
+    ggml_backend_metal_split_buffer_type_context * ctx = (ggml_backend_metal_split_buffer_type_context *)buft->context;
+    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
+
+    size_t total_size = 0;
+
+    const int64_t ne0 = tensor->ne[0];
+
+    // For Metal, we only have one device
+    int id = 0;
+    int64_t row_low, row_high;
+    get_row_split(&row_low, &row_high, tensor, ctx->tensor_split, id);
+
+    int64_t nrows_split = row_high - row_low;
+    if (nrows_split == 0) {
+        return total_size;
+    }
+
+    total_size += ggml_nbytes_split(tensor, nrows_split);
+
+    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
+    if (ne0 % MATRIX_ROW_PADDING != 0) {
+        total_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
+    }
+
+    return total_size;
+}
+
+static bool ggml_backend_metal_split_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
+    return false;
+    
+    GGML_UNUSED(buft);
+}
+
+// Buffer type interface
+static const ggml_backend_buffer_type_i ggml_backend_metal_split_buffer_type_interface = {
+    /* .get_name         = */ ggml_backend_metal_split_buffer_type_get_name,
+    /* .alloc_buffer     = */ ggml_backend_metal_split_buffer_type_alloc_buffer,
+    /* .get_alignment    = */ ggml_backend_metal_split_buffer_type_get_alignment,
+    /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
+    /* .get_alloc_size   = */ ggml_backend_metal_split_buffer_type_get_alloc_size,
+    /* .is_host          = */ ggml_backend_metal_split_buffer_type_is_host,
+};
+
+#endif // __cplusplus
+
+// Main function to create Metal split buffer type
+GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_metal_split_buffer_type(int main_device, const float * tensor_split) {
+    GGML_LOG_INFO("%s: creating Metal split buffer type, main_device=%d\n", __func__, main_device);
+#ifdef __cplusplus
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+
+    static std::map<std::pair<int, std::array<float, 1>>, struct ggml_backend_buffer_type> buft_map;
+
+    std::array<float, 1> tensor_split_arr = {};
+
+    // For Metal, we only support one device, so we simplify the tensor split logic
+    tensor_split_arr[0] = 1.0f; // All tensors go to the single Metal device
+
+    auto it = buft_map.find({main_device, tensor_split_arr});
+    if (it != buft_map.end()) {
+        GGML_LOG_INFO("%s: returning existing buffer type\n", __func__);
+        return &it->second;
+    }
+    
+    auto * ctx = new ggml_backend_metal_split_buffer_type_context{
+        main_device,
+        tensor_split_arr,
+        std::string("Metal_Split"),
+    };
+
+    struct ggml_backend_buffer_type buft {
+        /* .iface   = */ ggml_backend_metal_split_buffer_type_interface,
+        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_metal_reg(), main_device),
+        /* .context = */ ctx,
+    };
+
+    auto result = buft_map.emplace(std::make_pair(main_device, tensor_split_arr), buft);
+    GGML_LOG_INFO("%s: created new Metal split buffer type\n", __func__);
+    return &result.first->second;
+#else
+    // For C builds, return the regular Metal buffer type
+    GGML_LOG_INFO("%s: C build, returning regular Metal buffer type\n", __func__);
+    return ggml_backend_metal_buffer_type();
+#endif
 }
 
 // TODO: make thread-safe

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -1850,6 +1850,7 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
                     return false;
             }
         case GGML_OP_NONE:
+        //case GGML_OP_NOPE:
         case GGML_OP_RESHAPE:
         case GGML_OP_VIEW:
         case GGML_OP_TRANSPOSE:
@@ -6207,7 +6208,7 @@ static size_t ggml_backend_split_buffer_type_get_alloc_size(ggml_backend_buffer_
 }
 
 static bool ggml_backend_split_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
-    return false;
+    return true;
     
     GGML_UNUSED(buft);
 }
@@ -6913,9 +6914,14 @@ static bool ggml_backend_metal_device_supports_op(ggml_backend_dev_t dev, const 
 }
 
 static bool ggml_backend_metal_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
-    return
-        buft->iface.get_name == ggml_backend_metal_buffer_type_get_name ||
-        buft->iface.get_name == ggml_backend_metal_buffer_from_ptr_type_get_name;
+    bool res =
+        buft->iface.get_name == ggml_backend_metal_buffer_type_get_name 
+    ||
+        buft->iface.get_name == ggml_backend_metal_buffer_from_ptr_type_get_name
+    ||
+        buft->iface.get_name == ggml_backend_split_buffer_type_get_name;
+
+    return res;
 
     GGML_UNUSED(dev);
 }

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -14,7 +14,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 // max memory buffers that can be mapped to the device
-#define GGML_METAL_MAX_BUFFERS 64
+#define GGML_METAL_MAX_BUFFERS 128
 
 // max number of MTLCommandBuffer used to submit a graph for processing
 #define GGML_METAL_MAX_COMMAND_BUFFERS 8

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -36,6 +36,9 @@
 // overload of MTLGPUFamilyMetal3 (not available in some environments)
 static const NSInteger MTLGPUFamilyMetal3_GGML = 5001;
 
+// Matrix row padding to avoid out-of-bounds memory accesses
+#define MATRIX_ROW_PADDING 512
+
 // initialized in ggml_backend_metal_reg
 static struct ggml_backend_reg    g_ggml_backend_metal_reg;
 static struct ggml_backend_device g_ggml_backend_metal_device;
@@ -5881,27 +5884,38 @@ struct ggml_tensor_extra_metal {
 // Buffer type context
 struct ggml_backend_metal_split_buffer_type_context {
     int main_device;
-    std::array<float, 1> tensor_split;  // Metal only supports one device, but keeping array for API consistency
-    std::string name;
+    float tensor_split[1];  // Metal only supports one device, but keeping array for API consistency
+    char* name;
 };
 
 // Buffer context
 struct ggml_backend_metal_split_buffer_context {
-    ~ggml_backend_metal_split_buffer_context() {
-        for (ggml_tensor_extra_metal * extra : tensor_extras) {
+    struct ggml_tensor_extra_metal ** tensor_extras;
+    size_t tensor_extras_size;
+    size_t tensor_extras_capacity;
+};
+
+// Cleanup function for buffer context
+static void ggml_backend_metal_split_buffer_context_free(struct ggml_backend_metal_split_buffer_context * ctx) {
+    if (ctx == NULL) return;
+    
+    for (size_t i = 0; i < ctx->tensor_extras_size; i++) {
+        struct ggml_tensor_extra_metal * extra = ctx->tensor_extras[i];
+        if (extra != NULL) {
             // Clean up Metal buffers
-            if (extra->data_device[0] != nullptr) {
+            if (extra->data_device[0] != NULL) {
                 [extra->data_device[0] release];
             }
-            delete extra;
+            free(extra);
         }
     }
     
-    std::vector<ggml_tensor_extra_metal *> tensor_extras;
-};
+    free(ctx->tensor_extras);
+    free(ctx);
+}
 
 // Tensor split calculation
-static void get_row_split(int64_t * row_low, int64_t * row_high, const ggml_tensor * tensor, const std::array<float, 1> & tensor_split, int id) {
+static void get_row_split(int64_t * row_low, int64_t * row_high, const struct ggml_tensor * tensor, const float tensor_split[1], int id) {
     // For Metal, we only have one device, so all rows go to device 0
     if (id == 0) {
         *row_low = 0;
@@ -5916,8 +5930,8 @@ static void get_row_split(int64_t * row_low, int64_t * row_high, const ggml_tens
 
 // Buffer free function
 static void ggml_backend_metal_split_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
-    delete ctx;
+    struct ggml_backend_metal_split_buffer_context * ctx = (struct ggml_backend_metal_split_buffer_context *)buffer->context;
+    ggml_backend_metal_split_buffer_context_free(ctx);
 }
 
 // Buffer get base function
@@ -5929,17 +5943,20 @@ static void * ggml_backend_metal_split_buffer_get_base(ggml_backend_buffer_t buf
 }
 
 // Buffer init tensor function
-static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
-    GGML_ASSERT(tensor->view_src == nullptr); // views of split tensors are not supported
+static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
+    GGML_ASSERT(tensor->view_src == NULL); // views of split tensors are not supported
     GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
 
-    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
-    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+    struct ggml_backend_metal_split_buffer_context * ctx = (struct ggml_backend_metal_split_buffer_context *)buffer->context;
+    struct ggml_backend_metal_split_buffer_type_context * buft_ctx = (struct ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
 
     const int64_t ne0 = tensor->ne[0];
 
-    ggml_tensor_extra_metal * extra = new ggml_tensor_extra_metal{};
-    ctx->tensor_extras.push_back(extra);
+    struct ggml_tensor_extra_metal * extra = calloc(1, sizeof(struct ggml_tensor_extra_metal));
+    // For a dynamic array, we need to manually manage the array
+    ctx->tensor_extras = realloc(ctx->tensor_extras, (ctx->tensor_extras_size + 1) * sizeof(struct ggml_tensor_extra_metal *));
+    ctx->tensor_extras[ctx->tensor_extras_size] = extra;
+    ctx->tensor_extras_size++;
 
     // For Metal, we only have one device
     int id = 0;
@@ -5953,7 +5970,7 @@ static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend
     }
 
     size_t size = ggml_nbytes_split(tensor, nrows_split);
-    const size_t original_size = size;
+    // const size_t original_size = size; // Not used in this implementation
 
     // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
     if (ne0 % MATRIX_ROW_PADDING != 0) {
@@ -5962,10 +5979,9 @@ static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend
 
     // Get Metal device context
     struct ggml_backend_metal_device_context * ctx_dev = (struct ggml_backend_metal_device_context *)buffer->buft->device->context;
-    id<MTLDevice> device = ctx_dev->mtl_device;
 
-    // Allocate Metal buffer
-    extra->data_device[id] = [device newBufferWithLength:size options:MTLResourceStorageModePrivate];
+    // Allocate Metal buffer directly using ctx_dev->mtl_device
+    extra->data_device[id] = [ctx_dev->mtl_device newBufferWithLength:size options:MTLResourceStorageModePrivate];
     
     // Initialize buffer with zeros
     memset([extra->data_device[id] contents], 0, size);
@@ -5975,17 +5991,17 @@ static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend
 }
 
 // Buffer set tensor function
-static void ggml_backend_metal_split_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+static void ggml_backend_metal_split_buffer_set_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     // Split tensors must always be set in their entirety at once
     GGML_ASSERT(offset == 0);
     GGML_ASSERT(size == ggml_nbytes(tensor));
     GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
 
-    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+    struct ggml_backend_metal_split_buffer_type_context * buft_ctx = (struct ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
 
     const int64_t ne0 = tensor->ne[0];
     const size_t nb1 = tensor->nb[1];
-    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
+    struct ggml_tensor_extra_metal * extra = (struct ggml_tensor_extra_metal *)tensor->extra;
 
     // For Metal, we only have one device
     int id = 0;
@@ -6013,17 +6029,17 @@ static void ggml_backend_metal_split_buffer_set_tensor(ggml_backend_buffer_t buf
 }
 
 // Buffer get tensor function
-static void ggml_backend_metal_split_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+static void ggml_backend_metal_split_buffer_get_tensor(ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     // Split tensors must always be retrieved in their entirety at once
     GGML_ASSERT(offset == 0);
     GGML_ASSERT(size == ggml_nbytes(tensor));
     GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
 
-    ggml_backend_metal_split_buffer_type_context * buft_ctx = (ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
+    struct ggml_backend_metal_split_buffer_type_context * buft_ctx = (struct ggml_backend_metal_split_buffer_type_context *)buffer->buft->context;
 
     const int64_t ne0 = tensor->ne[0];
     const size_t nb1 = tensor->nb[1];
-    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
+    struct ggml_tensor_extra_metal * extra = (struct ggml_tensor_extra_metal *)tensor->extra;
 
     // For Metal, we only have one device
     int id = 0;
@@ -6058,7 +6074,7 @@ static void ggml_backend_metal_split_buffer_clear(ggml_backend_buffer_t buffer, 
 }
 
 // Buffer interface
-static const ggml_backend_buffer_i ggml_backend_metal_split_buffer_interface = {
+static const struct ggml_backend_buffer_i ggml_backend_metal_split_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_metal_split_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_metal_split_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_metal_split_buffer_init_tensor,
@@ -6072,8 +6088,8 @@ static const ggml_backend_buffer_i ggml_backend_metal_split_buffer_interface = {
 
 // Buffer type interface functions
 static const char * ggml_backend_split_buffer_type_get_name(ggml_backend_buffer_type_t buft) {
-    ggml_backend_metal_split_buffer_type_context * ctx = (ggml_backend_metal_split_buffer_type_context *)buft->context;
-    return ctx->name.c_str();
+    struct ggml_backend_metal_split_buffer_type_context * ctx = (struct ggml_backend_metal_split_buffer_type_context *)buft->context;
+    return ctx->name;
 }
 
 static bool ggml_backend_buft_is_metal_split(ggml_backend_buffer_type_t buft) {
@@ -6085,7 +6101,7 @@ static ggml_backend_buffer_t ggml_backend_split_buffer_type_alloc_buffer(ggml_ba
     // Instead, we allocate them for each tensor separately in init_tensor
     // However, the size still represents the maximum cumulative size of all the device buffers after the tensors are allocated,
     // as returned by get_alloc_size. This limit is enforced during tensor allocation by ggml-alloc, so it must be correct.
-    ggml_backend_metal_split_buffer_context * ctx = new ggml_backend_metal_split_buffer_context();
+    struct ggml_backend_metal_split_buffer_context * ctx = calloc(1, sizeof(struct ggml_backend_metal_split_buffer_context));
 
     return ggml_backend_buffer_init(buft, ggml_backend_metal_split_buffer_interface, ctx, size);
 }
@@ -6096,8 +6112,8 @@ static size_t ggml_backend_split_buffer_type_get_alignment(ggml_backend_buffer_t
     GGML_UNUSED(buft);
 }
 
-static size_t ggml_backend_split_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft, const ggml_tensor * tensor) {
-    ggml_backend_metal_split_buffer_type_context * ctx = (ggml_backend_metal_split_buffer_type_context *)buft->context;
+static size_t ggml_backend_split_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft, const struct ggml_tensor * tensor) {
+    struct ggml_backend_metal_split_buffer_type_context * ctx = (struct ggml_backend_metal_split_buffer_type_context *)buft->context;
     GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
 
     size_t total_size = 0;
@@ -6131,7 +6147,7 @@ static bool ggml_backend_split_buffer_type_is_host(ggml_backend_buffer_type_t bu
 }
 
 // Buffer type interface
-static const ggml_backend_buffer_type_i ggml_backend_split_buffer_type_interface = {
+static const struct ggml_backend_buffer_type_i ggml_backend_split_buffer_type_interface = {
     /* .get_name         = */ ggml_backend_split_buffer_type_get_name,
     /* .alloc_buffer     = */ ggml_backend_split_buffer_type_alloc_buffer,
     /* .get_alignment    = */ ggml_backend_split_buffer_type_get_alignment,
@@ -6143,35 +6159,21 @@ static const ggml_backend_buffer_type_i ggml_backend_split_buffer_type_interface
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_split_buffer_type(int main_device, const float * tensor_split) {
     GGML_LOG_INFO("%s: creating Metal split buffer type, main_device=%d\n", __func__, main_device);
     
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> lock(mutex);
-
-    static std::map<std::pair<int, std::array<float, 1>>, struct ggml_backend_buffer_type> buft_map;
-
-    std::array<float, 1> tensor_split_arr = {};
-
-    // For Metal, we only support one device, so we simplify the tensor split logic
-    tensor_split_arr[0] = 1.0f; // All tensors go to the single Metal device
-
-    auto it = buft_map.find({main_device, tensor_split_arr});
-    if (it != buft_map.end()) {
-        return &it->second;
-    }
+    // For Metal, we only support one device, so we simplify the implementation
+    // We'll just create a new buffer type context each time since Metal only has one device
     
-    auto * ctx = new ggml_backend_metal_split_buffer_type_context{
-        main_device,
-        tensor_split_arr,
-        std::string("Metal_Split"),
-    };
+    struct ggml_backend_metal_split_buffer_type_context * ctx = calloc(1, sizeof(struct ggml_backend_metal_split_buffer_type_context));
+    ctx->main_device = main_device;
+    ctx->tensor_split[0] = 1.0f; // All tensors go to the single Metal device
+    ctx->name = "Metal_Split";
 
-    struct ggml_backend_buffer_type buft {
-        /* .iface   = */ ggml_backend_split_buffer_type_interface,
-        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_metal_reg(), main_device),
-        /* .context = */ ctx,
-    };
+    // Allocate a new buffer type structure each time
+    struct ggml_backend_buffer_type * buft = calloc(1, sizeof(struct ggml_backend_buffer_type));
+    buft->iface = ggml_backend_split_buffer_type_interface;
+    buft->device = ggml_backend_reg_dev_get(ggml_backend_metal_reg(), main_device);
+    buft->context = ctx;
 
-    auto result = buft_map.emplace(std::make_pair(main_device, tensor_split_arr), buft);
-    return &result.first->second;
+    return buft;
 }
 
 
@@ -6911,297 +6913,6 @@ static struct ggml_backend_reg_i ggml_backend_metal_reg_i = {
 static void ggml_metal_cleanup(void) {
     ggml_backend_metal_device_rel(&g_ggml_ctx_dev_main);
 }
-
-//
-// Metal split buffer implementation
-//
-
-#ifdef __cplusplus
-
-#include <array>
-#include <map>
-#include <mutex>
-#include <vector>
-
-#define MATRIX_ROW_PADDING 512 // As defined in CUDA implementation
-
-// Metal equivalent of ggml_tensor_extra_gpu
-struct ggml_tensor_extra_metal {
-    // Metal buffers for each device (Metal only supports one device in current implementation)
-    // But we'll keep the array structure for consistency with CUDA
-    id<MTLBuffer> data_device[1];  // Metal only supports one device currently
-};
-
-// Buffer type context
-struct ggml_backend_split_buffer_type_context {
-    int main_device;
-    std::array<float, 1> tensor_split;  // Metal only supports one device, but keeping array for API consistency
-    std::string name;
-};
-
-// Buffer context
-struct ggml_backend_metal_split_buffer_context {
-    ~ggml_backend_metal_split_buffer_context() {
-        for (ggml_tensor_extra_metal * extra : tensor_extras) {
-            // Clean up Metal buffers
-            if (extra->data_device[0] != nullptr) {
-                [extra->data_device[0] release];
-            }
-            delete extra;
-        }
-    }
-    
-    std::vector<ggml_tensor_extra_metal *> tensor_extras;
-};
-
-// Helper function to calculate tensor size for split buffers
-static size_t ggml_nbytes_split(const struct ggml_tensor * tensor, int nrows_split) {
-    // Calculate the size based on the number of rows in the split
-    return nrows_split * ggml_row_size(tensor->type, tensor->ne[0]);
-}
-
-// Tensor split calculation
-static void get_row_split(int64_t * row_low, int64_t * row_high, const ggml_tensor * tensor, const std::array<float, 1> & tensor_split, int id) {
-    GGML_LOG_INFO("Returning Row Splits.\n");
-    // For Metal, we only have one device, so all rows go to device 0
-    if (id == 0) {
-        *row_low = 0;
-        *row_high = tensor->ne[1];
-    } else {
-        *row_low = 0;
-        *row_high = 0;
-    }
-    
-    GGML_UNUSED(tensor_split);
-}
-
-// Buffer free function
-static void ggml_backend_metal_split_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
-    delete ctx;
-}
-
-// Buffer get base function
-static void * ggml_backend_metal_split_buffer_get_base(ggml_backend_buffer_t buffer) {
-    // The pointers are stored in the tensor extras, this is just a dummy address
-    return (void *)0x1000;
-    
-    GGML_UNUSED(buffer);
-}
-
-// Buffer init tensor function
-static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
-    GGML_ASSERT(tensor->view_src == nullptr); // views of split tensors are not supported
-    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
-
-    ggml_backend_metal_split_buffer_context * ctx = (ggml_backend_metal_split_buffer_context *)buffer->context;
-    ggml_backend_split_buffer_type_context * buft_ctx = (ggml_backend_split_buffer_type_context *)buffer->buft->context;
-
-    const int64_t ne0 = tensor->ne[0];
-
-    ggml_tensor_extra_metal * extra = new ggml_tensor_extra_metal{};
-    ctx->tensor_extras.push_back(extra);
-
-    // For Metal, we only have one device
-    int id = 0;
-    int64_t row_low, row_high;
-    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
-
-    int64_t nrows_split = row_high - row_low;
-    if (nrows_split == 0) {
-        tensor->extra = extra;
-        return GGML_STATUS_SUCCESS;
-    }
-
-    size_t size = ggml_nbytes_split(tensor, nrows_split);
-    const size_t original_size = size;
-
-    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
-    if (ne0 % MATRIX_ROW_PADDING != 0) {
-        size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
-    }
-
-    // Get Metal device context
-    struct ggml_backend_metal_device_context * ctx_dev = (struct ggml_backend_metal_device_context *)buffer->buft->device->context;
-    id<MTLDevice> device = ctx_dev->mtl_device;
-
-    // Allocate Metal buffer
-    extra->data_device[id] = [device newBufferWithLength:size options:MTLResourceStorageModePrivate];
-    
-    // Initialize buffer with zeros
-    memset([extra->data_device[id] contents], 0, size);
-
-    tensor->extra = extra;
-    return GGML_STATUS_SUCCESS;
-}
-
-// Buffer set tensor function
-static void ggml_backend_metal_split_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    // Split tensors must always be set in their entirety at once
-    GGML_ASSERT(offset == 0);
-    GGML_ASSERT(size == ggml_nbytes(tensor));
-    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
-
-    ggml_backend_split_buffer_type_context * buft_ctx = (ggml_backend_split_buffer_type_context *)buffer->buft->context;
-
-    const int64_t ne0 = tensor->ne[0];
-    const size_t nb1 = tensor->nb[1];
-    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
-
-    // For Metal, we only have one device
-    int id = 0;
-    int64_t row_low, row_high;
-    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
-
-    int64_t nrows_split = row_high - row_low;
-    if (nrows_split == 0) {
-        return;
-    }
-
-    const size_t offset_split = row_low * nb1;
-    size_t alloc_size = ggml_nbytes_split(tensor, nrows_split);
-    const size_t original_size = alloc_size;
-
-    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
-    if (ne0 % MATRIX_ROW_PADDING != 0) {
-        alloc_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
-    }
-
-    const char * buf_host = (const char *)data + offset_split;
-    
-    // Copy data to Metal buffer
-    memcpy([extra->data_device[id] contents], buf_host, original_size);
-}
-
-// Buffer get tensor function
-static void ggml_backend_metal_split_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    // Split tensors must always be retrieved in their entirety at once
-    GGML_ASSERT(offset == 0);
-    GGML_ASSERT(size == ggml_nbytes(tensor));
-    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
-
-    ggml_backend_split_buffer_type_context * buft_ctx = (ggml_backend_split_buffer_type_context *)buffer->buft->context;
-
-    const int64_t ne0 = tensor->ne[0];
-    const size_t nb1 = tensor->nb[1];
-    ggml_tensor_extra_metal * extra = (ggml_tensor_extra_metal *)tensor->extra;
-
-    // For Metal, we only have one device
-    int id = 0;
-    int64_t row_low, row_high;
-    get_row_split(&row_low, &row_high, tensor, buft_ctx->tensor_split, id);
-
-    int64_t nrows_split = row_high - row_low;
-    if (nrows_split == 0) {
-        return;
-    }
-
-    const size_t offset_split = row_low * nb1;
-    size_t alloc_size = ggml_nbytes_split(tensor, nrows_split);
-    const size_t original_size = alloc_size;
-
-    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
-    if (ne0 % MATRIX_ROW_PADDING != 0) {
-        alloc_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
-    }
-
-    char * buf_host = (char *)data + offset_split;
-    
-    // Copy data from Metal buffer
-    memcpy(buf_host, [extra->data_device[id] contents], original_size);
-}
-
-// Buffer clear function
-static void ggml_backend_metal_split_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
-    GGML_UNUSED(buffer);
-    GGML_UNUSED(value);
-    // Not implemented for split buffers
-}
-
-// Buffer interface
-static const ggml_backend_buffer_i ggml_backend_metal_split_buffer_interface = {
-    /* .free_buffer     = */ ggml_backend_metal_split_buffer_free_buffer,
-    /* .get_base        = */ ggml_backend_metal_split_buffer_get_base,
-    /* .init_tensor     = */ ggml_backend_metal_split_buffer_init_tensor,
-    /* .memset_tensor   = */ NULL,
-    /* .set_tensor      = */ ggml_backend_metal_split_buffer_set_tensor,
-    /* .get_tensor      = */ ggml_backend_metal_split_buffer_get_tensor,
-    /* .cpy_tensor      = */ NULL,
-    /* .clear           = */ ggml_backend_metal_split_buffer_clear,
-    /* .reset           = */ NULL,
-};
-
-// Buffer type interface functions
-static const char * ggml_backend_split_buffer_type_get_name(ggml_backend_buffer_type_t buft) {
-    ggml_backend_split_buffer_type_context * ctx = (ggml_backend_split_buffer_type_context *)buft->context;
-    return ctx->name.c_str();
-}
-
-static bool ggml_backend_buft_is_metal_split(ggml_backend_buffer_type_t buft) {
-    return buft->iface.get_name == ggml_backend_split_buffer_type_get_name;
-}
-
-static ggml_backend_buffer_t ggml_backend_split_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    // Since we don't know the exact split after rounding, we cannot allocate the device buffers at this point
-    // Instead, we allocate them for each tensor separately in init_tensor
-    // However, the size still represents the maximum cumulative size of all the device buffers after the tensors are allocated,
-    // as returned by get_alloc_size. This limit is enforced during tensor allocation by ggml-alloc, so it must be correct.
-    ggml_backend_metal_split_buffer_context * ctx = new ggml_backend_metal_split_buffer_context();
-
-    return ggml_backend_buffer_init(buft, ggml_backend_metal_split_buffer_interface, ctx, size);
-}
-
-static size_t ggml_backend_split_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
-    return 128;
-    
-    GGML_UNUSED(buft);
-}
-
-static size_t ggml_backend_split_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft, const ggml_tensor * tensor) {
-    ggml_backend_split_buffer_type_context * ctx = (ggml_backend_split_buffer_type_context *)buft->context;
-    GGML_ASSERT(ggml_is_contiguous(tensor) && "split buffers only supported for contiguous tensors");
-
-    size_t total_size = 0;
-
-    const int64_t ne0 = tensor->ne[0];
-
-    // For Metal, we only have one device
-    int id = 0;
-    int64_t row_low, row_high;
-    get_row_split(&row_low, &row_high, tensor, ctx->tensor_split, id);
-
-    int64_t nrows_split = row_high - row_low;
-    if (nrows_split == 0) {
-        return total_size;
-    }
-
-    total_size += ggml_nbytes_split(tensor, nrows_split);
-
-    // Pad last row to a multiple of 512 elements to avoid out-of-bounds memory accesses
-    if (ne0 % MATRIX_ROW_PADDING != 0) {
-        total_size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
-    }
-
-    return total_size;
-}
-
-static bool ggml_backend_split_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
-    return false;
-    
-    GGML_UNUSED(buft);
-}
-
-// Buffer type interface
-static const ggml_backend_buffer_type_i ggml_backend_split_buffer_type_interface = {
-    /* .get_name         = */ ggml_backend_split_buffer_type_get_name,
-    /* .alloc_buffer     = */ ggml_backend_split_buffer_type_alloc_buffer,
-    /* .get_alignment    = */ ggml_backend_split_buffer_type_get_alignment,
-    /* .get_max_size     = */ NULL, // defaults to SIZE_MAX
-    /* .get_alloc_size   = */ ggml_backend_split_buffer_type_get_alloc_size,
-    /* .is_host          = */ ggml_backend_split_buffer_type_is_host,
-};
-
-#endif // __cplusplus
 
 // TODO: make thread-safe
 ggml_backend_reg_t ggml_backend_metal_reg(void) {

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -5916,15 +5916,20 @@ static void ggml_backend_metal_split_buffer_context_free(struct ggml_backend_met
 
 // Tensor split calculation
 static void get_row_split(int64_t * row_low, int64_t * row_high, const struct ggml_tensor * tensor, const float tensor_split[1], int id) {
+    GGML_LOG_DEBUG("%s: tensor '%s', id=%d, ne[1]=%lld\n", __func__, tensor->name, id, tensor->ne[1]);
+    
     // For Metal, we only have one device, so all rows go to device 0
     if (id == 0) {
         *row_low = 0;
         *row_high = tensor->ne[1];
+        GGML_LOG_DEBUG("%s: assigning rows [%lld, %lld] to device %d\n", __func__, *row_low, *row_high, id);
     } else {
         *row_low = 0;
         *row_high = 0;
+        GGML_LOG_DEBUG("%s: device %d gets no rows\n", __func__, id);
     }
     
+    GGML_LOG_DEBUG("%s: tensor_split[0] = %f\n", __func__, (double)tensor_split[0]);
     GGML_UNUSED(tensor_split);
 }
 
@@ -6012,7 +6017,7 @@ static enum ggml_status ggml_backend_metal_split_buffer_init_tensor(ggml_backend
         return GGML_STATUS_ALLOC_FAILED;
     }
     
-    GGML_LOG_DEBUG("%s: tensor '%s' Metal buffer allocated at %p\n", __func__, tensor->name, extra->data_device[id]);
+    GGML_LOG_DEBUG("%s: tensor '%s' Metal buffer allocated at %p\n", __func__, tensor->name, (void *)extra->data_device[id]);
 
     // Initialize buffer with zeros
     GGML_LOG_DEBUG("%s: tensor '%s' initializing buffer with zeros\n", __func__, tensor->name);
@@ -6212,7 +6217,7 @@ GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_split_buffer_type(int m
     ctx->tensor_split[0] = 1.0f; // All tensors go to the single Metal device
     ctx->name = "Metal_Split";
     
-    GGML_LOG_DEBUG("%s: tensor_split[0] = %f\n", __func__, ctx->tensor_split[0]);
+    GGML_LOG_DEBUG("%s: tensor_split[0] = %f\n", __func__, (double)ctx->tensor_split[0]);
 
     // Allocate a new buffer type structure each time
     struct ggml_backend_buffer_type * buft = calloc(1, sizeof(struct ggml_backend_buffer_type));

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1772,12 +1772,29 @@ static ggml_backend_dev_t ggml_backend_rpc_reg_get_device(ggml_backend_reg_t reg
     GGML_UNUSED(index);
 }
 
+static ggml_backend_buffer_type_t ggml_backend_rpc_split_buffer_type(int main_device, const float * tensor_split) {
+    // For RPC backend, we don't implement actual tensor splitting
+    // Just return the default buffer type for the main device
+    ggml_backend_dev_t dev = ggml_backend_reg_dev_get(ggml_backend_rpc_reg(), main_device);
+    if (!dev) {
+        return nullptr;
+    }
+    
+    // Suppress unused parameter warning
+    GGML_UNUSED(tensor_split);
+    
+    return ggml_backend_dev_buffer_type(dev);
+}
+
 static void * ggml_backend_rpc_get_proc_address(ggml_backend_reg_t reg, const char * name) {
     if (std::strcmp(name, "ggml_backend_rpc_add_device") == 0) {
         return (void *)ggml_backend_rpc_add_device;
     }
     if (std::strcmp(name, "ggml_backend_rpc_start_server") == 0) {
         return (void *)ggml_backend_rpc_start_server;
+    }
+    if (std::strcmp(name, "ggml_backend_split_buffer_type") == 0) {
+        return (void *)ggml_backend_rpc_split_buffer_type;
     }
     return NULL;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -377,8 +377,13 @@ static buft_list_t make_gpu_buft_list(ggml_backend_dev_t dev, llama_split_mode s
         if (ggml_backend_split_buffer_type_fn) {
             size_t dev_index = [&]() {
                 auto * reg = ggml_backend_dev_backend_reg(dev);
-                for (size_t i = 0; i < ggml_backend_reg_dev_count(reg); ++i) {
-                    if (ggml_backend_reg_dev_get(reg, i) == dev) {
+                size_t reg_dev_count = ggml_backend_reg_dev_count(reg);
+                LLAMA_LOG_DEBUG("%s: device %s, reg %s, device count %zu\n", __func__, ggml_backend_dev_name(dev), ggml_backend_reg_name(reg), reg_dev_count);
+                for (size_t i = 0; i < reg_dev_count; ++i) {
+                    ggml_backend_dev_t reg_dev = ggml_backend_reg_dev_get(reg, i);
+                    LLAMA_LOG_DEBUG("%s: comparing device %s with reg device %s at index %zu\n", __func__, ggml_backend_dev_name(dev), ggml_backend_dev_name(reg_dev), i);
+                    if (reg_dev == dev) {
+                        LLAMA_LOG_DEBUG("%s: found device %s at index %zu\n", __func__, ggml_backend_dev_name(dev), i);
                         return i;
                     }
                 }


### PR DESCRIPTION
# The PR

This work aims one goal; having row-splitting mode on RPC clusters.

## TL;DR

I got bored, wanted to contribute and join you guys on this beautiful journey. I hope you welcome me.

## Details & Background

Heavy WIP situation, including this description, I will work on this PR and make sure it fits well with the rest of the project.

### For the background:

Metal devices have only one GPU. This is a bit tricky because `Row splitting` has no use on one device/backend. But the ultimate goal is having it, so with RPC, devices can calculate inference effectively and faster. For this, I worked on both sides. I implemented a very, very early stage of row wise splitting mode on Metal backend and then make it work with RPC too.

The current PR has the implementation, but, -be aware- the performance is unacceptable and every device you add to the cluster, it gets worse. I will inspect the PR and will read sources I can find to have the Domain Knowledge I need to have to solve this.

### Tests & Results:

```sh
❯ ./build-rpc-split-mode-row-release/bin/llama-bench -m ../llama.cpp.org.new.rpc/hfmodels/models/llama-2-7b.Q4_0.gguf --split-mode row --rpc 127.0.0.1:50052
| model                          |       size |     params | backend    | threads |    sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ----: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Metal,BLAS,RPC |       8 |   row |           pp512 |         54.29 ± 6.55 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Metal,BLAS,RPC |       8 |   row |           tg128 |          0.64 ± 0.01 |

build: 997e3047 (6444)
```

#### In any cases, every comment, suggestion and support are very welcome.