### PR TITLE
ggml: migrate work_data to stack allocation

### DIFF
--- a/ggml/include/ggml-cpu.h
+++ b/ggml/include/ggml-cpu.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#define GGML_CPLAN_INLINE_SIZE 256 * 1024
+
     // the compute plan that needs to be prepared for ggml_graph_compute()
     // since https://github.com/ggml-org/ggml/issues/287
     struct ggml_cplan {
@@ -19,6 +21,8 @@ extern "C" {
         // abort ggml_graph_compute when true
         ggml_abort_callback abort_callback;
         void *              abort_callback_data;
+
+        uint8_t work_data_inline[GGML_CPLAN_INLINE_SIZE];
     };
 
     // numa strategies

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -42,6 +42,8 @@ void ggml_print_backtrace(void);
 #    define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+#define GGML_MAX_STACK_SIZE 2*1024*1024
+
 // required for mmap as gguf only guarantees 32-byte alignment
 #define TENSOR_ALIGNMENT 32
 

--- a/tests/test-barrier.cpp
+++ b/tests/test-barrier.cpp
@@ -47,8 +47,11 @@ static void test_barrier(int n_threads, int n_rounds) {
     // The test runs with constant number of threads
     struct ggml_cplan cplan = ggml_graph_plan(gf, n_threads, threadpool);
 
-    std::vector<uint8_t> work_data(cplan.work_size);
-    cplan.work_data = work_data.data();
+    std::vector<uint8_t> work_data;
+    if (cplan.work_size > 0 && cplan.work_data == NULL) {
+        work_data.resize(cplan.work_size);
+        cplan.work_data = work_data.data();
+    }
 
     std::cerr << "graph-compute with"
               << "\n n_threads: " << n_threads
@@ -125,8 +128,11 @@ static void test_active(int n_threads, int n_rounds) {
     for (int i=0; i < n_rounds; i++) {
         struct ggml_cplan cplan = ggml_graph_plan(gf, (i % 4) == 0 ? 1 : n_threads, threadpool);
 
-        std::vector<uint8_t> work_data(cplan.work_size);
-        cplan.work_data = work_data.data();
+        std::vector<uint8_t> work_data;
+        if (cplan.work_size > 0 && cplan.work_data == NULL) {
+            work_data.resize(cplan.work_size);
+            cplan.work_data = work_data.data();
+        }
 
         ggml_graph_compute(gf, &cplan);
     }
@@ -197,12 +203,18 @@ static void test_multi_graph(int n_threads, int n_rounds) {
 
     for (int i=0; i < n_rounds; i++) {
         struct ggml_cplan cplan0 = ggml_graph_plan(gf0, (i % 4) == 0 ? 1 : n_threads, threadpool);
-        std::vector<uint8_t> work_data0(cplan0.work_size);
-        cplan0.work_data = work_data0.data();
+        std::vector<uint8_t> work_data0;
+        if (cplan0.work_size > 0 && cplan0.work_data == NULL) {
+            work_data0.resize(cplan0.work_size);
+            cplan0.work_data = work_data0.data();
+        }
 
         struct ggml_cplan cplan1 = ggml_graph_plan(gf1, (i % 4) == 0 ? 1 : n_threads, threadpool);
-        std::vector<uint8_t> work_data1(cplan1.work_size);
-        cplan1.work_data = work_data1.data();
+        std::vector<uint8_t> work_data1;
+        if (cplan1.work_size > 0 && cplan1.work_data == NULL) {
+            work_data1.resize(cplan1.work_size);
+            cplan1.work_data = work_data1.data();
+        }
 
         ggml_graph_compute(gf0, &cplan0);
         ggml_graph_compute(gf1, &cplan1);

--- a/tests/test-rope.cpp
+++ b/tests/test-rope.cpp
@@ -116,7 +116,7 @@ static struct ggml_tensor * get_random_tensor_f32(
 static void ggml_graph_compute_helper(std::vector<uint8_t> & buf, ggml_cgraph * graph, int n_threads) {
     struct ggml_cplan plan = ggml_graph_plan(graph, n_threads, nullptr);
 
-    if (plan.work_size > 0) {
+    if (plan.work_size > 0 && plan.work_data == NULL) {
         buf.resize(plan.work_size);
         plan.work_data = buf.data();
     }


### PR DESCRIPTION
## Summary
As you can see from my tests, llama-bench finishes its work faster by as much as 5-7 seconds, and also shows the number of tokens better in the tg128 tests. Please check my changes, as I may have measurement errors due to NUMA architecture.

## References about changes

- https://publicwork.wordpress.com/2019/06/27/stack-allocation-vs-heap-allocation-performance-benchmark/
- https://stackoverflow.com/questions/24057331/is-accessing-data-in-the-heap-faster-than-from-the-stack
- https://blog.stratifylabs.dev/device/2021-10-28-The-Problem-with-malloc/

## My benchmark tests

### heap-to-stack branch

```
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ bash ./test.sh
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
Attaching to process 19315
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           pp512 |        424.85 ± 1.38 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           tg128 |         22.18 ± 0.09 |

build: d6742125 (7421)
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ bash ./test.sh
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
Attaching to process 23670
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           pp512 |        427.63 ± 8.25 |                                                                                      
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           tg128 |         29.12 ± 0.18 |                                                                                      
                                                                                                                                                                                                                  
build: 39b00eae (7422)                                                                             
```
quantize-perf log
[quantize-perf-benchmark_heap_to_stack.txt](https://github.com/user-attachments/files/24187156/quantize-perf-benchmark_heap_to_stack.txt)

monitor graph
<img width="640" height="480" alt="plot1b_heap_to_stack" src="https://github.com/user-attachments/assets/a197056a-37ab-4a03-b8ad-e082e7a26add" />

### master branch

```
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ bash ./test.sh
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
Attaching to process 21292
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           pp512 |        425.27 ± 3.99 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           tg128 |         17.31 ± 0.22 |

build: d6742125 (7421)
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ bash ./test.sh
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
Attaching to process 21808
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           pp512 |        426.61 ± 5.37 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |      36 |           tg128 |         18.12 ± 0.64 |

build: d6742125 (7421)
```

quantize-perf log
[quantize-perf-benchmark-master.txt](https://github.com/user-attachments/files/24187230/quantize-perf-benchmark-master.txt)


monitor graph
<img width="640" height="480" alt="plot1b_master" src="https://github.com/user-attachments/assets/d84aece6-0973-4622-9cac-5881d94aaee5" />
