### PR TITLE
Add a deepwiki badge to auto-refresh the wiki-in-deepwiki weekly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Release](https://img.shields.io/github/v/release/ggml-org/llama.cpp)](https://github.com/ggml-org/llama.cpp/releases)
 [![Server](https://github.com/ggml-org/llama.cpp/actions/workflows/server.yml/badge.svg)](https://github.com/ggml-org/llama.cpp/actions/workflows/server.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ggml-org/llama.cpp)
 
 [Manifesto](https://github.com/ggml-org/llama.cpp/discussions/205) / [ggml](https://github.com/ggml-org/ggml) / [ops](https://github.com/ggml-org/llama.cpp/blob/master/docs/ops.md)
 


### PR DESCRIPTION
## Background

When users want to learn more about a project, they often read the wiki firstly.

If a project lacks a complete wiki, DeepWiki can automatically provide an [alternative](https://deepwiki.com/ggml-org/llama.cpp).

DeepWiki also supports artificial intelligence interaction, making it faster and easier to get information such as project architecture.

## Request

Add a [badge](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2Fggml-org%2Fllama.cpp) to the `README` file to auto-refresh the [wiki-in-DeepWiki](https://deepwiki.com/ggml-org/llama.cpp) weekly.

<img width="1669" height="1241" alt="屏幕截图 2025-09-28 141053" src="https://github.com/user-attachments/assets/611eed17-7aaf-49a2-9107-5bd21a68a97e" />

## Preview

<img width="1015" height="632" alt="屏幕截图 2025-09-28 140901" src="https://github.com/user-attachments/assets/ab55b215-cab0-4921-8201-eb1cd8ac52fe" />
