### PR TITLE
ci: add Arm-hosted Graviton4 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1653,17 +1653,9 @@ jobs:
      runs-on: ah-ubuntu_22_04-c8g_8x
 
      steps:
-       - name: Install Git LFS
-         run: |
-          sudo apt-get update
-          sudo apt-get install -y git-lfs
-          git lfs install
-
        - name: Clone
          id: checkout
          uses: actions/checkout@v4
-         with:
-          lfs: true
 
        - name: Dependencies
          id: depends
@@ -1671,7 +1663,16 @@ jobs:
            set -euxo pipefail
            sudo apt-get update
            sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
-           apt-get install -y build-essential libcurl4-openssl-dev python3-venv gpg wget time
+           apt-get install -y \
+            build-essential \
+            libcurl4-openssl-dev \
+            python3-venv \
+            gpg \
+            wget \
+            time \
+            git-lfs
+
+           git lfs install
 
            # install the latest cmake
            sudo install -d /usr/share/keyrings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1653,9 +1653,17 @@ jobs:
      runs-on: ah-ubuntu_22_04-c8g_8x
 
      steps:
+       - name: Install Git LFS
+         run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
+          git lfs install
+
        - name: Clone
          id: checkout
          uses: actions/checkout@v4
+         with:
+          lfs: true
 
        - name: Dependencies
          id: depends

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1649,3 +1649,27 @@ jobs:
          run: |
            GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
+  ggml-ci-arm64-graviton4-kleidiai:
+     runs-on: ah-ubuntu_22_04-c8g_8x
+
+     steps:
+       - name: Clone
+         id: checkout
+         uses: actions/checkout@v4
+
+       - name: ccache
+         uses: ggml-org/ccache-action@v1.2.16
+         with:
+           key: ggml-ci-arm64-graviton4-kleidiai
+           evict-old-files: 1d
+
+       - name: Dependencies
+         id: depends
+         run: |
+           sudo apt-get update
+           sudo apt-get install -y build-essential libcurl4-openssl-dev python3-venv
+
+       - name: Test
+         id: ggml-ci
+         run: |
+           GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1657,19 +1657,33 @@ jobs:
          id: checkout
          uses: actions/checkout@v4
 
+       - name: Dependencies
+         id: depends
+         run: |
+           set -euxo pipefail
+           sudo apt-get update
+           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+           apt-get install -y build-essential libcurl4-openssl-dev python3-venv gpg wget time
+
+           # install the latest cmake
+           sudo install -d /usr/share/keyrings
+           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+            | sudo tee /etc/apt/sources.list.d/kitware.list
+           sudo apt-get update
+           sudo apt-get install -y cmake
+
        - name: ccache
          uses: ggml-org/ccache-action@v1.2.16
          with:
            key: ggml-ci-arm64-graviton4-kleidiai
            evict-old-files: 1d
 
-       - name: Dependencies
-         id: depends
-         run: |
-           sudo apt-get update
-           sudo apt-get install -y build-essential libcurl4-openssl-dev python3-venv
-
        - name: Test
          id: ggml-ci
          run: |
-           GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+           GG_BUILD_KLEIDIAI=1 \
+           GG_BUILD_EXTRA_TESTS_0=1 \
+           bash ./ci/run.sh ./tmp/results ./tmp/mnt

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -121,7 +121,12 @@ fi
 if [ -n "${GG_BUILD_KLEIDIAI}" ]; then
     echo ">>===== Enabling KleidiAI support"
 
-    CANDIDATES=("armv9-a+dotprod+i8mm" "armv8.6-a+dotprod+i8mm" "armv8.2-a+dotprod")
+    CANDIDATES=(
+        "armv9-a+dotprod+i8mm+sve2"
+        "armv9-a+dotprod+i8mm"
+        "armv8.6-a+dotprod+i8mm"
+        "armv8.2-a+dotprod"
+    )
     CPU=""
 
     for cpu in "${CANDIDATES[@]}"; do


### PR DESCRIPTION
**Summary**  
Add an Arm-hosted Graviton4 (ARM64) runner to the CI for build and test execution.

**Changes**  
- Enable ARM64 (Kleidiai) build and test path on the Graviton4 runner  
- CI-only update; no source code changes
