### PR TITLE
fix: TypeError when loading base model remotely in convert_lora_to_gguf

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -485,6 +485,7 @@ if __name__ == '__main__':
             dir_lora_model=dir_lora,
             lora_alpha=alpha,
             hparams=hparams,
+            remote_hf_model_id=base_model_id,
         )
 
         logger.info("Exporting model...")

--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -283,7 +283,7 @@ def load_hparams_from_hf(hf_model_id: str) -> tuple[dict[str, Any], Path | None]
     # normally, adapter does not come with base model config, we need to load it from AutoConfig
     config = AutoConfig.from_pretrained(hf_model_id)
     cache_dir = try_to_load_from_cache(hf_model_id, "config.json")
-    cache_dir = Path(cache_dir).parent if cache_dir is not None else None
+    cache_dir = Path(cache_dir).parent if isinstance(cache_dir, str) else None
 
     return config.to_dict(), cache_dir
 


### PR DESCRIPTION

When loading base model from Hugging Face, `dir_base_model` is `None`, causing `TypeError` in `index_tensors()`.

```python
TypeError: unsupported operand type(s) for /: 'NoneType' and 'str'
```

Passes `remote_hf_model_id` to `LoraModel` to load tensors from Hugging Face.

Related issue:

- #17350