### PR TITLE
fix: /metrics endpoint returning JSON-escaped Prometheus format

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4442,6 +4442,10 @@ struct server_res_generator : server_http_res {
         status = 200;
         data = safe_json_to_str(response_data);
     }
+    void ok(const std::string & response_data) {
+        status = 200;
+        data = response_data;
+    }
     void error(const json & error_data) {
         status = json_value(error_data, "code", 500);
         data = safe_json_to_str({{ "error", error_data }});

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -4442,10 +4442,6 @@ struct server_res_generator : server_http_res {
         status = 200;
         data = safe_json_to_str(response_data);
     }
-    void ok(const std::string & response_data) {
-        status = 200;
-        data = response_data;
-    }
     void error(const json & error_data) {
         status = json_value(error_data, "code", 500);
         data = safe_json_to_str({{ "error", error_data }});
@@ -4568,7 +4564,8 @@ public:
 
         res->headers["Process-Start-Time-Unix"] = std::to_string(res_task->t_start);
         res->content_type = "text/plain; version=0.0.4";
-        res->ok(prometheus.str());
+        res->status = 200;
+        res->data = prometheus.str();
         return res;
     };
 


### PR DESCRIPTION
The `/metrics` endpoint returns Prometheus-format text that is incorrectly JSON-escaped, causing the output to be wrapped in double quotes, which prevents Prometheus from parsing it correctly.

Related code snippets:

https://github.com/ggml-org/llama.cpp/blob/2eba631b8127a5a4853ea625a0eac4a7449bc7b8/tools/server/server.cpp#L4567

https://github.com/ggml-org/llama.cpp/blob/2eba631b8127a5a4853ea625a0eac4a7449bc7b8/tools/server/server.cpp#L4441-L4444

I added an `ok()` overload with a `std::string` parameter to fix this issue.

Related issue:
- #17384

Note: I've checked other calls to `ok()` and they all pass JSON types, so this issue won't occur elsewhere.
