### PR TITLE
cmake : use EXCLUDE_FROM_ALL to avoid patch-boringssl.cmake

### DIFF
--- a/vendor/cpp-httplib/CMakeLists.txt
+++ b/vendor/cpp-httplib/CMakeLists.txt
@@ -31,13 +31,16 @@ if (LLAMA_BUILD_BORINGSSL)
 
     message(STATUS "Fetching BoringSSL version ${BORINGSSL_VERSION}")
 
-    include(FetchContent)
-    FetchContent_Declare(
-        boringssl
+    set(BORINGSSL_ARGS
         GIT_REPOSITORY ${BORINGSSL_GIT}
         GIT_TAG        ${BORINGSSL_VERSION}
-        PATCH_COMMAND  ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/patch-boringssl.cmake"
     )
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        list(APPEND BORINGSSL_ARGS EXCLUDE_FROM_ALL)
+    endif()
+
+    include(FetchContent)
+    FetchContent_Declare(boringssl ${BORINGSSL_ARGS})
 
     set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
     set(SAVED_BUILD_TESTING ${BUILD_TESTING})
@@ -45,7 +48,15 @@ if (LLAMA_BUILD_BORINGSSL)
     set(BUILD_SHARED_LIBS OFF)
     set(BUILD_TESTING OFF)
 
-    FetchContent_MakeAvailable(boringssl)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        FetchContent_MakeAvailable(boringssl)
+    else()
+        FetchContent_GetProperties(boringssl)
+        if(NOT boringssl_POPULATED)
+            FetchContent_Populate(boringssl)
+            add_subdirectory(${boringssl_SOURCE_DIR} ${boringssl_BINARY_DIR} EXCLUDE_FROM_ALL)
+        endif()
+    endif()
 
     set(BUILD_SHARED_LIBS ${SAVED_BUILD_SHARED_LIBS})
     set(BUILD_TESTING ${SAVED_BUILD_TESTING})

--- a/vendor/cpp-httplib/patch-boringssl.cmake
+++ b/vendor/cpp-httplib/patch-boringssl.cmake
@@ -1,6 +1,0 @@
-# Remove bssl
-file(READ "CMakeLists.txt" content)
-string(REPLACE "add_executable(bssl" "#add_executable(bssl" content "${content}")
-string(REPLACE "target_link_libraries(bssl" "#target_link_libraries(bssl" content "${content}")
-string(REPLACE "install(TARGETS bssl" "#install(TARGETS bssl" content "${content}")
-file(WRITE "CMakeLists.txt" "${content}")


### PR DESCRIPTION
We have to separate the code path starting 3.28 because `FetchContent_Populate` is now deprecated and will be completely removed in a future version.
