### PR TITLE
Improving inference speed for the repack buffer type on NUMA architectures

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -517,6 +517,7 @@ static __m256 __lasx_xvreplfr2vr_s(const float val) {
 
 // TODO: move to ggml-threading
 void ggml_barrier(struct ggml_threadpool * tp);
+void ggml_cpu_set_numa_thread_affinity(int thread_n);
 
 void ggml_threadpool_chunk_set(struct ggml_threadpool * tp, int value);
 int  ggml_threadpool_chunk_add(struct ggml_threadpool * tp, int value);

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2087,7 +2087,7 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
 
 // Android's libc implementation "bionic" does not support setting affinity
 #if defined(__gnu_linux__)
-static void set_numa_thread_affinity(int thread_n) {
+void ggml_cpu_set_numa_thread_affinity(int thread_n) {
     if (!ggml_is_numa()) {
         return;
     }
@@ -2155,7 +2155,7 @@ static void clear_numa_thread_affinity(void) {
 #else
 // TODO: Windows etc.
 // (the linux implementation may also work on BSD, someone should test)
-static void set_numa_thread_affinity(int thread_n) { UNUSED(thread_n);  }
+void ggml_cpu_set_numa_thread_affinity(int thread_n) { UNUSED(thread_n);  }
 static void clear_numa_thread_affinity(void) {}
 #endif
 
@@ -2923,7 +2923,7 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
     const struct ggml_cgraph * cgraph = tp->cgraph;
     const struct ggml_cplan  * cplan  = tp->cplan;
 
-    set_numa_thread_affinity(state->ith);
+    ggml_cpu_set_numa_thread_affinity(state->ith);
 
     struct ggml_compute_params params = {
         /*.ith       =*/ state->ith,


### PR DESCRIPTION
DEPENDS ON PR #18239 
This PR implements parallelize repacking and is currently built on top of PR #18239 . Once PR #18239  is merged, I will rebase this branch.

When using repack buffer type, the physical memory allocation is dictated by the first-touch policy. Since the main thread performs the write operations, memory is often allocated on a single NUMA node, leading to uneven weight distribution.

Multi-threaded repack can alleviate this problem, but the threads are not bound to NUMA nodes.

This patch applies the same thread affinity strategy (--numa distribute) to the repacking phase. By binding the repack threads to the same nodes as the compute threads, we ensure that weights are written (and thus allocated) on the local NUMA node, minimizing cross-node memory access during inference.

Performance on Intel Xeon Silver 4514Y (32 core):
qwen3 8B Q4_K: 19.39 -> 26.92 t/s (+39%)
qwen3 32B Q4_K: 4.99 -> 7.38 t/s (+48%)

```shell
| model                  |      size |  params | backend | threads |  test |          t/s |
# master
| qwen3 8B Q4_K - Medium |  4.68 GiB |  8.19 B | CPU     |      32 | tg128 | 19.39 ± 0.23 |
# OMP Repack PR#18239
| qwen3 8B Q4_K - Medium |  4.68 GiB |  8.19 B | CPU     |      32 | tg128 | 21.81 ± 0.11 |
# bind core
| qwen3 8B Q4_K - Medium |  4.68 GiB |  8.19 B | CPU     |      32 | tg128 | 26.92 ± 0.16 |
```
```shell
| model                  |      size |  params | backend | threads |  test |          t/s |
# master
| qwen3 32B Q4_K - Medium | 18.40 GiB | 32.76 B | CPU     |      32 | tg128 |  4.99 ± 0.01 |
# OMP Repack PR#18239
| qwen3 32B Q4_K - Medium | 18.40 GiB | 32.76 B | CPU     |      32 | tg128 |  6.39 ± 0.03 |
# bind core
| qwen3 32B Q4_K - Medium | 18.40 GiB | 32.76 B | CPU     |      32 | tg128 |  7.38 ± 0.03 |
```