### PR TITLE
chat: make tool description and parameters optional per OpenAI spec

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -380,8 +380,8 @@ std::vector<common_chat_tool> common_chat_tools_parse_oaicompat(const json & too
                 const auto & function = tool.at("function");
                 result.push_back({
                     /* .name = */ function.at("name"),
-                    /* .description = */ function.at("description"),
-                    /* .parameters = */ function.at("parameters").dump(),
+                    /* .description = */ function.contains("description") ? function.at("description") : "",
+                    /* .parameters = */ (function.contains("parameters") ? function.at("parameters") : json::object()).dump(),
                 });
             }
         }

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -380,8 +380,8 @@ std::vector<common_chat_tool> common_chat_tools_parse_oaicompat(const json & too
                 const auto & function = tool.at("function");
                 result.push_back({
                     /* .name = */ function.at("name"),
-                    /* .description = */ function.contains("description") ? function.at("description") : "",
-                    /* .parameters = */ (function.contains("parameters") ? function.at("parameters") : json::object()).dump(),
+                    /* .description = */ function.value("description", ""),
+                    /* .parameters = */ function.value("parameters", json::object()).dump(),
                 });
             }
         }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -724,6 +724,30 @@ static void test_tools_oaicompat_json_conversion() {
             "]"
         ),
         common_chat_tools_to_json_oaicompat<json>({special_function_tool}).dump(2));
+
+    {
+        auto tools_no_params = common_chat_tools_parse_oaicompat(json::parse(
+            R"([{"type": "function", "function": {"name": "test_func", "description": "A test"}}])"));
+        assert_equals((size_t) 1, tools_no_params.size());
+        assert_equals(std::string("test_func"), tools_no_params[0].name);
+        assert_equals(std::string("A test"), tools_no_params[0].description);
+        assert_equals(std::string("{}"), tools_no_params[0].parameters);
+    }
+    {
+        auto tools_no_desc = common_chat_tools_parse_oaicompat(json::parse(
+            R"([{"type": "function", "function": {"name": "test_func", "parameters": {"type": "object"}}}])"));
+        assert_equals((size_t) 1, tools_no_desc.size());
+        assert_equals(std::string("test_func"), tools_no_desc[0].name);
+        assert_equals(std::string(""), tools_no_desc[0].description);
+    }
+    {
+        auto tools_minimal = common_chat_tools_parse_oaicompat(json::parse(
+            R"([{"type": "function", "function": {"name": "test_func"}}])"));
+        assert_equals((size_t) 1, tools_minimal.size());
+        assert_equals(std::string("test_func"), tools_minimal[0].name);
+        assert_equals(std::string(""), tools_minimal[0].description);
+        assert_equals(std::string("{}"), tools_minimal[0].parameters);
+    }
 }
 
 static void test_template_output_parsers() {


### PR DESCRIPTION
## Summary
- Makes `description` and `parameters` fields optional in tool function definitions
- Per the [OpenAI API specification](https://platform.openai.com/docs/api-reference/chat/create#chat_create-tools-function_tool-function-parameters), these fields are optional
- Previously, the parser would throw an exception if these fields were missing

## Test plan
- [x] Added test for tools without `parameters` field
- [x] Added test for tools without `description` field  
- [x] Added test for tools with only `name` (minimal valid tool)
- [x] Existing tests still pass

Attempts to fix #17667