### PR TITLE
context : fix reserve token padding to n_seqs

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1458,7 +1458,7 @@ ggml_cgraph * llama_context::graph_reserve(
 
     if (n_tokens % n_seqs != 0) {
         n_tokens = ((n_tokens + (n_seqs - 1)) / n_seqs) * n_seqs; // round to next multiple of n_seqs
-        n_outputs = std::min(n_outputs, n_tokens);
+        n_outputs = std::max(n_outputs, n_tokens);
 
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);
     }


### PR DESCRIPTION
fix #18532

We pad the `n_tokens` up -> we need to do the same for the outputs.