### PR TITLE
SOLVE_TRI CUDA kernel for small matrices

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -53,6 +53,7 @@
 #include "ggml-cuda/set.cuh"
 #include "ggml-cuda/set-rows.cuh"
 #include "ggml-cuda/pad_reflect_1d.cuh"
+#include "ggml-cuda/solve_tri.cuh"
 #include "ggml.h"
 
 #include <algorithm>
@@ -2717,6 +2718,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_OPT_STEP_SGD:
             ggml_cuda_opt_step_sgd(ctx, dst);
             break;
+        case GGML_OP_SOLVE_TRI:
+            ggml_cuda_op_solve_tri(ctx, dst);
+            break;
         default:
             return false;
     }
@@ -4255,6 +4259,8 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_OPT_STEP_ADAMW:
         case GGML_OP_OPT_STEP_SGD:
             return true;
+        case GGML_OP_SOLVE_TRI:
+            return op->src[0]->ne[0] <= 64 && op->src[1]->ne[0] <= 32;
         default:
             return false;
     }

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -1,0 +1,126 @@
+#include "common.cuh"
+#include "solve_tri.cuh"
+
+#include <cuda_fp16.h>
+
+#define MAX_N_FAST 64
+#define MAX_K_FAST 32
+#define WARP_SIZE 32
+
+// Warp reduction helper
+static __inline__ __device__ float warpReduceSum(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val += __shfl_down_sync(0xffffffff, val, offset);
+    }
+    return val;
+}
+
+// ======================
+// Fast Kernel (n <= 64, k <= 32) - Warp-based parallel reduction
+// ======================
+static __global__ void solve_tri_f32_fast(
+    const float* __restrict__ A,
+    const float* __restrict__ B,
+    float* __restrict__ X,
+    int n, int k,
+    int64_t ne02, int64_t ne03,
+    size_t nb02, size_t nb03,
+    size_t nb12, size_t nb13,
+    size_t nb2, size_t nb3)
+{
+    const int batch_idx = blockIdx.x;
+    const int lane      = threadIdx.x;
+    const int col_idx   = threadIdx.y;
+
+    // A block processes one batch, k warps process k columns
+    if (col_idx >= k) {
+        return;
+    }
+
+    const int64_t i03 = batch_idx / ne02;
+    const int64_t i02 = batch_idx % ne02;
+
+    const float* const A_batch = (const float*)((const char *)A + i02 * nb02 + i03 * nb03);
+    const float* const B_batch = (const float*)((const char *)B + i02 * nb12 + i03 * nb13);
+    float*             X_batch = (float*)      ((char *)X + i02 * nb2  + i03 * nb3);
+
+
+    __shared__ float sA[MAX_N_FAST * MAX_N_FAST];
+    __shared__ float sX[MAX_N_FAST * MAX_K_FAST];
+
+    // Load A into shared memory (coalesced)
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * n; i += blockDim.x * blockDim.y) {
+        sA[i] = A_batch[i];
+    }
+
+    // Load B into shared memory (coalesced)
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * k; i += blockDim.x * blockDim.y) {
+        sX[i] = B_batch[i];
+    }
+    __syncthreads();
+
+    // Each warp (32 threads with same col_idx) solves one column
+    for (int row = 0; row < n; ++row) {
+        float sum = 0.0f;
+
+        // Parallel reduction for sum
+        for (int j = lane; j < row; j += WARP_SIZE) {
+            sum += sA[row * n + j] * sX[j * k + col_idx];
+        }
+
+        sum = warpReduceSum(sum);
+
+        // Lane 0 computes and stores the final result for the current row
+        if (lane == 0) {
+            const float b_val = sX[row * k + col_idx]; // Value from B
+            const float a_diag = sA[row * n + row];
+            if (a_diag != 0.0f) {
+                sX[row * k + col_idx] = (b_val - sum) / a_diag;
+            } else {
+                sX[row * k + col_idx] = 0.0f; // Avoid division by zero
+            }
+        }
+        // Sync threads in block to make sure the result of sX is visible to all threads for the next row
+        __syncthreads();
+    }
+
+    // Write results from shared memory to global memory (coalesced)
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * k; i += blockDim.x * blockDim.y) {
+        X_batch[i] = sX[i];
+    }
+}
+
+// Launcher
+static void solve_tri_f32_cuda(
+    const float* A, const float* B, float* X,
+    int n, int k,
+    int64_t ne02, int64_t ne03,
+    size_t nb02, size_t nb03,
+    size_t nb12, size_t nb13,
+    size_t nb2, size_t nb3,
+    cudaStream_t stream)
+{
+    // n <= 64, k <= 32
+    dim3 threads(WARP_SIZE, k);
+    dim3 grid(ne02 * ne03);
+    solve_tri_f32_fast<<<grid, threads, 0, stream>>>(
+        A, B, X, n, k, ne02, ne03, nb02, nb03, nb12, nb13, nb2, nb3);
+}
+
+void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor* src0 = dst->src[0]; // A
+    const ggml_tensor* src1 = dst->src[1]; // B
+
+    const int64_t n = src0->ne[0];
+    const int64_t k = src1->ne[0];
+
+    solve_tri_f32_cuda(
+        (const float*)src0->data, (const float*)src1->data, (float*)dst->data,
+        n, k,
+        src0->ne[2], src0->ne[3],
+        src0->nb[2], src0->nb[3],
+        src1->nb[2], src1->nb[3],
+        dst->nb[2], dst->nb[3],
+        ctx.stream()
+    );
+}

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -135,37 +135,48 @@ static void solve_tri_f32_cuda(
     dim3 threads(WARP_SIZE, k);
     dim3 grid(ne02 * ne03);
     if (n == 64) {
-        if (k == 32) {
+        switch (k) {
+            case 32:
             solve_tri_f32_fast<64, 32><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 16) {
+            break;
+            case 16:
             solve_tri_f32_fast<64, 16><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 14) {
+            break;
+            case 14:
             solve_tri_f32_fast<64, 14><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 12) {
+            break;
+            case 12:
             solve_tri_f32_fast<64, 12><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 10) {
+            break;
+            case 10:
             solve_tri_f32_fast<64, 10><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 8) {
+            break;
+            case 8:
             solve_tri_f32_fast<64, 8><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 6) {
+            break;
+            case 6:
             solve_tri_f32_fast<64, 6><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 4) {
+            break;
+            case 4:
             solve_tri_f32_fast<64, 4><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 2) {
+            break;
+            case 2:
             solve_tri_f32_fast<64, 2><<<grid, threads, 0, stream>>>(
                 A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-        } else if (k == 1) {
+            break;
+            case 1:
             solve_tri_f32_fast<64, 1><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3,0, 0);
-        } else {
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+            default:
             solve_tri_f32_fast<0, 0><<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
         }
     } else { // run general case

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -1,33 +1,22 @@
 #include "common.cuh"
+#include "ggml.h"
 #include "solve_tri.cuh"
-
-#include <cuda_fp16.h>
 
 #define MAX_N_FAST 64
 #define MAX_K_FAST 32
-#define WARP_SIZE 32
-
-// Warp reduction helper
-static __inline__ __device__ float warpReduceSum(float val) {
-    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
-        val += __shfl_down_sync(0xffffffff, val, offset);
-    }
-    return val;
-}
 
 // ======================
 // Fast Kernel (n <= 64, k <= 32) - Warp-based parallel reduction
 // ======================
+template <int n, int k>
 static __global__ void solve_tri_f32_fast(
     const float* __restrict__ A,
     const float* __restrict__ B,
     float* __restrict__ X,
-    int n, int k,
-    int64_t ne02, int64_t ne03,
-    size_t nb02, size_t nb03,
-    size_t nb12, size_t nb13,
-    size_t nb2, size_t nb3)
-{
+    const int64_t ne02,
+    const size_t nb02, const size_t nb03,
+    const size_t nb12, const size_t nb13,
+    const size_t nb2, const size_t nb3) {
     const int batch_idx = blockIdx.x;
     const int lane      = threadIdx.x;
     const int col_idx   = threadIdx.y;
@@ -68,7 +57,7 @@ static __global__ void solve_tri_f32_fast(
             sum += sA[row * n + j] * sX[j * k + col_idx];
         }
 
-        sum = warpReduceSum(sum);
+        sum = warp_reduce_sum(sum);
 
         // Lane 0 computes and stores the final result for the current row
         if (lane == 0) {
@@ -90,6 +79,80 @@ static __global__ void solve_tri_f32_fast(
     }
 }
 
+static __global__ void solve_tri_f32_fast_general(
+    const float* __restrict__ A,
+    const float* __restrict__ B,
+    float* __restrict__ X,
+    const int64_t ne02,
+    const size_t nb02, const size_t nb03,
+    const size_t nb12, const size_t nb13,
+    const size_t nb2, const size_t nb3,
+    const int n, const int k) {
+    const int batch_idx = blockIdx.x;
+    const int lane      = threadIdx.x;
+    const int col_idx   = threadIdx.y;
+
+    // A block processes one batch, k warps process k columns
+    if (col_idx >= k) {
+        return;
+    }
+
+    const int64_t i03 = batch_idx / ne02;
+    const int64_t i02 = batch_idx % ne02;
+
+    const float* const A_batch = (const float*)((const char *)A + i02 * nb02 + i03 * nb03);
+    const float* const B_batch = (const float*)((const char *)B + i02 * nb12 + i03 * nb13);
+    float*             X_batch = (float*)      ((char *)X + i02 * nb2  + i03 * nb3);
+
+    __shared__ float sA[MAX_N_FAST * MAX_N_FAST];
+    __shared__ float sX[MAX_N_FAST * MAX_K_FAST];
+
+    // Load A into shared memory (coalesced)
+    #pragma unroll
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * n; i += blockDim.x * blockDim.y) {
+        sA[i] = A_batch[i];
+    }
+
+    // Load B into shared memory (coalesced)
+    #pragma unroll
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * k; i += blockDim.x * blockDim.y) {
+        sX[i] = B_batch[i];
+    }
+    __syncthreads();
+
+    // Each warp (32 threads with same col_idx) solves one column
+    for (int row = 0; row < n; ++row) {
+        float sum = 0.0f;
+
+        // Parallel reduction for sum
+        for (int j = lane; j < row; j += WARP_SIZE) {
+            sum += sA[row * n + j] * sX[j * k + col_idx];
+        }
+
+        sum = warp_reduce_sum(sum);
+
+        // Lane 0 computes and stores the final result for the current row
+        if (lane == 0) {
+            const float b_val = sX[row * k + col_idx]; // Value from B
+            const float a_diag = sA[row * n + row];
+            if (a_diag != 0.0f) {
+                sX[row * k + col_idx] = (b_val - sum) / a_diag;
+            } else {
+                sX[row * k + col_idx] = 0.0f; // Avoid division by zero
+            }
+        }
+        // Sync threads in block to make sure the result of sX is visible to all threads for the next row
+        __syncthreads();
+    }
+
+    // Write results from shared memory to global memory (coalesced)
+    #pragma unroll
+    for (int i = threadIdx.x + threadIdx.y * blockDim.x; i < n * k; i += blockDim.x * blockDim.y) {
+        X_batch[i] = sX[i];
+    }
+}
+
+
 // Launcher
 static void solve_tri_f32_cuda(
     const float* A, const float* B, float* X,
@@ -103,16 +166,57 @@ static void solve_tri_f32_cuda(
     // n <= 64, k <= 32
     dim3 threads(WARP_SIZE, k);
     dim3 grid(ne02 * ne03);
-    solve_tri_f32_fast<<<grid, threads, 0, stream>>>(
-        A, B, X, n, k, ne02, ne03, nb02, nb03, nb12, nb13, nb2, nb3);
+    if (n == 64) {
+        if (k == 32) {
+            solve_tri_f32_fast<64, 32><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 16) {
+            solve_tri_f32_fast<64, 16><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 14) {
+            solve_tri_f32_fast<64, 14><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 12) {
+            solve_tri_f32_fast<64, 12><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 10) {
+            solve_tri_f32_fast<64, 10><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 8) {
+            solve_tri_f32_fast<64, 8><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 6) {
+            solve_tri_f32_fast<64, 6><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 4) {
+            solve_tri_f32_fast<64, 4><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 2) {
+            solve_tri_f32_fast<64, 2><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else if (k == 1) {
+            solve_tri_f32_fast<64, 1><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3);
+        } else {
+            solve_tri_f32_fast_general<<<grid, threads, 0, stream>>>(A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+        }
+    } else { // run general case
+        solve_tri_f32_fast_general<<<grid, threads, 0, stream>>>(A, B, X, ne02, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+    }
 }
 
 void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor* src0 = dst->src[0]; // A
     const ggml_tensor* src1 = dst->src[1]; // B
 
+    ggml_is_contiguous(src0);
+    ggml_is_contiguous(src1);
+
     const int64_t n = src0->ne[0];
     const int64_t k = src1->ne[0];
+
+    GGML_ASSERT(n <= 64);
+    GGML_ASSERT(k <= 32);
 
     solve_tri_f32_cuda(
         (const float*)src0->data, (const float*)src1->data, (float*)dst->data,

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -9,15 +9,18 @@
 // Fast Kernel (n <= 64, k <= 32) - Warp-based parallel reduction
 // ======================
 template <int N, int K>
-static __global__ void solve_tri_f32_fast(
-    const float* __restrict__ A,
-    const float* __restrict__ B,
-    float* __restrict__ X,
-    const uint3 ne02,
-    const size_t nb02, const size_t nb03,
-    const size_t nb12, const size_t nb13,
-    const size_t nb2, const size_t nb3,
-    int n, int k) {
+static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
+                                          const float * __restrict__ B,
+                                          float * __restrict__ X,
+                                          const uint3  ne02,
+                                          const size_t nb02,
+                                          const size_t nb03,
+                                          const size_t nb12,
+                                          const size_t nb13,
+                                          const size_t nb2,
+                                          const size_t nb3,
+                                          int          n,
+                                          int          k) {
     const int batch_idx = blockIdx.x;
     const int lane      = threadIdx.x;
     const int col_idx   = threadIdx.y;
@@ -32,14 +35,13 @@ static __global__ void solve_tri_f32_fast(
         }
     }
 
-    const uint2 i02_i03 = fast_div_modulo(batch_idx, ne02);
-    const int64_t i02 = i02_i03.y;
-    const int64_t i03 = i02_i03.x;
+    const uint2   i02_i03 = fast_div_modulo(batch_idx, ne02);
+    const int64_t i02     = i02_i03.y;
+    const int64_t i03     = i02_i03.x;
 
-    const float* const A_batch = (const float*)((const char *)A + i02 * nb02 + i03 * nb03);
-    const float* const B_batch = (const float*)((const char *)B + i02 * nb12 + i03 * nb13);
-    float*             X_batch = (float*)      ((char *)X + i02 * nb2  + i03 * nb3);
-
+    const float * const A_batch = (const float *) ((const char *) A + i02 * nb02 + i03 * nb03);
+    const float * const B_batch = (const float *) ((const char *) B + i02 * nb12 + i03 * nb13);
+    float *             X_batch = (float *) ((char *) X + i02 * nb2 + i03 * nb3);
 
     __shared__ float sA[MAX_N_FAST * MAX_N_FAST];
     __shared__ float sX[MAX_N_FAST * MAX_K_FAST];
@@ -87,20 +89,20 @@ static __global__ void solve_tri_f32_fast(
 
         if (lane == 0) {
             if constexpr (K == 0) {
-                const float b_val = sX[row * k + col_idx]; // Value from B
+                const float b_val  = sX[row * k + col_idx];  // Value from B
                 const float a_diag = sA[row * n + row];
                 if (a_diag != 0.0f) {
                     sX[row * k + col_idx] = (b_val - sum) / a_diag;
                 } else {
-                    sX[row * k + col_idx] = 0.0f; // Avoid division by zero
+                    sX[row * k + col_idx] = 0.0f;  // Avoid division by zero
                 }
             } else {
-                const float b_val = sX[row * K + col_idx]; // Value from B
+                const float b_val  = sX[row * K + col_idx];  // Value from B
                 const float a_diag = sA[row * N + row];
                 if (a_diag != 0.0f) {
                     sX[row * K + col_idx] = (b_val - sum) / a_diag;
                 } else {
-                    sX[row * K + col_idx] = 0.0f; // Avoid division by zero
+                    sX[row * K + col_idx] = 0.0f;  // Avoid division by zero
                 }
             }
         }
@@ -114,79 +116,86 @@ static __global__ void solve_tri_f32_fast(
     } else {
 #pragma unroll
         for (int i = 0; i < N * K; i += K * WARP_SIZE) {
-            const int i0 = i + threadIdx.x + threadIdx.y*blockDim.x;
-            X_batch[i0] = sX[i0];
+            const int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
+            X_batch[i0]  = sX[i0];
         }
     }
 }
 
 // Launcher
-static void solve_tri_f32_cuda(
-    const float* A, const float* B, float* X,
-    int n, int k,
-    int64_t ne02, int64_t ne03,
-    size_t nb02, size_t nb03,
-    size_t nb12, size_t nb13,
-    size_t nb2, size_t nb3,
-    cudaStream_t stream)
-{
+static void solve_tri_f32_cuda(const float * A,
+                               const float * B,
+                               float *       X,
+                               int           n,
+                               int           k,
+                               int64_t       ne02,
+                               int64_t       ne03,
+                               size_t        nb02,
+                               size_t        nb03,
+                               size_t        nb12,
+                               size_t        nb13,
+                               size_t        nb2,
+                               size_t        nb3,
+                               cudaStream_t  stream) {
     // n <= 64, k <= 32
     const uint3 ne02_fd = init_fastdiv_values((uint32_t) ne02);
-    dim3 threads(WARP_SIZE, k);
-    dim3 grid(ne02 * ne03);
+    dim3        threads(WARP_SIZE, k);
+    dim3        grid(ne02 * ne03);
     if (n == 64) {
         switch (k) {
             case 32:
-            solve_tri_f32_fast<64, 32><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 32>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 16:
-            solve_tri_f32_fast<64, 16><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 16>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 14:
-            solve_tri_f32_fast<64, 14><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 14>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 12:
-            solve_tri_f32_fast<64, 12><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 12>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 10:
-            solve_tri_f32_fast<64, 10><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 10>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 8:
-            solve_tri_f32_fast<64, 8><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 8>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 6:
-            solve_tri_f32_fast<64, 6><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 6>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 4:
-            solve_tri_f32_fast<64, 4><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 4>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 2:
-            solve_tri_f32_fast<64, 2><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 2>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             case 1:
-            solve_tri_f32_fast<64, 1><<<grid, threads, 0, stream>>>(
-                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-            break;
+                solve_tri_f32_fast<64, 1>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+                break;
             default:
-            solve_tri_f32_fast<0, 0><<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+                solve_tri_f32_fast<0, 0>
+                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
         }
-    } else { // run general case
-        solve_tri_f32_fast<0, 0><<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+    } else {  // run general case
+        solve_tri_f32_fast<0, 0>
+            <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
     }
 }
 
 void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
-    const ggml_tensor* src0 = dst->src[0]; // A
-    const ggml_tensor* src1 = dst->src[1]; // B
+    const ggml_tensor * src0 = dst->src[0];  // A
+    const ggml_tensor * src1 = dst->src[1];  // B
 
     ggml_is_contiguous(src0);
     ggml_is_contiguous(src1);
@@ -197,13 +206,7 @@ void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
     GGML_ASSERT(n <= 64);
     GGML_ASSERT(k <= 32);
 
-    solve_tri_f32_cuda(
-        (const float*)src0->data, (const float*)src1->data, (float*)dst->data,
-        n, k,
-        src0->ne[2], src0->ne[3],
-        src0->nb[2], src0->nb[3],
-        src1->nb[2], src1->nb[3],
-        dst->nb[2], dst->nb[3],
-        ctx.stream()
-    );
+    solve_tri_f32_cuda((const float *) src0->data, (const float *) src1->data, (float *) dst->data, n, k, src0->ne[2],
+                       src0->ne[3], src0->nb[2], src0->nb[3], src1->nb[2], src1->nb[3], dst->nb[2], dst->nb[3],
+                       ctx.stream());
 }

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -61,7 +61,7 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
 
 #pragma unroll
     for (int i = 0; i < n * (k + 1); i += k * WARP_SIZE) {
-        int i0 = i + batch_idx + lane * col_idx;
+        int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
         if (i0 < n * k) {
             sX[i0] = B_batch[i0];
         }

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -8,43 +8,40 @@
 // ======================
 // Fast Kernel (n <= 64, k <= 32) - Warp-based parallel reduction
 // ======================
-// When ncols_template == 0 the bounds for the loops in this function are not known and can't be unrolled.
-// As we want to keep pragma unroll for all other cases we supress the clang transformation warning here.
+// When ncols_template == 0 the bounds for the loops in this function are not
+// known and can't be unrolled. As we want to keep pragma unroll for all other
+// cases we supress the clang transformation warning here.
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpass-failed"
 #endif // __clang__
 template <int n_template, int k_template>
-static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
-                                          const float * __restrict__ B,
-                                          float * __restrict__ X,
-                                          const uint3  ne02,
-                                          const size_t nb02,
-                                          const size_t nb03,
-                                          const size_t nb12,
-                                          const size_t nb13,
-                                          const size_t nb2,
-                                          const size_t nb3,
-                                          const int    n_arg,
-                                          const int    k_arg) {
+static __global__ void
+solve_tri_f32_fast(const float *__restrict__ A, const float *__restrict__ B,
+                   float *__restrict__ X, const uint3 ne02, const size_t nb02,
+                   const size_t nb03, const size_t nb12, const size_t nb13,
+                   const size_t nb2, const size_t nb3, const int n_arg,
+                   const int k_arg) {
     const int n = n_template == 0 ? n_arg : n_template;
     const int k = k_template == 0 ? k_arg : k_template;
 
     const int batch_idx = blockIdx.x;
-    const int lane      = threadIdx.x;
-    const int col_idx   = threadIdx.y;
+    const int lane = threadIdx.x;
+    const int col_idx = threadIdx.y;
 
     if (col_idx >= k) {
         return;
     }
 
-    const uint2   i02_i03 = fast_div_modulo(batch_idx, ne02);
-    const int64_t i02     = i02_i03.y;
-    const int64_t i03     = i02_i03.x;
+    const uint2 i02_i03 = fast_div_modulo(batch_idx, ne02);
+    const int64_t i02 = i02_i03.y;
+    const int64_t i03 = i02_i03.x;
 
-    const float * const A_batch = (const float *) ((const char *) A + i02 * nb02 + i03 * nb03);
-    const float * const B_batch = (const float *) ((const char *) B + i02 * nb12 + i03 * nb13);
-    float *             X_batch = (float *) ((char *) X + i02 * nb2 + i03 * nb3);
+    const float *const A_batch =
+        (const float *)(A + i02 * nb02 / sizeof(float) + i03 * nb03 / sizeof(float));
+    const float *const B_batch =
+        (const float *)(B + i02 * nb12 / sizeof(float) + i03 * nb13 / sizeof(float));
+    float *X_batch = (float *)(X + i02 * nb2 / sizeof(float) + i03 * nb3 / sizeof(float));
 
     __shared__ float sA[MAX_N_FAST * MAX_N_FAST];
     __shared__ float sXt[MAX_N_FAST * (MAX_K_FAST + 1)];
@@ -59,13 +56,13 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
         }
     }
 
-const int rows_per_warp = (n + WARP_SIZE - 1) / WARP_SIZE;
+    const int rows_per_warp = (n + WARP_SIZE - 1) / WARP_SIZE;
 
 #pragma unroll
     for (int i = 0; i < rows_per_warp; i++) {
         const int i0 = lane + i * WARP_SIZE;
         if (i0 < n) {
-            sXt[col_idx * n + i0] = B_batch[i0 * k +  col_idx];
+            sXt[col_idx * n + i0] = B_batch[i0 * k + col_idx];
         }
     }
 
@@ -76,14 +73,14 @@ const int rows_per_warp = (n + WARP_SIZE - 1) / WARP_SIZE;
         float sum = 0.0f;
 
         // First warp
-            {
+        {
             int j = lane;
             if (j < row) {
                 sum += sA[row * n + j] * sXt[col_idx * n + j];
             }
         }
         // Second warp
-            if (row >= WARP_SIZE) {
+        if (row >= WARP_SIZE) {
             int j = WARP_SIZE + lane;
             if (j < row) {
                 sum += sA[row * n + j] * sXt[col_idx * n + j];
@@ -95,7 +92,8 @@ const int rows_per_warp = (n + WARP_SIZE - 1) / WARP_SIZE;
         if (lane == 0) {
             const float b_val = sXt[col_idx * n + row];
             const float a_diag = sA[row * n + row];
-            // no safeguards for division by zero because that indicates corrupt data anyway
+            // no safeguards for division by zero because that indicates corrupt
+            // data anyway
             sXt[col_idx * n + row] = (b_val - sum) / a_diag;
         }
     }
@@ -115,79 +113,69 @@ const int rows_per_warp = (n + WARP_SIZE - 1) / WARP_SIZE;
 #endif // __clang__
 
 // Launcher
-static void solve_tri_f32_cuda(const float * A,
-                               const float * B,
-                               float *       X,
-                               int           n,
-                               int           k,
-                               int64_t       ne02,
-                               int64_t       ne03,
-                               size_t        nb02,
-                               size_t        nb03,
-                               size_t        nb12,
-                               size_t        nb13,
-                               size_t        nb2,
-                               size_t        nb3,
-                               cudaStream_t  stream) {
+static void solve_tri_f32_cuda(const float *A, const float *B, float *X, int n,
+                               int k, int64_t ne02, int64_t ne03, size_t nb02,
+                               size_t nb03, size_t nb12, size_t nb13,
+                               size_t nb2, size_t nb3, cudaStream_t stream) {
     // n <= 64, k <= 32
-    const uint3 ne02_fd = init_fastdiv_values((uint32_t) ne02);
-    dim3        threads(WARP_SIZE, k);
-    dim3        grid(ne02 * ne03);
+    const uint3 ne02_fd = init_fastdiv_values((uint32_t)ne02);
+    dim3 threads(WARP_SIZE, k);
+    dim3 grid(ne02 * ne03);
     if (n == 64) {
         switch (k) {
-            case 32:
-                solve_tri_f32_fast<64, 32>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 16:
-                solve_tri_f32_fast<64, 16>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 14:
-                solve_tri_f32_fast<64, 14>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 12:
-                solve_tri_f32_fast<64, 12>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 10:
-                solve_tri_f32_fast<64, 10>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 8:
-                solve_tri_f32_fast<64, 8>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 6:
-                solve_tri_f32_fast<64, 6>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 4:
-                solve_tri_f32_fast<64, 4>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 2:
-                solve_tri_f32_fast<64, 2>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            case 1:
-                solve_tri_f32_fast<64, 1>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
-                break;
-            default:
-                solve_tri_f32_fast<0, 0>
-                    <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+        case 32:
+            solve_tri_f32_fast<64, 32><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 16:
+            solve_tri_f32_fast<64, 16><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 14:
+            solve_tri_f32_fast<64, 14><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 12:
+            solve_tri_f32_fast<64, 12><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 10:
+            solve_tri_f32_fast<64, 10><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 8:
+            solve_tri_f32_fast<64, 8><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 6:
+            solve_tri_f32_fast<64, 6><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 4:
+            solve_tri_f32_fast<64, 4><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 2:
+            solve_tri_f32_fast<64, 2><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        case 1:
+            solve_tri_f32_fast<64, 1><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, 0, 0);
+            break;
+        default:
+            solve_tri_f32_fast<0, 0><<<grid, threads, 0, stream>>>(
+                A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
         }
-    } else {  // run general case
-        solve_tri_f32_fast<0, 0>
-            <<<grid, threads, 0, stream>>>(A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
+    } else { // run general case
+        solve_tri_f32_fast<0, 0><<<grid, threads, 0, stream>>>(
+            A, B, X, ne02_fd, nb02, nb03, nb12, nb13, nb2, nb3, n, k);
     }
 }
 
-void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
-    const ggml_tensor * src0 = dst->src[0];  // A
-    const ggml_tensor * src1 = dst->src[1];  // B
+void ggml_cuda_op_solve_tri(ggml_backend_cuda_context &ctx, ggml_tensor *dst) {
+    const ggml_tensor *src0 = dst->src[0]; // A
+    const ggml_tensor *src1 = dst->src[1]; // B
 
     ggml_is_contiguous(src0);
     ggml_is_contiguous(src1);
@@ -198,7 +186,8 @@ void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
     GGML_ASSERT(n <= 64);
     GGML_ASSERT(k <= 32);
 
-    solve_tri_f32_cuda((const float *) src0->data, (const float *) src1->data, (float *) dst->data, n, k, src0->ne[2],
-                       src0->ne[3], src0->nb[2], src0->nb[3], src1->nb[2], src1->nb[3], dst->nb[2], dst->nb[3],
-                       ctx.stream());
+    solve_tri_f32_cuda((const float *)src0->data, (const float *)src1->data,
+                       (float *)dst->data, n, k, src0->ne[2], src0->ne[3],
+                       src0->nb[2], src0->nb[3], src1->nb[2], src1->nb[3],
+                       dst->nb[2], dst->nb[3], ctx.stream());
 }

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -60,13 +60,17 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
 #pragma unroll
         for (int i = 0; i < N * N; i += K * WARP_SIZE) {
             int i0 = i + offset;
-            sA[i0] = A_batch[i0];
+            if (i0 < N * N) {
+                sA[i0] = A_batch[i0];
+            }
         }
 
 #pragma unroll
         for (int i = 0; i < N * K; i += K * WARP_SIZE) {
             int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
-            sX[i0] = B_batch[i0];
+            if (i0 < N * K) {
+                sX[i0] = B_batch[i0];
+            }
         }
     }
 
@@ -117,7 +121,9 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
 #pragma unroll
         for (int i = 0; i < N * K; i += K * WARP_SIZE) {
             const int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
-            X_batch[i0]  = sX[i0];
+            if (i0 < N * K) {
+                X_batch[i0]  = sX[i0];
+            }
         }
     }
 }

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -40,14 +40,12 @@ static __global__ void solve_tri_f32_fast(
 
     const int offset = threadIdx.x + threadIdx.y * blockDim.x;
     // Load A into shared memory (coalesced)
-#pragma unroll
     for (int i = 0; i < n * n; i += k * WARP_SIZE) {
         int i0 = i + offset;
         sA[i0] = A_batch[i0];
     }
 
     // Load B into shared memory (coalesced)
-#pragma unroll
     for (int i = 0; i < n * k; i += k * WARP_SIZE) {
         int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
         sX[i0] = B_batch[i0];

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -61,7 +61,7 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
 
 #pragma unroll
     for (int i = 0; i < n * (k + 1); i += k * WARP_SIZE) {
-        int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
+        int i0 = i + offset;
         if (i0 < n * k) {
             sX[i0] = B_batch[i0];
         }
@@ -86,12 +86,13 @@ static __global__ void solve_tri_f32_fast(const float * __restrict__ A,
             // no safeguards for division by zero because that indicates corrupt data anyway
             sX[row * k + col_idx] = (b_val - sum) / a_diag;
         }
-        __syncthreads();
     }
+
+    __syncthreads();
 
 #pragma unroll
     for (int i = 0; i < n * k; i += k * WARP_SIZE) {
-        const int i0 = i + threadIdx.x + threadIdx.y * blockDim.x;
+        const int i0 = i + offset;
         if (i0 < n * k) {
             X_batch[i0]  = sX[i0];
         }

--- a/ggml/src/ggml-cuda/solve_tri.cuh
+++ b/ggml/src/ggml-cuda/solve_tri.cuh
@@ -1,0 +1,5 @@
+#include "common.cuh"
+
+#define CUDA_SOLVE_TRI_BLOCK_SIZE 256
+
+void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/solve_tri.cuh
+++ b/ggml/src/ggml-cuda/solve_tri.cuh
@@ -1,5 +1,3 @@
 #include "common.cuh"
 
-#define CUDA_SOLVE_TRI_BLOCK_SIZE 256
-
 void ggml_cuda_op_solve_tri(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7809,6 +7809,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F32, 16416, 1, 128, {8,  1}, {4, 1}, {0, 2, 1, 3}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F32, 128, 1, 16416, {8,  1}, {4, 1}, {0, 1, 2, 3}, 2*16416));
 
+    test_cases.emplace_back(new test_solve_tri(GGML_TYPE_F32, { 64, 64, 4, 2 }, { 6, 64, 4, 2 }));
+    test_cases.emplace_back(new test_solve_tri(GGML_TYPE_F32, { 128, 128, 4, 1 }, { 8, 128, 4, 1 }));
+
     for (int bs : {1, 2, 3, 4, 5, 8, 512}) {
         for (ggml_type type_a : all_types) {
             for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
I've managed to actually poke enough LLMs in the correct direction to end up with this:

CPU:
```console
  SOLVE_TRI(type=f32,ne_lhs=[64,64,4,2],ne_rhs=[6,64,4,2]):                    32760 runs -    37.34 us/run -      152 kB/run -    3.88 GB/s
```

CUDA:
```console
  SOLVE_TRI(type=f32,ne_lhs=[64,64,4,2],ne_rhs=[6,64,4,2]):                    49140 runs -    22.52 us/run -      152 kB/run -    6.44 GB/s
```

This can most certainly be improved by someone who knows what they're doing, but at least it does the bare minimum by supplying a CUDA kernel that's around twice as fast as the optimized CPU implementation.