### PR TITLE
convert : sort and use file parts from model index if present

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -197,10 +197,10 @@ class ModelBase:
             return tensors
 
         prefix = "model" if not self.is_mistral_format else "consolidated"
-        part_names: set[str] = set(ModelBase.get_model_part_names(self.dir_model, prefix, ".safetensors"))
+        part_names: list[str] = ModelBase.get_model_part_names(self.dir_model, prefix, ".safetensors")
         is_safetensors: bool = len(part_names) > 0
         if not is_safetensors:
-            part_names = set(ModelBase.get_model_part_names(self.dir_model, "pytorch_model", ".bin"))
+            part_names = ModelBase.get_model_part_names(self.dir_model, "pytorch_model", ".bin")
 
         tensor_names_from_index: set[str] = set()
 
@@ -217,7 +217,8 @@ class ModelBase:
                     if weight_map is None or not isinstance(weight_map, dict):
                         raise ValueError(f"Can't load 'weight_map' from {index_name!r}")
                     tensor_names_from_index.update(weight_map.keys())
-                    part_names |= set(weight_map.values())
+                    part_dict: dict[str, None] = dict.fromkeys(list(weight_map.values()) + part_names, None)
+                    part_names = list(part_dict.keys())
             else:
                 weight_map = {}
         else:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -217,7 +217,7 @@ class ModelBase:
                     if weight_map is None or not isinstance(weight_map, dict):
                         raise ValueError(f"Can't load 'weight_map' from {index_name!r}")
                     tensor_names_from_index.update(weight_map.keys())
-                    part_dict: dict[str, None] = dict.fromkeys(list(weight_map.values()) + part_names, None)
+                    part_dict: dict[str, None] = dict.fromkeys(weight_map.values(), None)
                     part_names = list(part_dict.keys())
             else:
                 weight_map = {}

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -218,7 +218,7 @@ class ModelBase:
                         raise ValueError(f"Can't load 'weight_map' from {index_name!r}")
                     tensor_names_from_index.update(weight_map.keys())
                     part_dict: dict[str, None] = dict.fromkeys(weight_map.values(), None)
-                    part_names = list(part_dict.keys())
+                    part_names = sorted(part_dict.keys())
             else:
                 weight_map = {}
         else:


### PR DESCRIPTION
Follow up to #17286

The previous PR made tensor order more random than necessary, if there's an index, ~keep the same file order~use a sorted list of all unique file parts from there, if not keep the sorted order from `get_model_part_names` for consistent conversions.