### PR TITLE
devops: add s390x release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
         include:
           - build: 'x64'
             os: ubuntu-22.04
+          - build: 's390x-z15' # z15 because our CI runners are on z15
+            os: ubuntu-22.04-s390x
           # GGML_BACKEND_DL and GGML_CPU_ALL_VARIANTS are not currently supported on arm
           # - build: 'arm64'
           #   os: ubuntu-22.04-arm


### PR DESCRIPTION
This PR introduces the s390x binaries to be released in https://github.com/ggml-org/llama.cpp/releases.

We have to specify a suffix of `z15` for now as the CI used is an IBM z15. IBM z16 and later systems can use the z15 binaries provided but will not get better performance improvements as the instruction set is not optimised for the newer systems.

We also unfortunately do not provide IBM zDNN backend binaries for now because it is only available on IBM z17 and later systems, which our CI is not at that hardware level yet.