### PR TITLE
ggml: correct comment for GGML_OP_MUL_MAT in ggml_compute_backward [no ci]

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1,96 +1,96 @@
-#define _CRT_SECURE_NO_DEPRECATE // Disables "unsafe" warnings on Windows
-#define _USE_MATH_DEFINES // For M_PI on MSVC
+#define _CRT_SECURE_NO_DEPRECATE  // Disables "unsafe" warnings on Windows
+#define _USE_MATH_DEFINES         // For M_PI on MSVC
+
+#include "ggml.h"
 
 #include "ggml-backend.h"
+#include "ggml-cpu.h"
 #include "ggml-impl.h"
 #include "ggml-threading.h"
-#include "ggml-cpu.h"
-#include "ggml.h"
 
 // FIXME: required here for quantization functions
 #include "ggml-quants.h"
 
 #ifdef GGML_USE_CPU_HBM
-#include <hbwmalloc.h>
+#    include <hbwmalloc.h>
 #endif
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
-#include <malloc.h> // using malloc.h with MSC/MINGW
+#    include <malloc.h>  // using malloc.h with MSC/MINGW
 #elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
-#include <alloca.h>
+#    include <alloca.h>
 #endif
 
 #include <assert.h>
 #include <errno.h>
-#include <time.h>
+#include <float.h>
+#include <inttypes.h>
+#include <limits.h>
 #include <math.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <float.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <signal.h>
+#include <time.h>
 #if defined(__gnu_linux__)
-#include <syscall.h>
+#    include <syscall.h>
 #endif
 
 #if defined(__APPLE__)
-#include <unistd.h>
-#include <mach/mach.h>
-#include <TargetConditionals.h>
+#    include <mach/mach.h>
+#    include <TargetConditionals.h>
+#    include <unistd.h>
 #endif
 
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-    #define NOMINMAX
-#endif
-#include <windows.h>
+#    define WIN32_LEAN_AND_MEAN
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
 #endif
 
 #define UNUSED GGML_UNUSED
 
 #if defined(_MSC_VER)
-#define m512bh(p) p
-#define m512i(p) p
+#    define m512bh(p) p
+#    define m512i(p)  p
 #else
-#define m512bh(p) (__m512bh)(p)
-#define m512i(p) (__m512i)(p)
+#    define m512bh(p) (__m512bh)(p)
+#    define m512i(p)  (__m512i)(p)
 #endif
 
-#if defined(__linux__) || \
-    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
     (defined(__APPLE__) && !TARGET_OS_TV && !TARGET_OS_WATCH)
 
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-#if defined(__linux__)
-#include <sys/prctl.h>
-#endif
+#    include <sys/stat.h>
+#    include <sys/types.h>
+#    include <sys/wait.h>
+#    include <unistd.h>
+#    if defined(__linux__)
+#        include <sys/prctl.h>
+#    endif
 
-#if defined(__ANDROID__)
-#include <unwind.h>
-#include <dlfcn.h>
-#include <stdio.h>
+#    if defined(__ANDROID__)
+#        include <dlfcn.h>
+#        include <stdio.h>
+#        include <unwind.h>
 
 struct backtrace_state {
     void ** current;
     void ** end;
 };
 
