### PR TITLE
ci : apply model label to models

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -76,6 +76,10 @@ ggml:
     - changed-files:
         - any-glob-to-any-file:
             - ggml/**
+model:
+    - changed-files:
+        - any-glob-to-any-file:
+            - src/models/**
 nix:
     - changed-files:
         - any-glob-to-any-file:


### PR DESCRIPTION
Apply `model` label to `src/models/` commits.