### PR TITLE
Q4 tiled Gemm Implementation

### DIFF
--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -1582,10 +1582,24 @@ class tinyBLAS_Q0_PPC {
                 float *C, int64_t ldc,
                 int ith, int nth)
         : A(A), B(B), C(C), k(k), lda(lda), ldb(ldb), ldc(ldc), ith(ith), nth(nth) {
+		kc=64;
+		//kc=k;
     }
 
     void matmul(int64_t m, int64_t n) {
-        mnpack(0, m, 0, n);
+	     int mc = 64; int nc = 64;
+       if (m%mc == 0 && n%nc == 0 && k%kc == 0) {
+          //debug_print_q4_0((const block_q4_0 *)A, lda, m);
+          //debug_print_q8_0((const block_q8_0 *)B, ldb, n);
+          //printf("Calling matmul_tiled with m = %ld n = %ld k =%ld\n",  m, n, k);
+          matmul_tiled(m, n, mc, nc, kc);
+       }
+       else {
+       //debug_print_q4_0((const block_q4_0 *)A, lda, m);
+       //debug_print_q8_0((const block_q8_0 *)B, ldb, n);
+       //printf("Calling mnpack with m = %ld n = %ld k =%ld\n",  m, n, k);
+         mnpack(0, m, 0, n);
+       }
     }
 
   private:
@@ -1597,9 +1611,28 @@ class tinyBLAS_Q0_PPC {
           }
        }
     }
+     void compute_scale(int64_t ii, int64_t jj, int blk, vector float* vs){
+       for (int I = 0; I<8; I++) {
+            float a_scale = unhalf((A+((ii+I)*lda)+blk)->d);// * unhalf((B+((jj+J)*ldb)+blk)->d));
+            for (int J = 0; J<4; J++) {
+                    //*((float*)&vs[I]+J) = (unhalf((A+((ii+I)*lda)+blk)->d) * unhalf((B+((jj+J)*ldb)+blk)->d));
+                    //*((float*)&vs[I+8]+J) = (unhalf((A+((ii+I)*lda)+blk)->d) * unhalf((B+((jj+J+4)*ldb)+blk)->d));
 
+                    *((float*)&vs[I]+J) = (a_scale * unhalf((B+((jj+J)*ldb)+blk)->d));
+                    *((float*)&vs[I+8]+J) = (a_scale * unhalf((B+((jj+J+4)*ldb)+blk)->d));
+                }
+            }
+    }
+     void add_save_res(int ii, int jj, int idx, vector float* fin_res, int RM=4, int RN=4) {
+       for (int I = 0; I < RM; I++) {
+          for (int J = 0; J < RN; J++) {
+             float * c_ptr = (float *)(C+ii+((jj+J)*ldc)+I);
+             *c_ptr += *((float*)&fin_res[idx+I]+J);
+          }
+       }
+    }
     template<int size>
-    inline void compute(acc_t* ACC, int c_idx, int s_idx, std::array<int, size>& comparray, vector float* vs, vector float* fin_res) {
+    inline void compute(acc_t* ACC, int c_idx, int s_idx, int* comparray, vector float* vs, vector float* fin_res) {
        vector signed int vec_C[4];
        vector float CA[4] = {0};
        vector float res[4] = {0};
@@ -1661,7 +1694,7 @@ class tinyBLAS_Q0_PPC {
     }
 
     template<int size>
-    void packNormalInt4(const TA* a, int64_t lda, int rows, int cols, int8_t* vec, std::array<int, size>& comparray) {
+    void packNormalInt4(const TA* a, int64_t lda, int rows, int cols, int8_t* vec, int*comparray, bool mb=false) {
         int64_t i, j;
         TA *aoffset = NULL;
         int8_t *vecOffset = NULL;
@@ -1671,6 +1704,10 @@ class tinyBLAS_Q0_PPC {
         vector signed char c5[2] = {0}, c6[2] = {0}, c7[2] = {0}, c8[2] = {0};
         aoffset = const_cast<TA*>(a);
         vecOffset = vec;
+	int index = 0;
+	int k_chunk = 1;
+	if (mb)
+		k_chunk=kc;
         j = (rows >> 3);
         if (j > 0) {
             do {
@@ -1683,43 +1720,40 @@ class tinyBLAS_Q0_PPC {
                 aoffset7 = aoffset6 + lda;
                 aoffset8 = aoffset7 + lda;
                 aoffset += 8 * lda;
-                i = (cols >> 2);
-                if (i > 0) {
-                    do {
-                        c1[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset1->qs));
-                        c2[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset2->qs));
-                        c3[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset3->qs));
-                        c4[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset4->qs));
-                        c5[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset5->qs));
-                        c6[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset6->qs));
-                        c7[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset7->qs));
-                        c8[1] = reinterpret_cast<vector signed char>(vec_xl(0, aoffset8->qs));
+		for (int blk = 0; blk < k_chunk; blk++) {
+                        c1[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset1+blk)->qs));
+                        c2[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset2+blk)->qs));
+                        c3[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset3+blk)->qs));
+                        c4[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset4+blk)->qs));
+                        c5[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset5+blk)->qs));
+                        c6[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset6+blk)->qs));
+                        c7[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset7+blk)->qs));
+                        c8[1] = reinterpret_cast<vector signed char>(vec_xl(0, (aoffset8+blk)->qs));
 
