### PR TITLE
Mamba2 SSD

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -444,7 +444,12 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
         res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
     }
 
-    res.smem = 32*sizeof(float)*nsg;
+    // Shared memory layout:
+    // - sgptg * NW floats for partial sums (nsg * 32)
+    // - sgptg floats for shared_x_dt (nsg)
+    // - sgptg floats for shared_dA (nsg)
+    // Total: nsg * (32 + 2) floats
+    res.smem = (32 + 2)*sizeof(float)*nsg;
 
     return res;
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -411,6 +411,23 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv(ggml_me
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched(ggml_metal_library_t lib, const ggml_tensor * op) {
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(ggml_is_contiguous(op->src[1]));
+
+    const char * name = "kernel_ssm_conv_f32_f32_b256";
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, name, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_metal_library_t lib, const ggml_tensor * op)  {
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -119,6 +119,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_soft_max 
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched  (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ext        (ggml_metal_library_t lib, enum ggml_type tsrc0, enum ggml_type tsrc1, int nsg, int nxpsg, int r1ptg);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm            (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -117,6 +117,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cumsum_ad
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_tri               (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_soft_max          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv          (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched  (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ext        (ggml_metal_library_t lib, enum ggml_type tsrc0, enum ggml_type tsrc1, int nsg, int nxpsg, int r1ptg);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1365,15 +1365,34 @@ int ggml_metal_op_ssm_conv(ggml_metal_op_t ctx, int idx) {
         /*.nb2  =*/ nb2,
     };
 
-    auto pipeline = ggml_metal_library_get_pipeline_ssm_conv(lib, op);
+    // Use batched kernel for prefill (ne1 > 1) to reduce threadgroup dispatch overhead
+    constexpr int BATCH_SIZE = 256;
+    const bool use_batched = (ne1 > 1);
 
-    ggml_metal_encoder_set_pipeline(enc, pipeline);
-    ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
-    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[0]), 1);
-    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[1]), 2);
-    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op),         3);
+    if (use_batched) {
+        auto pipeline = ggml_metal_library_get_pipeline_ssm_conv_batched(lib, op);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne1, ne02, 1, 1, 1);
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op),         3);
+
+        // Dispatch: ne01 rows, ceil(ne1/BATCH_SIZE) token batches, ne02 sequences
+        // Each threadgroup has BATCH_SIZE threads, each handling one token
+        const int n_token_batches = (ne1 + BATCH_SIZE - 1) / BATCH_SIZE;
+        ggml_metal_encoder_dispatch_threadgroups(enc, ne01, n_token_batches, ne02, BATCH_SIZE, 1, 1);
+    } else {
+        auto pipeline = ggml_metal_library_get_pipeline_ssm_conv(lib, op);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op),         3);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne1, ne02, 1, 1, 1);
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1471,7 +1471,13 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    auto pipeline = ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+    auto pipeline = (n_seq_tokens > 1)
+        ? ggml_metal_library_get_pipeline_ssm_scan_ssd(lib, op)
+        : ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+
+    // // Use sequential scan for now - the SSD kernel needs further optimization
+    // // to be competitive with the efficient sequential implementation
+    // auto pipeline = ggml_metal_library_get_pipeline_ssm_scan(lib, op);
 
     GGML_ASSERT(d_state <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2394,6 +2394,7 @@ kernel void kernel_ssm_conv_f32_f32_4(
 }
 
 // ref: ggml.c:ggml_compute_forward_ssm_scan_f32, Mamba-2 part
+// Optimized version: reduces redundant memory loads by having one thread load shared values
 kernel void kernel_ssm_scan_f32(
         constant ggml_metal_kargs_ssm_scan & args,
         device const void * src0,
@@ -2413,7 +2414,15 @@ kernel void kernel_ssm_scan_f32(
         uint3    tgpg[[threadgroups_per_grid]]) {
     constexpr short NW = N_SIMDWIDTH;
 
-    shared[tpitg.x] = 0.0f;
+    // Shared memory layout:
+    // [0..sgptg*NW-1]: partial sums for reduction (existing)
+    // [sgptg*NW..sgptg*NW+sgptg-1]: pre-computed x_dt values for each token in batch
+    // [sgptg*NW+sgptg..sgptg*NW+2*sgptg-1]: pre-computed dA values for each token in batch
+    threadgroup float * shared_sums = shared;
+    threadgroup float * shared_x_dt = shared + sgptg * NW;
+    threadgroup float * shared_dA   = shared + sgptg * NW + sgptg;
+
+    shared_sums[tpitg.x] = 0.0f;
 
     const int32_t i0 = tpitg.x;
     const int32_t i1 = tgpig.x;
@@ -2453,32 +2462,47 @@ kernel void kernel_ssm_scan_f32(
     for (int i2 = 0; i2 < n_t; i2 += sgptg) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        for (int t = 0; t < sgptg && i2 + t < n_t; t++) {
-            const float dt0  = dt[0];
+        // Pre-compute x_dt and dA for this batch of tokens
+        // Only first sgptg threads do the loads and expensive math
+        if (i0 < sgptg && i2 + i0 < n_t) {
+            // ns12 and ns21 are element strides (nb12/nb10, nb21/nb20)
+            device const float * x_t  = x  + i0 * args.ns12;
+            device const float * dt_t = dt + i0 * args.ns21;
+
+            const float dt0  = dt_t[0];
             const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
-            const float x_dt = x[0] * dtsp;
-            const float dA   = exp(dtsp * A0);
+            shared_x_dt[i0] = x_t[0] * dtsp;
+            shared_dA[i0]   = dtsp;  // Store dtsp, compute exp(dtsp * A0) per-thread since A0 varies
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int t = 0; t < sgptg && i2 + t < n_t; t++) {
+            const float x_dt = shared_x_dt[t];
+            const float dA   = exp(shared_dA[t] * A0);
 
             s = (s0 * dA) + (B[i0] * x_dt);
 
             const float sumf = simd_sum(s * C[i0]);
 
             if (tiisg == 0) {
-                shared[t*NW + sgitg] = sumf;
+                shared_sums[t*NW + sgitg] = sumf;
             }
 
             // recurse
             s0 = s;
 
-            x  += args.ns12;
-            dt += args.ns21;
             B  += args.ns42;
             C  += args.ns52;
         }
 
+        // Advance pointers for next batch
+        x  += sgptg * args.ns12;
+        dt += sgptg * args.ns21;
+
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        const float sumf = simd_sum(shared[sgitg*NW + tiisg]);
+        const float sumf = simd_sum(shared_sums[sgitg*NW + tiisg]);
 
         if (tiisg == 0 && i2 + sgitg < n_t) {
             y[sgitg*nh*nr] = sumf;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -124,6 +124,13 @@ static void ggml_print_backtrace_symbols(void) {
     int nptrs = backtrace(trace, sizeof(trace)/sizeof(trace[0]));
     backtrace_symbols_fd(trace, nptrs, STDERR_FILENO);
 }
+#elif defined(__APPLE__)
+#include <execinfo.h>
+static void ggml_print_backtrace_symbols(void) {
+    void * trace[100];
+    int nptrs = backtrace(trace, sizeof(trace)/sizeof(trace[0]));
+    backtrace_symbols_fd(trace, nptrs, STDERR_FILENO);
+}
 #else
 static void ggml_print_backtrace_symbols(void) {
     // platform not supported
@@ -135,6 +142,14 @@ void ggml_print_backtrace(void) {
     if (GGML_NO_BACKTRACE) {
         return;
     }
+#if defined(__APPLE__)
+    // On macOS, fork+debugger attachment is problematic due to:
+    // 1. libdispatch "poisons" forked child processes
+    // 2. lldb has issues attaching to parent from forked child
+    // Use simple backtrace() instead to avoid Terminal.app crashes
+    ggml_print_backtrace_symbols();
+    return;
+#endif
 #if defined(__linux__)
     FILE * f = fopen("/proc/self/status", "r");
     size_t size = 0;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1387,7 +1387,11 @@ void llama_context::output_reorder() {
 //
 
 uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
-    if (model.arch == LLM_ARCH_QWEN3NEXT) {
+    if (model.arch == LLM_ARCH_QWEN3NEXT ||
+        model.arch == LLM_ARCH_GRANITE_HYBRID ||
+        model.arch == LLM_ARCH_MAMBA2 ||
+        model.arch == LLM_ARCH_FALCON_H1 ||
+        model.arch == LLM_ARCH_NEMOTRON_H) {
         return std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
     }
     return std::max<uint32_t>(1024u, 8u*model.n_tensors());

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -244,6 +244,12 @@ void llm_graph_input_rs::set_input(const llama_ubatch * ubatch) {
     const int64_t n_rs = mctx->get_n_rs();
 
     if (s_copy) {
+        //DEBUG
+        if (!s_copy->buffer) {
+            return;
+        }
+        //DEBUG
+
         GGML_ASSERT(ggml_backend_buffer_is_host(s_copy->buffer));
         int32_t * data = (int32_t *) s_copy->data;
 

--- a/src/models/graph-context-mamba.cpp
+++ b/src/models/graph-context-mamba.cpp
@@ -247,8 +247,8 @@ ggml_tensor * llm_graph_context_mamba::build_mamba2_layer(llm_graph_input_rs * i
         auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
             ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
 
-            // if (n_seq_tokens == 1) {
-            if (true) {
+            if (n_seq_tokens == 1) {
+            // if (true) {
                 //DEBUG
                 LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
                 // If single-token, use ssm_scan op
@@ -258,171 +258,207 @@ ggml_tensor * llm_graph_context_mamba::build_mamba2_layer(llm_graph_input_rs * i
                 //DEBUG
                 LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): multi-token chunk scan\n", il);
 
-                // otherwise, use the SSD formulation
+                // ============================================================
+                // OPTIMIZED SSD (State Space Duality) Implementation
+                // Key optimizations:
+                // 1. Pre-permute B and C once at the start to avoid repeated permutes
+                // 2. Minimize ggml_cont() calls by choosing layouts carefully
+                // 3. Reuse intermediate tensors where possible
+                // ============================================================
 
                 // extract the state(s) for the sequences identified by ids
                 if (ssm->ne[3] != ids->ne[0]) {
-                    ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);        // put the target dim in dim 1
+                    ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);
                     ggml_tensor * ids_perm_rep = ggml_repeat_4d(ctx, ids,
-                        ids->ne[0], ssm->ne[1], ssm->ne[2], 1);                         // repeat to match expected shape
-                    ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep); // extract ids as rows
-                    ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));       // permute back to original shape
+                        ids->ne[0], ssm->ne[1], ssm->ne[2], 1);
+                    ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep);
+                    ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));
                     GGML_ASSERT(ssm->ne[3] == ids->ne[0]);
                 }
                 // ssm -> {d_state, head_dim, n_head, n_seqs}
 
                 // step 1: compute dt softplus
-                // NOTE: In other implementations, the bias is added after
-                //  the softplus. This shouldn't be a problem, but it's a
-                //  difference.
                 ggml_tensor * dt_softplus = ggml_softplus(ctx, dt); // {n_head, n_seq_tokens, n_seqs}
                 dt_softplus = ggml_clamp(ctx, dt_softplus, 0.001, 100.0);
                 cb(dt_softplus, "dt_softplus", il);
 
                 // step 2: compute dtA and dtX
-                ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1])); // {n_head, n_seq_tokens, n_seqs}
+                // dtA: {n_head, n_seq_tokens, n_seqs}
+                ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1]));
                 cb(dtA, "dtA", il);
-                ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus, 1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2])); // {head_dim, n_head, n_seq_tokens, n_seqs}
+
+                // dtX: {head_dim, n_head, n_seq_tokens, n_seqs}
+                ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus,
+                    1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2]));
                 cb(dtX, "dtX", il);
 
