### PR TITLE
mtmd: add --image-warmup-tokens

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1824,6 +1824,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.image_max_tokens = value;
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MAX_TOKENS"));
+    add_opt(common_arg(
+        {"--image-warmup-tokens"}, "N",
+        "number of tokens used for warming up the image encoder, only used by vision models",
+        [](common_params & params, int value) {
+            params.image_warmup_tokens = value;
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_WARMUP_TOKENS"));
     if (llama_supports_rpc()) {
         add_opt(common_arg(
             {"--rpc"}, "SERVERS",

--- a/common/common.h
+++ b/common/common.h
@@ -433,6 +433,7 @@ struct common_params {
     std::vector<std::string> image; // path to image file(s)
     int image_min_tokens = -1;
     int image_max_tokens = -1;
+    int image_warmup_tokens = -1;
 
     // finetune
     struct lr_opt lr;

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -34,6 +34,7 @@ struct clip_context_params {
     enum clip_flash_attn_type flash_attn_type;
     int image_min_tokens;
     int image_max_tokens;
+    int image_warmup_tokens;
 };
 
 struct clip_init_result {

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -138,6 +138,8 @@ struct mtmd_cli_context {
         mparams.flash_attn_type  = params.flash_attn_type;
         mparams.image_min_tokens = params.image_min_tokens;
         mparams.image_max_tokens = params.image_max_tokens;
+        mparams.image_warmup_tokens = params.image_warmup_tokens;
+
         ctx_vision.reset(mtmd_init_from_file(clip_path, model, mparams));
         if (!ctx_vision.get()) {
             LOG_ERR("Failed to load vision model from %s\n", clip_path);

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -110,6 +110,7 @@ mtmd_context_params mtmd_context_params_default() {
         /* flash_attn_type   */ LLAMA_FLASH_ATTN_TYPE_AUTO,
         /* image_min_tokens  */ -1,
         /* image_max_tokens  */ -1,
+        /* image_warmup_tokens */ -1,
     };
     return params;
 }
@@ -177,6 +178,7 @@ struct mtmd_context {
             /* flash_attn_type   */ CLIP_FLASH_ATTN_TYPE_AUTO,
             /* image_min_tokens  */ ctx_params.image_min_tokens,
             /* image_max_tokens  */ ctx_params.image_max_tokens,
+            /* image_warmup_tokens */ ctx_params.image_warmup_tokens,
         };
 
         auto res = clip_init(mmproj_fname, ctx_clip_params);

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -86,6 +86,8 @@ struct mtmd_context_params {
     // limit number of image tokens, only for vision models with dynamic resolution
     int image_min_tokens; // minimum number of tokens for image input (default: read from metadata)
     int image_max_tokens; // maximum number of tokens for image input (default: read from metadata)
+
+    int image_warmup_tokens; // number of tokens used for warmup image (default: -1 AKA hard-coded for different models)
 };
 
 MTMD_API const char * mtmd_default_marker(void);

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -172,6 +172,7 @@ The project is under active development, and we are [looking for feedback and co
 | `--no-mmproj-offload` | do not offload multimodal projector to GPU<br/>(env: LLAMA_ARG_NO_MMPROJ_OFFLOAD) |
 | `--image-min-tokens N` | minimum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MIN_TOKENS) |
 | `--image-max-tokens N` | maximum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MAX_TOKENS) |
+| `--image-warmup-tokens N` | number of tokens used for warming up the image encoder, only used by vision models (default: -1)<br/>(env: LLAMA_ARG_IMAGE_WARMUP_TOKENS) |
 | `--override-tensor-draft, -otd <tensor name pattern>=<buffer type>,...` | override tensor buffer type for draft model |
 | `--cpu-moe-draft, -cmoed` | keep all Mixture of Experts (MoE) weights in the CPU for the draft model<br/>(env: LLAMA_ARG_CPU_MOE_DRAFT) |
 | `--n-cpu-moe-draft, -ncmoed N` | keep the Mixture of Experts (MoE) weights of the first N layers in the CPU for the draft model<br/>(env: LLAMA_ARG_N_CPU_MOE_DRAFT) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -623,6 +623,8 @@ struct server_context_impl {
             mparams.flash_attn_type  = params_base.flash_attn_type;
             mparams.image_min_tokens = params_base.image_min_tokens;
             mparams.image_max_tokens = params_base.image_max_tokens;
+            mparams.image_warmup_tokens = params_base.image_warmup_tokens;
+
             mctx = mtmd_init_from_file(mmproj_path.c_str(), model, mparams);
             if (mctx == nullptr) {
                 SRV_ERR("failed to load multimodal model, '%s'\n", mmproj_path.c_str());


### PR DESCRIPTION
Noticed that a Q4_1 Qwen3-VL 2B mmproj reserved a surprisingly large amount of memory for one of its compute buffers during the image warmup part - larger than the model itself! 

Looking at the code, it seems that image warmup sizes are hard-coded for different models. For Qwen3-VL it's `2116` tokens, or an image with `1472 x 1472` dimensions. If I understand correctly, llama-cpp initially reserves memory proportional to the size of that warmup image.

But some users may be certain that their images will never exceed some dimensions (e.g: OCR'ing single lines of text or their preprocessing pipeline caps images at `512 x 512`), so they may want a smaller max image warmup size, reducing the memory consumption.

A few hundred MB cut down doesn't sound like much on its own, but it might help for development on the edge.

# Before (Initial behavior)
<img width="1444" height="244" alt="highmem" src="https://github.com/user-attachments/assets/1027ba20-5e2d-4407-94bf-e3941aa4f24a" />

# With ` --image-warmup-tokens 256`
<img width="993" height="191" alt="lowmem" src="https://github.com/user-attachments/assets/5d22dcae-416d-4e47-83a5-04ab19f2de2b" />