-                        process_q4_elements(c1, &comparray[0]);
-                        process_q4_elements(c2, &comparray[1]);
-                        process_q4_elements(c3, &comparray[2]);
-                        process_q4_elements(c4, &comparray[3]);
-                        process_q4_elements(c5, &comparray[4]);
-                        process_q4_elements(c6, &comparray[5]);
-                        process_q4_elements(c7, &comparray[6]);
-                        process_q4_elements(c8, &comparray[7]);
+                        process_q4_elements(c1, &comparray[index + 8*blk+0]);
+                        process_q4_elements(c2, &comparray[index + 8*blk+1]);
+                        process_q4_elements(c3, &comparray[index + 8*blk+2]);
+                        process_q4_elements(c4, &comparray[index + 8*blk+3]);
+                        process_q4_elements(c5, &comparray[index + 8*blk+4]);
+                        process_q4_elements(c6, &comparray[index + 8*blk+5]);
+                        process_q4_elements(c7, &comparray[index + 8*blk+6]);
+                        process_q4_elements(c8, &comparray[index + 8*blk+7]);
                         vector_permute_store<int8_t, vector signed char>(c1[0], c2[0], c3[0], c4[0], vecOffset, false);
                         vector_permute_store<int8_t, vector signed char>(c1[1], c2[1], c3[1], c4[1], vecOffset+64, false);
                         vector_permute_store<int8_t, vector signed char>(c5[0], c6[0], c7[0], c8[0], vecOffset+128, false);
                         vector_permute_store<int8_t, vector signed char>(c5[1], c6[1], c7[1], c8[1], vecOffset+192, false);
-                        aoffset1 += lda;
+                        /*aoffset1 += lda;
                         aoffset2 += lda;
                         aoffset3 += lda;
                         aoffset4 += lda;
                         aoffset5 += lda;
                         aoffset6 += lda;
                         aoffset7 += lda;
-                        aoffset8 += lda;
+                        aoffset8 += lda;*/
                         vecOffset += 256;
-                        i--;
-                    } while (i > 0);
-                }
+		}
                 j--;
+		index += 8*k_chunk;
             } while (j > 0);
         }
 
@@ -1782,7 +1816,7 @@ class tinyBLAS_Q0_PPC {
         }
     }
     template<typename VA, typename VB>
