### PR TITLE
model : Qwen3-Next-80B-A3B has 48 layers

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2257,7 +2257,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 }
 
                 switch (hparams.n_layer) {
-                    case 80: type = LLM_TYPE_80B_A3B; break;
+                    case 48: type = LLM_TYPE_80B_A3B; break;
                     default: type = LLM_TYPE_UNKNOWN;
                 }
             } break;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -120,6 +120,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_16B_A1B:       return "16B.A1B";
         case LLM_TYPE_21B_A3B:       return "21B.A3B";
         case LLM_TYPE_30B_A3B:       return "30B.A3B";
+        case LLM_TYPE_80B_A3B:       return "80B.A3B";
         case LLM_TYPE_100B_A6B:      return "100B.A6B";
         case LLM_TYPE_106B_A12B:     return "106B.A12B";
         case LLM_TYPE_230B_A10B:     return "230B.A10B";


### PR DESCRIPTION
Qwen3-Next-80B-A3B has 48 layers instead of 80, as pointed out by [model README](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct#model-overview) and a comment in [original PR](https://github.com/ggml-org/llama.cpp/pull/16095#discussion_r2568682155).

This change should be purely cosmetic, fixes "?B" model names shown by `llama-bench`, etc.