-static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context* context, void* arg) {
-    struct backtrace_state * state = (struct backtrace_state *)arg;
-    uintptr_t pc = _Unwind_GetIP(context);
+static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context * context, void * arg) {
+    struct backtrace_state * state = (struct backtrace_state *) arg;
+    uintptr_t                pc    = _Unwind_GetIP(context);
     if (pc) {
         if (state->current == state->end) {
             return _URC_END_OF_STACK;
         } else {
-            *state->current++ = (void*)pc;
+            *state->current++ = (void *) pc;
         }
     }
     return _URC_NO_REASON;
@@ -98,15 +98,15 @@ static _Unwind_Reason_Code unwind_callback(struct _Unwind_Context* context, void
 
 static void ggml_print_backtrace_symbols(void) {
     const int max = 100;
-    void* buffer[max];
+    void *    buffer[max];
 
-    struct backtrace_state state = {buffer, buffer + max};
+    struct backtrace_state state = { buffer, buffer + max };
     _Unwind_Backtrace(unwind_callback, &state);
 
     int count = state.current - buffer;
 
     for (int idx = 0; idx < count; ++idx) {
-        const void * addr = buffer[idx];
+        const void * addr   = buffer[idx];
         const char * symbol = "";
 
         Dl_info info;
@@ -117,32 +117,34 @@ static void ggml_print_backtrace_symbols(void) {
         fprintf(stderr, "%d: %p %s\n", idx, addr, symbol);
     }
 }
-#elif defined(__linux__) && defined(__GLIBC__)
-#include <execinfo.h>
+#    elif defined(__linux__) && defined(__GLIBC__)
+#        include <execinfo.h>
+
 static void ggml_print_backtrace_symbols(void) {
     void * trace[100];
-    int nptrs = backtrace(trace, sizeof(trace)/sizeof(trace[0]));
+    int    nptrs = backtrace(trace, sizeof(trace) / sizeof(trace[0]));
     backtrace_symbols_fd(trace, nptrs, STDERR_FILENO);
 }
-#elif defined(__APPLE__)
-#include <execinfo.h>
+#    elif defined(__APPLE__)
+#        include <execinfo.h>
+
 static void ggml_print_backtrace_symbols(void) {
     void * trace[100];
-    int nptrs = backtrace(trace, sizeof(trace)/sizeof(trace[0]));
+    int    nptrs = backtrace(trace, sizeof(trace) / sizeof(trace[0]));
     backtrace_symbols_fd(trace, nptrs, STDERR_FILENO);
 }
-#else
+#    else
 static void ggml_print_backtrace_symbols(void) {
     // platform not supported
 }
-#endif
+#    endif
 
 void ggml_print_backtrace(void) {
     const char * GGML_NO_BACKTRACE = getenv("GGML_NO_BACKTRACE");
     if (GGML_NO_BACKTRACE) {
         return;
     }
-#if defined(__APPLE__)
+#    if defined(__APPLE__)
     // On macOS, fork+debugger attachment is problematic due to:
     // 1. libdispatch "poisons" forked child processes
     // 2. lldb has issues attaching to parent from forked child
@@ -155,11 +157,11 @@ void ggml_print_backtrace(void) {
         ggml_print_backtrace_symbols();
         return;
     }
-#endif
-#if defined(__linux__)
-    FILE * f = fopen("/proc/self/status", "r");
-    size_t size = 0;
-    char * line = NULL;
+#    endif
+#    if defined(__linux__)
+    FILE *  f      = fopen("/proc/self/status", "r");
+    size_t  size   = 0;
+    char *  line   = NULL;
     ssize_t length = 0;
     while ((length = getline(&line, &size, f)) > 0) {
         if (!strncmp(line, "TracerPid:", sizeof("TracerPid:") - 1) &&
@@ -173,47 +175,39 @@ void ggml_print_backtrace(void) {
     free(line);
     fclose(f);
     int lock[2] = { -1, -1 };
-    (void) !pipe(lock); // Don't start gdb until after PR_SET_PTRACER
-#endif
+    (void) !pipe(lock);  // Don't start gdb until after PR_SET_PTRACER
+#    endif
     const int parent_pid = getpid();
-    const int child_pid = fork();
-    if (child_pid < 0) { // error
-#if defined(__linux__)
+    const int child_pid  = fork();
+    if (child_pid < 0) {  // error
+#    if defined(__linux__)
         close(lock[1]);
         close(lock[0]);
-#endif
+#    endif
         return;
-    } else if (child_pid == 0) { // child
+    } else if (child_pid == 0) {  // child
         char attach[32];
         snprintf(attach, sizeof(attach), "attach %d", parent_pid);
-#if defined(__linux__)
+#    if defined(__linux__)
         close(lock[1]);
         (void) !read(lock[0], lock, 1);
         close(lock[0]);
-#endif
+#    endif
         // try gdb
-        execlp("gdb", "gdb", "--batch",
-            "-ex", "set style enabled on",
-            "-ex", attach,
-            "-ex", "bt -frame-info source-and-location",
-            "-ex", "detach",
-            "-ex", "quit",
-            (char *) NULL);
+        execlp("gdb", "gdb", "--batch", "-ex", "set style enabled on", "-ex", attach, "-ex",
+               "bt -frame-info source-and-location", "-ex", "detach", "-ex", "quit", (char *) NULL);
         // try lldb
-        execlp("lldb", "lldb", "--batch",
-            "-o", "bt",
-            "-o", "quit",
-            "-p", &attach[sizeof("attach ") - 1],
-            (char *) NULL);
+        execlp("lldb", "lldb", "--batch", "-o", "bt", "-o", "quit", "-p", &attach[sizeof("attach ") - 1],
+               (char *) NULL);
         // gdb failed, fallback to backtrace_symbols
         ggml_print_backtrace_symbols();
         _Exit(0);
-    } else { // parent
-#if defined(__linux__)
+    } else {  // parent
+#    if defined(__linux__)
         prctl(PR_SET_PTRACER, child_pid);
         close(lock[1]);
         close(lock[0]);
-#endif
+#    endif
         waitpid(child_pid, NULL, 0);
     }
 }
@@ -228,7 +222,7 @@ static ggml_abort_callback_t g_abort_callback = NULL;
 // Set the abort callback (passing null will restore original abort functionality: printing a message to stdout)
 GGML_API ggml_abort_callback_t ggml_set_abort_callback(ggml_abort_callback_t callback) {
     ggml_abort_callback_t ret_val = g_abort_callback;
-    g_abort_callback = callback;
+    g_abort_callback              = callback;
     return ret_val;
 }
 
@@ -236,7 +230,7 @@ void ggml_abort(const char * file, int line, const char * fmt, ...) {
     fflush(stdout);
 
     char message[2048];
-    int offset = snprintf(message, sizeof(message), "%s:%d: ", file, line);
+    int  offset = snprintf(message, sizeof(message), "%s:%d: ", file, line);
 
     va_list args;
     va_start(args, fmt);
@@ -262,9 +256,9 @@ void ggml_abort(const char * file, int line, const char * fmt, ...) {
 
 struct ggml_logger_state {
     ggml_log_callback log_callback;
-    void * log_callback_user_data;
+    void *            log_callback_user_data;
 };
-static struct ggml_logger_state g_logger_state = {ggml_log_callback_default, NULL};
+static struct ggml_logger_state g_logger_state = { ggml_log_callback_default, NULL };
 
 static void ggml_log_internal_v(enum ggml_log_level level, const char * format, va_list args) {
     if (format == NULL) {
@@ -273,7 +267,7 @@ static void ggml_log_internal_v(enum ggml_log_level level, const char * format, 
     va_list args_copy;
     va_copy(args_copy, args);
     char buffer[128];
-    int len = vsnprintf(buffer, 128, format, args);
+    int  len = vsnprintf(buffer, 128, format, args);
     if (len < 128) {
         g_logger_state.log_callback(level, buffer, g_logger_state.log_callback_user_data);
     } else {
@@ -310,7 +304,6 @@ void ggml_log_callback_default(enum ggml_log_level level, const char * text, voi
 //#define GGML_SOFT_MAX_ACCELERATE
 #endif
 
-
 void * ggml_aligned_malloc(size_t size) {
 #if defined(__s390x__)
     const int alignment = 256;
@@ -326,11 +319,12 @@ void * ggml_aligned_malloc(size_t size) {
         return NULL;
     }
     void * aligned_memory = NULL;
-  #ifdef GGML_USE_CPU_HBM
+#    ifdef GGML_USE_CPU_HBM
     int result = hbw_posix_memalign(&aligned_memory, alignment, size);
-  #elif TARGET_OS_OSX
+#    elif TARGET_OS_OSX
     GGML_UNUSED(alignment);
-    kern_return_t alloc_status = vm_allocate((vm_map_t) mach_task_self(), (vm_address_t *) &aligned_memory, size, VM_FLAGS_ANYWHERE);
+    kern_return_t alloc_status =
+        vm_allocate((vm_map_t) mach_task_self(), (vm_address_t *) &aligned_memory, size, VM_FLAGS_ANYWHERE);
     int result = EFAULT;
     switch (alloc_status) {
         case KERN_SUCCESS:
@@ -346,12 +340,12 @@ void * ggml_aligned_malloc(size_t size) {
             result = EFAULT;
             break;
     }
-  #else
+#    else
     int result = posix_memalign(&aligned_memory, alignment, size);
-  #endif
+#    endif
     if (result != 0) {
         // Handle allocation failure
-        const char *error_desc = "unknown allocation error";
+        const char * error_desc = "unknown allocation error";
         switch (result) {
             case EINVAL:
                 error_desc = "invalid alignment value";
@@ -360,7 +354,7 @@ void * ggml_aligned_malloc(size_t size) {
                 error_desc = "insufficient memory";
                 break;
         }
-        GGML_LOG_ERROR("%s: %s (attempted to allocate %6.2f MB)\n", __func__, error_desc, size/(1024.0*1024.0));
+        GGML_LOG_ERROR("%s: %s (attempted to allocate %6.2f MB)\n", __func__, error_desc, size / (1024.0 * 1024.0));
         return NULL;
     }
     return aligned_memory;
@@ -377,13 +371,12 @@ void ggml_aligned_free(void * ptr, size_t size) {
     }
 #elif TARGET_OS_OSX
     if (ptr != NULL) {
-        vm_deallocate((vm_map_t)mach_task_self(), (vm_address_t)ptr, size);
+        vm_deallocate((vm_map_t) mach_task_self(), (vm_address_t) ptr, size);
     }
 #else
     free(ptr);
 #endif
 }
-
 
 inline static void * ggml_malloc(size_t size) {
     if (size == 0) {
@@ -392,7 +385,7 @@ inline static void * ggml_malloc(size_t size) {
     }
     void * result = malloc(size);
     if (result == NULL) {
-        GGML_LOG_ERROR("%s: failed to allocate %6.2f MB\n", __func__, size/(1024.0*1024.0));
+        GGML_LOG_ERROR("%s: failed to allocate %6.2f MB\n", __func__, size / (1024.0 * 1024.0));
         GGML_ABORT("fatal error");
     }
     return result;
@@ -406,7 +399,7 @@ inline static void * ggml_calloc(size_t num, size_t size) {
     }
     void * result = calloc(num, size);
     if (result == NULL) {
-        GGML_LOG_ERROR("%s: failed to allocate %6.2f MB\n", __func__, size/(1024.0*1024.0));
+        GGML_LOG_ERROR("%s: failed to allocate %6.2f MB\n", __func__, size / (1024.0 * 1024.0));
         GGML_ABORT("fatal error");
     }
     return result;
@@ -419,10 +412,14 @@ inline static void * ggml_calloc(size_t num, size_t size) {
 
 const char * ggml_status_to_string(enum ggml_status status) {
     switch (status) {
-        case GGML_STATUS_ALLOC_FAILED: return "GGML status: error (failed to allocate memory)";
-        case GGML_STATUS_FAILED:       return "GGML status: error (operation failed)";
-        case GGML_STATUS_SUCCESS:      return "GGML status: success";
-        case GGML_STATUS_ABORTED:      return "GGML status: warning (operation aborted)";
+        case GGML_STATUS_ALLOC_FAILED:
+            return "GGML status: error (failed to allocate memory)";
+        case GGML_STATUS_FAILED:
+            return "GGML status: error (operation failed)";
+        case GGML_STATUS_SUCCESS:
+            return "GGML status: success";
+        case GGML_STATUS_ABORTED:
+            return "GGML status: warning (operation aborted)";
     }
 
     return "GGML status: unknown";
@@ -475,15 +472,13 @@ void ggml_fp32_to_bf16_row_ref(const float * x, ggml_bf16_t * y, int64_t n) {
 }
 
 void ggml_fp32_to_bf16_row(const float * x, ggml_bf16_t * y, int64_t n) {
-  int i = 0;
+    int i = 0;
 #if defined(__AVX512BF16__)
-  // subnormals are flushed to zero on this platform
-  for (; i + 32 <= n; i += 32) {
-        _mm512_storeu_si512(
-            (__m512i *)(y + i),
-            m512i(_mm512_cvtne2ps_pbh(_mm512_loadu_ps(x + i + 16),
-                                _mm512_loadu_ps(x + i))));
-  }
+    // subnormals are flushed to zero on this platform
+    for (; i + 32 <= n; i += 32) {
+        _mm512_storeu_si512((__m512i *) (y + i),
+                            m512i(_mm512_cvtne2ps_pbh(_mm512_loadu_ps(x + i + 16), _mm512_loadu_ps(x + i))));
+    }
 #endif
     for (; i < n; i++) {
         y[i] = GGML_FP32_TO_BF16(x[i]);
@@ -508,6 +503,7 @@ const char * ggml_commit(void) {
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 static int64_t timer_freq, timer_start;
+
 void ggml_time_init(void) {
     LARGE_INTEGER t;
     QueryPerformanceFrequency(&t);
@@ -519,28 +515,31 @@ void ggml_time_init(void) {
     QueryPerformanceCounter(&t);
     timer_start = t.QuadPart;
 }
+
 int64_t ggml_time_ms(void) {
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);
-    return ((t.QuadPart-timer_start) * 1000) / timer_freq;
+    return ((t.QuadPart - timer_start) * 1000) / timer_freq;
 }
+
 int64_t ggml_time_us(void) {
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);
-    return ((t.QuadPart-timer_start) * 1000000) / timer_freq;
+    return ((t.QuadPart - timer_start) * 1000000) / timer_freq;
 }
 #else
 void ggml_time_init(void) {}
+
 int64_t ggml_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (int64_t)ts.tv_sec*1000 + (int64_t)ts.tv_nsec/1000000;
+    return (int64_t) ts.tv_sec * 1000 + (int64_t) ts.tv_nsec / 1000000;
 }
 
 int64_t ggml_time_us(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (int64_t)ts.tv_sec*1000000 + (int64_t)ts.tv_nsec/1000;
+    return (int64_t) ts.tv_sec * 1000000 + (int64_t) ts.tv_nsec / 1000;
 }
 #endif
 
@@ -549,7 +548,7 @@ int64_t ggml_cycles(void) {
 }
 
 int64_t ggml_cycles_per_ms(void) {
-    return CLOCKS_PER_SEC/1000;
+    return CLOCKS_PER_SEC / 1000;
 }
 
 //
@@ -565,7 +564,7 @@ static wchar_t * ggml_mbstowcs(const char * mbs) {
     }
 
     wchar_t * wbuf = GGML_MALLOC(wlen * sizeof(wchar_t));
-    wlen = MultiByteToWideChar(CP_UTF8, 0, mbs, -1, wbuf, wlen);
+    wlen           = MultiByteToWideChar(CP_UTF8, 0, mbs, -1, wbuf, wlen);
     if (!wlen) {
         GGML_FREE(wbuf);
         errno = EINVAL;
@@ -584,10 +583,10 @@ FILE * ggml_fopen(const char * fname, const char * mode) {
     wchar_t * wfname = ggml_mbstowcs(fname);
     if (wfname) {
         // convert mode (ANSI)
-        wchar_t * wmode = GGML_MALLOC((strlen(mode) + 1) * sizeof(wchar_t));
+        wchar_t * wmode   = GGML_MALLOC((strlen(mode) + 1) * sizeof(wchar_t));
         wchar_t * wmode_p = wmode;
         do {
-            *wmode_p++ = (wchar_t)*mode;
+            *wmode_p++ = (wchar_t) *mode;
         } while (*mode++);
 
         // open file
@@ -601,7 +600,6 @@ FILE * ggml_fopen(const char * fname, const char * mode) {
 #else
     return fopen(fname, mode);
 #endif
-
 }
 
 static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
@@ -928,7 +926,7 @@ struct ggml_context {
     bool   mem_buffer_owned;
     bool   no_alloc;
 
-    int    n_objects;
+    int n_objects;
 
     struct ggml_object * objects_begin;
     struct ggml_object * objects_end;
@@ -1159,53 +1157,29 @@ static_assert(GGML_OP_COUNT == 95, "GGML_OP_COUNT != 95");
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
 static const char * GGML_UNARY_OP_NAME[GGML_UNARY_OP_COUNT] = {
-    "ABS",
-    "SGN",
-    "NEG",
-    "STEP",
-    "TANH",
-    "ELU",
-    "RELU",
-    "SIGMOID",
-    "GELU",
-    "GELU_QUICK",
-    "SILU",
-    "HARDSWISH",
-    "HARDSIGMOID",
-    "EXP",
-    "EXPM1",
-    "SOFTPLUS",
-    "GELU_ERF",
-    "XIELU",
-    "FLOOR",
-    "CEIL",
-    "ROUND",
-    "TRUNC",
+    "ABS",      "SGN",        "NEG",   "STEP",      "TANH",        "ELU",   "RELU",  "SIGMOID",
+    "GELU",     "GELU_QUICK", "SILU",  "HARDSWISH", "HARDSIGMOID", "EXP",   "EXPM1", "SOFTPLUS",
+    "GELU_ERF", "XIELU",      "FLOOR", "CEIL",      "ROUND",       "TRUNC",
 };
 
 static_assert(GGML_UNARY_OP_COUNT == 22, "GGML_UNARY_OP_COUNT != 22");
 
 static const char * GGML_GLU_OP_NAME[GGML_GLU_OP_COUNT] = {
-    "REGLU",
-    "GEGLU",
-    "SWIGLU",
-    "SWIGLU_OAI",
-    "GEGLU_ERF",
-    "GEGLU_QUICK",
+    "REGLU", "GEGLU", "SWIGLU", "SWIGLU_OAI", "GEGLU_ERF", "GEGLU_QUICK",
 };
 
 static_assert(GGML_GLU_OP_COUNT == 6, "GGML_GLU_OP_COUNT != 6");
 
-
-static_assert(sizeof(struct ggml_object)%GGML_MEM_ALIGN == 0, "ggml_object size must be a multiple of GGML_MEM_ALIGN");
-static_assert(sizeof(struct ggml_tensor)%GGML_MEM_ALIGN == 0, "ggml_tensor size must be a multiple of GGML_MEM_ALIGN");
-
+static_assert(sizeof(struct ggml_object) % GGML_MEM_ALIGN == 0,
+              "ggml_object size must be a multiple of GGML_MEM_ALIGN");
+static_assert(sizeof(struct ggml_tensor) % GGML_MEM_ALIGN == 0,
+              "ggml_tensor size must be a multiple of GGML_MEM_ALIGN");
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void ggml_print_object(const struct ggml_object * obj) {
-    GGML_LOG_INFO(" - ggml_object: type = %d, offset = %zu, size = %zu, next = %p\n",
-            obj->type, obj->offs, obj->size, (const void *) obj->next);
+    GGML_LOG_INFO(" - ggml_object: type = %d, offset = %zu, size = %zu, next = %p\n", obj->type, obj->offs, obj->size,
+                  (const void *) obj->next);
 }
 
 void ggml_print_objects(const struct ggml_context * ctx) {
@@ -1224,13 +1198,13 @@ void ggml_print_objects(const struct ggml_context * ctx) {
 int64_t ggml_nelements(const struct ggml_tensor * tensor) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return tensor->ne[0]*tensor->ne[1]*tensor->ne[2]*tensor->ne[3];
+    return tensor->ne[0] * tensor->ne[1] * tensor->ne[2] * tensor->ne[3];
 }
 
 int64_t ggml_nrows(const struct ggml_tensor * tensor) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return tensor->ne[1]*tensor->ne[2]*tensor->ne[3];
+    return tensor->ne[1] * tensor->ne[2] * tensor->ne[3];
 }
 
 size_t ggml_nbytes(const struct ggml_tensor * tensor) {
@@ -1240,18 +1214,17 @@ size_t ggml_nbytes(const struct ggml_tensor * tensor) {
         }
     }
 
-    size_t nbytes;
+    size_t       nbytes;
     const size_t blck_size = ggml_blck_size(tensor->type);
     if (blck_size == 1) {
         nbytes = ggml_type_size(tensor->type);
         for (int i = 0; i < GGML_MAX_DIMS; ++i) {
-            nbytes += (tensor->ne[i] - 1)*tensor->nb[i];
+            nbytes += (tensor->ne[i] - 1) * tensor->nb[i];
         }
-    }
-    else {
-        nbytes = tensor->ne[0]*tensor->nb[0]/blck_size;
+    } else {
+        nbytes = tensor->ne[0] * tensor->nb[0] / blck_size;
         for (int i = 1; i < GGML_MAX_DIMS; ++i) {
-            nbytes += (tensor->ne[i] - 1)*tensor->nb[i];
+            nbytes += (tensor->ne[i] - 1) * tensor->nb[i];
         }
     }
 
@@ -1272,11 +1245,11 @@ size_t ggml_type_size(enum ggml_type type) {
 
 size_t ggml_row_size(enum ggml_type type, int64_t ne) {
     assert(ne % ggml_blck_size(type) == 0);
-    return ggml_type_size(type)*ne/ggml_blck_size(type);
+    return ggml_type_size(type) * ne / ggml_blck_size(type);
 }
 
 double ggml_type_sizef(enum ggml_type type) {
-    return ((double)(type_traits[type].type_size))/type_traits[type].blck_size;
+    return ((double) (type_traits[type].type_size)) / type_traits[type].blck_size;
 }
 
 const char * ggml_type_name(enum ggml_type type) {
@@ -1354,31 +1327,81 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
     enum ggml_type wtype = GGML_TYPE_COUNT;
 
     switch (ftype) {
-        case GGML_FTYPE_ALL_F32:              wtype = GGML_TYPE_F32;   break;
-        case GGML_FTYPE_MOSTLY_F16:           wtype = GGML_TYPE_F16;   break;
-        case GGML_FTYPE_MOSTLY_BF16:          wtype = GGML_TYPE_BF16;  break;
-        case GGML_FTYPE_MOSTLY_Q4_0:          wtype = GGML_TYPE_Q4_0;  break;
-        case GGML_FTYPE_MOSTLY_Q4_1:          wtype = GGML_TYPE_Q4_1;  break;
-        case GGML_FTYPE_MOSTLY_Q5_0:          wtype = GGML_TYPE_Q5_0;  break;
-        case GGML_FTYPE_MOSTLY_Q5_1:          wtype = GGML_TYPE_Q5_1;  break;
-        case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
-        case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
-        case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
-        case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
-        case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;
-        case GGML_FTYPE_MOSTLY_Q5_K:          wtype = GGML_TYPE_Q5_K;  break;
-        case GGML_FTYPE_MOSTLY_Q6_K:          wtype = GGML_TYPE_Q6_K;  break;
-        case GGML_FTYPE_MOSTLY_IQ2_XXS:       wtype = GGML_TYPE_IQ2_XXS;  break;
-        case GGML_FTYPE_MOSTLY_IQ2_XS:        wtype = GGML_TYPE_IQ2_XS;   break;
-        case GGML_FTYPE_MOSTLY_IQ3_XXS:       wtype = GGML_TYPE_IQ3_XXS;  break;
-        case GGML_FTYPE_MOSTLY_IQ1_S:         wtype = GGML_TYPE_IQ1_S;    break;
-        case GGML_FTYPE_MOSTLY_IQ1_M:         wtype = GGML_TYPE_IQ1_M;    break;
-        case GGML_FTYPE_MOSTLY_IQ4_NL:        wtype = GGML_TYPE_IQ4_NL;   break;
-        case GGML_FTYPE_MOSTLY_IQ4_XS:        wtype = GGML_TYPE_IQ4_XS;   break;
-        case GGML_FTYPE_MOSTLY_IQ3_S:         wtype = GGML_TYPE_IQ3_S;    break;
-        case GGML_FTYPE_MOSTLY_IQ2_S:         wtype = GGML_TYPE_IQ2_S;    break;
-        case GGML_FTYPE_UNKNOWN:              wtype = GGML_TYPE_COUNT; break;
-        case GGML_FTYPE_MOSTLY_Q4_1_SOME_F16: wtype = GGML_TYPE_COUNT; break;
+        case GGML_FTYPE_ALL_F32:
+            wtype = GGML_TYPE_F32;
+            break;
+        case GGML_FTYPE_MOSTLY_F16:
+            wtype = GGML_TYPE_F16;
+            break;
+        case GGML_FTYPE_MOSTLY_BF16:
+            wtype = GGML_TYPE_BF16;
+            break;
+        case GGML_FTYPE_MOSTLY_Q4_0:
+            wtype = GGML_TYPE_Q4_0;
+            break;
+        case GGML_FTYPE_MOSTLY_Q4_1:
+            wtype = GGML_TYPE_Q4_1;
+            break;
+        case GGML_FTYPE_MOSTLY_Q5_0:
+            wtype = GGML_TYPE_Q5_0;
+            break;
+        case GGML_FTYPE_MOSTLY_Q5_1:
+            wtype = GGML_TYPE_Q5_1;
+            break;
+        case GGML_FTYPE_MOSTLY_Q8_0:
+            wtype = GGML_TYPE_Q8_0;
+            break;
+        case GGML_FTYPE_MOSTLY_MXFP4:
+            wtype = GGML_TYPE_MXFP4;
+            break;
+        case GGML_FTYPE_MOSTLY_Q2_K:
+            wtype = GGML_TYPE_Q2_K;
+            break;
+        case GGML_FTYPE_MOSTLY_Q3_K:
+            wtype = GGML_TYPE_Q3_K;
+            break;
+        case GGML_FTYPE_MOSTLY_Q4_K:
+            wtype = GGML_TYPE_Q4_K;
+            break;
+        case GGML_FTYPE_MOSTLY_Q5_K:
+            wtype = GGML_TYPE_Q5_K;
+            break;
+        case GGML_FTYPE_MOSTLY_Q6_K:
+            wtype = GGML_TYPE_Q6_K;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ2_XXS:
+            wtype = GGML_TYPE_IQ2_XXS;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ2_XS:
+            wtype = GGML_TYPE_IQ2_XS;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ3_XXS:
+            wtype = GGML_TYPE_IQ3_XXS;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ1_S:
+            wtype = GGML_TYPE_IQ1_S;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ1_M:
+            wtype = GGML_TYPE_IQ1_M;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ4_NL:
+            wtype = GGML_TYPE_IQ4_NL;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ4_XS:
+            wtype = GGML_TYPE_IQ4_XS;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ3_S:
+            wtype = GGML_TYPE_IQ3_S;
+            break;
+        case GGML_FTYPE_MOSTLY_IQ2_S:
+            wtype = GGML_TYPE_IQ2_S;
+            break;
+        case GGML_FTYPE_UNKNOWN:
+            wtype = GGML_TYPE_COUNT;
+            break;
+        case GGML_FTYPE_MOSTLY_Q4_1_SOME_F16:
+            wtype = GGML_TYPE_COUNT;
+            break;
     }
 
     GGML_ASSERT(wtype != GGML_TYPE_COUNT);
@@ -1399,7 +1422,7 @@ static bool ggml_is_contiguous_n(const struct ggml_tensor * tensor, int n) {
     if (tensor->ne[0] != ggml_blck_size(tensor->type) && tensor->nb[0] != next_nb) {
         return false;
     }
-    next_nb *= tensor->ne[0]/ggml_blck_size(tensor->type);
+    next_nb *= tensor->ne[0] / ggml_blck_size(tensor->type);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         if (tensor->ne[i] != 1) {
             if (i > n) {
@@ -1409,7 +1432,7 @@ static bool ggml_is_contiguous_n(const struct ggml_tensor * tensor, int n) {
                 next_nb *= tensor->ne[i];
             } else {
                 // this dimension does not need to be contiguous
-                next_nb = tensor->ne[i]*tensor->nb[i];
+                next_nb = tensor->ne[i] * tensor->nb[i];
             }
         }
     }
@@ -1433,7 +1456,7 @@ bool ggml_is_contiguous_2(const struct ggml_tensor * tensor) {
 }
 
 bool ggml_is_contiguously_allocated(const struct ggml_tensor * tensor) {
-    return ggml_nbytes(tensor) == ggml_nelements(tensor) * ggml_type_size(tensor->type)/ggml_blck_size(tensor->type);
+    return ggml_nbytes(tensor) == ggml_nelements(tensor) * ggml_type_size(tensor->type) / ggml_blck_size(tensor->type);
 }
 
 bool ggml_is_permuted(const struct ggml_tensor * tensor) {
@@ -1443,25 +1466,19 @@ bool ggml_is_permuted(const struct ggml_tensor * tensor) {
 }
 
 bool ggml_is_contiguous_channels(const struct ggml_tensor * tensor) {
-    return
-        tensor->nb[0] > tensor->nb[2] &&
-        tensor->nb[1] > tensor->nb[0] &&
-        tensor->nb[2] == ggml_type_size(tensor->type);
+    return tensor->nb[0] > tensor->nb[2] && tensor->nb[1] > tensor->nb[0] &&
+           tensor->nb[2] == ggml_type_size(tensor->type);
 }
 
 bool ggml_is_contiguous_rows(const struct ggml_tensor * tensor) {
-    return
-        tensor->ne[0] == ggml_blck_size(tensor->type) ||
-        tensor->nb[0] == ggml_type_size(tensor->type);
+    return tensor->ne[0] == ggml_blck_size(tensor->type) || tensor->nb[0] == ggml_type_size(tensor->type);
 }
 
 static inline bool ggml_is_padded_1d(const struct ggml_tensor * tensor) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return
-        tensor->nb[0] == ggml_type_size(tensor->type) &&
-        tensor->nb[2] == tensor->nb[1]*tensor->ne[1] &&
-        tensor->nb[3] == tensor->nb[2]*tensor->ne[2];
+    return tensor->nb[0] == ggml_type_size(tensor->type) && tensor->nb[2] == tensor->nb[1] * tensor->ne[1] &&
+           tensor->nb[3] == tensor->nb[2] * tensor->ne[2];
 }
 
 bool ggml_is_empty(const struct ggml_tensor * tensor) {
@@ -1477,21 +1494,13 @@ bool ggml_is_empty(const struct ggml_tensor * tensor) {
 bool ggml_are_same_shape(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return
-        (t0->ne[0] == t1->ne[0]) &&
-        (t0->ne[1] == t1->ne[1]) &&
-        (t0->ne[2] == t1->ne[2]) &&
-        (t0->ne[3] == t1->ne[3]);
+    return (t0->ne[0] == t1->ne[0]) && (t0->ne[1] == t1->ne[1]) && (t0->ne[2] == t1->ne[2]) && (t0->ne[3] == t1->ne[3]);
 }
 
 bool ggml_are_same_stride(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return
-        (t0->nb[0] == t1->nb[0]) &&
-        (t0->nb[1] == t1->nb[1]) &&
-        (t0->nb[2] == t1->nb[2]) &&
-        (t0->nb[3] == t1->nb[3]);
+    return (t0->nb[0] == t1->nb[0]) && (t0->nb[1] == t1->nb[1]) && (t0->nb[2] == t1->nb[2]) && (t0->nb[3] == t1->nb[3]);
 }
 
 // check if t1 can be represented as a repetition of t0
@@ -1499,10 +1508,8 @@ bool ggml_can_repeat(const struct ggml_tensor * t0, const struct ggml_tensor * t
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
     return ggml_is_empty(t0) ? ggml_is_empty(t1) :
-        (t1->ne[0]%t0->ne[0] == 0) &&
-        (t1->ne[1]%t0->ne[1] == 0) &&
-        (t1->ne[2]%t0->ne[2] == 0) &&
-        (t1->ne[3]%t0->ne[3] == 0);
+                               (t1->ne[0] % t0->ne[0] == 0) && (t1->ne[1] % t0->ne[1] == 0) &&
+                                   (t1->ne[2] % t0->ne[2] == 0) && (t1->ne[3] % t0->ne[3] == 0);
 }
 
 static inline bool ggml_can_repeat_rows(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
@@ -1512,8 +1519,7 @@ static inline bool ggml_can_repeat_rows(const struct ggml_tensor * t0, const str
 }
 
 // assert that pointer is aligned to GGML_MEM_ALIGN
-#define GGML_ASSERT_ALIGNED(ptr) \
-    GGML_ASSERT(((uintptr_t) (ptr))%GGML_MEM_ALIGN == 0)
+#define GGML_ASSERT_ALIGNED(ptr) GGML_ASSERT(((uintptr_t) (ptr)) % GGML_MEM_ALIGN == 0)
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1541,13 +1547,13 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
     const size_t mem_size = params.mem_buffer ? params.mem_size : GGML_PAD(params.mem_size, GGML_MEM_ALIGN);
 
     *ctx = (struct ggml_context) {
-        /*.mem_size           =*/ mem_size,
-        /*.mem_buffer         =*/ params.mem_buffer ? params.mem_buffer : ggml_aligned_malloc(mem_size),
-        /*.mem_buffer_owned   =*/ params.mem_buffer ? false : true,
-        /*.no_alloc           =*/ params.no_alloc,
-        /*.n_objects          =*/ 0,
-        /*.objects_begin      =*/ NULL,
-        /*.objects_end        =*/ NULL,
+        /*.mem_size           =*/mem_size,
+        /*.mem_buffer         =*/params.mem_buffer ? params.mem_buffer : ggml_aligned_malloc(mem_size),
+        /*.mem_buffer_owned   =*/params.mem_buffer ? false : true,
+        /*.no_alloc           =*/params.no_alloc,
+        /*.n_objects          =*/0,
+        /*.objects_begin      =*/NULL,
+        /*.objects_end        =*/NULL,
     };
 
     GGML_ASSERT(ctx->mem_buffer != NULL);
@@ -1604,9 +1610,10 @@ size_t ggml_get_mem_size(const struct ggml_context * ctx) {
 size_t ggml_get_max_tensor_size(const struct ggml_context * ctx) {
     size_t max_size = 0;
 
-    for (struct ggml_tensor * tensor = ggml_get_first_tensor(ctx); tensor != NULL; tensor = ggml_get_next_tensor(ctx, tensor)) {
+    for (struct ggml_tensor * tensor = ggml_get_first_tensor(ctx); tensor != NULL;
+         tensor                      = ggml_get_next_tensor(ctx, tensor)) {
         size_t bytes = ggml_nbytes(tensor);
-        max_size = MAX(max_size, bytes);
+        max_size     = MAX(max_size, bytes);
     }
 
     return max_size;
@@ -1625,12 +1632,12 @@ static struct ggml_object * ggml_new_object(struct ggml_context * ctx, enum ggml
     // align to GGML_MEM_ALIGN
     size_t size_needed = GGML_PAD(size, GGML_MEM_ALIGN);
 
-    char * const mem_buffer = ctx->mem_buffer;
-    struct ggml_object * const obj_new = (struct ggml_object *)(mem_buffer + cur_end);
+    char * const               mem_buffer = ctx->mem_buffer;
+    struct ggml_object * const obj_new    = (struct ggml_object *) (mem_buffer + cur_end);
 
     if (cur_end + size_needed + GGML_OBJECT_SIZE > ctx->mem_size) {
-        GGML_LOG_WARN("%s: not enough space in the context's memory pool (needed %zu, available %zu)\n",
-                __func__, cur_end + size_needed + GGML_OBJECT_SIZE, ctx->mem_size);
+        GGML_LOG_WARN("%s: not enough space in the context's memory pool (needed %zu, available %zu)\n", __func__,
+                      cur_end + size_needed + GGML_OBJECT_SIZE, ctx->mem_size);
 #ifndef NDEBUG
         GGML_ABORT("not enough space in the context's memory pool");
 #endif
@@ -1660,21 +1667,19 @@ static struct ggml_object * ggml_new_object(struct ggml_context * ctx, enum ggml
     return obj_new;
 }
 
-static struct ggml_tensor * ggml_new_tensor_impl(
-        struct ggml_context * ctx,
-        enum   ggml_type      type,
-        int                   n_dims,
-        const int64_t       * ne,
-        struct ggml_tensor  * view_src,
-        size_t                view_offs) {
-
+static struct ggml_tensor * ggml_new_tensor_impl(struct ggml_context * ctx,
+                                                 enum ggml_type        type,
+                                                 int                   n_dims,
+                                                 const int64_t *       ne,
+                                                 struct ggml_tensor *  view_src,
+                                                 size_t                view_offs) {
     GGML_ASSERT(type >= 0 && type < GGML_TYPE_COUNT);
     GGML_ASSERT(n_dims >= 1 && n_dims <= GGML_MAX_DIMS);
 
     // find the base tensor and absolute offset
     if (view_src != NULL && view_src->view_src != NULL) {
         view_offs += view_src->view_offs;
-        view_src   = view_src->view_src;
+        view_src = view_src->view_src;
     }
 
     size_t data_size = ggml_row_size(type, ne[0]);
@@ -1696,26 +1701,32 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         obj_alloc_size = data_size;
     }
 
-    struct ggml_object * const obj_new = ggml_new_object(ctx, GGML_OBJECT_TYPE_TENSOR, GGML_TENSOR_SIZE + obj_alloc_size);
+    struct ggml_object * const obj_new =
+        ggml_new_object(ctx, GGML_OBJECT_TYPE_TENSOR, GGML_TENSOR_SIZE + obj_alloc_size);
     GGML_ASSERT(obj_new);
 
-    struct ggml_tensor * const result = (struct ggml_tensor *)((char *)ctx->mem_buffer + obj_new->offs);
+    struct ggml_tensor * const result = (struct ggml_tensor *) ((char *) ctx->mem_buffer + obj_new->offs);
 
     *result = (struct ggml_tensor) {
-        /*.type         =*/ type,
-        /*.buffer       =*/ NULL,
-        /*.ne           =*/ { 1, 1, 1, 1 },
-        /*.nb           =*/ { 0, 0, 0, 0 },
-        /*.op           =*/ GGML_OP_NONE,
-        /*.op_params    =*/ { 0 },
-        /*.flags        =*/ 0,
-        /*.src          =*/ { NULL },
-        /*.view_src     =*/ view_src,
-        /*.view_offs    =*/ view_offs,
-        /*.data         =*/ obj_alloc_size > 0 ? (void *)(result + 1) : data,
-        /*.name         =*/ { 0 },
-        /*.extra        =*/ NULL,
-        /*.padding      =*/ { 0 },
+        /*.type         =*/type,
+        /*.buffer       =*/NULL,
+        /*.ne           =*/{ 1, 1, 1, 1 },
+        /*.nb           =*/
+        { 0, 0, 0, 0 },
+        /*.op           =*/
+        GGML_OP_NONE,
+        /*.op_params    =*/{ 0 },
+        /*.flags        =*/
+        0,
+        /*.src          =*/{ NULL },
+        /*.view_src     =*/
+        view_src,
+        /*.view_offs    =*/view_offs,
+        /*.data         =*/obj_alloc_size > 0 ? (void *) (result + 1) : data,
+        /*.name         =*/{ 0 },
+        /*.extra        =*/
+        NULL,
+        /*.padding      =*/{ 0 },
     };
 
     // TODO: this should not be needed as long as we don't rely on aligned SIMD loads
@@ -1726,9 +1737,9 @@ static struct ggml_tensor * ggml_new_tensor_impl(
     }
 
     result->nb[0] = ggml_type_size(type);
-    result->nb[1] = result->nb[0]*(result->ne[0]/ggml_blck_size(type));
+    result->nb[1] = result->nb[0] * (result->ne[0] / ggml_blck_size(type));
     for (int i = 2; i < GGML_MAX_DIMS; i++) {
-        result->nb[i] = result->nb[i - 1]*result->ne[i - 1];
+        result->nb[i] = result->nb[i - 1] * result->ne[i - 1];
     }
 
     ctx->n_objects++;
@@ -1736,47 +1747,34 @@ static struct ggml_tensor * ggml_new_tensor_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_new_tensor(
-        struct ggml_context * ctx,
-        enum   ggml_type      type,
-        int                   n_dims,
-        const int64_t       * ne) {
+struct ggml_tensor * ggml_new_tensor(struct ggml_context * ctx, enum ggml_type type, int n_dims, const int64_t * ne) {
     return ggml_new_tensor_impl(ctx, type, n_dims, ne, NULL, 0);
 }
 
-struct ggml_tensor * ggml_new_tensor_1d(
-        struct ggml_context * ctx,
-        enum   ggml_type      type,
-        int64_t ne0) {
+struct ggml_tensor * ggml_new_tensor_1d(struct ggml_context * ctx, enum ggml_type type, int64_t ne0) {
     return ggml_new_tensor(ctx, type, 1, &ne0);
 }
 
-struct ggml_tensor * ggml_new_tensor_2d(
-        struct ggml_context * ctx,
-        enum   ggml_type      type,
-        int64_t ne0,
-        int64_t ne1) {
+struct ggml_tensor * ggml_new_tensor_2d(struct ggml_context * ctx, enum ggml_type type, int64_t ne0, int64_t ne1) {
     const int64_t ne[2] = { ne0, ne1 };
     return ggml_new_tensor(ctx, type, 2, ne);
 }
 
-struct ggml_tensor * ggml_new_tensor_3d(
-        struct ggml_context * ctx,
-        enum   ggml_type      type,
-        int64_t ne0,
-        int64_t ne1,
-        int64_t ne2) {
+struct ggml_tensor * ggml_new_tensor_3d(struct ggml_context * ctx,
+                                        enum ggml_type        type,
+                                        int64_t               ne0,
+                                        int64_t               ne1,
+                                        int64_t               ne2) {
     const int64_t ne[3] = { ne0, ne1, ne2 };
     return ggml_new_tensor(ctx, type, 3, ne);
 }
 
-struct ggml_tensor * ggml_new_tensor_4d(
-        struct ggml_context * ctx,
-        enum   ggml_type type,
-        int64_t ne0,
-        int64_t ne1,
-        int64_t ne2,
-        int64_t ne3) {
+struct ggml_tensor * ggml_new_tensor_4d(struct ggml_context * ctx,
+                                        enum ggml_type        type,
+                                        int64_t               ne0,
+                                        int64_t               ne1,
+                                        int64_t               ne2,
+                                        int64_t               ne3) {
     const int64_t ne[4] = { ne0, ne1, ne2, ne3 };
     return ggml_new_tensor(ctx, type, 4, ne);
 }
@@ -1784,34 +1782,39 @@ struct ggml_tensor * ggml_new_tensor_4d(
 void * ggml_new_buffer(struct ggml_context * ctx, size_t nbytes) {
     struct ggml_object * obj = ggml_new_object(ctx, GGML_OBJECT_TYPE_WORK_BUFFER, nbytes);
 
-    return (uint8_t *)ctx->mem_buffer + obj->offs;
+    return (uint8_t *) ctx->mem_buffer + obj->offs;
 }
 
 struct ggml_tensor * ggml_dup_tensor(struct ggml_context * ctx, const struct ggml_tensor * src) {
     return ggml_new_tensor(ctx, src->type, GGML_MAX_DIMS, src->ne);
 }
 
-void ggml_unravel_index(const struct ggml_tensor * tensor, int64_t i, int64_t * i0, int64_t * i1, int64_t * i2, int64_t * i3) {
+void ggml_unravel_index(const struct ggml_tensor * tensor,
+                        int64_t                    i,
+                        int64_t *                  i0,
+                        int64_t *                  i1,
+                        int64_t *                  i2,
+                        int64_t *                  i3) {
     const int64_t ne2 = tensor->ne[2];
     const int64_t ne1 = tensor->ne[1];
     const int64_t ne0 = tensor->ne[0];
 
-    const int64_t i3_ = (i/(ne2*ne1*ne0));
-    const int64_t i2_ = (i - i3_*ne2*ne1*ne0)/(ne1*ne0);
-    const int64_t i1_ = (i - i3_*ne2*ne1*ne0 - i2_*ne1*ne0)/ne0;
-    const int64_t i0_ = (i - i3_*ne2*ne1*ne0 - i2_*ne1*ne0 - i1_*ne0);
+    const int64_t i3_ = (i / (ne2 * ne1 * ne0));
+    const int64_t i2_ = (i - i3_ * ne2 * ne1 * ne0) / (ne1 * ne0);
+    const int64_t i1_ = (i - i3_ * ne2 * ne1 * ne0 - i2_ * ne1 * ne0) / ne0;
+    const int64_t i0_ = (i - i3_ * ne2 * ne1 * ne0 - i2_ * ne1 * ne0 - i1_ * ne0);
 
     if (i0) {
-        * i0 = i0_;
+        *i0 = i0_;
     }
     if (i1) {
-        * i1 = i1_;
+        *i1 = i1_;
     }
     if (i2) {
-        * i2 = i2_;
+        *i2 = i2_;
     }
     if (i3) {
-        * i3 = i3_;
+        *i3 = i3_;
     }
 }
 
@@ -1821,7 +1824,7 @@ void * ggml_get_data(const struct ggml_tensor * tensor) {
 
 float * ggml_get_data_f32(const struct ggml_tensor * tensor) {
     assert(tensor->type == GGML_TYPE_F32);
-    return (float *)(tensor->data);
+    return (float *) (tensor->data);
 }
 
 enum ggml_unary_op ggml_get_unary_op(const struct ggml_tensor * tensor) {
@@ -1855,9 +1858,7 @@ struct ggml_tensor * ggml_format_name(struct ggml_tensor * tensor, const char * 
     return tensor;
 }
 
-struct ggml_tensor * ggml_view_tensor(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * src) {
+struct ggml_tensor * ggml_view_tensor(struct ggml_context * ctx, struct ggml_tensor * src) {
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, src->type, GGML_MAX_DIMS, src->ne, src, 0);
     ggml_format_name(result, "%s (view)", src->name);
 
@@ -1875,7 +1876,7 @@ struct ggml_tensor * ggml_get_first_tensor(const struct ggml_context * ctx) {
 
     while (obj != NULL) {
         if (obj->type == GGML_OBJECT_TYPE_TENSOR) {
-            return (struct ggml_tensor *)(mem_buffer + obj->offs);
+            return (struct ggml_tensor *) (mem_buffer + obj->offs);
         }
 
         obj = obj->next;
@@ -1885,14 +1886,14 @@ struct ggml_tensor * ggml_get_first_tensor(const struct ggml_context * ctx) {
 }
 
 struct ggml_tensor * ggml_get_next_tensor(const struct ggml_context * ctx, struct ggml_tensor * tensor) {
-    struct ggml_object * obj = (struct ggml_object *) ((char *)tensor - GGML_OBJECT_SIZE);
-    obj = obj->next;
+    struct ggml_object * obj = (struct ggml_object *) ((char *) tensor - GGML_OBJECT_SIZE);
+    obj                      = obj->next;
 
     char * const mem_buffer = ctx->mem_buffer;
 
     while (obj != NULL) {
         if (obj->type == GGML_OBJECT_TYPE_TENSOR) {
-            return (struct ggml_tensor *)(mem_buffer + obj->offs);
+            return (struct ggml_tensor *) (mem_buffer + obj->offs);
         }
 
         obj = obj->next;
@@ -1908,7 +1909,7 @@ struct ggml_tensor * ggml_get_tensor(struct ggml_context * ctx, const char * nam
 
     while (obj != NULL) {
         if (obj->type == GGML_OBJECT_TYPE_TENSOR) {
-            struct ggml_tensor * cur = (struct ggml_tensor *)(mem_buffer + obj->offs);
+            struct ggml_tensor * cur = (struct ggml_tensor *) (mem_buffer + obj->offs);
             if (strcmp(cur->name, name) == 0) {
                 return cur;
             }
@@ -1924,10 +1925,7 @@ struct ggml_tensor * ggml_get_tensor(struct ggml_context * ctx, const char * nam
 
 // ggml_dup
 
-static struct ggml_tensor * ggml_dup_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_dup_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_DUP;
@@ -1936,25 +1934,20 @@ static struct ggml_tensor * ggml_dup_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_dup(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_dup(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_dup_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_dup_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_dup_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_dup_impl(ctx, a, true);
 }
 
 // ggml_add
 
-static struct ggml_tensor * ggml_add_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_add_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_can_repeat(b, a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -1966,35 +1959,26 @@ static struct ggml_tensor * ggml_add_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_add(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_add(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_add_impl(ctx, a, b, false);
 }
 
-struct ggml_tensor * ggml_add_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_add_inplace(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_add_impl(ctx, a, b, true);
 }
 
 // ggml_add_cast
 
-static struct ggml_tensor * ggml_add_cast_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        enum   ggml_type      type) {
+static struct ggml_tensor * ggml_add_cast_impl(struct ggml_context * ctx,
+                                               struct ggml_tensor *  a,
+                                               struct ggml_tensor *  b,
+                                               enum ggml_type        type) {
     // TODO: support less-strict constraint
     //       GGML_ASSERT(ggml_can_repeat(b, a));
     GGML_ASSERT(ggml_can_repeat_rows(b, a));
 
     // currently only supported for quantized input and f16
-    GGML_ASSERT(ggml_is_quantized(a->type) ||
-                a->type == GGML_TYPE_F16 ||
-                a->type == GGML_TYPE_BF16);
+    GGML_ASSERT(ggml_is_quantized(a->type) || a->type == GGML_TYPE_F16 || a->type == GGML_TYPE_BF16);
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, type, GGML_MAX_DIMS, a->ne);
 
@@ -2005,20 +1989,17 @@ static struct ggml_tensor * ggml_add_cast_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_add_cast(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        enum   ggml_type      type) {
+struct ggml_tensor * ggml_add_cast(struct ggml_context * ctx,
+                                   struct ggml_tensor *  a,
+                                   struct ggml_tensor *  b,
+                                   enum ggml_type        type) {
     return ggml_add_cast_impl(ctx, a, b, type);
 }
 
-struct ggml_tensor * ggml_add_id(
-            struct ggml_context * ctx,
-            struct ggml_tensor  * a,
-            struct ggml_tensor  * b,
-            struct ggml_tensor  * ids) {
-
+struct ggml_tensor * ggml_add_id(struct ggml_context * ctx,
+                                 struct ggml_tensor *  a,
+                                 struct ggml_tensor *  b,
+                                 struct ggml_tensor *  ids) {
     GGML_ASSERT(a->ne[0] == b->ne[0]);
     GGML_ASSERT(a->ne[1] == ids->ne[0]);
     GGML_ASSERT(a->ne[2] == ids->ne[1]);
@@ -2036,11 +2017,10 @@ struct ggml_tensor * ggml_add_id(
 
 // ggml_add1
 
-static struct ggml_tensor * ggml_add1_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_add1_impl(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           struct ggml_tensor *  b,
+                                           bool                  inplace) {
     GGML_ASSERT(ggml_is_scalar(b));
     GGML_ASSERT(ggml_is_padded_1d(a));
 
@@ -2053,31 +2033,24 @@ static struct ggml_tensor * ggml_add1_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_add1(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_add1(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_add1_impl(ctx, a, b, false);
 }
 
-struct ggml_tensor * ggml_add1_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_add1_inplace(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_add1_impl(ctx, a, b, true);
 }
 
 // ggml_acc
 
-static struct ggml_tensor * ggml_acc_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_acc_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          size_t                nb1,
+                                          size_t                nb2,
+                                          size_t                nb3,
+                                          size_t                offset,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_nelements(b) <= ggml_nelements(a));
     GGML_ASSERT(ggml_is_contiguous(a));
     GGML_ASSERT(a->type == GGML_TYPE_F32);
@@ -2095,35 +2068,32 @@ static struct ggml_tensor * ggml_acc_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_acc(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset) {
+struct ggml_tensor * ggml_acc(struct ggml_context * ctx,
+                              struct ggml_tensor *  a,
+                              struct ggml_tensor *  b,
+                              size_t                nb1,
+                              size_t                nb2,
+                              size_t                nb3,
+                              size_t                offset) {
     return ggml_acc_impl(ctx, a, b, nb1, nb2, nb3, offset, false);
 }
 
-struct ggml_tensor * ggml_acc_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset) {
+struct ggml_tensor * ggml_acc_inplace(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      struct ggml_tensor *  b,
+                                      size_t                nb1,
+                                      size_t                nb2,
+                                      size_t                nb3,
+                                      size_t                offset) {
     return ggml_acc_impl(ctx, a, b, nb1, nb2, nb3, offset, true);
 }
 
 // ggml_sub
 
-static struct ggml_tensor * ggml_sub_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_sub_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_can_repeat(b, a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -2135,27 +2105,20 @@ static struct ggml_tensor * ggml_sub_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_sub(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_sub(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_sub_impl(ctx, a, b, false);
 }
 
-struct ggml_tensor * ggml_sub_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_sub_inplace(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_sub_impl(ctx, a, b, true);
 }
 
 // ggml_mul
 
-static struct ggml_tensor * ggml_mul_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_mul_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_can_repeat(b, a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -2167,27 +2130,20 @@ static struct ggml_tensor * ggml_mul_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_mul(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_mul(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_mul_impl(ctx, a, b, false);
 }
 
-struct ggml_tensor * ggml_mul_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_mul_inplace(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_mul_impl(ctx, a, b, true);
 }
 
 // ggml_div
 
-static struct ggml_tensor * ggml_div_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_div_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_can_repeat(b, a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -2199,26 +2155,17 @@ static struct ggml_tensor * ggml_div_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_div(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_div(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_div_impl(ctx, a, b, false);
 }
 
-struct ggml_tensor * ggml_div_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_div_inplace(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_div_impl(ctx, a, b, true);
 }
 
 // ggml_sqr
 
-static struct ggml_tensor * ggml_sqr_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_sqr_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_SQR;
@@ -2227,24 +2174,17 @@ static struct ggml_tensor * ggml_sqr_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_sqr(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sqr(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sqr_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_sqr_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sqr_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sqr_impl(ctx, a, true);
 }
 
 // ggml_sqrt
 
-static struct ggml_tensor * ggml_sqrt_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_sqrt_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_SQRT;
@@ -2253,24 +2193,17 @@ static struct ggml_tensor * ggml_sqrt_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_sqrt(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sqrt(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sqrt_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_sqrt_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sqrt_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sqrt_impl(ctx, a, true);
 }
 
 // ggml_log
 
-static struct ggml_tensor * ggml_log_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_log_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_LOG;
@@ -2279,48 +2212,33 @@ static struct ggml_tensor * ggml_log_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_log(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_log(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_log_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_log_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_log_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_log_impl(ctx, a, true);
 }
 
-struct ggml_tensor * ggml_expm1(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_expm1(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_EXPM1);
 }
 
-struct ggml_tensor * ggml_expm1_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_expm1_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_EXPM1);
 }
 
-struct ggml_tensor * ggml_softplus(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_softplus(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_SOFTPLUS);
 }
 
-struct ggml_tensor * ggml_softplus_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_softplus_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_SOFTPLUS);
 }
 
 // ggml_sin
 
-static struct ggml_tensor * ggml_sin_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_sin_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_SIN;
@@ -2329,24 +2247,17 @@ static struct ggml_tensor * ggml_sin_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_sin(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sin(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sin_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_sin_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sin_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_sin_impl(ctx, a, true);
 }
 
 // ggml_cos
 
-static struct ggml_tensor * ggml_cos_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_cos_impl(struct ggml_context * ctx, struct ggml_tensor * a, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_COS;
@@ -2355,23 +2266,17 @@ static struct ggml_tensor * ggml_cos_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_cos(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_cos(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_cos_impl(ctx, a, false);
 }
 
-struct ggml_tensor * ggml_cos_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_cos_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_cos_impl(ctx, a, true);
 }
 
 // ggml_sum
 
-struct ggml_tensor * ggml_sum(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sum(struct ggml_context * ctx, struct ggml_tensor * a) {
     struct ggml_tensor * result = ggml_new_tensor_1d(ctx, a->type, 1);
 
     result->op     = GGML_OP_SUM;
@@ -2382,9 +2287,7 @@ struct ggml_tensor * ggml_sum(
 
 // ggml_sum_rows
 
-struct ggml_tensor * ggml_sum_rows(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sum_rows(struct ggml_context * ctx, struct ggml_tensor * a) {
     int64_t ne[GGML_MAX_DIMS] = { 1 };
     for (int i = 1; i < GGML_MAX_DIMS; ++i) {
         ne[i] = a->ne[i];
@@ -2400,9 +2303,7 @@ struct ggml_tensor * ggml_sum_rows(
 
 // ggml_cumsum
 
-struct ggml_tensor * ggml_cumsum(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_cumsum(struct ggml_context * ctx, struct ggml_tensor * a) {
     GGML_ASSERT(a->type == GGML_TYPE_F32);
 
     struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
@@ -2415,10 +2316,8 @@ struct ggml_tensor * ggml_cumsum(
 
 // ggml_mean
 
-struct ggml_tensor * ggml_mean(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
-    int64_t ne[4] = { 1, a->ne[1], a->ne[2], a->ne[3] };
+struct ggml_tensor * ggml_mean(struct ggml_context * ctx, struct ggml_tensor * a) {
+    int64_t              ne[4]  = { 1, a->ne[1], a->ne[2], a->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_MEAN;
@@ -2429,9 +2328,7 @@ struct ggml_tensor * ggml_mean(
 
 // ggml_argmax
 
-struct ggml_tensor * ggml_argmax(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_argmax(struct ggml_context * ctx, struct ggml_tensor * a) {
     GGML_ASSERT(ggml_is_matrix(a));
     GGML_ASSERT(a->ne[0] <= INT32_MAX);
 
@@ -2445,10 +2342,7 @@ struct ggml_tensor * ggml_argmax(
 
 // ggml_count_equal
 
-struct ggml_tensor * ggml_count_equal(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_count_equal(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_are_same_shape(a, b));
 
     struct ggml_tensor * result = ggml_new_tensor_1d(ctx, GGML_TYPE_I64, 1);
@@ -2462,10 +2356,7 @@ struct ggml_tensor * ggml_count_equal(
 
 // ggml_repeat
 
-struct ggml_tensor * ggml_repeat(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_repeat(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_can_repeat(a, b));
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, a->type, GGML_MAX_DIMS, b->ne);
@@ -2476,16 +2367,14 @@ struct ggml_tensor * ggml_repeat(
     return result;
 }
 
-struct ggml_tensor * ggml_repeat_4d(
-        struct ggml_context * ctx,
-        struct ggml_tensor * a,
-        int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3) {
-    const bool can_repeat = ggml_is_empty(a) || (
-        (ne0 % a->ne[0] == 0) &&
-        (ne1 % a->ne[1] == 0) &&
-        (ne2 % a->ne[2] == 0) &&
-        (ne3 % a->ne[3] == 0)
-    );
+struct ggml_tensor * ggml_repeat_4d(struct ggml_context * ctx,
+                                    struct ggml_tensor *  a,
+                                    int64_t               ne0,
+                                    int64_t               ne1,
+                                    int64_t               ne2,
+                                    int64_t               ne3) {
+    const bool can_repeat = ggml_is_empty(a) || ((ne0 % a->ne[0] == 0) && (ne1 % a->ne[1] == 0) &&
+                                                 (ne2 % a->ne[2] == 0) && (ne3 % a->ne[3] == 0));
     GGML_ASSERT(can_repeat);
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, ne0, ne1, ne2, ne3);
@@ -2498,10 +2387,7 @@ struct ggml_tensor * ggml_repeat_4d(
 
 // ggml_repeat_back
 
-struct ggml_tensor * ggml_repeat_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_repeat_back(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_can_repeat(b, a));
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, a->type, GGML_MAX_DIMS, b->ne);
@@ -2514,11 +2400,7 @@ struct ggml_tensor * ggml_repeat_back(
 
 // ggml_concat
 
-struct ggml_tensor * ggml_concat(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a,
-    struct ggml_tensor  * b,
-    int                   dim) {
+struct ggml_tensor * ggml_concat(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b, int dim) {
     GGML_ASSERT(dim >= 0 && dim < GGML_MAX_DIMS);
     GGML_ASSERT(a->type == b->type);
 
@@ -2545,109 +2427,80 @@ struct ggml_tensor * ggml_concat(
 
 // ggml_abs
 
-struct ggml_tensor * ggml_abs(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_abs(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_ABS);
 }
 
-struct ggml_tensor * ggml_abs_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_abs_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_ABS);
 }
 
 // ggml_sgn
 
-struct ggml_tensor * ggml_sgn(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sgn(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_SGN);
 }
 
-struct ggml_tensor * ggml_sgn_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sgn_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_SGN);
 }
 
 // ggml_neg
 
-struct ggml_tensor * ggml_neg(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_neg(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_NEG);
 }
 
-struct ggml_tensor * ggml_neg_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_neg_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_NEG);
 }
 
 // ggml_step
 
-struct ggml_tensor * ggml_step(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_step(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_STEP);
 }
 
-struct ggml_tensor * ggml_step_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_step_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_STEP);
 }
 
 // ggml_tanh
 
-struct ggml_tensor * ggml_tanh(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_tanh(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_TANH);
 }
 
-struct ggml_tensor * ggml_tanh_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_tanh_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_TANH);
 }
 
 // ggml_elu
 
-struct ggml_tensor * ggml_elu(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_elu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_ELU);
 }
 
-struct ggml_tensor * ggml_elu_inplace(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_elu_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_ELU);
 }
 
 // ggml_relu
 
-struct ggml_tensor * ggml_relu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_relu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_RELU);
 }
 
-struct ggml_tensor * ggml_relu_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_relu_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_RELU);
 }
 
 // ggml_leaky_relu
 
-struct ggml_tensor * ggml_leaky_relu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 negative_slope,
-        bool                  inplace) {
+struct ggml_tensor * ggml_leaky_relu(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     float                 negative_slope,
+                                     bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params(result, &negative_slope, sizeof(negative_slope));
@@ -2660,83 +2513,62 @@ struct ggml_tensor * ggml_leaky_relu(
 
 // ggml_sigmoid
 
-struct ggml_tensor * ggml_sigmoid(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sigmoid(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_SIGMOID);
 }
 
-struct ggml_tensor * ggml_sigmoid_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_sigmoid_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_SIGMOID);
 }
 
 // ggml_gelu
 
-struct ggml_tensor * ggml_gelu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_GELU);
 }
 
-struct ggml_tensor * ggml_gelu_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_GELU);
 }
 
 // ggml_gelu_erf
 
-struct ggml_tensor * ggml_gelu_erf(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu_erf(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_GELU_ERF);
 }
 
-struct ggml_tensor * ggml_gelu_erf_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu_erf_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_GELU_ERF);
 }
 
 // ggml_gelu_quick
 
-struct ggml_tensor * ggml_gelu_quick(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu_quick(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_GELU_QUICK);
 }
 
-struct ggml_tensor * ggml_gelu_quick_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_gelu_quick_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_GELU_QUICK);
 }
 
 // ggml_silu
 
-struct ggml_tensor * ggml_silu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_silu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_SILU);
 }
 
-struct ggml_tensor * ggml_silu_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_silu_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_SILU);
 }
 
 // ggml_xielu
 
-struct ggml_tensor * ggml_xielu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float alpha_n,
-        float alpha_p,
-        float beta,
-        float eps) {
+struct ggml_tensor * ggml_xielu(struct ggml_context * ctx,
+                                struct ggml_tensor *  a,
+                                float                 alpha_n,
+                                float                 alpha_p,
+                                float                 beta,
+                                float                 eps) {
     struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params_i32(result, 0, (int32_t) GGML_UNARY_OP_XIELU);
@@ -2753,10 +2585,7 @@ struct ggml_tensor * ggml_xielu(
 
 // ggml_silu_back
 
-struct ggml_tensor * ggml_silu_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_silu_back(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_SILU_BACK;
@@ -2768,42 +2597,33 @@ struct ggml_tensor * ggml_silu_back(
 
 // ggml hardswish
 
-struct ggml_tensor * ggml_hardswish(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_hardswish(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_HARDSWISH);
 }
 
 // ggml hardsigmoid
 
-struct ggml_tensor * ggml_hardsigmoid(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_hardsigmoid(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_HARDSIGMOID);
 }
 
 // ggml exp
 
-struct ggml_tensor * ggml_exp(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_exp(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_EXP);
 }
 
-struct ggml_tensor * ggml_exp_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_exp_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_EXP);
 }
 
 // ggml_glu
 
-static struct ggml_tensor * ggml_glu_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        enum ggml_glu_op      op,
-        bool                  swapped) {
+static struct ggml_tensor * ggml_glu_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          enum ggml_glu_op      op,
+                                          bool                  swapped) {
     GGML_ASSERT(ggml_is_contiguous_1(a));
 
     if (b) {
@@ -2812,7 +2632,10 @@ static struct ggml_tensor * ggml_glu_impl(
         GGML_ASSERT(a->type == b->type);
     }
 
-    int64_t ne[GGML_MAX_DIMS] = { a->ne[0] / 2 }; for (int i = 1; i < GGML_MAX_DIMS; i++) ne[i] = a->ne[i];
+    int64_t ne[GGML_MAX_DIMS] = { a->ne[0] / 2 };
+    for (int i = 1; i < GGML_MAX_DIMS; i++) {
+        ne[i] = a->ne[i];
+    }
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, GGML_MAX_DIMS, b ? a->ne : ne, NULL, 0);
 
     ggml_set_op_params_i32(result, 0, (int32_t) op);
@@ -2827,187 +2650,130 @@ static struct ggml_tensor * ggml_glu_impl(
 
 // ggml_floor
 
-struct ggml_tensor * ggml_floor(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_floor(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_FLOOR);
 }
 
-struct ggml_tensor * ggml_floor_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_floor_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_FLOOR);
 }
 
 // ggml_ceil
 
-struct ggml_tensor * ggml_ceil(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_ceil(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_CEIL);
 }
 
-struct ggml_tensor * ggml_ceil_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_ceil_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_CEIL);
 }
 
 //ggml_round
 
-struct ggml_tensor * ggml_round(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_round(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_ROUND);
 }
 
-struct ggml_tensor * ggml_round_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_round_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_ROUND);
 }
 
 //ggml_trunc
 
-struct ggml_tensor * ggml_trunc(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_trunc(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary(ctx, a, GGML_UNARY_OP_TRUNC);
 }
 
-struct ggml_tensor * ggml_trunc_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_trunc_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_TRUNC);
 }
 
-struct ggml_tensor * ggml_glu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_glu_op      op,
-        bool                  swapped) {
+struct ggml_tensor * ggml_glu(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_glu_op op, bool swapped) {
     return ggml_glu_impl(ctx, a, NULL, op, swapped);
 }
 
-struct ggml_tensor * ggml_glu_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        enum ggml_glu_op      op) {
+struct ggml_tensor * ggml_glu_split(struct ggml_context * ctx,
+                                    struct ggml_tensor *  a,
+                                    struct ggml_tensor *  b,
+                                    enum ggml_glu_op      op) {
     return ggml_glu_impl(ctx, a, b, op, false);
 }
 
 // ggml_reglu
 
-struct ggml_tensor * ggml_reglu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_reglu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_REGLU, false);
 }
 
-struct ggml_tensor * ggml_reglu_swapped(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_reglu_swapped(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_REGLU, true);
 }
 
-struct ggml_tensor * ggml_reglu_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_reglu_split(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_glu_impl(ctx, a, b, GGML_GLU_OP_REGLU, false);
 }
 
 // ggml_geglu
 
-struct ggml_tensor * ggml_geglu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU, false);
 }
 
-struct ggml_tensor * ggml_geglu_swapped(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu_swapped(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU, true);
 }
 
-struct ggml_tensor * ggml_geglu_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_geglu_split(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_glu_impl(ctx, a, b, GGML_GLU_OP_GEGLU, false);
 }
 
 // ggml_swiglu
 
-struct ggml_tensor * ggml_swiglu(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_swiglu(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_SWIGLU, false);
 }
 
-struct ggml_tensor * ggml_swiglu_swapped(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_swiglu_swapped(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_SWIGLU, true);
 }
 
-struct ggml_tensor * ggml_swiglu_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_swiglu_split(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_glu_impl(ctx, a, b, GGML_GLU_OP_SWIGLU, false);
 }
 
 // ggml_geglu_erf
 
-struct ggml_tensor * ggml_geglu_erf(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu_erf(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU_ERF, false);
 }
 
-struct ggml_tensor * ggml_geglu_erf_swapped(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu_erf_swapped(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU_ERF, true);
 }
 
-struct ggml_tensor * ggml_geglu_erf_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_geglu_erf_split(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_glu_impl(ctx, a, b, GGML_GLU_OP_GEGLU_ERF, false);
 }
 
 // ggml_geglu_quick
 
-struct ggml_tensor * ggml_geglu_quick(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu_quick(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU_QUICK, false);
 }
 
-struct ggml_tensor * ggml_geglu_quick_swapped(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_geglu_quick_swapped(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_glu_impl(ctx, a, NULL, GGML_GLU_OP_GEGLU_QUICK, true);
 }
 
-struct ggml_tensor * ggml_geglu_quick_split(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_geglu_quick_split(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_glu_impl(ctx, a, b, GGML_GLU_OP_GEGLU_QUICK, false);
 }
 
-struct ggml_tensor * ggml_swiglu_oai(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        float                 alpha,
-        float                 limit) {
+struct ggml_tensor * ggml_swiglu_oai(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     struct ggml_tensor *  b,
+                                     float                 alpha,
+                                     float                 limit) {
     struct ggml_tensor * result = ggml_glu_impl(ctx, a, b, GGML_GLU_OP_SWIGLU_OAI, false);
     ggml_set_op_params_f32(result, 2, alpha);
     ggml_set_op_params_f32(result, 3, limit);
@@ -3017,11 +2783,7 @@ struct ggml_tensor * ggml_swiglu_oai(
 
 // ggml_norm
 
-static struct ggml_tensor * ggml_norm_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_norm_impl(struct ggml_context * ctx, struct ggml_tensor * a, float eps, bool inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params(result, &eps, sizeof(eps));
@@ -3032,27 +2794,20 @@ static struct ggml_tensor * ggml_norm_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_norm(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_norm(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_norm_impl(ctx, a, eps, false);
 }
 
-struct ggml_tensor * ggml_norm_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_norm_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_norm_impl(ctx, a, eps, true);
 }
 
 // ggml_rms_norm
 
-static struct ggml_tensor * ggml_rms_norm_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_rms_norm_impl(struct ggml_context * ctx,
+                                               struct ggml_tensor *  a,
+                                               float                 eps,
+                                               bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params(result, &eps, sizeof(eps));
@@ -3063,27 +2818,20 @@ static struct ggml_tensor * ggml_rms_norm_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_rms_norm(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_rms_norm(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_rms_norm_impl(ctx, a, eps, false);
 }
 
-struct ggml_tensor * ggml_rms_norm_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_rms_norm_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_rms_norm_impl(ctx, a, eps, true);
 }
 
 // ggml_rms_norm_back
 
-struct ggml_tensor * ggml_rms_norm_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        float                 eps) {
+struct ggml_tensor * ggml_rms_norm_back(struct ggml_context * ctx,
+                                        struct ggml_tensor *  a,
+                                        struct ggml_tensor *  b,
+                                        float                 eps) {
     struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params(result, &eps, sizeof(eps));
@@ -3097,12 +2845,11 @@ struct ggml_tensor * ggml_rms_norm_back(
 
 // ggml_group_norm
 
-static struct ggml_tensor * ggml_group_norm_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_groups,
-        float                 eps,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_group_norm_impl(struct ggml_context * ctx,
+                                                 struct ggml_tensor *  a,
+                                                 int                   n_groups,
+                                                 float                 eps,
+                                                 bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params_i32(result, 0, n_groups);
@@ -3114,29 +2861,23 @@ static struct ggml_tensor * ggml_group_norm_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_group_norm(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_groups,
-        float                 eps) {
+struct ggml_tensor * ggml_group_norm(struct ggml_context * ctx, struct ggml_tensor * a, int n_groups, float eps) {
     return ggml_group_norm_impl(ctx, a, n_groups, eps, false);
 }
 
-struct ggml_tensor * ggml_group_norm_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_groups,
-        float                 eps) {
+struct ggml_tensor * ggml_group_norm_inplace(struct ggml_context * ctx,
+                                             struct ggml_tensor *  a,
+                                             int                   n_groups,
+                                             float                 eps) {
     return ggml_group_norm_impl(ctx, a, n_groups, eps, true);
 }
 
 // ggml_l2_norm
 
-static struct ggml_tensor * ggml_l2_norm_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_l2_norm_impl(struct ggml_context * ctx,
+                                              struct ggml_tensor *  a,
+                                              float                 eps,
+                                              bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params_f32(result, 0, eps);
@@ -3147,17 +2888,11 @@ static struct ggml_tensor * ggml_l2_norm_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_l2_norm(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_l2_norm(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_l2_norm_impl(ctx, a, eps, false);
 }
 
-struct ggml_tensor * ggml_l2_norm_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 eps) {
+struct ggml_tensor * ggml_l2_norm_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float eps) {
     return ggml_l2_norm_impl(ctx, a, eps, true);
 }
 
@@ -3166,19 +2901,15 @@ struct ggml_tensor * ggml_l2_norm_inplace(
 static inline bool ggml_can_mul_mat(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return (t0->ne[0]           == t1->ne[0])  &&
-           (t1->ne[2]%t0->ne[2] == 0)          && // verify t0 is broadcastable
-           (t1->ne[3]%t0->ne[3] == 0);
+    return (t0->ne[0] == t1->ne[0]) && (t1->ne[2] % t0->ne[2] == 0) &&  // verify t0 is broadcastable
+           (t1->ne[3] % t0->ne[3] == 0);
 }
 
-struct ggml_tensor * ggml_mul_mat(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_mul_mat(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_can_mul_mat(a, b));
     GGML_ASSERT(!ggml_is_transposed(a));
 
-    const int64_t ne[4] = { a->ne[1], b->ne[1], b->ne[2], b->ne[3] };
+    const int64_t        ne[4]  = { a->ne[1], b->ne[1], b->ne[2], b->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_MUL_MAT;
@@ -3188,9 +2919,7 @@ struct ggml_tensor * ggml_mul_mat(
     return result;
 }
 
-void ggml_mul_mat_set_prec(
-        struct ggml_tensor * a,
-        enum ggml_prec       prec) {
+void ggml_mul_mat_set_prec(struct ggml_tensor * a, enum ggml_prec prec) {
     GGML_ASSERT(a->op == GGML_OP_MUL_MAT);
 
     const int32_t prec_i32 = (int32_t) prec;
@@ -3212,22 +2941,21 @@ void ggml_mul_mat_set_prec(
 
     c ~= as[:,:,i] @ b[:,i%r,t], i = ids[e,t] for all e,t in ids
 */
-struct ggml_tensor * ggml_mul_mat_id(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * as,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * ids) {
+struct ggml_tensor * ggml_mul_mat_id(struct ggml_context * ctx,
+                                     struct ggml_tensor *  as,
+                                     struct ggml_tensor *  b,
+                                     struct ggml_tensor *  ids) {
     GGML_ASSERT(!ggml_is_transposed(as));
     GGML_ASSERT(ids->type == GGML_TYPE_I32);
 
-    GGML_ASSERT(as->ne[3] == 1); // as is 3d (one matrix per expert)
-    GGML_ASSERT(b->ne[3] == 1); // b is 3d
-    GGML_ASSERT(ids->ne[2] == 1 && ids->ne[3] == 1); // ids is 2d
-    GGML_ASSERT(ids->ne[1] == b->ne[2]); // must have an expert list per b row
-    GGML_ASSERT(as->ne[0] == b->ne[0]); // can_mul_mat
-    GGML_ASSERT(ids->ne[0] % b->ne[1] == 0); // can broadcast
+    GGML_ASSERT(as->ne[3] == 1);                      // as is 3d (one matrix per expert)
+    GGML_ASSERT(b->ne[3] == 1);                       // b is 3d
+    GGML_ASSERT(ids->ne[2] == 1 && ids->ne[3] == 1);  // ids is 2d
+    GGML_ASSERT(ids->ne[1] == b->ne[2]);              // must have an expert list per b row
+    GGML_ASSERT(as->ne[0] == b->ne[0]);               // can_mul_mat
+    GGML_ASSERT(ids->ne[0] % b->ne[1] == 0);          // can broadcast
 
-    const int64_t ne[4] = { as->ne[1], ids->ne[0], b->ne[2], 1 };
+    const int64_t        ne[4]  = { as->ne[1], ids->ne[0], b->ne[2], 1 };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_MUL_MAT_ID;
@@ -3243,20 +2971,16 @@ struct ggml_tensor * ggml_mul_mat_id(
 static inline bool ggml_can_out_prod(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
-    return (t0->ne[1] == t1->ne[1])   &&
-           (t1->ne[2]%t0->ne[2] == 0) && // verify t0 is broadcastable
-           (t1->ne[3]%t0->ne[3] == 0);
+    return (t0->ne[1] == t1->ne[1]) && (t1->ne[2] % t0->ne[2] == 0) &&  // verify t0 is broadcastable
+           (t1->ne[3] % t0->ne[3] == 0);
 }
 
-struct ggml_tensor * ggml_out_prod(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_out_prod(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_can_out_prod(a, b));
     GGML_ASSERT(!ggml_is_transposed(a));
 
     // a is broadcastable to b for ne[2] and ne[3] -> use b->ne[2] and b->ne[3]
-    const int64_t ne[4] = { a->ne[0], b->ne[0], b->ne[2], b->ne[3] };
+    const int64_t        ne[4]  = { a->ne[0], b->ne[0], b->ne[2], b->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_OUT_PROD;
@@ -3268,12 +2992,11 @@ struct ggml_tensor * ggml_out_prod(
 
 // ggml_scale
 
-static struct ggml_tensor * ggml_scale_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 s,
-        float                 b,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_scale_impl(struct ggml_context * ctx,
+                                            struct ggml_tensor *  a,
+                                            float                 s,
+                                            float                 b,
+                                            bool                  inplace) {
     GGML_ASSERT(ggml_is_padded_1d(a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -3287,53 +3010,38 @@ static struct ggml_tensor * ggml_scale_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_scale(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 s) {
+struct ggml_tensor * ggml_scale(struct ggml_context * ctx, struct ggml_tensor * a, float s) {
     return ggml_scale_impl(ctx, a, s, 0.0, false);
 }
 
-struct ggml_tensor * ggml_scale_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 s) {
+struct ggml_tensor * ggml_scale_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float s) {
     return ggml_scale_impl(ctx, a, s, 0.0, true);
 }
 
-struct ggml_tensor * ggml_scale_bias(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 s,
-        float                 b) {
+struct ggml_tensor * ggml_scale_bias(struct ggml_context * ctx, struct ggml_tensor * a, float s, float b) {
     return ggml_scale_impl(ctx, a, s, b, false);
 }
 
-struct ggml_tensor * ggml_scale_bias_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 s,
-        float                 b) {
+struct ggml_tensor * ggml_scale_bias_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float s, float b) {
     return ggml_scale_impl(ctx, a, s, b, true);
 }
 
 // ggml_set
 
-static struct ggml_tensor * ggml_set_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_set_impl(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          size_t                nb1,
+                                          size_t                nb2,
+                                          size_t                nb3,
+                                          size_t                offset,
+                                          bool                  inplace) {
     GGML_ASSERT(ggml_nelements(a) >= ggml_nelements(b));
 
     // make a view of the destination
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
-    GGML_ASSERT(offset < (size_t)(1 << 30));
+    GGML_ASSERT(offset < (size_t) (1 << 30));
     int32_t params[] = { nb1, nb2, nb3, offset, inplace ? 1 : 0 };
     ggml_set_op_params(result, params, sizeof(params));
 
@@ -3344,68 +3052,59 @@ static struct ggml_tensor * ggml_set_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_set(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset) {
+struct ggml_tensor * ggml_set(struct ggml_context * ctx,
+                              struct ggml_tensor *  a,
+                              struct ggml_tensor *  b,
+                              size_t                nb1,
+                              size_t                nb2,
+                              size_t                nb3,
+                              size_t                offset) {
     return ggml_set_impl(ctx, a, b, nb1, nb2, nb3, offset, false);
 }
 
-struct ggml_tensor * ggml_set_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset) {
+struct ggml_tensor * ggml_set_inplace(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      struct ggml_tensor *  b,
+                                      size_t                nb1,
+                                      size_t                nb2,
+                                      size_t                nb3,
+                                      size_t                offset) {
     return ggml_set_impl(ctx, a, b, nb1, nb2, nb3, offset, true);
 }
 
-struct ggml_tensor * ggml_set_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                offset) {
+struct ggml_tensor * ggml_set_1d(struct ggml_context * ctx,
+                                 struct ggml_tensor *  a,
+                                 struct ggml_tensor *  b,
+                                 size_t                offset) {
     return ggml_set_impl(ctx, a, b, a->nb[1], a->nb[2], a->nb[3], offset, false);
 }
 
-struct ggml_tensor * ggml_set_1d_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                offset) {
+struct ggml_tensor * ggml_set_1d_inplace(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,
+                                         struct ggml_tensor *  b,
+                                         size_t                offset) {
     return ggml_set_impl(ctx, a, b, a->nb[1], a->nb[2], a->nb[3], offset, true);
 }
 
-struct ggml_tensor * ggml_set_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                offset) {
+struct ggml_tensor * ggml_set_2d(struct ggml_context * ctx,
+                                 struct ggml_tensor *  a,
+                                 struct ggml_tensor *  b,
+                                 size_t                nb1,
+                                 size_t                offset) {
     return ggml_set_impl(ctx, a, b, nb1, a->nb[2], a->nb[3], offset, false);
 }
 
-struct ggml_tensor * ggml_set_2d_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        size_t                nb1,
-        size_t                offset) {
+struct ggml_tensor * ggml_set_2d_inplace(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,
+                                         struct ggml_tensor *  b,
+                                         size_t                nb1,
+                                         size_t                offset) {
     return ggml_set_impl(ctx, a, b, nb1, a->nb[2], a->nb[3], offset, true);
 }
 
 // ggml_cpy
 
-static struct ggml_tensor * ggml_cpy_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+static struct ggml_tensor * ggml_cpy_impl(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_nelements(a) == ggml_nelements(b));
 
     // make a view of the destination
@@ -3423,17 +3122,11 @@ static struct ggml_tensor * ggml_cpy_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_cpy(
-        struct ggml_context * ctx,
-        struct ggml_tensor * a,
-        struct ggml_tensor * b) {
+struct ggml_tensor * ggml_cpy(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_cpy_impl(ctx, a, b);
 }
 
-struct ggml_tensor * ggml_cast(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum   ggml_type      type) {
+struct ggml_tensor * ggml_cast(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_type type) {
     struct ggml_tensor * result = ggml_new_tensor(ctx, type, GGML_MAX_DIMS, a->ne);
     ggml_format_name(result, "%s (copy)", a->name);
 
@@ -3446,9 +3139,7 @@ struct ggml_tensor * ggml_cast(
 
 // ggml_cont
 
-static struct ggml_tensor * ggml_cont_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+static struct ggml_tensor * ggml_cont_impl(struct ggml_context * ctx, struct ggml_tensor * a) {
     struct ggml_tensor * result = ggml_dup_tensor(ctx, a);
     ggml_format_name(result, "%s (cont)", a->name);
 
@@ -3458,45 +3149,37 @@ static struct ggml_tensor * ggml_cont_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_cont(
-        struct ggml_context * ctx,
-        struct ggml_tensor * a) {
+struct ggml_tensor * ggml_cont(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_cont_impl(ctx, a);
 }
 
 // make contiguous, with new shape
-GGML_API struct ggml_tensor * ggml_cont_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0) {
+GGML_API struct ggml_tensor * ggml_cont_1d(struct ggml_context * ctx, struct ggml_tensor * a, int64_t ne0) {
     return ggml_cont_4d(ctx, a, ne0, 1, 1, 1);
 }
 
-GGML_API struct ggml_tensor * ggml_cont_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1) {
+GGML_API struct ggml_tensor * ggml_cont_2d(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           int64_t               ne0,
+                                           int64_t               ne1) {
     return ggml_cont_4d(ctx, a, ne0, ne1, 1, 1);
 }
 
-GGML_API struct ggml_tensor * ggml_cont_3d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2) {
+GGML_API struct ggml_tensor * ggml_cont_3d(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           int64_t               ne0,
+                                           int64_t               ne1,
+                                           int64_t               ne2) {
     return ggml_cont_4d(ctx, a, ne0, ne1, ne2, 1);
 }
 
-struct ggml_tensor * ggml_cont_4d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3) {
-    GGML_ASSERT(ggml_nelements(a) == (ne0*ne1*ne2*ne3));
+struct ggml_tensor * ggml_cont_4d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int64_t               ne0,
+                                  int64_t               ne1,
+                                  int64_t               ne2,
+                                  int64_t               ne3) {
+    GGML_ASSERT(ggml_nelements(a) == (ne0 * ne1 * ne2 * ne3));
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, ne0, ne1, ne2, ne3);
     ggml_format_name(result, "%s (cont)", a->name);
@@ -3509,10 +3192,7 @@ struct ggml_tensor * ggml_cont_4d(
 
 // ggml_reshape
 
-struct ggml_tensor * ggml_reshape(
-        struct ggml_context * ctx,
-        struct ggml_tensor * a,
-        struct ggml_tensor * b) {
+struct ggml_tensor * ggml_reshape(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(ggml_is_contiguous(a));
     // as only the shape of b is relevant, and not its memory layout, b is allowed to be non contiguous.
     GGML_ASSERT(ggml_nelements(a) == ggml_nelements(b));
@@ -3526,14 +3206,11 @@ struct ggml_tensor * ggml_reshape(
     return result;
 }
 
-struct ggml_tensor * ggml_reshape_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0) {
+struct ggml_tensor * ggml_reshape_1d(struct ggml_context * ctx, struct ggml_tensor * a, int64_t ne0) {
     GGML_ASSERT(ggml_is_contiguous(a));
     GGML_ASSERT(ggml_nelements(a) == ne0);
 
-    const int64_t ne[1] = { ne0 };
+    const int64_t        ne[1]  = { ne0 };
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, 1, ne, a, 0);
     ggml_format_name(result, "%s (reshaped)", a->name);
 
@@ -3543,15 +3220,11 @@ struct ggml_tensor * ggml_reshape_1d(
     return result;
 }
 
-struct ggml_tensor * ggml_reshape_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1) {
+struct ggml_tensor * ggml_reshape_2d(struct ggml_context * ctx, struct ggml_tensor * a, int64_t ne0, int64_t ne1) {
     GGML_ASSERT(ggml_is_contiguous(a));
-    GGML_ASSERT(ggml_nelements(a) == ne0*ne1);
+    GGML_ASSERT(ggml_nelements(a) == ne0 * ne1);
 
-    const int64_t ne[2] = { ne0, ne1 };
+    const int64_t        ne[2]  = { ne0, ne1 };
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, 2, ne, a, 0);
     ggml_format_name(result, "%s (reshaped)", a->name);
 
@@ -3561,16 +3234,15 @@ struct ggml_tensor * ggml_reshape_2d(
     return result;
 }
 
-struct ggml_tensor * ggml_reshape_3d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2) {
+struct ggml_tensor * ggml_reshape_3d(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     int64_t               ne0,
+                                     int64_t               ne1,
+                                     int64_t               ne2) {
     GGML_ASSERT(ggml_is_contiguous(a));
-    GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2);
+    GGML_ASSERT(ggml_nelements(a) == ne0 * ne1 * ne2);
 
-    const int64_t ne[3] = { ne0, ne1, ne2 };
+    const int64_t        ne[3]  = { ne0, ne1, ne2 };
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, 3, ne, a, 0);
     ggml_format_name(result, "%s (reshaped)", a->name);
 
@@ -3580,17 +3252,16 @@ struct ggml_tensor * ggml_reshape_3d(
     return result;
 }
 
-struct ggml_tensor * ggml_reshape_4d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3) {
+struct ggml_tensor * ggml_reshape_4d(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     int64_t               ne0,
+                                     int64_t               ne1,
+                                     int64_t               ne2,
+                                     int64_t               ne3) {
     GGML_ASSERT(ggml_is_contiguous(a));
-    GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2*ne3);
+    GGML_ASSERT(ggml_nelements(a) == ne0 * ne1 * ne2 * ne3);
 
-    const int64_t ne[4] = { ne0, ne1, ne2, ne3 };
+    const int64_t        ne[4]  = { ne0, ne1, ne2, ne3 };
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, 4, ne, a, 0);
     ggml_format_name(result, "%s (reshaped)", a->name);
 
@@ -3600,12 +3271,11 @@ struct ggml_tensor * ggml_reshape_4d(
     return result;
 }
 
-static struct ggml_tensor * ggml_view_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_dims,
-        const int64_t       * ne,
-        size_t                offset) {
+static struct ggml_tensor * ggml_view_impl(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           int                   n_dims,
+                                           const int64_t *       ne,
+                                           size_t                offset) {
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, a->type, n_dims, ne, a, offset);
     ggml_format_name(result, "%s (view)", a->name);
 
@@ -3619,11 +3289,7 @@ static struct ggml_tensor * ggml_view_impl(
 
 // ggml_view_1d
 
-struct ggml_tensor * ggml_view_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        size_t                offset) {
+struct ggml_tensor * ggml_view_1d(struct ggml_context * ctx, struct ggml_tensor * a, int64_t ne0, size_t offset) {
     struct ggml_tensor * result = ggml_view_impl(ctx, a, 1, &ne0, offset);
 
     return result;
@@ -3631,19 +3297,18 @@ struct ggml_tensor * ggml_view_1d(
 
 // ggml_view_2d
 
-struct ggml_tensor * ggml_view_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        size_t                nb1,
-        size_t                offset) {
+struct ggml_tensor * ggml_view_2d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int64_t               ne0,
+                                  int64_t               ne1,
+                                  size_t                nb1,
+                                  size_t                offset) {
     const int64_t ne[2] = { ne0, ne1 };
 
     struct ggml_tensor * result = ggml_view_impl(ctx, a, 2, ne, offset);
 
     result->nb[1] = nb1;
-    result->nb[2] = result->nb[1]*ne1;
+    result->nb[2] = result->nb[1] * ne1;
     result->nb[3] = result->nb[2];
 
     return result;
@@ -3651,39 +3316,37 @@ struct ggml_tensor * ggml_view_2d(
 
 // ggml_view_3d
 
-struct ggml_tensor * ggml_view_3d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                offset) {
+struct ggml_tensor * ggml_view_3d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int64_t               ne0,
+                                  int64_t               ne1,
+                                  int64_t               ne2,
+                                  size_t                nb1,
+                                  size_t                nb2,
+                                  size_t                offset) {
     const int64_t ne[3] = { ne0, ne1, ne2 };
 
     struct ggml_tensor * result = ggml_view_impl(ctx, a, 3, ne, offset);
 
     result->nb[1] = nb1;
     result->nb[2] = nb2;
-    result->nb[3] = result->nb[2]*ne2;
+    result->nb[3] = result->nb[2] * ne2;
 
     return result;
 }
 
 // ggml_view_4d
 
-struct ggml_tensor * ggml_view_4d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3,
-        size_t                nb1,
-        size_t                nb2,
-        size_t                nb3,
-        size_t                offset) {
+struct ggml_tensor * ggml_view_4d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int64_t               ne0,
+                                  int64_t               ne1,
+                                  int64_t               ne2,
+                                  int64_t               ne3,
+                                  size_t                nb1,
+                                  size_t                nb2,
+                                  size_t                nb3,
+                                  size_t                offset) {
     const int64_t ne[4] = { ne0, ne1, ne2, ne3 };
 
     struct ggml_tensor * result = ggml_view_impl(ctx, a, 4, ne, offset);
@@ -3697,13 +3360,12 @@ struct ggml_tensor * ggml_view_4d(
 
 // ggml_permute
 
-struct ggml_tensor * ggml_permute(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   axis0,
-        int                   axis1,
-        int                   axis2,
-        int                   axis3) {
+struct ggml_tensor * ggml_permute(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int                   axis0,
+                                  int                   axis1,
+                                  int                   axis2,
+                                  int                   axis3) {
     GGML_ASSERT(axis0 >= 0 && axis0 < GGML_MAX_DIMS);
     GGML_ASSERT(axis1 >= 0 && axis1 < GGML_MAX_DIMS);
     GGML_ASSERT(axis2 >= 0 && axis2 < GGML_MAX_DIMS);
@@ -3753,9 +3415,7 @@ struct ggml_tensor * ggml_permute(
 
 // ggml_transpose
 
-struct ggml_tensor * ggml_transpose(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_transpose(struct ggml_context * ctx, struct ggml_tensor * a) {
     struct ggml_tensor * result = ggml_view_tensor(ctx, a);
     ggml_format_name(result, "%s (transposed)", a->name);
 
@@ -3773,10 +3433,7 @@ struct ggml_tensor * ggml_transpose(
 
 // ggml_get_rows
 
-struct ggml_tensor * ggml_get_rows(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_get_rows(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     GGML_ASSERT(a->ne[2] == b->ne[1]);
     GGML_ASSERT(a->ne[3] == b->ne[2]);
     GGML_ASSERT(b->ne[3] == 1);
@@ -3798,11 +3455,10 @@ struct ggml_tensor * ggml_get_rows(
 
 // ggml_get_rows_back
 
-struct ggml_tensor * ggml_get_rows_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c) {
+struct ggml_tensor * ggml_get_rows_back(struct ggml_context * ctx,
+                                        struct ggml_tensor *  a,
+                                        struct ggml_tensor *  b,
+                                        struct ggml_tensor *  c) {
     GGML_ASSERT(ggml_is_matrix(a) && ggml_is_vector(b) && b->type == GGML_TYPE_I32);
     GGML_ASSERT(ggml_is_matrix(c) && (a->ne[0] == c->ne[0]));
 
@@ -3819,11 +3475,10 @@ struct ggml_tensor * ggml_get_rows_back(
 
 // ggml_set_rows
 
-struct ggml_tensor * ggml_set_rows(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c) {
+struct ggml_tensor * ggml_set_rows(struct ggml_context * ctx,
+                                   struct ggml_tensor *  a,
+                                   struct ggml_tensor *  b,
+                                   struct ggml_tensor *  c) {
     GGML_ASSERT(a->ne[0] == b->ne[0]);
     GGML_ASSERT(a->ne[2] == b->ne[2]);
     GGML_ASSERT(a->ne[3] == b->ne[3]);
@@ -3842,19 +3497,18 @@ struct ggml_tensor * ggml_set_rows(
     result->op     = GGML_OP_SET_ROWS;
     result->src[0] = b;
     result->src[1] = c;
-    result->src[2] = a; // note: order is weird due to legacy reasons (https://github.com/ggml-org/llama.cpp/pull/16063#discussion_r2385795931)
+    result->src[2] =
+        a;  // note: order is weird due to legacy reasons (https://github.com/ggml-org/llama.cpp/pull/16063#discussion_r2385795931)
 
     return result;
 }
 
 // ggml_diag
 
-struct ggml_tensor * ggml_diag(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_diag(struct ggml_context * ctx, struct ggml_tensor * a) {
     GGML_ASSERT(a->ne[1] == 1);
 
-    const int64_t ne[4] = { a->ne[0], a->ne[0], a->ne[2], a->ne[3] };
+    const int64_t        ne[4]  = { a->ne[0], a->ne[0], a->ne[2], a->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, a->type, 4, ne);
 
     result->op     = GGML_OP_DIAG;
@@ -3865,11 +3519,10 @@ struct ggml_tensor * ggml_diag(
 
 // ggml_diag_mask_inf
 
-static struct ggml_tensor * ggml_diag_mask_inf_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_diag_mask_inf_impl(struct ggml_context * ctx,
+                                                    struct ggml_tensor *  a,
+                                                    int                   n_past,
+                                                    bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     int32_t params[] = { n_past };
@@ -3881,27 +3534,20 @@ static struct ggml_tensor * ggml_diag_mask_inf_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_diag_mask_inf(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past) {
+struct ggml_tensor * ggml_diag_mask_inf(struct ggml_context * ctx, struct ggml_tensor * a, int n_past) {
     return ggml_diag_mask_inf_impl(ctx, a, n_past, false);
 }
 
-struct ggml_tensor * ggml_diag_mask_inf_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past) {
+struct ggml_tensor * ggml_diag_mask_inf_inplace(struct ggml_context * ctx, struct ggml_tensor * a, int n_past) {
     return ggml_diag_mask_inf_impl(ctx, a, n_past, true);
 }
 
 // ggml_diag_mask_zero
 
-static struct ggml_tensor * ggml_diag_mask_zero_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_diag_mask_zero_impl(struct ggml_context * ctx,
+                                                     struct ggml_tensor *  a,
+                                                     int                   n_past,
+                                                     bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     int32_t params[] = { n_past };
@@ -3913,29 +3559,22 @@ static struct ggml_tensor * ggml_diag_mask_zero_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_diag_mask_zero(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past) {
+struct ggml_tensor * ggml_diag_mask_zero(struct ggml_context * ctx, struct ggml_tensor * a, int n_past) {
     return ggml_diag_mask_zero_impl(ctx, a, n_past, false);
 }
 
-struct ggml_tensor * ggml_diag_mask_zero_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   n_past) {
+struct ggml_tensor * ggml_diag_mask_zero_inplace(struct ggml_context * ctx, struct ggml_tensor * a, int n_past) {
     return ggml_diag_mask_zero_impl(ctx, a, n_past, true);
 }
 
 // ggml_soft_max
 
-static struct ggml_tensor * ggml_soft_max_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * mask,
-        float                 scale,
-        float                 max_bias,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_soft_max_impl(struct ggml_context * ctx,
+                                               struct ggml_tensor *  a,
+                                               struct ggml_tensor *  mask,
+                                               float                 scale,
+                                               float                 max_bias,
+                                               bool                  inplace) {
     GGML_ASSERT(ggml_is_contiguous(a));
 
     if (mask) {
@@ -3943,8 +3582,8 @@ static struct ggml_tensor * ggml_soft_max_impl(
         GGML_ASSERT(ggml_is_contiguous(mask));
         GGML_ASSERT(mask->ne[0] == a->ne[0]);
         GGML_ASSERT(mask->ne[1] >= a->ne[1]);
-        GGML_ASSERT(a->ne[2]%mask->ne[2] == 0);
-        GGML_ASSERT(a->ne[3]%mask->ne[3] == 0);
+        GGML_ASSERT(a->ne[2] % mask->ne[2] == 0);
+        GGML_ASSERT(a->ne[3] % mask->ne[3] == 0);
     }
 
     if (max_bias > 0.0f) {
@@ -3963,39 +3602,31 @@ static struct ggml_tensor * ggml_soft_max_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_soft_max(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_soft_max(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_soft_max_impl(ctx, a, NULL, 1.0f, 0.0f, false);
 }
 
-struct ggml_tensor * ggml_soft_max_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a) {
+struct ggml_tensor * ggml_soft_max_inplace(struct ggml_context * ctx, struct ggml_tensor * a) {
     return ggml_soft_max_impl(ctx, a, NULL, 1.0f, 0.0f, true);
 }
 
-struct ggml_tensor * ggml_soft_max_ext(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * mask,
-        float                 scale,
-        float                 max_bias) {
+struct ggml_tensor * ggml_soft_max_ext(struct ggml_context * ctx,
+                                       struct ggml_tensor *  a,
+                                       struct ggml_tensor *  mask,
+                                       float                 scale,
+                                       float                 max_bias) {
     return ggml_soft_max_impl(ctx, a, mask, scale, max_bias, false);
 }
 
-struct ggml_tensor * ggml_soft_max_ext_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * mask,
-        float                 scale,
-        float                 max_bias) {
+struct ggml_tensor * ggml_soft_max_ext_inplace(struct ggml_context * ctx,
+                                               struct ggml_tensor *  a,
+                                               struct ggml_tensor *  mask,
+                                               float                 scale,
+                                               float                 max_bias) {
     return ggml_soft_max_impl(ctx, a, mask, scale, max_bias, true);
 }
 
-void ggml_soft_max_add_sinks(
-        struct ggml_tensor * a,
-        struct ggml_tensor * sinks) {
+void ggml_soft_max_add_sinks(struct ggml_tensor * a, struct ggml_tensor * sinks) {
     if (!sinks) {
         a->src[2] = NULL;
         return;
@@ -4011,61 +3642,57 @@ void ggml_soft_max_add_sinks(
 
 // ggml_soft_max_ext_back
 
-static struct ggml_tensor * ggml_soft_max_ext_back_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        float                 scale,
-        float                 max_bias,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_soft_max_ext_back_impl(struct ggml_context * ctx,
+                                                        struct ggml_tensor *  a,
+                                                        struct ggml_tensor *  b,
+                                                        float                 scale,
+                                                        float                 max_bias,
+                                                        bool                  inplace) {
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     result->op     = GGML_OP_SOFT_MAX_BACK;
     result->src[0] = a;
     result->src[1] = b;
 
-    memcpy((float *) result->op_params + 0, &scale,    sizeof(float));
+    memcpy((float *) result->op_params + 0, &scale, sizeof(float));
     memcpy((float *) result->op_params + 1, &max_bias, sizeof(float));
 
     return result;
 }
 
-struct ggml_tensor * ggml_soft_max_ext_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        float                 scale,
-        float                 max_bias) {
+struct ggml_tensor * ggml_soft_max_ext_back(struct ggml_context * ctx,
+                                            struct ggml_tensor *  a,
+                                            struct ggml_tensor *  b,
+                                            float                 scale,
+                                            float                 max_bias) {
     return ggml_soft_max_ext_back_impl(ctx, a, b, scale, max_bias, false);
 }
 
-struct ggml_tensor * ggml_soft_max_ext_back_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        float                 scale,
-        float                 max_bias) {
+struct ggml_tensor * ggml_soft_max_ext_back_inplace(struct ggml_context * ctx,
+                                                    struct ggml_tensor *  a,
+                                                    struct ggml_tensor *  b,
+                                                    float                 scale,
+                                                    float                 max_bias) {
     return ggml_soft_max_ext_back_impl(ctx, a, b, scale, max_bias, true);
 }
 
 // ggml_rope
 
-static struct ggml_tensor * ggml_rope_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   sections[GGML_MROPE_SECTIONS],
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_rope_impl(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           struct ggml_tensor *  b,
+                                           struct ggml_tensor *  c,
+                                           int                   n_dims,
+                                           int                   sections[GGML_MROPE_SECTIONS],
+                                           int                   mode,
+                                           int                   n_ctx_orig,
+                                           float                 freq_base,
+                                           float                 freq_scale,
+                                           float                 ext_factor,
+                                           float                 attn_factor,
+                                           float                 beta_fast,
+                                           float                 beta_slow,
+                                           bool                  inplace) {
     GGML_ASSERT((mode & 1) == 0 && "mode & 1 == 1 is no longer supported");
 
     GGML_ASSERT(ggml_is_vector(b));
@@ -4073,7 +3700,7 @@ static struct ggml_tensor * ggml_rope_impl(
 
     bool mrope_used = mode & GGML_ROPE_TYPE_MROPE;
     if (mrope_used) {
-        GGML_ASSERT(a->ne[2] * 4 == b->ne[0]); // mrope expecting 4 position ids per token
+        GGML_ASSERT(a->ne[2] * 4 == b->ne[0]);  // mrope expecting 4 position ids per token
     } else {
         GGML_ASSERT(a->ne[2] == b->ne[0]);
     }
@@ -4086,16 +3713,16 @@ static struct ggml_tensor * ggml_rope_impl(
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     int32_t params[15] = { /*n_past*/ 0, n_dims, mode, /*n_ctx*/ 0, n_ctx_orig };
-    memcpy(params +  5, &freq_base,    sizeof(float));
-    memcpy(params +  6, &freq_scale,   sizeof(float));
-    memcpy(params +  7, &ext_factor,   sizeof(float));
-    memcpy(params +  8, &attn_factor,  sizeof(float));
-    memcpy(params +  9, &beta_fast,    sizeof(float));
-    memcpy(params + 10, &beta_slow,    sizeof(float));
+    memcpy(params + 5, &freq_base, sizeof(float));
+    memcpy(params + 6, &freq_scale, sizeof(float));
+    memcpy(params + 7, &ext_factor, sizeof(float));
+    memcpy(params + 8, &attn_factor, sizeof(float));
+    memcpy(params + 9, &beta_fast, sizeof(float));
+    memcpy(params + 10, &beta_slow, sizeof(float));
     if (mrope_used && sections) {
-        memcpy(params + 11, sections,  sizeof(int32_t) * GGML_MROPE_SECTIONS);
+        memcpy(params + 11, sections, sizeof(int32_t) * GGML_MROPE_SECTIONS);
     } else {
-        memset(params + 11, 0,         sizeof(int32_t) * GGML_MROPE_SECTIONS);
+        memset(params + 11, 0, sizeof(int32_t) * GGML_MROPE_SECTIONS);
     }
     ggml_set_op_params(result, params, sizeof(params));
 
@@ -4107,213 +3734,187 @@ static struct ggml_tensor * ggml_rope_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_rope(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   n_dims,
-        int                   mode) {
-    return ggml_rope_impl(
-        ctx, a, b, NULL, n_dims, NULL, mode, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, false
-    );
+struct ggml_tensor * ggml_rope(struct ggml_context * ctx,
+                               struct ggml_tensor *  a,
+                               struct ggml_tensor *  b,
+                               int                   n_dims,
+                               int                   mode) {
+    return ggml_rope_impl(ctx, a, b, NULL, n_dims, NULL, mode, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, false);
 }
 
-struct ggml_tensor * ggml_rope_multi(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   sections[GGML_MROPE_SECTIONS],
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, false
-    );
+struct ggml_tensor * ggml_rope_multi(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     struct ggml_tensor *  b,
+                                     struct ggml_tensor *  c,
+                                     int                   n_dims,
+                                     int                   sections[GGML_MROPE_SECTIONS],
+                                     int                   mode,
+                                     int                   n_ctx_orig,
+                                     float                 freq_base,
+                                     float                 freq_scale,
+                                     float                 ext_factor,
+                                     float                 attn_factor,
+                                     float                 beta_fast,
+                                     float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base, freq_scale, ext_factor,
+                          attn_factor, beta_fast, beta_slow, false);
 }
 
-struct ggml_tensor * ggml_rope_multi_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   sections[GGML_MROPE_SECTIONS],
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, true
-    );
+struct ggml_tensor * ggml_rope_multi_inplace(struct ggml_context * ctx,
+                                             struct ggml_tensor *  a,
+                                             struct ggml_tensor *  b,
+                                             struct ggml_tensor *  c,
+                                             int                   n_dims,
+                                             int                   sections[GGML_MROPE_SECTIONS],
+                                             int                   mode,
+                                             int                   n_ctx_orig,
+                                             float                 freq_base,
+                                             float                 freq_scale,
+                                             float                 ext_factor,
+                                             float                 attn_factor,
+                                             float                 beta_fast,
+                                             float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base, freq_scale, ext_factor,
+                          attn_factor, beta_fast, beta_slow, true);
 }
 
-struct ggml_tensor * ggml_rope_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   n_dims,
-        int                   mode) {
-    return ggml_rope_impl(
-        ctx, a, b, NULL, n_dims, NULL, mode, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, true
-    );
+struct ggml_tensor * ggml_rope_inplace(struct ggml_context * ctx,
+                                       struct ggml_tensor *  a,
+                                       struct ggml_tensor *  b,
+                                       int                   n_dims,
+                                       int                   mode) {
+    return ggml_rope_impl(ctx, a, b, NULL, n_dims, NULL, mode, 0, 10000.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, true);
 }
 
-struct ggml_tensor * ggml_rope_ext(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, c, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, false
-    );
+struct ggml_tensor * ggml_rope_ext(struct ggml_context * ctx,
+                                   struct ggml_tensor *  a,
+                                   struct ggml_tensor *  b,
+                                   struct ggml_tensor *  c,
+                                   int                   n_dims,
+                                   int                   mode,
+                                   int                   n_ctx_orig,
+                                   float                 freq_base,
+                                   float                 freq_scale,
+                                   float                 ext_factor,
+                                   float                 attn_factor,
+                                   float                 beta_fast,
+                                   float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, c, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor,
+                          beta_fast, beta_slow, false);
 }
 
-struct ggml_tensor * ggml_rope_ext_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, c, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, true
-    );
+struct ggml_tensor * ggml_rope_ext_inplace(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           struct ggml_tensor *  b,
+                                           struct ggml_tensor *  c,
+                                           int                   n_dims,
+                                           int                   mode,
+                                           int                   n_ctx_orig,
+                                           float                 freq_base,
+                                           float                 freq_scale,
+                                           float                 ext_factor,
+                                           float                 attn_factor,
+                                           float                 beta_fast,
+                                           float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, c, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor,
+                          beta_fast, beta_slow, true);
 }
 
-struct ggml_tensor * ggml_rope_custom(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   n_dims,
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, NULL, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, false
-    );
+struct ggml_tensor * ggml_rope_custom(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      struct ggml_tensor *  b,
+                                      int                   n_dims,
+                                      int                   mode,
+                                      int                   n_ctx_orig,
+                                      float                 freq_base,
+                                      float                 freq_scale,
+                                      float                 ext_factor,
+                                      float                 attn_factor,
+                                      float                 beta_fast,
+                                      float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, NULL, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale, ext_factor,
+                          attn_factor, beta_fast, beta_slow, false);
 }
 
-struct ggml_tensor * ggml_rope_custom_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   n_dims,
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    return ggml_rope_impl(
-        ctx, a, b, NULL, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale,
-        ext_factor, attn_factor, beta_fast, beta_slow, true
-    );
+struct ggml_tensor * ggml_rope_custom_inplace(struct ggml_context * ctx,
+                                              struct ggml_tensor *  a,
+                                              struct ggml_tensor *  b,
+                                              int                   n_dims,
+                                              int                   mode,
+                                              int                   n_ctx_orig,
+                                              float                 freq_base,
+                                              float                 freq_scale,
+                                              float                 ext_factor,
+                                              float                 attn_factor,
+                                              float                 beta_fast,
+                                              float                 beta_slow) {
+    return ggml_rope_impl(ctx, a, b, NULL, n_dims, NULL, mode, n_ctx_orig, freq_base, freq_scale, ext_factor,
+                          attn_factor, beta_fast, beta_slow, true);
 }
 
 // Apparently solving `n_rot = 2pi * x * base^((2 * max_pos_emb) / n_dims)` for x, we get
 // `corr_dim(n_rot) = n_dims * log(max_pos_emb / (n_rot * 2pi)) / (2 * log(base))`
 static float ggml_rope_yarn_corr_dim(int n_dims, int n_ctx_orig, float n_rot, float base) {
-    return n_dims * logf(n_ctx_orig / (n_rot * 2 * (float)M_PI)) / (2 * logf(base));
+    return n_dims * logf(n_ctx_orig / (n_rot * 2 * (float) M_PI)) / (2 * logf(base));
 }
 
-void ggml_rope_yarn_corr_dims(
-    int n_dims, int n_ctx_orig, float freq_base, float beta_fast, float beta_slow, float dims[2]
-) {
+void ggml_rope_yarn_corr_dims(int   n_dims,
+                              int   n_ctx_orig,
+                              float freq_base,
+                              float beta_fast,
+                              float beta_slow,
+                              float dims[2]) {
     // start and end correction dims
     float start = floorf(ggml_rope_yarn_corr_dim(n_dims, n_ctx_orig, beta_fast, freq_base));
-    float end   =  ceilf(ggml_rope_yarn_corr_dim(n_dims, n_ctx_orig, beta_slow, freq_base));
-    dims[0] = MAX(0, start);
-    dims[1] = MIN(n_dims - 1, end);
+    float end   = ceilf(ggml_rope_yarn_corr_dim(n_dims, n_ctx_orig, beta_slow, freq_base));
+    dims[0]     = MAX(0, start);
+    dims[1]     = MIN(n_dims - 1, end);
 }
 
 // ggml_rope_back
 
-struct ggml_tensor * ggml_rope_ext_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    struct ggml_tensor * result = ggml_rope_ext(
-        ctx, a, b, c, n_dims, mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
-    result->op = GGML_OP_ROPE_BACK;
+struct ggml_tensor * ggml_rope_ext_back(struct ggml_context * ctx,
+                                        struct ggml_tensor *  a,
+                                        struct ggml_tensor *  b,
+                                        struct ggml_tensor *  c,
+                                        int                   n_dims,
+                                        int                   mode,
+                                        int                   n_ctx_orig,
+                                        float                 freq_base,
+                                        float                 freq_scale,
+                                        float                 ext_factor,
+                                        float                 attn_factor,
+                                        float                 beta_fast,
+                                        float                 beta_slow) {
+    struct ggml_tensor * result = ggml_rope_ext(ctx, a, b, c, n_dims, mode, n_ctx_orig, freq_base, freq_scale,
+                                                ext_factor, attn_factor, beta_fast, beta_slow);
+    result->op                  = GGML_OP_ROPE_BACK;
     return result;
 }
 
-struct ggml_tensor * ggml_rope_multi_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c,
-        int                   n_dims,
-        int                   sections[4],
-        int                   mode,
-        int                   n_ctx_orig,
-        float                 freq_base,
-        float                 freq_scale,
-        float                 ext_factor,
-        float                 attn_factor,
-        float                 beta_fast,
-        float                 beta_slow) {
-    struct ggml_tensor * result = ggml_rope_multi(
-        ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
-    result->op = GGML_OP_ROPE_BACK;
+struct ggml_tensor * ggml_rope_multi_back(struct ggml_context * ctx,
+                                          struct ggml_tensor *  a,
+                                          struct ggml_tensor *  b,
+                                          struct ggml_tensor *  c,
+                                          int                   n_dims,
+                                          int                   sections[4],
+                                          int                   mode,
+                                          int                   n_ctx_orig,
+                                          float                 freq_base,
+                                          float                 freq_scale,
+                                          float                 ext_factor,
+                                          float                 attn_factor,
+                                          float                 beta_fast,
+                                          float                 beta_slow) {
+    struct ggml_tensor * result = ggml_rope_multi(ctx, a, b, c, n_dims, sections, mode, n_ctx_orig, freq_base,
+                                                  freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+    result->op                  = GGML_OP_ROPE_BACK;
     return result;
 }
+
 // ggml_clamp
 
-struct ggml_tensor * ggml_clamp(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        float                 min,
-        float                 max) {
+struct ggml_tensor * ggml_clamp(struct ggml_context * ctx, struct ggml_tensor * a, float min, float max) {
     // TODO: when implement backward, fix this:
     struct ggml_tensor * result = ggml_view_tensor(ctx, a);
 
@@ -4334,18 +3935,17 @@ static int64_t ggml_calc_conv_output_size(int64_t ins, int64_t ks, int s, int p,
 // a: [OC，IC, KH, KW]
 // b: [N, IC, IH, IW]
 // result: [N, OH, OW, IC*KH*KW]
-struct ggml_tensor * ggml_im2col(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   s1,
-        int                   p0,
-        int                   p1,
-        int                   d0,
-        int                   d1,
-        bool                  is_2D,
-        enum ggml_type        dst_type) {
+struct ggml_tensor * ggml_im2col(struct ggml_context * ctx,
+                                 struct ggml_tensor *  a,
+                                 struct ggml_tensor *  b,
+                                 int                   s0,
+                                 int                   s1,
+                                 int                   p0,
+                                 int                   p1,
+                                 int                   d0,
+                                 int                   d1,
+                                 bool                  is_2D,
+                                 enum ggml_type        dst_type) {
     if (is_2D) {
         GGML_ASSERT(a->ne[2] == b->ne[2]);
     } else {
@@ -4355,20 +3955,20 @@ struct ggml_tensor * ggml_im2col(
     }
 
     const int64_t OH = is_2D ? ggml_calc_conv_output_size(b->ne[1], a->ne[1], s1, p1, d1) : 0;
-    const int64_t OW =         ggml_calc_conv_output_size(b->ne[0], a->ne[0], s0, p0, d0);
+    const int64_t OW = ggml_calc_conv_output_size(b->ne[0], a->ne[0], s0, p0, d0);
 
     GGML_ASSERT((!is_2D || OH > 0) && "b too small compared to a");
-    GGML_ASSERT((OW > 0)           && "b too small compared to a");
+    GGML_ASSERT((OW > 0) && "b too small compared to a");
 
     const int64_t ne[4] = {
         is_2D ? (a->ne[2] * a->ne[1] * a->ne[0]) : a->ne[1] * a->ne[0],
         OW,
         is_2D ? OH : b->ne[2],
-        is_2D ?      b->ne[3] : 1,
+        is_2D ? b->ne[3] : 1,
     };
 
-    struct ggml_tensor * result = ggml_new_tensor(ctx, dst_type, 4, ne);
-    int32_t params[] = { s0, s1, p0, p1, d0, d1, (is_2D ? 1 : 0) };
+    struct ggml_tensor * result   = ggml_new_tensor(ctx, dst_type, 4, ne);
+    int32_t              params[] = { s0, s1, p0, p1, d0, d1, (is_2D ? 1 : 0) };
     ggml_set_op_params(result, params, sizeof(params));
 
     result->op     = GGML_OP_IM2COL;
@@ -4378,20 +3978,19 @@ struct ggml_tensor * ggml_im2col(
     return result;
 }
 
-struct ggml_tensor * ggml_im2col_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int64_t             * ne,
-        int                   s0,
-        int                   s1,
-        int                   p0,
-        int                   p1,
-        int                   d0,
-        int                   d1,
-        bool                  is_2D) {
-    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
-    int32_t params[] = { s0, s1, p0, p1, d0, d1, (is_2D ? 1 : 0) };
+struct ggml_tensor * ggml_im2col_back(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      struct ggml_tensor *  b,
+                                      int64_t *             ne,
+                                      int                   s0,
+                                      int                   s1,
+                                      int                   p0,
+                                      int                   p1,
+                                      int                   d0,
+                                      int                   d1,
+                                      bool                  is_2D) {
+    struct ggml_tensor * result   = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
+    int32_t              params[] = { s0, s1, p0, p1, d0, d1, (is_2D ? 1 : 0) };
     ggml_set_op_params(result, params, sizeof(params));
 
     result->op     = GGML_OP_IM2COL_BACK;
@@ -4403,45 +4002,43 @@ struct ggml_tensor * ggml_im2col_back(
 
 // ggml_conv_1d
 
-struct ggml_tensor * ggml_conv_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   p0,
-        int                   d0) {
-    struct ggml_tensor * im2col = ggml_im2col(ctx, a, b, s0, 0, p0, 0, d0, 0, false, GGML_TYPE_F16); // [N, OL, IC * K]
+struct ggml_tensor * ggml_conv_1d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  struct ggml_tensor *  b,
+                                  int                   s0,
+                                  int                   p0,
+                                  int                   d0) {
+    struct ggml_tensor * im2col = ggml_im2col(ctx, a, b, s0, 0, p0, 0, d0, 0, false, GGML_TYPE_F16);  // [N, OL, IC * K]
 
     struct ggml_tensor * result =
         ggml_mul_mat(ctx,
-                ggml_reshape_2d(ctx, im2col, im2col->ne[0], (im2col->ne[2] * im2col->ne[1])), // [N, OL, IC * K] => [N*OL, IC * K]
-                ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1]), a->ne[2]));                    // [OC，IC, K] => [OC, IC * K]
+                     ggml_reshape_2d(ctx, im2col, im2col->ne[0],
+                                     (im2col->ne[2] * im2col->ne[1])),              // [N, OL, IC * K] => [N*OL, IC * K]
+                     ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1]), a->ne[2]));     // [OC，IC, K] => [OC, IC * K]
 
-    result = ggml_reshape_3d(ctx, result, im2col->ne[1], a->ne[2], im2col->ne[2]); // [N, OC, OL]
+    result = ggml_reshape_3d(ctx, result, im2col->ne[1], a->ne[2], im2col->ne[2]);  // [N, OC, OL]
 
     return result;
 }
 
 // ggml_conv_1d_ph
 
-struct ggml_tensor* ggml_conv_1d_ph(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s,
-        int                   d) {
+struct ggml_tensor * ggml_conv_1d_ph(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     struct ggml_tensor *  b,
+                                     int                   s,
+                                     int                   d) {
     return ggml_conv_1d(ctx, a, b, s, a->ne[0] / 2, d);
 }
 
 // ggml_conv_1d_dw
 
-struct ggml_tensor * ggml_conv_1d_dw(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   p0,
-        int                   d0) {
+struct ggml_tensor * ggml_conv_1d_dw(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     struct ggml_tensor *  b,
+                                     int                   s0,
+                                     int                   p0,
+                                     int                   d0) {
     struct ggml_tensor * new_b = ggml_reshape_4d(ctx, b, b->ne[0], 1, b->ne[1], b->ne[2]);
 
     struct ggml_tensor * im2col = ggml_im2col(ctx, a, new_b, s0, 0, p0, 0, d0, 0, false, GGML_TYPE_F16);
@@ -4455,12 +4052,11 @@ struct ggml_tensor * ggml_conv_1d_dw(
 
 // ggml_conv_1d_dw_ph
 
-struct ggml_tensor * ggml_conv_1d_dw_ph(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   d0) {
+struct ggml_tensor * ggml_conv_1d_dw_ph(struct ggml_context * ctx,
+                                        struct ggml_tensor *  a,
+                                        struct ggml_tensor *  b,
+                                        int                   s0,
+                                        int                   d0) {
     return ggml_conv_1d_dw(ctx, a, b, s0, a->ne[0] / 2, d0);
 }
 
@@ -4470,13 +4066,12 @@ static int64_t ggml_calc_conv_transpose_1d_output_size(int64_t ins, int64_t ks, 
     return (ins - 1) * s - 2 * p + d * (ks - 1) + 1;
 }
 
-GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   p0,
-        int                   d0) {
+GGML_API struct ggml_tensor * ggml_conv_transpose_1d(struct ggml_context * ctx,
+                                                     struct ggml_tensor *  a,
+                                                     struct ggml_tensor *  b,
+                                                     int                   s0,
+                                                     int                   p0,
+                                                     int                   d0) {
     GGML_ASSERT(ggml_is_matrix(b));
     GGML_ASSERT(a->ne[2] == b->ne[1]);
     GGML_ASSERT(a->ne[3] == 1);
@@ -4486,7 +4081,9 @@ GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
 
     const int64_t ne[4] = {
         ggml_calc_conv_transpose_1d_output_size(b->ne[0], a->ne[0], s0, 0 /*p0*/, 1 /*d0*/),
-        a->ne[1], b->ne[2], 1,
+        a->ne[1],
+        b->ne[2],
+        1,
     };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
@@ -4505,26 +4102,27 @@ GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
 // a: [OC，IC, KH, KW]
 // b: [N, IC, IH, IW]
 // result: [N, OC, OH, OW]
-struct ggml_tensor * ggml_conv_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   s1,
-        int                   p0,
-        int                   p1,
-        int                   d0,
-        int                   d1) {
-    struct ggml_tensor * im2col = ggml_im2col(ctx, a, b, s0, s1, p0, p1, d0, d1, true, a->type); // [N, OH, OW, IC * KH * KW]
+struct ggml_tensor * ggml_conv_2d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  struct ggml_tensor *  b,
+                                  int                   s0,
+                                  int                   s1,
+                                  int                   p0,
+                                  int                   p1,
+                                  int                   d0,
+                                  int                   d1) {
+    struct ggml_tensor * im2col =
+        ggml_im2col(ctx, a, b, s0, s1, p0, p1, d0, d1, true, a->type);  // [N, OH, OW, IC * KH * KW]
 
-    struct ggml_tensor * result =
-        ggml_mul_mat(ctx,
-                ggml_reshape_2d(ctx, im2col, im2col->ne[0],  im2col->ne[3] * im2col->ne[2] * im2col->ne[1]), // [N, OH, OW, IC * KH * KW] => [N*OH*OW, IC * KH * KW]
-                ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1] * a->ne[2]),  a->ne[3]));                       // [OC，IC, KH, KW] => [OC, IC * KH * KW]
+    struct ggml_tensor * result = ggml_mul_mat(
+        ctx,
+        ggml_reshape_2d(
+            ctx, im2col, im2col->ne[0],
+            im2col->ne[3] * im2col->ne[2] * im2col->ne[1]),  // [N, OH, OW, IC * KH * KW] => [N*OH*OW, IC * KH * KW]
+        ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1] * a->ne[2]), a->ne[3]));  // [OC，IC, KH, KW] => [OC, IC * KH * KW]
 
-    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], im2col->ne[3], a->ne[3]); // [OC, N, OH, OW]
-    result = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2)); // [N, OC, OH, OW]
-
+    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], im2col->ne[3], a->ne[3]);  // [OC, N, OH, OW]
+    result = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2));                                // [N, OC, OH, OW]
 
     return result;
 }
@@ -4532,22 +4130,21 @@ struct ggml_tensor * ggml_conv_2d(
 // a: [OC*IC, KD, KH, KW]
 // b: [N*IC, ID, IH, IW]
 // result: [N*OD, OH, OW, IC * KD * KH * KW]
-struct ggml_tensor * ggml_im2col_3d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int64_t               IC,
-        int                   s0, // stride width
-        int                   s1, // stride height
-        int                   s2, // stride depth
-        int                   p0, // padding width
-        int                   p1, // padding height
-        int                   p2, // padding depth
-        int                   d0, // dilation width
-        int                   d1, // dilation height
-        int                   d2, // dilation depth
-        enum ggml_type        dst_type) {
-    const int64_t N = b->ne[3] / IC;
+struct ggml_tensor * ggml_im2col_3d(struct ggml_context * ctx,
+                                    struct ggml_tensor *  a,
+                                    struct ggml_tensor *  b,
+                                    int64_t               IC,
+                                    int                   s0,  // stride width
+                                    int                   s1,  // stride height
+                                    int                   s2,  // stride depth
+                                    int                   p0,  // padding width
+                                    int                   p1,  // padding height
+                                    int                   p2,  // padding depth
+                                    int                   d0,  // dilation width
+                                    int                   d1,  // dilation height
+                                    int                   d2,  // dilation depth
+                                    enum ggml_type        dst_type) {
+    const int64_t N  = b->ne[3] / IC;
     const int64_t ID = b->ne[2];
     const int64_t IH = b->ne[1];
     const int64_t IW = b->ne[0];
@@ -4561,15 +4158,14 @@ struct ggml_tensor * ggml_im2col_3d(
     const int64_t OH = ggml_calc_conv_output_size(IH, KH, s1, p1, d1);
     const int64_t OW = ggml_calc_conv_output_size(IW, KW, s0, p0, d0);
 
-    GGML_ASSERT((OD > 0)  && "b too small compared to a");
-    GGML_ASSERT((OH > 0)  && "b too small compared to a");
-    GGML_ASSERT((OW > 0)  && "b too small compared to a");
+    GGML_ASSERT((OD > 0) && "b too small compared to a");
+    GGML_ASSERT((OH > 0) && "b too small compared to a");
+    GGML_ASSERT((OW > 0) && "b too small compared to a");
 
+    const int64_t ne[4] = { KW * KH * KD * IC, OW, OH, OD * N };
 
-    const int64_t ne[4] = {KW*KH*KD*IC, OW, OH, OD*N};
-
-    struct ggml_tensor * result = ggml_new_tensor(ctx, dst_type, 4, ne);
-    int32_t params[] = { s0, s1, s2, p0, p1, p2, d0, d1, d2, (int32_t)IC};
+    struct ggml_tensor * result   = ggml_new_tensor(ctx, dst_type, 4, ne);
+    int32_t              params[] = { s0, s1, s2, p0, p1, p2, d0, d1, d2, (int32_t) IC };
     ggml_set_op_params(result, params, sizeof(params));
 
     result->op     = GGML_OP_IM2COL_3D;
@@ -4582,93 +4178,91 @@ struct ggml_tensor * ggml_im2col_3d(
 // a: [OC*IC, KD, KH, KW]
 // b: [N*IC, ID, IH, IW]
 // result: [N*OC, OD, OH, OW]
-struct ggml_tensor * ggml_conv_3d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int64_t               IC,
-        int                   s0, // stride width
-        int                   s1, // stride height
-        int                   s2, // stride depth
-        int                   p0, // padding width
-        int                   p1, // padding height
-        int                   p2, // padding depth
-        int                   d0, // dilation width
-        int                   d1, // dilation height
-        int                   d2  // dilation depth
-        ) {
-    struct ggml_tensor * im2col = ggml_im2col_3d(ctx, a, b, IC, s0, s1, s2, p0, p1, p2, d0, d1, d2, a->type); // [N*OD, OH, OW, IC * KD * KH * KW]
+struct ggml_tensor * ggml_conv_3d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  struct ggml_tensor *  b,
+                                  int64_t               IC,
+                                  int                   s0,  // stride width
+                                  int                   s1,  // stride height
+                                  int                   s2,  // stride depth
+                                  int                   p0,  // padding width
+                                  int                   p1,  // padding height
+                                  int                   p2,  // padding depth
+                                  int                   d0,  // dilation width
+                                  int                   d1,  // dilation height
+                                  int                   d2   // dilation depth
+) {
+    struct ggml_tensor * im2col = ggml_im2col_3d(ctx, a, b, IC, s0, s1, s2, p0, p1, p2, d0, d1, d2,
+                                                 a->type);  // [N*OD, OH, OW, IC * KD * KH * KW]
 
-    int64_t OC = a->ne[3] / IC;
-    int64_t N = b->ne[3] / IC;
-    struct ggml_tensor * result =
-        ggml_mul_mat(ctx,
-                ggml_reshape_2d(ctx, im2col, im2col->ne[0], im2col->ne[3] * im2col->ne[2] * im2col->ne[1]), // [N*OD, OH, OW, IC * KD * KH * KW] => [N*OD*OH*OW, IC * KD * KH * KW]
-                ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1] * a->ne[2] * IC), OC));                          // [OC*IC, KD, KH, KW] => [OC, IC * KD * KH * KW]
+    int64_t              OC     = a->ne[3] / IC;
+    int64_t              N      = b->ne[3] / IC;
+    struct ggml_tensor * result = ggml_mul_mat(
+        ctx,
+        ggml_reshape_2d(ctx, im2col, im2col->ne[0],
+                        im2col->ne[3] * im2col->ne[2] *
+                            im2col->ne[1]),  // [N*OD, OH, OW, IC * KD * KH * KW] => [N*OD*OH*OW, IC * KD * KH * KW]
+        ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1] * a->ne[2] * IC),
+                        OC));                // [OC*IC, KD, KH, KW] => [OC, IC * KD * KH * KW]
 
     int64_t OD = im2col->ne[3] / N;
-    result = ggml_reshape_4d(ctx, result, im2col->ne[1]*im2col->ne[2], OD, N, OC); // [OC, N*OD*OH*OW] => [OC, N, OD, OH*OW]
-    result = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2)); // [N, OC, OD, OH*OW]
-    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], OD, OC * N); // [N*OC, OD, OH, OW]
+    result     = ggml_reshape_4d(ctx, result, im2col->ne[1] * im2col->ne[2], OD, N,
+                                 OC);                                    // [OC, N*OD*OH*OW] => [OC, N, OD, OH*OW]
+    result     = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2));  // [N, OC, OD, OH*OW]
+    result     = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], OD, OC * N);  // [N*OC, OD, OH, OW]
 
     return result;
 }
 
 // ggml_conv_2d_sk_p0
 
-struct ggml_tensor * ggml_conv_2d_sk_p0(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_conv_2d_sk_p0(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_conv_2d(ctx, a, b, a->ne[0], a->ne[1], 0, 0, 1, 1);
 }
 
 // ggml_conv_2d_s1_ph
 
-struct ggml_tensor * ggml_conv_2d_s1_ph(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_conv_2d_s1_ph(struct ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * b) {
     return ggml_conv_2d(ctx, a, b, 1, 1, a->ne[0] / 2, a->ne[1] / 2, 1, 1);
 }
 
 // ggml_conv_2d_dw
 
-struct ggml_tensor * ggml_conv_2d_dw(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   s1,
-        int                   p0,
-        int                   p1,
-        int                   d0,
-        int                   d1) {
+struct ggml_tensor * ggml_conv_2d_dw(struct ggml_context * ctx,
+                                     struct ggml_tensor *  a,
+                                     struct ggml_tensor *  b,
+                                     int                   s0,
+                                     int                   s1,
+                                     int                   p0,
+                                     int                   p1,
+                                     int                   d0,
+                                     int                   d1) {
     struct ggml_tensor * new_a = ggml_reshape_4d(ctx, a, a->ne[0], a->ne[1], 1, a->ne[2] * a->ne[3]);
-    struct ggml_tensor * im2col = ggml_im2col(ctx, new_a,
-                                        ggml_reshape_4d(ctx, b, b->ne[0], b->ne[1], 1, b->ne[2] * b->ne[3]),
-                                        s0, s1, p0, p1, d0, d1, true, GGML_TYPE_F16); // [N * IC, OH, OW, KH * KW]
-    struct ggml_tensor * new_b = ggml_reshape_4d(ctx, im2col, im2col->ne[0], im2col->ne[2] * im2col->ne[1], b->ne[2], b->ne[3]); // [N * IC, OH, OW, KH * KW] => [N, IC, OH * OW, KH * KW]
+    struct ggml_tensor * im2col =
+        ggml_im2col(ctx, new_a, ggml_reshape_4d(ctx, b, b->ne[0], b->ne[1], 1, b->ne[2] * b->ne[3]), s0, s1, p0, p1, d0,
+                    d1, true, GGML_TYPE_F16);                // [N * IC, OH, OW, KH * KW]
+    struct ggml_tensor * new_b = ggml_reshape_4d(ctx, im2col, im2col->ne[0], im2col->ne[2] * im2col->ne[1], b->ne[2],
+                                                 b->ne[3]);  // [N * IC, OH, OW, KH * KW] => [N, IC, OH * OW, KH * KW]
 
-    new_a = ggml_reshape_4d(ctx, new_a, (new_a->ne[0] * new_a->ne[1]), new_a->ne[2],  new_a->ne[3], 1);                       // [OC，1, KH, KW] => [1, OC, 1, KH * KW]
+    new_a                       = ggml_reshape_4d(ctx, new_a, (new_a->ne[0] * new_a->ne[1]), new_a->ne[2], new_a->ne[3],
+                                                  1);  // [OC，1, KH, KW] => [1, OC, 1, KH * KW]
     struct ggml_tensor * result = ggml_mul_mat(ctx, new_a, new_b);
-    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], b->ne[2], b->ne[3]); // [N, OC, OH, OW]
+    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], b->ne[2], b->ne[3]);  // [N, OC, OH, OW]
 
     return result;
 }
 
 // ggml_conv_2d_dw_direct
 
-struct ggml_tensor * ggml_conv_2d_dw_direct(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   stride0,
-        int                   stride1,
-        int                   pad0,
-        int                   pad1,
-        int                   dilation0,
-        int                   dilation1) {
+struct ggml_tensor * ggml_conv_2d_dw_direct(struct ggml_context * ctx,
+                                            struct ggml_tensor *  a,
+                                            struct ggml_tensor *  b,
+                                            int                   stride0,
+                                            int                   stride1,
+                                            int                   pad0,
+                                            int                   pad1,
+                                            int                   dilation0,
+                                            int                   dilation1) {
     GGML_ASSERT(a->ne[2] == 1);
     GGML_ASSERT(a->ne[3] == b->ne[2]);
     int64_t ne[4];
@@ -4699,16 +4293,15 @@ struct ggml_tensor * ggml_conv_2d_dw_direct(
 
 // ggml_conv_2d_direct
 
-struct ggml_tensor * ggml_conv_2d_direct(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,   // convolution kernel [KW, KH, IC, OC]
-        struct ggml_tensor  * b,   // input data [W, H, C, N]
-        int                   s0,  // stride dimension 0
-        int                   s1,  // stride dimension 1
-        int                   p0,  // padding dimension 0
-        int                   p1,  // padding dimension 1
-        int                   d0,  // dilation dimension 0
-        int                   d1) {// dilation dimension 1
+struct ggml_tensor * ggml_conv_2d_direct(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,   // convolution kernel [KW, KH, IC, OC]
+                                         struct ggml_tensor *  b,   // input data [W, H, C, N]
+                                         int                   s0,  // stride dimension 0
+                                         int                   s1,  // stride dimension 1
+                                         int                   p0,  // padding dimension 0
+                                         int                   p1,  // padding dimension 1
+                                         int                   d0,  // dilation dimension 0
+                                         int                   d1) {                  // dilation dimension 1
 
     GGML_ASSERT(a->ne[2] == b->ne[2]);
     //GGML_ASSERT(a->type == b->type);
@@ -4728,7 +4321,7 @@ struct ggml_tensor * ggml_conv_2d_direct(
     ggml_set_op_params_i32(result, 4, d0);
     ggml_set_op_params_i32(result, 5, d1);
 
-    result->op = GGML_OP_CONV_2D;
+    result->op     = GGML_OP_CONV_2D;
     result->src[0] = a;
     result->src[1] = b;
 
@@ -4737,23 +4330,21 @@ struct ggml_tensor * ggml_conv_2d_direct(
 
 // ggml_conv_3d_direct
 
-struct ggml_tensor * ggml_conv_3d_direct(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   s0,
-        int                   s1,
-        int                   s2,
-        int                   p0,
-        int                   p1,
-        int                   p2,
-        int                   d0,
-        int                   d1,
-        int                   d2,
-        int                   c,
-        int                   n,
-        int                   oc) {
-
+struct ggml_tensor * ggml_conv_3d_direct(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,
+                                         struct ggml_tensor *  b,
+                                         int                   s0,
+                                         int                   s1,
+                                         int                   s2,
+                                         int                   p0,
+                                         int                   p1,
+                                         int                   p2,
+                                         int                   d0,
+                                         int                   d1,
+                                         int                   d2,
+                                         int                   c,
+                                         int                   n,
+                                         int                   oc) {
     GGML_ASSERT(a->ne[3] == (int64_t) c * oc);
     GGML_ASSERT(b->ne[3] == (int64_t) c * n);
 
@@ -4765,20 +4356,20 @@ struct ggml_tensor * ggml_conv_3d_direct(
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
-    ggml_set_op_params_i32(result, 0,  s0);
-    ggml_set_op_params_i32(result, 1,  s1);
-    ggml_set_op_params_i32(result, 2,  s2);
-    ggml_set_op_params_i32(result, 3,  p0);
-    ggml_set_op_params_i32(result, 4,  p1);
-    ggml_set_op_params_i32(result, 5,  p2);
-    ggml_set_op_params_i32(result, 6,  d0);
-    ggml_set_op_params_i32(result, 7,  d1);
-    ggml_set_op_params_i32(result, 8,  d2);
-    ggml_set_op_params_i32(result, 9,  c);
+    ggml_set_op_params_i32(result, 0, s0);
+    ggml_set_op_params_i32(result, 1, s1);
+    ggml_set_op_params_i32(result, 2, s2);
+    ggml_set_op_params_i32(result, 3, p0);
+    ggml_set_op_params_i32(result, 4, p1);
+    ggml_set_op_params_i32(result, 5, p2);
+    ggml_set_op_params_i32(result, 6, d0);
+    ggml_set_op_params_i32(result, 7, d1);
+    ggml_set_op_params_i32(result, 8, d2);
+    ggml_set_op_params_i32(result, 9, c);
     ggml_set_op_params_i32(result, 10, n);
     ggml_set_op_params_i32(result, 11, oc);
 
-    result->op = GGML_OP_CONV_3D;
+    result->op     = GGML_OP_CONV_3D;
     result->src[0] = a;
     result->src[1] = b;
 
@@ -4791,20 +4382,20 @@ static int64_t ggml_calc_conv_transpose_output_size(int64_t ins, int64_t ks, int
     return (ins - 1) * s - 2 * p + ks;
 }
 
-struct ggml_tensor * ggml_conv_transpose_2d_p0(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        int                   stride) {
+struct ggml_tensor * ggml_conv_transpose_2d_p0(struct ggml_context * ctx,
+                                               struct ggml_tensor *  a,
+                                               struct ggml_tensor *  b,
+                                               int                   stride) {
     GGML_ASSERT(a->ne[3] == b->ne[2]);
 
     const int64_t ne[4] = {
         ggml_calc_conv_transpose_output_size(b->ne[0], a->ne[0], stride, 0 /*p0*/),
         ggml_calc_conv_transpose_output_size(b->ne[1], a->ne[1], stride, 0 /*p1*/),
-        a->ne[2], b->ne[3],
+        a->ne[2],
+        b->ne[3],
     };
 
-    struct ggml_tensor* result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
+    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     ggml_set_op_params_i32(result, 0, stride);
 
@@ -4823,13 +4414,12 @@ static int64_t ggml_calc_pool_output_size(int64_t ins, int ks, int s, float p) {
 
 // ggml_pool_1d
 
-struct ggml_tensor * ggml_pool_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_op_pool     op,
-        int                   k0,
-        int                   s0,
-        int                   p0) {
+struct ggml_tensor * ggml_pool_1d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  enum ggml_op_pool     op,
+                                  int                   k0,
+                                  int                   s0,
+                                  int                   p0) {
     const int64_t ne[4] = {
         ggml_calc_pool_output_size(a->ne[0], k0, s0, p0),
         a->ne[1],
@@ -4849,18 +4439,17 @@ struct ggml_tensor * ggml_pool_1d(
 
 // ggml_pool_2d
 
-struct ggml_tensor * ggml_pool_2d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_op_pool     op,
-        int                   k0,
-        int                   k1,
-        int                   s0,
-        int                   s1,
-        float                 p0,
-        float                 p1) {
+struct ggml_tensor * ggml_pool_2d(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  enum ggml_op_pool     op,
+                                  int                   k0,
+                                  int                   k1,
+                                  int                   s0,
+                                  int                   s1,
+                                  float                 p0,
+                                  float                 p1) {
     struct ggml_tensor * result;
-    const int64_t ne[4] = {
+    const int64_t        ne[4] = {
         ggml_calc_pool_output_size(a->ne[0], k0, s0, p0),
         ggml_calc_pool_output_size(a->ne[1], k1, s1, p1),
         a->ne[2],
@@ -4877,17 +4466,16 @@ struct ggml_tensor * ggml_pool_2d(
     return result;
 }
 
-struct ggml_tensor * ggml_pool_2d_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * af,
-        enum ggml_op_pool     op,
-        int                   k0,
-        int                   k1,
-        int                   s0,
-        int                   s1,
-        float                 p0,
-        float                 p1) {
+struct ggml_tensor * ggml_pool_2d_back(struct ggml_context * ctx,
+                                       struct ggml_tensor *  a,
+                                       struct ggml_tensor *  af,
+                                       enum ggml_op_pool     op,
+                                       int                   k0,
+                                       int                   k1,
+                                       int                   s0,
+                                       int                   s1,
+                                       float                 p0,
+                                       float                 p1) {
     struct ggml_tensor * result;
     result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, af->ne);
 
@@ -4903,21 +4491,20 @@ struct ggml_tensor * ggml_pool_2d_back(
 
 // ggml_upscale / ggml_interpolate
 
-static struct ggml_tensor * ggml_interpolate_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3,
-        uint32_t              mode) {
+static struct ggml_tensor * ggml_interpolate_impl(struct ggml_context * ctx,
+                                                  struct ggml_tensor *  a,
+                                                  int64_t               ne0,
+                                                  int64_t               ne1,
+                                                  int64_t               ne2,
+                                                  int64_t               ne3,
+                                                  uint32_t              mode) {
     GGML_ASSERT((mode & 0xFF) < GGML_SCALE_MODE_COUNT);
     // TODO: implement antialias for modes other than bilinear
     GGML_ASSERT(!(mode & GGML_SCALE_FLAG_ANTIALIAS) || (mode & 0xFF) == GGML_SCALE_MODE_BILINEAR);
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, ne0, ne1, ne2, ne3);
 
-    ggml_set_op_params_i32(result, 0, (int32_t)mode);
+    ggml_set_op_params_i32(result, 0, (int32_t) mode);
 
     result->op     = GGML_OP_UPSCALE;
     result->src[0] = a;
@@ -4925,78 +4512,63 @@ static struct ggml_tensor * ggml_interpolate_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_upscale(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   scale_factor,
-        enum ggml_scale_mode  mode) {
+struct ggml_tensor * ggml_upscale(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int                   scale_factor,
+                                  enum ggml_scale_mode  mode) {
     GGML_ASSERT(scale_factor > 1);
     return ggml_interpolate_impl(ctx, a, a->ne[0] * scale_factor, a->ne[1] * scale_factor, a->ne[2], a->ne[3], mode);
 }
 
-struct ggml_tensor * ggml_upscale_ext(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   ne0,
-        int                   ne1,
-        int                   ne2,
-        int                   ne3,
-        enum ggml_scale_mode  mode) {
+struct ggml_tensor * ggml_upscale_ext(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      int                   ne0,
+                                      int                   ne1,
+                                      int                   ne2,
+                                      int                   ne3,
+                                      enum ggml_scale_mode  mode) {
     return ggml_interpolate_impl(ctx, a, ne0, ne1, ne2, ne3, mode);
 }
 
-struct ggml_tensor * ggml_interpolate(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3,
-        uint32_t              mode) {
+struct ggml_tensor * ggml_interpolate(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      int64_t               ne0,
+                                      int64_t               ne1,
+                                      int64_t               ne2,
+                                      int64_t               ne3,
+                                      uint32_t              mode) {
     return ggml_interpolate_impl(ctx, a, ne0, ne1, ne2, ne3, mode);
 }
 
 // ggml_pad
 
-struct ggml_tensor * ggml_pad(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   p0,
-        int                   p1,
-        int                   p2,
-        int                   p3) {
+struct ggml_tensor * ggml_pad(struct ggml_context * ctx, struct ggml_tensor * a, int p0, int p1, int p2, int p3) {
     return ggml_pad_ext(ctx, a, 0, p0, 0, p1, 0, p2, 0, p3);
 }
 
 // ggml_pad_circular
 
-struct ggml_tensor * ggml_pad_circular(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   p0,
-        int                   p1,
-        int                   p2,
-        int                   p3) {
+struct ggml_tensor * ggml_pad_circular(struct ggml_context * ctx,
+                                       struct ggml_tensor *  a,
+                                       int                   p0,
+                                       int                   p1,
+                                       int                   p2,
+                                       int                   p3) {
     return ggml_pad_ext_circular(ctx, a, 0, p0, 0, p1, 0, p2, 0, p3);
 }
 
-struct ggml_tensor * ggml_pad_ext(
-            struct ggml_context * ctx,
-            struct ggml_tensor  * a,
-            int                  lp0,
-            int                  rp0,
-            int                  lp1,
-            int                  rp1,
-            int                  lp2,
-            int                  rp2,
-            int                  lp3,
-            int                  rp3
-            ) {
-    struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type,
-            a->ne[0] + lp0 + rp0,
-            a->ne[1] + lp1 + rp1,
-            a->ne[2] + lp2 + rp2,
-            a->ne[3] + lp3 + rp3);
+struct ggml_tensor * ggml_pad_ext(struct ggml_context * ctx,
+                                  struct ggml_tensor *  a,
+                                  int                   lp0,
+                                  int                   rp0,
+                                  int                   lp1,
+                                  int                   rp1,
+                                  int                   lp2,
+                                  int                   rp2,
+                                  int                   lp3,
+                                  int                   rp3) {
+    struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, a->ne[0] + lp0 + rp0, a->ne[1] + lp1 + rp1,
+                                                     a->ne[2] + lp2 + rp2, a->ne[3] + lp3 + rp3);
 
     ggml_set_op_params_i32(result, 0, lp0);
     ggml_set_op_params_i32(result, 1, rp0);
@@ -5006,8 +4578,7 @@ struct ggml_tensor * ggml_pad_ext(
     ggml_set_op_params_i32(result, 5, rp2);
     ggml_set_op_params_i32(result, 6, lp3);
     ggml_set_op_params_i32(result, 7, rp3);
-    ggml_set_op_params_i32(result, 8, 0); // not circular by default
-
+    ggml_set_op_params_i32(result, 8, 0);  // not circular by default
 
     result->op     = GGML_OP_PAD;
     result->src[0] = a;
@@ -5017,44 +4588,34 @@ struct ggml_tensor * ggml_pad_ext(
 
 // ggml_pad_ext_circular
 
-struct ggml_tensor * ggml_pad_ext_circular(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                  lp0,
-        int                  rp0,
-        int                  lp1,
-        int                  rp1,
-        int                  lp2,
-        int                  rp2,
-        int                  lp3,
-        int                  rp3
-        ) {
+struct ggml_tensor * ggml_pad_ext_circular(struct ggml_context * ctx,
+                                           struct ggml_tensor *  a,
+                                           int                   lp0,
+                                           int                   rp0,
+                                           int                   lp1,
+                                           int                   rp1,
+                                           int                   lp2,
+                                           int                   rp2,
+                                           int                   lp3,
+                                           int                   rp3) {
     struct ggml_tensor * result = ggml_pad_ext(ctx, a, lp0, rp0, lp1, rp1, lp2, rp2, lp3, rp3);
-    ggml_set_op_params_i32(result, 8, 1); // circular
+    ggml_set_op_params_i32(result, 8, 1);  // circular
     return result;
 }
 
 // ggml_pad_reflect_1d
 
-struct ggml_tensor * ggml_pad_reflect_1d(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   p0,
-        int                   p1) {
+struct ggml_tensor * ggml_pad_reflect_1d(struct ggml_context * ctx, struct ggml_tensor * a, int p0, int p1) {
     GGML_ASSERT(p0 >= 0);
     GGML_ASSERT(p1 >= 0);
 
-    GGML_ASSERT(p0 < a->ne[0]); // padding length on each size must be less than the
-    GGML_ASSERT(p1 < a->ne[0]); // existing length of the dimension being padded
+    GGML_ASSERT(p0 < a->ne[0]);  // padding length on each size must be less than the
+    GGML_ASSERT(p1 < a->ne[0]);  // existing length of the dimension being padded
 
     GGML_ASSERT(ggml_is_contiguous(a));
     GGML_ASSERT(a->type == GGML_TYPE_F32);
 
-    struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type,
-            a->ne[0] + p0 + p1,
-            a->ne[1],
-            a->ne[2],
-            a->ne[3]);
+    struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, a->ne[0] + p0 + p1, a->ne[1], a->ne[2], a->ne[3]);
 
     int32_t params[] = { p0, p1 };
     ggml_set_op_params(result, params, sizeof(params));
@@ -5067,13 +4628,12 @@ struct ggml_tensor * ggml_pad_reflect_1d(
 
 // ggml_roll
 
-struct ggml_tensor * ggml_roll(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   shift0,
-        int                   shift1,
-        int                   shift2,
-        int                   shift3) {
+struct ggml_tensor * ggml_roll(struct ggml_context * ctx,
+                               struct ggml_tensor *  a,
+                               int                   shift0,
+                               int                   shift1,
+                               int                   shift2,
+                               int                   shift3) {
     GGML_ASSERT(a->nb[0] == ggml_type_size(a->type));
     GGML_ASSERT(abs(shift0) < a->ne[0]);
     GGML_ASSERT(abs(shift1) < a->ne[1]);
@@ -5095,12 +4655,10 @@ struct ggml_tensor * ggml_roll(
 
 // ggml_timestep_embedding
 
-struct ggml_tensor * ggml_timestep_embedding(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * timesteps,
-        int                   dim,
-        int                   max_period) {
-
+struct ggml_tensor * ggml_timestep_embedding(struct ggml_context * ctx,
+                                             struct ggml_tensor *  timesteps,
+                                             int                   dim,
+                                             int                   max_period) {
     struct ggml_tensor * result = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, dim, timesteps->ne[0]);
 
     ggml_set_op_params_i32(result, 0, dim);
@@ -5114,10 +4672,7 @@ struct ggml_tensor * ggml_timestep_embedding(
 
 // ggml_tri
 
-struct ggml_tensor * ggml_tri(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a,
-    enum ggml_tri_type    type) {
+struct ggml_tensor * ggml_tri(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_tri_type type) {
     GGML_ASSERT(a->type == GGML_TYPE_F32);
 
     GGML_ASSERT(ggml_is_contiguous(a));
@@ -5127,7 +4682,7 @@ struct ggml_tensor * ggml_tri(
 
     ggml_set_op_params_i32(result, 0, type);
 
-    result->op = GGML_OP_TRI;
+    result->op     = GGML_OP_TRI;
     result->src[0] = a;
 
     return result;
@@ -5135,11 +4690,7 @@ struct ggml_tensor * ggml_tri(
 
 // ggml_fill
 
-static struct ggml_tensor * ggml_fill_impl(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a,
-    float                 c,
-    bool                  inplace) {
+static struct ggml_tensor * ggml_fill_impl(struct ggml_context * ctx, struct ggml_tensor * a, float c, bool inplace) {
     GGML_ASSERT(a->type == GGML_TYPE_F32);
     GGML_ASSERT(ggml_is_contiguous(a));
 
@@ -5147,32 +4698,23 @@ static struct ggml_tensor * ggml_fill_impl(
 
     ggml_set_op_params_f32(result, 0, c);
 
-    result->op = GGML_OP_FILL;
+    result->op     = GGML_OP_FILL;
     result->src[0] = a;
 
     return result;
 }
 
-struct ggml_tensor * ggml_fill(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a,
-    float                 c) {
+struct ggml_tensor * ggml_fill(struct ggml_context * ctx, struct ggml_tensor * a, float c) {
     return ggml_fill_impl(ctx, a, c, false);
 }
 
-struct ggml_tensor * ggml_fill_inplace(
-    struct ggml_context * ctx,
-    struct ggml_tensor  * a,
-    float                 c) {
+struct ggml_tensor * ggml_fill_inplace(struct ggml_context * ctx, struct ggml_tensor * a, float c) {
     return ggml_fill_impl(ctx, a, c, true);
 }
 
 // ggml_argsort
 
-struct ggml_tensor * ggml_argsort(
-        struct ggml_context  * ctx,
-        struct ggml_tensor   * a,
-        enum ggml_sort_order   order) {
+struct ggml_tensor * ggml_argsort(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_sort_order order) {
     GGML_ASSERT(a->ne[0] <= INT32_MAX);
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_I32, GGML_MAX_DIMS, a->ne);
@@ -5187,28 +4729,20 @@ struct ggml_tensor * ggml_argsort(
 
 // ggml_argsort_top_k
 
-struct ggml_tensor * ggml_argsort_top_k(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   k) {
+struct ggml_tensor * ggml_argsort_top_k(struct ggml_context * ctx, struct ggml_tensor * a, int k) {
     GGML_ASSERT(a->ne[0] >= k);
 
     struct ggml_tensor * result = ggml_argsort(ctx, a, GGML_SORT_ORDER_DESC);
 
-    result = ggml_view_4d(ctx, result,
-                k, result->ne[1], result->ne[2], result->ne[3],
-                   result->nb[1], result->nb[2], result->nb[3],
-                0);
+    result = ggml_view_4d(ctx, result, k, result->ne[1], result->ne[2], result->ne[3], result->nb[1], result->nb[2],
+                          result->nb[3], 0);
 
     return result;
 }
 
 // ggml_top_k
 
-struct ggml_tensor * ggml_top_k(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   k) {
+struct ggml_tensor * ggml_top_k(struct ggml_context * ctx, struct ggml_tensor * a, int k) {
     GGML_ASSERT(a->ne[0] >= k);
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, GGML_TYPE_I32, k, a->ne[1], a->ne[2], a->ne[3]);
@@ -5221,11 +4755,7 @@ struct ggml_tensor * ggml_top_k(
 
 // ggml_arange
 
-struct ggml_tensor * ggml_arange(
-        struct ggml_context * ctx,
-        float                 start,
-        float                 stop,
-        float                 step) {
+struct ggml_tensor * ggml_arange(struct ggml_context * ctx, float start, float stop, float step) {
     GGML_ASSERT(stop > start);
 
     const int64_t steps = (int64_t) ceilf((stop - start) / step);
@@ -5243,15 +4773,14 @@ struct ggml_tensor * ggml_arange(
 
 // ggml_flash_attn_ext
 
-struct ggml_tensor * ggml_flash_attn_ext(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * q,
-        struct ggml_tensor  * k,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * mask,
-        float                 scale,
-        float                 max_bias,
-        float                 logit_softcap) {
+struct ggml_tensor * ggml_flash_attn_ext(struct ggml_context * ctx,
+                                         struct ggml_tensor *  q,
+                                         struct ggml_tensor *  k,
+                                         struct ggml_tensor *  v,
+                                         struct ggml_tensor *  mask,
+                                         float                 scale,
+                                         float                 max_bias,
+                                         float                 logit_softcap) {
     GGML_ASSERT(ggml_can_mul_mat(k, q));
     // TODO: check if vT can be multiplied by (k*qT)
 
@@ -5260,8 +4789,9 @@ struct ggml_tensor * ggml_flash_attn_ext(
 
     if (mask) {
         GGML_ASSERT(ggml_is_contiguous(mask));
-        GGML_ASSERT(mask->ne[1] >= GGML_PAD(q->ne[1], GGML_KQ_MASK_PAD) &&
-                "the Flash-Attention kernel requires the mask to be padded to GGML_KQ_MASK_PAD and at least n_queries big");
+        GGML_ASSERT(
+            mask->ne[1] >= GGML_PAD(q->ne[1], GGML_KQ_MASK_PAD) &&
+            "the Flash-Attention kernel requires the mask to be padded to GGML_KQ_MASK_PAD and at least n_queries big");
         //GGML_ASSERT(ggml_can_repeat_rows(mask, qk));
 
         GGML_ASSERT(q->ne[2] % mask->ne[2] == 0);
@@ -5273,7 +4803,7 @@ struct ggml_tensor * ggml_flash_attn_ext(
     }
 
     // permute(0, 2, 1, 3)
-    int64_t ne[4] = { v->ne[0], q->ne[2], q->ne[1], q->ne[3] };
+    int64_t              ne[4]  = { v->ne[0], q->ne[2], q->ne[1], q->ne[3] };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     float params[] = { scale, max_bias, logit_softcap };
@@ -5288,18 +4818,15 @@ struct ggml_tensor * ggml_flash_attn_ext(
     return result;
 }
 
-void ggml_flash_attn_ext_set_prec(
-        struct ggml_tensor * a,
-        enum ggml_prec       prec) {
+void ggml_flash_attn_ext_set_prec(struct ggml_tensor * a, enum ggml_prec prec) {
     GGML_ASSERT(a->op == GGML_OP_FLASH_ATTN_EXT);
 
     const int32_t prec_i32 = (int32_t) prec;
 
-    ggml_set_op_params_i32(a, 3, prec_i32); // scale is on first pos, max_bias on second
+    ggml_set_op_params_i32(a, 3, prec_i32);  // scale is on first pos, max_bias on second
 }
 
-enum ggml_prec ggml_flash_attn_ext_get_prec(
-        const struct ggml_tensor * a) {
+enum ggml_prec ggml_flash_attn_ext_get_prec(const struct ggml_tensor * a) {
     GGML_ASSERT(a->op == GGML_OP_FLASH_ATTN_EXT);
 
     const int32_t prec_i32 = ggml_get_op_params_i32(a, 3);
@@ -5307,9 +4834,7 @@ enum ggml_prec ggml_flash_attn_ext_get_prec(
     return (enum ggml_prec) prec_i32;
 }
 
-void ggml_flash_attn_ext_add_sinks(
-        struct ggml_tensor * a,
-        struct ggml_tensor * sinks) {
+void ggml_flash_attn_ext_add_sinks(struct ggml_tensor * a, struct ggml_tensor * sinks) {
     if (!sinks) {
         a->src[4] = NULL;
         return;
@@ -5325,13 +4850,12 @@ void ggml_flash_attn_ext_add_sinks(
 
 // ggml_flash_attn_back
 
-struct ggml_tensor * ggml_flash_attn_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * q,
-        struct ggml_tensor  * k,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * d,
-        bool                  masked) {
+struct ggml_tensor * ggml_flash_attn_back(struct ggml_context * ctx,
+                                          struct ggml_tensor *  q,
+                                          struct ggml_tensor *  k,
+                                          struct ggml_tensor *  v,
+                                          struct ggml_tensor *  d,
+                                          bool                  masked) {
     GGML_ABORT("TODO: adapt to ggml_flash_attn_ext() changes");
 
     GGML_ASSERT(ggml_can_mul_mat(k, q));
@@ -5342,11 +4866,11 @@ struct ggml_tensor * ggml_flash_attn_back(
     // k shape [D,M,kvne2,ne3]
     // v shape [M,D,kvne2,ne3]
 
-    const int64_t     D = q->ne[0];
-    const int64_t     N = q->ne[1];
-    const int64_t     M = k->ne[1];
-    const int64_t   ne2 = q->ne[2];
-    const int64_t   ne3 = q->ne[3];
+    const int64_t D     = q->ne[0];
+    const int64_t N     = q->ne[1];
+    const int64_t M     = k->ne[1];
+    const int64_t ne2   = q->ne[2];
+    const int64_t ne3   = q->ne[3];
     const int64_t kvne2 = k->ne[2];
 
     GGML_ASSERT(k->ne[0] == D);
@@ -5378,7 +4902,7 @@ struct ggml_tensor * ggml_flash_attn_back(
     const size_t offs_v = offs_k + GGML_PAD(elem_k * tsize, GGML_MEM_ALIGN);
     const size_t end    = offs_v + GGML_PAD(elem_v * tsize, GGML_MEM_ALIGN);
 
-    const size_t nelements = (end + tsize - 1)/tsize;
+    const size_t nelements = (end + tsize - 1) / tsize;
 
     struct ggml_tensor * result = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, nelements);
 
@@ -5396,16 +4920,13 @@ struct ggml_tensor * ggml_flash_attn_back(
 
 // ggml_ssm_conv
 
-struct ggml_tensor * ggml_ssm_conv(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * sx,
-        struct ggml_tensor  * c) {
+struct ggml_tensor * ggml_ssm_conv(struct ggml_context * ctx, struct ggml_tensor * sx, struct ggml_tensor * c) {
     GGML_ASSERT(ggml_is_3d(sx));
     GGML_ASSERT(ggml_is_matrix(c));
 
     const int64_t d_conv  = c->ne[0];
     const int64_t d_inner = c->ne[1];
-    const int64_t n_t     = sx->ne[0] - d_conv + 1; // tokens per sequence
+    const int64_t n_t     = sx->ne[0] - d_conv + 1;  // tokens per sequence
     const int64_t n_s     = sx->ne[2];
 
     // TODO: maybe support other strides than 1?
@@ -5424,24 +4945,23 @@ struct ggml_tensor * ggml_ssm_conv(
 
 // ggml_ssm_scan
 
-struct ggml_tensor * ggml_ssm_scan(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * s,
-        struct ggml_tensor  * x,
-        struct ggml_tensor  * dt,
-        struct ggml_tensor  * A,
-        struct ggml_tensor  * B,
-        struct ggml_tensor  * C,
-        struct ggml_tensor  * ids) {
+struct ggml_tensor * ggml_ssm_scan(struct ggml_context * ctx,
+                                   struct ggml_tensor *  s,
+                                   struct ggml_tensor *  x,
+                                   struct ggml_tensor *  dt,
+                                   struct ggml_tensor *  A,
+                                   struct ggml_tensor *  B,
+                                   struct ggml_tensor *  C,
+                                   struct ggml_tensor *  ids) {
     GGML_ASSERT(ggml_is_contiguous(s));
     GGML_ASSERT(ggml_is_contiguous(dt));
     GGML_ASSERT(ggml_is_contiguous(A));
     GGML_ASSERT(x->nb[0] == ggml_type_size(x->type));
     GGML_ASSERT(B->nb[0] == ggml_type_size(B->type));
     GGML_ASSERT(C->nb[0] == ggml_type_size(C->type));
-    GGML_ASSERT(x->nb[1] == x->ne[0]*x->nb[0]);
-    GGML_ASSERT(B->nb[1] == B->ne[0]*B->nb[0]);
-    GGML_ASSERT(C->nb[1] == C->ne[0]*C->nb[0]);
+    GGML_ASSERT(x->nb[1] == x->ne[0] * x->nb[0]);
+    GGML_ASSERT(B->nb[1] == B->ne[0] * B->nb[0]);
+    GGML_ASSERT(C->nb[1] == C->ne[0] * C->nb[0]);
     GGML_ASSERT(ggml_are_same_shape(B, C));
     GGML_ASSERT(ids->type == GGML_TYPE_I32);
 
@@ -5473,9 +4993,10 @@ struct ggml_tensor * ggml_ssm_scan(
     }
 
     // concatenated y + ssm_states
-    struct ggml_tensor * result = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, ggml_nelements(x) + s->ne[0]*s->ne[1]*s->ne[2]*ids->ne[0]);
+    struct ggml_tensor * result =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_F32, ggml_nelements(x) + s->ne[0] * s->ne[1] * s->ne[2] * ids->ne[0]);
 
-    result->op   = GGML_OP_SSM_SCAN;
+    result->op     = GGML_OP_SSM_SCAN;
     result->src[0] = s;
     result->src[1] = x;
     result->src[2] = dt;
@@ -5489,22 +5010,24 @@ struct ggml_tensor * ggml_ssm_scan(
 
 // ggml_win_part
 
-struct ggml_tensor * ggml_win_part(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   w) {
+struct ggml_tensor * ggml_win_part(struct ggml_context * ctx, struct ggml_tensor * a, int w) {
     GGML_ASSERT(a->ne[3] == 1);
-    GGML_ASSERT(a->type  == GGML_TYPE_F32);
+    GGML_ASSERT(a->type == GGML_TYPE_F32);
 
     // padding
-    const int px = (w - a->ne[1]%w)%w;
-    const int py = (w - a->ne[2]%w)%w;
+    const int px = (w - a->ne[1] % w) % w;
+    const int py = (w - a->ne[2] % w) % w;
 
-    const int npx = (px + a->ne[1])/w;
-    const int npy = (py + a->ne[2])/w;
-    const int np  = npx*npy;
+    const int npx = (px + a->ne[1]) / w;
+    const int npy = (py + a->ne[2]) / w;
+    const int np  = npx * npy;
 
-    const int64_t ne[4] = { a->ne[0], w, w, np, };
+    const int64_t ne[4] = {
+        a->ne[0],
+        w,
+        w,
+        np,
+    };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     int32_t params[] = { npx, npy, w };
@@ -5518,15 +5041,15 @@ struct ggml_tensor * ggml_win_part(
 
 // ggml_win_unpart
 
-struct ggml_tensor * ggml_win_unpart(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   w0,
-        int                   h0,
-        int                   w) {
+struct ggml_tensor * ggml_win_unpart(struct ggml_context * ctx, struct ggml_tensor * a, int w0, int h0, int w) {
     GGML_ASSERT(a->type == GGML_TYPE_F32);
 
-    const int64_t ne[4] = { a->ne[0], w0, h0, 1, };
+    const int64_t ne[4] = {
+        a->ne[0],
+        w0,
+        h0,
+        1,
+    };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 3, ne);
 
     int32_t params[] = { w };
@@ -5540,15 +5063,16 @@ struct ggml_tensor * ggml_win_unpart(
 
 // ggml_get_rel_pos
 
-struct ggml_tensor * ggml_get_rel_pos(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        int                   qh,
-        int                   kh) {
+struct ggml_tensor * ggml_get_rel_pos(struct ggml_context * ctx, struct ggml_tensor * a, int qh, int kh) {
     GGML_ASSERT(qh == kh);
-    GGML_ASSERT(2*MAX(qh, kh) - 1 == a->ne[1]);
+    GGML_ASSERT(2 * MAX(qh, kh) - 1 == a->ne[1]);
 
-    const int64_t ne[4] = { a->ne[0], kh, qh, 1, };
+    const int64_t ne[4] = {
+        a->ne[0],
+        kh,
+        qh,
+        1,
+    };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F16, 3, ne);
 
     result->op     = GGML_OP_GET_REL_POS;
@@ -5559,12 +5083,11 @@ struct ggml_tensor * ggml_get_rel_pos(
 
 // ggml_add_rel_pos
 
-static struct ggml_tensor * ggml_add_rel_pos_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * pw,
-        struct ggml_tensor  * ph,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_add_rel_pos_impl(struct ggml_context * ctx,
+                                                  struct ggml_tensor *  a,
+                                                  struct ggml_tensor *  pw,
+                                                  struct ggml_tensor *  ph,
+                                                  bool                  inplace) {
     GGML_ASSERT(ggml_are_same_shape(pw, ph));
     GGML_ASSERT(ggml_is_contiguous(a));
     GGML_ASSERT(ggml_is_contiguous(pw));
@@ -5572,8 +5095,8 @@ static struct ggml_tensor * ggml_add_rel_pos_impl(
     GGML_ASSERT(ph->type == GGML_TYPE_F32);
     GGML_ASSERT(pw->type == GGML_TYPE_F32);
     GGML_ASSERT(pw->ne[3] == a->ne[2]);
-    GGML_ASSERT(pw->ne[0]*pw->ne[0] == a->ne[0]);
-    GGML_ASSERT(pw->ne[1]*pw->ne[2] == a->ne[1]);
+    GGML_ASSERT(pw->ne[0] * pw->ne[0] == a->ne[0]);
+    GGML_ASSERT(pw->ne[1] * pw->ne[2] == a->ne[1]);
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
     ggml_set_op_params_i32(result, 0, inplace ? 1 : 0);
@@ -5586,32 +5109,29 @@ static struct ggml_tensor * ggml_add_rel_pos_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_add_rel_pos(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * pw,
-        struct ggml_tensor  * ph) {
+struct ggml_tensor * ggml_add_rel_pos(struct ggml_context * ctx,
+                                      struct ggml_tensor *  a,
+                                      struct ggml_tensor *  pw,
+                                      struct ggml_tensor *  ph) {
     return ggml_add_rel_pos_impl(ctx, a, pw, ph, false);
 }
 
-struct ggml_tensor * ggml_add_rel_pos_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * pw,
-        struct ggml_tensor  * ph) {
+struct ggml_tensor * ggml_add_rel_pos_inplace(struct ggml_context * ctx,
+                                              struct ggml_tensor *  a,
+                                              struct ggml_tensor *  pw,
+                                              struct ggml_tensor *  ph) {
     return ggml_add_rel_pos_impl(ctx, a, pw, ph, true);
 }
 
 // ggml_rwkv_wkv6
 
-struct ggml_tensor * ggml_rwkv_wkv6(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * k,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * r,
-        struct ggml_tensor  * tf,
-        struct ggml_tensor  * td,
-        struct ggml_tensor  * state) {
+struct ggml_tensor * ggml_rwkv_wkv6(struct ggml_context * ctx,
+                                    struct ggml_tensor *  k,
+                                    struct ggml_tensor *  v,
+                                    struct ggml_tensor *  r,
+                                    struct ggml_tensor *  tf,
+                                    struct ggml_tensor *  td,
+                                    struct ggml_tensor *  state) {
     GGML_ASSERT(ggml_is_contiguous(k));
     GGML_ASSERT(ggml_is_contiguous(v));
     GGML_ASSERT(ggml_is_contiguous(r));
@@ -5619,10 +5139,10 @@ struct ggml_tensor * ggml_rwkv_wkv6(
     GGML_ASSERT(ggml_is_contiguous(td));
     GGML_ASSERT(ggml_is_contiguous(state));
 
-    const int64_t S = k->ne[0];
-    const int64_t H = k->ne[1];
+    const int64_t S        = k->ne[0];
+    const int64_t H        = k->ne[1];
     const int64_t n_tokens = k->ne[2];
-    const int64_t n_seqs = state->ne[1];
+    const int64_t n_seqs   = state->ne[1];
     {
         GGML_ASSERT(v->ne[0] == S && v->ne[1] == H && v->ne[2] == n_tokens);
         GGML_ASSERT(r->ne[0] == S && r->ne[1] == H && r->ne[2] == n_tokens);
@@ -5631,7 +5151,7 @@ struct ggml_tensor * ggml_rwkv_wkv6(
     }
 
     // concat output and new_state
-    const int64_t ne[4] = { S * H, n_tokens + S * n_seqs, 1, 1 };
+    const int64_t        ne[4]  = { S * H, n_tokens + S * n_seqs, 1, 1 };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_RWKV_WKV6;
@@ -5647,24 +5167,23 @@ struct ggml_tensor * ggml_rwkv_wkv6(
 
 // ggml_gated_linear_attn
 
-struct ggml_tensor * ggml_gated_linear_attn(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * k,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * q,
-        struct ggml_tensor  * g,
-        struct ggml_tensor  * state,
-        float scale) {
+struct ggml_tensor * ggml_gated_linear_attn(struct ggml_context * ctx,
+                                            struct ggml_tensor *  k,
+                                            struct ggml_tensor *  v,
+                                            struct ggml_tensor *  q,
+                                            struct ggml_tensor *  g,
+                                            struct ggml_tensor *  state,
+                                            float                 scale) {
     GGML_ASSERT(ggml_is_contiguous(k));
     GGML_ASSERT(ggml_is_contiguous(v));
     GGML_ASSERT(ggml_is_contiguous(q));
     GGML_ASSERT(ggml_is_contiguous(g));
     GGML_ASSERT(ggml_is_contiguous(state));
 
-    const int64_t S = k->ne[0];
-    const int64_t H = k->ne[1];
+    const int64_t S        = k->ne[0];
+    const int64_t H        = k->ne[1];
     const int64_t n_tokens = k->ne[2];
-    const int64_t n_seqs = state->ne[1];
+    const int64_t n_seqs   = state->ne[1];
     {
         GGML_ASSERT(v->ne[0] == S && v->ne[1] == H && v->ne[2] == n_tokens);
         GGML_ASSERT(q->ne[0] == S && q->ne[1] == H && q->ne[2] == n_tokens);
@@ -5673,7 +5192,7 @@ struct ggml_tensor * ggml_gated_linear_attn(
     }
 
     // concat output and new_state
-    const int64_t ne[4] = { S * H, n_tokens + S * n_seqs, 1, 1 };
+    const int64_t        ne[4]  = { S * H, n_tokens + S * n_seqs, 1, 1 };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     ggml_set_op_params_f32(result, 0, scale);
@@ -5690,15 +5209,14 @@ struct ggml_tensor * ggml_gated_linear_attn(
 
 // ggml_rwkv_wkv7
 
-struct ggml_tensor * ggml_rwkv_wkv7(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * r,
-        struct ggml_tensor  * w,
-        struct ggml_tensor  * k,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * state) {
+struct ggml_tensor * ggml_rwkv_wkv7(struct ggml_context * ctx,
+                                    struct ggml_tensor *  r,
+                                    struct ggml_tensor *  w,
+                                    struct ggml_tensor *  k,
+                                    struct ggml_tensor *  v,
+                                    struct ggml_tensor *  a,
+                                    struct ggml_tensor *  b,
+                                    struct ggml_tensor *  state) {
     GGML_ASSERT(ggml_is_contiguous(r));
     GGML_ASSERT(ggml_is_contiguous(w));
     GGML_ASSERT(ggml_is_contiguous(k));
@@ -5707,10 +5225,10 @@ struct ggml_tensor * ggml_rwkv_wkv7(
     GGML_ASSERT(ggml_is_contiguous(b));
     GGML_ASSERT(ggml_is_contiguous(state));
 
-    const int64_t S = k->ne[0];
-    const int64_t H = k->ne[1];
+    const int64_t S        = k->ne[0];
+    const int64_t H        = k->ne[1];
     const int64_t n_tokens = k->ne[2];
-    const int64_t n_seqs = state->ne[1];
+    const int64_t n_seqs   = state->ne[1];
     {
         GGML_ASSERT(w->ne[0] == S && w->ne[1] == H && w->ne[2] == n_tokens);
         GGML_ASSERT(k->ne[0] == S && k->ne[1] == H && k->ne[2] == n_tokens);
@@ -5721,7 +5239,7 @@ struct ggml_tensor * ggml_rwkv_wkv7(
     }
 
     // concat output and new_state
-    const int64_t ne[4] = { S * H, n_tokens + S * n_seqs, 1, 1 };
+    const int64_t        ne[4]  = { S * H, n_tokens + S * n_seqs, 1, 1 };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
     result->op     = GGML_OP_RWKV_WKV7;
@@ -5738,11 +5256,10 @@ struct ggml_tensor * ggml_rwkv_wkv7(
 
 // ggml_unary
 
-static struct ggml_tensor * ggml_unary_impl(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_unary_op    op,
-        bool                  inplace) {
+static struct ggml_tensor * ggml_unary_impl(struct ggml_context * ctx,
+                                            struct ggml_tensor *  a,
+                                            enum ggml_unary_op    op,
+                                            bool                  inplace) {
     GGML_ASSERT(ggml_is_contiguous_1(a));
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
@@ -5755,38 +5272,29 @@ static struct ggml_tensor * ggml_unary_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_unary(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_unary_op    op) {
+struct ggml_tensor * ggml_unary(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_unary_op op) {
     return ggml_unary_impl(ctx, a, op, false);
 }
 
-struct ggml_tensor * ggml_unary_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        enum ggml_unary_op    op) {
+struct ggml_tensor * ggml_unary_inplace(struct ggml_context * ctx, struct ggml_tensor * a, enum ggml_unary_op op) {
     return ggml_unary_impl(ctx, a, op, true);
 }
 
 // ggml_map_custom1
 
-static struct ggml_tensor * ggml_map_custom1_impl(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        const  ggml_custom1_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata,
-        bool                       inplace) {
+static struct ggml_tensor * ggml_map_custom1_impl(struct ggml_context *   ctx,
+                                                  struct ggml_tensor *    a,
+                                                  const ggml_custom1_op_t fun,
+                                                  int                     n_tasks,
+                                                  void *                  userdata,
+                                                  bool                    inplace) {
     GGML_ASSERT(n_tasks == GGML_N_TASKS_MAX || n_tasks > 0);
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
-    struct ggml_map_custom1_op_params params = {
-        /*.fun      =*/ fun,
-        /*.n_tasks  =*/ n_tasks,
-        /*.userdata =*/ userdata
-    };
+    struct ggml_map_custom1_op_params params = { /*.fun      =*/fun,
+                                                 /*.n_tasks  =*/n_tasks,
+                                                 /*.userdata =*/userdata };
     ggml_set_op_params(result, &params, sizeof(params));
 
     result->op     = GGML_OP_MAP_CUSTOM1;
@@ -5795,43 +5303,38 @@ static struct ggml_tensor * ggml_map_custom1_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_map_custom1(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        const  ggml_custom1_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom1(struct ggml_context *   ctx,
+                                      struct ggml_tensor *    a,
+                                      const ggml_custom1_op_t fun,
+                                      int                     n_tasks,
+                                      void *                  userdata) {
     return ggml_map_custom1_impl(ctx, a, fun, n_tasks, userdata, false);
 }
 
-struct ggml_tensor * ggml_map_custom1_inplace(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        const  ggml_custom1_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom1_inplace(struct ggml_context *   ctx,
+                                              struct ggml_tensor *    a,
+                                              const ggml_custom1_op_t fun,
+                                              int                     n_tasks,
+                                              void *                  userdata) {
     return ggml_map_custom1_impl(ctx, a, fun, n_tasks, userdata, true);
 }
 
 // ggml_map_custom2
 
-static struct ggml_tensor * ggml_map_custom2_impl(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        const  ggml_custom2_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata,
-        bool                       inplace) {
+static struct ggml_tensor * ggml_map_custom2_impl(struct ggml_context *   ctx,
+                                                  struct ggml_tensor *    a,
+                                                  struct ggml_tensor *    b,
+                                                  const ggml_custom2_op_t fun,
+                                                  int                     n_tasks,
+                                                  void *                  userdata,
+                                                  bool                    inplace) {
     GGML_ASSERT(n_tasks == GGML_N_TASKS_MAX || n_tasks > 0);
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
-    struct ggml_map_custom2_op_params params = {
-        /*.fun      =*/ fun,
-        /*.n_tasks  =*/ n_tasks,
-        /*.userdata =*/ userdata
-    };
+    struct ggml_map_custom2_op_params params = { /*.fun      =*/fun,
+                                                 /*.n_tasks  =*/n_tasks,
+                                                 /*.userdata =*/userdata };
     ggml_set_op_params(result, &params, sizeof(params));
 
     result->op     = GGML_OP_MAP_CUSTOM2;
@@ -5841,46 +5344,41 @@ static struct ggml_tensor * ggml_map_custom2_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_map_custom2(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        const  ggml_custom2_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom2(struct ggml_context *   ctx,
+                                      struct ggml_tensor *    a,
+                                      struct ggml_tensor *    b,
+                                      const ggml_custom2_op_t fun,
+                                      int                     n_tasks,
+                                      void *                  userdata) {
     return ggml_map_custom2_impl(ctx, a, b, fun, n_tasks, userdata, false);
 }
 
-struct ggml_tensor * ggml_map_custom2_inplace(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        const  ggml_custom2_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom2_inplace(struct ggml_context *   ctx,
+                                              struct ggml_tensor *    a,
+                                              struct ggml_tensor *    b,
+                                              const ggml_custom2_op_t fun,
+                                              int                     n_tasks,
+                                              void *                  userdata) {
     return ggml_map_custom2_impl(ctx, a, b, fun, n_tasks, userdata, true);
 }
 
 // ggml_map_custom3
 
-static struct ggml_tensor * ggml_map_custom3_impl(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        struct ggml_tensor       * c,
-        const  ggml_custom3_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata,
-        bool                       inplace) {
+static struct ggml_tensor * ggml_map_custom3_impl(struct ggml_context *   ctx,
+                                                  struct ggml_tensor *    a,
+                                                  struct ggml_tensor *    b,
+                                                  struct ggml_tensor *    c,
+                                                  const ggml_custom3_op_t fun,
+                                                  int                     n_tasks,
+                                                  void *                  userdata,
+                                                  bool                    inplace) {
     GGML_ASSERT(n_tasks == GGML_N_TASKS_MAX || n_tasks > 0);
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
-    struct ggml_map_custom3_op_params params = {
-        /*.fun      =*/ fun,
-        /*.n_tasks  =*/ n_tasks,
-        /*.userdata =*/ userdata
-    };
+    struct ggml_map_custom3_op_params params = { /*.fun      =*/fun,
+                                                 /*.n_tasks  =*/n_tasks,
+                                                 /*.userdata =*/userdata };
     ggml_set_op_params(result, &params, sizeof(params));
 
     result->op     = GGML_OP_MAP_CUSTOM3;
@@ -5891,50 +5389,44 @@ static struct ggml_tensor * ggml_map_custom3_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_map_custom3(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        struct ggml_tensor       * c,
-        const  ggml_custom3_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom3(struct ggml_context *   ctx,
+                                      struct ggml_tensor *    a,
+                                      struct ggml_tensor *    b,
+                                      struct ggml_tensor *    c,
+                                      const ggml_custom3_op_t fun,
+                                      int                     n_tasks,
+                                      void *                  userdata) {
     return ggml_map_custom3_impl(ctx, a, b, c, fun, n_tasks, userdata, false);
 }
 
-struct ggml_tensor * ggml_map_custom3_inplace(
-        struct ggml_context      * ctx,
-        struct ggml_tensor       * a,
-        struct ggml_tensor       * b,
-        struct ggml_tensor       * c,
-        const  ggml_custom3_op_t   fun,
-        int                        n_tasks,
-        void                     * userdata) {
+struct ggml_tensor * ggml_map_custom3_inplace(struct ggml_context *   ctx,
+                                              struct ggml_tensor *    a,
+                                              struct ggml_tensor *    b,
+                                              struct ggml_tensor *    c,
+                                              const ggml_custom3_op_t fun,
+                                              int                     n_tasks,
+                                              void *                  userdata) {
     return ggml_map_custom3_impl(ctx, a, b, c, fun, n_tasks, userdata, true);
 }
 
-struct ggml_tensor * ggml_custom_4d(
-        struct ggml_context * ctx,
-        enum ggml_type        type,
-        int64_t               ne0,
-        int64_t               ne1,
-        int64_t               ne2,
-        int64_t               ne3,
-        struct ggml_tensor ** args,
-        int                   n_args,
-        ggml_custom_op_t      fun,
-        int                   n_tasks,
-        void                * userdata) {
-
+struct ggml_tensor * ggml_custom_4d(struct ggml_context * ctx,
+                                    enum ggml_type        type,
+                                    int64_t               ne0,
+                                    int64_t               ne1,
+                                    int64_t               ne2,
+                                    int64_t               ne3,
+                                    struct ggml_tensor ** args,
+                                    int                   n_args,
+                                    ggml_custom_op_t      fun,
+                                    int                   n_tasks,
+                                    void *                userdata) {
     GGML_ASSERT(n_args < GGML_MAX_SRC);
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, type, ne0, ne1, ne2, ne3);
 
-    struct ggml_custom_op_params params = {
-        /*.fun      =*/ fun,
-        /*.n_tasks  =*/ n_tasks,
-        /*.userdata =*/ userdata
-    };
+    struct ggml_custom_op_params params = { /*.fun      =*/fun,
+                                            /*.n_tasks  =*/n_tasks,
+                                            /*.userdata =*/userdata };
     ggml_set_op_params(result, &params, sizeof(params));
 
     result->op = GGML_OP_CUSTOM;
@@ -5945,27 +5437,23 @@ struct ggml_tensor * ggml_custom_4d(
     return result;
 }
 
-struct ggml_tensor * ggml_custom_inplace(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor ** args,
-        int                   n_args,
-        ggml_custom_op_t      fun,
-        int                   n_tasks,
-        void                * userdata) {
-
+struct ggml_tensor * ggml_custom_inplace(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,
+                                         struct ggml_tensor ** args,
+                                         int                   n_args,
+                                         ggml_custom_op_t      fun,
+                                         int                   n_tasks,
+                                         void *                userdata) {
     GGML_ASSERT(n_args < GGML_MAX_SRC - 1);
 
     struct ggml_tensor * result = ggml_view_tensor(ctx, a);
 
-    struct ggml_custom_op_params params = {
-        /*.fun      =*/ fun,
-        /*.n_tasks  =*/ n_tasks,
-        /*.userdata =*/ userdata
-    };
+    struct ggml_custom_op_params params = { /*.fun      =*/fun,
+                                            /*.n_tasks  =*/n_tasks,
+                                            /*.userdata =*/userdata };
     ggml_set_op_params(result, &params, sizeof(params));
 
-    result->op = GGML_OP_CUSTOM;
+    result->op     = GGML_OP_CUSTOM;
     result->src[0] = a;
     for (int i = 0; i < n_args; i++) {
         result->src[i + 1] = args[i];
@@ -5973,12 +5461,12 @@ struct ggml_tensor * ggml_custom_inplace(
 
     return result;
 }
+
 // ggml_cross_entropy_loss
 
-struct ggml_tensor * ggml_cross_entropy_loss(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b) {
+struct ggml_tensor * ggml_cross_entropy_loss(struct ggml_context * ctx,
+                                             struct ggml_tensor *  a,
+                                             struct ggml_tensor *  b) {
     GGML_ASSERT(ggml_are_same_shape(a, b));
 
     struct ggml_tensor * result = ggml_new_tensor_1d(ctx, a->type, 1);
@@ -5992,11 +5480,10 @@ struct ggml_tensor * ggml_cross_entropy_loss(
 
 // ggml_cross_entropy_loss_back
 
-struct ggml_tensor * ggml_cross_entropy_loss_back(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        struct ggml_tensor  * c) {
+struct ggml_tensor * ggml_cross_entropy_loss_back(struct ggml_context * ctx,
+                                                  struct ggml_tensor *  a,
+                                                  struct ggml_tensor *  b,
+                                                  struct ggml_tensor *  c) {
     GGML_ASSERT(ggml_is_scalar(a));
     GGML_ASSERT(ggml_are_same_shape(b, c));
 
@@ -6012,13 +5499,12 @@ struct ggml_tensor * ggml_cross_entropy_loss_back(
 
 // opt_step_adamw
 
-struct ggml_tensor * ggml_opt_step_adamw(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * grad,
-        struct ggml_tensor  * m,
-        struct ggml_tensor  * v,
-        struct ggml_tensor  * adamw_params) {
+struct ggml_tensor * ggml_opt_step_adamw(struct ggml_context * ctx,
+                                         struct ggml_tensor *  a,
+                                         struct ggml_tensor *  grad,
+                                         struct ggml_tensor *  m,
+                                         struct ggml_tensor *  v,
+                                         struct ggml_tensor *  adamw_params) {
     GGML_ASSERT(a->flags & GGML_TENSOR_FLAG_PARAM);
     GGML_ASSERT(ggml_are_same_shape(a, grad));
     GGML_ASSERT(ggml_are_same_shape(a, m));
@@ -6040,11 +5526,10 @@ struct ggml_tensor * ggml_opt_step_adamw(
 
 // opt_step_sgd
 
-struct ggml_tensor * ggml_opt_step_sgd(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * grad,
-        struct ggml_tensor  * params) {
+struct ggml_tensor * ggml_opt_step_sgd(struct ggml_context * ctx,
+                                       struct ggml_tensor *  a,
+                                       struct ggml_tensor *  grad,
+                                       struct ggml_tensor *  params) {
     GGML_ASSERT(a->flags & GGML_TENSOR_FLAG_PARAM);
     GGML_ASSERT(ggml_are_same_shape(a, grad));
     GGML_ASSERT(params->type == GGML_TYPE_F32);
@@ -6062,13 +5547,12 @@ struct ggml_tensor * ggml_opt_step_sgd(
 
 // solve_tri
 
-struct ggml_tensor * ggml_solve_tri(
-        struct ggml_context * ctx,
-        struct ggml_tensor  * a,
-        struct ggml_tensor  * b,
-        bool                  left,
-        bool                  lower,
-        bool                  uni) {
+struct ggml_tensor * ggml_solve_tri(struct ggml_context * ctx,
+                                    struct ggml_tensor *  a,
+                                    struct ggml_tensor *  b,
+                                    bool                  left,
+                                    bool                  lower,
+                                    bool                  uni) {
     GGML_ASSERT(a->type == GGML_TYPE_F32);
     GGML_ASSERT(b->type == GGML_TYPE_F32);
 
@@ -6084,7 +5568,7 @@ struct ggml_tensor * ggml_solve_tri(
     GGML_ASSERT(ggml_is_contiguous(a));
     GGML_ASSERT(ggml_is_contiguous(b));
 
-    GGML_ASSERT(lower && left && !uni); // TODO: support other variants
+    GGML_ASSERT(lower && left && !uni);  // TODO: support other variants
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, b->ne[0], b->ne[1], b->ne[2], b->ne[3]);
 
@@ -6117,20 +5601,18 @@ void ggml_hash_set_free(struct ggml_hash_set * hash_set) {
 
 size_t ggml_hash_size(size_t min_sz) {
     // next primes after powers of two
-    static const size_t primes[] = {
-        2, 3, 5, 11, 17, 37, 67, 131, 257, 521, 1031,
-        2053, 4099, 8209, 16411, 32771, 65537, 131101,
-        262147, 524309, 1048583, 2097169, 4194319, 8388617,
-        16777259, 33554467, 67108879, 134217757, 268435459,
-        536870923, 1073741827, 2147483659
-    };
-    static const size_t n_primes = sizeof(primes)/sizeof(primes[0]);
+    static const size_t primes[] = { 2,         3,         5,          11,        17,       37,       67,
+                                     131,       257,       521,        1031,      2053,     4099,     8209,
+                                     16411,     32771,     65537,      131101,    262147,   524309,   1048583,
+                                     2097169,   4194319,   8388617,    16777259,  33554467, 67108879, 134217757,
+                                     268435459, 536870923, 1073741827, 2147483659 };
+    static const size_t n_primes = sizeof(primes) / sizeof(primes[0]);
 
     // find the smallest prime that is larger or equal than min_sz
     size_t l = 0;
     size_t r = n_primes;
     while (l < r) {
-        size_t m = (l + r)/2;
+        size_t m = (l + r) / 2;
         if (primes[m] < min_sz) {
             l = m + 1;
         } else {
@@ -6142,14 +5624,14 @@ size_t ggml_hash_size(size_t min_sz) {
 }
 
 struct hash_map {
-    struct ggml_hash_set set;
+    struct ggml_hash_set  set;
     struct ggml_tensor ** vals;
 };
 
 static struct hash_map * ggml_new_hash_map(size_t size) {
     struct hash_map * result = GGML_MALLOC(sizeof(struct hash_map));
-    result->set = ggml_hash_set_new(size);
-    result->vals = GGML_CALLOC(result->set.size, sizeof(struct ggml_tensor *));
+    result->set              = ggml_hash_set_new(size);
+    result->vals             = GGML_CALLOC(result->set.size, sizeof(struct ggml_tensor *));
     return result;
 }
 
@@ -6166,15 +5648,14 @@ static void ggml_hash_map_free(struct hash_map * map) {
 // else if there is no gradient for tensor, set the corresponding value
 // else, just add/subtract/etc. the gradients
 
-static void ggml_add_or_set(
-        struct ggml_context * ctx,
-        struct ggml_cgraph  * cgraph,
-        size_t                isrc,
-        struct ggml_tensor  * tensor) {
+static void ggml_add_or_set(struct ggml_context * ctx,
+                            struct ggml_cgraph *  cgraph,
+                            size_t                isrc,
+                            struct ggml_tensor *  tensor) {
     struct ggml_tensor * src = cgraph->visited_hash_set.keys[isrc];
     GGML_ASSERT(src);
     if (cgraph->grads[isrc]) {
-        cgraph->grads[isrc] = ggml_add_impl(ctx, cgraph->grads[isrc], tensor, /*inplace =*/ cgraph->grad_accs[isrc]);
+        cgraph->grads[isrc] = ggml_add_impl(ctx, cgraph->grads[isrc], tensor, /*inplace =*/cgraph->grad_accs[isrc]);
     } else {
         cgraph->grads[isrc] = tensor;
     }
@@ -6182,32 +5663,32 @@ static void ggml_add_or_set(
     ggml_build_forward_expand(cgraph, cgraph->grads[isrc]);
 }
 
-static void ggml_acc_or_set(
-        struct ggml_context * ctx,
-        struct ggml_cgraph  * cgraph,
-        size_t                isrc,
-        struct ggml_tensor  * tensor,
-        const  size_t         nb1,
-        const  size_t         nb2,
-        const  size_t         nb3,
-        const  size_t         offset) {
+static void ggml_acc_or_set(struct ggml_context * ctx,
+                            struct ggml_cgraph *  cgraph,
+                            size_t                isrc,
+                            struct ggml_tensor *  tensor,
+                            const size_t          nb1,
+                            const size_t          nb2,
+                            const size_t          nb3,
+                            const size_t          offset) {
     struct ggml_tensor * src = cgraph->visited_hash_set.keys[isrc];
     GGML_ASSERT(src);
     if (cgraph->grads[isrc]) {
-        cgraph->grads[isrc] = ggml_acc_impl(ctx, cgraph->grads[isrc], tensor, nb1, nb2, nb3, offset, cgraph->grad_accs[isrc]);
+        cgraph->grads[isrc] =
+            ggml_acc_impl(ctx, cgraph->grads[isrc], tensor, nb1, nb2, nb3, offset, cgraph->grad_accs[isrc]);
     } else {
-        struct ggml_tensor * a_zero = ggml_scale(ctx, src, 0.0f); // FIXME this is going to produce NaN if a contains inf/NaN
+        struct ggml_tensor * a_zero =
+            ggml_scale(ctx, src, 0.0f);  // FIXME this is going to produce NaN if a contains inf/NaN
         cgraph->grads[isrc] = ggml_acc_impl(ctx, a_zero, tensor, nb1, nb2, nb3, offset, false);
     }
     ggml_format_name(cgraph->grads[isrc], "grad for %s", cgraph->visited_hash_set.keys[isrc]->name);
     ggml_build_forward_expand(cgraph, cgraph->grads[isrc]);
 }
 
-static void ggml_add1_or_set(
-        struct ggml_context * ctx,
-        struct ggml_cgraph  * cgraph,
-        size_t                isrc,
-        struct ggml_tensor  * tensor) {
+static void ggml_add1_or_set(struct ggml_context * ctx,
+                             struct ggml_cgraph *  cgraph,
+                             size_t                isrc,
+                             struct ggml_tensor *  tensor) {
     struct ggml_tensor * src = cgraph->visited_hash_set.keys[isrc];
     GGML_ASSERT(src);
     if (cgraph->grads[isrc]) {
@@ -6219,11 +5700,10 @@ static void ggml_add1_or_set(
     ggml_build_forward_expand(cgraph, cgraph->grads[isrc]);
 }
 
-static void ggml_sub_or_set(
-        struct ggml_context * ctx,
-        struct ggml_cgraph  * cgraph,
-        size_t                isrc,
-        struct ggml_tensor  * tensor) {
+static void ggml_sub_or_set(struct ggml_context * ctx,
+                            struct ggml_cgraph *  cgraph,
+                            size_t                isrc,
+                            struct ggml_tensor *  tensor) {
     struct ggml_tensor * src = cgraph->visited_hash_set.keys[isrc];
     GGML_ASSERT(src);
     if (cgraph->grads[isrc]) {
@@ -6235,8 +5715,10 @@ static void ggml_sub_or_set(
     ggml_build_forward_expand(cgraph, cgraph->grads[isrc]);
 }
 
-static void ggml_compute_backward(
-        struct ggml_context * ctx, struct ggml_cgraph * cgraph, int i, const bool * grads_needed) {
+static void ggml_compute_backward(struct ggml_context * ctx,
+                                  struct ggml_cgraph *  cgraph,
+                                  int                   i,
+                                  const bool *          grads_needed) {
     struct ggml_tensor * tensor = cgraph->nodes[i];
     struct ggml_tensor * grad   = ggml_graph_get_grad(cgraph, tensor);
 
@@ -6244,475 +5726,580 @@ static void ggml_compute_backward(
         return;
     }
 
-    struct ggml_tensor * src0 = tensor->src[0];
-    struct ggml_tensor * src1 = tensor->src[1];
-    struct ggml_tensor * src2 = tensor->src[2];
+    struct ggml_tensor *   src0     = tensor->src[0];
+    struct ggml_tensor *   src1     = tensor->src[1];
+    struct ggml_tensor *   src2     = tensor->src[2];
     struct ggml_hash_set * hash_set = &cgraph->visited_hash_set;
-    const size_t isrc0 = src0 ? ggml_hash_find(hash_set, src0) : (size_t) -1;
-    const size_t isrc1 = src1 ? ggml_hash_find(hash_set, src1) : (size_t) -1;
-    const size_t isrc2 = src2 ? ggml_hash_find(hash_set, src2) : (size_t) -1;
-    const bool src0_needs_grads = src0 && isrc0 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc0) && grads_needed[isrc0];
-    const bool src1_needs_grads = src1 && isrc1 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc1) && grads_needed[isrc1];
-    const bool src2_needs_grads = src2 && isrc2 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc2) && grads_needed[isrc2];
+    const size_t           isrc0    = src0 ? ggml_hash_find(hash_set, src0) : (size_t) -1;
+    const size_t           isrc1    = src1 ? ggml_hash_find(hash_set, src1) : (size_t) -1;
+    const size_t           isrc2    = src2 ? ggml_hash_find(hash_set, src2) : (size_t) -1;
+    const bool             src0_needs_grads =
+        src0 && isrc0 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc0) && grads_needed[isrc0];
+    const bool src1_needs_grads =
+        src1 && isrc1 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc1) && grads_needed[isrc1];
+    const bool src2_needs_grads =
+        src2 && isrc2 != GGML_HASHSET_FULL && ggml_bitset_get(hash_set->used, isrc2) && grads_needed[isrc2];
 
     switch (tensor->op) {
-        case GGML_OP_DUP: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, grad);
-            }
-        } break;
-        case GGML_OP_ADD: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, grad);
-            }
-            if (src1_needs_grads) {
-                struct ggml_tensor * tmp = grad;
-                if (!ggml_are_same_shape(src0, src1)) {
-                    tmp = ggml_repeat_back(ctx, tmp, src1);
+        case GGML_OP_DUP:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, grad);
                 }
-                ggml_add_or_set(ctx, cgraph, isrc1, tmp);
             }
-        } break;
-        case GGML_OP_ADD1: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, grad);
-            }
-            if (src1_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc1, ggml_mean(ctx, grad)); // TODO: should probably be sum instead of mean
-            }
-        } break;
-        case GGML_OP_ACC: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, grad);
-            }
-            if (src1_needs_grads) {
-                const size_t nb1    = ((int32_t *) tensor->op_params)[0];
-                const size_t nb2    = ((int32_t *) tensor->op_params)[1];
-                const size_t nb3    = ((int32_t *) tensor->op_params)[2];
-                const size_t offset = ((int32_t *) tensor->op_params)[3];
-
-                struct ggml_tensor * tensor_grad_view = ggml_view_4d(ctx,
-                    grad, src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
-                    nb1, nb2, nb3, offset);
-
-                ggml_add_or_set(ctx, cgraph, isrc1, ggml_reshape(ctx, ggml_cont(ctx, tensor_grad_view), src1));
-            }
-        } break;
-        case GGML_OP_SUB: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, grad);
-            }
-            if (src1_needs_grads) {
-                ggml_sub_or_set(ctx, cgraph, isrc1, grad);
-            }
-        } break;
-        case GGML_OP_MUL: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, src1));
-            }
-            if (src1_needs_grads) {
-                struct ggml_tensor * tmp = ggml_mul(ctx, src0, grad);
-                if (!ggml_are_same_shape(src0, src1)) {
-                    tmp = ggml_repeat_back(ctx, tmp, src1);
+            break;
+        case GGML_OP_ADD:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, grad);
                 }
-                ggml_add_or_set(ctx, cgraph, isrc1, tmp);
-            }
-        } break;
-        case GGML_OP_DIV: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_div(ctx, grad, src1));
-            }
-            if (src1_needs_grads) {
-                ggml_sub_or_set(ctx, cgraph, isrc1, ggml_mul(ctx, grad, ggml_div(ctx, tensor, src1)));
-            }
-        } break;
-        case GGML_OP_SQR: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale(ctx, ggml_mul(ctx, src0, grad), 2.0f));
-            }
-        } break;
-        case GGML_OP_SQRT: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale(ctx, ggml_div(ctx, grad, tensor), 0.5f));
-            }
-        } break;
-        case GGML_OP_LOG: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_div(ctx, grad, src0));
-            }
-        } break;
-        case GGML_OP_SIN: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_cos(ctx, src0)));
-            }
-        } break;
-        case GGML_OP_COS: {
-            if (src0_needs_grads) {
-                ggml_sub_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_sin(ctx, src0)));
-            }
-        } break;
-        case GGML_OP_SUM: {
-            if (src0_needs_grads) {
-                ggml_add1_or_set(ctx, cgraph, isrc0, grad);
-            }
-        } break;
-        case GGML_OP_SUM_ROWS: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat(ctx, grad, src0));
-            }
-        } break;
-        case GGML_OP_MEAN: {
-            if (src0_needs_grads) {
-                ggml_add1_or_set(ctx, cgraph, isrc0, ggml_scale_impl(ctx, grad, 1.0f/src0->ne[0], 0.0, false));
-            }
-        } break;
-        case GGML_OP_REPEAT: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat_back(ctx, grad, src0));
-            }
-        } break;
-        case GGML_OP_REPEAT_BACK: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat(ctx, grad, src0));
-            }
-        } break;
-        case GGML_OP_RMS_NORM: {
-            if (src0_needs_grads) {
-                float eps;
-                memcpy(&eps, tensor->op_params, sizeof(float));
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_rms_norm_back(ctx, grad, src0, eps));
-            }
-        } break;
-        case GGML_OP_MUL_MAT: {
-            // https://cs231n.github.io/optimization-2/#staged
-            // # forward pass
-            // s0 = np.random.randn(5, 10)
-            // s1 = np.random.randn(10, 3)
-            // t = s0.dot(s1)
-
-            // # now suppose we had the gradient on t from above in the circuit
-            // dt = np.random.randn(*t.shape) # same shape as t
-            // ds0 = dt.dot(s1.T) #.T gives the transpose of the matrix
-            // ds1 = t.T.dot(dt)
-
-            // tensor.shape [m,p,qq,rr]
-            // src0.shape   [n,m,q1,r1]
-            // src1.shape   [n,p,qq,rr]
-
-            if (src0_needs_grads) {
-                GGML_ASSERT(grad->ne[2] == src1->ne[2]);
-                GGML_ASSERT(grad->ne[3] == src1->ne[3]);
-                struct ggml_tensor * tmp =
-                    ggml_out_prod(ctx, // [n,m,qq,rr]
-                        src1,          // [n,p,qq,rr]
-                        grad);         // [m,p,qq,rr]
-                if (!ggml_are_same_shape(tmp, src0)) {
-                    GGML_ASSERT(tmp->ne[0] == src0->ne[0]);
-                    GGML_ASSERT(tmp->ne[1] == src0->ne[1]);
-                    GGML_ASSERT(tmp->ne[3] == 1);
-
-                    const int64_t nr2 = tmp->ne[2] / src0->ne[2];
-                    const size_t nb2 = tmp->nb[2] * nr2;
-                    const size_t nb3 = tmp->nb[2];
-
-                    tmp = ggml_view_4d(ctx, tmp, src0->ne[0], src0->ne[1], src0->ne[2], nr2, tmp->nb[1], nb2, nb3, 0);
-                    tmp = ggml_repeat_back(ctx, tmp, src0);
+                if (src1_needs_grads) {
+                    struct ggml_tensor * tmp = grad;
+                    if (!ggml_are_same_shape(src0, src1)) {
+                        tmp = ggml_repeat_back(ctx, tmp, src1);
+                    }
+                    ggml_add_or_set(ctx, cgraph, isrc1, tmp);
                 }
-                ggml_add_or_set(ctx, cgraph, isrc0, tmp);
             }
-            if (src1_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc1,
-                        // ggml_mul_mat(ctx,                   // [n,p,qq,rr]
-                        //     ggml_cont(ctx,                  // [m,n,q1,r1]
-                        //         ggml_transpose(ctx, src0)), // [m,n,q1,r1]
-                        //     grad),                          // [m,p,qq,rr]
+            break;
+        case GGML_OP_ADD1:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, grad);
+                }
+                if (src1_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc1,
+                                    ggml_mean(ctx, grad));  // TODO: should probably be sum instead of mean
+                }
+            }
+            break;
+        case GGML_OP_ACC:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, grad);
+                }
+                if (src1_needs_grads) {
+                    const size_t nb1    = ((int32_t *) tensor->op_params)[0];
+                    const size_t nb2    = ((int32_t *) tensor->op_params)[1];
+                    const size_t nb3    = ((int32_t *) tensor->op_params)[2];
+                    const size_t offset = ((int32_t *) tensor->op_params)[3];
 
-                        // when src0 is bigger than tensor->grad (this is mostly the case in llama),
-                        // avoid transpose of src0, rather transpose smaller tensor->grad
-                        // and then use ggml_out_prod
-                        ggml_out_prod(ctx,      // [n,p,qq,rr]
-                            src0,               // [n,m,q1,r1]
-                            ggml_transpose(ctx, // [p,m,qq,rr]
-                                grad)));        // [m,p,qq,rr]
-            }
-        } break;
-        case GGML_OP_SCALE: {
-            if (src0_needs_grads) {
-                float s;
-                memcpy(&s, tensor->op_params, sizeof(float));
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale_impl(ctx, grad, s, 0.0, false));
-            }
-        } break;
-        case GGML_OP_SET: {
-            const size_t nb1    = ((const int32_t *) tensor->op_params)[0];
-            const size_t nb2    = ((const int32_t *) tensor->op_params)[1];
-            const size_t nb3    = ((const int32_t *) tensor->op_params)[2];
-            const size_t offset = ((const int32_t *) tensor->op_params)[3];
+                    struct ggml_tensor * tensor_grad_view = ggml_view_4d(
+                        ctx, grad, src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], nb1, nb2, nb3, offset);
 
-            struct ggml_tensor * tensor_grad_view = NULL;
-
-            if (src0_needs_grads || src1_needs_grads) {
-                GGML_ASSERT(src0->type == tensor->type);
-                GGML_ASSERT(!cgraph->grads[isrc0] ||                      cgraph->grads[isrc0]->type == grad->type);
-                GGML_ASSERT(!cgraph->grads[isrc1] || !src1_needs_grads || cgraph->grads[isrc1]->type == grad->type);
-
-                tensor_grad_view = ggml_view_4d(ctx,
-                    grad, src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3],
-                    nb1, nb2, nb3, offset);
+                    ggml_add_or_set(ctx, cgraph, isrc1, ggml_reshape(ctx, ggml_cont(ctx, tensor_grad_view), src1));
+                }
             }
+            break;
+        case GGML_OP_SUB:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, grad);
+                }
+                if (src1_needs_grads) {
+                    ggml_sub_or_set(ctx, cgraph, isrc1, grad);
+                }
+            }
+            break;
+        case GGML_OP_MUL:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, src1));
+                }
+                if (src1_needs_grads) {
+                    struct ggml_tensor * tmp = ggml_mul(ctx, src0, grad);
+                    if (!ggml_are_same_shape(src0, src1)) {
+                        tmp = ggml_repeat_back(ctx, tmp, src1);
+                    }
+                    ggml_add_or_set(ctx, cgraph, isrc1, tmp);
+                }
+            }
+            break;
+        case GGML_OP_DIV:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_div(ctx, grad, src1));
+                }
+                if (src1_needs_grads) {
+                    ggml_sub_or_set(ctx, cgraph, isrc1, ggml_mul(ctx, grad, ggml_div(ctx, tensor, src1)));
+                }
+            }
+            break;
+        case GGML_OP_SQR:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale(ctx, ggml_mul(ctx, src0, grad), 2.0f));
+                }
+            }
+            break;
+        case GGML_OP_SQRT:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale(ctx, ggml_div(ctx, grad, tensor), 0.5f));
+                }
+            }
+            break;
+        case GGML_OP_LOG:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_div(ctx, grad, src0));
+                }
+            }
+            break;
+        case GGML_OP_SIN:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_cos(ctx, src0)));
+                }
+            }
+            break;
+        case GGML_OP_COS:
+            {
+                if (src0_needs_grads) {
+                    ggml_sub_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_sin(ctx, src0)));
+                }
+            }
+            break;
+        case GGML_OP_SUM:
+            {
+                if (src0_needs_grads) {
+                    ggml_add1_or_set(ctx, cgraph, isrc0, grad);
+                }
+            }
+            break;
+        case GGML_OP_SUM_ROWS:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat(ctx, grad, src0));
+                }
+            }
+            break;
+        case GGML_OP_MEAN:
+            {
+                if (src0_needs_grads) {
+                    ggml_add1_or_set(ctx, cgraph, isrc0, ggml_scale_impl(ctx, grad, 1.0f / src0->ne[0], 0.0, false));
+                }
+            }
+            break;
+        case GGML_OP_REPEAT:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat_back(ctx, grad, src0));
+                }
+            }
+            break;
+        case GGML_OP_REPEAT_BACK:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_repeat(ctx, grad, src0));
+                }
+            }
+            break;
+        case GGML_OP_RMS_NORM:
+            {
+                if (src0_needs_grads) {
+                    float eps;
+                    memcpy(&eps, tensor->op_params, sizeof(float));
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_rms_norm_back(ctx, grad, src0, eps));
+                }
+            }
+            break;
+        case GGML_OP_MUL_MAT:
+            {
+                // https://cs231n.github.io/optimization-2/#staged
+                // # forward pass
+                // s0 = np.random.randn(5, 10)
+                // s1 = np.random.randn(10, 3)
+                // t = s0.dot(s1)
 
-            if (src0_needs_grads) {
-                struct ggml_tensor * tmp = ggml_neg(ctx, tensor_grad_view);
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_acc_impl(ctx, grad, tmp, nb1, nb2, nb3, offset, false));
-            }
+                // # now suppose we had the gradient on t from above in the circuit
+                // dt = np.random.randn(*t.shape) # same shape as t
+                // ds0 = dt.dot(s1.T) #.T gives the transpose of the matrix
+                // ds1 = s0.T.dot(dt)
 
-            if (src1_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc1, ggml_reshape(ctx, ggml_cont(ctx, tensor_grad_view), src1));
-            }
-        } break;
-        case GGML_OP_CPY: {
-            // cpy overwrites value of src1 by src0 and returns view(src1)
-            // the overwriting is mathematically equivalent to:
-            // tensor = src0 * 1 + src1 * 0
-            if (src0_needs_grads) {
-                // dsrc0 = dtensor * 1
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_reshape(ctx, grad, src0));
-            }
-            if (src1_needs_grads) {
-                // dsrc1 = dtensor * 0 -> noop
-            }
-        } break;
-        case GGML_OP_CONT: {
-            // same as cpy
-            if (src0_needs_grads) {
-                GGML_ASSERT(!cgraph->grads[isrc0] || ggml_is_contiguous(cgraph->grads[isrc0]));
-                GGML_ASSERT(ggml_is_contiguous(grad));
-                GGML_ASSERT(ggml_nelements(tensor) == ggml_nelements(src0));
-                ggml_add_or_set(ctx, cgraph, isrc0,
-                    ggml_are_same_shape(tensor, src0) ? grad : ggml_reshape(ctx, grad, src0));
-            }
-        } break;
-        case GGML_OP_RESHAPE: {
-            if (src0_needs_grads) {
-                struct ggml_tensor * grad_cont = ggml_is_contiguous(grad) ? grad : ggml_cont(ctx, grad);
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_reshape(ctx, grad_cont, src0));
-            }
-        } break;
-        case GGML_OP_VIEW: {
-            if (src0_needs_grads) {
-                size_t offset;
+                // tensor.shape [m,p,qq,rr]
+                // src0.shape   [n,m,q1,r1]
+                // src1.shape   [n,p,qq,rr]
 
-                memcpy(&offset, tensor->op_params, sizeof(offset));
+                if (src0_needs_grads) {
+                    GGML_ASSERT(grad->ne[2] == src1->ne[2]);
+                    GGML_ASSERT(grad->ne[3] == src1->ne[3]);
+                    struct ggml_tensor * tmp = ggml_out_prod(ctx,    // [n,m,qq,rr]
+                                                             src1,   // [n,p,qq,rr]
+                                                             grad);  // [m,p,qq,rr]
+                    if (!ggml_are_same_shape(tmp, src0)) {
+                        GGML_ASSERT(tmp->ne[0] == src0->ne[0]);
+                        GGML_ASSERT(tmp->ne[1] == src0->ne[1]);
+                        GGML_ASSERT(tmp->ne[3] == 1);
 
-                size_t nb1 = tensor->nb[1];
-                size_t nb2 = tensor->nb[2];
-                size_t nb3 = tensor->nb[3];
+                        const int64_t nr2 = tmp->ne[2] / src0->ne[2];
+                        const size_t  nb2 = tmp->nb[2] * nr2;
+                        const size_t  nb3 = tmp->nb[2];
 
-                if (cgraph->grads[isrc0] && src0->type != cgraph->grads[isrc0]->type) {
-                    // gradient is typically F32, but src0 could be other type
-                    size_t ng = ggml_element_size(cgraph->grads[isrc0]);
-                    size_t n0 = ggml_element_size(src0);
-                    GGML_ASSERT(offset % n0 == 0);
-                    GGML_ASSERT(nb1 % n0 == 0);
-                    GGML_ASSERT(nb2 % n0 == 0);
-                    GGML_ASSERT(nb3 % n0 == 0);
-                    offset = (offset / n0) * ng;
-                    nb1 = (nb1 / n0) * ng;
-                    nb2 = (nb2 / n0) * ng;
-                    nb3 = (nb3 / n0) * ng;
+                        tmp =
+                            ggml_view_4d(ctx, tmp, src0->ne[0], src0->ne[1], src0->ne[2], nr2, tmp->nb[1], nb2, nb3, 0);
+                        tmp = ggml_repeat_back(ctx, tmp, src0);
+                    }
+                    ggml_add_or_set(ctx, cgraph, isrc0, tmp);
+                }
+                if (src1_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc1,
+                                    // ggml_mul_mat(ctx,                   // [n,p,qq,rr]
+                                    //     ggml_cont(ctx,                  // [m,n,q1,r1]
+                                    //         ggml_transpose(ctx, src0)), // [m,n,q1,r1]
+                                    //     grad),                          // [m,p,qq,rr]
+
+                                    // when src0 is bigger than tensor->grad (this is mostly the case in llama),
+                                    // avoid transpose of src0, rather transpose smaller tensor->grad
+                                    // and then use ggml_out_prod
+                                    ggml_out_prod(ctx,                     // [n,p,qq,rr]
+                                                  src0,                    // [n,m,q1,r1]
+                                                  ggml_transpose(ctx,      // [p,m,qq,rr]
+                                                                 grad)));  // [m,p,qq,rr]
+                }
+            }
+            break;
+        case GGML_OP_SCALE:
+            {
+                if (src0_needs_grads) {
+                    float s;
+                    memcpy(&s, tensor->op_params, sizeof(float));
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_scale_impl(ctx, grad, s, 0.0, false));
+                }
+            }
+            break;
+        case GGML_OP_SET:
+            {
+                const size_t nb1    = ((const int32_t *) tensor->op_params)[0];
+                const size_t nb2    = ((const int32_t *) tensor->op_params)[1];
+                const size_t nb3    = ((const int32_t *) tensor->op_params)[2];
+                const size_t offset = ((const int32_t *) tensor->op_params)[3];
+
+                struct ggml_tensor * tensor_grad_view = NULL;
+
+                if (src0_needs_grads || src1_needs_grads) {
+                    GGML_ASSERT(src0->type == tensor->type);
+                    GGML_ASSERT(!cgraph->grads[isrc0] || cgraph->grads[isrc0]->type == grad->type);
+                    GGML_ASSERT(!cgraph->grads[isrc1] || !src1_needs_grads || cgraph->grads[isrc1]->type == grad->type);
+
+                    tensor_grad_view = ggml_view_4d(ctx, grad, src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], nb1,
+                                                    nb2, nb3, offset);
                 }
 
-                ggml_acc_or_set(ctx, cgraph, isrc0, grad, nb1, nb2, nb3, offset);
-            }
-        } break;
-        case GGML_OP_PERMUTE: {
-            if (src0_needs_grads) {
-                const int32_t * axes = (const int32_t *) tensor->op_params;
-                const int axis0 = axes[0] & 0x3;
-                const int axis1 = axes[1] & 0x3;
-                const int axis2 = axes[2] & 0x3;
-                const int axis3 = axes[3] & 0x3;
-                int axb[4] = {0,0,0,0}; // axes backward
-                axb[axis0] = 0;
-                axb[axis1] = 1;
-                axb[axis2] = 2;
-                axb[axis3] = 3;
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_permute(ctx, grad, axb[0], axb[1], axb[2], axb[3]));
-            }
-        } break;
-        case GGML_OP_TRANSPOSE: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_transpose(ctx, grad));
-            }
-        } break;
-        case GGML_OP_GET_ROWS: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_get_rows_back(ctx, grad, src1, src0));
-            }
-            if (src1_needs_grads) {
-                // noop
-            }
-        } break;
-        case GGML_OP_DIAG_MASK_INF: {
-            if (src0_needs_grads) {
-                /* ggml_diag_mask_inf_impl() shouldn't be here */
-                /* ref:  https://github.com/ggerganov/llama.cpp/pull/4203#discussion_r1412377992 */
-                const int n_past = ((const int32_t *) tensor->op_params)[0];
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_diag_mask_zero_impl(ctx, grad, n_past, false));
-            }
-        } break;
-        case GGML_OP_DIAG_MASK_ZERO: {
-            if (src0_needs_grads) {
-                const int n_past = ((const int32_t *) tensor->op_params)[0];
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_diag_mask_zero_impl(ctx, grad, n_past, false));
-            }
-        } break;
-        case GGML_OP_SOFT_MAX: {
-            if (src0_needs_grads) {
-                float scale    = 1.0f;
-                float max_bias = 0.0f;
+                if (src0_needs_grads) {
+                    struct ggml_tensor * tmp = ggml_neg(ctx, tensor_grad_view);
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_acc_impl(ctx, grad, tmp, nb1, nb2, nb3, offset, false));
+                }
 
-                memcpy(&scale,    (const float *) tensor->op_params + 0, sizeof(float));
-                memcpy(&max_bias, (const float *) tensor->op_params + 1, sizeof(float));
-
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_soft_max_ext_back(ctx, grad, tensor, scale, max_bias));
+                if (src1_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc1, ggml_reshape(ctx, ggml_cont(ctx, tensor_grad_view), src1));
+                }
             }
-            GGML_ASSERT((!src1 || !src1_needs_grads) && "backward pass for softmax mask not implemented");
-        } break;
-        case GGML_OP_ROPE: {
-            if (src0_needs_grads) {
-                //const int n_past = ((int32_t *) tensor->op_params)[0];
-                const int n_dims     = ((const int32_t *) tensor->op_params)[1];
-                const int mode       = ((const int32_t *) tensor->op_params)[2];
-                //const int n_ctx      = ((int32_t *) tensor->op_params)[3];
-                const int n_ctx_orig = ((const int32_t *) tensor->op_params)[4];
-                float freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow;
-                int sections[4] = {0, 0, 0, 0};
-
-                memcpy(&freq_base,   (const float *) tensor->op_params +  5, sizeof(float));
-                memcpy(&freq_scale,  (const float *) tensor->op_params +  6, sizeof(float));
-                memcpy(&ext_factor,  (const float *) tensor->op_params +  7, sizeof(float));
-                memcpy(&attn_factor, (const float *) tensor->op_params +  8, sizeof(float));
-                memcpy(&beta_fast,   (const float *) tensor->op_params +  9, sizeof(float));
-                memcpy(&beta_slow,   (const float *) tensor->op_params + 10, sizeof(float));
-                memcpy(&sections,                    tensor->op_params + 11, sizeof(sections));
-
-                struct ggml_tensor * rope_back = grad->ne[2] == src1->ne[0] ?
-                    ggml_rope_ext_back(ctx, grad, src1, src2, n_dims,
-                        mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow) :
-                    ggml_rope_multi_back(ctx, grad, src1, src2, n_dims, sections,
-                        mode, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
-                ggml_add_or_set(ctx, cgraph, isrc0, rope_back);
+            break;
+        case GGML_OP_CPY:
+            {
+                // cpy overwrites value of src1 by src0 and returns view(src1)
+                // the overwriting is mathematically equivalent to:
+                // tensor = src0 * 1 + src1 * 0
+                if (src0_needs_grads) {
+                    // dsrc0 = dtensor * 1
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_reshape(ctx, grad, src0));
+                }
+                if (src1_needs_grads) {
+                    // dsrc1 = dtensor * 0 -> noop
+                }
             }
-            GGML_ASSERT((!src2 || !src2_needs_grads) && "gradients for freq factors not implemented");
-        } break;
-        case GGML_OP_IM2COL: {
-            if (src1_needs_grads) {
-                const int32_t s0    = ggml_get_op_params_i32(tensor, 0);
-                const int32_t s1    = ggml_get_op_params_i32(tensor, 1);
-                const int32_t p0    = ggml_get_op_params_i32(tensor, 2);
-                const int32_t p1    = ggml_get_op_params_i32(tensor, 3);
-                const int32_t d0    = ggml_get_op_params_i32(tensor, 4);
-                const int32_t d1    = ggml_get_op_params_i32(tensor, 5);
-                const bool    is_2D = ggml_get_op_params_i32(tensor, 6) == 1;
-
-                ggml_add_or_set(ctx, cgraph, isrc1, ggml_im2col_back(ctx, grad, src0, src1->ne, s0, s1, p0, p1, d0, d1, is_2D));
+            break;
+        case GGML_OP_CONT:
+            {
+                // same as cpy
+                if (src0_needs_grads) {
+                    GGML_ASSERT(!cgraph->grads[isrc0] || ggml_is_contiguous(cgraph->grads[isrc0]));
+                    GGML_ASSERT(ggml_is_contiguous(grad));
+                    GGML_ASSERT(ggml_nelements(tensor) == ggml_nelements(src0));
+                    ggml_add_or_set(ctx, cgraph, isrc0,
+                                    ggml_are_same_shape(tensor, src0) ? grad : ggml_reshape(ctx, grad, src0));
+                }
             }
-        } break;
-        case GGML_OP_POOL_2D: {
-            if (src0_needs_grads) {
-                const enum ggml_op_pool op = ggml_get_op_params_i32(tensor, 0);
-                const      int32_t      k0 = ggml_get_op_params_i32(tensor, 1);
-                const      int32_t      k1 = ggml_get_op_params_i32(tensor, 2);
-                const      int32_t      s0 = ggml_get_op_params_i32(tensor, 3);
-                const      int32_t      s1 = ggml_get_op_params_i32(tensor, 4);
-                const      int32_t      p0 = ggml_get_op_params_i32(tensor, 5);
-                const      int32_t      p1 = ggml_get_op_params_i32(tensor, 6);
-
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_pool_2d_back(ctx, grad, src0, op, k0, k1, s0, s1, p0, p1));
+            break;
+        case GGML_OP_RESHAPE:
+            {
+                if (src0_needs_grads) {
+                    struct ggml_tensor * grad_cont = ggml_is_contiguous(grad) ? grad : ggml_cont(ctx, grad);
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_reshape(ctx, grad_cont, src0));
+                }
             }
-        } break;
+            break;
+        case GGML_OP_VIEW:
+            {
+                if (src0_needs_grads) {
+                    size_t offset;
+
+                    memcpy(&offset, tensor->op_params, sizeof(offset));
+
+                    size_t nb1 = tensor->nb[1];
+                    size_t nb2 = tensor->nb[2];
+                    size_t nb3 = tensor->nb[3];
+
+                    if (cgraph->grads[isrc0] && src0->type != cgraph->grads[isrc0]->type) {
+                        // gradient is typically F32, but src0 could be other type
+                        size_t ng = ggml_element_size(cgraph->grads[isrc0]);
+                        size_t n0 = ggml_element_size(src0);
+                        GGML_ASSERT(offset % n0 == 0);
+                        GGML_ASSERT(nb1 % n0 == 0);
+                        GGML_ASSERT(nb2 % n0 == 0);
+                        GGML_ASSERT(nb3 % n0 == 0);
+                        offset = (offset / n0) * ng;
+                        nb1    = (nb1 / n0) * ng;
+                        nb2    = (nb2 / n0) * ng;
+                        nb3    = (nb3 / n0) * ng;
+                    }
+
+                    ggml_acc_or_set(ctx, cgraph, isrc0, grad, nb1, nb2, nb3, offset);
+                }
+            }
+            break;
+        case GGML_OP_PERMUTE:
+            {
+                if (src0_needs_grads) {
+                    const int32_t * axes   = (const int32_t *) tensor->op_params;
+                    const int       axis0  = axes[0] & 0x3;
+                    const int       axis1  = axes[1] & 0x3;
+                    const int       axis2  = axes[2] & 0x3;
+                    const int       axis3  = axes[3] & 0x3;
+                    int             axb[4] = { 0, 0, 0, 0 };  // axes backward
+                    axb[axis0]             = 0;
+                    axb[axis1]             = 1;
+                    axb[axis2]             = 2;
+                    axb[axis3]             = 3;
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_permute(ctx, grad, axb[0], axb[1], axb[2], axb[3]));
+                }
+            }
+            break;
+        case GGML_OP_TRANSPOSE:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_transpose(ctx, grad));
+                }
+            }
+            break;
+        case GGML_OP_GET_ROWS:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_get_rows_back(ctx, grad, src1, src0));
+                }
+                if (src1_needs_grads) {
+                    // noop
+                }
+            }
+            break;
+        case GGML_OP_DIAG_MASK_INF:
+            {
+                if (src0_needs_grads) {
+                    /* ggml_diag_mask_inf_impl() shouldn't be here */
+                    /* ref:  https://github.com/ggerganov/llama.cpp/pull/4203#discussion_r1412377992 */
+                    const int n_past = ((const int32_t *) tensor->op_params)[0];
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_diag_mask_zero_impl(ctx, grad, n_past, false));
+                }
+            }
+            break;
+        case GGML_OP_DIAG_MASK_ZERO:
+            {
+                if (src0_needs_grads) {
+                    const int n_past = ((const int32_t *) tensor->op_params)[0];
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_diag_mask_zero_impl(ctx, grad, n_past, false));
+                }
+            }
+            break;
+        case GGML_OP_SOFT_MAX:
+            {
+                if (src0_needs_grads) {
+                    float scale    = 1.0f;
+                    float max_bias = 0.0f;
+
+                    memcpy(&scale, (const float *) tensor->op_params + 0, sizeof(float));
+                    memcpy(&max_bias, (const float *) tensor->op_params + 1, sizeof(float));
+
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_soft_max_ext_back(ctx, grad, tensor, scale, max_bias));
+                }
+                GGML_ASSERT((!src1 || !src1_needs_grads) && "backward pass for softmax mask not implemented");
+            }
+            break;
+        case GGML_OP_ROPE:
+            {
+                if (src0_needs_grads) {
+                    //const int n_past = ((int32_t *) tensor->op_params)[0];
+                    const int n_dims     = ((const int32_t *) tensor->op_params)[1];
+                    const int mode       = ((const int32_t *) tensor->op_params)[2];
+                    //const int n_ctx      = ((int32_t *) tensor->op_params)[3];
+                    const int n_ctx_orig = ((const int32_t *) tensor->op_params)[4];
+                    float     freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow;
+                    int       sections[4] = { 0, 0, 0, 0 };
+
+                    memcpy(&freq_base, (const float *) tensor->op_params + 5, sizeof(float));
+                    memcpy(&freq_scale, (const float *) tensor->op_params + 6, sizeof(float));
+                    memcpy(&ext_factor, (const float *) tensor->op_params + 7, sizeof(float));
+                    memcpy(&attn_factor, (const float *) tensor->op_params + 8, sizeof(float));
+                    memcpy(&beta_fast, (const float *) tensor->op_params + 9, sizeof(float));
+                    memcpy(&beta_slow, (const float *) tensor->op_params + 10, sizeof(float));
+                    memcpy(&sections, tensor->op_params + 11, sizeof(sections));
+
+                    struct ggml_tensor * rope_back =
+                        grad->ne[2] == src1->ne[0] ?
+                            ggml_rope_ext_back(ctx, grad, src1, src2, n_dims, mode, n_ctx_orig, freq_base, freq_scale,
+                                               ext_factor, attn_factor, beta_fast, beta_slow) :
+                            ggml_rope_multi_back(ctx, grad, src1, src2, n_dims, sections, mode, n_ctx_orig, freq_base,
+                                                 freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+                    ggml_add_or_set(ctx, cgraph, isrc0, rope_back);
+                }
+                GGML_ASSERT((!src2 || !src2_needs_grads) && "gradients for freq factors not implemented");
+            }
+            break;
+        case GGML_OP_IM2COL:
+            {
+                if (src1_needs_grads) {
+                    const int32_t s0    = ggml_get_op_params_i32(tensor, 0);
+                    const int32_t s1    = ggml_get_op_params_i32(tensor, 1);
+                    const int32_t p0    = ggml_get_op_params_i32(tensor, 2);
+                    const int32_t p1    = ggml_get_op_params_i32(tensor, 3);
+                    const int32_t d0    = ggml_get_op_params_i32(tensor, 4);
+                    const int32_t d1    = ggml_get_op_params_i32(tensor, 5);
+                    const bool    is_2D = ggml_get_op_params_i32(tensor, 6) == 1;
+
+                    ggml_add_or_set(ctx, cgraph, isrc1,
+                                    ggml_im2col_back(ctx, grad, src0, src1->ne, s0, s1, p0, p1, d0, d1, is_2D));
+                }
+            }
+            break;
+        case GGML_OP_POOL_2D:
+            {
+                if (src0_needs_grads) {
+                    const enum ggml_op_pool op = ggml_get_op_params_i32(tensor, 0);
+                    const int32_t           k0 = ggml_get_op_params_i32(tensor, 1);
+                    const int32_t           k1 = ggml_get_op_params_i32(tensor, 2);
+                    const int32_t           s0 = ggml_get_op_params_i32(tensor, 3);
+                    const int32_t           s1 = ggml_get_op_params_i32(tensor, 4);
+                    const int32_t           p0 = ggml_get_op_params_i32(tensor, 5);
+                    const int32_t           p1 = ggml_get_op_params_i32(tensor, 6);
+
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_pool_2d_back(ctx, grad, src0, op, k0, k1, s0, s1, p0, p1));
+                }
+            }
+            break;
         case GGML_OP_WIN_PART:
         case GGML_OP_WIN_UNPART:
-        case GGML_OP_UNARY: {
-            switch (ggml_get_unary_op(tensor)) {
-                case GGML_UNARY_OP_ABS: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, ggml_sgn(ctx, src0), grad));
-                    }
-                } break;
-                case GGML_UNARY_OP_SGN: {
-                    // noop
-                } break;
-                case GGML_UNARY_OP_NEG: {
-                    if (src0_needs_grads) {
-                        ggml_sub_or_set(ctx, cgraph, isrc0, grad);
-                    }
-                } break;
-                case GGML_UNARY_OP_STEP: {
-                    // noop
-                } break;
-                case GGML_UNARY_OP_RELU: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, ggml_step(ctx, src0), grad));
-                    }
-                } break;
-                case GGML_UNARY_OP_SILU: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_silu_back(ctx, grad, src0));
-                    }
-                } break;
-                case GGML_UNARY_OP_EXP: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, tensor, grad));
-                    }
-                } break;
-                case GGML_UNARY_OP_EXPM1: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_exp(ctx, src0)));
-                    }
-                } break;
-                case GGML_UNARY_OP_SOFTPLUS: {
-                    if (src0_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_sigmoid(ctx, src0)));
-                    }
-                } break;
-                default: {
-                    fprintf(stderr, "%s: unsupported unary op for backward pass: %s\n",
-                        __func__, ggml_unary_op_name(ggml_get_unary_op(tensor)));
-                    GGML_ABORT("fatal error");
-                } //break;
+        case GGML_OP_UNARY:
+            {
+                switch (ggml_get_unary_op(tensor)) {
+                    case GGML_UNARY_OP_ABS:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, ggml_sgn(ctx, src0), grad));
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_SGN:
+                        {
+                            // noop
+                        }
+                        break;
+                    case GGML_UNARY_OP_NEG:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_sub_or_set(ctx, cgraph, isrc0, grad);
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_STEP:
+                        {
+                            // noop
+                        }
+                        break;
+                    case GGML_UNARY_OP_RELU:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, ggml_step(ctx, src0), grad));
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_SILU:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_silu_back(ctx, grad, src0));
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_EXP:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, tensor, grad));
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_EXPM1:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_exp(ctx, src0)));
+                            }
+                        }
+                        break;
+                    case GGML_UNARY_OP_SOFTPLUS:
+                        {
+                            if (src0_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc0, ggml_mul(ctx, grad, ggml_sigmoid(ctx, src0)));
+                            }
+                        }
+                        break;
+                    default:
+                        {
+                            fprintf(stderr, "%s: unsupported unary op for backward pass: %s\n", __func__,
+                                    ggml_unary_op_name(ggml_get_unary_op(tensor)));
+                            GGML_ABORT("fatal error");
+                        }  //break;
+                }
             }
-        } break;
-        case GGML_OP_CROSS_ENTROPY_LOSS: {
-            if (src0_needs_grads) {
-                ggml_add_or_set(ctx, cgraph, isrc0, ggml_cross_entropy_loss_back(ctx, grad, src0, src1));
+            break;
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            {
+                if (src0_needs_grads) {
+                    ggml_add_or_set(ctx, cgraph, isrc0, ggml_cross_entropy_loss_back(ctx, grad, src0, src1));
+                }
+                GGML_ASSERT(!src1_needs_grads && "backward pass for labels not implemented");
             }
-            GGML_ASSERT(!src1_needs_grads && "backward pass for labels not implemented");
-        } break;
-        case GGML_OP_GLU: {
-            switch (ggml_get_glu_op(tensor)) {
-                case GGML_GLU_OP_SWIGLU: {
-                    if (src0_needs_grads) {
-                        GGML_ASSERT(src1 && "backward pass only implemented for split swiglu");
-                        ggml_add_or_set(ctx, cgraph, isrc0, ggml_silu_back(ctx, ggml_mul(ctx, grad, src1), src0));
-                    }
-                    if (src1_needs_grads) {
-                        ggml_add_or_set(ctx, cgraph, isrc1, ggml_mul(ctx, ggml_silu(ctx, src0), grad));
-                    }
-                } break;
-                default: {
-                    GGML_ABORT("unsupported glu op for backward pass: %s", ggml_glu_op_name(ggml_get_glu_op(tensor)));
-                } //break;
+            break;
+        case GGML_OP_GLU:
+            {
+                switch (ggml_get_glu_op(tensor)) {
+                    case GGML_GLU_OP_SWIGLU:
+                        {
+                            if (src0_needs_grads) {
+                                GGML_ASSERT(src1 && "backward pass only implemented for split swiglu");
+                                ggml_add_or_set(ctx, cgraph, isrc0,
+                                                ggml_silu_back(ctx, ggml_mul(ctx, grad, src1), src0));
+                            }
+                            if (src1_needs_grads) {
+                                ggml_add_or_set(ctx, cgraph, isrc1, ggml_mul(ctx, ggml_silu(ctx, src0), grad));
+                            }
+                        }
+                        break;
+                    default:
+                        {
+                            GGML_ABORT("unsupported glu op for backward pass: %s",
+                                       ggml_glu_op_name(ggml_get_glu_op(tensor)));
+                        }  //break;
+                }
             }
-        } break;
-        case GGML_OP_NONE: {
-            // noop
-        } break;
+            break;
+        case GGML_OP_NONE:
+            {
+                // noop
+            }
+            break;
         case GGML_OP_COUNT:
-        default: {
-            GGML_ABORT("%s: unsupported ggml op for backward pass: %s\n", __func__, ggml_op_name(tensor->op));
-        } //break;
+        default:
+            {
+                GGML_ABORT("%s: unsupported ggml op for backward pass: %s\n", __func__, ggml_op_name(tensor->op));
+            }  //break;
     }
 
     GGML_ASSERT(!src0_needs_grads || ggml_are_same_shape(src0, cgraph->grads[isrc0]));
@@ -6737,8 +6324,8 @@ static size_t ggml_visit_parents(struct ggml_cgraph * cgraph, struct ggml_tensor
     for (int i = 0; i < GGML_MAX_SRC; ++i) {
         const int k =
             (cgraph->order == GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT) ? i :
-            (cgraph->order == GGML_CGRAPH_EVAL_ORDER_RIGHT_TO_LEFT) ? (GGML_MAX_SRC-1-i) :
-            /* unknown order, just fall back to using i */ i;
+            (cgraph->order == GGML_CGRAPH_EVAL_ORDER_RIGHT_TO_LEFT) ? (GGML_MAX_SRC - 1 - i) :
+                                                                      /* unknown order, just fall back to using i */ i;
 
         struct ggml_tensor * src = node->src[k];
         if (src) {
@@ -6796,18 +6383,17 @@ void ggml_build_forward_expand(struct ggml_cgraph * cgraph, struct ggml_tensor *
     ggml_build_forward_impl(cgraph, tensor, true);
 }
 
-void ggml_build_backward_expand(
-        struct ggml_context *  ctx,
-        struct ggml_cgraph  *  cgraph,
-        struct ggml_tensor  ** grad_accs) {
+void ggml_build_backward_expand(struct ggml_context * ctx,
+                                struct ggml_cgraph *  cgraph,
+                                struct ggml_tensor ** grad_accs) {
     GGML_ASSERT(cgraph->n_nodes > 0);
     GGML_ASSERT(cgraph->grads);
     GGML_ASSERT(cgraph->grad_accs);
 
     const int n_nodes_f = cgraph->n_nodes;
 
-    memset(cgraph->grads,     0, cgraph->visited_hash_set.size*sizeof(struct ggml_tensor *));
-    memset(cgraph->grad_accs, 0, cgraph->visited_hash_set.size*sizeof(struct ggml_tensor *));
+    memset(cgraph->grads, 0, cgraph->visited_hash_set.size * sizeof(struct ggml_tensor *));
+    memset(cgraph->grad_accs, 0, cgraph->visited_hash_set.size * sizeof(struct ggml_tensor *));
     bool * grads_needed = calloc(cgraph->visited_hash_set.size, sizeof(bool));
 
     {
@@ -6815,8 +6401,8 @@ void ggml_build_backward_expand(
         bool any_loss   = false;
         for (int i = 0; i < n_nodes_f; ++i) {
             struct ggml_tensor * node = cgraph->nodes[i];
-            any_params = any_params || (node->flags & GGML_TENSOR_FLAG_PARAM);
-            any_loss   = any_loss   || (node->flags & GGML_TENSOR_FLAG_LOSS);
+            any_params                = any_params || (node->flags & GGML_TENSOR_FLAG_PARAM);
+            any_loss                  = any_loss || (node->flags & GGML_TENSOR_FLAG_LOSS);
         }
         GGML_ASSERT(any_params && "no trainable parameters found, did you forget to call ggml_set_param?");
         GGML_ASSERT(any_loss && "no training loss found, did you forget to call ggml_set_loss?");
@@ -6829,27 +6415,29 @@ void ggml_build_backward_expand(
             continue;
         }
 
-        bool node_needs_grad = (node->flags & GGML_TENSOR_FLAG_PARAM) || (node->flags & GGML_TENSOR_FLAG_LOSS);
-        bool ignore_src[GGML_MAX_SRC] = {false};
+        bool node_needs_grad          = (node->flags & GGML_TENSOR_FLAG_PARAM) || (node->flags & GGML_TENSOR_FLAG_LOSS);
+        bool ignore_src[GGML_MAX_SRC] = { false };
         switch (node->op) {
             // gradients in node->src[0] for one reason or another have no effect on output gradients
-            case GGML_OP_IM2COL:      // only used for its shape
-            case GGML_OP_IM2COL_BACK: // same as IM2COL
+            case GGML_OP_IM2COL:       // only used for its shape
+            case GGML_OP_IM2COL_BACK:  // same as IM2COL
                 ignore_src[0] = true;
                 break;
-            case GGML_OP_UNARY: {
-                const enum ggml_unary_op uop = ggml_get_unary_op(node);
-                // SGN and STEP unary ops are piecewise constant
-                if (uop == GGML_UNARY_OP_SGN || uop == GGML_UNARY_OP_STEP) {
-                    ignore_src[0] = true;
+            case GGML_OP_UNARY:
+                {
+                    const enum ggml_unary_op uop = ggml_get_unary_op(node);
+                    // SGN and STEP unary ops are piecewise constant
+                    if (uop == GGML_UNARY_OP_SGN || uop == GGML_UNARY_OP_STEP) {
+                        ignore_src[0] = true;
+                    }
                 }
-            } break;
+                break;
 
             // gradients in node->src[1] for one reason or another have no effect on output gradients
-            case GGML_OP_CPY:           // gradients in CPY target are irrelevant
-            case GGML_OP_GET_ROWS:      // row indices not differentiable
-            case GGML_OP_GET_ROWS_BACK: // same as for GET_ROWS
-            case GGML_OP_ROPE:          // positions not differentiable
+            case GGML_OP_CPY:            // gradients in CPY target are irrelevant
+            case GGML_OP_GET_ROWS:       // row indices not differentiable
+            case GGML_OP_GET_ROWS_BACK:  // same as for GET_ROWS
+            case GGML_OP_ROPE:           // positions not differentiable
                 ignore_src[1] = true;
                 break;
 
@@ -6857,7 +6445,8 @@ void ggml_build_backward_expand(
                 break;
         }
         for (int j = 0; j < GGML_MAX_SRC; ++j) {
-            if (!node->src[j] || ignore_src[j] || !grads_needed[ggml_hash_find(&cgraph->visited_hash_set, node->src[j])]) {
+            if (!node->src[j] || ignore_src[j] ||
+                !grads_needed[ggml_hash_find(&cgraph->visited_hash_set, node->src[j])]) {
                 continue;
             }
             GGML_ASSERT(node->src[j]->type == GGML_TYPE_F32 || node->src[j]->type == GGML_TYPE_F16);
@@ -6870,7 +6459,7 @@ void ggml_build_backward_expand(
 
         // inplace operations are currently not supported
         GGML_ASSERT(!node->view_src || node->op == GGML_OP_CPY || node->op == GGML_OP_VIEW ||
-            node->op == GGML_OP_RESHAPE || node->op == GGML_OP_PERMUTE || node->op == GGML_OP_TRANSPOSE);
+                    node->op == GGML_OP_RESHAPE || node->op == GGML_OP_PERMUTE || node->op == GGML_OP_TRANSPOSE);
 
         const size_t ihash = ggml_hash_find(&cgraph->visited_hash_set, node);
         GGML_ASSERT(ihash != GGML_HASHSET_FULL);
@@ -6897,22 +6486,22 @@ void ggml_build_backward_expand(
 
 static void * incr_ptr_aligned(void ** p, size_t size, size_t align) {
     void * ptr = *p;
-    ptr = (void *) GGML_PAD((uintptr_t) ptr, align);
-    *p = (void *) ((char *) ptr + size);
+    ptr        = (void *) GGML_PAD((uintptr_t) ptr, align);
+    *p         = (void *) ((char *) ptr + size);
     return ptr;
 }
 
 static size_t ggml_graph_nbytes(size_t size, bool grads) {
     size_t hash_size = ggml_hash_size(size * 2);
-    void * p = 0;
+    void * p         = 0;
     incr_ptr_aligned(&p, sizeof(struct ggml_cgraph), 1);
-    incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)); // nodes
-    incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)); // leafs
-    incr_ptr_aligned(&p, hash_size * sizeof(int32_t), sizeof(int32_t)); // use_counts
-    incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)); // hash keys
+    incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));           // nodes
+    incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));           // leafs
+    incr_ptr_aligned(&p, hash_size * sizeof(int32_t), sizeof(int32_t));                                // use_counts
+    incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));      // hash keys
     if (grads) {
-        incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)); // grads
-        incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)); // grad_accs
+        incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));  // grads
+        incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));  // grad_accs
     }
     incr_ptr_aligned(&p, ggml_bitset_size(hash_size) * sizeof(ggml_bitset_t), sizeof(ggml_bitset_t));
 
@@ -6929,44 +6518,51 @@ size_t ggml_graph_overhead(void) {
 }
 
 struct ggml_cgraph * ggml_new_graph_custom(struct ggml_context * ctx, size_t size, bool grads) {
-    const size_t obj_size = ggml_graph_nbytes(size, grads);
-    struct ggml_object * obj = ggml_new_object(ctx, GGML_OBJECT_TYPE_GRAPH, obj_size);
-    struct ggml_cgraph * cgraph = (struct ggml_cgraph *) ((char *) ctx->mem_buffer + obj->offs);
+    const size_t         obj_size = ggml_graph_nbytes(size, grads);
+    struct ggml_object * obj      = ggml_new_object(ctx, GGML_OBJECT_TYPE_GRAPH, obj_size);
+    struct ggml_cgraph * cgraph   = (struct ggml_cgraph *) ((char *) ctx->mem_buffer + obj->offs);
 
     // the size of the hash table is doubled since it needs to hold both nodes and leafs
     size_t hash_size = ggml_hash_size(size * 2);
 
     void * p = cgraph + 1;
 
-    struct ggml_tensor ** nodes_ptr      =         incr_ptr_aligned(&p, size      * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
-    struct ggml_tensor ** leafs_ptr      =         incr_ptr_aligned(&p, size      * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
-    int32_t             * use_counts_ptr =         incr_ptr_aligned(&p, hash_size * sizeof(int32_t), sizeof(int32_t));
-    struct ggml_tensor ** hash_keys_ptr  =         incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
-    struct ggml_tensor ** grads_ptr      = grads ? incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)) : NULL;
-    struct ggml_tensor ** grad_accs_ptr  = grads ? incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)) : NULL;
+    struct ggml_tensor ** nodes_ptr =
+        incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
+    struct ggml_tensor ** leafs_ptr =
+        incr_ptr_aligned(&p, size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
+    int32_t *             use_counts_ptr = incr_ptr_aligned(&p, hash_size * sizeof(int32_t), sizeof(int32_t));
+    struct ggml_tensor ** hash_keys_ptr =
+        incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *));
+    struct ggml_tensor ** grads_ptr =
+        grads ? incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)) : NULL;
+    struct ggml_tensor ** grad_accs_ptr =
+        grads ? incr_ptr_aligned(&p, hash_size * sizeof(struct ggml_tensor *), sizeof(struct ggml_tensor *)) : NULL;
 
-    ggml_bitset_t * hash_used = incr_ptr_aligned(&p, ggml_bitset_size(hash_size) * sizeof(ggml_bitset_t), sizeof(ggml_bitset_t));
+    ggml_bitset_t * hash_used =
+        incr_ptr_aligned(&p, ggml_bitset_size(hash_size) * sizeof(ggml_bitset_t), sizeof(ggml_bitset_t));
 
     // check that we allocated the correct amount of memory
-    assert(obj_size == (size_t)((char *)p - (char *)cgraph));
+    assert(obj_size == (size_t) ((char *) p - (char *) cgraph));
 
     *cgraph = (struct ggml_cgraph) {
-        /*.size         =*/ size,
-        /*.n_nodes      =*/ 0,
-        /*.n_leafs      =*/ 0,
-        /*.nodes        =*/ nodes_ptr,
-        /*.grads        =*/ grads_ptr,
-        /*.grad_accs    =*/ grad_accs_ptr,
-        /*.leafs        =*/ leafs_ptr,
-        /*.use_counts   =*/ use_counts_ptr,
-        /*.hash_table   =*/ { hash_size, hash_used, hash_keys_ptr },
-        /*.order        =*/ GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT,
+        /*.size         =*/size,
+        /*.n_nodes      =*/0,
+        /*.n_leafs      =*/0,
+        /*.nodes        =*/nodes_ptr,
+        /*.grads        =*/grads_ptr,
+        /*.grad_accs    =*/grad_accs_ptr,
+        /*.leafs        =*/leafs_ptr,
+        /*.use_counts   =*/use_counts_ptr,
+        /*.hash_table   =*/{ hash_size, hash_used, hash_keys_ptr },
+        /*.order        =*/
+        GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT,
     };
 
     ggml_hash_set_reset(&cgraph->visited_hash_set);
     if (grads) {
-        memset(cgraph->grads,     0, hash_size*sizeof(struct ggml_tensor *));
-        memset(cgraph->grad_accs, 0, hash_size*sizeof(struct ggml_tensor *));
+        memset(cgraph->grads, 0, hash_size * sizeof(struct ggml_tensor *));
+        memset(cgraph->grad_accs, 0, hash_size * sizeof(struct ggml_tensor *));
     }
 
     return cgraph;
@@ -6978,16 +6574,16 @@ struct ggml_cgraph * ggml_new_graph(struct ggml_context * ctx) {
 
 struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1) {
     struct ggml_cgraph cgraph = {
-        /*.size             =*/ 0,
-        /*.n_nodes          =*/ i1 - i0,
-        /*.n_leafs          =*/ 0,
-        /*.nodes            =*/ cgraph0->nodes + i0,
-        /*.grads            =*/ NULL, // gradients would need visited_hash_set
-        /*.grad_accs        =*/ NULL,
-        /*.leafs            =*/ NULL,
-        /*.use_counts       =*/ cgraph0->use_counts,
-        /*.visited_hash_set =*/ cgraph0->visited_hash_set,
-        /*.order            =*/ cgraph0->order,
+        /*.size             =*/0,
+        /*.n_nodes          =*/i1 - i0,
+        /*.n_leafs          =*/0,
+        /*.nodes            =*/cgraph0->nodes + i0,
+        /*.grads            =*/NULL,  // gradients would need visited_hash_set
+        /*.grad_accs        =*/NULL,
+        /*.leafs            =*/NULL,
+        /*.use_counts       =*/cgraph0->use_counts,
+        /*.visited_hash_set =*/cgraph0->visited_hash_set,
+        /*.order            =*/cgraph0->order,
     };
 
     return cgraph;
@@ -7013,17 +6609,17 @@ void ggml_graph_cpy(struct ggml_cgraph * src, struct ggml_cgraph * dst) {
     for (size_t i = 0; i < src->visited_hash_set.size; ++i) {
         // copy all hashset keys (tensors) that are in use
         if (ggml_bitset_get(src->visited_hash_set.used, i)) {
-            size_t new_hash_pos = ggml_hash_insert(&dst->visited_hash_set, src->visited_hash_set.keys[i]);
+            size_t new_hash_pos           = ggml_hash_insert(&dst->visited_hash_set, src->visited_hash_set.keys[i]);
             dst->use_counts[new_hash_pos] = src->use_counts[i];
         }
     }
 
     if (dst->grads) {
-        memset(dst->grads,     0, dst->visited_hash_set.size*sizeof(struct ggml_tensor *));
-        memset(dst->grad_accs, 0, dst->visited_hash_set.size*sizeof(struct ggml_tensor *));
+        memset(dst->grads, 0, dst->visited_hash_set.size * sizeof(struct ggml_tensor *));
+        memset(dst->grad_accs, 0, dst->visited_hash_set.size * sizeof(struct ggml_tensor *));
     }
     if (src->grads) {
-        GGML_ASSERT(dst->grads     != NULL);
+        GGML_ASSERT(dst->grads != NULL);
         GGML_ASSERT(dst->grad_accs != NULL);
         for (int i = 0; i < src->n_nodes; ++i) {
             const size_t igrad_src = ggml_hash_find(&src->visited_hash_set, src->nodes[i]);
@@ -7151,12 +6747,16 @@ struct ggml_tensor * ggml_graph_get_tensor(const struct ggml_cgraph * cgraph, co
 
 struct ggml_tensor * ggml_graph_get_grad(const struct ggml_cgraph * cgraph, const struct ggml_tensor * node) {
     const size_t igrad = ggml_hash_find(&cgraph->visited_hash_set, node);
-    return igrad != GGML_HASHSET_FULL && ggml_bitset_get(cgraph->visited_hash_set.used, igrad) && cgraph->grads ? cgraph->grads[igrad] : NULL;
+    return igrad != GGML_HASHSET_FULL && ggml_bitset_get(cgraph->visited_hash_set.used, igrad) && cgraph->grads ?
+               cgraph->grads[igrad] :
+               NULL;
 }
 
 struct ggml_tensor * ggml_graph_get_grad_acc(const struct ggml_cgraph * cgraph, const struct ggml_tensor * node) {
     const size_t igrad = ggml_hash_find(&cgraph->visited_hash_set, node);
-    return igrad != GGML_HASHSET_FULL && ggml_bitset_get(cgraph->visited_hash_set.used, igrad) && cgraph->grad_accs ? cgraph->grad_accs[igrad] : NULL;
+    return igrad != GGML_HASHSET_FULL && ggml_bitset_get(cgraph->visited_hash_set.used, igrad) && cgraph->grad_accs ?
+               cgraph->grad_accs[igrad] :
+               NULL;
 }
 
 void ggml_graph_print(const struct ggml_cgraph * cgraph) {
@@ -7166,22 +6766,19 @@ void ggml_graph_print(const struct ggml_cgraph * cgraph) {
     for (int i = 0; i < cgraph->n_nodes; i++) {
         struct ggml_tensor * node = cgraph->nodes[i];
 
-        GGML_LOG_INFO(" - %3d: [ %5" PRId64 ", %5" PRId64 ", %5" PRId64 "] %16s %s\n",
-                i,
-                node->ne[0], node->ne[1], node->ne[2],
-                ggml_op_name(node->op), (node->flags & GGML_TENSOR_FLAG_PARAM) ? "x" :
-                      ggml_graph_get_grad(cgraph, node) ? "g" : " ");
+        GGML_LOG_INFO(" - %3d: [ %5" PRId64 ", %5" PRId64 ", %5" PRId64 "] %16s %s\n", i, node->ne[0], node->ne[1],
+                      node->ne[2], ggml_op_name(node->op),
+                      (node->flags & GGML_TENSOR_FLAG_PARAM) ? "x" :
+                      ggml_graph_get_grad(cgraph, node)      ? "g" :
+                                                               " ");
     }
 
     GGML_LOG_INFO("n_leafs = %d\n", cgraph->n_leafs);
     for (int i = 0; i < cgraph->n_leafs; i++) {
         struct ggml_tensor * node = cgraph->leafs[i];
 
-        GGML_LOG_INFO(" - %3d: [ %5" PRId64 ", %5" PRId64 "] %8s %16s\n",
-                i,
-                node->ne[0], node->ne[1],
-                ggml_op_name(node->op),
-                ggml_get_name(node));
+        GGML_LOG_INFO(" - %3d: [ %5" PRId64 ", %5" PRId64 "] %8s %16s\n", i, node->ne[0], node->ne[1],
+                      ggml_op_name(node->op), ggml_get_name(node));
     }
 
     GGML_LOG_INFO("========================================\n");
@@ -7277,7 +6874,7 @@ static bool ggml_graph_find(const struct ggml_cgraph * cgraph, const struct ggml
 static struct ggml_tensor * ggml_graph_get_parent(const struct ggml_cgraph * cgraph, const struct ggml_tensor * node) {
     for (int i = 0; i < cgraph->n_nodes; i++) {
         struct ggml_tensor * parent = cgraph->nodes[i];
-        struct ggml_tensor * grad = ggml_graph_get_grad(cgraph, parent);
+        struct ggml_tensor * grad   = ggml_graph_get_grad(cgraph, parent);
 
         if (grad == node) {
             return parent;
@@ -7287,22 +6884,23 @@ static struct ggml_tensor * ggml_graph_get_parent(const struct ggml_cgraph * cgr
     return NULL;
 }
 
-static void ggml_graph_dump_dot_node_edge(FILE * fp, const struct ggml_cgraph * gb, struct ggml_tensor * node, struct ggml_tensor * parent, const char * label)  {
-    struct ggml_tensor * gparent = ggml_graph_get_parent(gb, node);
+static void ggml_graph_dump_dot_node_edge(FILE *                     fp,
+                                          const struct ggml_cgraph * gb,
+                                          struct ggml_tensor *       node,
+                                          struct ggml_tensor *       parent,
+                                          const char *               label) {
+    struct ggml_tensor * gparent  = ggml_graph_get_parent(gb, node);
     struct ggml_tensor * gparent0 = ggml_graph_get_parent(gb, parent);
     fprintf(fp, "  \"%p\" -> \"%p\" [ arrowhead = %s; style = %s; label = \"%s\"; ]\n",
-            gparent0 ? (void *) gparent0 : (void *) parent,
-            gparent ? (void *) gparent : (void *) node,
-            gparent ? "empty" : "vee",
-            gparent ? "dashed" : "solid",
-            label);
+            gparent0 ? (void *) gparent0 : (void *) parent, gparent ? (void *) gparent : (void *) node,
+            gparent ? "empty" : "vee", gparent ? "dashed" : "solid", label);
 }
 
-static void ggml_graph_dump_dot_leaf_edge(FILE * fp, struct ggml_tensor * node, struct ggml_tensor * parent, const char * label)  {
-    fprintf(fp, "  \"%p\" -> \"%p\" [ label = \"%s\"; ]\n",
-            (void *) parent,
-            (void *) node,
-            label);
+static void ggml_graph_dump_dot_leaf_edge(FILE *               fp,
+                                          struct ggml_tensor * node,
+                                          struct ggml_tensor * parent,
+                                          const char *         label) {
+    fprintf(fp, "  \"%p\" -> \"%p\" [ label = \"%s\"; ]\n", (void *) parent, (void *) node, label);
 }
 
 void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph * gf, const char * filename) {
@@ -7335,9 +6933,10 @@ void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph
             snprintf(color, sizeof(color), "white");
         }
 
-        fprintf(fp, "  \"%p\" [ "
-                    "style = filled; fillcolor = %s; shape = record; "
-                    "label=\"",
+        fprintf(fp,
+                "  \"%p\" [ "
+                "style = filled; fillcolor = %s; shape = record; "
+                "label=\"",
                 (void *) node, color);
 
         if (strlen(node->name) > 0) {
@@ -7349,7 +6948,8 @@ void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph
         if (ggml_is_matrix(node)) {
             fprintf(fp, "%d [%" PRId64 ", %" PRId64 "] | <x>%s", i, node->ne[0], node->ne[1], ggml_op_symbol(node->op));
         } else {
-            fprintf(fp, "%d [%" PRId64 ", %" PRId64 ", %" PRId64 "] | <x>%s", i, node->ne[0], node->ne[1], node->ne[2], ggml_op_symbol(node->op));
+            fprintf(fp, "%d [%" PRId64 ", %" PRId64 ", %" PRId64 "] | <x>%s", i, node->ne[0], node->ne[1], node->ne[2],
+                    ggml_op_symbol(node->op));
         }
 
         if (grad) {
@@ -7364,9 +6964,10 @@ void ggml_graph_dump_dot(const struct ggml_cgraph * gb, const struct ggml_cgraph
 
         snprintf(color, sizeof(color), "pink");
 
-        fprintf(fp, "  \"%p\" [ "
-                    "style = filled; fillcolor = %s; shape = record; "
-                    "label=\"<x>",
+        fprintf(fp,
+                "  \"%p\" [ "
+                "style = filled; fillcolor = %s; shape = record; "
+                "label=\"<x>",
                 (void *) node, color);
 
         if (strlen(node->name) > 0) {
@@ -7463,10 +7064,16 @@ void ggml_quantize_init(enum ggml_type type) {
         case GGML_TYPE_IQ2_XS:
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ1_S:
-        case GGML_TYPE_IQ1_M:   iq2xs_init_impl(type); break;
-        case GGML_TYPE_IQ3_XXS: iq3xs_init_impl(256); break;
-        case GGML_TYPE_IQ3_S:   iq3xs_init_impl(512); break;
-        default: // nothing
+        case GGML_TYPE_IQ1_M:
+            iq2xs_init_impl(type);
+            break;
+        case GGML_TYPE_IQ3_XXS:
+            iq3xs_init_impl(256);
+            break;
+        case GGML_TYPE_IQ3_S:
+            iq3xs_init_impl(512);
+            break;
+        default:  // nothing
             break;
     }
 
@@ -7485,21 +7092,17 @@ void ggml_quantize_free(void) {
 }
 
 bool ggml_quantize_requires_imatrix(enum ggml_type type) {
-    return
-        type == GGML_TYPE_IQ2_XXS ||
-        type == GGML_TYPE_IQ2_XS  ||
-        type == GGML_TYPE_IQ1_S;//   ||
-        //type == GGML_TYPE_IQ1_M;
+    return type == GGML_TYPE_IQ2_XXS || type == GGML_TYPE_IQ2_XS || type == GGML_TYPE_IQ1_S;  //   ||
+                                                                                              //type == GGML_TYPE_IQ1_M;
 }
 
-size_t ggml_quantize_chunk(
-        enum ggml_type   type,
-           const float * src,
-                  void * dst,
-               int64_t   start,
-               int64_t   nrows,
-               int64_t   n_per_row,
-           const float * imatrix) {
+size_t ggml_quantize_chunk(enum ggml_type type,
+                           const float *  src,
+                           void *         dst,
+                           int64_t        start,
+                           int64_t        nrows,
+                           int64_t        n_per_row,
+                           const float *  imatrix) {
     const int64_t n = (int64_t) nrows * n_per_row;
 
     if (ggml_quantize_requires_imatrix(type)) {
@@ -7509,7 +7112,7 @@ size_t ggml_quantize_chunk(
     GGML_ASSERT(start % type_traits[type].blck_size == 0);
     GGML_ASSERT(start % n_per_row == 0);
 
-    ggml_quantize_init(type); // this is noop if already initialized
+    ggml_quantize_init(type);  // this is noop if already initialized
 
     const size_t start_row = start / n_per_row;
     const size_t row_size  = ggml_row_size(type, n_per_row);
@@ -7517,46 +7120,93 @@ size_t ggml_quantize_chunk(
     size_t result = 0;
 
     switch (type) {
-        case GGML_TYPE_Q4_0:    result = quantize_q4_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q4_1:    result = quantize_q4_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q5_0:    result = quantize_q5_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q5_1:    result = quantize_q5_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q8_0:    result = quantize_q8_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_MXFP4:   result = quantize_mxfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q2_K:    result = quantize_q2_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q3_K:    result = quantize_q3_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q4_K:    result = quantize_q4_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q5_K:    result = quantize_q5_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_Q6_K:    result = quantize_q6_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_TQ1_0:   result = quantize_tq1_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_TQ2_0:   result = quantize_tq2_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ2_XXS: result = quantize_iq2_xxs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ2_XS:  result = quantize_iq2_xs (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ3_XXS: result = quantize_iq3_xxs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ3_S:   result = quantize_iq3_s  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ2_S:   result = quantize_iq2_s  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ1_S:   result = quantize_iq1_s  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ1_M:   result = quantize_iq1_m  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ4_NL:  result = quantize_iq4_nl (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
-        case GGML_TYPE_IQ4_XS:  result = quantize_iq4_xs (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_Q4_0:
+            result = quantize_q4_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q4_1:
+            result = quantize_q4_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q5_0:
+            result = quantize_q5_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q5_1:
+            result = quantize_q5_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q8_0:
+            result = quantize_q8_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_MXFP4:
+            result = quantize_mxfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q2_K:
+            result = quantize_q2_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q3_K:
+            result = quantize_q3_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q4_K:
+            result = quantize_q4_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q5_K:
+            result = quantize_q5_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_Q6_K:
+            result = quantize_q6_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_TQ1_0:
+            result = quantize_tq1_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_TQ2_0:
+            result = quantize_tq2_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ2_XXS:
+            result = quantize_iq2_xxs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ2_XS:
+            result = quantize_iq2_xs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ3_XXS:
+            result = quantize_iq3_xxs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ3_S:
+            result = quantize_iq3_s(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ2_S:
+            result = quantize_iq2_s(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ1_S:
+            result = quantize_iq1_s(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ1_M:
+            result = quantize_iq1_m(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ4_NL:
+            result = quantize_iq4_nl(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
+        case GGML_TYPE_IQ4_XS:
+            result = quantize_iq4_xs(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix);
+            break;
         case GGML_TYPE_F16:
             {
                 size_t elemsize = sizeof(ggml_fp16_t);
-                ggml_fp32_to_fp16_row(src + start, (ggml_fp16_t *)dst + start, n);
+                ggml_fp32_to_fp16_row(src + start, (ggml_fp16_t *) dst + start, n);
                 result = n * elemsize;
-            } break;
+            }
+            break;
         case GGML_TYPE_BF16:
             {
                 size_t elemsize = sizeof(ggml_bf16_t);
-                ggml_fp32_to_bf16_row_ref(src + start, (ggml_bf16_t *)dst + start, n);
+                ggml_fp32_to_bf16_row_ref(src + start, (ggml_bf16_t *) dst + start, n);
                 result = n * elemsize;
-            } break;
+            }
+            break;
         case GGML_TYPE_F32:
             {
                 size_t elemsize = sizeof(float);
-                result = n * elemsize;
-                memcpy((uint8_t *)dst + start * elemsize, src + start, result);
-            } break;
+                result          = n * elemsize;
+                memcpy((uint8_t *) dst + start * elemsize, src + start, result);
+            }
+            break;
         default:
             assert(false);
     }
@@ -7569,17 +7219,17 @@ size_t ggml_quantize_chunk(
 ////////////////////////////////////////////////////////////////////////////////
 
 void ggml_log_set(ggml_log_callback log_callback, void * user_data) {
-    g_logger_state.log_callback = log_callback ? log_callback : ggml_log_callback_default;
+    g_logger_state.log_callback           = log_callback ? log_callback : ggml_log_callback_default;
     g_logger_state.log_callback_user_data = user_data;
 }
 
 void ggml_threadpool_params_init(struct ggml_threadpool_params * p, int n_threads) {
     p->n_threads  = n_threads;
-    p->prio       = 0;     // default priority (usually means normal or inherited)
-    p->poll       = 50;    // hybrid-polling enabled
-    p->strict_cpu = false; // no strict placement (all threads share same cpumask)
-    p->paused     = false; // threads are ready to go
-    memset(p->cpumask, 0, GGML_MAX_N_THREADS); // all-zero means use the default affinity (usually inherited)
+    p->prio       = 0;                          // default priority (usually means normal or inherited)
+    p->poll       = 50;                         // hybrid-polling enabled
+    p->strict_cpu = false;                      // no strict placement (all threads share same cpumask)
+    p->paused     = false;                      // threads are ready to go
+    memset(p->cpumask, 0, GGML_MAX_N_THREADS);  // all-zero means use the default affinity (usually inherited)
 }
 
 struct ggml_threadpool_params ggml_threadpool_params_default(int n_threads) {
@@ -7589,9 +7239,17 @@ struct ggml_threadpool_params ggml_threadpool_params_default(int n_threads) {
 }
 
 bool ggml_threadpool_params_match(const struct ggml_threadpool_params * p0, const struct ggml_threadpool_params * p1) {
-    if (p0->n_threads      != p1->n_threads  )    return false;
-    if (p0->prio           != p1->prio       )    return false;
-    if (p0->poll           != p1->poll       )    return false;
-    if (p0->strict_cpu     != p1->strict_cpu )    return false;
+    if (p0->n_threads != p1->n_threads) {
+        return false;
+    }
+    if (p0->prio != p1->prio) {
+        return false;
+    }
+    if (p0->poll != p1->poll) {
+        return false;
+    }
+    if (p0->strict_cpu != p1->strict_cpu) {
+        return false;
+    }
     return memcmp(p0->cpumask, p1->cpumask, GGML_MAX_N_THREADS) == 0;
 }


### PR DESCRIPTION
fix ds1 calculation comment for GGML_OP_MUL_MAT backward propagation.