### PR TITLE
ggml-cpu: arm64: q4_K repack gemm and gemv implementations (i8mm)

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -54,7 +54,7 @@
 #define ggml_gemv_q4_K_8x8_q8_K_generic ggml_gemv_q4_K_8x8_q8_K
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_q2_K_8x8_q8_K_generic ggml_gemv_q2_K_8x8_q8_K
-#define ggml_gemm_q4_K_8x8_q8_K_generic ggml_gemm_q4_K_8x8_q8_K
+// #define ggml_gemm_q4_K_8x8_q8_K_generic ggml_gemm_q4_K_8x8_q8_K
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_q2_K_8x8_q8_K_generic ggml_gemm_q2_K_8x8_q8_K
 #elif defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -51,7 +51,6 @@
 #elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
 // repack.cpp
 #define ggml_quantize_mat_q8_K_4x8_generic ggml_quantize_mat_q8_K_4x8
-#define ggml_gemv_q4_K_8x8_q8_K_generic ggml_gemv_q4_K_8x8_q8_K
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_q2_K_8x8_q8_K_generic ggml_gemv_q2_K_8x8_q8_K
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -54,7 +54,6 @@
 #define ggml_gemv_q4_K_8x8_q8_K_generic ggml_gemv_q4_K_8x8_q8_K
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_q2_K_8x8_q8_K_generic ggml_gemv_q2_K_8x8_q8_K
-// #define ggml_gemm_q4_K_8x8_q8_K_generic ggml_gemm_q4_K_8x8_q8_K
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_q2_K_8x8_q8_K_generic ggml_gemm_q2_K_8x8_q8_K
 #elif defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -525,7 +525,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+#if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
     constexpr int col_pairs = ncols_interleaved / 2;
     const uint8x16_t m4b = vdupq_n_u8(0x0f);
 
@@ -596,15 +596,15 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
                     uint8x16_t q4_qs_cp_2 = vld1q_u8(q4_base + 16 * cp + 128);
                     uint8x16_t q4_qs_cp_3 = vld1q_u8(q4_base + 16 * cp + 192);
 
-                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_0, m4b)), q8_qs[0]); // 0 .. 7
-                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_1, m4b)), q8_qs[1]); // 8 ..15
-                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_2, m4b)), q8_qs[2]); // 16..23
-                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_3, m4b)), q8_qs[3]); // 24..31
+                    acc_lo[cp] = ggml_vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_0, m4b)), q8_qs[0]); // 0 .. 7
+                    acc_lo[cp] = ggml_vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_1, m4b)), q8_qs[1]); // 8 ..15
+                    acc_lo[cp] = ggml_vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_2, m4b)), q8_qs[2]); // 16..23
+                    acc_lo[cp] = ggml_vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_3, m4b)), q8_qs[3]); // 24..31
 
-                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_0, 4)), q8_qs[4]); // 32..39
-                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_1, 4)), q8_qs[5]); // 40..47
-                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_2, 4)), q8_qs[6]); // 48..55
-                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_3, 4)), q8_qs[7]); // 56..63
+                    acc_hi[cp] = ggml_vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_0, 4)), q8_qs[4]); // 32..39
+                    acc_hi[cp] = ggml_vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_1, 4)), q8_qs[5]); // 40..47
+                    acc_hi[cp] = ggml_vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_2, 4)), q8_qs[6]); // 48..55
+                    acc_hi[cp] = ggml_vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_3, 4)), q8_qs[7]); // 56..63
                 }
 
 
@@ -652,7 +652,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
         vst1q_f32(s + base + 4, acc_f32[1]);
     }  // for x
     return;
-#endif
+#endif // #if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
     ggml_gemv_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
 }
 

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -2260,7 +2260,6 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
 
                 for (int i = 0; i < q8_k_blocklen; i++) {
                     for (int j = 0; j < 2; j++) {
-                        // TODO: Change to a single vmul
                         float32x4_t q8_d = vdupq_n_f32(q8_ptr[b].d[i]);
                         float32x4_t q4_dmin = vcvt_f32_f16(vld1_f16((const __fp16 *)(q4_ptr[b].dmin + j * 4)));
                         const float32x4_t dmins = vmulq_f32(q4_dmin, q8_d);

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -2086,8 +2086,6 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
 
     constexpr int ncols_interleaved = 8;
     constexpr int blocklen          = 8;
-    constexpr int q8_k_blocklen     = 4;
-
 
     assert(n % qk == 0);
     assert(nr % 4 == 0);
@@ -2104,6 +2102,7 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
     UNUSED(blocklen);
 
 #if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
+    constexpr int q8_k_blocklen     = 4;
     const uint8x16_t m4b = vdupq_n_u8(0x0f);
 
     // 8 accumulators: 2 row pairs × 4 col pairs

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -525,7 +525,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+#if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
     constexpr int col_pairs = ncols_interleaved / 2;
     const uint8x16_t m4b = vdupq_n_u8(0x0f);
 

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -1889,3 +1889,29 @@ void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
 #endif // #if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
     ggml_gemm_iq4_nl_4x4_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
+
+void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    GGML_ABORT("Expected in GEMV");
+}
+
+void ggml_gemm_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+    const int blocklen = 8;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+
+    UNUSED(s);
+    UNUSED(bs);
+    UNUSED(vx);
+    UNUSED(vy);
+    UNUSED(nr);
+    UNUSED(nc);
+    UNUSED(nb);
+    UNUSED(ncols_interleaved);
+    UNUSED(blocklen);
+
+    GGML_ABORT("Expected in GEMM");
+}

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -1890,75 +1890,48 @@ void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
     ggml_gemm_iq4_nl_4x4_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
 
