### PR TITLE
convert : avoid dequantizing mxfp4 for GPT-OSS

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -8943,6 +8943,13 @@ class SmolLM3Model(LlamaModel):
 class GptOssModel(TextModel):
     model_arch = gguf.MODEL_ARCH.GPT_OSS
 
+    # TODO: remove once MXFP4 is supported more generally
+    def dequant_model(self):
+        quant_config = self.hparams.get("quantization_config")
+        if quant_config is not None and quant_config.get("quant_method") == "mxfp4":
+            return
+        return super().dequant_model()
+
     def transform_nibble_layout(self, tensor):
         assert tensor.dtype == torch.uint8
         assert tensor.shape[-1] == 16


### PR DESCRIPTION
Follow-up to #14810.

I accidentally broke MXFP4 GPT-OSS conversion in #14810 :

```
  File "/.../llama.cpp/convert_hf_to_gguf.py", line 656, in __init__
    super().__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/.../llama.cpp/convert_hf_to_gguf.py", line 155, in __init__
    self.dequant_model()
    ~~~~~~~~~~~~~~~~~~^^
  File "/.../llama.cpp/convert_hf_to_gguf.py", line 375, in dequant_model
    raise NotImplementedError(f"Quant method is not yet supported: {quant_method!r}")
NotImplementedError: Quant method is not yet supported: 'mxfp4'
```

This PR makes the convert script avoid running `dequant_model()` for GPT-OSS when the `quant_method` of the `quantization_config` is `mxfp4`.

Tested with a `--dry-run` conversion of <https://huggingface.co/openai/gpt-oss-20b>, which no longer fails.

---

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
