### PR TITLE
Add logging hooks to mtmd to allow redirection to appropriate log message sinks

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -416,6 +416,10 @@ void common_log_add(struct common_log * log, enum ggml_log_level level, const ch
     va_end(args);
 }
 
+void common_log_add_v(struct common_log * log, enum ggml_log_level level, const char * fmt, va_list args) {
+    log->add(level, fmt, args);
+}
+
 void common_log_set_file(struct common_log * log, const char * file) {
     log->set_file(file);
 }

--- a/common/log.h
+++ b/common/log.h
@@ -49,6 +49,8 @@ void                common_log_free  (struct common_log * log);
 LOG_ATTRIBUTE_FORMAT(3, 4)
 void common_log_add(struct common_log * log, enum ggml_log_level level, const char * fmt, ...);
 
+void common_log_add_v(struct common_log * log, enum ggml_log_level level, const char * fmt, va_list args);
+
 // defaults: file = NULL, colors = false, prefix = false, timestamps = false
 //
 // regular log output:

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -208,6 +208,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #define GGML_FILE_MAGIC   0x67676d6c // "ggml"
 #define GGML_FILE_VERSION 2

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -266,6 +266,13 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg) {
     return 0;
 }
 
+static void mtmd_log_callback(enum ggml_log_level level, const char * fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+   common_log_add_v(common_log_main(), level, fmt, args);
+    va_end(args);
+}
+
 int main(int argc, char ** argv) {
     ggml_time_init();
 
@@ -277,6 +284,7 @@ int main(int argc, char ** argv) {
     }
 
     common_init();
+    mtmd_set_log_callback(mtmd_log_callback);
 
     if (params.mmproj.path.empty()) {
         show_additional_info(argc, argv);
@@ -285,7 +293,7 @@ int main(int argc, char ** argv) {
     }
 
     mtmd_cli_context ctx(params);
-    LOG("%s: loading model: %s\n", __func__, params.model.path.c_str());
+    LOG_INF("%s: loading model: %s\n", __func__, params.model.path.c_str());
 
     bool is_single_turn = !params.prompt.empty() && !params.image.empty();
 

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -32,8 +32,24 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 
-#define LOG_INF(...) fprintf(stdout, __VA_ARGS__)
-#define LOG_ERR(...) fprintf(stderr, __VA_ARGS__)
+static void log_callback_default(enum ggml_log_level level, const char * fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    if (level >= GGML_LOG_LEVEL_ERROR) {
+        vfprintf(stderr, fmt, args);
+    } else {
+        vfprintf(stdout, fmt, args);
+    }
+    va_end(args);
+
+}
+static mtmd_log_callback_t log_callback = log_callback_default;
+
+void mtmd_set_log_callback(mtmd_log_callback_t callback) {
+    log_callback = callback;
+}
+#define LOG_INF(...) (*log_callback)(GGML_LOG_LEVEL_INFO, __VA_ARGS__)
+#define LOG_ERR(...) (*log_callback)(GGML_LOG_LEVEL_ERROR, __VA_ARGS__)
 
 size_t mtmd_helper_get_n_tokens(const mtmd_input_chunks * chunks) {
     size_t n_tokens = 0;

--- a/tools/mtmd/mtmd-helper.h
+++ b/tools/mtmd/mtmd-helper.h
@@ -80,6 +80,9 @@ MTMD_API int32_t mtmd_helper_decode_image_chunk(mtmd_context * ctx,
                                                 int32_t n_batch,
                                                 llama_pos * new_n_past);
 
+typedef void (*mtmd_log_callback_t)(enum ggml_log_level level, const char * fmt, ...);                                                
+MTMD_API void mtmd_set_log_callback(mtmd_log_callback_t callback);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

Add logging hooks to mtmd so that the log messages from the library can be redirected to appropriate log message sinks as needed by the clients. 

The main underlying issue is that log messages from mtmd are blindly emitted to stdout which pollute the stdout from llama-mtmd-cli as just a stream of model output.

Rework of an earlier PullRequest #17223 that was rejected because mtmd cannot take a dependency on libcommon which allow for log messages 