### PR TITLE
add option --tensor-type-file to llama-quantize

### DIFF
--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -419,6 +419,7 @@ static bool parse_tensor_type(const char * data, std::vector<tensor_quantization
 static bool parse_tensor_type_file(const char * filename, std::vector<tensor_quantization> & tensor_type) {
     std::ifstream file(filename);
     if (!file) {
+        printf("Failed to open file '%s': %s\n\n", filename, std::strerror(errno));
         return false;
     }
 

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -119,7 +119,7 @@ static bool try_parse_ftype(const std::string & ftype_str_in, llama_ftype & ftyp
 [[noreturn]]
 static void usage(const char * executable) {
     printf("usage: %s [--help] [--allow-requantize] [--leave-output-tensor] [--pure] [--imatrix] [--include-weights]\n", executable);
-    printf("       [--exclude-weights] [--output-tensor-type] [--token-embedding-type] [--tensor-type] [--prune-layers] [--keep-split] [--override-kv]\n");
+    printf("       [--exclude-weights] [--output-tensor-type] [--token-embedding-type] [--tensor-type] [--tensor-type-file] [--prune-layers] [--keep-split] [--override-kv]\n");
     printf("       model-f32.gguf [model-quant.gguf] type [nthreads]\n\n");
     printf("  --allow-requantize: Allows requantizing tensors that have already been quantized. Warning: This can severely reduce quality compared to quantizing from 16bit or 32bit\n");
     printf("  --leave-output-tensor: Will leave output.weight un(re)quantized. Increases model size but may also increase quality, especially when requantizing\n");
@@ -131,7 +131,8 @@ static void usage(const char * executable) {
     printf("  --token-embedding-type ggml_type: use this ggml_type for the token embeddings tensor\n");
     printf("  --tensor-type TENSOR=TYPE: quantize this tensor to this ggml_type. example: --tensor-type attn_q=q8_0\n");
     printf("      Advanced option to selectively quantize tensors. May be specified multiple times.\n");
-    printf("  --tensor-type-file tensor_type.txt: lookup the ggml_types in the input text file, which contains a list of \"tensor=ggml_type\" separated by spaces\n");
+    printf("  --tensor-type-file tensor_type.txt: list of tensors to quantize to specific ggml_type. example: --tensor-type-file tensor_type_list.txt\n");
+    printf("      Advanced option to selectively quantize a long list of tensors. Format to be tensor_name=ggml_type, separated by spaces/newline.\n");
     printf("  --prune-layers L0,L1,L2...comma-separated list of layer numbers to prune from the model\n");
     printf("      Advanced option to remove all tensors from the given layers\n");
     printf("  --keep-split: will generate quantized model in the same shards as input\n");
@@ -419,7 +420,7 @@ static bool parse_tensor_type(const char * data, std::vector<tensor_quantization
 static bool parse_tensor_type_file(const char * filename, std::vector<tensor_quantization> & tensor_type) {
     std::ifstream file(filename);
     if (!file) {
-        printf("Failed to open file '%s': %s\n\n", filename, std::strerror(errno));
+        printf("\n%s: failed to open file '%s': %s\n\n", __func__, filename, std::strerror(errno));
         return false;
     }
 
@@ -708,3 +709,4 @@ int main(int argc, char ** argv) {
 
     return 0;
 }
+


### PR DESCRIPTION
Fix of https://github.com/ggml-org/llama.cpp/issues/18565

For now it compiles but it raises an error
```
Error during quantization (Exit Code 1):
main: invalid ftype '--tensor-type-file'
```