### PR TITLE
common: fix typo in cli help text [no ci]

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3203,7 +3203,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
     add_opt(common_arg(
         {"--parse-special"},
-        string_format("prase special tokens (chat, tool, etc) (default: %s)", params.parse_special ? "true" : "false"),
+        string_format("parse special tokens (chat, tool, etc) (default: %s)", params.parse_special ? "true" : "false"),
         [](common_params & params) {
             params.parse_special = true;
         }


### PR DESCRIPTION
This fixes a typo in the `--parse-special` help text of `imatrix` cli