-                // loop over all chunks
+                // Pre-permute dtX once for the attention-like matmul: {head_dim, n_head, n_seq_tokens, n_seqs} -> {n_head, n_seq_tokens, head_dim, n_seqs}
+                // This layout is what we need for: y = SAM @ dtX^T
+                ggml_tensor * dtX_perm = ggml_cont(ctx, ggml_permute(ctx, dtX, 1, 2, 0, 3)); // {n_head, n_seq_tokens, head_dim, n_seqs}
+                cb(dtX_perm, "dtX_perm", il);
+
+                // Pre-permute B and C for mul_mat: {d_state, n_group, n_seq_tokens, n_seqs} -> {d_state, n_seq_tokens, n_group, n_seqs}
+                // These permuted versions will be used throughout
+                ggml_tensor * B_perm_full = ggml_permute(ctx, B, 0, 2, 1, 3); // {d_state, n_seq_tokens, n_group, n_seqs}
+                ggml_tensor * C_perm_full = ggml_permute(ctx, C, 0, 2, 1, 3); // {d_state, n_seq_tokens, n_group, n_seqs}
+
                 uint32_t repeats = n_head / n_group;
+
+                // For the state update, we need B in a different layout
+                // Pre-compute the expanded B for state updates: {d_state, n_seq_tokens, n_head, n_seqs}
+                ggml_tensor * B_for_state = ggml_cont(ctx, B_perm_full);
+                B_for_state = ggml_repeat_4d(ctx, B_for_state,
+                    B_for_state->ne[0], B_for_state->ne[1], B_for_state->ne[2] * repeats, B_for_state->ne[3]);
+                // Permute for mul_mat: {n_seq_tokens, d_state, n_head, n_seqs}
+                ggml_tensor * B_for_state_perm = ggml_cont(ctx, ggml_permute(ctx, B_for_state, 1, 0, 2, 3));
+                cb(B_for_state_perm, "B_for_state_perm", il);
 
                 // Empty y that will be extended with each chunk of tokens
                 ggml_tensor * y = ggml_new_tensor_4d(ctx, x->type, x->ne[0], x->ne[1], 0, x->ne[3]);
-                // TODO: make this configurable
-                const uint32_t chunk_size = 512; // default ubatch size
-                for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
-                    ggml_tensor * dtA_chunk;
-                    ggml_tensor * dtX_chunk;
-                    ggml_tensor * B_chunk;
-                    ggml_tensor * C_chunk;
-                    const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
-                    if (chunk_size_i == n_seq_tokens) {
-                        dtA_chunk = dtA;
-                        dtX_chunk = dtX;
-                        B_chunk = B;
-                        C_chunk = C;
-                    } else {
-                        // chunk views
-                        // slice dtA on dim 1
-                        dtA_chunk = ggml_view_3d(ctx, dtA,
-                            dtA->ne[0], chunk_size_i, dtA->ne[2],
-                            dtA->nb[1], dtA->nb[2],
-                            chunk_i * dtA->nb[1]);
-                        // slice dtX on dim 2
-                        dtX_chunk = ggml_view_4d(ctx, dtX,
-                            dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
-                            dtX->nb[1], dtX->nb[2], dtX->nb[3],
-                            chunk_i * dtX->nb[2]);
-                        // slice B on dim 2
-                        B_chunk = ggml_view_4d(ctx, B,
-                            B->ne[0], B->ne[1], chunk_size_i, B->ne[3],
-                            B->nb[1], B->nb[2], B->nb[3],
-                            chunk_i * B->nb[2]);
-                        // slice C on dim 2
-                        C_chunk = ggml_view_4d(ctx, C,
-                            C->ne[0], C->ne[1], chunk_size_i, C->ne[3],
-                            C->nb[1], C->nb[2], C->nb[3],
-                            chunk_i * C->nb[2]);
-                    }
-                    cb(dtA_chunk, "dtA_chunk", il); // {n_head, chunk_size_i, n_seqs}
-                    cb(dtX_chunk, "dtX_chunk", il); // {head_dim, n_head, chunk_size_i, n_seqs}
-                    cb(B_chunk,   "B_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
-                    cb(C_chunk,   "C_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
 
-                    // step 3: compute CB
-                    ggml_tensor * C_perm = ggml_permute(ctx, C_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-                    ggml_tensor * B_perm = ggml_permute(ctx, B_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-                    ggml_tensor * CB = ggml_mul_mat(ctx, B_perm, C_perm); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
-                    CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]); // {chunk_size_i, chunk_size_i, n_head (repeats * n_group), n_seqs}
+                const uint32_t chunk_size = 512;
+                for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
+                    const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
+
+                    // Create chunk views
+                    ggml_tensor * dtA_chunk = (chunk_size_i == n_seq_tokens) ? dtA :
+                        ggml_view_3d(ctx, dtA, dtA->ne[0], chunk_size_i, dtA->ne[2],
+                            dtA->nb[1], dtA->nb[2], chunk_i * dtA->nb[1]);
+
+                    ggml_tensor * dtX_chunk_perm = (chunk_size_i == n_seq_tokens) ? dtX_perm :
+                        ggml_view_4d(ctx, dtX_perm,
+                            dtX_perm->ne[0], chunk_size_i, dtX_perm->ne[2], dtX_perm->ne[3],
+                            dtX_perm->nb[1], dtX_perm->nb[2], dtX_perm->nb[3],
+                            chunk_i * dtX_perm->nb[1]);
+
+                    ggml_tensor * dtX_chunk = (chunk_size_i == n_seq_tokens) ? dtX :
+                        ggml_view_4d(ctx, dtX, dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
+                            dtX->nb[1], dtX->nb[2], dtX->nb[3], chunk_i * dtX->nb[2]);
+
+                    // Use pre-permuted B and C chunks
+                    ggml_tensor * B_perm_chunk = (chunk_size_i == n_seq_tokens) ? B_perm_full :
+                        ggml_view_4d(ctx, B_perm_full,
+                            B_perm_full->ne[0], chunk_size_i, B_perm_full->ne[2], B_perm_full->ne[3],
+                            B_perm_full->nb[1], B_perm_full->nb[2], B_perm_full->nb[3],
+                            chunk_i * B_perm_full->nb[1]);
+
+                    ggml_tensor * C_perm_chunk = (chunk_size_i == n_seq_tokens) ? C_perm_full :
+                        ggml_view_4d(ctx, C_perm_full,
+                            C_perm_full->ne[0], chunk_size_i, C_perm_full->ne[2], C_perm_full->ne[3],
+                            C_perm_full->nb[1], C_perm_full->nb[2], C_perm_full->nb[3],
+                            chunk_i * C_perm_full->nb[1]);
+
+                    ggml_tensor * B_state_chunk = (chunk_size_i == n_seq_tokens) ? B_for_state_perm :
+                        ggml_view_4d(ctx, B_for_state_perm,
+                            chunk_size_i, B_for_state_perm->ne[1], B_for_state_perm->ne[2], B_for_state_perm->ne[3],
+                            B_for_state_perm->nb[1], B_for_state_perm->nb[2], B_for_state_perm->nb[3],
+                            chunk_i * B_for_state_perm->nb[0]);
+
+                    cb(dtA_chunk, "dtA_chunk", il);
+                    cb(dtX_chunk_perm, "dtX_chunk_perm", il);
+
+                    // step 3: compute CB = C @ B^T
+                    // B_perm_chunk, C_perm_chunk: {d_state, chunk_size_i, n_group, n_seqs}
+                    ggml_tensor * CB = ggml_mul_mat(ctx, B_perm_chunk, C_perm_chunk); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
+                    CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]);
                     cb(CB, "CB", il);
 
-                    // step 4: compute decay
-                    dtA_chunk = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
-                    ggml_tensor * dtA_tmp0 = ggml_repeat_4d(ctx, dtA_chunk,
-                        dtA_chunk->ne[0] * chunk_size_i, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3]); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    ggml_tensor * dtA_tmp1 = ggml_tri(ctx, dtA_tmp0, GGML_TRI_TYPE_LOWER); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tmp1); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
-                    cb(segsum, "segsum", il);
-                    ggml_tensor * decay = ggml_exp(ctx, segsum); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
+                    // step 4: compute decay matrix
+                    // dtA_chunk: {n_head, chunk_size_i, n_seqs}
+                    // We need to build the lower-triangular cumsum matrix
+                    ggml_tensor * dtA_for_decay = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
+                    ggml_tensor * dtA_expanded = ggml_repeat_4d(ctx, dtA_for_decay,
+                        dtA_for_decay->ne[0] * chunk_size_i, dtA_for_decay->ne[1],
+                        dtA_for_decay->ne[2], dtA_for_decay->ne[3]);
+                    ggml_tensor * dtA_tri = ggml_tri(ctx, dtA_expanded, GGML_TRI_TYPE_LOWER);
+                    ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tri);
+                    segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // Need cont for transpose
+                    ggml_tensor * decay = ggml_exp(ctx, segsum);
                     cb(decay, "decay", il);
 
-                    // step 5: compute surrogate_attention_matrix
+                    // step 5: compute surrogate attention matrix
                     ggml_tensor * CBdecay = ggml_mul(ctx, CB, decay);
-                    ggml_tensor * surrogate_attention_matrix = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
-                    cb(surrogate_attention_matrix, "surrogate_attention_matrix", il);
+                    ggml_tensor * SAM = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
+                    cb(SAM, "SAM", il);
 
-                    // step 6: compute y
-                    ggml_tensor * dtX_chunk_perm = ggml_cont(ctx, ggml_permute(ctx, dtX_chunk, 1, 2, 0, 3));
-                    ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, surrogate_attention_matrix);
+                    // step 6: compute y = SAM @ dtX^T
+                    // SAM: {chunk_size_i, chunk_size_i, n_head, n_seqs}
+                    // dtX_chunk_perm: {n_head, chunk_size_i, head_dim, n_seqs}
+                    ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, SAM);
+                    // Result: {head_dim, chunk_size_i, n_head, n_seqs}
+                    // We need: {head_dim, n_head, chunk_size_i, n_seqs}
                     y_chunk = ggml_cont(ctx, ggml_permute(ctx, y_chunk, 0, 2, 1, 3));
-                    cb(y_chunk, "y_chunk", il); // {n_head, chunk_size_i, n_seqs}
+                    cb(y_chunk, "y_chunk", il);
 
-                    // step 7: compute dtxdecay
+                    // step 7: compute state update contribution
+                    // decay_last: last row of decay matrix
                     ggml_tensor * decay_last = ggml_view_4d(ctx, decay,
                         decay->ne[0], 1, decay->ne[2], decay->ne[3],
                         decay->nb[1], decay->nb[2], decay->nb[3],
                         (decay->ne[1] - 1) * decay->nb[1]);
-                    decay_last = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
-                    cb(decay_last, "decay_last", il);
-                    B_perm = ggml_cont(ctx, B_perm);
-                    B_perm = ggml_repeat_4d(ctx, B_perm,
-                        B_perm->ne[0], B_perm->ne[1], B_perm->ne[2] * repeats, B_perm->ne[3]);
-                    ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last);
-                    dtxdecay = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
-                    cb(dtxdecay, "dtxdecay", il);
+                    // decay_last: {chunk_size_i, 1, n_head, n_seqs} -> need {1, n_head, chunk_size_i, n_seqs} for broadcast
+                    ggml_tensor * decay_last_bc = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
 
