### PR TITLE
ggml-cuda: extend concat support for more types

### DIFF
--- a/ggml/src/ggml-cuda/concat.cu
+++ b/ggml/src/ggml-cuda/concat.cu
@@ -1,7 +1,8 @@
 #include "concat.cuh"
 
 // contiguous kernels
-static __global__ void concat_f32_dim0(const float * x, const float * y, float * dst, const int ne0, const int ne00) {
+template <typename T>
+static __global__ void concat_dim0(const T * x, const T * y, T * dst, const int ne0, const int ne00) {
     int nidx = threadIdx.x + blockIdx.x * blockDim.x;
     if (nidx >= ne0) {
         return;
@@ -27,7 +28,8 @@ static __global__ void concat_f32_dim0(const float * x, const float * y, float *
     }
 }
 
-static __global__ void concat_f32_dim1(const float * x, const float * y, float * dst, const int ne0, const int ne01) {
+template <typename T>
+static __global__ void concat_dim1(const T * x, const T * y, T * dst, const int ne0, const int ne01) {
     int nidx = threadIdx.x + blockIdx.x * blockDim.x;
     if (nidx >= ne0) {
         return;
@@ -53,7 +55,8 @@ static __global__ void concat_f32_dim1(const float * x, const float * y, float *
     }
 }
 
-static __global__ void concat_f32_dim2(const float * x, const float * y, float * dst, const int ne0, const int ne02) {
+template <typename T>
+static __global__ void concat_dim2(const T * x, const T * y, T * dst, const int ne0, const int ne02) {
     int nidx = threadIdx.x + blockIdx.x * blockDim.x;
     if (nidx >= ne0) {
         return;
@@ -79,24 +82,25 @@ static __global__ void concat_f32_dim2(const float * x, const float * y, float *
     }
 }
 
-static void concat_f32_cuda(const float * x, const float * y, float * dst, int ne00, int ne01, int ne02, int ne0, int ne1, int ne2, int dim, cudaStream_t stream) {
+template <typename T>
+static void concat_cuda(const char * x, const char * y, char * dst, int ne00, int ne01, int ne02, int ne0, int ne1, int ne2, int dim, cudaStream_t stream) {
     int num_blocks = (ne0 + CUDA_CONCAT_BLOCK_SIZE - 1) / CUDA_CONCAT_BLOCK_SIZE;
     dim3 gridDim(num_blocks, ne1, ne2);
     if (dim == 0) {
-        concat_f32_dim0<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(x, y, dst, ne0, ne00);
+        concat_dim0<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>((const T *) x, (const T *) y, (T *) dst, ne0, ne00);
         return;
     }
     if (dim == 1) {
-        concat_f32_dim1<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(x, y, dst, ne0, ne01);
+        concat_dim1<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>((const T *) x, (const T *) y, (T *) dst, ne0, ne01);
         return;
     }
-    concat_f32_dim2<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(x, y, dst, ne0, ne02);
+    concat_dim2<<<gridDim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>((const T *) x, (const T *) y, (T *) dst, ne0, ne02);
 }
 
 // non-contiguous kernel (slow)
-template <int dim>
+template <typename T, int dim>
 static __global__ void __launch_bounds__(CUDA_CONCAT_BLOCK_SIZE)
-    concat_f32_non_cont(
+    concat_non_cont(
         const char * src0,
         const char * src1,
               char * dst,
@@ -130,24 +134,24 @@ static __global__ void __launch_bounds__(CUDA_CONCAT_BLOCK_SIZE)
     const int64_t i2 = blockIdx.y;
     const int64_t i1 = blockIdx.x;
 
-    const float * x;
+    const T * x;
 
     for (int64_t i0 = threadIdx.x; i0 < ne0; i0 += blockDim.x) {
         if (i0 < ne00 && i1 < ne01 && i2 < ne02 && i3 < ne03) {
-            x = (const float *)(src0 + (i3       )*nb03 + (i2       )*nb02 + (i1       )*nb01 + (i0       )*nb00);
+            x = (const T *)(src0 + (i3       )*nb03 + (i2       )*nb02 + (i1       )*nb01 + (i0       )*nb00);
         } else {
             if constexpr (dim == 0) {
-                x = (const float *) (src1 + i3 * nb13 + i2 * nb12 + i1 * nb11 + (i0 - ne00) * nb10);
+                x = (const T *) (src1 + i3 * nb13 + i2 * nb12 + i1 * nb11 + (i0 - ne00) * nb10);
             } else if constexpr (dim == 1) {
-                x = (const float *) (src1 + i3 * nb13 + i2 * nb12 + (i1 - ne01) * nb11 + i0 * nb10);
+                x = (const T *) (src1 + i3 * nb13 + i2 * nb12 + (i1 - ne01) * nb11 + i0 * nb10);
             } else if constexpr (dim == 2) {
-                x = (const float *) (src1 + i3 * nb13 + (i2 - ne02) * nb12 + i1 * nb11 + i0 * nb10);
+                x = (const T *) (src1 + i3 * nb13 + (i2 - ne02) * nb12 + i1 * nb11 + i0 * nb10);
             } else if constexpr (dim == 3) {
-                x = (const float *) (src1 + (i3 - ne03) * nb13 + i2 * nb12 + i1 * nb11 + i0 * nb10);
+                x = (const T *) (src1 + (i3 - ne03) * nb13 + i2 * nb12 + i1 * nb11 + i0 * nb10);
             }
         }
 
-        float * y = (float *)(dst + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
+        T * y = (T *)(dst + i3*nb3 + i2*nb2 + i1*nb1 + i0*nb0);
 
         *y = *x;
     }
@@ -162,22 +166,44 @@ void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     const int32_t dim = ((int32_t *) dst->op_params)[0];
 
-    GGML_ASSERT(src0->type == GGML_TYPE_F32);
-    GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(src0->type == src1->type && src1->type == dst->type);
 
     if (ggml_is_contiguous(src0) && ggml_is_contiguous(src1)) {
-        const float * src0_d = (const float *)src0->data;
-        const float * src1_d = (const float *)src1->data;
+        const char * src0_d = (const char *)src0->data;
+        const char * src1_d = (const char *)src1->data;
 
-        float * dst_d = (float *)dst->data;
+        char * dst_d = (char *)dst->data;
+
+        decltype(concat_cuda<float>) * concat_cuda_func;
+        switch (dst->type) {
+            case GGML_TYPE_F32:
+                concat_cuda_func = concat_cuda<float>;
+                break;
+            case GGML_TYPE_I32:
+                concat_cuda_func = concat_cuda<int32_t>;
+                break;
+            case GGML_TYPE_F16:
+                concat_cuda_func = concat_cuda<half>;
+                break;
+            case GGML_TYPE_BF16:
+                concat_cuda_func = concat_cuda<nv_bfloat16>;
+                break;
+            case GGML_TYPE_I16:
+                concat_cuda_func = concat_cuda<int16_t>;
+                break;
+            case GGML_TYPE_I8:
+                concat_cuda_func = concat_cuda<int8_t>;
+                break;
+            default:
+                GGML_ABORT("concat: unsupported type %s", ggml_type_name(dst->type));
+        }
 
         if (dim != 3) {
             for (int i3 = 0; i3 < dst->ne[3]; i3++) {
-                concat_f32_cuda(
-                        src0_d + i3 * (src0->nb[3] / 4),
-                        src1_d + i3 * (src1->nb[3] / 4),
-                        dst_d + i3 * ( dst->nb[3] / 4),
+                concat_cuda_func(
+                        src0_d + i3 * src0->nb[3],
+                        src1_d + i3 * src1->nb[3],
+                        dst_d + i3 * dst->nb[3],
                         src0->ne[0], src0->ne[1], src0->ne[2],
                         dst->ne[0],  dst->ne[1],  dst->ne[2], dim, stream);
             }
@@ -185,13 +211,37 @@ void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
             const size_t size0 = ggml_nbytes(src0);
             const size_t size1 = ggml_nbytes(src1);
 
-            CUDA_CHECK(cudaMemcpyAsync(dst_d,           src0_d, size0, cudaMemcpyDeviceToDevice, stream));
-            CUDA_CHECK(cudaMemcpyAsync(dst_d + size0/4, src1_d, size1, cudaMemcpyDeviceToDevice, stream));
+            CUDA_CHECK(cudaMemcpyAsync(dst_d,         src0_d, size0, cudaMemcpyDeviceToDevice, stream));
+            CUDA_CHECK(cudaMemcpyAsync(dst_d + size0, src1_d, size1, cudaMemcpyDeviceToDevice, stream));
         }
     } else {
         dim3 grid_dim(dst->ne[1], dst->ne[2], dst->ne[3]);
         auto launch_kernel = [&](auto dim) {
-            concat_f32_non_cont<dim><<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
+            decltype(concat_non_cont<float, dim>) * concat_kernel;
+            switch (dst->type) {
+                case GGML_TYPE_F32:
+                    concat_kernel = concat_non_cont<float, dim>;
+                    break;
+                case GGML_TYPE_I32:
+                    concat_kernel = concat_non_cont<int32_t, dim>;
+                    break;
+                case GGML_TYPE_F16:
+                    concat_kernel = concat_non_cont<half, dim>;
+                    break;
+                case GGML_TYPE_BF16:
+                    concat_kernel = concat_non_cont<nv_bfloat16, dim>;
+                    break;
+                case GGML_TYPE_I16:
+                    concat_kernel = concat_non_cont<int16_t, dim>;
+                    break;
+                case GGML_TYPE_I8:
+                    concat_kernel = concat_non_cont<int8_t, dim>;
+                    break;
+                default:
+                    GGML_ABORT("concat: unsupported type %s", ggml_type_name(dst->type));
+            }
+
+            concat_kernel<<<grid_dim, CUDA_CONCAT_BLOCK_SIZE, 0, stream>>>(
                 (const char *) src0->data, (const char *) src1->data, (char *) dst->data,
                 src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3],
                 src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3],


### PR DESCRIPTION
# Extend CUDA backend concat support to more data types.
Previously, only F32 was supported on CUDA, while the CPU backend already supports several types (F32, I32, F16, BF16, I16, I8).
This PR adds CUDA support for F16, I32, BF16, I16, I8 types, matching CPU side capabilities.

- Refactored the implementation by introducing templates in relevant functions and CUDA kernels to handle type dispatch and specialized logic for different tensor types.
- Added support for F16, I32, BF16, I16, I8 (alongside existing F32).
- Both contiguous and non-contiguous tensors are supported for concat along all four dims.

Tested concat for all supported types (F32, F16, I32, BF16, I16, I8)
across all four dimensions, with both contiguous and non-contiguous tensors.
All cases passed.