### PR TITLE
Revert "ggml-cuda: use CMAKE_CUDA_ARCHITECTURES if set when GGML_NATI…

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -37,13 +37,14 @@ if (CUDAToolkit_FOUND)
             endif()
         endif()
     endif()
+    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     enable_language(CUDA)
 
     # Replace any 12x-real architectures with 12x{a}-real. FP4 ptx instructions are not available in just 12x
     if (GGML_NATIVE)
         set(PROCESSED_ARCHITECTURES "")
-        if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND CMAKE_CUDA_ARCHITECTURES_NATIVE)
+        if (CMAKE_CUDA_ARCHITECTURES_NATIVE)
             set(ARCH_LIST ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
         else()
             set(ARCH_LIST ${CMAKE_CUDA_ARCHITECTURES})
@@ -65,7 +66,6 @@ if (CUDAToolkit_FOUND)
             endif()
         endforeach()
     endif()
-    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     file(GLOB   GGML_HEADERS_CUDA "*.cuh")
     list(APPEND GGML_HEADERS_CUDA "../../include/ggml-cuda.h")


### PR DESCRIPTION
…VE=ON (#18413)"

This reverts commit 4fd59e8427e78241b01b1db352ef28be6bf304fd.

The reason is that fix is only for the Docker builds without GPU and breaks all native builds otherwise. We also cannot allow users to specify `120-real` and expect compilation to work at the moment. For Docker builds without GPU the correct way would be to build without GGML_NATIVE