-                    // step 8: compute next_state
-                    ggml_tensor * next_state = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_permute(ctx, B_perm, 1, 0, 2, 3)), dtxdecay);
+                    // dtxdecay = dtX * decay_last (broadcast)
+                    // dtX_chunk: {head_dim, n_head, chunk_size_i, n_seqs}
+                    ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last_bc);
+                    // Permute for mul_mat: {n_head, chunk_size_i, head_dim, n_seqs}
+                    ggml_tensor * dtxdecay_perm = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
+
+                    // step 8: compute next_state = B^T @ dtxdecay
+                    // B_state_chunk: {chunk_size_i, d_state, n_head, n_seqs}
+                    // dtxdecay_perm: {n_head, chunk_size_i, head_dim, n_seqs}
+                    ggml_tensor * next_state = ggml_mul_mat(ctx, B_state_chunk, dtxdecay_perm);
+                    // Result: {d_state, head_dim, n_head, n_seqs}
                     if (next_state->type != ssm->type) {
                         next_state = ggml_cast(ctx, next_state, ssm->type);
                     }
                     cb(next_state, "next_state", il);
 
-                    // TODO: Skip y and state updates if no previous state
+                    // step 9: update state from previous state
+                    // Compute exp(cumsum(dtA)) for state decay
+                    ggml_tensor * dtA_for_state = ggml_cont(ctx, dtA_for_decay);
+                    ggml_tensor * dtA_flat = ggml_view_3d(ctx, dtA_for_state,
+                        dtA_for_state->ne[1], dtA_for_state->ne[2], dtA_for_state->ne[3],
+                        dtA_for_state->nb[2], dtA_for_state->nb[3], 0);
+                    ggml_tensor * exp_dtA_cumsum = ggml_exp(ctx, ggml_cumsum(ctx, dtA_flat));
+                    exp_dtA_cumsum = ggml_view_4d(ctx, exp_dtA_cumsum,
+                        1, dtA_for_state->ne[1], dtA_for_state->ne[2], dtA_for_state->ne[3],
+                        dtA_for_state->nb[1], dtA_for_state->nb[2], dtA_for_state->nb[3], 0);
 
-                    // step 9: update from previous state
-                    dtA_chunk = ggml_cont(ctx, dtA_chunk);
-                    ggml_tensor * dtA_chunk_flat = ggml_view_3d(ctx,
-                        dtA_chunk, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-                        dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {chunk_size_i, n_head, n_seqs, 1}
-                    ggml_tensor * exp_dtA_cumsum = ggml_view_4d(ctx,
-                        ggml_exp(ctx, ggml_cumsum(ctx, dtA_chunk_flat)),
-                        1, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-                        dtA_chunk->nb[1], dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {1, chunk_size_i, n_head, n_seqs}
-                    cb(exp_dtA_cumsum, "exp_dtA_cumsum", il);
-                    ggml_tensor * exp_dtA_cumsum_last = ggml_view_4d(ctx, exp_dtA_cumsum,
+                    // Get last value for state update
+                    ggml_tensor * state_decay = ggml_view_4d(ctx, exp_dtA_cumsum,
                         exp_dtA_cumsum->ne[0], 1, exp_dtA_cumsum->ne[2], exp_dtA_cumsum->ne[3],
                         exp_dtA_cumsum->nb[1], exp_dtA_cumsum->nb[2], exp_dtA_cumsum->nb[3],
-                        (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]); // {1, 1, n_head, n_seqs}
-                    cb(exp_dtA_cumsum_last, "exp_dtA_cumsum_last", il);
-                    // ggml_tensor * exp_dtA_cumsum_perm = ggml_permute(ctx, exp_dtA_cumsum_last, 2, 1, 3, 0); // {1, 1, n_head, n_seqs}
-                    next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, exp_dtA_cumsum_last)));
+                        (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]);
+
+                    next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, state_decay)));
                     cb(next_state, "next_state_updated", il);
 
-                    // step 10: update from previous y
-                    ggml_tensor * y_prev = ggml_mul_mat(ctx,
-                        C_perm, // {d_state, chunk_size_i, n_group, n_seqs}
-                        ssm     // {d_state, head_dim, n_head, n_seqs}
-                    ); // {chunk_size_i, head_dim, n_head, n_seqs}
-                    cb(y_prev, "y_prev", il);
-                    y_prev = ggml_mul(ctx,
-                        ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3)),        // {head_dim, n_head, chunk_size_i, n_seqs}
-                        ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3)) // {1,        n_head, chunk_size_i, n_seqs}
-                    ); // {head_dim, chunk_size_i, n_head, n_seqs}
-                    cb(y_prev, "y_prev_mul", il);
-                    y_chunk = ggml_add(ctx, y_chunk, y_prev);
-                    cb(y_chunk, "y_chunk_updated", il);
+                    // step 10: update y from previous state
+                    // y_prev = C @ ssm (project state through C)
+                    // C_perm_chunk: {d_state, chunk_size_i, n_group, n_seqs}
+                    // ssm: {d_state, head_dim, n_head, n_seqs}
+                    ggml_tensor * y_prev = ggml_mul_mat(ctx, C_perm_chunk, ssm);
+                    // Result: {chunk_size_i, head_dim, n_head, n_seqs}
+                    // Need: {head_dim, n_head, chunk_size_i, n_seqs}
+                    y_prev = ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3));
 
-                    // step 11: recurse
+                    // Scale by cumulative decay
+                    // exp_dtA_cumsum: {1, chunk_size_i, n_head, n_seqs}
+                    // Need: {1, n_head, chunk_size_i, n_seqs} for broadcast
+                    ggml_tensor * y_decay = ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3));
+                    y_prev = ggml_mul(ctx, y_prev, y_decay);
+
+                    y_chunk = ggml_add(ctx, y_chunk, y_prev);
+                    cb(y_chunk, "y_chunk_final", il);
+
+                    // step 11: accumulate results
                     if (chunk_size_i == n_seq_tokens) {
                         y = y_chunk;
                     } else {
                         y = ggml_concat(ctx, y, y_chunk, 2);
                     }
-                    cb(y, "y", il);
                     ssm = next_state;
                 }
 

--- a/src/models/graph-context-mamba.cpp
+++ b/src/models/graph-context-mamba.cpp
@@ -216,252 +216,256 @@ ggml_tensor * llm_graph_context_mamba::build_mamba2_layer(llm_graph_input_rs * i
         // For simultaneous sequences, all sequences need to have the same length.
         xBC = ggml_ssm_conv(ctx0, conv_x, model.layers[il].ssm_conv1d);
 
-        // bias
-        xBC = ggml_add(ctx0, xBC, model.layers[il].ssm_conv1d_b);
+        // // bias
+        // xBC = ggml_add(ctx0, xBC, model.layers[il].ssm_conv1d_b);
 
-        xBC = ggml_silu(ctx0, xBC);
+        // xBC = ggml_silu(ctx0, xBC);
     }
+
+    //DEBUG
+    cur = ggml_view_4d(ctx0, xBC, cur->ne[0], cur->ne[1], cur->ne[2], cur->ne[3],
+        cur->nb[1], cur->nb[2], cur->nb[3], 0);
 
     // ssm
-    {
-        // These correspond to V K Q in SSM/attention duality
-        ggml_tensor * x = ggml_view_4d(ctx0, xBC, head_dim, n_head, n_seq_tokens, n_seqs, head_dim * xBC->nb[0],
-                                       xBC->nb[1], xBC->nb[2], 0);
-        ggml_tensor * B = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
-                                       xBC->nb[1], xBC->nb[2], d_inner * ggml_element_size(xBC));
-        ggml_tensor * C = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
-                                       xBC->nb[1], xBC->nb[2], (d_inner + n_group * d_state) * ggml_element_size(xBC));
+    // {
+    //     // These correspond to V K Q in SSM/attention duality
+    //     ggml_tensor * x = ggml_view_4d(ctx0, xBC, head_dim, n_head, n_seq_tokens, n_seqs, head_dim * xBC->nb[0],
+    //                                    xBC->nb[1], xBC->nb[2], 0);
+    //     ggml_tensor * B = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
+    //                                    xBC->nb[1], xBC->nb[2], d_inner * ggml_element_size(xBC));
+    //     ggml_tensor * C = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
+    //                                    xBC->nb[1], xBC->nb[2], (d_inner + n_group * d_state) * ggml_element_size(xBC));
 
-        // {n_head, n_seq_tokens, n_seqs}
-        dt = ggml_add(ctx0, ggml_cont(ctx0, dt), model.layers[il].ssm_dt_b);
+    //     // {n_head, n_seq_tokens, n_seqs}
+    //     dt = ggml_add(ctx0, ggml_cont(ctx0, dt), model.layers[il].ssm_dt_b);
 
-        ggml_tensor * A = model.layers[il].ssm_a;
+    //     ggml_tensor * A = model.layers[il].ssm_a;
 
-        // use the states and the indices provided by build_recurrent_state
-        // (this is necessary in order to properly use the states before they are overwritten,
-        //  while avoiding to make unnecessary copies of the states)
-        auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
-            ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
+    //     // use the states and the indices provided by build_recurrent_state
+    //     // (this is necessary in order to properly use the states before they are overwritten,
+    //     //  while avoiding to make unnecessary copies of the states)
+    //     auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
+    //         ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
 
-            if (n_seq_tokens == 1) {
-            // if (true) {
-                //DEBUG
-                LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
-                // If single-token, use ssm_scan op
-                ssm = ggml_cast(ctx, ssm, GGML_TYPE_F32);
-                return ggml_ssm_scan(ctx, ssm, x, dt, A, B, C, ids);
-            } else {
-                //DEBUG
-                LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): multi-token chunk scan\n", il);
+    //         // if (n_seq_tokens == 1) {
+    //         if (true) {
+    //             //DEBUG
+    //             LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
+    //             // If single-token, use ssm_scan op
+    //             ssm = ggml_cast(ctx, ssm, GGML_TYPE_F32);
+    //             return ggml_ssm_scan(ctx, ssm, x, dt, A, B, C, ids);
+    //         } else {
+    //             //DEBUG
+    //             LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): multi-token chunk scan\n", il);
 
-                // otherwise, use the SSD formulation
+    //             // otherwise, use the SSD formulation
 
-                // extract the state(s) for the sequences identified by ids
-                if (ssm->ne[3] != ids->ne[0]) {
-                    ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);        // put the target dim in dim 1
-                    ggml_tensor * ids_perm_rep = ggml_repeat_4d(ctx, ids,
-                        ids->ne[0], ssm->ne[1], ssm->ne[2], 1);                         // repeat to match expected shape
-                    ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep); // extract ids as rows
-                    ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));       // permute back to original shape
-                    GGML_ASSERT(ssm->ne[3] == ids->ne[0]);
-                }
-                // ssm -> {d_state, head_dim, n_head, n_seqs}
+    //             // extract the state(s) for the sequences identified by ids
+    //             if (ssm->ne[3] != ids->ne[0]) {
+    //                 ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);        // put the target dim in dim 1
+    //                 ggml_tensor * ids_perm_rep = ggml_repeat_4d(ctx, ids,
+    //                     ids->ne[0], ssm->ne[1], ssm->ne[2], 1);                         // repeat to match expected shape
+    //                 ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep); // extract ids as rows
+    //                 ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));       // permute back to original shape
+    //                 GGML_ASSERT(ssm->ne[3] == ids->ne[0]);
+    //             }
+    //             // ssm -> {d_state, head_dim, n_head, n_seqs}
 
