### PR TITLE
docs: Clarify the endpoint that webui uses

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -277,7 +277,7 @@ For more details, please refer to [multimodal documentation](../../docs/multimod
 
 ## Web UI
 
-The project includes a web-based user interface that enables interaction with the model through the `/chat/completions` endpoint.
+The project includes a web-based user interface that enables interaction with the model through the `/v1/chat/completions` endpoint.
 
 The web UI is developed using:
 - `react` framework for frontend development


### PR DESCRIPTION
server/README says webui uses `/chat/completions` however we currently have `/completion`, `/v1/completions`, and `/v1/chat/completions`.
Actually, there is `/chat/completion` but it is not documented and misleading.

https://github.com/ggml-org/llama.cpp/blob/5e90233bdba013838c1a69df7738e08bd5c058d5/tools/server/server.cpp#L5629-L5632

This PR fixes readme to show exact endpoint(which is `/v1/chat/completions`).

https://github.com/ggml-org/llama.cpp/blob/cc98f8d3499c7de931218d8802daae56747ecbbb/tools/server/webui/src/lib/services/chat.ts#L179