### PR TITLE
gguf-py: Add requests to dependencies

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -22,6 +22,7 @@ python = ">=3.8"
 numpy = ">=1.17"
 tqdm = ">=4.27"
 pyyaml = ">=5.1"
+requests = ">=2.25"
 sentencepiece = { version = ">=0.1.98,<=0.2.0", optional = true }
 PySide6 = { version = "^6.9", python = ">=3.9,<3.14", optional = true }
 


### PR DESCRIPTION
It's used here:

https://github.com/ggml-org/llama.cpp/blob/e443fbcfa51a8a27b15f949397ab94b5e87b2450/gguf-py/gguf/utility.py#L220-L226

Or maybe an optional dependency would suffice?