### PR TITLE
ggml : remove redundant src in ggml_cast

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3418,7 +3418,6 @@ struct ggml_tensor * ggml_cast(
 
     result->op     = GGML_OP_CPY;
     result->src[0] = a;
-    result->src[1] = result;
 
     return result;
 }


### PR DESCRIPTION
Don't think this `src[1]` is needed