### PR TITLE
common : fix Hermes/Qwen tool-call parsing to stop wrapper leaks

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -391,3 +391,14 @@ std::optional<common_chat_msg_parser::consume_json_result> common_chat_msg_parse
 void common_chat_msg_parser::clear_tools() {
     result_.tool_calls.clear();
 }
+
+void common_chat_msg_parser::remove_content_suffix(size_t len) {
+    if (len == 0 || result_.content.empty()) {
+        return;
+    }
+    if (len >= result_.content.size()) {
+        result_.content.clear();
+        return;
+    }
+    result_.content.erase(result_.content.size() - len);
+}

--- a/common/chat-parser.h
+++ b/common/chat-parser.h
@@ -117,4 +117,6 @@ class common_chat_msg_parser {
     );
 
     void clear_tools();
+
+    void remove_content_suffix(size_t len);
 };

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -826,6 +826,16 @@ static void test_template_output_parsers() {
                 "</tool_call>",
                 /* is_partial= */ false,
                 {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
+        assert_msg_equals(message_assist_call_content,
+            common_chat_parse(
+                "Hello, world!\nWhat's up?\n"
+                "<tool_call>\n"
+                "<function=special_function>\n"
+                "{\"arg1\": 1}\n"
+                "</function>\n"
+                "</tool_call>\n",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
         assert_msg_equals(
             message_assist_call,
             common_chat_parse(

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -843,6 +843,16 @@ static void test_template_output_parsers() {
         assert_msg_equals(
             message_assist_call,
             common_chat_parse(
+                "<tool_call>\n"
+                "<function=special_function>\n"
+                "{\"arg1\": 1}\n"
+                "</function>\n"
+                "</tool_call>\n",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
+        assert_msg_equals(
+            message_assist_call,
+            common_chat_parse(
                 "<tool>\n"
                 "  {\"name\": \"special_function\", \"arguments\": {\"arg1\": 1}}\n"
                 "</tool>",


### PR DESCRIPTION
Fixes #15012 

(in the sense that XML no longer shows up in content, and qwen-code works with Qwen3-Coder-30B-A3B-Instruct-UD_Q4_K_XL)

- teach the Hermes/Qwen parser to strip `<tool_call>`/`<function...>` wrappers when the model nests a function block inside them
- add a helper that removes wrapper-only suffix deltas so streaming outputs no longer emit XML fragments for tool calls
- cover newline + nested `<tool_call><function...>` cases in the chat parser tests