### PR TITLE
cuda : avoid initializing unused devices

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3867,7 +3867,6 @@ ggml_backend_reg_t ggml_backend_cuda_reg() {
                 dev_ctx->device = i;
                 dev_ctx->name = GGML_CUDA_NAME + std::to_string(i);
 
-                ggml_cuda_set_device(i);
                 cudaDeviceProp prop;
                 CUDA_CHECK(cudaGetDeviceProperties(&prop, i));
                 dev_ctx->description = prop.name;


### PR DESCRIPTION
Remove an unnecessary call to `cudaSetDevice` during initialization. Calling this function will initialize the CUDA runtime for the device and allocate resources that may not be necessary if the device is not actually used.

Fixes #16509