### PR TITLE
ggml : add ggml_backend_sched_debug_tensor ggml_backend API

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -339,6 +339,13 @@ extern "C" {
     // Set a callback to be called for each resulting node during graph compute
     GGML_API void                 ggml_backend_sched_set_eval_callback(ggml_backend_sched_t sched, ggml_backend_sched_eval_callback callback, void * user_data);
 
+    // Debug/log the tensor mean squared value and optionally a specified number
+    // of values from the tensor.
+    //
+    // Note that the tensor in needs to be named using ggml_set_name or equivalent,
+    // and it also has to be prevented from being reused (optimized out) by the graph scheduler.
+    GGML_API void                 ggml_backend_sched_debug_tensor(ggml_backend_sched_t sched, struct ggml_cgraph * graph, const char * name, size_t n_values_to_log);
+
     //
     // Utils
     //


### PR DESCRIPTION
This commit adds a new function `ggml_backend_sched_debug_tensor` to the ggml_backend API. This function allows users to print the values of a specified tensor after graph computation, along with the mean squared value.

The motivation for this addition is that it can be useful to use this as ha "ballpark" check to check tensors before/after operations have been been executed. This came out of use cases when converting new models to llama.cpp and the need to track down discrepancies in tensor values.

As an example of usage, this function can be called after the graph has been excuted, for example in `process_ubatch` in llama-context.cpp:
```c++
    ggml_backend_sched_debug_tensor(sched.get(), res->get_gf(), "inp_embd", 10);
```
This will log something like the following, assuming logging is set to debug/verbose level:
```console
ggml_backend_sched_debug_tensor: Tensor 'inp_embd', type: f32
ggml_backend_sched_debug_tensor: ne = [2048 6 1 1]
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 0]: 7.241361
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 1]: 5.649519
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 2]: 9.418730
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 3]: 8.292873
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 4]: 9.473540
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 5]: 9.034624
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 6]: 9.187912
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 7]: 1.406322
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 8]: 4.729420
ggml_backend_sched_debug_tensor: Tensor value at [0, 0, 0, 9]: 4.343110
ggml_backend_sched_debug_tensor: inp_embd mean_sq = 41.4566065470
```
One thing to keep in mind is that the tensor needs to have a name and also we need to ensure that the graph does not reuse the tensor during scheduling. This can be done by setting the tensor as output to preserve it.
