### PR TITLE
grammar : parallel rejects

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,14 @@ target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
 
 target_link_libraries(llama PUBLIC ggml)
 
+if (GGML_OPENMP) # FIXME: Add LLAMA_OPENMP option?
+    find_package(OpenMP)
+    if (OpenMP_FOUND)
+        target_compile_definitions(llama PRIVATE LLAMA_USE_OPENMP)
+        target_link_libraries(llama PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
+    endif()
+endif()
+
 if (BUILD_SHARED_LIBS)
     set_target_properties(llama PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(llama PRIVATE LLAMA_BUILD)

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -1305,7 +1305,7 @@ void llama_grammar_apply_impl(const struct llama_grammar & grammar, llama_token_
 
 #ifdef LLAMA_USE_OPENMP
     size_t chunk_size = 4096;
-    size_t chunks = (cur_p->size + chunk_size - 1) / chunk_size;
+    int chunks = static_cast<int>((cur_p->size + chunk_size - 1) / chunk_size);
 
     #pragma omp parallel for num_threads(8) schedule(dynamic, 1)
     for (int chunk = 0; chunk < chunks; ++chunk) {

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -131,6 +131,8 @@ struct llama_grammar {
     const llama_grammar_rules  rules;  // TODO: shared ptr
           llama_grammar_stacks stacks;
 
+    std::vector<std::pair<std::vector<uint32_t>, llama_partial_utf8>> utf8_cpt_cache;
+
     // buffer for partially generated UTF-8 sequence from accepted tokens
     llama_partial_utf8 partial_utf8;
 

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -121,6 +121,12 @@ struct llama_grammar_trigger_pattern {
     std::regex  regex;
 };
 
+struct llama_grammar_cached_token_data {
+    bool is_eog;
+    bool is_valid;
+    std::vector<uint32_t> codepoints;
+};
+
 struct llama_grammar {
     // maintain a list of llama_tokens and their positions in the trigger_buffer
     using token_pos = std::pair<llama_token, std::pair<size_t, size_t>>;
@@ -131,7 +137,7 @@ struct llama_grammar {
     const llama_grammar_rules  rules;  // TODO: shared ptr
           llama_grammar_stacks stacks;
 
-    std::vector<std::pair<std::vector<uint32_t>, llama_partial_utf8>> utf8_cpt_cache;
+    std::vector<llama_grammar_cached_token_data> token_cache;
 
     // buffer for partially generated UTF-8 sequence from accepted tokens
     llama_partial_utf8 partial_utf8;


### PR DESCRIPTION
The grammar sampling changes were a bit rougher than I anticipated, and I'm seeing complaints that I suspect are related.

Without grammar sampling, I hit around `~160 t/s` on `gpt-oss-20b`. With grammar, I get `~20 t/s`. It's a pretty big drop!

This is mainly a PoC to see if we can get some easy gains by running the grammar rejections in parallel. It gets me to `~80 t/s`, not great but better.

I tried to use a threadpool with `std::thread`, but did not see nearly as noticeable improvement. Either I'm doing something terribly wrong or OpenMP is really good at parallel workloads. @ggerganov not sure how receptive you are to introducing OpenMP to the llama source, but I at least wanted to show that it is possible to run this part in parallel.

Testing with:

```
llama-cli -m E:\Models\gpt-oss-20b-mxfp4.gguf --jinja --grammar "root ::= .*" -c 4096 -st -p "Explain why the sky is blue."
```