### PR TITLE
CUDA: add stream-based concurrency

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1008,7 +1008,7 @@ struct ggml_cuda_concurrent_event {
     }
 
     // 1. check if any branches write to overlapping memory ranges (except the join node)
-    // 2. check all srcs are either within the branch or outside the event
+    // 2. check whether all srcs are either within the branch or outside the nodes covered by ggml_cuda_concurrent_event
     // we assume all nodes have the same buffer
     bool is_valid() const {
         std::vector<std::vector<std::pair<int64_t, int64_t>>> write_ranges;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1007,8 +1007,8 @@ struct ggml_cuda_concurrent_event {
         other.fork_event = nullptr;
     }
 
-    // check if all branches don't read to the overlapping buffers
-    // check all read_srcs are either within the branch or are at or before the node
+    // 1. check if all branches don't write to the overlapping memory ranges (except the join node)
+    // 2. check all srcs are either within the branch or outside the event
     // we assume all nodes have the same buffer
     bool is_valid() const {
         std::vector<std::vector<std::pair<int64_t, int64_t>>> write_ranges;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -974,9 +974,8 @@ struct ggml_cuda_graph {
 };
 
 struct ggml_cuda_concurrent_event {
-    std::vector<cudaEvent_t> per_stream_events;
+    std::vector<cudaEvent_t> join_events;
     cudaEvent_t              fork_event;
-    cudaEvent_t              join_event;
 
     int                                          n_streams = 0;
     std::unordered_map<const ggml_tensor *, int> stream_mapping;
@@ -986,14 +985,13 @@ struct ggml_cuda_concurrent_event {
     ggml_cuda_concurrent_event() = default;
 
     explicit ggml_cuda_concurrent_event(int n_streams) : n_streams(n_streams) {
-        per_stream_events.resize(n_streams);
+        join_events.resize(n_streams);
 
-        for (size_t i = 0; i < per_stream_events.size(); ++i) {
-            CUDA_CHECK(cudaEventCreateWithFlags(&per_stream_events[i], cudaEventDisableTiming));
+        for (size_t i = 0; i < join_events.size(); ++i) {
+            CUDA_CHECK(cudaEventCreateWithFlags(&join_events[i], cudaEventDisableTiming));
         }
 
         CUDA_CHECK(cudaEventCreateWithFlags(&fork_event, cudaEventDisableTiming));
-        CUDA_CHECK(cudaEventCreateWithFlags(&join_event, cudaEventDisableTiming));
     }
 };
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -25,6 +25,7 @@
 #include <cfloat>
 #include <cstdio>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #if defined(GGML_USE_HIP)
@@ -988,11 +989,11 @@ struct ggml_cuda_concurrent_event {
         per_stream_events.resize(n_streams);
 
         for (size_t i = 0; i < per_stream_events.size(); ++i) {
-            cudaEventCreateWithFlags(&per_stream_events[i], cudaEventDisableTiming);
+            CUDA_CHECK(cudaEventCreateWithFlags(&per_stream_events[i], cudaEventDisableTiming));
         }
 
-        cudaEventCreateWithFlags(&fork_event, cudaEventDisableTiming);
-        cudaEventCreateWithFlags(&join_event, cudaEventDisableTiming);
+        CUDA_CHECK(cudaEventCreateWithFlags(&fork_event, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventCreateWithFlags(&join_event, cudaEventDisableTiming));
     }
 };
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -997,7 +997,15 @@ struct ggml_cuda_concurrent_event {
     }
 };
 
-using ggml_cuda_stream_context = std::unordered_map<const ggml_tensor *, ggml_cuda_concurrent_event>;
+struct ggml_cuda_stream_context {
+    std::vector<const ggml_tensor *> original_graph;
+    std::unordered_map<const ggml_tensor *, ggml_cuda_concurrent_event> concurrent_events;
+
+    void reset() {
+        original_graph.clear();
+        concurrent_events.clear();
+    }
+};
 
 struct ggml_backend_cuda_context {
     int device;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1007,7 +1007,7 @@ struct ggml_cuda_concurrent_event {
         other.fork_event = nullptr;
     }
 
-    // 1. check if all branches don't write to the overlapping memory ranges (except the join node)
+    // 1. check if any branches write to overlapping memory ranges (except the join node)
     // 2. check all srcs are either within the branch or outside the event
     // we assume all nodes have the same buffer
     bool is_valid() const {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1014,8 +1014,8 @@ struct ggml_cuda_concurrent_event {
         std::vector<std::vector<std::pair<int64_t, int64_t>>> write_ranges;
         write_ranges.resize(n_streams);
 
-        // Get join_node's memory range to exclude from overlap checking.
-        // Multiple nodes can use join_node's buffer; we synchronize on the join node.
+        // get join_node's memory range to exclude from overlap checking.
+        // multiple nodes can use join_node's buffer; we synchronize on the join node.
         const ggml_tensor * join_t     = join_node->view_src ? join_node->view_src : join_node;
         const int64_t       join_start = (int64_t) join_t->data;
         const int64_t       join_end   = join_start + ggml_nbytes(join_t);
@@ -1025,8 +1025,8 @@ struct ggml_cuda_concurrent_event {
             const int64_t       t_start = (int64_t) t->data;
             const int64_t       t_end   = t_start + ggml_nbytes(t);
 
-            // Skip tensors that overlap with join_node's buffer.
-            if (t_start < join_end && join_start < t_end) {
+            // skip tensors that overlap with join_node's buffer.
+            if ((t_start <= join_start && join_start < t_end) || (join_start <= t_start && t_start < join_end)) {
                 continue;
             }
 
@@ -1046,8 +1046,8 @@ struct ggml_cuda_concurrent_event {
             const int64_t       t_start = (int64_t) t->data;
             const int64_t       t_end   = t_start + ggml_nbytes(t);
 
-            // Skip tensors that overlap with join_node's buffer (already excluded from write_ranges).
-            if (t_start < join_end && join_start < t_end) {
+            // skip tensors that overlap with join_node's buffer
+            if ((t_start <= join_start && join_start < t_end) || (join_start <= t_start && t_start < join_end)) {
                 continue;
             }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3037,7 +3037,7 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph * cgraph, int node_idx, 
 #ifndef NDEBUG
     const size_t num_unary = std::count(ops.begin(), ops.end(), GGML_OP_UNARY);
     GGML_ASSERT(unary_ops.size() == num_unary);
-#endif;
+#endif
 
     //TODO: remove special case once ggml_can_fuse can handle empty nodes
     std::initializer_list<enum ggml_op> topk_moe_ops =

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3193,6 +3193,7 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
     // flag used to determine whether it is an integrated_gpu
     const bool integrated = ggml_cuda_info().devices[cuda_ctx->device].integrated;
 
+    ggml_cuda_stream_context & stream_ctx = cuda_ctx->stream_context();
     bool                         is_concurrent_event_active = false;
     ggml_cuda_concurrent_event * concurrent_event           = nullptr;
 
@@ -3219,9 +3220,8 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
         if (!use_cuda_graph || cuda_graph_update_required) {
             [[maybe_unused]] int prev_i = 0;
 
-            ggml_cuda_stream_context & stream_ctx = cuda_ctx->stream_context();
-
             if (stream_ctx.concurrent_events.size() > 0) {
+                //Restore the original graph to enable fusion within the streams
                 cgraph->nodes = const_cast<ggml_tensor **>(stream_ctx.original_graph.data());
             }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3740,7 +3740,7 @@ static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph
         return;
     }
 
-    GGML_ASSERT(ggml_backend_cuda_get_device_count() == 1 && "cuda graph optimization is only supported on single GPU");
+    GGML_ASSERT(ggml_backend_cuda_get_device_count() == 1 && "compute graph optimization is only supported on single GPU in the CUDA backend");
     GGML_LOG_DEBUG("Optimizing CUDA graph %p %d\n", cgraph->nodes, cgraph->n_nodes);
 
     ggml_cuda_stream_context & stream_context = cuda_ctx->stream_context();

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3224,9 +3224,9 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
             [[maybe_unused]] int prev_i = 0;
 
             if (stream_ctx.concurrent_events.size() > 0) {
-                bool should_launch_concurrent_events = true;
+                should_launch_concurrent_events = true;
                 for (const auto & [tensor, event] : stream_ctx.concurrent_events) {
-                    should_launch_concurrent_events &= event.is_valid();
+                    should_launch_concurrent_events = should_launch_concurrent_events && event.is_valid();
                 }
             }
             if (should_launch_concurrent_events) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3233,10 +3233,10 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
                     if (node == concurrent_event->join_node) {
                         cuda_ctx->curr_stream_no = 0;
                         for (int i = 1; i <= concurrent_event->n_streams; ++i) {
-                            // Wait on join events of forked streams in the main stream 
-                            CUDA_CHECK(cudaEventRecord(concurrent_event->per_stream_events[i - 1],
+                            // Wait on join events of forked streams in the main stream
+                            CUDA_CHECK(cudaEventRecord(concurrent_event->join_events[i - 1],
                                                        cuda_ctx->stream(cuda_ctx->device, i)));
-                            CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->per_stream_events[i - 1]));
+                            CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->join_events[i - 1]));
                         }
 
                         is_concurrent_event_active = false;

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -105,7 +105,7 @@
 #define cudaStreamNonBlocking hipStreamNonBlocking
 #define cudaStreamPerThread hipStreamPerThread
 #define cudaStreamSynchronize hipStreamSynchronize
-#define cudaStreamWaitEvent(stream, event, flags) hipStreamWaitEvent(stream, event, flags)
+#define cudaStreamWaitEvent hipStreamWaitEvent
 #define cudaGraphExec_t hipGraphExec_t
 #define cudaGraphNode_t hipGraphNode_t
 #define cudaKernelNodeParams hipKernelNodeParams


### PR DESCRIPTION
Possibly supersede #16813. 

This PR adds support to run concurrent CUDA streams on single GPU setups. 
At the moment this only targets the Q, K, V branch. I feel this is the "correct" approach in case the Q, K, V tensors are of different types/not in the same place in memory. The downside is that this approach doesn't come for free and there's some complexity involved, but I'm not an expert at the ggml graph and I feel it could be simplified. 

Currently this is hidden by an env variable flag. To run you can use `GGML_CUDA_GRAPH_OPT=1`

TG Performance gain is more than the previous PR (1-9% gain depending on the model/GPU), probably because we parallelize MUL_MAT + NORM + ROPE rather than just MUL_MAT. At the moment we leave some performance on the table where we don't fuse operations in the parallel streams themselves (e.g. MUL_MAT + BIAS, RMS_NORM + MUL etc.), I couldn't find a simple enough way to enable fusion there.

Performance details:

<details> 

5090:

| Model                   | Test   |   t/s mxfp4 |   t/s 0fa5630c0 |   Speedup |
|:------------------------|:-------|------------:|----------------:|----------:|
| gpt-oss 20B MXFP4 MoE   | pp512  |    10554.76 |        10572.61 |      1.00 |
| gpt-oss 20B MXFP4 MoE   | tg128  |      359.67 |          382.52 |      1.06 |
| llama 8B Q8_0           | pp512  |    13948.06 |        13903.74 |      1.00 |
| llama 8B Q8_0           | tg128  |      166.44 |          174.08 |      1.05 |
| qwen3 8B F16            | pp512  |    14120.38 |        14170.43 |      1.00 |
| qwen3 8B F16            | tg128  |       97.21 |          100.39 |      1.03 |
| qwen3moe 30B.A3B Q4_K_M | pp512  |     7361.89 |         7367.90 |      1.00 |
| qwen3moe 30B.A3B Q4_K_M | tg128  |      306.84 |          334.19 |      1.09 |

4090:

| Model                   | Test   |   t/s mxfp4 |   t/s 0fa5630c0 |   Speedup |
|:------------------------|:-------|------------:|----------------:|----------:|
| gpt-oss 20B MXFP4 MoE   | pp512  |     9551.59 |         9549.55 |      1.00 |
| gpt-oss 20B MXFP4 MoE   | tg128  |      263.77 |          271.84 |      1.03 |
| llama 8B Q8_0           | pp512  |    12111.67 |        12105.00 |      1.00 |
| llama 8B Q8_0           | tg128  |      105.57 |          107.57 |      1.02 |
| qwen3 8B F16            | pp512  |    10437.09 |        10414.37 |      1.00 |
| qwen3 8B F16            | tg128  |       58.99 |           59.79 |      1.01 |
| qwen3moe 30B.A3B Q4_K_M | pp512  |     7246.49 |         7246.52 |      1.00 |
| qwen3moe 30B.A3B Q4_K_M | tg128  |      248.75 |          268.12 |      1.08 |

</details>

And just for comparison, this is without fusing ops inside a stream 

<details> 

5090:

| Model                   | Test   |   t/s mxfp4 |   t/s e50fbde39 |   Speedup |
|:------------------------|:-------|------------:|----------------:|----------:|
| gpt-oss 20B MXFP4 MoE   | pp512  |    10570.11 |        10548.35 |      1.00 |
| gpt-oss 20B MXFP4 MoE   | tg128  |      359.37 |          373.34 |      1.04 |
| llama 8B Q8_0           | pp512  |    13905.82 |        13913.88 |      1.00 |
| llama 8B Q8_0           | tg128  |      166.30 |          174.15 |      1.05 |
| qwen3 8B F16            | pp512  |    14108.08 |        14116.40 |      1.00 |
| qwen3 8B F16            | tg128  |       97.20 |           99.69 |      1.03 |
| qwen3moe 30B.A3B Q4_K_M | pp512  |     7358.84 |         7354.03 |      1.00 |
| qwen3moe 30B.A3B Q4_K_M | tg128  |      306.36 |          325.89 |      1.06 |


4090:
| Model                   | Test   |   t/s mxfp4 |   t/s e50fbde39 |   Speedup |
|:------------------------|:-------|------------:|----------------:|----------:|
| gpt-oss 20B MXFP4 MoE   | pp512  |     9547.67 |         9545.65 |      1.00 |
| gpt-oss 20B MXFP4 MoE   | tg128  |      263.74 |          270.22 |      1.02 |
| llama 8B Q8_0           | pp512  |    12071.11 |        12041.15 |      1.00 |
| llama 8B Q8_0           | tg128  |      105.57 |          107.61 |      1.02 |
| qwen3 8B F16            | pp512  |    10409.54 |        10385.86 |      1.00 |
| qwen3 8B F16            | tg128  |       59.00 |           59.64 |      1.01 |
| qwen3moe 30B.A3B Q4_K_M | pp512  |     7254.97 |         7240.68 |      1.00 |
| qwen3moe 30B.A3B Q4_K_M | tg128  |      248.53 |          263.10 |      1.06 |

</details>

TODO:
- [x] Enable fusion within a stream
- [ ] Add tests?