### PR TITLE
webui: switch to hash-based routing (alternative of #16079)

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -5262,42 +5262,6 @@ int main(int argc, char ** argv) {
     svr->Get (params.api_prefix + "/slots",               handle_slots);
     svr->Post(params.api_prefix + "/slots/:id_slot",      handle_slots_action);
 
-    // SPA fallback route - serve index.html for any route that doesn't match API endpoints
-    // This enables client-side routing for dynamic routes like /chat/[id]
-    if (params.webui && params.public_path.empty()) {
-        // Only add fallback when using embedded static files
-        svr->Get(".*", [](const httplib::Request & req, httplib::Response & res) {
-            // Skip API routes - they should have been handled above
-            if (req.path.find("/v1/") != std::string::npos ||
-                req.path.find("/health") != std::string::npos ||
-                req.path.find("/metrics") != std::string::npos ||
-                req.path.find("/props") != std::string::npos ||
-                req.path.find("/models") != std::string::npos ||
-                req.path.find("/api/tags") != std::string::npos ||
-                req.path.find("/completions") != std::string::npos ||
-                req.path.find("/chat/completions") != std::string::npos ||
-                req.path.find("/embeddings") != std::string::npos ||
-                req.path.find("/tokenize") != std::string::npos ||
-                req.path.find("/detokenize") != std::string::npos ||
-                req.path.find("/lora-adapters") != std::string::npos ||
-                req.path.find("/slots") != std::string::npos) {
-                return false; // Let other handlers process API routes
-            }
-
-            // Serve index.html for all other routes (SPA fallback)
-            if (req.get_header_value("Accept-Encoding").find("gzip") == std::string::npos) {
-                res.set_content("Error: gzip is not supported by this browser", "text/plain");
-            } else {
-                res.set_header("Content-Encoding", "gzip");
-                // COEP and COOP headers, required by pyodide (python interpreter)
-                res.set_header("Cross-Origin-Embedder-Policy", "require-corp");
-                res.set_header("Cross-Origin-Opener-Policy", "same-origin");
-                res.set_content(reinterpret_cast<const char*>(index_html_gz), index_html_gz_len, "text/html; charset=utf-8");
-            }
-            return false;
-        });
-    }
-
     //
     // Start the server
     //

--- a/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebar.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebar.svelte
@@ -70,7 +70,7 @@
 
 <ScrollArea class="h-[100vh]">
 	<Sidebar.Header class=" top-0 z-10 gap-6 bg-sidebar/50 px-4 pt-4 pb-2 backdrop-blur-lg md:sticky">
-		<a href="/" onclick={handleMobileSidebarItemClick}>
+		<a href="#/" onclick={handleMobileSidebarItemClick}>
 			<h1 class="inline-flex items-center gap-1 px-2 text-xl font-semibold">llama.cpp</h1>
 		</a>
 

--- a/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebar.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebar.svelte
@@ -64,7 +64,7 @@
 			searchQuery = '';
 		}
 
-		await goto(`/chat/${id}`);
+		await goto(`#/chat/${id}`);
 	}
 </script>
 

--- a/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebarActions.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatSidebar/ChatSidebarActions.svelte
@@ -51,7 +51,7 @@
 	{:else}
 		<Button
 			class="w-full justify-between hover:[&>kbd]:opacity-100"
-			href="/?new_chat=true"
+			href="?new_chat=true#/"
 			onclick={handleMobileSidebarItemClick}
 			variant="ghost"
 		>

--- a/tools/server/webui/src/lib/components/app/server/ServerErrorSplash.svelte
+++ b/tools/server/webui/src/lib/components/app/server/ServerErrorSplash.svelte
@@ -64,7 +64,7 @@
 			updateConfig('apiKey', apiKeyInput.trim());
 
 			// Test the API key by making a real request to the server