-static inline void print_s8x16(const char *label, uint8x16_t v, bool print) {
-    if (!print) return;
-    int8_t tmp[16];
-    vst1q_s8(tmp, v); // store vector to memory
-    printf("%s:  ", label);
-    for (int i = 0; i < 16; i++) {
-        printf("%02x ", (uint8_t)tmp[i]);
-        if ((i + 1) % 8 == 0) printf("- ");  // wrap lines
-    }
-    printf("\n");
-}
-
-static inline void print_u8x16(const char *label, uint8x16_t v, bool print) {
-    if (!print) return;
-    uint8_t tmp[16];
-    vst1q_u8(tmp, v); // store vector to memory
-    printf("%s:  ", label);
-    for (int i = 0; i < 16; i++) {
-        printf("%02x ", tmp[i]);
-        if ((i + 1) % 8 == 0) printf("- ");  // wrap lines
-    }
-    printf("\n");
-}
-
-static inline void print_u16x8(const char *label, uint16x8_t v, bool print) {
-    if (!print) return;
-    uint16_t tmp[8];
-    vst1q_u16(tmp, v);
-
-    printf("%s:  ", label);
-    for (int i = 0; i < 8; i++) {
-        printf("%04x ", tmp[i]);
-    }
-    printf("\n");
-}
-
-
-static inline void print_s32x4(const char *label, int32x4_t v, bool print) {
-    if (!print) return;
-    int32_t tmp[4];
-    vst1q_s32(tmp, v);
-    printf("%s:  %d %d %d %d\n", label, tmp[0], tmp[1], tmp[2], tmp[3]);
-}
-
-
-static inline uint64_t ns_now() {
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-    return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
-}
-
-void ggml_gemm_q4_K_8x8_q8_K(int                        n, float * GGML_RESTRICT      s,
-                             size_t                     bs, const void * GGML_RESTRICT vx,
-                             const void * GGML_RESTRICT vy, int                        nr,
-                             int                        nc) {
-    constexpr int qk = QK_K;
-    const int nb = n / qk;
-
-    constexpr int ncols_interleaved = 8;
-    constexpr int blocklen = 8;
-    constexpr int q8_k_blocklen = 4;
-
+static inline void decode_q4_Kx8_scales_mins(const uint8_t * scales_in,
+                                             int16x8_t *     out_mins,
+                                             int8_t *        out_scales) {
     constexpr uint32_t kmask1 = 0x3f3f3f3f;
     constexpr uint32_t kmask2 = 0x0f0f0f0f;
     constexpr uint32_t kmask3 = 0x03030303;
+    constexpr uint8_t  scales_size = 12;
 
-    assert (n % qk == 0);
-    assert (nr % 4 == 0);
-    assert (nc % ncols_interleaved == 0);
+    uint32_t sm[3];
+    memcpy(sm, scales_in, scales_size);
+
+    const uint32_t   mins_0_3 = sm[1] & kmask1;
+    const uint32_t   mins_4_7 = ((sm[2] >> 4) & kmask2) | (((sm[1] >> 6) & kmask3) << 4);
+    const uint32x2_t mins_u32 = { mins_0_3, mins_4_7 };
+
+    *out_mins = vreinterpretq_s16_u16(vmovl_u8(vreinterpret_u8_u32(mins_u32)));
+
+    uint32_t scales_u32[2];
+    scales_u32[0] = sm[0] & kmask1;
+    scales_u32[1] = (sm[2] & kmask2) | (((sm[0] >> 6) & kmask3) << 4);
+    memcpy(out_scales, scales_u32, 8);
+}
+
+
+void ggml_gemm_q4_K_8x8_q8_K(int                        n,
+                             float * GGML_RESTRICT      s,
+                             size_t                     bs,
+                             const void * GGML_RESTRICT vx,
+                             const void * GGML_RESTRICT vy,
+                             int                        nr,
+                             int                        nc) {
+    constexpr int qk = QK_K;
+    const int     nb = n / qk;
+
+    constexpr int ncols_interleaved = 8;
+    constexpr int blocklen          = 8;
+    constexpr int q8_k_blocklen     = 4;
+
+
+    assert(n % qk == 0);
+    assert(nr % 4 == 0);
+    assert(nc % ncols_interleaved == 0);
 
     UNUSED(s);
     UNUSED(bs);
@@ -1972,461 +1945,187 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n, float * GGML_RESTRICT
 
     const uint8x16_t m4b = vdupq_n_u8(0x0f);
 
-    float sumf[blocklen][ncols_interleaved];
-    float sum_minf[blocklen][ncols_interleaved];
+    // 8 accumulators: 2 row pairs × 4 col pairs
+    float32x4_t acc_f32[blocklen];
 
-    uint32_t utmp[32];
-
-    int sumi1;
-    int sumi2;
-    int sumi;
-
-    static bool print_block = true;
-    if (print_block) {
-        printf("\n[DEBUG q4_K repack] ----\n");
-        const block_q4_Kx8 * q4_ptr = static_cast<const block_q4_Kx8*>(vx);
-        for (int sample = 0; sample < 2; sample++) {
-            printf("\nvy.qs (interleaved):\n");
-            for (int i = 0; i < 512; i++) {       // print first 256 bytes of result
-                printf("%02x ", ((const uint8_t*)q4_ptr[sample].qs)[i]);
-                if ((i + 1) % 8 == 0) printf("- ");  // wrap lines
-                if ((i + 1) % 64 == 0) printf("\n");  // wrap lines
-            }
-            printf("\n------------------------------------------------\n");
-        }
-        printf("\n[DEBUG q8_K block] ----\n");
-        const block_q8_Kx4 *q8_ptr = static_cast<const block_q8_Kx4*>(vy);
-        for (int sample = 0; sample < 2; sample++) {
-            printf("\nq8_ptr->qs (interleaved) sample %d:\n", sample);
-            const uint8_t *qs = reinterpret_cast<const uint8_t *>(q8_ptr->qs);
-            for (int i = 0; i < 256; i++) {
-                printf("%02x ", qs[256 * sample + i]);
-                if ((i + 1) % 8 == 0)  printf("- ");
-                if ((i + 1) % 64 == 0) printf("\n");
-            }
-            printf("\n------------------------------------------------\n");
-        }
-    }
-
-    // INFO: TILING
-    // TODO: Fix boundaries for the tiling once the inner mul_mat is done
-    constexpr int y_step = blocklen / q8_k_blocklen; // 8 / 4 == 2
-    for (int y = 0; y < nr / q8_k_blocklen; y += y_step) {
+    for (int y = 0; y < nr / q8_k_blocklen; y++) {
         const block_q8_Kx4 * GGML_RESTRICT q8_ptr = (const block_q8_Kx4 *) vy + (y * nb);
 
-        // TODO: Fix boundaries for the tiling once the inner mul_mat is done
         for (int x = 0; x < nc / ncols_interleaved; x++) {
             const block_q4_Kx8 * GGML_RESTRICT q4_ptr = (const block_q4_Kx8 *) vx + (x * nb);
 
-            // TODO: float32x4x8
-            for (int m = 0; m < blocklen; m++) {
-                for (int j = 0; j < ncols_interleaved; j++) {
-                    sumf[m][j] = 0.0;
-                    sum_minf[m][j] = 0.0;
+            for (int i = 0; i < blocklen; i++) {
+                acc_f32[i] = vdupq_n_f32(0);
+            }
+
+            for (int b = 0; b < nb; b++) {
+                // bsums pairs belongs to the same q8_k subblock
+                const int16x8_t y_bsums[4]{
+                    vpaddq_s16(vld1q_s16(q8_ptr[b].bsums + 16 * 0), vld1q_s16(q8_ptr[b].bsums + 16 * 0 + 8)),
+                    vpaddq_s16(vld1q_s16(q8_ptr[b].bsums + 16 * 1), vld1q_s16(q8_ptr[b].bsums + 16 * 1 + 8)),
+                    vpaddq_s16(vld1q_s16(q8_ptr[b].bsums + 16 * 2), vld1q_s16(q8_ptr[b].bsums + 16 * 2 + 8)),
+                    vpaddq_s16(vld1q_s16(q8_ptr[b].bsums + 16 * 3), vld1q_s16(q8_ptr[b].bsums + 16 * 3 + 8)),
+                };
+
+                int32x4_t sb_acc[4];   // Aux accumulators to store subblock (partial) results
+                int32x4_t acc[8];      // rows 01 stored in [0][1][2][3] rows 23 stored in [4][5][6][7]
+                int32x4_t bias_acc[8]; // interleaved bias_acc: [0]->r0 0123, [1]->r0 4567, [2]->r1 0123 ...
+                for (int i = 0; i < 8; ++i) {
+                    acc[i]      = vdupq_n_s32(0);
+                    bias_acc[i] = vdupq_n_s32(0);
+                }
+
+                for (int sb = 0; sb < QK_K / 64; sb++) {
+                    // Need scales for the low and high nibbles
+                    // 2 * 12 = 24 bytes per subblock, 4 sbs -> 4 * 24 = 96 bytes total
+                    int8_t    q4sb_scales[2][8];
+                    int16x8_t q4sb_mins[2];  // int16 as its needed for bias_acc later
+                    for (int i = 0; i < 2; i++) {
+                        const int offset = sb * 24 + i * 12;
+                        decode_q4_Kx8_scales_mins(&q4_ptr[b].scales[offset], &q4sb_mins[i], q4sb_scales[i]);
+                    }
+
+                    // q8_ptr[b].qs has interleaved Q8 rows (01, 23)
+                    const int8_t *q8_base = q8_ptr[b].qs + sb * 256;
+
+                    int8x16_t q8_qs_01[8];
+                    int8x16_t q8_qs_23[8];
+
+                    // Load 32-byte per row pair, 1 subblock each time
+                    for (int i = 0; i < 8; ++i) {
+                        const int offset = i * 32;  // 16 for row 01, 16 for row 23
+                        q8_qs_01[i] = vld1q_s8(q8_base + offset);
+                        q8_qs_23[i] = vld1q_s8(q8_base + offset + 16);
+                    }
+
+                    const int8x16_t q8s[2][8] = {
+                        { q8_qs_01[0], q8_qs_01[1], q8_qs_01[2], q8_qs_01[3],
+                          q8_qs_01[4], q8_qs_01[5], q8_qs_01[6], q8_qs_01[7] },
+                        { q8_qs_23[0], q8_qs_23[1], q8_qs_23[2], q8_qs_23[3],
+                          q8_qs_23[4], q8_qs_23[5], q8_qs_23[6], q8_qs_23[7] },
+                    };
+
+                    // Q4s columns iterated in pairs (01, 23, 45, 67)
+                    for (int cp = 0; cp < ncols_interleaved / 2; cp++) {
+                        for (int i = 0; i < 4; ++i) {
+                            sb_acc[i] = vdupq_n_s32(0);
+                        }
+
+                        uint8x16_t q4_qs_cp_0 = vld1q_u8(q4_ptr[b].qs + sb * QK_K + 16 * cp + 0);    // 0 .. 7 & 32..39
+                        uint8x16_t q4_qs_cp_1 = vld1q_u8(q4_ptr[b].qs + sb * QK_K + 16 * cp + 64);   // 8 ..15 & 40..47
+                        uint8x16_t q4_qs_cp_2 = vld1q_u8(q4_ptr[b].qs + sb * QK_K + 16 * cp + 128);  // 16..23 & 48..55
+                        uint8x16_t q4_qs_cp_3 = vld1q_u8(q4_ptr[b].qs + sb * QK_K + 16 * cp + 192);  // 24..31 & 56..63
+                        const int8x16_t q4_nibbles[2][4] = {
+                            {
+                                vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_0, m4b)),
+                                vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_1, m4b)),
+                                vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_2, m4b)),
+                                vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_3, m4b)),
+                            },
+                            {
+                                vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_0, 4)),
+                                vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_1, 4)),
+                                vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_2, 4)),
+                                vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_3, 4)),
+                            }
+                        };
+
+                        // Calculates the Qs muladd of every row pair (rp) rows 01 and 23 of q8
+                        // for each of the internal 32 qs subblock (blk)
+                        for (int rp = 0; rp < 2; rp++) {
+                            for (int blk = 0; blk < 2; blk++) {
+                                const int8x16_t * q8  = &q8s[rp][4 * blk];
+                                const int8x16_t * q4  = q4_nibbles[blk];
+                                int32x4_t         acc = sb_acc[2 * rp + blk];
+                                // mul add for each qs in the same subblock
+                                for (int qs_offset = 0; qs_offset < 4; qs_offset++) {
+                                    acc = vmmlaq_s32(acc, q4[qs_offset], q8[qs_offset]);
+                                }
+                                sb_acc[2 * rp + blk] = acc;
+                            }
+                        }
+
+                        // Scales[i] corresponds to column i
+                        const int scale_offset = cp * 2;
+                        for (int blk = 0; blk < 2; blk++) {
+                            const int32x4_t block_scale = {
+                                (int32_t) q4sb_scales[blk][scale_offset],
+                                (int32_t) q4sb_scales[blk][scale_offset],
+                                (int32_t) q4sb_scales[blk][scale_offset + 1],
+                                (int32_t) q4sb_scales[blk][scale_offset + 1],
+                            };
+                            acc[cp]     = vmlaq_s32(acc[cp], sb_acc[blk], block_scale);
+                            acc[cp + 4] = vmlaq_s32(acc[cp + 4], sb_acc[blk + 2], block_scale);
+                        }
+                    }
+
+                    // Multiply Acc bsum + mins
+                    for (int q8_row = 0; q8_row < 4; q8_row++) {
+                        // Each pair of subblocks share the same bsums
+                        // Load scalar bsum → broadcast to a vector (vdupq_n_s16(s)).
+                        int16x8_t bsums_vec_lo = vdupq_n_s16(y_bsums[sb][q8_row * 2]);
+                        int16x8_t bsums_vec_hi = vdupq_n_s16(y_bsums[sb][q8_row * 2 + 1]);
+
+                        bias_acc[2 * q8_row] =
+                            vmlal_s16(bias_acc[2 * q8_row], vget_low_s16(bsums_vec_lo), vget_low_s16(q4sb_mins[0]));
+                        bias_acc[2 * q8_row] =
+                            vmlal_s16(bias_acc[2 * q8_row], vget_low_s16(bsums_vec_hi), vget_low_s16(q4sb_mins[1]));
+                        bias_acc[2 * q8_row + 1] = vmlal_s16(bias_acc[2 * q8_row + 1], vget_high_s16(bsums_vec_lo),
+                                                             vget_high_s16(q4sb_mins[0]));
+                        bias_acc[2 * q8_row + 1] = vmlal_s16(bias_acc[2 * q8_row + 1], vget_high_s16(bsums_vec_hi),
+                                                             vget_high_s16(q4sb_mins[1]));
+                    }
+                }  // for sb
+
+                // Reorder of i8mm output with bias and output layout
+                for (int i = 0; i < 8; i++) {
+                    int32x2x2_t aux = vzip_s32(vget_low_s32(acc[i]), vget_high_s32(acc[i]));
+                    acc[i]          = vcombine_s32(aux.val[0], aux.val[1]);
+                }
+                int32x4_t reorder_acc[8] = {
+                    vcombine_s32(vget_low_s32(acc[0]), vget_low_s32(acc[1])),
+                    vcombine_s32(vget_low_s32(acc[2]), vget_low_s32(acc[3])),
+                    vcombine_s32(vget_high_s32(acc[0]), vget_high_s32(acc[1])),
+                    vcombine_s32(vget_high_s32(acc[2]), vget_high_s32(acc[3])),
+                    vcombine_s32(vget_low_s32(acc[4]), vget_low_s32(acc[5])),
+                    vcombine_s32(vget_low_s32(acc[6]), vget_low_s32(acc[7])),
+                    vcombine_s32(vget_high_s32(acc[4]), vget_high_s32(acc[5])),
+                    vcombine_s32(vget_high_s32(acc[6]), vget_high_s32(acc[7])),
+                };
+
+                for (int i = 0; i < q8_k_blocklen; i++) {
+                    for (int j = 0; j < 2; j++) {
+                        const float32x4_t dmins = {
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].dmin[j * 4 + 0]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].dmin[j * 4 + 1]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].dmin[j * 4 + 2]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].dmin[j * 4 + 3]),
+                        };
+
+                        const float32x4_t scale = {
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].d[j * 4 + 0]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].d[j * 4 + 1]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].d[j * 4 + 2]),
+                            q8_ptr[b].d[i] * GGML_CPU_FP16_TO_FP32(q4_ptr[b].d[j * 4 + 3]),
+                        };
+
+                        acc_f32[2 * i + j] = vmlsq_f32(acc_f32[2 * i + j], vcvtq_f32_s32(bias_acc[2 * i + j]), dmins);
+                        acc_f32[2 * i + j] =
+                            vmlaq_f32(acc_f32[2 * i + j], vcvtq_f32_s32(reorder_acc[2 * i + j]), scale);
+                    }
+                }
+            }  // for b
+
+            // With the previous reorder, the tile is already in the correct memory layout.
+            for (int i = 0; i < q8_k_blocklen; i++) {
+                int row = y * q8_k_blocklen + i;
+                for (int j = 0; j < 2; j++) {
+                    int col    = x * ncols_interleaved + j * 4;
+                    int offset = row * bs + col;
+                    vst1q_f32(s + offset, acc_f32[2 * i + j]);
                 }
             }
