### PR TITLE
mtmd : fix integer overflow when n_tokens equals INT32_MIN

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -774,6 +774,10 @@ struct mtmd_tokenizer {
         int n_tokens = text.length() + 2 * add_special;
         std::vector<llama_token> result(n_tokens);
         n_tokens = llama_tokenize(vocab, text.data(), text.length(), result.data(), result.size(), add_special, parse_special);
+        // -2147483648 is std::numeric_limits<int32_t>::min()
+        if (n_tokens == -2147483648) {
+            throw std::runtime_error("Tokenization failed: input text too large, tokenization result exceeds int32_t limit");
+        }
         if (n_tokens < 0) {
             result.resize(-n_tokens);
             int check = llama_tokenize(vocab, text.data(), text.length(), result.data(), result.size(), add_special, parse_special);

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -774,8 +774,7 @@ struct mtmd_tokenizer {
         int n_tokens = text.length() + 2 * add_special;
         std::vector<llama_token> result(n_tokens);
         n_tokens = llama_tokenize(vocab, text.data(), text.length(), result.data(), result.size(), add_special, parse_special);
-        // -2147483648 is std::numeric_limits<int32_t>::min()
-        if (n_tokens == -2147483648) {
+        if (n_tokens == std::numeric_limits<int32_t>::min()) {
             throw std::runtime_error("Tokenization failed: input text too large, tokenization result exceeds int32_t limit");
         }
         if (n_tokens < 0) {


### PR DESCRIPTION
## Summary
Fixes an integer overflow vulnerability (GHSA-gqvc-wp2r-9gr6) in `mtmd_tokenize_text_internal` that was previously patched in `common_tokenize` but not propagated to the MTMD tool.

## Problem
When `llama_tokenize` returns `INT32_MIN` (-2147483648) to indicate the input text is too large, the code performs a negation operation:

```cpp
if (n_tokens < 0) {
    result.resize(-n_tokens);  // Integer overflow when n_tokens == INT32_MIN
    ...
}
```

Negating `INT32_MIN` causes undefined behavior due to integer overflow, as `-(-2147483648)` cannot be represented in `int32_t`, resulting in the same value `-2147483648` and causing `std::vector::resize()` to throw `std::length_error`.

## Solution
Apply the same fix that was previously implemented in llama.cpp/common/common.cpp `common_tokenize`:

```cpp
if (n_tokens == std::numeric_limits<int32_t>::min()) {
    throw std::runtime_error("Tokenization failed: input text too large, tokenization result exceeds int32_t limit");
}
if (n_tokens < 0) {
    result.resize(-n_tokens);
    ...
}
```

This check detects the overflow condition and throws a clear error message instead of triggering undefined behavior.