### PR TITLE
Add build-essential to Ubuntu 26.04 image

### DIFF
--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -50,6 +50,7 @@ WORKDIR /app
 
 RUN apt-get update \
     && apt-get install -y \
+    build-essential \
     git \
     python3 \
     python3-pip \


### PR DESCRIPTION
This is no longer passing the build, needs more packages.

