### PR TITLE
vulkan: use 4 rows for scalar FA large tile size

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2535,12 +2535,11 @@ static constexpr uint32_t flash_attention_num_small_rows = 32;
 static constexpr uint32_t scalar_flash_attention_num_small_rows = 1;
 
 static uint32_t get_fa_scalar_num_large_rows(uint32_t hsk, uint32_t hsv) {
+    GGML_UNUSED(hsk);
     if (hsv >= 192) {
         return 2;
-    } else if ((hsv | hsk) & 8) {
-        return 4;
     } else {
-        return 8;
+        return 4;
     }
 }
 


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/issues/17715#issuecomment-3650484669. I also tested locally on 5090 in scalar mode and it was a few percent faster on several models.