-
-            // 8 accumulators: 2 row pairs × 4 col pairs
-            int32x4_t acc[8];
-            for (int i = 0; i < 8; ++i) {
-                acc[i] = vdupq_n_s32(0);
-            }
-            // INFO: Computation of a single 8x4 block
-            for (int b = 0; b < nb; b++) {
-
-                // two rows in q4_Kx8 matches a single row in q8_Kx4
-                int32x4_t sb_acc[4];
-                for (int sb = 0; sb < QK_K / 64; sb++) {
-
-                    // decode scales and mins
-                    // TODO: Need lo and hi scales 2*12 = 24 bytes per sb, 4 sbs -> 4 * 24 = 96 bytes total
-                    int8_t q4sb_scales[2][8];
-                    int16x8_t q4sb_mins[2];  // int16 as its needed for bias correction later
-                    {  //r0-7 0..31
-                        uint32_t scales_mins[3];
-                        memcpy(scales_mins, &q4_ptr[b].scales[sb * 24], 12);
-                        const uint32_t mins_0_3 = scales_mins[1] & kmask1;
-                        const uint32_t mins_4_7 = ((scales_mins[2] >> 4) & kmask2) | (((scales_mins[1] >> 6) & kmask3) << 4);
-                        const uint32x2_t mins = {mins_0_3, mins_4_7};
-                        q4sb_mins[0] = vreinterpretq_s16_u16(vmovl_u8(vreinterpret_u8_u32(mins)));
-                        uint32_t scales[2];
-                        scales[0] = scales_mins[0] & kmask1; // scales 0~3
-                        scales[1] = (scales_mins[2] & kmask2) | (((scales_mins[0] >> 6) & kmask3) << 4); // scales 4~7
-                        memcpy(q4sb_scales[0], scales, 8);
-                    }
-                    {  //r 0-7 32..64
-                        uint32_t scales_mins[3];
-                        memcpy(scales_mins, &q4_ptr[b].scales[sb * 24 + 12], 12);
-                        const uint32_t mins_0_3 = scales_mins[1] & kmask1;
-                        const uint32_t mins_4_7 = ((scales_mins[2] >> 4) & kmask2) | (((scales_mins[1] >> 6) & kmask3) << 4);
-                        const uint32x2_t mins = {mins_0_3, mins_4_7};
-                        q4sb_mins[1] = vreinterpretq_s16_u16(vmovl_u8(vreinterpret_u8_u32(mins)));
-                        uint32_t scales[2];
-                        scales[0] = scales_mins[0] & kmask1; // scales 0~3
-                        scales[1] = (scales_mins[2] & kmask2) | (((scales_mins[0] >> 6) & kmask3) << 4); // scales 4~7
-                        memcpy(q4sb_scales[1], scales, 8);
-                    }
-
-                    if (b == 0) print_block = true;
-                    if(print_block) printf(" SB == %d (B = %d) -------  \n", sb, b);
-                    if(print_block) printf(" blk = %d ", 2 * sb);
-                    if(print_block) printf("q4_scales_lo: ");
-                    for (int ii = 0; ii < 8; ii++) {
-                        if(print_block) printf("%d ", q4sb_scales[0][ii]);
-                    }
-                    if(print_block) printf("\n");
-                    if(print_block) printf(" blk = %d ", 2 * sb + 1);
-                    if(print_block) printf("q4_scales_hi: ");
-                    for (int ii = 0; ii < 8; ii++) {
-                        if(print_block) printf("%d ", q4sb_scales[1][ii]);
-                    }
-                    if(print_block) printf("\n");
-                    print_u16x8("q4sb_mins_lo", q4sb_mins[0], print_block);
-                    print_u16x8("q4sb_mins_hi", q4sb_mins[1], print_block);
-                    print_block = false;
-
-                    // TODO: x4 reads
-                    uint8x16_t q4_qs_01_0 = vld1q_u8(q4_ptr[b].qs + sb * QK_K);
-                    uint8x16_t q4_qs_23_0 = vld1q_u8(q4_ptr[b].qs + 16 + sb * QK_K);
-                    uint8x16_t q4_qs_45_0 = vld1q_u8(q4_ptr[b].qs + 32 + sb * QK_K);
-                    uint8x16_t q4_qs_67_0 = vld1q_u8(q4_ptr[b].qs + 48 + sb * QK_K);
-
-                    print_u8x16("q4_qs_01_0", q4_qs_01_0, print_block);
-                    print_u8x16("q4_qs_23_0", q4_qs_23_0, print_block);
-                    print_u8x16("q4_qs_45_0", q4_qs_45_0, print_block);
-                    print_u8x16("q4_qs_67_0", q4_qs_67_0, print_block);
-
-                    uint8x16_t q4_qs_01_1 = vld1q_u8(q4_ptr[b].qs + 64 + sb * QK_K);
-                    uint8x16_t q4_qs_23_1 = vld1q_u8(q4_ptr[b].qs + 80 + sb * QK_K);
-                    uint8x16_t q4_qs_45_1 = vld1q_u8(q4_ptr[b].qs + 96 + sb * QK_K);
-                    uint8x16_t q4_qs_67_1 = vld1q_u8(q4_ptr[b].qs + 112 + sb * QK_K);
-                    print_u8x16("q4_qs_01_1", q4_qs_01_1, print_block);
-                    print_u8x16("q4_qs_23_1", q4_qs_23_1, print_block);
-                    print_u8x16("q4_qs_45_1", q4_qs_45_1, print_block);
-                    print_u8x16("q4_qs_67_1", q4_qs_67_1, print_block);
-
-                    uint8x16_t q4_qs_01_2 = vld1q_u8(q4_ptr[b].qs + 128 + sb * QK_K);
-                    uint8x16_t q4_qs_23_2 = vld1q_u8(q4_ptr[b].qs + 144 + sb * QK_K);
-                    uint8x16_t q4_qs_45_2 = vld1q_u8(q4_ptr[b].qs + 160 + sb * QK_K);
-                    uint8x16_t q4_qs_67_2 = vld1q_u8(q4_ptr[b].qs + 176 + sb * QK_K);
-                    print_u8x16("q4_qs_01_2", q4_qs_01_2, print_block);
-                    print_u8x16("q4_qs_23_2", q4_qs_23_2, print_block);
-                    print_u8x16("q4_qs_45_2", q4_qs_45_2, print_block);
-                    print_u8x16("q4_qs_67_2", q4_qs_67_2, print_block);
-
-                    uint8x16_t q4_qs_01_3 = vld1q_u8(q4_ptr[b].qs + 192 +sb * QK_K);
-                    uint8x16_t q4_qs_23_3 = vld1q_u8(q4_ptr[b].qs + 208 + sb * QK_K);
-                    uint8x16_t q4_qs_45_3 = vld1q_u8(q4_ptr[b].qs + 224 + sb * QK_K);
-                    uint8x16_t q4_qs_67_3 = vld1q_u8(q4_ptr[b].qs + 240 + sb * QK_K);
-                    print_u8x16("q4_qs_01_3", q4_qs_01_3, print_block);
-                    print_u8x16("q4_qs_23_3", q4_qs_23_3, print_block);
-                    print_u8x16("q4_qs_45_3", q4_qs_45_3, print_block);
-                    print_u8x16("q4_qs_67_3", q4_qs_67_3, print_block);
-
-                    int8x16_t q8_qs_01_0 = vld1q_s8(q8_ptr[b].qs + sb * 256 +   0);  // Q8-01, 0..7
-                    int8x16_t q8_qs_23_0 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  16);  // Q8-23, 0..7
-                    int8x16_t q8_qs_01_1 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  32);  // Q8-01, 8..15
-                    int8x16_t q8_qs_23_1 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  48);  // Q8-23, 8..15
-
-                    int8x16_t q8_qs_01_2 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  64);  // Q8-01, 16..23
-                    int8x16_t q8_qs_23_2 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  80);  // Q8-23, 16..23
-                    int8x16_t q8_qs_01_3 = vld1q_s8(q8_ptr[b].qs + sb * 256 +  96);  // Q8-01, 24..31
-                    int8x16_t q8_qs_23_3 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 112);  // Q8-23, 24..31
-
-                    int8x16_t q8_qs_01_4 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 128);  // Q8-01, 32..39
-                    int8x16_t q8_qs_23_4 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 144);  // Q8-23, 32..39
-                    int8x16_t q8_qs_01_5 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 160);  // Q8-01, 40..47
-                    int8x16_t q8_qs_23_5 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 176);  // Q8-23, 40..47
-
-                    int8x16_t q8_qs_01_6 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 192);  // Q8-01, 48..55
-                    int8x16_t q8_qs_23_6 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 208);  // Q8-23, 48..55
-                    int8x16_t q8_qs_01_7 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 224);  // Q8-01, 56..63
-                    int8x16_t q8_qs_23_7 = vld1q_s8(q8_ptr[b].qs + sb * 256 + 240);  // Q8-23, 56..63
-
-                    // ---- q4_qs_01 ----
-                    for (int i = 0; i < 4; ++i) {
-                        sb_acc[i] = vdupq_n_s32(0);
-                    }
-
-                    int8x16_t q4_qs_01_0_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_01_0, m4b)); // Q4-01 0..7
-                    int8x16_t q4_qs_01_1_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_01_1, m4b)); // Q4-01 8..15
-                    int8x16_t q4_qs_01_2_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_01_2, m4b)); // Q4-01 16..23
-                    int8x16_t q4_qs_01_3_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_01_3, m4b)); // Q4-01 24..31
-                    int8x16_t q4_qs_01_0_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_01_0, 4)); // Q4-01 32..39
-                    int8x16_t q4_qs_01_1_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_01_1, 4)); // Q4-01 40..47
-                    int8x16_t q4_qs_01_2_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_01_2, 4)); // Q4-01 48..55
-                    int8x16_t q4_qs_01_3_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_01_3, 4)); // Q4-01 56..63
-
-                    // 01-01
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_01_0_lo, q8_qs_01_0); // 0011 blk0
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_01_1_lo, q8_qs_01_1);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_01_2_lo, q8_qs_01_2);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_01_3_lo, q8_qs_01_3);
-
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_01_0_hi, q8_qs_01_4); // 0011 blk1
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_01_1_hi, q8_qs_01_5);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_01_2_hi, q8_qs_01_6);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_01_3_hi, q8_qs_01_7);
-
-                    // 23-01
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_01_0_lo, q8_qs_23_0); // 0011 blk0
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_01_1_lo, q8_qs_23_1);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_01_2_lo, q8_qs_23_2);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_01_3_lo, q8_qs_23_3);
-
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_01_0_hi, q8_qs_23_4); // 0011 blk1
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_01_1_hi, q8_qs_23_5);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_01_2_hi, q8_qs_23_6);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_01_3_hi, q8_qs_23_7);
-
-
-                    int blk = 0;
-                    int row_begin = 0;
-                    for (int tid = 0; tid < 4; tid++) {
-                        const int32x4_t block_scale = {
-                            (int32_t) q4sb_scales[blk][0],
-                            (int32_t) q4sb_scales[blk][0],
-                            (int32_t) q4sb_scales[blk][1],
-                            (int32_t) q4sb_scales[blk][1],
-                        };
-                        // if (print_block) printf("-- ACC = %d (0011 blk %d) ", tid, blk);
-                        blk ^= 1;
-                        // if (b == 0) print_block = true;
-                        // print_s32x4("block_scale", block_scale, print_block);
-                        // print_s32x4("sb_acc", sb_acc[tid], print_block);
-                        acc[tid / 2 + row_begin] = vmlaq_s32(acc[tid / 2 + row_begin], sb_acc[tid], block_scale);
-                        // print_s32x4("acc[tid]", acc[tid / 2], print_block);
-                        print_block=false;
-                    }
-
-                    // ---- q4_qs_23 ----
-                    for (int i = 0; i < 4; ++i) {
-                        sb_acc[i] = vdupq_n_s32(0);
-                    }
-                    int8x16_t q4_qs_23_0_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_23_0, m4b)); // Q4-23 0..7
-                    int8x16_t q4_qs_23_1_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_23_1, m4b)); // Q4-23 8..15
-                    int8x16_t q4_qs_23_2_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_23_2, m4b)); // Q4-23 16..23
-                    int8x16_t q4_qs_23_3_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_23_3, m4b)); // Q4-23 24..31
-                    int8x16_t q4_qs_23_0_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_23_0, 4)); // Q4-23 32..39
-                    int8x16_t q4_qs_23_1_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_23_1, 4)); // Q4-23 40..47
-                    int8x16_t q4_qs_23_2_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_23_2, 4)); // Q4-23 48..55
-                    int8x16_t q4_qs_23_3_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_23_3, 4)); // Q4-23 56..63
-
-                    // 01-23
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_23_0_lo, q8_qs_01_0);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_23_1_lo, q8_qs_01_1);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_23_2_lo, q8_qs_01_2);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_23_3_lo, q8_qs_01_3);
-
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_23_0_hi, q8_qs_01_4);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_23_1_hi, q8_qs_01_5);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_23_2_hi, q8_qs_01_6);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_23_3_hi, q8_qs_01_7);
-
-                    // 23-23
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_23_0_lo, q8_qs_23_0);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_23_1_lo, q8_qs_23_1);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_23_2_lo, q8_qs_23_2);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_23_3_lo, q8_qs_23_3);
-
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_23_0_hi, q8_qs_23_4);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_23_1_hi, q8_qs_23_5);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_23_2_hi, q8_qs_23_6);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_23_3_hi, q8_qs_23_7);
-
-                    blk = 0;
-                    row_begin += 2;
-                    for (int tid = 0; tid < 4; tid++) {
-                        const int32x4_t block_scale = {
-                            (int32_t) q4sb_scales[blk][2],
-                            (int32_t) q4sb_scales[blk][2],
-                            (int32_t) q4sb_scales[blk][3],
-                            (int32_t) q4sb_scales[blk][3],
-                        };
-                        if (b == 0) print_block = true;
-                        if (print_block) printf("-- ACC = %d (begin %d blk %d) ", tid, row_begin, blk);
-                        blk ^= 1;
-                        print_s32x4("block_scale", block_scale, print_block);
-                        print_s32x4("sb_acc", sb_acc[tid], print_block);
-                        acc[tid / 2 + row_begin] = vmlaq_s32(acc[tid / 2 + row_begin], sb_acc[tid], block_scale);
-                        print_s32x4("acc[tid]", acc[tid / 2 + row_begin], print_block);
-                        print_block=false;
-                    }
-
-
-                    // ---- q4_qs_45 ----
-                    for (int i = 0; i < 4; ++i) {
-                        sb_acc[i] = vdupq_n_s32(0);
-                    }
-                    int8x16_t q4_qs_45_0_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_45_0, m4b)); // Q4-45 0..7
-                    int8x16_t q4_qs_45_1_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_45_1, m4b)); // Q4-45 8..15
-                    int8x16_t q4_qs_45_2_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_45_2, m4b)); // Q4-45 16..23
-                    int8x16_t q4_qs_45_3_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_45_3, m4b)); // Q4-45 24..31
-                    int8x16_t q4_qs_45_0_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_45_0, 4)); // Q4-45 32..39
-                    int8x16_t q4_qs_45_1_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_45_1, 4)); // Q4-45 40..47
-                    int8x16_t q4_qs_45_2_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_45_2, 4)); // Q4-45 48..55
-                    int8x16_t q4_qs_45_3_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_45_3, 4)); // Q4-45 56..63
-                    // 01-45
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_45_0_lo, q8_qs_01_0);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_45_1_lo, q8_qs_01_1);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_45_2_lo, q8_qs_01_2);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_45_3_lo, q8_qs_01_3);
-
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_45_0_hi, q8_qs_01_4);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_45_1_hi, q8_qs_01_5);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_45_2_hi, q8_qs_01_6);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_45_3_hi, q8_qs_01_7);
-
-                    // 23-45
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_45_0_lo, q8_qs_23_0);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_45_1_lo, q8_qs_23_1);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_45_2_lo, q8_qs_23_2);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_45_3_lo, q8_qs_23_3);
-
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_45_0_hi, q8_qs_23_4);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_45_1_hi, q8_qs_23_5);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_45_2_hi, q8_qs_23_6);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_45_3_hi, q8_qs_23_7);
-
-                    blk = 0;
-                    row_begin += 2;
-                    for (int tid = 0; tid < 4; tid++) {
-                        const int32x4_t block_scale = {
-                            (int32_t) q4sb_scales[blk][4],
-                            (int32_t) q4sb_scales[blk][4],
-                            (int32_t) q4sb_scales[blk][5],
-                            (int32_t) q4sb_scales[blk][5],
-                        };
-                        if (b == 0) print_block = true;
-                        if (print_block) printf("-- ACC = %d (begin %d blk %d) ", tid, row_begin, blk);
-                        blk ^= 1;
-                        print_s32x4("block_scale", block_scale, print_block);
-                        print_s32x4("sb_acc", sb_acc[tid], print_block);
-                        acc[tid / 2 + row_begin] = vmlaq_s32(acc[tid / 2 + row_begin], sb_acc[tid], block_scale);
-                        print_s32x4("acc[tid]", acc[tid / 2 + row_begin], print_block);
-                        print_block=false;
-                    }
-
-                    // ---- q4_qs_67 ----
-                    for (int i = 0; i < 4; ++i) {
-                        sb_acc[i] = vdupq_n_s32(0);
-                    }
-                    int8x16_t q4_qs_67_0_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_67_0, m4b)); // Q4-67 0..7
-                    int8x16_t q4_qs_67_1_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_67_1, m4b)); // Q4-67 8..15
-                    int8x16_t q4_qs_67_2_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_67_2, m4b)); // Q4-67 16..23
-                    int8x16_t q4_qs_67_3_lo = vreinterpretq_s8_u8(vandq_u8(q4_qs_67_3, m4b)); // Q4-67 24..31
-                    int8x16_t q4_qs_67_0_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_67_0, 4)); // Q4-67 32..39
-                    int8x16_t q4_qs_67_1_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_67_1, 4)); // Q4-67 40..47
-                    int8x16_t q4_qs_67_2_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_67_2, 4)); // Q4-67 48..55
-                    int8x16_t q4_qs_67_3_hi = vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_67_3, 4)); // Q4-67 56..63
-                    // 01-67
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_67_0_lo, q8_qs_01_0);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_67_1_lo, q8_qs_01_1);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_67_2_lo, q8_qs_01_2);
-                    sb_acc[0] = vmmlaq_s32(sb_acc[0], q4_qs_67_3_lo, q8_qs_01_3);
-
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_67_0_hi, q8_qs_01_4);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_67_1_hi, q8_qs_01_5);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_67_2_hi, q8_qs_01_6);
-                    sb_acc[1] = vmmlaq_s32(sb_acc[1], q4_qs_67_3_hi, q8_qs_01_7);
-
-                    // 23-67
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_67_0_lo, q8_qs_23_0);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_67_1_lo, q8_qs_23_1);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_67_2_lo, q8_qs_23_2);
-                    sb_acc[2] = vmmlaq_s32(sb_acc[2], q4_qs_67_3_lo, q8_qs_23_3);
-
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_67_0_hi, q8_qs_23_4);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_67_1_hi, q8_qs_23_5);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_67_2_hi, q8_qs_23_6);
-                    sb_acc[3] = vmmlaq_s32(sb_acc[3], q4_qs_67_3_hi, q8_qs_23_7);
-
-                    blk = 0;
-                    row_begin += 2;
-                    for (int tid = 0; tid < 4; tid++) {
-                        const int32x4_t block_scale = {
-                            (int32_t) q4sb_scales[blk][6],
-                            (int32_t) q4sb_scales[blk][6],
-                            (int32_t) q4sb_scales[blk][7],
-                            (int32_t) q4sb_scales[blk][7],
-                        };
-                        if (b == 0) print_block = true;
-                        if (print_block) printf("-- ACC = %d (row %d blk %d) ", tid, row_begin, blk);
-                        blk ^= 1;
-                        print_s32x4("block_scale", block_scale, print_block);
-                        print_s32x4("sb_acc", sb_acc[tid], print_block);
-                        acc[tid / 2 + row_begin] = vmlaq_s32(acc[tid / 2 + row_begin], sb_acc[tid], block_scale);
-                        print_s32x4("acc[tid]", acc[tid / 2 + 6], print_block);
-                        print_block=false;
-                    }
-
-                    // Acc has 00, 01, 10, 11
-                    // Will need Accs for:
-                    // 00, 01, 10, 11, sb_acc[0]
-                    // 20, 21, 30, 31, sb_acc[1]
-                    //
-                    // 02, 03, 12, 13 sb_acc[2]
-                    // 22, 23, 32, 33 sb_acc[3]
-                    //
-                    // 04, 05, 14, 15 sb_acc[4]
-                    // 24, 25, 34, 35 sb_acc[5]
-                    //
-                    // 06, 07, 16, 17 sb_acc[6]
-                    // 26, 27, 36, 37 sb_acc[7]
-
-                    // if (sb == 1) print_block = false;
-
-                    }
-            }
-            GGML_ABORT(" A" );
-
-
-            // for (int l = 0; l < nb; l++) {
-            //     for (int sb = 0; sb < 8; sb++) {
-            //         memcpy(utmp + sb * 4, b_ptr[l].scales + sb * 12, 12);
-            //         utmp[sb * 4 + 3] = ((utmp[sb * 4 + 2] >> 4) & kmask2) | (((utmp[sb * 4 + 1] >> 6) & kmask3) << 4);
-            //         const uint32_t uaux_0 = utmp[sb * 4 + 1] & kmask1;
-            //         utmp[sb * 4 + 1] = (utmp[sb * 4 + 2] & kmask2) | (((utmp[sb * 4 + 0] >> 6) & kmask3) << 4);
-            //         utmp[sb * 4 + 2] = uaux_0;
-            //         utmp[sb * 4 + 0] &= kmask1;
-            //     }
-            //     for (int k = 0; k < (qk / (2 * blocklen)); k++) {
-            //         uint8_t *scales_0 = (uint8_t*) utmp + (k / 4) * 32;
-            //         uint8_t *scales_1 = (uint8_t*) utmp + (k / 4) * 32 + 16;
-            //         for (int m = 0; m < 4; m++) {
-            //             for (int j = 0; j < ncols_interleaved; j++) {
-            //                 sumi1 = 0;
-            //                 sumi2 = 0;
-            //                 sumi = 0;
-            //                 for (int i = 0; i < blocklen; ++i) {
-            //                     const int v0 = (int8_t) (b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i] & 0xF);
-            //                     const int v1 = (int8_t) (b_ptr[l].qs[k * ncols_interleaved * blocklen + j * blocklen + i] >> 4);
-            //                     sumi1 = (v0 * a_ptr[l].qs[(k >> 2) * 256 + (k % 4) * 4 * blocklen + m * blocklen + i]);
-            //                     sumi2 = (v1 * a_ptr[l].qs[(k >> 2) * 256 + (k % 4) * 4 * blocklen + m * blocklen + i + 128]);
-            //                     sumi1 = sumi1 * scales_0[j];
-            //                     sumi2 = sumi2 * scales_1[j];
-            //                     sumi += sumi1 + sumi2;
-            //                 }
-            //                 sumf[m][j] += sumi * GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]) * a_ptr[l].d[m];
-            //             }
-            //         }
-            //     }
-            //     for (int sb = 0; sb < 8; sb++) {
-            //         uint8_t *mins = (uint8_t*) utmp + 8 + sb * 16;
-            //         for(int m = 0; m < 4; m++) {
-            //             const int16_t *bsums = a_ptr[l].bsums + (sb * 8) + (m * 4) - ((sb % 2) * 6);
-            //             for(int j = 0; j < ncols_interleaved; j++) {
-            //                 sum_minf[m][j] += mins[j] * (bsums[0] + bsums[1]) * GGML_CPU_FP16_TO_FP32(b_ptr[l].dmin[j]) * a_ptr[l].d[m];
-            //             }
-            //         }
-            //     }
-            // }
-            // for (int m = 0; m < 4; m++) {
-            //     for (int j = 0; j < ncols_interleaved; j++) {
-            //         s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j] - sum_minf[m][j];
-            //     }
-            // }
-        }
-    }
+        }  // for x
+    }  // for y
 }
 

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -514,12 +514,6 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
     assert(nr % 4 == 0);
     assert(nc % ncols_interleaved == 0);
 
