### PR TITLE
server : log requests to /v1/completions

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4368,7 +4368,7 @@ struct server_context {
 
 static void log_server_request(const httplib::Request & req, const httplib::Response & res) {
     // skip GH copilot requests when using default port
-    if (req.path == "/v1/health" || req.path == "/v1/completions") {
+    if (req.path == "/v1/health") {
         return;
     }
 


### PR DESCRIPTION
Logging the requests along with their HTTP status is quite useful for traceability and observability purposes. For some reason which I don't understand, `/v1/health` and `/v1/completions` requests are being ignored and not logged.

We don't really care about `/v1/health`, but we really need logs for `/v1/completions` requests.