### PR TITLE
build: for GGML_BACKEND_DL, ggml need not depend on backend

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -253,7 +253,6 @@ function(ggml_add_backend_library backend)
         # write the shared library to the output directory
         set_target_properties(${backend} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
         target_compile_definitions(${backend} PRIVATE GGML_BACKEND_DL)
-        add_dependencies(ggml ${backend})
         if (GGML_BACKEND_DIR)
             install(TARGETS ${backend} LIBRARY DESTINATION ${GGML_BACKEND_DIR})
         else()


### PR DESCRIPTION
Removing this dependency allows more of the build to run in parallel with building the backend. I don't think this dependency is necessary since the backend is dynamically linked.

Build time on my system with this change stacked on #17708.
```
vulkan #17708
========== Rebuild started at 3:36 PM and took 01:57.272 minutes ==========
vulkan GGML_BACKEND_DL with dep removed
========== Rebuild started at 3:52 PM and took 01:13.617 minutes ==========

cuda #17708
========== Rebuild started at 3:38 PM and took 06:17.516 minutes ==========
cuda GGML_BACKEND_DL with dep removed
========== Rebuild started at 3:55 PM and took 05:34.916 minutes ==========
```
