### PR TITLE
CI: reenable cdna in rocm docker builds

### DIFF
--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -16,7 +16,7 @@ FROM ${BASE_ROCM_DEV_CONTAINER} AS build
 # gfx803, gfx900, gfx906, gfx1032, gfx1101, gfx1102,not officialy supported
 # check https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.4.1/reference/system-requirements.html
 
-ARG ROCM_DOCKER_ARCH='gfx803;gfx900;gfx906;gfx1010;gfx1030;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx1151'
+ARG ROCM_DOCKER_ARCH='gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1010;gfx1030;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx1151'
 #ARG ROCM_DOCKER_ARCH='gfx1151'
 
 # Set ROCm architectures


### PR DESCRIPTION
@slaren as discussed in #16305 
