### PR TITLE
common: fix missing chrono header for common.cpp

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -14,6 +14,7 @@
 #include <climits>
 #include <cmath>
 #include <codecvt>
+#include <chrono>
 #include <cstdarg>
 #include <cstring>
 #include <ctime>


### PR DESCRIPTION
Greetings!

The llama.cpp project is available through many package managers, including Conan. During the current version update there (PR https://github.com/conan-io/conan-center-index/pull/28435), we found the Windows build [failed](https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-28435/5/package_build_logs/build_log_llama-cpp_b4079_a101ce40228ffd7377aa0b3d7979edd9_f6e5ac131a4e0e29fdc594016ca9e30185cddc1e.txt) with the following error:

```
common\common.cpp(432): error C2039: 'system_clock': is not a member of 'std::chrono'
```

Doing a quick read in `common.cpp`, it misses the C++11 header `chrono`. This PR is related to https://github.com/ggml-org/llama.cpp/pull/11836

The CI there is using Windows + MSVC 194 + Release + C++14, in case you want to try to reproduce that scenario. And Llama is built as a shared library in that case. Previously, we did not note this error when building with MSVC 193, it started with the new version of Visual Studio compiler. 

Let me know if you need more information about that case. Regards! 



- [x] *Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
