### PR TITLE
ggml-cuda: filter architectures in CMAKE_CUDA_ARCHITECTURES_NATIVE

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -37,13 +37,13 @@ if (CUDAToolkit_FOUND)
             endif()
         endif()
     endif()
-    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     enable_language(CUDA)
 
     # Replace any 12x-real architectures with 12x{a}-real. FP4 ptx instructions are not available in just 12x
     if (GGML_NATIVE)
         set(PROCESSED_ARCHITECTURES "")
+        list(FILTER CMAKE_CUDA_ARCHITECTURES_NATIVE INCLUDE REGEX "^[0-9]+(a|f)?(-real|-virtual)?$")
         if (CMAKE_CUDA_ARCHITECTURES_NATIVE)
             set(ARCH_LIST ${CMAKE_CUDA_ARCHITECTURES_NATIVE})
         else()
@@ -66,6 +66,7 @@ if (CUDAToolkit_FOUND)
             endif()
         endforeach()
     endif()
+    message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
     file(GLOB   GGML_HEADERS_CUDA "*.cuh")
     list(APPEND GGML_HEADERS_CUDA "../../include/ggml-cuda.h")


### PR DESCRIPTION
#18430 and #18434.

Honestly this is an upstream issue, cmake should set `CMAKE_CUDA_ARCHITECTURES_NATIVE` to empty if no devices found. `No CUDA Devices found.-real` is definitely not expected.

The regex could be simpler (`^[0-9]+-real$`) if just looking at their tests: https://github.com/Kitware/CMake/tree/master/Tests/RunCMake/CUDA_architectures.

Should only affect `-DGGML_NATIVE=ON`.