### PR TITLE
fix: prevent integer overflow in chat template functions

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2829,7 +2829,7 @@ static common_chat_params common_chat_templates_apply_legacy(
 
     // run the first time to get the total output length
     const auto & src = tmpls->template_default->source();
-    int32_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
+    int64_t res = llama_chat_apply_template(src.c_str(), chat.data(), chat.size(), inputs.add_generation_prompt, buf.data(), buf.size());
 
     // error: chat template is not supported
     if (res < 0) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1116,13 +1116,13 @@ extern "C" {
     /// @param buf A buffer to hold the output formatted prompt. The recommended alloc size is 2 * (total number of characters of all messages)
     /// @param length The size of the allocated buffer
     /// @return The total number of bytes of the formatted prompt. If is it larger than the size of buffer, you may need to re-alloc it and then re-apply the template.
-    LLAMA_API int32_t llama_chat_apply_template(
+    LLAMA_API int64_t llama_chat_apply_template(
                             const char * tmpl,
        const struct llama_chat_message * chat,
                                 size_t   n_msg,
                                   bool   add_ass,
                                   char * buf,
-                               int32_t   length);
+                               int64_t   length);
 
     // Get list of built-in chat templates
     LLAMA_API int32_t llama_chat_builtin_templates(const char ** output, size_t len);

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -222,7 +222,7 @@ llm_chat_template llm_chat_detect_template(const std::string & tmpl) {
 
 // Simple version of "llama_apply_chat_template" that only works with strings
 // This function uses heuristic checks to determine commonly used template. It is not a jinja parser.
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass) {

--- a/src/llama-chat.h
+++ b/src/llama-chat.h
@@ -63,7 +63,7 @@ llm_chat_template llm_chat_template_from_str(const std::string & name);
 
 llm_chat_template llm_chat_detect_template(const std::string & tmpl);
 
-int32_t llm_chat_apply_template(
+int64_t llm_chat_apply_template(
     llm_chat_template tmpl,
     const std::vector<const llama_chat_message *> & chat,
     std::string & dest, bool add_ass);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1012,13 +1012,13 @@ void llama_model_save_to_file(const struct llama_model * model, const char * pat
 // chat templates
 //
 
-int32_t llama_chat_apply_template(
+int64_t llama_chat_apply_template(
                               const char * tmpl,
          const struct llama_chat_message * chat,
                                   size_t   n_msg,
                                     bool   add_ass,
                                     char * buf,
-                                 int32_t   length) {
+                                 int64_t   length) {
     const std::string curr_tmpl(tmpl == nullptr ? "chatml" : tmpl);
 
     // format the chat to string
@@ -1033,7 +1033,7 @@ int32_t llama_chat_apply_template(
     if (detected_tmpl == LLM_CHAT_TEMPLATE_UNKNOWN) {
         return -1;
     }
-    int32_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
+    int64_t res = llm_chat_apply_template(detected_tmpl, chat_vec, formatted_chat, add_ass);
     if (res < 0) {
         return res;
     }


### PR DESCRIPTION
## Summary

Fixes #17463

Changes return type and length parameter from `int32_t` to `int64_t` in chat template functions to prevent integer overflow when processing large inputs (>2GB).

## Problem

When `buf.size()` exceeds `INT32_MAX` (2,147,483,647), casting to `int32_t` causes overflow to a negative value. This triggers a misleading error:

```json
{"error": {"code": 500, "message": "this custom template is not supported, try using --jinja"}}
```

The real issue is integer overflow, not an unsupported template.

## Solution

Change all related types from `int32_t` to `int64_t`:

| File | Change |
|------|--------|
| `include/llama.h` | Return type + `length` parameter |
| `src/llama.cpp` | Function signature + `res` variable |
| `src/llama-chat.h` | Return type |
| `src/llama-chat.cpp` | Return type |
| `common/chat.cpp` | `res` variable |

## Backward Compatibility

Fully backward compatible - `int64_t` handles all existing `int32_t` values correctly. Only difference is proper handling of inputs >2GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)