### PR TITLE
ggml-hexagon: flash-attn opt

### DIFF
--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -376,8 +376,8 @@ static void flash_attn_ext_f16_thread(struct htp_ops_context * octx, int ith, in
 
                 HVX_Vector M_new_vec = hvx_vec_splat_f32(M_new);
                 HVX_Vector p_sum_vec = hvx_vec_splat_f32(0.0f);
-                for (uint32_t ic = 0; ic < FLASH_ATTN_BLOCK_SIZE; ic += VLEN_FP32) {
-                    HVX_Vector scores = *(HVX_Vector *) &scores_x4[ic];
+                for (uint32_t ic2 = 0; ic2 + VLEN_FP32 <= current_block_size; ic2 += VLEN_FP32) {
+                    HVX_Vector scores = *(HVX_Vector *) &scores_x4[ic2];
                     HVX_Vector scores_shifted = Q6_Vqf32_vsub_VsfVsf(scores, M_new_vec);
                     HVX_Vector P = hvx_vec_exp_f32(Q6_Vsf_equals_Vqf32(scores_shifted));
 
@@ -388,7 +388,7 @@ static void flash_attn_ext_f16_thread(struct htp_ops_context * octx, int ith, in
                     *(HVX_Vector*)p_arr = P;
 
                     for (int j = 0; j < VLEN_FP32; ++j) {
-                        const uint32_t cur_ic = ic + j;
+                        const uint32_t cur_ic = ic2 + j;
                         const uint8_t * v_ptr = v_base + cur_ic * size_v_row_padded;
                         hvx_mad_f32_f16_aa(VKQ32, v_ptr, DV, p_arr[j]);
                     }


### PR DESCRIPTION
This pull request refactors and optimizes the `flash_attn_ext_f16_thread` function in `flash-attn-ops.c`, focusing on more efficient vectorized computation and improved numerical stability in the softmax calculation. The main changes involve restructuring the computation of scores and their accumulation, as well as ensuring proper handling of vector sizes and maximum value tracking.

**Vectorization and Softmax Optimization:**

* Introduced a `static_assert` to ensure `FLASH_ATTN_BLOCK_SIZE` is compatible with the usage of `HVX_Vector_x4`, and refactored the loop to use `scores_x4` for storing intermediate score vectors, improving vectorization and memory alignment.
* Changed the accumulation of the maximum value (`v_max`) to be computed across all score vectors before reducing to a scalar, enhancing numerical stability for the softmax step. [[1]](diffhunk://#diff-703a5dfdf5d9711789e72c854d70db2559000749823e0cb8fa9defc4b276e7b8L321-R326) [[2]](diffhunk://#diff-703a5dfdf5d9711789e72c854d70db2559000749823e0cb8fa9defc4b276e7b8R362-R400)
* Refactored the softmax calculation to accumulate probabilities (`p_sum_vec`) in a vectorized manner, then reduced and updated the running sum (`S`) more efficiently.
