### PR TITLE
server : fix crash when seq_rm fails for hybrid/recurrent models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -948,8 +948,10 @@ struct server_context_impl {
         return ret;
     }
 
-    void clear_slot(server_slot & slot) const {
-        GGML_ASSERT(!slot.is_processing());
+    void clear_slot(server_slot & slot, bool allow_processing = false) const {
+        if (!allow_processing) {
+            GGML_ASSERT(!slot.is_processing());
+        }
 
         SLT_WRN(slot, "clearing slot with %zu tokens\n", slot.prompt.tokens.size());
 
@@ -2220,8 +2222,7 @@ struct server_context_impl {
                     if (!llama_memory_seq_rm(llama_get_memory(ctx), slot.id, p0, -1)) {
                         SLT_WRN(slot, "failed to truncate tokens with position >= %d - clearing the memory\n", p0);
 
-                        llama_memory_seq_rm(llama_get_memory(ctx), slot.id, -1, -1);
-                        slot.prompt.tokens.clear();
+                        clear_slot(slot, /*allow_processing=*/true);
 
                         // there is no common part left
                         slot.n_prompt_tokens_cache = 0;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2220,7 +2220,8 @@ struct server_context_impl {
                     if (!llama_memory_seq_rm(llama_get_memory(ctx), slot.id, p0, -1)) {
                         SLT_WRN(slot, "failed to truncate tokens with position >= %d - clearing the memory\n", p0);
 
-                        clear_slot(slot);
+                        llama_memory_seq_rm(llama_get_memory(ctx), slot.id, -1, -1);
+                        slot.prompt.tokens.clear();
 
                         // there is no common part left
                         slot.n_prompt_tokens_cache = 0;


### PR DESCRIPTION
When the model is a hybrid/recurrent model, `llama_memory_seq_rm` may fail. In this case, the slot's status is not `SLOT_STATE_IDLE`.

https://github.com/ggml-org/llama.cpp/blob/10b4f82d441b611231a20633036439622e22f199/tools/server/server-context.cpp#L2220-L2227

So calling `clear_slot` will trigger `GGML_ASSERT`, causing the program to crash.

https://github.com/ggml-org/llama.cpp/blob/af3be131c065a38e476c34295bceda6cb956e7d7/tools/server/server-context.cpp#L1010-L1017

Related issue:
- https://github.com/ggml-org/llama.cpp/issues/18235