### PR TITLE
Changed runner label for RISCV64 builds

### DIFF
--- a/.github/workflows/build-riscv-native.yml
+++ b/.github/workflows/build-riscv-native.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   debian-13-riscv64-native: # Bianbu 2.2
-    runs-on: self-hosted
+    runs-on: RISCV64
 
     steps:
       - name: Install prerequisites


### PR DESCRIPTION
I have added the `RISCV64` label to the workflow, which uses Cloud-V Runner so that it doesnt conflict with `ggml-4-x86-cuda-v100`, which is also a `self-hosted` runner.
