### PR TITLE
build: enable parallel builds in msbuild using MTT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if (MSVC)
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/bigobj>")
 endif()
 
+# enable parallel builds for msbuild
+list(APPEND CMAKE_VS_GLOBALS UseMultiToolTask=true)
+list(APPEND CMAKE_VS_GLOBALS EnforceProcessCountAcrossBuilds=true)
+
 if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(LLAMA_TOOLS_INSTALL_DEFAULT OFF)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,11 @@ if (MSVC)
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/bigobj>")
 endif()
 
-# enable parallel builds for msbuild
-list(APPEND CMAKE_VS_GLOBALS UseMultiToolTask=true)
-list(APPEND CMAKE_VS_GLOBALS EnforceProcessCountAcrossBuilds=true)
+if (LLAMA_STANDALONE)
+    # enable parallel builds for msbuild
+    list(APPEND CMAKE_VS_GLOBALS UseMultiToolTask=true)
+    list(APPEND CMAKE_VS_GLOBALS EnforceProcessCountAcrossBuilds=true)
+endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(LLAMA_TOOLS_INSTALL_DEFAULT OFF)


### PR DESCRIPTION
msbuild performance has been poor recently, particularly since the model implementations were split into separate source files. This change enables MultiToolTask which enables parallelism within a project without the problems of /MP. See https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.

I tested each of the vulkan and cuda backends. My CPU is a 32-core threadripper.

```
vulkan before
========== Rebuild started at 2:50 PM and took 03:38.550 minutes ==========
vulkan after
========== Rebuild started at 3:36 PM and took 01:57.272 minutes ==========

cuda before
========== Rebuild started at 3:27 PM and took 07:59.340 minutes ==========
cuda after
========== Rebuild started at 3:38 PM and took 06:17.516 minutes ==========
```

This is supported in vs2019+. I think unknown options are ignored, so this shouldn't be harmful on older versions.