### PR TITLE
server: update readme to mention n_past_max metric

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1045,6 +1045,7 @@ Available metrics:
 - `llamacpp:kv_cache_tokens`: KV-cache tokens.
 - `llamacpp:requests_processing`: Number of requests processing.
 - `llamacpp:requests_deferred`: Number of requests deferred.
+- `llamacpp:n_past_max`: High watermark of the context size observed.
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/pull/15361 added new metric exported, but I've missed this doc.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
