### PR TITLE
graph : fix graph reuse logic when `n_pos_per_embd > 1`

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -32,7 +32,7 @@ bool llm_graph_input_embd::can_reuse(const llm_graph_params & params) {
     bool res = true;
 
     res &= (!tokens && !params.ubatch.token) || (tokens && tokens->ne[0] == params.ubatch.n_tokens);
-    res &= (!embd   && !params.ubatch.embd)  || (embd   &&   embd->ne[0] == params.ubatch.n_tokens);
+    res &= (!embd   && !params.ubatch.embd)  || (embd   &&   embd->ne[1] == params.ubatch.n_tokens);
 
     return res;
 }
@@ -62,7 +62,7 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
 bool llm_graph_input_pos::can_reuse(const llm_graph_params & params) {
     bool res = true;
 
-    res &= pos->ne[0] == params.ubatch.n_tokens;
+    res &= pos->ne[0] == params.ubatch.n_tokens*n_pos_per_embd;
 
     return res;
 }


### PR DESCRIPTION
cont #14482

Improves performance for models such as Qwen3 VL

| Model                   | Test   |   t/s master |   t/s gg/models-fix-qwen3-vl-graph-reuse |   Speedup |
|:------------------------|:-------|-------------:|-----------------------------------------:|----------:|
| qwen3vlmoe 30B.A3B Q8_0 | pp512  |      2137.88 |                                  2159.40 |      1.01 |
| qwen3vlmoe 30B.A3B Q8_0 | pp2048 |      2440.65 |                                  2453.89 |      1.01 |
| qwen3vlmoe 30B.A3B Q8_0 | tg32   |        76.53 |                                    81.36 |      1.06 |