### PR TITLE
gguf-py : use copy-on-write mode for localtensor

### DIFF
--- a/gguf-py/gguf/utility.py
+++ b/gguf-py/gguf/utility.py
@@ -288,7 +288,7 @@ class LocalTensor:
     data_range: LocalTensorRange
 
     def mmap_bytes(self) -> np.ndarray:
-        return np.memmap(self.data_range.filename, mode='r', offset=self.data_range.offset, shape=self.data_range.size)
+        return np.memmap(self.data_range.filename, mode='c', offset=self.data_range.offset, shape=self.data_range.size)
 
 
 class SafetensorsLocal:


### PR DESCRIPTION
Follow up to #18100

Allows read-only access to files while not triggering PyTorch warning about read-only tensors.

Fixes #18161