### PR TITLE
codeowners: add codeowners for opencl backend

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,6 +60,7 @@
 /ggml/src/ggml-cuda/mmvq.*              @JohannesGaessler
 /ggml/src/ggml-impl.h                   @ggerganov @slaren
 /ggml/src/ggml-metal/                   @ggerganov
+/ggml/src/ggml-opencl/                  @lhez @max-krasnyansky
 /ggml/src/ggml-opt.cpp                  @JohannesGaessler
 /ggml/src/ggml-quants.*                 @ggerganov
 /ggml/src/ggml-rpc/                     @rgerganov


### PR DESCRIPTION
Add @max-krasnyansky and myself as codeowners for opencl backend.