### PR TITLE
Try fixing non-ASCII parameters in llama-cli on Windows

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <io.h>
+#include <shellapi.h>
 #else
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -58,6 +59,39 @@
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
+#ifdef _WIN32
+void common_init_args(int & argc, char ** & argv) {
+    int wargc;
+    static std::vector<char*> argv_utf8;
+    static std::vector<std::string> args_utf8;
+    LPWSTR * wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (!wargv) return;
+
+    args_utf8.resize(wargc);
+    argv_utf8.resize(wargc + 1);
+
+    for (int i = 0; i < wargc; ++i) {
+        int size = WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, NULL, 0, NULL, NULL);
+        if (size > 0) {
+            args_utf8[i].resize(size);
+            WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, &args_utf8[i][0], size, NULL, NULL);
+            args_utf8[i].resize(size - 1);
+            argv_utf8[i] = &args_utf8[i][0];
+        }
+    }
+    argv_utf8[wargc] = nullptr;
+
+    argc = wargc;
+    argv = argv_utf8.data();
+
+    LocalFree(wargv);
+}
+#else
+void common_init_args(int &, char ** &) {
+    // no-op on non-Windows
+}
 #endif
 
 common_time_meas::common_time_meas(int64_t & t_acc, bool disable) : t_start_us(disable ? -1 : ggml_time_us()), t_acc(t_acc) {}

--- a/common/common.h
+++ b/common/common.h
@@ -582,6 +582,8 @@ struct common_params {
 // initializes the logging system and prints info about the build
 void common_init();
 
+void common_init_args(int & argc, char **& argv);
+
 std::string common_params_get_system_info(const common_params & params);
 
 bool parse_cpu_range(const std::string & range, bool(&boolmask)[GGML_MAX_N_THREADS]);

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -159,6 +159,8 @@ struct cli_context {
 };
 
 int main(int argc, char ** argv) {
+    common_init_args(argc, argv);
+
     common_params params;
 
     params.verbosity = LOG_LEVEL_ERROR; // by default, less verbose logs


### PR DESCRIPTION
I have encountered an issue similar to https://github.com/ggml-org/llama.cpp/issues/18571 where the input parameters containing non-ascii characters appear as `?`:

This seems to solve that for me and seems to be a small change.
Please let me know if it makes sense to merge something like that, and if so, what is the process of properly submitting this as a PR?

Thanks.


Here is the log without the change:
```
gguf_init_from_file: failed to open GGUF file 'C:\Users\llama.cpp\??????\TinyStories-656K-Q4_K_M.gguf'
mllama_model_load: error loading model: llama_model_loader: failed to load model from C:\Users\llama.cpp\?
?????\TinyStories-656K-Q4_K_M.gguf
mllama_model_load_from_file_impl: failed to load model
common_init_from_params: failed to load model 'C:\Users\llama.cpp\??????\TinyStories-656K-Q4_K_M.gguf'
srv load_model: failed to load model, 'C:\Users\llama.cpp\??????\TinyStories-656K-Q4_K_M.gguf'
Loading model...
Failed to load the model
```

After:
```
srv    load_model: loading model 'C:\Users\forsh\work\llama.cpp\漢語汉语�\TinyStories-656K-Q4_K_M.gguf'
```