### PR TITLE
CUDA: fix MMQ stream-k fixup ne1 indices

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3494,7 +3494,7 @@ static __global__ void mul_mat_q_stream_k_fixup(
     const int col_diff = col_high - col_low;
 
     for (int j = threadIdx.y*warp_size + threadIdx.x; j < mmq_x; j += nwarps*warp_size) {
-        ids_dst_shared[j] = ids_dst[col_low + j];
+        ids_dst_shared[j] = ids_dst[col_low + jt*mmq_x + j];
     }
     __syncthreads();
 


### PR DESCRIPTION
See discussion starting with https://github.com/ikawrakow/ik_llama.cpp/pull/728#issuecomment-3494522254 , the use of MMQ MoE optimizations is resulting in increased perplexity on master. The problem is that the wrong indices are being used when determining which `dst` columns should be receiving the stream-k fixup. This is a very typical bug that I encounter during development but unfortunately? this is one of the rare cases where the impact is small enough to be overlooked. Generally speaking, the impact will be largest for the combination of small models are large GPUs where the SM count is not a power of 2 (RTX 4090 for example has 128 SMs). Example models:

| Model              | GPU      | PPL master |  PPL PR |
|--------------------|----------|------------|---------|
| GraniteMoe 3b q4_0 | RTX 3090 |    10.5577 | 10.0799 |
| GraniteMoe 3b q4_0 | RTX 4090 |    10.0879 | 10.0877 |
| GraniteMoe 3b q4_0 | RTX 5090 |    15.4910 | 10.0853 |
| Qwen 3 30b q4_0    | RTX 3090 |     9.3418 |  9.2930 |
| Qwen 3 30b q4_0    | RTX 4090 |     9.2928 |  9.2928 |
| Qwen 3 30b q4_0    | RTX 5090 |     9.4052 |  9.2930 |


The bug in question has been on master since https://github.com/ggml-org/llama.cpp/pull/13199 though the impact became larger with https://github.com/ggml-org/llama.cpp/pull/15525 when the upper bound for CUDA blocks was tightened and more stream-k seams ended up in tiles that are not being skipped. 