### PR TITLE
ggml-cpu: detect correct cpu flags for arm64 (#16229)

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -118,18 +118,18 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                 # so we check for them manually and enable them if available
 
                 execute_process(
-                    COMMAND ${CMAKE_C_COMPILER} -mcpu=native -E -v -
+                    COMMAND ${CMAKE_C_COMPILER} -march=native -E -v -
                     INPUT_FILE "/dev/null"
                     OUTPUT_QUIET
                     ERROR_VARIABLE ARM_MCPU
                     RESULT_VARIABLE ARM_MCPU_RESULT
                 )
                 if (NOT ARM_MCPU_RESULT)
-                    string(REGEX MATCH "-mcpu=[^ ']+" ARM_MCPU_FLAG "${ARM_MCPU}")
+                    string(REGEX MATCH "-march=[^ ']+" ARM_MCPU_FLAG "${ARM_MCPU}")
                 endif()
                 if ("${ARM_MCPU_FLAG}" STREQUAL "")
-                    set(ARM_MCPU_FLAG -mcpu=native)
-                    message(STATUS "ARM -mcpu not found, -mcpu=native will be used")
+                    set(ARM_MCPU_FLAG -march=native)
+                    message(STATUS "ARM -mcpu not found, -march=native will be used")
                 endif()
 
                 include(CheckCXXSourceRuns)


### PR DESCRIPTION
When using GCC 9 and GCC 12 on the arm64 platform of ubuntu 2004, the command "gcc -mcpu=native -E -v -" fails to detect the correct CPU flags, which results in compilation failures for certain extended instructions, but the correct CPU flags can be obtained by using gcc -march.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
