### PR TITLE
server: support multiple generations from one prompt (OAI "n" option)

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -493,6 +493,8 @@ Note for `multimodal_data` in JSON object prompts. This should be an array of st
 `n_keep`: Specify the number of tokens from the prompt to retain when the context size is exceeded and tokens need to be discarded. The number excludes the BOS token.
 By default, this value is set to `0`, meaning no tokens are kept. Use `-1` to retain all tokens from the prompt.
 
+`n_cmpl`: Number of completions to generate from the current prompt. If input has multiple prompts, the output will have N prompts times `n_cmpl` entries.
+
 `stream`: Allows receiving each predicted token in real-time instead of waiting for the completion to finish (uses a different response format). To enable this, set to `true`.
 
 `stop`: Specify a JSON array of stopping strings.

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -757,7 +757,7 @@ json oaicompat_completion_params_parse(const json & body) {
         llama_params["stop"] = json_value(body, "stop", json::array());
     }
 
-    llama_params["n"] = json_value(body, "n", 1);
+    llama_params["n_cmpl"] = json_value(body, "n", 1);
 
     // Handle "echo" field
     if (json_value(body, "echo", false)) {
@@ -1057,7 +1057,7 @@ json oaicompat_chat_params_parse(
         llama_params["chat_parser"] = chat_params.parser;
     }
 
-    llama_params["n"] = json_value(body, "n", 1);
+    llama_params["n_cmpl"] = json_value(body, "n", 1);
 
     // Handle "logprobs" field
     // TODO: The response format of this option is not yet OAI-compatible, but seems like no one really using it; We may need to fix it in the future

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -757,8 +757,6 @@ json oaicompat_completion_params_parse(const json & body) {
         llama_params["stop"] = json_value(body, "stop", json::array());
     }
 
-    llama_params["n_cmpl"] = json_value(body, "n", 1);
-
     // Handle "echo" field
     if (json_value(body, "echo", false)) {
         throw std::runtime_error("Only no echo is supported");
@@ -1056,8 +1054,6 @@ json oaicompat_chat_params_parse(
     if (!chat_params.parser.empty()) {
         llama_params["chat_parser"] = chat_params.parser;
     }
-
-    llama_params["n_cmpl"] = json_value(body, "n", 1);
 
     // Handle "logprobs" field
     // TODO: The response format of this option is not yet OAI-compatible, but seems like no one really using it; We may need to fix it in the future

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -215,6 +215,8 @@ public:
                 llama_pos pos,
                 int32_t seq_id,
                 size_t & n_tokens_out) const;
+    
+    server_tokens clone() const;
 };
 
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -215,7 +215,7 @@ public:
                 llama_pos pos,
                 int32_t seq_id,
                 size_t & n_tokens_out) const;
-    
+
     server_tokens clone() const;
 };
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -255,6 +255,7 @@ struct server_slot {
         generated_token_probs.push_back(token);
     }
 
+    // note: a slot can also be either a parent or a child
     bool is_parent() const {
         return is_processing() && task->n_children > 0;
     }
@@ -1704,6 +1705,12 @@ struct server_context_impl {
                     // we should never reach this because params_base.ctx_shift is automatically disabled if mmproj is loaded
                     // we don't support ctx_shift because an image chunk may contains multiple tokens
                     GGML_ABORT("not supported by multimodal");
+                }
+
+                if (slot.is_parent() || slot.is_child()) {
+                    send_error(slot, "context shift cannot be used for shared prompt", ERROR_TYPE_SERVER);
+                    slot.release();
+                    continue;
                 }
 
                 // Shift context

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -386,6 +386,7 @@ struct server_slot {
     }
 
     void copy_state_to(server_slot & other) const {
+        llama_memory_seq_rm(llama_get_memory(ctx), other.id, 0, -1);
         llama_memory_seq_cp(llama_get_memory(ctx), id, other.id, 0, -1);
         other.n_decoded   = n_decoded;
         other.n_remaining = n_remaining;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -35,10 +35,10 @@ constexpr int HTTP_POLLING_SECONDS = 1;
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
 enum slot_state {
     SLOT_STATE_IDLE,
-    SLOT_STATE_STARTED, // after assigning a task
+    SLOT_STATE_WAIT_OTHER, // after assigning a task, but waiting for parent slot to process prompt
+    SLOT_STATE_STARTED,    // after assigning a task and about to process prompt
     SLOT_STATE_PROCESSING_PROMPT,
     SLOT_STATE_DONE_PROMPT,
-    SLOT_STATE_WAIT_OTHER, // prompt processed, but waiting for other slots to copy the state
     SLOT_STATE_GENERATING,
 };
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2354,7 +2354,6 @@ struct server_context_impl {
                             slot.copy_state_to(*child);
                             child->state = SLOT_STATE_DONE_PROMPT;
                         }
-                        slot.state = SLOT_STATE_DONE_PROMPT;
                     }
                 }
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -175,6 +175,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
     params.n_discard        = json_value(data,       "n_discard",          defaults.n_discard);
