### PR TITLE
Update release workflow to store XCFramework as Zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,7 +690,7 @@ jobs:
         run: |
           # Zip file is required for Swift Package Manager, which does not support tar.gz for binary targets.
           # For more details, see https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages
-          cd build-apple && zip -r -y ../llama-${{ steps.tag.outputs.name }}-xcframework.zip llama.xcframework
+          zip -r -y llama-${{ steps.tag.outputs.name }}-xcframework.zip build-apple/llama.xcframework
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,13 +688,13 @@ jobs:
       - name: Pack artifacts
         id: pack_artifacts
         run: |
-          tar -czvf llama-${{ steps.tag.outputs.name }}-xcframework.tar.gz -C build-apple llama.xcframework
+          cd build-apple && zip -r -y ../llama-${{ steps.tag.outputs.name }}-xcframework.zip llama.xcframework
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: llama-${{ steps.tag.outputs.name }}-xcframework.tar.gz
-          name: llama-${{ steps.tag.outputs.name }}-xcframework.tar.gz
+          path: llama-${{ steps.tag.outputs.name }}-xcframework.zip
+          name: llama-${{ steps.tag.outputs.name }}-xcframework.zip
 
 
   openEuler-cann:
@@ -863,7 +863,7 @@ jobs:
             **macOS/iOS:**
             - [macOS Apple Silicon (arm64)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-macos-arm64.tar.gz)
             - [macOS Intel (x64)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-macos-x64.tar.gz)
-            - [iOS XCFramework](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-xcframework.tar.gz)
+            - [iOS XCFramework](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-xcframework.zip)
 
             **Linux:**
             - [Ubuntu x64 (CPU)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-x64.tar.gz)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,6 +688,8 @@ jobs:
       - name: Pack artifacts
         id: pack_artifacts
         run: |
+          # Zip file is required for Swift Package Manager, which does not support tar.gz for binary targets.
+          # For more details, see https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages
           cd build-apple && zip -r -y ../llama-${{ steps.tag.outputs.name }}-xcframework.zip llama.xcframework
 
       - name: Upload artifacts


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/pull/17299 updated the release workflow to produce `.tar.gz` archives instead of `.zip` files. However, [Swift Package Manager requires XCFramework binary artifacts to be Zip files](https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages):

> To distribute code in binary form as a Swift package, create an XCFramework bundle, or artifact, that contains the binaries. Then, make the bundle available locally or on a server:
> - When you host the binaries on a server, create a ZIP archive with the XCFramework in its root directory and make it available publicly.

Currently, if you try to include llama.cpp in a Swift project...

```swift
    targets: [
        .binaryTarget(
            name: "llama-cpp",
            url:
                "https://github.com/ggml-org/llama.cpp/releases/download/b7503/llama-b7503-xcframework.tar.gz",
            checksum: "7d65a78175b71132401efc99b3898cf6b3779e9782c5d3cbc6e123108b91807b"
        ),
   ]
```

...you get the following error:

> unsupported extension for binary target 'llama-cpp'; valid extensions are: 'artifactbundleindex', 'zip'

This PR partially reverts https://github.com/ggml-org/llama.cpp/commit/7b6d7453649be7e7aa37589a2da6d2f60ca9e548, updating the release workflow to package XCFramework artifacts as Zip files once again, and adds a comment documenting this requirement.