### PR TITLE
[fix](ggml-cuda): ensure min 1 block per SM

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -895,6 +895,7 @@ void launch_fattn(
     const dim3 block_dim(warp_size, nwarps, 1);
     int max_blocks_per_sm = 1; // Max. number of active blocks limited by occupancy.
     CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, fattn_kernel, block_dim.x * block_dim.y * block_dim.z, nbytes_shared));
+    max_blocks_per_sm = std::max(max_blocks_per_sm, 1); // Safeguard, ensures at least one block can be launched.
     int parallel_blocks = max_blocks_per_sm;
 
     dim3 blocks_num;


### PR DESCRIPTION
# Description
Testing llama.cpp with Llama 3.2 model on RX 6700XT caused a floating point exception (SIGFPE) when launching the FlashAttention kernel (fattn_kernel):

```bash
Thread 1 "llama-cli" received signal SIGFPE, Arithmetic exception. 
0x000079c19ca40223 in void launch_fattn<64, 16, 1>(ggml_backend_cuda_context&, ggml_tensor*, void (*)(char const*, char const*, char const*, char const*, char const*, int const*, float*, HIP_vector_type<float, 2u>*, float, float, float, float, unsigned int, float, int, int, int, int, int, int, int, int, int, int, int, int, int, long, int, int, long, int, int, int, int, int, long), int, unsigned long, int, bool, bool, bool, int) () 
from /therock/src/external-builds/llama.cpp/llama.cpp/build/bin/libggml-hip.so
```
# Technical Explanation

The issue occurs because cudaOccupancyMaxActiveBlocksPerMultiprocessor sometimes returns 0 for max_blocks_per_sm due to high shared memory or register usage. This value is later used in a division:
```cpp
const int max_blocks = max_blocks_per_sm * nsm;
const int tiles_nwaves = (ntiles_total + max_blocks - 1) / max_blocks;
```
When max_blocks_per_sm is 0, this causes a division by zero, triggering the FPE.

# Fix:
Add a safeguard to ensure at least one block is launched:
```cpp
max_blocks_per_sm = std::max(max_blocks_per_sm, 1);
```

