### PR TITLE
Optimization: Qwen3 next autoregressive pass

### DIFF
--- a/src/models/models.h
+++ b/src/models/models.h
@@ -469,6 +469,15 @@ private:
                 ggml_tensor * identity,
                         int   il);
 
+    ggml_tensor * build_delta_net_autoregressive(
+                ggml_tensor * q,
+                ggml_tensor * k,
+                ggml_tensor * v,
+                ggml_tensor * g,
+                ggml_tensor * beta,
+                ggml_tensor * state,
+                int           il);
+
     ggml_tensor * build_norm_gated(
                 ggml_tensor * input,
                 ggml_tensor * weights,

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -447,17 +447,6 @@ private:
                 ggml_tensor * cur,
                         int   il);
 
-    ggml_tensor * build_delta_net_recurrent(
-                ggml_tensor * q,
-                ggml_tensor * k,
-                ggml_tensor * v,
-                ggml_tensor * g,
-                ggml_tensor * beta,
-                ggml_tensor * state,
-                ggml_tensor * causal_mask,
-                ggml_tensor * identity,
-                        int   il);
-
     ggml_tensor * build_delta_net_chunking(
                 ggml_tensor * q,
                 ggml_tensor * k,

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -441,6 +441,7 @@ private:
                 ggml_tensor * cur,
                 ggml_tensor * causal_mask,
                 ggml_tensor * identity,
+                ggml_tensor * diag_mask,
                         int   il);
 
     ggml_tensor * build_layer_ffn(
@@ -456,6 +457,7 @@ private:
                 ggml_tensor * state,
                 ggml_tensor * causal_mask,
                 ggml_tensor * identity,
+                ggml_tensor * diag_mask,
                         int   il);
 
     ggml_tensor * build_delta_net_autoregressive(


### PR DESCRIPTION
This change adds a dedicated autoregressive version of delta-net which short cirtuits all the recurrent computations for `n_seq_tokens == 1`. The end result is roughly a 40% bump in token generation speed.