### PR TITLE
removed metal for nix

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -128,10 +128,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    substituteInPlace ./ggml/src/ggml-metal/ggml-metal.m \
-      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
-    substituteInPlace ./ggml/src/ggml-metal/ggml-metal.m \
-      --replace '[bundle pathForResource:@"default" ofType:@"metallib"];' "@\"$out/bin/default.metallib\";"
   '';
 
   # With PR#6015 https://github.com/ggml-org/llama.cpp/pull/6015,


### PR DESCRIPTION
Fixes: https://github.com/ggml-org/llama.cpp/issues/16096

Tested working on AMD 395 with gpt-oss 120b.

Can any mac users try this? I presume it'll be safe as the underlying file is gone, and there is be no reason why this would break anything if the previous commit hasn't.