### PR TITLE
arg: allow -kvu flag for llama-perplexity

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1140,7 +1140,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params) {
             params.kv_unified = true;
         }
-    ).set_env("LLAMA_ARG_KV_UNIFIED").set_examples({LLAMA_EXAMPLE_SERVER}));
+    ).set_env("LLAMA_ARG_KV_UNIFIED").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_PERPLEXITY}));
     add_opt(common_arg(
         {"--context-shift"},
         {"--no-context-shift"},


### PR DESCRIPTION
The `-kvu` (`--kv-unified`) flag is required for hellaswag and winogrande benchmarks which use coupled sequences. Without unified KV cache, these benchmarks fail with:

```text
split_equal: sequential split is not supported when there are coupled sequences in the input batch (you may need to use the -kvu flag)
```

This change adds LLAMA_EXAMPLE_PERPLEXITY to the allowed examples for the -kvu argument, enabling its use with llama-perplexity.