### PR TITLE
server: fix incomplete unicode text output in top_logprobs

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1304,6 +1304,9 @@ private:
     void populate_token_probs(const server_slot & slot, completion_token_output & result, bool post_sampling, bool special, int idx) const {
         const size_t n_probs = slot.task->params.sampling.n_probs;
 
+        // get the previous token text in case of incomplete unicode token
+        std::string tok_prefix = slot.generated_text.substr(slot.n_sent_text);
+
         if (post_sampling) {
             const auto * cur_p = common_sampler_get_candidates(slot.smpl.get(), true);
             const size_t max_probs = cur_p->size;
@@ -1321,7 +1324,7 @@ private:
             for (size_t i = 0; i < std::min(max_probs, n_probs); i++) {
                 result.probs.push_back({
                     cur_p->data[i].id,
-                    common_token_to_piece(ctx, cur_p->data[i].id, special),
+                    tok_prefix + common_token_to_piece(ctx, cur_p->data[i].id, special),
                     cur_p->data[i].p
                 });
             }
@@ -1343,7 +1346,7 @@ private:
             for (size_t i = 0; i < std::min(cur.size(), n_probs); i++) {
                 result.probs.push_back({
                     cur[i].id,
-                    common_token_to_piece(ctx, cur[i].id, special),
+                    tok_prefix + common_token_to_piece(ctx, cur[i].id, special),
                     cur[i].p
                 });
             }


### PR DESCRIPTION
This pull request fixes an issue of `top_logprobs` the llama-server returned.

In some cases, the generated token can be truncated unicode text and there will be an unknown unicode char `(�)` in the result of `top_logprobs`. We should add the begin part of the generated text to the token text of logprobs.

Before the fix:
```json
{
    "id": 96,
    "token": " 散",
    "bytes": [
        32,
        230,
        149,
        163
    ],
    "logprob": -0.29159486293792725,
    "top_logprobs": [
        {
            "id": 96,
            "token": "�",
            "bytes": [
                163
            ],
            "logprob": -0.29159486293792725
        },
        {
            "id": 230,
            "token": "�",
            "bytes": [
                136
            ],
            "logprob": -1.7886403799057007
        }
    ]
}
```
After the fix:
```json
{
    "id": 96,
    "token": " 散",
    "bytes": [
        32,
        230,
        149,
        163
    ],
    "logprob": -0.326882928609848,
    "top_logprobs": [
        {
            "id": 96,
            "token": " 散",
            "bytes": [
                32,
                230,
                149,
                163
            ],
            "logprob": -0.326882928609848
        },
        {
            "id": 230,
            "token": " 效",
            "bytes": [
                32,
                230,
                149,
                136
            ],
            "logprob": -1.6588340997695923
        }
    ]
}
```
---
**AI Disclosure:** The code modifications are suggested by Claude Opus 4.5, and I have made some simplifications based on it. I have compiled and tested it on my machine with ROCM backend and it worked without issues.