-    UNUSED(s);
-    UNUSED(bs);
-    UNUSED(vx);
-    UNUSED(vy);
-    UNUSED(nr);
-    UNUSED(nc);
     UNUSED(nb);
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
@@ -2092,12 +2086,6 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
     assert(nr % 4 == 0);
     assert(nc % ncols_interleaved == 0);
 
-    UNUSED(s);
-    UNUSED(bs);
-    UNUSED(vx);
-    UNUSED(vy);
-    UNUSED(nr);
-    UNUSED(nc);
     UNUSED(nb);
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -633,12 +633,12 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
                 // cols 0-3 bias
                 bias_acc[0] =
                     vmlal_s16(bias_acc[0], bsums_vec_lo, vget_low_s16(q4sb_mins[0]));
-                bias_acc[1] = vmlal_s16(bias_acc[1], bsums_vec_lo,
-                        vget_high_s16(q4sb_mins[0]));
-
-                // cols 4-7 bias
                 bias_acc[0] =
                     vmlal_s16(bias_acc[0], bsums_vec_hi, vget_low_s16(q4sb_mins[1]));
+
+                // cols 4-7 bias
+                bias_acc[1] = vmlal_s16(bias_acc[1], bsums_vec_lo,
+                        vget_high_s16(q4sb_mins[0]));
                 bias_acc[1] = vmlal_s16(bias_acc[1], bsums_vec_hi,
                         vget_high_s16(q4sb_mins[1]));
             }  // for sb

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -498,6 +498,165 @@ void ggml_gemv_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
     ggml_gemv_iq4_nl_4x4_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
 
