### PR TITLE
llama: remove init f16 tables

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -69,13 +69,6 @@ bool llama_supports_rpc(void) {
 
 void llama_backend_init(void) {
     ggml_time_init();
-
-    // needed to initialize f16 tables
-    {
-        struct ggml_init_params params = { 0, NULL, false };
-        struct ggml_context * ctx = ggml_init(params);
-        ggml_free(ctx);
-    }
 }
 
 void llama_numa_init(enum ggml_numa_strategy numa) {


### PR DESCRIPTION
It seems there's no need to initialize the f16 tables.