### PR TITLE
CUDA: Factor out and re-use `block_reduce` function

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -537,12 +537,15 @@ struct block_reduce_policy;
 template <typename T, typename... Ts>
 constexpr bool is_any = (std::is_same_v<T, Ts> || ...);
 
+template<typename...>
+constexpr bool ggml_cuda_dependent_false_v = false;
+
 template <typename T> struct block_reduce_policy<block_reduce_method::SUM, T> {
     static __device__ T reduce(T val) {
         if constexpr(is_any<T, float, float2, half2, int>) {
             return warp_reduce_sum(val);
         } else {
-            static_assert(false, "Unsupported type for block reduce sum");
+            static_assert(ggml_cuda_dependent_false_v<T>, "Unsupported type for block reduce sum");
         }
     }
 
@@ -556,7 +559,7 @@ template <typename T> struct block_reduce_policy<block_reduce_method::SUM, T> {
         } else if constexpr (std::is_same_v<T, int>) {
             return 0;
         } else {
-            static_assert(false, "Unsupported type for block reduce sum");
+            static_assert(ggml_cuda_dependent_false_v<T>, "Unsupported type for block reduce sum");
         }
     }
 };
@@ -566,7 +569,7 @@ template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
         if constexpr (is_any<T, float, half2>) {
             return warp_reduce_max(val);
         } else {
-            static_assert(false, "Unsupported type for block reduce max");
+            static_assert(ggml_cuda_dependent_false_v<T>, "Unsupported type for block reduce max");
         }
     }
 
@@ -576,7 +579,7 @@ template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
         } else if constexpr (std::is_same_v<T, half2>) {
             return make_half2(-INFINITY, -INFINITY);
         } else {
-            static_assert(false, "Unsupported type for block reduce max");
+            static_assert(ggml_cuda_dependent_false_v<T>, "Unsupported type for block reduce max");
         }
     }
 };

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -535,10 +535,10 @@ template<block_reduce_method method_t, typename T>
 struct block_reduce_policy;
 
 template <typename T, typename... Ts>
-constexpr bool is_any = (std::is_same_v<T, Ts> || ...);
+inline constexpr bool is_any = (std::is_same_v<T, Ts> || ...);
 
 template<typename...>
-constexpr bool ggml_cuda_dependent_false_v = false;
+inline constexpr bool ggml_cuda_dependent_false_v = false;
 
 template <typename T> struct block_reduce_policy<block_reduce_method::SUM, T> {
     static __device__ T reduce(T val) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -598,8 +598,8 @@ static __device__ T block_reduce(T val, T * shared_vals) {
             val = shared_vals[lane_id];
         }
         return block_reduce_policy<reduce_method_t, T>::reduce(val);
-    } 
-    
+    }
+
     return val;
 }
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -526,7 +526,7 @@ static __device__ __forceinline__ half2 warp_prefix_inclusive_sum(half2 a) {
 #endif // FP16_AVAILABLE
 }
 
