### PR TITLE
ggml-hexagon: graceful fallback for older socs where rpcmem_alloc2 and FASTRPC_GET_URI is unsupported

### DIFF
--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <dlfcn.h>
 
 #ifdef _WIN32
 #    include <sal.h>
@@ -50,6 +51,15 @@ static int    opt_experimental = 0;
 // Enable all stages by default
 static int opt_opmask = HTP_OPMASK_QUEUE | HTP_OPMASK_QUANTIZE | HTP_OPMASK_COMPUTE;
 static int opt_opsync = 0;  // synchronous ops
+
+// function signature defined in rpcmem.h
+using pfn_rpc_mem_alloc                         = void *(*)(int, uint32_t, size_t);
+
+// Dynamic pointers to functions in lib[cdsp]rpc.so, used for backward compatibility with older SoCs
+// library open happens in the constructor of ggml_hexagon_registry, and closed in the destructor
+
+// dynamic pointer to function rpcmem_alloc or rpcmem_alloc2 at runtime
+static pfn_rpc_mem_alloc _pfn_rpc_mem_alloc = nullptr;
 
 #define HEX_VERBOSE(...) \
     if (opt_verbose) GGML_LOG_DEBUG(__VA_ARGS__)
@@ -367,7 +377,9 @@ struct ggml_backend_hexagon_buffer_context {
     ggml_backend_hexagon_buffer_context(ggml_hexagon_session * sess, size_t size, bool repack) {
         size += 4 * 1024;  // extra page for padding
 
-        this->base = (uint8_t *) rpcmem_alloc(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG, size);
+        GGML_ASSERT(_pfn_rpc_mem_alloc != nullptr);
+
+        this->base = (uint8_t *) _pfn_rpc_mem_alloc(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG, size);
         if (!this->base) {
             GGML_LOG_ERROR("ggml-hex: %s failed to allocate buffer : size %zu\n", sess->name.c_str(), size);
             throw std::runtime_error("ggml-hex: rpcmem_alloc failed (see log for details)");
@@ -1683,7 +1695,7 @@ void ggml_hexagon_session::allocate(int dev_id) noexcept(false) {
     sprintf(htp_uri, "file:///libggml-htp-v%u.so?htp_iface_skel_handle_invoke&_modver=1.0", opt_arch);
 
     char session_uri[256];
-    if(false) {
+    {
         struct remote_rpc_get_uri u;
         u.session_id      = this->session_id;
         u.domain_name     = const_cast<char *>(CDSP_DOMAIN_NAME);
@@ -1695,13 +1707,13 @@ void ggml_hexagon_session::allocate(int dev_id) noexcept(false) {
 
         int err = remote_session_control(FASTRPC_GET_URI, (void *) &u, sizeof(u));
         if (err != AEE_SUCCESS) {
-            GGML_LOG_ERROR("ggml-hex: failed to get URI for session %d : error 0x%x\n", dev_id, err);
-            throw std::runtime_error("ggml-hex: remote_session_control(get-uri) failed (see log for details)");
-        }
-    } else {
-        int htp_URI_domain_len = strlen(htp_uri) + MAX_DOMAIN_NAMELEN;
+            // fallback to single session uris
+            int htp_URI_domain_len = strlen(htp_uri) + MAX_DOMAIN_NAMELEN;
 
-        snprintf(session_uri, htp_URI_domain_len, "%s%s", htp_uri, my_domain->uri);
+            snprintf(session_uri, htp_URI_domain_len, "%s%s", htp_uri, my_domain->uri);
+
+            GGML_LOG_WARN("ggml-hex: failed to get URI for session %d : error 0x%x. Falling back to single session URI: %s\n", dev_id, err, session_uri);
+        }
     }
 
     // Enable Unsigned PD
@@ -3659,6 +3671,9 @@ struct ggml_hexagon_registry {
     ~ggml_hexagon_registry();
 
     ggml_backend_device devices[GGML_HEXAGON_MAX_SESSIONS];
+
+    // dynamic handles
+    void * _rpc_lib_handle      = nullptr;
 };
 
 ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
@@ -3685,6 +3700,30 @@ ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
             devices[i].context = nullptr;
         }
     }
+
+    // obtain handle to dsp library
+    _rpc_lib_handle = dlopen("libcdsprpc.so", RTLD_NOW | RTLD_LOCAL);
+    if (nullptr == _rpc_lib_handle) {
+        GGML_LOG_ERROR("ggml-hex: failed to load rpc lib: %s", dlerror());
+        throw std::runtime_error("failed to load rpc lib");
+    }
+
+    // attempt to load rpc_memalloc2 first
+    _pfn_rpc_mem_alloc  = reinterpret_cast<pfn_rpc_mem_alloc>(dlsym(_rpc_lib_handle,"rpcmem_alloc2"));
+
+    // fallback to rpc_memalloc
+    if(_pfn_rpc_mem_alloc == nullptr) {
+        _pfn_rpc_mem_alloc  = reinterpret_cast<pfn_rpc_mem_alloc>(dlsym(_rpc_lib_handle,"rpcmem_alloc"));
+
+        if(_pfn_rpc_mem_alloc == nullptr) {
+            GGML_LOG_ERROR("ggml-hex: failed to get rpcmem_alloc function address: %s", dlerror());
+            throw std::runtime_error("failed to get rpcmem_alloc function address");
+        } else {
+            GGML_LOG_INFO("ggml-hex: using rpcmem_alloc\n");
+        }
+    } else {
+        GGML_LOG_INFO("ggml-hex: using rpcmem_alloc2\n");
+    }
 }
 
 ggml_hexagon_registry::~ggml_hexagon_registry() {
@@ -3695,6 +3734,8 @@ ggml_hexagon_registry::~ggml_hexagon_registry() {
         auto sess = static_cast<ggml_hexagon_session *>(devices[i].context);
         delete sess;
     }
+
+    if(_rpc_lib_handle) dlclose(_rpc_lib_handle);
 }
 
 static const char * ggml_backend_hexagon_reg_get_name(ggml_backend_reg_t reg) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3679,6 +3679,11 @@ ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
         }
     }
 
