### PR TITLE
Support TranslateGemma text+image translation in llama-server (lang codes + image url)

### DIFF
--- a/common/chat.h
+++ b/common/chat.h
@@ -25,9 +25,18 @@ struct common_chat_tool_call {
 struct common_chat_msg_content_part {
     std::string type;
     std::string text;
+    std::string source_lang_code;
+    std::string target_lang_code;
+    bool has_source_lang_code = false;
+    bool has_target_lang_code = false;
 
     bool operator==(const common_chat_msg_content_part & other) const {
-        return type == other.type && text == other.text;
+        return type == other.type
+            && text == other.text
+            && source_lang_code == other.source_lang_code
+            && target_lang_code == other.target_lang_code
+            && has_source_lang_code == other.has_source_lang_code
+            && has_target_lang_code == other.has_target_lang_code;
     }
 };
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -922,6 +922,18 @@ json oaicompat_chat_params_parse(
                 p["text"] = mtmd_default_marker();
                 p.erase("image_url");
 
+            } else if (type == "image") {
+                if (!opt.allow_image) {
+                    throw std::runtime_error("image input is not supported - hint: if this is unexpected, you may need to provide the mmproj");
+                }
+
+                handle_media(out_files, p, opt.media_path);
+
+                // replace this chunk with a marker
+                p["type"] = "text";
+                p["text"] = mtmd_default_marker();
+                p.erase("url");
+
             } else if (type == "input_audio") {
                 if (!opt.allow_audio) {
                     throw std::runtime_error("audio input is not supported - hint: if this is unexpected, you may need to provide the mmproj");


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

## Goal/Motivation
Support TranslateGemma text and image translation in llama-server, and allow request-level default language codes and message-level language codes to coexist, overcoming the previous limitation where only template default values could be used.

## Candidate Approaches:

### Approach 1 
Pass `source_lang_code`/`target_lang_code` only via `chat_template_kwargs` as global defaults. This approach does not modify the `common_chat_msg_content_part` struct in `common/chat.h`. However, it causes language code fields written by downstream developers/users in the official Google/TranslateGemma recommended request body to be ignored, leaving only the defaults. Below is an example request/response using only `chat_template_kwargs`:

**Request Body**
```json
{
  "model": "translategemma-4b-it",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "欢迎，翻译Gemma模型。"
        }
      ]
    }
  ],
  "chat_template_kwargs": {
    "source_lang_code": "zh",
    "target_lang_code": "en"
  },
  "temperature": 0,
  "max_tokens": 1024
}
```
**Response Body**
```json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Welcome! I am Gemma, a translation model."
      }
    }
  ],
  "created": 1768903118,
  "model": "translategemma-4b-it.Q8_0.gguf",
  "system_fingerprint": "b7763-addc3aac5",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 11,
    "prompt_tokens": 82,
    "total_tokens": 93
  },
  "id": "chatcmpl-C3AkwTeEEC3dyioOrNvP3DD47kT1M0kE",
  "timings": {
    "cache_n": 0,
    "prompt_n": 82,
    "prompt_ms": 1354.697,
    "prompt_per_token_ms": 16.520695121951217,
    "prompt_per_second": 60.53014068828676,
    "predicted_n": 11,
    "predicted_ms": 1775.798,
    "predicted_per_token_ms": 161.4361818181818,
    "predicted_per_second": 6.194398236736387
  }
}
```

### Approach 2

Extend the message structure to preserve `messages[0].content[0].source_lang_code`/`target_lang_code`. This approach ensures that the language code fields written by downstream developers/users in the official Google/TranslateGemma recommended request body are not ignored. Below is an example request/response compatible with the official message format:

**Request Body**
```json
{
  "model": "translategemma-4b-it",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "source_lang_code": "en",
          "target_lang_code": "zh",
          "text": "welcome, translategemma model."
        }
      ]
    }
  ],
  "temperature": 0,
  "max_tokens": 1024
}
```
**Response Body**
```json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "欢迎，翻译Gemma模型。"
      }
    }
  ],
  "created": 1768905402,
  "model": "translategemma-4b-it.Q8_0.gguf",
  "system_fingerprint": "b7764-4dd087a5f",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 8,
    "prompt_tokens": 82,
    "total_tokens": 90
  },
  "id": "chatcmpl-b0wPKXp6EROLUvHU8mkWZcYw9ntT7Hxd",
  "timings": {
    "cache_n": 0,
    "prompt_n": 82,
    "prompt_ms": 1314.545,
    "prompt_per_token_ms": 16.031036585365854,
    "prompt_per_second": 62.37899805636171,
    "predicted_n": 8,
    "predicted_ms": 1244.181,
    "predicted_per_token_ms": 155.522625,
    "predicted_per_second": 6.429932622343533
  }
}
```

## Choice and Rationale
The current change adopts a combined approach of “extend the message structure + preserve `chat_template_kwargs` defaults,” for the following reasons:
- **Compatible with the official request format:** The official format places language codes on the content part (`message[0].content[0].source_lang_code/target_lang_code`). Without extending the structure, these fields are ignored during parsing and only the default language codes can be used.
- **Avoid losing fields during template concatenation:** When the template does not require typed content (i.e., `requires_typed_content` is `false`), `common_chat_msgs_to_json_oaicompat` concatenates `content_parts` into plain text. Only when language codes are explicitly marked in the part will typed content be preserved, ensuring the fields enter template rendering.
- **Keep a simple calling path:** You can still set default language codes only via `chat_template_kwargs`, as the simplest request body and a backward-compatible path.

## Main Changes
- `chat.h` extends `common_chat_msg_content_part` to store language codes and marker flags.
- `chat.cpp` reads/writes language codes in OAI parsing/serialization and avoids losing them during concatenation (without this change, `messages[0].content[0].source_lang_code/target_lang_code` would be ignored at parse time and fall back to the default language codes). Meanwhile, `common_chat_params_init_translategemma` supports reading default language codes from `chat_template_kwargs` and, when content is an image marker, constructs the `image` structure required by TranslateGemma.
- `server-common.cpp` adds a parsing branch for `/v1/chat/completions` to handle `content[0].type = "image"` (the `url` field) as a compatibility extension for `image_url`, and uniformly converts it to an MTMD marker.

## Compatibility/Behavior

**Command used for debugging:**
```bash
llama-server -m "E:/data/llama.cpp-data/gguf-models/translategemma-4b-it.Q8_0.gguf" -mm "E:/data/llama.cpp-data/gguf-models/translategemma-4b-it.mmproj-Q8_0.gguf" -ngl 99 --jinja --media-path "E:/data/llama.cpp-data/translategemma-data" -c 2048
```

Images take effect only when mmproj is enabled and `allow_image` is true; otherwise the same error is returned consistently. Text-only models and non-multimodal requests are unaffected. Language code precedence is: “message-level fields > `chat_template_kwargs` defaults > built-in fallback.”