### PR TITLE
ggml : fix build broken with -march=armv9-a on MacOS

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -68,7 +68,7 @@ struct ggml_compute_params {
 #endif  // __VXE2__
 #endif  // __s390x__ && __VEC__
 
-#if defined(__ARM_FEATURE_SVE)
+#if defined(__ARM_FEATURE_SVE) && defined(__linux__)
 #include <sys/prctl.h>
 #endif
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -694,7 +694,7 @@ static void ggml_init_arm_arch_features(void) {
     ggml_arm_arch_features.sve_cnt = PR_SVE_VL_LEN_MASK & prctl(PR_SVE_GET_VL);
 #else
     // TODO: add support of SVE for non-linux systems
-#error message("TODO: to use SVE, sve_cnt needs to be initialized here.")
+#error "TODO: SVE is not supported on this platform. To use SVE, sve_cnt needs to be initialized here."
 #endif
 #endif
 }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -689,8 +689,13 @@ bool ggml_is_numa(void) {
 #endif
 
 static void ggml_init_arm_arch_features(void) {
-#if defined(__linux__) && defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__linux__)
     ggml_arm_arch_features.sve_cnt = PR_SVE_VL_LEN_MASK & prctl(PR_SVE_GET_VL);
+#else
+    // TODO: add support of SVE for non-linux systems
+#pragma message("TODO: to use SVE, sve_cnt needs to be initialized here.")
+#endif
 #endif
 }
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -694,7 +694,7 @@ static void ggml_init_arm_arch_features(void) {
     ggml_arm_arch_features.sve_cnt = PR_SVE_VL_LEN_MASK & prctl(PR_SVE_GET_VL);
 #else
     // TODO: add support of SVE for non-linux systems
-#pragma message("TODO: to use SVE, sve_cnt needs to be initialized here.")
+#error message("TODO: to use SVE, sve_cnt needs to be initialized here.")
 #endif
 #endif
 }


### PR DESCRIPTION
llama.cpp fails to build with `-march=armv9-a` on MacOS.
```bash
cmake .. -DCMAKE_C_FLAGS=-march=armv9-a \
         -DCMAKE_CXX_FLAGS=-march=armv9-a
```

The failure is caused by 'sys/prctl.h' file not found.
```
In file included from /Users/jiefu/llama.cpp/ggml/src/ggml-quants.c:6:
/Users/jiefu/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-impl.h:72:10: fatal error: 'sys/prctl.h' file not found
   72 | #include <sys/prctl.h>
      |          ^~~~~~~~~~~~~
1 error generated.
```

Similar issue had been reported before: https://github.com/sysown/proxysql/issues/1920 .
Reason: `sys/prctl.h` does not exist on Mac OS X, only on Linux.

The fix follows what has been done in ggml by adding `defined(__linux__)` : https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/ggml.c#L72
