### PR TITLE
ggml-backend : fallback to cpu memory when backend reports zero memory

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -490,6 +490,15 @@ const char * ggml_backend_dev_description(ggml_backend_dev_t device) {
 void ggml_backend_dev_memory(ggml_backend_dev_t device, size_t * free, size_t * total) {
     GGML_ASSERT(device);
     device->iface.get_memory(device, free, total);
+
+    // If func get_memory returns zeros, fall back to the CPU backend and query it.
+    if (*free == 0 && *total == 0) {
+        ggml_backend_dev_t cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+        GGML_ASSERT(cpu_dev);
+
+        cpu_dev->iface.get_memory(cpu_dev, free, total);
+        GGML_ASSERT(*free != 0 && *total != 0);
+    }
 }
 
 enum ggml_backend_dev_type ggml_backend_dev_type(ggml_backend_dev_t device) {


### PR DESCRIPTION
Fix #18577

Some GGML backends(e.g. BLAS, IBM zDNN, AMD ZenDNN, OpenCL) may report both total and free device memory as zero. This can lead to invalid tensor split computation during model loading, including NaN split values and out-of-range device indexing.

Previously this PR #18578 was addressed in a backend-specific way (e.g. BLAS), but the underlying issue is generic: backends are allowed to report zero memory and should fall back to host memory provided by `ggml-cpu`.

This PR fixes the issue at the GGML level by updating `ggml_backend_dev_memory` to fall back to the `ggml-cpu` backend whenever a backend reports zero total and free memory, ensuring valid memory information is always available for tensor placement.