### PR TITLE
mtmd: add `mtmd_get_output_embd_size`

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -862,6 +862,10 @@ float * mtmd_get_output_embd(mtmd_context * ctx) {
     return ctx->image_embd_v.data();
 }
 
+size_t mtmd_get_output_embd_size(mtmd_context * ctx) {
+    return ctx->image_embd_v.size();
+}
+
 bool mtmd_decode_use_non_causal(mtmd_context * ctx) {
     switch (ctx->proj_type_v()) {
         case PROJECTOR_TYPE_GEMMA3:

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -224,8 +224,11 @@ MTMD_API int32_t mtmd_encode_chunk(mtmd_context * ctx,
 
 // get output embeddings from the last encode pass
 // the reading size (in bytes) is equal to:
-// llama_model_n_embd(model) * mtmd_input_chunk_get_n_tokens(chunk) * sizeof(float)
+// mtmd_get_output_embd_size(ctx) * sizeof(float)
 MTMD_API float * mtmd_get_output_embd(mtmd_context * ctx);
+
+// get the size of the output embeddings from the last encode pass
+MTMD_API size_t mtmd_get_output_embd_size(mtmd_context * ctx);
 
 // Set callback for all future logging events.
 // If this is not called, or NULL is supplied, everything is output on stderr.


### PR DESCRIPTION
It appears that `llama_model_n_embd(model) * mtmd_input_chunk_get_n_tokens(chunk)` is no longer valid to calculate the size of the mtmd output embedding, so this PR adds another method to get the size of the embedding directly.

