### PR TITLE
server : Fixed canceling pending tasks

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1937,7 +1937,7 @@ private:
     void cleanup_pending_task(int id_target) {
         // no need lock because this is called exclusively by post()
         auto rm_func = [id_target](const server_task & task) {
-            return task.id_target == id_target;
+            return task.id == id_target;
         };
         queue_tasks.erase(
             std::remove_if(queue_tasks.begin(),          queue_tasks.end(),          rm_func),


### PR DESCRIPTION
# Description
There’s an issue in the condition used when canceling pending tasks in llama-server.
Because of this, when there are two or more queued tasks, pending tasks cannot be canceled properly.
(Only the currently running task can be canceled.)

# Steps to reproduce
You can easily reproduce this by repeatedly sending and canceling heavy requests:

1. Send a prompt to llama_decode that takes several seconds to process.
2. Quickly repeat sending and canceling the request several times.
3. After llama_decode finishes, the active task is canceled as expected, but pending tasks remain uncanceled and continue to run.

This issue is especially critical for use cases such as code completion, where requests are sent and canceled rapidly.
Thank you for your review and consideration.