### PR TITLE
model-conversion : remove -c 0 from model card template [no ci]

### DIFF
--- a/examples/model-conversion/scripts/causal/modelcard.template
+++ b/examples/model-conversion/scripts/causal/modelcard.template
@@ -7,7 +7,7 @@ base_model:
 Recommended way to run this model:
 
 ```sh
-llama-server -hf {namespace}/{model_name}-GGUF -c 0
+llama-server -hf {namespace}/{model_name}-GGUF
 ```
 
 Then, access http://localhost:8080


### PR DESCRIPTION
This commit removes the `-c, --ctx-size N` from the llama-server command in the model card template for causal models.

The motivation for this is that -c 0 is the default and specifying it is redundant.