### PR TITLE
ggml: Remove duplicate static_assert

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -110,7 +110,6 @@ static const std::map<gguf_type, const char *> GGUF_TYPE_NAME = {
     {GGUF_TYPE_INT64,   "i64"},
     {GGUF_TYPE_FLOAT64, "f64"},
 };
-static_assert(GGUF_TYPE_NAME == 13, "GGUF_TYPE_NAME != 13");
 
 size_t gguf_type_size(enum gguf_type type) {
     auto it = GGUF_TYPE_SIZE.find(type);

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -110,7 +110,7 @@ static const std::map<gguf_type, const char *> GGUF_TYPE_NAME = {
     {GGUF_TYPE_INT64,   "i64"},
     {GGUF_TYPE_FLOAT64, "f64"},
 };
-static_assert(GGUF_TYPE_COUNT == 13, "GGUF_TYPE_COUNT != 13");
+static_assert(GGUF_TYPE_NAME == 13, "GGUF_TYPE_NAME != 13");
 
 size_t gguf_type_size(enum gguf_type type) {
     auto it = GGUF_TYPE_SIZE.find(type);


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/blob/dbed61294abbc91b93aef64047bf2fecbf44b48b/ggml/src/gguf.cpp#L96

https://github.com/ggml-org/llama.cpp/blob/dbed61294abbc91b93aef64047bf2fecbf44b48b/ggml/src/gguf.cpp#L113

The two lines above are identical. This PR removes the second one.