### PR TITLE
sgemm: reuse loaded vector in AVX dot product calculation

### DIFF
--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -881,27 +881,24 @@ class tinyBLAS_Q0_AVX {
                     __m128 da = _mm_set1_ps(unhalf((A[lda * (ii + i) + l].d)));
                     // Computation of product of delta values for four blocks and replicate it across 256 bit lane
                     __m256 dvec =  _mm256_castps128_ps256(_mm_mul_ps(da, db));
+                    __m256i avec = load(A + lda * (ii + i) + l);
                     dvec = _mm256_permute2f128_ps(dvec ,dvec, 0);
                     // Computation of dot product and multiplication with appropriate delta value products
                     Cv[0][i] = madd(_mm256_shuffle_ps(dvec, dvec, 0),
-                                    updot(_mm256_sign_epi8(load(A + lda * (ii + i) + l),
-                                                            load(A + lda * (ii + i) + l)),
-                                            _mm256_sign_epi8(bvec0, load(A + lda * (ii + i) + l))),
+                                    updot(_mm256_sign_epi8(avec, avec),
+                                            _mm256_sign_epi8(bvec0, avec)),
                                     Cv[0][i]);
                     Cv[1][i] = madd(_mm256_shuffle_ps(dvec, dvec, 85),
-                                    updot(_mm256_sign_epi8(load(A + lda * (ii + i) + l),
-                                                            load(A + lda * (ii + i) + l)),
-                                            _mm256_sign_epi8(bvec1, load(A + lda * (ii + i) + l))),
+                                    updot(_mm256_sign_epi8(avec, avec),
+                                            _mm256_sign_epi8(bvec1, avec)),
                                     Cv[1][i]);
                     Cv[2][i] = madd(_mm256_shuffle_ps(dvec, dvec, 170),
-                                    updot(_mm256_sign_epi8(load(A + lda * (ii + i) + l),
-                                                            load(A + lda * (ii + i) + l)),
-                                            _mm256_sign_epi8(bvec2, load(A + lda * (ii + i) + l))),
+                                    updot(_mm256_sign_epi8(avec, avec),
+                                            _mm256_sign_epi8(bvec2, avec)),
                                     Cv[2][i]);
                     Cv[3][i] = madd(_mm256_shuffle_ps(dvec, dvec, 255),
-                                    updot(_mm256_sign_epi8(load(A + lda * (ii + i) + l),
-                                                            load(A + lda * (ii + i) + l)),
-                                            _mm256_sign_epi8(bvec3, load(A + lda * (ii + i) + l))),
+                                    updot(_mm256_sign_epi8(avec, avec),
+                                            _mm256_sign_epi8(bvec3, avec)),
                                     Cv[3][i]);
                 }
             }


### PR DESCRIPTION
This change optimizes the AVX-based `sgemm` (single-precision general matrix multiplication) kernel by introducing a local `__m256i` variable, `avec`, to cache the result of `load(A + lda * (ii + i) + l)`. Previously, this memory load was redundantly performed four times for each iteration within the `updot` calls for `Cv[0][i]` through `Cv[3][i]`.

By loading vector once and reusing it, the code eliminates these redundant memory accesses, reducing memory latency and improving instruction-level parallelism. This is a common subexpression elimination (CSE) optimization, crucial for performance in tight loops of vectorized kernels.

References:
*   [Common Subexpression Elimination - Wikipedia](https://en.wikipedia.org/wiki/Common_subexpression_elimination)
*   [Optimizing with Intel AVX2 - Intel Developer Zone](https://www.intel.com/content/www/us/en/developer/articles/technical/optimizing-with-intel-avx2.html)
*   [SIMD performance: data alignment and memory access - Daniel Lemire's Blog](https://lemire.me/blog/2012/05/31/simd-performance-data-alignment-and-memory-access/)
*   [Loop Optimization in Compiler Design - GeeksforGeeks](https://www.geeksforgeeks.org/loop-optimization-in-compiler-design/)
*   [Performance Optimization - CPU Caches and Memory Hierarchy - Princeton University](https://www.cs.princeton.edu/courses/archive/fall09/cos333/lectures/17_perf.pdf)

Co-Authored-By: Gemini 2.5 Pro (References and desc commit changes)
