### PR TITLE
refactor: update CMakeLists.txt and enhance llama vocabulary management

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -189,9 +189,9 @@ endif()
 
 # ggml
 
-if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
-    message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
-endif()
+# if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
+#    message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
+# endif()
 
 add_library(ggml-base
             ../include/ggml.h

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -54,6 +54,8 @@ struct llama_context {
 
     llama_memory_t get_memory() const;
 
+    llama_memory_i * get_memory_ptr() { return memory.get(); }
+
     // return true if the memory was updated
     bool memory_update(bool optimize);
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -182,7 +182,7 @@ public:
     void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
     void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
 
-private:
+public: // private:
     const llama_model & model;
     const llama_hparams & hparams;
 

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3829,3 +3829,7 @@ int32_t llama_detokenize(
                         bool   unparse_special) {
     return vocab->detokenize(tokens, n_tokens, text, text_len_max, remove_special, unparse_special);
 }
+
+void llama_vocab::set_n_vocab(uint32_t n) {
+    pimpl->id_to_token.resize(n);
+}

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -174,6 +174,8 @@ struct llama_vocab {
 
     void print_info() const;
 
+    void set_n_vocab(uint32_t n);
+
 private:
     struct impl;
     std::unique_ptr<impl> pimpl;


### PR DESCRIPTION
- Commented out error message in CMakeLists.txt for GGML_BACKEND_DL
- Added get_memory_ptr method to llama_context for memory access
- Changed access modifier of model and hparams in llama_kv_cache to public
- Implemented set_n_vocab method in llama_vocab to resize id_to_token

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
