### PR TITLE
fix(ggml): use safe character conversion in ggml_fopen on Windows

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -562,18 +562,15 @@ FILE * ggml_fopen(const char * fname, const char * mode) {
     // convert fname (UTF-8)
     wchar_t * wfname = ggml_mbstowcs(fname);
     if (wfname) {
-        // convert mode (ANSI)
-        wchar_t * wmode = GGML_MALLOC((strlen(mode) + 1) * sizeof(wchar_t));
-        wchar_t * wmode_p = wmode;
-        do {
-            *wmode_p++ = (wchar_t)*mode;
-        } while (*mode++);
-
-        // open file
-        file = _wfopen(wfname, wmode);
+        // convert mode (UTF-8)
+        wchar_t * wmode = ggml_mbstowcs(mode);
+        if (wmode) {
+            // open file
+            file = _wfopen(wfname, wmode);
+            GGML_FREE(wmode);
+        }
 
         GGML_FREE(wfname);
-        GGML_FREE(wmode);
     }
 
     return file;


### PR DESCRIPTION
This commit fixes an unsafe character conversion in the `ggml_fopen` function on Windows. The file `mode` string was being converted from `char *` to `wchar_t *` by simple casting, which is not safe for multi-byte character sets.

This change replaces the manual conversion with a call to the `ggml_mbstowcs` helper function, which properly handles UTF-8 to wide character conversion. This makes the code more robust and correct, especially for handling file paths on Windows.
