### PR TITLE
ggml-cpu: optimise rms_norm op

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -3534,31 +3534,22 @@ static void ggml_compute_forward_rms_norm_f32(
 
     GGML_ASSERT(eps >= 0.0f);
 
-    // TODO: optimize
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = ith; i01 < ne01; i01 += nth) {
                 const float * x = (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03);
+                      float * y = (float *) ((char *)  dst->data + i01*nb1  + i02*nb2  + i03*nb3);
 
-                ggml_float sum = 0.0;
-                for (int64_t i00 = 0; i00 < ne00; i00++) {
-                    sum += (ggml_float)(x[i00] * x[i00]);
-                }
+                float sum = 0.0f;
+                ggml_vec_dot_f32(ne00, &sum, 0, x, 0, x, 0, 1);
 
-                const float mean = sum/ne00;
-
-                float * y = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
-
-                memcpy(y, x, ne00 * sizeof(float));
-                // for (int i00 = 0; i00 < ne00; i00++) {
-                //     y[i00] = x[i00];
-                // }
-
-                const float scale = 1.0f/sqrtf(mean + eps);
+                const float mean = sum / ne00;
+                const float scale = 1.0f / sqrtf(mean + eps);
 
                 // if you hit this, likely you got an inf somewhere earlier
                 assert(scale > 0.0f);
 
+                ggml_vec_cpy_f32(ne00, y, x);
                 ggml_vec_scale_f32(ne00, y, scale);
             }
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7012,6 +7012,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
         test_cases.emplace_back(new test_sum(GGML_TYPE_F32, it));
     }
 
+    test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, { 1024, 2, 1, 1 }, false, 1e-6f, false)); // qwen3-0.6b
+    test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, { 2048, 2, 1, 1 }, false, 1e-5f, false)); // llama-3.2-1b, granite-3.3-2b
+    test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, { 2880, 2, 1, 1 }, false, 1e-5f, false)); // gpt-oss-20b
+
     return test_cases;
 }
 


### PR DESCRIPTION
This PR optimises the `GGML_OP_RMS_NORM` operation and introduces performance test cases with reference to Qwen3-0.6B, Llama-3.2-1B, Granite-3.3-2B and GPT-OSS-20B dimensions and epsilons.

### Benchmark

This PR was tested on an Apple M1 Pro 10 Cores / 32 GB RAM.

#### Before Optimisation

```bash
$ build/bin/test-backend-ops -b CPU -o RMS_NORM

ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.026 sec
ggml_metal_device_init: GPU name:   Apple M1 Pro
ggml_metal_device_init: GPU family: MTLGPUFamilyApple7  (1007)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 22906.50 MB
Testing 3 devices

Backend 1/3: Metal
  Skipping
Backend 2/3: BLAS
  Skipping
Backend 3/3: CPU
  Device description: Apple M1 Pro
  Device memory: 32768 MB (32768 MB free)

  RMS_NORM(type=f32,ne=[1024,2,1,1],v=0,eps=0.000001,inplace=0):               98292 runs -    10.22 us/run -       16 kB/run -    1.49 GB/s
  RMS_NORM(type=f32,ne=[2048,2,1,1],v=0,eps=0.000010,inplace=0):               65528 runs -    15.65 us/run -       32 kB/run -    1.95 GB/s
  RMS_NORM(type=f32,ne=[2880,2,1,1],v=0,eps=0.000010,inplace=0):               57337 runs -    18.07 us/run -       45 kB/run -    2.38 GB/s
  Backend CPU: OK
3/3 backends passed
OK
```

#### After Optimisation

```bash
$ build/bin/test-backend-ops -b CPU -o RMS_NORM

ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.026 sec
ggml_metal_device_init: GPU name:   Apple M1 Pro
ggml_metal_device_init: GPU family: MTLGPUFamilyApple7  (1007)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 22906.50 MB
Testing 3 devices

Backend 1/3: Metal
  Skipping
Backend 2/3: BLAS
  Skipping
Backend 3/3: CPU
  Device description: Apple M1 Pro
  Device memory: 32768 MB (32768 MB free)

  RMS_NORM(type=f32,ne=[1024,2,1,1],v=0,eps=0.000001,inplace=0):              155629 runs -     6.88 us/run -       16 kB/run -    2.22 GB/s
  RMS_NORM(type=f32,ne=[2048,2,1,1],v=0,eps=0.000010,inplace=0):              139247 runs -     7.36 us/run -       32 kB/run -    4.14 GB/s
  RMS_NORM(type=f32,ne=[2880,2,1,1],v=0,eps=0.000010,inplace=0):              122865 runs -     8.26 us/run -       45 kB/run -    5.20 GB/s
  Backend CPU: OK
3/3 backends passed
OK
```