### PR TITLE
server: modify return_progress to also report 0% processing state

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2313,6 +2313,12 @@ private:
                         slot.n_prompt_tokens_processed = 0;
 
                         slot.prompt.tokens.keep_first(n_past);
+
+                        // send initial 0% progress update if needed
+                        // this is to signal the client that the request has started processing
+                        if (slot.task->params.stream && slot.task->params.return_progress) {
+                            send_partial_response(slot, {}, true);
+                        }
                     }
 
                     if (!slot.can_split()) {


### PR DESCRIPTION
Ref comment: https://github.com/ggml-org/llama.cpp/issues/17079#issuecomment-3683031957

(See the test to understand what's included in the first chunk)
