### PR TITLE
server: strip content-length header on proxy

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -900,6 +900,7 @@ static bool should_strip_proxy_header(const std::string & header_name) {
     // Headers that get duplicated when router forwards child responses
     if (header_name == "server" ||
         header_name == "transfer-encoding" ||
+        header_name == "content-length" || // quick fix for https://github.com/ggml-org/llama.cpp/issues/17710
         header_name == "keep-alive") {
         return true;
     }


### PR DESCRIPTION
fix https://github.com/ggml-org/llama.cpp/issues/17710

Note: there is also another alternative fix is to allow `server_http_proxy` to select if it wants to return a stream
 or not. but IMO this solution is not elegant because in case of non-stream:
- it is difficult to track timeout errors
- proxy with large amount of data becomes slow
- higher memory usage
- add lot more code