### PR TITLE
ggml-alloc: optimize free block shifting with `memmove`

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -142,9 +142,8 @@ static void ggml_dyn_tallocr_insert_block(struct tallocr_chunk * chunk, size_t o
         insert_pos++;
     }
     // shift all blocks from insert_pos onward to make room for the new block
-    for (int i = chunk->n_free_blocks; i > insert_pos; i--) {
-        chunk->free_blocks[i] = chunk->free_blocks[i-1];
-    }
+    memmove(&chunk->free_blocks[insert_pos + 1], &chunk->free_blocks[insert_pos], (chunk->n_free_blocks - insert_pos) * sizeof(struct free_block));
+
     // insert the new block
     chunk->free_blocks[insert_pos].offset = offset;
     chunk->free_blocks[insert_pos].size = size;


### PR DESCRIPTION
Replaced a manual `for` loop responsible for shifting elements in the `chunk->free_blocks` array with a single call to `memmove`. This change leverages an optimized standard library function for block memory operations, which can be significantly more efficient than a manual loop. `memmove` is designed to handle potentially overlapping memory regions correctly and is often implemented using highly optimized assembly instructions (like SIMD) or intrinsic functions, leading to improved performance during free block insertion in the memory allocator.

References:
*   **Performance of `memmove` vs. manual loops:**
    [https://stackoverflow.com/questions/11090176/is-it-faster-to-loop-and-copy-or-use-memmove](https://stackoverflow.com/questions/11090176/is-it-faster-to-loop-and-copy-or-use-memmove)
    (A discussion highlighting why `memmove` is generally faster due to compiler and library optimizations.)

*   **Inside `memcpy` and `memmove` Implementations:**
    [https://nullprogram.com/blog/2023/08/17/](https://nullprogram.com/blog/2023/08/17/)
    (Explores how `memcpy` and `memmove` are often implemented at a low level to achieve high performance.)

*   **C Programming Optimizations - General Techniques:**
    [https://www.geeksforgeeks.org/c-programming-optimizations/](https://www.geeksforgeeks.org/c-programming-optimizations/)
    (Discusses various C optimization techniques, including the use of efficient standard library functions.)

*   **Memory Allocation Principles and Optimizations:**
    [https://www.cs.cornell.edu/courses/cs3410/2019sp/schedule/L24-MemoryAlloc.pdf](https://www.cs.cornell.edu/courses/cs3410/2019sp/schedule/L24-MemoryAlloc.pdf)
    (Lecture slides providing context on memory allocation strategies and where optimizations like this fit in.)

Co-Authored-By: Gemini 2.5 Pro (References and description commit changes)