### PR TITLE
webui: Fix the header backdrop blur

### DIFF
--- a/tools/server/webui/src/lib/components/app/chat/ChatScreen/ChatScreenHeader.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatScreen/ChatScreenHeader.svelte
@@ -2,8 +2,10 @@
 	import { Settings } from '@lucide/svelte';
 	import { ChatSettingsDialog } from '$lib/components/app';
 	import { Button } from '$lib/components/ui/button';
+	import { useSidebar } from '$lib/components/ui/sidebar';
 
 	let settingsOpen = $state(false);
+	const sidebar = useSidebar();
 
 	function toggleSettings() {
 		settingsOpen = true;
@@ -11,7 +13,9 @@
 </script>
 
 <header
-	class="md:background-transparent pointer-events-none fixed top-0 right-0 left-0 z-50 flex items-center justify-end bg-background/40 p-4 backdrop-blur-xl md:left-[var(--sidebar-width)]"
+	class="md:background-transparent pointer-events-none fixed top-0 right-0 left-0 z-50 flex items-center justify-end bg-background/40 p-4 backdrop-blur-xl transition-all duration-200 ease-linear {sidebar.open
+		? 'md:left-[var(--sidebar-width)]'
+		: ''}"
 >
 	<div class="pointer-events-auto flex items-center space-x-2">
 		<Button variant="ghost" size="sm" onclick={toggleSettings}>


### PR DESCRIPTION
This PR addresses issue [#18229](https://github.com/ggml-org/llama.cpp/issues/18229) by conditionally applying the `md:left-[var(--sidebar-width)]` class based on the sidebar's open state.

@allozaur @ServeurpersoCom 