### PR TITLE
model: add llama 4 scaling for mistral-large (deepseek arch)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1628,6 +1628,10 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 }
                 ml.get_key(LLM_KV_ROPE_SCALING_YARN_LOG_MUL, hparams.rope_yarn_log_mul, false);
 
+                // (optional) temperature tuning - used by mistral-large
+                ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_SCALE,  hparams.f_attn_temp_scale,       false);
+                ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_LENGTH, hparams.n_attn_temp_floor_scale, false);
+
                 switch (hparams.n_layer) {
                     case 27: type = LLM_TYPE_16B; break;
                     case 60: type = LLM_TYPE_236B; break;


### PR DESCRIPTION
Cont https://github.com/ggml-org/llama.cpp/pull/17730

This should allow Mistral Large to go past 16K context length (hopefully, someone with enough VRAM can verify if this works or not)
