### PR TITLE
model-conversion : remove -fa option in model card template [no ci]

### DIFF
--- a/examples/model-conversion/scripts/causal/modelcard.template
+++ b/examples/model-conversion/scripts/causal/modelcard.template
@@ -7,7 +7,7 @@ base_model:
 Recommended way to run this model:
 
 ```sh
-llama-server -hf {namespace}/{model_name}-GGUF -c 0 -fa
+llama-server -hf {namespace}/{model_name}-GGUF -c 0
 ```
 
 Then, access http://localhost:8080


### PR DESCRIPTION
This commit updates the causal model card template and removes the `-fa` option as it is no longer required (fa is auto detected).

