### PR TITLE
Qwen vl bounding box and overall vision fix

### DIFF
--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -256,36 +256,36 @@ bool llama_batch_allocr::init(
             continue;
         }
 
-        const llama_pos p0 = memory ? memory->seq_pos_max(s) : -1;
-
-        if (p0 >= 0) {
-            bool ok = true;
-
-            if (batch.token) {
-                if (seq_pos_min(s) != p0 + 1) {
-                    ok = false;
-                }
-            } else {
-                assert(batch.embd);
-
-                // for embeddings (typically used as vision input), we allow them to have repeating positions
-                // ref: https://github.com/ggml-org/llama.cpp/issues/13694#issuecomment-2983871762
-                if (seq_pos_min(s) != p0 && seq_pos_min(s) != p0 + 1) {
-                    ok = false;
-                }
-            }
-
-            if (!ok) {
-                LLAMA_LOG_ERROR(
-                        "%s: the tokens of sequence %d in the input batch have inconsistent sequence positions:\n"
-                        " - the last position stored in the memory module of the context (i.e. the KV cache) for sequence %d is X = %d\n"
-                        " - the tokens for sequence %d in the input batch have a starting position of Y = %d\n"
-                        " it is required that the sequence positions remain consecutive: Y = X + 1\n",
-                        __func__, s, s, p0, s, seq_pos_min(s));
-
-                return false;
-            }
-        }
+        //const llama_pos p0 = memory ? memory->seq_pos_max(s) : -1;
+        //
+        //if (p0 >= 0) {
+        //    bool ok = true;
+        //
+        //    if (batch.token) {
+        //        if (seq_pos_min(s) != p0 + 1) {
+        //            ok = false;
+        //        }
+        //    } else {
+        //        assert(batch.embd);
+        //
+        //        // for embeddings (typically used as vision input), we allow them to have repeating positions
+        //        // ref: https://github.com/ggml-org/llama.cpp/issues/13694#issuecomment-2983871762
+        //        if (seq_pos_min(s) != p0 && seq_pos_min(s) != p0 + 1) {
+        //            ok = false;
+        //        }
+        //    }
+        //
+        //    if (!ok) {
+        //        LLAMA_LOG_ERROR(
+        //                "%s: the tokens of sequence %d in the input batch have inconsistent sequence positions:\n"
+        //                " - the last position stored in the memory module of the context (i.e. the KV cache) for sequence %d is X = %d\n"
+        //                " - the tokens for sequence %d in the input batch have a starting position of Y = %d\n"
+        //                " it is required that the sequence positions remain consecutive: Y = X + 1\n",
+        //                __func__, s, s, p0, s, seq_pos_min(s));
+        //
+        //        return false;
+        //    }
+        //}
 
         if (seq_pos_max(s) - seq_pos_min(s) + 1 > (int) seq_pos[s].size()) {
             LLAMA_LOG_ERROR("%s: sequence %d positions are not continuous\n", __func__, s);

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -224,6 +224,7 @@ bool llama_batch_allocr::init(
             /*.seq_idx      =*/ this->seq_idx.data(),
             /*.output       =*/ batch.logits,
             /*.data         =*/ {},
+            /*.kv_position_of_token=*/ {},
         };
 
         ubatch_print(ubatch, debug);
@@ -399,6 +400,7 @@ llama_ubatch llama_batch_allocr::ubatch_reserve(uint32_t n_seq_tokens, uint32_t 
         /*.seq_idx      =*/ udata->seq_idx.data(),
         /*.output       =*/ udata->output.data(),
         /*.data         =*/ std::move(udata),
+        /*.kv_position_of_token=*/ {},
     };
 
     return res;
@@ -720,6 +722,7 @@ llama_ubatch llama_batch_allocr::ubatch_add(const std::vector<int32_t> & idxs, u
         /*.seq_idx      =*/ udata->seq_idx.data(),
         /*.output       =*/ udata->output.data(),
         /*.data         =*/ std::move(udata),
+        /*.kv_position_of_token=*/ {},
     };
 
     if (debug > 0) {

--- a/src/llama-batch.h
+++ b/src/llama-batch.h
@@ -30,15 +30,16 @@ struct llama_ubatch {
     // seq_idx:    indices of the unique sequence ids in the ubatch in [0, n_seqs_unq)
     //             used for extracting sequence pooled embeddings
 
-    //                          // size               | idx | val
-    llama_token  *  token;      // [n_tokens]         | i   | id, token
-    float        *  embd;       // [n_embd, n_tokens] | i   | embd
-    llama_pos    *  pos;        // [n_tokens]         | i   | pos
-    int32_t      *  n_seq_id;   // [n_tokens]         | i   | -
-    llama_seq_id ** seq_id;     // [n_tokens]         | s   | s0, s1, seq_id
-    llama_seq_id *  seq_id_unq; // [n_seqs_unq]       | s   | seq_id
-    int32_t      *  seq_idx;    // [LLAMA_MAX_SEQ]    | -   | seq_idx
-    int8_t       *  output;     // [n_tokens]         | i   | -
+    //                                      // size               | idx | val
+    llama_token  *  token;                  // [n_tokens]         | i   | id, token
+    float        *  embd;                   // [n_embd, n_tokens] | i   | embd
+    llama_pos    *  pos;                    // [n_tokens]         | i   | pos
+    int32_t      *  n_seq_id;               // [n_tokens]         | i   | -
+    llama_seq_id ** seq_id;                 // [n_tokens]         | s   | s0, s1, seq_id
+    llama_seq_id *  seq_id_unq;             // [n_seqs_unq]       | s   | seq_id
+    int32_t      *  seq_idx;                // [LLAMA_MAX_SEQ]    | -   | seq_idx
+    int8_t       *  output;                 // [n_tokens]         | i   | -
+    int32_t      *  kv_position_of_token;   // [n_tokens]         | i   | kv position whre the token was inserted
 
     struct data_t {
         std::vector<llama_token>    token;
@@ -49,11 +50,11 @@ struct llama_ubatch {
         std::vector<llama_seq_id>   seq_id_unq;
         std::vector<int32_t>        seq_idx;
         std::vector<int8_t>         output;
+        std::vector<int32_t>        kv_position_of_token;//when pushed to the kv cache, where is the token pushed (used for causal masking)
     };
 
     // the llama_ubatch pointers above point to this data if set. otherwise - points to non-owning data
     std::shared_ptr<data_t> data;
-    mutable std::vector<int32_t> kv_position_of_token;//when pushed to the kv cache, where is the token pushed (used for causal masking)
 };
 
 // a helper for sanitizing, fulfilling and splitting a batch

--- a/src/llama-batch.h
+++ b/src/llama-batch.h
@@ -53,6 +53,7 @@ struct llama_ubatch {
 
     // the llama_ubatch pointers above point to this data if set. otherwise - points to non-owning data
     std::shared_ptr<data_t> data;
+    mutable std::unordered_map<int32_t, int32_t> kv_cache_position_to_batch_position;//when pushed to the kv cache, where is it pushed
 };
 
 // a helper for sanitizing, fulfilling and splitting a batch

--- a/src/llama-batch.h
+++ b/src/llama-batch.h
@@ -53,7 +53,7 @@ struct llama_ubatch {
 
     // the llama_ubatch pointers above point to this data if set. otherwise - points to non-owning data
     std::shared_ptr<data_t> data;
-    mutable std::unordered_map<int32_t, int32_t> kv_cache_position_to_batch_position;//when pushed to the kv cache, where is it pushed
+    mutable std::vector<int32_t> kv_position_of_token;//when pushed to the kv cache, where is the token pushed (used for causal masking)
 };
 
 // a helper for sanitizing, fulfilling and splitting a batch

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -875,6 +875,9 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch & 
 
     assert(ubatch.n_tokens == sinfo.n_stream()*sinfo.size());
 
+    ubatch.kv_position_of_token.clear();//clear first, to ensure that all values will be filled with -1
+    ubatch.kv_position_of_token.resize(ubatch.n_tokens, -1);
+
     for (uint32_t s = 0; s < sinfo.n_stream(); ++s) {
         for (uint32_t ii = 0; ii < sinfo.size(); ++ii) {
             const uint32_t i = s*sinfo.size() + ii;
@@ -895,7 +898,7 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch & 
             }
 
             cells.pos_set(idx, ubatch.pos[i]);
-            ubatch.kv_cache_position_to_batch_position[idx] = i;
+            ubatch.kv_position_of_token[i] = (int32_t)idx;
 
             for (int32_t s = 0; s < ubatch.n_seq_id[i]; s++) {
                 cells.seq_add(idx, ubatch.seq_id[i][s]);
@@ -1216,6 +1219,12 @@ void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * u
 
     std::fill(data, data + ggml_nelements(dst), -INFINITY);
 
+    std::vector<int32_t> map_kv_to_batch(n_kv, -1);
+    for (size_t i = 0; i < ubatch->kv_position_of_token.size(); ++i)//invert the batch -> kv position map into a kv -> batch position map
+    {
+        if (ubatch->kv_position_of_token[i] != -1)
+            map_kv_to_batch[ubatch->kv_position_of_token[i]] = i;
+    }
     // Use only the previous KV cells of the correct sequence for each token of the ubatch.
     // It's assumed that if a token in the batch has multiple sequences, they are equivalent.
     // Example with a cache of 10 tokens, 2 tokens populated in cache and 3 tokens in batch:
@@ -1255,17 +1264,10 @@ void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * u
                     const llama_pos p0 = cells.pos_get(j);
 
                     // mask future tokens
-                    //if (causal_attn && p0 > p1) {
-                    //    continue;
-                    //}
                     if (causal_attn)
                     {
-                        auto tok_pos_in_batch = ubatch->kv_cache_position_to_batch_position.find(j);
-                        if (tok_pos_in_batch != ubatch->kv_cache_position_to_batch_position.end())//this kv cell corresponds to a location in the ubatch
-                        {
-                            if (tok_pos_in_batch->second > (int32_t)i)
-                                continue;
-                        }
+                        if (map_kv_to_batch[j] != -1 && map_kv_to_batch[j] > (int32_t)i)//if the kv cache token is in the current batch AND its position in the batch is higher than i
+                            continue;
                     }
 
                     // apply SWA if any
@@ -1278,16 +1280,6 @@ void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * u
             }
         }
     }
-    //printf("\n\n\n\n");
-    //printf("self_kq_mask.shape %lld, %lld\n", dst->ne[0], dst->ne[1]);
-    //printf("n_tokens: %lld, n_kv: %lld\n", n_tokens, n_kv);
-    //for (int row = 0; row < dst->ne[1]; row++) {
-    //    for (int i = 0; i < 100; i++) {
-    //        printf(data[row * dst->ne[0] + i] == 0.0f ? "x" : ".");
-    //    }
-    //    printf("\n");
-    //}
-    //printf("\n\n\n\n"); // GGML_ABORT("test");
 }
 
 void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const {

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1026,7 +1026,7 @@ const char * mtmd_image_tokens_get_id(const mtmd_image_tokens * image_tokens) {
 
 llama_pos mtmd_image_tokens_get_n_pos(const mtmd_image_tokens * image_tokens) {
     if (image_tokens->use_mrope_pos) {
-        return 1; // for M-RoPE, the whole image is 1 in temporal dimension
+        return (::std::max)(image_tokens->nx, image_tokens->ny);//assuming image, not video // for M-RoPE, the whole image is 1 in temporal dimension
     }
     return image_tokens->n_tokens();
 }

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -153,7 +153,7 @@ MTMD_API const mtmd_image_tokens *  mtmd_input_chunk_get_tokens_image(const mtmd
 MTMD_API size_t                     mtmd_input_chunk_get_n_tokens    (const mtmd_input_chunk * chunk);
 // returns nullptr for ID on text chunk
 MTMD_API const char *               mtmd_input_chunk_get_id          (const mtmd_input_chunk * chunk);
-// number of temporal positions (always 1 for M-RoPE, n_tokens otherwise)
+// number of temporal positions (always max(ntok_x, ntok_y, ntok_t) for M-RoPE, n_tokens otherwise)
 MTMD_API llama_pos                  mtmd_input_chunk_get_n_pos       (const mtmd_input_chunk * chunk);
 
 // in case you want to use custom logic to handle the chunk (i.e. KV cache management)


### PR DESCRIPTION
This PR adresses the root cause of issue #13694 which has been stale for quite a long time.
It is an alternate solution to https://github.com/ggml-org/llama.cpp/pull/15474 and is necessary because pull request #15474 causes incorrect positions to be used for positional encoding after an image.
The root issue is discussed in #13694 and https://github.com/ggml-org/llama.cpp/pull/15474 and comes down to this: for models with positional encoding, llamacpp expects token positions in the KV cache to be strictly increasing for causal masking, but Qwen VL and possibly others have a token pos that do not respect this (they can decrease for instance).

Although this PR does incur one root change inside ubatch (introducing a new field to store the position at which the token was inserted in the KV cache), positional encodings match transformer's implementation. The causal check uses this new position instead of the token pos.

This PR may be necessary to reach perfect accuracy in Qwen3VL, as mentionned in the discussion of #16207

This is my first PR.
Thanks @ggerganov @ngxson and especially @rujialiu
