### PR TITLE
doc: Windows + clang/ninja build guide format cleanup

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -74,12 +74,13 @@ cmake --build build --config Release
     cmake --preset arm64-windows-llvm-release -D GGML_OPENMP=OFF
     cmake --build build-arm64-windows-llvm-release
     ```
-    For building with ninja generator and clang compiler as default:
-      -set path:set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64
-      ```bash
-      cmake --preset x64-windows-llvm-release
-      cmake --build build-x64-windows-llvm-release
-      ```
+    - For building with ninja generator and clang compiler as default:
+      - Set path (Replace the paths with the versions installed on your system): `set LIB=C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\um\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\lib\x64\uwp;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22621.0\ucrt\x64`.
+      - Then run:
+        ```bash
+        cmake --preset x64-windows-llvm-release
+        cmake --build build-x64-windows-llvm-release
+        ```
 - If you want HTTPS/TLS features, you may install OpenSSL development libraries. If not installed, the project will build and run without SSL support.
   - **Debian / Ubuntu:** `sudo apt-get install libssl-dev`
   - **Fedora / RHEL / Rocky / Alma:** `sudo dnf install openssl-devel`


### PR DESCRIPTION
The current doc about building with clang and ninja on windows contains a minor formatting issue, this pr improves this part's readability.

See the current version:
<img width="1553" height="642" alt="image" src="https://github.com/user-attachments/assets/cb67e6c8-7428-44cd-aa5e-9334e3a45417" />

Should be more clear now:
<img width="1603" height="825" alt="image" src="https://github.com/user-attachments/assets/5637f1f2-b58b-4f92-923d-47dd2f89ed33" />
