### PR TITLE
vulkan: add more num_blocks instantiations in rms_norm

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/rms_norm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/rms_norm.comp
@@ -131,8 +131,12 @@ void main() {
         rms_norm(num_blocks);
     } else if (num_blocks > 16) {
         rms_norm(32);
-    } else if (num_blocks > 8) {
+    } else if (num_blocks > 12) {
         rms_norm(16);
+    } else if (num_blocks > 10) {
+        rms_norm(12);
+    } else if (num_blocks > 8) {
+        rms_norm(10);
     } else if (num_blocks > 4) {
         rms_norm(8);
     } else if (num_blocks == 4) {


### PR DESCRIPTION
I noticed a couple models had rms_norm running slower than others, because the sizes from 8-16 were all doing 16 iterations. This change adds a couple more special cases to improve these sizes:

```
DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf
before:
RMS_NORM_MUL RMS_NORM(5120,1,1,1): 124257 x 6.172 us
| qwen2 14B Q4_K - Medium        |   8.37 GiB |    14.77 B | Vulkan     |  99 |  1 |           tg128 |        136.93 ± 0.09 |

after: 
RMS_NORM_MUL RMS_NORM(5120,1,1,1): 124257 x 4.274 us
| qwen2 14B Q4_K - Medium        |   8.37 GiB |    14.77 B | Vulkan     |  99 |  1 |           tg128 |        139.89 ± 0.15 |

Mistral-22B-v0.2-Q4_K_M.gguf
before:
RMS_NORM_MUL RMS_NORM(6144,1,1,1): 144753 x 6.215 us
| llama ?B Q4_K - Medium         |  12.42 GiB |    22.24 B | Vulkan     |  99 |  1 |           tg128 |         95.67 ± 0.14 |

after:
RMS_NORM_MUL RMS_NORM(6144,1,1,1): 144753 x 4.766 
| llama ?B Q4_K - Medium         |  12.42 GiB |    22.24 B | Vulkan     |  99 |  1 |           tg128 |         97.10 ± 0.08 |
```

The perf_logger results are over a full run of tg128 with `-r 10`.