### PR TITLE
ci : run cann build unconditionally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1418,7 +1418,6 @@ jobs:
           echo "FIXME: test on devices"
 
   openEuler-latest-cmake-cann:
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'Ascend NPU') }}
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
The builds aren't particularly heavy, just run them to avoid issues like this https://github.com/ggml-org/llama.cpp/pull/18624#issuecomment-3717107203