+    if(opt_arch < 75) {
+        opt_ndev = 1;
+        GGML_LOG_WARN("ggml-hex: forcing ndev to 1 for SoCs archs lower than v75.\n");
+    }
+
     GGML_LOG_INFO("ggml-hex: Hexagon Arch version v%d\n", opt_arch);
 
     // Create devices / sessions

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -328,8 +328,6 @@ struct ggml_backend_hexagon_buffer_type_context {
     std::string            name;
 };
 
-#pragma weak rpcmem_alloc2
-
 struct ggml_backend_hexagon_buffer_context {
     bool mmap_to(ggml_hexagon_session * s) {
         HEX_VERBOSE("ggml-hex: %s mmaping buffer: base %p domain-id %d session-id %d size %zu fd %d repack %d\n",

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -367,7 +367,7 @@ struct ggml_backend_hexagon_buffer_context {
     ggml_backend_hexagon_buffer_context(ggml_hexagon_session * sess, size_t size, bool repack) {
         size += 4 * 1024;  // extra page for padding
 
-        this->base = (uint8_t *) rpcmem_alloc2(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG, size);
+        this->base = (uint8_t *) rpcmem_alloc(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG, size);
         if (!this->base) {
             GGML_LOG_ERROR("ggml-hex: %s failed to allocate buffer : size %zu\n", sess->name.c_str(), size);
             throw std::runtime_error("ggml-hex: rpcmem_alloc failed (see log for details)");
@@ -1683,7 +1683,7 @@ void ggml_hexagon_session::allocate(int dev_id) noexcept(false) {
     sprintf(htp_uri, "file:///libggml-htp-v%u.so?htp_iface_skel_handle_invoke&_modver=1.0", opt_arch);
 
     char session_uri[256];
-    {
+    if(false) {
         struct remote_rpc_get_uri u;
         u.session_id      = this->session_id;
         u.domain_name     = const_cast<char *>(CDSP_DOMAIN_NAME);
@@ -1698,6 +1698,10 @@ void ggml_hexagon_session::allocate(int dev_id) noexcept(false) {
             GGML_LOG_ERROR("ggml-hex: failed to get URI for session %d : error 0x%x\n", dev_id, err);
             throw std::runtime_error("ggml-hex: remote_session_control(get-uri) failed (see log for details)");
         }
+    } else {
+        int htp_URI_domain_len = strlen(htp_uri) + MAX_DOMAIN_NAMELEN;
+
+        snprintf(session_uri, htp_URI_domain_len, "%s%s", htp_uri, my_domain->uri);
     }
 
     // Enable Unsigned PD

--- a/ggml/src/ggml-hexagon/htp-utils.h
+++ b/ggml/src/ggml-hexagon/htp-utils.h
@@ -64,6 +64,7 @@ extern "C" {
 #    pragma weak remote_handle64_control
 #    pragma weak fastrpc_mmap
 #    pragma weak fastrpc_munmap
+#    pragma weak rpcmem_alloc2
 #endif
 
 #if !defined(_WINDOWS)


### PR DESCRIPTION
Older SoCs like the Gen2 does not seem to support obtaining session URIs via `FASTRPC_GET_URI`. Additionally, they do not support the new `rpcmem_alloc2`, and should use `rpcmem_alloc` instead.

This PR adds graceful fallback for older SoCs:
1. dynamically load `rpcmem_alloc2` instead of statically loading, fall back to `rpcmem_alloc` if unable to find `alloc2`
2. added fallback for older SoCs which do not support `FASTRPC_GET_URI`, falls back to single session uri

Previously, `ggml-hexagon` quits when running on an SD8 Gen2, which does not support `alloc2` nor allow creating multiple sessions.

This PR is tested to work on both consumer S23 Ultra (SD8 Gen2), and S25+ Ultra (SD8 Gen4).

@max-krasnyansky I would appreciate your direction on if this PR is the way to go forward providing graceful fallback for older SoCs?
1. ~~`libcdsprpc.so` library name is hard-coded, is this a problem?~~
2. undefined results if you enable multiple devices (i.e. HTP0, HTP1) on Gen2, all the opened session URIs are the same, but `ggml-hexagon` still thinks multiple session are open, should this be the end-users responsibility to not open multiple sessions on devices that do not support it?
3. ~~function pointer type to `rpcmem_allow[2]` is hardcoded, and declared as static, `dlopen` and `dlclose` happens in `ggml_hexagon_registry`, from my understanding, it seems it's guaranteed to only initialise once~~
4. I do not have a Windows Snapdragon device to test, but theoretically porting this to windows should be a simple as conditionally compiling the `dlopen` and `dlclose` part to use `.dll` instead

EDIT: thanks to @chraac in here: https://github.com/ggml-org/llama.cpp/issues/16911#issuecomment-3489159753, updated PR to use weak symbols instead of dynamically loading `libcdsprpc.so`, which is a much more elegant solution