### PR TITLE
server : don't print user inputs to console

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3796,7 +3796,7 @@ struct server_context {
 
                                 // when the prompt prefix does not match, print the tokens around the mismatch
                                 // this is useful for debugging prompt caching
-                                {
+                                if (slots_debug) {
                                     const int np0 = std::max<int>(n_past - 4, 0);
                                     const int np1 = std::min<int>(n_past + 6, std::min(slot.prompt.tokens.size(), slot.task->tokens.size()));
 


### PR DESCRIPTION
fix #16870

These will be printed only if the `LLAMA_SERVER_SLOTS_DEBUG` env is set.