### PR TITLE
Corrected: In ggml_cuda_mul_mat_q(), s13 is declared incorrectly to nb[2] instead of nb[3]

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -190,7 +190,7 @@ void ggml_cuda_mul_mat_q(
     {
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
-        const int64_t s13 = src1->nb[2] / ts_src1;
+        const int64_t s13 = src1->nb[3] / ts_src1;
 
         if (use_native_mxfp4) {
             quantize_mmq_mxfp4_cuda(src1_d, ids_src1.get(), src1_q8_1.get(), src0->type, ne10, s11, s12, s13,


### PR DESCRIPTION
In  ggml_cuda_mul_mat_q(), when in the MoE path and when quantizing src1, s13 is incorrectly declared to nb[2] instead of nb[3].

Earlier in the function:
    const int64_t s03 = src0->nb[3] / ts_src0;
    const int64_t s3  =  dst->nb[3] / ts_dst;
    ...
    
  if (!ids) {
     ...
        {
            const int64_t s11 = src1->nb[1] / ts_src1;
            const int64_t s12 = src1->nb[2] / ts_src1;
            const int64_t s13 = src1->nb[3] / ts_src1;
       }
     Later, in the ids path:
        const int64_t s11 = src1->nb[1] / ts_src1;
        const int64_t s12 = src1->nb[2] / ts_src1;
        const int64_t s13 = src1->**nb[2]** / ts_src1;     _<--- [2] here, repeated, should be [3]._

ne13 is currently asserted to 1 , so this very likely doesn't affect anything yet, but it should still be fixed for correctness.
     
  Copilot summary:
This pull request fixes an indexing bug in the `ggml_cuda_mul_mat_q` function in `mmq.cu`. The change corrects the calculation of the `s13` variable to use the correct dimension of the `src1` tensor, which improves the accuracy of subsequent operations.

* Bug fix:
  * Corrected the calculation of `s13` to use `src1->nb[3]` instead of `src1->nb[2]`, ensuring the correct tensor dimension is used in matrix multiplication operations.