### PR TITLE
metal: Change `gpuAddress` for `contents`

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -989,7 +989,7 @@ ggml_metal_buffer_t ggml_metal_buffer_init(ggml_metal_device_t dev, size_t size,
             } else {
                 res->buffers[0].metal = [res->device newBufferWithLength:size_aligned options:MTLResourceStorageModePrivate];
 
-                res->all_data = (void *) (res->buffers[0].metal.gpuAddress);
+                res->all_data = (void *) (res->buffers[0].metal.contents);
             }
         }
 


### PR DESCRIPTION
Hi!

Thank you for developing `llama.cpp`.

Updating the distribution of `llama.cpp` on `conda-forge`, I had to perform this change so that it could be built for Apple Metal on `osx_arm64` (see https://github.com/conda-forge/llama.cpp-feedstock/pull/62 which first has introduced this patch).