### PR TITLE
gguf-py: allow converting multi-tensor models from read-only locations

### DIFF
--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -288,7 +288,7 @@ class LocalTensor:
     data_range: LocalTensorRange
 
     def mmap_bytes(self) -> np.ndarray:
-        return np.memmap(self.data_range.filename, offset=self.data_range.offset, shape=self.data_range.size)
+        return np.memmap(self.data_range.filename, mode='r', offset=self.data_range.offset, shape=self.data_range.size)
 
 
 class SafetensorsLocal:


### PR DESCRIPTION
The problem raises when there is a model with multiple tensor files, the memmap uses `r+` as a default flag which is "read and write" 

https://numpy.org/devdocs/reference/generated/numpy.memmap.html#numpy-memmap