### PR TITLE
server : implement extra_args support for /models/load endpoint

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2812,6 +2812,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
     add_opt(common_arg(
+        {"--models-allow-extra-args"},
+        {"--no-models-allow-extra-args"},
+        string_format("for router server, whether to allow extra_args in /models/load endpoint (default: %s)", params.models_allow_extra_args ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.models_allow_extra_args = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_ALLOW_EXTRA_ARGS"));
+    add_opt(common_arg(
         {"--jinja"},
         {"--no-jinja"},
         string_format("whether to use jinja template engine for chat (default: %s)", params.use_jinja ? "enabled" : "disabled"),

--- a/common/common.h
+++ b/common/common.h
@@ -499,6 +499,7 @@ struct common_params {
     std::string models_preset = ""; // directory containing model presets for the router server
     int models_max = 4;             // maximum number of models to load simultaneously
     bool models_autoload = true;    // automatically load models when requested via the router server
+    bool models_allow_extra_args = false; // allow extra_args in /models/load endpoint
 
     bool log_json = false;
 

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -114,7 +114,7 @@ public:
 
     // load and unload model instances
     // these functions are thread-safe
-    void load(const std::string & name);
+    void load(const std::string & name, const std::vector<std::string> & extra_args = {});
     void unload(const std::string & name);
     void unload_all();
 


### PR DESCRIPTION
Implements the `extra_args` feature for `/models/load` that is already documented in the server README but was not yet implemented.

From the docs:
> `extra_args`: (optional) an array of additional arguments to be passed to the model instance. Note: you must start the server with `--models-allow-extra-args` to enable this feature.

### Changes

- `common/common.h`: Add `models_allow_extra_args` param
- `common/arg.cpp`: Add `--models-allow-extra-args` / `--no-models-allow-extra-args` flag
- `tools/server/server-models.h`: Update `load()` signature to accept `extra_args`
- `tools/server/server-models.cpp`: Parse `extra_args` from JSON body and append to child process args

See [server README](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) for usage documentation.