-                // step 1: compute dt softplus
-                // NOTE: In other implementations, the bias is added after
-                //  the softplus. This shouldn't be a problem, but it's a
-                //  difference.
-                ggml_tensor * dt_softplus = ggml_softplus(ctx, dt); // {n_head, n_seq_tokens, n_seqs}
-                dt_softplus = ggml_clamp(ctx, dt_softplus, 0.001, 100.0);
-                cb(dt_softplus, "dt_softplus", il);
+    //             // step 1: compute dt softplus
+    //             // NOTE: In other implementations, the bias is added after
+    //             //  the softplus. This shouldn't be a problem, but it's a
+    //             //  difference.
+    //             ggml_tensor * dt_softplus = ggml_softplus(ctx, dt); // {n_head, n_seq_tokens, n_seqs}
+    //             dt_softplus = ggml_clamp(ctx, dt_softplus, 0.001, 100.0);
+    //             cb(dt_softplus, "dt_softplus", il);
 
-                // step 2: compute dtA and dtX
-                ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1])); // {n_head, n_seq_tokens, n_seqs}
-                cb(dtA, "dtA", il);
-                ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus, 1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2])); // {head_dim, n_head, n_seq_tokens, n_seqs}
-                cb(dtX, "dtX", il);
+    //             // step 2: compute dtA and dtX
+    //             ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1])); // {n_head, n_seq_tokens, n_seqs}
+    //             cb(dtA, "dtA", il);
+    //             ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus, 1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2])); // {head_dim, n_head, n_seq_tokens, n_seqs}
+    //             cb(dtX, "dtX", il);
 
-                // loop over all chunks
-                uint32_t repeats = n_head / n_group;
+    //             // loop over all chunks
+    //             uint32_t repeats = n_head / n_group;
 
-                // Empty y that will be extended with each chunk of tokens
-                ggml_tensor * y = ggml_new_tensor_4d(ctx, x->type, x->ne[0], x->ne[1], 0, x->ne[3]);
-                // TODO: make this configurable
-                const uint32_t chunk_size = 512; // default ubatch size
-                for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
-                    ggml_tensor * dtA_chunk;
-                    ggml_tensor * dtX_chunk;
-                    ggml_tensor * B_chunk;
-                    ggml_tensor * C_chunk;
-                    const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
-                    if (chunk_size_i == n_seq_tokens) {
-                        dtA_chunk = dtA;
-                        dtX_chunk = dtX;
-                        B_chunk = B;
-                        C_chunk = C;
-                    } else {
-                        // chunk views
-                        // slice dtA on dim 1
-                        dtA_chunk = ggml_view_3d(ctx, dtA,
-                            dtA->ne[0], chunk_size_i, dtA->ne[2],
-                            dtA->nb[1], dtA->nb[2],
-                            chunk_i * dtA->nb[1]);
-                        // slice dtX on dim 2
-                        dtX_chunk = ggml_view_4d(ctx, dtX,
-                            dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
-                            dtX->nb[1], dtX->nb[2], dtX->nb[3],
-                            chunk_i * dtX->nb[2]);
-                        // slice B on dim 2
-                        B_chunk = ggml_view_4d(ctx, B,
-                            B->ne[0], B->ne[1], chunk_size_i, B->ne[3],
-                            B->nb[1], B->nb[2], B->nb[3],
-                            chunk_i * B->nb[2]);
-                        // slice C on dim 2
-                        C_chunk = ggml_view_4d(ctx, C,
-                            C->ne[0], C->ne[1], chunk_size_i, C->ne[3],
-                            C->nb[1], C->nb[2], C->nb[3],
-                            chunk_i * C->nb[2]);
-                    }
-                    cb(dtA_chunk, "dtA_chunk", il); // {n_head, chunk_size_i, n_seqs}
-                    cb(dtX_chunk, "dtX_chunk", il); // {head_dim, n_head, chunk_size_i, n_seqs}
-                    cb(B_chunk,   "B_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
-                    cb(C_chunk,   "C_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
+    //             // Empty y that will be extended with each chunk of tokens
+    //             ggml_tensor * y = ggml_new_tensor_4d(ctx, x->type, x->ne[0], x->ne[1], 0, x->ne[3]);
+    //             // TODO: make this configurable
+    //             const uint32_t chunk_size = 512; // default ubatch size
+    //             for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
+    //                 ggml_tensor * dtA_chunk;
+    //                 ggml_tensor * dtX_chunk;
+    //                 ggml_tensor * B_chunk;
+    //                 ggml_tensor * C_chunk;
+    //                 const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
+    //                 if (chunk_size_i == n_seq_tokens) {
+    //                     dtA_chunk = dtA;
+    //                     dtX_chunk = dtX;
+    //                     B_chunk = B;
+    //                     C_chunk = C;
+    //                 } else {
+    //                     // chunk views
+    //                     // slice dtA on dim 1
+    //                     dtA_chunk = ggml_view_3d(ctx, dtA,
+    //                         dtA->ne[0], chunk_size_i, dtA->ne[2],
+    //                         dtA->nb[1], dtA->nb[2],
+    //                         chunk_i * dtA->nb[1]);
+    //                     // slice dtX on dim 2
+    //                     dtX_chunk = ggml_view_4d(ctx, dtX,
+    //                         dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
+    //                         dtX->nb[1], dtX->nb[2], dtX->nb[3],
+    //                         chunk_i * dtX->nb[2]);
+    //                     // slice B on dim 2
+    //                     B_chunk = ggml_view_4d(ctx, B,
+    //                         B->ne[0], B->ne[1], chunk_size_i, B->ne[3],
+    //                         B->nb[1], B->nb[2], B->nb[3],
+    //                         chunk_i * B->nb[2]);
+    //                     // slice C on dim 2
+    //                     C_chunk = ggml_view_4d(ctx, C,
+    //                         C->ne[0], C->ne[1], chunk_size_i, C->ne[3],
+    //                         C->nb[1], C->nb[2], C->nb[3],
+    //                         chunk_i * C->nb[2]);
+    //                 }
+    //                 cb(dtA_chunk, "dtA_chunk", il); // {n_head, chunk_size_i, n_seqs}
+    //                 cb(dtX_chunk, "dtX_chunk", il); // {head_dim, n_head, chunk_size_i, n_seqs}
+    //                 cb(B_chunk,   "B_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
+    //                 cb(C_chunk,   "C_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
 
-                    // step 3: compute CB
-                    ggml_tensor * C_perm = ggml_permute(ctx, C_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-                    ggml_tensor * B_perm = ggml_permute(ctx, B_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-                    ggml_tensor * CB = ggml_mul_mat(ctx, B_perm, C_perm); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
-                    CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]); // {chunk_size_i, chunk_size_i, n_head (repeats * n_group), n_seqs}
-                    cb(CB, "CB", il);
+    //                 // step 3: compute CB
+    //                 ggml_tensor * C_perm = ggml_permute(ctx, C_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
+    //                 ggml_tensor * B_perm = ggml_permute(ctx, B_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
+    //                 ggml_tensor * CB = ggml_mul_mat(ctx, B_perm, C_perm); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
+    //                 CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]); // {chunk_size_i, chunk_size_i, n_head (repeats * n_group), n_seqs}
+    //                 cb(CB, "CB", il);
 
-                    // step 4: compute decay
-                    dtA_chunk = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
-                    ggml_tensor * dtA_tmp0 = ggml_repeat_4d(ctx, dtA_chunk,
-                        dtA_chunk->ne[0] * chunk_size_i, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3]); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    ggml_tensor * dtA_tmp1 = ggml_tri(ctx, dtA_tmp0, GGML_TRI_TYPE_LOWER); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tmp1); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-                    segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
-                    cb(segsum, "segsum", il);
-                    ggml_tensor * decay = ggml_exp(ctx, segsum); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
-                    cb(decay, "decay", il);
+    //                 // step 4: compute decay
+    //                 dtA_chunk = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
+    //                 ggml_tensor * dtA_tmp0 = ggml_repeat_4d(ctx, dtA_chunk,
+    //                     dtA_chunk->ne[0] * chunk_size_i, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3]); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+    //                 ggml_tensor * dtA_tmp1 = ggml_tri(ctx, dtA_tmp0, GGML_TRI_TYPE_LOWER); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+    //                 ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tmp1); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+    //                 segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
+    //                 cb(segsum, "segsum", il);
+    //                 ggml_tensor * decay = ggml_exp(ctx, segsum); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
+    //                 cb(decay, "decay", il);
 
-                    // step 5: compute surrogate_attention_matrix
-                    ggml_tensor * CBdecay = ggml_mul(ctx, CB, decay);
-                    ggml_tensor * surrogate_attention_matrix = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
-                    cb(surrogate_attention_matrix, "surrogate_attention_matrix", il);
+    //                 // step 5: compute surrogate_attention_matrix
+    //                 ggml_tensor * CBdecay = ggml_mul(ctx, CB, decay);
+    //                 ggml_tensor * surrogate_attention_matrix = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
+    //                 cb(surrogate_attention_matrix, "surrogate_attention_matrix", il);
 
-                    // step 6: compute y
-                    ggml_tensor * dtX_chunk_perm = ggml_cont(ctx, ggml_permute(ctx, dtX_chunk, 1, 2, 0, 3));
-                    ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, surrogate_attention_matrix);
-                    y_chunk = ggml_cont(ctx, ggml_permute(ctx, y_chunk, 0, 2, 1, 3));
-                    cb(y_chunk, "y_chunk", il); // {n_head, chunk_size_i, n_seqs}
+    //                 // step 6: compute y
+    //                 ggml_tensor * dtX_chunk_perm = ggml_cont(ctx, ggml_permute(ctx, dtX_chunk, 1, 2, 0, 3));
+    //                 ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, surrogate_attention_matrix);
+    //                 y_chunk = ggml_cont(ctx, ggml_permute(ctx, y_chunk, 0, 2, 1, 3));
+    //                 cb(y_chunk, "y_chunk", il); // {n_head, chunk_size_i, n_seqs}
 
-                    // step 7: compute dtxdecay
-                    ggml_tensor * decay_last = ggml_view_4d(ctx, decay,
-                        decay->ne[0], 1, decay->ne[2], decay->ne[3],
-                        decay->nb[1], decay->nb[2], decay->nb[3],
-                        (decay->ne[1] - 1) * decay->nb[1]);
-                    decay_last = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
-                    cb(decay_last, "decay_last", il);
-                    B_perm = ggml_cont(ctx, B_perm);
-                    B_perm = ggml_repeat_4d(ctx, B_perm,
-                        B_perm->ne[0], B_perm->ne[1], B_perm->ne[2] * repeats, B_perm->ne[3]);
-                    ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last);
-                    dtxdecay = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
-                    cb(dtxdecay, "dtxdecay", il);
+    //                 // step 7: compute dtxdecay
+    //                 ggml_tensor * decay_last = ggml_view_4d(ctx, decay,
+    //                     decay->ne[0], 1, decay->ne[2], decay->ne[3],
+    //                     decay->nb[1], decay->nb[2], decay->nb[3],
+    //                     (decay->ne[1] - 1) * decay->nb[1]);
+    //                 decay_last = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
+    //                 cb(decay_last, "decay_last", il);
+    //                 B_perm = ggml_cont(ctx, B_perm);
+    //                 B_perm = ggml_repeat_4d(ctx, B_perm,
+    //                     B_perm->ne[0], B_perm->ne[1], B_perm->ne[2] * repeats, B_perm->ne[3]);
+    //                 ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last);
+    //                 dtxdecay = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
+    //                 cb(dtxdecay, "dtxdecay", il);
 
-                    // step 8: compute next_state
-                    ggml_tensor * next_state = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_permute(ctx, B_perm, 1, 0, 2, 3)), dtxdecay);
-                    if (next_state->type != ssm->type) {
-                        next_state = ggml_cast(ctx, next_state, ssm->type);
-                    }
-                    cb(next_state, "next_state", il);
+    //                 // step 8: compute next_state
+    //                 ggml_tensor * next_state = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_permute(ctx, B_perm, 1, 0, 2, 3)), dtxdecay);
+    //                 if (next_state->type != ssm->type) {
+    //                     next_state = ggml_cast(ctx, next_state, ssm->type);
+    //                 }
+    //                 cb(next_state, "next_state", il);
 
