### PR TITLE
model-loader : support bool array sliding window pattern

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -2,6 +2,7 @@
 
 #include "ggml.h"
 
+#include <algorithm>
 #include <array>
 #include <cinttypes>
 #include <cstring>
@@ -344,6 +345,7 @@ namespace GGUFMeta {
             GGUFMeta::GKV<GGUFMeta::ArrayInfo>::get_kv(ctx, kid);
 
         switch (arr_info.gt) {
+            case GGUF_TYPE_BOOL:
             case GGUF_TYPE_UINT32:
             case GGUF_TYPE_INT32:   GGML_ASSERT((std::is_same<T,     int32_t>::value) ||
                                                 (std::is_same<T,    uint32_t>::value)); break;
@@ -365,7 +367,13 @@ namespace GGUFMeta {
                 result[i] = value;
             }
         } else {
-            std::copy((const T*)arr_info.data, (const T *)arr_info.data + arr_info.length, result.begin());
+            if (arr_info.gt == GGUF_TYPE_BOOL) {
+                std::transform((const bool *)arr_info.data, (const bool *)arr_info.data + arr_info.length, result.begin(), [](bool x) {
+                    return static_cast<T>(x);
+                });
+            } else {
+                std::copy((const T*)arr_info.data, (const T *)arr_info.data + arr_info.length, result.begin());
+            }
         }
 
         return true;


### PR DESCRIPTION
Several models have been storing sliding window pattern metadata as bool arrays. Attempting to load this metadata will crash because (a) BOOL arrays are unsupported (b) the arrays are copied directly.

Luckily none of the models in questions have actually used this data yet, nevertheless this PR implements support by transforming the bools to avoid confusion, like here https://github.com/ggml-org/llama.cpp/pull/18719#discussion_r2690691130

* Gemma3 https://github.com/ggml-org/llama.cpp/blob/599af063fad56928cca26bb2fff06dfa25b852a3/convert_hf_to_gguf.py#L6302-L6305
* Olmo3 https://github.com/ggml-org/llama.cpp/blob/599af063fad56928cca26bb2fff06dfa25b852a3/convert_hf_to_gguf.py#L7051-L7060
* Exaone4 https://github.com/ggml-org/llama.cpp/blob/599af063fad56928cca26bb2fff06dfa25b852a3/convert_hf_to_gguf.py#L8711-L8712