### PR TITLE
cmake: add option to build and link BoringSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,10 @@ option(LLAMA_BUILD_SERVER   "llama: build server example" ${LLAMA_STANDALONE})
 option(LLAMA_TOOLS_INSTALL  "llama: install tools"        ${LLAMA_TOOLS_INSTALL_DEFAULT})
 
 # 3rd party libs
-option(LLAMA_CURL       "llama: use libcurl to download model from an URL" ON)
-option(LLAMA_OPENSSL    "llama: use openssl to support HTTPS" OFF)
-option(LLAMA_LLGUIDANCE "llama-common: include LLGuidance library for structured output in common utils" OFF)
+option(LLAMA_CURL              "llama: use libcurl to download model from an URL" ON)
+option(LLAMA_OPENSSL           "llama: use openssl to support HTTPS" OFF)
+option(LLAMA_BUILD_BORINGSSL   "llama: build and statically link BoringSSL" OFF)
+option(LLAMA_LLGUIDANCE        "llama-common: include LLGuidance library for structured output in common utils" OFF)
 
 # Required for relocatable CMake package
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-info.cmake)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -90,7 +90,56 @@ if (LLAMA_CURL)
     set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${CURL_LIBRARIES})
 endif()
 
-if (LLAMA_OPENSSL)
+set(LLAMA_BORINGSSL_VERSION "0.20251002.0" CACHE STRING "llama: BoringSSL version")
+
+if (LLAMA_BUILD_BORINGSSL)
+    include(FetchContent)
+    message("Building BoringSSL version ${LLAMA_BORINGSSL_VERSION}")
+
+    FetchContent_Declare(
+        boringssl
+        GIT_REPOSITORY   https://boringssl.googlesource.com/boringssl
+        GIT_TAG          ${LLAMA_BORINGSSL_VERSION}
+    )
+
+    # TODO: fix FetchContent_MakeAvailable with EXCLUDE_FROM_ALL
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+
+    if(NOT boringssl_POPULATED)
+        # force BUILD_SHARED_LIBS=OFF, avoid installing SSL libs
+        set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+        set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+        FetchContent_Populate(boringssl)
+        add_subdirectory(${boringssl_SOURCE_DIR} ${boringssl_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+        set(BUILD_SHARED_LIBS ${SAVED_BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
+    endif()
+
+    set(BORINGSSL_FLAGS
+        -Wno-error
+        -Wno-unused-parameter
+        -Wno-missing-noreturn
+    )
+
+    if(TARGET fipsmodule)
+        target_compile_options(fipsmodule PRIVATE ${BORINGSSL_FLAGS})
+    endif()
+
+    if(TARGET ssl)
+        target_compile_options(ssl PRIVATE ${BORINGSSL_FLAGS})
+    endif()
+
+    if(TARGET crypto)
+        target_compile_options(crypto PRIVATE ${BORINGSSL_FLAGS})
+    endif()
+
+    set(CPPHTTPLIB_OPENSSL_SUPPORT TRUE)
+    target_link_libraries(${TARGET} PUBLIC ssl crypto)
+
+elseif (LLAMA_OPENSSL)
     find_package(OpenSSL)
     if (OpenSSL_FOUND)
         include(CheckCSourceCompiles)
@@ -112,17 +161,21 @@ if (LLAMA_OPENSSL)
         set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
         if (OPENSSL_VERSION_SUPPORTED)
             message(STATUS "OpenSSL found: ${OPENSSL_VERSION}")
-            target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT)
+            set(CPPHTTPLIB_OPENSSL_SUPPORT TRUE)
             target_link_libraries(${TARGET} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
-            if (APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-                target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN)
-                find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
-                find_library(SECURITY_FRAMEWORK Security REQUIRED)
-                target_link_libraries(${TARGET} PUBLIC ${CORE_FOUNDATION_FRAMEWORK} ${SECURITY_FRAMEWORK})
-            endif()
         endif()
     else()
         message(STATUS "OpenSSL not found, SSL support disabled")
+    endif()
+endif()
+
+if (CPPHTTPLIB_OPENSSL_SUPPORT)
+    target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT)
+    if (APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN)
+        find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+        find_library(SECURITY_FRAMEWORK Security REQUIRED)
+        target_link_libraries(${TARGET} PUBLIC ${CORE_FOUNDATION_FRAMEWORK} ${SECURITY_FRAMEWORK})
     endif()
 endif()
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -108,14 +108,16 @@ if (LLAMA_BUILD_BORINGSSL)
     endif()
 
     if(NOT boringssl_POPULATED)
-        # force BUILD_SHARED_LIBS=OFF, avoid installing SSL libs
-        set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-        set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
         FetchContent_Populate(boringssl)
         add_subdirectory(${boringssl_SOURCE_DIR} ${boringssl_BINARY_DIR} EXCLUDE_FROM_ALL)
 
-        set(BUILD_SHARED_LIBS ${SAVED_BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
+        if(TARGET ssl)
+            set_target_properties(ssl PROPERTIES OUTPUT_NAME "llama-ssl")
+        endif()
+
+        if(TARGET crypto)
+            set_target_properties(crypto PROPERTIES OUTPUT_NAME "llama-crypto")
+        endif()
     endif()
 
     set(BORINGSSL_FLAGS
@@ -139,6 +141,14 @@ if (LLAMA_BUILD_BORINGSSL)
 
     set(CPPHTTPLIB_OPENSSL_SUPPORT TRUE)
     target_link_libraries(${TARGET} PUBLIC ssl crypto)
+
+    if(BUILD_SHARED_LIBS)
+        install(TARGETS ssl crypto
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif()
 
 elseif (LLAMA_OPENSSL)
     find_package(OpenSSL)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -122,6 +122,7 @@ if (LLAMA_BUILD_BORINGSSL)
         -Wno-error
         -Wno-unused-parameter
         -Wno-missing-noreturn
+        -Wno-cast-qual
     )
 
     if(TARGET fipsmodule)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -124,6 +124,7 @@ if (LLAMA_BUILD_BORINGSSL)
         -Wno-error
         -Wno-unused-parameter
         -Wno-missing-noreturn
+        -Wno-pedantic
         -Wno-cast-qual
     )
 


### PR DESCRIPTION
This commit adds an easy way to fetch, build, and statically link the BoringSSL library when LLAMA_BUILD_BORINGSSL is enabled.

The version can be set via the LLAMA_BORINGSSL_VERSION cache variable.

