### PR TITLE
CLI: llama-cli and llama-completion cosmetics

### DIFF
--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -44,6 +44,7 @@ body:
         - Documentation/Github
         - libllama (core library)
         - llama-cli
+        - llama-completion
         - llama-server
         - llama-bench
         - llama-quantize

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -183,7 +183,8 @@ Add `ggml-ci` to commit message to trigger heavy CI workloads on the custom CI i
 
 ### Built Executables (in `build/bin/`)
 Primary tools:
-- **`llama-cli`**: Main inference tool
+- **`llama-cli`**: Main CLI tool
+- **`llama-completion`**: Text completion tool
 - **`llama-server`**: OpenAI-compatible HTTP server
 - **`llama-quantize`**: Model quantization utility
 - **`llama-perplexity`**: Model evaluation tool

--- a/docs/backend/SYCL.md
+++ b/docs/backend/SYCL.md
@@ -116,7 +116,7 @@ SYCL backend supports Intel GPU Family:
 *Notes:*
 
 - **Memory**
-  - The device memory is a limitation when running a large model. The loaded model size, *`llm_load_tensors: buffer_size`*, is displayed in the log when running `./bin/llama-cli`.
+  - The device memory is a limitation when running a large model. The loaded model size, *`llm_load_tensors: buffer_size`*, is displayed in the log when running `./bin/llama-completion`.
   - Please make sure the GPU shared memory from the host is large enough to account for the model's size. For e.g. the *llama-2-7b.Q4_0* requires at least 8.0GB for integrated GPU and 4.0GB for discrete GPU.
 
 - **Execution Unit (EU)**

--- a/docs/backend/hexagon/README.md
+++ b/docs/backend/hexagon/README.md
@@ -62,6 +62,7 @@ To generate an installable "package" simply use cmake --install:
 ...
 -- Installing: /workspace/pkg-adb/llama.cpp/bin/llama-bench
 -- Installing: /workspace/pkg-adb/llama.cpp/bin/llama-cli
+-- Installing: /workspace/pkg-adb/llama.cpp/bin/llama-completion
 ...
 ```
 

--- a/docs/backend/hexagon/developer.md
+++ b/docs/backend/hexagon/developer.md
@@ -53,7 +53,7 @@ M=gpt-oss-20b-Q4_0.gguf NDEV=4 D=HTP0,HTP1,HTP2,HTP3 P=surfing.txt scripts/snapd
 ...
 LD_LIBRARY_PATH=/data/local/tmp/llama.cpp/lib
 ADSP_LIBRARY_PATH=/data/local/tmp/llama.cpp/lib
-GGML_HEXAGON_NDEV=4 ./bin/llama-cli --no-mmap -m /data/local/tmp/llama.cpp/../gguf/gpt-oss-20b-Q4_0.gguf
+GGML_HEXAGON_NDEV=4 ./bin/llama-completion --no-mmap -m /data/local/tmp/llama.cpp/../gguf/gpt-oss-20b-Q4_0.gguf
       -t 4 --ctx-size 8192 --batch-size 128 -ctk q8_0 -ctv q8_0 -fa on -ngl 99 --device HTP0,HTP1,HTP2,HTP3 -no-cnv -f surfing.txt
 ...
 llama_model_loader: - type  f32:  289 tensors

--- a/scripts/fetch_server_test_models.py
+++ b/scripts/fetch_server_test_models.py
@@ -74,11 +74,11 @@ if __name__ == '__main__':
     for m in models:
         logging.info(f'  - {m.hf_repo} / {m.hf_file}')
 
-    cli_path = os.environ.get(
+    completion_path = os.environ.get(
         'LLAMA_CLI_BIN_PATH',
         os.path.join(
             os.path.dirname(__file__),
-            '../build/bin/Release/llama-cli.exe' if os.name == 'nt' else '../build/bin/llama-cli'))
+            '../build/bin/Release/llama-completion.exe' if os.name == 'nt' else '../build/bin/llama-completion'))
 
     for m in models:
         if '<' in m.hf_repo or (m.hf_file is not None and '<' in m.hf_file):
@@ -86,9 +86,9 @@ if __name__ == '__main__':
         if m.hf_file is not None and '-of-' in m.hf_file:
             logging.warning(f'Skipping model at {m.hf_repo} / {m.hf_file} because it is a split file')
             continue
-        logging.info(f'Using llama-cli to ensure model {m.hf_repo}/{m.hf_file} was fetched')
+        logging.info(f'Using llama-completion to ensure model {m.hf_repo}/{m.hf_file} was fetched')
         cmd = [
-            cli_path,
+            completion_path,
             '-hfr', m.hf_repo,
             *([] if m.hf_file is None else ['-hff', m.hf_file]),
             '-n', '1',


### PR DESCRIPTION
Hello, I've just finished the last (I think) PR regarding separation of `llama-cli` and `llama-completion` in docs and scripts. Here I tried to fix places where `llama-cli` and `llama-completion` are absolutely obvious, so it is safe to make updates.

1. Added `llama-completion` to `.dockerignore`
2. Added `llama-completion` to the GitHub issue template.
3. Fixed docs in copilot instructions.
4. Fixed writing a bash completion in README (because `>` implies non-interactive mode, so for now `llama-cli` is not possible here)
5. Used `llama-completion` in `docs/backend/SYCL` (`llm_load_tensors: ...` is the output of `llama-completion`)
6. Added `llama-completion` to `docs/backend/hexagon/README`
7. Used `llama-completion` in `docs/backend/hexagon/developer` (`llama_model_loader: ...` is the output of `llama-completion`)
8. Used `llama-completion` in `scripts/fetch_server_test_models.py` because it uses non-interactive mode.

PS I found other places where I can't understand whether `llama-cli` or `llama-completion` should be used. I think maintainers of these docs may update them later.

Related PRs: #17993, #18003