### PR TITLE
server : handle failures to restore host cache

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -1690,6 +1690,9 @@ struct server_slot {
         bool res = prompt_cache.load(prompt, tokens, ctx, id);
         if (!res) {
             SLT_WRN(*this, "%s", "failed to load prompt from cache\n");
+
+            llama_memory_seq_rm(llama_get_memory(ctx), id, -1, -1);
+            prompt.tokens.clear();
         }
     }
 


### PR DESCRIPTION
fix #17060 #17118
cont #16391 

With unified caches, restoring an old prompt from the host-memory cache is not guaranteed to be successful because there might not be enough free room in the context memory to fit it. Handle this gracefully by reprocessing the prompt from scratch.