### PR TITLE
CUDA:  Improve performance via less synchronizations between token

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1483,7 +1483,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 } else {
                     ggml_backend_synchronize_if_required(split_backend);
                 }
-                ggml_backend_tensor_copy(input, input_cpy);
+                ggml_backend_tensor_copy_async(input_backend, split_backend, input, input_cpy);
+                ggml_backend_synchronize_if_required(split_backend);
             } else {
                 // wait for the split backend to finish using the input before overwriting it
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -673,9 +673,9 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #endif
 
 enum ggml_backend_sync_mode {
-    GGML_SPLIT_SYNC_MODE_IMPLICIT = 0,            // splits which can rely on implicit sync mechanisms of its backend like a queue or stream
+    GGML_SPLIT_SYNC_MODE_EXPLICIT = 0,            // splits which require explicit synchronization throughout (default)
     GGML_SPLIT_SYNC_MODE_WRITE_READ_BOUNDARY = 1, // splits which require only a single explicit sync between the last write and the first read
-    GGML_SPLIT_SYNC_MODE_EXPLICIT = 2             // splits which require explicit synchronization throughout (default)
+    GGML_SPLIT_SYNC_MODE_IMPLICIT = 2             // splits which can rely on implicit sync mechanisms of its backend like a queue or stream
 };
 
 struct ggml_backend_sched_split {
@@ -686,7 +686,7 @@ struct ggml_backend_sched_split {
     int n_inputs;
     // graph view of this split
     struct ggml_cgraph graph;
-    enum ggml_backend_sync_mode backend_sync_mode = GGML_SPLIT_SYNC_MODE_EXPLICIT;
+    enum ggml_backend_sync_mode backend_sync_mode;
 };
 
 struct ggml_backend_sched {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -672,6 +672,12 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #define GGML_SCHED_MAX_COPIES 4
 #endif
 
+enum ggml_backend_sync_mode {
+    GGML_SPLIT_SYNC_MODE_IMPLICIT = 0,            // splits which can rely on implicit sync mechanisms of its backend like a queue or stream
+    GGML_SPLIT_SYNC_MODE_WRITE_READ_BOUNDARY = 1, // splits which require only a single explicit sync between the last write and the first read
+    GGML_SPLIT_SYNC_MODE_EXPLICIT = 2             // splits which require explicit synchronization throughout (default)
+};
+
 struct ggml_backend_sched_split {
     int backend_id;
     int i_start;
@@ -680,6 +686,7 @@ struct ggml_backend_sched_split {
     int n_inputs;
     // graph view of this split
     struct ggml_cgraph graph;
+    enum ggml_backend_sync_mode backend_sync_mode = GGML_SPLIT_SYNC_MODE_EXPLICIT;
 };
 
 struct ggml_backend_sched {
@@ -738,30 +745,40 @@ struct ggml_backend_sched {
     int debug_prev_graph_size;
 };
 
-static void ggml_backend_synchronize_if_required(ggml_backend_t current_backend, bool backend_implicitly_synced) {
 
-    if (backend_implicitly_synced) {
+static void ggml_backend_synchronize_if_required(ggml_backend_sched_split * split, ggml_backend_t current_backend, bool is_final_write = 0) {
+
+    if (split->backend_sync_mode == GGML_SPLIT_SYNC_MODE_IMPLICIT) {
+        return;
+    }
+
+    if (split->backend_sync_mode == GGML_SPLIT_SYNC_MODE_WRITE_READ_BOUNDARY && !is_final_write) {
         return;
     }
 
     ggml_backend_synchronize(current_backend);
 }
 
-static bool ggml_backend_implicitly_synced(ggml_backend_t current_backend) {
+static void ggml_backend_implicitly_synced(ggml_backend_sched_split * split, ggml_backend_t current_backend) {
     /*
      * Some backends have implicit synchronization mechanisms, which allows several parallel asynchronous memory copies without data races.
      * An example for that is the CUDA backend with the CUDA stream.
      * For these backends, we can skip costly explicit synchronizations during compute split scheduling.
      */
+    if (split->backend_sync_mode != GGML_SPLIT_SYNC_MODE_EXPLICIT) {
+        // indicates that this function has already changed the default value, no repeat check necessary
+        return;
+    }
 
     // To not change any APIs or change what ggml-base links to, we can only detect backends by string matching
     auto backend_name = ggml_backend_name(current_backend);
     if (strncmp(backend_name, "CUDA", 4) == 0) {
-        return true;
+        split->backend_sync_mode = GGML_SPLIT_SYNC_MODE_IMPLICIT;
+        return;
     }
 
-    // sync other backends to ensure correctness
-    return false;
+    // retain default explicit synchronization on other backends for correctness
+    return;
 }
 
 #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
@@ -1480,30 +1497,33 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         struct ggml_backend_sched_split * split = &splits[split_id];
         int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
-        // some backends can avoid costly syncs between async copies
-        bool backend_implicitly_synced = ggml_backend_implicitly_synced(split_backend);
+
+        // determine if backend can avoid costly syncs between HtoD async copies
+        ggml_backend_implicitly_synced(split, split_backend);
+
 
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[input_id]);
             struct ggml_tensor * input = split->inputs[input_id];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
+            bool last_input = (input_id + 1) == split->n_inputs;
 
             if (input->flags & GGML_TENSOR_FLAG_INPUT) {
                 // inputs from the user must be copied immediately to prevent the user overwriting the data before the copy is done
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_synchronize(sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
+                    ggml_backend_synchronize_if_required(split, split_backend);
                 }
                 ggml_backend_tensor_copy_async(input_backend, split_backend, input, input_cpy);
-                ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
+                ggml_backend_synchronize_if_required(split, split_backend, last_input);
             } else {
                 // wait for the split backend to finish using the input before overwriting it
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_wait(split_backend, sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
+                    ggml_backend_synchronize_if_required(split, split_backend, last_input);
                 }
 
                 // when offloading MoE weights, we can reduce the amount of data copied by copying only the experts that are used

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -11,6 +11,8 @@
 #include "ggml-backend.h"
 #include "ggml-backend-impl.h"
 #include "ggml-alloc.h"
+#include "ggml-cpu.h"
+#include "ggml-cuda.h"  // TODO add IFDEFs for CUDA-specific parts
 #include "ggml-impl.h"
 
 #include <assert.h>
@@ -737,6 +739,19 @@ struct ggml_backend_sched {
     int debug_graph_size;
     int debug_prev_graph_size;
 };
+
+static void ggml_backend_synchronize_if_required(ggml_backend_t current_backend) {
+    // TODO add env-flag check here to auto-disable this change
+    // CUDA backends have an implicit order between execution and memory operations via the CUDA stream.
+    // Multiple parallel copies are also possible.
+    // There is consequently no need to synchronize in between computation and subsequent memcpys
+    if (ggml_backend_is_cuda(current_backend)) {
+        return;
+    }
+
+    // in all other cases, just sync.
+    ggml_backend_synchronize(current_backend);
+}
 
 #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
 #define tensor_backend_id(tensor) sched->hv_tensor_backend_ids[hash_id(tensor)]
@@ -1466,7 +1481,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_synchronize(sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize(split_backend);
+                    ggml_backend_synchronize_if_required(split_backend);
                 }
                 ggml_backend_tensor_copy(input, input_cpy);
             } else {
@@ -1474,7 +1489,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_wait(split_backend, sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize(split_backend);
+                    ggml_backend_synchronize_if_required(split_backend);
                 }
 
                 // when offloading MoE weights, we can reduce the amount of data copied by copying only the experts that are used

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -754,12 +754,6 @@ static bool ggml_backend_implicitly_synced(ggml_backend_t current_backend) {
      * For these backends, we can skip costly explicit synchronizations during compute split scheduling.
      */
 
-    static bool disable_scheduler_sync_opt = (getenv("GGML_SCHED_DISABLE_SYNC_OPT") != nullptr);
-
-    if (disable_scheduler_sync_opt) {
-        return false;
-    }
-
     // To not change any APIs or change what ggml-base links to, we can only detect backends by string matching
     auto backend_name = ggml_backend_name(current_backend);
     if (strncmp(backend_name, "CUDA", 4) == 0) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -672,12 +672,6 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #define GGML_SCHED_MAX_COPIES 4
 #endif
 
-enum ggml_backend_sync_mode {
-    GGML_SPLIT_SYNC_MODE_EXPLICIT = 0,            // splits which require explicit synchronization throughout (default)
-    GGML_SPLIT_SYNC_MODE_WRITE_READ_BOUNDARY = 1, // splits which require only a single explicit sync between the last write and the first read
-    GGML_SPLIT_SYNC_MODE_IMPLICIT = 2             // splits which can rely on implicit sync mechanisms of its backend like a queue or stream
-};
-
 struct ggml_backend_sched_split {
     int backend_id;
     int i_start;
@@ -686,7 +680,6 @@ struct ggml_backend_sched_split {
     int n_inputs;
     // graph view of this split
     struct ggml_cgraph graph;
-    enum ggml_backend_sync_mode backend_sync_mode;
 };
 
 struct ggml_backend_sched {
@@ -744,42 +737,6 @@ struct ggml_backend_sched {
     int debug_graph_size;
     int debug_prev_graph_size;
 };
-
-
-static void ggml_backend_synchronize_if_required(ggml_backend_sched_split * split, ggml_backend_t current_backend, bool is_final_write = 0) {
-
-    if (split->backend_sync_mode == GGML_SPLIT_SYNC_MODE_IMPLICIT) {
-        return;
-    }
-
-    if (split->backend_sync_mode == GGML_SPLIT_SYNC_MODE_WRITE_READ_BOUNDARY && !is_final_write) {
-        return;
-    }
-
-    ggml_backend_synchronize(current_backend);
-}
-
-static void ggml_backend_implicitly_synced(ggml_backend_sched_split * split, ggml_backend_t current_backend) {
-    /*
-     * Some backends have implicit synchronization mechanisms, which allows several parallel asynchronous memory copies without data races.
-     * An example for that is the CUDA backend with the CUDA stream.
-     * For these backends, we can skip costly explicit synchronizations during compute split scheduling.
-     */
-    if (split->backend_sync_mode != GGML_SPLIT_SYNC_MODE_EXPLICIT) {
-        // indicates that this function has already changed the default value, no repeat check necessary
-        return;
-    }
-
-    // To not change any APIs or change what ggml-base links to, we can only detect backends by string matching
-    auto backend_name = ggml_backend_name(current_backend);
-    if (strncmp(backend_name, "CUDA", 4) == 0) {
-        split->backend_sync_mode = GGML_SPLIT_SYNC_MODE_IMPLICIT;
-        return;
-    }
-
-    // retain default explicit synchronization on other backends for correctness
-    return;
-}
 
 #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
 #define tensor_backend_id(tensor) sched->hv_tensor_backend_ids[hash_id(tensor)]
@@ -1498,32 +1455,26 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
 
-        // determine if backend can avoid costly syncs between HtoD async copies
-        ggml_backend_implicitly_synced(split, split_backend);
-
+        if (sched->events[split_backend_id][sched->cur_copy] == NULL) {
+            ggml_backend_synchronize(split_backend);
+        }
 
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[input_id]);
             struct ggml_tensor * input = split->inputs[input_id];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
-            bool last_input = (input_id + 1) == split->n_inputs;
 
             if (input->flags & GGML_TENSOR_FLAG_INPUT) {
                 // inputs from the user must be copied immediately to prevent the user overwriting the data before the copy is done
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_synchronize(sched->events[split_backend_id][sched->cur_copy]);
-                } else {
-                    ggml_backend_synchronize_if_required(split, split_backend);
                 }
                 ggml_backend_tensor_copy_async(input_backend, split_backend, input, input_cpy);
-                ggml_backend_synchronize_if_required(split, split_backend, last_input);
             } else {
                 // wait for the split backend to finish using the input before overwriting it
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_wait(split_backend, sched->events[split_backend_id][sched->cur_copy]);
-                } else {
-                    ggml_backend_synchronize_if_required(split, split_backend, last_input);
                 }
 
                 // when offloading MoE weights, we can reduce the amount of data copied by copying only the experts that are used
@@ -1625,6 +1576,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     }
                 }
             }
+        }
+
+        if (sched->events[split_backend_id][sched->cur_copy] == NULL) {
+            ggml_backend_synchronize(split_backend);
         }
 
         if (!sched->callback_eval) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -12,7 +12,9 @@
 #include "ggml-backend-impl.h"
 #include "ggml-alloc.h"
 #include "ggml-cpu.h"
-#include "ggml-cuda.h"  // TODO add IFDEFs for CUDA-specific parts
+#ifdef GGML_CUDA
+#include "ggml-cuda.h"
+#endif // GGML_CUDA
 #include "ggml-impl.h"
 
 #include <assert.h>
@@ -742,12 +744,15 @@ struct ggml_backend_sched {
 
 static void ggml_backend_synchronize_if_required(ggml_backend_t current_backend) {
     // TODO add env-flag check here to auto-disable this change
+
+#ifdef GGML_CUDA
     // CUDA backends have an implicit order between execution and memory operations via the CUDA stream.
     // Multiple parallel copies are also possible.
     // There is consequently no need to synchronize in between computation and subsequent memcpys
     if (ggml_backend_is_cuda(current_backend)) {
         return;
     }
+#endif // GGML_CUDA
 
     // in all other cases, just sync.
     ggml_backend_synchronize(current_backend);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -11,10 +11,6 @@
 #include "ggml-backend.h"
 #include "ggml-backend-impl.h"
 #include "ggml-alloc.h"
-#include "ggml-cpu.h"
-#ifdef GGML_CUDA
-#include "ggml-cuda.h"
-#endif // GGML_CUDA
 #include "ggml-impl.h"
 
 #include <assert.h>
@@ -742,20 +738,36 @@ struct ggml_backend_sched {
     int debug_prev_graph_size;
 };
 
-static void ggml_backend_synchronize_if_required(ggml_backend_t current_backend) {
-    // TODO add env-flag check here to auto-disable this change
+static void ggml_backend_synchronize_if_required(ggml_backend_t current_backend, bool backend_implicitly_synced) {
 
-#ifdef GGML_CUDA
-    // CUDA backends have an implicit order between execution and memory operations via the CUDA stream.
-    // Multiple parallel copies are also possible.
-    // There is consequently no need to synchronize in between computation and subsequent memcpys
-    if (ggml_backend_is_cuda(current_backend)) {
+    if (backend_implicitly_synced) {
         return;
     }
-#endif // GGML_CUDA
 
-    // in all other cases, just sync.
     ggml_backend_synchronize(current_backend);
+}
+
+static bool ggml_backend_implicitly_synced(ggml_backend_t current_backend) {
+    /*
+     * Some backends have implicit synchronization mechanisms, which allows several parallel asynchronous memory copies without data races.
+     * An example for that is the CUDA backend with the CUDA stream.
+     * For these backends, we can skip costly explicit synchronizations during compute split scheduling.
+     */
+
+    static bool disable_scheduler_sync_opt = (getenv("GGML_SCHED_DISABLE_SYNC_OPT") != nullptr);
+
+    if (disable_scheduler_sync_opt) {
+        return false;
+    }
+
+    // To not change any APIs or change what ggml-base links to, we can only detect backends by string matching
+    auto backend_name = ggml_backend_name(current_backend);
+    if (strncmp(backend_name, "CUDA", 4) == 0) {
+        return true;
+    }
+
+    // sync other backends to ensure correctness
+    return false;
 }
 
 #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
@@ -1474,6 +1486,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         struct ggml_backend_sched_split * split = &splits[split_id];
         int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
+        // some backends can avoid costly syncs between async copies
+        bool backend_implicitly_synced = ggml_backend_implicitly_synced(split_backend);
 
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
@@ -1486,16 +1500,16 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_synchronize(sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize_if_required(split_backend);
+                    ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
                 }
                 ggml_backend_tensor_copy_async(input_backend, split_backend, input, input_cpy);
-                ggml_backend_synchronize_if_required(split_backend);
+                ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
             } else {
                 // wait for the split backend to finish using the input before overwriting it
                 if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                     ggml_backend_event_wait(split_backend, sched->events[split_backend_id][sched->cur_copy]);
                 } else {
-                    ggml_backend_synchronize_if_required(split_backend);
+                    ggml_backend_synchronize_if_required(split_backend, backend_implicitly_synced);
                 }
 
                 // when offloading MoE weights, we can reduce the amount of data copied by copying only the experts that are used

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2807,7 +2807,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
         return false;
     }
 
-    if (!(copy_from_host || ggml_backend_buffer_is_cuda(src->buffer)) || !ggml_backend_buffer_is_cuda(dst->buffer)) {
+    if (!(copy_from_host || ggml_backend_buffer_is_cuda(buf_src)) || !ggml_backend_buffer_is_cuda(dst->buffer)) {
         return false;
     }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2801,7 +2801,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     ggml_backend_buffer_t buf_dst = dst->view_src ? dst->view_src->buffer : dst->buffer;
 
     //enables async copies from CPU to CUDA, instead of only CUDA-to-CUDA
-    bool copy_from_host = ggml_backend_buffer_is_host(src->buffer) && ggml_backend_dev_type(backend_src->device) == GGML_BACKEND_DEVICE_TYPE_CPU;
+    bool copy_from_host = ggml_backend_buffer_is_host(buf_src) && ggml_backend_dev_type(backend_src->device) == GGML_BACKEND_DEVICE_TYPE_CPU;
 
     if (!(copy_from_host || ggml_backend_is_cuda(backend_src)) || !ggml_backend_is_cuda(backend_dst)) {
         return false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2818,7 +2818,8 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     ggml_backend_cuda_buffer_context * buf_ctx_src = (ggml_backend_cuda_buffer_context *)buf_src->context;
     ggml_backend_cuda_buffer_context * buf_ctx_dst = (ggml_backend_cuda_buffer_context *)buf_dst->context;
 
-    if (!copy_from_host && (cuda_ctx_src->device != buf_ctx_src->device || cuda_ctx_dst->device != buf_ctx_dst->device)) {
+    if ((copy_from_host && cuda_ctx_dst->device != buf_ctx_dst->device) ||
+        !copy_from_host && (cuda_ctx_src->device != buf_ctx_src->device || cuda_ctx_dst->device != buf_ctx_dst->device)) {
 #ifndef NDEBUG
         GGML_LOG_DEBUG("%s: backend and buffer devices do not match\n", __func__);
 #endif
@@ -2826,9 +2827,6 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     }
 
     if (copy_from_host) {
-        if (!cuda_ctx_dst->stream()) {
-            return false;
-        }
         CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(dst), cudaMemcpyHostToDevice, cuda_ctx_dst->stream()));
     } else if (backend_src != backend_dst) {
         // copy on src stream

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -61,7 +61,6 @@
 #include "ggml-cuda/cumsum.cuh"
 #include "ggml-cuda/fill.cuh"
 #include "ggml.h"
-#include "ggml-cpu.h"
 
 #include <algorithm>
 #include <array>
@@ -2802,13 +2801,13 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     ggml_backend_buffer_t buf_dst = dst->view_src ? dst->view_src->buffer : dst->buffer;
 
     //enables async copies from CPU to CUDA, instead of only CUDA-to-CUDA
-    bool copy_from_cpu = ggml_backend_is_cpu(backend_src) && ggml_backend_buffer_is_host(src->buffer);
+    bool copy_from_host = ggml_backend_buffer_is_host(src->buffer);
 
-    if (!(copy_from_cpu || ggml_backend_is_cuda(backend_src)) || !ggml_backend_is_cuda(backend_dst)) {
+    if (!(copy_from_host || ggml_backend_is_cuda(backend_src)) || !ggml_backend_is_cuda(backend_dst)) {
         return false;
     }
 
-    if (!(copy_from_cpu || ggml_backend_buffer_is_cuda(src->buffer)) || !ggml_backend_buffer_is_cuda(dst->buffer)) {
+    if (!(copy_from_host || ggml_backend_buffer_is_cuda(src->buffer)) || !ggml_backend_buffer_is_cuda(dst->buffer)) {
         return false;
     }
 
@@ -2819,14 +2818,14 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     ggml_backend_cuda_buffer_context * buf_ctx_src = (ggml_backend_cuda_buffer_context *)buf_src->context;
     ggml_backend_cuda_buffer_context * buf_ctx_dst = (ggml_backend_cuda_buffer_context *)buf_dst->context;
 
-    if (!copy_from_cpu && (cuda_ctx_src->device != buf_ctx_src->device || cuda_ctx_dst->device != buf_ctx_dst->device)) {
+    if (!copy_from_host && (cuda_ctx_src->device != buf_ctx_src->device || cuda_ctx_dst->device != buf_ctx_dst->device)) {
 #ifndef NDEBUG
         GGML_LOG_DEBUG("%s: backend and buffer devices do not match\n", __func__);
 #endif
         return false;
     }
 
-    if (copy_from_cpu) {
+    if (copy_from_host) {
         if (!cuda_ctx_dst->stream()) {
             return false;
         }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2801,7 +2801,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
     ggml_backend_buffer_t buf_dst = dst->view_src ? dst->view_src->buffer : dst->buffer;
 
     //enables async copies from CPU to CUDA, instead of only CUDA-to-CUDA
-    bool copy_from_host = ggml_backend_buffer_is_host(src->buffer);
+    bool copy_from_host = ggml_backend_buffer_is_host(src->buffer) && ggml_backend_dev_type(backend_src->device) == GGML_BACKEND_DEVICE_TYPE_CPU;
 
     if (!(copy_from_host || ggml_backend_is_cuda(backend_src)) || !ggml_backend_is_cuda(backend_dst)) {
         return false;


### PR DESCRIPTION
See [comment below](https://github.com/ggml-org/llama.cpp/pull/17795#issuecomment-3675566278)

--------------
This PR suggest to remove some superfluous synchronization calls between tokens to be faster on CUDA backends. I see between 1% and 2% perf gain depending on the model, GPU and settings. 

### Mechanism
The performance impact is best explained visually. Here are the "before" and "after" nsight system traces. They are not to scale. The relevant part is the row with the green and red bubbles. Both images show the overhead between the GPU execution of two tokens. The generation of the n-th token ends on the left hand side of the screenshot, in the  green bubble titled `cudaStreamSynchronize`. The calculation of the next/n+1st token starts on the right hand side, at the green bar titled `cudaGraphLaunch`. In between, there is CPU orchestration overhead. This PR aims to shrink the time spent in the middle, between GPU token generation. Original:

<img width="2476" height="452" alt="Screenshot 2025-12-05 at 14 45 35" src="https://github.com/user-attachments/assets/1a67b62a-3c67-4b2e-aed9-a92850ef2e2e" />


In the middle of the above image, we see red and green bubbles alternating. In this case, the green bubbles are synchronization steps, the red bubbles are asynchronous copy calls from host to device. If async operations are immediately followed by synchronization calls, they are executed synchronously. This is not efficient. Removing the green synchronization operations between asynchronous copy calls leads to asynchronous copies and reduced overhead between GPU token generation:



<img width="2485" height="479" alt="Screenshot 2025-12-05 at 14 45 10" src="https://github.com/user-attachments/assets/c75b35c3-7e4b-43a6-b6e1-d7fbb1491998" />

### Performance
I benchmarked on a RTX Pro 6000 Blackwell using `./llama-bench -m $models -p 0 -n 128,256,512 -fa 1`.
My testing shows around 1% improvement, with `gpt-oss-20b` gaining up to 1.4%. `llama 3B Q4_K - Medium` shows very high variance, prompting me to run the tests again with ` -r 100`. At `-r 100`, a clearer trend  of improved performance for `gemma3n E2B Q8_0` is also visible.


<details>
<summary>Details with default `-r 5` </summary>

Baseline:
```
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg128 |        392.24 ± 1.07 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg256 |        392.72 ± 0.35 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg512 |        387.72 ± 0.38 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg128 |        464.85 ± 0.55 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg256 |        465.39 ± 0.59 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg512 |        461.87 ± 0.74 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg128 |        231.59 ± 0.09 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg256 |        231.47 ± 0.03 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg512 |        228.21 ± 0.46 |

build: 909072abc (7176)
```
PR:
```
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg128 |        397.14 ± 1.50 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg256 |        398.36 ± 0.45 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg512 |        393.25 ± 0.65 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg128 |        472.48 ± 3.71 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg256 |        468.81 ± 0.19 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg512 |        463.62 ± 1.28 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg128 |        232.84 ± 0.18 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg256 |        232.82 ± 0.08 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg512 |        229.62 ± 0.25 |

build: f6b408d84 (7178)
```
Speedup:
```
1.01249
1.01436
1.01426
1.01641
1.00735
1.00379
1.0054
1.00583
1.00618
```
</details>


<details>
<summary>Details with `-r 100` </summary>

Baseline:
```
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg128 |        393.24 ± 0.45 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg256 |        393.33 ± 2.97 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg512 |        381.93 ± 2.40 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg128 |       446.41 ± 40.17 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg256 |       451.55 ± 21.34 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg512 |        454.89 ± 0.33 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg128 |        231.90 ± 0.27 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg256 |        231.93 ± 0.21 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg512 |        228.47 ± 0.14 |

build: 909072abc (7176)
```
PR:
```
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg128 |        398.52 ± 0.41 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg256 |        397.32 ± 5.71 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |  1 |           tg512 |        383.53 ± 3.06 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg128 |       441.09 ± 50.39 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg256 |       456.69 ± 20.91 |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | CUDA       |  99 |  1 |           tg512 |        458.19 ± 0.32 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg128 |        233.98 ± 0.13 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg256 |        233.65 ± 0.25 |
| gemma3n E2B Q8_0               |   4.45 GiB |     4.46 B | CUDA       |  99 |  1 |           tg512 |        230.18 ± 0.14 |

build: aebcdf119 (7178)
```
Speedup:
```
1.01366
1.01025
1.00408
0.982033
1.00875
1.00819
1.00893
1.00876
1.00938
```
</details>

### Implementation Concerns

See updated comment below.

@ggerganov @JohannesGaessler 