+void ggml_gemv_q4_K_8x8_q8_K(int                        n,
+                             float * GGML_RESTRICT      s,
+                             size_t                     bs,
+                             const void * GGML_RESTRICT vx,
+                             const void * GGML_RESTRICT vy,
+                             int                        nr,
+                             int                        nc) {
+    constexpr int qk = QK_K;
+    const int     nb = n / qk;
+
+    constexpr int ncols_interleaved = 8;
+    constexpr int blocklen          = 8;
+
+    assert(n % qk == 0);
+    assert(nr % 4 == 0);
+    assert(nc % ncols_interleaved == 0);
+
+    UNUSED(s);
+    UNUSED(bs);
+    UNUSED(vx);
+    UNUSED(vy);
+    UNUSED(nr);
+    UNUSED(nc);
+    UNUSED(nb);
+    UNUSED(ncols_interleaved);
+    UNUSED(blocklen);
+
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+    constexpr int col_pairs = ncols_interleaved / 2;
+    const uint8x16_t m4b = vdupq_n_u8(0x0f);
+
+    // 1x8 tile = 2 x 4
+    float32x4_t acc_f32[ncols_interleaved / 4];
+
+    const block_q8_K * GGML_RESTRICT q8_ptr = (const block_q8_K *) vy;
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_q4_Kx8 * GGML_RESTRICT q4_ptr = (const block_q4_Kx8 *) vx + (x * nb);
+
+        for (int i = 0; i < ncols_interleaved / 4; i++) {
+            acc_f32[i] = vdupq_n_f32(0);
+        }
+
+        for (int b = 0; b < nb; b++) {
+            float32x4_t q4_d_0 = vcvt_f32_f16(vld1_f16((const __fp16 *)q4_ptr[b].d));     // d0 d1 d2 d3
+            float32x4_t q4_d_1 = vcvt_f32_f16(vld1_f16((const __fp16 *)q4_ptr[b].d + 4)); // d4 d5 d6 d7
+            float32x4_t q8_d = vdupq_n_f32(q8_ptr[b].d);
+            float32x4_t sb_scale_0 = vmulq_f32 (q4_d_0, q8_d);
+            float32x4_t sb_scale_1 = vmulq_f32 (q4_d_1, q8_d);
+            float32x4_t q4_dmin_0 = vcvt_f32_f16(vld1_f16((const __fp16 *) q4_ptr[b].dmin));     // dmin 0..3
+            float32x4_t q4_dmin_1 = vcvt_f32_f16(vld1_f16((const __fp16 *) q4_ptr[b].dmin + 4)); // dmin 4..7
+            float32x4_t sb_min_0 = vmulq_f32(q4_dmin_0, q8_d);
+            float32x4_t sb_min_1 = vmulq_f32(q4_dmin_1, q8_d);
+
+            // interleaved bias_acc: [0]->r0 0123, [1]->r0 4567
+            int32x4_t bias_acc[2] = {vdupq_n_s32(0), vdupq_n_s32(0)};
+            // 2 sb each iteration
+            int32x4_t acc_lo[col_pairs];
+            int32x4_t acc_hi[col_pairs];
+
+            // Each bsum is 16 elements, pairwise add leaves us with the 8 bsums of the entire block
+            const int16x8_t bsums = vpaddq_s16(vld1q_s16(q8_ptr[b].bsums), vld1q_s16(q8_ptr[b].bsums + 8));
+            int16_t bsums_arr[8];
+            vst1q_s16(bsums_arr, bsums);
+            for (int sb = 0; sb < QK_K / 64; sb++) {
+                for (int i = 0; i < col_pairs; i++) {
+                    acc_lo[i] = vdupq_n_s32(0);
+                    acc_hi[i] = vdupq_n_s32(0);
+                }
+                // Need scales for the low and high nibbles
+                // 2 * 12 = 24 bytes per subblock, 4 sbs -> 4 * 24 = 96 bytes total
+                int16x8_t q4sb_mins[2];  // int16 as its needed for bias_acc later
+                int16x8_t q4sb_scales[2];
+                for (int i = 0; i < 2; i++) {
+                    int8_t    aux_q4sb[8];
+                    const int offset = sb * 24 + i * 12;
+                    decode_q4_Kx8_scales_mins(&q4_ptr[b].scales[offset], &q4sb_mins[i], aux_q4sb);
+                    q4sb_scales[i] = vmovl_s8(vld1_s8(aux_q4sb));
+                }
+
+                const uint8_t *q4_base = q4_ptr[b].qs + sb * QK_K;
+
+                // Load the 64 quants from q8K duplicated to use vecdots with the interelaved columns
+                // but still need the qs to use the low and hi bits from q4
+                const int8_t *q8_base = q8_ptr[b].qs + sb * 64;
+                int8x16_t q8_qs[8];
+                for (int i = 0; i < 8; i++) {
+                    q8_qs[i] = (int8x16_t) vld1q_dup_s64((const int64_t *)(q8_base + i * 8));
+                }
+
+
+                // Q4s columns iterated in pairs (01, 23, 45, 67)
+                for (int cp = 0; cp < col_pairs; cp++) {
+                    uint8x16_t q4_qs_cp_0 = vld1q_u8(q4_base + 16 * cp);
+                    uint8x16_t q4_qs_cp_1 = vld1q_u8(q4_base + 16 * cp + 64);
+                    uint8x16_t q4_qs_cp_2 = vld1q_u8(q4_base + 16 * cp + 128);
+                    uint8x16_t q4_qs_cp_3 = vld1q_u8(q4_base + 16 * cp + 192);
+
+                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_0, m4b)), q8_qs[0]); // 0 .. 7
+                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_1, m4b)), q8_qs[1]); // 8 ..15
+                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_2, m4b)), q8_qs[2]); // 16..23
+                    acc_lo[cp] = vdotq_s32(acc_lo[cp], vreinterpretq_s8_u8(vandq_u8(q4_qs_cp_3, m4b)), q8_qs[3]); // 24..31
+
+                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_0, 4)), q8_qs[4]); // 32..39
+                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_1, 4)), q8_qs[5]); // 40..47
+                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_2, 4)), q8_qs[6]); // 48..55
+                    acc_hi[cp] = vdotq_s32(acc_hi[cp], vreinterpretq_s8_u8(vshrq_n_u8(q4_qs_cp_3, 4)), q8_qs[7]); // 56..63
+                }
+
+
+                // Iterates over a pair of column pairs (4 columns) to use a single 128 register
+                // p = 0 -> 0123  p2 -> 4567
+                for (int i = 0, p = 0; p < col_pairs; i++, p += 2) {
+                    int16x4_t group_scales_lo = p == 0 ? vget_low_s16(q4sb_scales[0]) : vget_high_s16(q4sb_scales[0]);
+                    int16x4_t group_scales_hi = p == 0 ? vget_low_s16(q4sb_scales[1]) : vget_high_s16(q4sb_scales[1]);
+                    float32x4_t sb_scale = p == 0 ? sb_scale_0 : sb_scale_1;
+
+                    // 0123 or 4567
+                    // TODO: Single superblock mul at the end of the superblock
+                    float32x4_t sumf_0 = vcvtq_f32_s32(vmulq_s32(vmovl_s16(group_scales_lo), vpaddq_s32(acc_lo[p], acc_lo[p + 1])));
+                    acc_f32[i] = vfmaq_f32(acc_f32[i], sb_scale, sumf_0);
+
+                    float32x4_t sumf_1 = vcvtq_f32_s32(vmulq_s32(vmovl_s16(group_scales_hi), vpaddq_s32(acc_hi[p], acc_hi[p + 1])));
+                    acc_f32[i] = vfmaq_f32(acc_f32[i], sb_scale, sumf_1);
+                }
+
+                // Multiply Acc bsum + mins
+                // Each pair of subblocks share the same bsums
+                // Load scalar bsum → broadcast to a vector (vdupq_n_s16(s)).
+                int16x4_t bsums_vec_lo = vdup_n_s16(bsums_arr[2 * sb + 0]);
+                int16x4_t bsums_vec_hi = vdup_n_s16(bsums_arr[2 * sb + 1]);
+
+                // cols 0-3 bias
+                bias_acc[0] =
+                    vmlal_s16(bias_acc[0], bsums_vec_lo, vget_low_s16(q4sb_mins[0]));
+                bias_acc[1] = vmlal_s16(bias_acc[1], bsums_vec_lo,
+                        vget_high_s16(q4sb_mins[0]));
+
+                // cols 4-7 bias
+                bias_acc[0] =
+                    vmlal_s16(bias_acc[0], bsums_vec_hi, vget_low_s16(q4sb_mins[1]));
+                bias_acc[1] = vmlal_s16(bias_acc[1], bsums_vec_hi,
+                        vget_high_s16(q4sb_mins[1]));
+            }  // for sb
+
+            acc_f32[0] = vmlsq_f32(acc_f32[0], vcvtq_f32_s32(bias_acc[0]), sb_min_0);
+            acc_f32[1] = vmlsq_f32(acc_f32[1], vcvtq_f32_s32(bias_acc[1]), sb_min_1);
+        }  // for b
+
+        int base = x * ncols_interleaved;
+        vst1q_f32(s + base, acc_f32[0]);
+        vst1q_f32(s + base + 4, acc_f32[1]);
+    }  // for x
+    return;
+#endif
+    ggml_gemv_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
+}
+
+
 void ggml_gemm_q4_0_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
     const int qk = QK8_0;
     const int nb = n / qk;

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -47,7 +47,6 @@ static inline void decode_q4_Kx8_scales_mins(const uint8_t * scales_in,
     memcpy(out_scales, scales_u32, 8);
 }
 
