### PR TITLE
feat: Add memory factory hook for custom KV cache implementations

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -737,6 +737,20 @@ extern "C" {
     LLAMA_API bool llama_memory_can_shift(llama_memory_t mem);
 
     //
+    // Memory factory extension
+    //
+    // Allows custom memory (KV cache) implementations to be used.
+    // Factory returns non-null to use custom implementation, null to use default.
+    // Call llama_set_memory_factory() before llama_init_from_model().
+
+    typedef llama_memory_t (*llama_memory_factory_fn)(
+            const struct llama_model * model,
+      const struct llama_context_params * params,
+                                   void * user_data);
+
+    LLAMA_API void llama_set_memory_factory(llama_memory_factory_fn factory, void * user_data);
+
+    //
     // State / sessions
     //
 


### PR DESCRIPTION
## Summary

Add a minimal extension point for custom memory (KV cache) implementations.

### Motivation
- KV cache optimization is an active research area (compression, semantic caching, etc.)
- Currently requires forking llama.cpp to experiment with custom implementations
- GGML backends already use similar factory patterns

### Changes
- Add `llama_memory_factory_fn` typedef to `llama.h`
- Add `llama_set_memory_factory()` to set custom factory
- Check factory before default memory creation in `llama_context` constructor

### Usage
1. Implement factory function returning `llama_memory_t`
2. Call `llama_set_memory_factory()` before `llama_init_from_model()`
3. Factory can return `nullptr` to use default implementation

### Example

```cpp
static llama_memory_t my_cache_factory(
    const struct llama_model * model,
    const struct llama_context_params * params,
    void * user_data
) {
    if (should_use_custom_cache(params)) {
        return create_my_custom_cache(model, params);
    }
    return nullptr;  // Fall back to default
}

// Register before context creation
llama_set_memory_factory(my_cache_factory, nullptr);
```

### Impact
- Zero overhead when not used (single null pointer check)
- No breaking changes to existing API
- 35 lines total across 2 files