### PR TITLE
mtmd : Fix/Add non-ASCII file path support on Windows

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -24,6 +24,13 @@
 #include <array>
 #include <functional>
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 struct clip_logger_state g_logger_state = {clip_log_callback_default, NULL};
 
 //#define CLIP_DEBUG_FUNCTIONS
@@ -1837,7 +1844,21 @@ struct clip_model_loader {
         {
             std::vector<uint8_t> read_buf;
 
+#ifdef _WIN32
+            // Convert UTF-8 to UTF-16 for Windows
+            int wlen = MultiByteToWideChar(CP_UTF8, 0, fname.c_str(), -1, NULL, 0);
+            if (!wlen) {
+                throw std::runtime_error(string_format("%s: failed to convert filename to UTF-16: %s\n", __func__, fname.c_str()));
+            }
+            std::vector<wchar_t> wfname(wlen);
+            wlen = MultiByteToWideChar(CP_UTF8, 0, fname.c_str(), -1, wfname.data(), wlen);
+            if (!wlen) {
+                throw std::runtime_error(string_format("%s: failed to convert filename to UTF-16: %s\n", __func__, fname.c_str()));
+            }
+            auto fin = std::ifstream(wfname.data(), std::ios::binary);
+#else
             auto fin = std::ifstream(fname, std::ios::binary);
+#endif
             if (!fin) {
                 throw std::runtime_error(string_format("%s: failed to open %s\n", __func__, fname.c_str()));
             }

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -298,6 +298,9 @@ int main(int argc, char ** argv) {
 
     int n_predict = params.n_predict < 0 ? INT_MAX : params.n_predict;
 
+    console::init(params.simple_io, params.use_color);
+    atexit([]() { console::cleanup(); });
+
     // Ctrl+C handling
     {
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))


### PR DESCRIPTION
## Summary

Fixed path handling in the mtmd feature on Windows to correctly convert and process non-ASCII file paths.

Additionally, fixed a missing console initialization in mtmd-cli.

## Issues Resolved

- Failed to load .mmproj files with non-ASCII file paths

- Failed to load image files with non-ASCII file paths

- Incorrect path parsing in mtmd-cli when using `/image <filepath>` with non-ASCII characters

## Comparison of behavior

Windows 11 Pro 24H2

```
PS > Get-WinSystemLocale
LCID             Name             DisplayName
----             ----             -----------
1041             ja-JP            Japanese (Japan)
PS > [Console]::InputEncoding.EncodingName
Japanese (Shift-JIS)
PS > [Console]::OutputEncoding.EncodingName
Unicode (UTF-8)
```

b6756
```
PS > llama-mtmd-cli.exe -m ... --mmproj ...
~~~
> /image テスト画像.jpg
Unable to open file ﾂテﾂスﾂトﾂ嘉ｦﾂ堕・jpg: Illegal byte sequence
```

This PR
```
PS > llama-mtmd-cli.exe -m ... --mmproj ...
~~~
> /image テスト画像.jpg
テスト画像.jpg image loaded
```

## Notes

The general argument-handling logic in llama.cpp also has issues with non-ASCII paths.
Since the impact area is broad, I will submit a separate PR to address this.