### PR TITLE
llama: fix pooled embedding readback sizing/stride and state I/O

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1207,12 +1207,21 @@ int llama_context::encode(const llama_batch & batch_inp) {
                     // extract sequence embeddings
                     auto & embd_seq_out = embd_seq;
 
+                    const uint32_t n_embd_out = (uint32_t) t_embd->ne[0];
+
                     for (uint32_t s = 0; s < ubatch.n_seqs_unq; ++s) {
                         const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                         const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
-                        embd_seq_out[seq_id].resize(n_embd);
-                        ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd*seq_idx)*sizeof(float), n_embd*sizeof(float));
+                        GGML_ASSERT(seq_idx >= 0);
+
+                        embd_seq_out[seq_id].resize(n_embd_out);
+                        ggml_backend_tensor_get_async(
+                                backend_embd,
+                                t_embd,
+                                embd_seq_out[seq_id].data(),
+                                (size_t) seq_idx * t_embd->nb[1],
+                                (size_t) n_embd_out * sizeof(float));
                     }
                 } break;
             case LLAMA_POOLING_TYPE_RANK:
@@ -1220,14 +1229,21 @@ int llama_context::encode(const llama_batch & batch_inp) {
                     // extract the rerank score - n_cls_out floats per sequence
                     auto & embd_seq_out = embd_seq;
 
-                    const uint32_t n_cls_out = hparams.n_cls_out;
+                    const uint32_t n_cls_out = (uint32_t) t_embd->ne[0];
 
                     for (uint32_t s = 0; s < ubatch.n_seqs_unq; ++s) {
                         const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                         const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
+                        GGML_ASSERT(seq_idx >= 0);
+
                         embd_seq_out[seq_id].resize(n_cls_out);
-                        ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_cls_out*seq_idx)*sizeof(float), n_cls_out*sizeof(float));
+                        ggml_backend_tensor_get_async(
+                                backend_embd,
+                                t_embd,
+                                embd_seq_out[seq_id].data(),
+                                (size_t) seq_idx * t_embd->nb[1],
+                                (size_t) n_cls_out * sizeof(float));
                     }
                 } break;
             case LLAMA_POOLING_TYPE_UNSPECIFIED:
@@ -1618,12 +1634,21 @@ int llama_context::decode(const llama_batch & batch_inp) {
                         // extract sequence embeddings (cleared before processing each batch)
                         auto & embd_seq_out = embd_seq;
 
+                        const uint32_t n_embd_out = (uint32_t) t_embd->ne[0];
+
                         for (uint32_t s = 0; s < ubatch.n_seqs_unq; ++s) {
                             const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                             const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
-                            embd_seq_out[seq_id].resize(n_embd);
-                            ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd*seq_idx)*sizeof(float), n_embd*sizeof(float));
+                            GGML_ASSERT(seq_idx >= 0);
+
+                            embd_seq_out[seq_id].resize(n_embd_out);
+                            ggml_backend_tensor_get_async(
+                                    backend_embd,
+                                    t_embd,
+                                    embd_seq_out[seq_id].data(),
+                                    (size_t) seq_idx * t_embd->nb[1],
+                                    (size_t) n_embd_out * sizeof(float));
                         }
                     } break;
                 case LLAMA_POOLING_TYPE_RANK:
@@ -1631,14 +1656,21 @@ int llama_context::decode(const llama_batch & batch_inp) {
                         // extract the rerank score - n_cls_out floats per sequence
                         auto & embd_seq_out = embd_seq;
 
-                        const uint32_t n_cls_out = hparams.n_cls_out;
+                        const uint32_t n_cls_out = (uint32_t) t_embd->ne[0];
 
                         for (uint32_t s = 0; s < ubatch.n_seqs_unq; ++s) {
                             const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                             const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
+                            GGML_ASSERT(seq_idx >= 0);
+
                             embd_seq_out[seq_id].resize(n_cls_out);
-                            ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_cls_out*seq_idx)*sizeof(float), n_cls_out*sizeof(float));
+                            ggml_backend_tensor_get_async(
+                                    backend_embd,
+                                    t_embd,
+                                    embd_seq_out[seq_id].data(),
+                                    (size_t) seq_idx * t_embd->nb[1],
+                                    (size_t) n_cls_out * sizeof(float));
                         }
                     } break;
                 case LLAMA_POOLING_TYPE_UNSPECIFIED:
@@ -1890,7 +1922,7 @@ uint32_t llama_context::output_reserve(int32_t n_outputs, const llama_batch & ba
 
 void llama_context::output_reorder() {
     const uint64_t n_vocab = model.vocab.n_tokens();
-    const uint64_t n_embd  = model.hparams.n_embd;
+    const uint64_t n_embd  = model.hparams.get_n_embd_out();
 
     for (size_t s = 0; s < output_swaps.size(); ++s) {
         const uint64_t i0 = output_swaps[s].i0;
@@ -2488,7 +2520,7 @@ size_t llama_context::state_write_data(llama_io_write_i & io) {
     {
         LLAMA_LOG_DEBUG("%s: - writing embeddings\n", __func__);
 
-        const uint64_t embd_size = std::min((uint64_t) this->embd_size, (uint64_t) n_outputs * model.hparams.n_embd);
+        const uint64_t embd_size = std::min((uint64_t) this->embd_size, (uint64_t) n_outputs * model.hparams.get_n_embd_out());
 
         io.write(&embd_size, sizeof(embd_size));
 


### PR DESCRIPTION
When pooling, size and copy embd_seq using the
pooled tensor's actual width (t_embd->ne[0])
and row stride (t_embd->nb[1]) instead of n_embd.
This avoids ggml_backend_tensor_get_async bounds
assertions (abort) when n_embd_out < n_embd, and
prevents heap OOB reads when n_embd_out > n_embd
when callers treat pooled embeddings as length
n_embd_out. Also use get_n_embd_out() in
state_write_data() and output_reorder()

Also add GGML_ASSERT(seq_idx >= 0) before computing 
byte offsets for readback to prevent negative overflow.

Fix: `PWNO-0023`

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
