### PR TITLE
fix: correct bounds check in XCDA array access

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1013,7 +1013,7 @@ private:
         }
     private:
         uint32_t get_node(size_t index) {
-            if (index > xcda_array_size) {
+            if (index >= xcda_array_size) {
                 throw std::runtime_error("Index out of array bounds in XCDA array!");
             }
             return xcda_array[index];


### PR DESCRIPTION
In the constructor of `llm_tokenizer_ugm`, `xcda_array` is an array with `xcda_array_size` elements:

https://github.com/ggml-org/llama.cpp/blob/017eceed61e885b79f6cf3542e0879be68c6e922/src/llama-vocab.cpp#L776-L777

The valid index range is `[0, xcda_array_size)`.

When `xcda_array_view` is constructed using these parameters:

https://github.com/ggml-org/llama.cpp/blob/017eceed61e885b79f6cf3542e0879be68c6e922/src/llama-vocab.cpp#L1048

The accessible index range remains `[0, xcda_array_size)`.

Therefore, in the `xcda_array_view::get_node` function, it should use `>=` to check for bounds violation instead of `>`.
