### PR TITLE
llama: max ctx by default, fix fit magic number

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1226,11 +1226,11 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.lookup_cache_dynamic = value;
         }
     ).set_examples({LLAMA_EXAMPLE_LOOKUP}));
-    GGML_ASSERT(params.n_ctx <= 0); // string_format would need to be extended for a default > 0
+    const std::string ctx_default_str = params.n_ctx > 0 ? std::to_string(params.n_ctx) : params.n_ctx == -1 ? "auto" : "full";
     add_opt(common_arg(
         {"-c", "--ctx-size"}, "[N|full]",
         string_format("size of the prompt context in tokens, either an exact number, 'auto', or 'full' (default: '%s')",
-                      params.speculative.n_ctx == -1 ? "auto" : "full"),
+                      ctx_default_str.c_str()),
         [](common_params & params, const std::string & value) {
             if (value == "auto") {
                 params.n_ctx = -1;
@@ -2316,10 +2316,11 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_N_CPU_MOE_DRAFT"));
-    GGML_ASSERT(params.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
+    const std::string n_gpu_layers_default_str = params.n_gpu_layers > 0 ? std::to_string(params.n_gpu_layers) :
+        params.n_gpu_layers == -1 ? "auto" : "all";
     add_opt(common_arg(
         {"-ngl", "--gpu-layers", "--n-gpu-layers"}, "[N|auto|all]",
-        string_format("max. number of layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)", params.n_gpu_layers == -1 ? "auto" : "all"),
+        string_format("max. number of layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)", n_gpu_layers_default_str.c_str()),
         [](common_params & params, const std::string & value) {
             if (value == "auto") {
                 params.n_gpu_layers = -1;
@@ -3351,11 +3352,12 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.p_min = std::stof(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DRAFT_P_MIN"));
-    GGML_ASSERT(params.speculative.n_ctx <= 0); // string_format would need to be extended for a default > 0
+    const std::string speculative_ctx_default_str = params.speculative.n_ctx > 0 ? std::to_string(params.speculative.n_ctx) :
+        params.speculative.n_ctx == -1 ? "auto" : "full";
     add_opt(common_arg(
         {"-cd", "--ctx-size-draft"}, "[N|auto|full]",
         string_format("size of the prompt context for the draft model in tokens, either an exact number, 'auto', or 'full' (default: '%s')",
-                      params.speculative.n_ctx == -1 ? "auto" : "full"),
+                      speculative_ctx_default_str.c_str()),
         [](common_params & params, const std::string & value) {
             if (value == "auto") {
                 params.speculative.n_ctx = -1;
@@ -3374,11 +3376,12 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.devices = parse_device_list(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    GGML_ASSERT(params.speculative.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
+    const std::string n_gpu_layers_speculative_default_str = params.speculative.n_gpu_layers > 0 ? std::to_string(params.speculative.n_gpu_layers) :
+        params.speculative.n_gpu_layers == -1 ? "auto" : "all";
     add_opt(common_arg(
         {"-ngld", "--gpu-layers-draft", "--n-gpu-layers-draft"}, "[N|auto|all]",
         string_format("max. number of draft model layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)",
-            params.speculative.n_gpu_layers == -1 ? "auto" : "all"),
+            n_gpu_layers_speculative_default_str.c_str()),
         [](common_params & params, const std::string & value) {
             if (value == "auto") {
                 params.speculative.n_gpu_layers = -1;

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1226,11 +1226,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.lookup_cache_dynamic = value;
         }
     ).set_examples({LLAMA_EXAMPLE_LOOKUP}));
+    GGML_ASSERT(params.n_ctx <= 0); // string_format would need to be extended for a default > 0
     add_opt(common_arg(
-        {"-c", "--ctx-size"}, "N",
-        string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
-        [](common_params & params, int value) {
-            params.n_ctx = value;
+        {"-c", "--ctx-size"}, "[N|full]",
+        string_format("size of the prompt context in tokens, either an exact number, 'auto', or 'full' (default: '%s')",
+                      params.speculative.n_ctx == -1 ? "auto" : "full"),
+        [](common_params & params, const std::string & value) {
+            if (value == "auto") {
+                params.n_ctx = -1;
+            } else if (value == "full") {
+                params.n_ctx = 0;
+            } else {
+                params.n_ctx = std::stoi(value);
+            }
         }
     ).set_env("LLAMA_ARG_CTX_SIZE"));
     add_opt(common_arg(
@@ -2310,7 +2318,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_N_CPU_MOE_DRAFT"));
     GGML_ASSERT(params.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
     add_opt(common_arg(
-        {"-ngl", "--gpu-layers", "--n-gpu-layers"}, "N",
+        {"-ngl", "--gpu-layers", "--n-gpu-layers"}, "[N|auto|all]",
         string_format("max. number of layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)", params.n_gpu_layers == -1 ? "auto" : "all"),
         [](common_params & params, const std::string & value) {
             if (value == "auto") {
@@ -2427,7 +2435,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_env("LLAMA_ARG_FIT_TARGET"));
     add_opt(common_arg(
         { "-fitc", "--fit-ctx" }, "N",
-        string_format("minimum ctx size that can be set by --fit option, default: %" PRIu32, params.fit_params_min_ctx),
+        string_format("minimum ctx size that can be set by --fit option, default: %" PRIi32, params.fit_params_min_ctx),
         [](common_params & params, int value) {
             params.fit_params_min_ctx = value;
         }
@@ -3343,11 +3351,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.p_min = std::stof(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DRAFT_P_MIN"));
+    GGML_ASSERT(params.speculative.n_ctx <= 0); // string_format would need to be extended for a default > 0
     add_opt(common_arg(
-        {"-cd", "--ctx-size-draft"}, "N",
-        string_format("size of the prompt context for the draft model (default: %d, 0 = loaded from model)", params.speculative.n_ctx),
-        [](common_params & params, int value) {
-            params.speculative.n_ctx = value;
+        {"-cd", "--ctx-size-draft"}, "[N|auto|full]",
+        string_format("size of the prompt context for the draft model in tokens, either an exact number, 'auto', or 'full' (default: '%s')",
+                      params.speculative.n_ctx == -1 ? "auto" : "full"),
+        [](common_params & params, const std::string & value) {
+            if (value == "auto") {
+                params.speculative.n_ctx = -1;
+            } else if (value == "full") {
+                params.speculative.n_ctx = 0;
+            } else {
+                params.speculative.n_ctx = std::stoi(value);
+            }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_CTX_SIZE_DRAFT"));
     add_opt(common_arg(
@@ -3360,7 +3376,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     GGML_ASSERT(params.speculative.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
     add_opt(common_arg(
-        {"-ngld", "--gpu-layers-draft", "--n-gpu-layers-draft"}, "N",
+        {"-ngld", "--gpu-layers-draft", "--n-gpu-layers-draft"}, "[N|auto|all]",
         string_format("max. number of draft model layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)",
             params.speculative.n_gpu_layers == -1 ? "auto" : "all"),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -245,7 +245,7 @@ struct common_params_model {
 struct common_params_speculative {
     std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
 
-    int32_t n_ctx        =     0; // draft context size
+    int32_t n_ctx        =    -1; // draft context size
     int32_t n_max        =    16; // maximum number of tokens to draft during speculative decoding
     int32_t n_min        =     0; // minimum number of draft tokens to use for speculative decoding
     int32_t n_gpu_layers =    -1; // number of layers to store in VRAM for the draft model (-1 - use default)
@@ -318,7 +318,7 @@ struct ggml_opt_optimizer_params common_opt_lr_pars(void * userdata);
 
 struct common_params {
     int32_t n_predict             =    -1; // max. number of new tokens to predict, -1 == no limit
-    int32_t n_ctx                 =     0; // context size, 0 == context the model was trained with
+    int32_t n_ctx                 =    -1; // context size, 0 == context the model was trained with, < 0 == auto
     int32_t n_batch               =  2048; // logical batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_ubatch              =   512; // physical batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_keep                =     0; // number of tokens to keep from initial prompt

--- a/include/llama.h
+++ b/include/llama.h
@@ -325,7 +325,7 @@ extern "C" {
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
     //       https://github.com/ggml-org/llama.cpp/pull/7544
     struct llama_context_params {
-        uint32_t n_ctx;             // text context, 0 = from model
+        int32_t  n_ctx;             // context size in tokens, use llama_model_n_ctx_train for values <= 0
         uint32_t n_batch;           // logical maximum batch size that can be submitted to llama_decode
         uint32_t n_ubatch;          // physical maximum batch size
         uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
@@ -496,7 +496,7 @@ extern "C" {
                                           float * tensor_split,          // writable buffer for tensor split, needs at least llama_max_devices elements
         struct llama_model_tensor_buft_override * tensor_buft_overrides, // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
                                          size_t * margins,               // margins of memory to leave per device in bytes
-                                       uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
+                                        int32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
                             enum ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
 
     LLAMA_API int64_t llama_time_us(void);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -49,7 +49,7 @@ llama_context::llama_context(
     cparams.pooling_type     = params.pooling_type;
     cparams.warmup           = false;
 
-    cparams.n_ctx            = params.n_ctx           == 0    ? hparams.n_ctx_train           : params.n_ctx;
+    cparams.n_ctx            = params.n_ctx           <= 0    ? hparams.n_ctx_train           : params.n_ctx;
     cparams.rope_freq_base   = params.rope_freq_base  == 0.0f ? hparams.rope_freq_base_train  : params.rope_freq_base;
     cparams.rope_freq_scale  = params.rope_freq_scale == 0.0f ? hparams.rope_freq_scale_train : params.rope_freq_scale;
 
@@ -2983,7 +2983,7 @@ void llama_context::opt_epoch(
 
 llama_context_params llama_context_default_params() {
     llama_context_params result = {
-        /*.n_ctx                       =*/ 512,
+        /*.n_ctx                       =*/ -1,
         /*.n_batch                     =*/ 2048,
         /*.n_ubatch                    =*/ 512,
         /*.n_seq_max                   =*/ 1,
@@ -3033,7 +3033,7 @@ llama_context * llama_init_from_model(
         return nullptr;
     }
 
-    if (params.n_ctx == 0 && model->hparams.n_ctx_train == 0) {
+    if (params.n_ctx <= 0 && model->hparams.n_ctx_train == 0) {
         LLAMA_LOG_ERROR("%s: n_ctx and model->hparams.n_ctx_train cannot both be zero\n", __func__);
         return nullptr;
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -270,7 +270,7 @@ static void llama_params_fit_impl(
                     __func__, -global_surplus/MiB);
             }
             if (cparams->n_ctx == default_cparams.n_ctx) {
-                if (n_ctx_min > 0 && hp_nct > n_ctx_min) {
+                if (n_ctx_min > 0 && hp_nct > uint32_t(n_ctx_min)) {
                     int64_t sum_used_target = sum_free;
                     for (size_t id = 0; id < nd; id++) {
                         sum_used_target -= margins[id];

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -159,10 +159,11 @@ class llama_params_fit_exception : public std::runtime_error {
 static void llama_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins_s, int32_t n_ctx_min, enum ggml_log_level log_level) {
     constexpr int64_t MiB = 1024*1024;
     typedef std::vector<llama_device_memory_data> dmds_t;
-    const llama_model_params default_mparams = llama_model_default_params();
+    const llama_model_params   default_mparams = llama_model_default_params();
+    const llama_context_params default_cparams = llama_context_default_params();
 
     std::vector<ggml_backend_dev_t> devs;
     uint32_t hp_ngl = 0; // hparams.n_gpu_layers
@@ -268,8 +269,8 @@ static void llama_params_fit_impl(
                     "%s: cannot meet free memory targets on all devices, need to use %" PRId64 " MiB less in total\n",
                     __func__, -global_surplus/MiB);
             }
-            if (cparams->n_ctx == 0) {
-                if (hp_nct > n_ctx_min) {
+            if (cparams->n_ctx == default_cparams.n_ctx) {
+                if (n_ctx_min > 0 && hp_nct > n_ctx_min) {
                     int64_t sum_used_target = sum_free;
                     for (size_t id = 0; id < nd; id++) {
                         sum_used_target -= margins[id];
@@ -315,7 +316,7 @@ static void llama_params_fit_impl(
                         __func__, hp_nct, n_ctx_min);
                 }
             } else {
-                LLAMA_LOG_INFO("%s: context size set by user to %" PRIu32 " -> no change\n", __func__, cparams->n_ctx);
+                LLAMA_LOG_INFO("%s: context size set by user to %" PRIi32 "%s -> no change\n", __func__, cparams->n_ctx, cparams->n_ctx <= 0 ? " (full)" : "");
             }
         }
     }
@@ -737,7 +738,7 @@ static void llama_params_fit_impl(
 enum llama_params_fit_status llama_params_fit(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins, int32_t n_ctx_min, enum ggml_log_level log_level) {
     const int64_t t0_us = llama_time_us();
     llama_params_fit_status status = LLAMA_PARAMS_FIT_STATUS_SUCCESS;
     try {

--- a/tests/test-tokenizer-0.cpp
+++ b/tests/test-tokenizer-0.cpp
@@ -160,6 +160,7 @@ int main(int argc, char **argv) {
         }
 
         auto cparams = llama_context_default_params();
+        cparams.n_ctx = 512;
 
         ctx = llama_init_from_model(model, cparams);
 

--- a/tests/test-tokenizer-1-bpe.cpp
+++ b/tests/test-tokenizer-1-bpe.cpp
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
         }
 
         auto cparams = llama_context_default_params();
+        cparams.n_ctx = 512;
 
         ctx = llama_init_from_model(model, cparams);
 

--- a/tests/test-tokenizer-1-spm.cpp
+++ b/tests/test-tokenizer-1-spm.cpp
@@ -43,6 +43,7 @@ int main(int argc, char ** argv) {
         }
 
         auto cparams = llama_context_default_params();
+        cparams.n_ctx = 512;
 
         ctx = llama_init_from_model(model, cparams);
 

--- a/tools/fit-params/fit-params.cpp
+++ b/tools/fit-params/fit-params.cpp
@@ -36,7 +36,7 @@ int main(int argc, char ** argv) {
 
     LOG_INF("%s: printing fitted CLI arguments to stdout...\n", __func__);
     common_log_flush(common_log_main());
-    printf("-c %" PRIu32 " -ngl %" PRIu32, cparams.n_ctx, mparams.n_gpu_layers);
+    printf("-c %" PRIi32 " -ngl %" PRIi32, cparams.n_ctx, mparams.n_gpu_layers);
 
     size_t nd = llama_max_devices();
     while (nd > 1 && mparams.tensor_split[nd - 1] == 0.0f) {


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/18376 .

The intent with `llama_params_fit` is to only change those parameters that a user is not setting explicitly themself. However, if a user is explicitly setting `-c 0` this is currently being changed by `llama_params_fit`. I would propose the following changes to fix this:

* Change the data type of `llama_context_params::n_ctx` from `uint32_t` to `int32_t` with all values <= 0 being interpreted to mean that the full context should be used.
* Change the default value set `llama_context_default_params` from 512 to -1. This would mean with the llama C API by default the full context of the model would now be used, consistent with the common API.
* In `llama_params_fit`, check the context size against the new default value instead of vs. 0.
* For the CLI, add strings "auto" and "full" for `--ctx-size` which by default both use the full context but differ w.r.t. whether they should be changed by `llama_params_fit`.

An alternative approach would be keep the changes entirely in the common API.