### PR TITLE
quantize: prevent input/output file collision

### DIFF
--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cctype>
 #include <algorithm>
+#include <filesystem>
 
 struct quant_option {
     std::string name;
@@ -640,6 +641,11 @@ int main(int argc, char ** argv) {
         fprintf(stderr, "\n==========================================================================================================\n");
         fprintf(stderr, "Please do not use IQ1_S, IQ1_M, IQ2_S, IQ2_XXS, IQ2_XS or Q2_K_S quantization without an importance matrix\n");
         fprintf(stderr, "==========================================================================================================\n\n\n");
+        return 1;
+    }
+
+    if (std::error_code ec; std::filesystem::equivalent(fname_inp, fname_out, ec)) {
+        fprintf(stderr, "%s: error: input and output files are the same: '%s'\n", __func__, fname_inp.c_str());
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- Add check to prevent quantizing when input and output files are the same
- Uses `std::filesystem::equivalent()` to handle path variations (e.g., `./file` vs `file`)
- Prevents file corruption caused by mmap reading from a file being simultaneously written

## Test
```bash
# Before fix: file gets corrupted (19MB -> 727KB)
llama-quantize model.gguf model.gguf Q4_0

# After fix: clean error message, file preserved
main: error: input and output files are the same: 'model.gguf'
```

Fixes #12753