### PR TITLE
codeowners : claim responsibility for ci, models, gguf-py and convert

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,7 @@
 /ggml/src/gguf.cpp @JohannesGaessler
 /ggml/src/ggml-vulkan/ @0cc4m
 /ggml/src/ggml-zdnn/ @taronaeo
+/.github/workflows/ @CISC
+/gguf-py/ @CISC
+/convert_*.py @CISC
+requirements*.txt @CISC

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,11 @@
 /ggml/src/ggml-vulkan/ @0cc4m
 /ggml/src/ggml-zdnn/ @taronaeo
 /.github/workflows/ @CISC
+/src/llama-adapter.* @CISC
+/src/llama-arch.* @CISC
+/src/llama-graph.* @CISC
+/src/llama-model.* @CISC
+/src/llama-vocab.* @CISC
 /gguf-py/ @CISC
 /convert_*.py @CISC
 requirements*.txt @CISC


### PR DESCRIPTION
I'm willing to claim responsibility for reviewing and maintaining various bits I've come to know in a fair amount of detail. If desirable by the individuals in question I feel I should append the following people to these:

* /.github/workflows/ @slaren @danbev
* /gguf-py/ @compilade 
* /convert_*.py @compilade
* requirements*.txt @compilade

I'm also willing to claim more, f.ex. model specific files in `/src`, however it's probably not a good idea to add too many lines to `CODEOWNERS`, and in almost all cases I will get pulled into those PRs anyway.