### PR TITLE
ggml : fix dependencies for ggml_set_rows

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3687,6 +3687,7 @@ struct ggml_tensor * ggml_set_rows(
     result->op     = GGML_OP_SET_ROWS;
     result->src[0] = b;
     result->src[1] = c;
+    result->src[2] = a; // note: order is weird due to legacy reasons (https://github.com/ggml-org/llama.cpp/pull/16063#discussion_r2385795931)
 
     return result;
 }


### PR DESCRIPTION
cont #14274 
ref https://github.com/ggml-org/llama.cpp/pull/16063#discussion_r2385795931

The result of `ggml_set_rows` requires to have a dependency on the destination tensor `a` that we actually modify.