### PR TITLE
security: make it clear about subtopics in server

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,10 +38,11 @@ Only vulnerabilities that fall within these parts of the project are considered 
 - `src/**/*`
 - `ggml/**/*`
 - `gguf-py/**/*`
-- `tools/server/*`, excluding the following topics:
+- `tools/server/*`, **excluding** the following topics:
     - Web UI
     - Features marked as experimental
     - Features not recommended for use in untrusted environments (e.g., router, MCP)
+    - Bugs that can lead to Denial-of-Service attack
 
 Note that none of the topics under [Using llama.cpp securely](#using-llamacpp-securely) are considered vulnerabilities in LLaMA C++.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,10 @@ Only vulnerabilities that fall within these parts of the project are considered 
 - `src/**/*`
 - `ggml/**/*`
 - `gguf-py/**/*`
-- `tools/server/*` (note: Web UI is not covered)
+- `tools/server/*`, excluding the following topics:
+    - Web UI
+    - Features marked as experimental
+    - Features not recommended for use in untrusted environments (e.g., router, MCP)
 
 Note that none of the topics under [Using llama.cpp securely](#using-llamacpp-securely) are considered vulnerabilities in LLaMA C++.
 


### PR DESCRIPTION
Make it clear which parts of the server are excluded.

MCP is mentioned here because we will have stdio implementation in the future (provided by `subprocess.h`), as well as a CORS proxy. These features are unsafe to be used publicly, it's only intended to be used via localhost or private deployment.