-enum block_reduce_method {
+enum class block_reduce_method {
     MAX,
     SUM,
 };
@@ -537,8 +537,7 @@ struct block_reduce_policy;
 template <typename T, typename... Ts>
 constexpr bool is_any = (std::is_same_v<T, Ts> || ...);
 
-template<typename T>
-struct block_reduce_policy<SUM, T> {
+template <typename T> struct block_reduce_policy<block_reduce_method::SUM, T> {
     static __device__ T reduce(T val) {
         if constexpr(is_any<T, float, float2, half2, int>) {
             return warp_reduce_sum(val);
@@ -562,8 +561,7 @@ struct block_reduce_policy<SUM, T> {
     }
 };
 
-template<typename T>
-struct block_reduce_policy<MAX, T> {
+template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
     static __device__ T reduce(T val) {
         if constexpr (is_any<T, float, half2>) {
             return warp_reduce_max(val);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -565,9 +565,9 @@ template <warp_reduce_method reduce_method, const unsigned int block_size_templa
             val = shared_vals[lane_id];
         }
         return reduce_fun(val);
-    } else {
-        return val;
-    }
+    } 
+    
+    return val;
 }
 
 static __device__ __forceinline__ half ggml_cuda_hmax(const half a, const half b) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -531,7 +531,7 @@ enum class block_reduce_method {
     SUM,
 };
 
-template<block_reduce_method method, typename T>
+template<block_reduce_method method_t, typename T>
 struct block_reduce_policy;
 
 template <typename T, typename... Ts>
@@ -581,9 +581,9 @@ template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
     }
 };
 
-template <block_reduce_method reduce_method, const unsigned int block_size_template = 0, typename T>
+template <block_reduce_method reduce_method_t, const unsigned int block_size_template = 0, typename T>
 static __device__ T two_stage_warp_reduce(T val, T * shared_vals) {
-    val                           = block_reduce_policy<reduce_method, T>::reduce(val);
+    val                           = block_reduce_policy<reduce_method_t, T>::reduce(val);
     const unsigned int block_size = block_size_template == 0 ? blockDim.x : block_size_template;
     if (block_size > WARP_SIZE) {
         assert((block_size <= 1024) && (block_size % WARP_SIZE) == 0);
@@ -593,11 +593,11 @@ static __device__ T two_stage_warp_reduce(T val, T * shared_vals) {
             shared_vals[warp_id] = val;
         }
         __syncthreads();
-        val = block_reduce_policy<reduce_method, T>::sentinel();
+        val = block_reduce_policy<reduce_method_t, T>::sentinel();
         if (lane_id < (static_cast<int>(block_size) / WARP_SIZE)) {
             val = shared_vals[lane_id];
         }
-        return block_reduce_policy<reduce_method, T>::reduce(val);
+        return block_reduce_policy<reduce_method_t, T>::reduce(val);
     } 
     
     return val;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -582,7 +582,7 @@ template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
 };
 
 template <block_reduce_method reduce_method_t, const unsigned int block_size_template = 0, typename T>
-static __device__ T two_stage_warp_reduce(T val, T * shared_vals) {
+static __device__ T block_reduce(T val, T * shared_vals) {
     val                           = block_reduce_policy<reduce_method_t, T>::reduce(val);
     const unsigned int block_size = block_size_template == 0 ? blockDim.x : block_size_template;
     if (block_size > WARP_SIZE) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4550,7 +4550,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_L2_NORM:
             return true;
         case GGML_OP_RMS_NORM_BACK:
-            return ggml_is_contiguous(op->src[0]) && op->ne[0] % WARP_SIZE == 0;
+            return ggml_is_contiguous(op->src[0]);
             break;
         case GGML_OP_NONE:
         case GGML_OP_RESHAPE:

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -301,7 +301,7 @@ static void norm_f32_cuda(
         norm_f32<WARP_SIZE><<<blocks_num, block_dims, 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
     } else {
         const dim3 block_dims(1024, 1, 1);
-        norm_f32<1024><<<blocks_num, block_dims, 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
+        norm_f32<1024><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
     }
 }
 
@@ -312,7 +312,7 @@ static void group_norm_f32_cuda(
         group_norm_f32<WARP_SIZE><<<num_groups, block_dims, 0, stream>>>(x, dst, group_size, ne_elements, eps);
     } else {
         const dim3 block_dims(1024, 1, 1);
-        group_norm_f32<1024><<<num_groups, block_dims, block_dims.x > WARP_SIZE ? 32: 0, stream>>>(x, dst, group_size, ne_elements, eps);
+        group_norm_f32<1024><<<num_groups, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(x, dst, group_size, ne_elements, eps);
     }
 }
 
@@ -322,10 +322,10 @@ static void rms_norm_f32_cuda(
     const dim3 blocks_num(nrows, nchannels, nsamples);
     if (ncols < 1024) {
         const dim3 block_dims(256, 1, 1);
-        rms_norm_f32<256, false><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32: 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
+        rms_norm_f32<256, false><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
     } else {
         const dim3 block_dims(1024, 1, 1);
-        rms_norm_f32<1024, false><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32: 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
+        rms_norm_f32<1024, false><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
     }
 }
 
@@ -368,12 +368,12 @@ static void rms_norm_mul_f32_cuda(const float *  x,
         const uint3 mul_nsamples_packed  = init_fastdiv_values(mul_nsamples);
         if (ncols < 1024) {
             const dim3 block_dims(256, 1, 1);
-            rms_norm_f32<256, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE? 32 : 0, stream>>>(
+            rms_norm_f32<256, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed);
         } else {
             const dim3 block_dims(1024, 1, 1);
-            rms_norm_f32<1024, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE? 32 : 0, stream>>>(
+            rms_norm_f32<1024, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed);
         }
@@ -389,14 +389,14 @@ static void rms_norm_mul_f32_cuda(const float *  x,
         const uint3 add_nsamples_packed  = init_fastdiv_values(add_nsamples);
         if (ncols < 1024) {
             const dim3 block_dims(256, 1, 1);
-            rms_norm_f32<256, true, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE? 32 : 0, stream>>>(
+            rms_norm_f32<256, true, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed, add,
                 add_stride_row, add_stride_channel, add_stride_sample, add_ncols_packed, add_nrows_packed,
                 add_nchannels_packed, add_nsamples_packed);
         } else {
             const dim3 block_dims(1024, 1, 1);
-            rms_norm_f32<1024, true, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE? 32 : 0, stream>>>(
+            rms_norm_f32<1024, true, true><<<blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream>>>(
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed, add,
                 add_stride_row, add_stride_channel, add_stride_sample, add_ncols_packed, add_nrows_packed,

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -26,7 +26,7 @@ static __global__ void norm_f32(
 
     // sum up partial sums
     extern __shared__ float2 s_sum2[];
-    mean_var = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size>(mean_var, s_sum2);
+    mean_var = two_stage_warp_reduce<SUM, block_size>(mean_var, s_sum2);
 
     const float mean = mean_var.x / ncols;
     const float var = mean_var.y / ncols - mean * mean;
@@ -51,7 +51,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
     }
 
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / group_size;
     tmp = 0.0f;
@@ -62,7 +62,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
         tmp += xi * xi;
     }
 
-    tmp = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
 
     const float variance = tmp / group_size;
     const float scale = rsqrtf(variance + eps);
@@ -131,7 +131,7 @@ static __global__ void rms_norm_f32(const float * x,
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / ncols;
     const float scale = rsqrtf(mean + eps);
@@ -260,7 +260,7 @@ static __global__ void l2_norm_f32(
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
 
     // from https://pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html
     const float scale = rsqrtf(fmaxf(tmp, eps * eps));

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -26,7 +26,7 @@ static __global__ void norm_f32(
 
     // sum up partial sums
     extern __shared__ float2 s_sum2[];
-    mean_var = two_stage_warp_reduce<SUM, block_size>(mean_var, s_sum2);
+    mean_var = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(mean_var, s_sum2);
 
     const float mean = mean_var.x / ncols;
     const float var = mean_var.y / ncols - mean * mean;
@@ -51,7 +51,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
     }
 
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / group_size;
     tmp = 0.0f;
@@ -62,7 +62,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
         tmp += xi * xi;
     }
 
-    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float variance = tmp / group_size;
     const float scale = rsqrtf(variance + eps);
@@ -131,7 +131,7 @@ static __global__ void rms_norm_f32(const float * x,
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / ncols;
     const float scale = rsqrtf(mean + eps);
@@ -260,7 +260,7 @@ static __global__ void l2_norm_f32(
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<SUM, block_size>(tmp, s_sum);
+    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     // from https://pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html
     const float scale = rsqrtf(fmaxf(tmp, eps * eps));

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -26,7 +26,7 @@ static __global__ void norm_f32(
 
     // sum up partial sums
     extern __shared__ float2 s_sum2[];
-    mean_var = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(mean_var, s_sum2);
+    mean_var = block_reduce<block_reduce_method::SUM, block_size>(mean_var, s_sum2);
 
     const float mean = mean_var.x / ncols;
     const float var = mean_var.y / ncols - mean * mean;
@@ -51,7 +51,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
     }
 
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / group_size;
     tmp = 0.0f;
@@ -62,7 +62,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
         tmp += xi * xi;
     }
 
-    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float variance = tmp / group_size;
     const float scale = rsqrtf(variance + eps);
@@ -131,7 +131,7 @@ static __global__ void rms_norm_f32(const float * x,
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     const float mean = tmp / ncols;
     const float scale = rsqrtf(mean + eps);
@@ -260,7 +260,7 @@ static __global__ void l2_norm_f32(
 
     // sum up partial sums
     extern __shared__ float s_sum[];
-    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
 
     // from https://pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html
     const float scale = rsqrtf(fmaxf(tmp, eps * eps));

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -29,7 +29,7 @@ static __global__ void reduce_rows_f32(const float * __restrict__ x, float * __r
 
     // sum up partial sums
     __shared__ float shared_vals[32];
-    sum = two_stage_warp_reduce<SUM>(sum, shared_vals);
+    sum = two_stage_warp_reduce<block_reduce_method::SUM>(sum, shared_vals);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -29,7 +29,7 @@ static __global__ void reduce_rows_f32(const float * __restrict__ x, float * __r
 
     // sum up partial sums
     __shared__ float shared_vals[32];
-    sum = two_stage_warp_reduce<block_reduce_method::SUM>(sum, shared_vals);
+    sum = block_reduce<block_reduce_method::SUM>(sum, shared_vals);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -28,7 +28,8 @@ static __global__ void reduce_rows_f32(const float * __restrict__ x, float * __r
     }
 
     // sum up partial sums
-    sum = two_stage_warp_reduce<WARP_REDUCE_SUM>(sum);
+    __shared__ float shared_vals[32];
+    sum = two_stage_warp_reduce<WARP_REDUCE_SUM>(sum, shared_vals);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -28,22 +28,7 @@ static __global__ void reduce_rows_f32(const float * __restrict__ x, float * __r
     }
 
     // sum up partial sums
-    sum = warp_reduce_sum(sum);
-    if (blockDim.x > WARP_SIZE) {
-        assert((blockDim.x <= 1024) && (blockDim.x % WARP_SIZE) == 0);
-        __shared__ float s_sum[32];
-        const int        warp_id = threadIdx.x / WARP_SIZE;
-        const int        lane_id = threadIdx.x % WARP_SIZE;
-        if (lane_id == 0) {
-            s_sum[warp_id] = sum;
-        }
-        __syncthreads();
-        sum = 0.0f;
-        if (lane_id < (static_cast<int>(blockDim.x) / WARP_SIZE)) {
-            sum = s_sum[lane_id];
-        }
-        sum = warp_reduce_sum(sum);
-    }
+    sum = two_stage_warp_reduce<WARP_REDUCE_SUM>(sum);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -29,7 +29,7 @@ static __global__ void reduce_rows_f32(const float * __restrict__ x, float * __r
 
     // sum up partial sums
     __shared__ float shared_vals[32];
-    sum = two_stage_warp_reduce<WARP_REDUCE_SUM>(sum, shared_vals);
+    sum = two_stage_warp_reduce<SUM>(sum, shared_vals);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/softmax.cu
+++ b/ggml/src/ggml-cuda/softmax.cu
@@ -99,7 +99,7 @@ static __global__ void soft_max_f32(
     }
 
     // find the max value in the block
-    max_val = two_stage_warp_reduce<WARP_REDUCE_MAX, block_size_template>(max_val, buf_iw);
+    max_val = two_stage_warp_reduce<MAX, block_size_template>(max_val, buf_iw);
 
     float tmp = 0.0f; // partial sum
 
@@ -117,7 +117,7 @@ static __global__ void soft_max_f32(
     }
 
     // find the sum of exps in the block
-    tmp = two_stage_warp_reduce<WARP_REDUCE_SUM, block_size_template>(tmp, buf_iw);
+    tmp = two_stage_warp_reduce<SUM, block_size_template>(tmp, buf_iw);
 
     if (sinks) {
         tmp += expf(sinks[i02] - max_val);
@@ -171,7 +171,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     }
 
     // Compute CTA-level max
-    local_max = two_stage_warp_reduce<WARP_REDUCE_MAX>(local_max, shared_vals);
+    local_max = two_stage_warp_reduce<MAX>(local_max, shared_vals);
 
     // Store CTA-level max to GMEM
     if (tid == 0) {
@@ -186,7 +186,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     } else {
         local_max = -INFINITY;
     }
-    local_max = two_stage_warp_reduce<WARP_REDUCE_MAX>(local_max, shared_vals);
+    local_max = two_stage_warp_reduce<MAX>(local_max, shared_vals);
 
     // Compute softmax dividends, accumulate divisor
     float tmp_expf = 0.0f;
@@ -209,7 +209,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     }
 
     // Reduce divisor within CTA
-    tmp_expf = two_stage_warp_reduce<WARP_REDUCE_SUM>(tmp_expf, shared_vals);
+    tmp_expf = two_stage_warp_reduce<SUM>(tmp_expf, shared_vals);
 
     // Store CTA-level sum to GMEM
     if (tid == 0) {
@@ -223,7 +223,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     } else {
         tmp_expf = 0.0f;
     }
-    tmp_expf = two_stage_warp_reduce<WARP_REDUCE_SUM>(tmp_expf, shared_vals);
+    tmp_expf = two_stage_warp_reduce<SUM>(tmp_expf, shared_vals);
 
     // Divide dividend by global sum + store data
     for (int col = col_start; col < p.ncols;) {

--- a/ggml/src/ggml-cuda/softmax.cu
+++ b/ggml/src/ggml-cuda/softmax.cu
@@ -99,7 +99,7 @@ static __global__ void soft_max_f32(
     }
 
     // find the max value in the block
-    max_val = two_stage_warp_reduce<MAX, block_size_template>(max_val, buf_iw);
+    max_val = two_stage_warp_reduce<block_reduce_method::MAX, block_size_template>(max_val, buf_iw);
 
     float tmp = 0.0f; // partial sum
 
@@ -117,7 +117,7 @@ static __global__ void soft_max_f32(
     }
 
     // find the sum of exps in the block
-    tmp = two_stage_warp_reduce<SUM, block_size_template>(tmp, buf_iw);
+    tmp = two_stage_warp_reduce<block_reduce_method::SUM, block_size_template>(tmp, buf_iw);
 
     if (sinks) {
         tmp += expf(sinks[i02] - max_val);
@@ -171,7 +171,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     }
 
     // Compute CTA-level max
-    local_max = two_stage_warp_reduce<MAX>(local_max, shared_vals);
+    local_max = two_stage_warp_reduce<block_reduce_method::MAX>(local_max, shared_vals);
 
     // Store CTA-level max to GMEM
     if (tid == 0) {
@@ -186,7 +186,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     } else {
         local_max = -INFINITY;
     }
-    local_max = two_stage_warp_reduce<MAX>(local_max, shared_vals);
+    local_max = two_stage_warp_reduce<block_reduce_method::MAX>(local_max, shared_vals);
 
     // Compute softmax dividends, accumulate divisor
     float tmp_expf = 0.0f;
@@ -209,7 +209,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     }
 
     // Reduce divisor within CTA
-    tmp_expf = two_stage_warp_reduce<SUM>(tmp_expf, shared_vals);
+    tmp_expf = two_stage_warp_reduce<block_reduce_method::SUM>(tmp_expf, shared_vals);
 
     // Store CTA-level sum to GMEM
     if (tid == 0) {
@@ -223,7 +223,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     } else {
         tmp_expf = 0.0f;
     }
-    tmp_expf = two_stage_warp_reduce<SUM>(tmp_expf, shared_vals);
+    tmp_expf = two_stage_warp_reduce<block_reduce_method::SUM>(tmp_expf, shared_vals);
 
     // Divide dividend by global sum + store data
     for (int col = col_start; col < p.ncols;) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7482,25 +7482,29 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_softcap(GGML_TYPE_F32, {10, 10, 10, 10}, 50.0f));
     test_cases.emplace_back(new test_silu_back());
 
-    for (float eps : {0.0f, 1e-6f, 1e-4f, 1e-1f}) {
-        for (bool v : {false, true}) {
-            test_cases.emplace_back(new test_norm    (GGML_TYPE_F32, {64, 5, 4, 3}, v, eps));
-            test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, {64, 5, 4, 3}, v, eps));
+    for (float eps : { 0.0f, 1e-6f, 1e-4f, 1e-1f }) {
+        for (uint32_t n : { 64, 1025 }) {
+            for (bool v : { false, true }) {
+                test_cases.emplace_back(new test_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, v, eps));
+                test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, v, eps));
+            }
+            test_cases.emplace_back(new test_rms_norm_back(GGML_TYPE_F32, { n, 5, 4, 3 }, eps));
+            test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps));
         }
-        test_cases.emplace_back(new test_rms_norm_back(GGML_TYPE_F32, {64, 5, 4, 3}, eps));
-        test_cases.emplace_back(new test_l2_norm      (GGML_TYPE_F32, {64, 5, 4, 3}, eps));
     }
 
     // in-place tests
     test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, {64, 5, 4, 3}, false, 1e-6f, true));
 
-    for (float eps : {0.0f, 1e-6f, 1e-4f, 1e-1f, 1.0f}) {
-        test_cases.emplace_back(new test_rms_norm_mul_add(GGML_TYPE_F32, {64, 5, 4, 3}, eps, false));
-        test_cases.emplace_back(new test_rms_norm_mul_add(GGML_TYPE_F32, {64, 5, 4, 3}, eps, true));
-        test_cases.emplace_back(new test_norm_mul_add(GGML_TYPE_F32, {64, 5, 4, 3}, eps, false));
-        test_cases.emplace_back(new test_norm_mul_add(GGML_TYPE_F32, {64, 5, 4, 3}, eps, true));
-        test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, {64, 5, 4, 3}, eps, false));
-        test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, {64, 5, 4, 3}, eps, true));
+    for (float eps : { 0.0f, 1e-6f, 1e-4f, 1e-1f, 1.0f }) {
+        for (uint32_t n : { 64, 1025 }) {
+            test_cases.emplace_back(new test_rms_norm_mul_add(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false));
+            test_cases.emplace_back(new test_rms_norm_mul_add(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
+            test_cases.emplace_back(new test_norm_mul_add(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false));
+            test_cases.emplace_back(new test_norm_mul_add(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
+            test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false));
+            test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
+        }
     }
     for (uint32_t n : {1, 511, 1025, 8192, 33*512}) {
         for (bool multi_add : {false, true}) {
@@ -7524,9 +7528,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             }
         }
     }
-
-    test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, {64, 5, 4, 3}, 1e-12f));
-
     for (int64_t d_conv : {3, 4, 9}) {
         for (int64_t d_inner: {1024, 1536, 2048}) {
             test_cases.emplace_back(new test_ssm_conv(GGML_TYPE_F32, {d_conv, d_inner, 1, 1}, {d_conv, d_inner, 1, 1}));


### PR DESCRIPTION
This was an open TODO from #17004 on CUDA side