### PR TITLE
mmap: add Haiku support by skipping RLIMIT_MEMLOCK check

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -614,9 +614,9 @@ struct llama_mlock::impl {
 
         char* errmsg = std::strerror(errno);
         bool suggest = (errno == ENOMEM);
-#if defined(TARGET_OS_VISION) || defined(TARGET_OS_TV) || defined(_AIX)
-        // visionOS/tvOS dont't support RLIMIT_MEMLOCK
-        // Skip resource limit checks on visionOS/tvOS
+#if defined(TARGET_OS_VISION) || defined(TARGET_OS_TV) || defined(_AIX) || defined(__HAIKU__)
+        // visionOS/tvOS/Haiku don't support RLIMIT_MEMLOCK
+        // Skip resource limit checks on these platforms
         suggest = false;
 #else
         struct rlimit lock_limit;


### PR DESCRIPTION
## Summary

Add Haiku OS to the list of platforms that skip the RLIMIT_MEMLOCK check in mmap handling.

Haiku does not support RLIMIT_MEMLOCK (it has no equivalent resource limit), so attempting to check it causes build failures when compiling llama.cpp on Haiku.

## Changes

- Added defined(__HAIKU__) to the platform check that skips RLIMIT_MEMLOCK handling (alongside visionOS, tvOS, and AIX)

## Testing

Tested on Haiku OS with Vulkan GPU acceleration using NVIDIA RTX 3080 Ti.