### PR TITLE
opencl: enable the general fp mm for non-cont input and as a fallback for specialized kqv kernel for adreno

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -8066,25 +8066,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
     if (src1t == GGML_TYPE_F32 &&
         ne00 % 16 == 0 &&
         ne11 > 1) {
-        cl_mem mem_src0 = extra0->data_device;
-        cl_mem mem_src1 = extra1->data_device;
-
-        if (!ggml_is_contiguous(src0)) {
-            backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
-            ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
-                nb00, nb01, nb02, nb03);
-            mem_src0 = backend_ctx->prealloc_src0.buffer;
-            offset0 = 0;
-        }
-
-        if (!ggml_is_contiguous(src1)) {
-            backend_ctx->prealloc_src1.allocate(backend_ctx->context, ggml_nbytes(src1));
-            ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
-                    nb10, nb11, nb12, nb13);
-            mem_src1 = backend_ctx->prealloc_src1.buffer;
-            offset1 = 0;
-        }
-
         switch(src0t) {
             case GGML_TYPE_F32: {
                 kernel = backend_ctx->kernel_mul_mm_f32_f32_l4_lm;
@@ -8093,6 +8074,25 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 int batch_stride_a = ne00*ne01;
                 int batch_stride_b = ne10*ne11;
                 int batch_stride_d = ne0*ne1;
+
+                cl_mem mem_src0 = extra0->data_device;
+                cl_mem mem_src1 = extra1->data_device;
+
+                if (!ggml_is_contiguous(src0)) {
+                    backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
+                    ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
+                        nb00, nb01, nb02, nb03);
+                    mem_src0 = backend_ctx->prealloc_src0.buffer;
+                    offset0 = 0;
+                }
+
+                if (!ggml_is_contiguous(src1)) {
+                    backend_ctx->prealloc_src1.allocate(backend_ctx->context, ggml_nbytes(src1));
+                    ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
+                            nb10, nb11, nb12, nb13);
+                    mem_src1 = backend_ctx->prealloc_src1.buffer;
+                    offset1 = 0;
+                }
 
                 CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &mem_src0));
                 CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
@@ -8129,6 +8129,25 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 int batch_stride_b = ne10*ne11;
                 int batch_stride_d = ne0*ne1;
 
+                cl_mem mem_src0 = extra0->data_device;
+                cl_mem mem_src1 = extra1->data_device;
+
+                if (!ggml_is_contiguous(src0)) {
+                    backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
+                    ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
+                        nb00, nb01, nb02, nb03);
+                    mem_src0 = backend_ctx->prealloc_src0.buffer;
+                    offset0 = 0;
+                }
+
+                if (!ggml_is_contiguous(src1)) {
+                    backend_ctx->prealloc_src1.allocate(backend_ctx->context, ggml_nbytes(src1));
+                    ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
+                            nb10, nb11, nb12, nb13);
+                    mem_src1 = backend_ctx->prealloc_src1.buffer;
+                    offset1 = 0;
+                }
+
                 CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &mem_src0));
                 CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
                 CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &mem_src1));
@@ -8160,6 +8179,10 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 if (ne11 < 32) {
                     break;
                 }
+                if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
+                    break;
+                }
+
                 kernel = backend_ctx->kernel_mul_mm_q8_0_f32_l4_lm;
                 nth0 = 128; // calculated as (BM*BN)/(TM*TN)
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7713,20 +7713,20 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
     const int  ne02 = src0 ? src0->ne[2] : 0;
     const int  ne03 = src0 ? src0->ne[3] : 0;
 
-    cl_ulong nb00 = src0 ? src0->nb[0] : 0;
-    cl_ulong nb01 = src0 ? src0->nb[1] : 0;
-    cl_ulong nb02 = src0 ? src0->nb[2] : 0;
-    cl_ulong nb03 = src0 ? src0->nb[3] : 0;
+    const cl_ulong nb00 = src0 ? src0->nb[0] : 0;
+    const cl_ulong nb01 = src0 ? src0->nb[1] : 0;
+    const cl_ulong nb02 = src0 ? src0->nb[2] : 0;
+    const cl_ulong nb03 = src0 ? src0->nb[3] : 0;
 
     const int  ne10 = src1 ? src1->ne[0] : 0;
     const int  ne11 = src1 ? src1->ne[1] : 0;
     const int  ne12 = src1 ? src1->ne[2] : 0;
     const int  ne13 = src1 ? src1->ne[3] : 0;
 
