### PR TITLE
vulkan: Improve build time for MSVC

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.19)
 cmake_policy(SET CMP0114 NEW)
 cmake_policy(SET CMP0116 NEW)
+if (POLICY CMP0147)
+    # Parallel build custom build steps
+    cmake_policy(SET CMP0147 NEW)
+endif()
 
 find_package(Vulkan COMPONENTS glslc REQUIRED)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Parallel build object files
+    add_definitions(/MP)
+endif()
 
 function(detect_host_compiler)
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
Enable CMP0147 so custom build steps (invoking vulkan-shader-gen) are run in parallel.

Enable /MP so source files are compiled in parallel.

#16341 made full shader rebuilds slower using MSVC due to reduced parallelism. This change enables two kinds of parallelism in the build. I think this is all MSVC-specific.

Build times before/after, for touching types.glsl, broken down into compiling the shaders and compiling the cpp files:
```
before: 55s + 26s
after: 29s + 15s
```
I think both steps are still limited by mul_mm being so much bigger than all the others, the improvement in parallelism is very clear when you see it in action.
