### PR TITLE
[SYCL] use malloc to support both iGPU and dGPU in same time

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1157,12 +1157,28 @@ static const char * ggml_backend_sycl_host_buffer_type_name(ggml_backend_buffer_
     GGML_UNUSED(buft);
 }
 
+inline void * aligned_malloc_host(size_t alignment, size_t size) {
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
+    return aligned_alloc(alignment, size);
+#endif
+}
+
+inline void free_aligned_mem_host(void * memblock) {
+#ifdef _WIN32
+    _aligned_free(memblock);
+#else
+    free(memblock);
+#endif
+}
+
 static void ggml_backend_sycl_host_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    free(buffer->context);
+    free_aligned_mem_host((void *)buffer->context);
 }
 
 static ggml_backend_buffer_t ggml_backend_sycl_host_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    void * ptr = aligned_alloc(TENSOR_ALIGNMENT, size);
+    void * ptr = aligned_malloc_host(TENSOR_ALIGNMENT, size);
     if (ptr == nullptr) {
         // fallback to cpu buffer
         return ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), size);

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1158,12 +1158,11 @@ static const char * ggml_backend_sycl_host_buffer_type_name(ggml_backend_buffer_
 }
 
 static void ggml_backend_sycl_host_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    ggml_sycl_host_free(buffer->context);
+    free(buffer->context);
 }
 
 static ggml_backend_buffer_t ggml_backend_sycl_host_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    void * ptr = ggml_sycl_host_malloc(size);
-
+    void * ptr = aligned_alloc(TENSOR_ALIGNMENT, size);
     if (ptr == nullptr) {
         // fallback to cpu buffer
         return ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), size);


### PR DESCRIPTION
Fix the issue: https://github.com/ggml-org/llama.cpp/issues/9241.

The host_buffer is used to create the copy of memory on devices.
The original code use the malloc_host() which bind with queue/devices.
When copy the memory from another device which has different context of malloc_host, the memcpy() is forbidden:
    SYCL need both queues' context are same when copy memory between devices. 
    It's same for the memory created by malloc_host().

In the issue case, two dGPU belong to different context, the malloc_host() will be executed on the queue of second GPU.
When set the -ngl 48 (total 49), during load model, the tensor of first GPU will be copied to host_buffer based on queue of second GPU. It will trigger the error of L0.

To support iGPU+dGPU, we can't resolve it by add both GPUs' queue to same context. (iGPU and dGPU are different family and can't belong to same context).

So, we use the malloc() to replace the malloc_host() to support more multiple GPUs cases.

It won't impact the performance.
