### PR TITLE
llama-bench: add --devices and --list-devices support

### DIFF
--- a/tools/llama-bench/README.md
+++ b/tools/llama-bench/README.md
@@ -30,6 +30,7 @@ options:
   --delay <0...N> (seconds)                 delay between each test (default: 0)
   -o, --output <csv|json|jsonl|md|sql>      output format printed to stdout (default: md)
   -oe, --output-err <csv|json|jsonl|md|sql> output format printed to stderr (default: none)
+  --list-devices                            list available devices and exit
   -v, --verbose                             verbose output
   --progress                                print test progress indicators
 
@@ -48,11 +49,13 @@ test parameters:
   --cpu-strict <0|1>                        (default: 0)
   --poll <0...100>                          (default: 50)
   -ngl, --n-gpu-layers <n>                  (default: 99)
+  -ncmoe, --n-cpu-moe <n>                   (default: 0)
   -rpc, --rpc <rpc_servers>                 (default: none)
   -sm, --split-mode <none|layer|row>        (default: layer)
   -mg, --main-gpu <i>                       (default: 0)
   -nkvo, --no-kv-offload <0|1>              (default: 0)
   -fa, --flash-attn <0|1>                   (default: 0)
+  -dev, --device <dev0/dev1/...>            (default: auto)
   -mmp, --mmap <0|1>                        (default: 1)
   -embd, --embeddings <0|1>                 (default: 0)
   -ts, --tensor-split <ts0/ts1/..>          (default: 0)

--- a/tools/llama-bench/README.md
+++ b/tools/llama-bench/README.md
@@ -33,6 +33,7 @@ options:
   --list-devices                            list available devices and exit
   -v, --verbose                             verbose output
   --progress                                print test progress indicators
+  -rpc, --rpc <rpc_servers>                 register RPC devices (comma separated)
 
 test parameters:
   -m, --model <filename>                    (default: models/7B/ggml-model-q4_0.gguf)
@@ -50,7 +51,6 @@ test parameters:
   --poll <0...100>                          (default: 50)
   -ngl, --n-gpu-layers <n>                  (default: 99)
   -ncmoe, --n-cpu-moe <n>                   (default: 0)
-  -rpc, --rpc <rpc_servers>                 (default: none)
   -sm, --split-mode <none|layer|row>        (default: layer)
   -mg, --main-gpu <i>                       (default: 0)
   -nkvo, --no-kv-offload <0|1>              (default: 0)

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -733,7 +733,6 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                     invalid_param = true;
                     break;
                 }
