### PR TITLE
Github: ask for -v logs for params_fit [no ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -86,6 +86,7 @@ body:
       description: >
           If applicable, please copy and paste any relevant log output, including any generated text.
           This will be automatically formatted into code, so no need for backticks.
+          If you are encountering problems specifically with the `llama_params_fit` module, always upload `--verbose` logs as well.
       render: shell
     validations:
       required: false


### PR DESCRIPTION
Updates the misc. issue template to clarify that `--verbose` logs are needed to debug `llama_params_fit`.