### PR TITLE
Fix grammar README: Update non-terminal naming rules

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -36,7 +36,7 @@ castle ::= ...
 
 ## Non-Terminals and Terminals
 
-Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. They are required to be a dashed lowercase word, like `move`, `castle`, or `check-mate`.
+Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. Rule names can be composed of letters (both uppercase and lowercase), numbers, dashes, and underscores. For example: `move`, `castle`, `check-mate`, `dataType`, `UPPER-CASE`, or `rule_123` are all valid non-terminal names.
 
 Terminals are actual characters ([code points](https://en.wikipedia.org/wiki/Code_point)). They can be specified as a sequence like `"1"` or `"O-O"` or as ranges like `[1-9]` or `[NBKQR]`.
 


### PR DESCRIPTION
I noticed the grammar README documentation was outdated. It stated that rule names must be 'dashed lowercase words', but when I looked at the examples like `c.gbnf`, I saw it uses `dataType` with an uppercase letter.

After checking the discussion in #7720, it's clear the parser actually supports much more flexibility than the docs suggested:
- Uppercase and lowercase letters
- Numbers  
- Both dashes and underscores

This PR updates the documentation to accurately reflect what the parser actually supports. The examples work fine - the docs just needed updating to match reality.

**Changes:**
- Updated the 'Non-Terminals and Terminals' section to list all supported characters
- Added examples showing the flexibility (dataType, UPPER-CASE, rule_123)

This should help people understand they have more flexibility when naming their grammar rules.

Fixes #7720