### PR TITLE
Update README.md incorrect argument

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1430,7 +1430,7 @@ Model presets allow advanced users to define custom configurations using an `.in
 llama-server --models-preset ./my-models.ini
 ```
 
-Each section in the file defines a new preset. Keys within a section correspond to command-line arguments (without leading dashes). For example, the argument `--n-gpu-layer 123` is written as `n-gpu-layer = 123`.
+Each section in the file defines a new preset. Keys within a section correspond to command-line arguments (without leading dashes). For example, the argument `--n-gpu-layers 123` is written as `n-gpu-layers = 123`.
 
 Short argument forms (e.g., `c`, `ngl`) and environment variable names (e.g., `LLAMA_ARG_N_GPU_LAYERS`) are also supported as keys.
 
@@ -1445,7 +1445,7 @@ version = 1
 ; string value
 chat-template = chatml
 ; numeric value
-n-gpu-layer = 123
+n-gpu-layers = 123
 ; flag value (for certain flags, you need to use the "no-" prefix for negation)
 jinja = true
 ; shorthand argument (for example, context size)


### PR DESCRIPTION
detected error in readme quoting `n-gpu-layer` which is incorrect
argument is `n-gpu-layers` with the 's'
verified correct from to doco on L83
https://github.com/ggml-org/llama.cpp/blob/d6a1e18c651a46109cbf2ad3b299581f0651128f/tools/server/README.md?plain=1#L83


*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

i have read contributing guidelines
documentation typo fix only, no code impacted

typo in Commit f32ca51
