### PR TITLE
CUDA: Changing the CUDA scheduling strategy to spin

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -277,7 +277,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
         
         // Temporary performance fix:
         // Setting device scheduling strategy for iGPUs with cc121 to "spinning" to avoid delays in cuda synchronize calls.
-        // TODO: Check for future drivers the default scheduling strategy and 
+        // TODO: Check for future drivers the default scheduling strategy and
         // remove this call again when cudaDeviceScheduleSpin is default.
         if (prop.major == 12 && prop.minor == 1) {
             CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleSpin));

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -230,6 +230,8 @@ static ggml_cuda_device_info ggml_cuda_init() {
         cudaDeviceProp prop;
         CUDA_CHECK(cudaGetDeviceProperties(&prop, id));
 
+        is_cc121 |= prop.major == 12 && prop.minor == 1;
+
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
         info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
@@ -275,8 +277,6 @@ static ggml_cuda_device_info ggml_cuda_init() {
             turing_devices_without_mma.push_back({ id, device_name });
         }
 
-        is_cc121 |= info.devices[id].cc == 1210;
-
 #endif  // defined(GGML_USE_HIP)
     }
 
@@ -298,6 +298,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
     // CUBLAS_CHECK(cublasLoggerConfigure(1, 1, 0, nullptr));
 
     // Setting device scheduling strategy for iGPUs to "spinning" to avoid delays in cuda synchronize calls.
+    // This fix is temporary, as the strategy will be the default in later drivers.    
     if (is_cc121) {
         CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleSpin));
     }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -274,7 +274,6 @@ static ggml_cuda_device_info ggml_cuda_init() {
             turing_devices_without_mma.push_back({ id, device_name });
         }
 
-        
         // Temporary performance fix:
         // Setting device scheduling strategy for iGPUs with cc121 to "spinning" to avoid delays in cuda synchronize calls.
         // TODO: Check for future drivers the default scheduling strategy and


### PR DESCRIPTION
The PR [#16308](https://github.com/ggml-org/llama.cpp/pull/16308) sets as device property by default `integrated = false` to disable host buffers. While this change is needed, the additional memory copies introduce multiple `cudaStreamSynchronize` calls. With the default scheduling strategy, each synchronization has a small latency between kernel termination and freeing the CPU thread on sm121, leading to a ~15% performance regression on gpt-oss-20b-mxfp4. This can be fixed by setting the default scheduling strategy to `cudaDeviceScheduleSpin`. With the missing latency for each synchronization, the performance is roughly equal as handling the device as integrated.

This code change checks whether the device has compute capability 12.1 and then sets the CUDA flag `cudaDeviceScheduleSpin`.