### PR TITLE
server : run child server on localhost

### DIFF
--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -51,6 +51,7 @@ struct server_model_meta {
     std::string path;
     std::string path_mmproj; // only available if in_cache=false
     bool in_cache = false; // if true, use -hf; use -m otherwise
+    std::string hostname;
     int port = 0;
     server_model_status status = SERVER_MODEL_STATUS_UNLOADED;
     int64_t last_used = 0; // for LRU unloading


### PR DESCRIPTION
When passing in `--host 0.0.0.0`, the child runs on host `0.0.0.0` and the router tries to access it at `0.0.0.0`. I can't think of why the child should not always run on `127.0.0.1`.

`get_free_port()` binds to `INADDR_ANY`, which should select a port that is available across all interfaces. This can be changed to `INADDR_LOOPBACK` if we ensure the child will only ever bind to `127.0.0.1`. If not, then `INADDR_ANY` is a safe choice.

fixes #17862