### PR TITLE
CUDA: fix FA FP16 accumulator overflow for Granite

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -11,10 +11,12 @@
 #define SOFTMAX_FTZ_THRESHOLD -20.0f                   // Softmax exp. of values smaller than this are flushed to zero to avoid NaNs.
 
 // log(2) = 0.6931, by adding this to the KQ maximum used for the softmax the numerical range representable
-//     by the VKQ accumulators is effectively being shifted up by a factor of 8.
+//     by the VKQ accumulators is effectively being shifted up by a factor of 2.
 // This reduces issues with numerical overflow but also causes larger values to be flushed to zero.
 // However, as the output from FlashAttention will usually be used as an input for a matrix multiplication this should be negligible.
-#define FATTN_KQ_MAX_OFFSET 0.6931f
+// Still, the value range should be shifted as much as necessary but as little as possible.
+// The macro on the following line shifts it by a factor of 2**3=8, as was needed to fix https://github.com/ggml-org/llama.cpp/issues/18606 .
+#define FATTN_KQ_MAX_OFFSET (3.0f*0.6931f)
 
 typedef void (* fattn_kernel_t)(
         const char * __restrict__ Q,


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/18606 .

The problem seems to be the same as in https://github.com/ggml-org/llama.cpp/issues/17610 where extremal values in the V cache cause an overflow of the FP16 VKQ accumulators. It can be fixed by applying a more aggressive shift of the numerical range. On master it is being shifted by a factor of 2, with this PR it would increase to a factor of 8. The smallest representable value in the VKQ accumulators would then be $2^{-11}$ rather than $2^{-13}$.