### PR TITLE
Add basic support for MXFP6_MOE quantization

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -417,7 +417,8 @@ extern "C" {
         // GGML_TYPE_IQ4_NL_4_8 = 37,
         // GGML_TYPE_IQ4_NL_8_8 = 38,
         GGML_TYPE_MXFP4   = 39, // MXFP4 (1 block)
-        GGML_TYPE_COUNT   = 40,
+        GGML_TYPE_MXFP6_E3M2   = 40,
+        GGML_TYPE_COUNT   = 41,
     };
 
     // precision
@@ -453,6 +454,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_IQ1_M   = 23, // except 1d tensors
         GGML_FTYPE_MOSTLY_BF16    = 24, // except 1d tensors
         GGML_FTYPE_MOSTLY_MXFP4   = 25, // except 1d tensors
+        GGML_FTYPE_MOSTLY_MXFP6_E3M2   = 26, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -418,7 +418,8 @@ extern "C" {
         // GGML_TYPE_IQ4_NL_8_8 = 38,
         GGML_TYPE_MXFP4   = 39, // MXFP4 (1 block)
         GGML_TYPE_MXFP6_E3M2   = 40,
-        GGML_TYPE_COUNT   = 41,
+        GGML_TYPE_MXFP6_E2M3   = 41,
+        GGML_TYPE_COUNT   = 42,
     };
 
     // precision
@@ -455,6 +456,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_BF16    = 24, // except 1d tensors
         GGML_FTYPE_MOSTLY_MXFP4   = 25, // except 1d tensors
         GGML_FTYPE_MOSTLY_MXFP6_E3M2   = 26, // except 1d tensors
+        GGML_FTYPE_MOSTLY_MXFP6_E2M3   = 27, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -102,6 +102,10 @@ typedef sycl::half2 ggml_half2;
 #define QI_MXFP4 (QK_MXFP4 / (4 * QR_MXFP4))
 #define QR_MXFP4 2
 
+#define QI_MXFP6_E3M2 (QK_MXFP6_E3M2 * 3 / (4 * 4))
+// FIXME: QR(Value Per Byte) does not match this
+#define QR_MXFP6_E3M2 2
+
 #define QI5_0 (QK5_0 / (4 * QR5_0))
 #define QR5_0 2
 
@@ -1103,6 +1107,8 @@ GGML_TABLE_BEGIN(int8_t, kvalues_mxfp4, 16)
     0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12,
 GGML_TABLE_END()
 
+// 16^(-1)
+#define MXFP6_SCALER 0.0625f
 GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e3m2, 64)
     0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28,
     32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224,

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -194,6 +194,14 @@ typedef struct {
 } block_mxfp4;
 static_assert(sizeof(block_mxfp4) == sizeof(uint8_t) + QK_MXFP4/2, "wrong mxfp4 block size/padding");
 
+#define QK_MXFP6_E3M2 32
+typedef struct {
+    uint8_t e; // E8M0
+    uint8_t qs[QK_MXFP6_E3M2 * 3 / 4]; // 6bits -> 8bits
+} block_mxfp6_e3m2;
+static_assert(sizeof(block_mxfp6_e3m2) == sizeof(uint8_t) + QK_MXFP6_E3M2 * 3 / 4, "wrong mxfp6_e3m2 block size/padding");
+
+
 #define QK5_0 32
 typedef struct {
     ggml_half d;           // delta
@@ -1093,6 +1101,15 @@ GGML_TABLE_END()
 // ref: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 GGML_TABLE_BEGIN(int8_t, kvalues_mxfp4, 16)
     0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12,
+GGML_TABLE_END()
+
+GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e3m2, 64)
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28,
+    32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224,
+    256, 320, 384, 448,
+    0, -1, -2, -3, -4, -5, -6, -7, -8, -10, -12, -14, -16, -20, -24, -28,
+    -32, -40, -48, -56, -64, -80, -96, -112, -128, -160, -192, -224,
+    -256, -320, -384, -448,
 GGML_TABLE_END()
 
 #define NGRID_IQ1S 2048

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -106,6 +106,10 @@ typedef sycl::half2 ggml_half2;
 // FIXME: QR(Value Per Byte) does not match this
 #define QR_MXFP6_E3M2 2
 
+#define QI_MXFP6_E2M3 (QK_MXFP6_E3M2 * 3 / (4 * 4))
+// FIXME: QR(Value Per Byte) does not match this
+#define QR_MXFP6_E2M3 2
+
 #define QI5_0 (QK5_0 / (4 * QR5_0))
 #define QR5_0 2
 
@@ -205,6 +209,12 @@ typedef struct {
 } block_mxfp6_e3m2;
 static_assert(sizeof(block_mxfp6_e3m2) == sizeof(uint8_t) + QK_MXFP6_E3M2 * 3 / 4, "wrong mxfp6_e3m2 block size/padding");
 
+#define QK_MXFP6_E2M3 32
+typedef struct {
+    uint8_t e; // E8M0
+    uint8_t qs[QK_MXFP6_E2M3 * 3 / 4]; // 6bits -> 8bits
+} block_mxfp6_e2m3;
+static_assert(sizeof(block_mxfp6_e2m3) == sizeof(uint8_t) + QK_MXFP6_E2M3 * 3 / 4, "wrong mxfp6_e2m3 block size/padding");
 
 #define QK5_0 32
 typedef struct {
@@ -1117,6 +1127,20 @@ GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e3m2, 64)
     -32, -40, -48, -56, -64, -80, -96, -112, -128, -160, -192, -224,
     -256, -320, -384, -448,
 GGML_TABLE_END()
+
+// 8^(-1)
+#define MXFP6_SCALER 0.125f
+GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e2m3, 64)
+    0, 1, 2, 3, 4, 5, 6, 7,
+    8, 9, 10, 11, 12, 13, 14, 15,
+    16, 18, 20, 22, 24, 26, 28, 30,
+    32, 36, 40, 44, 48, 52, 56, 60,
+    0, -1, -2, -3, -4, -5, -6, -7,
+    -8, -9, -10, -11, -12, -13, -14, -15,
+    -16, -18, -20, -22, -24, -26, -28, -30,
+    -32, -36, -40, -44, -48, -52, -56, -60
+GGML_TABLE_END()
+
 
 #define NGRID_IQ1S 2048
 #define IQ1S_DELTA 0.125f

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -1118,7 +1118,7 @@ GGML_TABLE_BEGIN(int8_t, kvalues_mxfp4, 16)
 GGML_TABLE_END()
 
 // 16^(-1)
-#define MXFP6_SCALER 0.0625f
+#define MXFP6_E3M2_SCALER 0.0625f
 GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e3m2, 64)
     0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28,
     32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224,
@@ -1129,7 +1129,7 @@ GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e3m2, 64)
 GGML_TABLE_END()
 
 // 8^(-1)
-#define MXFP6_SCALER 0.125f
+#define MXFP6_E2M3_SCALER 0.125f
 GGML_TABLE_BEGIN(int16_t, kvalues_mxfp6_e2m3, 64)
     0, 1, 2, 3, 4, 5, 6, 7,
     8, 9, 10, 11, 12, 13, 14, 15,

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -51,6 +51,9 @@
 #define ggml_gemm_iq4_nl_4x4_q8_0_generic ggml_gemm_iq4_nl_4x4_q8_0
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
+// quants.c
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_K_4x8_generic ggml_quantize_mat_q8_K_4x8
 #define ggml_gemv_q4_K_8x8_q8_K_generic ggml_gemv_q4_K_8x8_q8_K

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -15,6 +15,7 @@
 #define ggml_vec_dot_q8_0_q8_0_generic ggml_vec_dot_q8_0_q8_0
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_q2_K_q8_K_generic ggml_vec_dot_q2_K_q8_K
@@ -74,6 +75,8 @@
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -100,6 +103,7 @@
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -134,6 +138,7 @@
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -163,6 +168,8 @@
 #define ggml_vec_dot_iq3_s_q8_K_generic ggml_vec_dot_iq3_s_q8_K
 #define ggml_vec_dot_iq1_s_q8_K_generic ggml_vec_dot_iq1_s_q8_K
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -197,6 +204,7 @@
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
+#define ggml_vec_dot_mxfp6_e2m3_q8_0_generic ggml_vec_dot_mxfp6_e2m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -14,6 +14,7 @@
 #define ggml_vec_dot_q5_1_q8_1_generic ggml_vec_dot_q5_1_q8_1
 #define ggml_vec_dot_q8_0_q8_0_generic ggml_vec_dot_q8_0_q8_0
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_q2_K_q8_K_generic ggml_vec_dot_q2_K_q8_K
@@ -98,6 +99,7 @@
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -131,6 +133,7 @@
 #define ggml_vec_dot_iq4_nl_q8_0_generic ggml_vec_dot_iq4_nl_q8_0
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8
@@ -193,6 +196,7 @@
 #define ggml_vec_dot_iq4_nl_q8_0_generic ggml_vec_dot_iq4_nl_q8_0
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp6_e3m2_q8_0_generic ggml_vec_dot_mxfp6_e3m2_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_0_4x8_generic ggml_quantize_mat_q8_0_4x8

--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -650,42 +650,6 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
-void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
-    assert(nrc == 1);
-    UNUSED(nrc);
-    UNUSED(bx);
-    UNUSED(by);
-    UNUSED(bs);
-    assert(n % QK_MXFP6_E3M2 == 0);
-    static_assert(QK_MXFP6_E3M2 == QK8_0, "QK_MXFP6_E3M2 and QK8_0 must be the same");
-
-    const block_mxfp6_e3m2 * GGML_RESTRICT x = vx;
-    const block_q8_0 * GGML_RESTRICT y = vy;
-
-    const int nb = n / QK_MXFP6_E3M2;
-
-    int ib = 0;
-    float sumf = 0;
-
-    for (; ib < nb; ++ib) {
-        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
-        int sumi1 = 0;
-        int sumi2 = 0;
-        int sumi3 = 0;
-        int sumi4 = 0;
-        // Q8_0 (y) * MXFP6 (block_size = 32)
-        for (int j = 0; j < QK_MXFP6_E3M2/4; ++j) {
-            sumi1 += y[ib].qs[j +                   0] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j] & 0x3f];
-            sumi2 += y[ib].qs[j + 1 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j]     >> 6) | ((x[ib].qs[3 * j + 1] & 0x0F) << 2)];
-            sumi3 += y[ib].qs[j + 2 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j + 1] >> 4) | ((x[ib].qs[3 * j + 2] & 0x03) << 4)];
-            sumi4 += y[ib].qs[j + 3 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j + 2] >> 2];
-        }
-        sumf += d * (sumi1 + sumi2 + sumi3 + sumi4);
-    }
-    *s = sumf;
-}
-
-
 void ggml_vec_dot_q5_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK8_0;
     const int nb = n / qk;

--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -650,6 +650,42 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
+void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_MXFP6_E3M2 == 0);
+    static_assert(QK_MXFP6_E3M2 == QK8_0, "QK_MXFP6_E3M2 and QK8_0 must be the same");
+
+    const block_mxfp6_e3m2 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_MXFP6_E3M2;
+
+    int ib = 0;
+    float sumf = 0;
+
+    for (; ib < nb; ++ib) {
+        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
+        int sumi1 = 0;
+        int sumi2 = 0;
+        int sumi3 = 0;
+        int sumi4 = 0;
+        // Q8_0 (y) * MXFP6 (block_size = 32)
+        for (int j = 0; j < QK_MXFP6_E3M2/4; ++j) {
+            sumi1 += y[ib].qs[j +                   0] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j] & 0x3f];
+            sumi2 += y[ib].qs[j + 1 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j]     >> 6) | ((x[ib].qs[3 * j + 1] & 0x0F) << 2)];
+            sumi3 += y[ib].qs[j + 2 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j + 1] >> 4) | ((x[ib].qs[3 * j + 2] & 0x03) << 4)];
+            sumi4 += y[ib].qs[j + 3 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j + 2] >> 2];
+        }
+        sumf += d * (sumi1 + sumi2 + sumi3 + sumi4);
+    }
+    *s = sumf;
+}
+
+
 void ggml_vec_dot_q5_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK8_0;
     const int nb = n / qk;
@@ -3647,4 +3683,3 @@ void ggml_vec_dot_iq4_xs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
     ggml_vec_dot_iq4_xs_q8_K_generic(n, s, bs, vx, bx, vy, by, nrc);
 #endif
 }
-

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -860,7 +860,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
         int ib = 0;
         float sumf = 0;
 
-    #if 0 //defined __AVX2__
+    #if defined __AVX2__
         __m256 accum_ps = _mm256_setzero_ps();
 
         for (; ib + 1 < nb; ib += 2) {
@@ -968,6 +968,134 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
 
         *s = sumf;
 }
+
+void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+        UNUSED(nrc);
+        UNUSED(bx);
+        UNUSED(by);
+        UNUSED(bs);
+        assert(n % QK_MXFP6_E2M3 == 0);
+        static_assert(QK_MXFP6_E2M3 == QK8_0, "QK_MXFP6_E2M3 and QK8_0 must be the same");
+        assert(QK_MXFP6_E2M3 == 32);
+
+        const block_mxfp6_e2m3 * GGML_RESTRICT x = vx;
+        const block_q8_0 * GGML_RESTRICT y = vy;
+
+        const int nb = n / QK_MXFP6_E2M3;
+
+        int ib = 0;
+        float sumf = 0;
+
+    #if defined __AVX2__
+        __m256 accum_ps = _mm256_setzero_ps();
+
+        for (; ib + 1 < nb; ib += 2) {
+            const block_mxfp6_e2m3 * x1 = &x[ib + 0];
+            const block_q8_0       * y1 = &y[ib + 0];
+
+            const block_mxfp6_e2m3 * x2 = &x[ib + 1];
+            const block_q8_0       * y2 = &y[ib + 1];
+
+            int16_t k_vals_1[32];
+            {
+                const uint8_t * q3 = x1->qs;
+                for (int j = 0; j < 8; ++j) {
+                    const uint8_t b0 = q3[0];
+                    const uint8_t b1 = q3[1];
+                    const uint8_t b2 = q3[2];
+                    k_vals_1[4*j + 0] = kvalues_mxfp6_e2m3[b0 & 0x3F];
+                    k_vals_1[4*j + 1] = kvalues_mxfp6_e2m3[(b0 >> 6) | ((b1 & 0x0F) << 2)];
+                    k_vals_1[4*j + 2] = kvalues_mxfp6_e2m3[(b1 >> 4) | ((b2 & 0x03) << 4)];
+                    k_vals_1[4*j + 3] = kvalues_mxfp6_e2m3[b2 >> 2];
+                    q3 += 3;
+                }
+            }
+
+            int16_t k_vals_2[32];
+            {
+                const uint8_t * q3 = x2->qs;
+                for (int j = 0; j < 8; ++j) {
+                    const uint8_t b0 = q3[0];
+                    const uint8_t b1 = q3[1];
+                    const uint8_t b2 = q3[2];
+                    k_vals_2[4*j + 0] = kvalues_mxfp6_e2m3[b0 & 0x3F];
+                    k_vals_2[4*j + 1] = kvalues_mxfp6_e2m3[(b0 >> 6) | ((b1 & 0x0F) << 2)];
+                    k_vals_2[4*j + 2] = kvalues_mxfp6_e2m3[(b1 >> 4) | ((b2 & 0x03) << 4)];
+                    k_vals_2[4*j + 3] = kvalues_mxfp6_e2m3[b2 >> 2];
+                    q3 += 3;
+                }
+            }
+
+            const __m256i k_1_lo = _mm256_load_si256((const __m256i *)(k_vals_1 +  0)); // k-vals 0-15
+            const __m256i k_1_hi = _mm256_load_si256((const __m256i *)(k_vals_1 + 16)); // k-vals 16-31
+
+            const __m256i q8_1_all = _mm256_loadu_si256((const __m256i *)y1->qs);
+
+            const __m256i q8_1_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 0)); // q-vals 0-15
+            const __m256i q8_1_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 1)); // q-vals 16-31
+
+            const __m256i p_1_lo = _mm256_madd_epi16(k_1_lo, q8_1_lo);
+            const __m256i p_1_hi = _mm256_madd_epi16(k_1_hi, q8_1_hi);
+
+            const __m256i p_1_all = _mm256_add_epi32(p_1_lo, p_1_hi); // 8x s32
+
+            const __m256i k_2_lo = _mm256_load_si256((const __m256i *)(k_vals_2 +  0));
+            const __m256i k_2_hi = _mm256_load_si256((const __m256i *)(k_vals_2 + 16));
+            const __m256i q8_2_all = _mm256_loadu_si256((const __m256i *)y2->qs);
+            const __m256i q8_2_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 0));
+            const __m256i q8_2_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 1));
+            const __m256i p_2_lo = _mm256_madd_epi16(k_2_lo, q8_2_lo);
+            const __m256i p_2_hi = _mm256_madd_epi16(k_2_hi, q8_2_hi);
+            const __m256i p_2_all = _mm256_add_epi32(p_2_lo, p_2_hi); // 8x s32
+
+            const __m256 p_1_ps = _mm256_cvtepi32_ps(p_1_all);
+            const __m256 p_2_ps = _mm256_cvtepi32_ps(p_2_all);
+
+            // (d = d_y * d_x)
+            const float d1 = GGML_CPU_FP16_TO_FP32(y1->d) * GGML_E8M0_TO_FP32_HALF(x1->e);
+            const float d2 = GGML_CPU_FP16_TO_FP32(y2->d) * GGML_E8M0_TO_FP32_HALF(x2->e);
+
+            const __m256 d_1_ps = _mm256_set1_ps(d1);
+            const __m256 d_2_ps = _mm256_set1_ps(d2);
+
+            // Fused Multiply-Add (FMA): accum = (d * p) + accum
+            accum_ps = _mm256_fmadd_ps(d_1_ps, p_1_ps, accum_ps);
+            accum_ps = _mm256_fmadd_ps(d_2_ps, p_2_ps, accum_ps);
+        }
+
+        sumf = hsum_float_8(accum_ps);
+    #endif
+
+        for (; ib < nb; ++ib) {
+            const float d = GGML_CPU_FP16_TO_FP32(y[ib].d) * GGML_E8M0_TO_FP32_HALF(x[ib].e);
+
+            int sumi = 0;
+
+            for (int j = 0; j < QK_MXFP6_E2M3 / 4; ++j) {
+                const uint8_t * q3 = x[ib].qs + 3 * j;
+                const int8_t * q8 = y[ib].qs + 4 * j;
+
+                const uint8_t b0 = q3[0];
+                const uint8_t b1 = q3[1];
+                const uint8_t b2 = q3[2];
+
+                const uint8_t v0_idx = b0 & 0x3F;
+                const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);
+                const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
+                const uint8_t v3_idx = b2 >> 2;
+
+                sumi += q8[0] * kvalues_mxfp6_e2m3[v0_idx];
+                sumi += q8[1] * kvalues_mxfp6_e2m3[v1_idx];
+                sumi += q8[2] * kvalues_mxfp6_e2m3[v2_idx];
+                sumi += q8[3] * kvalues_mxfp6_e2m3[v3_idx];
+            }
+            sumf += d * sumi;
+        }
+
+        *s = sumf;
+}
+
 
 void ggml_vec_dot_q5_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK8_0;

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -861,7 +861,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
         const int16_t* kvalues = (const int16_t*)kvalues_mxfp6_e3m2;
 
         for (int i = 0; i < nb; ++i) {
-            const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_HALF(x[i].e);
+            const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_ANY(x[i].e, 4);
 
             const __m256i q8_v = _mm256_loadu_si256((const __m256i*)y[i].qs);
 
@@ -932,7 +932,7 @@ void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
     const int16_t* kvalues = (const int16_t*)kvalues_mxfp6_e2m3;
 
     for (int i = 0; i < nb; ++i) {
-        const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_HALF(x[i].e);
+        const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_ANY(x[i].e, 3);
 
         const __m256i q8_v = _mm256_loadu_si256((const __m256i*)y[i].qs);
 

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -860,7 +860,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
         int ib = 0;
         float sumf = 0;
 
-    #if defined __AVX2__
+    #if 0 //defined __AVX2__
         __m256 accum_ps = _mm256_setzero_ps();
 
         for (; ib + 1 < nb; ib += 2) {
@@ -870,7 +870,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
             const block_mxfp6_e3m2 * x2 = &x[ib + 1];
             const block_q8_0       * y2 = &y[ib + 1];
 
-            alignas(32) int16_t k_vals_1[32];
+            int16_t k_vals_1[32];
             {
                 const uint8_t * q3 = x1->qs;
                 for (int j = 0; j < 8; ++j) {
@@ -885,7 +885,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
                 }
             }
 
-            alignas(32) int16_t k_vals_2[32];
+            int16_t k_vals_2[32];
             {
                 const uint8_t * q3 = x2->qs;
                 for (int j = 0; j < 8; ++j) {

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -860,7 +860,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
         int ib = 0;
         float sumf = 0;
 
-    #if defined __AVX2__
+    #if 0//defined __AVX2__
         __m256 accum_ps = _mm256_setzero_ps();
 
         for (; ib + 1 < nb; ib += 2) {
@@ -987,7 +987,7 @@ void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
         int ib = 0;
         float sumf = 0;
 
-    #if defined __AVX2__
+    #if 0 //defined __AVX2__
         __m256 accum_ps = _mm256_setzero_ps();
 
         for (; ib + 1 < nb; ib += 2) {

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -856,8 +856,6 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
     const block_q8_0 * GGML_RESTRICT y = vy;
     const int nb = n / QK_MXFP6_E3M2;
 
-    int ib = 0;
-
     #if defined __AVX2__
         __m256 acc = _mm256_setzero_ps();
         const int16_t* kvalues = (const int16_t*)kvalues_mxfp6_e3m2;
@@ -928,8 +926,6 @@ void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, con
     const block_mxfp6_e2m3 * GGML_RESTRICT x = vx;
     const block_q8_0 * GGML_RESTRICT y = vy;
     const int nb = n / QK_MXFP6_E2M3;
-
-    int ib = 0;
 
     #if defined __AVX2__
     __m256 acc = _mm256_setzero_ps();

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -844,256 +844,148 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
 
 void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);
-        UNUSED(nrc);
-        UNUSED(bx);
-        UNUSED(by);
-        UNUSED(bs);
-        assert(n % QK_MXFP6_E3M2 == 0);
-        static_assert(QK_MXFP6_E3M2 == QK8_0, "QK_MXFP6_E3M2 and QK8_0 must be the same");
-        assert(QK_MXFP6_E3M2 == 32);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_MXFP6_E3M2 == 0);
+    static_assert(QK_MXFP6_E3M2 == QK8_0, "QK_MXFP6_E3M2 and QK8_0 must be the same");
+    assert(QK_MXFP6_E3M2 == 32);
 
-        const block_mxfp6_e3m2 * GGML_RESTRICT x = vx;
-        const block_q8_0 * GGML_RESTRICT y = vy;
+    const block_mxfp6_e3m2 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+    const int nb = n / QK_MXFP6_E3M2;
 
-        const int nb = n / QK_MXFP6_E3M2;
+    int ib = 0;
 
-        int ib = 0;
-        float sumf = 0;
+    #if defined __AVX2__
+        __m256 acc = _mm256_setzero_ps();
+        const int16_t* kvalues = (const int16_t*)kvalues_mxfp6_e3m2;
 
-    #if 0//defined __AVX2__
-        __m256 accum_ps = _mm256_setzero_ps();
+        for (int i = 0; i < nb; ++i) {
+            const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_HALF(x[i].e);
 
-        for (; ib + 1 < nb; ib += 2) {
-            const block_mxfp6_e3m2 * x1 = &x[ib + 0];
-            const block_q8_0       * y1 = &y[ib + 0];
+            const __m256i q8_v = _mm256_loadu_si256((const __m256i*)y[i].qs);
 
-            const block_mxfp6_e3m2 * x2 = &x[ib + 1];
-            const block_q8_0       * y2 = &y[ib + 1];
-
-            int16_t k_vals_1[32];
-            {
-                const uint8_t * q3 = x1->qs;
-                for (int j = 0; j < 8; ++j) {
-                    const uint8_t b0 = q3[0];
-                    const uint8_t b1 = q3[1];
-                    const uint8_t b2 = q3[2];
-                    k_vals_1[4*j + 0] = kvalues_mxfp6_e3m2[b0 & 0x3F];
-                    k_vals_1[4*j + 1] = kvalues_mxfp6_e3m2[(b0 >> 6) | ((b1 & 0x0F) << 2)];
-                    k_vals_1[4*j + 2] = kvalues_mxfp6_e3m2[(b1 >> 4) | ((b2 & 0x03) << 4)];
-                    k_vals_1[4*j + 3] = kvalues_mxfp6_e3m2[b2 >> 2];
-                    q3 += 3;
-                }
-            }
-
-            int16_t k_vals_2[32];
-            {
-                const uint8_t * q3 = x2->qs;
-                for (int j = 0; j < 8; ++j) {
-                    const uint8_t b0 = q3[0];
-                    const uint8_t b1 = q3[1];
-                    const uint8_t b2 = q3[2];
-                    k_vals_2[4*j + 0] = kvalues_mxfp6_e3m2[b0 & 0x3F];
-                    k_vals_2[4*j + 1] = kvalues_mxfp6_e3m2[(b0 >> 6) | ((b1 & 0x0F) << 2)];
-                    k_vals_2[4*j + 2] = kvalues_mxfp6_e3m2[(b1 >> 4) | ((b2 & 0x03) << 4)];
-                    k_vals_2[4*j + 3] = kvalues_mxfp6_e3m2[b2 >> 2];
-                    q3 += 3;
-                }
-            }
-
-            const __m256i k_1_lo = _mm256_load_si256((const __m256i *)(k_vals_1 +  0)); // k-vals 0-15
-            const __m256i k_1_hi = _mm256_load_si256((const __m256i *)(k_vals_1 + 16)); // k-vals 16-31
-
-            const __m256i q8_1_all = _mm256_loadu_si256((const __m256i *)y1->qs);
-
-            const __m256i q8_1_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 0)); // q-vals 0-15
-            const __m256i q8_1_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 1)); // q-vals 16-31
-
-            const __m256i p_1_lo = _mm256_madd_epi16(k_1_lo, q8_1_lo);
-            const __m256i p_1_hi = _mm256_madd_epi16(k_1_hi, q8_1_hi);
-
-            const __m256i p_1_all = _mm256_add_epi32(p_1_lo, p_1_hi); // 8x s32
-
-            const __m256i k_2_lo = _mm256_load_si256((const __m256i *)(k_vals_2 +  0));
-            const __m256i k_2_hi = _mm256_load_si256((const __m256i *)(k_vals_2 + 16));
-            const __m256i q8_2_all = _mm256_loadu_si256((const __m256i *)y2->qs);
-            const __m256i q8_2_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 0));
-            const __m256i q8_2_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 1));
-            const __m256i p_2_lo = _mm256_madd_epi16(k_2_lo, q8_2_lo);
-            const __m256i p_2_hi = _mm256_madd_epi16(k_2_hi, q8_2_hi);
-            const __m256i p_2_all = _mm256_add_epi32(p_2_lo, p_2_hi); // 8x s32
-
-            const __m256 p_1_ps = _mm256_cvtepi32_ps(p_1_all);
-            const __m256 p_2_ps = _mm256_cvtepi32_ps(p_2_all);
-
-            // (d = d_y * d_x)
-            const float d1 = GGML_CPU_FP16_TO_FP32(y1->d) * GGML_E8M0_TO_FP32_HALF(x1->e);
-            const float d2 = GGML_CPU_FP16_TO_FP32(y2->d) * GGML_E8M0_TO_FP32_HALF(x2->e);
-
-            const __m256 d_1_ps = _mm256_set1_ps(d1);
-            const __m256 d_2_ps = _mm256_set1_ps(d2);
-
-            // Fused Multiply-Add (FMA): accum = (d * p) + accum
-            accum_ps = _mm256_fmadd_ps(d_1_ps, p_1_ps, accum_ps);
-            accum_ps = _mm256_fmadd_ps(d_2_ps, p_2_ps, accum_ps);
-        }
-
-        sumf = hsum_float_8(accum_ps);
-    #endif
-
-        for (; ib < nb; ++ib) {
-            const float d = GGML_CPU_FP16_TO_FP32(y[ib].d) * GGML_E8M0_TO_FP32_HALF(x[ib].e);
-
-            int sumi = 0;
-
-            for (int j = 0; j < QK_MXFP6_E3M2 / 4; ++j) {
-                const uint8_t * q3 = x[ib].qs + 3 * j;
-                const int8_t * q8 = y[ib].qs + 4 * j;
-
+            uint8_t indices_buf[32];
+            const uint8_t* q3 = x[i].qs;
+            for (int j = 0; j < 8; ++j) {
                 const uint8_t b0 = q3[0];
                 const uint8_t b1 = q3[1];
                 const uint8_t b2 = q3[2];
+                q3 += 3;
 
-                const uint8_t v0_idx = b0 & 0x3F;
-                const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);
-                const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
-                const uint8_t v3_idx = b2 >> 2;
-
-                sumi += q8[0] * kvalues_mxfp6_e3m2[v0_idx];
-                sumi += q8[1] * kvalues_mxfp6_e3m2[v1_idx];
-                sumi += q8[2] * kvalues_mxfp6_e3m2[v2_idx];
-                sumi += q8[3] * kvalues_mxfp6_e3m2[v3_idx];
+                indices_buf[4*j + 0] = b0 & 0x3F;
+                indices_buf[4*j + 1] = (b0 >> 6) | ((b1 & 0x0F) << 2);
+                indices_buf[4*j + 2] = (b1 >> 4) | ((b2 & 0x03) << 4);
+                indices_buf[4*j + 3] = b2 >> 2;
             }
-            sumf += d * sumi;
+
+            int16_t x_dequant_buf_lo[16];
+            for (int j = 0; j < 16; ++j) {
+                x_dequant_buf_lo[j] = kvalues[indices_buf[j]];
+            }
+            int16_t x_dequant_buf_hi[16];
+            for (int j = 0; j < 16; ++j) {
+                x_dequant_buf_hi[j] = kvalues[indices_buf[j + 16]];
+            }
+
+            const __m256i x_s16_lo = _mm256_loadu_si256((const __m256i*)x_dequant_buf_lo); // 16x s16
+            const __m128i y_s8_lo = _mm256_castsi256_si128(q8_v);                           // 16x s8
+            const __m256i y_s16_lo = _mm256_cvtepi8_epi16(y_s8_lo);                         // 16x s16
+            const __m256i prod_lo = _mm256_madd_epi16(x_s16_lo, y_s16_lo);                  // 8x s32
+
+            const __m256i x_s16_hi = _mm256_loadu_si256((const __m256i*)x_dequant_buf_hi); // 16x s16
+            const __m128i y_s8_hi = _mm256_extracti128_si256(q8_v, 1);                      // 16x s8
+            const __m256i y_s16_hi = _mm256_cvtepi8_epi16(y_s8_hi);                         // 16x s16
+            const __m256i prod_hi = _mm256_madd_epi16(x_s16_hi, y_s16_hi);                  // 8x s32
+
+            const __m256i sumi_v = _mm256_add_epi32(prod_lo, prod_hi); // 8x s32
+
+            const __m256 sumf_v = _mm256_cvtepi32_ps(sumi_v);
+            acc = _mm256_fmadd_ps(_mm256_broadcast_ss(&d), sumf_v, acc);
         }
 
-        *s = sumf;
+        *s = hsum_float_8(acc);
+    #else
+        UNUSED(x);
+        UNUSED(y);
+        UNUSED(nb);
+        ggml_vec_dot_mxfp6_e3m2_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+    #endif
 }
 
 void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);
-        UNUSED(nrc);
-        UNUSED(bx);
-        UNUSED(by);
-        UNUSED(bs);
-        assert(n % QK_MXFP6_E2M3 == 0);
-        static_assert(QK_MXFP6_E2M3 == QK8_0, "QK_MXFP6_E2M3 and QK8_0 must be the same");
-        assert(QK_MXFP6_E2M3 == 32);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_MXFP6_E2M3 == 0);
+    static_assert(QK_MXFP6_E2M3 == QK8_0, "QK_MXFP6_E2M3 and QK8_0 must be the same");
+    assert(QK_MXFP6_E2M3 == 32);
 
-        const block_mxfp6_e2m3 * GGML_RESTRICT x = vx;
-        const block_q8_0 * GGML_RESTRICT y = vy;
+    const block_mxfp6_e2m3 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+    const int nb = n / QK_MXFP6_E2M3;
 
-        const int nb = n / QK_MXFP6_E2M3;
+    int ib = 0;
 
-        int ib = 0;
-        float sumf = 0;
+    #if defined __AVX2__
+    __m256 acc = _mm256_setzero_ps();
+    const int16_t* kvalues = (const int16_t*)kvalues_mxfp6_e2m3;
 
-    #if 0 //defined __AVX2__
-        __m256 accum_ps = _mm256_setzero_ps();
+    for (int i = 0; i < nb; ++i) {
+        const float d = GGML_CPU_FP16_TO_FP32(y[i].d) * GGML_E8M0_TO_FP32_HALF(x[i].e);
 
-        for (; ib + 1 < nb; ib += 2) {
-            const block_mxfp6_e2m3 * x1 = &x[ib + 0];
-            const block_q8_0       * y1 = &y[ib + 0];
+        const __m256i q8_v = _mm256_loadu_si256((const __m256i*)y[i].qs);
 
-            const block_mxfp6_e2m3 * x2 = &x[ib + 1];
-            const block_q8_0       * y2 = &y[ib + 1];
+        uint8_t indices_buf[32];
+        const uint8_t* q3 = x[i].qs;
+        for (int j = 0; j < 8; ++j) {
+            const uint8_t b0 = q3[0];
+            const uint8_t b1 = q3[1];
+            const uint8_t b2 = q3[2];
+            q3 += 3;
 
-            int16_t k_vals_1[32];
-            {
-                const uint8_t * q3 = x1->qs;
-                for (int j = 0; j < 8; ++j) {
-                    const uint8_t b0 = q3[0];
-                    const uint8_t b1 = q3[1];
-                    const uint8_t b2 = q3[2];
-                    k_vals_1[4*j + 0] = kvalues_mxfp6_e2m3[b0 & 0x3F];
-                    k_vals_1[4*j + 1] = kvalues_mxfp6_e2m3[(b0 >> 6) | ((b1 & 0x0F) << 2)];
-                    k_vals_1[4*j + 2] = kvalues_mxfp6_e2m3[(b1 >> 4) | ((b2 & 0x03) << 4)];
-                    k_vals_1[4*j + 3] = kvalues_mxfp6_e2m3[b2 >> 2];
-                    q3 += 3;
-                }
-            }
-
-            int16_t k_vals_2[32];
-            {
-                const uint8_t * q3 = x2->qs;
-                for (int j = 0; j < 8; ++j) {
-                    const uint8_t b0 = q3[0];
-                    const uint8_t b1 = q3[1];
-                    const uint8_t b2 = q3[2];
-                    k_vals_2[4*j + 0] = kvalues_mxfp6_e2m3[b0 & 0x3F];
-                    k_vals_2[4*j + 1] = kvalues_mxfp6_e2m3[(b0 >> 6) | ((b1 & 0x0F) << 2)];
-                    k_vals_2[4*j + 2] = kvalues_mxfp6_e2m3[(b1 >> 4) | ((b2 & 0x03) << 4)];
-                    k_vals_2[4*j + 3] = kvalues_mxfp6_e2m3[b2 >> 2];
-                    q3 += 3;
-                }
-            }
-
-            const __m256i k_1_lo = _mm256_load_si256((const __m256i *)(k_vals_1 +  0)); // k-vals 0-15
-            const __m256i k_1_hi = _mm256_load_si256((const __m256i *)(k_vals_1 + 16)); // k-vals 16-31
-
-            const __m256i q8_1_all = _mm256_loadu_si256((const __m256i *)y1->qs);
-
-            const __m256i q8_1_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 0)); // q-vals 0-15
-            const __m256i q8_1_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_1_all, 1)); // q-vals 16-31
-
-            const __m256i p_1_lo = _mm256_madd_epi16(k_1_lo, q8_1_lo);
-            const __m256i p_1_hi = _mm256_madd_epi16(k_1_hi, q8_1_hi);
-
-            const __m256i p_1_all = _mm256_add_epi32(p_1_lo, p_1_hi); // 8x s32
-
-            const __m256i k_2_lo = _mm256_load_si256((const __m256i *)(k_vals_2 +  0));
-            const __m256i k_2_hi = _mm256_load_si256((const __m256i *)(k_vals_2 + 16));
-            const __m256i q8_2_all = _mm256_loadu_si256((const __m256i *)y2->qs);
-            const __m256i q8_2_lo = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 0));
-            const __m256i q8_2_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_2_all, 1));
-            const __m256i p_2_lo = _mm256_madd_epi16(k_2_lo, q8_2_lo);
-            const __m256i p_2_hi = _mm256_madd_epi16(k_2_hi, q8_2_hi);
-            const __m256i p_2_all = _mm256_add_epi32(p_2_lo, p_2_hi); // 8x s32
-
-            const __m256 p_1_ps = _mm256_cvtepi32_ps(p_1_all);
-            const __m256 p_2_ps = _mm256_cvtepi32_ps(p_2_all);
-
-            // (d = d_y * d_x)
-            const float d1 = GGML_CPU_FP16_TO_FP32(y1->d) * GGML_E8M0_TO_FP32_HALF(x1->e);
-            const float d2 = GGML_CPU_FP16_TO_FP32(y2->d) * GGML_E8M0_TO_FP32_HALF(x2->e);
-
-            const __m256 d_1_ps = _mm256_set1_ps(d1);
-            const __m256 d_2_ps = _mm256_set1_ps(d2);
-
-            // Fused Multiply-Add (FMA): accum = (d * p) + accum
-            accum_ps = _mm256_fmadd_ps(d_1_ps, p_1_ps, accum_ps);
-            accum_ps = _mm256_fmadd_ps(d_2_ps, p_2_ps, accum_ps);
+            indices_buf[4*j + 0] = b0 & 0x3F;
+            indices_buf[4*j + 1] = (b0 >> 6) | ((b1 & 0x0F) << 2);
+            indices_buf[4*j + 2] = (b1 >> 4) | ((b2 & 0x03) << 4);
+            indices_buf[4*j + 3] = b2 >> 2;
         }
 
-        sumf = hsum_float_8(accum_ps);
+        int16_t x_dequant_buf_lo[16];
+        for (int j = 0; j < 16; ++j) {
+            x_dequant_buf_lo[j] = kvalues[indices_buf[j]];
+        }
+        int16_t x_dequant_buf_hi[16];
+        for (int j = 0; j < 16; ++j) {
+            x_dequant_buf_hi[j] = kvalues[indices_buf[j + 16]];
+        }
+
+        const __m256i x_s16_lo = _mm256_loadu_si256((const __m256i*)x_dequant_buf_lo); // 16x s16
+        const __m128i y_s8_lo = _mm256_castsi256_si128(q8_v);                           // 16x s8
+        const __m256i y_s16_lo = _mm256_cvtepi8_epi16(y_s8_lo);                         // 16x s16
+        const __m256i prod_lo = _mm256_madd_epi16(x_s16_lo, y_s16_lo);                  // 8x s32
+
+        const __m256i x_s16_hi = _mm256_loadu_si256((const __m256i*)x_dequant_buf_hi); // 16x s16
+        const __m128i y_s8_hi = _mm256_extracti128_si256(q8_v, 1);                      // 16x s8
+        const __m256i y_s16_hi = _mm256_cvtepi8_epi16(y_s8_hi);                         // 16x s16
+        const __m256i prod_hi = _mm256_madd_epi16(x_s16_hi, y_s16_hi);                  // 8x s32
+
+        const __m256i sumi_v = _mm256_add_epi32(prod_lo, prod_hi); // 8x s32
+
+        const __m256 sumf_v = _mm256_cvtepi32_ps(sumi_v);
+        acc = _mm256_fmadd_ps(_mm256_broadcast_ss(&d), sumf_v, acc);
+    }
+
+    *s = hsum_float_8(acc);
+    #else
+        UNUSED(x);
+        UNUSED(y);
+        UNUSED(nb);
+        ggml_vec_dot_mxfp6_e2m3_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
     #endif
-
-        for (; ib < nb; ++ib) {
-            const float d = GGML_CPU_FP16_TO_FP32(y[ib].d) * GGML_E8M0_TO_FP32_HALF(x[ib].e);
-
-            int sumi = 0;
-
-            for (int j = 0; j < QK_MXFP6_E2M3 / 4; ++j) {
-                const uint8_t * q3 = x[ib].qs + 3 * j;
-                const int8_t * q8 = y[ib].qs + 4 * j;
-
-                const uint8_t b0 = q3[0];
-                const uint8_t b1 = q3[1];
-                const uint8_t b2 = q3[2];
-
-                const uint8_t v0_idx = b0 & 0x3F;
-                const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);
-                const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
-                const uint8_t v3_idx = b2 >> 2;
-
-                sumi += q8[0] * kvalues_mxfp6_e2m3[v0_idx];
-                sumi += q8[1] * kvalues_mxfp6_e2m3[v1_idx];
-                sumi += q8[2] * kvalues_mxfp6_e2m3[v2_idx];
-                sumi += q8[3] * kvalues_mxfp6_e2m3[v3_idx];
-            }
-            sumf += d * sumi;
-        }
-
-        *s = sumf;
 }
 
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -259,6 +259,12 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
         .vec_dot_type             = GGML_TYPE_Q8_0,
         .nrows                    = 1,
     },
+    [GGML_TYPE_MXFP6_E3M2] = {
+        .from_float               = quantize_row_mxfp6_e3m2,
+        .vec_dot                  = ggml_vec_dot_mxfp6_e3m2_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+    },
     [GGML_TYPE_Q2_K] = {
         .from_float               = quantize_row_q2_K,
         .vec_dot                  = ggml_vec_dot_q2_K_q8_K,

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -265,6 +265,12 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
         .vec_dot_type             = GGML_TYPE_Q8_0,
         .nrows                    = 1,
     },
+    [GGML_TYPE_MXFP6_E2M3] = {
+        .from_float               = quantize_row_mxfp6_e2m3,
+        .vec_dot                  = ggml_vec_dot_mxfp6_e2m3_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+    },
     [GGML_TYPE_Q2_K] = {
         .from_float               = quantize_row_q2_K,
         .vec_dot                  = ggml_vec_dot_q2_K_q8_K,

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -668,6 +668,7 @@ void ggml_compute_forward_add(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1117,6 +1118,7 @@ void ggml_compute_forward_add1(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1244,7 +1246,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4140,7 +4142,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
-        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4415,7 +4417,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4677,7 +4679,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -5401,7 +5403,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
-        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -669,6 +669,7 @@ void ggml_compute_forward_add(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1119,6 +1120,7 @@ void ggml_compute_forward_add1(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1247,6 +1249,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4143,6 +4146,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4418,6 +4422,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4680,6 +4685,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -5404,6 +5410,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP6_E3M2:
+        case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -1248,6 +1248,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
+        case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
@@ -4145,6 +4146,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
@@ -4421,6 +4423,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
+        case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
@@ -4684,6 +4687,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
+        case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:
@@ -5409,6 +5413,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
+        case GGML_TYPE_MXFP4:
         case GGML_TYPE_MXFP6_E3M2:
         case GGML_TYPE_MXFP6_E2M3:
         case GGML_TYPE_Q2_K:

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -243,7 +243,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0_generic(int n, float * GGML_RESTRICT s, size_t
     float sumf = 0;
 
     for (; ib < nb; ++ib) {
-        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
+        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_ANY(x[ib].e, 4);
         int sumi = 0;
         // Q8_0 (y) * MXFP6 (block_size = 32)
         for (int j = 0; j < QK_MXFP6_E3M2/4; ++j) {
@@ -294,7 +294,7 @@ void ggml_vec_dot_mxfp6_e2m3_q8_0_generic(int n, float * GGML_RESTRICT s, size_t
     float sumf = 0;
 
     for (; ib < nb; ++ib) {
-        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
+        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_ANY(x[ib].e, 3);
         int sumi = 0;
         // Q8_0 (y) * MXFP6 (block_size = 32)
         for (int j = 0; j < QK_MXFP6_E2M3/4; ++j) {

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -50,6 +50,10 @@ void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, i
     quantize_row_mxfp4_ref(x, y, k);
 }
 
+void quantize_row_mxfp6_e3m2(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_mxfp6_e3m2_ref(x, y, k);
+}
+
 //
 // 2-6 bit quantization in super-blocks
 //
@@ -213,6 +217,41 @@ void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, 
         }
         sumf += d * (sumi1 + sumi2);
     }
+    *s = sumf;
+}
+
+void ggml_vec_dot_mxfp6_e3m2_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_MXFP6_E3M2 == 0);
+    static_assert(QK_MXFP6_E3M2 == QK8_0, "QK_MXFP6_E3M2 and QK8_0 must be the same");
+
+    const block_mxfp6_e3m2 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_MXFP6_E3M2;
+
+    int ib = 0;
+    float sumf = 0;
+
+    for (; ib < nb; ++ib) {
+        const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
+        int sumi1 = 0;
+        int sumi2 = 0;
+        int sumi3 = 0;
+        int sumi4 = 0;
+            // Q8_0 (y) * MXFP6 (block_size = 32)
+            for (int j = 0; j < QK_MXFP6_E3M2/4; ++j) {
+                sumi1 += y[ib].qs[j +                   0] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j] & 0x3f];
+                sumi2 += y[ib].qs[j + 1 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j]     >> 6) | ((x[ib].qs[3 * j + 1] & 0x0F) << 2)];
+                sumi3 += y[ib].qs[j + 2 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[(x[ib].qs[3 * j + 1] >> 4) | ((x[ib].qs[3 * j + 2] & 0x03) << 4)];
+                sumi4 += y[ib].qs[j + 3 * QK_MXFP6_E3M2/4] * kvalues_mxfp6_e3m2[ x[ib].qs[3 * j + 2] >> 2];
+            }
+            sumf += d * (sumi1 + sumi2 + sumi3 + sumi4);
+        }
     *s = sumf;
 }
 

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -240,7 +240,7 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0_generic(int n, float * GGML_RESTRICT s, size_t
 
     for (; ib < nb; ++ib) {
         const float d = GGML_CPU_FP16_TO_FP32(y[ib].d)*GGML_E8M0_TO_FP32_HALF(x[ib].e);
-        int sumi1 = 0;
+        int sumi = 0;
         // Q8_0 (y) * MXFP6 (block_size = 32)
         for (int j = 0; j < QK_MXFP6_E3M2/4; ++j) {
             // Current Packed MXFP6
@@ -252,7 +252,6 @@ void ggml_vec_dot_mxfp6_e3m2_q8_0_generic(int n, float * GGML_RESTRICT s, size_t
             const uint8_t b1 = q3[1];
             const uint8_t b2 = q3[2];
 
-            const uint8_t v0_idx = b0 & 0x3F;
             const uint8_t v0_idx = b0 & 0x3F;
             const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);
             const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -20,6 +20,7 @@ void quantize_row_q8_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, in
 void quantize_row_q8_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_mxfp6_e3m2(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_q2_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_q3_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
@@ -42,6 +43,7 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const voi
 void ggml_vec_dot_q8_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_q3_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -21,6 +21,7 @@ void quantize_row_q8_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, in
 
 void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_mxfp6_e3m2(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_mxfp6_e2m3(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_q2_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_q3_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
@@ -44,6 +45,7 @@ void ggml_vec_dot_q8_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 
 void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_mxfp6_e3m2_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp6_e2m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_q3_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
@@ -75,6 +77,8 @@ void ggml_vec_dot_q5_1_q8_1_generic(int n, float * GGML_RESTRICT s, size_t bs, c
 void ggml_vec_dot_q8_0_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp6_e2m3_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp6_e3m2_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_tq1_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_tq2_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -513,10 +513,10 @@ static __global__ void dequantize_block_mxfp6_e3m2(const void * __restrict__ vx,
         const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
         const uint8_t v3_idx = b2 >> 2;
 
-        y[y_offset + 0] = d * kvalues_mxfp6_e3m2[v0_idx]*0.0625f;
-        y[y_offset + 1] = d * kvalues_mxfp6_e3m2[v1_idx]*0.0625f;
-        y[y_offset + 2] = d * kvalues_mxfp6_e3m2[v2_idx]*0.0625f;
-        y[y_offset + 3] = d * kvalues_mxfp6_e3m2[v3_idx]*0.0625f;
+        y[y_offset + 0] = d * kvalues_mxfp6_e3m2[v0_idx]*MXFP6_E3M2_SCALER;
+        y[y_offset + 1] = d * kvalues_mxfp6_e3m2[v1_idx]*MXFP6_E3M2_SCALER;
+        y[y_offset + 2] = d * kvalues_mxfp6_e3m2[v2_idx]*MXFP6_E3M2_SCALER;
+        y[y_offset + 3] = d * kvalues_mxfp6_e3m2[v3_idx]*MXFP6_E3M2_SCALER;
     }
 }
 
@@ -552,11 +552,10 @@ static __global__ void dequantize_block_mxfp6_e2m3(const void * __restrict__ vx,
         const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
         const uint8_t v3_idx = b2 >> 2;
 
-        // Is this correct?
-        y[y_offset + 0] = d * kvalues_mxfp6_e2m3[v0_idx]*0.0625f;
-        y[y_offset + 1] = d * kvalues_mxfp6_e2m3[v1_idx]*0.0625f;
-        y[y_offset + 2] = d * kvalues_mxfp6_e2m3[v2_idx]*0.0625f;
-        y[y_offset + 3] = d * kvalues_mxfp6_e2m3[v3_idx]*0.0625f;
+        y[y_offset + 0] = d * kvalues_mxfp6_e2m3[v0_idx]*MXFP6_E2M3_SCALER;
+        y[y_offset + 1] = d * kvalues_mxfp6_e2m3[v1_idx]*MXFP6_E2M3_SCALER;
+        y[y_offset + 2] = d * kvalues_mxfp6_e2m3[v2_idx]*MXFP6_E2M3_SCALER;
+        y[y_offset + 3] = d * kvalues_mxfp6_e2m3[v3_idx]*MXFP6_E2M3_SCALER;
     }
 }
 

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -506,7 +506,7 @@ static __global__ void dequantize_block_mxfp6_e3m2(const void * __restrict__ vx,
 
         const uint8_t b0 = q3[0];
         const uint8_t b1 = q3[1];
-        const uint8_t b3 = q3[2];
+        const uint8_t b2 = q3[2];
 
         const uint8_t v0_idx = b0 & 0x3F;
         const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -481,6 +481,46 @@ static __global__ void dequantize_block_mxfp4(const void * __restrict__ vx, dst_
     }
 }
 
+template<typename dst_t>
+static __global__ void dequantize_block_mxfp6_e3m2(const void * __restrict__ vx, dst_t * __restrict__ yy) {
+
+    // QK_K(256) / QK_MXFP6_E3M2(32) = 8 blocks
+    const int64_t i   = blockIdx.x;
+    const block_mxfp6_e3m2 * x = (const block_mxfp6_e3m2 *) vx + i*(QK_K/QK_MXFP6_E3M2);
+
+    const int64_t tid = threadIdx.x;
+    // MXFP6 has 32 6-bit values, packed into 24 bytes.
+    // For 4 thread model, each thread handle 24 / 4 = 6 bytes = 2 3-byte block
+    // Each thread generate 8 values.
+    const int64_t il = tid/8; // 0...3 -> 4 threads
+    const int64_t ib = tid%8; // 0...7 -> each threads handle 2 (3 bytes) block
+    dst_t * y = yy + i*QK_K + 32*ib;
+    const uint8_t  * qs = x[ib].qs;
+    const float d = ggml_cuda_e8m0_to_fp32(x[ib].e);
+    for (int g_idx = 0; g_idx < 2; ++g_idx) {
+        const int g = 2 * il + g_idx;
+        // input index -> 3 byte * current index
+        const uint8_t* q3 = qs + 3*g;
+        // output index -> 4 byte * current index
+        const int y_offset = 4 * g;
+
+        const uint8_t b0 = q3[0];
+        const uint8_t b1 = q3[1];
+        const uint8_t b3 = q3[2];
+
+        const uint8_t v0_idx = b0 & 0x3F;
+        const uint8_t v1_idx = (b0 >> 6) | ((b1 & 0x0F) << 2);
+        const uint8_t v2_idx = (b1 >> 4) | ((b2 & 0x03) << 4);
+        const uint8_t v3_idx = b2 >> 2;
+
+        y[y_offset + 0] = d * kvalues_mxfp6_e3m2[v0_idx]*0.0625f;
+        y[y_offset + 1] = d * kvalues_mxfp6_e3m2[v1_idx]*0.0625f;
+        y[y_offset + 2] = d * kvalues_mxfp6_e3m2[v2_idx]*0.0625f;
+        y[y_offset + 3] = d * kvalues_mxfp6_e3m2[v3_idx]*0.0625f;
+    }
+}
+
+
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
 static void dequantize_block_cuda(const void * vx, dst_t * y,
         const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t ne03,
@@ -610,6 +650,12 @@ static void dequantize_row_mxfp4_cuda(const void * vx, dst_t * y, const int64_t 
     dequantize_block_mxfp4<<<nb, 32, 0, stream>>>(vx, y);
 }
 
+template<typename dst_t>
+static void dequantize_row_mxfp6_e3m2_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
+    const int nb = (k + QK_K - 1) / QK_K;
+    dequantize_block_mxfp6_e3m2<<<nb, 32, 0, stream>>>(vx, y);
+}
+
 template <typename src_t, typename dst_t>
 static __global__ void convert_unary(
         const void * __restrict__ vx, dst_t * __restrict__ y, const int64_t ne00, const int64_t ne01, const int64_t ne02,
@@ -701,6 +747,8 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
             return dequantize_row_iq3_s_cuda;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_cuda;
+        case GGML_TYPE_MXFP6_E3M2:
+            return dequantize_row_mxfp6_e3m2_cuda;
         case GGML_TYPE_F32:
             return convert_unary_cont_cuda<float>;
         case GGML_TYPE_BF16:
@@ -752,6 +800,8 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return dequantize_row_iq3_s_cuda;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_cuda;
+        case GGML_TYPE_MXFP6_E3M2:
+            return dequantize_row_mxfp6_e3m2_cuda;
         case GGML_TYPE_F16:
             return convert_unary_cont_cuda<half>;
         case GGML_TYPE_BF16:

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -308,12 +308,11 @@ void quantize_row_mxfp6_e3m2_ref(const float * GGML_RESTRICT x, block_mxfp6_e3m2
         y[i].e = e;
 
         // 4 * 6bit quant -> 3 bytes
-        // Final Size: qk * 3 / 4
         for (int j = 0; j < qk / 4; ++j) {
-            const uint8_t x0 = best_index_mxfp6_e3m2(x[i*qk + 0          + j], d);
-            const uint8_t x1 = best_index_mxfp6_e3m2(x[i*qk + 1 * qk / 4 + j], d);
-            const uint8_t x2 = best_index_mxfp6_e3m2(x[i*qk + 2 * qk / 4 + j], d);
-            const uint8_t x3 = best_index_mxfp6_e3m2(x[i*qk + 3 * qk / 4 + j], d);
+            const uint8_t x0 = best_index_mxfp6_e3m2(x[i*qk + 4*j + 0], d);
+            const uint8_t x1 = best_index_mxfp6_e3m2(x[i*qk + 4*j + 1], d);
+            const uint8_t x2 = best_index_mxfp6_e3m2(x[i*qk + 4*j + 2], d);
+            const uint8_t x3 = best_index_mxfp6_e3m2(x[i*qk + 4*j + 3], d);
 
             // 1100 0000
             y[i].qs[3*j] = x0 | ((x1 & 0x03) << 6);
@@ -500,15 +499,15 @@ void dequantize_row_mxfp6_e3m2(const block_mxfp6_e3m2 * GGML_RESTRICT x, float *
         const float d = GGML_E8M0_TO_FP32_HALF(x[i].e);
 
         for (int j = 0; j < qk / 4; ++j) {
-            const int8_t x0 = kvalues_mxfp6_e3m2[x[i].qs[3 * j] & 0x3F];
-            const int8_t x1 = kvalues_mxfp6_e3m2[(x[i].qs[3 * j] >> 6) | ((x[i].qs[3 * j + 1] & 0x0F) << 2)];
-            const int8_t x2 = kvalues_mxfp6_e3m2[(x[i].qs[3 * j + 1] >> 4) | ((x[i].qs[3 * j + 2] & 0x03) << 4)];
-            const int8_t x3 = kvalues_mxfp6_e3m2[x[i].qs[3 * j + 2] >> 2];
+            const int16_t x0 = kvalues_mxfp6_e3m2[x[i].qs[3 * j] & 0x3F];
+            const int16_t x1 = kvalues_mxfp6_e3m2[(x[i].qs[3 * j] >> 6) | ((x[i].qs[3 * j + 1] & 0x0F) << 2)];
+            const int16_t x2 = kvalues_mxfp6_e3m2[(x[i].qs[3 * j + 1] >> 4) | ((x[i].qs[3 * j + 2] & 0x03) << 4)];
+            const int16_t x3 = kvalues_mxfp6_e3m2[x[i].qs[3 * j + 2] >> 2];
 
-            y[i*qk + j + 0   ] = x0*d;
-            y[i*qk + j + 1 * qk/4] = x1*d;
-            y[i*qk + j + 2 * qk/4] = x2*d;
-            y[i*qk + j + 3 * qk/4] = x3*d;
+            y[i*qk + 4 * j + 0] = x0*d;
+            y[i*qk + 4 * j + 1] = x1*d;
+            y[i*qk + 4 * j + 2] = x2*d;
+            y[i*qk + 4 * j + 3] = x3*d;
         }
     }
 }

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -301,7 +301,7 @@ void quantize_row_mxfp6_e3m2_ref(const float * GGML_RESTRICT x, block_mxfp6_e3m2
             }
         }
 
-        const uint8_t e = amax > 0.0f ? (uint8_t) (floorf(log2f(amax)) - 9 + 127) : 0;
+        const uint8_t e = amax > 0.0f ? (uint8_t) (floorf(log2f(amax)) - 4 + 127) : 0;
 
         const float d = GGML_E8M0_TO_FP32_HALF(e);
 

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -23,6 +23,7 @@ GGML_API void quantize_row_q8_1_ref(const float * GGML_RESTRICT x, block_q8_1 * 
 
 GGML_API void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_mxfp6_e3m2_ref(const float * GGML_RESTRICT x, block_mxfp6_e3m2 * GGML_RESTRICT y, int64_t k);
+GGML_API void quantize_row_mxfp6_e2m3_ref(const float * GGML_RESTRICT x, block_mxfp6_e2m3 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_q2_K_ref(const float * GGML_RESTRICT x, block_q2_K * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_q3_K_ref(const float * GGML_RESTRICT x, block_q3_K * GGML_RESTRICT y, int64_t k);
@@ -50,6 +51,7 @@ GGML_API void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GG
 
 GGML_API void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_mxfp6_e3m2(const block_mxfp6_e3m2 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_mxfp6_e2m3(const block_mxfp6_e2m3 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_q2_K(const block_q2_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_q3_K(const block_q3_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -98,6 +100,7 @@ GGML_API size_t quantize_q8_0(const float * GGML_RESTRICT src, void * GGML_RESTR
 
 GGML_API size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_mxfp6_e3m2(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_mxfp6_e2m3(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API void iq2xs_init_impl(enum ggml_type type);
 GGML_API void iq2xs_free_impl(enum ggml_type type);

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -22,6 +22,7 @@ GGML_API void quantize_row_q8_0_ref(const float * GGML_RESTRICT x, block_q8_0 * 
 GGML_API void quantize_row_q8_1_ref(const float * GGML_RESTRICT x, block_q8_1 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RESTRICT y, int64_t k);
+GGML_API void quantize_row_mxfp6_e3m2_ref(const float * GGML_RESTRICT x, block_mxfp6_e3m2 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_q2_K_ref(const float * GGML_RESTRICT x, block_q2_K * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_q3_K_ref(const float * GGML_RESTRICT x, block_q3_K * GGML_RESTRICT y, int64_t k);
@@ -48,6 +49,7 @@ GGML_API void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GG
 //GGML_API void dequantize_row_q8_1(const block_q8_1 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_mxfp6_e3m2(const block_mxfp6_e3m2 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_q2_K(const block_q2_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_q3_K(const block_q3_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -95,6 +97,7 @@ GGML_API size_t quantize_q5_1(const float * GGML_RESTRICT src, void * GGML_RESTR
 GGML_API size_t quantize_q8_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_mxfp6_e3m2(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API void iq2xs_init_impl(enum ggml_type type);
 GGML_API void iq2xs_free_impl(enum ggml_type type);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -695,6 +695,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_mxfp4,
         .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp4_ref,
     },
+    [GGML_TYPE_MXFP6_E3M2] = {
+        .type_name                = "mxfp6_e3m2",
+        .blck_size                = QK_MXFP6_E3M2,
+        .type_size                = sizeof(block_mxfp6_e3m2),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_mxfp6_e3m2,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp6_e3m2_ref,
+    },
     [GGML_TYPE_Q2_K] = {
         .type_name                = "q2_K",
         .blck_size                = QK_K,
@@ -1330,6 +1338,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q5_1:          wtype = GGML_TYPE_Q5_1;  break;
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
+        case GGML_FTYPE_MOSTLY_MXFP6_E3M2:     wtype = GGML_TYPE_MXFP6_E3M2; break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
         case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;
@@ -7300,6 +7309,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_Q5_1:    result = quantize_q5_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q8_0:    result = quantize_q8_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_MXFP4:   result = quantize_mxfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_MXFP6_E3M2:result = quantize_mxfp6_e3m2(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q2_K:    result = quantize_q2_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q3_K:    result = quantize_q3_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_K:    result = quantize_q4_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1346,8 +1346,8 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q5_1:          wtype = GGML_TYPE_Q5_1;  break;
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
-        case GGML_FTYPE_MOSTLY_MXFP6_E3M2:     wtype = GGML_TYPE_MXFP6_E3M2; break;
-        case GGML_FTYPE_MOSTLY_MXFP6_E2M3:     wtype = GGML_TYPE_MXFP6_E2M3; break;
+        case GGML_FTYPE_MOSTLY_MXFP6_E3M2:    wtype = GGML_TYPE_MXFP6_E3M2; break;
+        case GGML_FTYPE_MOSTLY_MXFP6_E2M3:    wtype = GGML_TYPE_MXFP6_E2M3; break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
         case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -703,6 +703,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_mxfp6_e3m2,
         .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp6_e3m2_ref,
     },
+    [GGML_TYPE_MXFP6_E2M3] = {
+        .type_name                = "mxfp6_e2m3",
+        .blck_size                = QK_MXFP6_E2M3,
+        .type_size                = sizeof(block_mxfp6_e2m3),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_mxfp6_e2m3,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp6_e2m3_ref,
+    },
     [GGML_TYPE_Q2_K] = {
         .type_name                = "q2_K",
         .blck_size                = QK_K,
@@ -1339,6 +1347,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
         case GGML_FTYPE_MOSTLY_MXFP6_E3M2:     wtype = GGML_TYPE_MXFP6_E3M2; break;
+        case GGML_FTYPE_MOSTLY_MXFP6_E2M3:     wtype = GGML_TYPE_MXFP6_E2M3; break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
         case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;
@@ -7310,6 +7319,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_Q8_0:    result = quantize_q8_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_MXFP4:   result = quantize_mxfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_MXFP6_E3M2:result = quantize_mxfp6_e3m2(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_MXFP6_E2M3:result = quantize_mxfp6_e2m3(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q2_K:    result = quantize_q2_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q3_K:    result = quantize_q3_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_K:    result = quantize_q4_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -2956,8 +2956,8 @@ class GGMLQuantizationType(IntEnum):
     TQ1_0 = 34
     TQ2_0 = 35
     MXFP4 = 39
-    MXFP6E3M2 = 40
-    MXFP6E2M3 = 41
+    MXFP6_E3M2 = 40
+    MXFP6_E2M3 = 41
 
 
 class ExpertGatingFuncType(IntEnum):

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -2957,6 +2957,7 @@ class GGMLQuantizationType(IntEnum):
     TQ2_0 = 35
     MXFP4 = 39
     MXFP6E3M2 = 40
+    MXFP6E2M3 = 41
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -3101,7 +3102,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.TQ2_0: (256, 2 + 64),
     GGMLQuantizationType.MXFP4: (32, 1 + 16),
     GGMLQuantizationType.MXFP6_E3M2: (32, 1 + 24),
-    # GGMLQuantizationType.MXFP6E2M3: (32, 1 + 24),
+    GGMLQuantizationType.MXFP6_E2M3: (32, 1 + 24),
 }
 
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -7,10 +7,10 @@ from typing import Any
 # constants
 #
 
-GGUF_MAGIC             = 0x46554747  # "GGUF"
-GGUF_VERSION           = 3
+GGUF_MAGIC = 0x46554747  # "GGUF"
+GGUF_VERSION = 3
 GGUF_DEFAULT_ALIGNMENT = 32
-GGML_QUANT_VERSION     = 2  # GGML_QNT_VERSION from ggml.h
+GGML_QUANT_VERSION = 2  # GGML_QNT_VERSION from ggml.h
 
 #
 # metadata keys
@@ -19,186 +19,190 @@ GGML_QUANT_VERSION     = 2  # GGML_QNT_VERSION from ggml.h
 
 class Keys:
     class General:
-        TYPE                       = "general.type"
-        ARCHITECTURE               = "general.architecture"
-        QUANTIZATION_VERSION       = "general.quantization_version"
-        ALIGNMENT                  = "general.alignment"
-        FILE_TYPE                  = "general.file_type"
+        TYPE = "general.type"
+        ARCHITECTURE = "general.architecture"
+        QUANTIZATION_VERSION = "general.quantization_version"
+        ALIGNMENT = "general.alignment"
+        FILE_TYPE = "general.file_type"
 
         # Authorship Metadata
-        NAME                       = "general.name"
-        AUTHOR                     = "general.author"
-        VERSION                    = "general.version"
-        ORGANIZATION               = "general.organization"
+        NAME = "general.name"
+        AUTHOR = "general.author"
+        VERSION = "general.version"
+        ORGANIZATION = "general.organization"
 
-        FINETUNE                   = "general.finetune"
-        BASENAME                   = "general.basename"
+        FINETUNE = "general.finetune"
+        BASENAME = "general.basename"
 
-        DESCRIPTION                = "general.description"
-        QUANTIZED_BY               = "general.quantized_by"
+        DESCRIPTION = "general.description"
+        QUANTIZED_BY = "general.quantized_by"
 
-        SIZE_LABEL                 = "general.size_label"
+        SIZE_LABEL = "general.size_label"
 
         # Licensing details
-        LICENSE                    = "general.license"
-        LICENSE_NAME               = "general.license.name"
-        LICENSE_LINK               = "general.license.link"
+        LICENSE = "general.license"
+        LICENSE_NAME = "general.license.name"
+        LICENSE_LINK = "general.license.link"
 
         # Typically represents the converted GGUF repo (Unless native)
-        URL                        = "general.url" # Model Website/Paper
-        DOI                        = "general.doi"
-        UUID                       = "general.uuid"
-        REPO_URL                   = "general.repo_url" # Model Source Repository (git/svn/etc...)
+        URL = "general.url"  # Model Website/Paper
+        DOI = "general.doi"
+        UUID = "general.uuid"
+        REPO_URL = "general.repo_url"  # Model Source Repository (git/svn/etc...)
 
         # Model Source during conversion
-        SOURCE_URL                 = "general.source.url" # Model Website/Paper
-        SOURCE_DOI                 = "general.source.doi"
-        SOURCE_UUID                = "general.source.uuid"
-        SOURCE_REPO_URL            = "general.source.repo_url" # Model Source Repository (git/svn/etc...)
+        SOURCE_URL = "general.source.url"  # Model Website/Paper
+        SOURCE_DOI = "general.source.doi"
+        SOURCE_UUID = "general.source.uuid"
+        SOURCE_REPO_URL = (
+            "general.source.repo_url"  # Model Source Repository (git/svn/etc...)
+        )
 
         # Base Model Source. There can be more than one source if it's a merged
         # model like with 'Mistral-7B-Merge-14-v0.1'. This will assist in
         # tracing linage of models as it is finetuned or merged over time.
-        BASE_MODEL_COUNT           = "general.base_model.count"
-        BASE_MODEL_NAME            = "general.base_model.{id}.name"
-        BASE_MODEL_AUTHOR          = "general.base_model.{id}.author"
-        BASE_MODEL_VERSION         = "general.base_model.{id}.version"
-        BASE_MODEL_ORGANIZATION    = "general.base_model.{id}.organization"
-        BASE_MODEL_DESCRIPTION     = "general.base_model.{id}.description"
-        BASE_MODEL_URL             = "general.base_model.{id}.url" # Model Website/Paper
-        BASE_MODEL_DOI             = "general.base_model.{id}.doi"
-        BASE_MODEL_UUID            = "general.base_model.{id}.uuid"
-        BASE_MODEL_REPO_URL        = "general.base_model.{id}.repo_url" # Model Source Repository (git/svn/etc...)
+        BASE_MODEL_COUNT = "general.base_model.count"
+        BASE_MODEL_NAME = "general.base_model.{id}.name"
+        BASE_MODEL_AUTHOR = "general.base_model.{id}.author"
+        BASE_MODEL_VERSION = "general.base_model.{id}.version"
+        BASE_MODEL_ORGANIZATION = "general.base_model.{id}.organization"
+        BASE_MODEL_DESCRIPTION = "general.base_model.{id}.description"
+        BASE_MODEL_URL = "general.base_model.{id}.url"  # Model Website/Paper
+        BASE_MODEL_DOI = "general.base_model.{id}.doi"
+        BASE_MODEL_UUID = "general.base_model.{id}.uuid"
+        BASE_MODEL_REPO_URL = "general.base_model.{id}.repo_url"  # Model Source Repository (git/svn/etc...)
 
         # Dataset Source
-        DATASET_COUNT           = "general.dataset.count"
-        DATASET_NAME            = "general.dataset.{id}.name"
-        DATASET_AUTHOR          = "general.dataset.{id}.author"
-        DATASET_VERSION         = "general.dataset.{id}.version"
-        DATASET_ORGANIZATION    = "general.dataset.{id}.organization"
-        DATASET_DESCRIPTION     = "general.dataset.{id}.description"
-        DATASET_URL             = "general.dataset.{id}.url" # Model Website/Paper
-        DATASET_DOI             = "general.dataset.{id}.doi"
-        DATASET_UUID            = "general.dataset.{id}.uuid"
-        DATASET_REPO_URL        = "general.dataset.{id}.repo_url" # Model Source Repository (git/svn/etc...)
+        DATASET_COUNT = "general.dataset.count"
+        DATASET_NAME = "general.dataset.{id}.name"
+        DATASET_AUTHOR = "general.dataset.{id}.author"
+        DATASET_VERSION = "general.dataset.{id}.version"
+        DATASET_ORGANIZATION = "general.dataset.{id}.organization"
+        DATASET_DESCRIPTION = "general.dataset.{id}.description"
+        DATASET_URL = "general.dataset.{id}.url"  # Model Website/Paper
+        DATASET_DOI = "general.dataset.{id}.doi"
+        DATASET_UUID = "general.dataset.{id}.uuid"
+        DATASET_REPO_URL = (
+            "general.dataset.{id}.repo_url"  # Model Source Repository (git/svn/etc...)
+        )
 
         # Array based KV stores
-        TAGS                       = "general.tags"
-        LANGUAGES                  = "general.languages"
+        TAGS = "general.tags"
+        LANGUAGES = "general.languages"
 
     class LLM:
-        VOCAB_SIZE                        = "{arch}.vocab_size"
-        CONTEXT_LENGTH                    = "{arch}.context_length"
-        EMBEDDING_LENGTH                  = "{arch}.embedding_length"
-        FEATURES_LENGTH                   = "{arch}.features_length"
-        BLOCK_COUNT                       = "{arch}.block_count"
-        LEADING_DENSE_BLOCK_COUNT         = "{arch}.leading_dense_block_count"
-        FEED_FORWARD_LENGTH               = "{arch}.feed_forward_length"
-        EXPERT_FEED_FORWARD_LENGTH        = "{arch}.expert_feed_forward_length"
+        VOCAB_SIZE = "{arch}.vocab_size"
+        CONTEXT_LENGTH = "{arch}.context_length"
+        EMBEDDING_LENGTH = "{arch}.embedding_length"
+        FEATURES_LENGTH = "{arch}.features_length"
+        BLOCK_COUNT = "{arch}.block_count"
+        LEADING_DENSE_BLOCK_COUNT = "{arch}.leading_dense_block_count"
+        FEED_FORWARD_LENGTH = "{arch}.feed_forward_length"
+        EXPERT_FEED_FORWARD_LENGTH = "{arch}.expert_feed_forward_length"
         EXPERT_SHARED_FEED_FORWARD_LENGTH = "{arch}.expert_shared_feed_forward_length"
-        EXPERT_CHUNK_FEED_FORWARD_LENGTH  = "{arch}.expert_chunk_feed_forward_length"
-        USE_PARALLEL_RESIDUAL             = "{arch}.use_parallel_residual"
-        TENSOR_DATA_LAYOUT                = "{arch}.tensor_data_layout"
-        EXPERT_COUNT                      = "{arch}.expert_count"
-        EXPERT_USED_COUNT                 = "{arch}.expert_used_count"
-        EXPERT_SHARED_COUNT               = "{arch}.expert_shared_count"
-        EXPERT_GROUP_COUNT                = "{arch}.expert_group_count"
-        EXPERT_GROUP_USED_COUNT           = "{arch}.expert_group_used_count"
-        EXPERT_WEIGHTS_SCALE              = "{arch}.expert_weights_scale"
-        EXPERT_WEIGHTS_NORM               = "{arch}.expert_weights_norm"
-        EXPERT_GATING_FUNC                = "{arch}.expert_gating_func"
-        EXPERT_GROUP_SCALE                = "{arch}.expert_group_scale"
-        EXPERTS_PER_GROUP                 = "{arch}.experts_per_group"
-        MOE_EVERY_N_LAYERS                = "{arch}.moe_every_n_layers"
-        NEXTN_PREDICT_LAYERS              = "{arch}.nextn_predict_layers"
-        POOLING_TYPE                      = "{arch}.pooling_type"
-        LOGIT_SCALE                       = "{arch}.logit_scale"
-        DECODER_START_TOKEN_ID            = "{arch}.decoder_start_token_id"
-        DECODER_BLOCK_COUNT               = "{arch}.decoder_block_count"
-        ATTN_LOGIT_SOFTCAPPING            = "{arch}.attn_logit_softcapping"
-        ROUTER_LOGIT_SOFTCAPPING          = "{arch}.router_logit_softcapping"
-        FINAL_LOGIT_SOFTCAPPING           = "{arch}.final_logit_softcapping"
-        SWIN_NORM                         = "{arch}.swin_norm"
-        RESCALE_EVERY_N_LAYERS            = "{arch}.rescale_every_n_layers"
-        TIME_MIX_EXTRA_DIM                = "{arch}.time_mix_extra_dim"
-        TIME_DECAY_EXTRA_DIM              = "{arch}.time_decay_extra_dim"
-        RESIDUAL_SCALE                    = "{arch}.residual_scale"
-        EMBEDDING_SCALE                   = "{arch}.embedding_scale"
-        TOKEN_SHIFT_COUNT                 = "{arch}.token_shift_count"
-        INTERLEAVE_MOE_LAYER_STEP         = "{arch}.interleave_moe_layer_step"
-        ACTIVATION_SPARSITY_SCALE         = "{arch}.activation_sparsity_scale"
-        ALTUP_ACTIVE_IDX                  = "{arch}.altup.active_idx"
-        ALTUP_NUM_INPUTS                  = "{arch}.altup.num_inputs"
-        EMBD_LENGTH_PER_LAYER_INP         = "{arch}.embedding_length_per_layer_input"
-        DENSE_FEAT_IN_SIZE                = "{arch}.{dense}_feat_in"
-        DENSE_FEAT_OUT_SIZE               = "{arch}.{dense}_feat_out"
+        EXPERT_CHUNK_FEED_FORWARD_LENGTH = "{arch}.expert_chunk_feed_forward_length"
+        USE_PARALLEL_RESIDUAL = "{arch}.use_parallel_residual"
+        TENSOR_DATA_LAYOUT = "{arch}.tensor_data_layout"
+        EXPERT_COUNT = "{arch}.expert_count"
+        EXPERT_USED_COUNT = "{arch}.expert_used_count"
+        EXPERT_SHARED_COUNT = "{arch}.expert_shared_count"
+        EXPERT_GROUP_COUNT = "{arch}.expert_group_count"
+        EXPERT_GROUP_USED_COUNT = "{arch}.expert_group_used_count"
+        EXPERT_WEIGHTS_SCALE = "{arch}.expert_weights_scale"
+        EXPERT_WEIGHTS_NORM = "{arch}.expert_weights_norm"
+        EXPERT_GATING_FUNC = "{arch}.expert_gating_func"
+        EXPERT_GROUP_SCALE = "{arch}.expert_group_scale"
+        EXPERTS_PER_GROUP = "{arch}.experts_per_group"
+        MOE_EVERY_N_LAYERS = "{arch}.moe_every_n_layers"
+        NEXTN_PREDICT_LAYERS = "{arch}.nextn_predict_layers"
+        POOLING_TYPE = "{arch}.pooling_type"
+        LOGIT_SCALE = "{arch}.logit_scale"
+        DECODER_START_TOKEN_ID = "{arch}.decoder_start_token_id"
+        DECODER_BLOCK_COUNT = "{arch}.decoder_block_count"
+        ATTN_LOGIT_SOFTCAPPING = "{arch}.attn_logit_softcapping"
+        ROUTER_LOGIT_SOFTCAPPING = "{arch}.router_logit_softcapping"
+        FINAL_LOGIT_SOFTCAPPING = "{arch}.final_logit_softcapping"
+        SWIN_NORM = "{arch}.swin_norm"
+        RESCALE_EVERY_N_LAYERS = "{arch}.rescale_every_n_layers"
+        TIME_MIX_EXTRA_DIM = "{arch}.time_mix_extra_dim"
+        TIME_DECAY_EXTRA_DIM = "{arch}.time_decay_extra_dim"
+        RESIDUAL_SCALE = "{arch}.residual_scale"
+        EMBEDDING_SCALE = "{arch}.embedding_scale"
+        TOKEN_SHIFT_COUNT = "{arch}.token_shift_count"
+        INTERLEAVE_MOE_LAYER_STEP = "{arch}.interleave_moe_layer_step"
+        ACTIVATION_SPARSITY_SCALE = "{arch}.activation_sparsity_scale"
+        ALTUP_ACTIVE_IDX = "{arch}.altup.active_idx"
+        ALTUP_NUM_INPUTS = "{arch}.altup.num_inputs"
+        EMBD_LENGTH_PER_LAYER_INP = "{arch}.embedding_length_per_layer_input"
+        DENSE_FEAT_IN_SIZE = "{arch}.{dense}_feat_in"
+        DENSE_FEAT_OUT_SIZE = "{arch}.{dense}_feat_out"
 
     class Attention:
-        HEAD_COUNT                   = "{arch}.attention.head_count"
-        HEAD_COUNT_KV                = "{arch}.attention.head_count_kv"
-        MAX_ALIBI_BIAS               = "{arch}.attention.max_alibi_bias"
-        CLAMP_KQV                    = "{arch}.attention.clamp_kqv"
-        KEY_LENGTH                   = "{arch}.attention.key_length"
-        VALUE_LENGTH                 = "{arch}.attention.value_length"
-        LAYERNORM_EPS                = "{arch}.attention.layer_norm_epsilon"
-        LAYERNORM_RMS_EPS            = "{arch}.attention.layer_norm_rms_epsilon"
-        GROUPNORM_EPS                = "{arch}.attention.group_norm_epsilon"
-        GROUPNORM_GROUPS             = "{arch}.attention.group_norm_groups"
-        CAUSAL                       = "{arch}.attention.causal"
-        Q_LORA_RANK                  = "{arch}.attention.q_lora_rank"
-        KV_LORA_RANK                 = "{arch}.attention.kv_lora_rank"
-        DECAY_LORA_RANK              = "{arch}.attention.decay_lora_rank"
-        ICLR_LORA_RANK               = "{arch}.attention.iclr_lora_rank"
+        HEAD_COUNT = "{arch}.attention.head_count"
+        HEAD_COUNT_KV = "{arch}.attention.head_count_kv"
+        MAX_ALIBI_BIAS = "{arch}.attention.max_alibi_bias"
+        CLAMP_KQV = "{arch}.attention.clamp_kqv"
+        KEY_LENGTH = "{arch}.attention.key_length"
+        VALUE_LENGTH = "{arch}.attention.value_length"
+        LAYERNORM_EPS = "{arch}.attention.layer_norm_epsilon"
+        LAYERNORM_RMS_EPS = "{arch}.attention.layer_norm_rms_epsilon"
+        GROUPNORM_EPS = "{arch}.attention.group_norm_epsilon"
+        GROUPNORM_GROUPS = "{arch}.attention.group_norm_groups"
+        CAUSAL = "{arch}.attention.causal"
+        Q_LORA_RANK = "{arch}.attention.q_lora_rank"
+        KV_LORA_RANK = "{arch}.attention.kv_lora_rank"
+        DECAY_LORA_RANK = "{arch}.attention.decay_lora_rank"
+        ICLR_LORA_RANK = "{arch}.attention.iclr_lora_rank"
         VALUE_RESIDUAL_MIX_LORA_RANK = "{arch}.attention.value_residual_mix_lora_rank"
-        GATE_LORA_RANK               = "{arch}.attention.gate_lora_rank"
-        REL_BUCKETS_COUNT            = "{arch}.attention.relative_buckets_count"
-        SLIDING_WINDOW               = "{arch}.attention.sliding_window"
-        SCALE                        = "{arch}.attention.scale"
-        OUTPUT_SCALE                 = "{arch}.attention.output_scale"
-        TEMPERATURE_LENGTH           = "{arch}.attention.temperature_length"
-        KEY_LENGTH_MLA               = "{arch}.attention.key_length_mla"
-        VALUE_LENGTH_MLA             = "{arch}.attention.value_length_mla"
-        SHARED_KV_LAYERS             = "{arch}.attention.shared_kv_layers"
-        SLIDING_WINDOW_PATTERN       = "{arch}.attention.sliding_window_pattern"
+        GATE_LORA_RANK = "{arch}.attention.gate_lora_rank"
+        REL_BUCKETS_COUNT = "{arch}.attention.relative_buckets_count"
+        SLIDING_WINDOW = "{arch}.attention.sliding_window"
+        SCALE = "{arch}.attention.scale"
+        OUTPUT_SCALE = "{arch}.attention.output_scale"
+        TEMPERATURE_LENGTH = "{arch}.attention.temperature_length"
+        KEY_LENGTH_MLA = "{arch}.attention.key_length_mla"
+        VALUE_LENGTH_MLA = "{arch}.attention.value_length_mla"
+        SHARED_KV_LAYERS = "{arch}.attention.shared_kv_layers"
+        SLIDING_WINDOW_PATTERN = "{arch}.attention.sliding_window_pattern"
 
     class Rope:
-        DIMENSION_COUNT          = "{arch}.rope.dimension_count"
-        DIMENSION_SECTIONS       = "{arch}.rope.dimension_sections"
-        FREQ_BASE                = "{arch}.rope.freq_base"
-        SCALING_TYPE             = "{arch}.rope.scaling.type"
-        SCALING_FACTOR           = "{arch}.rope.scaling.factor"
-        SCALING_ATTN_FACTOR      = "{arch}.rope.scaling.attn_factor"
-        SCALING_ORIG_CTX_LEN     = "{arch}.rope.scaling.original_context_length"
-        SCALING_FINETUNED        = "{arch}.rope.scaling.finetuned"
-        SCALING_YARN_LOG_MUL     = "{arch}.rope.scaling.yarn_log_multiplier"
-        SCALING_YARN_EXT_FACTOR  = "{arch}.rope.scaling.yarn_ext_factor"
+        DIMENSION_COUNT = "{arch}.rope.dimension_count"
+        DIMENSION_SECTIONS = "{arch}.rope.dimension_sections"
+        FREQ_BASE = "{arch}.rope.freq_base"
+        SCALING_TYPE = "{arch}.rope.scaling.type"
+        SCALING_FACTOR = "{arch}.rope.scaling.factor"
+        SCALING_ATTN_FACTOR = "{arch}.rope.scaling.attn_factor"
+        SCALING_ORIG_CTX_LEN = "{arch}.rope.scaling.original_context_length"
+        SCALING_FINETUNED = "{arch}.rope.scaling.finetuned"
+        SCALING_YARN_LOG_MUL = "{arch}.rope.scaling.yarn_log_multiplier"
+        SCALING_YARN_EXT_FACTOR = "{arch}.rope.scaling.yarn_ext_factor"
         SCALING_YARN_ATTN_FACTOR = "{arch}.rope.scaling.yarn_attn_factor"
-        SCALING_YARN_BETA_FAST   = "{arch}.rope.scaling.yarn_beta_fast"
-        SCALING_YARN_BETA_SLOW   = "{arch}.rope.scaling.yarn_beta_slow"
+        SCALING_YARN_BETA_FAST = "{arch}.rope.scaling.yarn_beta_fast"
+        SCALING_YARN_BETA_SLOW = "{arch}.rope.scaling.yarn_beta_slow"
 
     class Split:
-        LLM_KV_SPLIT_NO            = "split.no"
-        LLM_KV_SPLIT_COUNT         = "split.count"
+        LLM_KV_SPLIT_NO = "split.no"
+        LLM_KV_SPLIT_COUNT = "split.count"
         LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count"
 
     class SSM:
-        CONV_KERNEL    = "{arch}.ssm.conv_kernel"
-        INNER_SIZE     = "{arch}.ssm.inner_size"
-        STATE_SIZE     = "{arch}.ssm.state_size"
+        CONV_KERNEL = "{arch}.ssm.conv_kernel"
+        INNER_SIZE = "{arch}.ssm.inner_size"
+        STATE_SIZE = "{arch}.ssm.state_size"
         TIME_STEP_RANK = "{arch}.ssm.time_step_rank"
-        GROUP_COUNT    = "{arch}.ssm.group_count"
-        DT_B_C_RMS     = "{arch}.ssm.dt_b_c_rms"
+        GROUP_COUNT = "{arch}.ssm.group_count"
+        DT_B_C_RMS = "{arch}.ssm.dt_b_c_rms"
 
     class WKV:
         HEAD_SIZE = "{arch}.wkv.head_size"
 
     class PosNet:
         EMBEDDING_LENGTH = "{arch}.posnet.embedding_length"
-        BLOCK_COUNT      = "{arch}.posnet.block_count"
+        BLOCK_COUNT = "{arch}.posnet.block_count"
 
     class ConvNext:
         EMBEDDING_LENGTH = "{arch}.convnext.embedding_length"
-        BLOCK_COUNT      = "{arch}.convnext.block_count"
+        BLOCK_COUNT = "{arch}.convnext.block_count"
 
     class Classifier:
         OUTPUT_LABELS = "{arch}.classifier.output_labels"
@@ -207,106 +211,108 @@ class Keys:
         L_CACHE = "{arch}.shortconv.l_cache"
 
     class Tokenizer:
-        MODEL                = "tokenizer.ggml.model"
-        PRE                  = "tokenizer.ggml.pre"
-        LIST                 = "tokenizer.ggml.tokens"
-        TOKEN_TYPE           = "tokenizer.ggml.token_type"
-        TOKEN_TYPE_COUNT     = "tokenizer.ggml.token_type_count"  # for BERT-style token types
-        SCORES               = "tokenizer.ggml.scores"
-        MERGES               = "tokenizer.ggml.merges"
-        BOS_ID               = "tokenizer.ggml.bos_token_id"
-        EOS_ID               = "tokenizer.ggml.eos_token_id"
-        EOT_ID               = "tokenizer.ggml.eot_token_id"
-        EOM_ID               = "tokenizer.ggml.eom_token_id"
-        UNK_ID               = "tokenizer.ggml.unknown_token_id"
-        SEP_ID               = "tokenizer.ggml.seperator_token_id"
-        PAD_ID               = "tokenizer.ggml.padding_token_id"
-        MASK_ID              = "tokenizer.ggml.mask_token_id"
-        ADD_BOS              = "tokenizer.ggml.add_bos_token"
-        ADD_EOS              = "tokenizer.ggml.add_eos_token"
-        ADD_SEP              = "tokenizer.ggml.add_sep_token"
-        ADD_PREFIX           = "tokenizer.ggml.add_space_prefix"
-        REMOVE_EXTRA_WS      = "tokenizer.ggml.remove_extra_whitespaces"
+        MODEL = "tokenizer.ggml.model"
+        PRE = "tokenizer.ggml.pre"
+        LIST = "tokenizer.ggml.tokens"
+        TOKEN_TYPE = "tokenizer.ggml.token_type"
+        TOKEN_TYPE_COUNT = (
+            "tokenizer.ggml.token_type_count"  # for BERT-style token types
+        )
+        SCORES = "tokenizer.ggml.scores"
+        MERGES = "tokenizer.ggml.merges"
+        BOS_ID = "tokenizer.ggml.bos_token_id"
+        EOS_ID = "tokenizer.ggml.eos_token_id"
+        EOT_ID = "tokenizer.ggml.eot_token_id"
+        EOM_ID = "tokenizer.ggml.eom_token_id"
+        UNK_ID = "tokenizer.ggml.unknown_token_id"
+        SEP_ID = "tokenizer.ggml.seperator_token_id"
+        PAD_ID = "tokenizer.ggml.padding_token_id"
+        MASK_ID = "tokenizer.ggml.mask_token_id"
+        ADD_BOS = "tokenizer.ggml.add_bos_token"
+        ADD_EOS = "tokenizer.ggml.add_eos_token"
+        ADD_SEP = "tokenizer.ggml.add_sep_token"
+        ADD_PREFIX = "tokenizer.ggml.add_space_prefix"
+        REMOVE_EXTRA_WS = "tokenizer.ggml.remove_extra_whitespaces"
         PRECOMPILED_CHARSMAP = "tokenizer.ggml.precompiled_charsmap"
-        HF_JSON              = "tokenizer.huggingface.json"
-        RWKV                 = "tokenizer.rwkv.world"
-        CHAT_TEMPLATE        = "tokenizer.chat_template"
-        CHAT_TEMPLATE_N      = "tokenizer.chat_template.{name}"
-        CHAT_TEMPLATES       = "tokenizer.chat_templates"
+        HF_JSON = "tokenizer.huggingface.json"
+        RWKV = "tokenizer.rwkv.world"
+        CHAT_TEMPLATE = "tokenizer.chat_template"
+        CHAT_TEMPLATE_N = "tokenizer.chat_template.{name}"
+        CHAT_TEMPLATES = "tokenizer.chat_templates"
         # FIM/Infill special tokens constants
-        FIM_PRE_ID           = "tokenizer.ggml.fim_pre_token_id"
-        FIM_SUF_ID           = "tokenizer.ggml.fim_suf_token_id"
-        FIM_MID_ID           = "tokenizer.ggml.fim_mid_token_id"
-        FIM_PAD_ID           = "tokenizer.ggml.fim_pad_token_id"
-        FIM_REP_ID           = "tokenizer.ggml.fim_rep_token_id"
-        FIM_SEP_ID           = "tokenizer.ggml.fim_sep_token_id"
+        FIM_PRE_ID = "tokenizer.ggml.fim_pre_token_id"
+        FIM_SUF_ID = "tokenizer.ggml.fim_suf_token_id"
+        FIM_MID_ID = "tokenizer.ggml.fim_mid_token_id"
+        FIM_PAD_ID = "tokenizer.ggml.fim_pad_token_id"
+        FIM_REP_ID = "tokenizer.ggml.fim_rep_token_id"
+        FIM_SEP_ID = "tokenizer.ggml.fim_sep_token_id"
         # deprecated:
-        PREFIX_ID            = "tokenizer.ggml.prefix_token_id"
-        SUFFIX_ID            = "tokenizer.ggml.suffix_token_id"
-        MIDDLE_ID            = "tokenizer.ggml.middle_token_id"
+        PREFIX_ID = "tokenizer.ggml.prefix_token_id"
+        SUFFIX_ID = "tokenizer.ggml.suffix_token_id"
+        MIDDLE_ID = "tokenizer.ggml.middle_token_id"
 
     class Adapter:
-        TYPE                    = "adapter.type"
-        LORA_ALPHA              = "adapter.lora.alpha"
-        LORA_TASK_NAME          = "adapter.lora.task_name"
-        LORA_PROMPT_PREFIX      = "adapter.lora.prompt_prefix"
+        TYPE = "adapter.type"
+        LORA_ALPHA = "adapter.lora.alpha"
+        LORA_TASK_NAME = "adapter.lora.task_name"
+        LORA_PROMPT_PREFIX = "adapter.lora.prompt_prefix"
         ALORA_INVOCATION_TOKENS = "adapter.alora.invocation_tokens"
 
     class IMatrix:
         CHUNK_COUNT = "imatrix.chunk_count"
-        CHUNK_SIZE  = "imatrix.chunk_size"
-        DATASETS    = "imatrix.datasets"
+        CHUNK_SIZE = "imatrix.chunk_size"
+        DATASETS = "imatrix.datasets"
 
     class Clip:
-        PROJECTOR_TYPE      = "clip.projector_type"
-        HAS_VISION_ENCODER  = "clip.has_vision_encoder"
-        HAS_AUDIO_ENCODER   = "clip.has_audio_encoder"
+        PROJECTOR_TYPE = "clip.projector_type"
+        HAS_VISION_ENCODER = "clip.has_vision_encoder"
+        HAS_AUDIO_ENCODER = "clip.has_audio_encoder"
         HAS_LLAVA_PROJECTOR = "clip.has_llava_projector"
 
     class ClipVision:
-        IMAGE_SIZE          = "clip.vision.image_size"
-        PREPROC_IMAGE_SIZE  = "clip.vision.preproc_image_size"
-        PATCH_SIZE          = "clip.vision.patch_size"
-        EMBEDDING_LENGTH    = "clip.vision.embedding_length"
+        IMAGE_SIZE = "clip.vision.image_size"
+        PREPROC_IMAGE_SIZE = "clip.vision.preproc_image_size"
+        PATCH_SIZE = "clip.vision.patch_size"
+        EMBEDDING_LENGTH = "clip.vision.embedding_length"
         FEED_FORWARD_LENGTH = "clip.vision.feed_forward_length"
-        PROJECTION_DIM      = "clip.vision.projection_dim"
-        BLOCK_COUNT         = "clip.vision.block_count"
-        IMAGE_MEAN          = "clip.vision.image_mean"
-        IMAGE_STD           = "clip.vision.image_std"
-        SPATIAL_MERGE_SIZE  = "clip.vision.spatial_merge_size"
-        USE_GELU            = "clip.use_gelu"
-        USE_SILU            = "clip.use_silu"
-        N_WA_PATTERN        = "clip.vision.n_wa_pattern" # used by qwen2.5vl
+        PROJECTION_DIM = "clip.vision.projection_dim"
+        BLOCK_COUNT = "clip.vision.block_count"
+        IMAGE_MEAN = "clip.vision.image_mean"
+        IMAGE_STD = "clip.vision.image_std"
+        SPATIAL_MERGE_SIZE = "clip.vision.spatial_merge_size"
+        USE_GELU = "clip.use_gelu"
+        USE_SILU = "clip.use_silu"
+        N_WA_PATTERN = "clip.vision.n_wa_pattern"  # used by qwen2.5vl
 
         class Attention:
-            HEAD_COUNT      = "clip.vision.attention.head_count"
-            LAYERNORM_EPS   = "clip.vision.attention.layer_norm_epsilon"
+            HEAD_COUNT = "clip.vision.attention.head_count"
+            LAYERNORM_EPS = "clip.vision.attention.layer_norm_epsilon"
 
         class Projector:
-            SCALE_FACTOR    = "clip.vision.projector.scale_factor"
+            SCALE_FACTOR = "clip.vision.projector.scale_factor"
 
     class ClipAudio:
-        NUM_MEL_BINS        = "clip.audio.num_mel_bins"
-        EMBEDDING_LENGTH    = "clip.audio.embedding_length"
+        NUM_MEL_BINS = "clip.audio.num_mel_bins"
+        EMBEDDING_LENGTH = "clip.audio.embedding_length"
         FEED_FORWARD_LENGTH = "clip.audio.feed_forward_length"
-        PROJECTION_DIM      = "clip.audio.projection_dim"
-        BLOCK_COUNT         = "clip.audio.block_count"
+        PROJECTION_DIM = "clip.audio.projection_dim"
+        BLOCK_COUNT = "clip.audio.block_count"
 
         class Attention:
-            HEAD_COUNT      = "clip.audio.attention.head_count"
-            LAYERNORM_EPS   = "clip.audio.attention.layer_norm_epsilon"
+            HEAD_COUNT = "clip.audio.attention.head_count"
+            LAYERNORM_EPS = "clip.audio.attention.layer_norm_epsilon"
 
         class Projector:
-            STACK_FACTOR    = "clip.audio.projector.stack_factor"
+            STACK_FACTOR = "clip.audio.projector.stack_factor"
 
     class Diffusion:
-        SHIFT_LOGITS        = "diffusion.shift_logits"
+        SHIFT_LOGITS = "diffusion.shift_logits"
 
     class xIELU:
-        ALPHA_P             = "xielu.alpha_p"
-        ALPHA_N             = "xielu.alpha_n"
-        BETA                = "xielu.beta"
-        EPS                 = "xielu.eps"
+        ALPHA_P = "xielu.alpha_p"
+        ALPHA_N = "xielu.alpha_n"
+        BETA = "xielu.beta"
+        EPS = "xielu.eps"
 
 
 #
@@ -315,702 +321,702 @@ class Keys:
 
 
 class GGUFType:
-    MODEL   = "model"
+    MODEL = "model"
     ADAPTER = "adapter"
     IMATRIX = "imatrix"
-    MMPROJ  = "mmproj" # dummy, unused for now
+    MMPROJ = "mmproj"  # dummy, unused for now
 
 
 class MODEL_ARCH(IntEnum):
-    MMPROJ           = auto() # dummy arch for clip.cpp
-    LLAMA            = auto()
-    LLAMA4           = auto()
-    DECI             = auto()
-    FALCON           = auto()
-    FALCON_H1        = auto()
-    BAICHUAN         = auto()
-    GROK             = auto()
-    GPT2             = auto()
-    GPTJ             = auto()
-    GPTNEOX          = auto()
-    MPT              = auto()
-    STARCODER        = auto()
-    REFACT           = auto()
-    BERT             = auto()
-    NOMIC_BERT       = auto()
-    NOMIC_BERT_MOE   = auto()
-    NEO_BERT         = auto()
-    JINA_BERT_V2     = auto()
-    JINA_BERT_V3     = auto()
-    BLOOM            = auto()
-    STABLELM         = auto()
-    QWEN             = auto()
-    QWEN2            = auto()
-    QWEN2MOE         = auto()
-    QWEN2VL          = auto()
-    QWEN3            = auto()
-    QWEN3MOE         = auto()
-    PHI2             = auto()
-    PHI3             = auto()
-    PHIMOE           = auto()
-    PLAMO            = auto()
-    PLAMO2           = auto()
-    CODESHELL        = auto()
-    ORION            = auto()
-    INTERNLM2        = auto()
-    MINICPM          = auto()
-    MINICPM3         = auto()
-    GEMMA            = auto()
-    GEMMA2           = auto()
-    GEMMA3           = auto()
-    GEMMA3N          = auto()
-    GEMMA_EMBEDDING  = auto()
-    STARCODER2       = auto()
-    RWKV6            = auto()
-    RWKV6QWEN2       = auto()
-    RWKV7            = auto()
-    ARWKV7           = auto()
-    MAMBA            = auto()
-    MAMBA2           = auto()
-    JAMBA            = auto()
-    XVERSE           = auto()
-    COMMAND_R        = auto()
-    COHERE2          = auto()
-    DBRX             = auto()
-    OLMO             = auto()
-    OLMO2            = auto()
-    OLMOE            = auto()
-    OPENELM          = auto()
-    ARCTIC           = auto()
-    DEEPSEEK         = auto()
-    DEEPSEEK2        = auto()
-    CHATGLM          = auto()
-    GLM4             = auto()
-    GLM4_MOE         = auto()
-    BITNET           = auto()
-    T5               = auto()
-    T5ENCODER        = auto()
-    JAIS             = auto()
-    NEMOTRON         = auto()
-    NEMOTRON_H       = auto()
-    EXAONE           = auto()
-    EXAONE4          = auto()
-    GRANITE          = auto()
-    GRANITE_MOE      = auto()
-    GRANITE_HYBRID   = auto()
-    CHAMELEON        = auto()
+    MMPROJ = auto()  # dummy arch for clip.cpp
+    LLAMA = auto()
+    LLAMA4 = auto()
+    DECI = auto()
+    FALCON = auto()
+    FALCON_H1 = auto()
+    BAICHUAN = auto()
+    GROK = auto()
+    GPT2 = auto()
+    GPTJ = auto()
+    GPTNEOX = auto()
+    MPT = auto()
+    STARCODER = auto()
+    REFACT = auto()
+    BERT = auto()
+    NOMIC_BERT = auto()
+    NOMIC_BERT_MOE = auto()
+    NEO_BERT = auto()
+    JINA_BERT_V2 = auto()
+    JINA_BERT_V3 = auto()
+    BLOOM = auto()
+    STABLELM = auto()
+    QWEN = auto()
+    QWEN2 = auto()
+    QWEN2MOE = auto()
+    QWEN2VL = auto()
+    QWEN3 = auto()
+    QWEN3MOE = auto()
+    PHI2 = auto()
+    PHI3 = auto()
+    PHIMOE = auto()
+    PLAMO = auto()
+    PLAMO2 = auto()
+    CODESHELL = auto()
+    ORION = auto()
+    INTERNLM2 = auto()
+    MINICPM = auto()
+    MINICPM3 = auto()
+    GEMMA = auto()
+    GEMMA2 = auto()
+    GEMMA3 = auto()
+    GEMMA3N = auto()
+    GEMMA_EMBEDDING = auto()
+    STARCODER2 = auto()
+    RWKV6 = auto()
+    RWKV6QWEN2 = auto()
+    RWKV7 = auto()
+    ARWKV7 = auto()
+    MAMBA = auto()
+    MAMBA2 = auto()
+    JAMBA = auto()
+    XVERSE = auto()
+    COMMAND_R = auto()
+    COHERE2 = auto()
+    DBRX = auto()
+    OLMO = auto()
+    OLMO2 = auto()
+    OLMOE = auto()
+    OPENELM = auto()
+    ARCTIC = auto()
+    DEEPSEEK = auto()
+    DEEPSEEK2 = auto()
+    CHATGLM = auto()
+    GLM4 = auto()
+    GLM4_MOE = auto()
+    BITNET = auto()
+    T5 = auto()
+    T5ENCODER = auto()
+    JAIS = auto()
+    NEMOTRON = auto()
+    NEMOTRON_H = auto()
+    EXAONE = auto()
+    EXAONE4 = auto()
+    GRANITE = auto()
+    GRANITE_MOE = auto()
+    GRANITE_HYBRID = auto()
+    CHAMELEON = auto()
     WAVTOKENIZER_DEC = auto()
-    PLM              = auto()
-    BAILINGMOE       = auto()
-    BAILINGMOE2      = auto()
-    DOTS1            = auto()
-    ARCEE            = auto()
-    ERNIE4_5         = auto()
-    ERNIE4_5_MOE     = auto()
-    HUNYUAN_MOE      = auto()
-    HUNYUAN_DENSE    = auto()
-    SMOLLM3          = auto()
-    GPT_OSS          = auto()
-    LFM2             = auto()
-    LFM2MOE          = auto()
-    DREAM            = auto()
-    SMALLTHINKER     = auto()
-    LLADA            = auto()
-    LLADA_MOE        = auto()
-    SEED_OSS         = auto()
-    GROVEMOE         = auto()
-    APERTUS          = auto()
+    PLM = auto()
+    BAILINGMOE = auto()
+    BAILINGMOE2 = auto()
+    DOTS1 = auto()
+    ARCEE = auto()
+    ERNIE4_5 = auto()
+    ERNIE4_5_MOE = auto()
+    HUNYUAN_MOE = auto()
+    HUNYUAN_DENSE = auto()
+    SMOLLM3 = auto()
+    GPT_OSS = auto()
+    LFM2 = auto()
+    LFM2MOE = auto()
+    DREAM = auto()
+    SMALLTHINKER = auto()
+    LLADA = auto()
+    LLADA_MOE = auto()
+    SEED_OSS = auto()
+    GROVEMOE = auto()
+    APERTUS = auto()
 
 
 class VISION_PROJECTOR_TYPE(IntEnum):
-    MLP       = auto()
-    LDP       = auto()
-    LDPV2     = auto()
+    MLP = auto()
+    LDP = auto()
+    LDPV2 = auto()
     RESAMPLER = auto()
-    GLM_EDGE  = auto()
-    MERGER    = auto()
-    GEMMA3    = auto()
+    GLM_EDGE = auto()
+    MERGER = auto()
+    GEMMA3 = auto()
 
 
 class MODEL_TENSOR(IntEnum):
-    TOKEN_EMBD           = auto()
-    TOKEN_EMBD_NORM      = auto()
-    TOKEN_TYPES          = auto()
-    POS_EMBD             = auto()
-    OUTPUT               = auto()
-    DENSE_2_OUT          = auto() # embeddinggemma 2_Dense
-    DENSE_3_OUT          = auto() # embeddinggemma 3_Dense
-    OUTPUT_NORM          = auto()
-    ROPE_FREQS           = auto()
-    ROPE_FACTORS_LONG    = auto()
-    ROPE_FACTORS_SHORT   = auto()
-    ATTN_Q               = auto()
-    ATTN_K               = auto()
-    ATTN_V               = auto()
-    ATTN_QKV             = auto()
-    ATTN_OUT             = auto()
-    ATTN_NORM            = auto()
-    ATTN_NORM_2          = auto()
-    ATTN_OUT_NORM        = auto()
-    ATTN_POST_NORM       = auto()
-    ATTN_ROT_EMBD        = auto()
-    ATTN_SINKS           = auto()
-    FFN_GATE_INP         = auto()
-    FFN_GATE_INP_SHEXP   = auto()
-    FFN_NORM             = auto()
-    FFN_PRE_NORM         = auto()
-    FFN_POST_NORM        = auto()
-    FFN_GATE             = auto()
-    FFN_DOWN             = auto()
-    FFN_UP               = auto()
-    FFN_ACT              = auto()
-    FFN_NORM_EXP         = auto()
-    FFN_GATE_EXP         = auto()
-    FFN_DOWN_EXP         = auto()
-    FFN_UP_EXP           = auto()
-    FFN_GATE_SHEXP       = auto()
-    FFN_DOWN_SHEXP       = auto()
-    FFN_UP_SHEXP         = auto()
-    FFN_GATE_CHEXP       = auto()
-    FFN_DOWN_CHEXP       = auto()
-    FFN_UP_CHEXP         = auto()
-    FFN_EXP_PROBS_B      = auto()
-    ATTN_Q_NORM          = auto()
-    ATTN_K_NORM          = auto()
-    LAYER_OUT_NORM       = auto()
-    PER_LAYER_TOKEN_EMBD = auto() # gemma3n
-    PER_LAYER_MODEL_PROJ = auto() # gemma3n
-    PER_LAYER_INP_GATE   = auto() # gemma3n
-    PER_LAYER_PROJ       = auto() # gemma3n
-    PER_LAYER_PROJ_NORM  = auto() # gemma3n
-    PER_LAYER_POST_NORM  = auto() # gemma3n
-    ALTUP_PROJ           = auto() # gemma3n
-    ALTUP_UNEMBD_PROJ    = auto() # gemma3n
-    ALTUP_CORRECT_COEF   = auto() # gemma3n
-    ALTUP_CORRECT_SCALE  = auto() # gemma3n
-    ALTUP_PREDICT_COEF   = auto() # gemma3n
-    ALTUP_ROUTER         = auto() # gemma3n
-    ALTUP_ROUTER_NORM    = auto() # gemma3n
-    LAUREL_L             = auto() # gemma3n
-    LAUREL_R             = auto() # gemma3n
-    LAUREL_POST_NORM     = auto() # gemma3n
-    SSM_IN               = auto()
-    SSM_CONV1D           = auto()
-    SSM_X                = auto()
-    SSM_DT               = auto()
-    SSM_DT_NORM          = auto()
-    SSM_A                = auto()
-    SSM_B_NORM           = auto()
-    SSM_C_NORM           = auto()
-    SSM_D                = auto()
-    SSM_NORM             = auto()
-    SSM_OUT              = auto()
-    TIME_MIX_W0          = auto()
-    TIME_MIX_W1          = auto()
-    TIME_MIX_W2          = auto()
-    TIME_MIX_A0          = auto()
-    TIME_MIX_A1          = auto()
-    TIME_MIX_A2          = auto()
-    TIME_MIX_V0          = auto()
-    TIME_MIX_V1          = auto()
-    TIME_MIX_V2          = auto()
-    TIME_MIX_G1          = auto()
-    TIME_MIX_G2          = auto()
-    TIME_MIX_K_K         = auto()
-    TIME_MIX_K_A         = auto()
-    TIME_MIX_R_K         = auto()
-    TIME_MIX_LERP_X      = auto()
-    TIME_MIX_LERP_K      = auto()
-    TIME_MIX_LERP_V      = auto()
-    TIME_MIX_LERP_R      = auto()
-    TIME_MIX_LERP_G      = auto()
-    TIME_MIX_LERP_FUSED  = auto()
-    TIME_MIX_LERP_W      = auto()
-    TIME_MIX_FIRST       = auto()
-    TIME_MIX_DECAY       = auto()
-    TIME_MIX_DECAY_W1    = auto()
-    TIME_MIX_DECAY_W2    = auto()
-    TIME_MIX_KEY         = auto()
-    TIME_MIX_VALUE       = auto()
-    TIME_MIX_RECEPTANCE  = auto()
-    TIME_MIX_GATE        = auto()
-    TIME_MIX_LN          = auto()
-    TIME_MIX_OUTPUT      = auto()
-    CHANNEL_MIX_LERP_K   = auto()
-    CHANNEL_MIX_LERP_R   = auto()
-    CHANNEL_MIX_KEY      = auto()
+    TOKEN_EMBD = auto()
+    TOKEN_EMBD_NORM = auto()
+    TOKEN_TYPES = auto()
+    POS_EMBD = auto()
+    OUTPUT = auto()
+    DENSE_2_OUT = auto()  # embeddinggemma 2_Dense
+    DENSE_3_OUT = auto()  # embeddinggemma 3_Dense
+    OUTPUT_NORM = auto()
+    ROPE_FREQS = auto()
+    ROPE_FACTORS_LONG = auto()
+    ROPE_FACTORS_SHORT = auto()
+    ATTN_Q = auto()
+    ATTN_K = auto()
+    ATTN_V = auto()
+    ATTN_QKV = auto()
+    ATTN_OUT = auto()
+    ATTN_NORM = auto()
+    ATTN_NORM_2 = auto()
+    ATTN_OUT_NORM = auto()
+    ATTN_POST_NORM = auto()
+    ATTN_ROT_EMBD = auto()
+    ATTN_SINKS = auto()
+    FFN_GATE_INP = auto()
+    FFN_GATE_INP_SHEXP = auto()
+    FFN_NORM = auto()
+    FFN_PRE_NORM = auto()
+    FFN_POST_NORM = auto()
+    FFN_GATE = auto()
+    FFN_DOWN = auto()
+    FFN_UP = auto()
+    FFN_ACT = auto()
+    FFN_NORM_EXP = auto()
+    FFN_GATE_EXP = auto()
+    FFN_DOWN_EXP = auto()
+    FFN_UP_EXP = auto()
+    FFN_GATE_SHEXP = auto()
+    FFN_DOWN_SHEXP = auto()
+    FFN_UP_SHEXP = auto()
+    FFN_GATE_CHEXP = auto()
+    FFN_DOWN_CHEXP = auto()
+    FFN_UP_CHEXP = auto()
+    FFN_EXP_PROBS_B = auto()
+    ATTN_Q_NORM = auto()
+    ATTN_K_NORM = auto()
+    LAYER_OUT_NORM = auto()
+    PER_LAYER_TOKEN_EMBD = auto()  # gemma3n
+    PER_LAYER_MODEL_PROJ = auto()  # gemma3n
+    PER_LAYER_INP_GATE = auto()  # gemma3n
+    PER_LAYER_PROJ = auto()  # gemma3n
+    PER_LAYER_PROJ_NORM = auto()  # gemma3n
+    PER_LAYER_POST_NORM = auto()  # gemma3n
+    ALTUP_PROJ = auto()  # gemma3n
+    ALTUP_UNEMBD_PROJ = auto()  # gemma3n
+    ALTUP_CORRECT_COEF = auto()  # gemma3n
+    ALTUP_CORRECT_SCALE = auto()  # gemma3n
+    ALTUP_PREDICT_COEF = auto()  # gemma3n
+    ALTUP_ROUTER = auto()  # gemma3n
+    ALTUP_ROUTER_NORM = auto()  # gemma3n
+    LAUREL_L = auto()  # gemma3n
+    LAUREL_R = auto()  # gemma3n
+    LAUREL_POST_NORM = auto()  # gemma3n
+    SSM_IN = auto()
+    SSM_CONV1D = auto()
+    SSM_X = auto()
+    SSM_DT = auto()
+    SSM_DT_NORM = auto()
+    SSM_A = auto()
+    SSM_B_NORM = auto()
+    SSM_C_NORM = auto()
+    SSM_D = auto()
+    SSM_NORM = auto()
+    SSM_OUT = auto()
+    TIME_MIX_W0 = auto()
+    TIME_MIX_W1 = auto()
+    TIME_MIX_W2 = auto()
+    TIME_MIX_A0 = auto()
+    TIME_MIX_A1 = auto()
+    TIME_MIX_A2 = auto()
+    TIME_MIX_V0 = auto()
+    TIME_MIX_V1 = auto()
+    TIME_MIX_V2 = auto()
+    TIME_MIX_G1 = auto()
+    TIME_MIX_G2 = auto()
+    TIME_MIX_K_K = auto()
+    TIME_MIX_K_A = auto()
+    TIME_MIX_R_K = auto()
+    TIME_MIX_LERP_X = auto()
+    TIME_MIX_LERP_K = auto()
+    TIME_MIX_LERP_V = auto()
+    TIME_MIX_LERP_R = auto()
+    TIME_MIX_LERP_G = auto()
+    TIME_MIX_LERP_FUSED = auto()
+    TIME_MIX_LERP_W = auto()
+    TIME_MIX_FIRST = auto()
+    TIME_MIX_DECAY = auto()
+    TIME_MIX_DECAY_W1 = auto()
+    TIME_MIX_DECAY_W2 = auto()
+    TIME_MIX_KEY = auto()
+    TIME_MIX_VALUE = auto()
+    TIME_MIX_RECEPTANCE = auto()
+    TIME_MIX_GATE = auto()
+    TIME_MIX_LN = auto()
+    TIME_MIX_OUTPUT = auto()
+    CHANNEL_MIX_LERP_K = auto()
+    CHANNEL_MIX_LERP_R = auto()
+    CHANNEL_MIX_KEY = auto()
     CHANNEL_MIX_RECEPTANCE = auto()
-    CHANNEL_MIX_VALUE    = auto()
-    ATTN_Q_A             = auto()
-    ATTN_Q_B             = auto()
-    ATTN_KV_A_MQA        = auto()
-    ATTN_KV_B            = auto()
-    ATTN_K_B             = auto()
-    ATTN_V_B             = auto()
-    ATTN_Q_A_NORM        = auto()
-    ATTN_KV_A_NORM       = auto()
-    FFN_SUB_NORM         = auto()
-    ATTN_SUB_NORM        = auto()
-    DEC_ATTN_NORM        = auto()
-    DEC_ATTN_Q           = auto()
-    DEC_ATTN_K           = auto()
-    DEC_ATTN_V           = auto()
-    DEC_ATTN_OUT         = auto()
-    DEC_ATTN_REL_B       = auto()
-    DEC_CROSS_ATTN_NORM  = auto()
-    DEC_CROSS_ATTN_Q     = auto()
-    DEC_CROSS_ATTN_K     = auto()
-    DEC_CROSS_ATTN_V     = auto()
-    DEC_CROSS_ATTN_OUT   = auto()
+    CHANNEL_MIX_VALUE = auto()
+    ATTN_Q_A = auto()
+    ATTN_Q_B = auto()
+    ATTN_KV_A_MQA = auto()
+    ATTN_KV_B = auto()
+    ATTN_K_B = auto()
+    ATTN_V_B = auto()
+    ATTN_Q_A_NORM = auto()
+    ATTN_KV_A_NORM = auto()
+    FFN_SUB_NORM = auto()
+    ATTN_SUB_NORM = auto()
+    DEC_ATTN_NORM = auto()
+    DEC_ATTN_Q = auto()
+    DEC_ATTN_K = auto()
+    DEC_ATTN_V = auto()
+    DEC_ATTN_OUT = auto()
+    DEC_ATTN_REL_B = auto()
+    DEC_CROSS_ATTN_NORM = auto()
+    DEC_CROSS_ATTN_Q = auto()
+    DEC_CROSS_ATTN_K = auto()
+    DEC_CROSS_ATTN_V = auto()
+    DEC_CROSS_ATTN_OUT = auto()
     DEC_CROSS_ATTN_REL_B = auto()
-    DEC_FFN_NORM         = auto()
-    DEC_FFN_GATE         = auto()
-    DEC_FFN_DOWN         = auto()
-    DEC_FFN_UP           = auto()
-    DEC_OUTPUT_NORM      = auto()
-    ENC_ATTN_NORM        = auto()
-    ENC_ATTN_Q           = auto()
-    ENC_ATTN_K           = auto()
-    ENC_ATTN_V           = auto()
-    ENC_ATTN_OUT         = auto()
-    ENC_ATTN_REL_B       = auto()
-    ENC_FFN_NORM         = auto()
-    ENC_FFN_GATE         = auto()
-    ENC_FFN_DOWN         = auto()
-    ENC_FFN_UP           = auto()
-    ENC_OUTPUT_NORM      = auto()
-    CLS                  = auto() # classifier
-    CLS_OUT              = auto() # classifier output projection
-    CONV1D               = auto()
-    CONVNEXT_DW          = auto()
-    CONVNEXT_NORM        = auto()
-    CONVNEXT_PW1         = auto()
-    CONVNEXT_PW2         = auto()
-    CONVNEXT_GAMMA       = auto()
-    POSNET_CONV1         = auto()
-    POSNET_CONV2         = auto()
-    POSNET_NORM          = auto()
-    POSNET_NORM1         = auto()
-    POSNET_NORM2         = auto()
-    POSNET_ATTN_NORM     = auto()
-    POSNET_ATTN_Q        = auto()
-    POSNET_ATTN_K        = auto()
-    POSNET_ATTN_V        = auto()
-    POSNET_ATTN_OUT      = auto()
-    SHORTCONV_CONV       = auto()
-    SHORTCONV_INPROJ     = auto()
-    SHORTCONV_OUTPROJ    = auto()
+    DEC_FFN_NORM = auto()
+    DEC_FFN_GATE = auto()
+    DEC_FFN_DOWN = auto()
+    DEC_FFN_UP = auto()
+    DEC_OUTPUT_NORM = auto()
+    ENC_ATTN_NORM = auto()
+    ENC_ATTN_Q = auto()
+    ENC_ATTN_K = auto()
+    ENC_ATTN_V = auto()
+    ENC_ATTN_OUT = auto()
+    ENC_ATTN_REL_B = auto()
+    ENC_FFN_NORM = auto()
+    ENC_FFN_GATE = auto()
+    ENC_FFN_DOWN = auto()
+    ENC_FFN_UP = auto()
+    ENC_OUTPUT_NORM = auto()
+    CLS = auto()  # classifier
+    CLS_OUT = auto()  # classifier output projection
+    CONV1D = auto()
+    CONVNEXT_DW = auto()
+    CONVNEXT_NORM = auto()
+    CONVNEXT_PW1 = auto()
+    CONVNEXT_PW2 = auto()
+    CONVNEXT_GAMMA = auto()
+    POSNET_CONV1 = auto()
+    POSNET_CONV2 = auto()
+    POSNET_NORM = auto()
+    POSNET_NORM1 = auto()
+    POSNET_NORM2 = auto()
+    POSNET_ATTN_NORM = auto()
+    POSNET_ATTN_Q = auto()
+    POSNET_ATTN_K = auto()
+    POSNET_ATTN_V = auto()
+    POSNET_ATTN_OUT = auto()
+    SHORTCONV_CONV = auto()
+    SHORTCONV_INPROJ = auto()
+    SHORTCONV_OUTPROJ = auto()
     # vision
-    V_MMPROJ             = auto()
-    V_MMPROJ_FC          = auto()
-    V_MMPROJ_MLP         = auto()
-    V_MMPROJ_PEG         = auto()
-    V_ENC_EMBD_CLS       = auto()
-    V_ENC_EMBD_PATCH     = auto()
-    V_ENC_EMBD_POS       = auto()
-    V_ENC_INPUT_NORM     = auto()
-    V_ENC_ATTN_Q         = auto()
-    V_ENC_ATTN_Q_NORM    = auto()
-    V_ENC_ATTN_K         = auto()
-    V_ENC_ATTN_K_NORM    = auto()
-    V_ENC_ATTN_V         = auto()
-    V_ENC_ATTN_O         = auto()
-    V_ENC_ATTN_O_NORM    = auto()
+    V_MMPROJ = auto()
+    V_MMPROJ_FC = auto()
+    V_MMPROJ_MLP = auto()
+    V_MMPROJ_PEG = auto()
+    V_ENC_EMBD_CLS = auto()
+    V_ENC_EMBD_PATCH = auto()
+    V_ENC_EMBD_POS = auto()
+    V_ENC_INPUT_NORM = auto()
+    V_ENC_ATTN_Q = auto()
+    V_ENC_ATTN_Q_NORM = auto()
+    V_ENC_ATTN_K = auto()
+    V_ENC_ATTN_K_NORM = auto()
+    V_ENC_ATTN_V = auto()
+    V_ENC_ATTN_O = auto()
+    V_ENC_ATTN_O_NORM = auto()
     V_ENC_POST_ATTN_NORM = auto()
-    V_ENC_FFN_UP         = auto()
-    V_ENC_FFN_GATE       = auto()
-    V_ENC_FFN_DOWN       = auto()
-    V_LAYER_SCALE_1      = auto()
-    V_LAYER_SCALE_2      = auto()
-    V_PRE_NORM           = auto()
-    V_POST_NORM          = auto()
-    V_MM_INP_NORM        = auto()
-    V_MM_INP_PROJ        = auto() # gemma3
-    V_MM_SOFT_EMB_NORM   = auto() # gemma3
-    V_RESMPL_POS_EMBD_K  = auto() # minicpmv
-    V_RESMPL_ATTN_Q      = auto() # minicpmv
-    V_RESMPL_ATTN_K      = auto() # minicpmv
-    V_RESMPL_ATTN_V      = auto() # minicpmv
-    V_RESMPL_ATTN_OUT    = auto() # minicpmv
-    V_RESMPL_KV          = auto() # minicpmv
-    V_RESMPL_KV_NORM     = auto() # minicpmv
-    V_RESMPL_POST_NORM   = auto() # minicpmv
-    V_RESMPL_Q_NORM      = auto() # minicpmv
-    V_RESMPL_PROJ        = auto() # minicpmv
-    V_RESMPL_QUERY       = auto() # minicpmv
-    V_TOK_EMBD_IMG_BREAK = auto() # pixtral
-    V_MM_PATCH_MERGER    = auto() # mistral small 3.1
+    V_ENC_FFN_UP = auto()
+    V_ENC_FFN_GATE = auto()
+    V_ENC_FFN_DOWN = auto()
+    V_LAYER_SCALE_1 = auto()
+    V_LAYER_SCALE_2 = auto()
+    V_PRE_NORM = auto()
+    V_POST_NORM = auto()
+    V_MM_INP_NORM = auto()
+    V_MM_INP_PROJ = auto()  # gemma3
+    V_MM_SOFT_EMB_NORM = auto()  # gemma3
+    V_RESMPL_POS_EMBD_K = auto()  # minicpmv
+    V_RESMPL_ATTN_Q = auto()  # minicpmv
+    V_RESMPL_ATTN_K = auto()  # minicpmv
+    V_RESMPL_ATTN_V = auto()  # minicpmv
+    V_RESMPL_ATTN_OUT = auto()  # minicpmv
+    V_RESMPL_KV = auto()  # minicpmv
+    V_RESMPL_KV_NORM = auto()  # minicpmv
+    V_RESMPL_POST_NORM = auto()  # minicpmv
+    V_RESMPL_Q_NORM = auto()  # minicpmv
+    V_RESMPL_PROJ = auto()  # minicpmv
+    V_RESMPL_QUERY = auto()  # minicpmv
+    V_TOK_EMBD_IMG_BREAK = auto()  # pixtral
+    V_MM_PATCH_MERGER = auto()  # mistral small 3.1
     # audio (mtmd)
-    A_ENC_EMBD_POS       = auto()
-    A_ENC_CONV1D         = auto()
-    A_PRE_NORM           = auto()
-    A_POST_NORM          = auto()
-    A_ENC_ATTN_Q         = auto()
-    A_ENC_ATTN_K         = auto()
-    A_ENC_ATTN_V         = auto()
-    A_ENC_INPUT_NORM     = auto()
-    A_ENC_OUTPUT         = auto()
-    A_ENC_OUTPUT_NORM    = auto()
-    A_ENC_FFN_UP         = auto()
-    A_ENC_FFN_GATE       = auto()
-    A_ENC_FFN_DOWN       = auto()
-    A_MMPROJ             = auto()
-    A_MMPROJ_FC          = auto()
-    A_MM_NORM_PRE        = auto()
-    A_MM_NORM_MID        = auto()
+    A_ENC_EMBD_POS = auto()
+    A_ENC_CONV1D = auto()
+    A_PRE_NORM = auto()
+    A_POST_NORM = auto()
+    A_ENC_ATTN_Q = auto()
+    A_ENC_ATTN_K = auto()
+    A_ENC_ATTN_V = auto()
+    A_ENC_INPUT_NORM = auto()
+    A_ENC_OUTPUT = auto()
+    A_ENC_OUTPUT_NORM = auto()
+    A_ENC_FFN_UP = auto()
+    A_ENC_FFN_GATE = auto()
+    A_ENC_FFN_DOWN = auto()
+    A_MMPROJ = auto()
+    A_MMPROJ_FC = auto()
+    A_MM_NORM_PRE = auto()
+    A_MM_NORM_MID = auto()
     # nextn/mtp
-    NEXTN_EH_PROJ        = auto()
-    NEXTN_EMBED_TOKENS   = auto()
-    NEXTN_ENORM          = auto()
-    NEXTN_HNORM          = auto()
+    NEXTN_EH_PROJ = auto()
+    NEXTN_EMBED_TOKENS = auto()
+    NEXTN_ENORM = auto()
+    NEXTN_HNORM = auto()
     NEXTN_SHARED_HEAD_HEAD = auto()
     NEXTN_SHARED_HEAD_NORM = auto()
 
 
 MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
-    MODEL_ARCH.MMPROJ:           "clip", # dummy arch for clip.cpp
-    MODEL_ARCH.LLAMA:            "llama",
-    MODEL_ARCH.LLAMA4:           "llama4",
-    MODEL_ARCH.DECI:             "deci",
-    MODEL_ARCH.FALCON:           "falcon",
-    MODEL_ARCH.BAICHUAN:         "baichuan",
-    MODEL_ARCH.GROK:             "grok",
-    MODEL_ARCH.GPT2:             "gpt2",
-    MODEL_ARCH.GPTJ:             "gptj",
-    MODEL_ARCH.GPTNEOX:          "gptneox",
-    MODEL_ARCH.MPT:              "mpt",
-    MODEL_ARCH.STARCODER:        "starcoder",
-    MODEL_ARCH.REFACT:           "refact",
-    MODEL_ARCH.BERT:             "bert",
-    MODEL_ARCH.NOMIC_BERT:       "nomic-bert",
-    MODEL_ARCH.NOMIC_BERT_MOE:   "nomic-bert-moe",
-    MODEL_ARCH.NEO_BERT:         "neo-bert",
-    MODEL_ARCH.JINA_BERT_V2:     "jina-bert-v2",
-    MODEL_ARCH.JINA_BERT_V3:     "jina-bert-v3",
-    MODEL_ARCH.BLOOM:            "bloom",
-    MODEL_ARCH.STABLELM:         "stablelm",
-    MODEL_ARCH.QWEN:             "qwen",
-    MODEL_ARCH.QWEN2:            "qwen2",
-    MODEL_ARCH.QWEN2MOE:         "qwen2moe",
-    MODEL_ARCH.QWEN2VL:          "qwen2vl",
-    MODEL_ARCH.QWEN3:            "qwen3",
-    MODEL_ARCH.QWEN3MOE:         "qwen3moe",
-    MODEL_ARCH.PHI2:             "phi2",
-    MODEL_ARCH.PHI3:             "phi3",
-    MODEL_ARCH.PHIMOE:           "phimoe",
-    MODEL_ARCH.PLAMO:            "plamo",
-    MODEL_ARCH.PLAMO2:           "plamo2",
-    MODEL_ARCH.CODESHELL:        "codeshell",
-    MODEL_ARCH.ORION:            "orion",
-    MODEL_ARCH.INTERNLM2:        "internlm2",
-    MODEL_ARCH.MINICPM:          "minicpm",
-    MODEL_ARCH.MINICPM3:         "minicpm3",
-    MODEL_ARCH.GEMMA:            "gemma",
-    MODEL_ARCH.GEMMA2:           "gemma2",
-    MODEL_ARCH.GEMMA3:           "gemma3",
-    MODEL_ARCH.GEMMA3N:          "gemma3n",
-    MODEL_ARCH.GEMMA_EMBEDDING:  "gemma-embedding",
-    MODEL_ARCH.STARCODER2:       "starcoder2",
-    MODEL_ARCH.RWKV6:            "rwkv6",
-    MODEL_ARCH.RWKV6QWEN2:       "rwkv6qwen2",
-    MODEL_ARCH.RWKV7:            "rwkv7",
-    MODEL_ARCH.ARWKV7:           "arwkv7",
-    MODEL_ARCH.MAMBA:            "mamba",
-    MODEL_ARCH.MAMBA2:           "mamba2",
-    MODEL_ARCH.JAMBA:            "jamba",
-    MODEL_ARCH.XVERSE:           "xverse",
-    MODEL_ARCH.COMMAND_R:        "command-r",
-    MODEL_ARCH.COHERE2:          "cohere2",
-    MODEL_ARCH.DBRX:             "dbrx",
-    MODEL_ARCH.OLMO:             "olmo",
-    MODEL_ARCH.OLMO2:            "olmo2",
-    MODEL_ARCH.OLMOE:            "olmoe",
-    MODEL_ARCH.OPENELM:          "openelm",
-    MODEL_ARCH.ARCTIC:           "arctic",
-    MODEL_ARCH.DEEPSEEK:         "deepseek",
-    MODEL_ARCH.DEEPSEEK2:        "deepseek2",
-    MODEL_ARCH.CHATGLM:          "chatglm",
-    MODEL_ARCH.GLM4:             "glm4",
-    MODEL_ARCH.GLM4_MOE:         "glm4moe",
-    MODEL_ARCH.BITNET:           "bitnet",
-    MODEL_ARCH.T5:               "t5",
-    MODEL_ARCH.T5ENCODER:        "t5encoder",
-    MODEL_ARCH.JAIS:             "jais",
-    MODEL_ARCH.NEMOTRON:         "nemotron",
-    MODEL_ARCH.NEMOTRON_H:       "nemotron_h",
-    MODEL_ARCH.EXAONE:           "exaone",
-    MODEL_ARCH.EXAONE4:          "exaone4",
-    MODEL_ARCH.GRANITE:          "granite",
-    MODEL_ARCH.GRANITE_MOE:      "granitemoe",
-    MODEL_ARCH.GRANITE_HYBRID:   "granitehybrid",
-    MODEL_ARCH.CHAMELEON:        "chameleon",
+    MODEL_ARCH.MMPROJ: "clip",  # dummy arch for clip.cpp
+    MODEL_ARCH.LLAMA: "llama",
+    MODEL_ARCH.LLAMA4: "llama4",
+    MODEL_ARCH.DECI: "deci",
+    MODEL_ARCH.FALCON: "falcon",
+    MODEL_ARCH.BAICHUAN: "baichuan",
+    MODEL_ARCH.GROK: "grok",
+    MODEL_ARCH.GPT2: "gpt2",
+    MODEL_ARCH.GPTJ: "gptj",
+    MODEL_ARCH.GPTNEOX: "gptneox",
+    MODEL_ARCH.MPT: "mpt",
+    MODEL_ARCH.STARCODER: "starcoder",
+    MODEL_ARCH.REFACT: "refact",
+    MODEL_ARCH.BERT: "bert",
+    MODEL_ARCH.NOMIC_BERT: "nomic-bert",
+    MODEL_ARCH.NOMIC_BERT_MOE: "nomic-bert-moe",
+    MODEL_ARCH.NEO_BERT: "neo-bert",
+    MODEL_ARCH.JINA_BERT_V2: "jina-bert-v2",
+    MODEL_ARCH.JINA_BERT_V3: "jina-bert-v3",
+    MODEL_ARCH.BLOOM: "bloom",
+    MODEL_ARCH.STABLELM: "stablelm",
+    MODEL_ARCH.QWEN: "qwen",
+    MODEL_ARCH.QWEN2: "qwen2",
+    MODEL_ARCH.QWEN2MOE: "qwen2moe",
+    MODEL_ARCH.QWEN2VL: "qwen2vl",
+    MODEL_ARCH.QWEN3: "qwen3",
+    MODEL_ARCH.QWEN3MOE: "qwen3moe",
+    MODEL_ARCH.PHI2: "phi2",
+    MODEL_ARCH.PHI3: "phi3",
+    MODEL_ARCH.PHIMOE: "phimoe",
+    MODEL_ARCH.PLAMO: "plamo",
+    MODEL_ARCH.PLAMO2: "plamo2",
+    MODEL_ARCH.CODESHELL: "codeshell",
+    MODEL_ARCH.ORION: "orion",
+    MODEL_ARCH.INTERNLM2: "internlm2",
+    MODEL_ARCH.MINICPM: "minicpm",
+    MODEL_ARCH.MINICPM3: "minicpm3",
+    MODEL_ARCH.GEMMA: "gemma",
+    MODEL_ARCH.GEMMA2: "gemma2",
+    MODEL_ARCH.GEMMA3: "gemma3",
+    MODEL_ARCH.GEMMA3N: "gemma3n",
+    MODEL_ARCH.GEMMA_EMBEDDING: "gemma-embedding",
+    MODEL_ARCH.STARCODER2: "starcoder2",
+    MODEL_ARCH.RWKV6: "rwkv6",
+    MODEL_ARCH.RWKV6QWEN2: "rwkv6qwen2",
+    MODEL_ARCH.RWKV7: "rwkv7",
+    MODEL_ARCH.ARWKV7: "arwkv7",
+    MODEL_ARCH.MAMBA: "mamba",
+    MODEL_ARCH.MAMBA2: "mamba2",
+    MODEL_ARCH.JAMBA: "jamba",
+    MODEL_ARCH.XVERSE: "xverse",
+    MODEL_ARCH.COMMAND_R: "command-r",
+    MODEL_ARCH.COHERE2: "cohere2",
+    MODEL_ARCH.DBRX: "dbrx",
+    MODEL_ARCH.OLMO: "olmo",
+    MODEL_ARCH.OLMO2: "olmo2",
+    MODEL_ARCH.OLMOE: "olmoe",
+    MODEL_ARCH.OPENELM: "openelm",
+    MODEL_ARCH.ARCTIC: "arctic",
+    MODEL_ARCH.DEEPSEEK: "deepseek",
+    MODEL_ARCH.DEEPSEEK2: "deepseek2",
+    MODEL_ARCH.CHATGLM: "chatglm",
+    MODEL_ARCH.GLM4: "glm4",
+    MODEL_ARCH.GLM4_MOE: "glm4moe",
+    MODEL_ARCH.BITNET: "bitnet",
+    MODEL_ARCH.T5: "t5",
+    MODEL_ARCH.T5ENCODER: "t5encoder",
+    MODEL_ARCH.JAIS: "jais",
+    MODEL_ARCH.NEMOTRON: "nemotron",
+    MODEL_ARCH.NEMOTRON_H: "nemotron_h",
+    MODEL_ARCH.EXAONE: "exaone",
+    MODEL_ARCH.EXAONE4: "exaone4",
+    MODEL_ARCH.GRANITE: "granite",
+    MODEL_ARCH.GRANITE_MOE: "granitemoe",
+    MODEL_ARCH.GRANITE_HYBRID: "granitehybrid",
+    MODEL_ARCH.CHAMELEON: "chameleon",
     MODEL_ARCH.WAVTOKENIZER_DEC: "wavtokenizer-dec",
-    MODEL_ARCH.PLM:              "plm",
-    MODEL_ARCH.BAILINGMOE:       "bailingmoe",
-    MODEL_ARCH.BAILINGMOE2:      "bailingmoe2",
-    MODEL_ARCH.DOTS1:            "dots1",
-    MODEL_ARCH.ARCEE:            "arcee",
-    MODEL_ARCH.ERNIE4_5:         "ernie4_5",
-    MODEL_ARCH.ERNIE4_5_MOE:     "ernie4_5-moe",
-    MODEL_ARCH.FALCON_H1:        "falcon-h1",
-    MODEL_ARCH.HUNYUAN_MOE:      "hunyuan-moe",
-    MODEL_ARCH.HUNYUAN_DENSE:    "hunyuan-dense",
-    MODEL_ARCH.SMOLLM3:          "smollm3",
-    MODEL_ARCH.GPT_OSS:          "gpt-oss",
-    MODEL_ARCH.LFM2:             "lfm2",
-    MODEL_ARCH.LFM2MOE:          "lfm2moe",
-    MODEL_ARCH.DREAM:            "dream",
-    MODEL_ARCH.SMALLTHINKER:     "smallthinker",
-    MODEL_ARCH.LLADA:            "llada",
-    MODEL_ARCH.LLADA_MOE:        "llada-moe",
-    MODEL_ARCH.SEED_OSS:         "seed_oss",
-    MODEL_ARCH.GROVEMOE:         "grovemoe",
-    MODEL_ARCH.APERTUS:          "apertus",
+    MODEL_ARCH.PLM: "plm",
+    MODEL_ARCH.BAILINGMOE: "bailingmoe",
+    MODEL_ARCH.BAILINGMOE2: "bailingmoe2",
+    MODEL_ARCH.DOTS1: "dots1",
+    MODEL_ARCH.ARCEE: "arcee",
+    MODEL_ARCH.ERNIE4_5: "ernie4_5",
+    MODEL_ARCH.ERNIE4_5_MOE: "ernie4_5-moe",
+    MODEL_ARCH.FALCON_H1: "falcon-h1",
+    MODEL_ARCH.HUNYUAN_MOE: "hunyuan-moe",
+    MODEL_ARCH.HUNYUAN_DENSE: "hunyuan-dense",
+    MODEL_ARCH.SMOLLM3: "smollm3",
+    MODEL_ARCH.GPT_OSS: "gpt-oss",
+    MODEL_ARCH.LFM2: "lfm2",
+    MODEL_ARCH.LFM2MOE: "lfm2moe",
+    MODEL_ARCH.DREAM: "dream",
+    MODEL_ARCH.SMALLTHINKER: "smallthinker",
+    MODEL_ARCH.LLADA: "llada",
+    MODEL_ARCH.LLADA_MOE: "llada-moe",
+    MODEL_ARCH.SEED_OSS: "seed_oss",
+    MODEL_ARCH.GROVEMOE: "grovemoe",
+    MODEL_ARCH.APERTUS: "apertus",
 }
 
 VISION_PROJECTOR_TYPE_NAMES: dict[VISION_PROJECTOR_TYPE, str] = {
-    VISION_PROJECTOR_TYPE.MLP:       "mlp",
-    VISION_PROJECTOR_TYPE.LDP:       "ldp",
-    VISION_PROJECTOR_TYPE.LDPV2:     "ldpv2",
+    VISION_PROJECTOR_TYPE.MLP: "mlp",
+    VISION_PROJECTOR_TYPE.LDP: "ldp",
+    VISION_PROJECTOR_TYPE.LDPV2: "ldpv2",
     VISION_PROJECTOR_TYPE.RESAMPLER: "resampler",
-    VISION_PROJECTOR_TYPE.GLM_EDGE:  "adapter",
-    VISION_PROJECTOR_TYPE.MERGER:    "qwen2vl_merger",
-    VISION_PROJECTOR_TYPE.GEMMA3:    "gemma3",
+    VISION_PROJECTOR_TYPE.GLM_EDGE: "adapter",
+    VISION_PROJECTOR_TYPE.MERGER: "qwen2vl_merger",
+    VISION_PROJECTOR_TYPE.GEMMA3: "gemma3",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
-    MODEL_TENSOR.TOKEN_EMBD:                "token_embd",
-    MODEL_TENSOR.TOKEN_EMBD_NORM:           "token_embd_norm",
-    MODEL_TENSOR.TOKEN_TYPES:               "token_types",
-    MODEL_TENSOR.POS_EMBD:                  "position_embd",
-    MODEL_TENSOR.OUTPUT_NORM:               "output_norm",
-    MODEL_TENSOR.OUTPUT:                    "output",
-    MODEL_TENSOR.DENSE_2_OUT:                "dense_2", # embeddinggemma 2_Dense
-    MODEL_TENSOR.DENSE_3_OUT:                "dense_3", # embeddinggemma 2_Dense
-    MODEL_TENSOR.ROPE_FREQS:                "rope_freqs",
-    MODEL_TENSOR.ROPE_FACTORS_LONG:         "rope_factors_long",
-    MODEL_TENSOR.ROPE_FACTORS_SHORT:        "rope_factors_short",
-    MODEL_TENSOR.ATTN_NORM:                 "blk.{bid}.attn_norm",
-    MODEL_TENSOR.ATTN_NORM_2:               "blk.{bid}.attn_norm_2",
-    MODEL_TENSOR.ATTN_QKV:                  "blk.{bid}.attn_qkv",
-    MODEL_TENSOR.ATTN_Q:                    "blk.{bid}.attn_q",
-    MODEL_TENSOR.ATTN_K:                    "blk.{bid}.attn_k",
-    MODEL_TENSOR.ATTN_V:                    "blk.{bid}.attn_v",
-    MODEL_TENSOR.ATTN_OUT:                  "blk.{bid}.attn_output",
-    MODEL_TENSOR.ATTN_ROT_EMBD:             "blk.{bid}.attn_rot_embd",
-    MODEL_TENSOR.ATTN_SINKS:                "blk.{bid}.attn_sinks",
-    MODEL_TENSOR.ATTN_Q_NORM:               "blk.{bid}.attn_q_norm",
-    MODEL_TENSOR.ATTN_K_NORM:               "blk.{bid}.attn_k_norm",
-    MODEL_TENSOR.ATTN_OUT_NORM:             "blk.{bid}.attn_output_norm",
-    MODEL_TENSOR.ATTN_POST_NORM:            "blk.{bid}.post_attention_norm",
-    MODEL_TENSOR.FFN_GATE_INP:              "blk.{bid}.ffn_gate_inp",
-    MODEL_TENSOR.FFN_GATE_INP_SHEXP:        "blk.{bid}.ffn_gate_inp_shexp",
-    MODEL_TENSOR.FFN_NORM:                  "blk.{bid}.ffn_norm",
-    MODEL_TENSOR.FFN_PRE_NORM:              "blk.{bid}.ffn_norm",
-    MODEL_TENSOR.FFN_POST_NORM:             "blk.{bid}.post_ffw_norm",
-    MODEL_TENSOR.FFN_GATE:                  "blk.{bid}.ffn_gate",
-    MODEL_TENSOR.FFN_DOWN:                  "blk.{bid}.ffn_down",
-    MODEL_TENSOR.FFN_UP:                    "blk.{bid}.ffn_up",
-    MODEL_TENSOR.FFN_GATE_SHEXP:            "blk.{bid}.ffn_gate_shexp",
-    MODEL_TENSOR.FFN_DOWN_SHEXP:            "blk.{bid}.ffn_down_shexp",
-    MODEL_TENSOR.FFN_UP_SHEXP:              "blk.{bid}.ffn_up_shexp",
-    MODEL_TENSOR.FFN_GATE_CHEXP:            "blk.{bid}.ffn_gate_chexps",
-    MODEL_TENSOR.FFN_DOWN_CHEXP:            "blk.{bid}.ffn_down_chexps",
-    MODEL_TENSOR.FFN_UP_CHEXP:              "blk.{bid}.ffn_up_chexps",
-    MODEL_TENSOR.FFN_ACT:                   "blk.{bid}.ffn",
-    MODEL_TENSOR.FFN_NORM_EXP:              "blk.{bid}.ffn_norm_exps",
-    MODEL_TENSOR.FFN_GATE_EXP:              "blk.{bid}.ffn_gate_exps",
-    MODEL_TENSOR.FFN_DOWN_EXP:              "blk.{bid}.ffn_down_exps",
-    MODEL_TENSOR.FFN_UP_EXP:                "blk.{bid}.ffn_up_exps",
-    MODEL_TENSOR.FFN_EXP_PROBS_B:           "blk.{bid}.exp_probs_b",
-    MODEL_TENSOR.LAYER_OUT_NORM:            "blk.{bid}.layer_output_norm",
-    MODEL_TENSOR.PER_LAYER_TOKEN_EMBD:      "per_layer_token_embd",           # gemma3n
-    MODEL_TENSOR.PER_LAYER_MODEL_PROJ:      "per_layer_model_proj",           # gemma3n
-    MODEL_TENSOR.PER_LAYER_PROJ_NORM:       "per_layer_proj_norm",            # gemma3n
-    MODEL_TENSOR.ALTUP_UNEMBD_PROJ:         "altup_unembd_proj",              # gemma3n
-    MODEL_TENSOR.ALTUP_PROJ:                "altup_proj",                     # gemma3n
-    MODEL_TENSOR.PER_LAYER_INP_GATE:        "blk.{bid}.inp_gate",             # gemma3n
-    MODEL_TENSOR.PER_LAYER_PROJ:            "blk.{bid}.proj",                 # gemma3n
-    MODEL_TENSOR.PER_LAYER_POST_NORM:       "blk.{bid}.post_norm",            # gemma3n
-    MODEL_TENSOR.ALTUP_CORRECT_COEF:        "blk.{bid}.altup_correct_coef",   # gemma3n
-    MODEL_TENSOR.ALTUP_CORRECT_SCALE:       "blk.{bid}.altup_correct_scale",  # gemma3n
-    MODEL_TENSOR.ALTUP_PREDICT_COEF:        "blk.{bid}.altup_predict_coef",   # gemma3n
-    MODEL_TENSOR.ALTUP_ROUTER:              "blk.{bid}.altup_router",         # gemma3n
-    MODEL_TENSOR.ALTUP_ROUTER_NORM:         "blk.{bid}.altup_router_norm",    # gemma3n
-    MODEL_TENSOR.LAUREL_L:                  "blk.{bid}.laurel_l",             # gemma3n
-    MODEL_TENSOR.LAUREL_R:                  "blk.{bid}.laurel_r",             # gemma3n
-    MODEL_TENSOR.LAUREL_POST_NORM:          "blk.{bid}.laurel_post_norm",     # gemma3n
-    MODEL_TENSOR.SSM_IN:                    "blk.{bid}.ssm_in",
-    MODEL_TENSOR.SSM_CONV1D:                "blk.{bid}.ssm_conv1d",
-    MODEL_TENSOR.SSM_X:                     "blk.{bid}.ssm_x",
-    MODEL_TENSOR.SSM_DT:                    "blk.{bid}.ssm_dt",
-    MODEL_TENSOR.SSM_DT_NORM:               "blk.{bid}.ssm_dt_norm",
-    MODEL_TENSOR.SSM_A:                     "blk.{bid}.ssm_a",
-    MODEL_TENSOR.SSM_B_NORM:                "blk.{bid}.ssm_b_norm",
-    MODEL_TENSOR.SSM_C_NORM:                "blk.{bid}.ssm_c_norm",
-    MODEL_TENSOR.SSM_D:                     "blk.{bid}.ssm_d",
-    MODEL_TENSOR.SSM_NORM:                  "blk.{bid}.ssm_norm",
-    MODEL_TENSOR.SSM_OUT:                   "blk.{bid}.ssm_out",
-    MODEL_TENSOR.TIME_MIX_W0:               "blk.{bid}.time_mix_w0",
-    MODEL_TENSOR.TIME_MIX_W1:               "blk.{bid}.time_mix_w1",
-    MODEL_TENSOR.TIME_MIX_W2:               "blk.{bid}.time_mix_w2",
-    MODEL_TENSOR.TIME_MIX_A0:               "blk.{bid}.time_mix_a0",
-    MODEL_TENSOR.TIME_MIX_A1:               "blk.{bid}.time_mix_a1",
-    MODEL_TENSOR.TIME_MIX_A2:               "blk.{bid}.time_mix_a2",
-    MODEL_TENSOR.TIME_MIX_V0:               "blk.{bid}.time_mix_v0",
-    MODEL_TENSOR.TIME_MIX_V1:               "blk.{bid}.time_mix_v1",
-    MODEL_TENSOR.TIME_MIX_V2:               "blk.{bid}.time_mix_v2",
-    MODEL_TENSOR.TIME_MIX_G1:               "blk.{bid}.time_mix_g1",
-    MODEL_TENSOR.TIME_MIX_G2:               "blk.{bid}.time_mix_g2",
-    MODEL_TENSOR.TIME_MIX_K_K:              "blk.{bid}.time_mix_k_k",
-    MODEL_TENSOR.TIME_MIX_K_A:              "blk.{bid}.time_mix_k_a",
-    MODEL_TENSOR.TIME_MIX_R_K:              "blk.{bid}.time_mix_r_k",
-    MODEL_TENSOR.TIME_MIX_LERP_X:           "blk.{bid}.time_mix_lerp_x",
-    MODEL_TENSOR.TIME_MIX_LERP_K:           "blk.{bid}.time_mix_lerp_k",
-    MODEL_TENSOR.TIME_MIX_LERP_V:           "blk.{bid}.time_mix_lerp_v",
-    MODEL_TENSOR.TIME_MIX_LERP_R:           "blk.{bid}.time_mix_lerp_r",
-    MODEL_TENSOR.TIME_MIX_LERP_G:           "blk.{bid}.time_mix_lerp_g",
-    MODEL_TENSOR.TIME_MIX_LERP_FUSED:       "blk.{bid}.time_mix_lerp_fused",
-    MODEL_TENSOR.TIME_MIX_LERP_W:           "blk.{bid}.time_mix_lerp_w",
-    MODEL_TENSOR.TIME_MIX_FIRST:            "blk.{bid}.time_mix_first",
-    MODEL_TENSOR.TIME_MIX_DECAY:            "blk.{bid}.time_mix_decay",
-    MODEL_TENSOR.TIME_MIX_DECAY_W1:         "blk.{bid}.time_mix_decay_w1",
-    MODEL_TENSOR.TIME_MIX_DECAY_W2:         "blk.{bid}.time_mix_decay_w2",
-    MODEL_TENSOR.TIME_MIX_KEY:              "blk.{bid}.time_mix_key",
-    MODEL_TENSOR.TIME_MIX_VALUE:            "blk.{bid}.time_mix_value",
-    MODEL_TENSOR.TIME_MIX_RECEPTANCE:       "blk.{bid}.time_mix_receptance",
-    MODEL_TENSOR.TIME_MIX_GATE:             "blk.{bid}.time_mix_gate",
-    MODEL_TENSOR.TIME_MIX_LN:               "blk.{bid}.time_mix_ln",
-    MODEL_TENSOR.TIME_MIX_OUTPUT:           "blk.{bid}.time_mix_output",
-    MODEL_TENSOR.CHANNEL_MIX_LERP_K:        "blk.{bid}.channel_mix_lerp_k",
-    MODEL_TENSOR.CHANNEL_MIX_LERP_R:        "blk.{bid}.channel_mix_lerp_r",
-    MODEL_TENSOR.CHANNEL_MIX_KEY:           "blk.{bid}.channel_mix_key",
-    MODEL_TENSOR.CHANNEL_MIX_RECEPTANCE:    "blk.{bid}.channel_mix_receptance",
-    MODEL_TENSOR.CHANNEL_MIX_VALUE:         "blk.{bid}.channel_mix_value",
-    MODEL_TENSOR.ATTN_Q_A:                  "blk.{bid}.attn_q_a",
-    MODEL_TENSOR.ATTN_Q_B:                  "blk.{bid}.attn_q_b",
-    MODEL_TENSOR.ATTN_KV_A_MQA:             "blk.{bid}.attn_kv_a_mqa",
-    MODEL_TENSOR.ATTN_KV_B:                 "blk.{bid}.attn_kv_b",
-    MODEL_TENSOR.ATTN_K_B:                  "blk.{bid}.attn_k_b",
-    MODEL_TENSOR.ATTN_V_B:                  "blk.{bid}.attn_v_b",
-    MODEL_TENSOR.ATTN_Q_A_NORM:             "blk.{bid}.attn_q_a_norm",
-    MODEL_TENSOR.ATTN_KV_A_NORM:            "blk.{bid}.attn_kv_a_norm",
-    MODEL_TENSOR.ATTN_SUB_NORM:             "blk.{bid}.attn_sub_norm",
-    MODEL_TENSOR.FFN_SUB_NORM:              "blk.{bid}.ffn_sub_norm",
-    MODEL_TENSOR.DEC_ATTN_NORM:             "dec.blk.{bid}.attn_norm",
-    MODEL_TENSOR.DEC_ATTN_Q:                "dec.blk.{bid}.attn_q",
-    MODEL_TENSOR.DEC_ATTN_K:                "dec.blk.{bid}.attn_k",
-    MODEL_TENSOR.DEC_ATTN_V:                "dec.blk.{bid}.attn_v",
-    MODEL_TENSOR.DEC_ATTN_OUT:              "dec.blk.{bid}.attn_o",
-    MODEL_TENSOR.DEC_ATTN_REL_B:            "dec.blk.{bid}.attn_rel_b",
-    MODEL_TENSOR.DEC_CROSS_ATTN_NORM:       "dec.blk.{bid}.cross_attn_norm",
-    MODEL_TENSOR.DEC_CROSS_ATTN_Q:          "dec.blk.{bid}.cross_attn_q",
-    MODEL_TENSOR.DEC_CROSS_ATTN_K:          "dec.blk.{bid}.cross_attn_k",
-    MODEL_TENSOR.DEC_CROSS_ATTN_V:          "dec.blk.{bid}.cross_attn_v",
-    MODEL_TENSOR.DEC_CROSS_ATTN_OUT:        "dec.blk.{bid}.cross_attn_o",
-    MODEL_TENSOR.DEC_CROSS_ATTN_REL_B:      "dec.blk.{bid}.cross_attn_rel_b",
-    MODEL_TENSOR.DEC_FFN_NORM:              "dec.blk.{bid}.ffn_norm",
-    MODEL_TENSOR.DEC_FFN_GATE:              "dec.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.DEC_FFN_DOWN:              "dec.blk.{bid}.ffn_down",
-    MODEL_TENSOR.DEC_FFN_UP:                "dec.blk.{bid}.ffn_up",
-    MODEL_TENSOR.DEC_OUTPUT_NORM:           "dec.output_norm",
-    MODEL_TENSOR.ENC_ATTN_NORM:             "enc.blk.{bid}.attn_norm",
-    MODEL_TENSOR.ENC_ATTN_Q:                "enc.blk.{bid}.attn_q",
-    MODEL_TENSOR.ENC_ATTN_K:                "enc.blk.{bid}.attn_k",
-    MODEL_TENSOR.ENC_ATTN_V:                "enc.blk.{bid}.attn_v",
-    MODEL_TENSOR.ENC_ATTN_OUT:              "enc.blk.{bid}.attn_o",
-    MODEL_TENSOR.ENC_ATTN_REL_B:            "enc.blk.{bid}.attn_rel_b",
-    MODEL_TENSOR.ENC_FFN_NORM:              "enc.blk.{bid}.ffn_norm",
-    MODEL_TENSOR.ENC_FFN_GATE:              "enc.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.ENC_FFN_DOWN:              "enc.blk.{bid}.ffn_down",
-    MODEL_TENSOR.ENC_FFN_UP:                "enc.blk.{bid}.ffn_up",
-    MODEL_TENSOR.ENC_OUTPUT_NORM:           "enc.output_norm",
-    MODEL_TENSOR.CLS:                       "cls",
-    MODEL_TENSOR.CLS_OUT:                   "cls.output",
-    MODEL_TENSOR.CONV1D:                    "conv1d",
-    MODEL_TENSOR.CONVNEXT_DW:               "convnext.{bid}.dw",
-    MODEL_TENSOR.CONVNEXT_NORM:             "convnext.{bid}.norm",
-    MODEL_TENSOR.CONVNEXT_PW1:              "convnext.{bid}.pw1",
-    MODEL_TENSOR.CONVNEXT_PW2:              "convnext.{bid}.pw2",
-    MODEL_TENSOR.CONVNEXT_GAMMA:            "convnext.{bid}.gamma",
-    MODEL_TENSOR.POSNET_CONV1:              "posnet.{bid}.conv1",
-    MODEL_TENSOR.POSNET_CONV2:              "posnet.{bid}.conv2",
-    MODEL_TENSOR.POSNET_NORM:               "posnet.{bid}.norm",
-    MODEL_TENSOR.POSNET_NORM1:              "posnet.{bid}.norm1",
-    MODEL_TENSOR.POSNET_NORM2:              "posnet.{bid}.norm2",
-    MODEL_TENSOR.POSNET_ATTN_NORM:          "posnet.{bid}.attn_norm",
-    MODEL_TENSOR.POSNET_ATTN_Q:             "posnet.{bid}.attn_q",
-    MODEL_TENSOR.POSNET_ATTN_K:             "posnet.{bid}.attn_k",
-    MODEL_TENSOR.POSNET_ATTN_V:             "posnet.{bid}.attn_v",
-    MODEL_TENSOR.POSNET_ATTN_OUT:           "posnet.{bid}.attn_output",
-    MODEL_TENSOR.SHORTCONV_CONV:            "blk.{bid}.shortconv.conv",
-    MODEL_TENSOR.SHORTCONV_INPROJ:          "blk.{bid}.shortconv.in_proj",
-    MODEL_TENSOR.SHORTCONV_OUTPROJ:         "blk.{bid}.shortconv.out_proj",
+    MODEL_TENSOR.TOKEN_EMBD: "token_embd",
+    MODEL_TENSOR.TOKEN_EMBD_NORM: "token_embd_norm",
+    MODEL_TENSOR.TOKEN_TYPES: "token_types",
+    MODEL_TENSOR.POS_EMBD: "position_embd",
+    MODEL_TENSOR.OUTPUT_NORM: "output_norm",
+    MODEL_TENSOR.OUTPUT: "output",
+    MODEL_TENSOR.DENSE_2_OUT: "dense_2",  # embeddinggemma 2_Dense
+    MODEL_TENSOR.DENSE_3_OUT: "dense_3",  # embeddinggemma 2_Dense
+    MODEL_TENSOR.ROPE_FREQS: "rope_freqs",
+    MODEL_TENSOR.ROPE_FACTORS_LONG: "rope_factors_long",
+    MODEL_TENSOR.ROPE_FACTORS_SHORT: "rope_factors_short",
+    MODEL_TENSOR.ATTN_NORM: "blk.{bid}.attn_norm",
+    MODEL_TENSOR.ATTN_NORM_2: "blk.{bid}.attn_norm_2",
+    MODEL_TENSOR.ATTN_QKV: "blk.{bid}.attn_qkv",
+    MODEL_TENSOR.ATTN_Q: "blk.{bid}.attn_q",
+    MODEL_TENSOR.ATTN_K: "blk.{bid}.attn_k",
+    MODEL_TENSOR.ATTN_V: "blk.{bid}.attn_v",
+    MODEL_TENSOR.ATTN_OUT: "blk.{bid}.attn_output",
+    MODEL_TENSOR.ATTN_ROT_EMBD: "blk.{bid}.attn_rot_embd",
+    MODEL_TENSOR.ATTN_SINKS: "blk.{bid}.attn_sinks",
+    MODEL_TENSOR.ATTN_Q_NORM: "blk.{bid}.attn_q_norm",
+    MODEL_TENSOR.ATTN_K_NORM: "blk.{bid}.attn_k_norm",
+    MODEL_TENSOR.ATTN_OUT_NORM: "blk.{bid}.attn_output_norm",
+    MODEL_TENSOR.ATTN_POST_NORM: "blk.{bid}.post_attention_norm",
+    MODEL_TENSOR.FFN_GATE_INP: "blk.{bid}.ffn_gate_inp",
+    MODEL_TENSOR.FFN_GATE_INP_SHEXP: "blk.{bid}.ffn_gate_inp_shexp",
+    MODEL_TENSOR.FFN_NORM: "blk.{bid}.ffn_norm",
+    MODEL_TENSOR.FFN_PRE_NORM: "blk.{bid}.ffn_norm",
+    MODEL_TENSOR.FFN_POST_NORM: "blk.{bid}.post_ffw_norm",
+    MODEL_TENSOR.FFN_GATE: "blk.{bid}.ffn_gate",
+    MODEL_TENSOR.FFN_DOWN: "blk.{bid}.ffn_down",
+    MODEL_TENSOR.FFN_UP: "blk.{bid}.ffn_up",
+    MODEL_TENSOR.FFN_GATE_SHEXP: "blk.{bid}.ffn_gate_shexp",
+    MODEL_TENSOR.FFN_DOWN_SHEXP: "blk.{bid}.ffn_down_shexp",
+    MODEL_TENSOR.FFN_UP_SHEXP: "blk.{bid}.ffn_up_shexp",
+    MODEL_TENSOR.FFN_GATE_CHEXP: "blk.{bid}.ffn_gate_chexps",
+    MODEL_TENSOR.FFN_DOWN_CHEXP: "blk.{bid}.ffn_down_chexps",
+    MODEL_TENSOR.FFN_UP_CHEXP: "blk.{bid}.ffn_up_chexps",
+    MODEL_TENSOR.FFN_ACT: "blk.{bid}.ffn",
+    MODEL_TENSOR.FFN_NORM_EXP: "blk.{bid}.ffn_norm_exps",
+    MODEL_TENSOR.FFN_GATE_EXP: "blk.{bid}.ffn_gate_exps",
+    MODEL_TENSOR.FFN_DOWN_EXP: "blk.{bid}.ffn_down_exps",
+    MODEL_TENSOR.FFN_UP_EXP: "blk.{bid}.ffn_up_exps",
+    MODEL_TENSOR.FFN_EXP_PROBS_B: "blk.{bid}.exp_probs_b",
+    MODEL_TENSOR.LAYER_OUT_NORM: "blk.{bid}.layer_output_norm",
+    MODEL_TENSOR.PER_LAYER_TOKEN_EMBD: "per_layer_token_embd",  # gemma3n
+    MODEL_TENSOR.PER_LAYER_MODEL_PROJ: "per_layer_model_proj",  # gemma3n
+    MODEL_TENSOR.PER_LAYER_PROJ_NORM: "per_layer_proj_norm",  # gemma3n
+    MODEL_TENSOR.ALTUP_UNEMBD_PROJ: "altup_unembd_proj",  # gemma3n
+    MODEL_TENSOR.ALTUP_PROJ: "altup_proj",  # gemma3n
+    MODEL_TENSOR.PER_LAYER_INP_GATE: "blk.{bid}.inp_gate",  # gemma3n
+    MODEL_TENSOR.PER_LAYER_PROJ: "blk.{bid}.proj",  # gemma3n
+    MODEL_TENSOR.PER_LAYER_POST_NORM: "blk.{bid}.post_norm",  # gemma3n
+    MODEL_TENSOR.ALTUP_CORRECT_COEF: "blk.{bid}.altup_correct_coef",  # gemma3n
+    MODEL_TENSOR.ALTUP_CORRECT_SCALE: "blk.{bid}.altup_correct_scale",  # gemma3n
+    MODEL_TENSOR.ALTUP_PREDICT_COEF: "blk.{bid}.altup_predict_coef",  # gemma3n
+    MODEL_TENSOR.ALTUP_ROUTER: "blk.{bid}.altup_router",  # gemma3n
+    MODEL_TENSOR.ALTUP_ROUTER_NORM: "blk.{bid}.altup_router_norm",  # gemma3n
+    MODEL_TENSOR.LAUREL_L: "blk.{bid}.laurel_l",  # gemma3n
+    MODEL_TENSOR.LAUREL_R: "blk.{bid}.laurel_r",  # gemma3n
+    MODEL_TENSOR.LAUREL_POST_NORM: "blk.{bid}.laurel_post_norm",  # gemma3n
+    MODEL_TENSOR.SSM_IN: "blk.{bid}.ssm_in",
+    MODEL_TENSOR.SSM_CONV1D: "blk.{bid}.ssm_conv1d",
+    MODEL_TENSOR.SSM_X: "blk.{bid}.ssm_x",
+    MODEL_TENSOR.SSM_DT: "blk.{bid}.ssm_dt",
+    MODEL_TENSOR.SSM_DT_NORM: "blk.{bid}.ssm_dt_norm",
+    MODEL_TENSOR.SSM_A: "blk.{bid}.ssm_a",
+    MODEL_TENSOR.SSM_B_NORM: "blk.{bid}.ssm_b_norm",
+    MODEL_TENSOR.SSM_C_NORM: "blk.{bid}.ssm_c_norm",
+    MODEL_TENSOR.SSM_D: "blk.{bid}.ssm_d",
+    MODEL_TENSOR.SSM_NORM: "blk.{bid}.ssm_norm",
+    MODEL_TENSOR.SSM_OUT: "blk.{bid}.ssm_out",
+    MODEL_TENSOR.TIME_MIX_W0: "blk.{bid}.time_mix_w0",
+    MODEL_TENSOR.TIME_MIX_W1: "blk.{bid}.time_mix_w1",
+    MODEL_TENSOR.TIME_MIX_W2: "blk.{bid}.time_mix_w2",
+    MODEL_TENSOR.TIME_MIX_A0: "blk.{bid}.time_mix_a0",
+    MODEL_TENSOR.TIME_MIX_A1: "blk.{bid}.time_mix_a1",
+    MODEL_TENSOR.TIME_MIX_A2: "blk.{bid}.time_mix_a2",
+    MODEL_TENSOR.TIME_MIX_V0: "blk.{bid}.time_mix_v0",
+    MODEL_TENSOR.TIME_MIX_V1: "blk.{bid}.time_mix_v1",
+    MODEL_TENSOR.TIME_MIX_V2: "blk.{bid}.time_mix_v2",
+    MODEL_TENSOR.TIME_MIX_G1: "blk.{bid}.time_mix_g1",
+    MODEL_TENSOR.TIME_MIX_G2: "blk.{bid}.time_mix_g2",
+    MODEL_TENSOR.TIME_MIX_K_K: "blk.{bid}.time_mix_k_k",
+    MODEL_TENSOR.TIME_MIX_K_A: "blk.{bid}.time_mix_k_a",
+    MODEL_TENSOR.TIME_MIX_R_K: "blk.{bid}.time_mix_r_k",
+    MODEL_TENSOR.TIME_MIX_LERP_X: "blk.{bid}.time_mix_lerp_x",
+    MODEL_TENSOR.TIME_MIX_LERP_K: "blk.{bid}.time_mix_lerp_k",
+    MODEL_TENSOR.TIME_MIX_LERP_V: "blk.{bid}.time_mix_lerp_v",
+    MODEL_TENSOR.TIME_MIX_LERP_R: "blk.{bid}.time_mix_lerp_r",
+    MODEL_TENSOR.TIME_MIX_LERP_G: "blk.{bid}.time_mix_lerp_g",
+    MODEL_TENSOR.TIME_MIX_LERP_FUSED: "blk.{bid}.time_mix_lerp_fused",
+    MODEL_TENSOR.TIME_MIX_LERP_W: "blk.{bid}.time_mix_lerp_w",
+    MODEL_TENSOR.TIME_MIX_FIRST: "blk.{bid}.time_mix_first",
+    MODEL_TENSOR.TIME_MIX_DECAY: "blk.{bid}.time_mix_decay",
+    MODEL_TENSOR.TIME_MIX_DECAY_W1: "blk.{bid}.time_mix_decay_w1",
+    MODEL_TENSOR.TIME_MIX_DECAY_W2: "blk.{bid}.time_mix_decay_w2",
+    MODEL_TENSOR.TIME_MIX_KEY: "blk.{bid}.time_mix_key",
+    MODEL_TENSOR.TIME_MIX_VALUE: "blk.{bid}.time_mix_value",
+    MODEL_TENSOR.TIME_MIX_RECEPTANCE: "blk.{bid}.time_mix_receptance",
+    MODEL_TENSOR.TIME_MIX_GATE: "blk.{bid}.time_mix_gate",
+    MODEL_TENSOR.TIME_MIX_LN: "blk.{bid}.time_mix_ln",
+    MODEL_TENSOR.TIME_MIX_OUTPUT: "blk.{bid}.time_mix_output",
+    MODEL_TENSOR.CHANNEL_MIX_LERP_K: "blk.{bid}.channel_mix_lerp_k",
+    MODEL_TENSOR.CHANNEL_MIX_LERP_R: "blk.{bid}.channel_mix_lerp_r",
+    MODEL_TENSOR.CHANNEL_MIX_KEY: "blk.{bid}.channel_mix_key",
+    MODEL_TENSOR.CHANNEL_MIX_RECEPTANCE: "blk.{bid}.channel_mix_receptance",
+    MODEL_TENSOR.CHANNEL_MIX_VALUE: "blk.{bid}.channel_mix_value",
+    MODEL_TENSOR.ATTN_Q_A: "blk.{bid}.attn_q_a",
+    MODEL_TENSOR.ATTN_Q_B: "blk.{bid}.attn_q_b",
+    MODEL_TENSOR.ATTN_KV_A_MQA: "blk.{bid}.attn_kv_a_mqa",
+    MODEL_TENSOR.ATTN_KV_B: "blk.{bid}.attn_kv_b",
+    MODEL_TENSOR.ATTN_K_B: "blk.{bid}.attn_k_b",
+    MODEL_TENSOR.ATTN_V_B: "blk.{bid}.attn_v_b",
+    MODEL_TENSOR.ATTN_Q_A_NORM: "blk.{bid}.attn_q_a_norm",
+    MODEL_TENSOR.ATTN_KV_A_NORM: "blk.{bid}.attn_kv_a_norm",
+    MODEL_TENSOR.ATTN_SUB_NORM: "blk.{bid}.attn_sub_norm",
+    MODEL_TENSOR.FFN_SUB_NORM: "blk.{bid}.ffn_sub_norm",
+    MODEL_TENSOR.DEC_ATTN_NORM: "dec.blk.{bid}.attn_norm",
+    MODEL_TENSOR.DEC_ATTN_Q: "dec.blk.{bid}.attn_q",
+    MODEL_TENSOR.DEC_ATTN_K: "dec.blk.{bid}.attn_k",
+    MODEL_TENSOR.DEC_ATTN_V: "dec.blk.{bid}.attn_v",
+    MODEL_TENSOR.DEC_ATTN_OUT: "dec.blk.{bid}.attn_o",
+    MODEL_TENSOR.DEC_ATTN_REL_B: "dec.blk.{bid}.attn_rel_b",
+    MODEL_TENSOR.DEC_CROSS_ATTN_NORM: "dec.blk.{bid}.cross_attn_norm",
+    MODEL_TENSOR.DEC_CROSS_ATTN_Q: "dec.blk.{bid}.cross_attn_q",
+    MODEL_TENSOR.DEC_CROSS_ATTN_K: "dec.blk.{bid}.cross_attn_k",
+    MODEL_TENSOR.DEC_CROSS_ATTN_V: "dec.blk.{bid}.cross_attn_v",
+    MODEL_TENSOR.DEC_CROSS_ATTN_OUT: "dec.blk.{bid}.cross_attn_o",
+    MODEL_TENSOR.DEC_CROSS_ATTN_REL_B: "dec.blk.{bid}.cross_attn_rel_b",
+    MODEL_TENSOR.DEC_FFN_NORM: "dec.blk.{bid}.ffn_norm",
+    MODEL_TENSOR.DEC_FFN_GATE: "dec.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.DEC_FFN_DOWN: "dec.blk.{bid}.ffn_down",
+    MODEL_TENSOR.DEC_FFN_UP: "dec.blk.{bid}.ffn_up",
+    MODEL_TENSOR.DEC_OUTPUT_NORM: "dec.output_norm",
+    MODEL_TENSOR.ENC_ATTN_NORM: "enc.blk.{bid}.attn_norm",
+    MODEL_TENSOR.ENC_ATTN_Q: "enc.blk.{bid}.attn_q",
+    MODEL_TENSOR.ENC_ATTN_K: "enc.blk.{bid}.attn_k",
+    MODEL_TENSOR.ENC_ATTN_V: "enc.blk.{bid}.attn_v",
+    MODEL_TENSOR.ENC_ATTN_OUT: "enc.blk.{bid}.attn_o",
+    MODEL_TENSOR.ENC_ATTN_REL_B: "enc.blk.{bid}.attn_rel_b",
+    MODEL_TENSOR.ENC_FFN_NORM: "enc.blk.{bid}.ffn_norm",
+    MODEL_TENSOR.ENC_FFN_GATE: "enc.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.ENC_FFN_DOWN: "enc.blk.{bid}.ffn_down",
+    MODEL_TENSOR.ENC_FFN_UP: "enc.blk.{bid}.ffn_up",
+    MODEL_TENSOR.ENC_OUTPUT_NORM: "enc.output_norm",
+    MODEL_TENSOR.CLS: "cls",
+    MODEL_TENSOR.CLS_OUT: "cls.output",
+    MODEL_TENSOR.CONV1D: "conv1d",
+    MODEL_TENSOR.CONVNEXT_DW: "convnext.{bid}.dw",
+    MODEL_TENSOR.CONVNEXT_NORM: "convnext.{bid}.norm",
+    MODEL_TENSOR.CONVNEXT_PW1: "convnext.{bid}.pw1",
+    MODEL_TENSOR.CONVNEXT_PW2: "convnext.{bid}.pw2",
+    MODEL_TENSOR.CONVNEXT_GAMMA: "convnext.{bid}.gamma",
+    MODEL_TENSOR.POSNET_CONV1: "posnet.{bid}.conv1",
+    MODEL_TENSOR.POSNET_CONV2: "posnet.{bid}.conv2",
+    MODEL_TENSOR.POSNET_NORM: "posnet.{bid}.norm",
+    MODEL_TENSOR.POSNET_NORM1: "posnet.{bid}.norm1",
+    MODEL_TENSOR.POSNET_NORM2: "posnet.{bid}.norm2",
+    MODEL_TENSOR.POSNET_ATTN_NORM: "posnet.{bid}.attn_norm",
+    MODEL_TENSOR.POSNET_ATTN_Q: "posnet.{bid}.attn_q",
+    MODEL_TENSOR.POSNET_ATTN_K: "posnet.{bid}.attn_k",
+    MODEL_TENSOR.POSNET_ATTN_V: "posnet.{bid}.attn_v",
+    MODEL_TENSOR.POSNET_ATTN_OUT: "posnet.{bid}.attn_output",
+    MODEL_TENSOR.SHORTCONV_CONV: "blk.{bid}.shortconv.conv",
+    MODEL_TENSOR.SHORTCONV_INPROJ: "blk.{bid}.shortconv.in_proj",
+    MODEL_TENSOR.SHORTCONV_OUTPROJ: "blk.{bid}.shortconv.out_proj",
     # vision
-    MODEL_TENSOR.V_MMPROJ:                  "mm.{bid}",
-    MODEL_TENSOR.V_MMPROJ_FC:               "mm.model.fc",
-    MODEL_TENSOR.V_MMPROJ_MLP:              "mm.model.mlp.{bid}",
-    MODEL_TENSOR.V_MMPROJ_PEG:              "mm.model.peg.{bid}",
-    MODEL_TENSOR.V_ENC_EMBD_CLS:            "v.class_embd",
-    MODEL_TENSOR.V_ENC_EMBD_PATCH:          "v.patch_embd",
-    MODEL_TENSOR.V_ENC_EMBD_POS:            "v.position_embd",
-    MODEL_TENSOR.V_ENC_ATTN_Q:              "v.blk.{bid}.attn_q",
-    MODEL_TENSOR.V_ENC_ATTN_Q_NORM:         "v.blk.{bid}.attn_q_norm",
-    MODEL_TENSOR.V_ENC_ATTN_K:              "v.blk.{bid}.attn_k",
-    MODEL_TENSOR.V_ENC_ATTN_K_NORM:         "v.blk.{bid}.attn_k_norm",
-    MODEL_TENSOR.V_ENC_ATTN_V:              "v.blk.{bid}.attn_v",
-    MODEL_TENSOR.V_ENC_INPUT_NORM:          "v.blk.{bid}.ln1",
-    MODEL_TENSOR.V_ENC_ATTN_O:              "v.blk.{bid}.attn_out",
-    MODEL_TENSOR.V_ENC_ATTN_O_NORM:         "v.blk.{bid}.attn_out_norm",
-    MODEL_TENSOR.V_ENC_POST_ATTN_NORM:      "v.blk.{bid}.ln2",
-    MODEL_TENSOR.V_ENC_FFN_UP:              "v.blk.{bid}.ffn_up",
-    MODEL_TENSOR.V_ENC_FFN_GATE:            "v.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.V_ENC_FFN_DOWN:            "v.blk.{bid}.ffn_down",
-    MODEL_TENSOR.V_LAYER_SCALE_1:           "v.blk.{bid}.ls1",
-    MODEL_TENSOR.V_LAYER_SCALE_2:           "v.blk.{bid}.ls2",
-    MODEL_TENSOR.V_PRE_NORM:                "v.pre_ln",
-    MODEL_TENSOR.V_POST_NORM:               "v.post_ln",
-    MODEL_TENSOR.V_MM_INP_PROJ:             "mm.input_projection",
-    MODEL_TENSOR.V_MM_INP_NORM:             "mm.input_norm",
-    MODEL_TENSOR.V_MM_SOFT_EMB_NORM:        "mm.soft_emb_norm",
-    MODEL_TENSOR.V_RESMPL_POS_EMBD_K:       "resampler.pos_embd_k",
-    MODEL_TENSOR.V_RESMPL_ATTN_Q:           "resampler.attn.q",
-    MODEL_TENSOR.V_RESMPL_ATTN_K:           "resampler.attn.k",
-    MODEL_TENSOR.V_RESMPL_ATTN_V:           "resampler.attn.v",
-    MODEL_TENSOR.V_RESMPL_ATTN_OUT:         "resampler.attn.out",
-    MODEL_TENSOR.V_RESMPL_KV:               "resampler.kv",
-    MODEL_TENSOR.V_RESMPL_KV_NORM:          "resampler.ln_kv",
-    MODEL_TENSOR.V_RESMPL_POST_NORM:        "resampler.ln_post",
-    MODEL_TENSOR.V_RESMPL_Q_NORM:           "resampler.ln_q",
-    MODEL_TENSOR.V_RESMPL_PROJ:             "resampler.proj",
-    MODEL_TENSOR.V_RESMPL_QUERY:            "resampler.query",
-    MODEL_TENSOR.V_TOK_EMBD_IMG_BREAK:      "v.token_embd.img_break", # pixtral
-    MODEL_TENSOR.V_MM_PATCH_MERGER:         "mm.patch_merger", # mistral small 3.1
+    MODEL_TENSOR.V_MMPROJ: "mm.{bid}",
+    MODEL_TENSOR.V_MMPROJ_FC: "mm.model.fc",
+    MODEL_TENSOR.V_MMPROJ_MLP: "mm.model.mlp.{bid}",
+    MODEL_TENSOR.V_MMPROJ_PEG: "mm.model.peg.{bid}",
+    MODEL_TENSOR.V_ENC_EMBD_CLS: "v.class_embd",
+    MODEL_TENSOR.V_ENC_EMBD_PATCH: "v.patch_embd",
+    MODEL_TENSOR.V_ENC_EMBD_POS: "v.position_embd",
+    MODEL_TENSOR.V_ENC_ATTN_Q: "v.blk.{bid}.attn_q",
+    MODEL_TENSOR.V_ENC_ATTN_Q_NORM: "v.blk.{bid}.attn_q_norm",
+    MODEL_TENSOR.V_ENC_ATTN_K: "v.blk.{bid}.attn_k",
+    MODEL_TENSOR.V_ENC_ATTN_K_NORM: "v.blk.{bid}.attn_k_norm",
+    MODEL_TENSOR.V_ENC_ATTN_V: "v.blk.{bid}.attn_v",
+    MODEL_TENSOR.V_ENC_INPUT_NORM: "v.blk.{bid}.ln1",
+    MODEL_TENSOR.V_ENC_ATTN_O: "v.blk.{bid}.attn_out",
+    MODEL_TENSOR.V_ENC_ATTN_O_NORM: "v.blk.{bid}.attn_out_norm",
+    MODEL_TENSOR.V_ENC_POST_ATTN_NORM: "v.blk.{bid}.ln2",
+    MODEL_TENSOR.V_ENC_FFN_UP: "v.blk.{bid}.ffn_up",
+    MODEL_TENSOR.V_ENC_FFN_GATE: "v.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.V_ENC_FFN_DOWN: "v.blk.{bid}.ffn_down",
+    MODEL_TENSOR.V_LAYER_SCALE_1: "v.blk.{bid}.ls1",
+    MODEL_TENSOR.V_LAYER_SCALE_2: "v.blk.{bid}.ls2",
+    MODEL_TENSOR.V_PRE_NORM: "v.pre_ln",
+    MODEL_TENSOR.V_POST_NORM: "v.post_ln",
+    MODEL_TENSOR.V_MM_INP_PROJ: "mm.input_projection",
+    MODEL_TENSOR.V_MM_INP_NORM: "mm.input_norm",
+    MODEL_TENSOR.V_MM_SOFT_EMB_NORM: "mm.soft_emb_norm",
+    MODEL_TENSOR.V_RESMPL_POS_EMBD_K: "resampler.pos_embd_k",
+    MODEL_TENSOR.V_RESMPL_ATTN_Q: "resampler.attn.q",
+    MODEL_TENSOR.V_RESMPL_ATTN_K: "resampler.attn.k",
+    MODEL_TENSOR.V_RESMPL_ATTN_V: "resampler.attn.v",
+    MODEL_TENSOR.V_RESMPL_ATTN_OUT: "resampler.attn.out",
+    MODEL_TENSOR.V_RESMPL_KV: "resampler.kv",
+    MODEL_TENSOR.V_RESMPL_KV_NORM: "resampler.ln_kv",
+    MODEL_TENSOR.V_RESMPL_POST_NORM: "resampler.ln_post",
+    MODEL_TENSOR.V_RESMPL_Q_NORM: "resampler.ln_q",
+    MODEL_TENSOR.V_RESMPL_PROJ: "resampler.proj",
+    MODEL_TENSOR.V_RESMPL_QUERY: "resampler.query",
+    MODEL_TENSOR.V_TOK_EMBD_IMG_BREAK: "v.token_embd.img_break",  # pixtral
+    MODEL_TENSOR.V_MM_PATCH_MERGER: "mm.patch_merger",  # mistral small 3.1
     # audio (mtmd)
-    MODEL_TENSOR.A_ENC_EMBD_POS:            "a.position_embd",
-    MODEL_TENSOR.A_ENC_CONV1D:              "a.conv1d.{bid}",
-    MODEL_TENSOR.A_PRE_NORM:                "a.pre_ln",
-    MODEL_TENSOR.A_POST_NORM:               "a.post_ln",
-    MODEL_TENSOR.A_ENC_ATTN_Q:              "a.blk.{bid}.attn_q",
-    MODEL_TENSOR.A_ENC_ATTN_K:              "a.blk.{bid}.attn_k",
-    MODEL_TENSOR.A_ENC_ATTN_V:              "a.blk.{bid}.attn_v",
-    MODEL_TENSOR.A_ENC_INPUT_NORM:          "a.blk.{bid}.ln1",
-    MODEL_TENSOR.A_ENC_OUTPUT:              "a.blk.{bid}.attn_out",
-    MODEL_TENSOR.A_ENC_OUTPUT_NORM:         "a.blk.{bid}.ln2",
-    MODEL_TENSOR.A_ENC_FFN_UP:              "a.blk.{bid}.ffn_up",
-    MODEL_TENSOR.A_ENC_FFN_GATE:            "a.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.A_ENC_FFN_DOWN:            "a.blk.{bid}.ffn_down",
-    MODEL_TENSOR.A_MMPROJ:                  "mm.a.mlp.{bid}",
-    MODEL_TENSOR.A_MMPROJ_FC:               "mm.a.fc",
-    MODEL_TENSOR.A_MM_NORM_PRE:             "mm.a.norm_pre",
-    MODEL_TENSOR.A_MM_NORM_MID:             "mm.a.norm_mid",
+    MODEL_TENSOR.A_ENC_EMBD_POS: "a.position_embd",
+    MODEL_TENSOR.A_ENC_CONV1D: "a.conv1d.{bid}",
+    MODEL_TENSOR.A_PRE_NORM: "a.pre_ln",
+    MODEL_TENSOR.A_POST_NORM: "a.post_ln",
+    MODEL_TENSOR.A_ENC_ATTN_Q: "a.blk.{bid}.attn_q",
+    MODEL_TENSOR.A_ENC_ATTN_K: "a.blk.{bid}.attn_k",
+    MODEL_TENSOR.A_ENC_ATTN_V: "a.blk.{bid}.attn_v",
+    MODEL_TENSOR.A_ENC_INPUT_NORM: "a.blk.{bid}.ln1",
+    MODEL_TENSOR.A_ENC_OUTPUT: "a.blk.{bid}.attn_out",
+    MODEL_TENSOR.A_ENC_OUTPUT_NORM: "a.blk.{bid}.ln2",
+    MODEL_TENSOR.A_ENC_FFN_UP: "a.blk.{bid}.ffn_up",
+    MODEL_TENSOR.A_ENC_FFN_GATE: "a.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.A_ENC_FFN_DOWN: "a.blk.{bid}.ffn_down",
+    MODEL_TENSOR.A_MMPROJ: "mm.a.mlp.{bid}",
+    MODEL_TENSOR.A_MMPROJ_FC: "mm.a.fc",
+    MODEL_TENSOR.A_MM_NORM_PRE: "mm.a.norm_pre",
+    MODEL_TENSOR.A_MM_NORM_MID: "mm.a.norm_mid",
     # NextN/MTP
-    MODEL_TENSOR.NEXTN_EH_PROJ:             "blk.{bid}.nextn.eh_proj",
-    MODEL_TENSOR.NEXTN_EMBED_TOKENS:        "blk.{bid}.nextn.embed_tokens",
-    MODEL_TENSOR.NEXTN_ENORM:               "blk.{bid}.nextn.enorm",
-    MODEL_TENSOR.NEXTN_HNORM:               "blk.{bid}.nextn.hnorm",
-    MODEL_TENSOR.NEXTN_SHARED_HEAD_HEAD:    "blk.{bid}.nextn.shared_head_head",
-    MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM:    "blk.{bid}.nextn.shared_head_norm",
+    MODEL_TENSOR.NEXTN_EH_PROJ: "blk.{bid}.nextn.eh_proj",
+    MODEL_TENSOR.NEXTN_EMBED_TOKENS: "blk.{bid}.nextn.embed_tokens",
+    MODEL_TENSOR.NEXTN_ENORM: "blk.{bid}.nextn.enorm",
+    MODEL_TENSOR.NEXTN_HNORM: "blk.{bid}.nextn.hnorm",
+    MODEL_TENSOR.NEXTN_SHARED_HEAD_HEAD: "blk.{bid}.nextn.shared_head_head",
+    MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM: "blk.{bid}.nextn.shared_head_norm",
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -2214,7 +2220,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_DOWN,
     ],
-    MODEL_ARCH.CHATGLM : [
+    MODEL_ARCH.CHATGLM: [
         MODEL_TENSOR.TOKEN_EMBD,
         MODEL_TENSOR.ROPE_FREQS,
         MODEL_TENSOR.OUTPUT_NORM,
@@ -2229,7 +2235,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
     ],
-    MODEL_ARCH.GLM4 : [
+    MODEL_ARCH.GLM4: [
         MODEL_TENSOR.TOKEN_EMBD,
         MODEL_TENSOR.ROPE_FREQS,
         MODEL_TENSOR.OUTPUT_NORM,
@@ -2622,36 +2628,30 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
     MODEL_ARCH.FALCON_H1: [
         # Token embedding
         MODEL_TENSOR.TOKEN_EMBD,
-
         # Input layernorm
         MODEL_TENSOR.ATTN_NORM,
-
         # Attention components
-        MODEL_TENSOR.ATTN_Q,         # Query projection
-        MODEL_TENSOR.ATTN_K,         # Key projection
-        MODEL_TENSOR.ATTN_V,         # Value projection
-        MODEL_TENSOR.ATTN_OUT,       # Output projection
-
+        MODEL_TENSOR.ATTN_Q,  # Query projection
+        MODEL_TENSOR.ATTN_K,  # Key projection
+        MODEL_TENSOR.ATTN_V,  # Value projection
+        MODEL_TENSOR.ATTN_OUT,  # Output projection
         # SSM components (Mamba2 specific)
-        MODEL_TENSOR.SSM_IN,         # Input projection for SSM
-        MODEL_TENSOR.SSM_CONV1D,     # Convolution layer
-        MODEL_TENSOR.SSM_DT,         # Delta time projection
-        MODEL_TENSOR.SSM_A,          # A parameter (log form)
-        MODEL_TENSOR.SSM_D,          # D parameter
-        MODEL_TENSOR.SSM_NORM,       # Normalization in SSM
-        MODEL_TENSOR.SSM_OUT,        # Output projection
-
+        MODEL_TENSOR.SSM_IN,  # Input projection for SSM
+        MODEL_TENSOR.SSM_CONV1D,  # Convolution layer
+        MODEL_TENSOR.SSM_DT,  # Delta time projection
+        MODEL_TENSOR.SSM_A,  # A parameter (log form)
+        MODEL_TENSOR.SSM_D,  # D parameter
+        MODEL_TENSOR.SSM_NORM,  # Normalization in SSM
+        MODEL_TENSOR.SSM_OUT,  # Output projection
         # Pre-feedforward layernorm
         MODEL_TENSOR.FFN_PRE_NORM,
-
         # Feed-forward network components
-        MODEL_TENSOR.FFN_GATE,       # Gate projection (SwiGLU)
-        MODEL_TENSOR.FFN_DOWN,       # Down projection
-        MODEL_TENSOR.FFN_UP,         # Up projection
-
+        MODEL_TENSOR.FFN_GATE,  # Gate projection (SwiGLU)
+        MODEL_TENSOR.FFN_DOWN,  # Down projection
+        MODEL_TENSOR.FFN_UP,  # Up projection
         # Post-feedforward layernorm
-        MODEL_TENSOR.OUTPUT_NORM,    # Final layer norm
-        MODEL_TENSOR.OUTPUT,         # Output projection (lm_head)
+        MODEL_TENSOR.OUTPUT_NORM,  # Final layer norm
+        MODEL_TENSOR.OUTPUT,  # Output projection (lm_head)
     ],
     MODEL_ARCH.HUNYUAN_MOE: [
         MODEL_TENSOR.TOKEN_EMBD,
@@ -2732,7 +2732,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_NORM,
-        MODEL_TENSOR.ATTN_NORM, # operator_norm
+        MODEL_TENSOR.ATTN_NORM,  # operator_norm
         MODEL_TENSOR.ATTN_Q_NORM,
         MODEL_TENSOR.ATTN_K_NORM,
         MODEL_TENSOR.ATTN_Q,
@@ -2751,7 +2751,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_NORM,
-        MODEL_TENSOR.ATTN_NORM, # operator_norm
+        MODEL_TENSOR.ATTN_NORM,  # operator_norm
         MODEL_TENSOR.ATTN_Q_NORM,
         MODEL_TENSOR.ATTN_K_NORM,
         MODEL_TENSOR.ATTN_Q,
@@ -2900,67 +2900,68 @@ MODEL_TENSOR_SKIP: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
 
 
 class TokenType(IntEnum):
-    NORMAL       = 1
-    UNKNOWN      = 2
-    CONTROL      = 3
+    NORMAL = 1
+    UNKNOWN = 2
+    CONTROL = 3
     USER_DEFINED = 4
-    UNUSED       = 5
-    BYTE         = 6
+    UNUSED = 5
+    BYTE = 6
 
 
 class RopeScalingType(Enum):
-    NONE     = 'none'
-    LINEAR   = 'linear'
-    YARN     = 'yarn'
-    LONGROPE = 'longrope'
+    NONE = "none"
+    LINEAR = "linear"
+    YARN = "yarn"
+    LONGROPE = "longrope"
 
 
 class PoolingType(IntEnum):
     NONE = 0
     MEAN = 1
-    CLS  = 2
+    CLS = 2
     LAST = 3
     RANK = 4
 
 
 class GGMLQuantizationType(IntEnum):
-    F32     = 0
-    F16     = 1
-    Q4_0    = 2
-    Q4_1    = 3
-    Q5_0    = 6
-    Q5_1    = 7
-    Q8_0    = 8
-    Q8_1    = 9
-    Q2_K    = 10
-    Q3_K    = 11
-    Q4_K    = 12
-    Q5_K    = 13
-    Q6_K    = 14
-    Q8_K    = 15
+    F32 = 0
+    F16 = 1
+    Q4_0 = 2
+    Q4_1 = 3
+    Q5_0 = 6
+    Q5_1 = 7
+    Q8_0 = 8
+    Q8_1 = 9
+    Q2_K = 10
+    Q3_K = 11
+    Q4_K = 12
+    Q5_K = 13
+    Q6_K = 14
+    Q8_K = 15
     IQ2_XXS = 16
-    IQ2_XS  = 17
+    IQ2_XS = 17
     IQ3_XXS = 18
-    IQ1_S   = 19
-    IQ4_NL  = 20
-    IQ3_S   = 21
-    IQ2_S   = 22
-    IQ4_XS  = 23
-    I8      = 24
-    I16     = 25
-    I32     = 26
-    I64     = 27
-    F64     = 28
-    IQ1_M   = 29
-    BF16    = 30
-    TQ1_0   = 34
-    TQ2_0   = 35
-    MXFP4   = 39
+    IQ1_S = 19
+    IQ4_NL = 20
+    IQ3_S = 21
+    IQ2_S = 22
+    IQ4_XS = 23
+    I8 = 24
+    I16 = 25
+    I32 = 26
+    I64 = 27
+    F64 = 28
+    IQ1_M = 29
+    BF16 = 30
+    TQ1_0 = 34
+    TQ2_0 = 35
+    MXFP4 = 39
+    MXFP6E3M2 = 40
 
 
 class ExpertGatingFuncType(IntEnum):
-    SOFTMAX  = 1
-    SIGMOID  = 2
+    SOFTMAX = 1
+    SIGMOID = 2
 
 
 # TODO: add GGMLFileType from ggml_ftype in ggml.h
@@ -2969,46 +2970,46 @@ class ExpertGatingFuncType(IntEnum):
 # from llama_ftype in llama.h
 # ALL VALUES SHOULD BE THE SAME HERE AS THEY ARE OVER THERE.
 class LlamaFileType(IntEnum):
-    ALL_F32              = 0
-    MOSTLY_F16           = 1   # except 1d tensors
-    MOSTLY_Q4_0          = 2   # except 1d tensors
-    MOSTLY_Q4_1          = 3   # except 1d tensors
+    ALL_F32 = 0
+    MOSTLY_F16 = 1  # except 1d tensors
+    MOSTLY_Q4_0 = 2  # except 1d tensors
+    MOSTLY_Q4_1 = 3  # except 1d tensors
     # MOSTLY_Q4_1_SOME_F16 = 4   # tok_embeddings.weight and output.weight are F16
     # MOSTLY_Q4_2        = 5   # support has been removed
     # MOSTLY_Q4_3        = 6   # support has been removed
-    MOSTLY_Q8_0          = 7   # except 1d tensors
-    MOSTLY_Q5_0          = 8   # except 1d tensors
-    MOSTLY_Q5_1          = 9   # except 1d tensors
-    MOSTLY_Q2_K          = 10  # except 1d tensors
-    MOSTLY_Q3_K_S        = 11  # except 1d tensors
-    MOSTLY_Q3_K_M        = 12  # except 1d tensors
-    MOSTLY_Q3_K_L        = 13  # except 1d tensors
-    MOSTLY_Q4_K_S        = 14  # except 1d tensors
-    MOSTLY_Q4_K_M        = 15  # except 1d tensors
-    MOSTLY_Q5_K_S        = 16  # except 1d tensors
-    MOSTLY_Q5_K_M        = 17  # except 1d tensors
-    MOSTLY_Q6_K          = 18  # except 1d tensors
-    MOSTLY_IQ2_XXS       = 19  # except 1d tensors
-    MOSTLY_IQ2_XS        = 20  # except 1d tensors
-    MOSTLY_Q2_K_S        = 21  # except 1d tensors
-    MOSTLY_IQ3_XS        = 22  # except 1d tensors
-    MOSTLY_IQ3_XXS       = 23  # except 1d tensors
-    MOSTLY_IQ1_S         = 24  # except 1d tensors
-    MOSTLY_IQ4_NL        = 25  # except 1d tensors
-    MOSTLY_IQ3_S         = 26  # except 1d tensors
-    MOSTLY_IQ3_M         = 27  # except 1d tensors
-    MOSTLY_IQ2_S         = 28  # except 1d tensors
-    MOSTLY_IQ2_M         = 29  # except 1d tensors
-    MOSTLY_IQ4_XS        = 30  # except 1d tensors
-    MOSTLY_IQ1_M         = 31  # except 1d tensors
-    MOSTLY_BF16          = 32  # except 1d tensors
+    MOSTLY_Q8_0 = 7  # except 1d tensors
+    MOSTLY_Q5_0 = 8  # except 1d tensors
+    MOSTLY_Q5_1 = 9  # except 1d tensors
+    MOSTLY_Q2_K = 10  # except 1d tensors
+    MOSTLY_Q3_K_S = 11  # except 1d tensors
+    MOSTLY_Q3_K_M = 12  # except 1d tensors
+    MOSTLY_Q3_K_L = 13  # except 1d tensors
+    MOSTLY_Q4_K_S = 14  # except 1d tensors
+    MOSTLY_Q4_K_M = 15  # except 1d tensors
+    MOSTLY_Q5_K_S = 16  # except 1d tensors
+    MOSTLY_Q5_K_M = 17  # except 1d tensors
+    MOSTLY_Q6_K = 18  # except 1d tensors
+    MOSTLY_IQ2_XXS = 19  # except 1d tensors
+    MOSTLY_IQ2_XS = 20  # except 1d tensors
+    MOSTLY_Q2_K_S = 21  # except 1d tensors
+    MOSTLY_IQ3_XS = 22  # except 1d tensors
+    MOSTLY_IQ3_XXS = 23  # except 1d tensors
+    MOSTLY_IQ1_S = 24  # except 1d tensors
+    MOSTLY_IQ4_NL = 25  # except 1d tensors
+    MOSTLY_IQ3_S = 26  # except 1d tensors
+    MOSTLY_IQ3_M = 27  # except 1d tensors
+    MOSTLY_IQ2_S = 28  # except 1d tensors
+    MOSTLY_IQ2_M = 29  # except 1d tensors
+    MOSTLY_IQ4_XS = 30  # except 1d tensors
+    MOSTLY_IQ1_M = 31  # except 1d tensors
+    MOSTLY_BF16 = 32  # except 1d tensors
     # MOSTLY_Q4_0_4_4      = 33  # removed from gguf files, use Q4_0 and runtime repack
     # MOSTLY_Q4_0_4_8      = 34  # removed from gguf files, use Q4_0 and runtime repack
     # MOSTLY_Q4_0_8_8      = 35  # removed from gguf files, use Q4_0 and runtime repack
-    MOSTLY_TQ1_0         = 36  # except 1d tensors
-    MOSTLY_TQ2_0         = 37  # except 1d tensors
+    MOSTLY_TQ1_0 = 36  # except 1d tensors
+    MOSTLY_TQ2_0 = 37  # except 1d tensors
 
-    GUESSED              = 1024  # not specified in the model file
+    GUESSED = 1024  # not specified in the model file
 
 
 class GGUFEndian(IntEnum):
@@ -3017,18 +3018,18 @@ class GGUFEndian(IntEnum):
 
 
 class GGUFValueType(IntEnum):
-    UINT8   = 0
-    INT8    = 1
-    UINT16  = 2
-    INT16   = 3
-    UINT32  = 4
-    INT32   = 5
+    UINT8 = 0
+    INT8 = 1
+    UINT16 = 2
+    INT16 = 3
+    UINT32 = 4
+    INT32 = 5
     FLOAT32 = 6
-    BOOL    = 7
-    STRING  = 8
-    ARRAY   = 9
-    UINT64  = 10
-    INT64   = 11
+    BOOL = 7
+    STRING = 8
+    ARRAY = 9
+    UINT64 = 10
+    INT64 = 11
     FLOAT64 = 12
 
     @staticmethod
@@ -3057,8 +3058,8 @@ class VisionProjectorType:
     QWEN25VL = "qwen2.5vl_merger"
     ULTRAVOX = "ultravox"
     INTERNVL = "internvl"
-    QWEN2A = "qwen2a" # audio
-    QWEN25O = "qwen2.5o" # omni
+    QWEN2A = "qwen2a"  # audio
+    QWEN25O = "qwen2.5o"  # omni
     VOXTRAL = "voxtral"
     LFM2 = "lfm2"
     KIMIVL = "kimivl"
@@ -3067,105 +3068,107 @@ class VisionProjectorType:
 # Items here are (block size, type size)
 QK_K = 256
 GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
-    GGMLQuantizationType.F32:     (1, 4),
-    GGMLQuantizationType.F16:     (1, 2),
-    GGMLQuantizationType.Q4_0:    (32, 2 + 16),
-    GGMLQuantizationType.Q4_1:    (32, 2 + 2 + 16),
-    GGMLQuantizationType.Q5_0:    (32, 2 + 4 + 16),
-    GGMLQuantizationType.Q5_1:    (32, 2 + 2 + 4 + 16),
-    GGMLQuantizationType.Q8_0:    (32, 2 + 32),
-    GGMLQuantizationType.Q8_1:    (32, 4 + 4 + 32),
-    GGMLQuantizationType.Q2_K:    (256, 2 + 2 + QK_K // 16 + QK_K // 4),
-    GGMLQuantizationType.Q3_K:    (256, 2 + QK_K // 4 + QK_K // 8 + 12),
-    GGMLQuantizationType.Q4_K:    (256, 2 + 2 + QK_K // 2 + 12),
-    GGMLQuantizationType.Q5_K:    (256, 2 + 2 + QK_K // 2 + QK_K // 8 + 12),
-    GGMLQuantizationType.Q6_K:    (256, 2 + QK_K // 2 + QK_K // 4 + QK_K // 16),
-    GGMLQuantizationType.Q8_K:    (256, 4 + QK_K + QK_K // 8),
+    GGMLQuantizationType.F32: (1, 4),
+    GGMLQuantizationType.F16: (1, 2),
+    GGMLQuantizationType.Q4_0: (32, 2 + 16),
+    GGMLQuantizationType.Q4_1: (32, 2 + 2 + 16),
+    GGMLQuantizationType.Q5_0: (32, 2 + 4 + 16),
+    GGMLQuantizationType.Q5_1: (32, 2 + 2 + 4 + 16),
+    GGMLQuantizationType.Q8_0: (32, 2 + 32),
+    GGMLQuantizationType.Q8_1: (32, 4 + 4 + 32),
+    GGMLQuantizationType.Q2_K: (256, 2 + 2 + QK_K // 16 + QK_K // 4),
+    GGMLQuantizationType.Q3_K: (256, 2 + QK_K // 4 + QK_K // 8 + 12),
+    GGMLQuantizationType.Q4_K: (256, 2 + 2 + QK_K // 2 + 12),
+    GGMLQuantizationType.Q5_K: (256, 2 + 2 + QK_K // 2 + QK_K // 8 + 12),
+    GGMLQuantizationType.Q6_K: (256, 2 + QK_K // 2 + QK_K // 4 + QK_K // 16),
+    GGMLQuantizationType.Q8_K: (256, 4 + QK_K + QK_K // 8),
     GGMLQuantizationType.IQ2_XXS: (256, 2 + QK_K // 4),
-    GGMLQuantizationType.IQ2_XS:  (256, 2 + QK_K // 4 + QK_K // 32),
+    GGMLQuantizationType.IQ2_XS: (256, 2 + QK_K // 4 + QK_K // 32),
     GGMLQuantizationType.IQ3_XXS: (256, 2 + QK_K // 4 + QK_K // 8),
-    GGMLQuantizationType.IQ1_S:   (256, 2 + QK_K // 8 + QK_K // 16),
-    GGMLQuantizationType.IQ4_NL:  (32, 2 + 16),
-    GGMLQuantizationType.IQ3_S:   (256, 2 + QK_K // 4 + QK_K // 8 + QK_K // 32 + 4),
-    GGMLQuantizationType.IQ2_S:   (256, 2 + QK_K // 4 + QK_K // 16),
-    GGMLQuantizationType.IQ4_XS:  (256, 2 + 2 + QK_K // 2 + QK_K // 64),
-    GGMLQuantizationType.I8:      (1, 1),
-    GGMLQuantizationType.I16:     (1, 2),
-    GGMLQuantizationType.I32:     (1, 4),
-    GGMLQuantizationType.I64:     (1, 8),
-    GGMLQuantizationType.F64:     (1, 8),
-    GGMLQuantizationType.IQ1_M:   (256, QK_K // 8 + QK_K // 16  + QK_K // 32),
-    GGMLQuantizationType.BF16:    (1, 2),
-    GGMLQuantizationType.TQ1_0:   (256, 2 + 4 * 13),
-    GGMLQuantizationType.TQ2_0:   (256, 2 + 64),
-    GGMLQuantizationType.MXFP4:   (32, 1 + 16),
+    GGMLQuantizationType.IQ1_S: (256, 2 + QK_K // 8 + QK_K // 16),
+    GGMLQuantizationType.IQ4_NL: (32, 2 + 16),
+    GGMLQuantizationType.IQ3_S: (256, 2 + QK_K // 4 + QK_K // 8 + QK_K // 32 + 4),
+    GGMLQuantizationType.IQ2_S: (256, 2 + QK_K // 4 + QK_K // 16),
+    GGMLQuantizationType.IQ4_XS: (256, 2 + 2 + QK_K // 2 + QK_K // 64),
+    GGMLQuantizationType.I8: (1, 1),
+    GGMLQuantizationType.I16: (1, 2),
+    GGMLQuantizationType.I32: (1, 4),
+    GGMLQuantizationType.I64: (1, 8),
+    GGMLQuantizationType.F64: (1, 8),
+    GGMLQuantizationType.IQ1_M: (256, QK_K // 8 + QK_K // 16 + QK_K // 32),
+    GGMLQuantizationType.BF16: (1, 2),
+    GGMLQuantizationType.TQ1_0: (256, 2 + 4 * 13),
+    GGMLQuantizationType.TQ2_0: (256, 2 + 64),
+    GGMLQuantizationType.MXFP4: (32, 1 + 16),
+    GGMLQuantizationType.MXFP6_E3M2: (32, 1 + 24),
+    # GGMLQuantizationType.MXFP6E2M3: (32, 1 + 24),
 }
 
 
 # Aliases for backward compatibility.
 
 # general
-KEY_GENERAL_ARCHITECTURE         = Keys.General.ARCHITECTURE
+KEY_GENERAL_ARCHITECTURE = Keys.General.ARCHITECTURE
 KEY_GENERAL_QUANTIZATION_VERSION = Keys.General.QUANTIZATION_VERSION
-KEY_GENERAL_ALIGNMENT            = Keys.General.ALIGNMENT
-KEY_GENERAL_NAME                 = Keys.General.NAME
-KEY_GENERAL_AUTHOR               = Keys.General.AUTHOR
-KEY_GENERAL_URL                  = Keys.General.URL
-KEY_GENERAL_DESCRIPTION          = Keys.General.DESCRIPTION
-KEY_GENERAL_LICENSE              = Keys.General.LICENSE
-KEY_GENERAL_SOURCE_URL           = Keys.General.SOURCE_URL
-KEY_GENERAL_FILE_TYPE            = Keys.General.FILE_TYPE
+KEY_GENERAL_ALIGNMENT = Keys.General.ALIGNMENT
+KEY_GENERAL_NAME = Keys.General.NAME
+KEY_GENERAL_AUTHOR = Keys.General.AUTHOR
+KEY_GENERAL_URL = Keys.General.URL
+KEY_GENERAL_DESCRIPTION = Keys.General.DESCRIPTION
+KEY_GENERAL_LICENSE = Keys.General.LICENSE
+KEY_GENERAL_SOURCE_URL = Keys.General.SOURCE_URL
+KEY_GENERAL_FILE_TYPE = Keys.General.FILE_TYPE
 
 # LLM
-KEY_VOCAB_SIZE            = Keys.LLM.VOCAB_SIZE
-KEY_CONTEXT_LENGTH        = Keys.LLM.CONTEXT_LENGTH
-KEY_EMBEDDING_LENGTH      = Keys.LLM.EMBEDDING_LENGTH
-KEY_BLOCK_COUNT           = Keys.LLM.BLOCK_COUNT
-KEY_FEED_FORWARD_LENGTH   = Keys.LLM.FEED_FORWARD_LENGTH
+KEY_VOCAB_SIZE = Keys.LLM.VOCAB_SIZE
+KEY_CONTEXT_LENGTH = Keys.LLM.CONTEXT_LENGTH
+KEY_EMBEDDING_LENGTH = Keys.LLM.EMBEDDING_LENGTH
+KEY_BLOCK_COUNT = Keys.LLM.BLOCK_COUNT
+KEY_FEED_FORWARD_LENGTH = Keys.LLM.FEED_FORWARD_LENGTH
 KEY_USE_PARALLEL_RESIDUAL = Keys.LLM.USE_PARALLEL_RESIDUAL
-KEY_TENSOR_DATA_LAYOUT    = Keys.LLM.TENSOR_DATA_LAYOUT
+KEY_TENSOR_DATA_LAYOUT = Keys.LLM.TENSOR_DATA_LAYOUT
 
 # attention
-KEY_ATTENTION_HEAD_COUNT        = Keys.Attention.HEAD_COUNT
-KEY_ATTENTION_HEAD_COUNT_KV     = Keys.Attention.HEAD_COUNT_KV
-KEY_ATTENTION_MAX_ALIBI_BIAS    = Keys.Attention.MAX_ALIBI_BIAS
-KEY_ATTENTION_CLAMP_KQV         = Keys.Attention.CLAMP_KQV
-KEY_ATTENTION_LAYERNORM_EPS     = Keys.Attention.LAYERNORM_EPS
+KEY_ATTENTION_HEAD_COUNT = Keys.Attention.HEAD_COUNT
+KEY_ATTENTION_HEAD_COUNT_KV = Keys.Attention.HEAD_COUNT_KV
+KEY_ATTENTION_MAX_ALIBI_BIAS = Keys.Attention.MAX_ALIBI_BIAS
+KEY_ATTENTION_CLAMP_KQV = Keys.Attention.CLAMP_KQV
+KEY_ATTENTION_LAYERNORM_EPS = Keys.Attention.LAYERNORM_EPS
 KEY_ATTENTION_LAYERNORM_RMS_EPS = Keys.Attention.LAYERNORM_RMS_EPS
 
 # RoPE
-KEY_ROPE_DIMENSION_COUNT      = Keys.Rope.DIMENSION_COUNT
-KEY_ROPE_FREQ_BASE            = Keys.Rope.FREQ_BASE
-KEY_ROPE_SCALING_TYPE         = Keys.Rope.SCALING_TYPE
-KEY_ROPE_SCALING_FACTOR       = Keys.Rope.SCALING_FACTOR
+KEY_ROPE_DIMENSION_COUNT = Keys.Rope.DIMENSION_COUNT
+KEY_ROPE_FREQ_BASE = Keys.Rope.FREQ_BASE
+KEY_ROPE_SCALING_TYPE = Keys.Rope.SCALING_TYPE
+KEY_ROPE_SCALING_FACTOR = Keys.Rope.SCALING_FACTOR
 KEY_ROPE_SCALING_ORIG_CTX_LEN = Keys.Rope.SCALING_ORIG_CTX_LEN
-KEY_ROPE_SCALING_FINETUNED    = Keys.Rope.SCALING_FINETUNED
+KEY_ROPE_SCALING_FINETUNED = Keys.Rope.SCALING_FINETUNED
 
 # SSM
-KEY_SSM_CONV_KERNEL    = Keys.SSM.CONV_KERNEL
-KEY_SSM_INNER_SIZE     = Keys.SSM.INNER_SIZE
-KEY_SSM_STATE_SIZE     = Keys.SSM.STATE_SIZE
+KEY_SSM_CONV_KERNEL = Keys.SSM.CONV_KERNEL
+KEY_SSM_INNER_SIZE = Keys.SSM.INNER_SIZE
+KEY_SSM_STATE_SIZE = Keys.SSM.STATE_SIZE
 KEY_SSM_TIME_STEP_RANK = Keys.SSM.TIME_STEP_RANK
-KEY_SSM_GROUP_COUNT    = Keys.SSM.GROUP_COUNT
-KEY_SSM_DT_B_C_RMS     = Keys.SSM.DT_B_C_RMS
+KEY_SSM_GROUP_COUNT = Keys.SSM.GROUP_COUNT
+KEY_SSM_DT_B_C_RMS = Keys.SSM.DT_B_C_RMS
 
 # tokenization
-KEY_TOKENIZER_MODEL      = Keys.Tokenizer.MODEL
-KEY_TOKENIZER_PRE        = Keys.Tokenizer.PRE
-KEY_TOKENIZER_LIST       = Keys.Tokenizer.LIST
+KEY_TOKENIZER_MODEL = Keys.Tokenizer.MODEL
+KEY_TOKENIZER_PRE = Keys.Tokenizer.PRE
+KEY_TOKENIZER_LIST = Keys.Tokenizer.LIST
 KEY_TOKENIZER_TOKEN_TYPE = Keys.Tokenizer.TOKEN_TYPE
-KEY_TOKENIZER_SCORES     = Keys.Tokenizer.SCORES
-KEY_TOKENIZER_MERGES     = Keys.Tokenizer.MERGES
-KEY_TOKENIZER_BOS_ID     = Keys.Tokenizer.BOS_ID
-KEY_TOKENIZER_EOS_ID     = Keys.Tokenizer.EOS_ID
-KEY_TOKENIZER_EOT_ID     = Keys.Tokenizer.EOT_ID
-KEY_TOKENIZER_EOM_ID     = Keys.Tokenizer.EOM_ID
-KEY_TOKENIZER_UNK_ID     = Keys.Tokenizer.UNK_ID
-KEY_TOKENIZER_SEP_ID     = Keys.Tokenizer.SEP_ID
-KEY_TOKENIZER_PAD_ID     = Keys.Tokenizer.PAD_ID
-KEY_TOKENIZER_MASK_ID    = Keys.Tokenizer.MASK_ID
-KEY_TOKENIZER_HF_JSON    = Keys.Tokenizer.HF_JSON
-KEY_TOKENIZER_RWKV       = Keys.Tokenizer.RWKV
+KEY_TOKENIZER_SCORES = Keys.Tokenizer.SCORES
+KEY_TOKENIZER_MERGES = Keys.Tokenizer.MERGES
+KEY_TOKENIZER_BOS_ID = Keys.Tokenizer.BOS_ID
+KEY_TOKENIZER_EOS_ID = Keys.Tokenizer.EOS_ID
+KEY_TOKENIZER_EOT_ID = Keys.Tokenizer.EOT_ID
+KEY_TOKENIZER_EOM_ID = Keys.Tokenizer.EOM_ID
+KEY_TOKENIZER_UNK_ID = Keys.Tokenizer.UNK_ID
+KEY_TOKENIZER_SEP_ID = Keys.Tokenizer.SEP_ID
+KEY_TOKENIZER_PAD_ID = Keys.Tokenizer.PAD_ID
+KEY_TOKENIZER_MASK_ID = Keys.Tokenizer.MASK_ID
+KEY_TOKENIZER_HF_JSON = Keys.Tokenizer.HF_JSON
+KEY_TOKENIZER_RWKV = Keys.Tokenizer.RWKV
 
 KEY_TOKENIZER_FIM_PRE_ID = Keys.Tokenizer.FIM_PRE_ID
 KEY_TOKENIZER_FIM_SUF_ID = Keys.Tokenizer.FIM_SUF_ID
@@ -3175,6 +3178,6 @@ KEY_TOKENIZER_FIM_REP_ID = Keys.Tokenizer.FIM_REP_ID
 KEY_TOKENIZER_FIM_SEP_ID = Keys.Tokenizer.FIM_SEP_ID
 
 # deprecated
-KEY_TOKENIZER_PREFIX_ID  = Keys.Tokenizer.PREFIX_ID
-KEY_TOKENIZER_SUFFIX_ID  = Keys.Tokenizer.SUFFIX_ID
-KEY_TOKENIZER_MIDDLE_ID  = Keys.Tokenizer.MIDDLE_ID
+KEY_TOKENIZER_PREFIX_ID = Keys.Tokenizer.PREFIX_ID
+KEY_TOKENIZER_SUFFIX_ID = Keys.Tokenizer.SUFFIX_ID
+KEY_TOKENIZER_MIDDLE_ID = Keys.Tokenizer.MIDDLE_ID

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -7,10 +7,10 @@ from typing import Any
 # constants
 #
 
-GGUF_MAGIC = 0x46554747  # "GGUF"
-GGUF_VERSION = 3
+GGUF_MAGIC             = 0x46554747  # "GGUF"
+GGUF_VERSION           = 3
 GGUF_DEFAULT_ALIGNMENT = 32
-GGML_QUANT_VERSION = 2  # GGML_QNT_VERSION from ggml.h
+GGML_QUANT_VERSION     = 2  # GGML_QNT_VERSION from ggml.h
 
 #
 # metadata keys
@@ -19,190 +19,186 @@ GGML_QUANT_VERSION = 2  # GGML_QNT_VERSION from ggml.h
 
 class Keys:
     class General:
-        TYPE = "general.type"
-        ARCHITECTURE = "general.architecture"
-        QUANTIZATION_VERSION = "general.quantization_version"
-        ALIGNMENT = "general.alignment"
-        FILE_TYPE = "general.file_type"
+        TYPE                       = "general.type"
+        ARCHITECTURE               = "general.architecture"
+        QUANTIZATION_VERSION       = "general.quantization_version"
+        ALIGNMENT                  = "general.alignment"
+        FILE_TYPE                  = "general.file_type"
 
         # Authorship Metadata
-        NAME = "general.name"
-        AUTHOR = "general.author"
-        VERSION = "general.version"
-        ORGANIZATION = "general.organization"
+        NAME                       = "general.name"
+        AUTHOR                     = "general.author"
+        VERSION                    = "general.version"
+        ORGANIZATION               = "general.organization"
 
-        FINETUNE = "general.finetune"
-        BASENAME = "general.basename"
+        FINETUNE                   = "general.finetune"
+        BASENAME                   = "general.basename"
 
-        DESCRIPTION = "general.description"
-        QUANTIZED_BY = "general.quantized_by"
+        DESCRIPTION                = "general.description"
+        QUANTIZED_BY               = "general.quantized_by"
 
-        SIZE_LABEL = "general.size_label"
+        SIZE_LABEL                 = "general.size_label"
 
         # Licensing details
-        LICENSE = "general.license"
-        LICENSE_NAME = "general.license.name"
-        LICENSE_LINK = "general.license.link"
+        LICENSE                    = "general.license"
+        LICENSE_NAME               = "general.license.name"
+        LICENSE_LINK               = "general.license.link"
 
         # Typically represents the converted GGUF repo (Unless native)
-        URL = "general.url"  # Model Website/Paper
-        DOI = "general.doi"
-        UUID = "general.uuid"
-        REPO_URL = "general.repo_url"  # Model Source Repository (git/svn/etc...)
+        URL                        = "general.url" # Model Website/Paper
+        DOI                        = "general.doi"
+        UUID                       = "general.uuid"
+        REPO_URL                   = "general.repo_url" # Model Source Repository (git/svn/etc...)
 
         # Model Source during conversion
-        SOURCE_URL = "general.source.url"  # Model Website/Paper
-        SOURCE_DOI = "general.source.doi"
-        SOURCE_UUID = "general.source.uuid"
-        SOURCE_REPO_URL = (
-            "general.source.repo_url"  # Model Source Repository (git/svn/etc...)
-        )
+        SOURCE_URL                 = "general.source.url" # Model Website/Paper
+        SOURCE_DOI                 = "general.source.doi"
+        SOURCE_UUID                = "general.source.uuid"
+        SOURCE_REPO_URL            = "general.source.repo_url" # Model Source Repository (git/svn/etc...)
 
         # Base Model Source. There can be more than one source if it's a merged
         # model like with 'Mistral-7B-Merge-14-v0.1'. This will assist in
         # tracing linage of models as it is finetuned or merged over time.
-        BASE_MODEL_COUNT = "general.base_model.count"
-        BASE_MODEL_NAME = "general.base_model.{id}.name"
-        BASE_MODEL_AUTHOR = "general.base_model.{id}.author"
-        BASE_MODEL_VERSION = "general.base_model.{id}.version"
-        BASE_MODEL_ORGANIZATION = "general.base_model.{id}.organization"
-        BASE_MODEL_DESCRIPTION = "general.base_model.{id}.description"
-        BASE_MODEL_URL = "general.base_model.{id}.url"  # Model Website/Paper
-        BASE_MODEL_DOI = "general.base_model.{id}.doi"
-        BASE_MODEL_UUID = "general.base_model.{id}.uuid"
-        BASE_MODEL_REPO_URL = "general.base_model.{id}.repo_url"  # Model Source Repository (git/svn/etc...)
+        BASE_MODEL_COUNT           = "general.base_model.count"
+        BASE_MODEL_NAME            = "general.base_model.{id}.name"
+        BASE_MODEL_AUTHOR          = "general.base_model.{id}.author"
+        BASE_MODEL_VERSION         = "general.base_model.{id}.version"
+        BASE_MODEL_ORGANIZATION    = "general.base_model.{id}.organization"
+        BASE_MODEL_DESCRIPTION     = "general.base_model.{id}.description"
+        BASE_MODEL_URL             = "general.base_model.{id}.url" # Model Website/Paper
+        BASE_MODEL_DOI             = "general.base_model.{id}.doi"
+        BASE_MODEL_UUID            = "general.base_model.{id}.uuid"
+        BASE_MODEL_REPO_URL        = "general.base_model.{id}.repo_url" # Model Source Repository (git/svn/etc...)
 
         # Dataset Source
-        DATASET_COUNT = "general.dataset.count"
-        DATASET_NAME = "general.dataset.{id}.name"
-        DATASET_AUTHOR = "general.dataset.{id}.author"
-        DATASET_VERSION = "general.dataset.{id}.version"
-        DATASET_ORGANIZATION = "general.dataset.{id}.organization"
-        DATASET_DESCRIPTION = "general.dataset.{id}.description"
-        DATASET_URL = "general.dataset.{id}.url"  # Model Website/Paper
-        DATASET_DOI = "general.dataset.{id}.doi"
-        DATASET_UUID = "general.dataset.{id}.uuid"
-        DATASET_REPO_URL = (
-            "general.dataset.{id}.repo_url"  # Model Source Repository (git/svn/etc...)
-        )
+        DATASET_COUNT           = "general.dataset.count"
+        DATASET_NAME            = "general.dataset.{id}.name"
+        DATASET_AUTHOR          = "general.dataset.{id}.author"
+        DATASET_VERSION         = "general.dataset.{id}.version"
+        DATASET_ORGANIZATION    = "general.dataset.{id}.organization"
+        DATASET_DESCRIPTION     = "general.dataset.{id}.description"
+        DATASET_URL             = "general.dataset.{id}.url" # Model Website/Paper
+        DATASET_DOI             = "general.dataset.{id}.doi"
+        DATASET_UUID            = "general.dataset.{id}.uuid"
+        DATASET_REPO_URL        = "general.dataset.{id}.repo_url" # Model Source Repository (git/svn/etc...)
 
         # Array based KV stores
-        TAGS = "general.tags"
-        LANGUAGES = "general.languages"
+        TAGS                       = "general.tags"
+        LANGUAGES                  = "general.languages"
 
     class LLM:
-        VOCAB_SIZE = "{arch}.vocab_size"
-        CONTEXT_LENGTH = "{arch}.context_length"
-        EMBEDDING_LENGTH = "{arch}.embedding_length"
-        FEATURES_LENGTH = "{arch}.features_length"
-        BLOCK_COUNT = "{arch}.block_count"
-        LEADING_DENSE_BLOCK_COUNT = "{arch}.leading_dense_block_count"
-        FEED_FORWARD_LENGTH = "{arch}.feed_forward_length"
-        EXPERT_FEED_FORWARD_LENGTH = "{arch}.expert_feed_forward_length"
+        VOCAB_SIZE                        = "{arch}.vocab_size"
+        CONTEXT_LENGTH                    = "{arch}.context_length"
+        EMBEDDING_LENGTH                  = "{arch}.embedding_length"
+        FEATURES_LENGTH                   = "{arch}.features_length"
+        BLOCK_COUNT                       = "{arch}.block_count"
+        LEADING_DENSE_BLOCK_COUNT         = "{arch}.leading_dense_block_count"
+        FEED_FORWARD_LENGTH               = "{arch}.feed_forward_length"
+        EXPERT_FEED_FORWARD_LENGTH        = "{arch}.expert_feed_forward_length"
         EXPERT_SHARED_FEED_FORWARD_LENGTH = "{arch}.expert_shared_feed_forward_length"
-        EXPERT_CHUNK_FEED_FORWARD_LENGTH = "{arch}.expert_chunk_feed_forward_length"
-        USE_PARALLEL_RESIDUAL = "{arch}.use_parallel_residual"
-        TENSOR_DATA_LAYOUT = "{arch}.tensor_data_layout"
-        EXPERT_COUNT = "{arch}.expert_count"
-        EXPERT_USED_COUNT = "{arch}.expert_used_count"
-        EXPERT_SHARED_COUNT = "{arch}.expert_shared_count"
-        EXPERT_GROUP_COUNT = "{arch}.expert_group_count"
-        EXPERT_GROUP_USED_COUNT = "{arch}.expert_group_used_count"
-        EXPERT_WEIGHTS_SCALE = "{arch}.expert_weights_scale"
-        EXPERT_WEIGHTS_NORM = "{arch}.expert_weights_norm"
-        EXPERT_GATING_FUNC = "{arch}.expert_gating_func"
-        EXPERT_GROUP_SCALE = "{arch}.expert_group_scale"
-        EXPERTS_PER_GROUP = "{arch}.experts_per_group"
-        MOE_EVERY_N_LAYERS = "{arch}.moe_every_n_layers"
-        NEXTN_PREDICT_LAYERS = "{arch}.nextn_predict_layers"
-        POOLING_TYPE = "{arch}.pooling_type"
-        LOGIT_SCALE = "{arch}.logit_scale"
-        DECODER_START_TOKEN_ID = "{arch}.decoder_start_token_id"
-        DECODER_BLOCK_COUNT = "{arch}.decoder_block_count"
-        ATTN_LOGIT_SOFTCAPPING = "{arch}.attn_logit_softcapping"
-        ROUTER_LOGIT_SOFTCAPPING = "{arch}.router_logit_softcapping"
-        FINAL_LOGIT_SOFTCAPPING = "{arch}.final_logit_softcapping"
-        SWIN_NORM = "{arch}.swin_norm"
-        RESCALE_EVERY_N_LAYERS = "{arch}.rescale_every_n_layers"
-        TIME_MIX_EXTRA_DIM = "{arch}.time_mix_extra_dim"
-        TIME_DECAY_EXTRA_DIM = "{arch}.time_decay_extra_dim"
-        RESIDUAL_SCALE = "{arch}.residual_scale"
-        EMBEDDING_SCALE = "{arch}.embedding_scale"
-        TOKEN_SHIFT_COUNT = "{arch}.token_shift_count"
-        INTERLEAVE_MOE_LAYER_STEP = "{arch}.interleave_moe_layer_step"
-        ACTIVATION_SPARSITY_SCALE = "{arch}.activation_sparsity_scale"
-        ALTUP_ACTIVE_IDX = "{arch}.altup.active_idx"
-        ALTUP_NUM_INPUTS = "{arch}.altup.num_inputs"
-        EMBD_LENGTH_PER_LAYER_INP = "{arch}.embedding_length_per_layer_input"
-        DENSE_FEAT_IN_SIZE = "{arch}.{dense}_feat_in"
-        DENSE_FEAT_OUT_SIZE = "{arch}.{dense}_feat_out"
+        EXPERT_CHUNK_FEED_FORWARD_LENGTH  = "{arch}.expert_chunk_feed_forward_length"
+        USE_PARALLEL_RESIDUAL             = "{arch}.use_parallel_residual"
+        TENSOR_DATA_LAYOUT                = "{arch}.tensor_data_layout"
+        EXPERT_COUNT                      = "{arch}.expert_count"
+        EXPERT_USED_COUNT                 = "{arch}.expert_used_count"
+        EXPERT_SHARED_COUNT               = "{arch}.expert_shared_count"
+        EXPERT_GROUP_COUNT                = "{arch}.expert_group_count"
+        EXPERT_GROUP_USED_COUNT           = "{arch}.expert_group_used_count"
+        EXPERT_WEIGHTS_SCALE              = "{arch}.expert_weights_scale"
+        EXPERT_WEIGHTS_NORM               = "{arch}.expert_weights_norm"
+        EXPERT_GATING_FUNC                = "{arch}.expert_gating_func"
+        EXPERT_GROUP_SCALE                = "{arch}.expert_group_scale"
+        EXPERTS_PER_GROUP                 = "{arch}.experts_per_group"
+        MOE_EVERY_N_LAYERS                = "{arch}.moe_every_n_layers"
+        NEXTN_PREDICT_LAYERS              = "{arch}.nextn_predict_layers"
+        POOLING_TYPE                      = "{arch}.pooling_type"
+        LOGIT_SCALE                       = "{arch}.logit_scale"
+        DECODER_START_TOKEN_ID            = "{arch}.decoder_start_token_id"
+        DECODER_BLOCK_COUNT               = "{arch}.decoder_block_count"
+        ATTN_LOGIT_SOFTCAPPING            = "{arch}.attn_logit_softcapping"
+        ROUTER_LOGIT_SOFTCAPPING          = "{arch}.router_logit_softcapping"
+        FINAL_LOGIT_SOFTCAPPING           = "{arch}.final_logit_softcapping"
+        SWIN_NORM                         = "{arch}.swin_norm"
+        RESCALE_EVERY_N_LAYERS            = "{arch}.rescale_every_n_layers"
+        TIME_MIX_EXTRA_DIM                = "{arch}.time_mix_extra_dim"
+        TIME_DECAY_EXTRA_DIM              = "{arch}.time_decay_extra_dim"
+        RESIDUAL_SCALE                    = "{arch}.residual_scale"
+        EMBEDDING_SCALE                   = "{arch}.embedding_scale"
+        TOKEN_SHIFT_COUNT                 = "{arch}.token_shift_count"
+        INTERLEAVE_MOE_LAYER_STEP         = "{arch}.interleave_moe_layer_step"
+        ACTIVATION_SPARSITY_SCALE         = "{arch}.activation_sparsity_scale"
+        ALTUP_ACTIVE_IDX                  = "{arch}.altup.active_idx"
+        ALTUP_NUM_INPUTS                  = "{arch}.altup.num_inputs"
+        EMBD_LENGTH_PER_LAYER_INP         = "{arch}.embedding_length_per_layer_input"
+        DENSE_FEAT_IN_SIZE                = "{arch}.{dense}_feat_in"
+        DENSE_FEAT_OUT_SIZE               = "{arch}.{dense}_feat_out"
 
     class Attention:
-        HEAD_COUNT = "{arch}.attention.head_count"
-        HEAD_COUNT_KV = "{arch}.attention.head_count_kv"
-        MAX_ALIBI_BIAS = "{arch}.attention.max_alibi_bias"
-        CLAMP_KQV = "{arch}.attention.clamp_kqv"
-        KEY_LENGTH = "{arch}.attention.key_length"
-        VALUE_LENGTH = "{arch}.attention.value_length"
-        LAYERNORM_EPS = "{arch}.attention.layer_norm_epsilon"
-        LAYERNORM_RMS_EPS = "{arch}.attention.layer_norm_rms_epsilon"
-        GROUPNORM_EPS = "{arch}.attention.group_norm_epsilon"
-        GROUPNORM_GROUPS = "{arch}.attention.group_norm_groups"
-        CAUSAL = "{arch}.attention.causal"
-        Q_LORA_RANK = "{arch}.attention.q_lora_rank"
-        KV_LORA_RANK = "{arch}.attention.kv_lora_rank"
-        DECAY_LORA_RANK = "{arch}.attention.decay_lora_rank"
-        ICLR_LORA_RANK = "{arch}.attention.iclr_lora_rank"
+        HEAD_COUNT                   = "{arch}.attention.head_count"
+        HEAD_COUNT_KV                = "{arch}.attention.head_count_kv"
+        MAX_ALIBI_BIAS               = "{arch}.attention.max_alibi_bias"
+        CLAMP_KQV                    = "{arch}.attention.clamp_kqv"
+        KEY_LENGTH                   = "{arch}.attention.key_length"
+        VALUE_LENGTH                 = "{arch}.attention.value_length"
+        LAYERNORM_EPS                = "{arch}.attention.layer_norm_epsilon"
+        LAYERNORM_RMS_EPS            = "{arch}.attention.layer_norm_rms_epsilon"
+        GROUPNORM_EPS                = "{arch}.attention.group_norm_epsilon"
+        GROUPNORM_GROUPS             = "{arch}.attention.group_norm_groups"
+        CAUSAL                       = "{arch}.attention.causal"
+        Q_LORA_RANK                  = "{arch}.attention.q_lora_rank"
+        KV_LORA_RANK                 = "{arch}.attention.kv_lora_rank"
+        DECAY_LORA_RANK              = "{arch}.attention.decay_lora_rank"
+        ICLR_LORA_RANK               = "{arch}.attention.iclr_lora_rank"
         VALUE_RESIDUAL_MIX_LORA_RANK = "{arch}.attention.value_residual_mix_lora_rank"
-        GATE_LORA_RANK = "{arch}.attention.gate_lora_rank"
-        REL_BUCKETS_COUNT = "{arch}.attention.relative_buckets_count"
-        SLIDING_WINDOW = "{arch}.attention.sliding_window"
-        SCALE = "{arch}.attention.scale"
-        OUTPUT_SCALE = "{arch}.attention.output_scale"
-        TEMPERATURE_LENGTH = "{arch}.attention.temperature_length"
-        KEY_LENGTH_MLA = "{arch}.attention.key_length_mla"
-        VALUE_LENGTH_MLA = "{arch}.attention.value_length_mla"
-        SHARED_KV_LAYERS = "{arch}.attention.shared_kv_layers"
-        SLIDING_WINDOW_PATTERN = "{arch}.attention.sliding_window_pattern"
+        GATE_LORA_RANK               = "{arch}.attention.gate_lora_rank"
+        REL_BUCKETS_COUNT            = "{arch}.attention.relative_buckets_count"
+        SLIDING_WINDOW               = "{arch}.attention.sliding_window"
+        SCALE                        = "{arch}.attention.scale"
+        OUTPUT_SCALE                 = "{arch}.attention.output_scale"
+        TEMPERATURE_LENGTH           = "{arch}.attention.temperature_length"
+        KEY_LENGTH_MLA               = "{arch}.attention.key_length_mla"
+        VALUE_LENGTH_MLA             = "{arch}.attention.value_length_mla"
+        SHARED_KV_LAYERS             = "{arch}.attention.shared_kv_layers"
+        SLIDING_WINDOW_PATTERN       = "{arch}.attention.sliding_window_pattern"
 
     class Rope:
-        DIMENSION_COUNT = "{arch}.rope.dimension_count"
-        DIMENSION_SECTIONS = "{arch}.rope.dimension_sections"
-        FREQ_BASE = "{arch}.rope.freq_base"
-        SCALING_TYPE = "{arch}.rope.scaling.type"
-        SCALING_FACTOR = "{arch}.rope.scaling.factor"
-        SCALING_ATTN_FACTOR = "{arch}.rope.scaling.attn_factor"
-        SCALING_ORIG_CTX_LEN = "{arch}.rope.scaling.original_context_length"
-        SCALING_FINETUNED = "{arch}.rope.scaling.finetuned"
-        SCALING_YARN_LOG_MUL = "{arch}.rope.scaling.yarn_log_multiplier"
-        SCALING_YARN_EXT_FACTOR = "{arch}.rope.scaling.yarn_ext_factor"
+        DIMENSION_COUNT          = "{arch}.rope.dimension_count"
+        DIMENSION_SECTIONS       = "{arch}.rope.dimension_sections"
+        FREQ_BASE                = "{arch}.rope.freq_base"
+        SCALING_TYPE             = "{arch}.rope.scaling.type"
+        SCALING_FACTOR           = "{arch}.rope.scaling.factor"
+        SCALING_ATTN_FACTOR      = "{arch}.rope.scaling.attn_factor"
+        SCALING_ORIG_CTX_LEN     = "{arch}.rope.scaling.original_context_length"
+        SCALING_FINETUNED        = "{arch}.rope.scaling.finetuned"
+        SCALING_YARN_LOG_MUL     = "{arch}.rope.scaling.yarn_log_multiplier"
+        SCALING_YARN_EXT_FACTOR  = "{arch}.rope.scaling.yarn_ext_factor"
         SCALING_YARN_ATTN_FACTOR = "{arch}.rope.scaling.yarn_attn_factor"
-        SCALING_YARN_BETA_FAST = "{arch}.rope.scaling.yarn_beta_fast"
-        SCALING_YARN_BETA_SLOW = "{arch}.rope.scaling.yarn_beta_slow"
+        SCALING_YARN_BETA_FAST   = "{arch}.rope.scaling.yarn_beta_fast"
+        SCALING_YARN_BETA_SLOW   = "{arch}.rope.scaling.yarn_beta_slow"
 
     class Split:
-        LLM_KV_SPLIT_NO = "split.no"
-        LLM_KV_SPLIT_COUNT = "split.count"
+        LLM_KV_SPLIT_NO            = "split.no"
+        LLM_KV_SPLIT_COUNT         = "split.count"
         LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count"
 
     class SSM:
-        CONV_KERNEL = "{arch}.ssm.conv_kernel"
-        INNER_SIZE = "{arch}.ssm.inner_size"
-        STATE_SIZE = "{arch}.ssm.state_size"
+        CONV_KERNEL    = "{arch}.ssm.conv_kernel"
+        INNER_SIZE     = "{arch}.ssm.inner_size"
+        STATE_SIZE     = "{arch}.ssm.state_size"
         TIME_STEP_RANK = "{arch}.ssm.time_step_rank"
-        GROUP_COUNT = "{arch}.ssm.group_count"
-        DT_B_C_RMS = "{arch}.ssm.dt_b_c_rms"
+        GROUP_COUNT    = "{arch}.ssm.group_count"
+        DT_B_C_RMS     = "{arch}.ssm.dt_b_c_rms"
 
     class WKV:
         HEAD_SIZE = "{arch}.wkv.head_size"
 
     class PosNet:
         EMBEDDING_LENGTH = "{arch}.posnet.embedding_length"
-        BLOCK_COUNT = "{arch}.posnet.block_count"
+        BLOCK_COUNT      = "{arch}.posnet.block_count"
 
     class ConvNext:
         EMBEDDING_LENGTH = "{arch}.convnext.embedding_length"
-        BLOCK_COUNT = "{arch}.convnext.block_count"
+        BLOCK_COUNT      = "{arch}.convnext.block_count"
 
     class Classifier:
         OUTPUT_LABELS = "{arch}.classifier.output_labels"
@@ -211,108 +207,106 @@ class Keys:
         L_CACHE = "{arch}.shortconv.l_cache"
 
     class Tokenizer:
-        MODEL = "tokenizer.ggml.model"
-        PRE = "tokenizer.ggml.pre"
-        LIST = "tokenizer.ggml.tokens"
-        TOKEN_TYPE = "tokenizer.ggml.token_type"
-        TOKEN_TYPE_COUNT = (
-            "tokenizer.ggml.token_type_count"  # for BERT-style token types
-        )
-        SCORES = "tokenizer.ggml.scores"
-        MERGES = "tokenizer.ggml.merges"
-        BOS_ID = "tokenizer.ggml.bos_token_id"
-        EOS_ID = "tokenizer.ggml.eos_token_id"
-        EOT_ID = "tokenizer.ggml.eot_token_id"
-        EOM_ID = "tokenizer.ggml.eom_token_id"
-        UNK_ID = "tokenizer.ggml.unknown_token_id"
-        SEP_ID = "tokenizer.ggml.seperator_token_id"
-        PAD_ID = "tokenizer.ggml.padding_token_id"
-        MASK_ID = "tokenizer.ggml.mask_token_id"
-        ADD_BOS = "tokenizer.ggml.add_bos_token"
-        ADD_EOS = "tokenizer.ggml.add_eos_token"
-        ADD_SEP = "tokenizer.ggml.add_sep_token"
-        ADD_PREFIX = "tokenizer.ggml.add_space_prefix"
-        REMOVE_EXTRA_WS = "tokenizer.ggml.remove_extra_whitespaces"
+        MODEL                = "tokenizer.ggml.model"
+        PRE                  = "tokenizer.ggml.pre"
+        LIST                 = "tokenizer.ggml.tokens"
+        TOKEN_TYPE           = "tokenizer.ggml.token_type"
+        TOKEN_TYPE_COUNT     = "tokenizer.ggml.token_type_count"  # for BERT-style token types
+        SCORES               = "tokenizer.ggml.scores"
+        MERGES               = "tokenizer.ggml.merges"
+        BOS_ID               = "tokenizer.ggml.bos_token_id"
+        EOS_ID               = "tokenizer.ggml.eos_token_id"
+        EOT_ID               = "tokenizer.ggml.eot_token_id"
+        EOM_ID               = "tokenizer.ggml.eom_token_id"
+        UNK_ID               = "tokenizer.ggml.unknown_token_id"
+        SEP_ID               = "tokenizer.ggml.seperator_token_id"
+        PAD_ID               = "tokenizer.ggml.padding_token_id"
+        MASK_ID              = "tokenizer.ggml.mask_token_id"
+        ADD_BOS              = "tokenizer.ggml.add_bos_token"
+        ADD_EOS              = "tokenizer.ggml.add_eos_token"
+        ADD_SEP              = "tokenizer.ggml.add_sep_token"
+        ADD_PREFIX           = "tokenizer.ggml.add_space_prefix"
+        REMOVE_EXTRA_WS      = "tokenizer.ggml.remove_extra_whitespaces"
         PRECOMPILED_CHARSMAP = "tokenizer.ggml.precompiled_charsmap"
-        HF_JSON = "tokenizer.huggingface.json"
-        RWKV = "tokenizer.rwkv.world"
-        CHAT_TEMPLATE = "tokenizer.chat_template"
-        CHAT_TEMPLATE_N = "tokenizer.chat_template.{name}"
-        CHAT_TEMPLATES = "tokenizer.chat_templates"
+        HF_JSON              = "tokenizer.huggingface.json"
+        RWKV                 = "tokenizer.rwkv.world"
+        CHAT_TEMPLATE        = "tokenizer.chat_template"
+        CHAT_TEMPLATE_N      = "tokenizer.chat_template.{name}"
+        CHAT_TEMPLATES       = "tokenizer.chat_templates"
         # FIM/Infill special tokens constants
-        FIM_PRE_ID = "tokenizer.ggml.fim_pre_token_id"
-        FIM_SUF_ID = "tokenizer.ggml.fim_suf_token_id"
-        FIM_MID_ID = "tokenizer.ggml.fim_mid_token_id"
-        FIM_PAD_ID = "tokenizer.ggml.fim_pad_token_id"
-        FIM_REP_ID = "tokenizer.ggml.fim_rep_token_id"
-        FIM_SEP_ID = "tokenizer.ggml.fim_sep_token_id"
+        FIM_PRE_ID           = "tokenizer.ggml.fim_pre_token_id"
+        FIM_SUF_ID           = "tokenizer.ggml.fim_suf_token_id"
+        FIM_MID_ID           = "tokenizer.ggml.fim_mid_token_id"
+        FIM_PAD_ID           = "tokenizer.ggml.fim_pad_token_id"
+        FIM_REP_ID           = "tokenizer.ggml.fim_rep_token_id"
+        FIM_SEP_ID           = "tokenizer.ggml.fim_sep_token_id"
         # deprecated:
-        PREFIX_ID = "tokenizer.ggml.prefix_token_id"
-        SUFFIX_ID = "tokenizer.ggml.suffix_token_id"
-        MIDDLE_ID = "tokenizer.ggml.middle_token_id"
+        PREFIX_ID            = "tokenizer.ggml.prefix_token_id"
+        SUFFIX_ID            = "tokenizer.ggml.suffix_token_id"
+        MIDDLE_ID            = "tokenizer.ggml.middle_token_id"
 
     class Adapter:
-        TYPE = "adapter.type"
-        LORA_ALPHA = "adapter.lora.alpha"
-        LORA_TASK_NAME = "adapter.lora.task_name"
-        LORA_PROMPT_PREFIX = "adapter.lora.prompt_prefix"
+        TYPE                    = "adapter.type"
+        LORA_ALPHA              = "adapter.lora.alpha"
+        LORA_TASK_NAME          = "adapter.lora.task_name"
+        LORA_PROMPT_PREFIX      = "adapter.lora.prompt_prefix"
         ALORA_INVOCATION_TOKENS = "adapter.alora.invocation_tokens"
 
     class IMatrix:
         CHUNK_COUNT = "imatrix.chunk_count"
-        CHUNK_SIZE = "imatrix.chunk_size"
-        DATASETS = "imatrix.datasets"
+        CHUNK_SIZE  = "imatrix.chunk_size"
+        DATASETS    = "imatrix.datasets"
 
     class Clip:
-        PROJECTOR_TYPE = "clip.projector_type"
-        HAS_VISION_ENCODER = "clip.has_vision_encoder"
-        HAS_AUDIO_ENCODER = "clip.has_audio_encoder"
+        PROJECTOR_TYPE      = "clip.projector_type"
+        HAS_VISION_ENCODER  = "clip.has_vision_encoder"
+        HAS_AUDIO_ENCODER   = "clip.has_audio_encoder"
         HAS_LLAVA_PROJECTOR = "clip.has_llava_projector"
 
     class ClipVision:
-        IMAGE_SIZE = "clip.vision.image_size"
-        PREPROC_IMAGE_SIZE = "clip.vision.preproc_image_size"
-        PATCH_SIZE = "clip.vision.patch_size"
-        EMBEDDING_LENGTH = "clip.vision.embedding_length"
+        IMAGE_SIZE          = "clip.vision.image_size"
+        PREPROC_IMAGE_SIZE  = "clip.vision.preproc_image_size"
+        PATCH_SIZE          = "clip.vision.patch_size"
+        EMBEDDING_LENGTH    = "clip.vision.embedding_length"
         FEED_FORWARD_LENGTH = "clip.vision.feed_forward_length"
-        PROJECTION_DIM = "clip.vision.projection_dim"
-        BLOCK_COUNT = "clip.vision.block_count"
-        IMAGE_MEAN = "clip.vision.image_mean"
-        IMAGE_STD = "clip.vision.image_std"
-        SPATIAL_MERGE_SIZE = "clip.vision.spatial_merge_size"
-        USE_GELU = "clip.use_gelu"
-        USE_SILU = "clip.use_silu"
-        N_WA_PATTERN = "clip.vision.n_wa_pattern"  # used by qwen2.5vl
+        PROJECTION_DIM      = "clip.vision.projection_dim"
+        BLOCK_COUNT         = "clip.vision.block_count"
+        IMAGE_MEAN          = "clip.vision.image_mean"
+        IMAGE_STD           = "clip.vision.image_std"
+        SPATIAL_MERGE_SIZE  = "clip.vision.spatial_merge_size"
+        USE_GELU            = "clip.use_gelu"
+        USE_SILU            = "clip.use_silu"
+        N_WA_PATTERN        = "clip.vision.n_wa_pattern" # used by qwen2.5vl
 
         class Attention:
-            HEAD_COUNT = "clip.vision.attention.head_count"
-            LAYERNORM_EPS = "clip.vision.attention.layer_norm_epsilon"
+            HEAD_COUNT      = "clip.vision.attention.head_count"
+            LAYERNORM_EPS   = "clip.vision.attention.layer_norm_epsilon"
 
         class Projector:
-            SCALE_FACTOR = "clip.vision.projector.scale_factor"
+            SCALE_FACTOR    = "clip.vision.projector.scale_factor"
 
     class ClipAudio:
-        NUM_MEL_BINS = "clip.audio.num_mel_bins"
-        EMBEDDING_LENGTH = "clip.audio.embedding_length"
+        NUM_MEL_BINS        = "clip.audio.num_mel_bins"
+        EMBEDDING_LENGTH    = "clip.audio.embedding_length"
         FEED_FORWARD_LENGTH = "clip.audio.feed_forward_length"
-        PROJECTION_DIM = "clip.audio.projection_dim"
-        BLOCK_COUNT = "clip.audio.block_count"
+        PROJECTION_DIM      = "clip.audio.projection_dim"
+        BLOCK_COUNT         = "clip.audio.block_count"
 
         class Attention:
-            HEAD_COUNT = "clip.audio.attention.head_count"
-            LAYERNORM_EPS = "clip.audio.attention.layer_norm_epsilon"
+            HEAD_COUNT      = "clip.audio.attention.head_count"
+            LAYERNORM_EPS   = "clip.audio.attention.layer_norm_epsilon"
 
         class Projector:
-            STACK_FACTOR = "clip.audio.projector.stack_factor"
+            STACK_FACTOR    = "clip.audio.projector.stack_factor"
 
     class Diffusion:
-        SHIFT_LOGITS = "diffusion.shift_logits"
+        SHIFT_LOGITS        = "diffusion.shift_logits"
 
     class xIELU:
-        ALPHA_P = "xielu.alpha_p"
-        ALPHA_N = "xielu.alpha_n"
-        BETA = "xielu.beta"
-        EPS = "xielu.eps"
+        ALPHA_P             = "xielu.alpha_p"
+        ALPHA_N             = "xielu.alpha_n"
+        BETA                = "xielu.beta"
+        EPS                 = "xielu.eps"
 
 
 #
@@ -321,702 +315,702 @@ class Keys:
 
 
 class GGUFType:
-    MODEL = "model"
+    MODEL   = "model"
     ADAPTER = "adapter"
     IMATRIX = "imatrix"
-    MMPROJ = "mmproj"  # dummy, unused for now
+    MMPROJ  = "mmproj" # dummy, unused for now
 
 
 class MODEL_ARCH(IntEnum):
-    MMPROJ = auto()  # dummy arch for clip.cpp
-    LLAMA = auto()
-    LLAMA4 = auto()
-    DECI = auto()
-    FALCON = auto()
-    FALCON_H1 = auto()
-    BAICHUAN = auto()
-    GROK = auto()
-    GPT2 = auto()
-    GPTJ = auto()
-    GPTNEOX = auto()
-    MPT = auto()
-    STARCODER = auto()
-    REFACT = auto()
-    BERT = auto()
-    NOMIC_BERT = auto()
-    NOMIC_BERT_MOE = auto()
-    NEO_BERT = auto()
-    JINA_BERT_V2 = auto()
-    JINA_BERT_V3 = auto()
-    BLOOM = auto()
-    STABLELM = auto()
-    QWEN = auto()
-    QWEN2 = auto()
-    QWEN2MOE = auto()
-    QWEN2VL = auto()
-    QWEN3 = auto()
-    QWEN3MOE = auto()
-    PHI2 = auto()
-    PHI3 = auto()
-    PHIMOE = auto()
-    PLAMO = auto()
-    PLAMO2 = auto()
-    CODESHELL = auto()
-    ORION = auto()
-    INTERNLM2 = auto()
-    MINICPM = auto()
-    MINICPM3 = auto()
-    GEMMA = auto()
-    GEMMA2 = auto()
-    GEMMA3 = auto()
-    GEMMA3N = auto()
-    GEMMA_EMBEDDING = auto()
-    STARCODER2 = auto()
-    RWKV6 = auto()
-    RWKV6QWEN2 = auto()
-    RWKV7 = auto()
-    ARWKV7 = auto()
-    MAMBA = auto()
-    MAMBA2 = auto()
-    JAMBA = auto()
-    XVERSE = auto()
-    COMMAND_R = auto()
-    COHERE2 = auto()
-    DBRX = auto()
-    OLMO = auto()
-    OLMO2 = auto()
-    OLMOE = auto()
-    OPENELM = auto()
-    ARCTIC = auto()
-    DEEPSEEK = auto()
-    DEEPSEEK2 = auto()
-    CHATGLM = auto()
-    GLM4 = auto()
-    GLM4_MOE = auto()
-    BITNET = auto()
-    T5 = auto()
-    T5ENCODER = auto()
-    JAIS = auto()
-    NEMOTRON = auto()
-    NEMOTRON_H = auto()
-    EXAONE = auto()
-    EXAONE4 = auto()
-    GRANITE = auto()
-    GRANITE_MOE = auto()
-    GRANITE_HYBRID = auto()
-    CHAMELEON = auto()
+    MMPROJ           = auto() # dummy arch for clip.cpp
+    LLAMA            = auto()
+    LLAMA4           = auto()
+    DECI             = auto()
+    FALCON           = auto()
+    FALCON_H1        = auto()
+    BAICHUAN         = auto()
+    GROK             = auto()
+    GPT2             = auto()
+    GPTJ             = auto()
+    GPTNEOX          = auto()
+    MPT              = auto()
+    STARCODER        = auto()
+    REFACT           = auto()
+    BERT             = auto()
+    NOMIC_BERT       = auto()
+    NOMIC_BERT_MOE   = auto()
+    NEO_BERT         = auto()
+    JINA_BERT_V2     = auto()
+    JINA_BERT_V3     = auto()
+    BLOOM            = auto()
+    STABLELM         = auto()
+    QWEN             = auto()
+    QWEN2            = auto()
+    QWEN2MOE         = auto()
+    QWEN2VL          = auto()
+    QWEN3            = auto()
+    QWEN3MOE         = auto()
+    PHI2             = auto()
+    PHI3             = auto()
+    PHIMOE           = auto()
+    PLAMO            = auto()
+    PLAMO2           = auto()
+    CODESHELL        = auto()
+    ORION            = auto()
+    INTERNLM2        = auto()
+    MINICPM          = auto()
+    MINICPM3         = auto()
+    GEMMA            = auto()
+    GEMMA2           = auto()
+    GEMMA3           = auto()
+    GEMMA3N          = auto()
+    GEMMA_EMBEDDING  = auto()
+    STARCODER2       = auto()
+    RWKV6            = auto()
+    RWKV6QWEN2       = auto()
+    RWKV7            = auto()
+    ARWKV7           = auto()
+    MAMBA            = auto()
+    MAMBA2           = auto()
+    JAMBA            = auto()
+    XVERSE           = auto()
+    COMMAND_R        = auto()
+    COHERE2          = auto()
+    DBRX             = auto()
+    OLMO             = auto()
+    OLMO2            = auto()
+    OLMOE            = auto()
+    OPENELM          = auto()
+    ARCTIC           = auto()
+    DEEPSEEK         = auto()
+    DEEPSEEK2        = auto()
+    CHATGLM          = auto()
+    GLM4             = auto()
+    GLM4_MOE         = auto()
+    BITNET           = auto()
+    T5               = auto()
+    T5ENCODER        = auto()
+    JAIS             = auto()
+    NEMOTRON         = auto()
+    NEMOTRON_H       = auto()
+    EXAONE           = auto()
+    EXAONE4          = auto()
+    GRANITE          = auto()
+    GRANITE_MOE      = auto()
+    GRANITE_HYBRID   = auto()
+    CHAMELEON        = auto()
     WAVTOKENIZER_DEC = auto()
-    PLM = auto()
-    BAILINGMOE = auto()
-    BAILINGMOE2 = auto()
-    DOTS1 = auto()
-    ARCEE = auto()
-    ERNIE4_5 = auto()
-    ERNIE4_5_MOE = auto()
-    HUNYUAN_MOE = auto()
-    HUNYUAN_DENSE = auto()
-    SMOLLM3 = auto()
-    GPT_OSS = auto()
-    LFM2 = auto()
-    LFM2MOE = auto()
-    DREAM = auto()
-    SMALLTHINKER = auto()
-    LLADA = auto()
-    LLADA_MOE = auto()
-    SEED_OSS = auto()
-    GROVEMOE = auto()
-    APERTUS = auto()
+    PLM              = auto()
+    BAILINGMOE       = auto()
+    BAILINGMOE2      = auto()
+    DOTS1            = auto()
+    ARCEE            = auto()
+    ERNIE4_5         = auto()
+    ERNIE4_5_MOE     = auto()
+    HUNYUAN_MOE      = auto()
+    HUNYUAN_DENSE    = auto()
+    SMOLLM3          = auto()
+    GPT_OSS          = auto()
+    LFM2             = auto()
+    LFM2MOE          = auto()
+    DREAM            = auto()
+    SMALLTHINKER     = auto()
+    LLADA            = auto()
+    LLADA_MOE        = auto()
+    SEED_OSS         = auto()
+    GROVEMOE         = auto()
+    APERTUS          = auto()
 
 
 class VISION_PROJECTOR_TYPE(IntEnum):
-    MLP = auto()
-    LDP = auto()
-    LDPV2 = auto()
+    MLP       = auto()
+    LDP       = auto()
+    LDPV2     = auto()
     RESAMPLER = auto()
-    GLM_EDGE = auto()
-    MERGER = auto()
-    GEMMA3 = auto()
+    GLM_EDGE  = auto()
+    MERGER    = auto()
+    GEMMA3    = auto()
 
 
 class MODEL_TENSOR(IntEnum):
-    TOKEN_EMBD = auto()
-    TOKEN_EMBD_NORM = auto()
-    TOKEN_TYPES = auto()
-    POS_EMBD = auto()
-    OUTPUT = auto()
-    DENSE_2_OUT = auto()  # embeddinggemma 2_Dense
-    DENSE_3_OUT = auto()  # embeddinggemma 3_Dense
-    OUTPUT_NORM = auto()
-    ROPE_FREQS = auto()
-    ROPE_FACTORS_LONG = auto()
-    ROPE_FACTORS_SHORT = auto()
-    ATTN_Q = auto()
-    ATTN_K = auto()
-    ATTN_V = auto()
-    ATTN_QKV = auto()
-    ATTN_OUT = auto()
-    ATTN_NORM = auto()
-    ATTN_NORM_2 = auto()
-    ATTN_OUT_NORM = auto()
-    ATTN_POST_NORM = auto()
-    ATTN_ROT_EMBD = auto()
-    ATTN_SINKS = auto()
-    FFN_GATE_INP = auto()
-    FFN_GATE_INP_SHEXP = auto()
-    FFN_NORM = auto()
-    FFN_PRE_NORM = auto()
-    FFN_POST_NORM = auto()
-    FFN_GATE = auto()
-    FFN_DOWN = auto()
-    FFN_UP = auto()
-    FFN_ACT = auto()
-    FFN_NORM_EXP = auto()
-    FFN_GATE_EXP = auto()
-    FFN_DOWN_EXP = auto()
-    FFN_UP_EXP = auto()
-    FFN_GATE_SHEXP = auto()
-    FFN_DOWN_SHEXP = auto()
-    FFN_UP_SHEXP = auto()
-    FFN_GATE_CHEXP = auto()
-    FFN_DOWN_CHEXP = auto()
-    FFN_UP_CHEXP = auto()
-    FFN_EXP_PROBS_B = auto()
-    ATTN_Q_NORM = auto()
-    ATTN_K_NORM = auto()
-    LAYER_OUT_NORM = auto()
-    PER_LAYER_TOKEN_EMBD = auto()  # gemma3n
-    PER_LAYER_MODEL_PROJ = auto()  # gemma3n
-    PER_LAYER_INP_GATE = auto()  # gemma3n
-    PER_LAYER_PROJ = auto()  # gemma3n
-    PER_LAYER_PROJ_NORM = auto()  # gemma3n
-    PER_LAYER_POST_NORM = auto()  # gemma3n
-    ALTUP_PROJ = auto()  # gemma3n
-    ALTUP_UNEMBD_PROJ = auto()  # gemma3n
-    ALTUP_CORRECT_COEF = auto()  # gemma3n
-    ALTUP_CORRECT_SCALE = auto()  # gemma3n
-    ALTUP_PREDICT_COEF = auto()  # gemma3n
-    ALTUP_ROUTER = auto()  # gemma3n
-    ALTUP_ROUTER_NORM = auto()  # gemma3n
-    LAUREL_L = auto()  # gemma3n
-    LAUREL_R = auto()  # gemma3n
-    LAUREL_POST_NORM = auto()  # gemma3n
-    SSM_IN = auto()
-    SSM_CONV1D = auto()
-    SSM_X = auto()
-    SSM_DT = auto()
-    SSM_DT_NORM = auto()
-    SSM_A = auto()
-    SSM_B_NORM = auto()
-    SSM_C_NORM = auto()
-    SSM_D = auto()
-    SSM_NORM = auto()
-    SSM_OUT = auto()
-    TIME_MIX_W0 = auto()
-    TIME_MIX_W1 = auto()
-    TIME_MIX_W2 = auto()
-    TIME_MIX_A0 = auto()
-    TIME_MIX_A1 = auto()
-    TIME_MIX_A2 = auto()
-    TIME_MIX_V0 = auto()
-    TIME_MIX_V1 = auto()
-    TIME_MIX_V2 = auto()
-    TIME_MIX_G1 = auto()
-    TIME_MIX_G2 = auto()
-    TIME_MIX_K_K = auto()
-    TIME_MIX_K_A = auto()
-    TIME_MIX_R_K = auto()
-    TIME_MIX_LERP_X = auto()
-    TIME_MIX_LERP_K = auto()
-    TIME_MIX_LERP_V = auto()
-    TIME_MIX_LERP_R = auto()
-    TIME_MIX_LERP_G = auto()
-    TIME_MIX_LERP_FUSED = auto()
-    TIME_MIX_LERP_W = auto()
-    TIME_MIX_FIRST = auto()
-    TIME_MIX_DECAY = auto()
-    TIME_MIX_DECAY_W1 = auto()
-    TIME_MIX_DECAY_W2 = auto()
-    TIME_MIX_KEY = auto()
-    TIME_MIX_VALUE = auto()
-    TIME_MIX_RECEPTANCE = auto()
-    TIME_MIX_GATE = auto()
-    TIME_MIX_LN = auto()
-    TIME_MIX_OUTPUT = auto()
-    CHANNEL_MIX_LERP_K = auto()
-    CHANNEL_MIX_LERP_R = auto()
-    CHANNEL_MIX_KEY = auto()
+    TOKEN_EMBD           = auto()
+    TOKEN_EMBD_NORM      = auto()
+    TOKEN_TYPES          = auto()
+    POS_EMBD             = auto()
+    OUTPUT               = auto()
+    DENSE_2_OUT          = auto() # embeddinggemma 2_Dense
+    DENSE_3_OUT          = auto() # embeddinggemma 3_Dense
+    OUTPUT_NORM          = auto()
+    ROPE_FREQS           = auto()
+    ROPE_FACTORS_LONG    = auto()
+    ROPE_FACTORS_SHORT   = auto()
+    ATTN_Q               = auto()
+    ATTN_K               = auto()
+    ATTN_V               = auto()
+    ATTN_QKV             = auto()
+    ATTN_OUT             = auto()
+    ATTN_NORM            = auto()
+    ATTN_NORM_2          = auto()
+    ATTN_OUT_NORM        = auto()
+    ATTN_POST_NORM       = auto()
+    ATTN_ROT_EMBD        = auto()
+    ATTN_SINKS           = auto()
+    FFN_GATE_INP         = auto()
+    FFN_GATE_INP_SHEXP   = auto()
+    FFN_NORM             = auto()
+    FFN_PRE_NORM         = auto()
+    FFN_POST_NORM        = auto()
+    FFN_GATE             = auto()
+    FFN_DOWN             = auto()
+    FFN_UP               = auto()
+    FFN_ACT              = auto()
+    FFN_NORM_EXP         = auto()
+    FFN_GATE_EXP         = auto()
+    FFN_DOWN_EXP         = auto()
+    FFN_UP_EXP           = auto()
+    FFN_GATE_SHEXP       = auto()
+    FFN_DOWN_SHEXP       = auto()
+    FFN_UP_SHEXP         = auto()
+    FFN_GATE_CHEXP       = auto()
+    FFN_DOWN_CHEXP       = auto()
+    FFN_UP_CHEXP         = auto()
+    FFN_EXP_PROBS_B      = auto()
+    ATTN_Q_NORM          = auto()
+    ATTN_K_NORM          = auto()
+    LAYER_OUT_NORM       = auto()
+    PER_LAYER_TOKEN_EMBD = auto() # gemma3n
+    PER_LAYER_MODEL_PROJ = auto() # gemma3n
+    PER_LAYER_INP_GATE   = auto() # gemma3n
+    PER_LAYER_PROJ       = auto() # gemma3n
+    PER_LAYER_PROJ_NORM  = auto() # gemma3n
+    PER_LAYER_POST_NORM  = auto() # gemma3n
+    ALTUP_PROJ           = auto() # gemma3n
+    ALTUP_UNEMBD_PROJ    = auto() # gemma3n
+    ALTUP_CORRECT_COEF   = auto() # gemma3n
+    ALTUP_CORRECT_SCALE  = auto() # gemma3n
+    ALTUP_PREDICT_COEF   = auto() # gemma3n
+    ALTUP_ROUTER         = auto() # gemma3n
+    ALTUP_ROUTER_NORM    = auto() # gemma3n
+    LAUREL_L             = auto() # gemma3n
+    LAUREL_R             = auto() # gemma3n
+    LAUREL_POST_NORM     = auto() # gemma3n
+    SSM_IN               = auto()
+    SSM_CONV1D           = auto()
+    SSM_X                = auto()
+    SSM_DT               = auto()
+    SSM_DT_NORM          = auto()
+    SSM_A                = auto()
+    SSM_B_NORM           = auto()
+    SSM_C_NORM           = auto()
+    SSM_D                = auto()
+    SSM_NORM             = auto()
+    SSM_OUT              = auto()
+    TIME_MIX_W0          = auto()
+    TIME_MIX_W1          = auto()
+    TIME_MIX_W2          = auto()
+    TIME_MIX_A0          = auto()
+    TIME_MIX_A1          = auto()
+    TIME_MIX_A2          = auto()
+    TIME_MIX_V0          = auto()
+    TIME_MIX_V1          = auto()
+    TIME_MIX_V2          = auto()
+    TIME_MIX_G1          = auto()
+    TIME_MIX_G2          = auto()
+    TIME_MIX_K_K         = auto()
+    TIME_MIX_K_A         = auto()
+    TIME_MIX_R_K         = auto()
+    TIME_MIX_LERP_X      = auto()
+    TIME_MIX_LERP_K      = auto()
+    TIME_MIX_LERP_V      = auto()
+    TIME_MIX_LERP_R      = auto()
+    TIME_MIX_LERP_G      = auto()
+    TIME_MIX_LERP_FUSED  = auto()
+    TIME_MIX_LERP_W      = auto()
+    TIME_MIX_FIRST       = auto()
+    TIME_MIX_DECAY       = auto()
+    TIME_MIX_DECAY_W1    = auto()
+    TIME_MIX_DECAY_W2    = auto()
+    TIME_MIX_KEY         = auto()
+    TIME_MIX_VALUE       = auto()
+    TIME_MIX_RECEPTANCE  = auto()
+    TIME_MIX_GATE        = auto()
+    TIME_MIX_LN          = auto()
+    TIME_MIX_OUTPUT      = auto()
+    CHANNEL_MIX_LERP_K   = auto()
+    CHANNEL_MIX_LERP_R   = auto()
+    CHANNEL_MIX_KEY      = auto()
     CHANNEL_MIX_RECEPTANCE = auto()
-    CHANNEL_MIX_VALUE = auto()
-    ATTN_Q_A = auto()
-    ATTN_Q_B = auto()
-    ATTN_KV_A_MQA = auto()
-    ATTN_KV_B = auto()
-    ATTN_K_B = auto()
-    ATTN_V_B = auto()
-    ATTN_Q_A_NORM = auto()
-    ATTN_KV_A_NORM = auto()
-    FFN_SUB_NORM = auto()
-    ATTN_SUB_NORM = auto()
-    DEC_ATTN_NORM = auto()
-    DEC_ATTN_Q = auto()
-    DEC_ATTN_K = auto()
-    DEC_ATTN_V = auto()
-    DEC_ATTN_OUT = auto()
-    DEC_ATTN_REL_B = auto()
-    DEC_CROSS_ATTN_NORM = auto()
-    DEC_CROSS_ATTN_Q = auto()
-    DEC_CROSS_ATTN_K = auto()
-    DEC_CROSS_ATTN_V = auto()
-    DEC_CROSS_ATTN_OUT = auto()
+    CHANNEL_MIX_VALUE    = auto()
+    ATTN_Q_A             = auto()
+    ATTN_Q_B             = auto()
+    ATTN_KV_A_MQA        = auto()
+    ATTN_KV_B            = auto()
+    ATTN_K_B             = auto()
+    ATTN_V_B             = auto()
+    ATTN_Q_A_NORM        = auto()
+    ATTN_KV_A_NORM       = auto()
+    FFN_SUB_NORM         = auto()
+    ATTN_SUB_NORM        = auto()
+    DEC_ATTN_NORM        = auto()
+    DEC_ATTN_Q           = auto()
+    DEC_ATTN_K           = auto()
+    DEC_ATTN_V           = auto()
+    DEC_ATTN_OUT         = auto()
+    DEC_ATTN_REL_B       = auto()
+    DEC_CROSS_ATTN_NORM  = auto()
+    DEC_CROSS_ATTN_Q     = auto()
+    DEC_CROSS_ATTN_K     = auto()
+    DEC_CROSS_ATTN_V     = auto()
+    DEC_CROSS_ATTN_OUT   = auto()
     DEC_CROSS_ATTN_REL_B = auto()
-    DEC_FFN_NORM = auto()
-    DEC_FFN_GATE = auto()
-    DEC_FFN_DOWN = auto()
-    DEC_FFN_UP = auto()
-    DEC_OUTPUT_NORM = auto()
-    ENC_ATTN_NORM = auto()
-    ENC_ATTN_Q = auto()
-    ENC_ATTN_K = auto()
-    ENC_ATTN_V = auto()
-    ENC_ATTN_OUT = auto()
-    ENC_ATTN_REL_B = auto()
-    ENC_FFN_NORM = auto()
-    ENC_FFN_GATE = auto()
-    ENC_FFN_DOWN = auto()
-    ENC_FFN_UP = auto()
-    ENC_OUTPUT_NORM = auto()
-    CLS = auto()  # classifier
-    CLS_OUT = auto()  # classifier output projection
-    CONV1D = auto()
-    CONVNEXT_DW = auto()
-    CONVNEXT_NORM = auto()
-    CONVNEXT_PW1 = auto()
-    CONVNEXT_PW2 = auto()
-    CONVNEXT_GAMMA = auto()
-    POSNET_CONV1 = auto()
-    POSNET_CONV2 = auto()
-    POSNET_NORM = auto()
-    POSNET_NORM1 = auto()
-    POSNET_NORM2 = auto()
-    POSNET_ATTN_NORM = auto()
-    POSNET_ATTN_Q = auto()
-    POSNET_ATTN_K = auto()
-    POSNET_ATTN_V = auto()
-    POSNET_ATTN_OUT = auto()
-    SHORTCONV_CONV = auto()
-    SHORTCONV_INPROJ = auto()
-    SHORTCONV_OUTPROJ = auto()
+    DEC_FFN_NORM         = auto()
+    DEC_FFN_GATE         = auto()
+    DEC_FFN_DOWN         = auto()
+    DEC_FFN_UP           = auto()
+    DEC_OUTPUT_NORM      = auto()
+    ENC_ATTN_NORM        = auto()
+    ENC_ATTN_Q           = auto()
+    ENC_ATTN_K           = auto()
+    ENC_ATTN_V           = auto()
+    ENC_ATTN_OUT         = auto()
+    ENC_ATTN_REL_B       = auto()
+    ENC_FFN_NORM         = auto()
+    ENC_FFN_GATE         = auto()
+    ENC_FFN_DOWN         = auto()
+    ENC_FFN_UP           = auto()
+    ENC_OUTPUT_NORM      = auto()
+    CLS                  = auto() # classifier
+    CLS_OUT              = auto() # classifier output projection
+    CONV1D               = auto()
+    CONVNEXT_DW          = auto()
+    CONVNEXT_NORM        = auto()
+    CONVNEXT_PW1         = auto()
+    CONVNEXT_PW2         = auto()
+    CONVNEXT_GAMMA       = auto()
+    POSNET_CONV1         = auto()
+    POSNET_CONV2         = auto()
+    POSNET_NORM          = auto()
+    POSNET_NORM1         = auto()
+    POSNET_NORM2         = auto()
+    POSNET_ATTN_NORM     = auto()
+    POSNET_ATTN_Q        = auto()
+    POSNET_ATTN_K        = auto()
+    POSNET_ATTN_V        = auto()
+    POSNET_ATTN_OUT      = auto()
+    SHORTCONV_CONV       = auto()
+    SHORTCONV_INPROJ     = auto()
+    SHORTCONV_OUTPROJ    = auto()
     # vision
-    V_MMPROJ = auto()
-    V_MMPROJ_FC = auto()
-    V_MMPROJ_MLP = auto()
-    V_MMPROJ_PEG = auto()
-    V_ENC_EMBD_CLS = auto()
-    V_ENC_EMBD_PATCH = auto()
-    V_ENC_EMBD_POS = auto()
-    V_ENC_INPUT_NORM = auto()
-    V_ENC_ATTN_Q = auto()
-    V_ENC_ATTN_Q_NORM = auto()
-    V_ENC_ATTN_K = auto()
-    V_ENC_ATTN_K_NORM = auto()
-    V_ENC_ATTN_V = auto()
-    V_ENC_ATTN_O = auto()
-    V_ENC_ATTN_O_NORM = auto()
+    V_MMPROJ             = auto()
+    V_MMPROJ_FC          = auto()
+    V_MMPROJ_MLP         = auto()
+    V_MMPROJ_PEG         = auto()
+    V_ENC_EMBD_CLS       = auto()
+    V_ENC_EMBD_PATCH     = auto()
+    V_ENC_EMBD_POS       = auto()
+    V_ENC_INPUT_NORM     = auto()
+    V_ENC_ATTN_Q         = auto()
+    V_ENC_ATTN_Q_NORM    = auto()
+    V_ENC_ATTN_K         = auto()
+    V_ENC_ATTN_K_NORM    = auto()
+    V_ENC_ATTN_V         = auto()
+    V_ENC_ATTN_O         = auto()
+    V_ENC_ATTN_O_NORM    = auto()
     V_ENC_POST_ATTN_NORM = auto()
-    V_ENC_FFN_UP = auto()
-    V_ENC_FFN_GATE = auto()
-    V_ENC_FFN_DOWN = auto()
-    V_LAYER_SCALE_1 = auto()
-    V_LAYER_SCALE_2 = auto()
-    V_PRE_NORM = auto()
-    V_POST_NORM = auto()
-    V_MM_INP_NORM = auto()
-    V_MM_INP_PROJ = auto()  # gemma3
-    V_MM_SOFT_EMB_NORM = auto()  # gemma3
-    V_RESMPL_POS_EMBD_K = auto()  # minicpmv
-    V_RESMPL_ATTN_Q = auto()  # minicpmv
-    V_RESMPL_ATTN_K = auto()  # minicpmv
-    V_RESMPL_ATTN_V = auto()  # minicpmv
-    V_RESMPL_ATTN_OUT = auto()  # minicpmv
-    V_RESMPL_KV = auto()  # minicpmv
-    V_RESMPL_KV_NORM = auto()  # minicpmv
-    V_RESMPL_POST_NORM = auto()  # minicpmv
-    V_RESMPL_Q_NORM = auto()  # minicpmv
-    V_RESMPL_PROJ = auto()  # minicpmv
-    V_RESMPL_QUERY = auto()  # minicpmv
-    V_TOK_EMBD_IMG_BREAK = auto()  # pixtral
-    V_MM_PATCH_MERGER = auto()  # mistral small 3.1
+    V_ENC_FFN_UP         = auto()
+    V_ENC_FFN_GATE       = auto()
+    V_ENC_FFN_DOWN       = auto()
+    V_LAYER_SCALE_1      = auto()
+    V_LAYER_SCALE_2      = auto()
+    V_PRE_NORM           = auto()
+    V_POST_NORM          = auto()
+    V_MM_INP_NORM        = auto()
+    V_MM_INP_PROJ        = auto() # gemma3
+    V_MM_SOFT_EMB_NORM   = auto() # gemma3
+    V_RESMPL_POS_EMBD_K  = auto() # minicpmv
+    V_RESMPL_ATTN_Q      = auto() # minicpmv
+    V_RESMPL_ATTN_K      = auto() # minicpmv
+    V_RESMPL_ATTN_V      = auto() # minicpmv
+    V_RESMPL_ATTN_OUT    = auto() # minicpmv
+    V_RESMPL_KV          = auto() # minicpmv
+    V_RESMPL_KV_NORM     = auto() # minicpmv
+    V_RESMPL_POST_NORM   = auto() # minicpmv
+    V_RESMPL_Q_NORM      = auto() # minicpmv
+    V_RESMPL_PROJ        = auto() # minicpmv
+    V_RESMPL_QUERY       = auto() # minicpmv
+    V_TOK_EMBD_IMG_BREAK = auto() # pixtral
+    V_MM_PATCH_MERGER    = auto() # mistral small 3.1
     # audio (mtmd)
-    A_ENC_EMBD_POS = auto()
-    A_ENC_CONV1D = auto()
-    A_PRE_NORM = auto()
-    A_POST_NORM = auto()
-    A_ENC_ATTN_Q = auto()
-    A_ENC_ATTN_K = auto()
-    A_ENC_ATTN_V = auto()
-    A_ENC_INPUT_NORM = auto()
-    A_ENC_OUTPUT = auto()
-    A_ENC_OUTPUT_NORM = auto()
-    A_ENC_FFN_UP = auto()
-    A_ENC_FFN_GATE = auto()
-    A_ENC_FFN_DOWN = auto()
-    A_MMPROJ = auto()
-    A_MMPROJ_FC = auto()
-    A_MM_NORM_PRE = auto()
-    A_MM_NORM_MID = auto()
+    A_ENC_EMBD_POS       = auto()
+    A_ENC_CONV1D         = auto()
+    A_PRE_NORM           = auto()
+    A_POST_NORM          = auto()
+    A_ENC_ATTN_Q         = auto()
+    A_ENC_ATTN_K         = auto()
+    A_ENC_ATTN_V         = auto()
+    A_ENC_INPUT_NORM     = auto()
+    A_ENC_OUTPUT         = auto()
+    A_ENC_OUTPUT_NORM    = auto()
+    A_ENC_FFN_UP         = auto()
+    A_ENC_FFN_GATE       = auto()
+    A_ENC_FFN_DOWN       = auto()
+    A_MMPROJ             = auto()
+    A_MMPROJ_FC          = auto()
+    A_MM_NORM_PRE        = auto()
+    A_MM_NORM_MID        = auto()
     # nextn/mtp
-    NEXTN_EH_PROJ = auto()
-    NEXTN_EMBED_TOKENS = auto()
-    NEXTN_ENORM = auto()
-    NEXTN_HNORM = auto()
+    NEXTN_EH_PROJ        = auto()
+    NEXTN_EMBED_TOKENS   = auto()
+    NEXTN_ENORM          = auto()
+    NEXTN_HNORM          = auto()
     NEXTN_SHARED_HEAD_HEAD = auto()
     NEXTN_SHARED_HEAD_NORM = auto()
 
 
 MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
-    MODEL_ARCH.MMPROJ: "clip",  # dummy arch for clip.cpp
-    MODEL_ARCH.LLAMA: "llama",
-    MODEL_ARCH.LLAMA4: "llama4",
-    MODEL_ARCH.DECI: "deci",
-    MODEL_ARCH.FALCON: "falcon",
-    MODEL_ARCH.BAICHUAN: "baichuan",
-    MODEL_ARCH.GROK: "grok",
-    MODEL_ARCH.GPT2: "gpt2",
-    MODEL_ARCH.GPTJ: "gptj",
-    MODEL_ARCH.GPTNEOX: "gptneox",
-    MODEL_ARCH.MPT: "mpt",
-    MODEL_ARCH.STARCODER: "starcoder",
-    MODEL_ARCH.REFACT: "refact",
-    MODEL_ARCH.BERT: "bert",
-    MODEL_ARCH.NOMIC_BERT: "nomic-bert",
-    MODEL_ARCH.NOMIC_BERT_MOE: "nomic-bert-moe",
-    MODEL_ARCH.NEO_BERT: "neo-bert",
-    MODEL_ARCH.JINA_BERT_V2: "jina-bert-v2",
-    MODEL_ARCH.JINA_BERT_V3: "jina-bert-v3",
-    MODEL_ARCH.BLOOM: "bloom",
-    MODEL_ARCH.STABLELM: "stablelm",
-    MODEL_ARCH.QWEN: "qwen",
-    MODEL_ARCH.QWEN2: "qwen2",
-    MODEL_ARCH.QWEN2MOE: "qwen2moe",
-    MODEL_ARCH.QWEN2VL: "qwen2vl",
-    MODEL_ARCH.QWEN3: "qwen3",
-    MODEL_ARCH.QWEN3MOE: "qwen3moe",
-    MODEL_ARCH.PHI2: "phi2",
-    MODEL_ARCH.PHI3: "phi3",
-    MODEL_ARCH.PHIMOE: "phimoe",
-    MODEL_ARCH.PLAMO: "plamo",
-    MODEL_ARCH.PLAMO2: "plamo2",
-    MODEL_ARCH.CODESHELL: "codeshell",
-    MODEL_ARCH.ORION: "orion",
-    MODEL_ARCH.INTERNLM2: "internlm2",
-    MODEL_ARCH.MINICPM: "minicpm",
-    MODEL_ARCH.MINICPM3: "minicpm3",
-    MODEL_ARCH.GEMMA: "gemma",
-    MODEL_ARCH.GEMMA2: "gemma2",
-    MODEL_ARCH.GEMMA3: "gemma3",
-    MODEL_ARCH.GEMMA3N: "gemma3n",
-    MODEL_ARCH.GEMMA_EMBEDDING: "gemma-embedding",
-    MODEL_ARCH.STARCODER2: "starcoder2",
-    MODEL_ARCH.RWKV6: "rwkv6",
-    MODEL_ARCH.RWKV6QWEN2: "rwkv6qwen2",
-    MODEL_ARCH.RWKV7: "rwkv7",
-    MODEL_ARCH.ARWKV7: "arwkv7",
-    MODEL_ARCH.MAMBA: "mamba",
-    MODEL_ARCH.MAMBA2: "mamba2",
-    MODEL_ARCH.JAMBA: "jamba",
-    MODEL_ARCH.XVERSE: "xverse",
-    MODEL_ARCH.COMMAND_R: "command-r",
-    MODEL_ARCH.COHERE2: "cohere2",
-    MODEL_ARCH.DBRX: "dbrx",
-    MODEL_ARCH.OLMO: "olmo",
-    MODEL_ARCH.OLMO2: "olmo2",
-    MODEL_ARCH.OLMOE: "olmoe",
-    MODEL_ARCH.OPENELM: "openelm",
-    MODEL_ARCH.ARCTIC: "arctic",
-    MODEL_ARCH.DEEPSEEK: "deepseek",
-    MODEL_ARCH.DEEPSEEK2: "deepseek2",
-    MODEL_ARCH.CHATGLM: "chatglm",
-    MODEL_ARCH.GLM4: "glm4",
-    MODEL_ARCH.GLM4_MOE: "glm4moe",
-    MODEL_ARCH.BITNET: "bitnet",
-    MODEL_ARCH.T5: "t5",
-    MODEL_ARCH.T5ENCODER: "t5encoder",
-    MODEL_ARCH.JAIS: "jais",
-    MODEL_ARCH.NEMOTRON: "nemotron",
-    MODEL_ARCH.NEMOTRON_H: "nemotron_h",
-    MODEL_ARCH.EXAONE: "exaone",
-    MODEL_ARCH.EXAONE4: "exaone4",
-    MODEL_ARCH.GRANITE: "granite",
-    MODEL_ARCH.GRANITE_MOE: "granitemoe",
-    MODEL_ARCH.GRANITE_HYBRID: "granitehybrid",
-    MODEL_ARCH.CHAMELEON: "chameleon",
+    MODEL_ARCH.MMPROJ:           "clip", # dummy arch for clip.cpp
+    MODEL_ARCH.LLAMA:            "llama",
+    MODEL_ARCH.LLAMA4:           "llama4",
+    MODEL_ARCH.DECI:             "deci",
+    MODEL_ARCH.FALCON:           "falcon",
+    MODEL_ARCH.BAICHUAN:         "baichuan",
+    MODEL_ARCH.GROK:             "grok",
+    MODEL_ARCH.GPT2:             "gpt2",
+    MODEL_ARCH.GPTJ:             "gptj",
+    MODEL_ARCH.GPTNEOX:          "gptneox",
+    MODEL_ARCH.MPT:              "mpt",
+    MODEL_ARCH.STARCODER:        "starcoder",
+    MODEL_ARCH.REFACT:           "refact",
+    MODEL_ARCH.BERT:             "bert",
+    MODEL_ARCH.NOMIC_BERT:       "nomic-bert",
+    MODEL_ARCH.NOMIC_BERT_MOE:   "nomic-bert-moe",
+    MODEL_ARCH.NEO_BERT:         "neo-bert",
+    MODEL_ARCH.JINA_BERT_V2:     "jina-bert-v2",
+    MODEL_ARCH.JINA_BERT_V3:     "jina-bert-v3",
+    MODEL_ARCH.BLOOM:            "bloom",
+    MODEL_ARCH.STABLELM:         "stablelm",
+    MODEL_ARCH.QWEN:             "qwen",
+    MODEL_ARCH.QWEN2:            "qwen2",
+    MODEL_ARCH.QWEN2MOE:         "qwen2moe",
+    MODEL_ARCH.QWEN2VL:          "qwen2vl",
+    MODEL_ARCH.QWEN3:            "qwen3",
+    MODEL_ARCH.QWEN3MOE:         "qwen3moe",
+    MODEL_ARCH.PHI2:             "phi2",
+    MODEL_ARCH.PHI3:             "phi3",
+    MODEL_ARCH.PHIMOE:           "phimoe",
+    MODEL_ARCH.PLAMO:            "plamo",
+    MODEL_ARCH.PLAMO2:           "plamo2",
+    MODEL_ARCH.CODESHELL:        "codeshell",
+    MODEL_ARCH.ORION:            "orion",
+    MODEL_ARCH.INTERNLM2:        "internlm2",
+    MODEL_ARCH.MINICPM:          "minicpm",
+    MODEL_ARCH.MINICPM3:         "minicpm3",
+    MODEL_ARCH.GEMMA:            "gemma",
+    MODEL_ARCH.GEMMA2:           "gemma2",
+    MODEL_ARCH.GEMMA3:           "gemma3",
+    MODEL_ARCH.GEMMA3N:          "gemma3n",
+    MODEL_ARCH.GEMMA_EMBEDDING:  "gemma-embedding",
+    MODEL_ARCH.STARCODER2:       "starcoder2",
+    MODEL_ARCH.RWKV6:            "rwkv6",
+    MODEL_ARCH.RWKV6QWEN2:       "rwkv6qwen2",
+    MODEL_ARCH.RWKV7:            "rwkv7",
+    MODEL_ARCH.ARWKV7:           "arwkv7",
+    MODEL_ARCH.MAMBA:            "mamba",
+    MODEL_ARCH.MAMBA2:           "mamba2",
+    MODEL_ARCH.JAMBA:            "jamba",
+    MODEL_ARCH.XVERSE:           "xverse",
+    MODEL_ARCH.COMMAND_R:        "command-r",
+    MODEL_ARCH.COHERE2:          "cohere2",
+    MODEL_ARCH.DBRX:             "dbrx",
+    MODEL_ARCH.OLMO:             "olmo",
+    MODEL_ARCH.OLMO2:            "olmo2",
+    MODEL_ARCH.OLMOE:            "olmoe",
+    MODEL_ARCH.OPENELM:          "openelm",
+    MODEL_ARCH.ARCTIC:           "arctic",
+    MODEL_ARCH.DEEPSEEK:         "deepseek",
+    MODEL_ARCH.DEEPSEEK2:        "deepseek2",
+    MODEL_ARCH.CHATGLM:          "chatglm",
+    MODEL_ARCH.GLM4:             "glm4",
+    MODEL_ARCH.GLM4_MOE:         "glm4moe",
+    MODEL_ARCH.BITNET:           "bitnet",
+    MODEL_ARCH.T5:               "t5",
+    MODEL_ARCH.T5ENCODER:        "t5encoder",
+    MODEL_ARCH.JAIS:             "jais",
+    MODEL_ARCH.NEMOTRON:         "nemotron",
+    MODEL_ARCH.NEMOTRON_H:       "nemotron_h",
+    MODEL_ARCH.EXAONE:           "exaone",
+    MODEL_ARCH.EXAONE4:          "exaone4",
+    MODEL_ARCH.GRANITE:          "granite",
+    MODEL_ARCH.GRANITE_MOE:      "granitemoe",
+    MODEL_ARCH.GRANITE_HYBRID:   "granitehybrid",
+    MODEL_ARCH.CHAMELEON:        "chameleon",
     MODEL_ARCH.WAVTOKENIZER_DEC: "wavtokenizer-dec",
-    MODEL_ARCH.PLM: "plm",
-    MODEL_ARCH.BAILINGMOE: "bailingmoe",
-    MODEL_ARCH.BAILINGMOE2: "bailingmoe2",
-    MODEL_ARCH.DOTS1: "dots1",
-    MODEL_ARCH.ARCEE: "arcee",
-    MODEL_ARCH.ERNIE4_5: "ernie4_5",
-    MODEL_ARCH.ERNIE4_5_MOE: "ernie4_5-moe",
-    MODEL_ARCH.FALCON_H1: "falcon-h1",
-    MODEL_ARCH.HUNYUAN_MOE: "hunyuan-moe",
-    MODEL_ARCH.HUNYUAN_DENSE: "hunyuan-dense",
-    MODEL_ARCH.SMOLLM3: "smollm3",
-    MODEL_ARCH.GPT_OSS: "gpt-oss",
-    MODEL_ARCH.LFM2: "lfm2",
-    MODEL_ARCH.LFM2MOE: "lfm2moe",
-    MODEL_ARCH.DREAM: "dream",
-    MODEL_ARCH.SMALLTHINKER: "smallthinker",
-    MODEL_ARCH.LLADA: "llada",
-    MODEL_ARCH.LLADA_MOE: "llada-moe",
-    MODEL_ARCH.SEED_OSS: "seed_oss",
-    MODEL_ARCH.GROVEMOE: "grovemoe",
-    MODEL_ARCH.APERTUS: "apertus",
+    MODEL_ARCH.PLM:              "plm",
+    MODEL_ARCH.BAILINGMOE:       "bailingmoe",
+    MODEL_ARCH.BAILINGMOE2:      "bailingmoe2",
+    MODEL_ARCH.DOTS1:            "dots1",
+    MODEL_ARCH.ARCEE:            "arcee",
+    MODEL_ARCH.ERNIE4_5:         "ernie4_5",
+    MODEL_ARCH.ERNIE4_5_MOE:     "ernie4_5-moe",
+    MODEL_ARCH.FALCON_H1:        "falcon-h1",
+    MODEL_ARCH.HUNYUAN_MOE:      "hunyuan-moe",
+    MODEL_ARCH.HUNYUAN_DENSE:    "hunyuan-dense",
+    MODEL_ARCH.SMOLLM3:          "smollm3",
+    MODEL_ARCH.GPT_OSS:          "gpt-oss",
+    MODEL_ARCH.LFM2:             "lfm2",
+    MODEL_ARCH.LFM2MOE:          "lfm2moe",
+    MODEL_ARCH.DREAM:            "dream",
+    MODEL_ARCH.SMALLTHINKER:     "smallthinker",
+    MODEL_ARCH.LLADA:            "llada",
+    MODEL_ARCH.LLADA_MOE:        "llada-moe",
+    MODEL_ARCH.SEED_OSS:         "seed_oss",
+    MODEL_ARCH.GROVEMOE:         "grovemoe",
+    MODEL_ARCH.APERTUS:          "apertus",
 }
 
 VISION_PROJECTOR_TYPE_NAMES: dict[VISION_PROJECTOR_TYPE, str] = {
-    VISION_PROJECTOR_TYPE.MLP: "mlp",
-    VISION_PROJECTOR_TYPE.LDP: "ldp",
-    VISION_PROJECTOR_TYPE.LDPV2: "ldpv2",
+    VISION_PROJECTOR_TYPE.MLP:       "mlp",
+    VISION_PROJECTOR_TYPE.LDP:       "ldp",
+    VISION_PROJECTOR_TYPE.LDPV2:     "ldpv2",
     VISION_PROJECTOR_TYPE.RESAMPLER: "resampler",
-    VISION_PROJECTOR_TYPE.GLM_EDGE: "adapter",
-    VISION_PROJECTOR_TYPE.MERGER: "qwen2vl_merger",
-    VISION_PROJECTOR_TYPE.GEMMA3: "gemma3",
+    VISION_PROJECTOR_TYPE.GLM_EDGE:  "adapter",
+    VISION_PROJECTOR_TYPE.MERGER:    "qwen2vl_merger",
+    VISION_PROJECTOR_TYPE.GEMMA3:    "gemma3",
 }
 
 TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
-    MODEL_TENSOR.TOKEN_EMBD: "token_embd",
-    MODEL_TENSOR.TOKEN_EMBD_NORM: "token_embd_norm",
-    MODEL_TENSOR.TOKEN_TYPES: "token_types",
-    MODEL_TENSOR.POS_EMBD: "position_embd",
-    MODEL_TENSOR.OUTPUT_NORM: "output_norm",
-    MODEL_TENSOR.OUTPUT: "output",
-    MODEL_TENSOR.DENSE_2_OUT: "dense_2",  # embeddinggemma 2_Dense
-    MODEL_TENSOR.DENSE_3_OUT: "dense_3",  # embeddinggemma 2_Dense
-    MODEL_TENSOR.ROPE_FREQS: "rope_freqs",
-    MODEL_TENSOR.ROPE_FACTORS_LONG: "rope_factors_long",
-    MODEL_TENSOR.ROPE_FACTORS_SHORT: "rope_factors_short",
-    MODEL_TENSOR.ATTN_NORM: "blk.{bid}.attn_norm",
-    MODEL_TENSOR.ATTN_NORM_2: "blk.{bid}.attn_norm_2",
-    MODEL_TENSOR.ATTN_QKV: "blk.{bid}.attn_qkv",
-    MODEL_TENSOR.ATTN_Q: "blk.{bid}.attn_q",
-    MODEL_TENSOR.ATTN_K: "blk.{bid}.attn_k",
-    MODEL_TENSOR.ATTN_V: "blk.{bid}.attn_v",
-    MODEL_TENSOR.ATTN_OUT: "blk.{bid}.attn_output",
-    MODEL_TENSOR.ATTN_ROT_EMBD: "blk.{bid}.attn_rot_embd",
-    MODEL_TENSOR.ATTN_SINKS: "blk.{bid}.attn_sinks",
-    MODEL_TENSOR.ATTN_Q_NORM: "blk.{bid}.attn_q_norm",
-    MODEL_TENSOR.ATTN_K_NORM: "blk.{bid}.attn_k_norm",
-    MODEL_TENSOR.ATTN_OUT_NORM: "blk.{bid}.attn_output_norm",
-    MODEL_TENSOR.ATTN_POST_NORM: "blk.{bid}.post_attention_norm",
-    MODEL_TENSOR.FFN_GATE_INP: "blk.{bid}.ffn_gate_inp",
-    MODEL_TENSOR.FFN_GATE_INP_SHEXP: "blk.{bid}.ffn_gate_inp_shexp",
-    MODEL_TENSOR.FFN_NORM: "blk.{bid}.ffn_norm",
-    MODEL_TENSOR.FFN_PRE_NORM: "blk.{bid}.ffn_norm",
-    MODEL_TENSOR.FFN_POST_NORM: "blk.{bid}.post_ffw_norm",
-    MODEL_TENSOR.FFN_GATE: "blk.{bid}.ffn_gate",
-    MODEL_TENSOR.FFN_DOWN: "blk.{bid}.ffn_down",
-    MODEL_TENSOR.FFN_UP: "blk.{bid}.ffn_up",
-    MODEL_TENSOR.FFN_GATE_SHEXP: "blk.{bid}.ffn_gate_shexp",
-    MODEL_TENSOR.FFN_DOWN_SHEXP: "blk.{bid}.ffn_down_shexp",
-    MODEL_TENSOR.FFN_UP_SHEXP: "blk.{bid}.ffn_up_shexp",
-    MODEL_TENSOR.FFN_GATE_CHEXP: "blk.{bid}.ffn_gate_chexps",
-    MODEL_TENSOR.FFN_DOWN_CHEXP: "blk.{bid}.ffn_down_chexps",
-    MODEL_TENSOR.FFN_UP_CHEXP: "blk.{bid}.ffn_up_chexps",
-    MODEL_TENSOR.FFN_ACT: "blk.{bid}.ffn",
-    MODEL_TENSOR.FFN_NORM_EXP: "blk.{bid}.ffn_norm_exps",
-    MODEL_TENSOR.FFN_GATE_EXP: "blk.{bid}.ffn_gate_exps",
-    MODEL_TENSOR.FFN_DOWN_EXP: "blk.{bid}.ffn_down_exps",
-    MODEL_TENSOR.FFN_UP_EXP: "blk.{bid}.ffn_up_exps",
-    MODEL_TENSOR.FFN_EXP_PROBS_B: "blk.{bid}.exp_probs_b",
-    MODEL_TENSOR.LAYER_OUT_NORM: "blk.{bid}.layer_output_norm",
-    MODEL_TENSOR.PER_LAYER_TOKEN_EMBD: "per_layer_token_embd",  # gemma3n
-    MODEL_TENSOR.PER_LAYER_MODEL_PROJ: "per_layer_model_proj",  # gemma3n
-    MODEL_TENSOR.PER_LAYER_PROJ_NORM: "per_layer_proj_norm",  # gemma3n
-    MODEL_TENSOR.ALTUP_UNEMBD_PROJ: "altup_unembd_proj",  # gemma3n
-    MODEL_TENSOR.ALTUP_PROJ: "altup_proj",  # gemma3n
-    MODEL_TENSOR.PER_LAYER_INP_GATE: "blk.{bid}.inp_gate",  # gemma3n
-    MODEL_TENSOR.PER_LAYER_PROJ: "blk.{bid}.proj",  # gemma3n
-    MODEL_TENSOR.PER_LAYER_POST_NORM: "blk.{bid}.post_norm",  # gemma3n
-    MODEL_TENSOR.ALTUP_CORRECT_COEF: "blk.{bid}.altup_correct_coef",  # gemma3n
-    MODEL_TENSOR.ALTUP_CORRECT_SCALE: "blk.{bid}.altup_correct_scale",  # gemma3n
-    MODEL_TENSOR.ALTUP_PREDICT_COEF: "blk.{bid}.altup_predict_coef",  # gemma3n
-    MODEL_TENSOR.ALTUP_ROUTER: "blk.{bid}.altup_router",  # gemma3n
-    MODEL_TENSOR.ALTUP_ROUTER_NORM: "blk.{bid}.altup_router_norm",  # gemma3n
-    MODEL_TENSOR.LAUREL_L: "blk.{bid}.laurel_l",  # gemma3n
-    MODEL_TENSOR.LAUREL_R: "blk.{bid}.laurel_r",  # gemma3n
-    MODEL_TENSOR.LAUREL_POST_NORM: "blk.{bid}.laurel_post_norm",  # gemma3n
-    MODEL_TENSOR.SSM_IN: "blk.{bid}.ssm_in",
-    MODEL_TENSOR.SSM_CONV1D: "blk.{bid}.ssm_conv1d",
-    MODEL_TENSOR.SSM_X: "blk.{bid}.ssm_x",
-    MODEL_TENSOR.SSM_DT: "blk.{bid}.ssm_dt",
-    MODEL_TENSOR.SSM_DT_NORM: "blk.{bid}.ssm_dt_norm",
-    MODEL_TENSOR.SSM_A: "blk.{bid}.ssm_a",
-    MODEL_TENSOR.SSM_B_NORM: "blk.{bid}.ssm_b_norm",
-    MODEL_TENSOR.SSM_C_NORM: "blk.{bid}.ssm_c_norm",
-    MODEL_TENSOR.SSM_D: "blk.{bid}.ssm_d",
-    MODEL_TENSOR.SSM_NORM: "blk.{bid}.ssm_norm",
-    MODEL_TENSOR.SSM_OUT: "blk.{bid}.ssm_out",
-    MODEL_TENSOR.TIME_MIX_W0: "blk.{bid}.time_mix_w0",
-    MODEL_TENSOR.TIME_MIX_W1: "blk.{bid}.time_mix_w1",
-    MODEL_TENSOR.TIME_MIX_W2: "blk.{bid}.time_mix_w2",
-    MODEL_TENSOR.TIME_MIX_A0: "blk.{bid}.time_mix_a0",
-    MODEL_TENSOR.TIME_MIX_A1: "blk.{bid}.time_mix_a1",
-    MODEL_TENSOR.TIME_MIX_A2: "blk.{bid}.time_mix_a2",
-    MODEL_TENSOR.TIME_MIX_V0: "blk.{bid}.time_mix_v0",
-    MODEL_TENSOR.TIME_MIX_V1: "blk.{bid}.time_mix_v1",
-    MODEL_TENSOR.TIME_MIX_V2: "blk.{bid}.time_mix_v2",
-    MODEL_TENSOR.TIME_MIX_G1: "blk.{bid}.time_mix_g1",
-    MODEL_TENSOR.TIME_MIX_G2: "blk.{bid}.time_mix_g2",
-    MODEL_TENSOR.TIME_MIX_K_K: "blk.{bid}.time_mix_k_k",
-    MODEL_TENSOR.TIME_MIX_K_A: "blk.{bid}.time_mix_k_a",
-    MODEL_TENSOR.TIME_MIX_R_K: "blk.{bid}.time_mix_r_k",
-    MODEL_TENSOR.TIME_MIX_LERP_X: "blk.{bid}.time_mix_lerp_x",
-    MODEL_TENSOR.TIME_MIX_LERP_K: "blk.{bid}.time_mix_lerp_k",
-    MODEL_TENSOR.TIME_MIX_LERP_V: "blk.{bid}.time_mix_lerp_v",
-    MODEL_TENSOR.TIME_MIX_LERP_R: "blk.{bid}.time_mix_lerp_r",
-    MODEL_TENSOR.TIME_MIX_LERP_G: "blk.{bid}.time_mix_lerp_g",
-    MODEL_TENSOR.TIME_MIX_LERP_FUSED: "blk.{bid}.time_mix_lerp_fused",
-    MODEL_TENSOR.TIME_MIX_LERP_W: "blk.{bid}.time_mix_lerp_w",
-    MODEL_TENSOR.TIME_MIX_FIRST: "blk.{bid}.time_mix_first",
-    MODEL_TENSOR.TIME_MIX_DECAY: "blk.{bid}.time_mix_decay",
-    MODEL_TENSOR.TIME_MIX_DECAY_W1: "blk.{bid}.time_mix_decay_w1",
-    MODEL_TENSOR.TIME_MIX_DECAY_W2: "blk.{bid}.time_mix_decay_w2",
-    MODEL_TENSOR.TIME_MIX_KEY: "blk.{bid}.time_mix_key",
-    MODEL_TENSOR.TIME_MIX_VALUE: "blk.{bid}.time_mix_value",
-    MODEL_TENSOR.TIME_MIX_RECEPTANCE: "blk.{bid}.time_mix_receptance",
-    MODEL_TENSOR.TIME_MIX_GATE: "blk.{bid}.time_mix_gate",
-    MODEL_TENSOR.TIME_MIX_LN: "blk.{bid}.time_mix_ln",
-    MODEL_TENSOR.TIME_MIX_OUTPUT: "blk.{bid}.time_mix_output",
-    MODEL_TENSOR.CHANNEL_MIX_LERP_K: "blk.{bid}.channel_mix_lerp_k",
-    MODEL_TENSOR.CHANNEL_MIX_LERP_R: "blk.{bid}.channel_mix_lerp_r",
-    MODEL_TENSOR.CHANNEL_MIX_KEY: "blk.{bid}.channel_mix_key",
-    MODEL_TENSOR.CHANNEL_MIX_RECEPTANCE: "blk.{bid}.channel_mix_receptance",
-    MODEL_TENSOR.CHANNEL_MIX_VALUE: "blk.{bid}.channel_mix_value",
-    MODEL_TENSOR.ATTN_Q_A: "blk.{bid}.attn_q_a",
-    MODEL_TENSOR.ATTN_Q_B: "blk.{bid}.attn_q_b",
-    MODEL_TENSOR.ATTN_KV_A_MQA: "blk.{bid}.attn_kv_a_mqa",
-    MODEL_TENSOR.ATTN_KV_B: "blk.{bid}.attn_kv_b",
-    MODEL_TENSOR.ATTN_K_B: "blk.{bid}.attn_k_b",
-    MODEL_TENSOR.ATTN_V_B: "blk.{bid}.attn_v_b",
-    MODEL_TENSOR.ATTN_Q_A_NORM: "blk.{bid}.attn_q_a_norm",
-    MODEL_TENSOR.ATTN_KV_A_NORM: "blk.{bid}.attn_kv_a_norm",
-    MODEL_TENSOR.ATTN_SUB_NORM: "blk.{bid}.attn_sub_norm",
-    MODEL_TENSOR.FFN_SUB_NORM: "blk.{bid}.ffn_sub_norm",
-    MODEL_TENSOR.DEC_ATTN_NORM: "dec.blk.{bid}.attn_norm",
-    MODEL_TENSOR.DEC_ATTN_Q: "dec.blk.{bid}.attn_q",
-    MODEL_TENSOR.DEC_ATTN_K: "dec.blk.{bid}.attn_k",
-    MODEL_TENSOR.DEC_ATTN_V: "dec.blk.{bid}.attn_v",
-    MODEL_TENSOR.DEC_ATTN_OUT: "dec.blk.{bid}.attn_o",
-    MODEL_TENSOR.DEC_ATTN_REL_B: "dec.blk.{bid}.attn_rel_b",
-    MODEL_TENSOR.DEC_CROSS_ATTN_NORM: "dec.blk.{bid}.cross_attn_norm",
-    MODEL_TENSOR.DEC_CROSS_ATTN_Q: "dec.blk.{bid}.cross_attn_q",
-    MODEL_TENSOR.DEC_CROSS_ATTN_K: "dec.blk.{bid}.cross_attn_k",
-    MODEL_TENSOR.DEC_CROSS_ATTN_V: "dec.blk.{bid}.cross_attn_v",
-    MODEL_TENSOR.DEC_CROSS_ATTN_OUT: "dec.blk.{bid}.cross_attn_o",
-    MODEL_TENSOR.DEC_CROSS_ATTN_REL_B: "dec.blk.{bid}.cross_attn_rel_b",
-    MODEL_TENSOR.DEC_FFN_NORM: "dec.blk.{bid}.ffn_norm",
-    MODEL_TENSOR.DEC_FFN_GATE: "dec.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.DEC_FFN_DOWN: "dec.blk.{bid}.ffn_down",
-    MODEL_TENSOR.DEC_FFN_UP: "dec.blk.{bid}.ffn_up",
-    MODEL_TENSOR.DEC_OUTPUT_NORM: "dec.output_norm",
-    MODEL_TENSOR.ENC_ATTN_NORM: "enc.blk.{bid}.attn_norm",
-    MODEL_TENSOR.ENC_ATTN_Q: "enc.blk.{bid}.attn_q",
-    MODEL_TENSOR.ENC_ATTN_K: "enc.blk.{bid}.attn_k",
-    MODEL_TENSOR.ENC_ATTN_V: "enc.blk.{bid}.attn_v",
-    MODEL_TENSOR.ENC_ATTN_OUT: "enc.blk.{bid}.attn_o",
-    MODEL_TENSOR.ENC_ATTN_REL_B: "enc.blk.{bid}.attn_rel_b",
-    MODEL_TENSOR.ENC_FFN_NORM: "enc.blk.{bid}.ffn_norm",
-    MODEL_TENSOR.ENC_FFN_GATE: "enc.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.ENC_FFN_DOWN: "enc.blk.{bid}.ffn_down",
-    MODEL_TENSOR.ENC_FFN_UP: "enc.blk.{bid}.ffn_up",
-    MODEL_TENSOR.ENC_OUTPUT_NORM: "enc.output_norm",
-    MODEL_TENSOR.CLS: "cls",
-    MODEL_TENSOR.CLS_OUT: "cls.output",
-    MODEL_TENSOR.CONV1D: "conv1d",
-    MODEL_TENSOR.CONVNEXT_DW: "convnext.{bid}.dw",
-    MODEL_TENSOR.CONVNEXT_NORM: "convnext.{bid}.norm",
-    MODEL_TENSOR.CONVNEXT_PW1: "convnext.{bid}.pw1",
-    MODEL_TENSOR.CONVNEXT_PW2: "convnext.{bid}.pw2",
-    MODEL_TENSOR.CONVNEXT_GAMMA: "convnext.{bid}.gamma",
-    MODEL_TENSOR.POSNET_CONV1: "posnet.{bid}.conv1",
-    MODEL_TENSOR.POSNET_CONV2: "posnet.{bid}.conv2",
-    MODEL_TENSOR.POSNET_NORM: "posnet.{bid}.norm",
-    MODEL_TENSOR.POSNET_NORM1: "posnet.{bid}.norm1",
-    MODEL_TENSOR.POSNET_NORM2: "posnet.{bid}.norm2",
-    MODEL_TENSOR.POSNET_ATTN_NORM: "posnet.{bid}.attn_norm",
-    MODEL_TENSOR.POSNET_ATTN_Q: "posnet.{bid}.attn_q",
-    MODEL_TENSOR.POSNET_ATTN_K: "posnet.{bid}.attn_k",
-    MODEL_TENSOR.POSNET_ATTN_V: "posnet.{bid}.attn_v",
-    MODEL_TENSOR.POSNET_ATTN_OUT: "posnet.{bid}.attn_output",
-    MODEL_TENSOR.SHORTCONV_CONV: "blk.{bid}.shortconv.conv",
-    MODEL_TENSOR.SHORTCONV_INPROJ: "blk.{bid}.shortconv.in_proj",
-    MODEL_TENSOR.SHORTCONV_OUTPROJ: "blk.{bid}.shortconv.out_proj",
+    MODEL_TENSOR.TOKEN_EMBD:                "token_embd",
+    MODEL_TENSOR.TOKEN_EMBD_NORM:           "token_embd_norm",
+    MODEL_TENSOR.TOKEN_TYPES:               "token_types",
+    MODEL_TENSOR.POS_EMBD:                  "position_embd",
+    MODEL_TENSOR.OUTPUT_NORM:               "output_norm",
+    MODEL_TENSOR.OUTPUT:                    "output",
+    MODEL_TENSOR.DENSE_2_OUT:                "dense_2", # embeddinggemma 2_Dense
+    MODEL_TENSOR.DENSE_3_OUT:                "dense_3", # embeddinggemma 2_Dense
+    MODEL_TENSOR.ROPE_FREQS:                "rope_freqs",
+    MODEL_TENSOR.ROPE_FACTORS_LONG:         "rope_factors_long",
+    MODEL_TENSOR.ROPE_FACTORS_SHORT:        "rope_factors_short",
+    MODEL_TENSOR.ATTN_NORM:                 "blk.{bid}.attn_norm",
+    MODEL_TENSOR.ATTN_NORM_2:               "blk.{bid}.attn_norm_2",
+    MODEL_TENSOR.ATTN_QKV:                  "blk.{bid}.attn_qkv",
+    MODEL_TENSOR.ATTN_Q:                    "blk.{bid}.attn_q",
+    MODEL_TENSOR.ATTN_K:                    "blk.{bid}.attn_k",
+    MODEL_TENSOR.ATTN_V:                    "blk.{bid}.attn_v",
+    MODEL_TENSOR.ATTN_OUT:                  "blk.{bid}.attn_output",
+    MODEL_TENSOR.ATTN_ROT_EMBD:             "blk.{bid}.attn_rot_embd",
+    MODEL_TENSOR.ATTN_SINKS:                "blk.{bid}.attn_sinks",
+    MODEL_TENSOR.ATTN_Q_NORM:               "blk.{bid}.attn_q_norm",
+    MODEL_TENSOR.ATTN_K_NORM:               "blk.{bid}.attn_k_norm",
+    MODEL_TENSOR.ATTN_OUT_NORM:             "blk.{bid}.attn_output_norm",
+    MODEL_TENSOR.ATTN_POST_NORM:            "blk.{bid}.post_attention_norm",
+    MODEL_TENSOR.FFN_GATE_INP:              "blk.{bid}.ffn_gate_inp",
+    MODEL_TENSOR.FFN_GATE_INP_SHEXP:        "blk.{bid}.ffn_gate_inp_shexp",
+    MODEL_TENSOR.FFN_NORM:                  "blk.{bid}.ffn_norm",
+    MODEL_TENSOR.FFN_PRE_NORM:              "blk.{bid}.ffn_norm",
+    MODEL_TENSOR.FFN_POST_NORM:             "blk.{bid}.post_ffw_norm",
+    MODEL_TENSOR.FFN_GATE:                  "blk.{bid}.ffn_gate",
+    MODEL_TENSOR.FFN_DOWN:                  "blk.{bid}.ffn_down",
+    MODEL_TENSOR.FFN_UP:                    "blk.{bid}.ffn_up",
+    MODEL_TENSOR.FFN_GATE_SHEXP:            "blk.{bid}.ffn_gate_shexp",
+    MODEL_TENSOR.FFN_DOWN_SHEXP:            "blk.{bid}.ffn_down_shexp",
+    MODEL_TENSOR.FFN_UP_SHEXP:              "blk.{bid}.ffn_up_shexp",
+    MODEL_TENSOR.FFN_GATE_CHEXP:            "blk.{bid}.ffn_gate_chexps",
+    MODEL_TENSOR.FFN_DOWN_CHEXP:            "blk.{bid}.ffn_down_chexps",
+    MODEL_TENSOR.FFN_UP_CHEXP:              "blk.{bid}.ffn_up_chexps",
+    MODEL_TENSOR.FFN_ACT:                   "blk.{bid}.ffn",
+    MODEL_TENSOR.FFN_NORM_EXP:              "blk.{bid}.ffn_norm_exps",
+    MODEL_TENSOR.FFN_GATE_EXP:              "blk.{bid}.ffn_gate_exps",
+    MODEL_TENSOR.FFN_DOWN_EXP:              "blk.{bid}.ffn_down_exps",
+    MODEL_TENSOR.FFN_UP_EXP:                "blk.{bid}.ffn_up_exps",
+    MODEL_TENSOR.FFN_EXP_PROBS_B:           "blk.{bid}.exp_probs_b",
+    MODEL_TENSOR.LAYER_OUT_NORM:            "blk.{bid}.layer_output_norm",
+    MODEL_TENSOR.PER_LAYER_TOKEN_EMBD:      "per_layer_token_embd",           # gemma3n
+    MODEL_TENSOR.PER_LAYER_MODEL_PROJ:      "per_layer_model_proj",           # gemma3n
+    MODEL_TENSOR.PER_LAYER_PROJ_NORM:       "per_layer_proj_norm",            # gemma3n
+    MODEL_TENSOR.ALTUP_UNEMBD_PROJ:         "altup_unembd_proj",              # gemma3n
+    MODEL_TENSOR.ALTUP_PROJ:                "altup_proj",                     # gemma3n
+    MODEL_TENSOR.PER_LAYER_INP_GATE:        "blk.{bid}.inp_gate",             # gemma3n
+    MODEL_TENSOR.PER_LAYER_PROJ:            "blk.{bid}.proj",                 # gemma3n
+    MODEL_TENSOR.PER_LAYER_POST_NORM:       "blk.{bid}.post_norm",            # gemma3n
+    MODEL_TENSOR.ALTUP_CORRECT_COEF:        "blk.{bid}.altup_correct_coef",   # gemma3n
+    MODEL_TENSOR.ALTUP_CORRECT_SCALE:       "blk.{bid}.altup_correct_scale",  # gemma3n
+    MODEL_TENSOR.ALTUP_PREDICT_COEF:        "blk.{bid}.altup_predict_coef",   # gemma3n
+    MODEL_TENSOR.ALTUP_ROUTER:              "blk.{bid}.altup_router",         # gemma3n
+    MODEL_TENSOR.ALTUP_ROUTER_NORM:         "blk.{bid}.altup_router_norm",    # gemma3n
+    MODEL_TENSOR.LAUREL_L:                  "blk.{bid}.laurel_l",             # gemma3n
+    MODEL_TENSOR.LAUREL_R:                  "blk.{bid}.laurel_r",             # gemma3n
+    MODEL_TENSOR.LAUREL_POST_NORM:          "blk.{bid}.laurel_post_norm",     # gemma3n
+    MODEL_TENSOR.SSM_IN:                    "blk.{bid}.ssm_in",
+    MODEL_TENSOR.SSM_CONV1D:                "blk.{bid}.ssm_conv1d",
+    MODEL_TENSOR.SSM_X:                     "blk.{bid}.ssm_x",
+    MODEL_TENSOR.SSM_DT:                    "blk.{bid}.ssm_dt",
+    MODEL_TENSOR.SSM_DT_NORM:               "blk.{bid}.ssm_dt_norm",
+    MODEL_TENSOR.SSM_A:                     "blk.{bid}.ssm_a",
+    MODEL_TENSOR.SSM_B_NORM:                "blk.{bid}.ssm_b_norm",
+    MODEL_TENSOR.SSM_C_NORM:                "blk.{bid}.ssm_c_norm",
+    MODEL_TENSOR.SSM_D:                     "blk.{bid}.ssm_d",
+    MODEL_TENSOR.SSM_NORM:                  "blk.{bid}.ssm_norm",
+    MODEL_TENSOR.SSM_OUT:                   "blk.{bid}.ssm_out",
+    MODEL_TENSOR.TIME_MIX_W0:               "blk.{bid}.time_mix_w0",
+    MODEL_TENSOR.TIME_MIX_W1:               "blk.{bid}.time_mix_w1",
+    MODEL_TENSOR.TIME_MIX_W2:               "blk.{bid}.time_mix_w2",
+    MODEL_TENSOR.TIME_MIX_A0:               "blk.{bid}.time_mix_a0",
+    MODEL_TENSOR.TIME_MIX_A1:               "blk.{bid}.time_mix_a1",
+    MODEL_TENSOR.TIME_MIX_A2:               "blk.{bid}.time_mix_a2",
+    MODEL_TENSOR.TIME_MIX_V0:               "blk.{bid}.time_mix_v0",
+    MODEL_TENSOR.TIME_MIX_V1:               "blk.{bid}.time_mix_v1",
+    MODEL_TENSOR.TIME_MIX_V2:               "blk.{bid}.time_mix_v2",
+    MODEL_TENSOR.TIME_MIX_G1:               "blk.{bid}.time_mix_g1",
+    MODEL_TENSOR.TIME_MIX_G2:               "blk.{bid}.time_mix_g2",
+    MODEL_TENSOR.TIME_MIX_K_K:              "blk.{bid}.time_mix_k_k",
+    MODEL_TENSOR.TIME_MIX_K_A:              "blk.{bid}.time_mix_k_a",
+    MODEL_TENSOR.TIME_MIX_R_K:              "blk.{bid}.time_mix_r_k",
+    MODEL_TENSOR.TIME_MIX_LERP_X:           "blk.{bid}.time_mix_lerp_x",
+    MODEL_TENSOR.TIME_MIX_LERP_K:           "blk.{bid}.time_mix_lerp_k",
+    MODEL_TENSOR.TIME_MIX_LERP_V:           "blk.{bid}.time_mix_lerp_v",
+    MODEL_TENSOR.TIME_MIX_LERP_R:           "blk.{bid}.time_mix_lerp_r",
+    MODEL_TENSOR.TIME_MIX_LERP_G:           "blk.{bid}.time_mix_lerp_g",
+    MODEL_TENSOR.TIME_MIX_LERP_FUSED:       "blk.{bid}.time_mix_lerp_fused",
+    MODEL_TENSOR.TIME_MIX_LERP_W:           "blk.{bid}.time_mix_lerp_w",
+    MODEL_TENSOR.TIME_MIX_FIRST:            "blk.{bid}.time_mix_first",
+    MODEL_TENSOR.TIME_MIX_DECAY:            "blk.{bid}.time_mix_decay",
+    MODEL_TENSOR.TIME_MIX_DECAY_W1:         "blk.{bid}.time_mix_decay_w1",
+    MODEL_TENSOR.TIME_MIX_DECAY_W2:         "blk.{bid}.time_mix_decay_w2",
+    MODEL_TENSOR.TIME_MIX_KEY:              "blk.{bid}.time_mix_key",
+    MODEL_TENSOR.TIME_MIX_VALUE:            "blk.{bid}.time_mix_value",
+    MODEL_TENSOR.TIME_MIX_RECEPTANCE:       "blk.{bid}.time_mix_receptance",
+    MODEL_TENSOR.TIME_MIX_GATE:             "blk.{bid}.time_mix_gate",
+    MODEL_TENSOR.TIME_MIX_LN:               "blk.{bid}.time_mix_ln",
+    MODEL_TENSOR.TIME_MIX_OUTPUT:           "blk.{bid}.time_mix_output",
+    MODEL_TENSOR.CHANNEL_MIX_LERP_K:        "blk.{bid}.channel_mix_lerp_k",
+    MODEL_TENSOR.CHANNEL_MIX_LERP_R:        "blk.{bid}.channel_mix_lerp_r",
+    MODEL_TENSOR.CHANNEL_MIX_KEY:           "blk.{bid}.channel_mix_key",
+    MODEL_TENSOR.CHANNEL_MIX_RECEPTANCE:    "blk.{bid}.channel_mix_receptance",
+    MODEL_TENSOR.CHANNEL_MIX_VALUE:         "blk.{bid}.channel_mix_value",
+    MODEL_TENSOR.ATTN_Q_A:                  "blk.{bid}.attn_q_a",
+    MODEL_TENSOR.ATTN_Q_B:                  "blk.{bid}.attn_q_b",
+    MODEL_TENSOR.ATTN_KV_A_MQA:             "blk.{bid}.attn_kv_a_mqa",
+    MODEL_TENSOR.ATTN_KV_B:                 "blk.{bid}.attn_kv_b",
+    MODEL_TENSOR.ATTN_K_B:                  "blk.{bid}.attn_k_b",
+    MODEL_TENSOR.ATTN_V_B:                  "blk.{bid}.attn_v_b",
+    MODEL_TENSOR.ATTN_Q_A_NORM:             "blk.{bid}.attn_q_a_norm",
+    MODEL_TENSOR.ATTN_KV_A_NORM:            "blk.{bid}.attn_kv_a_norm",
+    MODEL_TENSOR.ATTN_SUB_NORM:             "blk.{bid}.attn_sub_norm",
+    MODEL_TENSOR.FFN_SUB_NORM:              "blk.{bid}.ffn_sub_norm",
+    MODEL_TENSOR.DEC_ATTN_NORM:             "dec.blk.{bid}.attn_norm",
+    MODEL_TENSOR.DEC_ATTN_Q:                "dec.blk.{bid}.attn_q",
+    MODEL_TENSOR.DEC_ATTN_K:                "dec.blk.{bid}.attn_k",
+    MODEL_TENSOR.DEC_ATTN_V:                "dec.blk.{bid}.attn_v",
+    MODEL_TENSOR.DEC_ATTN_OUT:              "dec.blk.{bid}.attn_o",
+    MODEL_TENSOR.DEC_ATTN_REL_B:            "dec.blk.{bid}.attn_rel_b",
+    MODEL_TENSOR.DEC_CROSS_ATTN_NORM:       "dec.blk.{bid}.cross_attn_norm",
+    MODEL_TENSOR.DEC_CROSS_ATTN_Q:          "dec.blk.{bid}.cross_attn_q",
+    MODEL_TENSOR.DEC_CROSS_ATTN_K:          "dec.blk.{bid}.cross_attn_k",
+    MODEL_TENSOR.DEC_CROSS_ATTN_V:          "dec.blk.{bid}.cross_attn_v",
+    MODEL_TENSOR.DEC_CROSS_ATTN_OUT:        "dec.blk.{bid}.cross_attn_o",
+    MODEL_TENSOR.DEC_CROSS_ATTN_REL_B:      "dec.blk.{bid}.cross_attn_rel_b",
+    MODEL_TENSOR.DEC_FFN_NORM:              "dec.blk.{bid}.ffn_norm",
+    MODEL_TENSOR.DEC_FFN_GATE:              "dec.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.DEC_FFN_DOWN:              "dec.blk.{bid}.ffn_down",
+    MODEL_TENSOR.DEC_FFN_UP:                "dec.blk.{bid}.ffn_up",
+    MODEL_TENSOR.DEC_OUTPUT_NORM:           "dec.output_norm",
+    MODEL_TENSOR.ENC_ATTN_NORM:             "enc.blk.{bid}.attn_norm",
+    MODEL_TENSOR.ENC_ATTN_Q:                "enc.blk.{bid}.attn_q",
+    MODEL_TENSOR.ENC_ATTN_K:                "enc.blk.{bid}.attn_k",
+    MODEL_TENSOR.ENC_ATTN_V:                "enc.blk.{bid}.attn_v",
+    MODEL_TENSOR.ENC_ATTN_OUT:              "enc.blk.{bid}.attn_o",
+    MODEL_TENSOR.ENC_ATTN_REL_B:            "enc.blk.{bid}.attn_rel_b",
+    MODEL_TENSOR.ENC_FFN_NORM:              "enc.blk.{bid}.ffn_norm",
+    MODEL_TENSOR.ENC_FFN_GATE:              "enc.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.ENC_FFN_DOWN:              "enc.blk.{bid}.ffn_down",
+    MODEL_TENSOR.ENC_FFN_UP:                "enc.blk.{bid}.ffn_up",
+    MODEL_TENSOR.ENC_OUTPUT_NORM:           "enc.output_norm",
+    MODEL_TENSOR.CLS:                       "cls",
+    MODEL_TENSOR.CLS_OUT:                   "cls.output",
+    MODEL_TENSOR.CONV1D:                    "conv1d",
+    MODEL_TENSOR.CONVNEXT_DW:               "convnext.{bid}.dw",
+    MODEL_TENSOR.CONVNEXT_NORM:             "convnext.{bid}.norm",
+    MODEL_TENSOR.CONVNEXT_PW1:              "convnext.{bid}.pw1",
+    MODEL_TENSOR.CONVNEXT_PW2:              "convnext.{bid}.pw2",
+    MODEL_TENSOR.CONVNEXT_GAMMA:            "convnext.{bid}.gamma",
+    MODEL_TENSOR.POSNET_CONV1:              "posnet.{bid}.conv1",
+    MODEL_TENSOR.POSNET_CONV2:              "posnet.{bid}.conv2",
+    MODEL_TENSOR.POSNET_NORM:               "posnet.{bid}.norm",
+    MODEL_TENSOR.POSNET_NORM1:              "posnet.{bid}.norm1",
+    MODEL_TENSOR.POSNET_NORM2:              "posnet.{bid}.norm2",
+    MODEL_TENSOR.POSNET_ATTN_NORM:          "posnet.{bid}.attn_norm",
+    MODEL_TENSOR.POSNET_ATTN_Q:             "posnet.{bid}.attn_q",
+    MODEL_TENSOR.POSNET_ATTN_K:             "posnet.{bid}.attn_k",
+    MODEL_TENSOR.POSNET_ATTN_V:             "posnet.{bid}.attn_v",
+    MODEL_TENSOR.POSNET_ATTN_OUT:           "posnet.{bid}.attn_output",
+    MODEL_TENSOR.SHORTCONV_CONV:            "blk.{bid}.shortconv.conv",
+    MODEL_TENSOR.SHORTCONV_INPROJ:          "blk.{bid}.shortconv.in_proj",
+    MODEL_TENSOR.SHORTCONV_OUTPROJ:         "blk.{bid}.shortconv.out_proj",
     # vision
-    MODEL_TENSOR.V_MMPROJ: "mm.{bid}",
-    MODEL_TENSOR.V_MMPROJ_FC: "mm.model.fc",
-    MODEL_TENSOR.V_MMPROJ_MLP: "mm.model.mlp.{bid}",
-    MODEL_TENSOR.V_MMPROJ_PEG: "mm.model.peg.{bid}",
-    MODEL_TENSOR.V_ENC_EMBD_CLS: "v.class_embd",
-    MODEL_TENSOR.V_ENC_EMBD_PATCH: "v.patch_embd",
-    MODEL_TENSOR.V_ENC_EMBD_POS: "v.position_embd",
-    MODEL_TENSOR.V_ENC_ATTN_Q: "v.blk.{bid}.attn_q",
-    MODEL_TENSOR.V_ENC_ATTN_Q_NORM: "v.blk.{bid}.attn_q_norm",
-    MODEL_TENSOR.V_ENC_ATTN_K: "v.blk.{bid}.attn_k",
-    MODEL_TENSOR.V_ENC_ATTN_K_NORM: "v.blk.{bid}.attn_k_norm",
-    MODEL_TENSOR.V_ENC_ATTN_V: "v.blk.{bid}.attn_v",
-    MODEL_TENSOR.V_ENC_INPUT_NORM: "v.blk.{bid}.ln1",
-    MODEL_TENSOR.V_ENC_ATTN_O: "v.blk.{bid}.attn_out",
-    MODEL_TENSOR.V_ENC_ATTN_O_NORM: "v.blk.{bid}.attn_out_norm",
-    MODEL_TENSOR.V_ENC_POST_ATTN_NORM: "v.blk.{bid}.ln2",
-    MODEL_TENSOR.V_ENC_FFN_UP: "v.blk.{bid}.ffn_up",
-    MODEL_TENSOR.V_ENC_FFN_GATE: "v.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.V_ENC_FFN_DOWN: "v.blk.{bid}.ffn_down",
-    MODEL_TENSOR.V_LAYER_SCALE_1: "v.blk.{bid}.ls1",
-    MODEL_TENSOR.V_LAYER_SCALE_2: "v.blk.{bid}.ls2",
-    MODEL_TENSOR.V_PRE_NORM: "v.pre_ln",
-    MODEL_TENSOR.V_POST_NORM: "v.post_ln",
-    MODEL_TENSOR.V_MM_INP_PROJ: "mm.input_projection",
-    MODEL_TENSOR.V_MM_INP_NORM: "mm.input_norm",
-    MODEL_TENSOR.V_MM_SOFT_EMB_NORM: "mm.soft_emb_norm",
-    MODEL_TENSOR.V_RESMPL_POS_EMBD_K: "resampler.pos_embd_k",
-    MODEL_TENSOR.V_RESMPL_ATTN_Q: "resampler.attn.q",
-    MODEL_TENSOR.V_RESMPL_ATTN_K: "resampler.attn.k",
-    MODEL_TENSOR.V_RESMPL_ATTN_V: "resampler.attn.v",
-    MODEL_TENSOR.V_RESMPL_ATTN_OUT: "resampler.attn.out",
-    MODEL_TENSOR.V_RESMPL_KV: "resampler.kv",
-    MODEL_TENSOR.V_RESMPL_KV_NORM: "resampler.ln_kv",
-    MODEL_TENSOR.V_RESMPL_POST_NORM: "resampler.ln_post",
-    MODEL_TENSOR.V_RESMPL_Q_NORM: "resampler.ln_q",
-    MODEL_TENSOR.V_RESMPL_PROJ: "resampler.proj",
-    MODEL_TENSOR.V_RESMPL_QUERY: "resampler.query",
-    MODEL_TENSOR.V_TOK_EMBD_IMG_BREAK: "v.token_embd.img_break",  # pixtral
-    MODEL_TENSOR.V_MM_PATCH_MERGER: "mm.patch_merger",  # mistral small 3.1
+    MODEL_TENSOR.V_MMPROJ:                  "mm.{bid}",
+    MODEL_TENSOR.V_MMPROJ_FC:               "mm.model.fc",
+    MODEL_TENSOR.V_MMPROJ_MLP:              "mm.model.mlp.{bid}",
+    MODEL_TENSOR.V_MMPROJ_PEG:              "mm.model.peg.{bid}",
+    MODEL_TENSOR.V_ENC_EMBD_CLS:            "v.class_embd",
+    MODEL_TENSOR.V_ENC_EMBD_PATCH:          "v.patch_embd",
+    MODEL_TENSOR.V_ENC_EMBD_POS:            "v.position_embd",
+    MODEL_TENSOR.V_ENC_ATTN_Q:              "v.blk.{bid}.attn_q",
+    MODEL_TENSOR.V_ENC_ATTN_Q_NORM:         "v.blk.{bid}.attn_q_norm",
+    MODEL_TENSOR.V_ENC_ATTN_K:              "v.blk.{bid}.attn_k",
+    MODEL_TENSOR.V_ENC_ATTN_K_NORM:         "v.blk.{bid}.attn_k_norm",
+    MODEL_TENSOR.V_ENC_ATTN_V:              "v.blk.{bid}.attn_v",
+    MODEL_TENSOR.V_ENC_INPUT_NORM:          "v.blk.{bid}.ln1",
+    MODEL_TENSOR.V_ENC_ATTN_O:              "v.blk.{bid}.attn_out",
+    MODEL_TENSOR.V_ENC_ATTN_O_NORM:         "v.blk.{bid}.attn_out_norm",
+    MODEL_TENSOR.V_ENC_POST_ATTN_NORM:      "v.blk.{bid}.ln2",
+    MODEL_TENSOR.V_ENC_FFN_UP:              "v.blk.{bid}.ffn_up",
+    MODEL_TENSOR.V_ENC_FFN_GATE:            "v.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.V_ENC_FFN_DOWN:            "v.blk.{bid}.ffn_down",
+    MODEL_TENSOR.V_LAYER_SCALE_1:           "v.blk.{bid}.ls1",
+    MODEL_TENSOR.V_LAYER_SCALE_2:           "v.blk.{bid}.ls2",
+    MODEL_TENSOR.V_PRE_NORM:                "v.pre_ln",
+    MODEL_TENSOR.V_POST_NORM:               "v.post_ln",
+    MODEL_TENSOR.V_MM_INP_PROJ:             "mm.input_projection",
+    MODEL_TENSOR.V_MM_INP_NORM:             "mm.input_norm",
+    MODEL_TENSOR.V_MM_SOFT_EMB_NORM:        "mm.soft_emb_norm",
+    MODEL_TENSOR.V_RESMPL_POS_EMBD_K:       "resampler.pos_embd_k",
+    MODEL_TENSOR.V_RESMPL_ATTN_Q:           "resampler.attn.q",
+    MODEL_TENSOR.V_RESMPL_ATTN_K:           "resampler.attn.k",
+    MODEL_TENSOR.V_RESMPL_ATTN_V:           "resampler.attn.v",
+    MODEL_TENSOR.V_RESMPL_ATTN_OUT:         "resampler.attn.out",
+    MODEL_TENSOR.V_RESMPL_KV:               "resampler.kv",
+    MODEL_TENSOR.V_RESMPL_KV_NORM:          "resampler.ln_kv",
+    MODEL_TENSOR.V_RESMPL_POST_NORM:        "resampler.ln_post",
+    MODEL_TENSOR.V_RESMPL_Q_NORM:           "resampler.ln_q",
+    MODEL_TENSOR.V_RESMPL_PROJ:             "resampler.proj",
+    MODEL_TENSOR.V_RESMPL_QUERY:            "resampler.query",
+    MODEL_TENSOR.V_TOK_EMBD_IMG_BREAK:      "v.token_embd.img_break", # pixtral
+    MODEL_TENSOR.V_MM_PATCH_MERGER:         "mm.patch_merger", # mistral small 3.1
     # audio (mtmd)
-    MODEL_TENSOR.A_ENC_EMBD_POS: "a.position_embd",
-    MODEL_TENSOR.A_ENC_CONV1D: "a.conv1d.{bid}",
-    MODEL_TENSOR.A_PRE_NORM: "a.pre_ln",
-    MODEL_TENSOR.A_POST_NORM: "a.post_ln",
-    MODEL_TENSOR.A_ENC_ATTN_Q: "a.blk.{bid}.attn_q",
-    MODEL_TENSOR.A_ENC_ATTN_K: "a.blk.{bid}.attn_k",
-    MODEL_TENSOR.A_ENC_ATTN_V: "a.blk.{bid}.attn_v",
-    MODEL_TENSOR.A_ENC_INPUT_NORM: "a.blk.{bid}.ln1",
-    MODEL_TENSOR.A_ENC_OUTPUT: "a.blk.{bid}.attn_out",
-    MODEL_TENSOR.A_ENC_OUTPUT_NORM: "a.blk.{bid}.ln2",
-    MODEL_TENSOR.A_ENC_FFN_UP: "a.blk.{bid}.ffn_up",
-    MODEL_TENSOR.A_ENC_FFN_GATE: "a.blk.{bid}.ffn_gate",
-    MODEL_TENSOR.A_ENC_FFN_DOWN: "a.blk.{bid}.ffn_down",
-    MODEL_TENSOR.A_MMPROJ: "mm.a.mlp.{bid}",
-    MODEL_TENSOR.A_MMPROJ_FC: "mm.a.fc",
-    MODEL_TENSOR.A_MM_NORM_PRE: "mm.a.norm_pre",
-    MODEL_TENSOR.A_MM_NORM_MID: "mm.a.norm_mid",
+    MODEL_TENSOR.A_ENC_EMBD_POS:            "a.position_embd",
+    MODEL_TENSOR.A_ENC_CONV1D:              "a.conv1d.{bid}",
+    MODEL_TENSOR.A_PRE_NORM:                "a.pre_ln",
+    MODEL_TENSOR.A_POST_NORM:               "a.post_ln",
+    MODEL_TENSOR.A_ENC_ATTN_Q:              "a.blk.{bid}.attn_q",
+    MODEL_TENSOR.A_ENC_ATTN_K:              "a.blk.{bid}.attn_k",
+    MODEL_TENSOR.A_ENC_ATTN_V:              "a.blk.{bid}.attn_v",
+    MODEL_TENSOR.A_ENC_INPUT_NORM:          "a.blk.{bid}.ln1",
+    MODEL_TENSOR.A_ENC_OUTPUT:              "a.blk.{bid}.attn_out",
+    MODEL_TENSOR.A_ENC_OUTPUT_NORM:         "a.blk.{bid}.ln2",
+    MODEL_TENSOR.A_ENC_FFN_UP:              "a.blk.{bid}.ffn_up",
+    MODEL_TENSOR.A_ENC_FFN_GATE:            "a.blk.{bid}.ffn_gate",
+    MODEL_TENSOR.A_ENC_FFN_DOWN:            "a.blk.{bid}.ffn_down",
+    MODEL_TENSOR.A_MMPROJ:                  "mm.a.mlp.{bid}",
+    MODEL_TENSOR.A_MMPROJ_FC:               "mm.a.fc",
+    MODEL_TENSOR.A_MM_NORM_PRE:             "mm.a.norm_pre",
+    MODEL_TENSOR.A_MM_NORM_MID:             "mm.a.norm_mid",
     # NextN/MTP
-    MODEL_TENSOR.NEXTN_EH_PROJ: "blk.{bid}.nextn.eh_proj",
-    MODEL_TENSOR.NEXTN_EMBED_TOKENS: "blk.{bid}.nextn.embed_tokens",
-    MODEL_TENSOR.NEXTN_ENORM: "blk.{bid}.nextn.enorm",
-    MODEL_TENSOR.NEXTN_HNORM: "blk.{bid}.nextn.hnorm",
-    MODEL_TENSOR.NEXTN_SHARED_HEAD_HEAD: "blk.{bid}.nextn.shared_head_head",
-    MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM: "blk.{bid}.nextn.shared_head_norm",
+    MODEL_TENSOR.NEXTN_EH_PROJ:             "blk.{bid}.nextn.eh_proj",
+    MODEL_TENSOR.NEXTN_EMBED_TOKENS:        "blk.{bid}.nextn.embed_tokens",
+    MODEL_TENSOR.NEXTN_ENORM:               "blk.{bid}.nextn.enorm",
+    MODEL_TENSOR.NEXTN_HNORM:               "blk.{bid}.nextn.hnorm",
+    MODEL_TENSOR.NEXTN_SHARED_HEAD_HEAD:    "blk.{bid}.nextn.shared_head_head",
+    MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM:    "blk.{bid}.nextn.shared_head_norm",
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -2220,7 +2214,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_DOWN,
     ],
-    MODEL_ARCH.CHATGLM: [
+    MODEL_ARCH.CHATGLM : [
         MODEL_TENSOR.TOKEN_EMBD,
         MODEL_TENSOR.ROPE_FREQS,
         MODEL_TENSOR.OUTPUT_NORM,
@@ -2235,7 +2229,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
     ],
-    MODEL_ARCH.GLM4: [
+    MODEL_ARCH.GLM4 : [
         MODEL_TENSOR.TOKEN_EMBD,
         MODEL_TENSOR.ROPE_FREQS,
         MODEL_TENSOR.OUTPUT_NORM,
@@ -2628,30 +2622,36 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
     MODEL_ARCH.FALCON_H1: [
         # Token embedding
         MODEL_TENSOR.TOKEN_EMBD,
+
         # Input layernorm
         MODEL_TENSOR.ATTN_NORM,
+
         # Attention components
-        MODEL_TENSOR.ATTN_Q,  # Query projection
-        MODEL_TENSOR.ATTN_K,  # Key projection
-        MODEL_TENSOR.ATTN_V,  # Value projection
-        MODEL_TENSOR.ATTN_OUT,  # Output projection
+        MODEL_TENSOR.ATTN_Q,         # Query projection
+        MODEL_TENSOR.ATTN_K,         # Key projection
+        MODEL_TENSOR.ATTN_V,         # Value projection
+        MODEL_TENSOR.ATTN_OUT,       # Output projection
+
         # SSM components (Mamba2 specific)
-        MODEL_TENSOR.SSM_IN,  # Input projection for SSM
-        MODEL_TENSOR.SSM_CONV1D,  # Convolution layer
-        MODEL_TENSOR.SSM_DT,  # Delta time projection
-        MODEL_TENSOR.SSM_A,  # A parameter (log form)
-        MODEL_TENSOR.SSM_D,  # D parameter
-        MODEL_TENSOR.SSM_NORM,  # Normalization in SSM
-        MODEL_TENSOR.SSM_OUT,  # Output projection
+        MODEL_TENSOR.SSM_IN,         # Input projection for SSM
+        MODEL_TENSOR.SSM_CONV1D,     # Convolution layer
+        MODEL_TENSOR.SSM_DT,         # Delta time projection
+        MODEL_TENSOR.SSM_A,          # A parameter (log form)
+        MODEL_TENSOR.SSM_D,          # D parameter
+        MODEL_TENSOR.SSM_NORM,       # Normalization in SSM
+        MODEL_TENSOR.SSM_OUT,        # Output projection
+
         # Pre-feedforward layernorm
         MODEL_TENSOR.FFN_PRE_NORM,
+
         # Feed-forward network components
-        MODEL_TENSOR.FFN_GATE,  # Gate projection (SwiGLU)
-        MODEL_TENSOR.FFN_DOWN,  # Down projection
-        MODEL_TENSOR.FFN_UP,  # Up projection
+        MODEL_TENSOR.FFN_GATE,       # Gate projection (SwiGLU)
+        MODEL_TENSOR.FFN_DOWN,       # Down projection
+        MODEL_TENSOR.FFN_UP,         # Up projection
+
         # Post-feedforward layernorm
-        MODEL_TENSOR.OUTPUT_NORM,  # Final layer norm
-        MODEL_TENSOR.OUTPUT,  # Output projection (lm_head)
+        MODEL_TENSOR.OUTPUT_NORM,    # Final layer norm
+        MODEL_TENSOR.OUTPUT,         # Output projection (lm_head)
     ],
     MODEL_ARCH.HUNYUAN_MOE: [
         MODEL_TENSOR.TOKEN_EMBD,
@@ -2732,7 +2732,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_NORM,
-        MODEL_TENSOR.ATTN_NORM,  # operator_norm
+        MODEL_TENSOR.ATTN_NORM, # operator_norm
         MODEL_TENSOR.ATTN_Q_NORM,
         MODEL_TENSOR.ATTN_K_NORM,
         MODEL_TENSOR.ATTN_Q,
@@ -2751,7 +2751,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_DOWN,
         MODEL_TENSOR.FFN_UP,
         MODEL_TENSOR.FFN_NORM,
-        MODEL_TENSOR.ATTN_NORM,  # operator_norm
+        MODEL_TENSOR.ATTN_NORM, # operator_norm
         MODEL_TENSOR.ATTN_Q_NORM,
         MODEL_TENSOR.ATTN_K_NORM,
         MODEL_TENSOR.ATTN_Q,
@@ -2900,69 +2900,69 @@ MODEL_TENSOR_SKIP: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
 
 
 class TokenType(IntEnum):
-    NORMAL = 1
-    UNKNOWN = 2
-    CONTROL = 3
+    NORMAL       = 1
+    UNKNOWN      = 2
+    CONTROL      = 3
     USER_DEFINED = 4
-    UNUSED = 5
-    BYTE = 6
+    UNUSED       = 5
+    BYTE         = 6
 
 
 class RopeScalingType(Enum):
-    NONE = "none"
-    LINEAR = "linear"
-    YARN = "yarn"
-    LONGROPE = "longrope"
+    NONE     = 'none'
+    LINEAR   = 'linear'
+    YARN     = 'yarn'
+    LONGROPE = 'longrope'
 
 
 class PoolingType(IntEnum):
     NONE = 0
     MEAN = 1
-    CLS = 2
+    CLS  = 2
     LAST = 3
     RANK = 4
 
 
 class GGMLQuantizationType(IntEnum):
-    F32 = 0
-    F16 = 1
-    Q4_0 = 2
-    Q4_1 = 3
-    Q5_0 = 6
-    Q5_1 = 7
-    Q8_0 = 8
-    Q8_1 = 9
-    Q2_K = 10
-    Q3_K = 11
-    Q4_K = 12
-    Q5_K = 13
-    Q6_K = 14
-    Q8_K = 15
+    F32     = 0
+    F16     = 1
+    Q4_0    = 2
+    Q4_1    = 3
+    Q5_0    = 6
+    Q5_1    = 7
+    Q8_0    = 8
+    Q8_1    = 9
+    Q2_K    = 10
+    Q3_K    = 11
+    Q4_K    = 12
+    Q5_K    = 13
+    Q6_K    = 14
+    Q8_K    = 15
     IQ2_XXS = 16
-    IQ2_XS = 17
+    IQ2_XS  = 17
     IQ3_XXS = 18
-    IQ1_S = 19
-    IQ4_NL = 20
-    IQ3_S = 21
-    IQ2_S = 22
-    IQ4_XS = 23
-    I8 = 24
-    I16 = 25
-    I32 = 26
-    I64 = 27
-    F64 = 28
-    IQ1_M = 29
-    BF16 = 30
-    TQ1_0 = 34
-    TQ2_0 = 35
-    MXFP4 = 39
-    MXFP6_E3M2 = 40
-    MXFP6_E2M3 = 41
+    IQ1_S   = 19
+    IQ4_NL  = 20
+    IQ3_S   = 21
+    IQ2_S   = 22
+    IQ4_XS  = 23
+    I8      = 24
+    I16     = 25
+    I32     = 26
+    I64     = 27
+    F64     = 28
+    IQ1_M   = 29
+    BF16    = 30
+    TQ1_0   = 34
+    TQ2_0   = 35
+    MXFP4   = 39
+    MXFP6_E3M2   = 40
+    MXFP6_E2M3   = 41
 
 
 class ExpertGatingFuncType(IntEnum):
-    SOFTMAX = 1
-    SIGMOID = 2
+    SOFTMAX  = 1
+    SIGMOID  = 2
 
 
 # TODO: add GGMLFileType from ggml_ftype in ggml.h
@@ -2971,46 +2971,49 @@ class ExpertGatingFuncType(IntEnum):
 # from llama_ftype in llama.h
 # ALL VALUES SHOULD BE THE SAME HERE AS THEY ARE OVER THERE.
 class LlamaFileType(IntEnum):
-    ALL_F32 = 0
-    MOSTLY_F16 = 1  # except 1d tensors
-    MOSTLY_Q4_0 = 2  # except 1d tensors
-    MOSTLY_Q4_1 = 3  # except 1d tensors
+    ALL_F32              = 0
+    MOSTLY_F16           = 1   # except 1d tensors
+    MOSTLY_Q4_0          = 2   # except 1d tensors
+    MOSTLY_Q4_1          = 3   # except 1d tensors
     # MOSTLY_Q4_1_SOME_F16 = 4   # tok_embeddings.weight and output.weight are F16
     # MOSTLY_Q4_2        = 5   # support has been removed
     # MOSTLY_Q4_3        = 6   # support has been removed
-    MOSTLY_Q8_0 = 7  # except 1d tensors
-    MOSTLY_Q5_0 = 8  # except 1d tensors
-    MOSTLY_Q5_1 = 9  # except 1d tensors
-    MOSTLY_Q2_K = 10  # except 1d tensors
-    MOSTLY_Q3_K_S = 11  # except 1d tensors
-    MOSTLY_Q3_K_M = 12  # except 1d tensors
-    MOSTLY_Q3_K_L = 13  # except 1d tensors
-    MOSTLY_Q4_K_S = 14  # except 1d tensors
-    MOSTLY_Q4_K_M = 15  # except 1d tensors
-    MOSTLY_Q5_K_S = 16  # except 1d tensors
-    MOSTLY_Q5_K_M = 17  # except 1d tensors
-    MOSTLY_Q6_K = 18  # except 1d tensors
-    MOSTLY_IQ2_XXS = 19  # except 1d tensors
-    MOSTLY_IQ2_XS = 20  # except 1d tensors
-    MOSTLY_Q2_K_S = 21  # except 1d tensors
-    MOSTLY_IQ3_XS = 22  # except 1d tensors
-    MOSTLY_IQ3_XXS = 23  # except 1d tensors
-    MOSTLY_IQ1_S = 24  # except 1d tensors
-    MOSTLY_IQ4_NL = 25  # except 1d tensors
-    MOSTLY_IQ3_S = 26  # except 1d tensors
-    MOSTLY_IQ3_M = 27  # except 1d tensors
-    MOSTLY_IQ2_S = 28  # except 1d tensors
-    MOSTLY_IQ2_M = 29  # except 1d tensors
-    MOSTLY_IQ4_XS = 30  # except 1d tensors
-    MOSTLY_IQ1_M = 31  # except 1d tensors
-    MOSTLY_BF16 = 32  # except 1d tensors
+    MOSTLY_Q8_0          = 7   # except 1d tensors
+    MOSTLY_Q5_0          = 8   # except 1d tensors
+    MOSTLY_Q5_1          = 9   # except 1d tensors
+    MOSTLY_Q2_K          = 10  # except 1d tensors
+    MOSTLY_Q3_K_S        = 11  # except 1d tensors
+    MOSTLY_Q3_K_M        = 12  # except 1d tensors
+    MOSTLY_Q3_K_L        = 13  # except 1d tensors
+    MOSTLY_Q4_K_S        = 14  # except 1d tensors
+    MOSTLY_Q4_K_M        = 15  # except 1d tensors
+    MOSTLY_Q5_K_S        = 16  # except 1d tensors
+    MOSTLY_Q5_K_M        = 17  # except 1d tensors
+    MOSTLY_Q6_K          = 18  # except 1d tensors
+    MOSTLY_IQ2_XXS       = 19  # except 1d tensors
+    MOSTLY_IQ2_XS        = 20  # except 1d tensors
+    MOSTLY_Q2_K_S        = 21  # except 1d tensors
+    MOSTLY_IQ3_XS        = 22  # except 1d tensors
+    MOSTLY_IQ3_XXS       = 23  # except 1d tensors
+    MOSTLY_IQ1_S         = 24  # except 1d tensors
+    MOSTLY_IQ4_NL        = 25  # except 1d tensors
+    MOSTLY_IQ3_S         = 26  # except 1d tensors
+    MOSTLY_IQ3_M         = 27  # except 1d tensors
+    MOSTLY_IQ2_S         = 28  # except 1d tensors
+    MOSTLY_IQ2_M         = 29  # except 1d tensors
+    MOSTLY_IQ4_XS        = 30  # except 1d tensors
+    MOSTLY_IQ1_M         = 31  # except 1d tensors
+    MOSTLY_BF16          = 32  # except 1d tensors
     # MOSTLY_Q4_0_4_4      = 33  # removed from gguf files, use Q4_0 and runtime repack
     # MOSTLY_Q4_0_4_8      = 34  # removed from gguf files, use Q4_0 and runtime repack
     # MOSTLY_Q4_0_8_8      = 35  # removed from gguf files, use Q4_0 and runtime repack
-    MOSTLY_TQ1_0 = 36  # except 1d tensors
-    MOSTLY_TQ2_0 = 37  # except 1d tensors
+    MOSTLY_TQ1_0         = 36  # except 1d tensors
+    MOSTLY_TQ2_0         = 37  # except 1d tensors
+    LLAMA_FTYPE_MOSTLY_MXFP4_MOE       = 38 # except 1d tensors
+    LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE  = 39 # except 1d tensors
+    LLAMA_FTYPE_MOSTLY_MXFP6_E2M3_MOE  = 40 # except 1d tensors
 
-    GUESSED = 1024  # not specified in the model file
+    GUESSED              = 1024  # not specified in the model file
 
 
 class GGUFEndian(IntEnum):
@@ -3019,18 +3022,18 @@ class GGUFEndian(IntEnum):
 
 
 class GGUFValueType(IntEnum):
-    UINT8 = 0
-    INT8 = 1
-    UINT16 = 2
-    INT16 = 3
-    UINT32 = 4
-    INT32 = 5
+    UINT8   = 0
+    INT8    = 1
+    UINT16  = 2
+    INT16   = 3
+    UINT32  = 4
+    INT32   = 5
     FLOAT32 = 6
-    BOOL = 7
-    STRING = 8
-    ARRAY = 9
-    UINT64 = 10
-    INT64 = 11
+    BOOL    = 7
+    STRING  = 8
+    ARRAY   = 9
+    UINT64  = 10
+    INT64   = 11
     FLOAT64 = 12
 
     @staticmethod
@@ -3059,8 +3062,8 @@ class VisionProjectorType:
     QWEN25VL = "qwen2.5vl_merger"
     ULTRAVOX = "ultravox"
     INTERNVL = "internvl"
-    QWEN2A = "qwen2a"  # audio
-    QWEN25O = "qwen2.5o"  # omni
+    QWEN2A = "qwen2a" # audio
+    QWEN25O = "qwen2.5o" # omni
     VOXTRAL = "voxtral"
     LFM2 = "lfm2"
     KIMIVL = "kimivl"
@@ -3069,107 +3072,107 @@ class VisionProjectorType:
 # Items here are (block size, type size)
 QK_K = 256
 GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
-    GGMLQuantizationType.F32: (1, 4),
-    GGMLQuantizationType.F16: (1, 2),
-    GGMLQuantizationType.Q4_0: (32, 2 + 16),
-    GGMLQuantizationType.Q4_1: (32, 2 + 2 + 16),
-    GGMLQuantizationType.Q5_0: (32, 2 + 4 + 16),
-    GGMLQuantizationType.Q5_1: (32, 2 + 2 + 4 + 16),
-    GGMLQuantizationType.Q8_0: (32, 2 + 32),
-    GGMLQuantizationType.Q8_1: (32, 4 + 4 + 32),
-    GGMLQuantizationType.Q2_K: (256, 2 + 2 + QK_K // 16 + QK_K // 4),
-    GGMLQuantizationType.Q3_K: (256, 2 + QK_K // 4 + QK_K // 8 + 12),
-    GGMLQuantizationType.Q4_K: (256, 2 + 2 + QK_K // 2 + 12),
-    GGMLQuantizationType.Q5_K: (256, 2 + 2 + QK_K // 2 + QK_K // 8 + 12),
-    GGMLQuantizationType.Q6_K: (256, 2 + QK_K // 2 + QK_K // 4 + QK_K // 16),
-    GGMLQuantizationType.Q8_K: (256, 4 + QK_K + QK_K // 8),
+    GGMLQuantizationType.F32:     (1, 4),
+    GGMLQuantizationType.F16:     (1, 2),
+    GGMLQuantizationType.Q4_0:    (32, 2 + 16),
+    GGMLQuantizationType.Q4_1:    (32, 2 + 2 + 16),
+    GGMLQuantizationType.Q5_0:    (32, 2 + 4 + 16),
+    GGMLQuantizationType.Q5_1:    (32, 2 + 2 + 4 + 16),
+    GGMLQuantizationType.Q8_0:    (32, 2 + 32),
+    GGMLQuantizationType.Q8_1:    (32, 4 + 4 + 32),
+    GGMLQuantizationType.Q2_K:    (256, 2 + 2 + QK_K // 16 + QK_K // 4),
+    GGMLQuantizationType.Q3_K:    (256, 2 + QK_K // 4 + QK_K // 8 + 12),
+    GGMLQuantizationType.Q4_K:    (256, 2 + 2 + QK_K // 2 + 12),
+    GGMLQuantizationType.Q5_K:    (256, 2 + 2 + QK_K // 2 + QK_K // 8 + 12),
+    GGMLQuantizationType.Q6_K:    (256, 2 + QK_K // 2 + QK_K // 4 + QK_K // 16),
+    GGMLQuantizationType.Q8_K:    (256, 4 + QK_K + QK_K // 8),
     GGMLQuantizationType.IQ2_XXS: (256, 2 + QK_K // 4),
-    GGMLQuantizationType.IQ2_XS: (256, 2 + QK_K // 4 + QK_K // 32),
+    GGMLQuantizationType.IQ2_XS:  (256, 2 + QK_K // 4 + QK_K // 32),
     GGMLQuantizationType.IQ3_XXS: (256, 2 + QK_K // 4 + QK_K // 8),
-    GGMLQuantizationType.IQ1_S: (256, 2 + QK_K // 8 + QK_K // 16),
-    GGMLQuantizationType.IQ4_NL: (32, 2 + 16),
-    GGMLQuantizationType.IQ3_S: (256, 2 + QK_K // 4 + QK_K // 8 + QK_K // 32 + 4),
-    GGMLQuantizationType.IQ2_S: (256, 2 + QK_K // 4 + QK_K // 16),
-    GGMLQuantizationType.IQ4_XS: (256, 2 + 2 + QK_K // 2 + QK_K // 64),
-    GGMLQuantizationType.I8: (1, 1),
-    GGMLQuantizationType.I16: (1, 2),
-    GGMLQuantizationType.I32: (1, 4),
-    GGMLQuantizationType.I64: (1, 8),
-    GGMLQuantizationType.F64: (1, 8),
-    GGMLQuantizationType.IQ1_M: (256, QK_K // 8 + QK_K // 16 + QK_K // 32),
-    GGMLQuantizationType.BF16: (1, 2),
-    GGMLQuantizationType.TQ1_0: (256, 2 + 4 * 13),
-    GGMLQuantizationType.TQ2_0: (256, 2 + 64),
-    GGMLQuantizationType.MXFP4: (32, 1 + 16),
-    GGMLQuantizationType.MXFP6_E3M2: (32, 1 + 24),
-    GGMLQuantizationType.MXFP6_E2M3: (32, 1 + 24),
+    GGMLQuantizationType.IQ1_S:   (256, 2 + QK_K // 8 + QK_K // 16),
+    GGMLQuantizationType.IQ4_NL:  (32, 2 + 16),
+    GGMLQuantizationType.IQ3_S:   (256, 2 + QK_K // 4 + QK_K // 8 + QK_K // 32 + 4),
+    GGMLQuantizationType.IQ2_S:   (256, 2 + QK_K // 4 + QK_K // 16),
+    GGMLQuantizationType.IQ4_XS:  (256, 2 + 2 + QK_K // 2 + QK_K // 64),
+    GGMLQuantizationType.I8:      (1, 1),
+    GGMLQuantizationType.I16:     (1, 2),
+    GGMLQuantizationType.I32:     (1, 4),
+    GGMLQuantizationType.I64:     (1, 8),
+    GGMLQuantizationType.F64:     (1, 8),
+    GGMLQuantizationType.IQ1_M:   (256, QK_K // 8 + QK_K // 16  + QK_K // 32),
+    GGMLQuantizationType.BF16:    (1, 2),
+    GGMLQuantizationType.TQ1_0:   (256, 2 + 4 * 13),
+    GGMLQuantizationType.TQ2_0:   (256, 2 + 64),
+    GGMLQuantizationType.MXFP4:   (32, 1 + 16),
+    GGMLQuantizationType.MXFP6_E3M2:   (32, 1 + 24),
+    GGMLQuantizationType.MXFP6_E2M3:   (32, 1 + 24),
 }
 
 
 # Aliases for backward compatibility.
 
 # general
-KEY_GENERAL_ARCHITECTURE = Keys.General.ARCHITECTURE
+KEY_GENERAL_ARCHITECTURE         = Keys.General.ARCHITECTURE
 KEY_GENERAL_QUANTIZATION_VERSION = Keys.General.QUANTIZATION_VERSION
-KEY_GENERAL_ALIGNMENT = Keys.General.ALIGNMENT
-KEY_GENERAL_NAME = Keys.General.NAME
-KEY_GENERAL_AUTHOR = Keys.General.AUTHOR
-KEY_GENERAL_URL = Keys.General.URL
-KEY_GENERAL_DESCRIPTION = Keys.General.DESCRIPTION
-KEY_GENERAL_LICENSE = Keys.General.LICENSE
-KEY_GENERAL_SOURCE_URL = Keys.General.SOURCE_URL
-KEY_GENERAL_FILE_TYPE = Keys.General.FILE_TYPE
+KEY_GENERAL_ALIGNMENT            = Keys.General.ALIGNMENT
+KEY_GENERAL_NAME                 = Keys.General.NAME
+KEY_GENERAL_AUTHOR               = Keys.General.AUTHOR
+KEY_GENERAL_URL                  = Keys.General.URL
+KEY_GENERAL_DESCRIPTION          = Keys.General.DESCRIPTION
+KEY_GENERAL_LICENSE              = Keys.General.LICENSE
+KEY_GENERAL_SOURCE_URL           = Keys.General.SOURCE_URL
+KEY_GENERAL_FILE_TYPE            = Keys.General.FILE_TYPE
 
 # LLM
-KEY_VOCAB_SIZE = Keys.LLM.VOCAB_SIZE
-KEY_CONTEXT_LENGTH = Keys.LLM.CONTEXT_LENGTH
-KEY_EMBEDDING_LENGTH = Keys.LLM.EMBEDDING_LENGTH
-KEY_BLOCK_COUNT = Keys.LLM.BLOCK_COUNT
-KEY_FEED_FORWARD_LENGTH = Keys.LLM.FEED_FORWARD_LENGTH
+KEY_VOCAB_SIZE            = Keys.LLM.VOCAB_SIZE
+KEY_CONTEXT_LENGTH        = Keys.LLM.CONTEXT_LENGTH
+KEY_EMBEDDING_LENGTH      = Keys.LLM.EMBEDDING_LENGTH
+KEY_BLOCK_COUNT           = Keys.LLM.BLOCK_COUNT
+KEY_FEED_FORWARD_LENGTH   = Keys.LLM.FEED_FORWARD_LENGTH
 KEY_USE_PARALLEL_RESIDUAL = Keys.LLM.USE_PARALLEL_RESIDUAL
-KEY_TENSOR_DATA_LAYOUT = Keys.LLM.TENSOR_DATA_LAYOUT
+KEY_TENSOR_DATA_LAYOUT    = Keys.LLM.TENSOR_DATA_LAYOUT
 
 # attention
-KEY_ATTENTION_HEAD_COUNT = Keys.Attention.HEAD_COUNT
-KEY_ATTENTION_HEAD_COUNT_KV = Keys.Attention.HEAD_COUNT_KV
-KEY_ATTENTION_MAX_ALIBI_BIAS = Keys.Attention.MAX_ALIBI_BIAS
-KEY_ATTENTION_CLAMP_KQV = Keys.Attention.CLAMP_KQV
-KEY_ATTENTION_LAYERNORM_EPS = Keys.Attention.LAYERNORM_EPS
+KEY_ATTENTION_HEAD_COUNT        = Keys.Attention.HEAD_COUNT
+KEY_ATTENTION_HEAD_COUNT_KV     = Keys.Attention.HEAD_COUNT_KV
+KEY_ATTENTION_MAX_ALIBI_BIAS    = Keys.Attention.MAX_ALIBI_BIAS
+KEY_ATTENTION_CLAMP_KQV         = Keys.Attention.CLAMP_KQV
+KEY_ATTENTION_LAYERNORM_EPS     = Keys.Attention.LAYERNORM_EPS
 KEY_ATTENTION_LAYERNORM_RMS_EPS = Keys.Attention.LAYERNORM_RMS_EPS
 
 # RoPE
-KEY_ROPE_DIMENSION_COUNT = Keys.Rope.DIMENSION_COUNT
-KEY_ROPE_FREQ_BASE = Keys.Rope.FREQ_BASE
-KEY_ROPE_SCALING_TYPE = Keys.Rope.SCALING_TYPE
-KEY_ROPE_SCALING_FACTOR = Keys.Rope.SCALING_FACTOR
+KEY_ROPE_DIMENSION_COUNT      = Keys.Rope.DIMENSION_COUNT
+KEY_ROPE_FREQ_BASE            = Keys.Rope.FREQ_BASE
+KEY_ROPE_SCALING_TYPE         = Keys.Rope.SCALING_TYPE
+KEY_ROPE_SCALING_FACTOR       = Keys.Rope.SCALING_FACTOR
 KEY_ROPE_SCALING_ORIG_CTX_LEN = Keys.Rope.SCALING_ORIG_CTX_LEN
-KEY_ROPE_SCALING_FINETUNED = Keys.Rope.SCALING_FINETUNED
+KEY_ROPE_SCALING_FINETUNED    = Keys.Rope.SCALING_FINETUNED
 
 # SSM
-KEY_SSM_CONV_KERNEL = Keys.SSM.CONV_KERNEL
-KEY_SSM_INNER_SIZE = Keys.SSM.INNER_SIZE
-KEY_SSM_STATE_SIZE = Keys.SSM.STATE_SIZE
+KEY_SSM_CONV_KERNEL    = Keys.SSM.CONV_KERNEL
+KEY_SSM_INNER_SIZE     = Keys.SSM.INNER_SIZE
+KEY_SSM_STATE_SIZE     = Keys.SSM.STATE_SIZE
 KEY_SSM_TIME_STEP_RANK = Keys.SSM.TIME_STEP_RANK
-KEY_SSM_GROUP_COUNT = Keys.SSM.GROUP_COUNT
-KEY_SSM_DT_B_C_RMS = Keys.SSM.DT_B_C_RMS
+KEY_SSM_GROUP_COUNT    = Keys.SSM.GROUP_COUNT
+KEY_SSM_DT_B_C_RMS     = Keys.SSM.DT_B_C_RMS
 
 # tokenization
-KEY_TOKENIZER_MODEL = Keys.Tokenizer.MODEL
-KEY_TOKENIZER_PRE = Keys.Tokenizer.PRE
-KEY_TOKENIZER_LIST = Keys.Tokenizer.LIST
+KEY_TOKENIZER_MODEL      = Keys.Tokenizer.MODEL
+KEY_TOKENIZER_PRE        = Keys.Tokenizer.PRE
+KEY_TOKENIZER_LIST       = Keys.Tokenizer.LIST
 KEY_TOKENIZER_TOKEN_TYPE = Keys.Tokenizer.TOKEN_TYPE
-KEY_TOKENIZER_SCORES = Keys.Tokenizer.SCORES
-KEY_TOKENIZER_MERGES = Keys.Tokenizer.MERGES
-KEY_TOKENIZER_BOS_ID = Keys.Tokenizer.BOS_ID
-KEY_TOKENIZER_EOS_ID = Keys.Tokenizer.EOS_ID
-KEY_TOKENIZER_EOT_ID = Keys.Tokenizer.EOT_ID
-KEY_TOKENIZER_EOM_ID = Keys.Tokenizer.EOM_ID
-KEY_TOKENIZER_UNK_ID = Keys.Tokenizer.UNK_ID
-KEY_TOKENIZER_SEP_ID = Keys.Tokenizer.SEP_ID
-KEY_TOKENIZER_PAD_ID = Keys.Tokenizer.PAD_ID
-KEY_TOKENIZER_MASK_ID = Keys.Tokenizer.MASK_ID
-KEY_TOKENIZER_HF_JSON = Keys.Tokenizer.HF_JSON
-KEY_TOKENIZER_RWKV = Keys.Tokenizer.RWKV
+KEY_TOKENIZER_SCORES     = Keys.Tokenizer.SCORES
+KEY_TOKENIZER_MERGES     = Keys.Tokenizer.MERGES
+KEY_TOKENIZER_BOS_ID     = Keys.Tokenizer.BOS_ID
+KEY_TOKENIZER_EOS_ID     = Keys.Tokenizer.EOS_ID
+KEY_TOKENIZER_EOT_ID     = Keys.Tokenizer.EOT_ID
+KEY_TOKENIZER_EOM_ID     = Keys.Tokenizer.EOM_ID
+KEY_TOKENIZER_UNK_ID     = Keys.Tokenizer.UNK_ID
+KEY_TOKENIZER_SEP_ID     = Keys.Tokenizer.SEP_ID
+KEY_TOKENIZER_PAD_ID     = Keys.Tokenizer.PAD_ID
+KEY_TOKENIZER_MASK_ID    = Keys.Tokenizer.MASK_ID
+KEY_TOKENIZER_HF_JSON    = Keys.Tokenizer.HF_JSON
+KEY_TOKENIZER_RWKV       = Keys.Tokenizer.RWKV
 
 KEY_TOKENIZER_FIM_PRE_ID = Keys.Tokenizer.FIM_PRE_ID
 KEY_TOKENIZER_FIM_SUF_ID = Keys.Tokenizer.FIM_SUF_ID
@@ -3179,6 +3182,6 @@ KEY_TOKENIZER_FIM_REP_ID = Keys.Tokenizer.FIM_REP_ID
 KEY_TOKENIZER_FIM_SEP_ID = Keys.Tokenizer.FIM_SEP_ID
 
 # deprecated
-KEY_TOKENIZER_PREFIX_ID = Keys.Tokenizer.PREFIX_ID
-KEY_TOKENIZER_SUFFIX_ID = Keys.Tokenizer.SUFFIX_ID
-KEY_TOKENIZER_MIDDLE_ID = Keys.Tokenizer.MIDDLE_ID
+KEY_TOKENIZER_PREFIX_ID  = Keys.Tokenizer.PREFIX_ID
+KEY_TOKENIZER_SUFFIX_ID  = Keys.Tokenizer.SUFFIX_ID
+KEY_TOKENIZER_MIDDLE_ID  = Keys.Tokenizer.MIDDLE_ID

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -3009,9 +3009,9 @@ class LlamaFileType(IntEnum):
     # MOSTLY_Q4_0_8_8      = 35  # removed from gguf files, use Q4_0 and runtime repack
     MOSTLY_TQ1_0         = 36  # except 1d tensors
     MOSTLY_TQ2_0         = 37  # except 1d tensors
-    LLAMA_FTYPE_MOSTLY_MXFP4_MOE       = 38 # except 1d tensors
-    LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE  = 39 # except 1d tensors
-    LLAMA_FTYPE_MOSTLY_MXFP6_E2M3_MOE  = 40 # except 1d tensors
+    MOSTLY_MXFP4_MOE     = 38 # except 1d tensors
+    MOSTLY_MXFP6_E3M2_MOE  = 39 # except 1d tensors
+    MOSTLY_MXFP6_E2M3_MOE  = 40 # except 1d tensors
 
     GUESSED              = 1024  # not specified in the model file
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -920,7 +920,7 @@ class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6E3M2):
         with np.errstate(divide="ignore"):
             # convert log2(d_max) to e8m0
             # log2(448) = 8.8 -> shift 9
-            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 9 + 127, 0).astype(
+            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 4 + 127, 0).astype(
                 np.uint8
             )
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -919,7 +919,6 @@ class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6E3M2):
 
         with np.errstate(divide="ignore"):
             # convert log2(d_max) to e8m0
-            # log2(448) = 8.8 -> shift 9
             e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 4 + 127, 0).astype(
                 np.uint8
             )
@@ -978,7 +977,7 @@ class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6E3M2):
         indices = indices.reshape((n_blocks, cls.block_size, 1))
 
         kvalues = np.array(cls.kvalues, dtype=np.int16).reshape(1, 1, 64)
-        qs_dequant = np.take_long_axis(kvalues, indices, axis=-1).reshape(
+        qs_dequant = np.take_along_axis(kvalues, indices, axis=-1).reshape(
             (n_blocks, cls.block_size)
         )
 
@@ -1073,7 +1072,6 @@ class MXFP6E2M3(__Quant, qtype=GGMLQuantizationType.MXFP6E2M3):
 
         with np.errstate(divide="ignore"):
             # convert log2(d_max) to e8m0
-            # log2(448) = 8.8 -> shift 9
             e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 3 + 127, 0).astype(
                 np.uint8
             )
@@ -1132,7 +1130,7 @@ class MXFP6E2M3(__Quant, qtype=GGMLQuantizationType.MXFP6E2M3):
         indices = indices.reshape((n_blocks, cls.block_size, 1))
 
         kvalues = np.array(cls.kvalues, dtype=np.int16).reshape(1, 1, 64)
-        qs_dequant = np.take_long_axis(kvalues, indices, axis=-1).reshape(
+        qs_dequant = np.take_along_axis(kvalues, indices, axis=-1).reshape(
             (n_blocks, cls.block_size)
         )
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -15,6 +15,7 @@ def e8m0_to_fp32_any(x: np.ndarray, e: np.uint32) -> np.ndarray:
     bits = np.where(x < e + 1, np.uint32(1) << np.uint32(x - e + 22), np.uint32(x - e) << np.uint32(23))
     return bits.view(np.float32)
 
+
 def quant_shape_to_byte_shape(shape: Sequence[int], quant_type: GGMLQuantizationType) -> tuple[int, ...]:
     block_size, type_size = GGML_QUANT_SIZES[quant_type]
     if shape[-1] % block_size != 0:
@@ -730,9 +731,7 @@ class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6_E3M2):
 
         with np.errstate(divide="ignore"):
             # convert log2(d_max) to e8m0
-            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 9 + 127, 0).astype(
-                np.uint8
-            )
+            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 3 + 127, 0).astype(np.uint8)
 
         # d is float of above e8m0
         d = cls.__e8m0_to_fp32_scaled(e)
@@ -817,9 +816,7 @@ class MXFP6E2M3(__Quant, qtype=GGMLQuantizationType.MXFP6_E2M3):
 
         with np.errstate(divide="ignore"):
             # convert log2(d_max) to e8m0
-            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 6 + 127, 0).astype(
-                np.uint8
-            )
+            e = np.where(d_max > 0, np.floor(np.log2(d_max)) - 1 + 127, 0).astype(np.uint8)
 
         # d is float of above e8m0
         d = cls.__e8m0_to_fp32_scaled(e)

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -10,36 +10,27 @@ from .lazy import LazyNumpyTensor
 
 import numpy as np
 
+# see ggml_e8m0_to_fp32_half in ggml-impl.h
+def e8m0_to_fp32_half(x: np.ndarray) -> np.ndarray:
+    bits = np.where(x < 2, np.uint32(0x00200000) << np.uint32(x), np.uint32(x - 1) << np.uint32(23))
+    return bits.view(np.float32)
 
-def quant_shape_to_byte_shape(
-    shape: Sequence[int], quant_type: GGMLQuantizationType
-) -> tuple[int, ...]:
+def quant_shape_to_byte_shape(shape: Sequence[int], quant_type: GGMLQuantizationType) -> tuple[int, ...]:
     block_size, type_size = GGML_QUANT_SIZES[quant_type]
     if shape[-1] % block_size != 0:
-        raise ValueError(
-            f"Quantized tensor row size ({shape[-1]}) is not a multiple of {quant_type.name} block size ({block_size})"
-        )
+        raise ValueError(f"Quantized tensor row size ({shape[-1]}) is not a multiple of {quant_type.name} block size ({block_size})")
     return (*shape[:-1], shape[-1] // block_size * type_size)
 
 
-def quant_shape_from_byte_shape(
-    shape: Sequence[int], quant_type: GGMLQuantizationType
-) -> tuple[int, ...]:
+def quant_shape_from_byte_shape(shape: Sequence[int], quant_type: GGMLQuantizationType) -> tuple[int, ...]:
     block_size, type_size = GGML_QUANT_SIZES[quant_type]
     if shape[-1] % type_size != 0:
-        raise ValueError(
-            f"Quantized tensor bytes per row ({shape[-1]}) is not a multiple of {quant_type.name} type size ({type_size})"
-        )
+        raise ValueError(f"Quantized tensor bytes per row ({shape[-1]}) is not a multiple of {quant_type.name} type size ({type_size})")
     return (*shape[:-1], shape[-1] // type_size * block_size)
 
 
 # This is faster than np.vectorize and np.apply_along_axis because it works on more than one row at a time
-def _apply_over_grouped_rows(
-    func: Callable[[np.ndarray], np.ndarray],
-    arr: np.ndarray,
-    otype: DTypeLike,
-    oshape: tuple[int, ...],
-) -> np.ndarray:
+def _apply_over_grouped_rows(func: Callable[[np.ndarray], np.ndarray], arr: np.ndarray, otype: DTypeLike, oshape: tuple[int, ...]) -> np.ndarray:
     rows = arr.reshape((-1, arr.shape[-1]))
     osize = 1
     for dim in oshape:
@@ -47,11 +38,7 @@ def _apply_over_grouped_rows(
     out = np.empty(shape=osize, dtype=otype)
     # compute over groups of 16 rows (arbitrary, but seems good for performance)
     n_groups = (rows.shape[0] // 16) or 1
-    np.concatenate(
-        [func(group).ravel() for group in np.array_split(rows, n_groups)],
-        axis=0,
-        out=out,
-    )
+    np.concatenate([func(group).ravel() for group in np.array_split(rows, n_groups)], axis=0, out=out)
     return out.reshape(oshape)
 
 
@@ -78,9 +65,7 @@ def quantize(data: np.ndarray, qtype: GGMLQuantizationType) -> np.ndarray:
     elif (q := _type_traits.get(qtype)) is not None:
         return q.quantize(data)
     else:
-        raise NotImplementedError(
-            f"Quantization for {qtype.name} is not yet implemented"
-        )
+        raise NotImplementedError(f"Quantization for {qtype.name} is not yet implemented")
 
 
 def dequantize(data: np.ndarray, qtype: GGMLQuantizationType) -> np.ndarray:
@@ -91,9 +76,7 @@ def dequantize(data: np.ndarray, qtype: GGMLQuantizationType) -> np.ndarray:
     elif (q := _type_traits.get(qtype)) is not None:
         return q.dequantize(data)
     else:
-        raise NotImplementedError(
-            f"Dequantization for {qtype.name} is not yet implemented"
-        )
+        raise NotImplementedError(f"Dequantization for {qtype.name} is not yet implemented")
 
 
 class __Quant(ABC):
@@ -113,10 +96,12 @@ class __Quant(ABC):
         cls.qtype = qtype
         cls.block_size, cls.type_size = GGML_QUANT_SIZES[qtype]
         cls.__quantize_lazy = LazyNumpyTensor._wrap_fn(
-            cls.__quantize_array, meta_noop=(np.uint8, cls.__shape_to_bytes)
+            cls.__quantize_array,
+            meta_noop=(np.uint8, cls.__shape_to_bytes)
         )
         cls.__dequantize_lazy = LazyNumpyTensor._wrap_fn(
-            cls.__dequantize_array, meta_noop=(np.float32, cls.__shape_from_bytes)
+            cls.__dequantize_array,
+            meta_noop=(np.float32, cls.__shape_from_bytes)
         )
         assert qtype not in _type_traits
         _type_traits[qtype] = cls
@@ -133,14 +118,10 @@ class __Quant(ABC):
         grid = np.frombuffer(cls.grid_hex, dtype=np.uint8)
         # decode hexadecimal chars from grid
         grid = grid.reshape((-1, 2))
-        grid = (np.where(grid > 0x40, grid + 9, grid) & 0x0F) << np.array(
-            [4, 0], dtype=np.uint8
-        ).reshape((1, 2))
+        grid = (np.where(grid > 0x40, grid + 9, grid) & 0x0F) << np.array([4, 0], dtype=np.uint8).reshape((1, 2))
         grid = grid[..., 0] | grid[..., 1]
         # unpack the grid values
-        grid = grid.reshape((-1, 1)) >> np.array(
-            [i for i in range(0, 8, 8 // elems_per_byte)], dtype=np.uint8
-        ).reshape((1, elems_per_byte))
+        grid = grid.reshape((-1, 1)) >> np.array([i for i in range(0, 8, 8 // elems_per_byte)], dtype=np.uint8).reshape((1, elems_per_byte))
         grid = (grid & ((1 << bits_per_elem) - 1)).reshape((-1, 1))
         grid_map = np.array(cls.grid_map, dtype=np.float32).reshape((1, -1))
         grid = np.take_along_axis(grid_map, grid, axis=-1)
@@ -188,22 +169,12 @@ class __Quant(ABC):
 
     @classmethod
     def __quantize_array(cls, array: np.ndarray) -> np.ndarray:
-        return _apply_over_grouped_rows(
-            cls.quantize_rows,
-            arr=array,
-            otype=np.uint8,
-            oshape=cls.__shape_to_bytes(array.shape),
-        )
+        return _apply_over_grouped_rows(cls.quantize_rows, arr=array, otype=np.uint8, oshape=cls.__shape_to_bytes(array.shape))
 
     @classmethod
     def __dequantize_array(cls, array: np.ndarray) -> np.ndarray:
         cls.init_grid()
-        return _apply_over_grouped_rows(
-            cls.dequantize_rows,
-            arr=array,
-            otype=np.float32,
-            oshape=cls.__shape_from_bytes(array.shape),
-        )
+        return _apply_over_grouped_rows(cls.dequantize_rows, arr=array, otype=np.float32, oshape=cls.__shape_from_bytes(array.shape))
 
     @classmethod
     def __quantize_lazy(cls, lazy_tensor: LazyNumpyTensor, /) -> Any:
@@ -220,9 +191,7 @@ class __Quant(ABC):
     @classmethod
     def quantize(cls, tensor: np.ndarray | LazyNumpyTensor) -> np.ndarray:
         if not cls.can_quantize(tensor):
-            raise QuantError(
-                f"Can't quantize tensor with shape {tensor.shape} to {cls.qtype.name}"
-            )
+            raise QuantError(f"Can't quantize tensor with shape {tensor.shape} to {cls.qtype.name}")
         if isinstance(tensor, LazyNumpyTensor):
             return cls.__quantize_lazy(tensor)
         else:
@@ -242,13 +211,9 @@ class BF16(__Quant, qtype=GGMLQuantizationType.BF16):
     def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
         n = blocks.view(np.uint32)
         # force nan to quiet
-        n = np.where(
-            (n & 0x7FFFFFFF) > 0x7F800000,
-            (n & np.uint32(0xFFFF0000)) | np.uint32(64 << 16),
-            n,
-        )
+        n = np.where((n & 0x7fffffff) > 0x7f800000, (n & np.uint32(0xffff0000)) | np.uint32(64 << 16), n)
         # round to nearest even
-        n = (np.uint64(n) + (0x7FFF + ((n >> 16) & 1))) >> 16
+        n = (np.uint64(n) + (0x7fff + ((n >> 16) & 1))) >> 16
         return n.astype(np.uint16).view(np.uint8)
 
     @classmethod
@@ -267,11 +232,7 @@ class Q4_0(__Quant, qtype=GGMLQuantizationType.Q4_0):
         d = max / -8
         with np.errstate(divide="ignore"):
             id = np.where(d == 0, 0, 1 / d)
-        qs = (
-            np.trunc((blocks * id) + np.float32(8.5), dtype=np.float32)
-            .astype(np.uint8)
-            .clip(0, 15)
-        )
+        qs = np.trunc((blocks * id) + np.float32(8.5), dtype=np.float32).astype(np.uint8).clip(0, 15)
 
         qs = qs.reshape((n_blocks, 2, cls.block_size // 2))
         qs = qs[..., 0, :] | (qs[..., 1, :] << np.uint8(4))
@@ -288,12 +249,10 @@ class Q4_0(__Quant, qtype=GGMLQuantizationType.Q4_0):
 
         d = d.view(np.float16).astype(np.float32)
 
-        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1)).astype(np.int8) - np.int8(8)
 
-        return d * qs.astype(np.float32)
+        return (d * qs.astype(np.float32))
 
 
 class Q4_1(__Quant, qtype=GGMLQuantizationType.Q4_1):
@@ -307,11 +266,7 @@ class Q4_1(__Quant, qtype=GGMLQuantizationType.Q4_1):
         d = (max - min) / 15
         with np.errstate(divide="ignore"):
             id = np.where(d == 0, 0, 1 / d)
-        qs = (
-            np.trunc((blocks - min) * id + np.float32(0.5), dtype=np.float32)
-            .astype(np.uint8)
-            .clip(0, 15)
-        )
+        qs = np.trunc((blocks - min) * id + np.float32(0.5), dtype=np.float32).astype(np.uint8).clip(0, 15)
 
         qs = qs.reshape((n_blocks, 2, cls.block_size // 2))
         qs = qs[..., 0, :] | (qs[..., 1, :] << np.uint8(4))
@@ -331,9 +286,7 @@ class Q4_1(__Quant, qtype=GGMLQuantizationType.Q4_1):
         d = d.view(np.float16).astype(np.float32)
         m = m.view(np.float16).astype(np.float32)
 
-        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1)).astype(np.float32)
 
         return (d * qs) + m
@@ -350,18 +303,12 @@ class Q5_0(__Quant, qtype=GGMLQuantizationType.Q5_0):
         d = max / -16
         with np.errstate(divide="ignore"):
             id = np.where(d == 0, 0, 1 / d)
-        q = (
-            np.trunc((blocks * id) + np.float32(16.5), dtype=np.float32)
-            .astype(np.uint8)
-            .clip(0, 31)
-        )
+        q = np.trunc((blocks * id) + np.float32(16.5), dtype=np.float32).astype(np.uint8).clip(0, 31)
 
         qs = q.reshape((n_blocks, 2, cls.block_size // 2))
         qs = (qs[..., 0, :] & np.uint8(0x0F)) | (qs[..., 1, :] << np.uint8(4))
 
-        qh = np.packbits(
-            q.reshape((n_blocks, 1, 32)) >> np.uint8(4), axis=-1, bitorder="little"
-        ).reshape(n_blocks, 4)
+        qh = np.packbits(q.reshape((n_blocks, 1, 32)) >> np.uint8(4), axis=-1, bitorder="little").reshape(n_blocks, 4)
 
         d = d.astype(np.float16).view(np.uint8)
 
@@ -377,18 +324,14 @@ class Q5_0(__Quant, qtype=GGMLQuantizationType.Q5_0):
         d = d.view(np.float16).astype(np.float32)
         qh = qh.view(np.uint32)
 
-        qh = qh.reshape((n_blocks, 1)) >> np.array(
-            [i for i in range(32)], dtype=np.uint32
-        ).reshape((1, 32))
-        ql = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qh = qh.reshape((n_blocks, 1)) >> np.array([i for i in range(32)], dtype=np.uint32).reshape((1, 32))
+        ql = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qh = (qh & np.uint32(0x01)).astype(np.uint8)
         ql = (ql & np.uint8(0x0F)).reshape((n_blocks, -1))
 
         qs = (ql | (qh << np.uint8(4))).astype(np.int8) - np.int8(16)
 
-        return d * qs.astype(np.float32)
+        return (d * qs.astype(np.float32))
 
 
 class Q5_1(__Quant, qtype=GGMLQuantizationType.Q5_1):
@@ -402,18 +345,12 @@ class Q5_1(__Quant, qtype=GGMLQuantizationType.Q5_1):
         d = (max - min) / 31
         with np.errstate(divide="ignore"):
             id = np.where(d == 0, 0, 1 / d)
-        q = (
-            np.trunc((blocks - min) * id + np.float32(0.5), dtype=np.float32)
-            .astype(np.uint8)
-            .clip(0, 31)
-        )
+        q = np.trunc((blocks - min) * id + np.float32(0.5), dtype=np.float32).astype(np.uint8).clip(0, 31)
 
         qs = q.reshape((n_blocks, 2, cls.block_size // 2))
         qs = (qs[..., 0, :] & np.uint8(0x0F)) | (qs[..., 1, :] << np.uint8(4))
 
-        qh = np.packbits(
-            q.reshape((n_blocks, 1, 32)) >> np.uint8(4), axis=-1, bitorder="little"
-        ).reshape(n_blocks, 4)
+        qh = np.packbits(q.reshape((n_blocks, 1, 32)) >> np.uint8(4), axis=-1, bitorder="little").reshape(n_blocks, 4)
 
         d = d.astype(np.float16).view(np.uint8)
         m = min.astype(np.float16).view(np.uint8)
@@ -432,12 +369,8 @@ class Q5_1(__Quant, qtype=GGMLQuantizationType.Q5_1):
         m = m.view(np.float16).astype(np.float32)
         qh = qh.view(np.uint32)
 
-        qh = qh.reshape((n_blocks, 1)) >> np.array(
-            [i for i in range(32)], dtype=np.uint32
-        ).reshape((1, 32))
-        ql = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qh = qh.reshape((n_blocks, 1)) >> np.array([i for i in range(32)], dtype=np.uint32).reshape((1, 32))
+        ql = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qh = (qh & np.uint32(0x01)).astype(np.uint8)
         ql = (ql & np.uint8(0x0F)).reshape((n_blocks, -1))
 
@@ -450,6 +383,7 @@ class Q8_0(__Quant, qtype=GGMLQuantizationType.Q8_0):
     @classmethod
     # Implementation of Q8_0 with bit-exact same results as reference implementation in ggml-quants.c
     def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
+
         d = abs(blocks).max(axis=1, keepdims=True) / 127
         with np.errstate(divide="ignore"):
             id = np.where(d == 0, 0, 1 / d)
@@ -468,7 +402,7 @@ class Q8_0(__Quant, qtype=GGMLQuantizationType.Q8_0):
         d = d.view(np.float16).astype(np.float32)
         x = x.view(np.int8).astype(np.float32)
 
-        return x * d
+        return (x * d)
 
 
 class Q2_K(__Quant, qtype=GGMLQuantizationType.Q2_K):
@@ -485,9 +419,7 @@ class Q2_K(__Quant, qtype=GGMLQuantizationType.Q2_K):
 
         # (n_blocks, 16, 1)
         dl = (d * (scales & 0xF).astype(np.float32)).reshape((n_blocks, QK_K // 16, 1))
-        ml = (dmin * (scales >> 4).astype(np.float32)).reshape(
-            (n_blocks, QK_K // 16, 1)
-        )
+        ml = (dmin * (scales >> 4).astype(np.float32)).reshape((n_blocks, QK_K // 16, 1))
 
         shift = np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4, 1))
 
@@ -525,33 +457,21 @@ class Q3_K(__Quant, qtype=GGMLQuantizationType.Q3_K):
         # 10: OOKKGGCC
         # 11: PPLLHHDD
         lscales, hscales = np.hsplit(scales, [8])
-        lscales = lscales.reshape((n_blocks, 1, 8)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 2, 1))
+        lscales = lscales.reshape((n_blocks, 1, 8)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 2, 1))
         lscales = lscales.reshape((n_blocks, 16))
-        hscales = hscales.reshape((n_blocks, 1, 4)) >> np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 4, 1))
+        hscales = hscales.reshape((n_blocks, 1, 4)) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 4, 1))
         hscales = hscales.reshape((n_blocks, 16))
-        scales = (lscales & np.uint8(0x0F)) | (
-            (hscales & np.uint8(0x03)) << np.uint8(4)
-        )
+        scales = (lscales & np.uint8(0x0F)) | ((hscales & np.uint8(0x03)) << np.uint8(4))
         scales = (scales.astype(np.int8) - np.int8(32)).astype(np.float32)
 
         dl = (d * scales).reshape((n_blocks, 16, 1))
 
-        ql = qs.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
-        qh = hmask.reshape(n_blocks, -1, 1, 32) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 8, 1))
+        ql = qs.reshape((n_blocks, -1, 1, 32)) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4, 1))
+        qh = hmask.reshape(n_blocks, -1, 1, 32) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 8, 1))
         ql = ql.reshape((n_blocks, 16, QK_K // 16)) & np.uint8(3)
-        qh = qh.reshape((n_blocks, 16, QK_K // 16)) & np.uint8(1)
+        qh = (qh.reshape((n_blocks, 16, QK_K // 16)) & np.uint8(1))
         qh = qh ^ np.uint8(1)  # strangely, the offset is zero when the bitmask is 1
-        q = (ql.astype(np.int8) - (qh << np.uint8(2)).astype(np.int8)).astype(
-            np.float32
-        )
+        q = (ql.astype(np.int8) - (qh << np.uint8(2)).astype(np.int8)).astype(np.float32)
 
         return (dl * q).reshape((n_blocks, QK_K))
 
@@ -600,9 +520,7 @@ class Q4_K(__Quant, qtype=GGMLQuantizationType.Q4_K):
         d = (d * sc.astype(np.float32)).reshape((n_blocks, -1, 1))
         dm = (dmin * m.astype(np.float32)).reshape((n_blocks, -1, 1))
 
-        qs = qs.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qs = qs.reshape((n_blocks, -1, 1, 32)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1, 32)).astype(np.float32)
 
         return (d * qs - dm).reshape((n_blocks, QK_K))
@@ -626,12 +544,8 @@ class Q5_K(__Quant, qtype=GGMLQuantizationType.Q5_K):
         d = (d * sc.astype(np.float32)).reshape((n_blocks, -1, 1))
         dm = (dmin * m.astype(np.float32)).reshape((n_blocks, -1, 1))
 
-        ql = qs.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
-        qh = qh.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 8, 1))
+        ql = qs.reshape((n_blocks, -1, 1, 32)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
+        qh = qh.reshape((n_blocks, -1, 1, 32)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 8, 1))
         ql = (ql & np.uint8(0x0F)).reshape((n_blocks, -1, 32))
         qh = (qh & np.uint8(0x01)).reshape((n_blocks, -1, 32))
         q = (ql | (qh << np.uint8(4))).astype(np.float32)
@@ -652,13 +566,9 @@ class Q6_K(__Quant, qtype=GGMLQuantizationType.Q6_K):
         d = d.view(np.float16).astype(np.float32)
         d = (d * scales).reshape((n_blocks, QK_K // 16, 1))
 
-        ql = ql.reshape((n_blocks, -1, 1, 64)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        ql = ql.reshape((n_blocks, -1, 1, 64)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         ql = (ql & np.uint8(0x0F)).reshape((n_blocks, -1, 32))
-        qh = qh.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
+        qh = qh.reshape((n_blocks, -1, 1, 32)) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4, 1))
         qh = (qh & np.uint8(0x03)).reshape((n_blocks, -1, 32))
         q = (ql | (qh << np.uint8(4))).astype(np.int8) - np.int8(32)
         q = q.reshape((n_blocks, QK_K // 16, -1)).astype(np.float32)
@@ -677,22 +587,12 @@ class TQ1_0(__Quant, qtype=GGMLQuantizationType.TQ1_0):
         qs = np_roundf(blocks * id)
         qs = (qs.astype(np.int8) + np.int8(1)).astype(np.uint8)
 
-        qs0, qs1, qh = (
-            qs[..., : (32 * 5)],
-            qs[..., (32 * 5) : (48 * 5)],
-            qs[..., (48 * 5) :],
-        )
-        qs0 = qs0.reshape((n_blocks, -1, 5, 32)) * np.array(
-            [81, 27, 9, 3, 1], dtype=np.uint8
-        ).reshape((1, 1, 5, 1))
+        qs0, qs1, qh = qs[..., :(32 * 5)], qs[..., (32 * 5):(48 * 5)], qs[..., (48 * 5):]
+        qs0 = qs0.reshape((n_blocks, -1, 5, 32)) * np.array([81, 27, 9, 3, 1], dtype=np.uint8).reshape((1, 1, 5, 1))
         qs0 = np.sum(qs0, axis=-2).reshape((n_blocks, -1))
-        qs1 = qs1.reshape((n_blocks, -1, 5, 16)) * np.array(
-            [81, 27, 9, 3, 1], dtype=np.uint8
-        ).reshape((1, 1, 5, 1))
+        qs1 = qs1.reshape((n_blocks, -1, 5, 16)) * np.array([81, 27, 9, 3, 1], dtype=np.uint8).reshape((1, 1, 5, 1))
         qs1 = np.sum(qs1, axis=-2).reshape((n_blocks, -1))
-        qh = qh.reshape((n_blocks, -1, 4, 4)) * np.array(
-            [81, 27, 9, 3], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
+        qh = qh.reshape((n_blocks, -1, 4, 4)) * np.array([81, 27, 9, 3], dtype=np.uint8).reshape((1, 1, 4, 1))
         qh = np.sum(qh, axis=-2).reshape((n_blocks, -1))
         qs = np.concatenate([qs0, qs1, qh], axis=-1)
         qs = (qs.astype(np.uint16) * 256 + (243 - 1)) // 243
@@ -712,22 +612,16 @@ class TQ1_0(__Quant, qtype=GGMLQuantizationType.TQ1_0):
         d = d.view(np.float16).astype(np.float32)
 
         qs0, qs1 = qs[..., :32], qs[..., 32:]
-        qs0 = qs0.reshape((n_blocks, -1, 1, 32)) * np.array(
-            [1, 3, 9, 27, 81], dtype=np.uint8
-        ).reshape((1, 1, 5, 1))
+        qs0 = qs0.reshape((n_blocks, -1, 1, 32)) * np.array([1, 3, 9, 27, 81], dtype=np.uint8).reshape((1, 1, 5, 1))
         qs0 = qs0.reshape((n_blocks, -1))
-        qs1 = qs1.reshape((n_blocks, -1, 1, 16)) * np.array(
-            [1, 3, 9, 27, 81], dtype=np.uint8
-        ).reshape((1, 1, 5, 1))
+        qs1 = qs1.reshape((n_blocks, -1, 1, 16)) * np.array([1, 3, 9, 27, 81], dtype=np.uint8).reshape((1, 1, 5, 1))
         qs1 = qs1.reshape((n_blocks, -1))
-        qh = qh.reshape((n_blocks, -1, 1, 4)) * np.array(
-            [1, 3, 9, 27], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
+        qh = qh.reshape((n_blocks, -1, 1, 4)) * np.array([1, 3, 9, 27], dtype=np.uint8).reshape((1, 1, 4, 1))
         qh = qh.reshape((n_blocks, -1))
         qs = np.concatenate([qs0, qs1, qh], axis=-1)
         qs = ((qs.astype(np.uint16) * 3) >> 8).astype(np.int8) - np.int8(1)
 
-        return d * qs.astype(np.float32)
+        return (d * qs.astype(np.float32))
 
 
 class TQ2_0(__Quant, qtype=GGMLQuantizationType.TQ2_0):
@@ -741,9 +635,7 @@ class TQ2_0(__Quant, qtype=GGMLQuantizationType.TQ2_0):
         qs = np_roundf(blocks * id)
         qs = (qs.astype(np.int8) + np.int8(1)).astype(np.uint8)
 
-        qs = qs.reshape((n_blocks, -1, 4, 32)) << np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
+        qs = qs.reshape((n_blocks, -1, 4, 32)) << np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4, 1))
         qs = qs[..., 0, :] | qs[..., 1, :] | qs[..., 2, :] | qs[..., 3, :]
         qs = qs.reshape((n_blocks, -1))
 
@@ -759,28 +651,16 @@ class TQ2_0(__Quant, qtype=GGMLQuantizationType.TQ2_0):
 
         d = d.view(np.float16).astype(np.float32)
 
-        qs = qs.reshape((n_blocks, -1, 1, 32)) >> np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 1, 4, 1))
+        qs = qs.reshape((n_blocks, -1, 1, 32)) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4, 1))
         qs = (qs & 0x03).reshape((n_blocks, -1)).astype(np.int8) - np.int8(1)
 
-        return d * qs.astype(np.float32)
+        return (d * qs.astype(np.float32))
 
 
 class MXFP4(__Quant, qtype=GGMLQuantizationType.MXFP4):
     # e2m1 values (doubled)
     # ref: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
     kvalues = (0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12)
-
-    @staticmethod
-    # see ggml_e8m0_to_fp32_half in ggml-impl.h
-    def e8m0_to_fp32_half(x: np.ndarray) -> np.ndarray:
-        bits = np.where(
-            x < 2,
-            np.uint32(0x00200000) << np.uint32(x),
-            np.uint32(x - 1) << np.uint32(23),
-        )
-        return bits.view(np.float32)
 
     @classmethod
     def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
@@ -795,10 +675,7 @@ class MXFP4(__Quant, qtype=GGMLQuantizationType.MXFP4):
 
         kvalues = np.array(cls.kvalues, dtype=np.int8).reshape((1, 1, 16))
 
-        errs = np.abs(
-            d.reshape((n_blocks, 1, 1)) * kvalues.astype(np.float32)
-            - blocks.reshape((n_blocks, cls.block_size, 1))
-        )
+        errs = np.abs(d.reshape((n_blocks, 1, 1)) * kvalues.astype(np.float32) - blocks.reshape((n_blocks, cls.block_size, 1)))
         best = np.argmin(errs, axis=-1, keepdims=True)
 
         qs = best.reshape(n_blocks, 2, cls.block_size // 2).astype(np.uint8)
@@ -816,100 +693,25 @@ class MXFP4(__Quant, qtype=GGMLQuantizationType.MXFP4):
 
         d = cls.e8m0_to_fp32_half(e)
 
-        qs = qs.reshape((n_blocks, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 2, 1))
+        qs = qs.reshape((n_blocks, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 2, 1))
         qs = (qs & np.uint8(0x0F)).view(np.int8)
 
         kvalues = np.array(cls.kvalues, dtype=np.int8).reshape(1, 1, 16)
-        qs = np.take_along_axis(kvalues, qs, axis=-1).reshape(
-            (n_blocks, cls.block_size)
-        )
+        qs = np.take_along_axis(kvalues, qs, axis=-1).reshape((n_blocks, cls.block_size))
 
-        return d * qs.astype(np.float32)
+        return (d * qs.astype(np.float32))
 
-
-class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6E3M2):
+class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6_E3M2):
     # e3m2 values (origin * 16)
     # ref: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
     kvalues = (
         # 32 Positive values
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10,
-        12,
-        14,
-        16,
-        20,
-        24,
-        28,
-        32,
-        40,
-        48,
-        56,
-        64,
-        80,
-        96,
-        112,
-        128,
-        160,
-        192,
-        224,
-        256,
-        320,
-        384,
-        448,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40,
+        48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 448,
         # 32 Negative values
-        0,
-        -1,
-        -2,
-        -3,
-        -4,
-        -5,
-        -6,
-        -7,
-        -8,
-        -10,
-        -12,
-        -14,
-        -16,
-        -20,
-        -24,
-        -28,
-        -32,
-        -40,
-        -48,
-        -56,
-        -64,
-        -80,
-        -96,
-        -112,
-        -128,
-        -160,
-        -192,
-        -224,
-        -256,
-        -320,
-        -384,
-        -448,
+        0, -1, -2, -3, -4, -5, -6, -7, -8, -10, -12, -14, -16, -20, -24, -28, -32, -40,
+        -48, -56, -64, -80, -96, -112, -128, -160, -192, -224, -256, -320, -384, -448,
     )
-
-    @staticmethod
-    # see ggml_e8m0_to_fp32_half in ggml-impl.h
-    def e8m0_to_fp32_half(x: np.ndarray) -> np.ndarray:
-        bits = np.where(
-            x < 2,
-            np.uint32(0x00200000) << np.uint32(x),
-            np.uint32(x - 1) << np.uint32(23),
-        )
-        return bits.view(np.float32)
 
     @classmethod
     def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
@@ -984,85 +786,15 @@ class MXFP6E3M2(__Quant, qtype=GGMLQuantizationType.MXFP6E3M2):
         return d * qs_dequant.astype(np.float32)
 
 
-class MXFP6E2M3(__Quant, qtype=GGMLQuantizationType.MXFP6E2M3):
+class MXFP6E2M3(__Quant, qtype=GGMLQuantizationType.MXFP6_E2M3):
     # e2m3 values (origin * 8)
     # ref: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
     kvalues = (
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        18,
-        20,
-        22,
-        24,
-        26,
-        28,
-        30,
-        32,
-        36,
-        40,
-        44,
-        48,
-        52,
-        56,
-        60,
-        0,
-        -1,
-        -2,
-        -3,
-        -4,
-        -5,
-        -6,
-        -7,
-        -8,
-        -9,
-        -10,
-        -11,
-        -12,
-        -13,
-        -14,
-        -15,
-        -16,
-        -18,
-        -20,
-        -22,
-        -24,
-        -26,
-        -28,
-        -30,
-        -32,
-        -36,
-        -40,
-        -44,
-        -48,
-        -52,
-        -56,
-        -60,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20,
+        22, 24, 26, 28, 30, 32, 36, 40, 44, 48, 52, 56, 60,
+        0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, -18, -20,
+        -22, -24, -26, -28, -30, -32, -36, -40, -44, -48, -52, -56, -60,
     )
-
-    @staticmethod
-    # see ggml_e8m0_to_fp32_half in ggml-impl.h
-    def e8m0_to_fp32_half(x: np.ndarray) -> np.ndarray:
-        bits = np.where(
-            x < 2,
-            np.uint32(0x00200000) << np.uint32(x),
-            np.uint32(x - 1) << np.uint32(23),
-        )
-        return bits.view(np.float32)
 
     @classmethod
     def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
@@ -1152,7 +884,7 @@ class IQ2_XXS(__Quant, qtype=GGMLQuantizationType.IQ2_XXS):
     # iq2xxs_grid, but with each byte of the original packed in 2 bits,
     # by mapping 0x08 to 0, 0x19 to 1, and 0x2b to 2.
     grid_shape = (256, 8)
-    grid_map = (0x08, 0x19, 0x2B)
+    grid_map = (0x08, 0x19, 0x2b)
     grid_hex = (
         b"00000200050008000a00110014002000220028002a0041004400500058006100"
         b"6400800082008a00a20001010401100115014001840198010002020222028202"
@@ -1182,33 +914,21 @@ class IQ2_XXS(__Quant, qtype=GGMLQuantizationType.IQ2_XXS):
 
         qs = qs.view(np.uint32).reshape(n_blocks, -1, 2)
 
-        db = (
-            d
-            * (np.float32(0.5) + (qs[..., 1] >> 28).astype(np.float32))
-            * np.float32(0.25)
-        )
+        db = d * (np.float32(0.5) + (qs[..., 1] >> 28).astype(np.float32)) * np.float32(0.25)
         db = db.reshape((n_blocks, -1, 1, 1))
 
         # get the sign indices and unpack the bits
-        signs = qs[..., 1].reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 7, 14, 21], dtype=np.uint32
-        ).reshape((1, 1, 4))
+        signs = qs[..., 1].reshape((n_blocks, -1, 1)) >> np.array([0, 7, 14, 21], dtype=np.uint32).reshape((1, 1, 4))
         ksigns = np.frombuffer(cls.ksigns, dtype=np.uint8).reshape((1, 1, 1, 128))
         signs = (signs & np.uint32(0x7F)).reshape((n_blocks, -1, 4, 1))
         signs = np.take_along_axis(ksigns, signs, axis=-1)
-        signs = signs.reshape((n_blocks, -1, 4, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 1, 8))
+        signs = signs.reshape((n_blocks, -1, 4, 1)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 1, 8))
         signs = signs & np.uint8(0x01)
         signs = np.where(signs == 0, np.float32(1), np.float32(-1))
         signs = signs.reshape((n_blocks, -1, 4, 8))
 
         assert cls.grid is not None
-        grid = np.take_along_axis(
-            cls.grid,
-            qs[..., 0].copy().view(np.uint8).reshape((n_blocks, -1, 1, 1)),
-            axis=-2,
-        )
+        grid = np.take_along_axis(cls.grid, qs[..., 0].copy().view(np.uint8).reshape((n_blocks, -1, 1, 1)), axis=-2)
         grid = grid.reshape((n_blocks, -1, 4, 8))
 
         return (db * grid * signs).reshape((n_blocks, -1))
@@ -1218,7 +938,7 @@ class IQ2_XS(__Quant, qtype=GGMLQuantizationType.IQ2_XS):
     # iq2xs_grid, but with each byte of the original packed in 2 bits,
     # by mapping 0x08 to 0, 0x19 to 1, and 0x2b to 2.
     grid_shape = (512, 8)
-    grid_map = (0x08, 0x19, 0x2B)
+    grid_map = (0x08, 0x19, 0x2b)
     grid_hex = (
         b"00000200050008000a0011001400160019002000220025002800410044004600"
         b"49005000520055005800610064008000820085008800910094009900a0000101"
@@ -1264,9 +984,7 @@ class IQ2_XS(__Quant, qtype=GGMLQuantizationType.IQ2_XS):
         d = d.view(np.float16).astype(np.float32)
         qs = qs.view(np.uint16)
 
-        scales = scales.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2))
+        scales = scales.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2))
         scales = (scales & 0x0F).reshape((n_blocks, -1))
         db = d * (np.float32(0.5) + scales) * np.float32(0.25)
         db = db.reshape((n_blocks, -1, 1, 1))
@@ -1274,17 +992,13 @@ class IQ2_XS(__Quant, qtype=GGMLQuantizationType.IQ2_XS):
         # get the sign indices and unpack the bits
         signs = np.frombuffer(IQ2_XXS.ksigns, dtype=np.uint8).reshape(1, 1, 128)
         signs = np.take_along_axis(signs, (qs >> 9).reshape((n_blocks, -1, 1)), axis=-1)
-        signs = signs.reshape((n_blocks, -1, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 8))
+        signs = signs.reshape((n_blocks, -1, 1)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 8))
         signs = signs & np.uint8(0x01)
         signs = np.where(signs == 0, np.float32(1), np.float32(-1))
         signs = signs.reshape((n_blocks, -1, 2, 8))
 
         assert cls.grid is not None
-        grid = np.take_along_axis(
-            cls.grid, (qs & np.uint16(511)).reshape((n_blocks, -1, 1, 1)), axis=-2
-        )
+        grid = np.take_along_axis(cls.grid, (qs & np.uint16(511)).reshape((n_blocks, -1, 1, 1)), axis=-2)
         grid = grid.reshape((n_blocks, -1, 2, 8))
 
         return (db * grid * signs).reshape((n_blocks, -1))
@@ -1294,7 +1008,7 @@ class IQ2_S(__Quant, qtype=GGMLQuantizationType.IQ2_S):
     # iq2s_grid, but with each byte of the original packed in 2 bits,
     # by mapping 0x08 to 0, 0x19 to 1, and 0x2b to 2.
     grid_shape = (1024, 8)
-    grid_map = (0x08, 0x19, 0x2B)
+    grid_map = (0x08, 0x19, 0x2b)
     grid_hex = (
         b"00000200050008000a0011001400160019002000220025002800410044004600"
         b"490050005200550058006100640066006900800082008500880091009400a000"
@@ -1373,27 +1087,19 @@ class IQ2_S(__Quant, qtype=GGMLQuantizationType.IQ2_S):
 
         d = d.view(np.float16).astype(np.float32)
 
-        scales = scales.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2))
+        scales = scales.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2))
         scales = (scales & 0x0F).reshape((n_blocks, -1))
         db = d * (np.float32(0.5) + scales) * np.float32(0.25)
         db = db.reshape((n_blocks, -1, 1, 1))
 
         # unpack the sign bits
-        signs = signs.reshape((n_blocks, -1, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 8))
+        signs = signs.reshape((n_blocks, -1, 1)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 8))
         signs = signs & np.uint8(0x01)
         signs = np.where(signs == 0, np.float32(1), np.float32(-1))
         signs = signs.reshape((n_blocks, -1, 2, 8))
 
-        qh = qh.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 2, 4, 6], dtype=np.uint8
-        ).reshape((1, 1, 4))
-        qs = qs.astype(np.uint16) | ((qh & 0x03).astype(np.uint16) << 8).reshape(
-            (n_blocks, -1)
-        )
+        qh = qh.reshape((n_blocks, -1, 1)) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape((1, 1, 4))
+        qs = qs.astype(np.uint16) | ((qh & 0x03).astype(np.uint16) << 8).reshape((n_blocks, -1))
 
         assert cls.grid is not None
         grid = np.take_along_axis(cls.grid, qs.reshape((n_blocks, -1, 1, 1)), axis=-2)
@@ -1404,7 +1110,7 @@ class IQ2_S(__Quant, qtype=GGMLQuantizationType.IQ2_S):
 
 class IQ3_XXS(__Quant, qtype=GGMLQuantizationType.IQ3_XXS):
     grid_shape = (256, 4)
-    grid_map = (0x04, 0x0C, 0x14, 0x1C, 0x24, 0x2C, 0x34, 0x3E)
+    grid_map = (0x04, 0x0c, 0x14, 0x1c, 0x24, 0x2c, 0x34, 0x3e)
     grid_hex = (
         b"0000020004001100130017002000220031004200730075000101030110011201"
         b"2101250130013201410154017001000202020402110220022202310233023702"
@@ -1438,15 +1144,11 @@ class IQ3_XXS(__Quant, qtype=GGMLQuantizationType.IQ3_XXS):
         db = db.reshape((n_blocks, -1, 1, 1))
 
         # get the sign indices and unpack the bits
-        signs = scales.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 7, 14, 21], dtype=np.uint32
-        ).reshape((1, 1, 4))
+        signs = scales.reshape((n_blocks, -1, 1)) >> np.array([0, 7, 14, 21], dtype=np.uint32).reshape((1, 1, 4))
         ksigns = np.frombuffer(IQ2_XXS.ksigns, dtype=np.uint8).reshape((1, 1, 1, 128))
         signs = (signs & np.uint32(0x7F)).reshape((n_blocks, -1, 4, 1))
         signs = np.take_along_axis(ksigns, signs, axis=-1)
-        signs = signs.reshape((n_blocks, -1, 4, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 1, 8))
+        signs = signs.reshape((n_blocks, -1, 4, 1)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 1, 8))
         signs = signs & np.uint8(0x01)
         signs = np.where(signs == 0, np.float32(1), np.float32(-1))
         signs = signs.reshape((n_blocks, -1, 4, 8))
@@ -1460,7 +1162,7 @@ class IQ3_XXS(__Quant, qtype=GGMLQuantizationType.IQ3_XXS):
 
 class IQ3_S(__Quant, qtype=GGMLQuantizationType.IQ3_S):
     grid_shape = (512, 4)
-    grid_map = (0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F)
+    grid_map = (0x01, 0x03, 0x05, 0x07, 0x09, 0x0b, 0x0d, 0x0f)
     grid_hex = (
         b"0000010002000500070010001100120014001600200021002500330040004200"
         b"4500470051005300600062007100740077000001010102010401100111011501"
@@ -1507,24 +1209,18 @@ class IQ3_S(__Quant, qtype=GGMLQuantizationType.IQ3_S):
 
         d = d.view(np.float16).astype(np.float32)
 
-        scales = scales.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2))
+        scales = scales.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2))
         scales = (scales & 0x0F).reshape((n_blocks, -1))
         db = d * (1 + 2 * scales)
         db = db.reshape((n_blocks, -1, 1, 1))
 
         # unpack the sign bits
-        signs = signs.reshape((n_blocks, -1, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        ).reshape((1, 1, 8))
+        signs = signs.reshape((n_blocks, -1, 1)) >> np.array([i for i in range(8)], dtype=np.uint8).reshape((1, 1, 8))
         signs = signs & np.uint8(0x01)
         signs = np.where(signs == 0, np.float32(1), np.float32(-1))
         signs = signs.reshape((n_blocks, -1, 4, 8))
 
-        qh = qh.reshape((n_blocks, -1, 1)) >> np.array(
-            [i for i in range(8)], dtype=np.uint8
-        )
+        qh = qh.reshape((n_blocks, -1, 1)) >> np.array([i for i in range(8)], dtype=np.uint8)
         qh = (qh & 0x01).astype(np.uint16).reshape((n_blocks, -1))
         qs = qs.astype(np.uint16) | (qh << 8)
 
@@ -1688,9 +1384,7 @@ class IQ1_S(__Quant, qtype=GGMLQuantizationType.IQ1_S):
         delta = np.where((qh & np.uint16(0x8000)) == 0, cls.delta, -cls.delta)
         delta = delta.reshape((n_blocks, -1, 1, 1))
 
-        qh = qh.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 3, 6, 9], dtype=np.uint16
-        ).reshape((1, 1, 4))
+        qh = qh.reshape((n_blocks, -1, 1)) >> np.array([0, 3, 6, 9], dtype=np.uint16).reshape((1, 1, 4))
         qs = qs.astype(np.uint16) | ((qh & 7) << 8).reshape((n_blocks, -1))
 
         assert cls.grid is not None
@@ -1717,25 +1411,17 @@ class IQ1_M(__Quant, qtype=GGMLQuantizationType.IQ1_M):
 
         # The f16 scale is packed across multiple bytes
         scales = scales.view(np.uint16)
-        d = (scales.reshape((n_blocks, 4)) & np.uint16(0xF000)) >> np.array(
-            [12, 8, 4, 0], dtype=np.uint16
-        ).reshape((1, 4))
+        d = (scales.reshape((n_blocks, 4)) & np.uint16(0xF000)) >> np.array([12, 8, 4, 0], dtype=np.uint16).reshape((1, 4))
         d = d[..., 0] | d[..., 1] | d[..., 2] | d[..., 3]
         d = d.view(np.float16).astype(np.float32).reshape((n_blocks, 1))
 
-        scales = scales.reshape(n_blocks, -1, 1) >> np.array(
-            [0, 3, 6, 9], dtype=np.uint16
-        ).reshape((1, 1, 4))
+        scales = scales.reshape(n_blocks, -1, 1) >> np.array([0, 3, 6, 9], dtype=np.uint16).reshape((1, 1, 4))
         scales = (scales & 0x07).reshape((n_blocks, -1))
         dl = d * (2 * scales + 1)
         dl = dl.reshape((n_blocks, -1, 2, 1, 1))
 
-        qh = qh.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape(
-            (1, 1, 2)
-        )
-        qs = qs.astype(np.uint16) | ((qh & 0x07).astype(np.uint16) << 8).reshape(
-            (n_blocks, -1)
-        )
+        qh = qh.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2))
+        qs = qs.astype(np.uint16) | ((qh & 0x07).astype(np.uint16) << 8).reshape((n_blocks, -1))
 
         delta = np.where(qh & 0x08 == 0, cls.delta, -cls.delta)
         delta = delta.reshape((n_blocks, -1, 2, 2, 1))
@@ -1758,20 +1444,14 @@ class IQ4_NL(__Quant, qtype=GGMLQuantizationType.IQ4_NL):
 
         d = d.view(np.float16).astype(np.float32)
 
-        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qs = qs.reshape((n_blocks, -1, 1, cls.block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
 
         qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1, 1))
 
         kvalues = np.array(cls.kvalues, dtype=np.int8).reshape(1, 1, 16)
-        qs = (
-            np.take_along_axis(kvalues, qs, axis=-1)
-            .astype(np.float32)
-            .reshape((n_blocks, -1))
-        )
+        qs = np.take_along_axis(kvalues, qs, axis=-1).astype(np.float32).reshape((n_blocks, -1))
 
-        return d * qs
+        return (d * qs)
 
 
 class IQ4_XS(__Quant, qtype=GGMLQuantizationType.IQ4_XS):
@@ -1786,28 +1466,18 @@ class IQ4_XS(__Quant, qtype=GGMLQuantizationType.IQ4_XS):
         d = d.view(np.float16).astype(np.float32)
         scales_h = scales_h.view(np.uint16)
 
-        scales_l = scales_l.reshape((n_blocks, -1, 1)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2))
-        scales_h = scales_h.reshape((n_blocks, 1, -1)) >> np.array(
-            [2 * i for i in range(QK_K // 32)], dtype=np.uint16
-        ).reshape((1, -1, 1))
+        scales_l = scales_l.reshape((n_blocks, -1, 1)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2))
+        scales_h = scales_h.reshape((n_blocks, 1, -1)) >> np.array([2 * i for i in range(QK_K // 32)], dtype=np.uint16).reshape((1, -1, 1))
         scales_l = scales_l.reshape((n_blocks, -1)) & np.uint8(0x0F)
         scales_h = scales_h.reshape((n_blocks, -1)).astype(np.uint8) & np.uint8(0x03)
 
         scales = (scales_l | (scales_h << np.uint8(4))).astype(np.int8) - np.int8(32)
         dl = (d * scales.astype(np.float32)).reshape((n_blocks, -1, 1))
 
-        qs = qs.reshape((n_blocks, -1, 1, 16)) >> np.array(
-            [0, 4], dtype=np.uint8
-        ).reshape((1, 1, 2, 1))
+        qs = qs.reshape((n_blocks, -1, 1, 16)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qs = qs.reshape((n_blocks, -1, 32, 1)) & np.uint8(0x0F)
 
         kvalues = np.array(IQ4_NL.kvalues, dtype=np.int8).reshape((1, 1, 1, -1))
-        qs = (
-            np.take_along_axis(kvalues, qs, axis=-1)
-            .astype(np.float32)
-            .reshape((n_blocks, -1, 32))
-        )
+        qs = np.take_along_axis(kvalues, qs, axis=-1).astype(np.float32).reshape((n_blocks, -1, 32))
 
         return (dl * qs).reshape((n_blocks, -1))

--- a/include/llama.h
+++ b/include/llama.h
@@ -152,7 +152,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_TQ2_0         = 37, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_MXFP4_MOE     = 38, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE     = 39, // except 1d tensors
-        //LLAMA_FTYPE_MOSTLY_MXFP6E2M3_MOE     = 40, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_MXFP6_E2M3_MOE     = 40, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };

--- a/include/llama.h
+++ b/include/llama.h
@@ -151,6 +151,8 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_TQ1_0         = 36, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_TQ2_0         = 37, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_MXFP4_MOE     = 38, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE     = 39, // except 1d tensors
+        //LLAMA_FTYPE_MOSTLY_MXFP6E2M3_MOE     = 40, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -37,7 +37,7 @@ static std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q8_0:     return "Q8_0";
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return "MXFP4 MoE";
         case LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE: return "MXFP6_E3M2 MoE";
-        //case LLAMA_FTYPE_MOSTLY_MXFP6E2M3_MOE: return "MXFP6E2M3 MoE";
+        case LLAMA_FTYPE_MOSTLY_MXFP6_E2M3_MOE: return "MXFP6_E2M3 MoE";
         case LLAMA_FTYPE_MOSTLY_Q2_K:     return "Q2_K - Medium";
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:   return "Q2_K - Small";
         case LLAMA_FTYPE_MOSTLY_Q3_K_S:   return "Q3_K - Small";

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -36,6 +36,8 @@ static std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q5_1:     return "Q5_1";
         case LLAMA_FTYPE_MOSTLY_Q8_0:     return "Q8_0";
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return "MXFP4 MoE";
+        case LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE: return "MXFP6_E3M2 MoE";
+        //case LLAMA_FTYPE_MOSTLY_MXFP6E2M3_MOE: return "MXFP6E2M3 MoE";
         case LLAMA_FTYPE_MOSTLY_Q2_K:     return "Q2_K - Medium";
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:   return "Q2_K - Small";
         case LLAMA_FTYPE_MOSTLY_Q3_K_S:   return "Q3_K - Small";

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -23,6 +23,8 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "MXFP6_E3M2_MOE",LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE," MXFP6_E3M2 MoE",  },
+    //{ "MXFP6_MOE",LLAMA_FTYPE_MOSTLY_MXFP6_MOE," MXFP6 MoE",  },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -24,6 +24,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
     { "MXFP6_E3M2_MOE",LLAMA_FTYPE_MOSTLY_MXFP6_E3M2_MOE," MXFP6_E3M2 MoE",  },
+    { "MXFP6_E2M3_MOE",LLAMA_FTYPE_MOSTLY_MXFP6_E2M3_MOE," MXFP6_E2M3 MoE",  },
     //{ "MXFP6_MOE",LLAMA_FTYPE_MOSTLY_MXFP6_MOE," MXFP6 MoE",  },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

* Add basic MXFP6 E3M2 and E2M3 to ggml
* CPU-only implementation (without CUDA and AVX2)

`test-quantize-*` passed in local CI.

```bash
d:\llama.cpp> ./build_cpu/bin/Debug/test-quantize-fns.exe
....
Testing tq2_0
Testing mxfp4
Testing mxfp6_e3m2
Testing mxfp6_e2m3

d:\llama.cpp> ./build_cpu/bin/Debug/test-quantize-perf.exe
...
mxfp4
  quantize_row_q_reference
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.08 GB/s
      quantized throughput :      0.01 GB/s

  quantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.08 GB/s
      quantized throughput :      0.01 GB/s

  dequantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.18 GB/s
      quantized throughput :      0.29 GB/s

  quantize_row_q_dot
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.46 GB/s
      quantized throughput :      0.33 GB/s

  vec_dot_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      5.87 GB/s
      quantized throughput :      0.78 GB/s

mxfp6_e3m2
  quantize_row_q_reference
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.02 GB/s
      quantized throughput :      0.00 GB/s

  quantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.02 GB/s
      quantized throughput :      0.00 GB/s

  dequantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.03 GB/s
      quantized throughput :      0.40 GB/s

  quantize_row_q_dot
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.46 GB/s
      quantized throughput :      0.48 GB/s

  vec_dot_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.06 GB/s
      quantized throughput :      0.40 GB/s

mxfp6_e2m3
  quantize_row_q_reference
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.02 GB/s
      quantized throughput :      0.00 GB/s

  quantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      0.02 GB/s
      quantized throughput :      0.00 GB/s

  dequantize_row_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.03 GB/s
      quantized throughput :      0.40 GB/s

  quantize_row_q_dot
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.42 GB/s
      quantized throughput :      0.47 GB/s

  vec_dot_q
    4096 values (0.02 MB)
      min cycles/32 vals   :      0.00
      avg cycles/32 vals   :      0.00
      float32 throughput   :      2.72 GB/s
      quantized throughput :      0.53 GB/s
```

```
      Start 29: test-gguf
29/35 Test #29: test-gguf .........................   Passed    0.15 sec
      Start 32: test-barrier
30/35 Test #32: test-barrier ......................   Passed    1.16 sec
      Start 33: test-quantize-fns
31/35 Test #33: test-quantize-fns .................   Passed   17.83 sec
      Start 34: test-quantize-perf
32/35 Test #34: test-quantize-perf ................   Passed    0.28 sec
      Start 35: test-rope
33/35 Test #35: test-rope .........................   Passed    0.06 sec
      Start 36: test-mtmd-c-api
34/35 Test #36: test-mtmd-c-api ...................   Passed    0.01 sec
      Start 37: test-alloc
35/35 Test #37: test-alloc ........................   Passed    0.00 sec

97% tests passed, 1 tests failed out of 35

Label Time Summary:
main    =  46.14 sec*proc (35 tests)

Total Test time (real) =  46.15 sec

The following tests FAILED:
	 14 - test-tokenizers-ggml-vocabs (Failed)
Errors while running CTest

real	0m46.164s
user	1m14.081s
sys	0m1.035s
```

`test-tokenizer-ggml-vocabs` reports failure but I don't think it's caused by this PR: (as this pr does not change gguf parser)

```
main : reading vocab from: 'models/ggml-vocabs/PLaMo2/ggml-vocab-plamo2.gguf'
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (AMD Ryzen 5 7600 6-Core Processor)
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /models/ggml-vocabs/PLaMo2/ggml-vocab-plamo2.gguf
```