-                ggml_backend_load_all();
                 try {
                     auto devices = register_rpc_device_list(argv[i]);
                     params.rpc_servers.push_back(argv[i]);
@@ -2052,7 +2051,6 @@ int main(int argc, char ** argv) {
     cmd_params params = parse_cmd_params(argc, argv);
 
     if (params.list_devices) {
-        ggml_backend_load_all();
         for (const auto & rpc : params.rpc_servers) {
             if (!rpc.empty()) {
                 try {

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1404,14 +1404,14 @@ struct test {
 
     static const std::vector<std::string> & get_fields() {
         static const std::vector<std::string> fields = {
-            "build_commit",   "build_number",  "cpu_info",      "gpu_info",       "backends",
-            "model_filename", "model_type",    "model_size",    "model_n_params", "n_batch",
-            "n_ubatch",       "n_threads",     "cpu_mask",      "cpu_strict",     "poll",
-            "type_k",         "type_v",        "n_gpu_layers",  "n_cpu_moe",      "split_mode",
-            "main_gpu",       "no_kv_offload", "flash_attn",    "tensor_split",   "tensor_buft_overrides",
-            "devices",        "use_mmap",       "embeddings",    "no_op_offload", "n_prompt",
-            "n_gen",          "n_depth",        "test_time",     "avg_ns",        "stddev_ns",
-            "avg_ts",        "stddev_ts"
+            "build_commit",   "build_number",   "cpu_info",      "gpu_info",       "backends",
+            "model_filename", "model_type",     "model_size",    "model_n_params", "n_batch",
+            "n_ubatch",       "n_threads",      "cpu_mask",      "cpu_strict",     "poll",
+            "type_k",         "type_v",         "n_gpu_layers",  "n_cpu_moe",      "split_mode",
+            "main_gpu",       "no_kv_offload",  "flash_attn",    "devices",        "tensor_split",
+            "tensor_buft_overrides",            "use_mmap",      "embeddings",     "no_op_offload",
+            "n_prompt",       "n_gen",          "n_depth",       "test_time",      "avg_ns",
+            "stddev_ns",      "avg_ts",         "stddev_ts"
         };
         return fields;
     }


### PR DESCRIPTION
Following up on part of issue to resolve #15974 

llama-bench was missing `--devices` which was recently enhanced in the main apps like server.  This PR looks to bring that configuration option to benchmarking, close to how server, etc implements.

- Provided `--device` option, so that one or more devices can be used from tensor splits.
- Provided `--list-devices` for convenience rather than having to switch to llama-server.
- Merged with the rpc device handling.  RPC device handling was heavily intertwined with local device handling.  Plus it already had a FIXME comment in the code.  So the shortest path felt like going ahead and preserving/providing rpc as equivalent device peers rather than pulling them apart.  Felt this expanded the PR a bit, but within reason and the other untangling options were likely worse or more risky.
- Doc update, including a quick cleanup to ensure the new -n-cpu-moe option is captured in the doc while I was in there.

Tested on Mac and Linux

Using different devices including RPC, benchmark each:
```
llama-bench -ngl 999 -m ~/models/gguf/Qwen3-4B-128K-Q4_K_M.gguf --rpc 192.168.1.59:50052 -dev ROCm0,Vulkan0,'RPC[192.168.1.59:50052]'
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes
load_backend: loaded CUDA backend from /base/llama.cpp/build/bin/libggml-cuda.so
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 ROCm devices:
  Device 0: AMD Radeon Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32
load_backend: loaded ROCm backend from /base/llama.cpp/build/bin/libggml-hip.so
load_backend: loaded RPC backend from /base/llama.cpp/build/bin/libggml-rpc.so
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Radeon 8060S Graphics (RADV GFX1151) (radv) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat
load_backend: loaded Vulkan backend from /base/llama.cpp/build/bin/libggml-vulkan.so
load_backend: loaded CPU backend from /base/llama.cpp/build/bin/libggml-cpu.so
| model                          |       size |     params | backend    | ngl | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------ | --------------: | -------------------: |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | ROCm0        |           pp512 |       1608.23 ± 9.44 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | ROCm0        |           tg128 |         63.41 ± 0.01 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | Vulkan0      |           pp512 |       1199.15 ± 1.34 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | Vulkan0      |           tg128 |         77.48 ± 0.03 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | RPC[192.168.1.59:50052] |           pp512 |        619.81 ± 0.21 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | RPC[192.168.1.59:50052] |           tg128 |         28.77 ± 1.18 |
```

Combined all devices, benchmark tensor split:
```
llama-bench -ngl 999 -m ~/models/gguf/Qwen3-4B-128K-Q4_K_M.gguf --rpc 192.168.1.59:50052 -dev ROCm0/Vulkan0/'RPC[192.168.1.59:50052]' -ts 1/2/1
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes
load_backend: loaded CUDA backend from /base/llama.cpp/build/bin/libggml-cuda.so
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 ROCm devices:
  Device 0: AMD Radeon Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32
load_backend: loaded ROCm backend from /base/llama.cpp/build/bin/libggml-hip.so
load_backend: loaded RPC backend from /base/llama.cpp/build/bin/libggml-rpc.so
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Radeon 8060S Graphics (RADV GFX1151) (radv) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat
load_backend: loaded Vulkan backend from /base/llama.cpp/build/bin/libggml-vulkan.so
load_backend: loaded CPU backend from /base/llama.cpp/build/bin/libggml-cpu.so
| model                          |       size |     params | backend    | ngl | dev          | ts           |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------------ | ------------ | --------------: | -------------------: |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | ROCm0/Vulkan0/RPC[192.168.1.59:50052] | 1.00/2.00/1.00 |           pp512 |       984.98 ± 10.09 |
| qwen3 4B Q4_K - Medium         |   2.32 GiB |     4.02 B | CUDA,ROCm,RPC,Vulkan | 999 | ROCm0/Vulkan0/RPC[192.168.1.59:50052] | 1.00/2.00/1.00 |           tg128 |         38.44 ± 0.40 |
```

Hopefully this helps get llama-bench more up-to-date with the core tool capabilities.  