### PR TITLE
ggml-webgpu: Fix GGML_MEM_ALIGN to 8 for emscripten.

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -235,6 +235,9 @@
 #if UINTPTR_MAX == 0xFFFFFFFF
     #define GGML_MEM_ALIGN 4
 #elif defined(__EMSCRIPTEN__)
+// emscripten uses max_align_t == 8, so we need GGML_MEM_ALIGN == 8 for 64-bit wasm.
+// (for 32-bit wasm, the first conditional is true and GGML_MEM_ALIGN stays 4.)
+// ref: https://github.com/ggml-org/llama.cpp/pull/18628
     #define GGML_MEM_ALIGN 8
 #else
     #define GGML_MEM_ALIGN 16

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -234,6 +234,8 @@
 
 #if UINTPTR_MAX == 0xFFFFFFFF
     #define GGML_MEM_ALIGN 4
+#elif defined(__EMSCRIPTEN__)
+    #define GGML_MEM_ALIGN 8
 #else
     #define GGML_MEM_ALIGN 16
 #endif


### PR DESCRIPTION
Hello. When attempting to run LLM inference in the browser using WebGPU, the following error occurs.

<img width="534" height="83" alt="スクリーンショット 2026-01-06 0 31 03" src="https://github.com/user-attachments/assets/29d59388-9756-4135-a1f7-623ccef9e4a5" />

In Emscripten, `max_align_t` is 0x8(ref. https://github.com/emscripten-core/emscripten/issues/10072, https://github.com/emscripten-core/emscripten/pull/14599/files), which causes `GGML_ASSERT_ALIGNED` to fail.
Therefore, I modified the code to set `GGML_MEM_ALIGN` to 8 when running in an Emscripten environment.

I have confirmed that inference works correctly with `examples/simple-chat` for at least the following three models:
- Llama-3.2-1B-Instruct-Q4_1.gguf
- Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf
- Qwen3-4B-Thinking-2507-UD-IQ1_S.gguf