### PR TITLE
metal : relax reorder conditions

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -256,8 +256,6 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
 
     // perform reorders only across these types of ops
     // can be expanded when needed
-    // IMPORTANT: do not add ops such as GGML_OP_CPY or GGML_OP_SET_ROWS
-    //            the dependencies from such ops are not always represented in the graph
     const auto & h_safe = [](ggml_op op) {
         switch (op) {
             case GGML_OP_MUL_MAT:
@@ -273,6 +271,8 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
             case GGML_OP_GLU:
             case GGML_OP_SCALE:
             case GGML_OP_GET_ROWS:
+            case GGML_OP_CPY:
+            case GGML_OP_SET_ROWS:
                 return true;
             default:
                 return ggml_op_is_empty(op);


### PR DESCRIPTION
Realized that the logic for reordering in the Metal backend is general enough to allow reorders even for nodes which dependencies might not be represented in the graph. The reason is that we keep track of the actual sources and destinations (either memory addresses or tensors) which is more general than the graph dependencies.

For example, the order of these ops would be preserved:

```c
ggml_build_forward_expand(gf, ggml_cpy(a, view(b));
ggml_something(b or another_view(b));
```

Reordering of CPY ops is useful in Whisper graphs.