### PR TITLE
llama-vocab: replace postfix with prefix increment for iterators

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2677,7 +2677,7 @@ void llama_vocab::impl::tokenizer_st_partition(std::forward_list<fragment_buffer
 
                         if (left_reminder_length > 0) {
                             buffer.emplace_after(it, raw_text, left_reminder_offset, left_reminder_length);
-                            it++;
+                            ++it;
                         }
 
 #ifdef PRETOKENIZERDEBUG
@@ -2687,7 +2687,7 @@ void llama_vocab::impl::tokenizer_st_partition(std::forward_list<fragment_buffer
 
                     // special token
                     buffer.emplace_after(it, special_id);
-                    it++;
+                    ++it;
 
                     // right
                     if (match + text.length() < raw_text_base_offset + raw_text_base_length) {
@@ -2703,7 +2703,7 @@ void llama_vocab::impl::tokenizer_st_partition(std::forward_list<fragment_buffer
 
                         if (right_reminder_length > 0) {
                             buffer.emplace_after(it, raw_text, right_reminder_offset, right_reminder_length);
-                            it++;
+                            ++it;
                         }
 
 #ifdef PRETOKENIZERDEBUG
@@ -2733,7 +2733,7 @@ void llama_vocab::impl::tokenizer_st_partition(std::forward_list<fragment_buffer
                     }
                 }
             }
-            it++;
+            ++it;
         }
     }
 }


### PR DESCRIPTION
For custom iterator types, such as those often found in standard library containers or custom data structures, prefix increment (`++it`) is generally more efficient than postfix increment (`it++`). The postfix version typically requires creating a temporary copy of the iterator's original state before performing the increment and returning the copy. In contrast, the prefix version increments the iterator directly and returns a reference to the modified iterator, avoiding the overhead of a temporary object.

References:
*   **Stack Overflow:** Is there a performance difference between ++i and i++ in C++?
    [https://stackoverflow.com/questions/248549/is-there-a-performance-difference-between-i-and-i-in-c](https://stackoverflow.com/questions/248549/is-there-a-performance-difference-between-i-and-i-in-c)
*   **GeeksforGeeks:** Prefix vs Postfix Increment/Decrement Operators in C++
    [https://www.geeksforgeeks.org/prefix-vs-postfix-increment-decrement-operators-in-cpp/](https://www.geeksforgeeks.org/prefix-vs-postfix-increment-decrement-operators-in-cpp/)
*   **Fluent C++:** The Performance of Prefix vs Postfix Increment Operator
    [https://www.fluentcpp.com/2019/02/15/the-performance-of-prefix-vs-postfix-increment-operator/](https://www.fluentcpp.com/2019/02/15/the-performance-of-prefix-vs-postfix-increment-operator/)
*   **Bjarne Stroustrup's FAQ:** Why should I prefer prefix to postfix increment?
    [https://www.stroustrup.com/bs_faq2.html#iterators](https://www.stroustrup.com/bs_faq2.html#iterators)
*   **Modern C++ Best Practices:** Prefer prefix increment/decrement
    [https://www.modernescpp.com/index.php/prefer-prefix-increment-decrement](https://www.modernescpp.com/index.php/prefer-prefix-increment-decrement)


Co-Authored-By: Gemini 2.5 Pro (References and desc commit changes)