### PR TITLE
cuda : Disable host buffers on integrated GPUs (#15034)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -231,7 +231,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
-        info.devices[id].integrated = prop.integrated;
+        info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
         info.devices[id].nsm        = prop.multiProcessorCount;
         info.devices[id].smpb       = prop.sharedMemPerBlock;
         info.devices[id].warp_size  = prop.warpSize;


### PR DESCRIPTION
"Integrated" CUDA devices seem to be bugged and produce incorrect output in specific cases. Since disabling the `integrated` flag seems to neither affect performance nor memory usage on Jetson, I propose disabling the option until the underlying issue is fixed.

Fixes #15034 and probably also #15923.