### PR TITLE
examples : add missing code block end marker [no ci]

### DIFF
--- a/examples/simple-cmake-pkg/README.md
+++ b/examples/simple-cmake-pkg/README.md
@@ -18,6 +18,7 @@ cd llama.cpp
 cmake -S . -B build
 cmake --build build
 cmake --install build --prefix inst
+```
 
 ### Build simple-cmake-pkg
 


### PR DESCRIPTION
This commit adds the missing code block end marker in simple-cmake-pkg to correct the formatting.
