### PR TITLE
arg: slightly reduce compilation time

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -60,25 +60,25 @@ static std::string read_file(const std::string & fname) {
     return content;
 }
 
-common_arg & common_arg::set_examples(std::initializer_list<enum llama_example> examples) {
+common_arg && common_arg::set_examples(std::initializer_list<enum llama_example> examples) {
     this->examples = examples;
-    return *this;
+    return std::move(*this);
 }
 
-common_arg & common_arg::set_excludes(std::initializer_list<enum llama_example> excludes) {
+common_arg && common_arg::set_excludes(std::initializer_list<enum llama_example> excludes) {
     this->excludes = excludes;
-    return *this;
+    return std::move(*this);
 }
 
-common_arg & common_arg::set_env(const char * env) {
+common_arg && common_arg::set_env(const char * env) {
     help = help + "\n(env: " + env + ")";
     this->env = env;
-    return *this;
+    return std::move(*this);
 }
 
-common_arg & common_arg::set_sparam() {
+common_arg && common_arg::set_sparam() {
     is_sparam = true;
-    return *this;
+    return std::move(*this);
 }
 
 bool common_arg::in_example(enum llama_example ex) {
@@ -717,9 +717,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
      * - if LLAMA_EXAMPLE_* is set (other than COMMON), we only show the option in the corresponding example
      * - if both {LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_*,} are set, we will prioritize the LLAMA_EXAMPLE_* matching current example
      */
-    auto add_opt = [&](common_arg arg) {
+    auto add_opt = [&](common_arg && arg) {
         if ((arg.in_example(ex) || arg.in_example(LLAMA_EXAMPLE_COMMON)) && !arg.is_exclude(ex)) {
-            ctx_arg.options.push_back(std::move(arg));
+            ctx_arg.options.emplace_back(std::move(arg));
         }
     };
 

--- a/common/arg.h
+++ b/common/arg.h
@@ -53,10 +53,10 @@ struct common_arg {
         void (*handler)(common_params & params, const std::string &, const std::string &)
     ) : args(args), value_hint(value_hint), value_hint_2(value_hint_2), help(help), handler_str_str(handler) {}
 
-    common_arg & set_examples(std::initializer_list<enum llama_example> examples);
-    common_arg & set_excludes(std::initializer_list<enum llama_example> excludes);
-    common_arg & set_env(const char * env);
-    common_arg & set_sparam();
+    common_arg && set_examples(std::initializer_list<enum llama_example> examples);
+    common_arg && set_excludes(std::initializer_list<enum llama_example> excludes);
+    common_arg && set_env(const char * env);
+    common_arg && set_sparam();
     bool in_example(enum llama_example ex);
     bool is_exclude(enum llama_example ex);
     bool get_value_from_env(std::string & output) const;


### PR DESCRIPTION
Tested on my Macbook M3 Max, time reduced from ~13.46s to ~11.33s

### master

```
time cmake --build build --target common
[  0%] Built target build_info
[  6%] Built target ggml-base
[ 10%] Built target ggml-metal
[ 20%] Built target ggml-cpu
[ 20%] Built target ggml-blas
[ 20%] Built target ggml
[ 91%] Built target llama
[ 91%] Building CXX object common/CMakeFiles/common.dir/arg.cpp.o
[ 91%] Linking CXX static library libcommon.a
[100%] Built target common
cmake --build build --target common  13.46s user 0.53s system 97% cpu 14.291 total

Repeated 3 more times:
cmake --build build --target common  13.39s user 0.50s system 98% cpu 14.143 total
cmake --build build --target common  13.63s user 0.50s system 98% cpu 14.357 total
cmake --build build --target common  13.49s user 0.53s system 97% cpu 14.388 total
```

### PR

```
time cmake --build build --target common
[  0%] Built target build_info
[  6%] Built target ggml-base
[ 10%] Built target ggml-metal
[ 20%] Built target ggml-cpu
[ 20%] Built target ggml-blas
[ 20%] Built target ggml
[ 91%] Built target llama
[ 91%] Building CXX object common/CMakeFiles/common.dir/arg.cpp.o
[ 91%] Linking CXX static library libcommon.a
[100%] Built target common
cmake --build build --target common  11.33s user 0.52s system 97% cpu 12.145 total

Repeated 3 more times:
cmake --build build --target common  11.16s user 0.50s system 97% cpu 11.984 total
cmake --build build --target common  11.26s user 0.50s system 97% cpu 12.048 total
cmake --build build --target common  11.65s user 0.50s system 97% cpu 12.438 total
```