### PR TITLE
metal: add ops DIAG_MASK_INF, IM2COL_3D, fix op PAD

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1563,3 +1563,22 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd(ggml_metal_li
 
     return res;
 }
+
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_diag_mask_inf(ggml_metal_library_t lib, const ggml_tensor *op) {
+    assert(op->op == GGML_OP_DIAG_MASK_INF);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, sizeof(base), "kernel_op_diag_mask_inf_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, sizeof(name), "%s", base);
+
+    ggml_metal_pipeline_t res = ggml_metal_library_get_pipeline(lib, name);
+    if (res) {
+        return res;
+    }
+
+    res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+
+    return res;
+}

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1563,3 +1563,22 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd(ggml_metal_li
 
     return res;
 }
+
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_im2col_3d(ggml_metal_library_t lib, const ggml_tensor *op) {
+    assert(op->op == GGML_OP_IM2COL_3D);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_op_im2col_3d_%s", ggml_type_name(op->type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_t res = ggml_metal_library_get_pipeline(lib, base);
+    if (res) {
+        return res;
+    }
+
+    res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+
+    return res;
+}

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -138,6 +138,7 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_arange            (ggml_me
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_timestep_embedding(ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_adamw    (ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_diag_mask_inf     (ggml_metal_library_t lib, const struct ggml_tensor * op);
 
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_flash_attn_ext_pad(
         ggml_metal_library_t lib,

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -138,6 +138,7 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_arange            (ggml_me
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_timestep_embedding(ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_adamw    (ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_im2col_3d         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_flash_attn_ext_pad(
         ggml_metal_library_t lib,

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -814,6 +814,8 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_OPT_STEP_ADAMW:
         case GGML_OP_OPT_STEP_SGD:
             return has_simdgroup_reduction;
+        case GGML_OP_DIAG_MASK_INF:
+            return true;
         default:
             return false;
     }

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -691,8 +691,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_POOL_2D:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_PAD:
-            return (ggml_get_op_params_i32(op, 0) == 0) && (ggml_get_op_params_i32(op, 2) == 0) &&
-                   (ggml_get_op_params_i32(op, 4) == 0) && (ggml_get_op_params_i32(op, 6) == 0);
+            return true;
         case GGML_OP_PAD_REFLECT_1D:
         case GGML_OP_TIMESTEP_EMBEDDING:
         case GGML_OP_LEAKY_RELU:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -814,6 +814,8 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_OPT_STEP_ADAMW:
         case GGML_OP_OPT_STEP_SGD:
             return has_simdgroup_reduction;
+        case GGML_OP_IM2COL_3D:
+            return true;
         default:
             return false;
     }

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -728,6 +728,14 @@ typedef struct {
     uint64_t nb1;
     uint64_t nb2;
     uint64_t nb3;
+    int32_t  lp0;
+    int32_t  rp0;
+    int32_t  lp1;
+    int32_t  rp1;
+    int32_t  lp2;
+    int32_t  rp2;
+    int32_t  lp3;
+    int32_t  rp3;
 } ggml_metal_kargs_pad;
 
 typedef struct {

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -799,4 +799,12 @@ typedef struct {
     int64_t  np;
 } ggml_metal_kargs_opt_step_sgd;
 
+typedef struct {
+    uint64_t n_past;
+    uint64_t ne0;
+    uint64_t ne1;
+    uint64_t ne2;
+    uint64_t ne3;
+} ggml_metal_kargs_diag_mask_inf;
+
 #endif // GGML_METAL_IMPL

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -799,4 +799,35 @@ typedef struct {
     int64_t  np;
 } ggml_metal_kargs_opt_step_sgd;
 
+typedef struct {
+    uint32_t s0;
+    uint32_t s1;
+    uint32_t s2;
+    uint32_t p0;
+    uint32_t p1;
+    uint32_t p2;
+    uint32_t d0;
+    uint32_t d1;
+    uint32_t d2;
+    uint32_t IC;
+    uint32_t ID;
+    uint32_t IH;
+    uint32_t IW;
+    uint32_t KD;
+    uint32_t KH;
+    uint32_t KW;
+    uint32_t OD;
+    uint32_t OH;
+    uint32_t OW;
+    uint64_t nb13;
+    uint64_t nb12;
+    uint64_t nb11;
+    uint64_t nb10;
+    uint64_t OH_OW;
+    uint64_t KH_KW;
+    uint64_t KD_KH_KW;
+    uint64_t IC_KD_KH_KW;
+    uint64_t N;
+} ggml_metal_kargs_im2col_3d;
+
 #endif // GGML_METAL_IMPL

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -426,6 +426,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_opt_step_sgd(ctx, idx);
             } break;
+        case GGML_OP_IM2COL_3D:
+            {
+                n_fuse = ggml_metal_op_im2col_3d(ctx, idx);
+            } break;
        default:
             {
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(node->op));
@@ -3578,6 +3582,65 @@ int ggml_metal_op_opt_step_sgd(ggml_metal_op_t ctx, int idx) {
     const int64_t n = (np + nth - 1) / nth;
 
     ggml_metal_encoder_dispatch_threadgroups(enc, n, 1, 1, nth, 1, 1);
+
+    return 1;
+}
+
+int ggml_metal_op_im2col_3d(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor *dst = ctx->node(idx);
+    const ggml_tensor *src0 = dst->src[0];
+    const ggml_tensor *src1 = dst->src[1];
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_TENSOR_BINARY_OP_LOCALS;
+
+    ggml_metal_kargs_im2col_3d args = {
+        .s0 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 0)),
+        .s1 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 1)),
+        .s2 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 2)),
+        .p0 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 3)),
+        .p1 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 4)),
+        .p2 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 5)),
+        .d0 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 6)),
+        .d1 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 7)),
+        .d2 = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 8)),
+        .IC = static_cast<uint32_t>(ggml_get_op_params_i32(dst, 9)),
+
+        .ID = static_cast<uint32_t>(ne12),
+        .IH = static_cast<uint32_t>(ne11),
+        .IW = static_cast<uint32_t>(ne10),
+
+        .KD = static_cast<uint32_t>(ne02),
+        .KH = static_cast<uint32_t>(ne01),
+        .KW = static_cast<uint32_t>(ne00),
+
+        .OH = static_cast<uint32_t>(ne2),
+        .OW = static_cast<uint32_t>(ne1),
+    };
+
+    args.N            = ne13 / args.IC;
+    args.OD           = ne3 / args.N;
+    args.nb13         = nb13;
+    args.nb12         = nb12;
+    args.nb11         = nb11;
+    args.nb10         = nb10;
+
+    args.OH_OW        = (uint64_t) args.OH * args.OW;
+    args.KH_KW        = (uint64_t) args.KH * args.KW;
+    args.KD_KH_KW     = (uint64_t) args.KD * args.KH_KW;
+    args.IC_KD_KH_KW  = (uint64_t) args.IC * args.KD_KH_KW;
+
+    ggml_metal_pipeline_t pipeline = ggml_metal_library_get_pipeline_im2col_3d(lib, dst);
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(src1), 1);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(dst), 2);
+
+    const uint64_t total = (uint64_t) args.N * args.OD * args.OH * args.OW;
+    ggml_metal_encoder_dispatch_threadgroups(enc, total, 1, 1, 1, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -3242,6 +3242,15 @@ int ggml_metal_op_pad(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
     GGML_TENSOR_LOCALS(uint32_t, nb,  op,         nb);
 
+    const int32_t lp0 = ggml_get_op_params_i32(op, 0);
+    const int32_t rp0 = ggml_get_op_params_i32(op, 1);
+    const int32_t lp1 = ggml_get_op_params_i32(op, 2);
+    const int32_t rp1 = ggml_get_op_params_i32(op, 3);
+    const int32_t lp2 = ggml_get_op_params_i32(op, 4);
+    const int32_t rp2 = ggml_get_op_params_i32(op, 5);
+    const int32_t lp3 = ggml_get_op_params_i32(op, 6);
+    const int32_t rp3 = ggml_get_op_params_i32(op, 7);
+
     ggml_metal_kargs_pad args = {
         /*.ne00 =*/ ne00,
         /*.ne01 =*/ ne01,
@@ -3258,7 +3267,15 @@ int ggml_metal_op_pad(ggml_metal_op_t ctx, int idx) {
         /*.nb0  =*/ nb0,
         /*.nb1  =*/ nb1,
         /*.nb2  =*/ nb2,
-        /*.nb3  =*/ nb3
+        /*.nb3  =*/ nb3,
+        /*.lp0  =*/ lp0,
+        /*.rp0  =*/ rp0,
+        /*.lp1  =*/ lp1,
+        /*.rp1  =*/ rp1,
+        /*.lp2  =*/ lp2,
+        /*.rp2  =*/ rp2,
+        /*.lp3  =*/ lp3,
+        /*.rp3  =*/ rp3,
     };
 
     ggml_metal_pipeline_t pipeline = ggml_metal_library_get_pipeline_pad(lib, op);

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -82,6 +82,7 @@ int ggml_metal_op_argsort           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_leaky_relu        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_adamw    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_sgd      (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_diag_mask_inf     (ggml_metal_op_t ctx, int idx);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -82,6 +82,7 @@ int ggml_metal_op_argsort           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_leaky_relu        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_adamw    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_sgd      (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_im2col_3d         (ggml_metal_op_t ctx, int idx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I wrote this to fix a problem I was having working with [leejet/stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp). It may fix issues that other people are having, such as their [#850](https://github.com/leejet/stable-diffusion.cpp/issues/850) and [#857](https://github.com/leejet/stable-diffusion.cpp/issues/857).

As a user, I've already solved the issue for the audience that I care about. I'm offering this in hopes that it may be more helpful than merely opening an issue to complain about the missing/broken ops and going back to generating images of people with fish for heads walking down sidewalks. Yippee.

This commit is a (manual) octopus-merge of three independent commits, each of which could be converted into their own PR if this is overly broad.

``test-backend-ops -b Metal -o IM2COL_3D``, ``test-backend-ops -b Metal -o DIAG_MASK_INF``, and ``test-backend-ops -b Metal -o PAD`` all passed on:
```
ggml_metal_device_init: GPU name:   Apple M4 Pro
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 19069.67 MB
```