### PR TITLE
ci : use macos-latest for arm64 webgpu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           ctest -L main --verbose --timeout 900
 
   macOS-latest-cmake-arm64-webgpu:
-    runs-on: latest
+    runs-on: macos-latest
 
     steps:
       - name: Clone


### PR DESCRIPTION
This commit updates the runs-on field for the macOS arm64 webgpu build job to use macos-latest instead of just latest.

The motivation for this is that this job can wait for a runner to pick up the job for a very long time, sometimes over 7 hours. This is an attempt to see if this change can help reduce the wait time.

Refs: https://github.com/ggml-org/llama.cpp/actions/runs/17754163447/job/50454257570?pr=16004

----

With this change a runner picked up the job fairly quickly:
https://github.com/danbev/llama.cpp/actions/runs/17764796649/job/50485497894#logs

