### PR TITLE
hparams : add check for layer index in is_recurrent

### DIFF
--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -140,7 +140,11 @@ uint32_t llama_hparams::n_embd_s() const {
 }
 
 bool llama_hparams::is_recurrent(uint32_t il) const {
-    return recurrent_layer_arr[il];
+    if (il < n_layer) {
+        return recurrent_layer_arr[il];
+    }
+
+    GGML_ABORT("\n%s: il (%u) out of bounds (n_layer: %d)\n", __func__, il, (int)n_layer);
 }
 
 uint32_t llama_hparams::n_pos_per_embd() const {

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -144,7 +144,7 @@ bool llama_hparams::is_recurrent(uint32_t il) const {
         return recurrent_layer_arr[il];
     }
 
-    GGML_ABORT("\n%s: il (%u) out of bounds (n_layer: %d)\n", __func__, il, (int)n_layer);
+    GGML_ABORT("%s: il (%u) out of bounds (n_layer: %u)\n", __func__, il, n_layer);
 }
 
 uint32_t llama_hparams::n_pos_per_embd() const {


### PR DESCRIPTION
This commit adds a check in the is_recurrent method to ensure that the provided layer index is within the valid range.

The motivation for this change is to prevent potential out-of-bounds and also be consistent with other methods in the class that perform similar checks, like is_swa.