+    params.n_cmpl           = json_value(data,       "n_cmpl",             defaults.n_cmpl);
     //params.t_max_prompt_ms  = json_value(data,       "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement
     params.t_max_predict_ms = json_value(data,       "t_max_predict_ms",   defaults.t_max_predict_ms);
     params.response_fields  = json_value(data,       "response_fields",    std::vector<std::string>());
@@ -451,6 +452,10 @@ task_params server_task::params_from_json_cmpl(
         } else {
             params.sampling.samplers = defaults.sampling.samplers;
         }
+    }
+
+    if (params.n_cmpl > params_base.n_parallel) {
+        throw std::runtime_error("n_cmpl cannot be greater than the number of slots, please increase -np");
     }
 
     return params;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -669,7 +669,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat() {
 
     json choice {
         {"finish_reason", finish_reason},
-        {"index", 0},
+        {"index", index},
         {"message", msg.to_json_oaicompat<json>()},
     };
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1069,7 +1069,7 @@ json server_task_result_cmpl_partial::to_json_oaicompat_chat() {
             {"choices", json::array({
                 json {
                     {"finish_reason", nullptr},
-                    {"index", 0},
+                    {"index", index},
                     {"delta", delta},
                 },
             })},

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -175,7 +175,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
     params.n_discard        = json_value(data,       "n_discard",          defaults.n_discard);
-    params.n_cmpl           = json_value(data,       "n_cmpl",             defaults.n_cmpl);
+    params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     //params.t_max_prompt_ms  = json_value(data,       "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement
     params.t_max_predict_ms = json_value(data,       "t_max_predict_ms",   defaults.t_max_predict_ms);
     params.response_fields  = json_value(data,       "response_fields",    std::vector<std::string>());

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -53,6 +53,7 @@ struct task_params {
     int32_t n_discard =  0; // number of tokens after n_keep that may be discarded when shifting context, 0 defaults to half
     int32_t n_predict = -1; // new tokens to predict
     int32_t n_indent  =  0; // minimum line indentation for the generated text in number of whitespace characters
+    int32_t n_cmpl    =  1; // number of completions to generate from this prompt
 
     int64_t t_max_prompt_ms  = -1; // TODO: implement
     int64_t t_max_predict_ms = -1; // if positive, limit the generation phase to this time limit
@@ -133,6 +134,17 @@ struct server_task {
             ids.insert(tasks[i].id);
         }
         return ids;
+    }
+
+    server_task create_child(int id_parent, int id_child, int idx) const {
+        server_task copy;
+        copy.id        = id_child;
+        copy.index     = idx;
+        copy.id_parent = id_parent;
+        copy.params    = params;
+        copy.type      = type;
+        copy.tokens    = tokens.clone();
+        return copy;
     }
 };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -89,6 +89,10 @@ struct server_task {
     int id_target = -1;
     int id_slot   = -1;
 
+    // used by parallel sampling (multiple completions from same prompt)
+    size_t n_children =  0; // number of tasks reusing this prompt
+    int    id_parent  = -1;
+
     // used by SERVER_TASK_TYPE_INFERENCE
     task_params   params;
     server_tokens tokens;
@@ -465,6 +469,14 @@ struct server_prompt {
 
     int n_tokens() const {
         return tokens.size();
+    }
+
+    server_prompt clone() const {
+        return server_prompt {
+            tokens.clone(),
+            data,
+            checkpoints
+        };
     }
 };
 

--- a/tools/server/tests/unit/test_chat_completion.py
+++ b/tools/server/tests/unit/test_chat_completion.py
@@ -477,3 +477,22 @@ def test_return_progress(n_batch, batch_count, reuse_cache):
     assert last_progress["total"] > 0
     assert last_progress["processed"] == last_progress["total"]
     assert total_batch_count == batch_count
+
+
+def test_chat_completions_multiple_choices():
+    global server
+    server.start()
+    res = server.make_request("POST", "/chat/completions", data={
+        "max_tokens": 8,
+        "n": 2,
+        "messages": [
+            {"role": "system", "content": "Book"},
+            {"role": "user", "content": "What is the best book"},
+        ],
+    })
+    assert res.status_code == 200
+    assert len(res.body["choices"]) == 2
+    for choice in res.body["choices"]:
+        assert "assistant" == choice["message"]["role"]
+        assert match_regex("Suddenly", choice["message"]["content"])
+        assert choice["finish_reason"] == "length"


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/11142

---

## Implementation

The requirement is that number of slots must be equal or larger than number of "n" completion choices.

1. When task is created, we create N-1 child tasks and 1 parent task
2. Parent task is guaranteed to be loaded first (because we push all tasks into queue under one lock acquired). Child tasks are also loaded into slots at this point, but state will be set to `SLOT_STATE_WAIT_OTHER`
3. We begin processing parent's prompt
4. When parent prompt processing is done, we gather all children having `SLOT_STATE_WAIT_OTHER` state, then copy parent's state into these slots via `llama_memory_seq_cp`
    - Note: at this point, if we cannot yet gather all children (maybe one of slot is busying with another task), we wait until the task is done and all children are on their slots. This can potentially decrease the overall throughput, but makes the implementation easier to understand
5. Continue to sampling and token generation as usual

---

TODO:
- [x] fix "invalid input batch" error
- [x] do not allow context shifting
- [x] add OAI output format
- [x] add tests