### PR TITLE
Dont define _XOPEN_SOURCE on AIX

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -145,6 +145,9 @@ endif()
 # which was introduced in POSIX.1-2008, forcing us to go higher
 if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
     add_compile_definitions(_XOPEN_SOURCE=700)
+elseif (CMAKE_SYSTEM_NAME MATCHES "AIX")
+    # Don't define _XOPEN_SOURCE.  We need _ALL_SOURCE, which is the default,
+    # in order to define _SC_PHYS_PAGES.
 else()
     add_compile_definitions(_XOPEN_SOURCE=600)
 endif()


### PR DESCRIPTION
The AIX headers don't work with OpenXL(ibm-clang) compiler and `_XOPEN_SOURCE`. Build fails because `_SC_PHYS_PAGES` is not defined. On AIX, it's defined when `_ALL_SOURCE` is defined. So, in this cmake file, we don't define `_XOPEN_SOURCE`.  This will give us `_ALL_SOURCE` by default.
