### PR TITLE
docs(server): clarify that --ctx-size is total context divided among parallel slots

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -920,7 +920,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_LOOKUP}));
     add_opt(common_arg(
         {"-c", "--ctx-size"}, "N",
-        string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
+        string_format("size of the prompt context (default: %d, 0 = loaded from model). "
+            "Note: when using --parallel N, this is the TOTAL context divided among all slots, "
+            "not per-slot. For X tokens per slot with N parallel slots, use --ctx-size X*N", params.n_ctx),
         [](common_params & params, int value) {
             params.n_ctx = value;
         }
@@ -1756,7 +1758,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_env("LLAMA_ARG_DEFRAG_THOLD"));
     add_opt(common_arg(
         {"-np", "--parallel"}, "N",
-        string_format("number of parallel sequences to decode (default: %d)", params.n_parallel),
+        string_format("number of parallel sequences to decode (default: %d). "
+            "Note: total context (--ctx-size) is divided equally among parallel slots", params.n_parallel),
         [](common_params & params, int value) {
             params.n_parallel = value;
         }


### PR DESCRIPTION
## Summary

When using `--parallel N`, the `--ctx-size` value is the **total** context divided among all slots, not the per-slot context. This is a common source of confusion (see #11681, #5732).

## Changes

Added clarification to two flags in `tools/server/README.md`:

**`--ctx-size`**: Added note explaining that when using `--parallel N`, this is the total context divided among all slots. Each slot gets `ctx-size / parallel` tokens. To allocate X tokens per slot with N parallel slots, set `--ctx-size` to `X * N`.

**`--parallel`**: Added note that the total context is divided equally among these slots.

## Example

- `--ctx-size 4096 --parallel 4` → each slot gets 1024 tokens
- To get 4096 tokens per slot with 4 parallel slots, use `--ctx-size 16384 --parallel 4`

## Related Issues

- Fixes #11681 (ctx-size divided by parallel confusion)
- Related to #5732 (context length documentation confusion)