### PR TITLE
HIP: add myself as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,6 +59,9 @@
 /ggml/src/ggml-cuda/mmq.*               @JohannesGaessler
 /ggml/src/ggml-cuda/mmvf.*              @JohannesGaessler
 /ggml/src/ggml-cuda/mmvq.*              @JohannesGaessler
+/ggml/src/ggml-cuda/fattn-wmma*         @IMbackK
+/ggml/src/ggml-hip/                     @IMbackK
+/ggml/src/ggml-cuda/vendors/hip.h       @IMbackK
 /ggml/src/ggml-impl.h                   @ggerganov @slaren
 /ggml/src/ggml-metal/                   @ggerganov
 /ggml/src/ggml-opencl/                  @lhez @max-krasnyansky


### PR DESCRIPTION
Theoretically id like to see every pr that touches ggml-cuda to inspect how/if it impacts the hip backend.
If you believe it appropriate i would also take `/ggml/src/ggml-cuda/` with the understanding that i review only hip/amd specifics in this path.
