### PR TITLE
CUDA: better error for FA kernel with 0 occupancy

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -895,6 +895,7 @@ void launch_fattn(
     const dim3 block_dim(warp_size, nwarps, 1);
     int max_blocks_per_sm = 1; // Max. number of active blocks limited by occupancy.
     CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, fattn_kernel, block_dim.x * block_dim.y * block_dim.z, nbytes_shared));
+    GGML_ASSERT(max_blocks_per_sm > 0);
     int parallel_blocks = max_blocks_per_sm;
 
     dim3 blocks_num;


### PR DESCRIPTION
I am unable to reproduce it but in https://github.com/ggml-org/llama.cpp/pull/16633 someone was somehow able to get an occupancy of 0 for a kernel. This PR adds an assert in order to get a better error than an arithmetic exception.