### PR TITLE
github: update issue templates [no ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
+++ b/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
@@ -8,7 +8,8 @@ body:
       value: >
         Thanks for taking the time to fill out this bug report!
         This issue template is intended for bug reports where the compilation of llama.cpp fails.
-        Before opening an issue, please confirm that the compilation still fails with `-DGGML_CCACHE=OFF`.
+        Before opening an issue, please confirm that the compilation still fails
+        after recreating the CMake build directory and with `-DGGML_CCACHE=OFF`.
         If the compilation succeeds with ccache disabled you should be able to permanently fix the issue
         by clearing `~/.cache/ccache` (on Linux).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/011-bug-results.yml
+++ b/.github/ISSUE_TEMPLATE/011-bug-results.yml
@@ -103,13 +103,13 @@ body:
       value: |
         <details>
         <summary>Logs</summary>
-        <!-- Copy-pasted short logs go into the "shell" area here -->
+        <!-- Copy-pasted short logs go into the "console" area here -->
 
-        ```shell
+        ```console
 
         ```
         </details>
 
-        <!-- Long logs that you upload as files go here, outside the "shell" area -->
+        <!-- Long logs that you upload as files go here, outside the "console" area -->
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/011-bug-results.yml
+++ b/.github/ISSUE_TEMPLATE/011-bug-results.yml
@@ -98,7 +98,18 @@ body:
       label: Relevant log output
       description: >
           Please copy and paste any relevant log output, including the command that you entered and any generated text.
-          This will be automatically formatted into code, so no need for backticks.
-      render: shell
+          For very long logs (thousands of lines), preferably upload them as files instead.
+          On Linux you can redirect console output into a file by appending ` > llama.log 2>&1` to your command.
+      value: |
+        <details>
+        <summary>Logs</summary>
+        <!-- Copy-pasted short logs go into the "shell" area here -->
+
+        ```shell
+
+        ```
+        </details>
+
+        <!-- Long logs that you upload as files go here, outside the "shell" area -->
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -91,13 +91,13 @@ body:
       value: |
         <details>
         <summary>Logs</summary>
-        <!-- Copy-pasted short logs go into the "shell" area here -->
+        <!-- Copy-pasted short logs go into the "console" area here -->
 
-        ```shell
+        ```console
 
         ```
         </details>
 
-        <!-- Long logs that you upload as files go here, outside the "shell" area -->
+        <!-- Long logs that you upload as files go here, outside the "console" area -->
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -85,8 +85,19 @@ body:
       label: Relevant log output
       description: >
           If applicable, please copy and paste any relevant log output, including any generated text.
-          This will be automatically formatted into code, so no need for backticks.
           If you are encountering problems specifically with the `llama_params_fit` module, always upload `--verbose` logs as well.
-      render: shell
+          For very long logs (thousands of lines), please upload them as files instead.
+          On Linux you can redirect console output into a file by appending ` > llama.log 2>&1` to your command.
+      value: |
+        <details>
+        <summary>Logs</summary>
+        <!-- Copy-pasted short logs go into the "shell" area here -->
+
+        ```shell
+
+        ```
+        </details>
+
+        <!-- Long logs that you upload as files go here, outside the "shell" area -->
     validations:
       required: false


### PR DESCRIPTION
This PR updates the issue templates:

* Instructs users to first check whether their issue with compilation can be fixed by re-creating the CMake build directories.
* Changes the template for logs from `render: shell` to a commented pre-filled text area with a place for logs. The reason for this is that uploading files in a section with `render: shell` seems to be broken. I made the logs collapsible while I was at it.

I used a language model to give me suggestions for how to handle the broken file uploads, I copy-pasted and adapted one of the YAML snippets. Live demo of the templates here: https://github.com/JohannesGaessler/llama.cpp/issues