### PR TITLE
ggml-cpu: fix todo comment #15953 and SIMD-like calculate 4 elems

### DIFF
--- a/ggml/src/ggml-cpu/vec.cpp
+++ b/ggml/src/ggml-cpu/vec.cpp
@@ -634,10 +634,103 @@ ggml_float ggml_vec_log_soft_max_f32(const int n, float * y, const float * x, fl
 
     int i = 0;
     ggml_float sum = 0;
+#if defined(__AVX512F__) && defined(__AVX512DQ__)
+    __m512 sum_v = _mm512_setzero_ps();
+    for (; i + 63 < n; i += 64) {
+        __m512 val1 = _mm512_sub_ps(_mm512_loadu_ps(x + i + 0),  _mm512_set1_ps(max));
+        __m512 val2 = _mm512_sub_ps(_mm512_loadu_ps(x + i + 16), _mm512_set1_ps(max));
+        __m512 val3 = _mm512_sub_ps(_mm512_loadu_ps(x + i + 32), _mm512_set1_ps(max));
+        __m512 val4 = _mm512_sub_ps(_mm512_loadu_ps(x + i + 48), _mm512_set1_ps(max));
+        _mm512_storeu_ps(y + i + 0,  val1);
+        _mm512_storeu_ps(y + i + 16, val2);
+        _mm512_storeu_ps(y + i + 32, val3);
+        _mm512_storeu_ps(y + i + 48, val4);
+        sum_v = _mm512_add_ps(sum_v, ggml_v_expf(val1));
+        sum_v = _mm512_add_ps(sum_v, ggml_v_expf(val2));
+        sum_v = _mm512_add_ps(sum_v, ggml_v_expf(val3));
+        sum_v = _mm512_add_ps(sum_v, ggml_v_expf(val4));
+    }
+    for (; i + 15 < n; i += 16) {
+        __m512 val = _mm512_sub_ps(_mm512_loadu_ps(x + i), _mm512_set1_ps(max));
+        _mm512_storeu_ps(y + i, val);
+        sum_v = _mm512_add_ps(sum_v, ggml_v_expf(val));
+    }
+    sum = (ggml_float)_mm512_reduce_add_ps(sum_v);
+#elif defined(__AVX2__) && defined(__FMA__)
+    __m256 sum_v1 = _mm256_setzero_ps();
+    __m256 sum_v2 = _mm256_setzero_ps();
+    __m256 sum_v3 = _mm256_setzero_ps();
+    __m256 sum_v4 = _mm256_setzero_ps();
+    for (; i + 31 < n; i += 32) {
+        __m256 val1 = _mm256_sub_ps(_mm256_loadu_ps(x + i + 0),  _mm256_set1_ps(max));
+        __m256 val2 = _mm256_sub_ps(_mm256_loadu_ps(x + i + 8),  _mm256_set1_ps(max));
+        __m256 val3 = _mm256_sub_ps(_mm256_loadu_ps(x + i + 16), _mm256_set1_ps(max));
+        __m256 val4 = _mm256_sub_ps(_mm256_loadu_ps(x + i + 24), _mm256_set1_ps(max));
+        _mm256_storeu_ps(y + i + 0,  val1);
+        _mm256_storeu_ps(y + i + 8,  val2);
+        _mm256_storeu_ps(y + i + 16, val3);
+        _mm256_storeu_ps(y + i + 24, val4);
+        sum_v1 = _mm256_add_ps(sum_v1, ggml_v_expf(val1));
+        sum_v2 = _mm256_add_ps(sum_v2, ggml_v_expf(val2));
+        sum_v3 = _mm256_add_ps(sum_v3, ggml_v_expf(val3));
+        sum_v4 = _mm256_add_ps(sum_v4, ggml_v_expf(val4));
+    }
+    for (; i + 7 < n; i += 8) {
+        __m256 val = _mm256_sub_ps(_mm256_loadu_ps(x + i), _mm256_set1_ps(max));
+        _mm256_storeu_ps(y + i, val);
+        sum_v1 = _mm256_add_ps(sum_v1, ggml_v_expf(val));
+    }
+    sum_v1 = _mm256_add_ps(sum_v1, sum_v2);
+    sum_v1 = _mm256_add_ps(sum_v1, sum_v3);
+    sum_v1 = _mm256_add_ps(sum_v1, sum_v4);
+    __m128 val2 = _mm_add_ps(_mm256_extractf128_ps(sum_v1, 1), _mm256_castps256_ps128(sum_v1));
+    val2 = _mm_add_ps(val2, _mm_movehl_ps(val2, val2));
+    val2 = _mm_add_ss(val2, _mm_movehdup_ps(val2));
+    sum += (ggml_float)_mm_cvtss_f32(val2);
+#elif defined(__SSE2__)
+    for (; i + 3 < n; i += 4) {
+        __m128 val = _mm_sub_ps(_mm_loadu_ps(x + i), _mm_set1_ps(max));
+        _mm_storeu_ps(y + i, val);
+        val = ggml_v_expf(val);
+#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__)
+        val = _mm_add_ps(val, _mm_movehl_ps(val, val));
+        val = _mm_add_ss(val, _mm_movehdup_ps(val));
+#else
+        __m128 tmp = _mm_shuffle_ps(val, val, _MM_SHUFFLE(2, 3, 0, 1));
+        val = _mm_add_ps(val, tmp);
+        tmp = _mm_movehl_ps(tmp, val);
+        val = _mm_add_ss(val, tmp);
+#endif
+        sum += (ggml_float)_mm_cvtss_f32(val);
+    }
+#elif defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
+    const int vlen = svcntw();
+    for (; i < n; i += vlen) {
+        const svbool_t pg = svwhilelt_b32_s32(i, n);
+        svfloat32_t val = svsub_f32_x(pg, svld1_f32(pg, x + i), svdup_n_f32_x(pg, max));
+        svst1_f32(pg, y + i, val);
+        sum += (ggml_float)svaddv_f32(pg, ggml_v_expf(pg, val));
+    }
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+    for (; i + 3 < n; i += 4) {
+        float32x4_t val = vsubq_f32(vld1q_f32(x + i), vdupq_n_f32(max));
+        vst1q_f32(y + i, val);
+        sum += (ggml_float)vaddvq_f32(ggml_v_expf(val));
+    }
+#elif defined(__riscv_v_intrinsic)
+    vfloat64m1_t vsum = __riscv_vfmv_v_f_f64m1(0, 1);
+    for (int avl; i < n; i += avl) {
+        avl = __riscv_vsetvl_e32m2(n - i);
+        vfloat32m2_t val = __riscv_vfsub_vf_f32m2(__riscv_vle32_v_f32m2(&x[i], avl), max, avl);
+        __riscv_vse32_v_f32m2(&y[i], val, avl);
+        vsum = __riscv_vfwredusum_vs_f32m2_f64m1(ggml_v_expf_m2(val, avl), vsum, avl);
+    }
+    sum = (ggml_float)__riscv_vfmv_f_s_f64m1_f64(vsum);
+#endif
     for (; i < n; ++i) {
         float val = x[i] - max;
         y[i] = val;
         sum += (ggml_float)expf(val);
     }
-    return sum = (ggml_float)logf(sum);
+    return (ggml_float)logf(sum);
 }


