### PR TITLE
fix: use actual tensor embedding dimension instead of model parameter

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1204,6 +1204,8 @@ int llama_context::encode(const llama_batch & batch_inp) {
             case LLAMA_POOLING_TYPE_CLS:
             case LLAMA_POOLING_TYPE_LAST:
                 {
+                    const int64_t n_embd_tensor = t_embd ? t_embd->ne[0] : hparams.n_embd_inp();
+
                     // extract sequence embeddings
                     auto & embd_seq_out = embd_seq;
 
@@ -1211,8 +1213,8 @@ int llama_context::encode(const llama_batch & batch_inp) {
                         const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                         const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
-                        embd_seq_out[seq_id].resize(n_embd);
-                        ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd*seq_idx)*sizeof(float), n_embd*sizeof(float));
+                        embd_seq_out[seq_id].resize(n_embd_tensor);
+                        ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd_tensor*seq_idx)*sizeof(float), n_embd_tensor*sizeof(float));
                     }
                 } break;
             case LLAMA_POOLING_TYPE_RANK:
@@ -1615,6 +1617,8 @@ int llama_context::decode(const llama_batch & batch_inp) {
                 case LLAMA_POOLING_TYPE_CLS:
                 case LLAMA_POOLING_TYPE_LAST:
                     {
+                        const int64_t n_embd_tensor = t_embd ? t_embd->ne[0] : hparams.n_embd_inp();
+
                         // extract sequence embeddings (cleared before processing each batch)
                         auto & embd_seq_out = embd_seq;
 
@@ -1622,8 +1626,8 @@ int llama_context::decode(const llama_batch & batch_inp) {
                             const llama_seq_id seq_id  = ubatch.seq_id_unq[s];
                             const int32_t      seq_idx = ubatch.seq_idx[seq_id];
 
-                            embd_seq_out[seq_id].resize(n_embd);
-                            ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd*seq_idx)*sizeof(float), n_embd*sizeof(float));
+                            embd_seq_out[seq_id].resize(n_embd_tensor);
+                            ggml_backend_tensor_get_async(backend_embd, t_embd, embd_seq_out[seq_id].data(), (n_embd_tensor*seq_idx)*sizeof(float), n_embd_tensor*sizeof(float));
                         }
                     } break;
                 case LLAMA_POOLING_TYPE_RANK:


### PR DESCRIPTION
Replace hardcoded n_embd with n_embd_tensor in embedding extraction to handle cases where tensor dimensions differ from model parameters. 

This issue was only triggered when the pool type was changed.  This fixes https://github.com/ggml-org/llama.cpp/issues/18737.  

I have tested this fix extensively with `Qwen3-VL-Embedding-8b` with pooling set to `last`.  Of course, previously it didn't work at all so there was nothing to compare to.

So I also tested extensively with `llama-embed-nemotron-8b` with pooling set to `mean` both with and without my change.  The returned embeddings matched 100%.  (They matched when genned on the same backend, CPU - CPU and Vulkan - Vulkan, they interestingly did NOT match CPU - Vulkan, but I think that must have been the case previously?  Unfortunately I somehow broke my ROCM install so I was unable to retest HIP).

Please let me know if there are additional tests I can run or if I can provide my exact GGUFs.  Will try to retest HIP if I can get it working again, but the issue was reproducible solely with the CPU backend.