### PR TITLE
Correct XTC threshold args documentation

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2029,7 +2029,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_sparam());
     add_opt(common_arg(
         {"--xtc-threshold"}, "N",
-        string_format("xtc threshold (default: %.1f, 1.0 = disabled)", (double)params.sampling.xtc_threshold),
+        string_format("xtc threshold (default: %.1f, >0.5 = disabled)", (double)params.sampling.xtc_threshold),
         [](common_params & params, const std::string & value) {
             params.sampling.xtc_threshold = std::stof(value);
         }


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*


Relative to issue : https://github.com/ggml-org/llama.cpp/issues/16259

It's a really simple PR, just an update to the documentation of the arguments of XTC.
