### PR TITLE
ggml-cuda: use CMAKE_CUDA_ARCHITECTURES if set when GGML_NATIVE=ON

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -37,14 +37,13 @@ if (CUDAToolkit_FOUND)
             endif()
         endif()
     endif()
-    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     enable_language(CUDA)
 
     # Replace any 12x-real architectures with 12x{a}-real. FP4 ptx instructions are not available in just 12x
     if (GGML_NATIVE)
         set(PROCESSED_ARCHITECTURES "")
-        if (CMAKE_CUDA_ARCHITECTURES_NATIVE)
+        if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND CMAKE_CUDA_ARCHITECTURES_NATIVE)
             set(ARCH_LIST ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
         else()
             set(ARCH_LIST ${CMAKE_CUDA_ARCHITECTURES})
@@ -66,6 +65,7 @@ if (CUDAToolkit_FOUND)
             endif()
         endforeach()
     endif()
+    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     file(GLOB   GGML_HEADERS_CUDA "*.cuh")
     list(APPEND GGML_HEADERS_CUDA "../../include/ggml-cuda.h")


### PR DESCRIPTION
Fixed compilation error when building with GGML_NATIVE=ON and CUDA Toolkit but without a GPU (e.g. `docker build`) where `CMAKE_CUDA_ARCHITECTURES_NATIVE` will be `No CUDA Devices found.`, causing nvcc error `Unsupported gpu architecture 'compute_No CUDA Devices found.'`.

Also if `CMAKE_CUDA_ARCHITECTURES` is explicitly set by the user, maybe it's better to use it even when `GGML_NATIVE=ON`. Which is also consistent with the behavior before #18361.

Additionally moves the logging of `CMAKE_CUDA_ARCHITECTURES` after the replacement.

Possibly related to #18398.