### PR TITLE
llama: Fused QKV multiplication

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -757,6 +757,7 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
             { LLM_TENSOR_FFN_GATE,        "blk.%d.ffn_gate" },
             { LLM_TENSOR_FFN_DOWN,        "blk.%d.ffn_down" },
             { LLM_TENSOR_FFN_UP,          "blk.%d.ffn_up" },
+            { LLM_TENSOR_ATTN_QKV,        "blk.%d.attn_qkv" },
         },
     },
     {
@@ -777,6 +778,7 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
             { LLM_TENSOR_FFN_GATE_EXPS,      "blk.%d.ffn_gate_exps" },
             { LLM_TENSOR_FFN_DOWN_EXPS,      "blk.%d.ffn_down_exps" },
             { LLM_TENSOR_FFN_UP_EXPS,        "blk.%d.ffn_up_exps" },
+            { LLM_TENSOR_ATTN_QKV,           "blk.%d.attn_qkv" },
         },
     },
     {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -24,6 +24,8 @@ class llama_kv_cache_iswa_context;
 class llama_memory_recurrent_context;
 class llama_memory_hybrid_context;
 
+struct llama_layer;
+
 // certain models (typically multi-modal) can produce different types of graphs
 enum llm_graph_type {
     LLM_GRAPH_TYPE_DEFAULT,
@@ -603,6 +605,18 @@ struct llm_graph_context {
     ggml_tensor * build_lora_mm(
               ggml_tensor * w,
               ggml_tensor * cur) const;
+
+    void build_qkv(const llama_layer & layer,
+            ggml_tensor       * cur,
+            int64_t             n_embd_head_q,
+            int64_t             n_embd_head_k,
+            int64_t             n_embd_head_v,
+            int32_t             n_head,
+            int32_t             n_head_kv,
+            ggml_tensor      ** q_out,
+            ggml_tensor      ** k_out,
+            ggml_tensor      ** v_out,
+            int                 il) const;
 
     // do mat_mul_id, while optionally apply lora
     ggml_tensor * build_lora_mm_id(

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -147,6 +147,9 @@ struct llama_model_loader {
 
     struct ggml_tensor * create_tensor_as_view(struct ggml_context * ctx, struct ggml_tensor * base, const std::string & name, const std::initializer_list<int64_t> & ne, size_t offset, bool required = true);
 
+    struct ggml_tensor * create_contiguous_tensor(struct ggml_context * ctx, const std::string & fused_name, const std::initializer_list<int64_t> & ne
+        , std::vector<ggml_tensor**> tensors, int flags = 0);
+
     void done_getting_tensors() const;
 
     void init_mappings(bool prefetch = true, llama_mlocks * mlock_mmaps = nullptr);


### PR DESCRIPTION
This is a draft PR for comments about QKV fusion. Performance wise I checked CUDA it seems to be roughly ~4-5% performance gain (in PP and TG) for qwen3 models. 

This tries to merge the weights together to form a single GEMM, rather than 3 separate ones. The main drawback of this approach is that there might be other tensors in between the Q,K,V weights (like LoRAs) which would break mmap (as @slaren pointed out). However, doing this on the backend is a much more involved change which might not worth the benefit. For now I'm thinking the best way forward be

1. Add the wqkv, bqkv tensors to future GGUFs using an option in `convert_hf_to_gguf.py` 
2. In case the user wants and knows the weights are together, a flag `--fuse-qkv-weights` can be provided to take this path.

IMO the QKV weights should always live in the GGUF file together without exceptions as they're naturally used together.

Some performance numbers on a 4090:

Without fusion
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |           pp512 |      3846.64 ± 15.30 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp1024 |      5651.13 ± 21.24 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp2048 |      7024.90 ± 14.43 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp4096 |       7504.26 ± 9.66 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |           tg128 |        151.89 ± 0.10 |


With fusion

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |           pp512 |      3933.52 ± 20.74 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp1024 |      5768.19 ± 19.00 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp2048 |      7430.25 ± 14.64 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |          pp4096 |      8022.90 ± 13.50 |
| qwen3moe 30B.A3B Q4_0          |  16.11 GiB |    30.53 B | CUDA       |  99 |           tg128 |        159.59 ± 0.20 |

