### PR TITLE
mtmd : fix ASR for LFM2.5-Audio-1.5B

### DIFF
--- a/tools/mtmd/models/conformer.cpp
+++ b/tools/mtmd/models/conformer.cpp
@@ -12,7 +12,6 @@ ggml_cgraph * clip_graph_conformer::build() {
     ggml_build_forward_expand(gf, pos_emb);
 
     ggml_tensor * inp = build_inp_raw(1);
-    cb(inp, "input", -1);
 
     auto * cur = ggml_cont(ctx0, ggml_transpose(ctx0, inp));
 


### PR DESCRIPTION
The callback was renaming the input tensor and leading to error
```
/data/git/llama.cpp/tools/mtmd/clip.cpp:3358: Failed to get tensor inp_raw
```

The first commit causing the issue is https://github.com/ggml-org/llama.cpp/pull/17914.