### PR TITLE
ci : skip winget update when not in ggml-org

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,6 +9,7 @@ jobs:
   update:
     name: Update Winget Package
     runs-on: ubuntu-latest
+    if: ${{ github.repository.owner.login == 'ggml-org' }}
 
     steps:
       - name: Install cargo binstall


### PR DESCRIPTION
Prevent forks from generating daily failure notifications.