### PR TITLE
Support parsing JSON into grammar for schemas with no type and no properties

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -961,7 +961,10 @@ public:
             _build_min_max_int(min_value, max_value, out);
             out << ") space";
             return _add_rule(rule_name, out.str());
-        } else if (schema.empty() || schema_type == "object") {
+        } else if (schema.contains("required") && schema_type.is_null()) {
+	    // Type can be null if schema contains "required". Properties are optional too
+	    return _add_rule(rule_name, _add_primitive("object", PRIMITIVE_RULES.at("object")));
+	} else if (schema.empty() || schema_type == "object") {
             return _add_rule(rule_name, _add_primitive("object", PRIMITIVE_RULES.at("object")));
         } else {
             if (!schema_type.is_string() || PRIMITIVE_RULES.find(schema_type.get<std::string>()) == PRIMITIVE_RULES.end()) {


### PR DESCRIPTION
Fixes #18712

These changes work for me when working with Home Assistant `2026.1.0`, and `2025.12.5`. I also haven't found any issues using the llama-server web UI