### PR TITLE
CANN: support gated linear attn

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.h
+++ b/ggml/src/ggml-cann/aclnn_ops.h
@@ -252,6 +252,18 @@ void ggml_cann_l2_norm(ggml_backend_cann_context & ctx, ggml_tensor * dst);
 void ggml_cann_cross_entropy_loss(ggml_backend_cann_context & ctx, ggml_tensor * dst);
 
 /**
+ * @brief   Computes the Gated Linear Attention for a ggml tensor using the CANN
+ *          backend.
+ *
+ * @details ...
+ *
+ * @param ctx The CANN context used for operations.
+ * @param dst The destination tensor where the normalized values will be stored.
+ * @attention ...
+ */
+void ggml_cann_gated_linear_attn(ggml_backend_cann_context& ctx, ggml_tensor* dst);
+
+/**
  * @brief  Computes the Group Normalization for a ggml tensor using the CANN
  *         backend.
  *
@@ -673,6 +685,10 @@ void aclnn_cos(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor *
  * @param acl_dst The destination tensor where the sine results will be stored.
  */
 void aclnn_sin(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_dst);
+
+static void cann_copy(ggml_backend_cann_context& ctx, aclTensor* acl_src, aclTensor* acl_dst);
+static void aclnn_permute(ggml_backend_cann_context& ctx, aclTensor* acl_src,
+                          aclTensor* acl_dst, int64_t* new_dim, uint64_t dims);
 
 /**
  * @brief Prepares broadcast-compatible ACL tensors for two input tensors and one

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1888,6 +1888,8 @@ static bool ggml_cann_compute_forward(ggml_backend_cann_context & ctx, struct gg
             break;
         case GGML_OP_OUT_PROD:
             ggml_cann_out_prod(ctx, dst);
+        case GGML_OP_GATED_LINEAR_ATTN:
+            ggml_cann_gated_linear_attn(ctx, dst);
             break;
         default:
             return false;
@@ -2561,6 +2563,7 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev, const ggml_ten
         case GGML_OP_MEAN:
         case GGML_OP_PAD_REFLECT_1D:
         case GGML_OP_COUNT_EQUAL:
+        case GGML_OP_GATED_LINEAR_ATTN:
             return true;
         case GGML_OP_OUT_PROD:
             {

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1888,6 +1888,7 @@ static bool ggml_cann_compute_forward(ggml_backend_cann_context & ctx, struct gg
             break;
         case GGML_OP_OUT_PROD:
             ggml_cann_out_prod(ctx, dst);
+            break;
         case GGML_OP_GATED_LINEAR_ATTN:
             ggml_cann_gated_linear_attn(ctx, dst);
             break;


### PR DESCRIPTION
### Description

This PR adds support for the **Gated Linear Attention (GLA)** operator in the GGML CANN backend. GLA is widely used in efficient attention mechanisms (e.g., RWKV, Linear Transformer variants, etc.), which leverage gating signals and state accumulation to significantly reduce computational complexity while preserving strong modeling capacity.

#### Summary of Changes:

- Registered `GGML_OP_GATED_LINEAR_ATTN` in `ggml/src/ggml-cann/ggml-cann.cpp` and bound it to a newly implemented function `ggml_cann_gated_linear_attn`.
- Implemented the core forward logic of `ggml_cann_gated_linear_attn` in `ggml/src/ggml-cann/aclnn_ops.cpp`, using ACLNN primitives such as `Repeat`, `Mul`, `Add`, and `Mv` to compose the GLA computation.
- Supports **batched multi-head GLA** with input tensor layout `(C, H, T, B)`, where:
  - `C = H * D` (total channel dimension),
  - `T = B * L` (flattened batch × sequence length),
  - consistent with GGML’s internal memory layout conventions.
- Accepts learnable gate `g` and recurrent state `s` as additional inputs, enabling joint state update and output generation in a single pass.

#### Testing

**Build with CANN backend enabled:**
```bash
cmake -B build -DGGML_CANN=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release -j
```

**Run GLA-specific backend test** (requires adding a test case for `GATED_LINEAR_ATTN` in `tests/test-backend-ops.cpp`):
```bash
./bin/test-backend-ops test -b CANN0 -o GATED_LINEAR_ATTN
```

<img width="1940" height="958" alt="image" src="https://github.com/user-attachments/assets/33ae776d-e9fd-4f7e-b969-80af2dbf6205" />

