### PR TITLE
server: fix files built redundantly

### DIFF
--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -38,14 +38,6 @@ set(TARGET_SRCS
     server-http.h
     server-models.cpp
     server-models.h
-    server-task.cpp
-    server-task.h
-    server-queue.cpp
-    server-queue.h
-    server-common.cpp
-    server-common.h
-    server-context.cpp
-    server-context.h
 )
 set(PUBLIC_ASSETS
     index.html.gz


### PR DESCRIPTION
These files are built in server-context and don't need to also be built in server. I think this is just an artifact of #17859 and #17824 being developed at the same time.