### PR TITLE
CUDA: fix 0.0f/0.0f for FA fixup

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -713,7 +713,7 @@ static __global__ void flash_attn_stream_k_fixup(
     }
 
     // Write back final result:
-    *dst = dst_val / rowsum;
+    *dst = dst_val == 0.0f && rowsum == 0.0f ? 0.0f : dst_val / rowsum;
 }
 
 template<int D> // D == head size
@@ -766,7 +766,7 @@ static __global__ void flash_attn_combine_results(
         VKQ_denominator += KQ_max_scale * meta[l].y;
     }
 
-    dst[tid] = VKQ_numerator / VKQ_denominator;
+    dst[tid] = VKQ_numerator == 0.0f && VKQ_denominator == 0.0f ? 0.0f : VKQ_numerator / VKQ_denominator;
 }
 
 template <int DV, int ncols1, int ncols2>


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/18444 .

The problem seems to be the fixup kernel where results from multiple CUDA blocks are combined. As it turns out in this kernel the operation `0.0f/0.0f` can occur. According to IEEE 754 the result of this operation is NaN. However, because we are compiling with `-ffast_math` the behavior is actually undefined. If the code is compiled for Turing the result is NaN, for Ada Lovelace it randomly just happens to work out. 