### PR TITLE
examples(gguf): GGUF example outputs

### DIFF
--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -184,8 +184,9 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
             const char * name   = gguf_get_tensor_name  (ctx, i);
             const size_t size   = gguf_get_tensor_size  (ctx, i);
             const size_t offset = gguf_get_tensor_offset(ctx, i);
+            const char * type   = ggml_type_name(gguf_get_tensor_type(ctx, i));
 
-            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu\n", __func__, i, name, size, offset);
+            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu, type = %s\n", __func__, i, name, size, offset, type);
         }
     }
 

--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -184,9 +184,12 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
             const char * name   = gguf_get_tensor_name  (ctx, i);
             const size_t size   = gguf_get_tensor_size  (ctx, i);
             const size_t offset = gguf_get_tensor_offset(ctx, i);
-            const char * type   = ggml_type_name(gguf_get_tensor_type(ctx, i));
+            const auto type = gguf_get_tensor_type(ctx, i);
+            const char * type_name   = ggml_type_name(type);
+            const size_t type_size = ggml_type_size(type);
+            const size_t n_elements = size / type_size;
 
-            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu, type = %s\n", __func__, i, name, size, offset, type);
+            printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu, type = %s, n_elts = %zu\n", __func__, i, name, size, offset, type_name, n_elements);
         }
     }
 

--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -181,10 +181,11 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
         printf("%s: n_tensors: %d\n", __func__, n_tensors);
 
         for (int i = 0; i < n_tensors; ++i) {
-            const char * name       = gguf_get_tensor_name  (ctx, i);
-            const size_t size       = gguf_get_tensor_size  (ctx, i);
-            const size_t offset     = gguf_get_tensor_offset(ctx, i);
-            const auto   type       = gguf_get_tensor_type  (ctx, i);
+            const char * name   = gguf_get_tensor_name  (ctx, i);
+            const size_t size   = gguf_get_tensor_size  (ctx, i);
+            const size_t offset = gguf_get_tensor_offset(ctx, i);
+            const auto   type   = gguf_get_tensor_type  (ctx, i);
+
             const char * type_name  = ggml_type_name(type);
             const size_t type_size  = ggml_type_size(type);
             const size_t n_elements = size / type_size;

--- a/examples/gguf/gguf.cpp
+++ b/examples/gguf/gguf.cpp
@@ -181,12 +181,12 @@ static bool gguf_ex_read_1(const std::string & fname, bool check_data) {
         printf("%s: n_tensors: %d\n", __func__, n_tensors);
 
         for (int i = 0; i < n_tensors; ++i) {
-            const char * name   = gguf_get_tensor_name  (ctx, i);
-            const size_t size   = gguf_get_tensor_size  (ctx, i);
-            const size_t offset = gguf_get_tensor_offset(ctx, i);
-            const auto type = gguf_get_tensor_type(ctx, i);
-            const char * type_name   = ggml_type_name(type);
-            const size_t type_size = ggml_type_size(type);
+            const char * name       = gguf_get_tensor_name  (ctx, i);
+            const size_t size       = gguf_get_tensor_size  (ctx, i);
+            const size_t offset     = gguf_get_tensor_offset(ctx, i);
+            const auto   type       = gguf_get_tensor_type  (ctx, i);
+            const char * type_name  = ggml_type_name(type);
+            const size_t type_size  = ggml_type_size(type);
             const size_t n_elements = size / type_size;
 
             printf("%s: tensor[%d]: name = %s, size = %zu, offset = %zu, type = %s, n_elts = %zu\n", __func__, i, name, size, offset, type_name, n_elements);


### PR DESCRIPTION
## Description

This PR is extracted from #16982 since it's an isolated change that's not strictly related to implementing the SSD algorithm.

The changes in this PR add some extra output to the `llama-gguf` tool to show each tensor's `type` and element count.

## Example Output

```
...
gguf_ex_read_1: tensor[0]: name = token_embd.weight, size = 513802240, offset = 0, type = bf16, n_elts = 256901120
gguf_ex_read_1: tensor[1]: name = blk.0.attn_norm.weight, size = 10240, offset = 513802240, type = f32, n_elts = 2560
gguf_ex_read_1: tensor[2]: name = blk.0.ffn_norm.weight, size = 10240, offset = 513812480, type = f32, n_elts = 2560
gguf_ex_read_1: tensor[3]: name = blk.0.attn_k.weight, size = 2621440, offset = 513822720, type = bf16, n_elts = 1310720
gguf_ex_read_1: tensor[4]: name = blk.0.attn_output.weight, size = 13107200, offset = 516444160, type = bf16, n_elts = 6553600
gguf_ex_read_1: tensor[5]: name = blk.0.attn_q.weight, size = 13107200, offset = 529551360, type = bf16, n_elts = 6553600
gguf_ex_read_1: tensor[6]: name = blk.0.attn_v.weight, size = 2621440, offset = 542658560, type = bf16, n_elts = 1310720
gguf_ex_read_1: tensor[7]: name = blk.0.ffn_gate.weight, size = 41943040, offset = 545280000, type = bf16, n_elts = 20971520
...
```
