### PR TITLE
cli: buffering info log, only show if model load failed

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1092,10 +1092,16 @@ common_init_result::common_init_result(common_params & params) :
     auto cparams = common_context_params_to_llama(params);
 
     if (params.fit_params) {
-        LOG_INF("%s: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on\n", __func__);
+        const char * msg = "%s: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on\n";
+        // hack: make sure this message is shown on CLI in case errors occur during fitting
+        if (params.verbosity == LOG_LEVEL_ERROR) {
+            LOG_WRN(msg, __func__);
+        } else {
+            LOG_INF(msg, __func__);
+        }
         llama_params_fit(params.model.path.c_str(), &mparams, &cparams,
             params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target, params.fit_params_min_ctx,
-            params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+            params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
     }
 
     llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);

--- a/common/log.h
+++ b/common/log.h
@@ -86,6 +86,22 @@ void common_log_set_prefix    (struct common_log * log, bool prefix);       // w
 void common_log_set_timestamps(struct common_log * log, bool timestamps);   // whether to output timestamps in the prefix
 void common_log_flush         (struct common_log * log);                    // flush all pending log messages
 
+// Buffering log messages allows to only write log if we encouter an error later on
+// This is useful for libraries where we want to avoid spamming the user with
+// debug/info messages unless something goes wrong.
+//
+// example:
+//  common_log_buffering(log, true);
+//  ... do stuff ...
+//  if (error) {
+//      common_log_buffering(log, false); // also flushes the log
+//  }
+//  common_log_drop(log);
+//  common_log_buffering(log, false);
+
+void common_log_buffering(struct common_log * log, bool buffering); // not thread-safe
+void common_log_drop     (struct common_log * log);
+
 // helper macros for logging
 // use these to avoid computing log arguments if the verbosity of the log is higher than the threshold
 //

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -175,6 +175,9 @@ int main(int argc, char ** argv) {
         console::error("please use llama-completion instead\n");
     }
 
+    // TODO @ngxson: we need this to have colors in log, will it have any side effects?
+    common_log_set_prefix(common_log_main(), true);
+
     common_init();
 
     // struct that contains llama context and inference
@@ -208,13 +211,14 @@ int main(int argc, char ** argv) {
     bool use_default_log = curr_log_level == default_log_lvl;
     if (use_default_log) {
         common_log_buffering(common_log_main(), true);
-        common_log_set_verbosity_thold(LOG_LEVEL_INFO);
+        common_log_set_verbosity_thold(LOG_LEVEL_WARN);
         console::log("\nLoading model... "); // followed by loading animation
         console::spinner::start();
     }
 
     if (!ctx_cli.ctx_server.load_model(params)) {
         if (use_default_log) {
+            console::error("\n----- ERROR -----\n");
             console::spinner::stop();
             console::log("\n");
             common_log_buffering(common_log_main(), false);


### PR DESCRIPTION
A QoL change that allow having more useful logs in case model loading failed.

Currently, the CLI uses ERROR as the default level, which make debugging quite tricky in some cases (in some cases INFO and WARN are also needed)

This PR introduce a "buffering" API to `common_log` that allows log lines to still be recorded, but can be dropped or flushed based on model load failed or success.

The behavior:
- If the default level is used (ERROR), buffering ERROR+WARN log lines. **They will only show if model load failed**
- Otherwise, if other log level is used, skip buffering (also skip the loading animation) --> real time logging as normal

CC @JohannesGaessler this can be useful for debugging problem with `-fit`. Although I know DEBUG level is preferred, it can be quite difficult to copy-paste if the log is too verbose. WDYT?