### PR TITLE
[Hybrid] Create checkpoints while processing the prompt

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3418,7 +3418,6 @@ struct server_context {
                     size_t token_count = 0;
                     size_t nread = llama_state_seq_load_file(ctx, filepath.c_str(), slot->id, tokens.data(), tokens.size(), &token_count);
                     if (nread == 0) {
-                        slot->prompt.tokens.clear(); // KV may already been invalidated?
                         send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }


### PR DESCRIPTION
Currently, llama-server creates a single checkpoint after e.g. processing 600000 tokens with IBM Granite. Which will likely get erased real soon.

I have deemed this sad state of affairs insufferable, so I instructed my girl Gemini to solve the issue, and generate half of the requested checkpoints during PP.

Now it's actually usable.

Here is the result, do the needful saars.

```
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 4096, batch.n_tokens = 2048, progress = 0.235375
slot update_slots: id  0 | task 487 | n_tokens = 4096, memory_seq_rm [4096, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 2 of 256 (pos_min = 4095, pos_max = 4095, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 6144, batch.n_tokens = 2048, progress = 0.353063
slot update_slots: id  0 | task 487 | n_tokens = 6144, memory_seq_rm [6144, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 3 of 256 (pos_min = 6143, pos_max = 6143, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 8192, batch.n_tokens = 2048, progress = 0.470750
slot update_slots: id  0 | task 487 | n_tokens = 8192, memory_seq_rm [8192, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 4 of 256 (pos_min = 8191, pos_max = 8191, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 10240, batch.n_tokens = 2048, progress = 0.588438
slot update_slots: id  0 | task 487 | n_tokens = 10240, memory_seq_rm [10240, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 5 of 256 (pos_min = 10239, pos_max = 10239, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 12288, batch.n_tokens = 2048, progress = 0.706126
slot update_slots: id  0 | task 487 | n_tokens = 12288, memory_seq_rm [12288, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 6 of 256 (pos_min = 12287, pos_max = 12287, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 14336, batch.n_tokens = 2048, progress = 0.823813
slot update_slots: id  0 | task 487 | n_tokens = 14336, memory_seq_rm [14336, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 7 of 256 (pos_min = 14335, pos_max = 14335, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 16384, batch.n_tokens = 2048, progress = 0.941501
slot update_slots: id  0 | task 487 | n_tokens = 16384, memory_seq_rm [16384, end)
slot update_slots: id  0 | task 487 | created prompt processing context checkpoint 8 of 256 (pos_min = 16383, pos_max = 16383, size = 147.481 MiB)
slot update_slots: id  0 | task 487 | prompt processing progress, n_tokens = 17402, batch.n_tokens = 1018, progress = 1.000000
slot update_slots: id  0 | task 487 | prompt done, n_tokens = 17402, batch.n_tokens = 1018
...
slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.999 (> 0.100 thold), f_keep = 0.923
slot launch_slot_: id  0 | task -1 | sampler chain: logits -> logit-bias -> penalties -> dry -> top-n-sigma -> top-k -> typical -> top-p -> min-p -> xtc -> temp-ext -> dist
slot launch_slot_: id  0 | task 1886 | processing task
slot update_slots: id  0 | task 1886 | new prompt, n_ctx_slot = 300032, n_keep = 256, task.n_tokens = 17352
slot update_slots: id  0 | task 1886 | n_past = 17338, slot.prompt.tokens.size() = 18790, seq_id = 0, pos_min = 18789, n_swa = 1
slot update_slots: id  0 | task 1886 | restored context checkpoint (pos_min = 16383, pos_max = 16383, size = 147.481 MiB)
slot update_slots: id  0 | task 1886 | n_tokens = 16384, memory_seq_rm [16384, end)
slot update_slots: id  0 | task 1886 | prompt processing progress, n_tokens = 17352, batch.n_tokens = 968, progress = 1.000000
slot update_slots: id  0 | task 1886 | prompt done, n_tokens = 17352, batch.n_tokens = 968

```