### PR TITLE
CLI: implemented non interactive mode

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(${TARGET} STATIC
     sampling.h
     speculative.cpp
     speculative.h
+    tty-utils.cpp
+    tty-utils.h
     unicode.cpp
     unicode.h
     )

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -9,6 +9,7 @@
 #include "log.h"
 #include "llama.h"
 #include "sampling.h"
+#include "tty-utils.h"
 
 #include <algorithm>
 #include <cinttypes>
@@ -1003,10 +1004,7 @@ bool tty_can_use_colors() {
 
     // Check if stdout and stderr are connected to a terminal
     // We check both because log messages can go to either
-    bool stdout_is_tty = isatty(fileno(stdout));
-    bool stderr_is_tty = isatty(fileno(stderr));
-
-    return stdout_is_tty || stderr_is_tty;
+    return common_tty_utils::is_stdout_a_terminal() || common_tty_utils::is_stderr_a_terminal();
 }
 
 //

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -4,6 +4,7 @@
 #include "gguf.h" // for reading GGUF splits
 #include "log.h"
 #include "download.h"
+#include "tty-utils.h"
 
 #define JSON_ASSERT GGML_ASSERT
 #include <nlohmann/json.hpp>
@@ -41,13 +42,6 @@
 #endif
 
 #define LLAMA_MAX_URL_LENGTH 2084 // Maximum URL Length in Chrome: 2083
-
-// isatty
-#if defined(_WIN32)
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
 
 using json = nlohmann::ordered_json;
 
@@ -486,14 +480,6 @@ class ProgressBar {
         }
     }
 
-    static bool is_output_a_tty() {
-#if defined(_WIN32)
-        return _isatty(_fileno(stdout));
-#else
-        return isatty(1);
-#endif
-    }
-
 public:
     ProgressBar() = default;
 
@@ -503,7 +489,7 @@ public:
     }
 
     void update(size_t current, size_t total) {
-        if (!is_output_a_tty()) {
+        if (!common_tty_utils::is_stdout_a_terminal()) {
             return;
         }
 

--- a/common/tty-utils.cpp
+++ b/common/tty-utils.cpp
@@ -1,0 +1,48 @@
+#include "tty-utils.h"
+
+#include <unistd.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace common_tty_utils {
+    bool is_stdin_a_terminal() {
+    #if defined(_WIN32)
+        HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+        if (hStdin == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+        DWORD mode;
+        return GetConsoleMode(hStdin, &mode);
+    #else
+        return isatty(STDIN_FILENO);
+    #endif
+    }
+
+    bool is_stdout_a_terminal() {
+    #if defined(_WIN32)
+        HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hStdin == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+        DWORD mode;
+        return GetConsoleMode(hStdout, &mode);
+    #else
+        return isatty(STDOUT_FILENO);
+    #endif
+    }
+
+    bool is_stderr_a_terminal() {
+    #if defined(_WIN32)
+        HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
+        if (hStdin == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+        DWORD mode;
+        return GetConsoleMode(hStderr, &mode);
+    #else
+        return isatty(STDERR_FILENO);
+    #endif
+    }
+} // namespace common_tty_utils

--- a/common/tty-utils.h
+++ b/common/tty-utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace common_tty_utils {
+  bool is_stdin_a_terminal();
+  bool is_stdout_a_terminal();
+  bool is_stderr_a_terminal();
+}

--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "llama-cpp.h"
 #include "log.h"
+#include "tty-utils.h"
 
 #include "linenoise.cpp/linenoise.h"
 
@@ -1243,26 +1244,6 @@ static int handle_user_input(std::string & user_input, const std::string & user)
     return read_user_input(user_input);  // Returns true if input ends the loop
 }
 
-static bool is_stdin_a_terminal() {
-#if defined(_WIN32)
-    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
-    DWORD  mode;
-    return GetConsoleMode(hStdin, &mode);
-#else
-    return isatty(STDIN_FILENO);
-#endif
-}
-
-static bool is_stdout_a_terminal() {
-#if defined(_WIN32)
-    HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
-    DWORD  mode;
-    return GetConsoleMode(hStdout, &mode);
-#else
-    return isatty(STDOUT_FILENO);
-#endif
-}
-
 // Function to handle user input
 static int get_user_input(std::string & user_input, const std::string & user) {
     while (true) {
@@ -1328,8 +1309,8 @@ static int chat_loop(LlamaData & llama_data, const Opt & opt) {
         chat_template = read_chat_template_file(opt.chat_template_file);
     }
 
-    common_chat_templates_ptr chat_templates    = common_chat_templates_init(llama_data.model.get(), chat_template);
-    static const bool stdout_a_terminal = is_stdout_a_terminal();
+    common_chat_templates_ptr chat_templates = common_chat_templates_init(llama_data.model.get(), chat_template);
+    static const bool stdout_a_terminal = common_tty_utils::is_stdout_a_terminal();
     while (true) {
         // Get user input
         std::string user_input;
@@ -1386,7 +1367,7 @@ int main(int argc, const char ** argv) {
         return 1;
     }
 
-    if (!is_stdin_a_terminal()) {
+    if (!common_tty_utils::is_stdin_a_terminal()) {
         if (!opt.user.empty()) {
             opt.user += "\n\n";
         }


### PR DESCRIPTION
I've implemented non-interactive mode for CLI in the following way:

1. Copied `is_stdin_a_terminal` and `is_stdout_a_terminal` functions from [run](tools/run).
2. Disabled conversation mode when `stdin` or `stdout` is not a tty.
3. Used `<think>` and `</think>` tags for marking think output.
4. Removed `console::log` messages from output in non-interactive mode.
5. Disabled the infinite loop case when it is not possible to get a new message in non-interactive mode.

Now it is possible to use the following commands: `cli <<< 'input'`, `echo 'input' | cli`, `cli > output`.

This PR is a draft; please discuss.