### PR TITLE
common: build as shared library when BUILD_SHARED_LIBS is ON

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -44,7 +44,13 @@ endif()
 
 set(TARGET common)
 
-add_library(${TARGET} STATIC
+if (BUILD_SHARED_LIBS)
+    set(COMMON_LIB_TYPE SHARED)
+else()
+    set(COMMON_LIB_TYPE STATIC)
+endif()
+
+add_library(${TARGET} ${COMMON_LIB_TYPE}
     arg.cpp
     arg.h
     base64.hpp


### PR DESCRIPTION
This makes it possible to use LLGuidance via Java FFI.
