### PR TITLE
Metal Pool 1D Kernel

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -7136,7 +7136,7 @@ static void ggml_compute_forward_pool_1d_ksp(
         float      * drow       = (float *) ((      char *) dst->data + ir * dst->nb[1]);
 
         for (int64_t ow = 0; ow < OW; ++ow) {
-            float res;
+            float res = 0;
             switch (op) {
                 case GGML_OP_POOL_AVG: res = 0.0f;     break;
                 case GGML_OP_POOL_MAX: res = -FLT_MAX; break;
@@ -7236,7 +7236,7 @@ void ggml_compute_forward_pool_2d(
             float * const out  = drow;
 
             for (int ox = 0; ox < px; ++ox) {
-                float res;
+                float res = 0;
                 switch (op) {
                     case GGML_OP_POOL_AVG: res = 0;        break;
                     case GGML_OP_POOL_MAX: res = -FLT_MAX; break;

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -7135,7 +7135,7 @@ static void ggml_compute_forward_pool_1d_ksp(
         (src->ne[2] > 0 ? src->ne[2] : 1) *
         (src->ne[3] > 0 ? src->ne[3] : 1);
 
-    for (int64_t ir = params->ith; ir < nr; ir += params->nth) {
+    for (int64_t ir = 0; ir < nr; ++ir) {
         const char * srow_bytes = (const char *) src->data + ir * src->nb[1];
         float      * drow       = (float *) ((char *) dst->data + ir * dst->nb[1]);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -94,6 +94,31 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy(ggml_metal_l
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_1d(ggml_metal_library_t lib, const ggml_tensor * op, ggml_op_pool op_pool) {
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32 && op->src[0]->type == op->type);
+
+    const char * pool_str = "undefined";
+    switch (op_pool) {
+        case GGML_OP_POOL_AVG: pool_str = "avg"; break;
+        case GGML_OP_POOL_MAX: pool_str = "max"; break;
+        default: GGML_ASSERT(false && "not implemented");
+    };
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, sizeof(base), "kernel_pool_1d_%s_%s", pool_str, ggml_type_name(op->src[0]->type));
+    snprintf(name, sizeof(name), "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_2d(ggml_metal_library_t lib, const ggml_tensor * op, ggml_op_pool op_pool) {
     GGML_ASSERT(ggml_is_contiguous(op->src[0]));
     GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32 && op->src[0]->type == op->type);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -104,6 +104,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
 
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_base              (ggml_metal_library_t lib, enum ggml_op op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy               (ggml_metal_library_t lib, enum ggml_type tsrc, enum ggml_type tdst);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_1d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_get_rows          (ggml_metal_library_t lib, enum ggml_type tsrc);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_set_rows          (ggml_metal_library_t lib, enum ggml_type tidx, enum ggml_type tdst);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1042,10 +1042,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                    op->src[1]->type == GGML_TYPE_F32 &&
                    op->type == GGML_TYPE_F32 &&
                    (op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
-        case GGML_OP_POOL_1D:
-            return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_UPSCALE:
             return op->src[0]->type == GGML_TYPE_F32 && op->op_params[0] == GGML_SCALE_MODE_NEAREST && !(op->op_params[0] & GGML_SCALE_FLAG_ANTIALIAS);
+        case GGML_OP_POOL_1D:
+            return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_POOL_2D:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_PAD:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1043,7 +1043,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                    op->type == GGML_TYPE_F32 &&
                    (op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
         case GGML_OP_POOL_1D:
-            return op->src[0]->type == GGML_TYPE_F32;
+            return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_UPSCALE:
             return op->src[0]->type == GGML_TYPE_F32 && op->op_params[0] == GGML_SCALE_MODE_NEAREST && !(op->op_params[0] & GGML_SCALE_FLAG_ANTIALIAS);
         case GGML_OP_POOL_2D:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1043,7 +1043,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                    op->type == GGML_TYPE_F32 &&
                    (op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
         case GGML_OP_POOL_1D:
-            return false;
+            return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_UPSCALE:
             return op->src[0]->type == GGML_TYPE_F32 && op->op_params[0] == GGML_SCALE_MODE_NEAREST && !(op->op_params[0] & GGML_SCALE_FLAG_ANTIALIAS);
         case GGML_OP_POOL_2D:

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -930,12 +930,12 @@ typedef struct {
 
 
 typedef struct {
-    int IW;
-    int OW;
-    int np;
-    int k0;
-    int s0;
-    int p0;
+    int32_t  k0;
+    int32_t  s0;
+    int32_t  p0;
+    int64_t  IW;
+    int64_t  OW;
+    int64_t  np;
 } ggml_metal_kargs_pool_1d;
 
 typedef struct {

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -928,6 +928,16 @@ typedef struct {
     int64_t  np;
 } ggml_metal_kargs_pool_2d;
 
+
+typedef struct {
+    int IW;
+    int OW;
+    int np;
+    int k0;
+    int s0;
+    int p0;
+} ggml_metal_kargs_pool_1d;
+
 typedef struct {
      int64_t ne00;
     uint64_t nb01;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -928,7 +928,6 @@ typedef struct {
     int64_t  np;
 } ggml_metal_kargs_pool_2d;
 
-
 typedef struct {
     int32_t  k0;
     int32_t  s0;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1654,12 +1654,12 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int64_t np = N * OC * OW;
 
     ggml_metal_kargs_pool_1d args_pool_1d = {
-        /* .k0 = */ k0,
-        /* .s0 = */ s0,
-        /* .p0 = */ p0,
-        /* .IW = */ (int) IW,
-        /* .OW = */ (int) OW,
-        /* .np = */ (int) np
+        /* .k0 = */  k0,
+        /* .s0 = */  s0,
+        /* .p0 = */  p0,
+        /* .IW = */  IW,
+        /* .OW = */  OW,
+        /* .np = */  np
     };
 
     auto pipeline = ggml_metal_library_get_pipeline_pool_1d(lib, op, op_pool);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1645,12 +1645,9 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int32_t p0 = opts[3];
 
     const int64_t IW = op->src[0]->ne[0];
-    const int64_t N  = op->ne[3];
-    const int64_t OC = op->ne[2];
-    const int64_t OH = op->ne[1];
     const int64_t OW = op->ne[0];
 
-    const int64_t np = N * OC * OH * OW;
+    const int64_t np = ggml_nelements(op);
 
     ggml_metal_kargs_pool_1d args_pool_1d = {
         /* .k0 = */  k0,

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1635,7 +1635,7 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
     GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
-    GGML_TENSOR_LOCALS(uint32_t, nb,  op,         nb);
+    GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
     const int32_t * opts = op->op_params;
     ggml_op_pool op_pool = (ggml_op_pool) opts[0];
@@ -1666,7 +1666,7 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int ntg = (np + nth - 1) / nth;
 
     ggml_metal_encoder_set_pipeline(enc, pipeline);
-    ggml_metal_encoder_set_bytes   (enc, &args_pool_1d, sizeof(args_pool_1d), 0);
+    ggml_metal_encoder_set_bytes   (enc, &args_pool_1d, sizeof(args_pool_1d),  0);
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1644,9 +1644,10 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int32_t s0 = opts[2];
     const int32_t p0 = opts[3];
 
-    const int64_t IW = op->src[0]->ne[0];
+    GGML_ASSERT(p0 == 0);
+    GGML_ASSERT(k0 == s0);
 
-    // planes are the remaining dims: N * OC * (and OH,OW in 2D; for 1D only OC & N + OW)
+    const int64_t IW = op->src[0]->ne[0];
     const int64_t N  = op->ne[3];
     const int64_t OC = op->ne[2];
     const int64_t OW = op->ne[0];

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1644,9 +1644,6 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int32_t s0 = opts[2];
     const int32_t p0 = opts[3];
 
-    GGML_ASSERT(p0 == 0);
-    GGML_ASSERT(k0 == s0);
-
     const int64_t IW = op->src[0]->ne[0];
     const int64_t N  = op->ne[3];
     const int64_t OC = op->ne[2];

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -432,6 +432,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_cpy(ctx, idx);
             } break;
+        case GGML_OP_POOL_1D:
+            {
+                n_fuse = ggml_metal_op_pool_1d(ctx, idx);
+            } break;
         case GGML_OP_POOL_2D:
             {
                 n_fuse = ggml_metal_op_pool_2d(ctx, idx);
@@ -1621,6 +1625,58 @@ int ggml_metal_op_cpy(ggml_metal_op_t ctx, int idx) {
 
     return 1;
 }
+
+int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
+    GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
+    GGML_TENSOR_LOCALS(uint32_t, nb,  op,         nb);
+
+    const int32_t * opts = op->op_params;
+    ggml_op_pool op_pool = (ggml_op_pool) opts[0];
+
+    const int32_t k0 = opts[1];
+    const int32_t s0 = opts[2];
+    const int32_t p0 = opts[3];
+
+    const int64_t IW = op->src[0]->ne[0];
+
+    // planes are the remaining dims: N * OC * (and OH,OW in 2D; for 1D only OC & N + OW)
+    const int64_t N  = op->ne[3];
+    const int64_t OC = op->ne[2];
+    const int64_t OW = op->ne[0];
+
+    const int64_t np = N * OC * OW;
+
+    ggml_metal_kargs_pool_1d args_pool_1d = {
+        /* .k0 = */ k0,
+        /* .s0 = */ s0,
+        /* .p0 = */ p0,
+        /* .IW = */ (int) IW,
+        /* .OW = */ (int) OW,
+        /* .np = */ (int) np
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_pool_1d(lib, op, op_pool);
+
+    const int nth = std::min(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), (int) np);
+    const int ntg = (np + nth - 1) / nth;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args_pool_1d, sizeof(args_pool_1d), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, ntg, 1, 1, nth, 1, 1);
+
+    return 1;
+}
+
 
 int ggml_metal_op_pool_2d(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1647,9 +1647,10 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     const int64_t IW = op->src[0]->ne[0];
     const int64_t N  = op->ne[3];
     const int64_t OC = op->ne[2];
+    const int64_t OH = op->ne[1];
     const int64_t OW = op->ne[0];
 
-    const int64_t np = N * OC * OW;
+    const int64_t np = N * OC * OH * OW;
 
     ggml_metal_kargs_pool_1d args_pool_1d = {
         /* .k0 = */  k0,

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -61,6 +61,7 @@ int ggml_metal_op_ssm_conv          (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_ssm_scan          (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_rwkv              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_cpy               (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_pool_1d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_pool_2d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat_id        (ggml_metal_op_t ctx, int idx);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -9870,67 +9870,70 @@ kernel void kernel_pool_2d_avg_f32(
 
 
 kernel void kernel_pool_1d_max_f32(
-        constant    ggml_metal_kargs_pool_1d & args,
-        device  const float * src0,
-        device        float * dst,
-        uint        gid[[thread_position_in_grid]]) {
+        constant        ggml_metal_kargs_pool_1d & args,
+        device  const   float * src,
+        device          float * dst,
+        uint            gid [[thread_position_in_grid]]
+) {
 
     if (gid >= args.np) {
         return;
     }
 
-    const int idx = gid;
-    const int O_L = args.OW;
-    const int nc = idx / O_L;
-    const int cur_o0 = idx % O_L;
+    const int ow  = (int)gid % args.OW;
+    const int row = (int)gid / args.OW;
 
-    device const float * i_ptr = src0 + nc * args.IW;
-    device       float * o_ptr = dst  + nc * O_L;
+    const int base = ow * args.s0 - args.p0;
 
-    const int start = cur_o0 * args.s0 - args.p0;
-    const int b = MAX(0, start);
-    const int e = MIN(args.IW, start + args.k0);
+    float acc = -INFINITY;
 
-    float res = -INFINITY;
+    const int src_off = row * args.IW;
+    const int dst_off = row * args.OW;
 
-    for (int j = b; j < e; ++j) {
-        res = MAX(res, i_ptr[j]);
+    for (int ki = 0; ki < args.k0; ++ki) {
+        int j = base + ki;
+        if (j < 0 || j >= args.IW){
+            continue;
+        }
+        float v = src[src_off + j];
+        acc = max(acc, v);
     }
 
-    o_ptr[cur_o0] = res;
+    dst[dst_off + ow] = acc; 
 }
 
 kernel void kernel_pool_1d_avg_f32(
-        constant    ggml_metal_kargs_pool_1d & args,
-        device  const float * src0,
-        device        float * dst,
-        uint        gid[[thread_position_in_grid]]) {
+        constant        ggml_metal_kargs_pool_1d & args,
+        device  const   float * src,
+        device          float * dst,
+        uint            gid [[thread_position_in_grid]]
+) {
 
     if (gid >= args.np) {
         return;
     }
 
-    const int idx = gid;
-    const int O_L = args.OW;
-    const int nc = idx / O_L;
-    const int cur_o0 = idx % O_L;
+    const int ow  = (int)gid % args.OW;
+    const int row = (int)gid / args.OW;
 
-    device const float * i_ptr = src0 + nc * args.IW;
-    device       float * o_ptr = dst  + nc * O_L;
+    const int base = ow * args.s0 - args.p0;
 
-    const int start = cur_o0 * args.s0 - args.p0;
-    const int b = MAX(0, start);
-    const int e = MIN(args.IW, start + args.k0);
+    float acc = 0.0f;
+    int   cnt = 0;
 
-    const float scale = 1.0f / args.k0;
+    const int src_off = row * args.IW;
+    const int dst_off = row * args.OW;
 
-    float res = 0.0f;
-
-    for (int j = b; j < e; ++j) {
-        res += i_ptr[j] * scale;
+    for (int ki = 0; ki < args.k0; ++ki) {
+        const int j = base + ki;
+        if (j < 0 || j >= args.IW) {
+            continue;
+        }
+        acc += src[src_off + j];
+        cnt += 1;
     }
 
-    o_ptr[cur_o0] = res;
+    dst[dst_off + ow] = (cnt > 0) ? (acc / (float)cnt) : 0.0f;
 }
 
 kernel void kernel_opt_step_adamw_f32(

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -9899,7 +9899,7 @@ kernel void kernel_pool_1d_max_f32(
         acc = max(acc, v);
     }
 
-    dst[dst_off + ow] = acc; 
+    dst[dst_off + ow] = acc;
 }
 
 kernel void kernel_pool_1d_avg_f32(

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4836,6 +4836,8 @@ struct ggml_tensor * ggml_pool_1d(
         a->ne[2],
         a->ne[3],
     };
+    GGML_ASSERT(ne[0] > 0);
+
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     int32_t params[] = { op, k0, s0, p0 };
@@ -4866,6 +4868,9 @@ struct ggml_tensor * ggml_pool_2d(
         a->ne[2],
         a->ne[3],
     };
+    GGML_ASSERT(ne[0] > 0);
+    GGML_ASSERT(ne[1] > 0);
+
     result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     int32_t params[] = { op, k0, k1, s0, s1, p0, p1 };

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6988,9 +6988,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             for (int k0 : {1, 3}) {
                 for (int s0 : {1, 2}) {
                     for (int p0 : {0, 1}) {
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10,  3, 1, 1 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11,  1, 1, 2 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 2, 1, 3 }, k0, s0, p0));
                     }
                 }
             }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6986,11 +6986,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (ggml_type type_input : {GGML_TYPE_F32}) {
         for (ggml_op_pool pool_type : {GGML_OP_POOL_AVG, GGML_OP_POOL_MAX}) {
             for (int k0 : {1, 3}) {
-                int s0 = k0;
-                int p0 = 0;
-                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
-                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
-                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
+                for (int s0 : {1, 2}) {
+                    for (int p0 : {0, 1}) {
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
+                    }
+                }
             }
         }
     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6986,13 +6986,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (ggml_type type_input : {GGML_TYPE_F32}) {
         for (ggml_op_pool pool_type : {GGML_OP_POOL_AVG, GGML_OP_POOL_MAX}) {
             for (int k0 : {1, 3}) {
-                for (int s0 : {1, 2, 3}) {
-                    for (int p0 : {0, 1}) {
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
-                    }
-                }
+                int s0 = k0;
+                int p0 = 0;
+                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
+                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
+                test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
             }
         }
     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6988,8 +6988,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             for (int k0 : {1, 3}) {
                 for (int s0 : {1, 2}) {
                     for (int p0 : {0, 1}) {
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10,  3, 1, 1 }, k0, s0, p0));
-                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11,  1, 1, 2 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10,  3, 2, 1 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11,  1, 3, 2 }, k0, s0, p0));
                         test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 2, 1, 3 }, k0, s0, p0));
                     }
                 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4573,6 +4573,37 @@ struct test_pool2d : public test_case {
     }
 };
 
+// GGML_OP_POOL1D
+struct test_pool1d : public test_case {
+    enum ggml_op_pool pool_type;
+    const ggml_type type_input;
+    const std::array<int64_t, 4> ne_input;
+    const int k0;
+    const int s0;
+    const int p0;
+
+    std::string vars() override {
+        return VARS_TO_STR6(pool_type, type_input, ne_input, k0, s0, p0);
+    }
+
+    test_pool1d(ggml_op_pool pool_type = GGML_OP_POOL_AVG,
+                ggml_type type_input = GGML_TYPE_F32,
+                std::array<int64_t,4> ne_input = {10, 1, 1, 1},
+                int k0 = 3, int s0 = 3, int p0 = 0)
+        : pool_type(pool_type), type_input(type_input), ne_input(ne_input), k0(k0), s0(s0), p0(p0) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * input = ggml_new_tensor(ctx, type_input, 4, ne_input.data());
+        ggml_set_param(input);
+        ggml_set_name(input, "input");
+
+        ggml_tensor * out = ggml_pool_1d(ctx, input, pool_type, k0, s0, p0);
+        ggml_set_name(out, "out");
+
+        return out;
+    }
+};
+
 // GGML_OP_CONV_TRANSPOSE_1D
 struct test_conv_transpose_1d : public test_case {
     const std::array<int64_t, 4> ne_input;
@@ -6946,6 +6977,20 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    for (ggml_type type_input : {GGML_TYPE_F32}) {
+        for (ggml_op_pool pool_type : {GGML_OP_POOL_AVG, GGML_OP_POOL_MAX}) {
+            for (int k0 : {1, 3}) {
+                for (int s0 : {1, 2, 3}) {
+                    for (int p0 : {0, 1}) {
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 10, 1, 1, 1 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 11, 1, 1, 2 }, k0, s0, p0));
+                        test_cases.emplace_back(new test_pool1d(pool_type, type_input, { 128, 1, 1, 3 }, k0, s0, p0));
                     }
                 }
             }


### PR DESCRIPTION
This PR adds Metal backend support for `POOL_1D` operators.
Until now, only the `POOL_2D` was implemented for Metal. 
With this change, models relying on 1D pooling can now run fully accelerated on Apple GPUs through Metal in an analog way.

---

### Implementation Details

* Added new Metal compute kernels in `ggml-metal.metal`:

  * `kernel_pool_1d_max_f32`
  * `kernel_pool_1d_avg_f32`
* Implemented `ggml_metal_op_pool_1d` analogous to `ggml_metal_op_pool_2d`, including:

  * Argument struct (`ggml_metal_kargs_pool_1d`)x
  * Threadgroup size calculation
  * Encoding input/output buffers

