### PR TITLE
vocab : mark EOT token for Granite models

### DIFF
--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -2541,6 +2541,9 @@ static void llama_sampler_infill_apply(struct llama_sampler * smpl, llama_token_
     if (n_non_eog == 0) {
         cur_p->size = 1;
         cur_p->data[0].id = ctx->vocab->token_eot();
+        if (cur_p->data[0].id == LLAMA_TOKEN_NULL) {
+            cur_p->data[0].id = ctx->vocab->token_eos();
+        }
         cur_p->data[0].logit = 1.0f;
 
         GGML_ASSERT(cur_p->data[0].id != LLAMA_TOKEN_NULL);

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -2543,6 +2543,8 @@ static void llama_sampler_infill_apply(struct llama_sampler * smpl, llama_token_
         cur_p->data[0].id = ctx->vocab->token_eot();
         cur_p->data[0].logit = 1.0f;
 
+        GGML_ASSERT(cur_p->data[0].id != LLAMA_TOKEN_NULL);
+
         return;
     }
 

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2171,6 +2171,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                         || t.first == "<|end|>"
                         || t.first == "<end_of_turn>"
                         || t.first == "<|endoftext|>"
+                        || t.first == "<|end_of_text|>" // granite
                         || t.first == "<EOT>"
                         || t.first == "_<EOT>"
                         || t.first == "<｜end▁of▁sentence｜>" // DeepSeek


### PR DESCRIPTION
fix #16498

The `infill` samplers requires a valid EOT token and the Granite models didn't have one defined.