### PR TITLE
fix UMA detection on discrete GPUs.

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3837,7 +3837,7 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
 
     // Check if UMA is explicitly enabled via environment variable
     bool uma_env = getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr;
-    bool is_uma = prop.unifiedAddressing > 0 || uma_env;
+    bool is_uma = prop.integrated > 0 || uma_env;
 
     if (is_uma) {
         // For UMA systems (like DGX Spark), use system memory info


### PR DESCRIPTION
Fixes #17536

Submitted as a draft for now as I do not have a Spark to hand to confirm ``cudaGetDeviceProperties``. I wrote a small CUDA to confirm that ``prop.unifiedAddressing == 1`` on my discrete GPUs. This means it cannot be used to check if the device is a DGX Spark. 

https://developer.download.nvidia.com/compute/DevZone/docs/html/C/doc/html/group__CUDART__DEVICE_g5aa4f47938af8276f08074d09b7d520c.html -- these docs seem to suggest that this should be ``prop.integrated`` instead? This flag is 0 on my discrete GPUs.