### PR TITLE
server: fix SSE and OpenAI compatibility for error messages when streaming

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4689,7 +4689,7 @@ int main(int argc, char ** argv) {
                         return server_sent_event(sink, "data", res_json);
                     }
                 }, [&](const json & error_data) {
-                    server_sent_event(sink, "error", error_data);
+                    server_sent_event(sink, "data", json{{"error", error_data}});
                 }, [&sink]() {
                     // note: do not use req.is_connection_closed here because req is already destroyed
                     return !sink.is_writable();

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4679,17 +4679,17 @@ int main(int argc, char ** argv) {
                     json res_json = result->to_json();
                     if (res_json.is_array()) {
                         for (const auto & res : res_json) {
-                            if (!server_sent_event(sink, "data", res)) {
+                            if (!server_sent_event(sink, res)) {
                                 // sending failed (HTTP connection closed), cancel the generation
                                 return false;
                             }
                         }
                         return true;
                     } else {
-                        return server_sent_event(sink, "data", res_json);
+                        return server_sent_event(sink, res_json);
                     }
                 }, [&](const json & error_data) {
-                    server_sent_event(sink, "data", json{{"error", error_data}});
+                    server_sent_event(sink, json{{"error", error_data}});
                 }, [&sink]() {
                     // note: do not use req.is_connection_closed here because req is already destroyed
                     return !sink.is_writable();

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -459,9 +459,9 @@ static std::string tokens_to_output_formatted_string(const llama_context * ctx, 
     return out;
 }
 
-static bool server_sent_event(httplib::DataSink & sink, const char * event, const json & data) {
+static bool server_sent_event(httplib::DataSink & sink, const json & data) {
     const std::string str =
-        std::string(event) + ": " +
+        "data: " +
         data.dump(-1, ' ', false, json::error_handler_t::replace) +
         "\n\n"; // required by RFC 8895 - A message is terminated by a blank line (two line terminators in a row).
 


### PR DESCRIPTION
This fixes compatibility with the SSE specification by not sending error messages out with an incompatible fieldname.
Therefore this also ensures proper exceptions when working for example with OpenAI client libraries, instead of being handled as an empty message.

Closes:
#16104