### PR TITLE
ci : disable ccache for android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1222,11 +1222,12 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: ccache
-        uses: ggml-org/ccache-action@v1.2.16
-        with:
-          key: android-build
-          evict-old-files: 1d
+      # Disabled due to size (400MB) and always 0 cache hits
+      # - name: ccache
+      #   uses: ggml-org/ccache-action@v1.2.16
+      #   with:
+      #     key: android-build
+      #     evict-old-files: 1d
 
       - name: Set up JDK
         uses: actions/setup-java@v3


### PR DESCRIPTION
Due to [impending updated eviction policy](https://github.blog/changelog/2025-09-29-new-date-for-enforcement-of-cache-eviction-policy/) we need to trim down our Actions Cache. One of the largest offenders is the android build ccache which claim 400MB on every build and never has any cache hits, so effectively useless:

https://github.com/ggml-org/llama.cpp/actions/runs/18123052287/job/51571820863
https://github.com/ggml-org/llama.cpp/actions/runs/18092686960/job/51477080980