### PR TITLE
cmake: fix macOS build with `-DGGML_BACKEND_DL=ON`

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -274,10 +274,13 @@ function(ggml_add_backend_library backend)
     endif()
 
     # Set versioning properties for all backend libraries
-    set_target_properties(${backend} PROPERTIES
-        VERSION ${GGML_VERSION}
-        SOVERSION ${GGML_VERSION_MAJOR}
-    )
+    # Building a MODULE library with a version is not supported on macOS (https://gitlab.kitware.com/cmake/cmake/-/issues/20782)
+    if (NOT (APPLE AND GGML_BACKEND_DL))
+        set_target_properties(${backend} PROPERTIES
+            VERSION ${GGML_VERSION}
+            SOVERSION ${GGML_VERSION_MAJOR}
+        )
+    endif()
 
     if(NOT GGML_AVAILABLE_BACKENDS)
         set(GGML_AVAILABLE_BACKENDS "${backend}"


### PR DESCRIPTION
#17091 introduced an issue where when building with `-DGGML_BACKEND_DL=ON` on macOS you get this error:
```
c++: error: invalid argument '-current_version 0.9.4' only allowed with '-dynamiclib'
make[2]: *** [bin/libggml-blas.so] Error 1
make[1]: *** [ggml/src/ggml-blas/CMakeFiles/ggml-blas.dir/all] Error 2
```

It appears that building a module library with a version is not supported on macOS ([CMake ticket](https://gitlab.kitware.com/cmake/cmake/-/issues/20782)), so this PR makes the build skip setting a version for backend module libraries on macOS.