### PR TITLE
webui : send both backend_sampling == false/true

### DIFF
--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_1ow7rhy = {
+					__sveltekit_1610ad9 = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_1ppa22i = {
+					__sveltekit_1ow7rhy = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/webui/src/lib/services/parameter-sync.service.ts
+++ b/tools/server/webui/src/lib/services/parameter-sync.service.ts
@@ -89,6 +89,12 @@ export const SYNCABLE_PARAMETERS: SyncableParameter[] = [
 	{ key: 'max_tokens', serverKey: 'max_tokens', type: SyncableParameterType.NUMBER, canSync: true },
 	{ key: 'samplers', serverKey: 'samplers', type: SyncableParameterType.STRING, canSync: true },
 	{
+		key: 'backend_sampling',
+		serverKey: 'backend_sampling',
+		type: SyncableParameterType.BOOLEAN,
+		canSync: true
+	},
+	{
 		key: 'pasteLongTextToFileLen',
 		serverKey: 'pasteLongTextToFileLen',
 		type: SyncableParameterType.NUMBER,

--- a/tools/server/webui/src/lib/stores/chat.svelte.ts
+++ b/tools/server/webui/src/lib/stores/chat.svelte.ts
@@ -1610,8 +1610,7 @@ class ChatStore {
 
 		if (currentConfig.samplers) apiOptions.samplers = currentConfig.samplers;
 
-		if (currentConfig.backend_sampling)
-			apiOptions.backend_sampling = currentConfig.backend_sampling;
+		apiOptions.backend_sampling = currentConfig.backend_sampling;
 
 		if (currentConfig.custom) apiOptions.custom = currentConfig.custom;
 


### PR DESCRIPTION
I believe the webui does not send `backend_sampling == false` in the request when the checkbox is unchecked. The goal is when the server is started with `-bs` to be able to disable backend sampling from the client.

Also I think the checkbox is currently not synchronized with the server argument like the rest of the sampling parameters. But not sure how to fix this of if it is supported for checkboxes.