### PR TITLE
cli: add URL support for /image and /audio commands

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -158,7 +158,7 @@
 | `-mmu, --mmproj-url URL` | URL to a multimodal projector file. see tools/mtmd/README.md<br/>(env: LLAMA_ARG_MMPROJ_URL) |
 | `--mmproj-auto, --no-mmproj, --no-mmproj-auto` | whether to use multimodal projector file (if available), useful when using -hf (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_AUTO) |
 | `--mmproj-offload, --no-mmproj-offload` | whether to enable GPU offloading for multimodal projector (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_OFFLOAD) |
-| `--image, --audio FILE` | path to an image or audio file. use with multimodal models, use comma-separated values for multiple files |
+| `--image, --audio FILE` | path or URL to an image or audio file. use with multimodal models, use comma-separated values for multiple files |
 | `--image-min-tokens N` | minimum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MIN_TOKENS) |
 | `--image-max-tokens N` | maximum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MAX_TOKENS) |
 | `-otd, --override-tensor-draft <tensor name pattern>=<buffer type>,...` | override tensor buffer type for draft model |

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -140,21 +140,72 @@ struct cli_context {
         return curr_content;
     }
 
-    // TODO: support remote files in the future (http, https, etc)
-    std::string load_input_file(const std::string & fname, bool is_media) {
-        std::ifstream file(fname, std::ios::binary);
+    bool load_data_from_url(const std::string & url, std::vector<char> & out) {
+#if defined(LLAMA_USE_CURL) || defined(LLAMA_USE_HTTPLIB)
+        try {
+            common_remote_params params;
+            params.headers.push_back("User-Agent: llama.cpp/" + build_info);
+            params.max_size = 1024 * 1024 * 10; // 10MB
+            params.timeout  = 10; // seconds
+            auto [http_code, data] = common_remote_get_content(url, params);
+            if (http_code != 200) {
+                console::error("Failed to fetch from URL: %s, HTTP code: %ld\n", url.c_str(), http_code);
+                return false;
+            }
+            if (data.empty()) {
+                console::error("Fetched empty content from URL: %s\n", url.c_str());
+                return false;
+            }
+            out = std::move(data);
+            return true;
+        } catch (const std::exception & e) {
+            console::error("Exception while fetching from URL: %s, error: %s\n", url.c_str(), e.what());
+            return false;
+        }
+#else
+        console::error("Network support is disabled. Compile with LLAMA_USE_CURL or LLAMA_USE_HTTPLIB to enable URL loading.\n");
+        GGML_UNUSED(url);
+        GGML_UNUSED(out);
+        return false;
+#endif
+    }
+
+    bool load_data_from_file(const std::string & path, std::vector<char> & out) {
+        std::ifstream file(path, std::ios::binary);
         if (!file) {
+            console::error("Failed to open file: %s\n", path.c_str());
+            return false;
+        }
+        out.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        return true;
+    }
+
+    // load input from local path or url
+    std::string load_input_file(const std::string & source, bool is_media) {
+        static auto is_url = [](const std::string & s) {
+            return s.find("http://") == 0 || s.find("https://") == 0;
+        };
+
+        std::vector<char> data;
+
+        bool success = false;
+        if (is_url(source)) {
+            success = load_data_from_url(source, data);
+        } else {
+            success = load_data_from_file(source, data);
+        }
+
+        if (!success) {
             return "";
         }
+
         if (is_media) {
             raw_buffer buf;
-            buf.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            buf.assign(data.begin(), data.end());
             input_files.push_back(std::move(buf));
             return mtmd_default_marker();
-        } else {
-            std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-            return content;
         }
+        return std::string(data.data(), data.size());
     }
 };
 
