### PR TITLE
server: [RFC] add optional POST /exit endpoint for graceful shutdown

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2642,6 +2642,12 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.endpoint_slots = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_SLOTS"));
+    add_opt(common_arg({ "--endpoint-exit" },
+                       string_format("enable POST /exit endpoint to shutdown the server (default: %s)",
+                                     params.endpoint_exit ? "enabled" : "disabled"),
+                       [](common_params & params) { params.endpoint_exit = true; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_ENDPOINT_EXIT"));
     add_opt(common_arg(
         {"--slot-save-path"}, "PATH",
         "path to save slot kv cache (default: disabled)",

--- a/common/common.h
+++ b/common/common.h
@@ -489,6 +489,7 @@ struct common_params {
     bool endpoint_slots   = true;
     bool endpoint_props   = false; // only control POST requests, not GET
     bool endpoint_metrics = false;
+    bool endpoint_exit    = false;
 
     // router server configs
     std::string models_dir    = ""; // directory containing models for the router server

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -51,8 +51,8 @@ struct server_context {
 struct server_res_generator;
 
 struct server_routes {
-    server_routes(const common_params & params, server_context & ctx_server, std::function<bool()> is_ready = []() { return true; })
-            : params(params), ctx_server(*ctx_server.impl), is_ready(is_ready) {
+    server_routes(const common_params & params, server_context & ctx_server, std::function<bool()> is_ready = []() { return true; }, std::function<void()> on_shutdown = nullptr)
+            : params(params), ctx_server(*ctx_server.impl), is_ready(is_ready), on_shutdown(on_shutdown) {
         init_routes();
     }
 
@@ -80,6 +80,8 @@ struct server_routes {
     server_http_context::handler_t post_rerank;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
+    server_http_context::handler_t post_exit;
+
 private:
     // TODO: move these outside of server_routes?
     std::unique_ptr<server_res_generator> handle_slots_save(const server_http_req & req, int id_slot);
@@ -90,4 +92,5 @@ private:
     const common_params & params;
     server_context_impl & ctx_server;
     std::function<bool()> is_ready;
+    const std::function<void()> on_shutdown;
 };


### PR DESCRIPTION
## Summary

This PR proposes adding an optional, explicitly gated HTTP endpoint (`POST /exit`) to `llama-server` that allows a client application to request a graceful server shutdown when traditional OS-level signals (e.g. `SIGTERM`, `SIGINT`) are unavailable or unreliable. (for eg. Windows)

The endpoint is **disabled by default** and can only be enabled via an explicit command-line flag or environment variable.

## Motivation

Many `llama-server` deployments are no longer run as simple foreground processes where POSIX signals are always available.

In these environments, the client cannot reliably send `SIGTERM` or `SIGINT`

As a result, client applications currently resort to hard process termination

An application-level shutdown API mechanism provides a portable, explicit, and graceful alternative for clients to request the server to clean up and shutdown.

## Proposed Solution

Introduce a **POST-only** endpoint:
```
POST /exit
```
### Behavior

- When enabled, the endpoint:
  - Validates an explicit confirmation token in the request body
  - Returns a success response immediately
  - Initiates a **graceful shutdown** after the response is sent
- When disabled (default):
  - Requests to `/exit` return an error indicating the endpoint is not supported

### Example Request

```json
POST /exit
Content-Type: application/json

{
  "confirm": "shutdown"
}
```
### Example Response:
```json
{
  "message": "Server shutdown initiated",
  "status": "terminating"
}
```

### Configuration & Safety Guarantees
Disabled by Default

The endpoint is off by default.
It must be explicitly enabled using either:

- A CLI flag:
```
--endpoint-exit
```


Or environment variable:
```
LLAMA_ARG_ENDPOINT_EXIT=1
```

I will update the docs after getting inputs and feedback's before merging.
Please note: This is definitely not indented for public servers!!

## Current issues
- shutdown_cb will invoke termination of all HTTP threads causing deadlock in some cases
- better API design to disable the endpoint completely in normal mode instead of returning an error that it is unavailable(?)