### PR TITLE
ggml: add ggml_can_fuse_subgraph

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2821,15 +2821,9 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
     std::initializer_list<enum ggml_op> topk_moe_ops           = ggml_cuda_topk_moe_ops(false);
     std::initializer_list<enum ggml_op> topk_moe_ops_with_norm = ggml_cuda_topk_moe_ops(true);
 
-    if (ops.size() == topk_moe_ops_with_norm.size() && std::equal(ops.begin(), ops.end(), topk_moe_ops_with_norm.begin())) {
-
-        if (node_idx + topk_moe_ops_with_norm.size() > (size_t)cgraph->n_nodes) {
-            return false;
-        }
-
-        for (size_t i = 0; i < topk_moe_ops_with_norm.size(); i++) {
-            if (cgraph->nodes[node_idx + i]->op != topk_moe_ops_with_norm.begin()[i]) return false;
-        }
+    if (ops.size() == topk_moe_ops_with_norm.size() && 
+        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops_with_norm, {node_idx}, {node_idx + 3, node_idx + 8})
+    ) {
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+8];
 
@@ -2838,15 +2832,7 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
         }
     }
 
-    if (ops.size() == topk_moe_ops.size() && std::equal(ops.begin(), ops.end(), topk_moe_ops.begin())) {
-
-        if (node_idx + topk_moe_ops.size() > (size_t)cgraph->n_nodes) {
-            return false;
-        }
-
-        for (size_t i = 0; i < topk_moe_ops.size(); i++) {
-            if (cgraph->nodes[node_idx + i]->op != topk_moe_ops.begin()[i]) return false;
-        }
+    if (ops.size() == topk_moe_ops.size() && ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops, {node_idx}, {node_idx+3, node_idx+4})) {
 
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+4];

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2822,8 +2822,7 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
     std::initializer_list<enum ggml_op> topk_moe_ops_with_norm = ggml_cuda_topk_moe_ops(true);
 
     if (ops.size() == topk_moe_ops_with_norm.size() &&
-        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops_with_norm, { node_idx },
-                               { node_idx + 3, node_idx + 8 })) {
+        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops_with_norm, { node_idx + 3, node_idx + 8 })) {
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+8];
 
@@ -2833,7 +2832,7 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
     }
 
     if (ops.size() == topk_moe_ops.size() &&
-        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops, { node_idx }, { node_idx + 3, node_idx + 4 })) {
+        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops, { node_idx + 3, node_idx + 4 })) {
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+4];
         if (ggml_cuda_should_use_topk_moe(softmax, weights)) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2821,9 +2821,9 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
     std::initializer_list<enum ggml_op> topk_moe_ops           = ggml_cuda_topk_moe_ops(false);
     std::initializer_list<enum ggml_op> topk_moe_ops_with_norm = ggml_cuda_topk_moe_ops(true);
 
-    if (ops.size() == topk_moe_ops_with_norm.size() && 
-        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops_with_norm, {node_idx}, {node_idx + 3, node_idx + 8})
-    ) {
+    if (ops.size() == topk_moe_ops_with_norm.size() &&
+        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops_with_norm, { node_idx },
+                               { node_idx + 3, node_idx + 8 })) {
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+8];
 
@@ -2832,8 +2832,8 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
         }
     }
 
