### PR TITLE
introduce legacy-torch flag for backward compatibility on older Intel…

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -13232,17 +13232,18 @@ class LazyTorchTensor(gguf.LazyBase):
     }
 
     # only used when byteswapping data. Only correct size is needed
+    # TODO: uncomment uint64, uint32, and uint16, ref: https://github.com/pytorch/pytorch/issues/58734
     _dtype_byteswap_map: dict[torch.dtype, type] = {
         torch.float64: np.float64,
         torch.float32: np.float32,
         torch.bfloat16: np.float16,
         torch.float16: np.float16,
         torch.int64: np.int64,
-        torch.uint64: np.uint64,
+        # torch.uint64: np.uint64,
         torch.int32: np.int32,
-        torch.uint32: np.uint32,
+        # torch.uint32: np.uint32,
         torch.int16: np.int16,
-        torch.uint16: np.uint16,
+        # torch.uint16: np.uint16,
         torch.int8: np.int8,
         torch.uint8: np.uint8,
         torch.bool: np.uint8,


### PR DESCRIPTION
## Intel-based Macs cannot upgrade PyTorch beyond version 2.2.2

Users with older Intel-based Macs cannot upgrade PyTorch beyond version 2.2.2, as Apple dropped support for these machines in newer macOS versions. The latest convert_hf_to_gguf.py fails on these systems with:

  AttributeError: module 'torch' has no attribute 'uint64'

  This occurs because torch.uint64, torch.uint32, and torch.uint16 were introduced in PyTorch 2.3.

As I love my 2013 Mac Pro I try to keep it useful as long as possible. I can fall back to the older types.
There are so many ways to do this but wanted to make it completely user driven with a '-legacy-torch' flag . I wanted to avoid any automatic fallback - user should know what they do and this is a "last resort" on older machines.

## Usage
`python3 convert_hf_to_gguf.py --legacy-torch /path/to/model --outfile output.gguf --outtype f16`
  
Other option would be maintaining a separate convert_hf_to_gguf_bw_comp script but I do not like that.
Please suggest if you have better suggestion to solve this. 
