### PR TITLE
Fix a crash on multiple active LoRa (issue 18050)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2293,7 +2293,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : string_split<std::string>(value, ',')) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr });
+                params.lora_adapters.push_back({ item, 1.0 });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2308,7 +2308,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]) });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg

--- a/common/common.h
+++ b/common/common.h
@@ -39,14 +39,17 @@ struct common_time_meas {
     int64_t & t_acc;
 };
 
-struct common_adapter_lora_info {
+struct common_adapter_lora_param {
     std::string path;
     float scale;
+};
 
+struct common_adapter_lora_info {
+    llama_adapter_lora_ptr ptr;
+
+    std::string path;
     std::string task_name;
     std::string prompt_prefix;
-
-    struct llama_adapter_lora * ptr;
 };
 
 using llama_tokens = std::vector<llama_token>;
@@ -375,8 +378,8 @@ struct common_params {
     std::vector<llama_model_kv_override> kv_overrides;
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
 
-    bool lora_init_without_apply = false; // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_adapter_lora_apply)
-    std::vector<common_adapter_lora_info> lora_adapters; // lora adapter path with user defined scale
+    bool lora_init_without_apply = false; // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_set_adapter_lora)
+    std::vector<common_adapter_lora_param> lora_adapters; // lora adapter path with user defined scale
 
     std::vector<common_control_vector_load_info> control_vectors; // control vector with user defined scale
 
@@ -691,7 +694,7 @@ struct common_init_result {
     llama_context * context();
     common_sampler * sampler(llama_seq_id seq_id);
 
-    std::vector<llama_adapter_lora_ptr> & lora();
+    const std::vector<common_adapter_lora_info> & loras() const;
 
     void free_context();
 
@@ -709,7 +712,10 @@ struct llama_context_params   common_context_params_to_llama(const common_params
 struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const cpu_params & params);
 
 // clear LoRA adapters from context, then apply new list of adapters
-void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora);
+void common_set_adapter_lora(
+            struct llama_context * ctx,
+            const std::vector<common_adapter_lora_param> & lora_params,
+            const std::vector<common_adapter_lora_info> & loras);
 
 std::string                   get_model_endpoint();
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -364,6 +364,8 @@ extern "C" {
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
+
+        uint64_t n_lora_tensors;
     };
 
     // model quantization parameters
@@ -625,6 +627,9 @@ extern "C" {
     // Manually free a LoRA adapter
     // NOTE: loaded adapters will be free when the associated model is deleted
     LLAMA_API void llama_adapter_lora_free(struct llama_adapter_lora * adapter);
+
+    // for llama_context_params::n_lora_tensors */
+    LLAMA_API uint64_t llama_adapter_lora_get_n_tensors(const struct llama_adapter_lora * adapter);
 
     // Get the invocation tokens if the current lora is an alora
     LLAMA_API uint64_t            llama_adapter_get_alora_n_invocation_tokens(const struct llama_adapter_lora * adapter);

--- a/src/llama-adapter.cpp
+++ b/src/llama-adapter.cpp
@@ -472,6 +472,13 @@ void llama_adapter_lora_free(llama_adapter_lora * adapter) {
     delete adapter;
 }
 
+uint64_t llama_adapter_lora_get_n_tensors(const struct llama_adapter_lora * adapter) {
+    if (!adapter) {
+        return 0;
+    }
+    return adapter->ab_map.size() * 2;
+}
+
 uint64_t llama_adapter_get_alora_n_invocation_tokens(const struct llama_adapter_lora * adapter) {
     if (!adapter) {
         return 0;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -201,7 +201,7 @@ private:
     //
 
 public:
-    uint32_t graph_max_nodes(uint32_t n_tokens) const;
+    uint32_t graph_max_nodes(uint32_t n_tokens, uint32_t n_lora_tensors) const;
 
     // can reuse the llm_graph_result instance of the context (for example to update a memory module)
     llm_graph_result * get_gf_res_reserve() const;

--- a/tools/export-lora/export-lora.cpp
+++ b/tools/export-lora/export-lora.cpp
@@ -129,7 +129,7 @@ struct lora_merge_ctx {
 
     lora_merge_ctx(
             std::string & base_fname,
-            std::vector<common_adapter_lora_info> & lora_files,
+            std::vector<common_adapter_lora_param> & lora_files,
             std::string & outfile,
             int n_threads) : base_model(base_fname, 0), n_threads(n_threads), fout(outfile, std::ios::binary) {
         fout.exceptions(std::ofstream::failbit); // fail fast on write errors

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -98,23 +98,26 @@ std::string gen_tool_call_id();
 // lora utils
 //
 
+using lora_scales = std::map<int, float>;
+
 // check whether the given lora set has only aloras activated (empty => false)
-bool lora_all_alora(const std::vector<common_adapter_lora_info> & loras);
+bool lora_all_alora(const std::vector<common_adapter_lora_info> & lora_adapters, const lora_scales & loras);
 
 // if the two sets of loras are different, they require a cache clear unless the
 // change is only from aloras to aloras.
 bool lora_should_clear_cache(
-        const std::vector<common_adapter_lora_info> & current,
-        const std::vector<common_adapter_lora_info> & next);
+        const std::vector<common_adapter_lora_info> & lora_adapters,
+        const lora_scales & current,
+        const lora_scales & next);
 
 std::map<int, float> parse_lora_request(const json & data);
 
 bool are_lora_equal(
-        const std::vector<common_adapter_lora_info> & l1,
-        const std::vector<common_adapter_lora_info> & l2);
+        const lora_scales & l1,
+        const lora_scales & l2);
 
 // get the ids of all enabled loras
-std::vector<size_t> lora_get_enabled_ids(const std::vector<common_adapter_lora_info> & loras);
+std::vector<size_t> lora_get_enabled_ids(const lora_scales & loras);
 
 //
 // server_tokens

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2028,7 +2028,7 @@ private:
         int32_t n_batch  = llama_n_batch(ctx);
         int32_t n_ubatch = llama_n_ubatch(ctx);
 
-        float  alora_scale       = -1.0f;
+        float  alora_scale       = 0.0f;
         size_t alora_disabled_id = 0;
 
         // next, batch any pending prompts without exceeding n_batch
@@ -2416,7 +2416,7 @@ private:
                         // if this is an alora request with pre-invocation
                         // tokens that are not cached, we need to stop filling
                         // this batch at those pre-invocation tokens.
-                        if (alora_scale > 0 && slot.prompt.n_tokens() == slot.alora_invocation_start - 1) {
+                        if (alora_scale != 0.0f && slot.prompt.n_tokens() == slot.alora_invocation_start - 1) {
                             SLT_DBG(slot, "stop prompt batch filling at (n_tokens = %d, alora_invocation_start = %d)\n", slot.prompt.n_tokens(), slot.alora_invocation_start);
                             break;
                         }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1332,10 +1332,10 @@ json server_task_result_get_lora::to_json() {
         auto & lora = loras[i];
         json entry = {
             {"id",            i},
-            {"path",          lora.info.path},
-            {"scale",         lora.info.scale},
-            {"task_name",     lora.info.task_name},
-            {"prompt_prefix", lora.info.prompt_prefix},
+            {"path",          lora.path},
+            {"scale",         lora.scale},
+            {"task_name",     lora.task_name},
+            {"prompt_prefix", lora.prompt_prefix},
         };
         if (!lora.alora_invocation_tokens.empty()) {
             entry["alora_invocation_string"] = lora.alora_invocation_string;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -444,7 +444,11 @@ struct server_task_result_slot_erase : server_task_result {
 
 struct server_task_result_get_lora : server_task_result {
     struct lora {
-        common_adapter_lora_info info;
+        std::string path;
+        float scale;
+        std::string task_name;
+        std::string prompt_prefix;
+
         std::string  alora_invocation_string;
         llama_tokens alora_invocation_tokens;
     };


### PR DESCRIPTION
Split command line parameters and runtime adapter info into different struct-s. 
Bump max graph size according to LoRa count and tensor size.   
Fixes bug https://github.com/ggml-org/llama.cpp/issues/18050

Some rationale on the changes. LoRa adapters can be as complex as the original model by hooking into every stage i.e. Wk, Wq, Wv in attention and Wup, Wgate, Wdown in FFN.  
With multiple LoRa-s the graph size can become more than double of the original graph, thus leading to the 18050 crash; this means that you cannot safely add arbitrary LoRa-s unless you specifically initialized `llama_context` via `common_init_from_params` for these specific adapters.  
I could have just passed the tensor count into `llama_context` constructor without much other noise, but that would make the mess even harder to untangle latter. And there are more issues to it, for example, with LoRa-s enabled I get:
```
ggml_gallocr_needs_realloc: graph has different number of nodes
ggml_gallocr_alloc_graph: reallocating buffers automatically
```
That's why the `build graph with all lora-s active?` question left in `llama_context::graph_reserve`.

So in the end I moved LoRa adapters initialization into `common_init_from_params` and explicitly bound the adapters lifetime to the `common_init_result` — original code implicitly stored adapters in `common_init_result` but most handling was done via raw pointers stored in `common_params` instead which was just a timebomb waiting to explode.  
Particulary, `server_context` makes unrestricted deep copies/assignments of `common_params`, so it was all messed up anyway (and that's also why ngxson left todo comments in the code).

Another small thing: adapter scale `-1.0f` is a valid scale i.e. inverted adapter
```
llama-server --lora-scaled lora1.gguf:-1.0
```
, but `server_context` treated negative scales as "adapter disabled" which is incorrect.