### PR TITLE
CUDA : fix unused argument when USE_CUDA_GRAPH=OFF

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3737,6 +3737,7 @@ static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx) {
 
     return cuda_ctx->cuda_graph->is_enabled();
 #else
+    GGML_UNUSED(cuda_ctx);
     return false;
 #endif // USE_CUDA_GRAPH
 }


### PR DESCRIPTION
ref https://github.com/ggml-org/whisper.cpp/actions/runs/20919955568/job/60102715218?pr=3606#step:3:187

Fix a minor compile warning when the CUDA graphs are disabled. Spotted in the `whisper.cpp` CI