### PR TITLE
feat: support GGML_BACKEND_DIR environment variable

### DIFF
--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -523,6 +523,11 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
 #ifdef GGML_BACKEND_DIR
         search_paths.push_back(fs::u8path(GGML_BACKEND_DIR));
 #endif
+        const char * backend_dir = getenv("GGML_BACKEND_DIR");
+        if (backend_dir) {
+            search_paths.push_back(fs::u8path(backend_dir));
+        }
+
         // default search paths: executable directory, current directory
         search_paths.push_back(get_executable_path());
         search_paths.push_back(fs::current_path());


### PR DESCRIPTION
Currently, CMake supports setting the `GGML_BACKEND_DIR` variable to specify the backend installation path:

https://github.com/ggml-org/llama.cpp/blob/583cb83416467e8abf9b37349dcf1f6a0083745a/ggml/CMakeLists.txt#L80

This path gets embedded into the code as a search path:

https://github.com/ggml-org/llama.cpp/blob/583cb83416467e8abf9b37349dcf1f6a0083745a/ggml/src/ggml-backend-reg.cpp#L521-L531

However, in some cases, users may need to adjust the backend path for various reasons, which would invalidate the embedded path in the code.

This PR adds an environment variable to improve this situation by allowing runtime path configuration.

Related Issue:
- #17491
- #15074