### PR TITLE
common/grammar : replace problematic backtracking regex `[\s\S]*`

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2397,17 +2397,17 @@ static common_chat_params common_chat_params_init_hermes_2_pro(const common_chat
                 (inputs.parallel_tool_calls ? "(" + tool_call + ")+" : tool_call));
             // Trigger on some common known "good bad" outputs (only from the start and with a json that's about a specific argument name to avoid false positives)
             data.grammar_triggers.push_back({
-                COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN_FULL,
+                COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN,
                 // If thinking_forced_open, then we capture the </think> tag in the grammar,
                 // (important for required tool choice) and in the trigger's first capture (decides what is sent to the grammar)
-                std::string(data.thinking_forced_open ? "[\\s\\S]*?(</think>\\s*)" : "(?:<think>[\\s\\S]*?</think>\\s*)?") + (
+                std::string(data.thinking_forced_open ? "(</think>\\s*)" : "") + (
                     "\\s*("
                     "(?:<tool_call>"
                     "|<function"
                     "|(?:```(?:json|xml)?\n\\s*)?(?:<function_call>|<tools>|<xml><json>|<response>)?"
                     "\\s*\\{\\s*\"name\"\\s*:\\s*\"(?:" + string_join(escaped_names, "|") + ")\""
                     ")"
-                    ")[\\s\\S]*"
+                    ")"
                 ),
             });
             data.preserved_tokens = {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2064,7 +2064,7 @@ static common_chat_params common_chat_params_init_gpt_oss(const common_chat_temp
             // Trigger on tool calls that appear in the commentary channel
             data.grammar_triggers.push_back({
                 COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN,
-                "<\\|channel\\|>(commentary|analysis) to"
+                "<\\|channel\\|>(?:commentary|analysis) to"
             });
 
             // Trigger tool calls that appear in the role section, either at the

--- a/common/regex-partial.cpp
+++ b/common/regex-partial.cpp
@@ -27,7 +27,7 @@ common_regex_match common_regex::search(const std::string & input, size_t pos, b
         return res;
     }
     std::match_results<std::string::const_reverse_iterator> srmatch;
-    if (std::regex_match(input.rbegin(), input.rend() - pos, srmatch, rx_reversed_partial)) {
+    if (std::regex_search(input.rbegin(), input.rend() - pos, srmatch, rx_reversed_partial, std::regex_constants::match_continuous)) {
         auto group = srmatch[1].str();
         if (group.length() != 0) {
             auto it = srmatch[1].second.base();
@@ -55,18 +55,18 @@ common_regex_match common_regex::search(const std::string & input, size_t pos, b
   to see if a string ends with a partial regex match, but but it's not in std::regex yet.
   Instead, we'll the regex into a partial match regex operating as a full match on the reverse iterators of the input.
 
-  - /abcd/ -> (dcba|cba|ba|a).* -> ((?:(?:(?:(?:d)?c)?b)?a).*
-  - /a|b/ -> (a|b).*
+  - /abcd/ -> ^(dcba|cba|ba|a) -> ^((?:(?:(?:(?:d)?c)?b)?a)
+  - /a|b/ -> ^(a|b)
   - /a*?/ -> error, could match ""
-  - /a*b/ -> ((?:b)?a*+).* (final repetitions become eager)
-  - /.*?ab/ -> ((?:b)?a).* (merge .*)
-  - /a.*?b/ -> ((?:b)?.*?a).* (keep reluctant matches)
-  - /a(bc)d/ -> ((?:(?:d)?(?:(?:c)?b))?a).*
-  - /a(bc|de)/ -> ((?:(?:(?:e)?d)?|(?:(?:c)?b)?)?a).*
-  - /ab{2,4}c/ -> abbb?b?c -> ((?:(?:(?:(?:(?:c)?b)?b)?b?)?b?)?a).*
+  - /a*b/ -> ^((?:b)?a*+) (final repetitions become eager)
+  - /.*?ab/ -> ^((?:b)?a) (omit .*)
+  - /a.*?b/ -> ^((?:b)?.*?a) (keep reluctant matches)
+  - /a(bc)d/ -> ^((?:(?:d)?(?:(?:c)?b))?a)
+  - /a(bc|de)/ -> ^((?:(?:(?:e)?d)?|(?:(?:c)?b)?)?a)
+  - /ab{2,4}c/ -> ^cbbb?b?a -> ^((?:(?:(?:(?:(?:c)?b)?b)?b?)?b?)?a)
 
-  The regex will match a reversed string fully, and the end of the first (And only) capturing group will indicate the reversed start of the original partial pattern
-  (i.e. just where the final .* starts in the inverted pattern; all other groups are turned into non-capturing groups, and reluctant quantifiers are ignored)
+  The regex will match a reversed string fully, and the end of the first (And only) capturing group will indicate the reversed start of the original partial pattern.
+  All other groups are turned into non-capturing groups, and reluctant quantifiers are ignored.
 */
 std::string regex_to_reversed_partial_regex(const std::string & pattern) {
     auto it = pattern.begin();
@@ -177,7 +177,7 @@ std::string regex_to_reversed_partial_regex(const std::string & pattern) {
             }
         }
 
-        // /abcd/ -> (dcba|cba|ba|a).* -> ((?:(?:(?:d)?c)?b)?a).*
+        // /abcd/ -> ^(dcba|cba|ba|a) -> ^((?:(?:(?:d)?c)?b)?a)
         // if n(=4) parts, opening n-1(=3) non-capturing groups after the 1 capturing group
         // We'll do the outermost capturing group and final .* in the enclosing function.
         std::vector<std::string> res_alts;
@@ -200,5 +200,5 @@ std::string regex_to_reversed_partial_regex(const std::string & pattern) {
         throw std::runtime_error("Unmatched '(' in pattern");
     }
 
-    return "(" + res + ")[\\s\\S]*";
+    return "^(" + res + ")";
 }

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -116,9 +116,17 @@ struct llama_grammar_parser {
     void print(FILE * file);
 };
 
+enum llama_grammar_trigger_pattern_type {
+    LLAMA_GRAMMAR_TRIGGER_PATTERN_TYPE_MATCH       = 0,
+    LLAMA_GRAMMAR_TRIGGER_PATTERN_TYPE_SEARCH      = 1,
+};
+
 struct llama_grammar_trigger_pattern {
+    llama_grammar_trigger_pattern_type type;
     std::string pattern;
     std::regex  regex;
+
+    size_t find(const std::string & input) const;
 };
 
 struct llama_grammar {

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -116,13 +116,7 @@ struct llama_grammar_parser {
     void print(FILE * file);
 };
 
-enum llama_grammar_trigger_pattern_type {
-    LLAMA_GRAMMAR_TRIGGER_PATTERN_TYPE_MATCH       = 0,
-    LLAMA_GRAMMAR_TRIGGER_PATTERN_TYPE_SEARCH      = 1,
-};
-
 struct llama_grammar_trigger_pattern {
-    llama_grammar_trigger_pattern_type type;
     std::string pattern;
     std::regex  regex;
 

--- a/tests/test-regex-partial.cpp
+++ b/tests/test-regex-partial.cpp
@@ -232,52 +232,52 @@ static void test_regex_to_reversed_partial_regex() {
     printf("[%s]\n", __func__);
 
     assert_equals<std::string>(
-        "((?:(?:c)?b)?a)[\\s\\S]*",
+        "^((?:(?:c)?b)?a)",
         regex_to_reversed_partial_regex("abc"));
 
     assert_equals<std::string>(
-        "(a+)[\\s\\S]*",
+        "^(a+)",
         regex_to_reversed_partial_regex("a+"));
 
     assert_equals<std::string>(
-        "(a*)[\\s\\S]*",
+        "^(a*)",
         regex_to_reversed_partial_regex("a*"));
 
     assert_equals<std::string>(
-        "(a?)[\\s\\S]*",
+        "^(a?)",
         regex_to_reversed_partial_regex("a?"));
 
     assert_equals<std::string>(
-        "([a-z])[\\s\\S]*",
+        "^([a-z])",
         regex_to_reversed_partial_regex("[a-z]"));
 
     assert_equals<std::string>(
-        "((?:\\w+)?[a-z])[\\s\\S]*",
+        "^((?:\\w+)?[a-z])",
         regex_to_reversed_partial_regex("[a-z]\\w+"));
 
     assert_equals<std::string>(
-        "((?:a|b))[\\s\\S]*",
+        "^((?:a|b))",
         regex_to_reversed_partial_regex("(?:a|b)"));
     assert_equals<std::string>(
-        "((?:(?:(?:d)?c)?b)?a)[\\s\\S]*",
+        "^((?:(?:(?:d)?c)?b)?a)",
         regex_to_reversed_partial_regex("abcd"));
     assert_equals<std::string>(
-        "((?:b)?a*)[\\s\\S]*", // TODO: ((?:b)?a*+).* ??
+        "^((?:b)?a*)", // TODO: ((?:b)?a*+).* ??
         regex_to_reversed_partial_regex("a*b"));
     assert_equals<std::string>(
-        "((?:(?:b)?a)?.*)[\\s\\S]*",
+        "^((?:(?:b)?a)?.*)",
         regex_to_reversed_partial_regex(".*?ab"));
     assert_equals<std::string>(
-        "((?:(?:b)?.*)?a)[\\s\\S]*",
+        "^((?:(?:b)?.*)?a)",
         regex_to_reversed_partial_regex("a.*?b"));
     assert_equals<std::string>(
-        "((?:(?:d)?(?:(?:c)?b))?a)[\\s\\S]*",
+        "^((?:(?:d)?(?:(?:c)?b))?a)",
         regex_to_reversed_partial_regex("a(bc)d"));
     assert_equals<std::string>(
-        "((?:(?:(?:c)?b|(?:e)?d))?a)[\\s\\S]*",
+        "^((?:(?:(?:c)?b|(?:e)?d))?a)",
         regex_to_reversed_partial_regex("a(bc|de)"));
     assert_equals<std::string>(
-        "((?:(?:(?:(?:(?:c)?b?)?b?)?b)?b)?a)[\\s\\S]*",
+        "^((?:(?:(?:(?:(?:c)?b?)?b?)?b)?b)?a)",
         regex_to_reversed_partial_regex("ab{2,4}c"));
 }
 


### PR DESCRIPTION
There are several regex patterns scattered throughout the codebase that use `[\s\S]*` or `[\s\S]*?`. This is problematic because it matches characters recursively in backtracking engines such as `std::regex`, causing stack overflows on large inputs.

**Minimal reproducing example**
```cpp
#include <iostream>
#include <regex>
#include <string>

int main() {
    std::string text = std::string(50000, 'a') + "b";
    std::regex pattern("[\\s\\S]*b"); // [\s\S]* is matched recursively
    
    std::smatch match;
    if (std::regex_match(text, match, pattern)) {
        std::cout << "Match\n";
    }
    
    return 0;
}
```

This PR replaces these instances with alternative solutions.

Fixes #17902, #18188

## Details

### src/llama-grammar.cpp

These patterns exist because the grammar sampler uses `std::regex_match()`. The only way to search for a needle is to surround it with `[\s\S]*?<pat>[\s\S]*`.

To address this, I check whether the pattern is wrapped in anchors (`^$`). If not, `std::regex_search()` is used instead. Most engines search by iteratively matching at each position, starting from the beginning. This is an improvement over recursively matching characters.

### common/sampling.cpp

To accommodate the grammar change, `COMMON_TRIGGER_TYPE_PATTERN_FULL` now wraps the pattern as `^<pat>$`. The problematic patterns are removed for `COMMON_TRIGGER_TYPE_PATTERN` and `COMMON_TRIGGER_TYPE_WORD`. This maintains existing semantics to remain compatible with chat parsing implementations.

Additionally, `COMMON_TRIGGER_TYPE_PATTERN` no longer adds an implicit capture group. The capture semantics now align with `COMMON_TRIGGER_TYPE_PATTERN_FULL` and can be used to determine the start of the input fed to the grammar sampler.

### common/chat.cpp

As an example, I removed `[\s\S]*?` from the Hermes 2 Pro implementation. I also removed `"(?:<think>[\\s\\S]*?</think>\\s*)?"` since it's optional and non-capturing—it would be consumed by `[\s\S]*?` anyway and isn't needed when using `std::regex_search()`.

I updated existing `COMMON_TRIGGER_TYPE_PATTERN` patterns to use non-capturing groups, since it now follows the same capture semantics as `COMMON_TRIGGER_TYPE_PATTERN_FULL`.

### common/regex-partial.cpp

The generated reverse regex pattern contains a trailing `[\s\S]*`. This is replaced by anchoring the generated pattern as `^<pat>` and using `std::regex_constants::match_continuous` to enforce matching at the start of the reverse iterator.

## Models Tested

I tested content, reasoning, tool calling, and agentic scenarios with [my own test suite](https://github.com/aldehir/llm-serving-tests) on the following models:

- Qwen3-Next-80B-A3B-Instruct
- Qwen3-VL-8B-Instruct
- Qwen3-VL-8B-Thinking
  - Reasoning + `tool_choice = required` is broken but this is an existing issue
- GPT-OSS-20B

---

@ochafik If you have some time, I'd appreciate your opinion on these changes.

No AI was used to code, only to review changes.