@@ -247,10 +298,10 @@ int main(int argc, char ** argv) {
     console::log("  /clear              clear the chat history\n");
     console::log("  /read               add a text file\n");
     if (inf.has_inp_image) {
-        console::log("  /image <file>       add an image file\n");
+        console::log("  /image <path|url>   add an image file (supports URL)\n");
     }
     if (inf.has_inp_audio) {
-        console::log("  /audio <file>       add an audio file\n");
+        console::log("  /audio <path|url>   add an audio file (supports URL)\n");
     }
     console::log("\n");
 


### PR DESCRIPTION
The `llama-cli` command now supports loading images or audio from URLs. 

<details>
<summary>Image Example:</summary>

```bash
./llama-cli -hf unsloth/InternVL3-1B-GGUF:Q4_K_M \
    --image "https://github.com/ggml-org/llama.cpp/raw/5b1248c9afa46be1a80bc71e2be8241f18529643/tools/mtmd/test-1.jpeg" \
    -p "What is in this picture?"
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.006 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   Apple M4
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 11453.25 MB
register_backend: registered backend Metal (1 devices)
register_device: registered device Metal (Apple M4)
register_backend: registered backend BLAS (1 devices)
register_device: registered device BLAS (Accelerate)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (Apple M4)
common_download_file_single_online: using cached file: /Users/o7si/Library/Caches/llama.cpp/unsloth_InternVL3-1B-GGUF_InternVL3-1B-Q4_K_M.gguf
common_download_file_single_online: using cached file: /Users/o7si/Library/Caches/llama.cpp/unsloth_InternVL3-1B-GGUF_mmproj-F16.gguf

Loading model...  


▄▄ ▄▄
██ ██
██ ██  ▀▀█▄ ███▄███▄  ▀▀█▄    ▄████ ████▄ ████▄
██ ██ ▄█▀██ ██ ██ ██ ▄█▀██    ██    ██ ██ ██ ██
██ ██ ▀█▄██ ██ ██ ██ ▀█▄██ ██ ▀████ ████▀ ████▀
                                    ██    ██
                                    ▀▀    ▀▀

build      : b7553-edd6a08ee
model      : unsloth/InternVL3-1B-GGUF:Q4_K_M
modalities : text, vision

available commands:
  /exit or Ctrl+C     stop or exit
  /regen              regenerate the last response
  /clear              clear the chat history
  /read               add a text file
  /image <path|url>   add an image file (supports URL)

Loaded media from 'https://github.com/ggml-org/llama.cpp/raw/5b1248c9afa46be1a80bc71e2be8241f18529643/tools/mtmd/test-1.jpeg'

> What is in this picture?

The image is a newspaper clipping from The New York Times from late 1953. It reports on the historic event of a group of astronauts landing on the Moon and collecting rocks and plants. The headline reads: "MEN WALK ON MOON," followed by a subheadline "ASTRONAUTS LAND ON PLAIN; COLLECT ROCKS, PLANT FLAGS." There are also two side articles:

1. "Voice From Moon: 'Eagle Has Landed'," which discusses the landing of an object resembling an eagle.
2. "A Powdery Surface; Is Closely Explored," which discusses the findings and exploration of a powdery surface.

The newspaper was published in New York and features a "Late Edition" label.

[ Prompt: 690.0 t/s | Generation: 128.8 t/s ]
```

</details>

<details>
<summary>Audio Example:</summary>

```bash
./llama-cli -hf ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF:Q8_0 \
    --audio "https://github.com/ggml-org/llama.cpp/raw/5b1248c9afa46be1a80bc71e2be8241f18529643/tools/mtmd/test-2.mp3" \
    -p "What is being said in this audio?"

ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.025 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   Apple M4
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 11453.25 MB
register_backend: registered backend Metal (1 devices)
register_device: registered device Metal (Apple M4)
register_backend: registered backend BLAS (1 devices)
register_device: registered device BLAS (Accelerate)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (Apple M4)
common_download_file_single_online: using cached file: /Users/o7si/Library/Caches/llama.cpp/ggml-org_ultravox-v0_5-llama-3_2-1b-GGUF_Llama-3.2-1B-Instruct-Q8_0.gguf
common_download_file_single_online: using cached file: /Users/o7si/Library/Caches/llama.cpp/ggml-org_ultravox-v0_5-llama-3_2-1b-GGUF_mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf

Loading model...  


▄▄ ▄▄
██ ██
██ ██  ▀▀█▄ ███▄███▄  ▀▀█▄    ▄████ ████▄ ████▄
██ ██ ▄█▀██ ██ ██ ██ ▄█▀██    ██    ██ ██ ██ ██
██ ██ ▀█▄██ ██ ██ ██ ▀█▄██ ██ ▀████ ████▀ ████▀
                                    ██    ██
                                    ▀▀    ▀▀

build      : b7553-edd6a08ee
model      : ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF:Q8_0
modalities : text, audio

available commands:
  /exit or Ctrl+C     stop or exit
  /regen              regenerate the last response
  /clear              clear the chat history
  /read               add a text file
  /audio <path|url>   add an audio file (supports URL)

Loaded media from 'https://github.com/ggml-org/llama.cpp/raw/5b1248c9afa46be1a80bc71e2be8241f18529643/tools/mtmd/test-2.mp3'

> What is being said in this audio?

The audio snippet from The New York Times on July 21, 1969, is an announcement that men have walked on the moon. The headline reads: "Men Walk On Moon Declares the Bold Headline Across America's Newspaper of Record for Over a Century".

[ Prompt: 182.1 t/s | Generation: 54.6 t/s ]
```

</details>