### PR TITLE
cmake: CLI should explicitly depend on mtmd headers now

### DIFF
--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -2,8 +2,7 @@ set(TARGET llama-cli)
 add_executable(${TARGET} cli.cpp)
 target_link_libraries(${TARGET} PRIVATE server-context PUBLIC common ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
-
-include_directories(../server)
+target_include_directories(${TARGET} PRIVATE ../server ../mtmd)
 
 if(LLAMA_TOOLS_INSTALL)
     install(TARGETS ${TARGET} RUNTIME)


### PR DESCRIPTION
Add explicit dep for includes, and switch from include_directories to using target_include_directories

The new CLI changes break builds for me when compiling llama.cpp as a cmake dependency as it doesn't see the mtmd.h header anymore.