### PR TITLE
ggml-backend : unify the dl_load_library() return type

### DIFF
--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -149,7 +149,7 @@ struct dl_handle_deleter {
     }
 };
 
-static void * dl_load_library(const fs::path & path) {
+static dl_handle * dl_load_library(const fs::path & path) {
     dl_handle * handle = dlopen(path.string().c_str(), RTLD_NOW | RTLD_LOCAL);
 
     return handle;


### PR DESCRIPTION
Use the unified type 'dl_handle' instead of 'void' directly, to match the Windows 'dl_load_library()' definition.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
