### PR TITLE
llama-server: friendlier error msg when ctx < input

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1283,11 +1283,6 @@ struct server_context_impl {
         queue_results.send(std::move(res));
     }
 
-    template <typename T, typename... Args>
-    void send_error(const T & obj, const enum error_type type, const char * fmt, Args... args) {
-        send_error(obj, string_format(fmt, args...), type);
-    }
-
     // if multimodal is enabled, send an error and return false
     bool check_no_mtmd(const int id_task) {
         if (mctx) {
@@ -1967,28 +1962,33 @@ struct server_context_impl {
 
                         if (!slot.can_split()) {
                             if (slot.task->n_tokens() > n_ubatch) {
-                                send_error(slot, ERROR_TYPE_SERVER,
-                                           "input (%d tokens) is too large to process. increase the physical batch "
-                                           "size (current batch size: %d)",
-                                           slot.task->n_tokens(), n_ubatch);
+                                send_error(slot,
+                                           string_format(
+                                               "input (%d tokens) is too large to process. increase the physical batch "
+                                               "size (current batch size: %d)",
+                                               slot.task->n_tokens(), n_ubatch),
+                                           ERROR_TYPE_SERVER);
                                 slot.release();
                                 continue;
                             }
 
                             if (slot.task->n_tokens() > slot.n_ctx) {
                                 send_error(
-                                    slot, ERROR_TYPE_EXCEED_CONTEXT_SIZE,
-                                    "input (%d tokens) is larger than the max context size (%d tokens). skipping",
-                                    slot.task->n_tokens(), slot.n_ctx);
+                                    slot,
+                                    string_format(
+                                        "input (%d tokens) is larger than the max context size (%d tokens). skipping",
+                                        slot.task->n_tokens(), slot.n_ctx),
+                                    ERROR_TYPE_EXCEED_CONTEXT_SIZE);
                                 slot.release();
                                 continue;
                             }
                         } else {
                             if (slot.task->n_tokens() >= slot.n_ctx) {
-                                send_error(
-                                    slot, ERROR_TYPE_EXCEED_CONTEXT_SIZE,
-                                    "request (%d tokens) exceeds available context size (%d tokens), try increasing it",
-                                    slot.task->n_tokens(), slot.n_ctx);
+                                send_error(slot,
+                                           string_format("request (%d tokens) exceeds available context size (%d "
+                                                         "tokens), try increasing it",
+                                                         slot.task->n_tokens(), slot.n_ctx),
+                                           ERROR_TYPE_EXCEED_CONTEXT_SIZE);
                                 slot.release();
                                 continue;
                             }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1985,7 +1985,7 @@ struct server_context_impl {
                         } else {
                             if (slot.task->n_tokens() >= slot.n_ctx) {
                                 send_error(slot,
-                                           string_format("request (%d tokens) exceeds available context size (%d "
+                                           string_format("request (%d tokens) exceeds the available context size (%d "
                                                          "tokens), try increasing it",
                                                          slot.task->n_tokens(), slot.n_ctx),
                                            ERROR_TYPE_EXCEED_CONTEXT_SIZE);


### PR DESCRIPTION
This PR adds formatted strings to the server's send_error function

I was testing out the new cli and I thought that these might be more helpful to debug when reading too large an input 