### PR TITLE
vulkan : fix FA mask load with bounds check (coopmat2)

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
@@ -156,7 +156,7 @@ void main() {
                 tensorLayoutM = setTensorLayoutStrideNV(tensorLayoutM, m_stride, 1);
                 tensorLayoutM = setTensorLayoutClampValueNV(tensorLayoutM, 0xfc00); // -inf in float16_t
 
-                coopmat<float16_t, gl_ScopeWorkgroup, Br, Bc, gl_MatrixUseAccumulator> mv, mvmax;
+                coopmat<float16_t, gl_ScopeWorkgroup, Br, Bc, gl_MatrixUseAccumulator> mvmax;
 
                 coopMatLoadTensorNV(mv, data_m, m_offset, sliceTensorLayoutNV(tensorLayoutM, i * Br, Br, j * Bc, Bc));
 


### PR DESCRIPTION
Bug was caused by variable shadowing in flash_attn_cm2, introduced in #17186

It was only observable with coopmat2 and `GGML_KQ_MASK_PAD=1`

Repro:
1. modify `ggml.h` and set `GGML_KQ_MASK_PAD 1`
2. run `test-backend-ops-o FLASH_ATTN_EXT`