### PR TITLE
update `LLAMA_ARG_KV_SPLIT` --> `LLAMA_ARG_KV_UNIFIED` to match CLI argument

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -980,7 +980,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params) {
             params.kv_unified = true;
         }
-    ).set_env("LLAMA_ARG_KV_SPLIT"));
+    ).set_env("LLAMA_ARG_KV_UNIFIED"));
     add_opt(common_arg(
         {"--no-context-shift"},
         string_format("disables context shift on infinite text generation (default: %s)", params.ctx_shift ? "disabled" : "enabled"),


### PR DESCRIPTION
In `common/arg.cpp`, the `--kv-unified`/`-kvu` option is controlled by the environment variable `LLAMA_ARG_KV_SPLIT`. This PR changes the env var to `LLAMA_ARG_KV_UNIFIED` to match the naming of the CLI argument.