### PR TITLE
server: Fix router proxying to child processes when --host is specified

### DIFF
--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -58,6 +58,7 @@ struct server_model_meta {
     int64_t last_used = 0; // for LRU unloading
     std::vector<std::string> args; // args passed to the model instance, will be populated by render_args()
     int exit_code = 0; // exit code of the model instance process (only valid if status == FAILED)
+    std::string hostname;
 
     bool is_active() const {
         return status == SERVER_MODEL_STATUS_LOADED || status == SERVER_MODEL_STATUS_LOADING;


### PR DESCRIPTION
llama-server --host now works for:

- specific external facing addresses both locally and externally (192.168.3.14)
- localhost (127.0.0.1)
- all interfaces (0.0.0.0) 

It worked with 127.0.0.1 and 0.0.0.0 before, but when a specific external facing address was specified it:

- served the WebUI correctly on the specified ip address
- switched to 127.0.0.1 for child when model was loaded and failed