### PR TITLE
server : fix division by zero when reporting stats

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4226,7 +4226,7 @@ struct server_context {
                     metrics.on_prompt_eval(slot);
                 }
 
-                slot.t_token_generation = (t_current - slot.t_start_generation) / 1e3;
+                slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
 
                 completion_token_output result;
                 result.tok          = id;


### PR DESCRIPTION
The `t_token_generaion` could become zero, causing division by zero here:

https://github.com/ggml-org/llama.cpp/blob/66892e160d9c9ad086f8681b0162d8da8dd92f20/tools/server/server.cpp#L1838