### PR TITLE
tests(test-backend-ops): Test backend ops verbosity

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -244,8 +244,9 @@ static void ggml_print_tensor(ggml_tensor * t, int64_t n = 3) {
     GGML_ASSERT(t != nullptr);
     GGML_ASSERT(n > 0);
 
-    std::stringstream src_ss;
-    src_ss << std::string("(");
+    printf("%s: %24s = (%s) %10s(", __func__,
+       t->name, ggml_type_name(t->type), ggml_op_desc(t));
+
     size_t last_src = 0;
     for (size_t i = 0; i < GGML_MAX_SRC; ++i) {
         if (t->src[i] != nullptr) {
@@ -254,18 +255,13 @@ static void ggml_print_tensor(ggml_tensor * t, int64_t n = 3) {
     }
     for (size_t i = 0; i < GGML_MAX_SRC; ++i) {
         if (t->src[i] != nullptr) {
-            src_ss << t->src[i]->name << std::string("{") << ggml_ne_string(t->src[i]) << std::string("}");
+            printf("%s{%s}", t->src[i]->name, ggml_ne_string(t->src[i]).c_str());
         }
-        if (i <= last_src) {
-            src_ss << std::string(", ");
+        if (i < last_src) {
+            printf(", ");
         }
     }
-    src_ss << std::string(")");
-
-    printf("%s: %24s = (%s) %10s%s = {%s}\n", __func__,
-         t->name, ggml_type_name(t->type), ggml_op_desc(t),
-         src_ss.str().c_str(),
-         ggml_ne_string(t).c_str());
+    printf(") = {%s}\n", ggml_ne_string(t).c_str());
 
     std::vector<float> tv;
     tv.reserve(ggml_nelements(t));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1183,7 +1183,7 @@ struct test_case {
     std::string current_op_name;
 
     // set to true to print tensors
-    bool verbose = false;
+    bool verbose = 0;
 
     void add_sentinel(ggml_context * ctx) {
         if (mode == MODE_PERF || mode == MODE_GRAD || mode == MODE_SUPPORT) {
@@ -1334,7 +1334,7 @@ struct test_case {
         // compare
         struct callback_userdata {
             bool   ok;
-            bool   verbose;
+            int    verbose;
             double max_err;
             ggml_backend_t backend1;
             ggml_backend_t backend2;
@@ -1368,8 +1368,8 @@ struct test_case {
             }
 
             if (ud->verbose) {
-                ggml_print_tensor(t1);
-                ggml_print_tensor(t2);
+                ggml_print_tensor(t1, ud->verbose >= 2 ? 1e10 : 3);
+                ggml_print_tensor(t2, ud->verbose >= 2 ? 1e10 : 3);
             }
 
             std::vector<float> f1 = tensor_to_float(t1);
@@ -6314,7 +6314,7 @@ static const ggml_type other_types[] = {
 };
 
 // Test cases for evaluation: should try to cover edge cases while using small input sizes to keep the runtime low
-static std::vector<std::unique_ptr<test_case>> make_test_cases_eval(bool verbose = false) {
+static std::vector<std::unique_ptr<test_case>> make_test_cases_eval(int verbose = 0) {
     std::vector<std::unique_ptr<test_case>> test_cases;
     std::default_random_engine rng(0);
 
@@ -7619,7 +7619,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
 }
 
 static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op_names_filter, const char * params_filter,
-                         printer * output_printer, bool verbose) {
+                         printer * output_printer, int verbose) {
     auto filter_test_cases = [](std::vector<std::unique_ptr<test_case>> & test_cases, const char * params_filter) {
         if (params_filter == nullptr) {
             return;
@@ -7827,7 +7827,7 @@ static void usage(char ** argv) {
     printf("    --output specifies output format (default: console, options: console, sql, csv)\n");
     printf("    --list-ops lists all available GGML operations\n");
     printf("    --show-coverage shows test coverage\n");
-    printf("    --verbose | -v print tensors during ops\n");
+    printf("    --verbose | -v print tensors during ops (can specify multiple times)\n");
 }
 
 int main(int argc, char ** argv) {
@@ -7836,7 +7836,7 @@ int main(int argc, char ** argv) {
     const char * op_names_filter = nullptr;
     const char * backend_filter = nullptr;
     const char * params_filter = nullptr;
-    bool verbose = false;
+    int verbose = 0;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "test") == 0) {
@@ -7885,7 +7885,7 @@ int main(int argc, char ** argv) {
             show_test_coverage();
             return 0;
         } else if (strcmp(argv[i], "--verbose") == 0 || strcmp(argv[i], "-v") == 0) {
-            verbose = true;
+            ++verbose;
         } else {
             usage(argv);
             return 1;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1401,11 +1401,12 @@ struct test_case {
             double err = nmse(f1.data(), f2.data(), f1.size());
             if (err > ud->max_err) {
                 printf("[%s] NMSE = %.9f > %.9f ", ggml_op_desc(t1), err, ud->max_err);
-                //for (int i = 0; i < (int) f1.size(); i++) {
-                //    printf("%5d %9.6f %9.6f, diff = %9.6f\n", i, f1[i], f2[i], f1[i] - f2[i]);
-                //}
-                //printf("\n");
-                //exit(1);
+                if (ud->verbose) {
+                    for (int i = 0; i < (int) f1.size(); i++) {
+                    printf("%5d %9.6f %9.6f, diff = %9.6f\n", i, f1[i], f2[i], f1[i] - f2[i]);
+                    }
+                    printf("\n");
+                }
                 ud->ok = false;
             }
             return true;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -245,7 +245,7 @@ static void ggml_print_tensor(ggml_tensor * t, int64_t n = 3) {
     GGML_ASSERT(n > 0);
 
     std::stringstream src_ss;
-    src_ss << "(";
+    src_ss << std::string("(");
     size_t last_src = 0;
     for (size_t i = 0; i < GGML_MAX_SRC; ++i) {
         if (t->src[i] != nullptr) {
@@ -254,13 +254,13 @@ static void ggml_print_tensor(ggml_tensor * t, int64_t n = 3) {
     }
     for (size_t i = 0; i < GGML_MAX_SRC; ++i) {
         if (t->src[i] != nullptr) {
-            src_ss << t->src[i]->name << "{" << ggml_ne_string(t->src[i]) <<"}";
+            src_ss << t->src[i]->name << std::string("{") << ggml_ne_string(t->src[i]) << std::string("}");
         }
         if (i <= last_src) {
-            src_ss << ", ";
+            src_ss << std::string(", ");
         }
     }
-    src_ss << ")";
+    src_ss << std::string(")");
 
     printf("%s: %24s = (%s) %10s%s = {%s}\n", __func__,
          t->name, ggml_type_name(t->type), ggml_op_desc(t),


### PR DESCRIPTION
## Description

This PR is extracted from https://github.com/ggml-org/llama.cpp/pull/16982 since it's an isolated change that's not strictly related to implementing the SSD algorithm.

The changes in this PR add better verbosity options to the `test-backend-ops` binary allowing higher precision printing and full-width tensor outputs.