### PR TITLE
server : fix MTMD image_url injection

### DIFF
--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -756,7 +756,13 @@ static json oaicompat_chat_params_parse(
     }
 
     llama_params["chat_format"]      = static_cast<int>(chat_params.format);
-    llama_params["prompt"]           = chat_params.prompt;
+    if (!out_files.empty()) {
+        std::string prompt_mm = chat_params.prompt;
+        string_replace_all(prompt_mm, "<start_of_image><end_of_image>", mtmd_default_marker());
+        llama_params["prompt"] = std::move(prompt_mm);
+    } else {
+        llama_params["prompt"] = chat_params.prompt;
+    }
     if (!chat_params.grammar.empty()) {
         llama_params["grammar"] = chat_params.grammar;
     }


### PR DESCRIPTION
## Summary
  - normalize chat-template vision markers `<start_of_image><end_of_image>` to mtmd_default_marker() when image_url content is present
  - ensure process_mtmd_prompt() actually receives the downloaded image bytes so the vision response matches expectations
  
## Testing
  - DEBUG_EXTERNAL=1 LLAMA_CACHE= path_of_llama-cache \
    pytest -q -x tools/server/tests/unit/test_vision_api.py::test_vision_chat_completion -k 'IMG_URL_0 or IMG_BASE64_URI_0'
