### PR TITLE
vulkan: remove shell call from vulkan-shaders-gen tool, revert file check

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -76,38 +76,7 @@ enum MatMulIdType {
 
 namespace {
 
-static std::vector<std::string> split_command(const std::string &cmd) {
-    std::vector<std::string> parts;
-    std::string cur;
-    bool in_single = false;
-    bool in_double = false;
-
-    for (const char c : cmd) {
-        if (c == '\'' && !in_double) {
-            in_single = !in_single;
-            continue;
-        }
-        if (c == '"' && !in_single) {
-            in_double = !in_double;
-            continue;
-        }
-        if (!in_single && !in_double && std::isspace(c)) {
-            if (!cur.empty()) {
-                parts.push_back(cur);
-                cur.clear();
-            }
-        } else {
-            cur.push_back(c);
-        }
-    }
-    if (!cur.empty()) {
-        parts.push_back(cur);
-    }
-
-    return parts;
-}
-
-void execute_command(const std::string& command, std::string& stdout_str, std::string& stderr_str) {
+void execute_command(const std::vector<std::string>& command, std::string& stdout_str, std::string& stderr_str) {
 #ifdef _WIN32
     HANDLE stdout_read, stdout_write;
     HANDLE stderr_read, stderr_write;
@@ -130,7 +99,13 @@ void execute_command(const std::string& command, std::string& stdout_str, std::s
     si.hStdOutput = stdout_write;
     si.hStdError = stderr_write;
 
-    std::vector<char> cmd(command.begin(), command.end());
+    std::vector<char> cmd;
+    for (const auto& part : command) {
+        for (char c : part) {
+            cmd.push_back(c);
+        }
+        cmd.push_back(' ');
+    }
     cmd.push_back('\0');
 
     if (!CreateProcessA(NULL, cmd.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
@@ -169,11 +144,9 @@ void execute_command(const std::string& command, std::string& stdout_str, std::s
         throw std::runtime_error("Failed to fork process");
     }
 
-    const std::vector<std::string> cmd_parts = split_command(command);
-
     std::vector<char*> argv;
-    for (const auto& part : cmd_parts) {
-        argv.push_back(const_cast<char*>(part.c_str()));
+    for (const std::string& part : command) {
+        argv.push_back(const_cast<char *>(part.c_str()));
     }
     argv.push_back(nullptr);
 
@@ -355,21 +328,23 @@ compile_count_guard acquire_compile_slot() {
 void string_to_spv_func(std::string name, std::string in_path, std::string out_path, std::map<std::string, std::string> defines, bool coopmat, bool dep_file, compile_count_guard slot) {
     std::string target_env = (name.find("_cm2") != std::string::npos) ? "--target-env=vulkan1.3" : "--target-env=vulkan1.2";
 
+    #ifdef _WIN32
+        std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, "\"" + in_path + "\"", "-o", "\"" + out_path + "\""};
+    #else
+        std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, in_path, "-o", out_path};
+    #endif
+
     // disable spirv-opt for coopmat shaders for https://github.com/ggerganov/llama.cpp/issues/10734
     // disable spirv-opt for bf16 shaders for https://github.com/ggml-org/llama.cpp/issues/15344
     // disable spirv-opt for rope shaders for https://github.com/ggml-org/llama.cpp/issues/16860
-    std::string opt_level = (coopmat || name.find("bf16") != std::string::npos || name.find("rope") != std::string::npos) ? "" : "-O";
-
-    #ifdef _WIN32
-        std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, opt_level, "\"" + in_path + "\"", "-o", "\"" + out_path + "\""};
-    #else
-        std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, opt_level, in_path, "-o",  out_path};
-    #endif
+    if (coopmat || name.find("bf16") != std::string::npos || name.find("rope") != std::string::npos) {
+        cmd.push_back("-O");
+    }
 
     if (dep_file) {
         cmd.push_back("-MD");
         cmd.push_back("-MF");
-        cmd.push_back("\"" + target_cpp + ".d\"");
+        cmd.push_back(target_cpp + ".d");
     }
 
     #ifdef GGML_VULKAN_SHADER_DEBUG_INFO
@@ -393,9 +368,13 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
         // }
         // std::cout << std::endl;
 
-        execute_command(command, stdout_str, stderr_str);
+        execute_command(cmd, stdout_str, stderr_str);
         if (!stderr_str.empty()) {
-            std::cerr << "cannot compile " << name << "\n\n" << command << "\n\n" << stderr_str << std::endl;
+            std::cerr << "cannot compile " << name << "\n\n";
+            for (const auto& part : cmd) {
+                std::cerr << part << " ";
+            }
+            std::cerr << "\n\n" << stderr_str << std::endl;
             return;
         }
 
@@ -469,7 +448,7 @@ void matmul_shaders(bool fp16, MatMulIdType matmul_id_type, bool coopmat, bool c
     base_dict["ACC_TYPE"     ] = f16acc ? "float16_t" : "float";
     base_dict["ACC_TYPE_VEC2"] = f16acc ? "f16vec2"   : "vec2";
     if (f16acc) {
-        base_dict["ACC_TYPE_MAX"] = "\"float16_t(65504.0)\"";
+        base_dict["ACC_TYPE_MAX"] = "float16_t(65504.0)";
     }
 
     if (coopmat) {
@@ -649,7 +628,7 @@ void process_shaders() {
         fa_base_dict["ACC_TYPE"] = f16acc ? "float16_t" : "float";
         fa_base_dict["ACC_TYPEV4"] = f16acc ? "f16vec4" : "vec4";
         if (f16acc) {
-            fa_base_dict["ACC_TYPE_MAX"] = "\"float16_t(65504.0)\"";
+            fa_base_dict["ACC_TYPE_MAX"] = "float16_t(65504.0)";
         }
 
         for (const auto& tname : type_names) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -76,7 +76,7 @@ enum MatMulIdType {
 
 namespace {
 
-void execute_command(const std::vector<std::string>& command, std::string& stdout_str, std::string& stderr_str) {
+void execute_command(std::vector<std::string>& command, std::string& stdout_str, std::string& stderr_str) {
 #ifdef _WIN32
     HANDLE stdout_read, stdout_write;
     HANDLE stderr_read, stderr_write;
@@ -99,14 +99,10 @@ void execute_command(const std::vector<std::string>& command, std::string& stdou
     si.hStdOutput = stdout_write;
     si.hStdError = stderr_write;
 
-    std::vector<char> cmd;
+    std::string cmd;
     for (const auto& part : command) {
-        for (char c : part) {
-            cmd.push_back(c);
-        }
-        cmd.push_back(' ');
+        cmd += part + " ";
     }
-    cmd.push_back('\0');
 
     if (!CreateProcessA(NULL, cmd.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
         throw std::runtime_error("Failed to create process");
@@ -145,8 +141,8 @@ void execute_command(const std::vector<std::string>& command, std::string& stdou
     }
 
     std::vector<char*> argv;
-    for (const std::string& part : command) {
-        argv.push_back(const_cast<char *>(part.c_str()));
+    for (std::string& part : command) {
+        argv.push_back(part.data());
     }
     argv.push_back(nullptr);
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -337,7 +337,7 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
     // disable spirv-opt for coopmat shaders for https://github.com/ggerganov/llama.cpp/issues/10734
     // disable spirv-opt for bf16 shaders for https://github.com/ggml-org/llama.cpp/issues/15344
     // disable spirv-opt for rope shaders for https://github.com/ggml-org/llama.cpp/issues/16860
-    if (coopmat || name.find("bf16") != std::string::npos || name.find("rope") != std::string::npos) {
+    if (!coopmat && name.find("bf16") == std::string::npos && name.find("rope") == std::string::npos) {
         cmd.push_back("-O");
     }
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -340,7 +340,11 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
     if (dep_file) {
         cmd.push_back("-MD");
         cmd.push_back("-MF");
+#ifdef _WIN32
+        cmd.push_back("\"" + target_cpp + ".d\"");
+#else
         cmd.push_back(target_cpp + ".d");
+#endif
     }
 
     #ifdef GGML_VULKAN_SHADER_DEBUG_INFO


### PR DESCRIPTION
This removes the shell invocation from the vulkan-shaders-gen tool, and instead splits the string and feeds separate arguments into `execvp`. This way, no shell is needed. I also removed the file check on glslc.

@MaggotHATE Please check if this works for you.