### PR TITLE
codeowners : add @danbev to model-conversion example [no ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@
 /examples/llama.vim                     @ggerganov
 /examples/lookahead/                    @ggerganov
 /examples/lookup/                       @JohannesGaessler
+/examples/model-conversion/             @danbev
 /examples/parallel/                     @ggerganov
 /examples/passkey/                      @ggerganov
 /examples/retrieval/                    @ggerganov


### PR DESCRIPTION
This commit adds examples/model-conversion/ to the CODEOWNERS file and assigns myself (@danbev) as the code owner for this directory.
