### PR TITLE
server: add group support for router mode model presets

### DIFF
--- a/common/preset.h
+++ b/common/preset.h
@@ -17,6 +17,7 @@ struct common_preset_context;
 
 struct common_preset {
     std::string name;
+    std::string group; // optional group name for cascading
 
     // options are stored as common_arg to string mapping, representing CLI arg and its value
     std::map<common_arg, std::string> options;
@@ -53,7 +54,8 @@ struct common_preset_context {
     common_preset_context(llama_example ex);
 
     // load presets from INI file
-    common_presets load_from_ini(const std::string & path, common_preset & global) const;
+    // groups: output parameter for group presets (sections starting with "group-")
+    common_presets load_from_ini(const std::string & path, common_preset & global, common_presets & groups) const;
 
     // generate presets from cached models
     common_presets load_from_cache() const;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1453,9 +1453,23 @@ version = 1
 c = 8192
 n-gpu-layer = 8
 
+; (Optional) Define groups to share parameters across multiple models.
+; Group sections must start with "group-" prefix.
+[group-mistral-small]
+c = 4096
+n-gpu-layers = 32
+chat-template = chatml
+
+[group-large-models]
+c = 16384
+n-gpu-layers = 48
+cache-ram = 0
+
 ; If the key corresponds to an existing model on the server,
 ; this will be used as the default config for that model
 [ggml-org/MY-MODEL-GGUF:Q8_0]
+; assign this model to a group (optional)
+group = group-mistral-small
 ; string value
 chat-template = chatml
 ; numeric value
@@ -1471,11 +1485,22 @@ model-draft = ./my-models/draft.gguf
 ; but it's RECOMMENDED to use absolute path
 model-draft = /Users/abc/my-models/draft.gguf
 
+; Another model using the same group
+[ggml-org/ANOTHER-MODEL:Q4_K_M]
+group = group-mistral-small
+; only override what's different from the group
+n-gpu-layers = 16
+
 ; If the key does NOT correspond to an existing model,
 ; you need to specify at least the model path or HF repo
 [custom_model]
 model = /Users/abc/my-awesome-model-Q4_K_M.gguf
 ```
+
+The settings cascade in the following order (later values override earlier ones):
+1. Global settings from `[*]` section
+2. Group settings from `[group-*]` section (if assigned via `group = group-name`)
+3. Model-specific settings
 
 Note: some arguments are controlled by router (e.g., host, port, API key, HF repo, model alias). They will be removed or overwritten upon loading.
 


### PR DESCRIPTION
### Description

This PR adds support for defining and using **groups** in the router mode's `models.ini` file to share parameters across multiple models.

### Problem
When configuring multiple similar models (e.g., multiple Mistral Small models), users had to repeat the same parameters for each model, leading to redundancy and maintenance issues.

### Solution
Added group support with the following features:

1. **Define groups** with the `[group-*]` prefix in INI files
2. **Assign models to groups** using the `group = group-name` option
3. **Proper cascading order**: global → group → model-specific settings

### Example Usage

```ini
version = 1

; Global settings
[*]
c = 8192
n-gpu-layers = 8

; Define a group for Mistral Small models
[group-mistral-small]
c = 4096
n-gpu-layers = 32
chat-template = chatml

; Models using the group
[model-1]
group = group-mistral-small
model = /path/to/model1.gguf

[model-2]
group = group-mistral-small
model = /path/to/model2.gguf
c = 2048  # Override group setting
```

### Changes

- **common/preset.h**: Added `group` field to `common_preset` struct
- **common/preset.cpp**: Modified `load_from_ini()` to parse group sections and extract group assignments
- **tools/server/server-models.cpp**: Updated `load_models()` to apply group settings with proper cascading
- **tools/server/README.md**: Added comprehensive documentation and examples

Fixes #18596