### PR TITLE
llama : use std::abs instead of abs

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2035,7 +2035,7 @@ int32_t llama_relative_position_bucket(llama_pos x, llama_pos y, uint64_t n_buck
 
     if (bidirectional) {
         relative_bucket += (relative_position > 0) * n_buckets;
-        relative_position = abs(relative_position);
+        relative_position = std::abs(relative_position);
     } else {
         relative_position = -std::min<int32_t>(relative_position, 0);
     }

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -653,7 +653,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                 gguf_set_val_f32(ctx_out.get(), o.key, o.val_f64);
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_INT) {
                 // Setting type to UINT32. See https://github.com/ggml-org/llama.cpp/pull/14182 for context
-                gguf_set_val_u32(ctx_out.get(), o.key, (uint32_t)abs(o.val_i64));
+                gguf_set_val_u32(ctx_out.get(), o.key, (uint32_t)std::abs(o.val_i64));
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_BOOL) {
                 gguf_set_val_bool(ctx_out.get(), o.key, o.val_bool);
             } else if (o.tag == LLAMA_KV_OVERRIDE_TYPE_STR) {


### PR DESCRIPTION
This replaces use of the global `abs` with `std::abs`.

The `abs` function declared outside of the `std` namespace is not required to have any of the C++ overloads defined. (Although it's also not precluded.)

Under Clang using the global `abs` with a larger integer type gives a truncation warning.

```
/home/kaetemi/llama.cpp/src/llama-quant.cpp:656:66: warning: absolute value function 'abs' given an argument of type 'const int64_t' (aka 'const long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
  656 |                 gguf_set_val_u32(ctx_out.get(), o.key, (uint32_t)abs(o.val_i64));
      |                                                                  ^
/home/kaetemi/llama.cpp/src/llama-quant.cpp:656:66: note: use function 'std::abs' instead
  656 |                 gguf_set_val_u32(ctx_out.get(), o.key, (uint32_t)abs(o.val_i64));
      |                                                                  ^~~
      |                                                                  std::abs
1 warning generated.
```

Some standard libraries define the overloads globally, some don't. Recommended to always use the `std::` functions to avoid anything unexpected.

See https://github.com/ggml-org/llama.cpp/issues/15374 for further references.

This also was reported in the following issues:
https://github.com/ggml-org/llama.cpp/issues/15044
https://github.com/ggml-org/llama.cpp/issues/15254

This PR replaces the following incorrect PR:
https://github.com/ggml-org/llama.cpp/pull/14209