### PR TITLE
convert : clarify sentence-transformers-dense-modules help [no ci]

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10974,7 +10974,7 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         "--sentence-transformers-dense-modules", action="store_true",
-        help=("Whether to include sentence-transformers dense modules."
+        help=("Whether to include sentence-transformers dense modules. "
               "It can be used for sentence-transformers models, like google/embeddinggemma-300m. "
               "Default these modules are not included.")
     )

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10975,7 +10975,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sentence-transformers-dense-modules", action="store_true",
         help=("Whether to include sentence-transformers dense modules."
-              "It can be used for sentence-transformers models, like google/embeddinggemma-300m"
+              "It can be used for sentence-transformers models, like google/embeddinggemma-300m. "
               "Default these modules are not included.")
     )
 


### PR DESCRIPTION
This commit updates this options help message which currently looks like this:
```console
  --sentence-transformers-dense-modules
                        Whether to include sentence-transformers dense modules.It can be used for sentence-transformers models, like
                        google/embeddinggemma-300mDefault these modules are not included.
```
