### PR TITLE
metal : fix mul-mm condition + fix mul-mv permuted kernels

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1546,9 +1546,8 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         !ggml_is_transposed(op->src[1]) &&
         // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
         // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel
-        props_dev->has_simdgroup_mm && ne00 >= 64 &&
-        (ne11 > ne11_mm_min || (ggml_is_quantized(op->src[0]->type) && ne12 > 1))) {
-        //printf("matrix: ne00 = %6d, ne01 = %6d, ne02 = %6d, ne11 = %6d, ne12 = %6d\n", ne00, ne01, ne02, ne11, ne12);
+        props_dev->has_simdgroup_mm && ne00 >= 64 && ne11 > ne11_mm_min) {
+        //GGML_LOG_INFO("matrix: ne00 = %6d, ne01 = %6d, ne02 = %6d, ne11 = %6d, ne12 = %6d\n", ne00, ne01, ne02, ne11, ne12);
 
         // some Metal matrix data types require aligned pointers
         // ref: https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf (Table 2.5)

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -16313,10 +16313,10 @@ struct llm_build_granite_hybrid : public llm_graph_context_mamba {
     }
 
     ggml_tensor * build_layer_ffn(
-              ggml_tensor       * cur,
-              ggml_tensor       * inpSA,
-        const llama_model       & model,
-        const int                 il) {
+              ggml_tensor * cur,
+              ggml_tensor * inpSA,
+        const llama_model & model,
+        const int           il) {
 
         // For Granite architectures - scale residual
         if (hparams.f_residual_scale) {


### PR DESCRIPTION
From the `llama-batched-bench` numbers in https://github.com/ggml-org/llama.cpp/pull/16490#issuecomment-3386921481 I realized that the wrong Metal kernels were being used for SSM models. Also fix some mv kernels when src0 is permuted.

```bash
make -j && ./bin/llama-batched-bench -hf unsloth/granite-4.0-h-micro-GGUF:Q4_0 -c 4096 -b 2048 -ub 512 -npp 512 -ntg 128 -npl 1,2,4 -ngl 99 -fa on
```

### Before

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.351 |  1458.49 |    1.358 |    94.25 |    1.709 |   374.45 |
|   512 |    128 |    2 |   1280 |    0.670 |  1527.90 |    3.064 |    83.54 |    3.735 |   342.75 |
|   512 |    128 |    4 |   2560 |    1.347 |  1520.46 |    4.693 |   109.10 |    6.040 |   423.86 |

### After

|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
|   512 |    128 |    1 |    640 |    0.337 |  1520.61 |    1.359 |    94.16 |    1.696 |   377.33 |
|   512 |    128 |    2 |   1280 |    0.682 |  1501.49 |    1.976 |   129.57 |    2.658 |   481.61 |
|   512 |    128 |    4 |   2560 |    1.347 |  1520.02 |    2.895 |   176.89 |    4.242 |   603.51 |