### PR TITLE
tests: Avoid floating point precision false positives in SUM

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -5348,7 +5348,7 @@ struct test_sum : public test_case {
     // Don't center the distribution around zero. Helps to avoid catastrophic cancellation.
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
-            init_tensor_uniform(t, -0.5f, 1.5f);
+            init_tensor_uniform(t, -0.9f, 1.1f);
         }
     }
 };
@@ -5416,6 +5416,13 @@ struct test_mean : public test_case {
 
     float grad_eps() override {
         return 0.1f * ne[0]*ne[1]*ne[2]*ne[3];
+    }
+
+    // Don't center the distribution around zero. Helps to avoid catastrophic cancellation.
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            init_tensor_uniform(t, -0.9f, 1.1f);
+        }
     }
 };
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -5344,6 +5344,13 @@ struct test_sum : public test_case {
     float grad_eps() override {
         return 0.1f * sqrtf(ne[0]*ne[1]*ne[2]*ne[3]);
     }
+
+    // Don't center the distribution around zero. Helps to avoid catastrophic cancellation.
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            init_tensor_uniform(t, -0.5f, 1.5f);
+        }
+    }
 };
 
 // GGML_OP_SUM_ROWS


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/pull/17413#issuecomment-3569680359

This was easily reproducible with both Vulkan and CUDA backends by running the tests in a loop, and is a floating point precision issue. With catastrophic cancellation I could even see some very large errors like:

```
[SUM] NMSE = 0.000918274 > 0.000000100     0 -0.000063 -0.000061, diff = -0.000002
```

Changing the input distribution to not be centered around zero seems to workaround the issue.