### PR TITLE
fix: convert_hf_to_gguf - use existing local chat_template if mistral-format model has one.

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2343,7 +2343,7 @@ class LlamaModel(TextModel):
 
         local_template_file_path = self.dir_model / "chat_template.jinja"
 
-        if self.is_mistral_format and local_template_file_path.exists():
+        if self.is_mistral_format and local_template_file_path.is_file():
             # Ministral-3 and other new Mistral models come with chat templates.
             # ref: https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512/tree/main
             logger.info("Using an existing Mistral local chat template.")


### PR DESCRIPTION
Cont. https://github.com/ggml-org/llama.cpp/pull/17712

Some of the new [Ministral-3](https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512/blob/main/chat_template.jinja) Instruct variants have local chat templates, unlike previous Mistral models which required community intervention.

Beforehand, Ministral-3 models were converted and given an Unsloth `Devstral` chat template. This PR ensures Ministral-3 models converted with `--mistral-format` use their own provided chat templates instead.

It should also affect [Mistral-Large-3](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512/tree/main) as it has its own chat template too - I don't have the resources to test converting it.