### PR TITLE
ggml : fix scalar path for computing norm

### DIFF
--- a/ggml/src/ggml-cpu/vec.cpp
+++ b/ggml/src/ggml-cpu/vec.cpp
@@ -463,9 +463,9 @@ ggml_float ggml_vec_cvar_f32(const int n, float * y, const float * x, const floa
 #endif
     for (; i < n; ++i) {
         float val = x[i] - mean;
+        y[i] = val;
         val *= val;
         sum += (ggml_float)val;
-        y[i] = val;
     }
     return sum/n;
 }


### PR DESCRIPTION
ref https://github.com/ggml-org/llama.cpp/pull/15953#issuecomment-3395672317

This bug was introduced in #15953 (cc @duduta)