### PR TITLE
Fix in the example in examples/retrieval

### DIFF
--- a/examples/retrieval/retrieval.cpp
+++ b/examples/retrieval/retrieval.cpp
@@ -222,8 +222,8 @@ int main(int argc, char ** argv) {
     float * emb = embeddings.data();
 
     // break into batches
-    int p = 0; // number of prompts processed already
-    int s = 0; // number of prompts in current batch
+    unsigned int p = 0; // number of prompts processed already
+    unsigned int s = 0; // number of prompts in current batch
     for (int k = 0; k < n_chunks; k++) {
         // clamp to n_batch tokens
         auto & inp = chunks[k].tokens;
@@ -231,7 +231,7 @@ int main(int argc, char ** argv) {
         const uint64_t n_toks = inp.size();
 
         // encode if at capacity
-        if (batch.n_tokens + n_toks > n_batch) {
+        if (batch.n_tokens + n_toks > n_batch || s >= llama_n_seq_max(ctx)) {
             float * out = emb + p * n_embd;
             batch_process(ctx, batch, out, s, n_embd);
             common_batch_clear(batch);


### PR DESCRIPTION
Quick fix in the retrieval example so that only at most n_seq_max chunks of
text are added to the llama_batch and this example stop crashing due attempting
to process more token sequences in a batch than allocated by llama_context::
encode and llama_context::decode.

The retrieval example crashes because (according to my understanding of the llama_context code) llama_context::encode is going to allocate n_seq_max sequences of tokens, and the loop in the example keeps adding more sequences. I added a condition so that the loop stops adding tokens when s reaches llama_n_seq_max(ctx).