### PR TITLE
enforce response_format and json_schema for Kimi K2

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1881,10 +1881,28 @@ static common_chat_params common_chat_params_init_qwen3_coder_xml(const common_c
 
 static common_chat_params common_chat_params_init_kimi_k2(const common_chat_template & tmpl, const struct templates_params & params) {
     common_chat_params data;
-    data.grammar_lazy = params.tools.is_array() && !params.tools.empty() && params.tool_choice != COMMON_CHAT_TOOL_CHOICE_REQUIRED;
+    const bool has_tools  = params.tools.is_array() && !params.tools.empty();
+    const bool has_schema = params.json_schema.is_object();
+
+    data.grammar_lazy = has_tools && params.tool_choice != COMMON_CHAT_TOOL_CHOICE_REQUIRED;
 
     data.prompt = apply(tmpl, params);
     data.format = COMMON_CHAT_FORMAT_KIMI_K2;
+
+    
+    if (has_tools && has_schema) {
+        throw std::runtime_error("Kimi K2: cannot combine \"tools\" with \"json_schema\"/response_format; remove tools or remove response_format");
+    }
+    
+    if (!has_tools && has_schema) {
+        if (!params.grammar.empty()) {
+            throw std::runtime_error("Either \"json_schema\" or \"grammar\" can be specified, but not both");
+        }
+        // Mirror the generic "content-only" schema enforcement behavior
+        data.grammar = json_schema_to_grammar(params.json_schema);
+    } else {
+        data.grammar = params.grammar;
+    }
 
     data.preserved_tokens = {
         "<think>",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,7 @@ llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)
 llama_build_and_test(test-chat-template.cpp)
 llama_build_and_test(test-jinja.cpp)
 llama_test(test-jinja NAME test-jinja-py ARGS -py LABEL python)
+llama_build_and_test(test-kimi-response-format.cpp)
 llama_build_and_test(test-json-partial.cpp)
 llama_build_and_test(test-log.cpp)
 llama_build_and_test(

--- a/tests/test-kimi-response-format.cpp
+++ b/tests/test-kimi-response-format.cpp
@@ -1,0 +1,121 @@
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "chat.h"
+
+// Regression test:
+// - llama-server /chat/completions parses `response_format` into a JSON schema and passes it into
+//   common_chat_templates_apply() as inputs.json_schema.
+// - For templates detected as "Kimi K2", llama.cpp selected a Kimi-specific handler that did not
+//   apply json_schema-to-grammar conversion, so schema enforcement was silently dropped.
+//
+// This test asserts that for the Kimi K2 chat template, providing a json_schema results in a
+// non-empty grammar being returned by common_chat_templates_apply() (hard enforcement expected).
+
+static const char * KIMI_K2_TEMPLATE = R"JINJA({%- if tools -%}
+  <|im_system|>tool_declare<|im_middle|>
+  # Tools
+  {{ tools | tojson }}<|im_end|>
+{%- endif -%}
+{%- for message in messages -%}
+  {%- if loop.first and messages[0]['role'] != 'system' -%}
+    <|im_system|>system<|im_middle|>You are Kimi, an AI assistant created by Moonshot AI.<|im_end|>
+  {%- endif -%}
+
+  {%- set role_name =  message.get('name') or  message['role'] -%}
+  {%- if message['role'] == 'user' -%}
+    <|im_user|>{{role_name}}<|im_middle|>
+  {%- elif message['role'] == 'assistant' -%}
+    <|im_assistant|>{{role_name}}<|im_middle|>
+  {%- else -%}
+    <|im_system|>{{role_name}}<|im_middle|>
+  {% endif %}
+
+  {%- if message['role'] == 'assistant' and message.get('tool_calls') -%}
+    {%- if message['content'] -%}{{ message['content'] }}{%- endif -%}
+    <|tool_calls_section_begin|>
+    {%- for tool_call in message['tool_calls'] -%}
+      {%- set formatted_id = tool_call['id'] -%}
+      <|tool_call_begin|>{{ formatted_id }}<|tool_call_argument_begin|>{% if tool_call['function']['arguments'] is string %}{{ tool_call['function']['arguments'] }}{% else %}{{ tool_call['function']['arguments'] | tojson }}{% endif %}<|tool_call_end|>
+    {%- endfor -%}
+    <|tool_calls_section_end|>
+  {%- elif message['role'] == 'tool' -%}
+    ## Return of {{ message.tool_call_id }}
+    {{ message['content'] }}
+  {%- elif message['content'] is string -%}
+    {{ message['content'] }}
+  {%- elif message['content'] is not none -%}
+    {% for content in message['content'] -%}
+      {% if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
+        <|media_start|>image<|media_content|><|media_pad|><|media_end|>
+      {% else -%}
+        {{ content['text'] }}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+  <|im_end|>
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  <|im_assistant|>assistant<|im_middle|>
+{%- endif -%})JINJA";
+
+int main() {
+    auto tmpls = common_chat_templates_init(/* model= */ nullptr, KIMI_K2_TEMPLATE);
+
+    common_chat_templates_inputs inputs;
+    inputs.use_jinja = true;
+    inputs.add_generation_prompt = true;
+
+    // No tools
+    inputs.tools = {};
+    inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_NONE;
+
+    inputs.json_schema = R"JSON({
+      "type": "object",
+      "properties": { "ok": { "type": "boolean" } },
+      "required": ["ok"],
+      "additionalProperties": false
+    })JSON";
+
+    inputs.messages = {
+        common_chat_msg{"system", "Return ONLY JSON with key ok.", {}, {}, "", "", ""},
+        common_chat_msg{"user", "ok", {}, {}, "", "", ""},
+    };
+
+    const auto out = common_chat_templates_apply(tmpls.get(), inputs);
+    
+    // Confirm the Kimi K2 handler was actually selected (not a generic fallback).
+    assert(out.format == COMMON_CHAT_FORMAT_KIMI_K2);
+    assert(!out.grammar.empty());
+
+    // tools + json_schema is explicitly unsupported for Kimi K2 (ambiguous composition).
+    // Ensure we fail loudly rather than silently dropping schema enforcement.
+    inputs.tools = {
+        common_chat_tool{
+            /* .name = */ "noop",
+            /* .description = */ "No-op tool",
+            /* .parameters = */ R"JSON({
+              "type": "object",
+              "properties": { "x": { "type": "string" } },
+              "required": ["x"],
+              "additionalProperties": false
+            })JSON",
+        },
+    };
+    inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
+
+    bool threw = false;
+    try {
+        (void) common_chat_templates_apply(tmpls.get(), inputs);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    // Avoid relying on assert() in Release builds (may be compiled out).
+    if (!threw) {
+        return 2;
+    }
+    return 0;
+}
+


