### PR TITLE
minor : fix a compile warning for Android platforms

### DIFF
--- a/vendor/miniaudio/miniaudio.h
+++ b/vendor/miniaudio/miniaudio.h
@@ -12106,7 +12106,7 @@ static MA_INLINE void ma_restore_denormals(unsigned int prevState)
 #ifdef MA_ANDROID
 #include <sys/system_properties.h>
 
-int ma_android_sdk_version()
+static int ma_android_sdk_version()
 {
     char sdkVersion[PROP_VALUE_MAX + 1] = {0, };
     if (__system_property_get("ro.build.version.sdk", sdkVersion)) {


### PR DESCRIPTION
This is a trivial fix for the following build warning for Android.
```
Building CXX object tools/mtmd/CMakeFiles/mtmd.dir/mtmd-helper.cpp.o
In file included from /Users/jiefu/llama.cpp/tools/mtmd/mtmd-helper.cpp:30:
/Users/jiefu/llama.cpp/tools/mtmd/../../vendor/miniaudio/miniaudio.h:12109:5: warning: no previous prototype for function 'ma_android_sdk_version' [-Wmissing-prototypes]
 12109 | int ma_android_sdk_version()
       |     ^
/Users/jiefu/llama.cpp/tools/mtmd/../../vendor/miniaudio/miniaudio.h:12109:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
 12109 | int ma_android_sdk_version()
       | ^
       | static
1 warning generated.
```
