### PR TITLE
metal : adjust .get_alloc_size to be alloc friendly

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -191,6 +191,15 @@ static size_t ggml_backend_metal_buffer_type_get_alloc_size(ggml_backend_buffer_
                 res += ggml_metal_op_mul_mat_id_extra_tpe(tensor);
                 res += ggml_metal_op_mul_mat_id_extra_ids(tensor);
             } break;
+        case GGML_OP_MUL:
+        case GGML_OP_ADD_ID:
+            {
+                // TODO: ideally this should not be necessary
+                //       ref: https://github.com/ggml-org/llama.cpp/issues/16646#issuecomment-3419232927
+                if (tensor->src[0]->op == GGML_OP_ADD_ID || tensor->src[0]->op == GGML_OP_MUL_MAT_ID) {
+                    res = ggml_backend_metal_buffer_type_get_alloc_size(buft, tensor->src[0]);
+                }
+            } break;
         case GGML_OP_FLASH_ATTN_EXT:
             {
                 res += ggml_metal_op_flash_attn_ext_extra_pad(tensor);

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1071,7 +1071,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
 
     if (!weight_before_ffn) {
         experts = ggml_mul(ctx0, experts, weights);
-        cb(cur, "ffn_moe_weighted", il);
+        cb(experts, "ffn_moe_weighted", il);
     }
 
     ggml_tensor * cur_experts[LLAMA_MAX_EXPERTS] = { nullptr };


### PR DESCRIPTION
ref https://github.com/ggml-org/llama.cpp/issues/16646#issuecomment-3419232927

This seems to resolve the excessive compute buffer size, but I'm not yet sure that it's a good solution.

An alternative solution that seems to be more generic is to inplace ops only when the alloc size matches:

```diff
diff --git a/ggml/src/ggml-alloc.c b/ggml/src/ggml-alloc.c
index 929bc4488..da2234c66 100644
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -632,6 +632,20 @@ static void ggml_gallocr_allocate_node(ggml_gallocr_t galloc, struct ggml_tensor
                 }
 
                 struct hash_node * p_hn = ggml_gallocr_hash_get(galloc, parent);
+
+                {
+                    ggml_backend_buffer_type_t p_buft = galloc->bufts[p_hn->buffer_id];
+                    const size_t p_size = ggml_backend_buft_get_alloc_size(p_buft, parent);
+
+                    ggml_backend_buffer_type_t buft = galloc->bufts[buffer_id];
+                    const size_t size = ggml_backend_buft_get_alloc_size(buft, node);
+
+                    if (size != p_size) {
+                        AT_PRINTF("not reusing parent %s for %s as alloc sizes are different\n", parent->name, node->name);
+                        continue;
+                    }
+                }
+
                 if (p_hn->n_children == 1 && p_hn->n_views == 0) {
                     if (ggml_is_view(parent)) {
                         struct ggml_tensor * view_src = parent->view_src;

```