### PR TITLE
llama-model : fix Nemotron V2 crash by moving MoE parameters calculation

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -5243,9 +5243,6 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     const int64_t n_group    = hparams.ssm_n_group;
                     const int64_t d_in_proj  = 2*d_inner + 2*n_group*d_state + n_ssm_head;
 
-                    const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff / n_expert_used;
-                    const int64_t n_ff_shexp = hparams.n_ff_shexp;
-
                     // embeddings
                     tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
 
@@ -5297,6 +5294,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             layer.bo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "bias",   i), {n_embd},         TENSOR_NOT_REQUIRED);
                         }  else {
                             if (n_expert != 0) {
+                                const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff / n_expert_used;
+                                const int64_t n_ff_shexp = hparams.n_ff_shexp;
+                                
                                 layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert}, 0);
                                 layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert         }, 0);
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -5296,7 +5296,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             if (n_expert != 0) {
                                 const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff / n_expert_used;
                                 const int64_t n_ff_shexp = hparams.n_ff_shexp;
-                                
+
                                 layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert}, 0);
                                 layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert         }, 0);
 


### PR DESCRIPTION
### Motivation
This PR fixes a regression introduced in build b7418 (support for Nemotron Nano v3 MoE). 

When loading Nemotron Nano v2 (which is a dense Mamba-Attention hybrid, not an MoE), the application crashes with a floating point exception (SIGFPE).

The crash occurs because the code attempts to calculate `n_ff_exp` using `n_ff / n_expert_used` at the top of the `case LLM_ARCH_NEMOTRON_H_MOE` block. For dense models like Nano v2, `n_expert_used` is 0, resulting in a division by zero.

### Changes
- Moved the calculation of `n_ff_exp` and `n_ff_shexp` inside the `if (n_expert != 0)` block. This ensures the division is only performed when the model is actually an MoE architecture.

### Testing
Tested on WSL 2 with `nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_S.gguf` on CPU. The model now loads correctly without crashing.

Fixes issue #18304