### PR TITLE
model-conversion : add token ids to prompt token output [no ci]

### DIFF
--- a/examples/model-conversion/logits.cpp
+++ b/examples/model-conversion/logits.cpp
@@ -144,7 +144,7 @@ int main(int argc, char ** argv) {
             return 1;
         }
         std::string s(buf, n);
-        printf("%s", s.c_str());
+        printf("%s (%d)", s.c_str(), id);
     }
     printf("\n");
 


### PR DESCRIPTION
This commit adds the token ids to the printed prompt outputs.

The motivation for this is that is can be useful to see the actual token ids alongside the token strings for debugging.
