### PR TITLE
Fix DoS / integer overflow

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -347,7 +347,7 @@ const char * llama_grammar_parser::parse_sequence(
     size_t last_sym_start = rule.size();
     const char * pos = src;
 
-    // use INT64_MAX as the empty value because we aligned to the proper unsigned long type so -1 can't be used
+    // use UINT64_MAX as the empty value because we aligned to the proper unsigned long type so -1 can't be used
     // (though it's technically the same as -1 now)
     auto handle_repetitions = [&](unsigned long min_times, unsigned long max_times) {
 
@@ -383,14 +383,14 @@ const char * llama_grammar_parser::parse_sequence(
         }
 
         uint32_t last_rec_rule_id = 0;
-        auto n_opt = max_times == INT64_MAX ? 1 : max_times - min_times;
+        auto n_opt = max_times == UINT64_MAX ? 1 : max_times - min_times;
 
         llama_grammar_rule rec_rule(prev_rule);
         for (unsigned long i = 0; i < n_opt; i++) {
             rec_rule.resize(prev_rule.size());
             uint32_t rec_rule_id = generate_symbol_id( rule_name);
-            if (i > 0 || max_times == INT64_MAX) {
-                rec_rule.push_back({LLAMA_GRETYPE_RULE_REF, max_times == INT64_MAX ? rec_rule_id : last_rec_rule_id});
+            if (i > 0 || max_times == UINT64_MAX) {
+                rec_rule.push_back({LLAMA_GRETYPE_RULE_REF, max_times == UINT64_MAX ? rec_rule_id : last_rec_rule_id});
             }
             rec_rule.push_back({LLAMA_GRETYPE_ALT, 0});
             rec_rule.push_back({LLAMA_GRETYPE_END, 0});
@@ -485,7 +485,7 @@ const char * llama_grammar_parser::parse_sequence(
             unsigned long min_times = std::stoul(std::string(pos, int_end - pos));
             pos = parse_space(int_end, is_nested);
 
-            unsigned long max_times = INT64_MAX;
+            unsigned long max_times = UINT64_MAX;
 
             if (*pos == '}') {
                 max_times = min_times;
@@ -506,7 +506,7 @@ const char * llama_grammar_parser::parse_sequence(
             } else {
                 throw std::runtime_error(std::string("expecting ',' at ") + pos);
             }
-            if (min_times > MAX_REPETITION_THRESHOLD || (max_times != INT64_MAX && max_times > MAX_REPETITION_THRESHOLD)) {
+            if (min_times > MAX_REPETITION_THRESHOLD || (max_times != UINT64_MAX && max_times > MAX_REPETITION_THRESHOLD)) {
                 throw std::runtime_error(std::string("number of repetitions exceeds sane defaults, please reduce the number of repetitions"));
             }
             handle_repetitions(min_times, max_times);

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -6,9 +6,10 @@
 
 #include <cmath>
 #include <algorithm>
-#include <optional>
+#include <cstdint>
 #include <stdexcept>
 
+#define MAX_REPETITION_THRESHOLD 2000
 //
 // helpers
 //
@@ -346,7 +347,9 @@ const char * llama_grammar_parser::parse_sequence(
     size_t last_sym_start = rule.size();
     const char * pos = src;
 
-    auto handle_repetitions = [&](int min_times, int max_times) {
+    // use INT64_MAX as the empty value because we aligned to the proper unsigned long type so -1 can't be used 
+    // (though it's technically the same as -1 now)
+    auto handle_repetitions = [&](unsigned long min_times, unsigned long max_times) {
 
         if (last_sym_start == rule.size()) {
             throw std::runtime_error(std::string("expecting preceding item to */+/?/{ at ") + pos);
@@ -374,20 +377,20 @@ const char * llama_grammar_parser::parse_sequence(
             rule.resize(last_sym_start);
         } else {
             // Repeat the previous elements (min_times - 1) times
-            for (int i = 1; i < min_times; i++) {
+            for (unsigned long i = 1; i < min_times; i++) {
                 rule.insert(rule.end(), prev_rule.begin(), prev_rule.end());
             }
         }
 
         uint32_t last_rec_rule_id = 0;
-        auto n_opt = max_times < 0 ? 1 : max_times - min_times;
+        auto n_opt = max_times == INT64_MAX ? 1 : max_times - min_times;
 
         llama_grammar_rule rec_rule(prev_rule);
-        for (int i = 0; i < n_opt; i++) {
+        for (unsigned long i = 0; i < n_opt; i++) {
             rec_rule.resize(prev_rule.size());
             uint32_t rec_rule_id = generate_symbol_id( rule_name);
-            if (i > 0 || max_times < 0) {
-                rec_rule.push_back({LLAMA_GRETYPE_RULE_REF, max_times < 0 ? rec_rule_id : last_rec_rule_id});
+            if (i > 0 || max_times == INT64_MAX) {
+                rec_rule.push_back({LLAMA_GRETYPE_RULE_REF, max_times == INT64_MAX ? rec_rule_id : last_rec_rule_id});
             }
             rec_rule.push_back({LLAMA_GRETYPE_ALT, 0});
             rec_rule.push_back({LLAMA_GRETYPE_END, 0});
@@ -482,7 +485,7 @@ const char * llama_grammar_parser::parse_sequence(
             unsigned long min_times = std::stoul(std::string(pos, int_end - pos));
             pos = parse_space(int_end, is_nested);
 
-            std::optional<unsigned long> max_times = std::optional<unsigned long>();
+            unsigned long max_times = INT64_MAX;
 
             if (*pos == '}') {
                 max_times = min_times;
@@ -503,10 +506,10 @@ const char * llama_grammar_parser::parse_sequence(
             } else {
                 throw std::runtime_error(std::string("expecting ',' at ") + pos);
             }
-            if (min_times > MAX_REPETITION_THRESHOLD || (max_times.has_value() && max_times.value() > MAX_REPETITION_THRESHOLD)) {
+            if (min_times > MAX_REPETITION_THRESHOLD || (max_times != INT64_MAX && max_times > MAX_REPETITION_THRESHOLD)) {
                 throw std::runtime_error(std::string("number of repetitions exceeds sane defaults, please reduce the number of repetitions"));
             }
-            handle_repetitions(min_times, max_times.value_or(-1));
+            handle_repetitions(min_times, max_times);
         } else {
             break;
         }

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -347,7 +347,7 @@ const char * llama_grammar_parser::parse_sequence(
     size_t last_sym_start = rule.size();
     const char * pos = src;
 
-    // use INT64_MAX as the empty value because we aligned to the proper unsigned long type so -1 can't be used 
+    // use INT64_MAX as the empty value because we aligned to the proper unsigned long type so -1 can't be used
     // (though it's technically the same as -1 now)
     auto handle_repetitions = [&](unsigned long min_times, unsigned long max_times) {
 

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -7,8 +7,6 @@
 #include <string>
 #include <vector>
 
-#define MAX_REPETITION_THRESHOLD 5000
-
 struct llama_vocab;
 
 // grammar element type

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#define MAX_REPETITION_THRESHOLD 5000
+
 struct llama_vocab;
 
 // grammar element type


### PR DESCRIPTION
Limit repetitions to 5000 max, store stoul in `unsigned long`.