### PR TITLE
convert: Handle mmproj model output filename properly

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1497,6 +1497,20 @@ class MmprojModel(ModelBase):
     def set_type(self):
         self.gguf_writer.add_type(gguf.GGUFType.MMPROJ)
 
+    def prepare_metadata(self, vocab_only: bool):
+        super().prepare_metadata(vocab_only)
+
+        output_type: str = self.ftype.name.partition("_")[2]
+        # Filename Output
+        if self.fname_out.is_dir():
+            fname_default: str = gguf.naming_convention(self.metadata.name, self.metadata.basename, self.metadata.finetune, self.metadata.version, size_label=None, output_type=output_type, model_type="mmproj")
+
+            # Use the default filename
+            self.fname_out = self.fname_out / f"{fname_default}.gguf"
+        else:
+            # Process templated file name with the output ftype, useful with the "auto" ftype
+            self.fname_out = self.fname_out.parent / gguf.fill_templated_filename(self.fname_out.name, output_type)
+
     def set_gguf_parameters(self):
         self.gguf_writer.add_file_type(self.ftype)
 
@@ -9721,10 +9735,6 @@ def main() -> None:
         fname_out = dir_model
 
     logger.info(f"Loading model: {dir_model.name}")
-
-    if args.mmproj:
-        if "mmproj" not in fname_out.name:
-            fname_out = ModelBase.add_prefix_to_filename(fname_out, "mmproj-")
 
     is_mistral_format = args.mistral_format
     if is_mistral_format and not _mistral_common_installed:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1501,14 +1501,11 @@ class MmprojModel(ModelBase):
         super().prepare_metadata(vocab_only)
 
         output_type: str = self.ftype.name.partition("_")[2]
-        # Filename Output
+
         if self.fname_out.is_dir():
             fname_default: str = gguf.naming_convention(self.metadata.name, self.metadata.basename, self.metadata.finetune, self.metadata.version, size_label=None, output_type=output_type, model_type="mmproj")
-
-            # Use the default filename
             self.fname_out = self.fname_out / f"{fname_default}.gguf"
         else:
-            # Process templated file name with the output ftype, useful with the "auto" ftype
             self.fname_out = self.fname_out.parent / gguf.fill_templated_filename(self.fname_out.name, output_type)
 
     def set_gguf_parameters(self):

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1503,8 +1503,8 @@ class MmprojModel(ModelBase):
         output_type: str = self.ftype.name.partition("_")[2]
 
         if self.fname_out.is_dir():
-            fname_default: str = gguf.naming_convention(self.metadata.name, self.metadata.basename, self.metadata.finetune, self.metadata.version, size_label=None, output_type=output_type, model_type="mmproj")
-            self.fname_out = self.fname_out / f"{fname_default}.gguf"
+            fname_default: str = gguf.naming_convention(self.metadata.name, self.metadata.basename, self.metadata.finetune, self.metadata.version, size_label=None, output_type=output_type, model_type=None)
+            self.fname_out = self.fname_out / f"mmproj-{fname_default}.gguf"
         else:
             self.fname_out = self.fname_out.parent / gguf.fill_templated_filename(self.fname_out.name, output_type)
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1498,7 +1498,7 @@ class MmprojModel(ModelBase):
         self.gguf_writer.add_type(gguf.GGUFType.MMPROJ)
 
     def prepare_metadata(self, vocab_only: bool):
-        super().prepare_metadata(vocab_only)
+        super().prepare_metadata(vocab_only=vocab_only)
 
         output_type: str = self.ftype.name.partition("_")[2]
 

--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -50,7 +50,7 @@ def size_label(total_params: int, shared_params: int, expert_params: int, expert
     return size_class
 
 
-def naming_convention(model_name: str | None, base_name: str | None, finetune_string: str | None, version_string: str | None, size_label: str | None, output_type: str | None, model_type: Literal['vocab', 'LoRA'] | None = None) -> str:
+def naming_convention(model_name: str | None, base_name: str | None, finetune_string: str | None, version_string: str | None, size_label: str | None, output_type: str | None, model_type: Literal['vocab', 'LoRA', 'mmproj'] | None = None) -> str:
     # Reference: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#gguf-naming-convention
 
     if base_name is not None:

--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -50,7 +50,7 @@ def size_label(total_params: int, shared_params: int, expert_params: int, expert
     return size_class
 
 
-def naming_convention(model_name: str | None, base_name: str | None, finetune_string: str | None, version_string: str | None, size_label: str | None, output_type: str | None, model_type: Literal['vocab', 'LoRA', 'mmproj'] | None = None) -> str:
+def naming_convention(model_name: str | None, base_name: str | None, finetune_string: str | None, version_string: str | None, size_label: str | None, output_type: str | None, model_type: Literal['vocab', 'LoRA'] | None = None) -> str:
     # Reference: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#gguf-naming-convention
 
     if base_name is not None:


### PR DESCRIPTION
Currently when output filename is not specified, script generates file called `mmproj-model-dir` without any extension, in a parent directory. 

This PR changes the way default filename is handled. With this change generated file will look like this `model-dir/model-dir-ftype-mmproj.gguf`.

Note this uses `-mmproj` suffix, instead of `mmproj-` prefix. I opted to follow the established convention.

Example:
Current: `Qwen3VL-2B-Instruct/Qwen3VL-2b-Instruct-F16-mmproj.gguf`
Previous: `mmproj-Qwen3VL-2B-Instruct`, note unspecified filetype, wrong directory and missing extension