### PR TITLE
[RFC] vulkan: fix matmul pipeline selection for small n values

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5826,10 +5826,10 @@ static vk_pipeline ggml_vk_guess_matmul_pipeline(ggml_backend_vk_context * ctx, 
         return aligned ? mmp->a_s : mmp->s;
     }
 
-    if ((ctx->device->mul_mat_s[src0_type] && (m <= 32 || n <= 32)) || (!ctx->device->mul_mat_m[src0_type] && !ctx->device->mul_mat_l[src0_type])) {
+    if ((ctx->device->mul_mat_s[src0_type] && (m * n <= 32 * 32)) || (!ctx->device->mul_mat_m[src0_type] && !ctx->device->mul_mat_l[src0_type])) {
         return aligned ? mmp->a_s : mmp->s;
     }
-    if ((ctx->device->mul_mat_m[src0_type] && (m <= 64 || n <= 64)) || !ctx->device->mul_mat_l[src0_type]) {
+    if ((ctx->device->mul_mat_m[src0_type] && (m * n <= 64 * 64)) || !ctx->device->mul_mat_l[src0_type]) {
         return aligned ? mmp->a_m : mmp->m;
     }
     return aligned ? mmp->a_l : mmp->l;
@@ -5892,10 +5892,10 @@ static vk_pipeline ggml_vk_guess_matmul_id_pipeline(ggml_backend_vk_context * ct
         return aligned ? mmp->a_s : mmp->s;
     }
 
-    if ((ctx->device->mul_mat_id_s[src0_type] && (m <= 32 || n <= 32)) || (!ctx->device->mul_mat_id_m[src0_type] && !ctx->device->mul_mat_id_l[src0_type])) {
+    if ((ctx->device->mul_mat_id_s[src0_type] && (m * n <= 32 * 32)) || (!ctx->device->mul_mat_id_m[src0_type] && !ctx->device->mul_mat_id_l[src0_type])) {
         return aligned ? mmp->a_s : mmp->s;
     }
-    if ((ctx->device->mul_mat_id_m[src0_type] && (m <= 64 || n <= 64)) || !ctx->device->mul_mat_id_l[src0_type]) {
+    if ((ctx->device->mul_mat_id_m[src0_type] && (m * n <= 64 * 64)) || !ctx->device->mul_mat_id_l[src0_type]) {
         return aligned ? mmp->a_m : mmp->m;
     }
     return aligned ? mmp->a_l : mmp->l;


### PR DESCRIPTION
 Change mul_mat and mul_mat_id pipeline selection heuristic to prevent Intel Arc GPU hangs.

The previous logic would select the small pipeline (mul_mat_id_s) when one dimension was small, causing hangs on Intel Arc when, e.g. m=512 and n=23 as it happens with IBM Granite 4.

I've tested it with NVIDIA L4 and it doesn't affect the performance.

Marked as RFC as I am not sure if it is the right thing to do, but it definitely solves the problem on Intel Arc and after this change I've no problems to run the IBM Granite models.

```
00:02.0 VGA compatible controller: Intel Corporation Meteor Lake-P [Intel Arc Graphics] (rev 08) (prog-if 00 [VGA controller])
        Subsystem: Lenovo Device 2235
        Flags: bus master, fast devsel, latency 0, IRQ 179, IOMMU group 0
        Memory at 4058000000 (64-bit, prefetchable) [size=16M]
        Memory at 4000000000 (64-bit, prefetchable) [size=256M]
        Expansion ROM at 000c0000 [virtual] [disabled] [size=128K]
        Capabilities: <access denied>
        Kernel driver in use: i915
        Kernel modules: i915, xe
```