### PR TITLE
jinja: correct member access rule

### DIFF
--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -56,6 +56,7 @@ struct context {
     // src is optional, used for error reporting
     context(std::string src = "") : src(std::make_shared<std::string>(std::move(src))) {
         env = mk_val<value_object>();
+        env->has_builtins = false; // context object has no builtins
         env->insert("true",  mk_val<value_bool>(true));
         env->insert("True",  mk_val<value_bool>(true));
         env->insert("false", mk_val<value_bool>(false));
@@ -265,7 +266,7 @@ struct comment_statement : public statement {
 struct member_expression : public expression {
     statement_ptr object;
     statement_ptr property;
-    bool computed;
+    bool computed; // true if obj[expr] and false if obj.prop
 
     member_expression(statement_ptr && object, statement_ptr && property, bool computed)
         : object(std::move(object)), property(std::move(property)), computed(computed) {

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -888,6 +888,11 @@ const func_builtins & value_array_t::get_builtins() const {
 
 
 const func_builtins & value_object_t::get_builtins() const {
+    if (!has_builtins) {
+        static const func_builtins no_builtins = {};
+        return no_builtins;
+    }
+
     static const func_builtins builtins = {
         // {"default", default_value}, // cause issue with gpt-oss
         {"get", [](const func_args & args) -> value {

--- a/common/jinja/value.h
+++ b/common/jinja/value.h
@@ -286,6 +286,7 @@ using value_array = std::shared_ptr<value_array_t>;
 
 
 struct value_object_t : public value_t {
+    bool has_builtins = true; // context and loop objects do not have builtins
     value_object_t() = default;
     value_object_t(value & v) {
         val_obj = v->val_obj;

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -1063,6 +1063,18 @@ static void test_object_methods(testing & t) {
         {{"obj", {{"items", json::array({1, 2, 3})}}}},
         "{\"items\": [1, 2, 3]}"
     );
+
+    test_template(t, "object attribute and key access",
+        "{{ obj.keys()|join(',') }} vs {{ obj['keys'] }} vs {{ obj.test }}",
+        {{"obj", {{"keys", "value"}, {"test", "attr_value"}}}},
+        "keys,test vs value vs attr_value"
+    );
+
+    test_template(t, "env should not have object methods",
+        "{{ keys is undefined }} {{ obj.keys is defined }}",
+        {{"obj", {{"a", "b"}}}},
+        "True True"
+    );
 }
 
 static void test_template(testing & t, const std::string & name, const std::string & tmpl, const json & vars, const std::string & expect) {


### PR DESCRIPTION
Bug spotted by @pwilkin 

If object contains a key that shadow the builtin function name, then depending on syntax:
- `obj.member` --> the builtin takes precedence over the defined value 
- `obj["member"]` --> the defined value takes precedence over the builtin

Example:

```
{{ obj.keys()|join(',') }} vs {{ obj['keys'] }} vs {{ obj.test }}
```

With input:

```json
{
  "obj": {
    "keys": "value",
    "test": "attr_value"
  }
}
```

Results in:

```
keys,test vs value vs attr_value
```