### PR TITLE
llama: fix direct-io loading fallback EOF exception

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -244,11 +244,14 @@ struct llama_file::impl {
         }
         errno = 0;
         if (fd == -1) {
-            std::size_t ret = std::fread(ptr, len, 1, fp);
+            const size_t curr_off = tell();
+            const size_t to_read = std::min(len, size - curr_off);
+
+            std::size_t ret = std::fread(ptr, to_read, 1, fp);
             if (ferror(fp)) {
                 throw std::runtime_error(format("read error: %s", strerror(errno)));
             }
-            if (ret != 1) {
+            if (to_read > 0 && ret != 1) {
                 throw std::runtime_error("unexpectedly reached end of file");
             }
         } else {


### PR DESCRIPTION
The issue was that `len` can be larger than the file size due to alignment padding. This is apparently fine for the direct-io path, but in case that fails, the fallback uses `std::fread`, which just returns EOF if there are not enough bytes left in the file pointer to read another object.

To fix this, I check how many bytes are left in the file pointer and if this is smaller than `len`, use that as object size for `std::fread`. In case `to_read` is 0, `std::fread` will do nothing and return 0, so I also checked this case for the EOF exception.

@JTischbein Let me know if this looks correct to you.

I have an AMD Vulkan system affected by this loading issue, and this does fix it for me.

Related issues: #18741 and maybe #18746 #18764 #18766