### PR TITLE
server: add encoder-decoder model support (T5, BART, MADLAD)

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -932,6 +932,36 @@ extern "C" {
             struct llama_context * ctx,
               struct llama_batch   batch);
 
+    // Get the encoder output (cross-attention state) after llama_encode().
+    // Returns the number of encoder tokens (n_enc), or 0 if no encoder output is stored.
+    // If embd is not NULL, copies the encoder embeddings to embd (must have space for n_enc * n_embd floats).
+    // If seq_ids and n_seq_ids are not NULL, copies the per-token sequence IDs used during encoding.
+    //   seq_ids must point to an array of n_enc pointers, each pointing to a buffer of at least max_seq_ids llama_seq_id elements.
+    //   n_seq_ids must point to an array of n_enc int32_t elements.
+    LLAMA_API int32_t llama_get_cross_state(
+            const struct llama_context * ctx,
+                           int64_t    * n_embd,
+                             float    * embd,
+                    llama_seq_id    ** seq_ids,
+                         int32_t    * n_seq_ids,
+                         int32_t      max_seq_ids);
+
+    // Set the encoder output (cross-attention state) before llama_decode().
+    // Used to restore or concatenate encoder outputs for concurrent encoder-decoder slots.
+    // embd must contain n_enc * n_embd floats.
+    // seq_ids[i] must point to n_seq_ids[i] sequence IDs for each encoder token i.
+    LLAMA_API void llama_set_cross_state(
+            struct llama_context * ctx,
+                       int64_t    n_embd,
+                       int64_t    n_enc,
+                   const float  * embd,
+          const llama_seq_id * const * seq_ids,
+                 const int32_t  * n_seq_ids);
+
+    // Clear the encoder output (cross-attention state).
+    LLAMA_API void llama_clear_cross_state(
+            struct llama_context * ctx);
+
     // Set the number of threads used for decoding
     // n_threads is the number of threads used for generation (single token)
     // n_threads_batch is the number of threads used for prompt and batch processing (multiple tokens)

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -263,6 +263,10 @@ private:
 
     llama_cross cross; // TODO: tmp for handling cross-attention - need something better probably
 
+    friend int32_t llama_get_cross_state(const llama_context *, int64_t *, float *, llama_seq_id **, int32_t *, int32_t);
+    friend void    llama_set_cross_state(llama_context *, int64_t, int64_t, const float *, const llama_seq_id * const *, const int32_t *);
+    friend void    llama_clear_cross_state(llama_context *);
+
     std::unique_ptr<llama_memory_i> memory;
 
     // decode output (2-dimensional array: [n_outputs][n_vocab])

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -504,7 +504,6 @@ void llm_graph_input_attn_cross::set_input(const llama_ubatch * ubatch) {
     const int64_t n_tokens = ubatch->n_tokens;
 
     GGML_ASSERT(ggml_backend_buffer_is_host(cross_kq_mask->buffer));
-    GGML_ASSERT(!ubatch->equal_seqs()); // TODO: use ubatch->n_seqs instead of failing
 
     float * data = (float *) cross_kq_mask->data;
 
@@ -1797,6 +1796,11 @@ ggml_tensor * llm_graph_context::build_attn_mha(
         }
 
         if (kq_b) {
+            if (n_stream > 1) {
+                // kq_b is [n_kv, n_tokens, n_head, 1] but kq is [n_kv, n_tokens/n_stream, n_head, n_stream]
+                // reshape kq_b to match the stream-split dimensions
+                kq_b = ggml_reshape_4d(ctx0, kq_b, kq_b->ne[0], kq_b->ne[1]/n_stream, kq_b->ne[2], n_stream);
+            }
             kq = ggml_add(ctx0, kq, kq_b);
             cb(kq, "kq_plus_kq_b", il);
         }

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1798,8 +1798,12 @@ ggml_tensor * llm_graph_context::build_attn_mha(
         if (kq_b) {
             if (n_stream > 1) {
                 // kq_b is [n_kv, n_tokens, n_head, 1] but kq is [n_kv, n_tokens/n_stream, n_head, n_stream]
-                // reshape kq_b to match the stream-split dimensions
-                kq_b = ggml_reshape_4d(ctx0, kq_b, kq_b->ne[0], kq_b->ne[1]/n_stream, kq_b->ne[2], n_stream);
+                // tokens in the ubatch are ordered by stream (all of stream 0 first, then stream 1, etc.)
+                // first split n_tokens into (n_tps, n_stream), then swap n_stream and n_head dims
+                const int64_t n_tps = kq_b->ne[1] / n_stream;
+                kq_b = ggml_reshape_4d(ctx0, kq_b, kq_b->ne[0], n_tps, n_stream, kq_b->ne[2]);
+                kq_b = ggml_permute(ctx0, kq_b, 0, 1, 3, 2);
+                kq_b = ggml_cont(ctx0, kq_b);
             }
             kq = ggml_add(ctx0, kq, kq_b);
             cb(kq, "kq_plus_kq_b", il);


### PR DESCRIPTION
Add support for encoder-decoder models in llama-server, matching the behavior of llama-cli. This enables translation models like MADLAD and other T5-based models to work with the server.

Changes:
- Add has_encoder flag to detect encoder-decoder models at load time
- Implement llama_encode() call for encoder-decoder prompt processing
- Use decoder_start_token to initialize decoder after encoding
- Clear decoder KV cache before each new request (no prefix caching)
- Disable incompatible features for encoder-decoder models:
  - Context shift (encoder outputs are fixed)
  - Speculative decoding (not supported)
  - Warn about prompt caching differences
- Add edge case handling for empty text tokens

The encoder processes the full prompt, then the decoder generates output using cross-attention to the encoder's hidden states.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*


Cursor /w Opus 4.5 was heavily utilized to develop this change.