### PR TITLE
server: add auto-sleep after N seconds of idle

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2888,6 +2888,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--sleep-idle-seconds"}, "SECONDS",
+        string_format("number of seconds of idleness after which the server will sleep (default: %d; -1 = disabled)", params.sleep_idle_seconds),
+        [](common_params & params, int value) {
+            params.sleep_idle_seconds = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--simple-io"},
         "use basic IO for better compatibility in subprocesses and limited consoles",
         [](common_params & params) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2891,6 +2891,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--sleep-idle-seconds"}, "SECONDS",
         string_format("number of seconds of idleness after which the server will sleep (default: %d; -1 = disabled)", params.sleep_idle_seconds),
         [](common_params & params, int value) {
+            if (value == 0 || value < -1) {
+                throw std::invalid_argument("invalid value: cannot be 0 or less than -1");
+            }
             params.sleep_idle_seconds = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));

--- a/common/common.h
+++ b/common/common.h
@@ -475,7 +475,8 @@ struct common_params {
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
     int reasoning_budget = -1;
-    bool prefill_assistant = true;                                                                          // if true, any trailing assistant message will be prefilled into the response
+    bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
+    int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
 
     std::vector<std::string> api_keys;
 

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -209,8 +209,6 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    ctx_cli.ctx_server.init();
-
     console::spinner::stop();
     console::log("\n");
 

--- a/tools/server/README-dev.md
+++ b/tools/server/README-dev.md
@@ -107,6 +107,8 @@ For detailed instructions, see the [test documentation](./tests/README.md).
 - Large-scale code base split into smaller files: https://github.com/ggml-org/llama.cpp/pull/17362
 - Introduction of router mode: https://github.com/ggml-org/llama.cpp/pull/17470
 - Speculative decoding: https://github.com/ggml-org/llama.cpp/pull/17808 and rework in https://github.com/ggml-org/llama.cpp/pull/17808
+- INI presets: https://github.com/ggml-org/llama.cpp/pull/17859 (+ refactoring: https://github.com/ggml-org/llama.cpp/pull/18169)
+- Sleeping mode: https://github.com/ggml-org/llama.cpp/pull/18228
 
 
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1621,6 +1621,16 @@ Example of an error:
 }
 ```
 
+## Sleeping on Idle
+
+The server supports an automatic sleep mode that activates after a specified period of inactivity (no incoming tasks). This feature, introduced in [PR #18228](https://github.com/ggml-org/llama.cpp/pull/18228), can be enabled using the `--sleep-idle-seconds` command-line argument. It works seamlessly in both single-model and multi-model configurations.
+
+When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.
+
+Note that the following endpoints are exempt from being considered as incoming tasks. They do not trigger model reloading and do not reset the idle timer:
+- `GET /health`
+- `GET /props`
+
 ## More examples
 
 ### Interactive mode

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1630,7 +1630,6 @@ When the server enters sleep mode, the model and its associated memory (includin
 Note that the following endpoints are exempt from being considered as incoming tasks. They do not trigger model reloading and do not reset the idle timer:
 - `GET /health`
 - `GET /props`
-- `GET /models` and `GET /v1/models`
 
 ## More examples
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1630,6 +1630,7 @@ When the server enters sleep mode, the model and its associated memory (includin
 Note that the following endpoints are exempt from being considered as incoming tasks. They do not trigger model reloading and do not reset the idle timer:
 - `GET /health`
 - `GET /props`
+- `GET /models` and `GET /v1/models`
 
 ## More examples
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2786,6 +2786,8 @@ struct server_res_generator : server_http_res {
     server_response_reader rd;
     server_res_generator(server_context_impl & ctx_server, bool bypass_sleep = false)
             : rd(ctx_server.queue_tasks, ctx_server.queue_results, HTTP_POLLING_SECONDS) {
+        // fast path in case sleeping is disabled
+        bypass_sleep |= ctx_server.params_base.sleep_idle_seconds < 0;
         if (!bypass_sleep) {
             ctx_server.queue_tasks.wait_until_no_sleep();
         }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -863,9 +863,12 @@ struct server_context_impl {
             common_chat_templates_source(chat_templates.get()),
             common_chat_format_example(chat_templates.get(), params_base.use_jinja, params_base.default_template_kwargs).c_str());
 
-        if (!populate_json_responses()) {
-            SRV_ERR("%s", "failed to populate JSON responses\n");
-            return false;
+        if (!is_resume) {
+            // do not repopulate on resume, as HTTP threads may be still using the existing JSON data
+            if (!populate_json_responses()) {
+                SRV_ERR("%s", "failed to populate JSON responses\n");
+                return false;
+            }
         }
 
         return true;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -560,6 +560,8 @@ struct server_context_impl {
 
     ~server_context_impl() {
         if (!sleeping) {
+            // destroy() is already called when entering sleeping state
+            // we don't call it again here to avoid double free
             destroy();
         }
     }
@@ -594,8 +596,7 @@ struct server_context_impl {
         } else {
             SRV_INF("%s", "server is exiting sleeping state\n");
             if (!load_model(params_base)) {
-                SRV_ERR("%s", "fatal: failed to reload model after sleeping\n");
-                exit(1);
+                GGML_ABORT("failed to reload model after sleeping");
             }
         }
         sleeping = new_state;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -809,13 +809,10 @@ struct server_context_impl {
             batch = llama_batch_init(std::max(n_batch, params_base.n_parallel), 0, 1);
         }
 
-        if (is_resume) {
-            return true;
+        // preserve metric state across resumes
+        if (!is_resume) {
+            metrics.init();
         }
-
-        // everything below this line is only for fresh model load
-
-        metrics.init();
 
         if (params_base.cache_ram_mib != 0) {
             if (params_base.cache_ram_mib < 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -851,7 +851,7 @@ struct server_context_impl {
 
         return true;
     }
-    
+
     // unlike load_model(), this is only called once during initialization
     bool init() {
         GGML_ASSERT(ctx != nullptr);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -565,7 +565,12 @@ struct server_context_impl {
     }
 
     void destroy() {
+        llama_init.reset();
+        ctx = nullptr;
+        model = nullptr;
+
         mtmd_free(mctx);
+        mctx = nullptr;
 
         // Clear any sampling context
         for (server_slot & slot : slots) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3453,10 +3453,6 @@ void server_routes::init_routes() {
             model_meta = ctx_server.json_server_model_meta;
         }
         bool has_mtmd = ctx_server.mctx != nullptr;
-
-        // IMPORTANT: this endpoint can be accessed on model loading and in sleeping mode
-        // do NOT access dynamic model info that requires calling libllama APIs
-
         json models = {
             {"models", {
                 {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3436,8 +3436,10 @@ void server_routes::init_routes() {
         return res;
     };
 
+    // TODO: this endpoint is unsafe to access during model reloading (i.e. wake up from sleeping)
+    // how to make it work even during load_model()?
     this->get_models = [this](const server_http_req &) {
-        auto res = std::make_unique<server_res_generator>(ctx_server, true);
+        auto res = std::make_unique<server_res_generator>(ctx_server);
         json model_meta = nullptr;
         if (is_ready()) {
             model_meta = ctx_server.json_server_model_meta;

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -22,9 +22,6 @@ struct server_context {
     server_context();
     ~server_context();
 
-    // initialize slots and server-related data
-    bool init();
-
     // load the model and initialize llama_context
     // returns true on success
     bool load_model(const common_params & params);

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -23,7 +23,7 @@ struct server_context {
     ~server_context();
 
     // initialize slots and server-related data
-    void init();
+    bool init();
 
     // load the model and initialize llama_context
     // returns true on success

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -32,7 +32,7 @@ struct server_context {
     // terminate main loop (will unblock start_loop)
     void terminate();
 
-    // get the underlaying llama_context
+    // get the underlaying llama_context, can return nullptr if sleeping
     llama_context * get_llama_context() const;
 
     // get a new response reader, used by CLI application

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -63,7 +63,7 @@ public:
      * - Process the task (i.e. maybe copy data into slot)
      * - Check if multitask is finished
      * - Update all slots
-     * 
+     *
      * Sleeping procedure (disabled if idle_sleep_ms < 0):
      * - If there is no task after idle_sleep_ms, enter sleeping state
      * - Call callback_sleeping_state(true)

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -12,7 +12,10 @@
 struct server_queue {
 private:
     int id = 0;
-    bool running;
+    bool running  = false;
+    bool sleeping = false;
+    bool req_stop_sleeping = false;
+    int64_t time_last_task = 0;
 
     // queues
     std::deque<server_task> queue_tasks;
@@ -24,6 +27,7 @@ private:
     // callback functions
     std::function<void(server_task &&)> callback_new_task;
     std::function<void(void)>           callback_update_slots;
+    std::function<void(bool)>           callback_sleeping_state;
 
 public:
     // Add a new task to the end of the queue
@@ -38,14 +42,17 @@ public:
     // Get the next id for creating a new task
     int get_new_id();
 
-    // Register function to process a new task
-    void on_new_task(std::function<void(server_task &&)> callback);
-
-    // Register the function to be called when all slots data is ready to be processed
-    void on_update_slots(std::function<void(void)> callback);
-
     // Call when the state of one slot is changed, it will move one task from deferred to main queue
     void pop_deferred_task();
+
+    // if sleeping, request exiting sleep state and wait until it is done
+    // returns immediately if not sleeping
+    void wait_until_no_sleep();
+
+    bool is_sleeping() {
+        std::unique_lock<std::mutex> lock(mutex_tasks);
+        return sleeping;
+    }
 
     // end the start_loop routine
     void terminate();
@@ -56,13 +63,41 @@ public:
      * - Process the task (i.e. maybe copy data into slot)
      * - Check if multitask is finished
      * - Update all slots
+     * 
+     * Sleeping procedure (disabled if idle_sleep_ms < 0):
+     * - If there is no task after idle_sleep_ms, enter sleeping state
+     * - Call callback_sleeping_state(true)
+     * - Wait until req_stop_sleeping is set to true
+     * - Call callback_sleeping_state(false)
+     * - Exit sleeping state
      */
-    void start_loop();
+    void start_loop(int64_t idle_sleep_ms = -1);
 
     // for metrics
     size_t queue_tasks_deferred_size() {
         std::unique_lock<std::mutex> lock(mutex_tasks);
         return queue_tasks_deferred.size();
+    }
+
+    //
+    // Functions below are not thread-safe, must only be used before start_loop() is called
+    //
+
+    // Register function to process a new task
+    void on_new_task(std::function<void(server_task &&)> callback) {
+        callback_new_task = std::move(callback);
+    }
+
+    // Register the function to be called when all slots data is ready to be processed
+    void on_update_slots(std::function<void(void)> callback) {
+        callback_update_slots = std::move(callback);
+    }
+
+    // Register callback for sleeping state change
+    // note: when entering sleeping state, the callback is called AFTER sleeping is set to true
+    //       when leaving sleeping state, the callback is called BEFORE sleeping is set to false
+    void on_sleeping_state(std::function<void(bool)> callback) {
+        callback_sleeping_state = std::move(callback);
     }
 
 private:

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -308,7 +308,11 @@ int main(int argc, char ** argv, char ** envp) {
         if (monitor_thread.joinable()) {
             monitor_thread.join();
         }
-        llama_memory_breakdown_print(ctx_server.get_llama_context());
+
+        auto * ll_ctx = ctx_server.get_llama_context();
+        if (ll_ctx != nullptr) {
+            llama_memory_breakdown_print(ll_ctx);
+        }
     }
 
     return 0;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -252,15 +252,6 @@ int main(int argc, char ** argv, char ** envp) {
             return 1;
         }
 
-        if (!ctx_server.init()) {
-            clean_up();
-            if (ctx_http.thread.joinable()) {
-                ctx_http.thread.join();
-            }
-            LOG_ERR("%s: exiting due to server initialization error\n", __func__);
-            return 1;
-        }
-
         ctx_http.is_ready.store(true);
 
         LOG_INF("%s: model loaded\n", __func__);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -252,7 +252,15 @@ int main(int argc, char ** argv, char ** envp) {
             return 1;
         }
 
-        ctx_server.init();
+        if (!ctx_server.init()) {
+            clean_up();
+            if (ctx_http.thread.joinable()) {
+                ctx_http.thread.join();
+            }
+            LOG_ERR("%s: exiting due to server initialization error\n", __func__);
+            return 1;
+        }
+
         ctx_http.is_ready.store(true);
 
         LOG_INF("%s: model loaded\n", __func__);

--- a/tools/server/tests/unit/test_sleep.py
+++ b/tools/server/tests/unit/test_sleep.py
@@ -1,0 +1,39 @@
+import pytest
+import time
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+
+
+def test_server_sleep():
+    global server
+    server.sleep_idle_seconds = 1
+    server.start()
+
+    # wait a bit so that server can go to sleep
+    time.sleep(2)
+
+    # make sure these endpoints are still responsive after sleep
+    res = server.make_request("GET", "/health")
+    assert res.status_code == 200
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    assert res.body["is_sleeping"] == True
+
+    # make a generation request to wake up the server
+    res = server.make_request("POST", "/completion", data={
+        "n_predict": 1,
+        "prompt": "Hello",
+    })
+    assert res.status_code == 200
+
+    # it should no longer be sleeping
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    assert res.body["is_sleeping"] == False

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -100,6 +100,7 @@ class ServerProcess:
     server_path: str | None = None
     mmproj_url: str | None = None
     media_path: str | None = None
+    sleep_idle_seconds: int | None = None
 
     # session variables
     process: subprocess.Popen | None = None
@@ -230,6 +231,8 @@ class ServerProcess:
             server_args.extend(["--mmproj-url", self.mmproj_url])
         if self.media_path:
             server_args.extend(["--media-path", self.media_path])
+        if self.sleep_idle_seconds is not None:
+            server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
 
         args = [str(arg) for arg in [server_path, *server_args]]
         print(f"tests: starting server with: {' '.join(args)}")


### PR DESCRIPTION
## Sleeping on Idle

The server supports an automatic sleep mode that activates after a specified period of inactivity (no incoming tasks). This feature, introduced in [PR #18228](https://github.com/ggml-org/llama.cpp/pull/18228), can be enabled using the `--sleep-idle-seconds` command-line argument. It works seamlessly in both single-model and multi-model configurations.

When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.

Note that the following endpoints are exempt from being considered as incoming tasks. They do not trigger model reloading and do not reset the idle timer:
- `GET /health`
- `GET /props`

---

## Implementation

The implementation of this feature consists of 3 main parts:
- `server_queue` sleeping state
- `server_context` sleeping state
- `server_res_generator` hook

The main loop inside `server_queue` acts as a watchdog timer (so we can avoid spawning a dedicated thread just for the watchdog). Upon timing condition passed, it signals to `server_context` to unload the model.

`server_res_generator` hooks on any incoming request, and will ask the `server_queue` to resume if it is in sleeping state. Note that some requests like `/health` bypass this check (they can only access read-only data of `server_context`)

Upon requested to resume, `server_queue` signals `server_context` to reload models, then unblock `server_res_generator` to proceed with the rest of the request.

IMPORTANT: for thread-safety reason, any requests to server will be blocked/delayed by `server_res_generator` until the server exits sleeping state