### PR TITLE
arg: add --cache-list argument to list cached models

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -750,7 +750,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             for (size_t i = 0; i < models.size(); i++) {
                 auto & model = models[i];
                 auto num = std::to_string(i+1); // so that we can print trailing space
-                printf("%4s. %-50s   tag: %s\n", num.c_str(), model.name.c_str(), model.tag.c_str());
+                printf("%4s. %s\n", num.c_str(), model.to_string().c_str());
             }
             exit(0);
         }

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -741,6 +741,21 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
+        {"-cl", "--cache-list"},
+        "show list of models in cache",
+        [](common_params &) {
+            printf("model cache directory: %s\n", fs_get_cache_directory().c_str());
+            auto models = common_list_cached_models();
+            printf("number of models in cache: %zu\n", models.size());
+            for (size_t i = 0; i < models.size(); i++) {
+                auto & model = models[i];
+                auto num = std::to_string(i+1); // so that we can print trailing space
+                printf("%4s. %-50s   tag: %s\n", num.c_str(), model.name.c_str(), model.tag.c_str());
+            }
+            exit(0);
+        }
+    ));
+    add_opt(common_arg(
         {"--completion-bash"},
         "print source-able bash completion script for llama.cpp",
         [](common_params & params) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -749,8 +749,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             printf("number of models in cache: %zu\n", models.size());
             for (size_t i = 0; i < models.size(); i++) {
                 auto & model = models[i];
-                auto num = std::to_string(i+1); // so that we can print trailing space
-                printf("%4s. %s\n", num.c_str(), model.to_string().c_str());
+                printf("%4d. %s\n", (int) i + 1, model.to_string().c_str());
             }
             exit(0);
         }

--- a/common/common.h
+++ b/common/common.h
@@ -611,6 +611,13 @@ bool fs_create_directory_with_parents(const std::string & path);
 std::string fs_get_cache_directory();
 std::string fs_get_cache_file(const std::string & filename);
 
+struct common_file_info {
+    std::string path;
+    std::string name;
+    size_t      size = 0; // in bytes
+};
+std::vector<common_file_info> fs_list_files(const std::string & path);
+
 //
 // Model utils
 //

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -919,10 +919,10 @@ std::vector<common_cached_model_info> common_list_cached_models() {
             string_replace_all(fname, ".json", ""); // remove extension
             auto parts = string_split<std::string>(fname, '=');
             if (parts.size() == 4) {
-                // expect format: manifest=<user>=<repo>=<tag>=<other>
-                model_info.user = parts[1];
-                model_info.repo = parts[2];
-                model_info.tag  = parts[3];
+                // expect format: manifest=<user>=<model>=<tag>=<other>
+                model_info.user  = parts[1];
+                model_info.model = parts[2];
+                model_info.tag   = parts[3];
             } else {
                 // invalid format
                 continue;

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -50,6 +50,14 @@ using json = nlohmann::ordered_json;
 // downloader
 //
 
+static std::string get_manifest_path(const std::string & repo, const std::string & tag) {
+    // we use "=" to avoid clashing with other component, while still being allowed on windows
+    std::string fname = "manifest=" + repo + "=" + tag + ".json";
+    string_replace_all(fname, "/", "_");
+    string_replace_all(fname, "\\", "_");
+    return fs_get_cache_file(fname);
+}
+
 static std::string read_file(const std::string & fname) {
     std::ifstream file(fname);
     if (!file) {
@@ -829,17 +837,13 @@ common_hf_file_res common_get_hf_file(const std::string & hf_repo_with_tag, cons
     // Important: the User-Agent must be "llama-cpp" to get the "ggufFile" field in the response
     // User-Agent header is already set in common_remote_get_content, no need to set it here
 
-    // we use "=" to avoid clashing with other component, while still being allowed on windows
-    std::string cached_response_fname = "manifest=" + hf_repo + "=" + tag + ".json";
-    string_replace_all(cached_response_fname, "/", "_");
-    std::string cached_response_path = fs_get_cache_file(cached_response_fname);
-
     // make the request
     common_remote_params params;
     params.headers = headers;
     long res_code = 0;
     std::string res_str;
     bool use_cache = false;
+    std::string cached_response_path = get_manifest_path(hf_repo, tag);
     if (!offline) {
         try {
             auto res = common_remote_get_content(url, params);
@@ -893,6 +897,29 @@ common_hf_file_res common_get_hf_file(const std::string & hf_repo_with_tag, cons
     }
 
     return { hf_repo, ggufFile, mmprojFile };
+}
+
+std::vector<common_cached_model_info> common_list_cached_models() {
+    std::vector<common_cached_model_info> models;
+    const std::string cache_dir = fs_get_cache_directory();
+    const std::vector<common_file_info> files = fs_list_files(cache_dir);
+    for (const auto & file : files) {
+        if (string_starts_with(file.name, "manifest=") && string_ends_with(file.name, ".json")) {
+            common_cached_model_info model_info;
+            model_info.manifest_path = file.path;
+            std::string fname = file.name;
+            string_replace_all(fname, ".json", ""); // remove extension
+            auto parts = string_split<std::string>(fname, '=');
+            if (parts.size() != 3) {
+                continue;
+            }
+            model_info.name = parts[1];
+            model_info.tag  = parts[2];
+            model_info.size = 0; // TODO: get GGUF size, not manifest size
+            models.push_back(model_info);
+        }
+    }
+    return models;
 }
 
 //
@@ -959,6 +986,7 @@ std::string common_docker_resolve_model(const std::string & docker) {
         std::string token = common_docker_get_token(repo);  // Get authentication token
 
         // Get manifest
+        // TODO: cache the manifest response so that it appears in the model list
         const std::string    url_prefix = "https://registry-1.docker.io/v2/" + repo;
         std::string          manifest_url = url_prefix + "/manifests/" + tag;
         common_remote_params manifest_params;

--- a/common/download.h
+++ b/common/download.h
@@ -10,9 +10,13 @@ struct common_params_model;
 
 struct common_cached_model_info {
     std::string manifest_path;
-    std::string name; // note: this is not "repo", slashes are replaced with underscores
+    std::string user;
+    std::string repo;
     std::string tag;
     size_t      size = 0; // GGUF size in bytes
+    std::string to_string() const {
+        return user + "/" + repo + ":" + tag;
+    }
 };
 
 struct common_hf_file_res {

--- a/common/download.h
+++ b/common/download.h
@@ -8,15 +8,18 @@ struct common_params_model;
 // download functionalities
 //
 
+struct common_cached_model_info {
+    std::string manifest_path;
+    std::string name; // note: this is not "repo", slashes are replaced with underscores
+    std::string tag;
+    size_t      size = 0; // GGUF size in bytes
+};
+
 struct common_hf_file_res {
     std::string repo; // repo name with ":tag" removed
     std::string ggufFile;
     std::string mmprojFile;
 };
-
-// resolve and download model from Docker registry
-// return local path to downloaded model file
-std::string common_docker_resolve_model(const std::string & docker);
 
 /**
  * Allow getting the HF file from the HF repo with tag (like ollama), for example:
@@ -39,3 +42,10 @@ bool common_download_model(
     const common_params_model & model,
     const std::string & bearer_token,
     bool offline);
+
+// returns list of cached models
+std::vector<common_cached_model_info> common_list_cached_models();
+
+// resolve and download model from Docker registry
+// return local path to downloaded model file
+std::string common_docker_resolve_model(const std::string & docker);

--- a/common/download.h
+++ b/common/download.h
@@ -11,11 +11,11 @@ struct common_params_model;
 struct common_cached_model_info {
     std::string manifest_path;
     std::string user;
-    std::string repo;
+    std::string model;
     std::string tag;
     size_t      size = 0; // GGUF size in bytes
     std::string to_string() const {
-        return user + "/" + repo + ":" + tag;
+        return user + "/" + model + ":" + tag;
     }
 };
 


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR changes the cached manifest format. You won't see your existing cached models until you update the manifest at least once, by running `-hf <user>/<model>:<tag>`  
> (Only the cached manifest will be updated, the GGUF file will NOT be re-downloaded)

Command:

```
llama-cli -cl
```

Output:

```
model cache directory: /Users/REDACTED/Library/Caches/llama.cpp/
number of models in cache: 7
   1. ggml-org/SmolVLM2-500M-Video-Instruct-GGUF:Q8_0
   2. cjpais/llava-1.6-mistral-7b-gguf:Q3_K_M
   3. THUDM/glm-edge-v-5b-gguf:Q4_K_M
   4. ggml-org/gemma-3-4b-it-GGUF:Q4_K_M
   5. second-state/Llava-v1.5-7B-GGUF:Q2_K
   6. ggml-org/SmolVLM2-2.2B-Instruct-GGUF:Q4_K_M
   7. ggml-org/SmolVLM-500M-Instruct-GGUF:Q8_0
```
