### PR TITLE
common : increase default `n_ctx_checkpoints` from 3 to 8

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -425,7 +425,7 @@ struct common_params {
     int32_t timeout_write     = timeout_read; // http write timeout in seconds
     int32_t n_threads_http    = -1;           // number of threads to process HTTP requests (TODO: support threadpool)
     int32_t n_cache_reuse     = 0;            // min chunk size to reuse from the cache via KV shifting
-    int32_t n_ctx_checkpoints = 3;            // max number of context checkpoints per slot
+    int32_t n_ctx_checkpoints = 8;            // max number of context checkpoints per slot
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT


### PR DESCRIPTION
Context checkpoints are usually relatively small, therefore, to avoid users complaining about excessive context re-processing for branching conversations, this PR bumps the default value of `n_ctx_checkpoints` from 3 to 8. Users can still configure the value with `--ctx-checkpoints N` or `--swa-checkpoints N`.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*