### PR TITLE
server: add memory breakdown print

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -5714,6 +5714,7 @@ int main(int argc, char ** argv) {
 
     clean_up();
     t.join();
+    llama_memory_breakdown_print(ctx_server.ctx);
 
     return 0;
 }


### PR DESCRIPTION
While looking at server logs for debugging I've noticed that it does not print a memory breakdown upon shutdown. This PR simply adds the corresponding call. The breakdown is printed after cleanup because otherwise the table would become misaligned from the `^C` in console.