### PR TITLE
Fix incomplete chunck handling in the webui

### DIFF
--- a/tools/server/webui/src/lib/services/chat.ts
+++ b/tools/server/webui/src/lib/services/chat.ts
@@ -264,12 +264,14 @@ export class ChatService {
 		let lastTimings: ChatMessageTimings | undefined;
 
 		try {
+			let chunk = '';
 			while (true) {
 				const { done, value } = await reader.read();
 				if (done) break;
 
-				const chunk = decoder.decode(value, { stream: true });
+				chunk += decoder.decode(value, { stream: true });
 				const lines = chunk.split('\n');
+				chunk = lines.pop() || ''; // Save incomplete line for next read
 
 				for (const line of lines) {
 					if (line.startsWith('data: ')) {


### PR DESCRIPTION
The new (awesome) webui does not parse incoming chunks correctly, because it assumed lines are complete (it split then loop over them even if they are incomplete, which rarely occurs locally but can if you access it over the network).

So I just made the chunk variable persistent to store the last incomplete line for the next read.

Thanks for your hard work!!