### PR TITLE
ci : remove vulkaninfo calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1396,7 +1396,6 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          vulkaninfo
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp /mnt/llama.cpp
 
   ggml-ci-x64-amd-v710-rocm:
@@ -1410,7 +1409,6 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          vulkaninfo
           GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS="gfx1101" bash ./ci/run.sh ~/results/llama.cpp /mnt/llama.cpp
 
   ggml-ci-mac-metal:


### PR DESCRIPTION
I think these calls seem to get stuck when the virtual GPU is not available.