### PR TITLE
server: (docs) remove mention about extra_args

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1567,7 +1567,6 @@ Load a model
 
 Payload:
 - `model`: name of the model to be loaded.
-- `extra_args`: (optional) an array of additional arguments to be passed to the model instance. Note: you must start the server with `--models-allow-extra-args` to enable this feature.
 
 ```json
 {


### PR DESCRIPTION
As discussed in https://github.com/ggml-org/llama.cpp/pull/17470 , this introduce too many security risks, thus the functionality was not added