### PR TITLE
ggml-cpu : add runtime rvv detection

### DIFF
--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -99,6 +99,7 @@ extern "C" {
     GGML_BACKEND_API int ggml_cpu_has_sme        (void);
     // other
     GGML_BACKEND_API int ggml_cpu_has_riscv_v    (void);
+    GGML_BACKEND_API int ggml_cpu_get_riscv_vlen (void);
     GGML_BACKEND_API int ggml_cpu_has_vsx        (void);
     GGML_BACKEND_API int ggml_cpu_has_vxe        (void);
     GGML_BACKEND_API int ggml_cpu_has_wasm_simd  (void);

--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -442,6 +442,7 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
         list(APPEND GGML_CPU_SOURCES
             ggml-cpu/arch/riscv/quants.c
             ggml-cpu/arch/riscv/repack.cpp
+            ggml-cpu/arch/riscv/rvv-init.cpp
             )
         if (GGML_CPU_RISCV64_SPACEMIT)
             target_compile_definitions(${GGML_CPU_NAME} PRIVATE GGML_USE_CPU_RISCV64_SPACEMIT ${RISCV64_SPACEMIT_IME_SPEC})

--- a/ggml/src/ggml-cpu/arch/riscv/cpu-feats.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/cpu-feats.cpp
@@ -1,4 +1,16 @@
+#include <algorithm>
+
 #include "ggml-backend-impl.h"
+#include "ggml-cpu.h"
+
+// static kernel selection for fixed-length kernels
+static int ggml_get_riscv_v_kernel_idx() {
+    int vlen = ggml_cpu_get_riscv_vlen();
+    vlen = std::min(vlen, 256);
+    return vlen / 128;
+}
+
+extern "C" int kernel_idx = ggml_get_riscv_v_kernel_idx();
 
 #if defined(__riscv) && __riscv_xlen == 64
 #include <sys/auxv.h>

--- a/ggml/src/ggml-cpu/arch/riscv/cpu-feats.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/cpu-feats.cpp
@@ -1,16 +1,4 @@
-#include <algorithm>
-
 #include "ggml-backend-impl.h"
-#include "ggml-cpu.h"
-
-// static kernel selection for fixed-length kernels
-static int ggml_get_riscv_v_kernel_idx() {
-    int vlen = ggml_cpu_get_riscv_vlen();
-    vlen = std::min(vlen, 256);
-    return vlen / 128;
-}
-
-extern "C" int kernel_idx = ggml_get_riscv_v_kernel_idx();
 
 #if defined(__riscv) && __riscv_xlen == 64
 #include <sys/auxv.h>

--- a/ggml/src/ggml-cpu/arch/riscv/quants.c
+++ b/ggml/src/ggml-cpu/arch/riscv/quants.c
@@ -24,8 +24,8 @@
 
 #define UNUSED GGML_UNUSED
 
-// defined in cpu-feats.cpp
-extern int kernel_idx;
+// defined in rvv-init.cpp
+extern int ggml_rvv_kernel_idx;
 
 void quantize_row_q8_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
     assert(QK8_0 == 32);
@@ -754,7 +754,7 @@ void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const voi
     static _Atomic ggml_vec_dot_t func_ptr = NULL;
     ggml_vec_dot_t func = atomic_load_explicit(&func_ptr, memory_order_relaxed);
     if (func == NULL) {
-        func = func_table[kernel_idx];
+        func = func_table[ggml_rvv_kernel_idx];
         atomic_compare_exchange_strong_explicit(&func_ptr, &(ggml_vec_dot_t){NULL}, func, memory_order_relaxed, memory_order_relaxed);
     }
 

--- a/ggml/src/ggml-cpu/arch/riscv/rvv-init.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/rvv-init.cpp
@@ -1,0 +1,11 @@
+#include <algorithm>
+#include "ggml-cpu.h"
+
+// static kernel selection for fixed-length kernels
+static int ggml_get_riscv_v_kernel_idx() {
+    int vlen = ggml_cpu_get_riscv_vlen();
+    vlen = std::min(vlen, 256);
+    return vlen / 128;
+}
+
+extern "C" int ggml_rvv_kernel_idx = ggml_get_riscv_v_kernel_idx();

--- a/ggml/src/ggml-cpu/arch/riscv/rvv-init.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/rvv-init.cpp
@@ -8,4 +8,6 @@ static int ggml_get_riscv_v_kernel_idx() {
     return vlen / 128;
 }
 
-extern "C" int ggml_rvv_kernel_idx = ggml_get_riscv_v_kernel_idx();
+extern "C" {
+    int ggml_rvv_kernel_idx = ggml_get_riscv_v_kernel_idx();
+}

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -50,6 +50,19 @@
 #include "llamafile/sgemm.h"
 #endif
 
+#if defined(__riscv)
+#if defined(__riscv_v_intrinsic)
+#include <riscv_vector.h>
+#endif
+#if defined(__linux__)
+#include <sys/auxv.h>
+// https://github.com/torvalds/linux/blob/master/arch/riscv/include/uapi/asm/hwcap.h#L24
+#if !defined(COMPAT_HWCAP_ISA_V)
+#define COMPAT_HWCAP_ISA_V (1 << ('V' - 'A'))
+#endif
+#endif
+#endif
+
 // Note: once we move threading into a separate C++ file
 // will use std::hardware_destructive_interference_size instead of hardcoding it here
 // and we'll use C++ attribute syntax.
@@ -3443,10 +3456,23 @@ int ggml_cpu_has_arm_fma(void) {
 
 int ggml_cpu_has_riscv_v(void) {
 #if defined(__riscv_v_intrinsic)
+#if defined(__linux__)
+    return !!(getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V);
+#else
     return 1;
+#endif
 #else
     return 0;
 #endif
+}
+
+int ggml_cpu_get_riscv_vlen(void) {
+#if defined(__riscv_v_intrinsic)
+    if (ggml_cpu_has_riscv_v()) {
+        return __riscv_vlenb() * 8;
+    }
+#endif
+    return 0;
 }
 
 int ggml_cpu_has_f16c(void) {

--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
+++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
@@ -583,6 +583,10 @@ static ggml_backend_feature * ggml_backend_cpu_get_features(ggml_backend_reg_t r
         if (ggml_cpu_has_riscv_v()) {
             features.push_back({ "RISCV_V", "1" });
         }
+        if (ggml_cpu_get_riscv_vlen() > 0) {
+            static std::string riscv_vlen = std::to_string(ggml_cpu_get_riscv_vlen());
+            features.push_back({ "RISCV_VLEN", riscv_vlen.c_str() });
+        }
         if (ggml_cpu_has_vsx()) {
             features.push_back({ "VSX", "1" });
         }


### PR DESCRIPTION
Also added VLEN-agnostic kernel selection to `ggml_vec_dot_q2_K_q8_K` for RVV-disabled and wider devices.