### PR TITLE
ci : revert back to macos-13 for macOS-latest-cmake-x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           ctest -L 'main|curl' --verbose --timeout 900
 
   macOS-latest-cmake-x64:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Clone


### PR DESCRIPTION
This commit reverts the change of the runs-on parameter for the macOS-latest-cmake-x64 job back to macos-13 that was make in Commit 51abc96bdc52ba8cd6ad78dcf12ed9a041d7b442 ("ci : update macos-latest* jobs to use macos-latest (#15938)").

The motivation for this is that using macos-latest will cause an ARM based runner to be used, and not an x64 based runner.

Refs: https://github.com/ggml-org/llama.cpp/pull/15938#issuecomment-3300805127
