### PR TITLE
release: update uploadReleaseAsset API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -897,7 +897,7 @@ jobs:
             for (let file of await fs.readdirSync('./release')) {
               if (path.extname(file) === '.zip' || file.endsWith('.tar.gz')) {
                 console.log('uploadReleaseAsset', file);
-                await github.repos.uploadReleaseAsset({
+                await github.rest.repos.uploadReleaseAsset({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   release_id: release_id,


### PR DESCRIPTION
fixes: #19011

GitHub Script v8 updated the way the API is called. Instead of calling `uploadReleaseAsset` as

```js
github.repos.uploadReleaseAsset(...)
```

we now need to use the `.rest` object as such

```js
github.rest.repos.uploadReleaseAsset(...)
```