-    cl_ulong nb10 = src1 ? src1->nb[0] : 0;
-    cl_ulong nb11 = src1 ? src1->nb[1] : 0;
-    cl_ulong nb12 = src1 ? src1->nb[2] : 0;
-    cl_ulong nb13 = src1 ? src1->nb[3] : 0;
+    const cl_ulong nb10 = src1 ? src1->nb[0] : 0;
+    const cl_ulong nb11 = src1 ? src1->nb[1] : 0;
+    const cl_ulong nb12 = src1 ? src1->nb[2] : 0;
+    const cl_ulong nb13 = src1 ? src1->nb[3] : 0;
 
     const int  ne0 = dst ? dst->ne[0] : 0;
     const int  ne1 = dst ? dst->ne[1] : 0;
@@ -8086,10 +8086,20 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 cl_mem mem_src0 = extra0->data_device;
                 cl_mem mem_src1 = extra1->data_device;
 
+                cl_ulong nb00_cont;
+                cl_ulong nb01_cont;
+                cl_ulong nb02_cont;
+                cl_ulong nb03_cont;
+
+                cl_ulong nb10_cont;
+                cl_ulong nb11_cont;
+                cl_ulong nb12_cont;
+                cl_ulong nb13_cont;
+
                 if (!ggml_is_contiguous(src0)) {
                     backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
                     ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
-                        nb00, nb01, nb02, nb03);
+                        nb00_cont, nb01_cont, nb02_cont, nb03_cont);
                     mem_src0 = backend_ctx->prealloc_src0.buffer;
                     offset0 = 0;
                 }
@@ -8097,7 +8107,7 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 if (!ggml_is_contiguous(src1)) {
                     backend_ctx->prealloc_src1.allocate(backend_ctx->context, ggml_nbytes(src1));
                     ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
-                            nb10, nb11, nb12, nb13);
+                        nb10_cont, nb11_cont, nb12_cont, nb13_cont);
                     mem_src1 = backend_ctx->prealloc_src1.buffer;
                     offset1 = 0;
                 }
@@ -8140,10 +8150,20 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 cl_mem mem_src0 = extra0->data_device;
                 cl_mem mem_src1 = extra1->data_device;
 
+                cl_ulong nb00_cont;
+                cl_ulong nb01_cont;
+                cl_ulong nb02_cont;
+                cl_ulong nb03_cont;
+
+                cl_ulong nb10_cont;
+                cl_ulong nb11_cont;
+                cl_ulong nb12_cont;
+                cl_ulong nb13_cont;
+
                 if (!ggml_is_contiguous(src0)) {
                     backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
                     ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
-                        nb00, nb01, nb02, nb03);
+                        nb00_cont, nb01_cont, nb02_cont, nb03_cont);
                     mem_src0 = backend_ctx->prealloc_src0.buffer;
                     offset0 = 0;
                 }
@@ -8151,7 +8171,7 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 if (!ggml_is_contiguous(src1)) {
                     backend_ctx->prealloc_src1.allocate(backend_ctx->context, ggml_nbytes(src1));
                     ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
-                            nb10, nb11, nb12, nb13);
+                            nb10_cont, nb11_cont, nb12_cont, nb13_cont);
                     mem_src1 = backend_ctx->prealloc_src1.buffer;
                     offset1 = 0;
                 }

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -8086,22 +8086,25 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 cl_mem mem_src0 = extra0->data_device;
                 cl_mem mem_src1 = extra1->data_device;
 
-                cl_ulong nb00_cont;
-                cl_ulong nb01_cont;
-                cl_ulong nb02_cont;
-                cl_ulong nb03_cont;
+                cl_ulong nb00_cont = nb00;
+                cl_ulong nb01_cont = nb01;
+                cl_ulong nb02_cont = nb02;
+                cl_ulong nb03_cont = nb03;
 
