### PR TITLE
CUDA: Blackwell features for non-native builds

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -35,6 +35,20 @@ if (CUDAToolkit_FOUND)
             if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
                 list(APPEND CMAKE_CUDA_ARCHITECTURES 89-real)
             endif()
+
+            if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
+                # The CUDA architecture 120f-virtual would in principle work for Blackwell support
+                #     but the newly added "f" suffix conflicted with a preexising regex for validating CUDA architectures in CMake.
+                # So either a recent CMake version or one with the backported fix is needed.
+                # The following versions should work:
+                #   - CMake >= v3.31.8 && CMake < v4.0.0
+                #   - CMake >= v4.0.2
+                # This is NOT documented in the CMake release notes,
+                #     check Modules/Internal/CMakeCUDAArchitecturesValidate.cmake in the CMake git repository instead.
+                # However, the architectures 120a-real and 121a-real should work with basically any CMake version and
+                #     until the release of e.g. Rubin there is no benefit to shipping virtual architectures for Blackwell.
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 120a-real 121a-real)
+            endif()
         endif()
     endif()
     message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
@@ -62,7 +76,7 @@ if (CUDAToolkit_FOUND)
     else()
         foreach(ARCH ${CMAKE_CUDA_ARCHITECTURES})
             if(ARCH MATCHES "^12[0-9](-real|-virtual)?$")
-                message(FATAL_ERROR "Compute capability ${ARCH} used, use ${ARCH}a or ${ARCH}f for Blackwell specific optimizations")
+                message(FATAL_ERROR "Compute capability ${ARCH} used, use ${ARCH}a or ${ARCH}f for Blackwell-specific optimizations")
             endif()
         endforeach()
     endif()


### PR DESCRIPTION
This PR adds architectures to enable the recent Blackwell-specific MXFP4 optimizations for non-native builds. The problem with `120f-virtual` which we were using in the initial PR is that it doesn't match some regex that CMake was using to validate CUDA architectures. But the same regex seems to be compatible with `120a-real` and `121a-real` so I would suggest that we for now simply build those since there is no other hardware to cover. Newer CMake versions come with a bugfix for the regex so presumably this will be less problematic for us to handle in the future. @CISC is there a way to run the Windows CUDA release CI without merging a PR?