### PR TITLE
server : print the samplers chain for each request

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -2823,6 +2823,8 @@ struct server_context {
                 send_error(task, "Failed to parse grammar", ERROR_TYPE_INVALID_REQUEST);
                 return false;
             }
+
+            SLT_INF(slot, "sampler chain: %s\n", common_sampler_print(slot.smpl).c_str());
         }
 
         // initialize draft batch


### PR DESCRIPTION
This is useful for debugging to track which samplers are being used:

```
0.06.413.534 I slot get_availabl: id  3 | task -1 | selected slot by LCP similarity, sim_best = 1.000 (> 0.100 thold), f_keep = 0.687
0.06.413.669 I slot launch_slot_: id  3 | task -1 | sampler chain: logits -> logit-bias -> penalties -> dry -> top-n-sigma -> top-k -> typical -> top-p -> min-p -> xtc -> temp-ext -> dist 
0.06.413.690 I slot launch_slot_: id  3 | task 38 | processing task
```