### PR TITLE
Cmdline arg -to changes http read timeout from current 600sec default

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -601,7 +601,9 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
             req.headers,
             req.body,
             req.should_stop,
-	    base_params);
+            base_params.timeout_read,
+            base_params.timeout_write
+            );
     return proxy;
 }
 
@@ -890,15 +892,17 @@ server_http_proxy::server_http_proxy(
         const std::map<std::string, std::string> & headers,
         const std::string & body,
         const std::function<bool()> should_stop,
-	const common_params & params) {
+        int32_t timeout_read,
+        int32_t timeout_write
+        ) {
     // shared between reader and writer threads
     auto cli  = std::make_shared<httplib::Client>(host, port);
     auto pipe = std::make_shared<pipe_t<msg_t>>();
 
     // setup Client
     cli->set_connection_timeout(0, 200000); // 200 milliseconds
-    cli->set_write_timeout(params.timeout_read, 0); // reversed for cli
-    cli->set_read_timeout(params.timeout_write, 0);
+    cli->set_write_timeout(timeout_read, 0); // reversed for cli (client) vs srv (server)
+    cli->set_read_timeout(timeout_write, 0);
     this->status = 500; // to be overwritten upon response
     this->cleanup = [pipe]() {
         pipe->close_read();

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -895,6 +895,7 @@ server_http_proxy::server_http_proxy(
 
     // setup Client
     cli->set_connection_timeout(0, 200000); // 200 milliseconds
+    cli->set_read_timeout(3600 * 24 * 90, 0); // Prevent crash if TTFT >300sec, boosted to 90 days
     this->status = 500; // to be overwritten upon response
     this->cleanup = [pipe]() {
         pipe->close_read();

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -600,7 +600,8 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
             req.path,
             req.headers,
             req.body,
-            req.should_stop);
+            req.should_stop,
+	    base_params);
     return proxy;
 }
 
@@ -888,14 +889,16 @@ server_http_proxy::server_http_proxy(
         const std::string & path,
         const std::map<std::string, std::string> & headers,
         const std::string & body,
-        const std::function<bool()> should_stop) {
+        const std::function<bool()> should_stop,
+	const common_params & params) {
     // shared between reader and writer threads
     auto cli  = std::make_shared<httplib::Client>(host, port);
     auto pipe = std::make_shared<pipe_t<msg_t>>();
 
     // setup Client
     cli->set_connection_timeout(0, 200000); // 200 milliseconds
-    cli->set_read_timeout(3600 * 24 * 90, 0); // Prevent crash if TTFT >300sec, boosted to 90 days
+    cli->set_write_timeout(params.timeout_read, 0); // reversed for cli
+    cli->set_read_timeout(params.timeout_write, 0);
     this->status = 500; // to be overwritten upon response
     this->cleanup = [pipe]() {
         pipe->close_read();

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -178,7 +178,9 @@ public:
                       const std::map<std::string, std::string> & headers,
                       const std::string & body,
                       const std::function<bool()> should_stop,
-		      const common_params & base_params);
+                      int32_t timeout_read,
+                      int32_t timeout_write
+                      );
     ~server_http_proxy() {
         if (cleanup) {
             cleanup();

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -177,7 +177,8 @@ public:
                       const std::string & path,
                       const std::map<std::string, std::string> & headers,
                       const std::string & body,
-                      const std::function<bool()> should_stop);
+                      const std::function<bool()> should_stop,
+		      const common_params & base_params);
     ~server_http_proxy() {
         if (cleanup) {
             cleanup();


### PR DESCRIPTION
llama-server has a hard-coded HTTP timeout of 300 seconds (the http library default). If the prompt and input files take longer than this timeout to process, the connection times out and is dropped, the WebUI gets out of sync, etc.

It is easy to exceed 300 (or 600) seconds on consumer hardware.

This PR reads the --timeout (-to) command-line argument. The default for --timeout is 600 seconds, twice as long as the http library's 300 seconds. The value of --timeout always overwrites the http library's default now. As a result, twice as long is now available by default. More is often needed though.

Huge timeouts can now be set with --timeout, circumventing this failure.

Note: Model unloading won't complete if cli->send() is active. A huge --timeout can make unloading impractical.