### PR TITLE
ggml : remove KQ mask padding

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2220,7 +2220,7 @@ extern "C" {
             struct ggml_tensor  * a,
             int                   k);
 
-#define GGML_KQ_MASK_PAD 64
+#define GGML_KQ_MASK_PAD 1
 
     // q:    [n_embd_k, n_batch,     n_head,    ne3 ]
     // k:    [n_embd_k, n_kv,        n_head_kv, ne3 ]


### PR DESCRIPTION
target #16148
save `gg/fa-no-kq-pad-save`

Gauging what would it take to remove the KQ mask padding along the batch dimension (`ne31`). Removing this padding would simplify the graph building logic and will reduce the amount of memory that we allocate and transfer for KQ masks.

- [x] Metal (after [46c338f](https://github.com/ggml-org/llama.cpp/pull/16148/commits/46c338fc6c5921656455b69b8588b5c3b42f3c3c))
- [x] CUDA (after https://github.com/ggml-org/llama.cpp/pull/17505)
- [x] Vulkan (after https://github.com/ggml-org/llama.cpp/pull/16316)
- [x] OpenCL?
- [x] CANN?