### PR TITLE
llama-fit-params: force disable mlock

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -71,8 +71,9 @@ static std::vector<llama_device_memory_data> llama_get_device_memory_data(
     }, &ud);
 
     llama_model_params mparams_copy = *mparams;
-    mparams_copy.no_alloc = true;
-    mparams_copy.use_mmap = false;
+    mparams_copy.no_alloc  = true;
+    mparams_copy.use_mmap  = false;
+    mparams_copy.use_mlock = false;
 
     llama_model * model = llama_model_load_from_file(path_model, mparams_copy);
     if (model == nullptr) {


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/18090 .

It seems that (unbeknownst to me) the code is trying to use a memory lock even when memory mapping is disabled which results in a crash. This PR force disables `mlock` for `llama_params_fit`.