### PR TITLE
chat-parser: handle whitespace around JSON in tool call parsing

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1018,6 +1018,15 @@ static void test_template_output_parsers() {
                 "<function=special_function>{\"arg1\": 1}</function>",
                 /* is_partial= */ false,
                 {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
+        // Test <function=name> with whitespace before JSON (issue: model outputs newline+spaces before JSON)
+        assert_msg_equals(
+            message_assist_call,
+            common_chat_parse(
+                "<function=special_function>\n"
+                "     {\"arg1\": 1}\n"
+                "</function>",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
         assert_msg_equals(
             message_assist_call,
             common_chat_parse(


### PR DESCRIPTION
Models often output whitespace (newlines, spaces) between XML tags and JSON content, e.g.:

    <function=transfer_to_human>
         {"reason": "..."}
    </function>

This can cause parsing failures in Hermes 2 Pro (e.g. happened to me w/ `unsloth/Qwen3-Coder-30B-A3B-Instruct-1M-GGUF:UD-Q4_K_XL`) and other formats because try_consume_json() expected JSON to start immediately at the current position.

Fix by modifying try_consume_json() to:
- Skip leading whitespace before attempting to parse JSON
- Consume trailing whitespace after successful JSON parse
- Restore position if JSON parsing fails (important for streaming)

This fix benefits all chat formats that use try_consume_json().

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
