### PR TITLE
server : fix router child env in containerized environments

### DIFF
--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -105,7 +105,7 @@ private:
     void add_model(server_model_meta && meta);
 
 public:
-    server_models(const common_params & params, int argc, char ** argv, char ** envp);
+    server_models(const common_params & params, int argc, char ** argv);
 
     void load_models();
 
@@ -147,8 +147,8 @@ struct server_models_routes {
     common_params params;
     json webui_settings = json::object();
     server_models models;
-    server_models_routes(const common_params & params, int argc, char ** argv, char ** envp)
-            : params(params), models(params, argc, argv, envp) {
+    server_models_routes(const common_params & params, int argc, char ** argv)
+            : params(params), models(params, argc, argv) {
         if (!this->params.webui_config_json.empty()) {
             try {
                 webui_settings = json::parse(this->params.webui_config_json);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -66,7 +66,7 @@ static server_http_context::handler_t ex_wrapper(server_http_context::handler_t 
     };
 }
 
-int main(int argc, char ** argv, char ** envp) {
+int main(int argc, char ** argv) {
     // own arguments required by this example
     common_params params;
 
@@ -126,7 +126,7 @@ int main(int argc, char ** argv, char ** envp) {
     if (is_router_server) {
         // setup server instances manager
         try {
-            models_routes.emplace(params, argc, argv, envp);
+            models_routes.emplace(params, argc, argv);
         } catch (const std::exception & e) {
             LOG_ERR("%s: failed to initialize router models: %s\n", __func__, e.what());
             return 1;


### PR DESCRIPTION
In router mode, the server captures environment variables from `envp` to pass to child processes
In containerized env with native & ROCm build, `envp` may become become stale - likely due to ROCm/HIP runtime initialization affecting memory layout

**Solution**

Use POSIX `environ` instead of `envp` on Linux/macOS and `GetEnvironmentStringsW` on Windows

**Reproduction**

- ROCm/HIP build `-DGGML_HIP=ON`
- Native build `-DGGML_NATIVE=ON`
- `ENV LLAMA_ARG_PORT=8080` in runtime stage of Dockerfile
- Router mode

**Testing**

- Docker + ROCm 7.1.1 + Native & HIP build for AMD RX 7900 XTX - fixed
- Docker + Native CPU build - works, no change in behavior
- Windows - works, no change in behavior

<details>
  <summary>System setup</summary>

gpu: AMD Radeon RX 7900 XTX
cpu: AMD Ryzen 7 7800X3D
os: Arch Linux
docker: Docker version 29.1.3, build f52814d454

```
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 ROCm devices:
  Device 0: AMD Radeon RX 7900 XTX, gfx1100 (0x1100), VMM: no, Wave Size: 32
load_backend: loaded ROCm backend from /app/libggml-hip.so
load_backend: loaded CPU backend from /app/libggml-cpu-zen4.so
main: n_parallel is set to auto, using n_parallel = 4 and kv_unified = true
build: 0 (unknown) with GNU 13.3.0 for Linux x86_64
system info: n_threads = 8, n_threads_batch = 8, total_threads = 16

system_info: n_threads = 8 (n_threads_batch = 8) / 16 | ROCm : NO_VMM = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 |
```
</details>

**AI usage**

Claude Opus 4.5:
- Conducted code review
- Discussed possible causes of the behavior with Native & ROCm build