-                    // TODO: Skip y and state updates if no previous state
+    //                 // TODO: Skip y and state updates if no previous state
 
-                    // step 9: update from previous state
-                    dtA_chunk = ggml_cont(ctx, dtA_chunk);
-                    ggml_tensor * dtA_chunk_flat = ggml_view_3d(ctx,
-                        dtA_chunk, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-                        dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {chunk_size_i, n_head, n_seqs, 1}
-                    ggml_tensor * exp_dtA_cumsum = ggml_view_4d(ctx,
-                        ggml_exp(ctx, ggml_cumsum(ctx, dtA_chunk_flat)),
-                        1, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-                        dtA_chunk->nb[1], dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {1, chunk_size_i, n_head, n_seqs}
-                    cb(exp_dtA_cumsum, "exp_dtA_cumsum", il);
-                    ggml_tensor * exp_dtA_cumsum_last = ggml_view_4d(ctx, exp_dtA_cumsum,
-                        exp_dtA_cumsum->ne[0], 1, exp_dtA_cumsum->ne[2], exp_dtA_cumsum->ne[3],
-                        exp_dtA_cumsum->nb[1], exp_dtA_cumsum->nb[2], exp_dtA_cumsum->nb[3],
-                        (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]); // {1, 1, n_head, n_seqs}
-                    cb(exp_dtA_cumsum_last, "exp_dtA_cumsum_last", il);
-                    // ggml_tensor * exp_dtA_cumsum_perm = ggml_permute(ctx, exp_dtA_cumsum_last, 2, 1, 3, 0); // {1, 1, n_head, n_seqs}
-                    next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, exp_dtA_cumsum_last)));
-                    cb(next_state, "next_state_updated", il);
+    //                 // step 9: update from previous state
+    //                 dtA_chunk = ggml_cont(ctx, dtA_chunk);
+    //                 ggml_tensor * dtA_chunk_flat = ggml_view_3d(ctx,
+    //                     dtA_chunk, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
+    //                     dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {chunk_size_i, n_head, n_seqs, 1}
+    //                 ggml_tensor * exp_dtA_cumsum = ggml_view_4d(ctx,
+    //                     ggml_exp(ctx, ggml_cumsum(ctx, dtA_chunk_flat)),
+    //                     1, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
+    //                     dtA_chunk->nb[1], dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {1, chunk_size_i, n_head, n_seqs}
+    //                 cb(exp_dtA_cumsum, "exp_dtA_cumsum", il);
+    //                 ggml_tensor * exp_dtA_cumsum_last = ggml_view_4d(ctx, exp_dtA_cumsum,
+    //                     exp_dtA_cumsum->ne[0], 1, exp_dtA_cumsum->ne[2], exp_dtA_cumsum->ne[3],
+    //                     exp_dtA_cumsum->nb[1], exp_dtA_cumsum->nb[2], exp_dtA_cumsum->nb[3],
+    //                     (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]); // {1, 1, n_head, n_seqs}
+    //                 cb(exp_dtA_cumsum_last, "exp_dtA_cumsum_last", il);
+    //                 // ggml_tensor * exp_dtA_cumsum_perm = ggml_permute(ctx, exp_dtA_cumsum_last, 2, 1, 3, 0); // {1, 1, n_head, n_seqs}
+    //                 next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, exp_dtA_cumsum_last)));
+    //                 cb(next_state, "next_state_updated", il);
 
-                    // step 10: update from previous y
-                    ggml_tensor * y_prev = ggml_mul_mat(ctx,
-                        C_perm, // {d_state, chunk_size_i, n_group, n_seqs}
-                        ssm     // {d_state, head_dim, n_head, n_seqs}
-                    ); // {chunk_size_i, head_dim, n_head, n_seqs}
-                    cb(y_prev, "y_prev", il);
-                    y_prev = ggml_mul(ctx,
-                        ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3)),        // {head_dim, n_head, chunk_size_i, n_seqs}
-                        ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3)) // {1,        n_head, chunk_size_i, n_seqs}
-                    ); // {head_dim, chunk_size_i, n_head, n_seqs}
-                    cb(y_prev, "y_prev_mul", il);
-                    y_chunk = ggml_add(ctx, y_chunk, y_prev);
-                    cb(y_chunk, "y_chunk_updated", il);
+    //                 // step 10: update from previous y
+    //                 ggml_tensor * y_prev = ggml_mul_mat(ctx,
+    //                     C_perm, // {d_state, chunk_size_i, n_group, n_seqs}
+    //                     ssm     // {d_state, head_dim, n_head, n_seqs}
+    //                 ); // {chunk_size_i, head_dim, n_head, n_seqs}
+    //                 cb(y_prev, "y_prev", il);
+    //                 y_prev = ggml_mul(ctx,
+    //                     ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3)),        // {head_dim, n_head, chunk_size_i, n_seqs}
+    //                     ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3)) // {1,        n_head, chunk_size_i, n_seqs}
+    //                 ); // {head_dim, chunk_size_i, n_head, n_seqs}
+    //                 cb(y_prev, "y_prev_mul", il);
+    //                 y_chunk = ggml_add(ctx, y_chunk, y_prev);
+    //                 cb(y_chunk, "y_chunk_updated", il);
 
-                    // step 11: recurse
-                    if (chunk_size_i == n_seq_tokens) {
-                        y = y_chunk;
-                    } else {
-                        y = ggml_concat(ctx, y, y_chunk, 2);
-                    }
-                    cb(y, "y", il);
-                    ssm = next_state;
-                }
+    //                 // step 11: recurse
+    //                 if (chunk_size_i == n_seq_tokens) {
+    //                     y = y_chunk;
+    //                 } else {
+    //                     y = ggml_concat(ctx, y, y_chunk, 2);
+    //                 }
+    //                 cb(y, "y", il);
+    //                 ssm = next_state;
+    //             }
 
-                // Concat the output y and state
-                if (ssm->type != y->type) {
-                    ssm = ggml_cast(ctx, ssm, y->type);
-                }
-                ggml_tensor * out = ggml_concat(ctx,
-                    ggml_view_1d(ctx, y, ggml_nelements(y), 0),
-                    ggml_view_1d(ctx, ssm, ggml_nelements(ssm), 0),
-                    0);
-                return out;
-            }
-        };
+    //             // Concat the output y and state
+    //             if (ssm->type != y->type) {
+    //                 ssm = ggml_cast(ctx, ssm, y->type);
+    //             }
+    //             ggml_tensor * out = ggml_concat(ctx,
+    //                 ggml_view_1d(ctx, y, ggml_nelements(y), 0),
+    //                 ggml_view_1d(ctx, ssm, ggml_nelements(ssm), 0),
+    //                 0);
+    //             return out;
+    //         }
+    //     };
 
-        ggml_tensor * y_ssm = build_rs(inp, ssm_states_all, hparams.n_embd_s(), ubatch.n_seqs, get_ssm_rows);
+    //     ggml_tensor * y_ssm = build_rs(inp, ssm_states_all, hparams.n_embd_s(), ubatch.n_seqs, get_ssm_rows);
 
-        // store last states
-        ggml_build_forward_expand(
-            gf, ggml_cpy(ctx0, ggml_view_1d(ctx0, y_ssm, d_state * d_inner * n_seqs, ggml_nelements(x) * x->nb[0]),
-                         ggml_view_1d(ctx0, ssm_states_all, d_state * d_inner * n_seqs,
-                                      kv_head * d_state * d_inner * ggml_element_size(ssm_states_all))));
+    //     // store last states
+    //     ggml_build_forward_expand(
+    //         gf, ggml_cpy(ctx0, ggml_view_1d(ctx0, y_ssm, d_state * d_inner * n_seqs, ggml_nelements(x) * x->nb[0]),
+    //                      ggml_view_1d(ctx0, ssm_states_all, d_state * d_inner * n_seqs,
+    //                                   kv_head * d_state * d_inner * ggml_element_size(ssm_states_all))));
 
-        ggml_tensor * y = ggml_view_4d(ctx0, y_ssm, head_dim, n_head, n_seq_tokens, n_seqs, x->nb[1], n_head * x->nb[1],
-                                       n_seq_tokens * n_head * x->nb[1], 0);
+    //     ggml_tensor * y = ggml_view_4d(ctx0, y_ssm, head_dim, n_head, n_seq_tokens, n_seqs, x->nb[1], n_head * x->nb[1],
+    //                                    n_seq_tokens * n_head * x->nb[1], 0);
 
-        // TODO: skip computing output earlier for unused tokens
+    //     // TODO: skip computing output earlier for unused tokens
 
-        y = ggml_add(ctx0, y, ggml_mul(ctx0, x, model.layers[il].ssm_d));
-        cb(y, "mamba2_y_add_d", il);
-        y = ggml_swiglu_split(ctx0, ggml_cont(ctx0, z), y);
+    //     y = ggml_add(ctx0, y, ggml_mul(ctx0, x, model.layers[il].ssm_d));
+    //     cb(y, "mamba2_y_add_d", il);
+    //     y = ggml_swiglu_split(ctx0, ggml_cont(ctx0, z), y);
 
-        // grouped RMS norm
-        if (model.layers[il].ssm_norm) {
-            y = ggml_reshape_4d(ctx0, y, d_inner / n_group, n_group, n_seq_tokens, n_seqs);
-            y = build_norm(y, model.layers[il].ssm_norm, NULL, LLM_NORM_RMS, il);
-        }
+    //     // grouped RMS norm
+    //     if (model.layers[il].ssm_norm) {
+    //         y = ggml_reshape_4d(ctx0, y, d_inner / n_group, n_group, n_seq_tokens, n_seqs);
+    //         y = build_norm(y, model.layers[il].ssm_norm, NULL, LLM_NORM_RMS, il);
+    //     }
 
-        y = ggml_reshape_3d(ctx0, y, d_inner, n_seq_tokens, n_seqs);
+    //     y = ggml_reshape_3d(ctx0, y, d_inner, n_seq_tokens, n_seqs);
 
-        // {d_inner, n_embd} @ {d_inner, n_seq_tokens, n_seqs} => {n_embd, n_seq_tokens, n_seqs}
-        cur = build_lora_mm(model.layers[il].ssm_out, y);
-    }
+    //     // {d_inner, n_embd} @ {d_inner, n_seq_tokens, n_seqs} => {n_embd, n_seq_tokens, n_seqs}
+    //     cur = build_lora_mm(model.layers[il].ssm_out, y);
+    // }
 
     // {n_embd, n_seq_tokens, n_seqs} => {n_embd, n_tokens}
     cur = ggml_reshape_2d(ctx0, cur, cur->ne[0], n_seq_tokens * n_seqs);

--- a/src/models/graph-context-mamba.cpp
+++ b/src/models/graph-context-mamba.cpp
@@ -216,256 +216,256 @@ ggml_tensor * llm_graph_context_mamba::build_mamba2_layer(llm_graph_input_rs * i
         // For simultaneous sequences, all sequences need to have the same length.
         xBC = ggml_ssm_conv(ctx0, conv_x, model.layers[il].ssm_conv1d);
 
-        // // bias
-        // xBC = ggml_add(ctx0, xBC, model.layers[il].ssm_conv1d_b);
+        // bias
+        xBC = ggml_add(ctx0, xBC, model.layers[il].ssm_conv1d_b);
 
-        // xBC = ggml_silu(ctx0, xBC);
+        xBC = ggml_silu(ctx0, xBC);
     }
 
     //DEBUG
