### PR TITLE
chat: fix int overflow, prevent size calculation in float/double

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3031,8 +3031,8 @@ static common_chat_params common_chat_templates_apply_legacy(
         const auto & msg = inputs.messages[i];
         const auto & content = contents[i];
         chat.push_back({msg.role.c_str(), content.c_str()});
-        size_t msg_sz = msg.role.size() + content.size();
-        alloc_size += msg_sz + (msg_sz / 4); // == msg_sz * 1.25 but avoiding float ops
+        size_t msg_size = msg.role.size() + content.size();
+        alloc_size += msg_size + (msg_size / 4); // == msg_size * 1.25 but avoiding float ops
     }
 
     std::vector<char> buf(alloc_size);

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3009,7 +3009,7 @@ static common_chat_params common_chat_templates_apply_legacy(
     const struct common_chat_templates * tmpls,
     const struct common_chat_templates_inputs & inputs)
 {
-    int alloc_size = 0;
+    size_t alloc_size = 0;
     std::vector<llama_chat_message> chat;
     std::vector<std::string> contents;
 
@@ -3031,7 +3031,8 @@ static common_chat_params common_chat_templates_apply_legacy(
         const auto & msg = inputs.messages[i];
         const auto & content = contents[i];
         chat.push_back({msg.role.c_str(), content.c_str()});
-        alloc_size += (msg.role.size() + content.size()) * 1.25;
+        size_t msg_sz = msg.role.size() + content.size();
+        alloc_size += msg_sz + (msg_sz / 4); // == msg_sz * 1.25 but avoiding float ops
     }
 
     std::vector<char> buf(alloc_size);
@@ -3051,6 +3052,11 @@ static common_chat_params common_chat_templates_apply_legacy(
     if ((size_t) res > buf.size()) {
         buf.resize(res);
         res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
+    }
+
+    // for safety, we check the result again
+    if (res < 0 || (size_t) res > buf.size()) {
+        throw std::runtime_error("failed to apply chat template, try using --jinja");
     }
 
     common_chat_params params;


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/17355

> Hmm on second thought, yes it can be better to use `size_t`, as even when overflow it won't be a negative.
> 
> But please note that overflow can still potentially happen.
> 
> Also, I didn't notice that `* 1.25` will convert it to double, so we should use integer division instead.

