### PR TITLE
common: fix return value check for setpriority

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -251,7 +251,7 @@ bool set_process_priority(enum ggml_sched_priority prio) {
         case GGML_SCHED_PRIO_REALTIME: p = -20; break;
     }
 
-    if (!setpriority(PRIO_PROCESS, 0, p)) {
+    if (setpriority(PRIO_PROCESS, 0, p) != 0) {
         LOG_WRN("failed to set process priority %d : %s (%d)\n", prio, strerror(errno), errno);
         return false;
     }

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -175,7 +175,10 @@ int main(int argc, char ** argv) {
     struct ggml_threadpool_params tpp =
             ggml_threadpool_params_from_cpu_params(params.cpuparams);
 
-    set_process_priority(params.cpuparams.priority);
+    if (!set_process_priority(params.cpuparams.priority)) {
+        LOG_ERR("%s: error: failed to set process priority\n", __func__);
+        return 1;
+    }
 
     struct ggml_threadpool * threadpool_batch = NULL;
     if (!ggml_threadpool_params_match(&tpp, &tpp_batch)) {

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2037,7 +2037,10 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
-    set_process_priority(params.prio);
+    if (!set_process_priority(params.prio)) {
+        fprintf(stderr, "%s: error: failed to set process priority\n", __func__);
+        return 1;
+    }
 
     // initialize printer
     std::unique_ptr<printer> p     = create_printer(params.output_format);


### PR DESCRIPTION
On macOS and POSIX systems, a return value of 0 from `getpriority()` indicates success. 
```
RETURN VALUES
     Since getpriority() can legitimately return the value -1, it is necessary to clear the external variable errno prior to
     the call, then check it afterward to determine if a -1 is an error or a legitimate value.  The setpriority() call returns
     0 if there is no error, or -1 if there is.
```
The `!` operator in the code should be removed.

https://github.com/ggml-org/llama.cpp/blob/06705fdcb3ef199d2c2c95a5e3cbb7cf9cc5256e/common/common.cpp#L254-L257

Additionally, the Windows version's logic for `SetPriorityClass` is correct, [since it returns 0 to indicate failure](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass#return-value).

https://github.com/ggml-org/llama.cpp/blob/06705fdcb3ef199d2c2c95a5e3cbb7cf9cc5256e/common/common.cpp#L228-L231