### PR TITLE
Massively Improved ROCm/HIP rocWMMA Performance (pp and tg)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -721,9 +721,12 @@ static __global__ void flash_attn_tile(
 
     // Skip unused kernel variants for faster compilation:
 
+    // Optionally disable pruning to keep all TILE variants for testing.
+#if !defined(GGML_USE_HIP)
     if (
 #ifdef GGML_USE_WMMA_FATTN
-            (ncols2 != 1 && DV != 40 && DV != 512) ||
+            // On CUDA WMMA builds, prune some TILE variants to reduce compile time/binary size.
+            (ncols2 != 1 && DV != 40 && DV != 64 && DV != 128 && DV != 256 && DV != 512) ||
 #endif // GGML_USE_WMMA_FATTN
             (use_logit_softcap && !(DV == 128 || DV == 256))
     ) {
@@ -739,6 +742,7 @@ static __global__ void flash_attn_tile(
         NO_DEVICE_CODE;
         return;
     }
+#endif // !defined(GGML_USE_HIP)
 
     static_assert(ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols1*ncols2) != 0, "kernel config not defined");
 

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cu
@@ -20,9 +20,24 @@ namespace wmma = rocwmma;
 #endif // !defined(GGML_USE_HIP)
 #endif // GGML_USE_WMMA_FATTN
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+static constexpr int GGML_ROCWMMA_FATTN_MIN_BLOCKS_PER_SM = 2;
+#else
+static constexpr int GGML_ROCWMMA_FATTN_MIN_BLOCKS_PER_SM = 1;
+#endif
+
+template <int D>
+constexpr int ggml_wmma_fattn_kq_stride() {
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+    return D <= 128 ? 128 : FATTN_KQ_STRIDE;
+#else
+    return FATTN_KQ_STRIDE;
+#endif
+}
+
 // D == head size, VKQ_stride == num VKQ rows calculated in parallel:
 template<int D, int ncols, int nwarps, int VKQ_stride, typename KQ_acc_t, bool use_logit_softcap>
-__launch_bounds__(nwarps*ggml_cuda_get_physical_warp_size(), 1)
+__launch_bounds__(nwarps*ggml_cuda_get_physical_warp_size(), GGML_ROCWMMA_FATTN_MIN_BLOCKS_PER_SM)
 static __global__ void flash_attn_ext_f16(
         const char * __restrict__ Q,
         const char * __restrict__ K,
@@ -55,10 +70,12 @@ static __global__ void flash_attn_ext_f16(
     //In this kernel Q, K, V are matrices while i, j, k are matrix indices.
 
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int fattn_kq_stride = ggml_wmma_fattn_kq_stride<D>();
+
+    static_assert(D <= fattn_kq_stride, "D must be <= fattn_kq_stride.");
 
     const int ic0 = ncols*blockIdx.x; // Index of the first Q/QKV column to work on.
 
-    static_assert(D <= FATTN_KQ_STRIDE, "D must be <= FATTN_KQ_STRIDE.");
     static_assert(ncols == 8 || ncols % 16 == 0, "ncols must be 8 or a multiple of 16.");
     constexpr int frag_m = ncols == 8 ? 32 : 16;
     constexpr int frag_n = ncols == 8 ?  8 : 16;
@@ -75,7 +92,7 @@ static __global__ void flash_attn_ext_f16(
 
     // Pad internal representation of KQ, KQV to reduce shared memory bank conflicts:
     constexpr int D_padded = D + 8;
-    constexpr int kqs_padded = FATTN_KQ_STRIDE + 8;
+    constexpr int kqs_padded = fattn_kq_stride + 8;
     constexpr int kqar = sizeof(KQ_acc_t)/sizeof(half);
 
     const int sequence = blockIdx.z / ne02;
@@ -168,10 +185,10 @@ static __global__ void flash_attn_ext_f16(
 
     // Iterate over ne11 == previous tokens:
     const int k_VKQ_max = KV_max ? KV_max[sequence*gridDim.x + blockIdx.x] : ne11;
-    for (int k_VKQ_0 = blockIdx.y*FATTN_KQ_STRIDE; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*FATTN_KQ_STRIDE) {
+    for (int k_VKQ_0 = blockIdx.y*fattn_kq_stride; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*fattn_kq_stride) {
         // Calculate tile of KQ:
 #pragma unroll
-        for (int i_KQ_0 = 0; i_KQ_0 < FATTN_KQ_STRIDE; i_KQ_0 += KQ_stride_tc) {
+        for (int i_KQ_0 = 0; i_KQ_0 < fattn_kq_stride; i_KQ_0 += KQ_stride_tc) {
             frag_c_KQ KQ_c[ncols/frag_n];
 #pragma unroll
             for (int j = 0; j < ncols/frag_n; ++j) {
@@ -201,9 +218,9 @@ static __global__ void flash_attn_ext_f16(
             const int j = j0 + threadIdx.y;
 
             if (std::is_same<KQ_acc_t, float>::value) {
-                float KQ_f_tmp[FATTN_KQ_STRIDE / warp_size];
+                float KQ_f_tmp[fattn_kq_stride / warp_size];
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     KQ_f_tmp[k0/warp_size] = KQ_f[j*kqs_padded + k];
@@ -215,7 +232,7 @@ static __global__ void flash_attn_ext_f16(
 
                 float KQ_max_new = KQ_max_f[j0/nwarps];
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     KQ_f_tmp[k0/warp_size] += mask ? __half2float(slopeh*maskh[j*(nb31/sizeof(half)) + k_VKQ_0 + k]) : 0.0f;
@@ -232,7 +249,7 @@ static __global__ void flash_attn_ext_f16(
 
                 float KQ_rowsum_add = 0.0f;
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     const float diff = KQ_f_tmp[k0/warp_size] - KQ_max_f[j0/nwarps];
@@ -248,9 +265,9 @@ static __global__ void flash_attn_ext_f16(
                 // Scale previous KQ_rowsum to account for a potential increase in KQ_max:
                 KQ_rowsum_f[j0/nwarps] = KQ_max_scale_f[j0/nwarps]*KQ_rowsum_f[j0/nwarps] + KQ_rowsum_add;
             } else {
-                half2 KQ2_tmp[FATTN_KQ_STRIDE/(2*warp_size)];
+                half2 KQ2_tmp[fattn_kq_stride/(2*warp_size)];
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE/2; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride/2; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     KQ2_tmp[k0/warp_size] = KQ2[j*(kqs_padded/2) + k];
@@ -267,7 +284,7 @@ static __global__ void flash_attn_ext_f16(
 
                 half2 KQ_max_new = KQ_max_h2[j0/nwarps];
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE/2; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride/2; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     KQ2_tmp[k0/warp_size] += mask ? slope2*mask2[(j*ne11 + k_VKQ_0)/2 + k] : make_half2(0.0f, 0.0f);
@@ -282,7 +299,7 @@ static __global__ void flash_attn_ext_f16(
 
                 half2 KQ_rowsum_add = make_half2(0.0f, 0.0f);
 #pragma unroll
-                for (int k0 = 0; k0 < FATTN_KQ_STRIDE/2; k0 += warp_size) {
+                for (int k0 = 0; k0 < fattn_kq_stride/2; k0 += warp_size) {
                     const int k = k0 + threadIdx.x;
 
                     const half2 diff = KQ2_tmp[k0/warp_size] - KQ_max_h2[j0/nwarps];
@@ -301,11 +318,11 @@ static __global__ void flash_attn_ext_f16(
 
         __syncthreads();
 
-        frag_b KQ_b[FATTN_KQ_STRIDE/(VKQ_ratio*16)][ncols/frag_n];
+        frag_b KQ_b[fattn_kq_stride/(VKQ_ratio*16)][ncols/frag_n];
 #pragma unroll
         for (int j0 = 0; j0 < ncols; j0 += frag_n) {
 #pragma unroll
-            for (int k0 = 0; k0 < FATTN_KQ_STRIDE; k0 += VKQ_ratio*16) {
+            for (int k0 = 0; k0 < fattn_kq_stride; k0 += VKQ_ratio*16) {
                 const int k = k0 + (threadIdx.y % VKQ_ratio)*16;
                 wmma::load_matrix_sync(
                     KQ_b[k0/(VKQ_ratio*16)][j0/frag_n],
@@ -323,7 +340,7 @@ static __global__ void flash_attn_ext_f16(
             }
 
 #pragma unroll
-            for (int k0 = 0; k0 < FATTN_KQ_STRIDE; k0 += VKQ_ratio*16) {
+            for (int k0 = 0; k0 < fattn_kq_stride; k0 += VKQ_ratio*16) {
                 const int k = k0 + (threadIdx.y % VKQ_ratio)*16;
 
                 frag_a_V v_a;
@@ -512,7 +529,12 @@ template <int D, int cols_per_block, typename KQ_acc_t>
 void ggml_cuda_flash_attn_ext_wmma_f16_case(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * KQV = dst;
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+    constexpr int nwarps = D <= 96 ? 8 : 4;
+#else
     constexpr int nwarps = 4;
+#endif
+    constexpr int fattn_kq_stride = ggml_wmma_fattn_kq_stride<D>();
 
     constexpr int frag_m = cols_per_block == 8 && D % 32 == 0 ? 32 : 16;
     const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
@@ -530,7 +552,7 @@ void ggml_cuda_flash_attn_ext_wmma_f16_case(ggml_backend_cuda_context & ctx, ggm
         fattn_kernel = flash_attn_ext_f16<
             D, cols_per_block, nwarps, get_VKQ_stride(D, nwarps, frag_m), KQ_acc_t, use_logit_softcap>;
     }
-    launch_fattn<D, cols_per_block, 1>(ctx, dst, fattn_kernel, nwarps, 0, FATTN_KQ_STRIDE, true, true, false, warp_size);
+    launch_fattn<D, cols_per_block, 1>(ctx, dst, fattn_kernel, nwarps, 0, fattn_kq_stride, true, true, false, warp_size);
 }
 
 void ggml_cuda_flash_attn_ext_wmma_f16(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -301,11 +301,64 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // Use the WMMA kernel if possible:
-    if (ggml_cuda_should_use_wmma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40 && Q->ne[0] != 576) {
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+    const bool hip_wmma_decode = Q->ne[1] == 1;
+#else
+    const bool hip_wmma_decode = false;
+#endif
+    if (!hip_wmma_decode && ggml_cuda_should_use_wmma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40 && Q->ne[0] != 576) {
         if (can_use_vector_kernel && Q->ne[1] <= 2) {
             return BEST_FATTN_KERNEL_VEC;
         }
         return BEST_FATTN_KERNEL_WMMA_F16;
+    }
+
+    // HIP decode path (Q->ne[1] == 1): fall through to generic HIP selection below (VEC/TILE),
+    // with a guard to avoid selecting a TILE shape that has no config.
+    if (hip_wmma_decode) {
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+        // Mirror the ncols2 selection from launch_fattn_tile_switch_ncols2 to predict if
+        // a multi-column TILE kernel (ncols2 != 1) would be chosen.
+        const bool nvidia_arch = GGML_CUDA_CC_IS_NVIDIA(cc);
+        const int  gqa_limit   = (nvidia_arch && gqa_ratio <= 4) ? 16 : INT_MAX;
+        const bool use_gqa_opt = mask && max_bias == 0.0f && Q->ne[1] <= gqa_limit && K->ne[1] % FATTN_KQ_STRIDE == 0;
+
+        int predicted_ncols2 = 1;
+        if (V->ne[0] == 512) {
+            if (use_gqa_opt && gqa_ratio % 16 == 0) predicted_ncols2 = 16;
+        } else if (V->ne[0] <= 256) {
+            if (use_gqa_opt && gqa_ratio % 8 == 0)      predicted_ncols2 = 8;
+            else if (use_gqa_opt && gqa_ratio % 4 == 0) predicted_ncols2 = 4;
+            else if (use_gqa_opt && gqa_ratio % 2 == 0) predicted_ncols2 = 2;
+        }
+
+        // Predict cols_per_block like launch_fattn_tile_switch_ncols1 does (HIP path):
+        int predicted_cols_per_block = 2;
+        if (predicted_ncols2 <= 2) {
+            predicted_cols_per_block = 2;
+        }
+        if (predicted_ncols2 <= 4 && Q->ne[1] > 2/predicted_ncols2) {
+            predicted_cols_per_block = 4;
+        }
+        if (predicted_ncols2 <= 8 && Q->ne[1] > 4/predicted_ncols2) {
+            predicted_cols_per_block = 8;
+        }
+        if (Q->ne[1] > 8/predicted_ncols2) {
+            predicted_cols_per_block = 16;
+        }
+        if (Q->ne[1] > 16/predicted_ncols2) {
+            predicted_cols_per_block = 32;
+        }
+        if (V->ne[0] <= 128 && Q->ne[1] > 32/predicted_ncols2) {
+            predicted_cols_per_block = 64;
+        }
+
+        const uint32_t cfg = ggml_cuda_fattn_tile_get_config((int)Q->ne[0], (int)V->ne[0], predicted_cols_per_block, cc);
+        if (predicted_ncols2 != 1 && cfg == 0) {
+            return BEST_FATTN_KERNEL_VEC;
+        }
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_ROCWMMA_FATTN)
+        // Otherwise, fall through.
     }
 
     // If there are no tensor cores available, use the generic tile kernel:


### PR DESCRIPTION
In the [HIP BUILD docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#hip) `-DGGML_HIP_ROCWMMA_FATTN=ON` is recommended for improved FA performance for RDNA3+/CDNA and in broad `pp512`/`tg128` performance testing it is usually the best option, but some users have noticed there is severe performance degradation, especially with decode (tg) as context gets longer.

I noticed too, and while I wwas doing some other spelunking, found what seemed like some relatively easy wins. There was a bit more fussing than I expected but ended up with a relatively clean patch that both fixes the long context tg regression and also optimizes the WMMA path for RDNA.

- Dramatically improve long context WMMA prefill improvements on RDNA3: increased HIP occupancy and reduced LDS footprint via adaptive KQ stride; pp speedups without touching CUDA or the deprecated Volta WMMA path.
- Fix long‑context decode regression on rocWMMA builds: decode now uses HIP’s tuned VEC/TILE selection instead of WMMA, aligning performance with the HIP baseline.
- Remove HIP‑side TILE pruning in WMMA builds: matches HIP‑only behavior and avoids device traps, binary growth for all tiles was neglible, ~+4 MiB to the build
- Add a decode‑time (HIP+rocWMMA only) safety guard: if a predicted TILE split has no config, fall back to VEC. This guard is not present in HIP‑only builds but seemed like a good idea to and avoid crashes on unusual dims.
- Changes are gated to ROCWMMA/HIP only; no impact to CUDA or the legacy Volta WMMA path.

The perf improvements are non-trivial and since the changes are all isolated, hopefully it won't be too hard to merge. Here's some performance testing on my Strix Halo (RDNA3.5) w/ ROCm 7.10.0a20251018:

## Llama 3.2 1B Q4_K_M

### Previous rocWMMA vs HIP
 
Prefill (pp)

| model                  |       size |   params | test           |     HIP |    WMMA |      Δ% |
|------------------------|------------|----------|----------------|---------|---------|---------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512          | 4703.28 | 4884.42 |   3.85% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d1024  | 4076.03 | 4204.81 |   3.16% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d4096  | 2936.89 | 2959.54 |   0.77% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d16384 | 1350.48 | 1265.62 |  -6.28% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d65536 |  424.76 |  360.24 | -15.19% |

Decode (tg)

| model                  |       size |   params | test           |    HIP |   WMMA |      Δ% |
|------------------------|------------|----------|----------------|--------|--------|---------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128          | 195.65 | 193.01 |  -1.35% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d1024  | 188.79 |  182.6 |  -3.28% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d4096  | 173.36 | 143.51 | -17.22% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d16384 | 126.86 |  87.53 | -31.01% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d65536 |  64.62 |  27.35 | -57.68% |


### My rocWMMA vs HIP

Prefill (pp)

| model                  |       size |   params | test           |     HIP |   lhl-tune-tile |     Δ% |
|------------------------|------------|----------|----------------|---------|-----------------|--------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512          | 4703.28 |         4970.14 |  5.67% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d1024  | 4076.03 |         4575.18 | 12.25% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d4096  | 2936.89 |         3788.92 | 29.01% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d16384 | 1350.48 |         2064.78 | 52.89% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d65536 |  424.76 |          706.46 | 66.32% |

Decode (tg)

| model                  |       size |   params | test           |    HIP |   lhl-tune-tile |     Δ% |
|------------------------|------------|----------|----------------|--------|-----------------|--------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128          | 195.65 |          195.59 | -0.03% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d1024  | 188.79 |          188.84 |  0.03% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d4096  | 173.36 |          173.28 | -0.05% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d16384 | 126.86 |          127.01 |  0.12% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d65536 |  64.62 |           64.55 | -0.10% |

### My rocWMMA vs Previous rocWMMA

Prefill (pp)

| model                  |       size |   params | test           |   default-rocwmma |   lhl-tune-tile |     Δ% |
|------------------------|------------|----------|----------------|-------------------|-----------------|--------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512          |           4884.42 |         4970.14 |  1.75% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d1024  |           4204.81 |         4575.18 |  8.81% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d4096  |           2959.54 |         3788.92 | 28.02% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d16384 |           1265.62 |         2064.78 | 63.14% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | pp512 @ d65536 |            360.24 |          706.46 | 96.11% |

Decode (tg)

| model                  |       size |   params | test           |   default-rocwmma |   lhl-tune-tile |      Δ% |
|------------------------|------------|----------|----------------|-------------------|-----------------|---------|
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128          |            193.01 |          195.59 |   1.34% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d1024  |             182.6 |          188.84 |   3.42% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d4096  |            143.51 |          173.28 |  20.74% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d16384 |             87.53 |          127.01 |  45.11% |
| llama 1B Q4_K - Medium | 762.81 MiB |   1.24 B | tg128 @ d65536 |             27.35 |           64.55 | 136.06% |


## gpt-oss-20b F16/MXFP4

### Previous rocWMMA vs HIP

Prefill (pp)
| model           |         size |   params | test           |     HIP |    WMMA |      Δ% |
|-----------------|--------------|----------|----------------|---------|---------|---------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512          | 1472.01 | 1513.79 |   2.84% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d1024  | 1387.58 | 1417.45 |   2.15% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d4096  | 1175.72 | 1205.37 |   2.52% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d16384 |   713.9 |  669.77 |  -6.18% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d65536 |  277.58 |  227.24 | -18.14% |

Decode (tg)
| model           |         size |   params | test           |   HIP |   WMMA |      Δ% |
|-----------------|--------------|----------|----------------|-------|--------|---------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128          | 49.92 |  50.23 |   0.61% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d1024  | 49.27 |  48.65 |  -1.26% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d4096  | 48.15 |  45.11 |  -6.32% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d16384 | 44.38 |  32.91 | -25.85% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d65536 | 34.76 |  14.63 | -57.92% |

### My rocWMMA vs HIP

Prefill (pp)

| model           |         size |   params | test           |     HIP |   lhl-tune-tile |     Δ% |
|-----------------|--------------|----------|----------------|---------|-----------------|--------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512          | 1472.01 |         1495.97 |  1.63% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d1024  | 1387.58 |         1456.15 |  4.94% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d4096  | 1175.72 |         1347.75 | 14.63% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d16384 |   713.9 |          962.98 | 34.89% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d65536 |  277.58 |          426.81 | 53.76% |

Decode (tg)

| model           |         size |   params | test           |   HIP |   lhl-tune-tile |     Δ% |
|-----------------|--------------|----------|----------------|-------|-----------------|--------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128          | 49.92 |            49.9 | -0.04% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d1024  | 49.27 |           49.21 | -0.11% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d4096  | 48.15 |           48.05 | -0.20% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d16384 | 44.38 |           44.34 | -0.11% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d65536 | 34.76 |           34.77 |  0.03% |

### My rocWMMA vs Previous rocWMMA

Prefill (pp)

| model           |         size |   params | test           |   default-rocwmma |   lhl-tune-tile |     Δ% |
|-----------------|--------------|----------|----------------|-------------------|-----------------|--------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512          |           1513.79 |         1495.97 | -1.18% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d1024  |           1417.45 |         1456.15 |  2.73% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d4096  |           1205.37 |         1347.75 | 11.81% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d16384 |            669.77 |          962.98 | 43.78% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | pp512 @ d65536 |            227.24 |          426.81 | 87.83% |

Decode (tg)

| model           |         size |   params | test           |   default-rocwmma |   lhl-tune-tile |      Δ% |
|-----------------|--------------|----------|----------------|-------------------|-----------------|---------|
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128          |             50.23 |            49.9 |  -0.64% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d1024  |             48.65 |           49.21 |   1.16% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d4096  |             45.11 |           48.05 |   6.53% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d16384 |             32.91 |           44.34 |  34.72% |
| gpt-oss 20B F16 | 13141.28 MiB |  20.91 B | tg128 @ d65536 |             14.63 |           34.77 | 137.71% |

---

I only tested small models while I was deving, but am running gpt-oss-120b overnight, since llama 3.2b dense and gpt-oss-20b moe have similar gains, expecting something not so different as context grows...