### PR TITLE
model: qwen3next: no concat-in-loop

### DIFF
--- a/src/models/models.h
+++ b/src/models/models.h
@@ -460,6 +460,7 @@ private:
                 ggml_tensor * causal_mask,
                 ggml_tensor * identity,
                 ggml_tensor * diag_mask,
+                ggml_tensor * out_chunk_row_idx,
                         int   il);
 
     ggml_tensor * build_layer_ffn(
@@ -477,6 +478,7 @@ private:
                 ggml_tensor * causal_mask,
                 ggml_tensor * identity,
                 ggml_tensor * diag_mask,
+                ggml_tensor * out_chunk_row_idx,
                         int   il);
 
     // returns pair of output and new state

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -39,7 +39,7 @@ llm_build_qwen3next::llm_build_qwen3next(const llama_model & model, const llm_gr
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
     ggml_tensor * inp_out_chunk_row_idx = nullptr;
-    {
+    if (ubatch.n_seq_tokens > 1) {
         auto inp = std::make_unique<llm_graph_input_set_chunk_row>();
         inp_out_chunk_row_idx = ggml_new_tensor_3d(ctx0, GGML_TYPE_I32, CHUNK_SIZE, 1, inp->get_n_chunks(&ubatch));
         ggml_set_input(inp_out_chunk_row_idx);


### PR DESCRIPTION
Ref: https://github.com/ggml-org/llama.cpp/issues/18725#issuecomment-3734462469

Alternative to doing `ggml_concat` in a loop is to use `ggml_set_rows`, but it requires adding quite a lot of code.

This PR is a PoC, just to see if `ggml_concat` is actually the root cause.

---

Testing with a large ubatch, `llama-bench -p 2048 -ub 1024`

**master:**

| model                          |       size |     params | backend    | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -------: | --------------: | -------------------: |
| qwen3next 80B.A3B F16          | 148.50 GiB |    79.67 B | Metal,BLAS |      24 |     1024 |          pp2048 |       1049.92 ± 8.52 |
| qwen3next 80B.A3B F16          | 148.50 GiB |    79.67 B | Metal,BLAS |      24 |     1024 |           tg128 |         28.85 ± 0.03 |

build: 506bb6e01 (7703)

**PR:**

| model                          |       size |     params | backend    | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -------: | --------------: | -------------------: |
| qwen3next 80B.A3B F16          | 148.50 GiB |    79.67 B | Metal,BLAS |      24 |     1024 |          pp2048 |       1049.65 ± 9.18 |
| qwen3next 80B.A3B F16          | 148.50 GiB |    79.67 B | Metal,BLAS |      24 |     1024 |           tg128 |         28.92 ± 0.12 |

build: 4c7e8303a (7705)

