### PR TITLE
vulkan: deduplicate Microsoft Direct3D12 devices

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4733,7 +4733,12 @@ static void ggml_vk_instance_init() {
                         vk::PhysicalDeviceIDProperties old_id;
                         old_props.pNext = &old_id;
                         devices[k].getProperties2(&old_props);
-                        return std::equal(std::begin(old_id.deviceUUID), std::end(old_id.deviceUUID), std::begin(new_id.deviceUUID));
+
+                        bool equals = std::equal(std::begin(old_id.deviceUUID), std::end(old_id.deviceUUID), std::begin(new_id.deviceUUID));
+                        equals |= old_id.deviceLUIDValid && new_id.deviceLUIDValid &&
+                                 std::equal(std::begin(old_id.deviceLUID), std::end(old_id.deviceLUID), std::begin(new_id.deviceLUID));
+
+                        return equals;
                     }
                 );
                 if (old_device == vk_instance.device_indices.end()) {
@@ -4771,6 +4776,7 @@ static void ggml_vk_instance_init() {
 #endif
                             break;
                     }
+                    driver_priorities[vk::DriverId::eMesaDozen] = 4;
 
                     if (driver_priorities.count(old_driver.driverID)) {
                         old_priority = driver_priorities[old_driver.driverID];

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4736,7 +4736,7 @@ static void ggml_vk_instance_init() {
 
                         bool equals = std::equal(std::begin(old_id.deviceUUID), std::end(old_id.deviceUUID), std::begin(new_id.deviceUUID));
                         equals |= old_id.deviceLUIDValid && new_id.deviceLUIDValid &&
-                                 std::equal(std::begin(old_id.deviceLUID), std::end(old_id.deviceLUID), std::begin(new_id.deviceLUID));
+                            std::equal(std::begin(old_id.deviceLUID), std::end(old_id.deviceLUID), std::begin(new_id.deviceLUID));
 
                         return equals;
                     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4735,8 +4735,10 @@ static void ggml_vk_instance_init() {
                         devices[k].getProperties2(&old_props);
 
                         bool equals = std::equal(std::begin(old_id.deviceUUID), std::end(old_id.deviceUUID), std::begin(new_id.deviceUUID));
-                        equals |= old_id.deviceLUIDValid && new_id.deviceLUIDValid &&
-                            std::equal(std::begin(old_id.deviceLUID), std::end(old_id.deviceLUID), std::begin(new_id.deviceLUID));
+                        equals = equals || (
+                            old_id.deviceLUIDValid && new_id.deviceLUIDValid &&
+                            std::equal(std::begin(old_id.deviceLUID), std::end(old_id.deviceLUID), std::begin(new_id.deviceLUID))
+                        );
 
                         return equals;
                     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4776,7 +4776,7 @@ static void ggml_vk_instance_init() {
 #endif
                             break;
                     }
-                    driver_priorities[vk::DriverId::eMesaDozen] = 4;
+                    driver_priorities[vk::DriverId::eMesaDozen] = 100;
 
                     if (driver_priorities.count(old_driver.driverID)) {
                         old_priority = driver_priorities[old_driver.driverID];


### PR DESCRIPTION
A Microsoft Direct3D12 device appears on some Windows machines, which comes from the [Microsoft Dozen (Dzn) Vulkan driver](https://www.phoronix.com/news/Micorosft-Dzn-99p-Vulkan) that is built on top of Direct3D 12.

This PR fixes an issue where sometimes both the native device entry and the Direct3D12 device entry are picked up by llama.cpp, and since both point to the same underlying device, after using all the memory of the first device, buffer allocations on the second will always fail.

When a native Vulkan driver is already available for a given device, we now prioritize it over the Dozen driver for reduced overhead.
I found a [note on VulkanHub about the Direct3D12 device](https://vkdoc.net/man/VkPhysicalDeviceIDProperties#nuxt-ui-variables:~:text=that%20supports%20the-,Direct3D,-12%20API%20and) that was helpful in figuring this out.

---

#### Before
```
ggml_vulkan: Found 4 Vulkan devices:
ggml_vulkan: 0 = Microsoft Direct3D12 (AMD Radeon(TM) Graphics) (Dozen) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 32768 | int dot: 1 | matrix cores: none
ggml_vulkan: 1 = AMD Radeon(TM) Graphics (AMD proprietary driver) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 65536 | int dot: 1 | matrix cores: none
ggml_vulkan: 2 = NVIDIA GeForce RTX 3070 Ti Laptop GPU (NVIDIA) | uma: 0 | fp16: 1 | bf16: 1 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: NV_coopmat2
ggml_vulkan: 3 = Microsoft Direct3D12 (NVIDIA GeForce RTX 3070 Ti Laptop GPU) (Dozen) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 32768 | int dot: 1 | matrix cores: none
```

#### After
```
ggml_vulkan: Found 2 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon(TM) Graphics (AMD proprietary driver) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 65536 | int dot: 1 | matrix cores: none
ggml_vulkan: 1 = NVIDIA GeForce RTX 3070 Ti Laptop GPU (NVIDIA) | uma: 0 | fp16: 1 | bf16: 1 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: NV_coopmat2
```