### PR TITLE
ggml-hexagon: Add lightweight atomic synchronization support to htp_ops_context for inter-task coordination

### DIFF
--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -50,6 +50,8 @@ struct htp_ops_context {
     struct fastdiv_values src1_div21; // fastdiv values for ne2 * ne1
 
     uint32_t flags;
+
+    atomic_uint shared_atomic_lock;
 };
 
 int op_matmul(struct htp_ops_context * octx);

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -1712,6 +1712,7 @@ static void quantize_fp32_q8x4x2(const struct htp_tensor * src,
 static void htp_quantize_fp32_q8x4x2(unsigned int n, unsigned int i, void * data) {
     struct htp_ops_context * octx = data;
     quantize_fp32_q8x4x2(&octx->src1, octx->src1_spad.data, &octx->src0_spad, n, i, octx->src1_nrows_per_thread);
+    atomic_fetch_add(&octx->shared_atomic_lock, 1);
 }
 
 // ** matmul callbacks for worker_pool
@@ -2027,12 +2028,16 @@ int op_matmul(struct htp_ops_context * octx) {
     octx->src0_nrows_per_thread = (src0_nrows + octx->n_threads - 1) / octx->n_threads;
     octx->src0_nrows_per_thread += (octx->src0_nrows_per_thread & 1);  // round up to even
 
+    atomic_store(&octx->shared_atomic_lock, 0);
+
     if (need_quant) {
         // Run quant jobs
         const uint32_t n_quant_jobs = MIN(src1_nrows, octx->n_threads);
         octx->src1_nrows_per_thread = (src1_nrows + n_quant_jobs - 1) / n_quant_jobs;
         worker_pool_run_func(octx->ctx->worker_pool, quant_job_func, octx, n_quant_jobs);
     }
+
+    FARF(HIGH, "matmul-%s : quant jobs finished! Atomic lock: %u\n", op_type, atomic_load(&octx->shared_atomic_lock));
 
     if (!(octx->flags & HTP_OPFLAGS_SKIP_COMPUTE)) {
         // Run matmul jobs


### PR DESCRIPTION
## Background:

The current ggml-hexagon backend uses a worker pool to launch user-defined tasks such as quantization and matrix multiplication. These worker threads are pre-created and execute independently, and the framework currently provides no synchronization primitives that can be safely used inside user task callbacks.

As a result:
1. User callbacks cannot coordinate or exchange state
2. Future optimizations that require staged execution, pipelining, or shared intermediate state are difficult to implement
3. Data sharing is currently not possible

## What this PR proposes
This PR explores adding a minimal atomic synchronization mechanism to the existing framework by introducing a shared atomic variable in `htp_ops_context`. This mechanism enables basic coordination (such as “all quant jobs finished”) while preserving the current worker pool design and execution model. 

With this minor change, together with previous work (thread id is provided for the worker function), we can almost program the NPU just like a **SIMT** architecture.

## Motivation

In the current design, multi-precision matrix multiplication requires the entire quantized src1 tensor to be stored in VTCM. This imposes a hard limit on the problem size that can be handled by the MM kernel.

Since src1 typically corresponds to the hidden states in an LLM, this effectively constrains the maximum context length that can be executed on the NPU.

If the proposed atomic synchronization mechanism is accepted, it would enable more flexible execution patterns and staged processing, allowing VTCM to be used more efficiently. This opens the door to follow-up work that reduces VTCM pressure and relaxes the current context-length limitations without major changes to the existing framework.

## Request for Feedback

I would appreciate feedback on:

1. Whether exposing a shared atomic in `htp_ops_context` is acceptable
2. Whether this aligns with the intended direction of the worker pool design
4. Suggestions for alternative lightweight synchronization mechanisms

If this approach is considered acceptable, I will follow up with a separate commit to remove the concept-demonstration logic currently added in `matmul-ops.c`, leaving only the minimal infrastructure changes required to support synchronization.