-                cl_ulong nb10_cont;
-                cl_ulong nb11_cont;
-                cl_ulong nb12_cont;
-                cl_ulong nb13_cont;
+                cl_ulong nb10_cont = nb10;
+                cl_ulong nb11_cont = nb11;
+                cl_ulong nb12_cont = nb12;
+                cl_ulong nb13_cont = nb13;
+
+                cl_ulong offset0_cont = offset0;
+                cl_ulong offset1_cont = offset1;
 
                 if (!ggml_is_contiguous(src0)) {
                     backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
                     ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
                         nb00_cont, nb01_cont, nb02_cont, nb03_cont);
                     mem_src0 = backend_ctx->prealloc_src0.buffer;
-                    offset0 = 0;
+                    offset0_cont = 0;
                 }
 
                 if (!ggml_is_contiguous(src1)) {
@@ -8109,13 +8112,13 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                     ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
                         nb10_cont, nb11_cont, nb12_cont, nb13_cont);
                     mem_src1 = backend_ctx->prealloc_src1.buffer;
-                    offset1 = 0;
+                    offset1_cont = 0;
                 }
 
                 CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &mem_src0));
-                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0_cont));
                 CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &mem_src1));
-                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1_cont));
                 CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extrad->data_device));
                 CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offsetd));
                 CL_CHECK(clSetKernelArg(kernel,  6, sizeof(int),      &ne00));
@@ -8150,22 +8153,25 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 cl_mem mem_src0 = extra0->data_device;
                 cl_mem mem_src1 = extra1->data_device;
 
-                cl_ulong nb00_cont;
-                cl_ulong nb01_cont;
-                cl_ulong nb02_cont;
-                cl_ulong nb03_cont;
+                cl_ulong nb00_cont = nb00;
+                cl_ulong nb01_cont = nb01;
+                cl_ulong nb02_cont = nb02;
+                cl_ulong nb03_cont = nb03;
 
-                cl_ulong nb10_cont;
-                cl_ulong nb11_cont;
-                cl_ulong nb12_cont;
-                cl_ulong nb13_cont;
+                cl_ulong nb10_cont = nb10;
+                cl_ulong nb11_cont = nb11;
+                cl_ulong nb12_cont = nb12;
+                cl_ulong nb13_cont = nb13;
+
+                cl_ulong offset0_cont = offset0;
+                cl_ulong offset1_cont = offset1;
 
                 if (!ggml_is_contiguous(src0)) {
                     backend_ctx->prealloc_src0.allocate(backend_ctx->context, ggml_nbytes(src0));
                     ggml_cl_copy_to_contiguous(backend, src0, backend_ctx->prealloc_src0.buffer,
                         nb00_cont, nb01_cont, nb02_cont, nb03_cont);
                     mem_src0 = backend_ctx->prealloc_src0.buffer;
-                    offset0 = 0;
+                    offset0_cont = 0;
                 }
 
                 if (!ggml_is_contiguous(src1)) {
@@ -8173,13 +8179,13 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                     ggml_cl_copy_to_contiguous(backend, src1, backend_ctx->prealloc_src1.buffer,
                             nb10_cont, nb11_cont, nb12_cont, nb13_cont);
                     mem_src1 = backend_ctx->prealloc_src1.buffer;
-                    offset1 = 0;
+                    offset1_cont = 0;
                 }
 
                 CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &mem_src0));
-                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0_cont));
                 CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &mem_src1));
-                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_ulong), &offset1_cont));
                 CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extrad->data_device));
                 CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offsetd));
                 CL_CHECK(clSetKernelArg(kernel,  6, sizeof(int),      &ne00));


### PR DESCRIPTION
The specialized kqv kernel for Adreno uses `image1d_buffer_t` to wrap `dst` to utilize texture processor. However, `image1d_buffer_t` has dimension limit. The limit can be reached when there are enough tokens in kv cache.

For example, providing gpt-oss-20b with a prompt of about 4k tokens using `llama-completion` with `-ub 1024` will hit the limit, resulting in assert failure.

This PR utilizes the general mm for floating point by copying to `src0` and `src1` to contiguous if necessary. I believe this has been used in vulkan backend. A check is added to ensure that the arguments are within the limit of `image1d_buffer_t` for the specialized kqv kernel.