-    if (ops.size() == topk_moe_ops.size() && ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops, {node_idx}, {node_idx+3, node_idx+4})) {
-
+    if (ops.size() == topk_moe_ops.size() &&
+        ggml_can_fuse_subgraph(cgraph, node_idx, topk_moe_ops, { node_idx }, { node_idx + 3, node_idx + 4 })) {
         ggml_tensor * softmax = cgraph->nodes[node_idx];
         ggml_tensor * weights = cgraph->nodes[node_idx+4];
         if (ggml_cuda_should_use_topk_moe(softmax, weights)) {

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -647,29 +647,26 @@ static inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx
     return ggml_can_fuse_ext(cgraph, idxs, ops, num_ops);
 }
 
-GGML_API bool ggml_can_fuse_subgraph_ext(
-        const struct ggml_cgraph * cgraph,
-        const int * node_idxs,
-        int count,
-        const enum ggml_op * ops,
-        const int * inputs,
-        int num_inputs,
-        const int * outputs,
-        int num_outputs);
+GGML_API bool ggml_can_fuse_subgraph_ext(const struct ggml_cgraph * cgraph,
+                                         const int *                node_idxs,
+                                         int                        count,
+                                         const enum ggml_op *       ops,
+                                         const int *                inputs,
+                                         int                        num_inputs,
+                                         const int *                outputs,
+                                         int                        num_outputs);
 
 // Returns true if the subgraph formed by {node_idxs} can be fused
 // checks whethers all nodes which are not part of inputs/outputs can be elided
 // by checking if their num_uses are confined to the subgraph
-static inline bool ggml_can_fuse_subgraph(
-        const struct ggml_cgraph * cgraph,
-        int node_idx,
-        int count,
-        const enum ggml_op * ops,
-        const int * inputs,
-        int num_inputs,
-        const int * outputs,
-        int num_outputs) {
-
+static inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph * cgraph,
+                                          int                        node_idx,
+                                          int                        count,
+                                          const enum ggml_op *       ops,
+                                          const int *                inputs,
+                                          int                        num_inputs,
+                                          const int *                outputs,
+                                          int                        num_outputs) {
     if (node_idx + count > cgraph->n_nodes) {
         return false;
     }
@@ -696,21 +693,13 @@ inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, std::
     return ggml_can_fuse(cgraph, node_idx, ops.begin(), (int)ops.size());
 }
 
-inline bool ggml_can_fuse_subgraph(
-        const struct ggml_cgraph * cgraph,
-        int start_idx,
-        std::initializer_list<enum ggml_op> ops,
-        std::initializer_list<int> inputs = {},
-        std::initializer_list<int> outputs = {}) {
-    return ggml_can_fuse_subgraph(
-        cgraph,
-        start_idx,
-        ops.size(),
-        ops.begin(),
-        inputs.begin(),
-        inputs.size(),
-        outputs.begin(),
-        outputs.size());
+inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph *          cgraph,
+                                   int                                 start_idx,
+                                   std::initializer_list<enum ggml_op> ops,
+                                   std::initializer_list<int>          inputs  = {},
+                                   std::initializer_list<int>          outputs = {}) {
+    return ggml_can_fuse_subgraph(cgraph, start_idx, ops.size(), ops.begin(), inputs.begin(), inputs.size(),
+                                  outputs.begin(), outputs.size());
 }
 
 // expose GGUF internals for test code

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -647,6 +647,42 @@ static inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx
     return ggml_can_fuse_ext(cgraph, idxs, ops, num_ops);
 }
 
+GGML_API bool ggml_can_fuse_subgraph_ext(
+        const struct ggml_cgraph * cgraph,
+        const int * node_idxs,
+        int count,
+        const enum ggml_op * ops,
+        const int * inputs,
+        int num_inputs,
+        const int * outputs,
+        int num_outputs);
+
+// Returns true if the subgraph formed by {node_idxs} can be fused
+// checks whethers all nodes which are not part of inputs/outputs can be elided
+// by checking if their num_uses are confined to the subgraph
+static inline bool ggml_can_fuse_subgraph(
+        const struct ggml_cgraph * cgraph,
+        int node_idx,
+        int count,
+        const enum ggml_op * ops,
+        const int * inputs,
+        int num_inputs,
+        const int * outputs,
+        int num_outputs) {
+
+    if (node_idx + count > cgraph->n_nodes) {
+        return false;
+    }
+
+    int idxs[32];
+
+    for (int i = 0; i < count; ++i) {
+        idxs[i] = node_idx + i;
+    }
+
+    return ggml_can_fuse_subgraph_ext(cgraph, idxs, count, ops, inputs, num_inputs, outputs, num_outputs);
+}
+
 #ifdef __cplusplus
 }
 #endif
@@ -658,6 +694,23 @@ static inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx
 // nicer C++ syntax for ggml_can_fuse
 inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, std::initializer_list<enum ggml_op> ops) {
     return ggml_can_fuse(cgraph, node_idx, ops.begin(), (int)ops.size());
+}
+
+inline bool ggml_can_fuse_subgraph(
+        const struct ggml_cgraph * cgraph,
+        int start_idx,
+        std::initializer_list<enum ggml_op> ops,
+        std::initializer_list<int> inputs = {},
+        std::initializer_list<int> outputs = {}) {
+    return ggml_can_fuse_subgraph(
+        cgraph,
+        start_idx,
+        ops.size(),
+        ops.begin(),
+        inputs.begin(),
+        inputs.size(),
+        outputs.begin(),
+        outputs.size());
 }
 
 // expose GGUF internals for test code

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -651,20 +651,16 @@ GGML_API bool ggml_can_fuse_subgraph_ext(const struct ggml_cgraph * cgraph,
                                          const int *                node_idxs,
                                          int                        count,
                                          const enum ggml_op *       ops,
-                                         const int *                inputs,
-                                         int                        num_inputs,
                                          const int *                outputs,
                                          int                        num_outputs);
 
 // Returns true if the subgraph formed by {node_idxs} can be fused
