### PR TITLE
ggml-zdnn: Mark zDNN buffers as non-host

### DIFF
--- a/ggml/src/ggml-zdnn/ggml-zdnn.cpp
+++ b/ggml/src/ggml-zdnn/ggml-zdnn.cpp
@@ -368,7 +368,8 @@ static size_t ggml_backend_zdnn_buffer_type_get_alignment(ggml_backend_buffer_ty
 }
 
 static bool ggml_backend_zdnn_buffer_type_is_host(ggml_backend_buffer_type_t buft) {
-    return true;
+    /* while it resides in host memory, additional transformation is needed */
+    return false;
 
     GGML_UNUSED(buft);
 }


### PR DESCRIPTION
While buffers reside in host memory,
additional transformation is needed to use buffers with zDNN.

This transformation was missing when using direct io.
Marking buffers as non-host forces use of ggml_backend_tensor_set function,
which in turn properly initializes and transforms buffers.

Fixes #18848