-
 void ggml_quantize_mat_q8_0_4x4(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
     assert(QK8_0 == 32);
     assert(k % QK8_0 == 0);
@@ -659,7 +658,6 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
 #endif  // #if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
     ggml_gemv_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
 }
-
 
 void ggml_gemm_q4_0_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
     const int qk = QK8_0;
@@ -2077,7 +2075,6 @@ void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
     ggml_gemm_iq4_nl_4x4_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
 
-
 void ggml_gemm_q4_K_8x8_q8_K(int                        n,
                              float * GGML_RESTRICT      s,
                              size_t                     bs,
@@ -2293,4 +2290,3 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
 #endif
     ggml_gemm_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
 }
-

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -518,7 +518,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if !((defined(_MSC_VER)) && !defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
+#if defined(__aarch64__) && defined(__ARM_NEON)
     constexpr int    col_pairs = ncols_interleaved / 2;
     const uint8x16_t m4b       = vdupq_n_u8(0x0f);
 
@@ -649,7 +649,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
         vst1q_f32(s + base + 4, acc_f32[1]);
     }  // for x
     return;
-#endif  // #if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
+#endif  // defined(__aarch64__) && defined(__ARM_NEON)
     ggml_gemv_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
 }
 
@@ -2090,8 +2090,7 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if !((defined(_MSC_VER)) && !defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON) && \
-    defined(__ARM_FEATURE_MATMUL_INT8)
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
     constexpr int    q8_k_blocklen = 4;
     const uint8x16_t m4b           = vdupq_n_u8(0x0f);
 
