### PR TITLE
server: fix proxy timeout in router mode - respect --timeout parameter

### DIFF
--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -183,7 +183,8 @@ public:
                       const std::string & path,
                       const std::map<std::string, std::string> & headers,
                       const std::string & body,
-                      const std::function<bool()> should_stop);
+                      const std::function<bool()> should_stop,
+                      int timeout_seconds);
     ~server_http_proxy() {
         if (cleanup) {
             cleanup();


### PR DESCRIPTION
## Problem

In multi-model router mode (`--models-dir`), the internal HTTP proxy client used hardcoded short timeout values (~200ms for connection, default httplib timeout for read/write). This caused "Failed to read connection" errors when processing large prompts with slow models.

This is especially problematic when running large models on CPU (e.g., 70B+ parameter models) where a single request can take several hours to complete. The proxy would timeout long before the model finished generating a response.

## Solution

Pass the `timeout_read` value from `--timeout` CLI parameter to the internal HTTP proxy client. This aligns router proxy behavior with single-model mode, where `--timeout` already works correctly.

**Changes:**
- Added `timeout_seconds` parameter to `server_http_proxy` constructor
- Modified `proxy_request()` to pass `base_params.timeout_read` to proxy
- Proxy now uses the same timeout for connection, read, and write operations

## Usage

```bash
# Default timeout: 600 seconds (10 minutes)
llama-server --models-dir ./models

# For large CPU models: 10 hours
llama-server --models-dir ./models --timeout 36000

# For very long runs: 24 hours  
llama-server --models-dir ./models --timeout 86400
```

## Use Case

Running large language models (70B-235B parameters) on CPU-only systems where:
- Prompt processing can take 30-60+ minutes for long contexts
- Token generation is slow (seconds per token)
- A complete request may take several hours

Previously, users had to use single-model mode (`-m model.gguf`) to avoid proxy timeout issues. Now router mode works correctly for long-running inference.

## Note

This PR contains AI-assisted code, as required by project guidelines.