### PR TITLE
server: prevent data race from HTTP threads

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -216,7 +216,7 @@ int main(int argc, char ** argv) {
         ctx_cli.ctx_server.start_loop();
     });
 
-    auto inf = ctx_cli.ctx_server.get_info();
+    auto inf = ctx_cli.ctx_server.get_meta();
     std::string modalities = "text";
     if (inf.has_inp_image) {
         modalities += ", vision";

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -115,26 +115,14 @@ bool lora_should_clear_cache(
         !lora_all_alora(next));
 }
 
-std::vector<common_adapter_lora_info> parse_lora_request(
-        const std::vector<common_adapter_lora_info> & lora_base,
-        const json & data) {
-    std::vector<common_adapter_lora_info> lora(lora_base);
-    int max_idx = lora.size();
-
-    // clear existing value
-    for (auto & entry : lora) {
-        entry.scale = 0.0f;
-    }
+std::map<int, float> parse_lora_request(const json & data) {
+    std::map<int, float> lora;
 
     // set value
     for (const auto & entry : data) {
         int id      = json_value(entry, "id", -1);
         float scale = json_value(entry, "scale", 0.0f);
-        if (0 <= id && id < max_idx) {
-            lora[id].scale = scale;
-        } else {
-            throw std::runtime_error("invalid adapter id");
-        }
+        lora[id] = scale;
     }
 
     return lora;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1435,7 +1435,7 @@ std::string safe_json_to_str(const json & data) {
 
 // TODO: reuse llama_detokenize
 template <class Iter>
-static std::string tokens_to_str(llama_context * ctx, Iter begin, Iter end) {
+static std::string tokens_to_str(const llama_vocab * ctx, Iter begin, Iter end) {
     std::string ret;
     for (; begin != end; ++begin) {
         ret += common_token_to_piece(ctx, *begin);
@@ -1445,7 +1445,12 @@ static std::string tokens_to_str(llama_context * ctx, Iter begin, Iter end) {
 }
 
 std::string tokens_to_str(llama_context * ctx, const llama_tokens & tokens) {
-    return tokens_to_str(ctx, tokens.begin(), tokens.end());
+    auto model = llama_get_model(ctx);
+    return tokens_to_str(llama_model_get_vocab(model), tokens.begin(), tokens.end());
+}
+
+std::string tokens_to_str(const llama_vocab * vocab, const llama_tokens & tokens) {
+    return tokens_to_str(vocab, tokens.begin(), tokens.end());
 }
 
 // format incomplete utf-8 multibyte character for output

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -107,9 +107,7 @@ bool lora_should_clear_cache(
         const std::vector<common_adapter_lora_info> & current,
         const std::vector<common_adapter_lora_info> & next);
 
-std::vector<common_adapter_lora_info> parse_lora_request(
-        const std::vector<common_adapter_lora_info> & lora_base,
-        const json & data);
+std::map<int, float> parse_lora_request(const json & data);
 
 bool are_lora_equal(
         const std::vector<common_adapter_lora_info> & l1,

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -325,6 +325,7 @@ std::vector<llama_token_data> get_token_probabilities(llama_context * ctx, int i
 std::string safe_json_to_str(const json & data);
 
 std::string tokens_to_str(llama_context * ctx, const llama_tokens & tokens);
+std::string tokens_to_str(const llama_vocab * vocab, const llama_tokens & tokens);
 
 // format incomplete utf-8 multibyte character for output
 std::string tokens_to_output_formatted_string(const llama_context * ctx, const llama_token token);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2734,6 +2734,7 @@ server_response_reader server_context::get_response_reader() {
 server_context_meta server_context::get_meta() const {
     auto tool_use_src = common_chat_templates_source(impl->chat_templates.get(), "tool_use");
     return server_context_meta {
+        /* params_base            */ impl->params_base,
         /* build_info             */ build_info,
         /* model_name             */ impl->model_name,
         /* model_path             */ impl->params_base.model.path,

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2822,12 +2822,10 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             inputs = tokenize_input_prompts(ctx_server.vocab, ctx_server.mctx, prompt, true, true);
         }
         tasks.reserve(inputs.size());
-        int idx = 0;
         for (size_t i = 0; i < inputs.size(); i++) {
             server_task task = server_task(type);
 
-            task.id    = rd.get_new_id();
-            task.index = idx++;
+            task.id = rd.get_new_id();
 
             task.tokens = std::move(inputs[i]);
             task.params = server_task::params_from_json_cmpl(
@@ -2847,8 +2845,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 for (size_t j = 0; j < task.n_children; j++) {
                     server_task child = task.create_child(
                         task.id,
-                        rd.get_new_id(),
-                        idx++);
+                        rd.get_new_id());
                     tasks.push_back(std::move(child));
                 }
             }
@@ -3609,7 +3606,6 @@ void server_routes::init_routes() {
                 auto tmp = format_prompt_rerank(ctx_server.model, ctx_server.vocab, ctx_server.mctx, query, documents[i]);
                 server_task task = server_task(SERVER_TASK_TYPE_RERANK);
                 task.id     = rd.get_new_id();
-                task.index  = i;
                 task.tokens = std::move(tmp);
                 tasks.push_back(std::move(task));
             }
@@ -3854,7 +3850,6 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
             server_task task = server_task(SERVER_TASK_TYPE_EMBEDDING);
 
             task.id     = rd.get_new_id();
-            task.index  = i;
             task.tokens = std::move(tokenized_prompts[i]);
 
             // OAI-compat

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -564,7 +564,7 @@ private:
 
     server_metrics metrics;
 
-    json json_webui_config = json::object();
+    json json_webui_settings = json::object();
 
     // Necessary similarity of prompt for slot selection
     float slot_prompt_similarity = 0.0f;
@@ -882,7 +882,7 @@ private:
         {
             if (!params_base.webui_config_json.empty()) {
                 try {
-                    json_webui_config = json::parse(params_base.webui_config_json);
+                    json_webui_settings = json::parse(params_base.webui_config_json);
                 } catch (const std::exception & e) {
                     SRV_ERR("%s: failed to parse webui config: %s\n", __func__, e.what());
                     return false;
@@ -2791,7 +2791,7 @@ server_context_meta server_context::get_meta() const {
         /* has_mtmd               */ impl->mctx != nullptr,
         /* has_inp_image          */ impl->oai_parser_opt.allow_image,
         /* has_inp_audio          */ impl->oai_parser_opt.allow_audio,
-        /* json_webui_settings    */ impl->json_webui_config,
+        /* json_webui_settings    */ impl->json_webui_settings,
         /* slot_n_ctx             */ impl->get_slot_n_ctx(),
         /* pooling_type           */ llama_pooling_type(impl->ctx),
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1821,9 +1821,9 @@ private:
                         llama_tokens alora_invocation_tokens;
                         if (n_alora_tokens) {
                             const llama_token * alora_tokens = llama_adapter_get_alora_invocation_tokens(lora.ptr);
-                            for (uint64_t i = 0; i < n_alora_tokens; ++i) {
-                                alora_invocation_string += common_token_to_piece(vocab, alora_tokens[i]);
-                                alora_invocation_tokens.push_back(alora_tokens[i]);
+                            for (uint64_t j = 0; j < n_alora_tokens; ++j) {
+                                alora_invocation_string += common_token_to_piece(vocab, alora_tokens[j]);
+                                alora_invocation_tokens.push_back(alora_tokens[j]);
                             }
                         }
                         res->loras.push_back(server_task_result_get_lora::lora{

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3213,7 +3213,7 @@ void server_routes::init_routes() {
         GGML_UNUSED(server_ctx);
 
         task_params tparams;
-        tparams.sampling = tparams.sampling;
+        tparams.sampling = params.sampling;
         json default_generation_settings_for_props = json {
             { "params", tparams.to_json(true) },
             { "n_ctx",  server_meta.slot_n_ctx },

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -109,11 +109,10 @@ struct server_routes {
     server_http_context::handler_t post_lora_adapters;
 private:
     std::unique_ptr<server_res_generator> handle_completions_impl(
-            std::unique_ptr<server_res_generator> && res_ptr,
+            const server_http_req & req,
             server_task_type type,
             const json & data,
             const std::vector<raw_buffer> & files,
-            const std::function<bool()> & should_stop,
             task_response_type res_type);
     std::unique_ptr<server_res_generator> handle_slots_save(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_slots_restore(const server_http_req & req, int id_slot);

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -9,11 +9,35 @@
 
 struct server_context_impl; // private implementation
 
-struct server_context_info {
+struct server_context_meta {
     std::string build_info;
     std::string model_name;
+    std::string model_path;
+    bool has_mtmd;
     bool has_inp_image;
     bool has_inp_audio;
+    json json_webui_settings;
+    int slot_n_ctx;
+    enum llama_pooling_type pooling_type;
+
+    // chat template
+    std::string chat_template;
+    std::string chat_template_tool_use;
+
+    // tokens
+    std::string bos_token_str;
+    std::string eos_token_str;
+    llama_token fim_pre_token;
+    llama_token fim_sub_token;
+    llama_token fim_mid_token;
+
+    // model meta
+    enum llama_vocab_type model_vocab_type;
+    int32_t model_vocab_n_tokens;
+    int32_t model_n_ctx_train;
+    int32_t model_n_embd_inp;
+    uint64_t model_n_params;
+    uint64_t model_size;
 };
 
 struct server_context {
@@ -33,14 +57,15 @@ struct server_context {
     void terminate();
 
     // get the underlaying llama_context, can return nullptr if sleeping
+    // not thread-safe, should only be used from the main thread
     llama_context * get_llama_context() const;
 
     // get a new response reader, used by CLI application
     server_response_reader get_response_reader();
 
-    // get server info
-    // used by CLI application
-    server_context_info get_info() const;
+    // get server metadata (read-only), can only be called after load_model()
+    // not thread-safe, should only be used from the main thread
+    server_context_meta get_meta() const;
 };
 
 
@@ -48,12 +73,15 @@ struct server_context {
 struct server_res_generator;
 
 struct server_routes {
-    server_routes(const common_params & params, server_context & ctx_server, std::function<bool()> is_ready = []() { return true; })
-            : params(params), ctx_server(*ctx_server.impl), is_ready(is_ready) {
-        init_routes();
-    }
+    server_routes(const common_params & params, server_context & ctx_server, std::function<bool()> is_ready);
 
     void init_routes();
+
+    // note: update_meta() is not thread-safe and can only be called once on the main thread
+    void update_meta(server_context & ctx_server) {
+        server_meta = ctx_server.get_meta();
+    }
+
     // handlers using lambda function, so that they can capture `this` without `std::bind`
     server_http_context::handler_t get_health;
     server_http_context::handler_t get_metrics;
@@ -78,13 +106,26 @@ struct server_routes {
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
 private:
-    // TODO: move these outside of server_routes?
+    std::unique_ptr<server_res_generator> handle_completions_impl(
+            std::unique_ptr<server_res_generator> && res_ptr,
+            server_task_type type,
+            const json & data,
+            const std::vector<raw_buffer> & files,
+            const std::function<bool()> & should_stop,
+            task_response_type res_type);
     std::unique_ptr<server_res_generator> handle_slots_save(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_slots_restore(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_slots_erase(const server_http_req &, int id_slot);
     std::unique_ptr<server_res_generator> handle_embeddings_impl(const server_http_req & req, task_response_type res_type);
 
+    // TODO: maybe make it const?
+    server_context_meta server_meta;
+
     const common_params & params;
-    server_context_impl & ctx_server;
     std::function<bool()> is_ready;
+
+    server_context_impl & ctx_server;
+    server_queue & queue_tasks;
+    server_response & queue_results;
+    std::unique_ptr<server_res_generator> create_response(bool bypass_sleep = false);
 };

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -10,6 +10,7 @@
 struct server_context_impl; // private implementation
 
 struct server_context_meta {
+    common_params params_base;
     std::string build_info;
     std::string model_name;
     std::string model_path;
@@ -80,6 +81,7 @@ struct server_routes {
     // note: update_meta() is not thread-safe and can only be called once on the main thread
     void update_meta(server_context & ctx_server) {
         server_meta = ctx_server.get_meta();
+        params = server_meta.params_base;
     }
 
     // handlers using lambda function, so that they can capture `this` without `std::bind`
@@ -121,7 +123,7 @@ private:
     // TODO: maybe make it const?
     server_context_meta server_meta;
 
-    const common_params & params;
+    common_params params;
     std::function<bool()> is_ready;
 
     server_context_impl & ctx_server;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -177,12 +177,11 @@ bool server_http_context::init(const common_params & params) {
         if (!ready) {
             auto tmp = string_split<std::string>(req.path, '.');
             if (req.path == "/" || tmp.back() == "html") {
-                res.set_content(reinterpret_cast<const char*>(loading_html), loading_html_len, "text/html; charset=utf-8");
                 res.status = 503;
-            } else if (req.path == "/models" || req.path == "/v1/models" || req.path == "/api/tags") {
-                // allow the models endpoint to be accessed during loading
-                return true;
+                res.set_content(reinterpret_cast<const char*>(loading_html), loading_html_len, "text/html; charset=utf-8");
             } else {
+                // no endpoints is allowed to be accessed when the server is not ready
+                // this is to prevent any data races or inconsistent states
                 res.status = 503;
                 res.set_content(
                     safe_json_to_str(json {

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -342,6 +342,7 @@ static void process_handler_response(server_http_req_ptr && request, server_http
         set_headers(res, response->headers);
         std::string content_type = response->content_type;
         // convert to shared_ptr as both chunked_content_provider() and on_complete() need to use it
+        std::shared_ptr<server_http_req> q_ptr = std::move(request);
         std::shared_ptr<server_http_res> r_ptr = std::move(response);
         const auto chunked_content_provider = [response = r_ptr](size_t, httplib::DataSink & sink) -> bool {
             std::string chunk;
@@ -357,7 +358,7 @@ static void process_handler_response(server_http_req_ptr && request, server_http
             }
             return has_next;
         };
-        const auto on_complete = [request = std::move(request), response = r_ptr](bool) mutable {
+        const auto on_complete = [request = q_ptr, response = r_ptr](bool) mutable {
             response.reset(); // trigger the destruction of the response object
             request.reset();  // trigger the destruction of the request object
         };

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -163,9 +163,7 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
             if (should_sleep()) {
                 QUE_INF("%s", "entering sleeping state\n");
                 sleeping = true;
-                for (const auto & cb : callback_sleeping_state) {
-                    cb(true);
-                }
+                callback_sleeping_state(true);
                 req_stop_sleeping = false;
                 // wait until we are requested to exit sleeping state
                 condition_tasks.wait(lock, [&]{
@@ -176,9 +174,7 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                 }
                 QUE_INF("%s", "exiting sleeping state\n");
                 req_stop_sleeping = false;
-                for (const auto & cb : callback_sleeping_state) {
-                    cb(false);
-                }
+                callback_sleeping_state(false);
                 sleeping = false;
                 time_last_task = ggml_time_ms();
                 condition_tasks.notify_all(); // notify wait_until_no_sleep()

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -389,6 +389,7 @@ server_task_result_ptr server_response_reader::next(const std::function<bool()> 
 
 server_response_reader::batch_response server_response_reader::wait_for_all(const std::function<bool()> & should_stop) {
     batch_response batch_res;
+    batch_res.results.clear();
     batch_res.results.resize(id_tasks.size());
     while (has_next()) {
         auto res = next(should_stop);

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -26,9 +26,9 @@ private:
     std::condition_variable condition_tasks;
 
     // callback functions
-    std::function<void(server_task &&)>    callback_new_task;
-    std::function<void(void)>              callback_update_slots;
-    std::vector<std::function<void(bool)>> callback_sleeping_state;
+    std::function<void(server_task &&)> callback_new_task;
+    std::function<void(void)>           callback_update_slots;
+    std::function<void(bool)>           callback_sleeping_state;
 
 public:
     // Add a new task to the end of the queue
@@ -98,7 +98,7 @@ public:
     // note: when entering sleeping state, the callback is called AFTER sleeping is set to true
     //       when leaving sleeping state, the callback is called BEFORE sleeping is set to false
     void on_sleeping_state(std::function<void(bool)> callback) {
-        callback_sleeping_state.push_back(std::move(callback));
+        callback_sleeping_state = std::move(callback);
     }
 
 private:

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -145,12 +145,10 @@ json task_params::to_json(bool only_metrics) const {
 //
 
 task_params server_task::params_from_json_cmpl(
-        const llama_context * ctx,
+        const llama_vocab * vocab,
         const common_params & params_base,
+        const int n_ctx_slot,
         const json & data) {
-    const llama_model * model = llama_get_model(ctx);
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-
     task_params params;
 
     // Sampling parameter defaults are loaded from the global server context (but individual requests can still them)
@@ -243,11 +241,11 @@ task_params server_task::params_from_json_cmpl(
 
     if (params.sampling.penalty_last_n == -1) {
         // note: should be the slot's context and not the full context, but it's ok
-        params.sampling.penalty_last_n = llama_n_ctx(ctx);
+        params.sampling.penalty_last_n = n_ctx_slot;
     }
 
     if (params.sampling.dry_penalty_last_n == -1) {
-        params.sampling.dry_penalty_last_n = llama_n_ctx(ctx);
+        params.sampling.dry_penalty_last_n = n_ctx_slot;
     }
 
     if (params.sampling.dry_base < 1.0f) {

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -32,8 +32,8 @@ json task_params::to_json(bool only_metrics) const {
     }
 
     json lora = json::array();
-    for (size_t i = 0; i < this->lora.size(); ++i) {
-        lora.push_back({{"id", i}, {"scale", this->lora[i].scale}});
+    for (auto & it : this->lora) {
+        lora.push_back({{"id", it.first}, {"scale", it.second}});
     }
 
     if (only_metrics) {
@@ -221,12 +221,12 @@ task_params server_task::params_from_json_cmpl(
 
     if (data.contains("lora")) {
         if (data.at("lora").is_array()) {
-            params.lora = parse_lora_request(params_base.lora_adapters, data.at("lora"));
+            params.lora = parse_lora_request(data.at("lora"));
         } else {
             throw std::runtime_error("Error: 'lora' must be an array of objects with 'id' and 'scale' fields");
         }
     } else {
-        params.lora = params_base.lora_adapters;
+        params.lora = {};
     }
 
     // TODO: add more sanity checks for the input parameters
@@ -1320,6 +1320,30 @@ json server_task_result_slot_erase::to_json() {
         { "id_slot",  id_slot },
         { "n_erased", n_erased },
     };
+}
+
+//
+// server_task_result_get_lora
+//
+
+json server_task_result_get_lora::to_json() {
+    json result = json::array();
+    for (size_t i = 0; i < loras.size(); ++i) {
+        auto & lora = loras[i];
+        json entry = {
+            {"id",            i},
+            {"path",          lora.info.path},
+            {"scale",         lora.info.scale},
+            {"task_name",     lora.info.task_name},
+            {"prompt_prefix", lora.info.prompt_prefix},
+        };
+        if (!lora.alora_invocation_tokens.empty()) {
+            entry["alora_invocation_string"] = lora.alora_invocation_string;
+            entry["alora_invocation_tokens"] = lora.alora_invocation_tokens;
+        }
+        result.push_back(std::move(entry));
+    }
+    return result;
 }
 
 //

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -149,9 +149,10 @@ struct server_task {
     }
 
     static task_params params_from_json_cmpl(
-            const llama_context * ctx,
-            const common_params & params_base,
-            const json & data);
+        const llama_vocab * vocab,
+        const common_params & params_base,
+        const int n_ctx_slot,
+        const json & data);
 
     // utility function
     static std::unordered_set<int> get_list_id(const std::vector<server_task> & tasks) {

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -105,8 +105,10 @@ struct task_result_state {
 };
 
 struct server_task {
-    int id    = -1; // to be filled by server_queue
-    int index = -1; // used when there are multiple prompts (batch request)
+    int id = -1; // to be filled by server_queue
+
+    // TODO @ngxson : remove this field and implement a mapping task_id -> idx in the response_reader
+    size_t index = 0; // used when there are multiple prompts (batch request)
 
     // used by SERVER_TASK_TYPE_CANCEL
     int id_target = -1;
@@ -212,7 +214,10 @@ struct result_prompt_progress {
 struct server_task_result {
     int id           = -1;
     int id_slot      = -1;
-    size_t index     =  0; // to be used for batched tasks
+
+    // TODO @ngxson : remove this field and implement a mapping task_id -> idx in the response_reader
+    size_t index = 0; // to be used for batched tasks
+
     virtual bool is_error() {
         // only used by server_task_result_error
         return false;
@@ -253,8 +258,6 @@ struct completion_token_output {
 };
 
 struct server_task_result_cmpl_final : server_task_result {
-    int index = 0;
-
     std::string content;
     llama_tokens tokens;
 
@@ -353,7 +356,6 @@ struct server_task_result_cmpl_partial : server_task_result {
 };
 
 struct server_task_result_embd : server_task_result {
-    int index = 0;
     std::vector<std::vector<float>> embedding;
 
     int32_t n_tokens;
@@ -369,7 +371,6 @@ struct server_task_result_embd : server_task_result {
 };
 
 struct server_task_result_rerank : server_task_result {
-    int index = 0;
     float score = -1e6;
 
     int32_t n_tokens;
@@ -378,7 +379,6 @@ struct server_task_result_rerank : server_task_result {
 };
 
 struct server_task_result_error : server_task_result {
-    int index = 0;
     error_type err_type = ERROR_TYPE_SERVER;
     std::string err_msg;
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -222,7 +222,7 @@ struct server_task_result {
         return true;
     }
     virtual int get_index() {
-        return -1;
+        return 0;
     }
     virtual void update(task_result_state &) {
         // only used by server_task_result_cmpl_*

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -252,6 +252,7 @@ int main(int argc, char ** argv, char ** envp) {
             return 1;
         }
 
+        routes.update_meta(ctx_server);
         ctx_http.is_ready.store(true);
 
         LOG_INF("%s: model loaded\n", __func__);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -119,7 +119,7 @@ int main(int argc, char ** argv, char ** envp) {
     //
 
     // register API routes
-    server_routes routes(params, ctx_server, [&ctx_http]() { return ctx_http.is_ready.load(); });
+    server_routes routes(params, ctx_server);
 
     bool is_router_server = params.model.path.empty();
     std::optional<server_models_routes> models_routes{};


### PR DESCRIPTION
Fix https://github.com/ggml-org/llama.cpp/issues/18234

This includes quite many changes, but on a high level:
- Accessing to `server_context_impl` class member is now highly restricted. Only some pointers like `vocab, model, mctx` are exposed.
- Any static data (i.e. model name, context size, etc) must now be rendered into `server_context_meta`. This is to prevent any accesses to non-thread-safe data inside `server_context_impl`
- From `server_routes`, the HTTP can only access some pointers like `vocab, model, mctx`. Any other data MUST be passed through `server_context_meta`

As a consequence:
- `/models` and `/v1/models` can no longer be accessed during model loading. It is NOT thread-safe and can potentially cause data race
- however, `/models` and `/v1/models` can now be accessed during server sleeping. This is because it no longer accesses `server_context_impl` directly

Also include some other fixes described in https://github.com/ggml-org/llama.cpp/pull/18263#issuecomment-3679747872 to make things safer

cc @ServeurpersoCom would appreciate if you can do some testing, thanks!
