### PR TITLE
displaying context and token stats in real time

### DIFF
--- a/tools/server/webui/src/lib/hooks/use-processing-state.svelte.ts
+++ b/tools/server/webui/src/lib/hooks/use-processing-state.svelte.ts
@@ -126,6 +126,30 @@ export function useProcessingState(): UseProcessingStateReturn {
 			);
 		}
 
+		// Show input parsing progress when preparing
+		if (
+			stateToUse.status === 'preparing' &&
+			stateToUse.inputTokensProcessed !== undefined &&
+			stateToUse.inputTokensTotal !== undefined &&
+			stateToUse.inputTokensTotal > 0
+		) {
+			const inputPercent = Math.round(
+				(stateToUse.inputTokensProcessed / stateToUse.inputTokensTotal) * 100
+			);
+			details.push(
+				`Input: ${stateToUse.inputTokensProcessed}/${stateToUse.inputTokensTotal} (${inputPercent}%)`
+			);
+
+			// Show parsing tokens per second if available
+			if (
+				currentConfig.showTokensPerSecond &&
+				stateToUse.parsingTokensPerSecond !== undefined &&
+				stateToUse.parsingTokensPerSecond > 0
+			) {
+				details.push(`${stateToUse.parsingTokensPerSecond.toFixed(1)} t/s`);
+			}
+		}
+
 		if (stateToUse.outputTokensUsed > 0) {
 			// Handle infinite max_tokens (-1) case
 			if (stateToUse.outputTokensMax <= 0) {
@@ -144,7 +168,8 @@ export function useProcessingState(): UseProcessingStateReturn {
 		if (
 			currentConfig.showTokensPerSecond &&
 			stateToUse.tokensPerSecond &&
-			stateToUse.tokensPerSecond > 0
+			stateToUse.tokensPerSecond > 0 &&
+			stateToUse.status !== 'preparing' // Don't show generation t/s when parsing
 		) {
 			details.push(`${stateToUse.tokensPerSecond.toFixed(1)} tokens/sec`);
 		}

--- a/tools/server/webui/src/lib/services/slots.ts
+++ b/tools/server/webui/src/lib/services/slots.ts
@@ -252,6 +252,11 @@ export class SlotsService {
 			? Math.round((promptProgress.processed / promptProgress.total) * 100)
 			: undefined;
 
+		// Calculate parsing tokens per second from prompt_progress
+		const parsingTokensPerSecond = promptProgress && promptProgress.time_ms > 0
+			? (promptProgress.processed / promptProgress.time_ms) * 1000
+			: undefined;
+
 		return {
 			status: predictedTokens > 0 ? 'generating' : promptProgress ? 'preparing' : 'idle',
 			tokensDecoded: predictedTokens,
@@ -267,7 +272,10 @@ export class SlotsService {
 			speculative: false,
 			progressPercent,
 			promptTokens,
-			cacheTokens
+			cacheTokens,
+			parsingTokensPerSecond,
+			inputTokensProcessed: promptProgress?.processed,
+			inputTokensTotal: promptProgress?.total
 		};
 	}
 

--- a/tools/server/webui/src/lib/types/api.d.ts
+++ b/tools/server/webui/src/lib/types/api.d.ts
@@ -294,4 +294,7 @@ export interface ApiProcessingState {
 	progressPercent?: number;
 	promptTokens?: number;
 	cacheTokens?: number;
+	parsingTokensPerSecond?: number;
+	inputTokensProcessed?: number; // Number of input tokens processed during parsing
+	inputTokensTotal?: number; // Total number of input tokens to process
 }


### PR DESCRIPTION
## Add parsing progress display to webui

Fixes #17079

Adds parsing progress during prompt tokenization, similar to token generation progress.

**Changes:**
- Display `Input: processed / total (percent%)` during prompt parsing
- Display parsing tokens/second (`X.X t/s`) during parsing
- Calculate parsing speed from `prompt_progress` timing data

**Implementation:**
- Added `parsingTokensPerSecond`, `inputTokensProcessed`, and `inputTokensTotal` to `ApiProcessingState`
- Updated `parseCompletionTimingData()` to calculate parsing speed from `prompt_progress.time_ms` and `prompt_progress.processed`
- Updated `getProcessingDetails()` to show input parsing progress when status is 'preparing'

Users now see real-time parsing progress instead of just "Processing...".