### PR TITLE
mtmd: add mtmd_get_vision_image_size() and mtmd_get_vision_patch_size() functions

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -834,6 +834,22 @@ int mtmd_get_audio_bitrate(mtmd_context * ctx) {
     return 16000; // 16kHz
 }
 
+int mtmd_get_vision_image_size(mtmd_context * ctx) {
+    if (!ctx->ctx_v) {
+        return -1;
+    }
+
+    return clip_get_image_size(ctx->ctx_v);
+}
+
+int mtmd_get_vision_patch_size(mtmd_context * ctx) {
+    if (!ctx->ctx_v) {
+        return -1;
+    }
+
+    return clip_get_patch_size(ctx->ctx_v);
+}
+
 //
 // public API functions
 //

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -112,6 +112,14 @@ MTMD_API bool mtmd_support_audio(mtmd_context * ctx);
 // return -1 if audio is not supported
 MTMD_API int mtmd_get_audio_bitrate(mtmd_context * ctx);
 
+// get vision image size in pixels, for example 1024
+// return -1 if vision is not supported
+MTMD_API int mtmd_get_vision_image_size(mtmd_context * ctx);
+
+// get vision patch size, for example 14
+// return -1 if vision is not supported
+MTMD_API int mtmd_get_vision_patch_size(mtmd_context * ctx);
+
 // mtmd_bitmap
 //
 // if bitmap is image:


### PR DESCRIPTION
This PR adds `mtmd_get_vision_image_size()` and `mtmd_get_vision_patch_size()` functions as mentioned in #16703 