### PR TITLE
android: Fix infinite generation by updating stop_generation_position and implement attention sinks

### DIFF
--- a/examples/llama.android/lib/src/main/cpp/ai_chat.cpp
+++ b/examples/llama.android/lib/src/main/cpp/ai_chat.cpp
@@ -269,23 +269,6 @@ static void reset_long_term_states(const bool clear_kv_cache = true) {
         llama_memory_clear(llama_get_memory(g_context), false);
 }
 
-/**
- * TODO-hyin: implement sliding-window version as a better alternative
- *
- * Context shifting by discarding the older half of the tokens appended after system prompt:
- * - take the [system_prompt_position] first tokens from the original prompt
- * - take half of the last (system_prompt_position - system_prompt_position) tokens
- * - recompute the logits in batches
- */
-static void shift_context() {
-    const int n_discard = (current_position - system_prompt_position) / 2;
-    LOGi("%s: Discarding %d tokens", __func__, n_discard);
-    llama_memory_seq_rm(llama_get_memory(g_context), 0, system_prompt_position, system_prompt_position + n_discard);
-    llama_memory_seq_add(llama_get_memory(g_context), 0, system_prompt_position + n_discard, current_position, -n_discard);
-    current_position -= n_discard;
-    LOGi("%s: Context shifting done! Current position: %d", __func__, current_position);
-}
-
 static std::string chat_add_and_format(const std::string &role, const std::string &content) {
     common_chat_msg new_msg;
     new_msg.role = role;
@@ -311,6 +294,30 @@ static void reset_short_term_states() {
     stop_generation_position = 0;
     cached_token_chars.clear();
     assistant_ss.str("");
+}
+
+/**
+ * TODO-hyin: implement sliding-window version as a better alternative
+ *
+ * Context shifting by discarding the older half of the tokens appended after system prompt:
+ * - take the [system_prompt_position] first tokens from the original prompt
+ * - take half of the last (system_prompt_position - system_prompt_position) tokens
+ * - recompute the logits in batches
+ */
+static void shift_context() {
+    const int attention_sink = 4;
+    const int keep_first = std::max(system_prompt_position, attention_sink);
+    const int n_discard = (current_position - keep_first) / 2;
+    if (n_discard <= 0) {
+        LOGi("%s: n_discard <= 0", __func__);
+        return;
+    }
+    LOGi("%s: Discarding %d tokens", __func__, n_discard);
+    llama_memory_seq_rm(llama_get_memory(g_context), 0, keep_first, keep_first + n_discard);
+    llama_memory_seq_add(llama_get_memory(g_context), 0, keep_first + n_discard, -1, -n_discard);
+    current_position -= n_discard;
+    stop_generation_position -= n_discard;
+    LOGi("%s: Context shifting done! Current position: %d", __func__, current_position);
 }
 
 static int decode_tokens_in_batches(

--- a/examples/llama.android/lib/src/main/cpp/ai_chat.cpp
+++ b/examples/llama.android/lib/src/main/cpp/ai_chat.cpp
@@ -300,9 +300,11 @@ static void reset_short_term_states() {
  * TODO-hyin: implement sliding-window version as a better alternative
  *
  * Context shifting by discarding the older half of the tokens appended after system prompt:
- * - take the [system_prompt_position] first tokens from the original prompt
- * - take half of the last (system_prompt_position - system_prompt_position) tokens
+ * - take the [keep_recent] first tokens from the original prompt
+ * - take half of the last (current_position - keep_first) tokens
  * - recompute the logits in batches
+ *
+ * attention_sink: keep the first 4 tokens to maintain attention.
  */
 static void shift_context() {
     const int attention_sink = 4;


### PR DESCRIPTION
### Summary

This PR addresses a logical error in the Android `ai_chat.cpp` example where context shifting caused infinite text generation. It also enhances the context management by implementing an Attention Sink mechanism to maintain model stability during long-stream generation.

### Changes

1. Bug Fix for Infinite Output:
  - Updated `shift_context()` to properly subtract `n_discard` from `stop_generation_position`.
  - Previously, when the KV cache was reduced, the generation would never hit the original stop position, leading to an infinite loop.

2. Attention Sink Implementation:
  - Introduced a new variable `attention_sink` to preserve the initial tokens in the KV cache.
  - This ensures the model maintains a stable "attention anchor", preventing performance degradation (perplexity explosion) when older tokens are discarded.

3. Code Refactoring:
  - Relocated the `shift_context()` function definition to appear after the declaration of `stop_generation_position` and other short-term state variables.
  - This ensures the function has the correct scope and access to these variables without requiring forward declarations.

### Attribution
- This issue was identified and reported by **@oopb** in #18409.
- Thank for quick fix by **@ssam18**, but your version is not working because the variable `stop_generation_position` is defined after the function `shift_context()`.

Fixes #18409
