### PR TITLE
server : do context shift only while generating

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3587,7 +3587,7 @@ struct server_context {
         // apply context-shift if needed
         // TODO: simplify and improve
         for (server_slot & slot : slots) {
-            if (slot.is_processing() && slot.prompt.n_tokens() + 1 >= slot.n_ctx) {
+            if (slot.state == SLOT_STATE_GENERATING && slot.prompt.n_tokens() + 1 >= slot.n_ctx) {
                 if (!params_base.ctx_shift) {
                     // this check is redundant (for good)
                     // we should never get here, because generation should already stopped in process_token()


### PR DESCRIPTION
fix #16983

Perform the check for context shifting only while the slot is generating tokens. Should not perform it during the start or prompt processing phase.