### PR TITLE
CANN: Make `valid_values` variable `static const`

### DIFF
--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -122,7 +122,7 @@ std::optional<std::string> get_env(const std::string & name) {
  * @brief Verify whether the environment variable is a valid value.
  */
 bool parse_bool(const std::string & value) {
-    std::unordered_set<std::string> valid_values = { "on", "1", "yes", "y", "enable", "true" };
+    static const std::unordered_set<std::string> valid_values = { "on", "1", "yes", "y", "enable", "true" };
     return valid_values.find(value) != valid_values.end();
 }
 


### PR DESCRIPTION
**Description of the problem**

Variable `valid_values` in function `parse_bool` is an unordered map whose content never changes. But the function is called multiple times, so the variable is unnecessarily created and destroyed at every call.

**Proposed solution**

Make the variable static and constant, so its contents are preserved across different calls of the enclosing function.

