### PR TITLE
convert : use n_groups instead of hardcoded values in reshape

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -9183,8 +9183,7 @@ class NemotronHModel(GraniteHybridModel):
                 return [(mapped_name, reshaped_data)]
 
             if name.endswith("mixer.norm.weight"):
-                n_groups = self.hparams["n_groups"]
-                reshaped_data = data_torch.reshape(n_groups, -1)
+                reshaped_data = data_torch.reshape(self.n_group, -1)
                 mapped_name = self.map_tensor_name(name)
                 return [(mapped_name, reshaped_data)]
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -9183,7 +9183,8 @@ class NemotronHModel(GraniteHybridModel):
                 return [(mapped_name, reshaped_data)]
 
             if name.endswith("mixer.norm.weight"):
-                reshaped_data = data_torch.reshape(8, 512)
+                n_groups = self.hparams["n_groups"]
+                reshaped_data = data_torch.reshape(n_groups, -1)
                 mapped_name = self.map_tensor_name(name)
                 return [(mapped_name, reshaped_data)]
 


### PR DESCRIPTION
This commit modifies the conversion script for NemotronHModel to use the `n_groups` hyperparameter, and allow Python to calculate the the last dimension, using -1, when reshaping the `mixer.norm.weight` tensor.
