### PR TITLE
common : skip model validation when --help is requested

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -427,7 +427,7 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
 
     // model is required (except for server)
     // TODO @ngxson : maybe show a list of available models in CLI in this case
-    if (params.model.path.empty() && ctx_arg.ex != LLAMA_EXAMPLE_SERVER) {
+    if (params.model.path.empty() && ctx_arg.ex != LLAMA_EXAMPLE_SERVER && !params.usage) {
         throw std::invalid_argument("error: --model is required\n");
     }
 


### PR DESCRIPTION
This commit skips the model validation check when the user specifies the --help option.

The motivation for this is that currently and error is thrown before the --help could be processed. Now skips validation if params.usage is set, allowing help to display without requiring --model.

Resolves: https://github.com/ggml-org/llama.cpp/issues/17754