-    void packNormal(const block_q8_0* a, int64_t lda, int rows, int cols, VA* vec, bool flip) {
+    void packNormal(const block_q8_0* a, int64_t lda, int rows, int cols, VA* vec, bool flip, bool mb = false) {
         int64_t i, j;
         block_q8_0 *aoffset = NULL;
         VA *vecOffset = NULL;
@@ -1792,19 +1826,18 @@ class tinyBLAS_Q0_PPC {
         VB c1[8] = {0}; VB c2[8] = {0};
         aoffset = const_cast<block_q8_0*>(a);
         vecOffset = vec;
+	int k_chunk = 1;
+	if (mb)
+		k_chunk = kc;
         j = (rows >> 3);
         if (j > 0) {
             do {
-                aoffsets[0] = aoffset;
-                for (int it = 1; it < 8; it++)
-                    aoffsets[it] = aoffsets[it-1] + lda;
+                for (int it = 0; it < 8; it++)
+                    aoffsets[it] = aoffset + it*lda;
                 aoffset += 8 * lda;
-
-                i = (cols >> 3);
-                if (i > 0) {
-                do {
+		for (int blk = 0; blk < k_chunk; blk++) {
                     for (int it = 0; it < 8; it++) {
-                        arr[it] = __builtin_vsx_lxvp(0, (__vector_pair*)aoffsets[it]->qs);
+                        arr[it] = __builtin_vsx_lxvp(0, (__vector_pair*)(aoffsets[it]+blk)->qs);
                         __builtin_vsx_disassemble_pair(c[it], &arr[it]);
                         c1[it] = c[it][0];
                         c2[it] = c[it][1];
@@ -1813,11 +1846,9 @@ class tinyBLAS_Q0_PPC {
                     vector_permute_store<VA, VB>(c2[0], c2[1], c2[2], c2[3], vecOffset+64, flip);
                     vector_permute_store<VA, VB>(c1[4], c1[5], c1[6], c1[7], vecOffset+128, flip);
                     vector_permute_store<VA, VB>(c2[4], c2[5], c2[6], c2[7], vecOffset+192, flip);
-                    for (int it = 0; it < 8; it++)
-                        aoffsets[it] += lda;
+                    /*for (int it = 0; it < 8; it++)
+                        aoffsets[it] += lda;*/
                     vecOffset += 256;
-                    i--;
-               } while(i > 0);
             }
             j--;
         } while(j > 0);
@@ -1918,7 +1949,8 @@ class tinyBLAS_Q0_PPC {
     void KERNEL_4x8(int64_t ii, int64_t jj) {
         vec_t vec_A[8], vec_B[16] = {0};
         acc_t acc_0, acc_1;
-        std::array<int, 4> comparray {};
+        //std::array<int, 4> comparray {};
+	int comparray[8] = {0};
         vector float fin_res[8] = {0};
         vector float vs[8] = {0};
         bool isAblock_q4 = std::is_same_v<TA, block_q4_0>;
@@ -1963,7 +1995,7 @@ class tinyBLAS_Q0_PPC {
     void KERNEL_8x4(int64_t ii, int64_t jj) {
         vec_t vec_A[16], vec_B[8] = {0};
         acc_t acc_0, acc_1;
-        std::array<int, 8> comparray {};
+	int comparray[8] = {0};
         vector float fin_res[8] = {0};
         vector float vs[8] = {0};
         bool isAblock_q4 = std::is_same_v<TA, block_q4_0>;
@@ -2007,7 +2039,7 @@ class tinyBLAS_Q0_PPC {
     void KERNEL_8x8(int64_t ii, int64_t jj) {
         vec_t vec_A[16], vec_B[16] = {0};
         acc_t acc_0, acc_1, acc_2, acc_3;
-        std::array<int, 8> comparray {};
+	int comparray[8] = {0};
         vector float fin_res[16] = {0};
         vector float vs[16] = {0};
         bool isAblock_q4 = std::is_same_v<TA, block_q4_0>;
@@ -2056,6 +2088,81 @@ class tinyBLAS_Q0_PPC {
         save_res(ii, jj+4, 8, fin_res);
         save_res(ii+4, jj+4, 12, fin_res);
     }
+    void KERNEL_Q4(int64_t ii, int64_t jj, int64_t mc, int64_t nc, int64_t kc, int64_t l, vec_t *vec_A, vec_t *vec_B, int *comparray) {
+      acc_t acc[4];
+       for (int i = 0; i < mc ; i += 8) {
+           for (int j = 0; j < nc; j += 8) {
+               //printf("in kernel q4 with i=%d j = %d\n", i, j);
+               vector float fin_res[16] = {0};
+               vector float vs[16] = {0};
+               for (int64_t kk = 0; kk < kc; kk++) {
+               //printf("Block  kk=%d\n", kk);
+                   for (int x = 0; x < 4; x++) {
+                       __builtin_mma_xxsetaccz(&acc[x]);
+                   }
+                   int A_block_idx = (i/8)*(16*kc) + kk*16;
+                   int B_block_idx = (j/8)*(16*kc)+ kk*16;
+                   vec_t *A_block = &vec_A[A_block_idx];
+                   vec_t *B_block = &vec_B[B_block_idx];
+                   /*printf("printing input vectors A and B\n");
+                   for (int i = 0; i< 16; i++){
+                           print_vec_q8("A", A_block[i]);
+                           print_vec_q8("B", B_block[i]);
+                   }*/
+                    for (int x = 0; x < 8; x++) {
+                        __builtin_mma_xvi8ger4pp(&acc[0], A_block[x],     B_block[x]);
+                        __builtin_mma_xvi8ger4pp(&acc[1], A_block[x + 8], B_block[x]);
+                        __builtin_mma_xvi8ger4pp(&acc[2], A_block[x],     B_block[x+8]);
+                        __builtin_mma_xvi8ger4pp(&acc[3], A_block[x+8],   B_block[x+8]);
+                    }
+                   compute_scale(ii+i, jj+j, l+kk, vs);
+                   int c_index = (i/8)*(8*kc)+ kk*8;
+                   int* c_block = &comparray[c_index];
+                   compute<8>(&acc[0], 0,  0,  c_block, vs, fin_res);
+                    compute<8>(&acc[1], 4,  4,  c_block, vs, fin_res);
+                    compute<8>(&acc[2], 0,  8,  c_block, vs, fin_res);
+                    compute<8>(&acc[3], 4, 12,  c_block, vs, fin_res);
+               }
+               if (l == 0) {
+                  save_res(ii+i,   jj+j,    0,  fin_res);
+                  save_res(ii+i+4, jj+j,    4,  fin_res);
+                  save_res(ii+i,   jj+j+4,  8,  fin_res);
+                  save_res(ii+i+4, jj+j+4, 12,  fin_res);
+               } else {
+                  add_save_res(ii+i,   jj+j,    0,  fin_res);
+                  add_save_res(ii+i+4, jj+j,    4,  fin_res);
+                  add_save_res(ii+i,   jj+j+4,  8,  fin_res);
+                  add_save_res(ii+i+4, jj+j+4, 12,  fin_res);
+              }
+           }
+
+           }
+    }
+
+    void matmul_tiled(int64_t m, int64_t n, int64_t mc, int64_t nc, int64_t kc) {
+        int64_t ytiles = m / mc;
+        int64_t xtiles = n / nc;
+        int64_t tiles  = xtiles * ytiles;
+        int64_t duty = (tiles + nth - 1) / nth;
+        int64_t start = duty * ith;
+        int64_t end = start + duty;
+        if (end > tiles) {
+            end = tiles;
+        }
+        for (int64_t job = start; job < end; ++job) {
+            int64_t ii = (job / xtiles) * mc;
+            int64_t jj = (job % xtiles) * nc;
+            for (int64_t kk = 0; kk < k; kk += kc) {
+                vec_t A_pack[mc*kc*2];
+                vec_t B_pack[nc*kc*2];
+                int comparray[mc*kc];
+                packNormalInt4<8>(A + ii*lda + kk, lda, mc, 4, (int8_t*)A_pack, comparray, true);
+                packNormal<uint8_t, vector unsigned char>(B + jj*ldb + kk, ldb, nc, 8, (uint8_t*)B_pack, true, true);
+                KERNEL_Q4(ii, jj, mc, nc, kc, kk, A_pack, B_pack, comparray);
+        }
+      }
+    }
+
 
     void gemm_small(int64_t m0, int64_t m, int64_t n0, int64_t n, int RM, int RN) {
         int64_t ytiles = (m - m0) / RM;
@@ -2074,7 +2181,8 @@ class tinyBLAS_Q0_PPC {
         for (int64_t job = start; job < end; ++job) {
             int64_t ii = m0 + job / xtiles * RM;
             int64_t jj = n0 + job % xtiles * RN;
-            std::array<int, 4> comparray{};
+            //std::array<int, 4> comparray{};
+	    int comparray[4] = {0};
             vector float res[4] = {0};
             vector float fin_res[4] = {0};
             vector float vs[4] = {0};
@@ -2159,6 +2267,7 @@ class tinyBLAS_Q0_PPC {
     const block_q8_0 *const B;
     float *C;
     const int64_t k;
+    int64_t kc;
     const int64_t lda;
     const int64_t ldb;
     const int64_t ldc;


### PR DESCRIPTION
This patch does tiled gemm approach similar to SGEMM. But, this degrades performance that current qgemm implementation.

This is gives 50% improvement for thread 1 case ( from 4.29 t/s to 6.1 t/s) but with 20 thraeds it drops from 68 t/s to 6 t/s )

Change 1:
The reason was inocrrect thread distribution logic . Fixed that. With that we see improvement also scaling as we increate the threads.

seeing about 30% gains with llama-bench( pp : 64,128,256,512).

Change 2 :
The big prompt is emitting junk  with llama-cli probably because of inocrrect chunks passed to mma engine. kc =k solved this issue. we need to call compute_scale with l+kk.

Results after chnage 2
 ./patch_build/bin/llama-bench -m /dev/shm/Models/Meta-Llama-3-8B/ggml-model-q4.gguf -p 64,128,256,512 -n 1 -t 20 |& tee patch.log
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |            pp64 |        75.99 ± 12.88 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp128 |         91.54 ± 0.38 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp256 |         91.57 ± 0.18 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp512 |         87.18 ± 0.31 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |             tg1 |         11.21 ± 0.06 |

build: 2a11f66e (6751)
[root@c643n08aix1-lp1 llama_2]# ./patch_build/bin/llama-bench -m /dev/shm/Models/Meta-Llama-3-8B/ggml-model-q4.gguf -p 1024,2048,4096 -n 1 -t 20 |& tee patch_large_pp.log
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp1024 |         82.18 ± 0.39 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp2048 |         73.23 ± 0.77 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp4096 |         61.18 ± 0.24 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |             tg1 |         11.59 ± 0.09 |

build: 2a11f66e (6751)
[root@c643n08aix1-lp1 llama_2]# ./base_build/bin/llama-bench -m /dev/shm/Models/Meta-Llama-3-8B/ggml-model-q4.gguf -p 64,128,256,512 -n 1 -t 20 |& tee base_pp.log
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |            pp64 |        54.71 ± 13.62 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp128 |         71.76 ± 0.12 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp256 |         69.91 ± 0.51 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp512 |         67.20 ± 0.74 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |             tg1 |         11.74 ± 0.05 |

build: 56fc38b9 (6750)
[root@c643n08aix1-lp1 llama_2]# ./base_build/bin/llama-bench -m /dev/shm/Models/Meta-Llama-3-8B/ggml-model-q4.gguf -p 1024,2048,4096 -n 1 -t 20 |& tee base_large_pp.log
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp1024 |         62.75 ± 0.89 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp2048 |         58.51 ± 0.03 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |          pp4096 |         50.10 ± 0.42 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |             tg1 |         11.57 ± 0.06 |

build: 56fc38b9 (6750)

Change3:
Trying to make kc = 64 so that we get better reults. It was because we called compute_scale(ii+i, jj+j, kk, vs). But the correction is compute_scale(ii+i, jj+j, l+kk, vs). This solved the junk output issue This keeps local fin_res and accumultes into final C resulst after partial kc chunks are completed.

One more thing to note is if we do not inline compute scale and hoist a_scale out of the inner loop, it gives good bosst in perfromance.

This change is the final result.

| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |            pp64 |        72.42 ± 11.74 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp128 |         94.64 ± 1.45 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp256 |         97.01 ± 0.66 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |           pp512 |         94.54 ± 0.78 |
| llama 8B Q4_0                  |   4.33 GiB |     8.03 B | CPU        |      20 |             tg1 |         11.81 ± 0.08 |

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
