### PR TITLE
common : fix Hermes tool-call parser leaking wrapper XML

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -391,3 +391,14 @@ std::optional<common_chat_msg_parser::consume_json_result> common_chat_msg_parse
 void common_chat_msg_parser::clear_tools() {
     result_.tool_calls.clear();
 }
+
+void common_chat_msg_parser::remove_content_suffix(size_t len) {
+    if (len == 0 || result_.content.empty()) {
+        return;
+    }
+    if (len >= result_.content.size()) {
+        result_.content.clear();
+        return;
+    }
+    result_.content.erase(result_.content.size() - len);
+}

--- a/common/chat-parser.h
+++ b/common/chat-parser.h
@@ -117,4 +117,6 @@ class common_chat_msg_parser {
     );
 
     void clear_tools();
+
+    void remove_content_suffix(size_t len);
 };

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -843,6 +843,16 @@ static void test_template_output_parsers() {
         assert_msg_equals(
             message_assist_call,
             common_chat_parse(
+                "<tool_call>\n"
+                "<function=special_function>\n"
+                "{\"arg1\": 1}\n"
+                "</function>\n"
+                "</tool_call>\n",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
+        assert_msg_equals(
+            message_assist_call,
+            common_chat_parse(
                 "<tool>\n"
                 "  {\"name\": \"special_function\", \"arguments\": {\"arg1\": 1}}\n"
                 "</tool>",


### PR DESCRIPTION
This has particularly been an issue when trying to use the `qwen-code` CLI in conjunction with llama.cpp - it essentially only works with vLLM for Qwen3-Coder models.

changes:
- strip `<tool_call>/<tool>` wrappers when parsing Hermes/Qwen function-tag tool calls so they no longer leak into assistant content
- add parser helper to drop wrapper-only preludes before consuming `<function=...>` blocks
- cover nested `<tool_call><function=...>` cases with a regression in `test-chat.cpp`