### PR TITLE
common: clarify instructions for bug reports

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1092,7 +1092,7 @@ common_init_result::common_init_result(common_params & params) :
     auto cparams = common_context_params_to_llama(params);
 
     if (params.fit_params) {
-        LOG_INF("%s: fitting params to device memory, to report bugs during this step use -fit off (or --verbose if you can't)\n", __func__);
+        LOG_INF("%s: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on\n", __func__);
         llama_params_fit(params.model.path.c_str(), &mparams, &cparams,
             params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target, params.fit_params_min_ctx,
             params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);


### PR DESCRIPTION
See discussion in https://github.com/ggml-org/llama.cpp/issues/18119 .

It seems I was too aggressive with trying to keep log messages short so the intent became unclear.