### PR TITLE
CANN: add support for partial RoPE and Vision mode

### DIFF
--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -315,7 +315,7 @@ struct ggml_cann_rope_cache {
         if (theta_scale_exp_host) {
             free(theta_scale_exp_host);
         }
-        if(position_select_index_host) {
+        if (position_select_index_host) {
             free(position_select_index_host);
         }
     }
@@ -330,17 +330,19 @@ struct ggml_cann_rope_cache {
                bool    indep_sects,
                bool    mrope_used,
                bool    is_imrope,
-               int     sections[4]) {
+               int     sections[4],
+               int64_t rope_dims) {
         return this->theta_scale_length == theta_scale_length && this->position_length == position_length &&
                this->ext_factor == ext_factor && this->theta_scale == theta_scale && this->freq_scale == freq_scale &&
                this->attn_factor == attn_factor && this->is_neox == is_neox && this->indep_sects == indep_sects &&
                this->mrope_used == mrope_used && this->is_imrope == is_imrope && this->sections[0] == sections[0] &&
-               this->sections[1] == sections[1] && this->sections[2] == sections[2] && this->sections[3] == sections[3];
+               this->sections[1] == sections[1] && this->sections[2] == sections[2] &&
+               this->sections[3] == sections[3] && this->rope_dims == rope_dims;
     }
 
     void set(int64_t theta_scale_length,
              int64_t position_length,
-             float    ext_factor,
+             float   ext_factor,
              float   theta_scale,
              float   freq_scale,
              float   attn_factor,
@@ -348,7 +350,8 @@ struct ggml_cann_rope_cache {
              bool    indep_sects,
              bool    mrope_used,
              bool    is_imrope,
-             int     sections[4]) {
+             int     sections[4],
+             int64_t rope_dims) {
         this->theta_scale_length = theta_scale_length;
         this->position_length    = position_length;
         this->ext_factor         = ext_factor;
@@ -363,6 +366,7 @@ struct ggml_cann_rope_cache {
         this->sections[1]        = sections[1];
         this->sections[2]        = sections[2];
         this->sections[3]        = sections[3];
+        this->rope_dims          = rope_dims;
     }
 
     // memory cache, prepare before inferencing.
@@ -386,6 +390,7 @@ struct ggml_cann_rope_cache {
     bool    mrope_used                 = false;
     int     sections[4]                = { 0, 0, 0, 0 };
     bool    is_imrope                  = false;
+    int64_t rope_dims                  = 0;
 };
 
 struct ggml_cann_tensor_cache {

--- a/ggml/src/ggml-cann/common.h
+++ b/ggml/src/ggml-cann/common.h
@@ -330,14 +330,12 @@ struct ggml_cann_rope_cache {
                bool    indep_sects,
                bool    mrope_used,
                bool    is_imrope,
-               int     sections[4],
-               int64_t rope_dims) {
+               int     sections[4]) {
         return this->theta_scale_length == theta_scale_length && this->position_length == position_length &&
                this->ext_factor == ext_factor && this->theta_scale == theta_scale && this->freq_scale == freq_scale &&
                this->attn_factor == attn_factor && this->is_neox == is_neox && this->indep_sects == indep_sects &&
                this->mrope_used == mrope_used && this->is_imrope == is_imrope && this->sections[0] == sections[0] &&
-               this->sections[1] == sections[1] && this->sections[2] == sections[2] &&
-               this->sections[3] == sections[3] && this->rope_dims == rope_dims;
+               this->sections[1] == sections[1] && this->sections[2] == sections[2] && this->sections[3] == sections[3];
     }
 
     void set(int64_t theta_scale_length,
@@ -350,8 +348,7 @@ struct ggml_cann_rope_cache {
              bool    indep_sects,
              bool    mrope_used,
              bool    is_imrope,
-             int     sections[4],
-             int64_t rope_dims) {
+             int     sections[4]) {
         this->theta_scale_length = theta_scale_length;
         this->position_length    = position_length;
         this->ext_factor         = ext_factor;
@@ -366,7 +363,6 @@ struct ggml_cann_rope_cache {
         this->sections[1]        = sections[1];
         this->sections[2]        = sections[2];
         this->sections[3]        = sections[3];
-        this->rope_dims          = rope_dims;
     }
 
     // memory cache, prepare before inferencing.
@@ -390,7 +386,6 @@ struct ggml_cann_rope_cache {
     bool    mrope_used                 = false;
     int     sections[4]                = { 0, 0, 0, 0 };
     bool    is_imrope                  = false;
-    int64_t rope_dims                  = 0;
 };
 
 struct ggml_cann_tensor_cache {

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -2308,7 +2308,7 @@ static enum ggml_status ggml_backend_cann_graph_compute(ggml_backend_t backend, 
 
     bool cann_graph_update_required = false;
 #ifdef USE_ACL_GRAPH
-    bool use_cann_graph             = true;
+    bool use_cann_graph = true;
 
     static bool prefill_use_graph = parse_bool(get_env("GGML_CANN_PREFILL_USE_GRAPH").value_or(""));
     if (!prefill_use_graph) {
@@ -2338,7 +2338,7 @@ static enum ggml_status ggml_backend_cann_graph_compute(ggml_backend_t backend, 
         }
     }
 #else
-    bool use_cann_graph             = false;
+    bool use_cann_graph = false;
 #endif  // USE_ACL_GRAPH
     evaluate_and_capture_cann_graph(cann_ctx, cgraph, use_cann_graph, cann_graph_update_required);
 
@@ -2474,16 +2474,14 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev, const ggml_ten
             }
         case GGML_OP_ROPE:
             {
-                // TODO: with ops-test v == 1
-                // TODO: n_dims <= ne0
-                if (op->src[0]->ne[0] != op->op_params[1]) {
-                    return false;
-                }
-
                 if (op->src[0]->ne[0] > 896) {
                     return false;
                 }
 #ifdef ASCEND_310P
+                // TODO: Support rope_dim < ne00(dim)
+                if (op->src[0]->ne[0] != op->op_params[1]) {
+                    return false;
+                }
                 if (!ggml_is_contiguous(op->src[0])) {
                     return false;
                 }


### PR DESCRIPTION
Add support for two important RoPE variants: partial rotation (rope_dims < ne0) and Vision mode rotation.

1. Support for partial RoPE (rope_dims < ne0):
   - Split tensor into head (first rope_dims dimensions) and tail portions
   - Apply rotation only to head portion using RotaryPositionEmbedding operator
   - Copy unrotated tail portion directly from source to destination
   - Handle both contiguous and non-contiguous tensor layouts

2. Support for Vision mode (GGML_ROPE_TYPE_VISION):
   - Set rope_dims = ne0 for Vision mode to rotate entire tensor
   - Vision mode pairs dimension i with dimension i+n_dims (where n_dims = ne0/2)
   - No tail handling needed since entire tensor is rotated

Implementation details:
   - Use has_tail flag to determine execution path: head/tail splitting when rope_dims < ne0, or full tensor rotation when rope_dims == ne0
   - Support both F32 and F16 data types with intermediate F32 conversion
   - Copy non-contiguous tensors to contiguous buffers before calling RotaryPositionEmbedding operator for compatibility
   - Improve cache invalidation logic to include rope_dims and indep_sects parameters

These enhancements enable CANN backend to handle various RoPE configurations used in modern vision-language models and models with partial rotation.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
