### PR TITLE
arg: fix ASAN error on sampler_type_names empty

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -873,7 +873,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         sampler_type_chars += common_sampler_type_to_chr(sampler);
         sampler_type_names += common_sampler_type_to_str(sampler) + ";";
     }
-    sampler_type_names.pop_back();
+    if (!sampler_type_names.empty()) {
+        sampler_type_names.pop_back(); // remove last semicolon
+    }
 
 
     /**


### PR DESCRIPTION
Fix a bug from https://github.com/ggml-org/llama.cpp/pull/18056 , cc @ServeurpersoCom 
