### PR TITLE
llama : fix integer overflow in llama_chat_apply_template

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -463,7 +463,7 @@ bool common_chat_verify_template(const std::string & tmpl, bool use_jinja) {
         }
     }
     llama_chat_message chat[] = {{"user", "test"}};
-    const int res = llama_chat_apply_template(tmpl.c_str(), chat, 1, true, nullptr, 0);
+    const int64_t res = llama_chat_apply_template(tmpl.c_str(), chat, 1, true, nullptr, 0);
     return res >= 0;
 }
 
@@ -2829,7 +2829,7 @@ static common_chat_params common_chat_templates_apply_legacy(
 
     // run the first time to get the total output length
     const auto & src = tmpls->template_default->source();
-    int32_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
+    int64_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
 
     // error: chat template is not supported
     if (res < 0) {
@@ -2840,7 +2840,7 @@ static common_chat_params common_chat_templates_apply_legacy(
 
     // if it turns out that our buffer is too small, we resize it
     if ((size_t) res > buf.size()) {
-        buf.resize(res);
+        buf.resize((size_t)res);
         res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
     }
 
@@ -2850,7 +2850,7 @@ static common_chat_params common_chat_templates_apply_legacy(
     }
 
     common_chat_params params;
-    params.prompt = std::string(buf.data(), res);
+    params.prompt = std::string(buf.data(), (size_t)res);
     if (!inputs.json_schema.empty()) {
         params.grammar = json_schema_to_grammar(json::parse(inputs.json_schema));
     } else {

--- a/examples/simple-chat/simple-chat.cpp
+++ b/examples/simple-chat/simple-chat.cpp
@@ -153,7 +153,7 @@ int main(int argc, char ** argv) {
 
     std::vector<llama_chat_message> messages;
     std::vector<char> formatted(llama_n_ctx(ctx));
-    int prev_len = 0;
+    int64_t prev_len = 0;
     while (true) {
         // get user input
         printf("\033[32m> \033[0m");
@@ -168,9 +168,9 @@ int main(int argc, char ** argv) {
 
         // add the user input to the message list and format it
         messages.push_back({"user", strdup(user.c_str())});
-        int new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
-        if (new_len > (int)formatted.size()) {
-            formatted.resize(new_len);
+        int64_t new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
+        if (new_len > (int64_t)formatted.size()) {
+            formatted.resize((size_t)new_len);
             new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
         }
         if (new_len < 0) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1109,13 +1109,13 @@ extern "C" {
     /// @param buf A buffer to hold the output formatted prompt. The recommended alloc size is 2 * (total number of characters of all messages)
     /// @param length The size of the allocated buffer
     /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
-    LLAMA_API int32_t llama_chat_apply_template(
+    LLAMA_API int64_t llama_chat_apply_template(
                             const char * tmpl,
        const struct llama_chat_message * chat,
                                 size_t   n_msg,
                                   bool   add_ass,
                                   char * buf,
-                               int32_t   length);
+                               int64_t   length);
 
     // Get list of built-in chat templates
     LLAMA_API int32_t llama_chat_builtin_templates(const char ** output, size_t len);

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -222,7 +222,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
 
 // Simple version of "llama_apply_chat_template" that only works with strings
 // This function uses heuristic checks to determine commonly used template. It is not a jinja parser.
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass) {

--- a/src/llama-chat.h
+++ b/src/llama-chat.h
@@ -63,7 +63,7 @@ llm_chat_template llm_chat_template_from_str(const std::string & name);
 
 llm_chat_template llm_chat_detect_template(const std::string & tmpl);
 
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -997,13 +997,13 @@ void llama_model_save_to_file(const struct llama_model * model, const char * pat
 // chat templates
 //
 
-int32_t llama_chat_apply_template(
+int64_t llama_chat_apply_template(
                               const char * tmpl,
          const struct llama_chat_message * chat,
                                   size_t   n_msg,
                                     bool   add_ass,
                                     char * buf,
-                                 int32_t   length) {
+                                 int64_t   length) {
     const std::string curr_tmpl(tmpl == nullptr ? "chatml" : tmpl);
 
     // format the chat to string
@@ -1018,12 +1018,12 @@ int32_t llama_chat_apply_template(
     if (detected_tmpl == LLM_CHAT_TEMPLATE_UNKNOWN) {
         return -1;
     }
-    int32_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
+    int64_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
     if (res < 0) {
         return res;
     }
     if (buf && length > 0) {
-        strncpy(buf, formatted_chat.c_str(), length);
+        strncpy(buf, formatted_chat.c_str(), (size_t)length);
     }
     return res;
 }

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -300,13 +300,13 @@ int main(void) {
         }
     };
     std::vector<char> formatted_chat(1024);
-    int32_t res;
+    int64_t res;
 
     // list all supported templates
     std::vector<const char *> supported_tmpl;
     res = llama_chat_builtin_templates(nullptr, 0);
     assert(res > 0);
-    supported_tmpl.resize(res);
+    supported_tmpl.resize((size_t)res);
     res = llama_chat_builtin_templates(supported_tmpl.data(), supported_tmpl.size());
     printf("Built-in chat templates:\n");
     for (auto tmpl : supported_tmpl) {
@@ -329,7 +329,7 @@ int main(void) {
             formatted_chat.data(),
             formatted_chat.size()
         );
-        formatted_chat.resize(res);
+        formatted_chat.resize((size_t)res);
         std::string output(formatted_chat.data(), formatted_chat.size());
         if (output != test_case.expected_output) {
             printf("Expected:\n%s\n", test_case.expected_output.c_str());


### PR DESCRIPTION
Fixes #17463

When the formatted chat output exceeds 2GB, the return value overflows from positive to negative (since it's stored in int32_t), which makes it look like a template error. Users get "this custom template is not supported" when the real problem is the output is just too large.

Fixed by changing the return type and length parameter from int32_t to int64_t. Updated all internal callers and added explicit casts where needed.

**Changes:**
- `include/llama.h` - public API
- `src/llama.cpp` - implementation  
- `src/llama-chat.h` / `src/llama-chat.cpp` - internal functions
- `common/chat.cpp` - callers
- `examples/simple-chat/simple-chat.cpp` - example
- `tests/test-chat-template.cpp` - tests