### PR TITLE
cmake: link ws2_32 for MinGW/w64devkit builds in cpp-httplib

### DIFF
--- a/vendor/cpp-httplib/CMakeLists.txt
+++ b/vendor/cpp-httplib/CMakeLists.txt
@@ -9,6 +9,10 @@ if (NOT MSVC)
 endif()
 
 target_link_libraries  (${TARGET} PRIVATE Threads::Threads)
+
+if (WIN32 AND NOT MSVC)
+    target_link_libraries(${TARGET} PUBLIC ws2_32)
+endif()
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
 target_compile_definitions(${TARGET} PRIVATE


### PR DESCRIPTION
Small linker fix to allow the procedure described in [build.md](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md) to work correctly using w64devkit.

Missing link found with Claude and corrected with Gemini.