-			const response = await fetch('/props', {
+			const response = await fetch('./props', {
 				headers: {
 					'Content-Type': 'application/json',
 					Authorization: `Bearer ${apiKeyInput.trim()}`
@@ -77,7 +77,7 @@
 
 				// Show success state briefly, then navigate to home
 				setTimeout(() => {
-					goto('/');
+					goto(`#/`);
 				}, 1000);
 			} else {
 				// API key is invalid - User Story A

--- a/tools/server/webui/src/lib/services/chat.ts
+++ b/tools/server/webui/src/lib/services/chat.ts
@@ -164,7 +164,7 @@ export class ChatService {
 			const currentConfig = config();
 			const apiKey = currentConfig.apiKey?.toString().trim();
 
-			const response = await fetch(`/v1/chat/completions`, {
+			const response = await fetch(`./v1/chat/completions`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
@@ -533,7 +533,7 @@ export class ChatService {
 			const currentConfig = config();
 			const apiKey = currentConfig.apiKey?.toString().trim();
 
-			const response = await fetch(`/props`, {
+			const response = await fetch(`./props`, {
 				headers: {
 					'Content-Type': 'application/json',
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})

--- a/tools/server/webui/src/lib/services/slots.ts
+++ b/tools/server/webui/src/lib/services/slots.ts
@@ -138,7 +138,7 @@ export class SlotsService {
 			const currentConfig = config();
 			const apiKey = currentConfig.apiKey?.toString().trim();
 
-			const response = await fetch('/slots', {
+			const response = await fetch(`./slots`, {
 				headers: {
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
 				}

--- a/tools/server/webui/src/lib/stores/chat.svelte.ts
+++ b/tools/server/webui/src/lib/stores/chat.svelte.ts
@@ -100,7 +100,7 @@ class ChatStore {
 
 		this.maxContextError = null;
 
-		await goto(`/chat/${conversation.id}`);
+		await goto(`#/chat/${conversation.id}`);
 
 		return conversation.id;
 	}
@@ -910,7 +910,7 @@ class ChatStore {
 			if (this.activeConversation?.id === convId) {
 				this.activeConversation = null;
 				this.activeMessages = [];
-				await goto('/?new_chat=true');
+				await goto(`?new_chat=true#/`);
 			}
 		} catch (error) {
 			console.error('Failed to delete conversation:', error);

--- a/tools/server/webui/src/lib/stores/server.svelte.ts
+++ b/tools/server/webui/src/lib/stores/server.svelte.ts
@@ -98,7 +98,7 @@ class ServerStore {
 			const currentConfig = config();
 			const apiKey = currentConfig.apiKey?.toString().trim();
 
-			const response = await fetch('/slots', {
+			const response = await fetch(`./slots`, {
 				headers: {
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
 				}

--- a/tools/server/webui/src/lib/utils/api-key-validation.ts
+++ b/tools/server/webui/src/lib/utils/api-key-validation.ts
@@ -22,7 +22,7 @@ export async function validateApiKey(fetch: typeof globalThis.fetch): Promise<vo
 			headers.Authorization = `Bearer ${apiKey}`;
 		}
 
-		const response = await fetch('/props', { headers });
+		const response = await fetch(`./props`, { headers });
 
 		if (!response.ok) {
 			if (response.status === 401 || response.status === 403) {

--- a/tools/server/webui/src/routes/+error.svelte
+++ b/tools/server/webui/src/routes/+error.svelte
@@ -17,7 +17,7 @@
 
 	function handleRetry() {
 		// Navigate back to home page after successful API key validation
-		goto('/');
+		goto('#/');
 	}
 </script>
 
@@ -60,7 +60,7 @@
 				</p>
 			</div>
 			<button
-				onclick={() => goto('/')}
+				onclick={() => goto('#/')}
 				class="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
 			>
 				Go Home

--- a/tools/server/webui/src/routes/+layout.svelte
+++ b/tools/server/webui/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
 
 		if (isCtrlOrCmd && event.shiftKey && event.key === 'o') {
 			event.preventDefault();
-			goto('/?new_chat=true');
+			goto('?new_chat=true#/');
 		}
 
 		if (event.shiftKey && isCtrlOrCmd && event.key === 'e') {
@@ -115,7 +115,7 @@
 				headers.Authorization = `Bearer ${apiKey.trim()}`;
 			}
 
-			fetch('/props', { headers })
+			fetch(`./props`, { headers })
 				.then((response) => {
 					if (response.status === 401 || response.status === 403) {
 						window.location.reload();

--- a/tools/server/webui/src/routes/+layout.ts
+++ b/tools/server/webui/src/routes/+layout.ts
@@ -1,3 +1,0 @@
-export const csr = true;
-export const prerender = false;
-export const ssr = false;

--- a/tools/server/webui/src/routes/chat/[id]/+page.svelte
+++ b/tools/server/webui/src/routes/chat/[id]/+page.svelte
@@ -44,7 +44,7 @@
 				const success = await chatStore.loadConversation(chatId);
 
 				if (!success) {
-					await goto('/');
+					await goto('#/');
 				}
 			})();
 		}

--- a/tools/server/webui/src/routes/chat/[id]/+page.svelte
+++ b/tools/server/webui/src/routes/chat/[id]/+page.svelte
@@ -26,7 +26,7 @@
 			await gracefulStop();
 
 			if (to?.url) {
-				await goto(to.url.pathname + to.url.search);
+				await goto(to.url.pathname + to.url.search + to.url.hash);
 			}
 		}
 	});

--- a/tools/server/webui/svelte.config.js
+++ b/tools/server/webui/svelte.config.js
@@ -8,6 +8,10 @@ const config = {
 	// for more information about preprocessors
 	preprocess: [vitePreprocess(), mdsvex()],
 	kit: {
+		paths: {
+			relative: true
+		},
+		router: { type: 'hash' },
 		adapter: adapter({
 			pages: '../public',
 			assets: '../public',


### PR DESCRIPTION
### Overview

This PR is an alternative to PR #16079. While that PR works to add subdirectory support to the server, it has a number of pitfalls that make it quite tricky to use in practice:
- The PR proposes an env var, `BASE_PATH`, to be added that will properly update paths in the web UI so that they work at a different subdirectory (ex. for deploying at `/server`)
- However that env var is *build-time* only, and does not work at runtime. This makes it unusable with tools like [llama-swap](https://github.com/mostlygeek/llama-swap), and probably some others, that need the same server to work at many different paths.

### Why it changed

The previous server used hash-based routing.

This worked because we could use relative paths in all cases and only the hash would change when moving between pages. Since the hash is a purely browser-side component of the URL the same file could be served at any path and it would work perfectly.

When we moved to SvelteKit we moved to absolute paths. This meant that ex. a full `llama.cpp` server at `/server` would try to hit `/props` (when it should be hitting `/server/props`) and fail.

### Alternatives considered

- We cannot enable SvelteKit's `prerender` option because routes like `/chat/<id>` will not work (they can't be prerendered).
- We cannot enable SvelteKit's `relative` option *without* hash-based routing because it will not work with a single-file build (because the same file will be served for all paths, so the client-side router can't know what files it needs to fetch).

### Proposed Solution

This PR enables SvelteKit's [hash-based routing mode](https://svelte.dev/docs/kit/configuration#router) as well as the relative path mode. This mode is non-ideal for most apps since it's bad for SEO and disables all server-side rendering, but is perfect for our use-case.

By enabling hash-based routing, we can serve the same `index.html` file for all paths, and the client-side router on SvelteKit will handle changing the page based on the path *after* the hash, such as `/#/chat/conv-1757280717333`.

### Caveats

A few things to keep in mind with this approach. All of these have been addressed in this PR:
- All links to other pages within the SvelteKit project need to start with `#`. So a link to `/chat/${id}` would now be `#/chat/${id}`.
- We no longer need a `+layout.ts` with `export const csr = true`. CSR is always enabled/forced with hash-based routing.
- Any links to the server, such as `/props`, need to be changed to be relative.
- If hitting a server at a subdirectory and you try and visit a URL without a trailing slash, such as `https://example.com/upstream/mistral3.2` (a real URL that might be used in llama-swap) it will cause a redirect loop.
  I'm still trying to track down the cause of this. Using a trailing slash fixes this for now (e.g `https://example.com/upstream/mistral3.2/`) (edit: is fixed in `llama-swap` by https://github.com/mostlygeek/llama-swap/issues/321).

### Testing

I tested this locally as much as I could. Everything seems to work well and I couldn't find any broken links manually.

I also tested this with `llama-swap` and it solves the related issue https://github.com/mostlygeek/llama-swap/issues/306.