### PR TITLE
mtmd: refactor preprocessing + support max/min pixels

### DIFF
--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -154,8 +154,8 @@ enum projector_type {
     PROJECTOR_TYPE_LFM2,
     PROJECTOR_TYPE_KIMIVL,
     PROJECTOR_TYPE_LIGHTONOCR,
-    PROJECTOR_TYPE_UNKNOWN,
     PROJECTOR_TYPE_COGVLM,
+    PROJECTOR_TYPE_UNKNOWN,
 };
 
 static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2753,8 +2753,11 @@ struct clip_model_loader {
                         // the actual max limit is 12845056/14/14/2/2/4 = 4096 tokens
                         // but we set a lower value to avoid OOM
                         // TODO: make it configurable by user
-                        hparams.set_limit_image_tokens(1, 2048);
-                        hparams.set_warmup_n_tokens(256); // avoid OOM on warmup
+                        // TODO (2): bbox coordinates become inaccurate with small number of tokens,
+                        //           therefore we need to increase the min_tokens
+                        //           see: https://github.com/ggml-org/llama.cpp/issues/16842#issuecomment-3475144858
+                        hparams.set_limit_image_tokens(256, 2048);
+                        hparams.set_warmup_n_tokens(1024); // avoid OOM on warmup
                     } break;
                 case PROJECTOR_TYPE_LLAMA4:
                     {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2756,8 +2756,8 @@ struct clip_model_loader {
                         // TODO (2): bbox coordinates become inaccurate with small number of tokens,
                         //           therefore we need to increase the min_tokens
                         //           see: https://github.com/ggml-org/llama.cpp/issues/16842#issuecomment-3475144858
-                        hparams.set_limit_image_tokens(256, 2048);
-                        hparams.set_warmup_n_tokens(1024); // avoid OOM on warmup
+                        hparams.set_limit_image_tokens(8, 2048);
+                        hparams.set_warmup_n_tokens(256); // avoid OOM on warmup
                     } break;
                 case PROJECTOR_TYPE_LLAMA4:
                     {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -4114,7 +4114,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
                 clip_image_u8_ptr temp(clip_image_u8_init()); // we will keep the input image data here temporarily
 
                 // The model config actually contains all we need to decide on how to preprocess, here we automatically switch to the new llava-1.6 preprocessing
-                if (params.mm_patch_merge_type == PATCH_MERGE_SPATIAL_UNPAD) { // pad_to_square
+                if (params.image_res_candidates.empty()) { // pad_to_square
                     // for llava-1.5, we resize image to a square, and pad the shorter side with a background color
                     // see https://github.com/haotian-liu/LLaVA/blob/e854a2bf85118c504f6f16bf5c3c7c92f8fa8c6b/llava/conversation.py#L113-L156
                     const int longer_side = std::max(img->nx, img->ny);
@@ -4131,9 +4131,8 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
                     clip_image_f32_ptr res(clip_image_f32_init());
                     normalize_image_u8_to_f32(*temp, *res, params.image_mean, params.image_std);
                     res_imgs->entries.push_back(std::move(res));
-                    return true;
 
-                } else if (!params.image_res_candidates.empty()) {
+                } else {
                     // "spatial_unpad" with "anyres" processing for llava-1.6
                     auto const inst = llava_uhd::get_slice_instructions(ctx, original_size);
                     std::vector<clip_image_u8_ptr> imgs = llava_uhd::slice_image(img, inst);
@@ -4144,8 +4143,6 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
                         normalize_image_u8_to_f32(*imgs[i], *res, params.image_mean, params.image_std);
                         res_imgs->entries.push_back(std::move(res));
                     }
-
-                    return true;
                 }
             } break;
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -3440,6 +3440,12 @@ struct img_tool {
         dst.ny = target_resolution.height;
         dst.buf.resize(3 * dst.nx * dst.ny);
 
+        if (dst.nx == src.nx && dst.ny == src.ny) {
+            // no resize needed, simple copy
+            dst.buf = src.buf;
+            return;
+        }
+
         if (!add_padding) {
             // direct resize
             switch (algo) {
@@ -4020,7 +4026,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
                     params.image_min_pixels,
                     params.image_max_pixels);
                 img_tool::resize(*img, resized, new_size, img_tool::RESIZE_ALGO_BILINEAR, false);
-                // clip_image_save_to_bmp(canvas, "preproc.bmp");
+                // clip_image_save_to_bmp(resized, "preproc.bmp");
                 clip_image_f32_ptr img_f32(clip_image_f32_init());
                 // clip_image_f32_ptr res(clip_image_f32_init());
                 normalize_image_u8_to_f32(resized, *img_f32, params.image_mean, params.image_std);


### PR DESCRIPTION
Fix #16842 Fix #13077

Implement "smart resize", aka `max_pixels` / `min_pixels` for preprocessing. This will now allow us to limit the input by number of tokens, no more hard limit on image height/width. This is particularly useful if you have an image which have large height but small width.

~~The preprocessing of QwenVL model is also improved. We now only pad the bottom-right corner of the image, so the x/y coordinate of elements stay unchanged. This should improve the accuracy of bbox application.~~
