### PR TITLE
GGML RPC - Add support for Unix Domain Sockets

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2183,7 +2183,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     if (llama_supports_rpc()) {
         add_opt(common_arg(
             {"--rpc"}, "SERVERS",
-            "comma separated list of RPC servers (host:port)",
+            "comma separated list of RPC servers (host:port or path ending in .sock)",
             [](common_params & params, const std::string & value) {
                 add_rpc_devices(value);
                 GGML_UNUSED(params);

--- a/tools/rpc/rpc-server.cpp
+++ b/tools/rpc/rpc-server.cpp
@@ -180,7 +180,7 @@ static void print_usage(int /*argc*/, char ** argv, rpc_server_params params) {
     fprintf(stderr, "  -h, --help                       show this help message and exit\n");
     fprintf(stderr, "  -t, --threads N                  number of threads for the CPU device (default: %d)\n", params.n_threads);
     fprintf(stderr, "  -d, --device <dev1,dev2,...>     comma-separated list of devices\n");
-    fprintf(stderr, "  -H, --host HOST                  host to bind to (default: %s)\n", params.host.c_str());
+    fprintf(stderr, "  -H, --host HOST                  host to bind to, or path to unix socket ending in .sock (default: %s)\n", params.host.c_str());
     fprintf(stderr, "  -p, --port PORT                  port to bind to (default: %d)\n", params.port);
     fprintf(stderr, "  -c, --cache                      enable local file cache\n");
     fprintf(stderr, "\n");
@@ -293,7 +293,10 @@ int main(int argc, char * argv[]) {
         return 1;
     }
 
-    if (params.host != "127.0.0.1") {
+    bool is_unix_socket = params.host.size() >= 5 &&
+                          params.host.rfind(".sock") == params.host.size() - 5;
+
+    if (!is_unix_socket && params.host != "127.0.0.1") {
         fprintf(stderr, "\n");
         fprintf(stderr, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
         fprintf(stderr, "WARNING: Host ('%s') is != '127.0.0.1'\n", params.host.c_str());
@@ -308,7 +311,12 @@ int main(int argc, char * argv[]) {
         fprintf(stderr, "No devices found\n");
         return 1;
     }
-    std::string endpoint = params.host + ":" + std::to_string(params.port);
+    std::string endpoint;
+    if (is_unix_socket) {
+        endpoint = params.host;
+    } else {
+        endpoint = params.host + ":" + std::to_string(params.port);
+    }
     const char * cache_dir = nullptr;
     std::string cache_dir_str;
     if (params.use_cache) {


### PR DESCRIPTION
Making this PR mainly for feedback at this stage (cc @rgerganov). This adds Unix Domain Socket support to the ggml rpc-server. I see a few different use cases and reasons for adding this functionality:

* A local unix socket provides a local only transport and removes an easily misconfigured footgun of binding to a network interface like 0.0.0.0 when you only want local clients to connect. It also integrates with the POSIX permission model (socket path + directory permissions) and things like systemd. Other llama.cpp utilities such as llama-server support this model. This is a much safer configuration for the use cases below.

* Connecting to an rpc-server across container environments can be done using mounted volumes to share sockets.

* Workloads on the same machine can run at different privilege levels and within sandboxes with varying access to hardware, but early access to file descriptors is a common use case and supported pattern even in the most hardened sandboxes.

* With sendmsg/recvmsg we can add (not currently implemented in this PR) fine grained authentication over the socket to ensure only specific processes can invoke it.

**Summary of implementation changes in this PR**

`rpc-server.cpp` - Modified to support using a socket path that ends in `.sock` with the existing -H argument

`ggml-rpc.cpp` - Modified in 2 important ways. First, `parse_endpoint` now determines whether the endpoint passed into the function is a unix socket (ends in `.sock`) or a network interface to listen on.

`ggml_backend_rpc_start_server` is a `host:port` pair or a unix socket path. Introduces a new simple structure, `endpoint_info`, to hold this information. The unix socket is opened with `0770` permission which should allow for users in the same group to connect. This can be hardened in the future if desired, but is still safer than binding to 0.0.0.0 by default.

These changes work with other llama.cpp tooling as-is. Here is an example from my testing:

Run the rpc-server reusing the `-H` argument similar to `llama-server`:

```
$ build/bin/rpc-server -t 1 -H local.sock
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GB10, compute capability 12.1, VMM: yes
register_backend: registered backend CUDA (1 devices)
register_device: registered device CUDA0 (NVIDIA GB10)
register_backend: registered backend RPC (0 devices)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (CPU)
Starting RPC server v3.6.0
  endpoint       : local.sock
  local cache    : n/a
Devices:
ggml_backend_cuda_get_available_uma_memory: final available_memory_kb: 119304108
  CUDA0: NVIDIA GB10 (122570 MiB, 116507 MiB free)
Accepted client connection
Client connection closed
```

And `llama-cli` connecting to it:

```
$ build/bin/llama-cli -m ~/models/meta-llama-3.1-8b-instruct-abliterated.Q6_K.gguf -n 64 -ngl 99 --rpc local.sock
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GB10, compute capability 12.1, VMM: yes
register_backend: registered backend CUDA (1 devices)
register_device: registered device CUDA0 (NVIDIA GB10)
register_backend: registered backend RPC (0 devices)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (CPU)
register_backend: registered backend RPC[local.sock] (1 devices)
register_device: registered device RPC0 (local.sock)

Loading model...  
...[cropped]...
build      : b0-unknown
model      : meta-llama-3.1-8b-instruct-abliterated.Q6_K.gguf
modalities : text

available commands:
  /exit or Ctrl+C     stop or exit
  /regen              regenerate the last response
  /clear              clear the chat history
  /read               add a text file

> This is a test!

A test! Well, I'm happy to report that I'm functioning properly and ready to assist with any...

[ Prompt: 284.8 t/s | Generation: 32.0 t/s ]
```