### PR TITLE
convert: avoid token collision when stripping ## prefix

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5288,7 +5288,12 @@ class BertModel(TextModel):
             if tok.startswith("[") and tok.endswith("]"):
                 return tok
             if tok.startswith("##"):
-                return tok[2:]
+                suffix = tok[2:]
+                # If the suffix resembles a special token, keep the original to avoid collision
+                # E.g., preserve "##[1]" to avoid conflict with an existing "[1]" token.
+                if suffix.startswith("[") and suffix.endswith("]"):
+                    return tok
+                return suffix
             return "\u2581" + tok
         tokens = list(map(phantom, tokens))
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5284,18 +5284,14 @@ class BertModel(TextModel):
         self.gguf_writer.add_token_type_count(self.hparams.get("type_vocab_size", 1))
 
         # convert to phantom space vocab
-        def phantom(tok):
-            if tok.startswith("[") and tok.endswith("]"):
+        def phantom(tok, toktype):
+            if toktype != gguf.TokenType.NORMAL:
                 return tok
             if tok.startswith("##"):
-                suffix = tok[2:]
-                # If the suffix resembles a special token, keep the original to avoid collision
-                # E.g., preserve "##[1]" to avoid conflict with an existing "[1]" token.
-                if suffix.startswith("[") and suffix.endswith("]"):
-                    return tok
-                return suffix
+                return tok[2:]
             return "\u2581" + tok
-        tokens = list(map(phantom, tokens))
+        assert len(tokens) == len(toktypes)
+        tokens = list(map(phantom, tokens, toktypes))
 
         # add vocab to gguf
         self.gguf_writer.add_tokenizer_model("bert")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5285,7 +5285,7 @@ class BertModel(TextModel):
 
         # convert to phantom space vocab
         def phantom(tok, toktype):
-            if toktype != gguf.TokenType.NORMAL:
+            if toktype == gguf.TokenType.CONTROL:
                 return tok
             if tok.startswith("##"):
                 return tok[2:]


### PR DESCRIPTION
When converting BERT models to GGUF, the `phantom()` function transforms wordpiece tokens by stripping the `##` prefix. This can cause token collisions:

**Example:**
- Original vocab contains both `[1]` and `##[1]`
- After transformation: `##[1]` → `[1]`
- Result: Two different tokens now have the same string representation