### PR TITLE
server: truncate base64 image data in debug logs

### DIFF
--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -313,6 +313,9 @@ std::vector<llama_token_data> get_token_probabilities(llama_context * ctx, int i
 
 std::string safe_json_to_str(const json & data);
 
+// Sanitize request body for logging (truncates base64 image data)
+std::string log_sanitize_request_body(const std::string & body);
+
 std::string tokens_to_str(llama_context * ctx, const llama_tokens & tokens);
 
 // format incomplete utf-8 multibyte character for output

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -37,7 +37,7 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
 
     SRV_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
 
-    SRV_DBG("request:  %s\n", req.body.c_str());
+    SRV_DBG("request:  %s\n", log_sanitize_request_body(req.body).c_str());
     SRV_DBG("response: %s\n", res.body.c_str());
 }
 


### PR DESCRIPTION
  Prevents log files from being inflated when sending images via the
  OpenAI API endpoint. Image data URLs are replaced with just the mime
  type and byte size (e.g., "data:image/png;base64,[102345 bytes]").

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
