### PR TITLE
server: explicitly set exec path when create new instance

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -139,7 +139,7 @@ server_models::server_models(
         const common_params & params,
         int argc,
         char ** argv,
-        char ** envp) : base_params(params) {
+        char ** envp) : base_params(params), server_binary_path(get_server_exec_path().string()) {
     for (int i = 0; i < argc; i++) {
         base_args.push_back(std::string(argv[i]));
     }
@@ -383,7 +383,7 @@ void server_models::load(const std::string & name, bool auto_load) {
         }
 
         // set executable path
-        child_args[0] = get_server_exec_path().string();
+        child_args[0] = server_binary_path;
 
         // set model args
         add_or_replace_arg(child_args, "--port", std::to_string(inst.meta.port));

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -3,7 +3,7 @@
 
 #include "download.h"
 
-#include <cpp-httplib/httplib.h>
+#include <cpp-httplib/httplib.h> // TODO: remove this once we use HTTP client from download.h
 #include <sheredom/subprocess.h>
 
 #include <functional>

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -365,7 +365,6 @@ void server_models::load(const std::string & name, bool auto_load) {
 
     inst.subproc = std::make_shared<subprocess_s>();
     {
-        //std::string exec_path = get_server_exec_path().string();
         SRV_INF("spawning server instance with name=%s on port %d\n", inst.meta.name.c_str(), inst.meta.port);
 
         std::vector<std::string> child_args;
@@ -382,6 +381,9 @@ void server_models::load(const std::string & name, bool auto_load) {
                 }
             }
         }
+
+        // set executable path
+        child_args[0] = get_server_exec_path().string();
 
         // set model args
         add_or_replace_arg(child_args, "--port", std::to_string(inst.meta.port));

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -3,7 +3,7 @@
 
 #include "download.h"
 
-#include <cpp-httplib/httplib.h> // TODO: remove this once we use HTTP client from download.h
+#include <cpp-httplib/httplib.h>
 #include <sheredom/subprocess.h>
 
 #include <functional>
@@ -24,7 +24,54 @@
 #include <unistd.h>
 #endif
 
+#if defined(__APPLE__) && defined(__MACH__)
+// macOS: use _NSGetExecutablePath to get the executable path
+#include <mach-o/dyld.h>
+#include <limits.h>
+#endif
+
 #define CMD_EXIT "exit"
+
+static std::filesystem::path get_server_exec_path() {
+#if defined(_WIN32)
+    wchar_t buf[32768] = { 0 };  // Large buffer to handle long paths
+    DWORD len = GetModuleFileNameW(nullptr, buf, _countof(buf));
+    if (len == 0 || len >= _countof(buf)) {
+        throw std::runtime_error("GetModuleFileNameW failed or path too long");
+    }
+    return std::filesystem::path(buf);
+#elif defined(__APPLE__) && defined(__MACH__)
+    char small_path[PATH_MAX];
+    uint32_t size = sizeof(small_path);
+
+    if (_NSGetExecutablePath(small_path, &size) == 0) {
+        // resolve any symlinks to get absolute path
+        try {
+            return std::filesystem::canonical(std::filesystem::path(small_path));
+        } catch (...) {
+            return std::filesystem::path(small_path);
+        }
+    } else {
+        // buffer was too small, allocate required size and call again
+        std::vector<char> buf(size);
+        if (_NSGetExecutablePath(buf.data(), &size) == 0) {
+            try {
+                return std::filesystem::canonical(std::filesystem::path(buf.data()));
+            } catch (...) {
+                return std::filesystem::path(buf.data());
+            }
+        }
+        throw std::runtime_error("_NSGetExecutablePath failed after buffer resize");
+    }
+#else
+    char path[FILENAME_MAX];
+    ssize_t count = readlink("/proc/self/exe", path, FILENAME_MAX);
+    if (count <= 0) {
+        throw std::runtime_error("failed to resolve /proc/self/exe");
+    }
+    return std::filesystem::path(std::string(path, count));
+#endif
+}
 
 struct local_model {
     std::string name;
@@ -318,6 +365,7 @@ void server_models::load(const std::string & name, bool auto_load) {
 
     inst.subproc = std::make_shared<subprocess_s>();
     {
+        //std::string exec_path = get_server_exec_path().string();
         SRV_INF("spawning server instance with name=%s on port %d\n", inst.meta.name.c_str(), inst.meta.port);
 
         std::vector<std::string> child_args;

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -84,7 +84,6 @@ private:
     common_params base_params;
     std::vector<std::string> base_args;
     std::vector<std::string> base_env;
-    std::string server_binary_path;
 
     void update_meta(const std::string & name, const server_model_meta & meta);
 

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -84,6 +84,7 @@ private:
     common_params base_params;
     std::vector<std::string> base_args;
     std::vector<std::string> base_env;
+    std::string server_binary_path;
 
     void update_meta(const std::string & name, const server_model_meta & meta);
 


### PR DESCRIPTION
Trying to fix https://github.com/ggml-org/llama.cpp/issues/16487#issuecomment-3598932331

In some cases, the first argument from the parent process doesn't reflect the binary path. So, we always resolve the binary path manually to make sure that it works.