### PR TITLE
fix: change llama_chat_apply_template return type from int32_t to int64_t

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -463,7 +463,7 @@ bool common_chat_verify_template(const std::string & tmpl, bool use_jinja) {
         }
     }
     llama_chat_message chat[] = {{"user", "test"}};
-    const int res = llama_chat_apply_template(tmpl.c_str(), chat, 1, true, nullptr, 0);
+    const int64_t res = llama_chat_apply_template(tmpl.c_str(), chat, 1, true, nullptr, 0);
     return res >= 0;
 }
 
@@ -2829,7 +2829,7 @@ static common_chat_params common_chat_templates_apply_legacy(
 
     // run the first time to get the total output length
     const auto & src = tmpls->template_default->source();
-    int32_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
+    int64_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
 
     // error: chat template is not supported
     if (res < 0) {

--- a/examples/simple-chat/simple-chat.cpp
+++ b/examples/simple-chat/simple-chat.cpp
@@ -153,7 +153,7 @@ int main(int argc, char ** argv) {
 
     std::vector<llama_chat_message> messages;
     std::vector<char> formatted(llama_n_ctx(ctx));
-    int prev_len = 0;
+    int64_t prev_len = 0;
     while (true) {
         // get user input
         printf("\033[32m> \033[0m");
@@ -168,8 +168,8 @@ int main(int argc, char ** argv) {
 
         // add the user input to the message list and format it
         messages.push_back({"user", strdup(user.c_str())});
-        int new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
-        if (new_len > (int)formatted.size()) {
+        int64_t new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
+        if (new_len > (int64_t)formatted.size()) {
             formatted.resize(new_len);
             new_len = llama_chat_apply_template(tmpl, messages.data(), messages.size(), true, formatted.data(), formatted.size());
         }

--- a/include/llama.h
+++ b/include/llama.h
@@ -1115,13 +1115,13 @@ extern "C" {
     /// @param buf A buffer to hold the output formatted prompt. The recommended alloc size is 2 * (total number of characters of all messages)
     /// @param length The size of the allocated buffer
     /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
-    LLAMA_API int32_t llama_chat_apply_template(
+    LLAMA_API int64_t llama_chat_apply_template(
                             const char * tmpl,
        const struct llama_chat_message * chat,
                                 size_t   n_msg,
                                   bool   add_ass,
                                   char * buf,
-                               int32_t   length);
+                               int64_t   length);
 
     // Get list of built-in chat templates
     LLAMA_API int32_t llama_chat_builtin_templates(const char ** output, size_t len);

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -222,7 +222,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
 
 // Simple version of "llama_apply_chat_template" that only works with strings
 // This function uses heuristic checks to determine commonly used template. It is not a jinja parser.
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass) {

--- a/src/llama-chat.h
+++ b/src/llama-chat.h
@@ -63,7 +63,7 @@ llm_chat_template llm_chat_template_from_str(const std::string & name);
 
 llm_chat_template llm_chat_detect_template(const std::string & tmpl);
 
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1009,13 +1009,13 @@ void llama_model_save_to_file(const struct llama_model * model, const char * pat
 // chat templates
 //
 
-int32_t llama_chat_apply_template(
+int64_t llama_chat_apply_template(
                               const char * tmpl,
          const struct llama_chat_message * chat,
                                   size_t   n_msg,
                                     bool   add_ass,
                                     char * buf,
-                                 int32_t   length) {
+                                 int64_t   length) {
     const std::string curr_tmpl(tmpl == nullptr ? "chatml" : tmpl);
 
     // format the chat to string
@@ -1030,7 +1030,7 @@ int32_t llama_chat_apply_template(
     if (detected_tmpl == LLM_CHAT_TEMPLATE_UNKNOWN) {
         return -1;
     }
-    int32_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
+    int64_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
     if (res < 0) {
         return res;
     }

--- a/tests/test-chat-template.cpp
+++ b/tests/test-chat-template.cpp
@@ -300,7 +300,7 @@ int main(void) {
         }
     };
     std::vector<char> formatted_chat(1024);
-    int32_t res;
+    int64_t res;
 
     // list all supported templates
     std::vector<const char *> supported_tmpl;


### PR DESCRIPTION
## Summary
- Fixes #17463 - Integer overflow in llama_chat_apply_template causing incorrect error messages for large tokens

## Changes
- Changed `llama_chat_apply_template` return type from `int32_t` to `int64_t`
- Changed `llama_chat_apply_template` length parameter from `int32_t` to `int64_t`
- Changed `llm_chat_apply_template` return type from `int32_t` to `int64_t`
- Updated all callers to use `int64_t` for the result variable

## Root Cause
The `llm_chat_apply_template` function returns `dest.size()` which is a `size_t`. When messages are very large (>2GB), storing this in `int32_t` causes integer overflow. This resulted in negative values being returned even for valid templates, triggering incorrect error messages like "this custom template is not supported" instead of proper size handling.

## Test plan
- [x] Existing tests pass with updated types
- [x] The overflow scenario described in #17463 now works correctly (large buffers return positive sizes instead of overflowing to negative)

## Files modified
- `include/llama.h` - API declaration
- `src/llama.cpp` - Implementation
- `src/llama-chat.h` - Internal header
- `src/llama-chat.cpp` - Internal implementation
- `common/chat.cpp` - Caller updates
- `examples/simple-chat/simple-chat.cpp` - Example updates
- `tests/test-chat-template.cpp` - Test updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)