### PR DESCRIPTION
@am17an, hi again. Thanks a lot for the past tests, I was able to better test my changes now, how will you have free time could you test this branch?

Reference: https://github.com/ggml-org/llama.cpp/pull/1595#pullrequestreview-3310928344

CTest successful all, but model not found strange
```
14 - test-tokenizers-ggml-vocabs (Failed)
Reason:

14/43 Test #14: test-tokenizers-ggml-vocabs .......***Failed    0.36 sec
Already up to date.
main : reading vocab from: '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/PLaMo2/ggml-vocab-plamo2.gguf'
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/PLaMo2/ggml-vocab-plamo2.gguf
llama_model_load_from_file_impl: failed to load model
main: error: failed to load vocab '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/PLaMo2/ggml-vocab-plamo2.gguf'
main : reading vocab from: '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/RWKV/ggml-vocab-rwkv-7-world.gguf'
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/RWKV/ggml-vocab-rwkv-7-world.gguf
llama_model_load_from_file_impl: failed to load model
main: error: failed to load vocab '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/RWKV/ggml-vocab-rwkv-7-world.gguf'
main : reading vocab from: '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/SPM/ggml-vocab-gemma-3.gguf'
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/SPM/ggml-vocab-gemma-3.gguf
llama_model_load_from_file_impl: failed to load model
main: error: failed to load vocab '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/SPM/ggml-vocab-gemma-3.gguf'
main : reading vocab from: '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/UGM/ggml-vocab-nomic-bert-moe.gguf'
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/UGM/ggml-vocab-nomic-bert-moe.gguf
llama_model_load_from_file_impl: failed to load model
main: error: failed to load vocab '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/UGM/ggml-vocab-nomic-bert-moe.gguf'
main : reading vocab from: '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/WPM/ggml-vocab-jina-v2-en.gguf'
gguf_init_from_file_impl: invalid magic characters: 'vers', expected 'GGUF'
llama_model_load: error loading model: llama_model_loader: failed to load model from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/WPM/ggml-vocab-jina-v2-en.gguf
llama_model_load_from_file_impl: failed to load model
main: error: failed to load vocab '/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/models/ggml-vocabs/WPM/ggml-vocab-jina-v2-en.gguf'
```
[ctest_all_output.txt](https://github.com/user-attachments/files/24223209/ctest_all_output.txt)

My hyperfine tests on NUMA Xeon 2xE5-2699:
```
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ hyperfine --warmup 1 -r 5 "./llama-bench -m Llama-3.2-1B-Instruct-Q2_K.gguf -p 512 -n 128"
Benchmark 1: ./llama-bench -m Llama-3.2-1B-Instruct-Q2_K.gguf -p 512 -n 128
  Time (mean ± σ):     32.360 s ±  0.182 s    [User: 1150.270 s, System: 1.218 s]
  Range (min … max):   32.049 s … 32.514 s    5 runs
 
devuan@devuan:/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/llama.cpp/cmake-build-release/bin$ hyperfine --warmup 1 -r 5 "./llama-bench -m Llama-3.2-1B-Instruct-Q2_K.gguf -p 512 -n 128"
Benchmark 1: ./llama-bench -m Llama-3.2-1B-Instruct-Q2_K.gguf -p 512 -n 128
  Time (mean ± σ):     28.896 s ±  0.267 s    [User: 1024.634 s, System: 1.303 s]
  Range (min … max):   28.568 s … 29.183 s    5 runs
```

Single run (not accuracy for me):

tg128 increased, as well as in hyperfine, average execution time llama-bench fell

**cpu-vec-simd**

| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           pp512 |         76.53 ± 0.09 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           tg128 |         28.97 ± 0.85 |

build: be23f5f7 (7424)

**master**

| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           pp512 |         77.00 ± 0.10 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           tg128 |         27.05 ± 0.73 |

build: d6742125 (7421)
