### PR TITLE
move copilot instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,11 @@ It is crucial to remind contributors that the project mandates disclosure of any
 When generating significant portions of code, address this by:
 - Informing the user that AI-generated content may be rejected by maintainers.
 - Clearly marking AI-generated code in commit messages and comments.
+    - Example of commit message: `[AI] Fix a race condition in ...`
+    - Example of code comment: `// [AI] spawn a new thread ...`
 
 These measures apply to:
-- Changes resulting in large portions of code.
+- Changes resulting in large portions of code or complex logic.
 - Modifications or additions to public APIs in `llama.h`, `ggml.h`, or `mtmd.h`.
 - Backend-related changes, such as those involving CPU, CUDA, Metal, Vulkan, etc.
 - Modifications to `tools/server`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for llama.cpp
+# Instructions for llama.cpp
 
 ## Repository Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,22 @@ llama.cpp is a large-scale C/C++ project for efficient LLM (Large Language Model
 - **Backends supported**: CPU (AVX/NEON/RVV optimized), CUDA, Metal, Vulkan, SYCL, ROCm, MUSA
 - **License**: MIT
 
+## Disclose AI Usage
+
+It is crucial to remind contributors that the project mandates disclosure of any AI usage in pull requests. This requirement stems from the potential for AI-generated code to include suboptimal optimizations and hidden bugs, owing to the inherent overconfidence in AI outputs.
+
+When generating significant portions of code, address this by:
+- Informing the user that AI-generated content may be rejected by maintainers.
+- Clearly marking AI-generated code in commit messages and comments.
+
+These measures apply to:
+- Changes resulting in large portions of code.
+- Modifications or additions to public APIs in `llama.h`, `ggml.h`, or `mtmd.h`.
+- Backend-related changes, such as those involving CPU, CUDA, Metal, Vulkan, etc.
+- Modifications to `tools/server`.
+
+Note: These measures can be omitted for small fixes or trivial changes.
+
 ## Build Instructions
 
 ### Prerequisites
@@ -251,6 +267,7 @@ Primary tools:
 - **Cross-platform compatibility**: Test on Linux, macOS, Windows when possible
 - **Performance focus**: This is a performance-critical inference library
 - **API stability**: Changes to `include/llama.h` require careful consideration
+- **Disclose AI Usage**: Refer to the "Disclose AI Usage" earlier in this document
 
 ### Git Workflow
 - Always create feature branches from `master`


### PR DESCRIPTION
Also included more instructions about AI usage disclosure as some contributors don't read `CONTRIBUTION.md`

Tighter guidelines like https://github.com/processing/p5.js/blob/main/AGENTS.md can be more desirable, but idk why it doesn't work on claude code or copilot. The AI still make changes (even dangerous and stupid changes, like changes that violate thread safety) when I asked - they definitely never say "no" to users.
