### PR TITLE
server: move msg diffs tracking to HTTP thread 

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2654,10 +2654,12 @@ static std::unique_ptr<server_res_generator> handle_completions_impl(
         }
 
         // next responses are streamed
+        // to be sent immediately
+        json first_result_json = first_result->to_json();
         if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
-            res->data = format_anthropic_sse(first_result->to_json());
+            res->data = format_anthropic_sse(first_result_json);
         } else {
-            res->data = format_oai_sse(first_result->to_json()); // to be sent immediately
+            res->data = format_oai_sse(first_result_json);
         }
         res->status = 200;
         res->content_type = "text/event-stream";
@@ -2698,8 +2700,8 @@ static std::unique_ptr<server_res_generator> handle_completions_impl(
             }
 
             // send the results
-            json res_json = result->to_json();
             if (result->is_error()) {
+                json res_json = result->to_json();
                 if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
                     output = format_anthropic_sse({
                         {"event", "error"},
@@ -2716,6 +2718,7 @@ static std::unique_ptr<server_res_generator> handle_completions_impl(
                     || dynamic_cast<server_task_result_cmpl_final*>(result.get()) != nullptr
                 );
                 result->update(states[result->get_index()]); // update generation state
+                json res_json = result->to_json();
                 if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
                     output = format_anthropic_sse(res_json);
                 } else {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2610,9 +2610,9 @@ static std::unique_ptr<server_res_generator> handle_completions_impl(
             task.params.res_type          = res_type;
             task.params.oaicompat_cmpl_id = completion_id;
             task.params.oaicompat_model   = ctx_server.model_name;
+            states.push_back(task.params.oaicompat_chat_syntax);
 
             tasks.push_back(std::move(task));
-            states.push_back(task.params.oaicompat_chat_syntax);
         }
 
         rd.post_tasks(std::move(tasks));

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2668,7 +2668,7 @@ static std::unique_ptr<server_res_generator> handle_completions_impl(
         }
         res->status = 200;
         res->content_type = "text/event-stream";
-        res->next = [res_this = res.get(), res_type, &should_stop](std::string & output) mutable -> bool {
+        res->next = [res_this = res.get(), res_type, &should_stop](std::string & output) -> bool {
             static auto format_error = [](task_response_type res_type, const json & res_json) {
                 if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
                     return format_anthropic_sse({

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -304,7 +304,7 @@ server_task_result_ptr server_response_reader::next(const std::function<bool()> 
             }
             if (!states.empty()) {
                 // update the generation state if needed
-                auto idx = result->get_index();
+                size_t idx = result->get_index();
                 GGML_ASSERT(idx >= 0 && idx < states.size());
                 result->update(states[idx]);
             }

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -305,7 +305,7 @@ server_task_result_ptr server_response_reader::next(const std::function<bool()> 
             if (!states.empty()) {
                 // update the generation state if needed
                 size_t idx = result->get_index();
-                GGML_ASSERT(idx >= 0 && idx < states.size());
+                GGML_ASSERT(idx < states.size());
                 result->update(states[idx]);
             }
             if (result->is_stop()) {

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -271,6 +271,10 @@ void server_response::terminate() {
 // server_response_reader
 //
 
+void server_response_reader::set_states(std::vector<task_result_state> && states) {
+    this->states = std::move(states);
+}
+
 void server_response_reader::post_tasks(std::vector<server_task> && tasks) {
     id_tasks = server_task::get_list_id(tasks);
     queue_results.add_waiting_tasks(tasks);
@@ -297,6 +301,12 @@ server_task_result_ptr server_response_reader::next(const std::function<bool()> 
                 stop(); // cancel remaining tasks
                 SRV_DBG("%s", "received error result, stopping further processing\n");
                 return result;
+            }
+            if (!states.empty()) {
+                // update the generation state if needed
+                auto idx = result->get_index();
+                GGML_ASSERT(idx >= 0 && idx < states.size());
+                result->update(states[idx]);
             }
             if (result->is_stop()) {
                 received_count++;

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <unordered_set>
 
+// struct for managing server tasks
+// in most cases, use server_response_reader to post new tasks and retrieve results
 struct server_queue {
 private:
     int id = 0;
@@ -67,6 +69,8 @@ private:
     void cleanup_pending_task(int id_target);
 };
 
+// struct for managing server responses
+// in most cases, use server_response_reader to retrieve results
 struct server_response {
 private:
     bool running = true;
@@ -120,6 +124,10 @@ struct server_response_reader {
     bool cancelled = false;
     int polling_interval_seconds;
 
+    // tracking generation state and partial tool calls
+    // only used by streaming completions
+    std::vector<task_result_state> states;
+
     // should_stop function will be called each polling_interval_seconds
     server_response_reader(std::pair<server_queue &, server_response &> server_queues, int polling_interval_seconds)
         : queue_tasks(server_queues.first), queue_results(server_queues.second), polling_interval_seconds(polling_interval_seconds) {}
@@ -127,6 +135,7 @@ struct server_response_reader {
         stop();
     }
 
+    void set_states(std::vector<task_result_state> && states);
     void post_tasks(std::vector<server_task> && tasks);
     bool has_next() const;
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -565,6 +565,7 @@ std::vector<unsigned char> completion_token_output::str_to_bytes(const std::stri
 // server_task_result_cmpl_final
 //
 json server_task_result_cmpl_final::to_json() {
+    GGML_ASSERT(is_updated && "update() must be called before to_json()");
     switch (res_type) {
         case TASK_RESPONSE_TYPE_NONE:
             return to_json_non_oaicompat();
@@ -975,6 +976,7 @@ json server_task_result_cmpl_final::to_json_anthropic_stream() {
 // server_task_result_cmpl_partial
 //
 json server_task_result_cmpl_partial::to_json() {
+    GGML_ASSERT(is_updated && "update() must be called before to_json()");
     switch (res_type) {
         case TASK_RESPONSE_TYPE_NONE:
             return to_json_non_oaicompat();

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -582,8 +582,8 @@ json server_task_result_cmpl_final::to_json() {
 json server_task_result_cmpl_final::to_json_non_oaicompat() {
     json res = json {
         {"index",               index},
-        {"content",             stream ? "" : content}, // in stream mode, content is already in last partial chunk
-        {"tokens",              stream ? llama_tokens {} : tokens},
+        {"content",             content},
+        {"tokens",              tokens},
         {"id_slot",             id_slot},
         {"stop",                true},
         {"model",               oaicompat_model},
@@ -619,7 +619,7 @@ json server_task_result_cmpl_final::to_json_oaicompat() {
     json res = json {
         {"choices",            json::array({
             json{
-                {"text",          stream ? "" : content}, // in stream mode, content is already in last partial chunk
+                {"text",          content},
                 {"index",         index},
                 {"logprobs",      logprobs},
                 {"finish_reason", finish_reason},

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -161,6 +161,25 @@ struct result_prompt_progress {
     json to_json() const;
 };
 
+// struct for tracking the state of a task (e.g., for streaming)
+struct task_result_state {
+    // tracking diffs for partial tool calls
+    std::vector<common_chat_msg_diff> diffs;
+    common_chat_syntax oaicompat_chat_syntax;
+    common_chat_msg chat_msg;
+    std::string generated_text; // append new chunks of generated text here
+    std::vector<std::string> generated_tool_call_ids;
+
+    task_result_state(const common_chat_syntax & oaicompat_chat_syntax)
+        : oaicompat_chat_syntax(oaicompat_chat_syntax) {}
+
+    // parse partial tool calls and update the internal state
+    common_chat_msg update_chat_msg(
+        const std::string & text_added,
+        bool is_partial,
+        std::vector<common_chat_msg_diff> & diffs);
+};
+
 struct server_task_result {
     int id           = -1;
     int id_slot      = -1;
@@ -174,6 +193,9 @@ struct server_task_result {
     }
     virtual int get_index() {
         return -1;
+    }
+    virtual void update(task_result_state &) {
+        // only used by server_task_result_cmpl_*
     }
     virtual json to_json() = 0;
     virtual ~server_task_result() = default;
@@ -233,9 +255,9 @@ struct server_task_result_cmpl_final : server_task_result {
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
-    common_chat_msg    oaicompat_msg;
+    common_chat_msg    oaicompat_msg; // to be populated by update()
 
-    std::vector<common_chat_msg_diff> oaicompat_msg_diffs;
+    std::vector<common_chat_msg_diff> oaicompat_msg_diffs; // to be populated by update()
 
     virtual int get_index() override {
         return index;
@@ -246,6 +268,10 @@ struct server_task_result_cmpl_final : server_task_result {
     }
 
     virtual json to_json() override;
+
+    virtual void update(task_result_state & state) override {
+        oaicompat_msg = state.update_chat_msg(content, false, oaicompat_msg_diffs);
+    }
 
     json to_json_non_oaicompat();
 
@@ -280,7 +306,7 @@ struct server_task_result_cmpl_partial : server_task_result {
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
-    std::vector<common_chat_msg_diff> oaicompat_msg_diffs;
+    std::vector<common_chat_msg_diff> oaicompat_msg_diffs; // to be populated by update()
 
     virtual int get_index() override {
         return index;
@@ -291,6 +317,10 @@ struct server_task_result_cmpl_partial : server_task_result {
     }
 
     virtual json to_json() override;
+
+    virtual void update(task_result_state & state) override {
+        state.update_chat_msg(content, true, oaicompat_msg_diffs);
+    }
 
     json to_json_non_oaicompat();
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -258,6 +258,7 @@ struct server_task_result_cmpl_final : server_task_result {
     common_chat_msg    oaicompat_msg; // to be populated by update()
 
     std::vector<common_chat_msg_diff> oaicompat_msg_diffs; // to be populated by update()
+    bool is_updated = false;
 
     virtual int get_index() override {
         return index;
@@ -270,6 +271,7 @@ struct server_task_result_cmpl_final : server_task_result {
     virtual json to_json() override;
 
     virtual void update(task_result_state & state) override {
+        is_updated = true;
         oaicompat_msg = state.update_chat_msg(content, false, oaicompat_msg_diffs);
     }
 
@@ -307,6 +309,7 @@ struct server_task_result_cmpl_partial : server_task_result {
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
     std::vector<common_chat_msg_diff> oaicompat_msg_diffs; // to be populated by update()
+    bool is_updated = false;
 
     virtual int get_index() override {
         return index;
@@ -319,6 +322,7 @@ struct server_task_result_cmpl_partial : server_task_result {
     virtual json to_json() override;
 
     virtual void update(task_result_state & state) override {
+        is_updated = true;
         state.update_chat_msg(content, true, oaicompat_msg_diffs);
     }
 


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/17726

The proposed approach: Delegate state tracking to HTTP thread
1. When creating a new task, we also create a new `task_result_state` that holds the state of the current generation "session". This object will be owned by the HTTP thread
2. Each time we receive a new result, we call `result.update(state)`; this allow the result to populate partial returns, at the same time also update the `state` object