-    cur = ggml_view_4d(ctx0, xBC, cur->ne[0], cur->ne[1], cur->ne[2], cur->ne[3],
-        cur->nb[1], cur->nb[2], cur->nb[3], 0);
+    // cur = ggml_view_4d(ctx0, xBC, cur->ne[0], cur->ne[1], cur->ne[2], cur->ne[3],
+    //     cur->nb[1], cur->nb[2], cur->nb[3], 0);
 
     // ssm
-    // {
-    //     // These correspond to V K Q in SSM/attention duality
-    //     ggml_tensor * x = ggml_view_4d(ctx0, xBC, head_dim, n_head, n_seq_tokens, n_seqs, head_dim * xBC->nb[0],
-    //                                    xBC->nb[1], xBC->nb[2], 0);
-    //     ggml_tensor * B = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
-    //                                    xBC->nb[1], xBC->nb[2], d_inner * ggml_element_size(xBC));
-    //     ggml_tensor * C = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
-    //                                    xBC->nb[1], xBC->nb[2], (d_inner + n_group * d_state) * ggml_element_size(xBC));
+    {
+        // These correspond to V K Q in SSM/attention duality
+        ggml_tensor * x = ggml_view_4d(ctx0, xBC, head_dim, n_head, n_seq_tokens, n_seqs, head_dim * xBC->nb[0],
+                                       xBC->nb[1], xBC->nb[2], 0);
+        ggml_tensor * B = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
+                                       xBC->nb[1], xBC->nb[2], d_inner * ggml_element_size(xBC));
+        ggml_tensor * C = ggml_view_4d(ctx0, xBC, d_state, n_group, n_seq_tokens, n_seqs, d_state * xBC->nb[0],
+                                       xBC->nb[1], xBC->nb[2], (d_inner + n_group * d_state) * ggml_element_size(xBC));
 
-    //     // {n_head, n_seq_tokens, n_seqs}
-    //     dt = ggml_add(ctx0, ggml_cont(ctx0, dt), model.layers[il].ssm_dt_b);
+        // {n_head, n_seq_tokens, n_seqs}
+        dt = ggml_add(ctx0, ggml_cont(ctx0, dt), model.layers[il].ssm_dt_b);
 
-    //     ggml_tensor * A = model.layers[il].ssm_a;
+        ggml_tensor * A = model.layers[il].ssm_a;
 
-    //     // use the states and the indices provided by build_recurrent_state
-    //     // (this is necessary in order to properly use the states before they are overwritten,
-    //     //  while avoiding to make unnecessary copies of the states)
-    //     auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
-    //         ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
+        // use the states and the indices provided by build_recurrent_state
+        // (this is necessary in order to properly use the states before they are overwritten,
+        //  while avoiding to make unnecessary copies of the states)
+        auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
+            ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
 
-    //         // if (n_seq_tokens == 1) {
-    //         if (true) {
-    //             //DEBUG
-    //             LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
-    //             // If single-token, use ssm_scan op
-    //             ssm = ggml_cast(ctx, ssm, GGML_TYPE_F32);
-    //             return ggml_ssm_scan(ctx, ssm, x, dt, A, B, C, ids);
-    //         } else {
-    //             //DEBUG
-    //             LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): multi-token chunk scan\n", il);
+            // if (n_seq_tokens == 1) {
+            if (true) {
+                //DEBUG
+                LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
+                // If single-token, use ssm_scan op
+                ssm = ggml_cast(ctx, ssm, GGML_TYPE_F32);
+                return ggml_ssm_scan(ctx, ssm, x, dt, A, B, C, ids);
+            } else {
+                //DEBUG
+                LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): multi-token chunk scan\n", il);
 
-    //             // otherwise, use the SSD formulation
+                // otherwise, use the SSD formulation
 
-    //             // extract the state(s) for the sequences identified by ids
-    //             if (ssm->ne[3] != ids->ne[0]) {
-    //                 ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);        // put the target dim in dim 1
-    //                 ggml_tensor * ids_perm_rep = ggml_repeat_4d(ctx, ids,
-    //                     ids->ne[0], ssm->ne[1], ssm->ne[2], 1);                         // repeat to match expected shape
-    //                 ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep); // extract ids as rows
-    //                 ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));       // permute back to original shape
-    //                 GGML_ASSERT(ssm->ne[3] == ids->ne[0]);
-    //             }
-    //             // ssm -> {d_state, head_dim, n_head, n_seqs}
+                // extract the state(s) for the sequences identified by ids
+                if (ssm->ne[3] != ids->ne[0]) {
+                    ggml_tensor * ssm_perm = ggml_permute(ctx, ssm, 0, 2, 3, 1);        // put the target dim in dim 1
+                    ggml_tensor * ids_perm_rep = ggml_repeat_4d(ctx, ids,
+                        ids->ne[0], ssm->ne[1], ssm->ne[2], 1);                         // repeat to match expected shape
+                    ggml_tensor * ssm_ids = ggml_get_rows(ctx, ssm_perm, ids_perm_rep); // extract ids as rows
+                    ssm = ggml_cont(ctx, ggml_permute(ctx, ssm_ids, 0, 3, 1, 2));       // permute back to original shape
+                    GGML_ASSERT(ssm->ne[3] == ids->ne[0]);
+                }
+                // ssm -> {d_state, head_dim, n_head, n_seqs}
 
-    //             // step 1: compute dt softplus
-    //             // NOTE: In other implementations, the bias is added after
-    //             //  the softplus. This shouldn't be a problem, but it's a
-    //             //  difference.
-    //             ggml_tensor * dt_softplus = ggml_softplus(ctx, dt); // {n_head, n_seq_tokens, n_seqs}
-    //             dt_softplus = ggml_clamp(ctx, dt_softplus, 0.001, 100.0);
-    //             cb(dt_softplus, "dt_softplus", il);
+                // step 1: compute dt softplus
+                // NOTE: In other implementations, the bias is added after
+                //  the softplus. This shouldn't be a problem, but it's a
+                //  difference.
+                ggml_tensor * dt_softplus = ggml_softplus(ctx, dt); // {n_head, n_seq_tokens, n_seqs}
+                dt_softplus = ggml_clamp(ctx, dt_softplus, 0.001, 100.0);
+                cb(dt_softplus, "dt_softplus", il);
 
-    //             // step 2: compute dtA and dtX
-    //             ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1])); // {n_head, n_seq_tokens, n_seqs}
-    //             cb(dtA, "dtA", il);
-    //             ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus, 1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2])); // {head_dim, n_head, n_seq_tokens, n_seqs}
-    //             cb(dtX, "dtX", il);
+                // step 2: compute dtA and dtX
+                ggml_tensor * dtA = ggml_mul(ctx, dt_softplus, ggml_reshape_1d(ctx, A, A->ne[1])); // {n_head, n_seq_tokens, n_seqs}
+                cb(dtA, "dtA", il);
+                ggml_tensor * dtX = ggml_mul(ctx, x, ggml_reshape_4d(ctx, dt_softplus, 1, dt_softplus->ne[0], dt_softplus->ne[1], dt_softplus->ne[2])); // {head_dim, n_head, n_seq_tokens, n_seqs}
+                cb(dtX, "dtX", il);
 
-    //             // loop over all chunks
-    //             uint32_t repeats = n_head / n_group;
+                // loop over all chunks
+                uint32_t repeats = n_head / n_group;
 
