### PR TITLE
Fix segfault in moe-expert-reduce test in support mode and coverage

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4844,7 +4844,9 @@ struct test_moe_expert_reduce : public test_case {
 
             std::string name = "expert_view_" + std::to_string(i);
             ggml_set_name(expert_views[i], name.c_str());
-            ggml_build_forward_expand(gf, expert_views[i]);
+            if (gf) {
+                ggml_build_forward_expand(gf, expert_views[i]);
+            }
         }
 
         ggml_tensor * moe_out = expert_views[0];

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4846,9 +4846,7 @@ struct test_moe_expert_reduce : public test_case {
 
             std::string name = "expert_view_" + std::to_string(i);
             ggml_set_name(expert_views[i], name.c_str());
-            if (gf) {
-                ggml_build_forward_expand(gf, expert_views[i]);
-            }
+            ggml_build_forward_expand(gf, expert_views[i]);
         }
 
         ggml_tensor * moe_out = expert_views[0];
@@ -7576,7 +7574,7 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
 
         // Filter out fusion cases
         test_cases.erase(
-            std::remove_if(test_cases.begin(), test_cases.end(), [](const std::unique_ptr<test_case>& tc) {
+            std::remove_if(test_cases.begin(), test_cases.end(), [](const std::unique_ptr<test_case> & tc) {
                 return tc->run_whole_graph();
             }),
             test_cases.end()
@@ -7632,6 +7630,14 @@ static void show_test_coverage() {
         all_ops.insert(ggml_glu_op_name((enum ggml_glu_op)i));
     }
     auto test_cases = make_test_cases_eval();
+    // Filter out fusion cases
+    test_cases.erase(
+        std::remove_if(test_cases.begin(), test_cases.end(), [](const std::unique_ptr<test_case> & tc) {
+            return tc->run_whole_graph();
+        }),
+        test_cases.end()
+    );
+
     std::set<std::string> tested_ops;
 
     ggml_init_params params = {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1463,11 +1463,6 @@ struct test_case {
             return true;
         }
 
-        // Filter out fusion tests in support mode
-        if (run_whole_graph()) {
-            return true;
-        }
-
         bool supported = ggml_backend_supports_op(backend, out);
 
         std::string device_desc = ggml_backend_dev_description(ggml_backend_get_device(backend));
@@ -7578,6 +7573,15 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     if (mode == MODE_SUPPORT) {
         auto test_cases = make_test_cases_eval();
         filter_test_cases(test_cases, params_filter);
+
+        // Filter out fusion cases
+        test_cases.erase(
+            std::remove_if(test_cases.begin(), test_cases.end(), [](const std::unique_ptr<test_case>& tc) {
+                return tc->run_whole_graph();
+            }),
+            test_cases.end()
+        );
+
         for (auto & test : test_cases) {
             test->eval_support(backend, op_names_filter, output_printer);
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1454,10 +1454,17 @@ struct test_case {
         ggml_context_ptr ctx(ggml_init(params)); // smart ptr
         GGML_ASSERT(ctx);
 
+        gf = ggml_new_graph_custom(ctx.get(), graph_nodes, false);
+
         ggml_tensor * out = build_graph(ctx.get());
         current_op_name   = op_desc(out);
 
         if (!matches_filter(out, op_names_filter)) {
+            return true;
+        }
+
+        // Filter out fusion tests in support mode
+        if (run_whole_graph()) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes a segmentation fault that occurs while running the `test-backend-ops` tool in `support` mode or with `--show-coverage` flag. This will also allow `docs/ops.md` to be updated for tracking https://github.com/ggml-org/llama.cpp/issues/14909 as it needs the results from `support` mode. 

#### Root Cause
Testing does not initialize `gf` (ggml_cgraph), it calls `build_graph` method for each test case. The `test_moe_expert_reduce` test case calls `ggml_build_forward_expand(gf, ...)` inside its `build_graph` method but `gf` is a `nullptr` in this flow which causes a seg fault.

#### Solution
Wrap the `ggml_build_forward_expand` call in a `gf` null check.