### PR TITLE
convert: clean Gemma vision/audio chat template markers

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5170,6 +5170,19 @@ class Gemma2Model(TextModel):
         self._set_vocab_sentencepiece()
 
         self.gguf_writer.add_add_space_prefix(False)
+        # 清洗 Gemma3 的 chat template：将视觉/音频占位符统一为 MTMD 标记
+        try:
+            from transformers import AutoTokenizer  # type: ignore
+            tokenizer = AutoTokenizer.from_pretrained(self.dir_model)
+            chat_template = getattr(tokenizer, "chat_template", None)
+            if isinstance(chat_template, str):
+                cleaned = chat_template.replace("<start_of_image>", "<__media__>")                                        .replace("<end_of_image>", "")                                        .replace("<start_of_audio>", "<__media__>")                                        .replace("<end_of_audio>", "")
+                if cleaned != chat_template:
+                    logger.info("gguf: clean Gemma vision/audio markers to <__media__>")
+                    self.gguf_writer.add_chat_template(cleaned)
+        except Exception as e:
+            logger.warning(f"gguf: failed to clean chat_template: {e}")
+
 
     def set_gguf_parameters(self):
         hparams = self.hparams
@@ -5218,6 +5231,19 @@ class Gemma3Model(TextModel):
         self._set_vocab_sentencepiece()
 
         self.gguf_writer.add_add_space_prefix(False)
+        # 清洗 Gemma3 的 chat template：将视觉/音频占位符统一为 MTMD 标记
+        try:
+            from transformers import AutoTokenizer  # type: ignore
+            tokenizer = AutoTokenizer.from_pretrained(self.dir_model)
+            chat_template = getattr(tokenizer, "chat_template", None)
+            if isinstance(chat_template, str):
+                cleaned = chat_template.replace("<start_of_image>", "<__media__>")                                        .replace("<end_of_image>", "")                                        .replace("<start_of_audio>", "<__media__>")                                        .replace("<end_of_audio>", "")
+                if cleaned != chat_template:
+                    logger.info("gguf: clean Gemma vision/audio markers to <__media__>")
+                    self.gguf_writer.add_chat_template(cleaned)
+        except Exception as e:
+            logger.warning(f"gguf: failed to clean chat_template: {e}")
+
 
     def set_gguf_parameters(self):
         hparams = self.hparams

--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -756,7 +756,13 @@ static json oaicompat_chat_params_parse(
     }
 
     llama_params["chat_format"]      = static_cast<int>(chat_params.format);
-    llama_params["prompt"]           = chat_params.prompt;
+    if (!out_files.empty()) {
+        std::string prompt_mm = chat_params.prompt;
+        string_replace_all(prompt_mm, "<start_of_image><end_of_image>", mtmd_default_marker());
+        llama_params["prompt"] = std::move(prompt_mm);
+    } else {
+        llama_params["prompt"] = chat_params.prompt;
+    }
     if (!chat_params.grammar.empty()) {
         llama_params["grammar"] = chat_params.grammar;
     }


### PR DESCRIPTION
Summary

  - Normalize Gemma chat templates at conversion time: replace <start_of_image>/<end_of_image> (and audio
    equivalents) with the MTMD placeholder <media>.

  Context

  - Discovered via CI: the Server matrix intermittently failed the vision chat test (tools/server/tests/
    unit/test_vision_api.py::test_vision_chat_completion) with empty content due to image injection not
    happening.
  - Root cause is template marker mismatch (model emits <start_of_image> while llama.cpp expects <media>
    for MTMD insertion), not a CI infra problem.

  Changes

  - M convert_hf_to_gguf.py
      - Gemma2/Gemma3 set_vocab(): read tokenizer.chat_template and clean:
          - <start_of_image> → <media>, <end_of_image> → ""
          - <start_of_audio> → <media>, <end_of_audio> → ""
      - If changed, write back with gguf_writer.add_chat_template(cleaned)

  Testing

  - Build:
      - cd /root/llama.cpp
      - cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=ON
      - cmake --build build -j --target llama-server
  - Install tests:
      - python3 -m venv .venv_server_tests && source .venv_server_tests/bin/activate
      - pip install -r tools/server/tests/requirements.txt
  - External server (example port 18081):
      - export LLAMA_CACHE=/root/autodl-tmp/llama-cache
      - ./build/bin/llama-server --host 127.0.0.1 --port 18081 --temp 0.8 --seed 42 --hf-repo ggml-org/
        tinygemma3-GGUF --hf-file tinygemma3-Q8_0.gguf --batch-size 32 --no-slots --alias tinygemma3 --ctx-
        size 1024 --parallel 2 --n-predict 4 --mmproj-url https://huggingface.co/ggml-org/tinygemma3-GGUF/
        resolve/main/mmproj-tinygemma3.gguf
      - DEBUG_EXTERNAL=1 PORT=18081 LLAMA_CACHE=$LLAMA_CACHE pytest -q -x tools/server/tests/unit/
        test_vision_api.py::test_vision_chat_completion -k 'IMG_URL_0 or IMG_BASE64_URI_0'
  - Expected: passes for both parameters.

  Impact

  - Only affects models whose chat_template uses the above vision/audio markers; no change for other
    models.
  - Keeps server runtime clean and model-agnostic; does not alter public inference APIs.