-    //             // Empty y that will be extended with each chunk of tokens
-    //             ggml_tensor * y = ggml_new_tensor_4d(ctx, x->type, x->ne[0], x->ne[1], 0, x->ne[3]);
-    //             // TODO: make this configurable
-    //             const uint32_t chunk_size = 512; // default ubatch size
-    //             for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
-    //                 ggml_tensor * dtA_chunk;
-    //                 ggml_tensor * dtX_chunk;
-    //                 ggml_tensor * B_chunk;
-    //                 ggml_tensor * C_chunk;
-    //                 const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
-    //                 if (chunk_size_i == n_seq_tokens) {
-    //                     dtA_chunk = dtA;
-    //                     dtX_chunk = dtX;
-    //                     B_chunk = B;
-    //                     C_chunk = C;
-    //                 } else {
-    //                     // chunk views
-    //                     // slice dtA on dim 1
-    //                     dtA_chunk = ggml_view_3d(ctx, dtA,
-    //                         dtA->ne[0], chunk_size_i, dtA->ne[2],
-    //                         dtA->nb[1], dtA->nb[2],
-    //                         chunk_i * dtA->nb[1]);
-    //                     // slice dtX on dim 2
-    //                     dtX_chunk = ggml_view_4d(ctx, dtX,
-    //                         dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
-    //                         dtX->nb[1], dtX->nb[2], dtX->nb[3],
-    //                         chunk_i * dtX->nb[2]);
-    //                     // slice B on dim 2
-    //                     B_chunk = ggml_view_4d(ctx, B,
-    //                         B->ne[0], B->ne[1], chunk_size_i, B->ne[3],
-    //                         B->nb[1], B->nb[2], B->nb[3],
-    //                         chunk_i * B->nb[2]);
-    //                     // slice C on dim 2
-    //                     C_chunk = ggml_view_4d(ctx, C,
-    //                         C->ne[0], C->ne[1], chunk_size_i, C->ne[3],
-    //                         C->nb[1], C->nb[2], C->nb[3],
-    //                         chunk_i * C->nb[2]);
-    //                 }
-    //                 cb(dtA_chunk, "dtA_chunk", il); // {n_head, chunk_size_i, n_seqs}
-    //                 cb(dtX_chunk, "dtX_chunk", il); // {head_dim, n_head, chunk_size_i, n_seqs}
-    //                 cb(B_chunk,   "B_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
-    //                 cb(C_chunk,   "C_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
+                // Empty y that will be extended with each chunk of tokens
+                ggml_tensor * y = ggml_new_tensor_4d(ctx, x->type, x->ne[0], x->ne[1], 0, x->ne[3]);
+                // TODO: make this configurable
+                const uint32_t chunk_size = 512; // default ubatch size
+                for (auto chunk_i = 0; chunk_i < n_seq_tokens; chunk_i += chunk_size) {
+                    ggml_tensor * dtA_chunk;
+                    ggml_tensor * dtX_chunk;
+                    ggml_tensor * B_chunk;
+                    ggml_tensor * C_chunk;
+                    const auto chunk_size_i = std::min(chunk_size, uint32_t(n_seq_tokens - chunk_i));
+                    if (chunk_size_i == n_seq_tokens) {
+                        dtA_chunk = dtA;
+                        dtX_chunk = dtX;
+                        B_chunk = B;
+                        C_chunk = C;
+                    } else {
+                        // chunk views
+                        // slice dtA on dim 1
+                        dtA_chunk = ggml_view_3d(ctx, dtA,
+                            dtA->ne[0], chunk_size_i, dtA->ne[2],
+                            dtA->nb[1], dtA->nb[2],
+                            chunk_i * dtA->nb[1]);
+                        // slice dtX on dim 2
+                        dtX_chunk = ggml_view_4d(ctx, dtX,
+                            dtX->ne[0], dtX->ne[1], chunk_size_i, dtX->ne[3],
+                            dtX->nb[1], dtX->nb[2], dtX->nb[3],
+                            chunk_i * dtX->nb[2]);
+                        // slice B on dim 2
+                        B_chunk = ggml_view_4d(ctx, B,
+                            B->ne[0], B->ne[1], chunk_size_i, B->ne[3],
+                            B->nb[1], B->nb[2], B->nb[3],
+                            chunk_i * B->nb[2]);
+                        // slice C on dim 2
+                        C_chunk = ggml_view_4d(ctx, C,
+                            C->ne[0], C->ne[1], chunk_size_i, C->ne[3],
+                            C->nb[1], C->nb[2], C->nb[3],
+                            chunk_i * C->nb[2]);
+                    }
+                    cb(dtA_chunk, "dtA_chunk", il); // {n_head, chunk_size_i, n_seqs}
+                    cb(dtX_chunk, "dtX_chunk", il); // {head_dim, n_head, chunk_size_i, n_seqs}
+                    cb(B_chunk,   "B_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
+                    cb(C_chunk,   "C_chunk",   il); // {d_state, n_group, chunk_size_i, n_seqs}
 
-    //                 // step 3: compute CB
-    //                 ggml_tensor * C_perm = ggml_permute(ctx, C_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-    //                 ggml_tensor * B_perm = ggml_permute(ctx, B_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
-    //                 ggml_tensor * CB = ggml_mul_mat(ctx, B_perm, C_perm); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
-    //                 CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]); // {chunk_size_i, chunk_size_i, n_head (repeats * n_group), n_seqs}
-    //                 cb(CB, "CB", il);
+                    // step 3: compute CB
+                    ggml_tensor * C_perm = ggml_permute(ctx, C_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
+                    ggml_tensor * B_perm = ggml_permute(ctx, B_chunk, 0, 2, 1, 3); // {d_state, chunk_size_i, n_group, n_seqs}
+                    ggml_tensor * CB = ggml_mul_mat(ctx, B_perm, C_perm); // {chunk_size_i, chunk_size_i, n_group, n_seqs}
+                    CB = ggml_repeat_4d(ctx, CB, CB->ne[0], CB->ne[1], CB->ne[2] * repeats, CB->ne[3]); // {chunk_size_i, chunk_size_i, n_head (repeats * n_group), n_seqs}
+                    cb(CB, "CB", il);
 
-    //                 // step 4: compute decay
-    //                 dtA_chunk = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
-    //                 ggml_tensor * dtA_tmp0 = ggml_repeat_4d(ctx, dtA_chunk,
-    //                     dtA_chunk->ne[0] * chunk_size_i, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3]); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-    //                 ggml_tensor * dtA_tmp1 = ggml_tri(ctx, dtA_tmp0, GGML_TRI_TYPE_LOWER); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-    //                 ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tmp1); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
-    //                 segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
-    //                 cb(segsum, "segsum", il);
-    //                 ggml_tensor * decay = ggml_exp(ctx, segsum); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
-    //                 cb(decay, "decay", il);
+                    // step 4: compute decay
+                    dtA_chunk = ggml_permute(ctx, dtA_chunk, 2, 1, 3, 0); // {1, chunk_size_i, n_head, n_seqs}
+                    ggml_tensor * dtA_tmp0 = ggml_repeat_4d(ctx, dtA_chunk,
+                        dtA_chunk->ne[0] * chunk_size_i, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3]); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+                    ggml_tensor * dtA_tmp1 = ggml_tri(ctx, dtA_tmp0, GGML_TRI_TYPE_LOWER); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+                    ggml_tensor * segsum = ggml_cumsum(ctx, dtA_tmp1); // {chunk_size_i_0, chunk_size_i_1, n_head, n_seqs}
+                    segsum = ggml_cont(ctx, ggml_transpose(ctx, segsum)); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
+                    cb(segsum, "segsum", il);
+                    ggml_tensor * decay = ggml_exp(ctx, segsum); // {chunk_size_i_1, chunk_size_i_0, n_head, n_seqs}
+                    cb(decay, "decay", il);
 
-    //                 // step 5: compute surrogate_attention_matrix
-    //                 ggml_tensor * CBdecay = ggml_mul(ctx, CB, decay);
-    //                 ggml_tensor * surrogate_attention_matrix = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
-    //                 cb(surrogate_attention_matrix, "surrogate_attention_matrix", il);
+                    // step 5: compute surrogate_attention_matrix
+                    ggml_tensor * CBdecay = ggml_mul(ctx, CB, decay);
+                    ggml_tensor * surrogate_attention_matrix = ggml_tri(ctx, CBdecay, GGML_TRI_TYPE_LOWER_DIAG);
+                    cb(surrogate_attention_matrix, "surrogate_attention_matrix", il);
 
-    //                 // step 6: compute y
-    //                 ggml_tensor * dtX_chunk_perm = ggml_cont(ctx, ggml_permute(ctx, dtX_chunk, 1, 2, 0, 3));
-    //                 ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, surrogate_attention_matrix);
-    //                 y_chunk = ggml_cont(ctx, ggml_permute(ctx, y_chunk, 0, 2, 1, 3));
-    //                 cb(y_chunk, "y_chunk", il); // {n_head, chunk_size_i, n_seqs}
+                    // step 6: compute y
+                    ggml_tensor * dtX_chunk_perm = ggml_cont(ctx, ggml_permute(ctx, dtX_chunk, 1, 2, 0, 3));
+                    ggml_tensor * y_chunk = ggml_mul_mat(ctx, dtX_chunk_perm, surrogate_attention_matrix);
+                    y_chunk = ggml_cont(ctx, ggml_permute(ctx, y_chunk, 0, 2, 1, 3));
+                    cb(y_chunk, "y_chunk", il); // {n_head, chunk_size_i, n_seqs}
 
-    //                 // step 7: compute dtxdecay
-    //                 ggml_tensor * decay_last = ggml_view_4d(ctx, decay,
-    //                     decay->ne[0], 1, decay->ne[2], decay->ne[3],
-    //                     decay->nb[1], decay->nb[2], decay->nb[3],
-    //                     (decay->ne[1] - 1) * decay->nb[1]);
-    //                 decay_last = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
-    //                 cb(decay_last, "decay_last", il);
-    //                 B_perm = ggml_cont(ctx, B_perm);
-    //                 B_perm = ggml_repeat_4d(ctx, B_perm,
-    //                     B_perm->ne[0], B_perm->ne[1], B_perm->ne[2] * repeats, B_perm->ne[3]);
-    //                 ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last);
-    //                 dtxdecay = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
-    //                 cb(dtxdecay, "dtxdecay", il);
+                    // step 7: compute dtxdecay
+                    ggml_tensor * decay_last = ggml_view_4d(ctx, decay,
+                        decay->ne[0], 1, decay->ne[2], decay->ne[3],
+                        decay->nb[1], decay->nb[2], decay->nb[3],
+                        (decay->ne[1] - 1) * decay->nb[1]);
+                    decay_last = ggml_cont(ctx, ggml_permute(ctx, decay_last, 2, 0, 1, 3));
+                    cb(decay_last, "decay_last", il);
+                    B_perm = ggml_cont(ctx, B_perm);
+                    B_perm = ggml_repeat_4d(ctx, B_perm,
+                        B_perm->ne[0], B_perm->ne[1], B_perm->ne[2] * repeats, B_perm->ne[3]);
+                    ggml_tensor * dtxdecay = ggml_mul(ctx, dtX_chunk, decay_last);
+                    dtxdecay = ggml_cont(ctx, ggml_permute(ctx, dtxdecay, 1, 2, 0, 3));
+                    cb(dtxdecay, "dtxdecay", il);
 
-    //                 // step 8: compute next_state
-    //                 ggml_tensor * next_state = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_permute(ctx, B_perm, 1, 0, 2, 3)), dtxdecay);
-    //                 if (next_state->type != ssm->type) {
-    //                     next_state = ggml_cast(ctx, next_state, ssm->type);
-    //                 }
-    //                 cb(next_state, "next_state", il);
+                    // step 8: compute next_state
+                    ggml_tensor * next_state = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_permute(ctx, B_perm, 1, 0, 2, 3)), dtxdecay);
+                    if (next_state->type != ssm->type) {
+                        next_state = ggml_cast(ctx, next_state, ssm->type);
+                    }
+                    cb(next_state, "next_state", il);
 
-    //                 // TODO: Skip y and state updates if no previous state
+                    // TODO: Skip y and state updates if no previous state
 
-    //                 // step 9: update from previous state
-    //                 dtA_chunk = ggml_cont(ctx, dtA_chunk);
-    //                 ggml_tensor * dtA_chunk_flat = ggml_view_3d(ctx,
-    //                     dtA_chunk, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-    //                     dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {chunk_size_i, n_head, n_seqs, 1}
-    //                 ggml_tensor * exp_dtA_cumsum = ggml_view_4d(ctx,
-    //                     ggml_exp(ctx, ggml_cumsum(ctx, dtA_chunk_flat)),
-    //                     1, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
-    //                     dtA_chunk->nb[1], dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {1, chunk_size_i, n_head, n_seqs}
-    //                 cb(exp_dtA_cumsum, "exp_dtA_cumsum", il);
-    //                 ggml_tensor * exp_dtA_cumsum_last = ggml_view_4d(ctx, exp_dtA_cumsum,
-    //                     exp_dtA_cumsum->ne[0], 1, exp_dtA_cumsum->ne[2], exp_dtA_cumsum->ne[3],
-    //                     exp_dtA_cumsum->nb[1], exp_dtA_cumsum->nb[2], exp_dtA_cumsum->nb[3],
-    //                     (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]); // {1, 1, n_head, n_seqs}
-    //                 cb(exp_dtA_cumsum_last, "exp_dtA_cumsum_last", il);
-    //                 // ggml_tensor * exp_dtA_cumsum_perm = ggml_permute(ctx, exp_dtA_cumsum_last, 2, 1, 3, 0); // {1, 1, n_head, n_seqs}
-    //                 next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, exp_dtA_cumsum_last)));
-    //                 cb(next_state, "next_state_updated", il);
+                    // step 9: update from previous state
+                    dtA_chunk = ggml_cont(ctx, dtA_chunk);
+                    ggml_tensor * dtA_chunk_flat = ggml_view_3d(ctx,
+                        dtA_chunk, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
+                        dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {chunk_size_i, n_head, n_seqs, 1}
+                    ggml_tensor * exp_dtA_cumsum = ggml_view_4d(ctx,
+                        ggml_exp(ctx, ggml_cumsum(ctx, dtA_chunk_flat)),
+                        1, dtA_chunk->ne[1], dtA_chunk->ne[2], dtA_chunk->ne[3],
+                        dtA_chunk->nb[1], dtA_chunk->nb[2], dtA_chunk->nb[3], 0); // {1, chunk_size_i, n_head, n_seqs}
+                    cb(exp_dtA_cumsum, "exp_dtA_cumsum", il);
+                    ggml_tensor * exp_dtA_cumsum_last = ggml_view_4d(ctx, exp_dtA_cumsum,
+                        exp_dtA_cumsum->ne[0], 1, exp_dtA_cumsum->ne[2], exp_dtA_cumsum->ne[3],
+                        exp_dtA_cumsum->nb[1], exp_dtA_cumsum->nb[2], exp_dtA_cumsum->nb[3],
+                        (exp_dtA_cumsum->ne[1] - 1) * exp_dtA_cumsum->nb[1]); // {1, 1, n_head, n_seqs}
+                    cb(exp_dtA_cumsum_last, "exp_dtA_cumsum_last", il);
+                    // ggml_tensor * exp_dtA_cumsum_perm = ggml_permute(ctx, exp_dtA_cumsum_last, 2, 1, 3, 0); // {1, 1, n_head, n_seqs}
+                    next_state = ggml_add(ctx, next_state, ggml_mul(ctx, ssm, ggml_cont(ctx, exp_dtA_cumsum_last)));
+                    cb(next_state, "next_state_updated", il);
 
-    //                 // step 10: update from previous y
-    //                 ggml_tensor * y_prev = ggml_mul_mat(ctx,
-    //                     C_perm, // {d_state, chunk_size_i, n_group, n_seqs}
-    //                     ssm     // {d_state, head_dim, n_head, n_seqs}
-    //                 ); // {chunk_size_i, head_dim, n_head, n_seqs}
-    //                 cb(y_prev, "y_prev", il);
-    //                 y_prev = ggml_mul(ctx,
-    //                     ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3)),        // {head_dim, n_head, chunk_size_i, n_seqs}
-    //                     ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3)) // {1,        n_head, chunk_size_i, n_seqs}
-    //                 ); // {head_dim, chunk_size_i, n_head, n_seqs}
-    //                 cb(y_prev, "y_prev_mul", il);
-    //                 y_chunk = ggml_add(ctx, y_chunk, y_prev);
-    //                 cb(y_chunk, "y_chunk_updated", il);
+                    // step 10: update from previous y
+                    ggml_tensor * y_prev = ggml_mul_mat(ctx,
+                        C_perm, // {d_state, chunk_size_i, n_group, n_seqs}
+                        ssm     // {d_state, head_dim, n_head, n_seqs}
+                    ); // {chunk_size_i, head_dim, n_head, n_seqs}
+                    cb(y_prev, "y_prev", il);
+                    y_prev = ggml_mul(ctx,
+                        ggml_cont(ctx, ggml_permute(ctx, y_prev, 2, 0, 1, 3)),        // {head_dim, n_head, chunk_size_i, n_seqs}
+                        ggml_cont(ctx, ggml_permute(ctx, exp_dtA_cumsum, 0, 2, 1, 3)) // {1,        n_head, chunk_size_i, n_seqs}
+                    ); // {head_dim, chunk_size_i, n_head, n_seqs}
+                    cb(y_prev, "y_prev_mul", il);
+                    y_chunk = ggml_add(ctx, y_chunk, y_prev);
+                    cb(y_chunk, "y_chunk_updated", il);
 
-    //                 // step 11: recurse
-    //                 if (chunk_size_i == n_seq_tokens) {
-    //                     y = y_chunk;
-    //                 } else {
-    //                     y = ggml_concat(ctx, y, y_chunk, 2);
-    //                 }
-    //                 cb(y, "y", il);
-    //                 ssm = next_state;
-    //             }
+                    // step 11: recurse
+                    if (chunk_size_i == n_seq_tokens) {
+                        y = y_chunk;
+                    } else {
+                        y = ggml_concat(ctx, y, y_chunk, 2);
+                    }
+                    cb(y, "y", il);
+                    ssm = next_state;
+                }
 
