### PR TITLE
model-conversion : remove max diff check in compare-logits [no ci]

### DIFF
--- a/examples/model-conversion/scripts/causal/compare-logits.py
+++ b/examples/model-conversion/scripts/causal/compare-logits.py
@@ -32,10 +32,6 @@ def quick_logits_check(pytorch_file, llamacpp_file):
     print(f"Top 10 llama.cpp logits: {llamacpp_logits[llamacpp_top10]}")
     print(f"Max absolute difference: {max_diff:.4f}")
 
-    if max_diff > 1.0:
-        print(f"❌ NOK: Large differences detected - max diff: {max_diff:.4f}")
-        return False
-
     return True
 
 def main():


### PR DESCRIPTION
This commit removes the maximum difference check from the compare-logits.py which would stop early if the difference between the logits exceeded a threshold.

The motivation for removing this is that it can be useful to be able to get the complete log for debugging/reporting purposes.
