### PR TITLE
Make sure that CMAKE will always use JSON headers under vendor directory

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -17,7 +17,7 @@
 #endif
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <algorithm>
 #include <cinttypes>

--- a/common/chat-parser-xml-toolcall.h
+++ b/common/chat-parser-xml-toolcall.h
@@ -2,7 +2,7 @@
 
 #include "chat.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <optional>
 #include <string>

--- a/common/chat-parser.h
+++ b/common/chat-parser.h
@@ -5,7 +5,7 @@
 #include "json-partial.h"
 #include "regex-partial.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <optional>
 #include <string>

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -1,6 +1,6 @@
 #include "chat-peg-parser.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 using json = nlohmann::json;
 

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -6,7 +6,7 @@
 #include "download.h"
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <algorithm>
 #include <filesystem>

--- a/common/json-partial.cpp
+++ b/common/json-partial.cpp
@@ -2,7 +2,7 @@
 
 #include "log.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <string>
 #include <regex>

--- a/common/json-partial.h
+++ b/common/json-partial.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 // Healing marker (empty if the JSON was fully parsed / wasn't healed).
 struct common_healing_marker {

--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -1,7 +1,7 @@
 #include "json-schema-to-grammar.h"
 #include "common.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <algorithm>
 #include <map>

--- a/common/json-schema-to-grammar.h
+++ b/common/json-schema-to-grammar.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include "../vendor/nlohmann/json_fwd.hpp"
 
 #include <functional>
 #include <memory>

--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -3,7 +3,7 @@
 #include "json-schema-to-grammar.h"
 #include "unicode.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <algorithm>
 #include <initializer_list>

--- a/common/peg-parser.h
+++ b/common/peg-parser.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include "../vendor/nlohmann/json_fwd.hpp"
 
 #include <memory>
 #include <unordered_map>

--- a/tests/peg-parser/tests.h
+++ b/tests/peg-parser/tests.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Common includes for all test files
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 #include <string>
 #include <vector>
 

--- a/tests/test-chat-peg-parser.cpp
+++ b/tests/test-chat-peg-parser.cpp
@@ -10,7 +10,7 @@
 #include "peg-parser.h"
 #include "peg-parser/testing.h"
 #include "peg-parser/simple-tokenize.h"
-#include "nlohmann/json.hpp"
+#include "../vendor/nlohmann/json.hpp"
 
 using json = nlohmann::ordered_json;
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -12,7 +12,7 @@
 #include "../src/unicode.h"
 #include "../src/llama-grammar.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -7,7 +7,7 @@
 #include "../src/unicode.h"
 #include "../src/llama-grammar.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <cassert>
 #include <string>

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -6,7 +6,7 @@
 
 #include "../src/llama-grammar.h"
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <cassert>
 #include <fstream>

--- a/tools/run/run.cpp
+++ b/tools/run/run.cpp
@@ -6,7 +6,7 @@
 #include "linenoise.cpp/linenoise.h"
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #if defined(_WIN32)
 #    define WIN32_LEAN_AND_MEAN

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -7,7 +7,7 @@
 #include "mtmd.h"
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <string>
 #include <vector>

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -2,7 +2,7 @@
 #include "server-task.h"
 #include "server-queue.h"
 
-#include <nlohmann/json_fwd.hpp>
+#include "../vendor/nlohmann/json_fwd.hpp"
 
 #include <cstddef>
 #include <memory>

--- a/tools/tts/tts.cpp
+++ b/tools/tts/tts.cpp
@@ -7,7 +7,7 @@
 #include "llama.h"
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/vendor/minja/chat-template.hpp
+++ b/vendor/minja/chat-template.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 using json = nlohmann::ordered_json;
 

--- a/vendor/minja/minja.hpp
+++ b/vendor/minja/minja.hpp
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include "../vendor/nlohmann/json.hpp"
 
 using json = nlohmann::ordered_json;
 


### PR DESCRIPTION
The previous including path of Json is `#include <nlohmann/json.hpp>`. It may result in different directories under different projects.
For projects under **tests**, they can find the correct directory, which is `vendor/nlohmann`(V3.12).
But project **common** can't find this one. Because this project adds one extra including directory, which is `include_directories(${CURL_INCLUDE_DIRS})`. For my device, it's  `~/miniforge3/include`. 
Unfortunately, I installed an old version(V3.11) of JSON just under `~/miniforge3/include`.  So, project **common** uses the older version while others use a newer version. Then I met a linking error.
The JSON version v3.12 is undefined:
```
test-grammar-integration.cpp:(.text+0x7b0f): undefined reference to `json_schema_to_grammar(nlohmann::json_abi_v3_12_0::basic_json<nlohmann::json_abi_v3_12_0::ordered_map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_12_0::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> >, void> const&, bool)'
collect2: error: ld returned 1 exit status
```

Look into libcommon.a, its JSON version is v3.11:
```
0000000000000030 d _ZTIZ22json_schema_to_grammarRKN8nlohmann16json_abi_v3_11_310basic_jsonINS0_11ordered_mapESt6vectorNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEblmdSaNS0_14adl_serializerES3_IhSaIhEEvEEbEUlRK22common_grammar_builderE_
0000000000000280 r _ZTSZ22json_schema_to_grammarRKN8nlohmann16json_abi_v3_11_310basic_jsonINS0_11ordered_mapESt6vectorNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEblmdSaNS0_14adl_serializerES3_IhSaIhEEvEEbEUlRK22common_grammar_builderE_
```