-    //             // Concat the output y and state
-    //             if (ssm->type != y->type) {
-    //                 ssm = ggml_cast(ctx, ssm, y->type);
-    //             }
-    //             ggml_tensor * out = ggml_concat(ctx,
-    //                 ggml_view_1d(ctx, y, ggml_nelements(y), 0),
-    //                 ggml_view_1d(ctx, ssm, ggml_nelements(ssm), 0),
-    //                 0);
-    //             return out;
-    //         }
-    //     };
+                // Concat the output y and state
+                if (ssm->type != y->type) {
+                    ssm = ggml_cast(ctx, ssm, y->type);
+                }
+                ggml_tensor * out = ggml_concat(ctx,
+                    ggml_view_1d(ctx, y, ggml_nelements(y), 0),
+                    ggml_view_1d(ctx, ssm, ggml_nelements(ssm), 0),
+                    0);
+                return out;
+            }
+        };
 
-    //     ggml_tensor * y_ssm = build_rs(inp, ssm_states_all, hparams.n_embd_s(), ubatch.n_seqs, get_ssm_rows);
+        ggml_tensor * y_ssm = build_rs(inp, ssm_states_all, hparams.n_embd_s(), ubatch.n_seqs, get_ssm_rows);
 
-    //     // store last states
-    //     ggml_build_forward_expand(
-    //         gf, ggml_cpy(ctx0, ggml_view_1d(ctx0, y_ssm, d_state * d_inner * n_seqs, ggml_nelements(x) * x->nb[0]),
-    //                      ggml_view_1d(ctx0, ssm_states_all, d_state * d_inner * n_seqs,
-    //                                   kv_head * d_state * d_inner * ggml_element_size(ssm_states_all))));
+        // store last states
+        ggml_build_forward_expand(
+            gf, ggml_cpy(ctx0, ggml_view_1d(ctx0, y_ssm, d_state * d_inner * n_seqs, ggml_nelements(x) * x->nb[0]),
+                         ggml_view_1d(ctx0, ssm_states_all, d_state * d_inner * n_seqs,
+                                      kv_head * d_state * d_inner * ggml_element_size(ssm_states_all))));
 
-    //     ggml_tensor * y = ggml_view_4d(ctx0, y_ssm, head_dim, n_head, n_seq_tokens, n_seqs, x->nb[1], n_head * x->nb[1],
-    //                                    n_seq_tokens * n_head * x->nb[1], 0);
+        ggml_tensor * y = ggml_view_4d(ctx0, y_ssm, head_dim, n_head, n_seq_tokens, n_seqs, x->nb[1], n_head * x->nb[1],
+                                       n_seq_tokens * n_head * x->nb[1], 0);
 
-    //     // TODO: skip computing output earlier for unused tokens
+        // TODO: skip computing output earlier for unused tokens
 
-    //     y = ggml_add(ctx0, y, ggml_mul(ctx0, x, model.layers[il].ssm_d));
-    //     cb(y, "mamba2_y_add_d", il);
-    //     y = ggml_swiglu_split(ctx0, ggml_cont(ctx0, z), y);
+        y = ggml_add(ctx0, y, ggml_mul(ctx0, x, model.layers[il].ssm_d));
+        cb(y, "mamba2_y_add_d", il);
+        y = ggml_swiglu_split(ctx0, ggml_cont(ctx0, z), y);
 
-    //     // grouped RMS norm
-    //     if (model.layers[il].ssm_norm) {
-    //         y = ggml_reshape_4d(ctx0, y, d_inner / n_group, n_group, n_seq_tokens, n_seqs);
-    //         y = build_norm(y, model.layers[il].ssm_norm, NULL, LLM_NORM_RMS, il);
-    //     }
+        // grouped RMS norm
+        if (model.layers[il].ssm_norm) {
+            y = ggml_reshape_4d(ctx0, y, d_inner / n_group, n_group, n_seq_tokens, n_seqs);
+            y = build_norm(y, model.layers[il].ssm_norm, NULL, LLM_NORM_RMS, il);
+        }
 
-    //     y = ggml_reshape_3d(ctx0, y, d_inner, n_seq_tokens, n_seqs);
+        y = ggml_reshape_3d(ctx0, y, d_inner, n_seq_tokens, n_seqs);
 
-    //     // {d_inner, n_embd} @ {d_inner, n_seq_tokens, n_seqs} => {n_embd, n_seq_tokens, n_seqs}
-    //     cur = build_lora_mm(model.layers[il].ssm_out, y);
-    // }
+        // {d_inner, n_embd} @ {d_inner, n_seq_tokens, n_seqs} => {n_embd, n_seq_tokens, n_seqs}
+        cur = build_lora_mm(model.layers[il].ssm_out, y);
+    }
 
     // {n_embd, n_seq_tokens, n_seqs} => {n_embd, n_tokens}
     cur = ggml_reshape_2d(ctx0, cur, cur->ne[0], n_seq_tokens * n_seqs);

--- a/src/models/graph-context-mamba.cpp
+++ b/src/models/graph-context-mamba.cpp
@@ -247,8 +247,10 @@ ggml_tensor * llm_graph_context_mamba::build_mamba2_layer(llm_graph_input_rs * i
         auto get_ssm_rows = [&](ggml_context * ctx, ggml_tensor * states, ggml_tensor * ids) {
             ggml_tensor * ssm = ggml_reshape_4d(ctx, states, d_state, head_dim, n_head, mctx_cur->get_size());
 
-            if (n_seq_tokens == 1) {
-            // if (true) {
+            // Use SSM_SCAN op for all cases - the Metal kernel handles both
+            // single-token (sequential scan) and multi-token (SSD formulation) internally
+            if (true) {
+            // if (n_seq_tokens == 1) {
                 //DEBUG
                 LLAMA_LOG_DEBUG("build_mamba2_layer(layer %d): single-token update\n", il);
                 // If single-token, use ssm_scan op


### PR DESCRIPTION
## DRAFT STATUS

This PR will remain in `Draft` until the items in the discussion section are resolved.

## Description

This PR is a draft implementation of the Structured Statespace Duality described in the original [mamba2 paper](https://arxiv.org/pdf/2405.21060) which reframes the `SSM_SCAN` op as a pseudo-attention operation. The paper describes it in great detail, but the short version is that when performing a multi-token scan, the recurrent formulation of `SSM_SCAN` is inefficient because it cannot parallelize over the sequence dimension the way an attention calculation can. With the SSD formulation, the logical attention matrix is decomposed into chunks and the state is updated at the chunk boundaries, allowing prefill to "jump" by the size of the chunk rather than proceed with tokens one-at-a-time.

## Reference Links

* Original Paper: https://arxiv.org/pdf/2405.21060
* Optimized triton implementation by paper authors: https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/triton/ssd_combined.py
* Unified implementation in `mlx-lm`: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/ssm.py

## Changes

* Introduce new primitive operations in `ggml`:
  * `ggml_cumsum` / `ggml_cumsum_0`: Perform a cumulative sum along a give dimension
    * **NOTE**: This adds the ability to specify dimension on top of the implementation in #16623 and relaxes the need for contiguous rows
  * `ggml_tri_dims` / `ggml_tri` / `ggml_tri_keep`: Apply a triangular mask to the given matrix
    * **NOTE**: This adds the ability to specify dimension on top of the implementation in #16623 and relaxes the need for contiguous rows with `ggml_tri_dims`
  * `ggml_softplus`: Perform the unary `softplus` operation

* Implement an alternate path through `llm_graph_context_mamba::build_mamba2_layer` when a multi-token update is detected
  * This path is the core of the SSD implementation and avoids calling `SSM_SCAN` in favor of the chunked pseudo-attention formulation

## Discussion

There are a _number_ of outstanding discussion points on this work that need to be resolved before moving it forward:

1. **Performance**: Currently, this implementation appears to be significantly slower than simply using `SSM_SCAN` which roundly defeats the purpose of the change! I suspect that the performance issues are due to the number of `ggml_permute` / `ggml_cont` ops that are added to the graph, but could use assistance figuring out how to eliminate them or identifying other sources of slowness.
2. **To chunk or not to chunk**: In this PR I have sub-`ubatch` chunking implemented. I had it mostly working before [the corresponding discussion on Qwen3Next](https://github.com/ggml-org/llama.cpp/pull/16095#issuecomment-3474795316). The inter-chunk update would be needed anyway, so I didn't strip it out, but it would be fairly trivial to do so and might offer some performance improvements.
3. **Handling of `repeat_interleave`**: Similar to [the issue](https://github.com/ggml-org/llama.cpp/pull/15625) that came up when initially implementing `NemotronH` support, I believe that `ggml_repeat` behaves differently than `mx.repeat`, resulting in incorrect results for models with `n_groups > 1` (tested with `NemotronH`).

## Testing

I've tested this locally with various members of the Granite 4 family and with `nvidia/NVIDIA-Nemotron-Nano-9B-v2`. For the Granite 4 models with `n_groups == 1`, I get _nearly_ identical results to running with purely `SSM_SCAN`, but `NemotronH` still struggles due to `repeat_interleave` issues (see above). I'll flesh out more testing results once we've worked through some of the above issues.

cc @compilade since I know this has been on your TODO list since the original `mamba2` implementation.