-// checks whethers all nodes which are not part of inputs/outputs can be elided
+// checks whethers all nodes which are not part of outputs can be elided
 // by checking if their num_uses are confined to the subgraph
 static inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph * cgraph,
                                           int                        node_idx,
                                           int                        count,
                                           const enum ggml_op *       ops,
-                                          const int *                inputs,
-                                          int                        num_inputs,
                                           const int *                outputs,
                                           int                        num_outputs) {
     if (node_idx + count > cgraph->n_nodes) {
@@ -677,7 +673,7 @@ static inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph * cgraph,
         idxs[i] = node_idx + i;
     }
 
-    return ggml_can_fuse_subgraph_ext(cgraph, idxs, count, ops, inputs, num_inputs, outputs, num_outputs);
+    return ggml_can_fuse_subgraph_ext(cgraph, idxs, count, ops, outputs, num_outputs);
 }
 
 #ifdef __cplusplus
@@ -696,10 +692,8 @@ inline bool ggml_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, std::
 inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph *          cgraph,
                                    int                                 start_idx,
                                    std::initializer_list<enum ggml_op> ops,
-                                   std::initializer_list<int>          inputs  = {},
                                    std::initializer_list<int>          outputs = {}) {
-    return ggml_can_fuse_subgraph(cgraph, start_idx, ops.size(), ops.begin(), inputs.begin(), inputs.size(),
-                                  outputs.begin(), outputs.size());
+    return ggml_can_fuse_subgraph(cgraph, start_idx, ops.size(), ops.begin(), outputs.begin(), outputs.size());
 }
 
 // expose GGUF internals for test code

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -663,6 +663,7 @@ static inline bool ggml_can_fuse_subgraph(const struct ggml_cgraph * cgraph,
                                           const enum ggml_op *       ops,
                                           const int *                outputs,
                                           int                        num_outputs) {
+    GGML_ASSERT(count < 32);
     if (node_idx + count > cgraph->n_nodes) {
         return false;
     }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6964,6 +6964,86 @@ void ggml_graph_print(const struct ggml_cgraph * cgraph) {
     GGML_LOG_INFO("========================================\n");
 }
 
+static int ggml_find_tensor_node_list(const struct ggml_cgraph * cgraph, const int * idxs, int count, const struct ggml_tensor * tensor) {
+    if (idxs == NULL || cgraph == NULL) {
+        return -1;
+    }
+
+    for(int i = 0; i < count; ++i) {
+        const int node_idx = idxs[count];
+
+        if (node_idx >= cgraph->n_nodes) {
+            return -1;
+        }
+        if (cgraph->nodes[node_idx] == tensor) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+bool ggml_can_fuse_subgraph_ext(
+        const struct ggml_cgraph * cgraph,
+        const int * node_idxs,
+        int count,
+        const enum ggml_op * ops,
+        const int * inputs,
+        int num_inputs,
+        const int * outputs,
+        int num_outputs) {
+
+    GGML_ASSERT(count < 32 && num_inputs > 0 && num_outputs > 0);
+    int interior_nodes_count = 0;
+    int interior_nodes[32];
+
+    for(int i = 0 ; i < count; ++i) {
+        if (node_idxs[i] >= cgraph->n_nodes || cgraph->nodes[node_idxs[i]]->op != ops[i]) {
+            return false;
+        }
+
+        const struct ggml_tensor * node = cgraph->nodes[node_idxs[i]];
+
+        if (node->flags & GGML_TENSOR_FLAG_OUTPUT) {
+            return false;
+        }
+
+        if (ggml_find_tensor_node_list(cgraph, inputs, num_inputs, node) != -1) {
+            continue;
+        }
+
+        if (ggml_find_tensor_node_list(cgraph, outputs, num_outputs, node) != -1) {
+            continue;
+        }
+
+        interior_nodes[interior_nodes_count++] = node_idxs[i];
+    }
+
+    // if interior-node has n-uses, ensure that all of them lie within in this subgraph
+    for(int i = 0 ; i < interior_nodes_count; ++i) {
+
+        const int num_uses = ggml_node_get_use_count(cgraph, interior_nodes[i]);
+
+        const struct ggml_tensor * node = cgraph->nodes[interior_nodes[i]];
+
+        int subgraph_uses = 0;
+        //check if all uses are within the graph
+        for(int j = 0; j < count; ++j) {
+            const struct ggml_tensor * other_node = cgraph->nodes[node_idxs[j]];
+            for(int src_idx = 0 ; src_idx < GGML_MAX_SRC; src_idx++) {
+                if (other_node->src[src_idx] && other_node->src[src_idx] == node) {
+                    subgraph_uses++;
+                }
+            }
+        }
+
+        if (subgraph_uses != num_uses) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // check if node is part of the graph
 static bool ggml_graph_find(const struct ggml_cgraph * cgraph, const struct ggml_tensor * node) {
     if (cgraph == NULL) {

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6964,13 +6964,16 @@ void ggml_graph_print(const struct ggml_cgraph * cgraph) {
     GGML_LOG_INFO("========================================\n");
 }
 
-static int ggml_find_tensor_node_list(const struct ggml_cgraph * cgraph, const int * idxs, int count, const struct ggml_tensor * tensor) {
+static int ggml_find_tensor_node_list(const struct ggml_cgraph * cgraph,
+                                      const int                *  idxs,
+                                      int                        count,
+                                      const struct ggml_tensor * tensor) {
     if (idxs == NULL || cgraph == NULL) {
         return -1;
     }
 
-    for(int i = 0; i < count; ++i) {
-        const int node_idx = idxs[count];
+    for (int i = 0; i < count; ++i) {
+        const int node_idx = idxs[i];
 
         if (node_idx >= cgraph->n_nodes) {
             return -1;
@@ -6982,21 +6985,19 @@ static int ggml_find_tensor_node_list(const struct ggml_cgraph * cgraph, const i
     return -1;
 }
 
-bool ggml_can_fuse_subgraph_ext(
-        const struct ggml_cgraph * cgraph,
-        const int * node_idxs,
-        int count,
-        const enum ggml_op * ops,
-        const int * inputs,
-        int num_inputs,
-        const int * outputs,
-        int num_outputs) {
-
+bool ggml_can_fuse_subgraph_ext(const struct ggml_cgraph * cgraph,
+                                const int *                node_idxs,
+                                int                        count,
+                                const enum ggml_op *       ops,
+                                const int *                inputs,
+                                int                        num_inputs,
+                                const int *                outputs,
+                                int                        num_outputs) {
     GGML_ASSERT(count < 32 && num_inputs > 0 && num_outputs > 0);
     int interior_nodes_count = 0;
     int interior_nodes[32];
 
-    for(int i = 0 ; i < count; ++i) {
+    for (int i = 0; i < count; ++i) {
         if (node_idxs[i] >= cgraph->n_nodes || cgraph->nodes[node_idxs[i]]->op != ops[i]) {
             return false;
         }
@@ -7019,17 +7020,16 @@ bool ggml_can_fuse_subgraph_ext(
     }
 
     // if interior-node has n-uses, ensure that all of them lie within in this subgraph
-    for(int i = 0 ; i < interior_nodes_count; ++i) {
-
+    for (int i = 0; i < interior_nodes_count; ++i) {
         const int num_uses = ggml_node_get_use_count(cgraph, interior_nodes[i]);
 
         const struct ggml_tensor * node = cgraph->nodes[interior_nodes[i]];
 
         int subgraph_uses = 0;
         //check if all uses are within the graph
-        for(int j = 0; j < count; ++j) {
+        for (int j = 0; j < count; ++j) {
             const struct ggml_tensor * other_node = cgraph->nodes[node_idxs[j]];
-            for(int src_idx = 0 ; src_idx < GGML_MAX_SRC; src_idx++) {
+            for (int src_idx = 0; src_idx < GGML_MAX_SRC; src_idx++) {
                 if (other_node->src[src_idx] && other_node->src[src_idx] == node) {
                     subgraph_uses++;
                 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7020,14 +7020,12 @@ bool ggml_can_fuse_subgraph_ext(const struct ggml_cgraph * cgraph,
         }
 
         // if node is a view, check if the view_src and all it's parent view_srcs are within the subgraph
-        if (node->view_src) {
-            struct ggml_tensor * view_src = node->view_src;
-            while (view_src) {
-                if (ggml_find_tensor_node_list(cgraph, node_idxs, count, view_src) == -1) {
-                    return false;
-                }
-                view_src = view_src->view_src;
+        struct ggml_tensor * view_src = node->view_src;
+        while (view_src) {
+            if (ggml_find_tensor_node_list(cgraph, node_idxs, count, view_src) == -1) {
+                return false;
             }
+            view_src = view_src->view_src;
         }
     }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6991,7 +6991,6 @@ bool ggml_can_fuse_subgraph_ext(const struct ggml_cgraph * cgraph,
     GGML_ASSERT(outputs && num_outputs > 0);
 
     for (int i = 0; i < count; ++i) {
-
         if (node_idxs[i] >= cgraph->n_nodes) {
             return false;
         }


### PR DESCRIPTION
This PR adds `ggml_can_fuse_subgraph` which is a less strict extension of `ggml_can_fuse`. It checks given inputs/outputs of a subgraph, whether all the intermediate tensors can be fused. Putting as draft to iterate on the correct API
