### PR TITLE
Enable CUDA graphs for embed gemma 300m

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2806,6 +2806,8 @@ static bool check_node_graph_compatibility(ggml_cgraph * cgraph,
     const std::string ffn_moe_down_bias_prefix = "ffn_moe_down_biased";
     const std::string nemotron_h_block_out_prefix = "nemotron_h_block_out";
     const std::string mamba2_y_add_d_prefix = "mamba2_y_add_d";
+    const std::string emGemma_sa_out_prefix = "emGemma_sa_out";
+    const std::string emGemma_l_out_prefix = "emGemma_l_out";
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -2836,7 +2838,9 @@ static bool check_node_graph_compatibility(ggml_cgraph * cgraph,
             strncmp(node->name, ffn_moe_up_bias_prefix.c_str(), ffn_moe_up_bias_prefix.size()) != 0 &&
             strncmp(node->name, ffn_moe_down_bias_prefix.c_str(), ffn_moe_down_bias_prefix.size()) != 0 &&
             strncmp(node->name, nemotron_h_block_out_prefix.c_str(), nemotron_h_block_out_prefix.size()) != 0 &&
-            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0) {
+            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0 &&
+            strncmp(node->name, emGemma_sa_out_prefix.c_str(), emGemma_sa_out_prefix.size()) != 0 &&
+            strncmp(node->name, emGemma_l_out_prefix.c_str(), emGemma_l_out_prefix.size()) != 0) {
             // disable CUDA graphs for batch size > 1 for now while excluding the matrix-matrix addition as part of Gemma3n's `project_per_layer_input` operation
             // by means of matching node names. See
             // https://github.com/ggml-org/llama.cpp/blob/f9a31eea06a859e34cecb88b4d020c7f03d86cc4/src/llama-model.cpp#L10199-L10241 and

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -11573,7 +11573,7 @@ struct llm_build_gemma_embedding : public llm_graph_context {
             cb(cur, "attn_post_norm", il);
 
             ggml_tensor * sa_out = ggml_add(ctx0, cur, inpL);
-            cb(sa_out, "sa_out", il);
+            cb(sa_out, "emGemma_sa_out", il);
 
             cur = build_norm(sa_out,
                     model.layers[il].ffn_norm, NULL,
@@ -11599,7 +11599,7 @@ struct llm_build_gemma_embedding : public llm_graph_context {
             cur = ggml_add(ctx0, cur, sa_out);
 
             cur = build_cvec(cur, il);
-            cb(cur, "l_out", il);
+            cb(cur, "emGemma_l_out", il);
 
             // input for next layer
             inpL = cur;


### PR DESCRIPTION
## Summary:
CUDA Graphs (CG) were being disabled for the Embedding Gemma model due to some heuristics. This PR addresses those cases to enable CG usage and improve performance.

## Fixes:
- Add-op  heuristic:
    - Location: [ggml-cuda.cu#L2831-L2849](https://github.com/ggml-org/llama.cpp/blob/10fcc41290e233788f5a4215314156e8e023eb92/ggml/src/ggml-cuda/ggml-cuda.cu#L2831-L2849)
    - Issue: The heuristic incorrectly triggered for Embedding Gemma which disabled CUDA Graphs
    - Fix: Skipped the heuristic for specific nodes that erroneously trigger it. Verified that the selected node names are unique and do not appear in other architectures.
    
## Results:
### Performance before:
<img width="1165" height="143" alt="image" src="https://github.com/user-attachments/assets/15a5fe70-2c6a-4981-b669-6ac9e3cbf992" />

### Performance after:
<img width="1165" height="139" alt="image" src="https://github.com/user-attachments/assets/5dc3b3f9-92b9-49b9-9834-7e82a492c310" />
