### PR TITLE
Fix mobile unwanted scrolling

### DIFF
--- a/tools/server/webui/src/routes/+layout.svelte
+++ b/tools/server/webui/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
 	let isNewChatMode = $derived(page.url.searchParams.get('new_chat') === 'true');
 	let showSidebarByDefault = $derived(activeMessages().length > 0 || isLoading());
 	let sidebarOpen = $state(false);
+	let innerHeight = $state<number | undefined>();
 	let chatSidebar:
 		| { activateSearchMode?: () => void; editActiveConversation?: () => void }
 		| undefined = $state();
@@ -140,8 +141,6 @@
 	});
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
 <ModeWatcher />
 
 <Toaster richColors />
@@ -157,7 +156,7 @@
 />
 
 <Sidebar.Provider bind:open={sidebarOpen}>
-	<div class="flex h-screen w-full">
+	<div class="flex h-screen w-full" style:height="{innerHeight}px">
 		<Sidebar.Root class="h-full">
 			<ChatSidebar bind:this={chatSidebar} />
 		</Sidebar.Root>
@@ -174,3 +173,5 @@
 		</Sidebar.Inset>
 	</div>
 </Sidebar.Provider>
+
+<svelte:window onkeydown={handleKeydown} bind:innerHeight />


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

Description

This patch introduces dynamic viewport height handling in the main Svelte WebUI layout.

Problem

Using Tailwind’s h-screen relies on the CSS visual viewport height, which often doesn’t match the actual available space in the browser. On mobile devices (iOS/Android), the browser’s address bar appearing/disappearing leads to layout jumps, empty gaps, or hidden content. The UI isn’t always filling the screen as expected.

Solution

Added a reactive viewportHeight state, updated on every window.resize.

On onMount, the value is initialized with window.innerHeight.

The root container’s height is conditionally set with an inline style:height={viewportHeight}px.

Event listeners are properly cleaned up on unmount.

This ensures the layout always matches the real viewport height instead of relying on 100vh/h-screen quirks.

Benefits

Mobile UX is fixed: no more ghost scrollbars or clipped areas when the browser chrome toggles.

No regressions on desktop: viewportHeight just tracks the window height.

Lightweight, clean solution with minimal code changes.