### PR TITLE
KYLIN: fix compile error for cuda backend

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -38,6 +38,13 @@ if (CUDAToolkit_FOUND)
     endif()
     message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
+    if(NOT DEFINED CMAKE_CUDA_COMPILER)
+        if(WIN32)
+            set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc.exe")
+        else()
+            set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc")
+        endif()
+    endif()
     enable_language(CUDA)
 
     file(GLOB   GGML_HEADERS_CUDA "*.cuh")


### PR DESCRIPTION
If we compile cuda backend, we must set different
cuda nvcc path to CMAKE_CUDA_COMPILER for diff
operating system, it's too troublesome.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
