### PR TITLE
cmake: fix Mach-O current version number

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(llama
 set_target_properties(llama PROPERTIES
     VERSION ${LLAMA_INSTALL_VERSION}
     SOVERSION 0
+    MACHO_CURRENT_VERSION 0 # keep macOS linker from seeing oversized version number
 )
 
 target_include_directories(llama PRIVATE .)

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(mtmd
 set_target_properties(mtmd PROPERTIES
     VERSION ${LLAMA_INSTALL_VERSION}
     SOVERSION 0
+    MACHO_CURRENT_VERSION 0 # keep macOS linker from seeing oversized version number
 )
 
 target_link_libraries     (mtmd PUBLIC ggml llama)


### PR DESCRIPTION
PR #17091 set the `VERSION` of various libraries to 0.0.<var>abcd</var>, where <var>abcd</var> is the `LLAMA_BUILD_NUMBER`. That build number is too large to fit in the Mach-O 'current version' field's 'micro' part, which only goes up to 255. This just sets the Mach-O current version to 0 to get it building properly again.

Fixes #17258.

I tried running the CPU-only CI command (`bash ./ci/run.sh ./tmp/results ./tmp/mnt`). It built successfully, but test 32 of 38 (`test-backend-ops`) sat there for a long time and eventually timed out. Everything else ran fine. For what it's worth, I've been using [a slightly fancier version](https://github.com/ggml-org/llama.cpp/issues/17258#issuecomment-3572819851) of this same patch via Nix, and it seems to be working properly.

If it would be better to keep the full build number in there, I can push an alternate patch that sets the Mach-O version to 0.<var>ab</var>.<var>cd</var> instead. Wasn't sure if that would conflict with any other version numbers you were planning though, so for now I went with just setting it to 0 as suggested in <https://github.com/ggml-org/llama.cpp/issues/17258#issuecomment-3572834220>.