### PR TITLE
disable D_TYPE same as A_TYPE cast for rope shaders

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
@@ -21,8 +21,13 @@ void main() {
     const uint ix   = channel_x*p.s2 + row_x*p.s1 + i0/2;
 
     if (i0 >= p.n_dims) {
+        #if D_TYPE == A_TYPE
         data_d[idst + i0/2 + 0] = data_a[ix + i0/2 + 0];
         data_d[idst + i0/2 + 1] = data_a[ix + i0/2 + 1];
+        #else
+        data_d[idst + i0/2 + 0] = D_TYPE(data_a[ix + i0/2 + 0]);
+        data_d[idst + i0/2 + 1] = D_TYPE(data_a[ix + i0/2 + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
@@ -21,8 +21,13 @@ void main() {
     const uint ix   = channel_x*p.s2 + row_x*p.s1 + i0/2;
 
     if (i0 >= p.n_dims) {
+        #ifdef ROPE_SAME_TYPE
         data_d[idst + i0/2 + 0] = data_a[ix + i0/2 + 0];
         data_d[idst + i0/2 + 1] = data_a[ix + i0/2 + 1];
+        #else
+        data_d[idst + i0/2 + 0] = D_TYPE(data_a[ix + i0/2 + 0]);
+        data_d[idst + i0/2 + 1] = D_TYPE(data_a[ix + i0/2 + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_neox.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_neox.comp
@@ -27,8 +27,13 @@ void main() {
     }
 
     if (i0 >= p.n_dims) {
+        #ifdef ROPE_SAME_TYPE
+        data_d[idst + i0/2 + 0] = data_a[ix + i0/2 + 0];
+        data_d[idst + i0/2 + 1] = data_a[ix + i0/2 + 1];
+        #else
         data_d[idst + i0/2 + 0] = D_TYPE(data_a[ix + i0/2 + 0]);
         data_d[idst + i0/2 + 1] = D_TYPE(data_a[ix + i0/2 + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_neox.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_neox.comp
@@ -27,8 +27,13 @@ void main() {
     }
 
     if (i0 >= p.n_dims) {
+        #if D_TYPE == A_TYPE
+        data_d[idst + i0/2 + 0] = data_a[ix + i0/2 + 0];
+        data_d[idst + i0/2 + 1] = data_a[ix + i0/2 + 1];
+        #else
         data_d[idst + i0/2 + 0] = D_TYPE(data_a[ix + i0/2 + 0]);
         data_d[idst + i0/2 + 1] = D_TYPE(data_a[ix + i0/2 + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_norm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_norm.comp
@@ -27,8 +27,13 @@ void main() {
     }
 
     if (i0 >= p.n_dims) {
+        #ifdef ROPE_SAME_TYPE
+        data_d[idst + 0] = data_a[ix + 0];
+        data_d[idst + 1] = data_a[ix + 1];
+        #else
         data_d[idst + 0] = D_TYPE(data_a[ix + 0]);
         data_d[idst + 1] = D_TYPE(data_a[ix + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_norm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_norm.comp
@@ -27,8 +27,13 @@ void main() {
     }
 
     if (i0 >= p.n_dims) {
+        #if D_TYPE == A_TYPE
+        data_d[idst + 0] = data_a[ix + 0];
+        data_d[idst + 1] = data_a[ix + 1];
+        #else
         data_d[idst + 0] = D_TYPE(data_a[ix + 0]);
         data_d[idst + 1] = D_TYPE(data_a[ix + 1]);
+        #endif
 
         return;
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -317,8 +317,7 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
 
     // disable spirv-opt for coopmat shaders for https://github.com/ggerganov/llama.cpp/issues/10734
     // disable spirv-opt for bf16 shaders for https://github.com/ggml-org/llama.cpp/issues/15344
-    // disable spirv-opt for rope shaders for https://github.com/ggml-org/llama.cpp/issues/16860
-    std::string opt_level = (coopmat || name.find("bf16") != std::string::npos || name.find("rope") != std::string::npos) ? "" : "-O";
+    std::string opt_level = (coopmat || name.find("bf16") != std::string::npos) ? "" : "-O";
 
     #ifdef _WIN32
         std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, opt_level, "\"" + in_path + "\"", "-o", "\"" + out_path + "\""};
@@ -338,6 +337,9 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
 
     for (const auto& define : defines) {
         cmd.push_back("-D" + define.first + "=" + define.second);
+    }
+    if (name.find("rope") != std::string::npos && defines["D_TYPE"] == defines["A_TYPE"] ) {
+        cmd.push_back("-DROPE_SAME_TYPE");
     }
 
     std::string command;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -317,8 +317,7 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
 
     // disable spirv-opt for coopmat shaders for https://github.com/ggerganov/llama.cpp/issues/10734
     // disable spirv-opt for bf16 shaders for https://github.com/ggml-org/llama.cpp/issues/15344
-    // disable spirv-opt for rope shaders for https://github.com/ggml-org/llama.cpp/issues/16860
-    std::string opt_level = (coopmat || name.find("bf16") != std::string::npos || name.find("rope") != std::string::npos) ? "" : "-O";
+    std::string opt_level = (coopmat || name.find("bf16") != std::string::npos) ? "" : "-O";
 
     #ifdef _WIN32
         std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, opt_level, "\"" + in_path + "\"", "-o", "\"" + out_path + "\""};

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -338,6 +338,7 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
     for (const auto& define : defines) {
         cmd.push_back("-D" + define.first + "=" + define.second);
     }
+    // disable D_TYPE same as A_TYPE cast for rope shaders https://github.com/ggml-org/llama.cpp/issues/16860
     if (name.find("rope") != std::string::npos && defines["D_TYPE"] == defines["A_TYPE"] ) {
         cmd.push_back("-DROPE_SAME_TYPE");
     }


### PR DESCRIPTION
revert: #16872

fix: #16860

This fix simply disables the optimization for the corresponding shader to address this issue. For glslc versions without this bug, it is unnecessary to turn off the optimization. I added a new macro to check if the data types are the same to avoid casting, rather than disabling optimization, ensuring that performance is not affected.

> ```
> cannot compile rope_norm_f16
> 
> /bin/glslc -fshader-stage=compute --target-env=vulkan1.2 -O /home/cix/llama.cpp/ggml/src/ggml-vulkan/vulkan-shaders/rope_norm.comp -o /home/cix/llama.cpp/build/ggml/src/ggml-vulkan/vulkan-shaders.spv/rope_norm_f16.spv -DA_TYPE=float16_t -DD_TYPE=float16_t 
> 
> shaderc: internal error: compilation succeeded but failed to optimize: Expected input to have different bit width from Result Type: FConvert
> %212 = OpFConvert %half %211
> ```
> During the process of compiling SPV with glslc, FConvert is used to convert variables of the same type. Shaderc considers this invalid, resulting in a compilation error.
> 

@jeffbolznv 