### PR TITLE
debug:Adding CPU-side visual trace for hexagon

### DIFF
--- a/ggml/src/ggml-hexagon/CMakeLists.txt
+++ b/ggml/src/ggml-hexagon/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(htp_iface PUBLIC
     ${HEXAGON_SDK_ROOT}/incs
     ${HEXAGON_SDK_ROOT}/incs/stddef
     ${HEXAGON_SDK_ROOT}/utils/examples
+    ${HEXAGON_SDK_ROOT}/libs/itrace/inc
     ${CMAKE_CURRENT_SOURCE_DIR}/htp
     ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -32,6 +33,7 @@ ggml_add_backend_library(${TARGET_NAME}
     ggml-hexagon.cpp htp-utils.c htp-utils.h ../../include/ggml-hexagon.h)
 
 target_link_libraries(${TARGET_NAME} PRIVATE htp_iface)
+target_link_libraries(${TARGET_NAME} PRIVATE ${HEXAGON_SDK_ROOT}/libs/itrace/prebuilt/android_aarch64/libitrace.so)
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/htp ${CMAKE_CURRENT_BINARY_DIR})
 
 # Build HTP bits

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3553,7 +3553,7 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
     if (opt_trace) {
         HEX_VERBOSE("ggml-hex: open itrace\n");
         itrace_open_logger(CPU_DOMAIN_ID, &g_itrace_logger_handle);
-        itrace_open_profiler(g_itrace_logger_handle, CPU_DOMAIN_ID, 0x1000000, &g_itrace_cpu_profiler_handle);
+        itrace_open_profiler(g_itrace_logger_handle, CPU_DOMAIN_ID, 4*1024*1024, &g_itrace_cpu_profiler_handle);
 
         itrace_start_section(g_itrace_cpu_profiler_handle, "open-itrace", NULL);
         itrace_end_section(g_itrace_cpu_profiler_handle, NULL);

--- a/scripts/snapdragon/adb/run-cli.sh
+++ b/scripts/snapdragon/adb/run-cli.sh
@@ -30,6 +30,9 @@ sched=
 profile=
 [ "$PROF" != "" ] && profile="GGML_HEXAGON_PROFILE=$PROF GGML_HEXAGON_OPSYNC=1"
 
+trace=
+[ "$TRACE" != "" ] && trace="GGML_HEXAGON_TRACE=$TRACE"
+
 opmask=
 [ "$OPMASK" != "" ] && opmask="GGML_HEXAGON_OPMASK=$OPMASK"
 
@@ -45,7 +48,7 @@ adb $adbserial shell " \
   cd $basedir; ulimit -c unlimited;        \
     LD_LIBRARY_PATH=$basedir/$branch/lib   \
     ADSP_LIBRARY_PATH=$basedir/$branch/lib \
-    $verbose $experimental $sched $opmask $profile $nhvx $ndev       \
+    $verbose $experimental $sched $opmask $profile $nhvx $ndev $trace \
       ./$branch/bin/llama-completion --no-mmap -m $basedir/../gguf/$model   \
          --poll 1000 -t 6 --cpu-mask 0xfc --cpu-strict 1             \
          --ctx-size 8192 --batch-size 128 -ctk q8_0 -ctv q8_0 -fa on \


### PR DESCRIPTION
Adding CPU-side visual trace for hexagon

<img width="1699" height="382" alt="hex-itrace" src="https://github.com/user-attachments/assets/fd4eb053-cd16-4778-83c9-7a586f8628d6" />


Known issue: when the running log is too large, it will overflow, resulting in the inability to generate the core json file for trace, but the impact is not significant.