### PR TITLE
Metal : Supplement floor operator

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -192,6 +192,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_unary(ggml_metal
                 case GGML_UNARY_OP_GELU_ERF:    op_str = "gelu_erf";    break;
                 case GGML_UNARY_OP_GELU_QUICK:  op_str = "gelu_quick";  break;
                 case GGML_UNARY_OP_SILU:        op_str = "silu";        break;
+                case GGML_UNARY_OP_FLOOR:       op_str = "floor";       break;
                 case GGML_UNARY_OP_ELU:         op_str = "elu";         break;
                 case GGML_UNARY_OP_NEG:         op_str = "neg";         break;
                 case GGML_UNARY_OP_ABS:         op_str = "abs";         break;

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1,5 +1,5 @@
 #import "ggml-metal-device.h"
-#include "ggml.h"
+
 
 #import "ggml-impl.h"
 

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1,4 +1,5 @@
 #import "ggml-metal-device.h"
+#include "ggml.h"
 
 #import "ggml-impl.h"
 
@@ -964,6 +965,8 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                 case GGML_UNARY_OP_SOFTPLUS:
                 case GGML_UNARY_OP_EXPM1:
                     return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
+                case GGML_UNARY_OP_FLOOR:
+                    return ggml_is_contiguous(op->src[0]) && (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16);
                 default:
                     return false;
             }

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1,6 +1,5 @@
 #import "ggml-metal-device.h"
 
-
 #import "ggml-impl.h"
 
 #include <Foundation/Foundation.h>

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1420,6 +1420,38 @@ kernel void kernel_silu_f32_4(
     dst[tpig] = x / (1.0f + exp(-x));
 }
 
+kernel void kernel_floor_f32(
+        device const float * src0,
+        device       float * dst,
+        uint tpig[[thread_position_in_grid]]){
+    device const float & x = src0[tpig];
+    dst[tpig] = floor(x);
+}
+
+kernel void kernel_floor_f16(
+        device const half * src0,
+        device       half * dst,
+        uint tpig[[thread_position_in_grid]]){
+    device const half & x = src0[tpig];
+    dst[tpig] = floor(x);
+}
+
+kernel void kernel_floor_f16_4(
+        device const half4 * src0,
+        device       half4 * dst,
+        uint tpig[[thread_position_in_grid]]){
+    device const half4 & x = src0[tpig];
+    dst[tpig] = floor(x);
+}
+
+kernel void kernel_floor_f32_4(
+        device const float4 * src0,
+        device       float4 * dst,
+        uint tpig[[thread_position_in_grid]]){
+    device const float4 & x = src0[tpig];
+    dst[tpig] = floor(x); 
+}
+
 kernel void kernel_elu_f32(
         device const float * src0,
         device       float * dst,


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

I noticed that ggml currently does not support the floor operation on Metal. As my first contribution, this PR implements Metal support for floor, currently limited to contiguous f16 and f32 tensors.
```
  Backend 1/3: Metal
  Device description: Apple M4 Pro
  Device memory: 36864 MB (36863 MB free)

  FLOOR(type=f16,ne_a=[128,2,2,2],v=0): SUPPORTED
  FLOOR(type=f16,ne_a=[5,7,11,13],v=0): SUPPORTED
  FLOOR(type=f16,ne_a=[128,2,2,2],v=1): NOT SUPPORTED
  FLOOR(type=f16,ne_a=[5,7,11,13],v=1): NOT SUPPORTED
  FLOOR(type=f32,ne_a=[128,2,2,2],v=0): SUPPORTED
  FLOOR(type=f32,ne_a=[5,7,11,13],v=0): SUPPORTED
  FLOOR(type=f32,ne_a=[128,2,2,2],v=1): NOT SUPPORTED
  FLOOR(type=f32,ne_a=[5,7,11,13],v=1): NOT SUPPORTED
  FLOOR(type=f16,ne=[10,2,2,2]): SUPPORTED
  FLOOR(type=f16,ne=[7,1,5,3]): SUPPORTED
  FLOOR(type=f16,ne=[1024,1024,1,1]): SUPPORTED
  FLOOR(type=f32,ne=[10,2,2,2]): SUPPORTED
  FLOOR(type=f32,ne=[7,1,5,3]): SUPPORTED
  FLOOR(type=f32,ne=[1024,1024,1,1]): SUPPORTED
  Backend Metal: OK
```
and 
```
Backend 1/3: Metal
  Device description: Apple M4 Pro
  Device memory: 36864 MB (36863 MB free)

ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_floor_f16_4', name = 'kernel_floor_f16_4'
ggml_metal_library_compile_pipeline: loaded kernel_floor_f16_4                            0x10551ccd0 | th_max = 1024 | th_width =   32
  FLOOR(type=f16,ne_a=[128,2,2,2],v=0): OK
ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_floor_f16', name = 'kernel_floor_f16'
ggml_metal_library_compile_pipeline: loaded kernel_floor_f16                              0x105518620 | th_max = 1024 | th_width =   32
  FLOOR(type=f16,ne_a=[5,7,11,13],v=0): OK
  FLOOR(type=f16,ne_a=[128,2,2,2],v=1): not supported [Metal] 
  FLOOR(type=f16,ne_a=[5,7,11,13],v=1): not supported [Metal] 
ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_floor_f32_4', name = 'kernel_floor_f32_4'
ggml_metal_library_compile_pipeline: loaded kernel_floor_f32_4                            0x1056060c0 | th_max = 1024 | th_width =   32
  FLOOR(type=f32,ne_a=[128,2,2,2],v=0): OK
ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_floor_f32', name = 'kernel_floor_f32'
ggml_metal_library_compile_pipeline: loaded kernel_floor_f32                              0x1411265d0 | th_max = 1024 | th_width =   32
  FLOOR(type=f32,ne_a=[5,7,11,13],v=0): OK
  FLOOR(type=f32,ne_a=[128,2,2,2],v=1): not supported [Metal] 
  FLOOR(type=f32,ne_a=[5,7,11,13],v=1): not supported [Metal] 
  FLOOR(type=f16,ne=[10,2,2,2]): OK
  FLOOR(type=f16,ne=[7,1,5,3]): OK
  FLOOR(type=f16,ne=[1024,1024,1,1]): OK
  FLOOR(type=f32,ne=[10,2,2,2]): OK
  FLOOR(type=f32,ne=[7,1,5,3]): OK
  FLOOR(type=f32,ne=[1024,1024,1,1]): OK
  10/10 tests passed
  Backend Metal: OK
```
ref:#14909