### PR TITLE
docs: vulkan add GGML_VK_ALLOW_SYSMEM_FALLBACK=1 docs

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -457,6 +457,10 @@ Finally, after finishing your build, you should be able to do something like thi
 # ggml_vulkan: Using Intel(R) Graphics (ADL GT2) | uma: 1 | fp16: 1 | warp size: 32
 ```
 
+### Unified Memory
+
+The environment variable `GGML_VK_ALLOW_SYSMEM_FALLBACK=1` can be used to enable unified memory in Linux. This allows swapping to system RAM instead of crashing when the GPU VRAM is exhausted.
+
 ## CANN
 This provides NPU acceleration using the AI cores of your Ascend NPU. And [CANN](https://www.hiascend.com/en/software/cann) is a hierarchical APIs to help you to quickly build AI applications and service based on Ascend NPU.
 


### PR DESCRIPTION
I was looking for the unified memory flag for Vulkan and noticed that it was not documented, while CUDA has it already inside `build.md`. This PR documents the environment variable for easy access.