### PR TITLE
Add Devstral-2 (Ministral3ForCausalLM) architeture to  convert_hf_to_gguf.py

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2979,7 +2979,11 @@ class Llama4VisionModel(MmprojModel):
         return []
 
 
-@ModelBase.register("Mistral3ForConditionalGeneration")
+@ModelBase.register(
+    "Mistral3ForConditionalGeneration",
+    "Ministral3ForCausalLM",
+)
+
 class Mistral3Model(LlamaModel):
     model_arch = gguf.MODEL_ARCH.MISTRAL3
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2983,7 +2983,6 @@ class Llama4VisionModel(MmprojModel):
     "Mistral3ForConditionalGeneration",
     "Ministral3ForCausalLM",
 )
-
 class Mistral3Model(LlamaModel):
     model_arch = gguf.MODEL_ARCH.MISTRAL3
 


### PR DESCRIPTION
This adds support for newer architectures like Devstral-2 (addresses [#17987](https://github.com/ggml-org/llama.cpp/issues/17987))

