### PR TITLE
Explicitly set cur to res->t_embd in PLaMo2 models

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -17965,6 +17965,8 @@ struct llm_build_plamo2 : public llm_graph_context_mamba {
         cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
         cb(cur, "result_norm", -1);
 
+        res->t_embd = cur;
+
         // lm_head
         cur = build_lora_mm(model.output, cur);
         cb(cur, "result_output", -1);


### PR DESCRIPTION
This PR adds a line to explicitly set `res->t_embd` with `cur` in the PLaMo2 model implementation.
Without this fix, the ollama always crashes because params.embeddings is hard-coded with `true` at [ollama/llama/llama.go:L120](https://github.com/ollama/ollama/blob/ad6f6a1d29f45a5c7266bcd7edb5671621e86810/llama/llama.go#L120) and it results in a call of this assertion:
https://github.com/ollama/ollama/blob/ad6f6a1d29f45a5c7266bcd7edb5671621e86810/llama/llama.cpp/src/llama-graph.cpp#L1894
then it fails because `res->t_embd` here:
https://github.com/ollama/ollama/blob/ad6f6a1d29f45a5c7266bcd7edb5671621e86810/llama/llama.cpp/src/llama-graph.cpp#L1882
 is null with the current code of PLaMo2 model.

This PR intends to fix this problem.