### PR TITLE
lookahead: fix n_seq_max and kv_unified configuration

### DIFF
--- a/examples/lookahead/lookahead.cpp
+++ b/examples/lookahead/lookahead.cpp
@@ -50,6 +50,12 @@ int main(int argc, char ** argv) {
     const int N = 5;  // n-gram size
     const int G = 15; // max verification n-grams
 
+    // lookahead requires W + G + 1 sequences for parallel Jacobi decoding
+    params.n_parallel = W + G + 1;
+
+    // unified KV cache is required for coupled sequences in batch splitting
+    params.kv_unified = true;
+
     // init llama.cpp
     llama_backend_init();
     llama_numa_init(params.numa);


### PR DESCRIPTION
## Summary

Fixes `llama-lookahead` configuration issues that have been broken since PR #14482 (July 2025).

**Note:** This PR depends on #18729 for the batch init fix. Both PRs are needed for lookahead to fully work.

## Root Cause

Two lookahead-specific configuration issues:

### 1. Sequence count (n_seq_max)
PR #14482 changed seq_id validation from `LLAMA_MAX_SEQ` (large constant) to `n_seq_max` (context-specific). Lookahead needs `W + G + 1 = 31` sequences for parallel Jacobi decoding, but `params.n_parallel` defaulted to 1.

### 2. KV unified mode
Batch splitting with "coupled sequences" requires unified KV cache. Lookahead didn't enable this, causing:
```
split_equal: sequential split is not supported when there are coupled sequences
```

## Fix

```cpp
// lookahead requires W + G + 1 sequences for parallel Jacobi decoding
params.n_parallel = W + G + 1;

// unified KV cache is required for coupled sequences in batch splitting
params.kv_unified = true;
```

## Bug Timeline

| Date | PR | Effect |
|------|-----|--------|
| Nov 2023 | #4207 | lookahead.cpp created - works |
| **July 2025** | **#14482** | seq_id validation changed - **breaks lookahead** |

## Testing

With both this PR and #18729 applied:

```
encoded    4 tokens in    0.138 seconds
decoded   51 tokens in   71.591 seconds
n_accept  = 13
```

## Dependencies

- **Requires #18729** for the batch init fix (`params.n_ctx` → `llama_n_ctx(ctx)`)

---
Bug history researched with Claude.