### PR TITLE
ci : clean up webui jobs

### DIFF
--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -43,12 +43,18 @@ jobs:
           ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
 
       - name: Setup Node.js
-        id: setup
+        id: node
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "tools/server/webui/package-lock.json"
+
+      - name: Install dependencies
+        id: setup
+        if: ${{ steps.node.conclusion == 'success' }}
+        run: npm ci
+        working-directory: tools/server/webui
 
       - name: Run type checking
         if: ${{ steps.setup.conclusion == 'success' }}

--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -34,6 +34,7 @@ jobs:
   webui-check:
     name: WebUI Checks
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,6 +43,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
 
       - name: Setup Node.js
+        id: setup
         uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -49,45 +51,49 @@ jobs:
           cache-dependency-path: "tools/server/webui/package-lock.json"
 
       - name: Run type checking
+        if: ${{ steps.setup.conclusion == 'success' }}
         run: npm run check
-        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run linting
+        if: ${{ steps.setup.conclusion == 'success' }}
         run: npm run lint
-        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Build application
+        if: ${{ steps.setup.conclusion == 'success' }}
         run: npm run build
         working-directory: tools/server/webui
 
       - name: Install Playwright browsers
+        id: playwright
+        if: ${{ steps.setup.conclusion == 'success' }}
         run: npx playwright install --with-deps
         working-directory: tools/server/webui
 
       - name: Build Storybook
+        if: ${{ steps.playwright.conclusion == 'success' }}
         run: npm run build-storybook
         working-directory: tools/server/webui
 
       - name: Run Client tests
+        if: ${{ steps.playwright.conclusion == 'success' }}
         run: npm run test:client
-        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run Unit tests
+        if: ${{ steps.playwright.conclusion == 'success' }}
         run: npm run test:unit
-        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run UI tests
+        if: ${{ steps.playwright.conclusion == 'success' }}
         run: npm run test:ui -- --testTimeout=60000
-        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run E2E tests
+        if: ${{ steps.playwright.conclusion == 'success' }}
         run: npm run test:e2e
-        continue-on-error: true
         working-directory: tools/server/webui
 
   server-build:

--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -31,8 +31,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  webui-setup:
-    name: WebUI Setup
+  webui-check:
+    name: WebUI Checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -48,104 +48,19 @@ jobs:
           cache: "npm"
           cache-dependency-path: "tools/server/webui/package-lock.json"
 
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        id: cache-node-modules
-        with:
-          path: tools/server/webui/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('tools/server/webui/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
-
-      - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
-        working-directory: tools/server/webui
-
-  webui-check:
-    needs: webui-setup
-    name: WebUI Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Restore node_modules cache
-        uses: actions/cache@v4
-        with:
-          path: tools/server/webui/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('tools/server/webui/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
-
       - name: Run type checking
         run: npm run check
+        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run linting
         run: npm run lint
+        continue-on-error: true
         working-directory: tools/server/webui
-
-  webui-build:
-    needs: webui-check
-    name: WebUI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Restore node_modules cache
-        uses: actions/cache@v4
-        with:
-          path: tools/server/webui/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('tools/server/webui/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
 
       - name: Build application
         run: npm run build
         working-directory: tools/server/webui
-
-  webui-tests:
-    needs: webui-build
-    name: Run WebUI tests
-    permissions:
-      contents: read
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Restore node_modules cache
-        uses: actions/cache@v4
-        with:
-          path: tools/server/webui/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('tools/server/webui/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -157,22 +72,25 @@ jobs:
 
       - name: Run Client tests
         run: npm run test:client
+        continue-on-error: true
         working-directory: tools/server/webui
 
-      - name: Run Server tests
-        run: npm run test:server
+      - name: Run Unit tests
+        run: npm run test:unit
+        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run UI tests
         run: npm run test:ui -- --testTimeout=60000
+        continue-on-error: true
         working-directory: tools/server/webui
 
       - name: Run E2E tests
         run: npm run test:e2e
+        continue-on-error: true
         working-directory: tools/server/webui
 
   server-build:
-    needs: [webui-tests]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -57,48 +57,48 @@ jobs:
         working-directory: tools/server/webui
 
       - name: Run type checking
-        if: ${{ steps.setup.conclusion == 'success' }}
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
         run: npm run check
         working-directory: tools/server/webui
 
       - name: Run linting
-        if: ${{ steps.setup.conclusion == 'success' }}
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
         run: npm run lint
         working-directory: tools/server/webui
 
       - name: Build application
-        if: ${{ steps.setup.conclusion == 'success' }}
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
         run: npm run build
         working-directory: tools/server/webui
 
       - name: Install Playwright browsers
         id: playwright
-        if: ${{ steps.setup.conclusion == 'success' }}
+        if: ${{ always() && steps.setup.conclusion == 'success' }}
         run: npx playwright install --with-deps
         working-directory: tools/server/webui
 
       - name: Build Storybook
-        if: ${{ steps.playwright.conclusion == 'success' }}
+        if: ${{ always() && steps.playwright.conclusion == 'success' }}
         run: npm run build-storybook
         working-directory: tools/server/webui
 
       - name: Run Client tests
-        if: ${{ steps.playwright.conclusion == 'success' }}
+        if: ${{ always() && steps.playwright.conclusion == 'success' }}
         run: npm run test:client
         working-directory: tools/server/webui
 
       - name: Run Unit tests
-        if: ${{ steps.playwright.conclusion == 'success' }}
+        if: ${{ always() && steps.playwright.conclusion == 'success' }}
         run: npm run test:unit
         working-directory: tools/server/webui
 
       - name: Run UI tests
-        if: ${{ steps.playwright.conclusion == 'success' }}
+        if: ${{ always() && steps.playwright.conclusion == 'success' }}
         run: npm run test:ui -- --testTimeout=60000
         working-directory: tools/server/webui
 
       - name: Run E2E tests
-        if: ${{ steps.playwright.conclusion == 'success' }}
+        if: ${{ always() && steps.playwright.conclusion == 'success' }}
         run: npm run test:e2e
         working-directory: tools/server/webui
 


### PR DESCRIPTION
Improved a few things:
* Merged all WebUI steps into one job
* Allow non-critical steps to fail without affecting the others
* Removed double npm packages caching
* Removed non-existing `server` test
* Added new `unit` test
* Allow `server-build` job to run independently from WebUI job

Ref: https://github.com/ggml-org/llama.cpp/pull/18072#issuecomment-3661953973 and https://github.com/ggml-org/llama.cpp/pull/18072#issuecomment-3661770508