### PR DESCRIPTION
This PR aims to fix an issue I encountered using response_format with Kimi K2 Instruct 0905.
Using the /v1/chat/completions endpoint in llama-server I noticed that I was receiving responses which were not adhereing to the submitted json_schema.

Simplest reproduction:

1. Build llama.cpp without this PR's changes
2. Download a version of https://huggingface.co/unsloth/Kimi-K2-Instruct-0905
3. Start llama-server. Do not manually specify a chat template file.

```sh
  ./build/bin/llama-server \
    --host 127.0.0.1 --port 5840 \
    --model /path/to/Kimi-K2-Instruct-0905-...-00001-of-00013.gguf \
    --ctx-size 8192 \
    --n-gpu-layers 0
```

4. Send a request that contains a json_schema as part of response_format

```
curl -sS http://127.0.0.1:5840/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d ' {
      "model": "any",
      "temperature": 0.1,
      "max_tokens": 64,
      "response_format": {
        "type": "json_schema",
        "json_schema": {
          "schema": {
            "type": "object",
            "properties": {"ok": {"type": "boolean"}},
            "required": ["ok"],
            "additionalProperties": false
          }
        }
      },
      "messages": [
        {"role": "system", "content": "Return the JSON wrapped in a ```json code fence```."},
        {"role": "user", "content": "Return ok=true as a JSON struct."}
      ]
    } '
```

You are likely to receive a response like the following, _backticks and json declaration included_:

````
  ```json
      {"ok": true}
  ```
````

This should not be possible if grammar is being created and enforced.

The issue is that for chat completions, when the Kimi format is detected it routes to the kimi based handler (common_chat_params_init_kimi_k2). This handler did not follow the same behavior as the generic handler which would generate a grammar for a schema in response_format, it only handled tool grammars. 

This revealed a second issue with the Kimi flags which included open bracket in tool separator and closing bracket in tool end. Due to those characters being in template tag definitions, the trim_suffix call was removing the ending bracket and producing invalid JSON strings, e.g. `{"ok": true`. I have modified the trim_suffix approach, but it is ugly and I'm hoping someone with better intuition will have a better solution. I see there is an Autoparser PR (#18675) but I have tested it and it does not resolve the original issue.

AI was used in the following ways for this PR:
- Locating and describing the source of the issue, after some iterative debugging sessions
- Suggesting possible fixes, namely included the grammar creation in the kimi specific path and following that how I might check for which characters to trim.
- I did have it create the boilerplate for the regression test, but all it's really doing is determining that the custom kimi path was selected and that a grammar was created

As requested, I ran the whole test suite which passed. Perplexity obviously not affected.