### PR TITLE
model: fix SWA per-layer freq_base

### DIFF
--- a/src/models/gemma3.cpp
+++ b/src/models/gemma3.cpp
@@ -33,7 +33,7 @@ llm_build_gemma3<iswa>::llm_build_gemma3(const llama_model & model, const llm_gr
         float freq_base_l  = 0.0f;
         float freq_scale_l = 0.0f;
 
-        if constexpr (iswa) {
+        if (hparams.is_swa(il)) {
             freq_base_l  = model.get_rope_freq_base (cparams, il);
             freq_scale_l = model.get_rope_freq_scale(cparams, il);
         } else {

--- a/src/models/modern-bert.cpp
+++ b/src/models/modern-bert.cpp
@@ -26,6 +26,7 @@ llm_build_modern_bert<iswa>::llm_build_modern_bert(const llama_model & model, co
     for (int il = 0; il < n_layer; ++il) {
         float freq_base_l  = 0.0f;
 
+        // TODO @ngxson : do we expect to apply this globally, or dynamically per layer?
         if constexpr (iswa) {
             freq_base_l = model.get_rope_freq_base(cparams, il);
         } else {

--- a/src/models/plamo3.cpp
+++ b/src/models/plamo3.cpp
@@ -26,7 +26,7 @@ llm_build_plamo3<iswa>::llm_build_plamo3(const llama_model & model, const llm_gr
 
         float freq_base_l  = 0.0f;
         float freq_scale_l = 0.0f;
-        if constexpr (iswa) {
+        if (hparams.is_swa(il)) {
             freq_base_l  = model.get_rope_freq_base (cparams, il);
             freq_scale_l = model.get_rope_freq_scale(cparams, il);
         } else {


### PR DESCRIPTION
I think the `if constexpr (iswa)` can be wrong here, so pushing this PR for discussion.

At least for gemma3, SWA layers are expected to use different freq_base than full attention layer. Using `if constexpr (iswa)` will make it a fixed value cross all layers.

Here is the original code of gemma3 (PR https://github.com/ggml-org/llama.cpp/pull/12343) for reference:

```cpp
        for (int il = 0; il < n_layer; ++il) {
            const bool is_sliding          = (il + 1) % sliding_window_pattern;
            const float freq_base_l        = is_sliding ? 10000.0f    : freq_base;
            const float freq_scale_l       = is_sliding ? 1.0f        : freq_scale;
            struct ggml_tensor * KQ_mask_l = is_sliding ? KQ_mask_swa : KQ_mask;
```