### PR TITLE
model-conversion : make causal-verify-logits fails with model names containing "."

### DIFF
--- a/examples/model-conversion/scripts/causal/compare-logits.py
+++ b/examples/model-conversion/scripts/causal/compare-logits.py
@@ -48,7 +48,7 @@ def main():
         print(f"Error: Model file not found: {model_path}")
         sys.exit(1)
 
-    model_name = os.path.splitext(os.path.basename(model_path))[0]
+    model_name = os.path.basename(model_path)
     data_dir = Path("data")
 
     pytorch_file = data_dir / f"pytorch-{model_name}.bin"

--- a/examples/model-conversion/scripts/utils/check-nmse.py
+++ b/examples/model-conversion/scripts/utils/check-nmse.py
@@ -67,7 +67,7 @@ def main():
     parser.add_argument('-m', '--model-path', required=True,  help='Path to the model directory')
     args = parser.parse_args()
 
-    model_name = os.path.splitext(os.path.basename(args.model_path))[0]
+    model_name = os.path.basename(args.model_path)
     data_dir = Path("data")
 
     pytorch_file = data_dir / f"pytorch-{model_name}.bin"


### PR DESCRIPTION
`make causal-verify-logits` fails if model names containing "." like `Qwen2.5-0.5B-Instruct`.
```bash
export MODEL_PATH=~/share/Qwen2.5-0.5B-Instruct
make causal-verify-logits
```

The following is the error msg.
```
Logits saved to data/llamacpp-Qwen2.5-0.5B-Instruct.bin
Logits saved to data/llamacpp-Qwen2.5-0.5B-Instruct.txt
ggml_metal_free: deallocating
Error: PyTorch logits file not found: data/pytorch-Qwen2.5-0.bin
Please run scripts/run-org-model.sh first to generate this file.
make: *** [causal-verify-logits] Error 1
```

It should be `data/pytorch-Qwen2.5-0.5B-Instruct.bin` instead of `data/pytorch-Qwen2.5-0.bin`.

I suggest just using `os.path.basename(model_path)` to fix it assuming that the `model_path` should be a dir path.