### PR TITLE
server: support image+text input for embeddings (Qwen3-VL-Embedding)

### DIFF
--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -289,6 +289,21 @@ struct oaicompat_parser_options {
     std::string media_path;
 };
 
+// parse the "content" field for /chat/completions endpoint
+// also used by /embeddings endpoint to parse content with multimodal data
+// NOTE:
+// - output content will be guaranteed to be text-only (can be chunks of text or single std::string)
+// - multimodal data (images/audio) will be extracted to out_files and replaced with media markers
+// ARGUMENTS:
+// - allow_null: whether to allow content to be null (useful for tools responses)
+// - force_output_string: whether to force output to be a single string instead of an array (used by embeddings endpoint)
+void oaicompat_content_parse(
+        json & content,
+        const oaicompat_parser_options & opt,
+        std::vector<raw_buffer> & out_files,
+        bool allow_null,
+        bool force_output_string);
+
 // used by /chat/completions endpoint
 json oaicompat_chat_params_parse(
     json & body, /* openai api json semantics */


### PR DESCRIPTION
Target support: https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B

> [!IMPORTANT]
> the original Qwen3-VL-Embedding model is missing 1_Pooling, I don't think it's actually ready to be used unless Qwen team fixed it (I already reached out to them, but got no responses)

But currently, the model is missing `1_Pooling`, so it cannot be correctly converted to GGUF

This PR aims to support mixed text+image (and maybe audio input for models supporting it) using OAI-compat `content`-like schema:

```json
{
    "input": [
        {
            "type": "text",
            "text": "mixed text and image input"
        },
        {
            "type": "image",
            "image_url": {
                "url": "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/11_truck.png"
            }
        }
    ]
}
```
