### PR TITLE
cuda : check src shapes for CUDA graphs

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1041,6 +1041,8 @@ struct ggml_graph_node_properties {
     int64_t ne[GGML_MAX_DIMS];
     size_t nb[GGML_MAX_DIMS];
     void * src_address[GGML_MAX_SRC];
+    int64_t src_ne[GGML_MAX_SRC][GGML_MAX_DIMS];
+    size_t src_nb[GGML_MAX_SRC][GGML_MAX_DIMS];
     int32_t op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];
 };
 


### PR DESCRIPTION
rel https://github.com/ggml-org/llama.cpp/pull/17004#issuecomment-3706865663

Add checks for the `src` shapes to determine if a graph node has matching properties (in the context of CUDA graphs)

Not sure if this is the ideal solution. The failure case that is observed is a graph with a single `ggml_top_k()` node. For constant `k`, the output tensor of this node has the same shape, but the `src` tensor shape is different. With the logic on `master` we incorrectly determine that the node properties match and the CUDA graph is being reused.