### PR TITLE
mtmd: clarify that we no longer accept AI-generated PRs

### DIFF
--- a/tools/mtmd/models/models.h
+++ b/tools/mtmd/models/models.h
@@ -2,6 +2,11 @@
 
 #include "../clip-graph.h"
 
+/*
+ * IMPORTANT: The mtmd module does NOT accept pull requests that are fully or predominantly AI-generated.
+ * We encourage human contributors to ensure the quality and reliability of the codebase.
+ */
+
 struct clip_graph_siglip : clip_graph {
     clip_graph_siglip(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
     ggml_cgraph * build() override;

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -27,6 +27,9 @@
  * - Make sure the C API is aligned with the libllama C API (as in llama.h)
  * - Do not include model name (e.g., qwen, gemma) in the API, use generic terms instead
  * - Keep the API minimal, do not expose internal details unless necessary
+ *
+ * IMPORTANT: The mtmd module does NOT accept pull requests that are fully or predominantly AI-generated.
+ * We encourage human contributors to ensure the quality and reliability of the codebase.
  */
 
 #ifdef LLAMA_SHARED


### PR DESCRIPTION
I demand other maintainers to either accept this or https://github.com/ggml-org/llama.cpp/pull/18388

AI-generated PRs in mtmd are often, if not always, lead to sub-optimal, low-quality code. These PRs are usually huge, take me too much time to review / optimize, adding more mental strain and make the productivity goes negative.

Therefore, I would like to explicitly reject PRs that are fully or predominantly AI-generated. Using AI as an assistive tool is always welcomed.

> [!IMPORTANT]
> **This message does not prevent contributors to push such PRs in the future, but serves as an explicit statement in case someone asks**

Some examples:
- https://github.com/ggml-org/llama.cpp/pull/18404
- https://github.com/ggml-org/llama.cpp/pull/18256
- https://github.com/ggml-org/llama.cpp/pull/17998
- https://github.com/ggml-org/llama.cpp/pull/17360