### PR TITLE
server: truncate large request bodies in debug logs

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1178,6 +1178,15 @@ std::string safe_json_to_str(const json & data) {
     return data.dump(-1, ' ', false, json::error_handler_t::replace);
 }
 
+// Truncate large request bodies for logging to prevent log bloat
+std::string log_sanitize_request_body(const std::string & body) {
+    const size_t max_len = 4096;
+    if (body.size() > max_len) {
+        return body.substr(0, max_len) + "...[truncated " + std::to_string(body.size() - max_len) + " bytes]";
+    }
+    return body;
+}
+
 // TODO: reuse llama_detokenize
 template <class Iter>
 static std::string tokens_to_str(llama_context * ctx, Iter begin, Iter end) {

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -313,6 +313,9 @@ std::vector<llama_token_data> get_token_probabilities(llama_context * ctx, int i
 
 std::string safe_json_to_str(const json & data);
 
+// Sanitize request body for logging (truncates base64 image data)
+std::string log_sanitize_request_body(const std::string & body);
+
 std::string tokens_to_str(llama_context * ctx, const llama_tokens & tokens);
 
 // format incomplete utf-8 multibyte character for output

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -37,7 +37,7 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
 
     SRV_INF("request: %s %s %s %d\n", req.method.c_str(), req.path.c_str(), req.remote_addr.c_str(), res.status);
 
-    SRV_DBG("request:  %s\n", req.body.c_str());
+    SRV_DBG("request:  %s\n", log_sanitize_request_body(req.body).c_str());
     SRV_DBG("response: %s\n", res.body.c_str());
 }
 


### PR DESCRIPTION
  Limits logged request bodies to 4KB to prevent log bloat from large
  payloads (e.g., base64-encoded images sent via the OpenAI API).

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
