### PR TITLE
convert: (demo) repacking compressed_tensor format of kimi-k2

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -352,6 +352,8 @@ class ModelBase:
                     device=weight.device,
                     dtype=torch.int32,
                 )
+                if self.lazy:
+                    unpacked = LazyTorchTensor.from_eager(unpacked)
                 for i in range(pack_factor):
                     unpacked[:, i::pack_factor] = (weight >> (num_bits * i)) & mask
                 # TODO: may need to unpad

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -7153,7 +7153,7 @@ class DeepseekV2Model(TextModel):
 
                     new_name = self.map_tensor_name(merged_name)
 
-                    target_shape = (n_experts, data_packed.shape[1], data_packed.shape[2] * 32)
+                    target_shape = (n_experts, data_packed.shape[1], data_packed.shape[2] * 8)
                     self.repack_compressed_tensor(new_name, data_packed, data_scale, target_shape)
                     #tensors.append((new_name, data_torch))
                 return []

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -401,8 +401,6 @@ class ModelBase:
                             )
                         ]
             elif quant_method == "compressed-tensors":
-                weight_block_size = quant_config["config_groups"]["group_0"]["weights"]["group_size"]
-                quant_config["weight_block_size"] = weight_block_size
                 for name in self.model_tensors.keys():
                     if name.endswith("_packed"):
                         base_name = name.removesuffix("_packed")


### PR DESCRIPTION
**This PR is a demo. It will definitely break models other than kimi-k2**

IMPORTANT: This requires deleting the `"quantization_config"` section in `config.json`; You can also rename it:

<img width="359" height="166" alt="image" src="https://github.com/user-attachments/assets/1ce5adb4-4193-48b3-b7bb-fb48e8862dad" />

---

How it works: we map int4 --> GGML's Q4_0; the original scale is BF16, and will be converted to F16 (as Q4_0 only support F16)

TODO: correct the nibble layout, seems to be reversed order

cc @jukofyork 