### PR TITLE
docs: remove llama_sampler_accept reference in sampling sample usage

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1111,8 +1111,6 @@ extern "C" {
     //        // sample from the logits of the last token in the batch
     //        const llama_token id = llama_sampler_sample(smpl, ctx, -1);
     //
-    //        // accepting the token updates the internal state of certain samplers (e.g. grammar, repetition, etc.)
-    //        llama_sampler_accept(smpl, id);
     //        ...
     //    }
     //


### PR DESCRIPTION
In #9386,  `llama_sampler_sample` was updated to include the call to `llama_sampler_accept`. This change made the sampling API sample usage misleading, as the documentation still referenced the subsequent `llama_sampler_accept`-call. 

This PR removes the documentation reference to `llama_sampler_accept`, clarifying that this method should not be invoked as part of the decoding loop, as it is already called internally as part of `llama_sampler_sample` (since  #9386).