### PR TITLE
fix: convert_hf_to_gguf - map new mistral-common valid_tokenizer_files output to avoid crash with --mistral-format

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -675,6 +675,11 @@ class MistralVocab(Vocab):
         all_files = [f.as_posix() for f in base_path.glob("**/*") if f.is_file()]
         valid_tokenizer_files = _filter_valid_tokenizer_files(all_files)
 
+        if len(valid_tokenizer_files) >= 1 and isinstance(valid_tokenizer_files[0], tuple):
+            # Later mistral-common versions return tuples of (file_name, file_path) instead of a string list file_names[]. 
+            # ref: https://github.com/ggml-org/llama.cpp/issues/17691
+            valid_tokenizer_files = [vf[0] for vf in valid_tokenizer_files]
+
         if len(valid_tokenizer_files) == 0:
             raise ValueError(f"No tokenizer file found in the directory: {base_path}")
         # If there are multiple tokenizer files, we use tekken.json if it exists, otherwise the versioned one.

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -684,8 +684,6 @@ class MistralVocab(Vocab):
 
         if get_one_valid_tokenizer_file is not None:
             tokenizer_file_path = get_one_valid_tokenizer_file(all_files)
-            # get_one_valid_tokenizer_file returns a path rather than just the file name e.g: "ministral3b\tekken.json" instead of "tekken.json"
-            tokenizer_file = Path(tokenizer_file_path).name
         else:
             valid_tokenizer_files = _filter_valid_tokenizer_files(all_files)
 
@@ -703,8 +701,10 @@ class MistralVocab(Vocab):
             else:
                 tokenizer_file = valid_tokenizer_files[0]
 
+            tokenizer_file_path = base_path / tokenizer_file
+
         self.tokenizer = MistralTokenizer.from_file(
-            base_path / tokenizer_file
+            tokenizer_file_path
         ).instruct_tokenizer.tokenizer
         self.tokenizer_type = (
             MistralTokenizerType.tekken
@@ -712,7 +712,7 @@ class MistralVocab(Vocab):
             else MistralTokenizerType.spm
         )
         self.vocab_size = self.tokenizer.n_words
-        self.fname_tokenizer = base_path / tokenizer_file
+        self.fname_tokenizer = tokenizer_file_path
         self._name = (
             "mistral-" + self.tokenizer_type.value + "-" + self.tokenizer.version
         )

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -683,7 +683,9 @@ class MistralVocab(Vocab):
         all_files = [f.as_posix() for f in base_path.glob("**/*") if f.is_file()]
 
         if get_one_valid_tokenizer_file is not None:
-            tokenizer_file = get_one_valid_tokenizer_file(all_files)
+            tokenizer_file_path = get_one_valid_tokenizer_file(all_files)
+            # get_one_valid_tokenizer_file returns a path rather than just the file name e.g: "ministral3b\tekken.json" instead of "tekken.json"
+            tokenizer_file = Path(tokenizer_file_path).name
         else:
             valid_tokenizer_files = _filter_valid_tokenizer_files(all_files)
 

--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -22,14 +22,6 @@ try:
     from mistral_common.tokens.tokenizers.sentencepiece import ( # pyright: ignore[reportMissingImports]
         SentencePieceTokenizer,
     )
-
-    try:
-        from mistral_common.tokens.tokenizers.utils import ( # pyright: ignore[reportMissingImports]
-            get_one_valid_tokenizer_file,
-        )
-    except ImportError:
-        # We still want the conversion to work with older mistral-common versions.
-        get_one_valid_tokenizer_file = None
 except ImportError:
     _mistral_common_installed = False
     MistralTokenizer = None
@@ -38,6 +30,14 @@ except ImportError:
     _filter_valid_tokenizer_files = None
 else:
     _mistral_common_installed = True
+
+try:
+    from mistral_common.tokens.tokenizers.utils import ( # pyright: ignore[reportMissingImports]
+        get_one_valid_tokenizer_file,
+    )
+except ImportError:
+    # We still want the conversion to work with older mistral-common versions.
+    get_one_valid_tokenizer_file = None
 
 
 import gguf


### PR DESCRIPTION
Fixes [#17691](https://github.com/ggml-org/llama.cpp/issues/17691)

`mistral-common` updated `_filter_valid_tokenizer_files` to return additional data we don't need or expect, causing the conversion to crash when `--mistral-format` is used.

This change just maps the output back into the format originally expected.

Tested on `mistral-common==1.8.3` and `mistral-common==1.8.6`


... that said, there's a different issue with the new Ministral models, which is partially related to how `--mistral-format` works:

`get_community_chat_templates()` is invoked with `--mistral-format`, and the logic there results in the model getting the `"unsloth-mistral-Devstral-Small-2507.jinja"` template - not Ministral's local `chat_template.jinja` - that's only used for `SpecialVocab` models (not `MistralVocab`).

To avoid this, users currently need to manually specify the chat template when running the model on e.g: llama-server with ` --jinja --chat-template-file "./chat_template.jinja"`

This issue is the case regardless of this PR - as long as `--mistral-format` is used I think.
