### PR TITLE
server: (preset) add `unsafe-allow-api-override`

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3518,15 +3518,16 @@ void common_params_add_preset_options(std::vector<common_arg> & args) {
         [](common_params &, const std::string &) { /* unused */ }
     ).set_env(COMMON_ARG_PRESET_LOAD_ON_STARTUP).set_preset_only());
 
+    args.push_back(common_arg(
+        {"unsafe-allow-api-override"}, "PARAM1,PARAM2,...",
+        "allow overriding these params via /models/load endpoint (unsafe)",
+        [](common_params &, const std::string &) { /* unused */ }
+    ).set_env(COMMON_ARG_PRESET_UNSAFE_ALLOW_API_OVERRIDE).set_preset_only());
+
+    // TODO:
     // args.push_back(common_arg(
     //     {"pin"},
     //     "in server router mode, do not unload this model if models_max is exceeded",
     //     [](common_params &) { /* unused */ }
-    // ).set_preset_only());
-
-    // args.push_back(common_arg(
-    //     {"unload-idle-seconds"}, "SECONDS",
-    //     "in server router mode, unload models idle for more than this many seconds",
-    //     [](common_params &, int) { /* unused */ }
     // ).set_preset_only());
 }

--- a/common/arg.h
+++ b/common/arg.h
@@ -9,7 +9,8 @@
 #include <cstring>
 
 // pseudo-env variable to identify preset-only arguments
-#define COMMON_ARG_PRESET_LOAD_ON_STARTUP "__PRESET_LOAD_ON_STARTUP"
+#define COMMON_ARG_PRESET_LOAD_ON_STARTUP           "__PRESET_LOAD_ON_STARTUP"
+#define COMMON_ARG_PRESET_UNSAFE_ALLOW_API_OVERRIDE "__PRESET_UNSAFE_ALLOW_API_OVERRIDE"
 
 //
 // CLI argument parsing

--- a/common/preset.h
+++ b/common/preset.h
@@ -65,6 +65,10 @@ struct common_preset_context {
     // generate one preset from CLI arguments
     common_preset load_from_args(int argc, char ** argv) const;
 
+    // generate one preset from mapping string to string
+    // key can be either arg name or env variable
+    common_preset load_from_map(const std::map<std::string, std::string> & arg_map) const;
+
     // cascade multiple presets if exist on both: base < added
     // if preset does not exist in base, it will be added without modification
     common_presets cascade(const common_presets & base, const common_presets & added) const;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1486,6 +1486,7 @@ The precedence rule for preset options is as follows:
 
 We also offer additional options that are exclusive to presets (these aren't treated as command-line arguments):
 - `load-on-startup` (boolean): Controls whether the model loads automatically when the server starts
+- `unsafe-allow-api-override` (string): Specifies which parameters can be overridden via the `/models/load` API endpoint. Accepts multiple values separated by commas. Example: `n-gpu-layers,jinja`. **Warning:** This feature is **unsafe** and must only be used in trusted environments.
 
 ### Routing requests
 
@@ -1571,11 +1572,15 @@ Load a model
 
 Payload:
 - `model`: name of the model to be loaded.
+- `overrides`: list of preset parameter override (an object mapping string to string). Parameters must be whitelisted via the `unsafe-allow-api-override` preset parameter.
 
 ```json
 {
   "model": "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M",
-  "extra_args": ["-n", "128", "--top-k", "4"]
+  "overrides": {
+    "c": "1024",
+    "jinja": "false"
+  }
 }
 ```
 

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -114,7 +114,8 @@ public:
 
     // load and unload model instances
     // these functions are thread-safe
-    void load(const std::string & name);
+    // load() returns the argument list used to launch the model instance
+    std::vector<std::string> load(const std::string & name, const std::map<std::string, std::string> & override_params);
     void unload(const std::string & name);
     void unload_all();
 


### PR DESCRIPTION
Ref discussion: https://github.com/ggml-org/llama.cpp/pull/18261#issuecomment-3685884635

@ServeurpersoCom I think we need to add a test with INI preset at some point

Example preset for this PR:

```ini
[THUDM/glm-edge-v-5b-gguf:Q4_K_M]
no-mmap = 0
temp = 123.000
autoload = 1
unsafe-allow-api-override = no-mmap,c
```

And API request:

```
{
        "model": "THUDM/glm-edge-v-5b-gguf:Q4_K_M",
        "overrides": {"c": "512"}
}
```

Returns:

```
{
    "success": true,
    "args": [
        "........../build/bin/llama-server",
        "--host",
        "127.0.0.1",
        "--mmap",
        "--port",
        "65054",
        "--temp",
        "123.000",
        "--alias",
        "THUDM/glm-edge-v-5b-gguf:Q4_K_M",
        "--ctx-size",
        "512",
        "--hf-repo",
        "THUDM/glm-edge-v-5b-gguf:Q4_K_M"
    ]
}
```