### PR TITLE
model : Fix marker placement for LFM2-VL in single turn llama-mtmd-cli

### DIFF
--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -265,6 +265,15 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg) {
     return 0;
 }
 
+static std::string insert_default_marker(mtmd_context * ctx, const std::string & msg) {
+    switch (mtmd_get_default_marker_placement(ctx)) {
+        case MTMD_DEFAULT_MARKER_PLACEMENT_BEGIN: return mtmd_default_marker() + msg;
+        case MTMD_DEFAULT_MARKER_PLACEMENT_NONE:
+        case MTMD_DEFAULT_MARKER_PLACEMENT_END:
+        default:                                  return msg + mtmd_default_marker();
+    }
+}
+
 int main(int argc, char ** argv) {
     ggml_time_init();
 
@@ -313,7 +322,7 @@ int main(int argc, char ** argv) {
         g_is_generating = true;
         if (params.prompt.find(mtmd_default_marker()) == std::string::npos) {
             for (size_t i = 0; i < params.image.size(); i++) {
-                params.prompt += mtmd_default_marker();
+                params.prompt = insert_default_marker(ctx.ctx_vision.get(), params.prompt);
             }
         }
         common_chat_msg msg;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1099,3 +1099,11 @@ void mtmd_log_set(ggml_log_callback log_callback, void * user_data) {
     g_logger_state.log_callback = log_callback ? log_callback : clip_log_callback_default;
     g_logger_state.log_callback_user_data = user_data;
 }
+
+mtmd_default_marker_placement mtmd_get_default_marker_placement(mtmd_context * ctx) {
+    if (ctx && ctx->ctx_v && clip_get_projector_type(ctx->ctx_v) == PROJECTOR_TYPE_LFM2) {
+        return MTMD_DEFAULT_MARKER_PLACEMENT_BEGIN;
+    }
+
+    return MTMD_DEFAULT_MARKER_PLACEMENT_NONE;
+}

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -94,7 +94,7 @@ struct mtmd_context_params {
     int image_max_tokens; // maximum number of tokens for image input (default: read from metadata)
 };
 
-MTMD_API const char * mtmd_default_marker(void);
+MTMD_API const char *                  mtmd_default_marker(void);
 MTMD_API mtmd_default_marker_placement mtmd_get_default_marker_placement(mtmd_context * ctx);
 
 MTMD_API struct mtmd_context_params mtmd_context_params_default(void);

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -51,6 +51,12 @@ enum mtmd_input_chunk_type {
     MTMD_INPUT_CHUNK_TYPE_AUDIO,
 };
 
+enum mtmd_default_marker_placement {
+    MTMD_DEFAULT_MARKER_PLACEMENT_NONE,  // place media marker freely inside the message
+    MTMD_DEFAULT_MARKER_PLACEMENT_BEGIN, // place media marker in the beginning of the message
+    MTMD_DEFAULT_MARKER_PLACEMENT_END,   // place media marker in the end of the message
+};
+
 // opaque types
 struct mtmd_context;
 struct mtmd_bitmap;
@@ -89,6 +95,7 @@ struct mtmd_context_params {
 };
 
 MTMD_API const char * mtmd_default_marker(void);
+MTMD_API mtmd_default_marker_placement mtmd_get_default_marker_placement(mtmd_context * ctx);
 
 MTMD_API struct mtmd_context_params mtmd_context_params_default(void);
 


### PR DESCRIPTION
cont: https://github.com/ggml-org/llama.cpp/pull/17577

LFM2-VL is sensitive to media marker placement and expects image embeddings to be placed before the text.

By default,
```
bin/llama-mtmd-cli -m $CKPT/LFM2-VL-1.6B-F32.gguf  --mmproj $CKPT/mmproj-LFM2-VL-1.6B-F32.gguf --image /data/playground/issue_17290/siglip_1024.png -p "OCR."
```
places a media marker after the message.

By @ngxson 's [suggestion](https://github.com/ggml-org/llama.cpp/pull/17577#discussion_r2572101620), a C-compatible API is introduced to control default media marker placement.

Affects only LFM2-VL.


For image
<img width="1100" height="67" alt="siglip_1024" src="https://github.com/user-attachments/assets/802e3677-f2ba-467d-8cd7-5c68647e8335" />

the output of
```
bin/llama-mtmd-cli -m $CKPT/LFM2-VL-1.6B-F32.gguf  --mmproj $CKPT/mmproj-LFM2-VL-1.6B-F32.gguf --image /data/playground/issue_17290/siglip_1024.png -p "OCR."
```

before change:
```
It looks like you're describing a system for converting input images into token sequences using specific encoders. Here's a more detailed and structured version of your description:
...
```
after change:
```
For the vision tower, LEM2-VL uses SigilLP2 NaFlex encoders to convert input images into token sequences. Two variants are implemented:
```