### PR TITLE
doc: ban AI-generated PR descriptions [no ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If AI is used to generate any portion of the code, contributors must adhere to t
 1. Explicitly disclose the manner in which AI was employed.
 2. Perform a comprehensive manual review prior to submitting the pull request.
 3. Be prepared to explain every line of code they submitted when asked about it by a maintainer.
-4. Using AI to respond to human reviewers is strictly prohibited.
+4. Using AI to write pull request descriptions or to respond to human reviewers is strictly prohibited.
 
 For more info, please refer to the [AGENTS.md](AGENTS.md) file.
 


### PR DESCRIPTION
We could maybe explicitly ban the use of language models to generate PR descriptions. In principle I think that this is maybe one of the more legitimate use cases for language models (if you wrote the code yourself and fully understand it). But basically all of the time-wasting slop PRs that we want to reject use language models to generate PR descriptions; the people pushing the submit button simply have no other way of creating the appearance of understanding the code they submit. So potentially this change would save maintainers a bit of time.

I personally never use language models for summarizing pull requests, and I would consider the potential time savings vs. actually writing the code negligible anyways (because I already know what it does). But I don't know the workflows of other maintainers/contributors. But we can also just write down strict rules to be followed "officially" and then make exceptions on a case-by-case basis for people who have proven themselves.