### PR TITLE
Typo in json.gbnf

### DIFF
--- a/grammars/json.gbnf
+++ b/grammars/json.gbnf
@@ -19,7 +19,7 @@ string ::=
     "\\" (["\\bfnrt] | "u" [0-9a-fA-F]{4}) # escapes
   )* "\"" ws
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9] [1-9]{0,15})? ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [1-9] [0-9]{0,15})? ws
 
 # Optional space: by convention, applied in this grammar after literal chars when allowed
 ws ::= | " " | "\n" [ \t]{0,20}


### PR DESCRIPTION
Small fix for typo in the number rule:
> `[eE] [-+]? [0-9] [1-9]{0,15}`

This would allow one leading zero and no trailing zeros; e.g. forbidding `e+10`, `e+100` etc. I assume the reverse was intended
