### PR TITLE
mtmd : update docs to use llama_model_n_embd_inp

### DIFF
--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -224,7 +224,7 @@ MTMD_API int32_t mtmd_encode_chunk(mtmd_context * ctx,
 
 // get output embeddings from the last encode pass
 // the reading size (in bytes) is equal to:
-// llama_model_n_embd(model) * mtmd_input_chunk_get_n_tokens(chunk) * sizeof(float)
+// llama_model_n_embd_inp(model) * mtmd_input_chunk_get_n_tokens(chunk) * sizeof(float)
 MTMD_API float * mtmd_get_output_embd(mtmd_context * ctx);
 
 // Set callback for all future logging events.


### PR DESCRIPTION
Supersede https://github.com/ggml-org/llama.cpp/pull/18998

A leftover change from the migration `llama_model_n_embd` --> `llama_model_n_embd_inp`
