### PR TITLE
server: implement --shutdown-timeout

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2898,6 +2898,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--shutdown-timeout"}, "SECONDS",
+        string_format("after requested shutdown, wait this many seconds before forcing termination (default: %d; -1 = disabled)", params.shutdown_timeout_seconds),
+        [](common_params & params, int value) {
+            if (value == 0 || value < -1) {
+                throw std::invalid_argument("invalid value: cannot be 0 or less than -1");
+            }
+            params.shutdown_timeout_seconds = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--simple-io"},
         "use basic IO for better compatibility in subprocesses and limited consoles",
         [](common_params & params) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2899,7 +2899,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--shutdown-timeout"}, "SECONDS",
-        string_format("after requested shutdown, wait this many seconds before forcing termination (default: %d; -1 = disabled)", params.shutdown_timeout_seconds),
+        string_format("after requested shutdown, wait for this many seconds before forcing termination (default: %d; -1 = disabled)", params.shutdown_timeout_seconds),
         [](common_params & params, int value) {
             if (value == 0 || value < -1) {
                 throw std::invalid_argument("invalid value: cannot be 0 or less than -1");

--- a/common/common.h
+++ b/common/common.h
@@ -475,8 +475,9 @@ struct common_params {
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
     int reasoning_budget = -1;
-    bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
-    int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    bool prefill_assistant = true;     // if true, any trailing assistant message will be prefilled into the response
+    int sleep_idle_seconds = -1;       // if >0, server will sleep after this many seconds of idle time
+    int shutdown_timeout_seconds = 10; // if >0, server will force-terminate after this many seconds
 
     std::vector<std::string> api_keys;
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -210,6 +210,8 @@ For the ful list of features, please refer to [server's changelog](https://githu
 | `--prefill-assistant, --no-prefill-assistant` | whether to prefill the assistant's response if the last message is an assistant message (default: prefill enabled)<br/>when this flag is set, if the last message is an assistant message then it will be treated as a full message and not prefilled<br/><br/>(env: LLAMA_ARG_PREFILL_ASSISTANT) |
 | `-sps, --slot-prompt-similarity SIMILARITY` | how much the prompt of a request must match the prompt of a slot in order to use that slot (default: 0.10, 0.0 = disabled)<br/> |
 | `--lora-init-without-apply` | load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: disabled) |
+| `--sleep-idle-seconds SECONDS` | number of seconds of idleness after which the server will sleep (default: -1; -1 = disabled) |
+| `--shutdown-timeout SECONDS` | after requested shutdown, wait for this many seconds before forcing termination (default: 10; -1 = disabled) |
 | `-td, --threads-draft N` | number of threads to use during generation (default: same as --threads) |
 | `-tbd, --threads-batch-draft N` | number of threads to use during batch and prompt processing (default: same as --threads-draft) |
 | `--draft, --draft-n, --draft-max N` | number of tokens to draft for speculative decoding (default: 16)<br/>(env: LLAMA_ARG_DRAFT_MAX) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2770,8 +2770,8 @@ void server_context::start_loop() {
     impl->queue_tasks.start_loop(params.sleep_idle_seconds * 1000);
 }
 
-void server_context::terminate() {
-    impl->queue_tasks.terminate();
+void server_context::terminate(int timeout_secs) {
+    impl->queue_tasks.terminate(timeout_secs);
 }
 
 llama_context * server_context::get_llama_context() const {

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -54,7 +54,7 @@ struct server_context {
     void start_loop();
 
     // terminate main loop (will unblock start_loop)
-    void terminate();
+    void terminate(int timeout_secs = -1);
 
     // get the underlaying llama_context, can return nullptr if sleeping
     // not thread-safe, should only be used from the main thread

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -604,6 +604,10 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
     return proxy;
 }
 
+//
+// used by child server
+//
+
 std::thread server_models::setup_child_server(const std::function<void(int)> & shutdown_handler) {
     // send a notification to the router server that a model instance is ready
     common_log_pause(common_log_main());

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -37,11 +37,7 @@ private:
     std::thread th_timer;
 
 public:
-    ~server_queue() {
-        if (th_timer.joinable()) {
-            th_timer.join();
-        }
-    }
+    ~server_queue();
 
     // Add a new task to the end of the queue
     int post(server_task && task, bool front = false);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -259,7 +259,7 @@ int main(int argc, char ** argv, char ** envp) {
 
         shutdown_handler = [&](int) {
             // this will unblock start_loop()
-            ctx_server.terminate();
+            ctx_server.terminate(params.shutdown_timeout_seconds);
         };
     }
 


### PR DESCRIPTION
Fix #18237 

This PR introduces `--shutdown-timeout` for forcefully terminate the server after N seconds of waiting since the first shutdown request received (i.e. SIGINT, SIGTERM)

The most commonly known use case is when `update_slots()` is being stuck on a large batch of tokens that can take minutes to finish.

NOTE: **this feature works on both router and single-model modes**

How I tested this PR:
- Start server with `-ngl 0 -t 1` to make it super slow
- Send a long input prompt
- Crtl+C to stop it, expected to force-terminated after 10s
