### PR TITLE
llama: Include algorithm header needed for C++23

### DIFF
--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -2,6 +2,7 @@
 
 #include "ggml.h"
 
+#include <algorithm>
 #include <cassert>
 
 void llama_hparams::set_swa_pattern(uint32_t n_pattern, bool dense_first) {


### PR DESCRIPTION
llama-hparams.cpp currently depends on the `<algorithm>` header being indirectly included by another std header. When compiling with -std=c++23, clang defines `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` [1] and libc++ std headers will include fewer other std headers indirectly. So include `<algorithm>` where it's needed.

[1] https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html

I see this error when building llama.cpp as part of Firefox with -std=c++23:

```
llama.cpp/src/llama-hparams.cpp:99:20: error: no member named 'max' in namespace 'std'
99 | val = std::max(val, n_embd_k_gqa(il));
| ~~~~~^
llama.cpp/src/llama-hparams.cpp:108:20: error: no member named 'max' in namespace 'std'
108 | val = std::max(val, n_embd_v_gqa(il));
| ~~~~~^
```