### PR TITLE
server: Allow for longer prompts in q URL parameter

### DIFF
--- a/tools/server/utils.hpp
+++ b/tools/server/utils.hpp
@@ -13,6 +13,8 @@
 #define CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH 1048576
 // increase backlog size to avoid connection resets for >> 1 slots
 #define CPPHTTPLIB_LISTEN_BACKLOG 512
+// increase max URI length to handle longer prompts in query string
+#define CPPHTTPLIB_REQUEST_URI_MAX_LENGTH 32768
 // disable Nagle's algorithm
 #define CPPHTTPLIB_TCP_NODELAY true
 #include <cpp-httplib/httplib.h>


### PR DESCRIPTION
Resolves the larger part of #16830.

The current limit is 8192 characters. This is not enough for summarizing most articles worth summarizing. Doubling handles many. Quadrupling would arguably handle most.

Supporting web browser integration introduces security risks. If there were an exploit opportunity that opened up in llama-server, this could give the exploiter quadruple the space for an exploit. Furthermore, an exploit might not always require the user to have inadvisably exposed the server to a public network. If a prompt injection attack on a website isn't handled properly anywhere along the way to/from the LLM, *and* there's some exploitable code where it's mishandled, this change could presumably make this easier/possible to exploit.

It could be sufficient to include a warning somewhere along with advice for good practices which might include using a combination of a strict content blocker and only allowing prompts from trusted websites.