### PR TITLE
sched : fix reserve ignoring user tensor assignments

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1698,8 +1698,6 @@ bool ggml_backend_sched_reserve(ggml_backend_sched_t sched, struct ggml_cgraph *
     GGML_ASSERT(sched);
     GGML_ASSERT((int)sched->hash_set.size >= measure_graph->n_nodes + measure_graph->n_leafs);
 
-    ggml_backend_sched_reset(sched);
-
     ggml_backend_sched_synchronize(sched);
 
     ggml_backend_sched_split_graph(sched, measure_graph);


### PR DESCRIPTION
Calling `ggml_backend_sched_reset` before splitting the graph was causing the user tensor backend assignments to be reset, which in turn causes future allocations to require a full re-allocation of the graph, which disables pipeline parallelism. I don't remember why I added this, but it is definitely wrong.

Fixes #17163