### PR TITLE
preserve .so symlinks for docker container builds

### DIFF
--- a/.devops/cann.Dockerfile
+++ b/.devops/cann.Dockerfile
@@ -49,7 +49,7 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh --force \
 # -- Organize build artifacts for copying in later stages --
 # Create a lib directory to store all .so files
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 # Create a full directory to store all executables and Python scripts
 RUN mkdir -p /app/full && \

--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
     cmake --build build -j $(nproc)
 
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -25,7 +25,7 @@ RUN if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
     cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \

--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -21,7 +21,7 @@ RUN if [ "${GGML_SYCL_F16}" = "ON" ]; then \
     cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \

--- a/.devops/musa.Dockerfile
+++ b/.devops/musa.Dockerfile
@@ -32,7 +32,7 @@ RUN if [ "${MUSA_DOCKER_ARCH}" != "default" ]; then \
     cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \

--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -45,7 +45,7 @@ RUN HIPCXX="$(hipconfig -l)/clang" HIP_PATH="$(hipconfig -R)" \
     && cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib \
-    && find build -name "*.so" -exec cp {} /app/lib \;
+    && find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \

--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -20,7 +20,7 @@ RUN cmake -B build -DGGML_NATIVE=OFF -DGGML_VULKAN=ON -DLLAMA_BUILD_TESTS=OFF -D
     cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib && \
-    find build -name "*.so" -exec cp {} /app/lib \;
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 RUN mkdir -p /app/full \
     && cp build/bin/* /app/full \


### PR DESCRIPTION
Previous PR #17091 broke the Dockerfiles because everything was previously linking against the unversioned so files.   With the versioning added, links are now against the major version symlink for the so files, and copying only the unversion so files is no longer adequate.

This should fix: https://github.com/ggml-org/llama.cpp/issues/17190, https://github.com/ggml-org/llama.cpp/issues/17176, https://github.com/ggml-org/llama.cpp/issues/17193

This PR preserves those symlinks and includes them in the container.

I have not included a fix for the s390x dockerfile in this PR for two reasons:
* the s390x Dockerfile is structured differently than the rest of the Dockerfiles and I want to ensure that the changes are fully tested and validated if we're going to modify it.  If I can get some guidance on validating that build I'm more than happy to help.
* I do not want to keep the CI broken for everyone that's not using the s390x Dockerfile while we're fixing that.

For that reason I think it's favorable to open a separate PR for strictly the s390x builds.  