@@ -2275,6 +2274,6 @@ void ggml_gemm_q4_K_8x8_q8_K(int                        n,
         }  // for x
     }  // for y
     return;
-#endif
+#endif  // defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
     ggml_gemm_q4_K_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
 }

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1960,8 +1960,11 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
             if (cur->ne[1] % 8 == 0) {
                 return &q4_K_8x8_q8_K;
             }
-        } else if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8()) {
-            return &q4_K_8x8_q8_K;
+        }
+        if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8() && ggml_cpu_has_dotprod()) {
+            if (cur->ne[1] % 8 == 0) {
+                return &q4_K_8x8_q8_K;
+            }
         }
     } else if (cur->type == GGML_TYPE_Q2_K) {
         if (ggml_cpu_has_avx512()) {

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1960,6 +1960,8 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
             if (cur->ne[1] % 8 == 0) {
                 return &q4_K_8x8_q8_K;
             }
+        } else if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8()) {
+            return &q4_K_8x8_q8_K;
         }
     } else if (cur->type == GGML_TYPE_Q2_K) {
         if (ggml_cpu_has_avx512()) {

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1961,7 +1961,7 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
                 return &q4_K_8x8_q8_K;
             }
         }
-        if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8() && ggml_cpu_has_dotprod()) {
+        if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8()) {
             if (cur->ne[1] % 8 == 0) {
                 return &q4_K_8x8_q8_K;
             }


### PR DESCRIPTION
This PR improves q4_k_q8_k gemm and gemv in arm64 using i8mm and vecdot instructions.

Tested on an Apple M4 Max:


### REPACK vs NO REPACK

| model                        | backend | threads | test  | REPACK t/s      | NO REPACK t/s   | speedup |
|-----------------------------|---------|---------|--------|-----------------:|-----------------:|--------:|
| lfm2 1.2B Q4_K       | CPU     | 8       | pp256 | 683.08 ± 1.56   | 408.04 ± 0.78   | 1.67    |
| lfm2 1.2B Q4_K       | CPU     | 8       | tg128 | 235.38 ± 0.81   | 214.06 ± 1.33   | 1.10    |
| lfm2 700M Q4_K              | CPU     | 8       | pp256 | 1070.35 ± 0.72  | 645.21 ± 15.57  | 1.66    |
| lfm2 700M Q4_K              | CPU     | 8       | tg128 | 335.03 ± 0.86   | 311.28 ± 3.89   | 1.08    |
| llama 8B Q4_K               | CPU     | 8       | pp256 | 98.37 ± 1.57    | 60.62 ± 0.20    | 1.62    |
| llama 8B Q4_K               | CPU     | 8       | tg128 | 42.25 ± 0.52    | 38.33 ± 0.38    | 1.10    |
| qwen3 8B Q4_K               | CPU     | 8       | pp256 | 92.10 ± 0.35    | 60.11 ± 0.21    | 1.53    |
| qwen3 8B Q4_K               | CPU     | 8       | tg128 | 40.60 ± 0.35    | 37.22 ± 0.42    | 1.09    |

REPACK: 8a2fd9344 (7070)
NO REPACK: 45c6ef730 (7058) 

### Perplexity
| model                  | REPACK PPL            | NO REPACK PPL        | 
|-----------------------|-----------------------|-----------------------|
| LFM2 700M Q4_K_M      | 20.2207 ± 0.86775     | 20.2207 ± 0.86775     | 
| Qwen3 8B 128K Q4_K_M  | 10.8862 ± 0.46691     | 10.8862 ± 0.46691     |
| LFM2 1.2B Q4_K_M      | 15.5833 ± 0.62558     | 15.5833 ± 0.62558     |

As for test-backend-ops, I've checked the output of the layer tensors manually comparing REPACK vs master, since https://github.com/ggml-org/llama.cpp/pull/16182 is still ongoing. 

