### PR TITLE
ggml-cpu: repack: Fix chunks being too small with small matrix shapes in REPACK forward_mul_mat

### DIFF
--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1731,11 +1731,12 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             nchunk0 = (nr0 + min_chunk_size - 1) / min_chunk_size;
         }
 
-        if (nth == 1 || nchunk0 < nth || disable_chunking) {
+        int64_t dr0 = (nr0 + nchunk0 - 1) / nchunk0;
+        // Only increase nchunk0 to nth if it won't make chunks too small
+        if (nth == 1 || ((nchunk0 < nth || disable_chunking) && (nr0 + nth - 1) / nth >= min_chunk_size)) {
             nchunk0 = nth;
+            dr0 = (nr0 + nchunk0 - 1) / nchunk0;
         }
-
-        const int64_t dr0 = (nr0 + nchunk0 - 1) / nchunk0;
 
         // Ensure nchunk doesn't exceed the number of rows divided by minimum chunk size
         // This prevents creating too many tiny chunks that could overlap after alignment


### PR DESCRIPTION
For small shapes where the number of columns is small (i.e. 16), the current logic skipped some chunks due to rounding. 

The issue was observed with NB_COLS 8 and ne01 16, and could potentially happen with NB_COLS 4 and other combinations threads/shape.
This is also affected the corner case where chunking is disabled.

@max-krasnyansky I checked the performance here and didn't see any issue. Let me know if you'd like me to perform any particular test

### Performance

#### RPI5

| model          | test  | 2f416b265 (7162) t/s     | 3e18dba9f (7161) t/s     |
| -------------- | ----- | ------------------- | ------------------- |
| lfm2 350M Q4_0    | pp256 | 174.46 ± 0.07       | 173.41 ± 0.64       |
| lfm2 350M Q4_0    | tg128 |  51.58 ± 0.03       |  51.38 ± 0.26       |
| lfm2 700M Q4_0    | pp256 |  81.79 ± 0.01       |  82.55 ± 0.03       |
| lfm2 700M Q4_0   | tg128 |  25.78 ± 0.00       |  25.86 ± 0.00       |


#### M4 max

| model                        | test  | 2f416b265 (7162) t/s     | 3e18dba9f (7161) t/s     | 
| ---------------------- | ----- | ------------------- | ------------------- | 
| lfm2 1.2B Q4_K Medium  |   pp256 | 682.39 ± 3.23       | 682.82 ± 2.97       | 
| lfm2 1.2B Q4_K Medium  | tg128 | 233.77 ± 4.45       | 234.96 ± 0.57       |
| lfm2 700M Q4_K Medium   | pp256 | 1070.08 ± 2.77      | 1067.29 ± 7.14      |
| lfm2 700M Q4_K Medium  | tg128 | 331.12 ± 1.27       | 333.13 ± 1.32       | 
| llama 8B Q4_K Medium     | pp256 | 100.26 ± 0.11       |  96.65 ± 1.75       | 
| llama 8B Q4_K Medium    | tg128 |  43.10 ± 0.50       |  41.69 ± 0.72       | 
| qwen3 8B Q4_K Medium       | pp256 |  94.40 ± 0.33       |  90.45 ± 0.34       | 
| qwen3 8B Q4_K Medium    | tg128 |  40.92 ± 0.33       |  40.29 ± 0.27       | 

