### PR TITLE
test-backend-ops: improve msvc build time

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6710,6 +6710,11 @@ static const ggml_type other_types[] = {
     GGML_TYPE_BF16,
 };
 
+#ifdef _MSC_VER
+// Workaround long compile time with msvc
+#pragma optimize("", off)
+#endif
+
 // Test cases for evaluation: should try to cover edge cases while using small input sizes to keep the runtime low
 static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     std::vector<std::unique_ptr<test_case>> test_cases;
@@ -7996,6 +8001,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     return test_cases;
 }
+#ifdef _MSC_VER
+#pragma optimize("", on)
+#endif
 
 // Test cases for performance evaluation: should be representative of real-world use cases
 static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {


### PR DESCRIPTION
Incremental build time for test-backend-ops with msvc has gotten much worse as make_test_cases_eval has gotten larger, it seems to be hitting some non-linear time thing in the compiler. This change disables optimizations for that function to workaround it.

```
before:
========== Build started at 4:10 PM and took 31.201 seconds ==========

after:
========== Build started at 4:09 PM and took 05.400 seconds ==========
```

Another option would be to split this function into smaller functions. I experimented with this and it helps, not quite as much, and is a more disruptive change that may still regress in the future. So I think the pragma would be better.
