### PR TITLE
ci: build Vulkan on Ubuntu with default packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,15 +420,6 @@ jobs:
         run: |
           cmake --build build -j $(nproc)
 
-      - name: Test
-        id: cmake_test
-        run: |
-          cd build
-          export GGML_VK_VISIBLE_DEVICES=0
-          export GGML_VK_DISABLE_F16=1
-          # This is using llvmpipe and runs slower than other backends
-          ctest -L main --verbose --timeout 4200
-
   ubuntu-24-cmake-vulkan:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,6 +387,48 @@ jobs:
           cd build
           ctest -L main --verbose
 
+  ubuntu-24-cmake-vulkan-deb:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.16
+        with:
+          key: ubuntu-24-cmake-vulkan-deb
+          evict-old-files: 1d
+
+      - name: Dependencies
+        id: depends
+        run: |
+          sudo apt-get install -y glslc libvulkan-dev libcurl4-openssl-dev
+
+      - name: Configure
+        id: cmake_configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_VULKAN=ON
+
+      - name: Build
+        id: cmake_build
+        run: |
+          cmake --build build -j $(nproc)
+
+      - name: Test
+        id: cmake_test
+        run: |
+          cd build
+          export GGML_VK_VISIBLE_DEVICES=0
+          export GGML_VK_DISABLE_F16=1
+          # This is using llvmpipe and runs slower than other backends
+          ctest -L main --verbose --timeout 4200
+
   ubuntu-24-cmake-vulkan:
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
This PR introduces a GitHub action building the Vulkan backend on Ubuntu using the default distribution packages. The goal is to be closer to the official Debian packaging of ggml and llama.cpp (which will be used by Ubuntu at some point) and also to test against an older, but still in use, version of Vulkan (v1.3).

I am co-maintainer (with @ckastner) of the official Debian packages for ggml and llama.cpp. I have contributed the packaging of the ggml Vulkan backend, and I am therefore following more closely its portability. We regularly face issues  [e.g. 1, 2, 3] on Debian 12/bookworm, which is still widely used, because it is using Vulkan v1.3, as is also the case of Ubuntu 24.04.

As we plan to soon provide backported ggml and llama.cpp packages for bookworm (until August 2026), it would be great if such compatibility issues could be caught directly during llama.cpp development. Otherwise we only notice them when the code gets merged into the ggml repository and when we then update the packages (which can take weeks). 

Moreover, at some point these Debian packages will likely also become the Ubuntu packages, so it would be useful long-term to have a straightforward build based on Ubuntu's Vulkan packages, in addition to the build based on the downloaded latest Vulkan SDK.

Dynamic backend loading and all CPU variants is enabled in this build, as is the case in the official Debian packages, but this could be disabled in order to make the build a bit faster.

[1] https://github.com/ggml-org/llama.cpp/pull/11117
[2] https://github.com/ggml-org/llama.cpp/pull/15939
[3] https://github.com/ggml-org/llama.cpp/pull/16345
