### PR TITLE
cli : load parser definition

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -84,6 +84,7 @@ struct cli_context {
             // chat template settings
             task.params.chat_parser_params = common_chat_parser_params(chat_params);
             task.params.chat_parser_params.reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
+            task.params.chat_parser_params.parser.load(chat_params.parser);
 
             rd.post_task({std::move(task)});
         }

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -84,7 +84,9 @@ struct cli_context {
             // chat template settings
             task.params.chat_parser_params = common_chat_parser_params(chat_params);
             task.params.chat_parser_params.reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
-            task.params.chat_parser_params.parser.load(chat_params.parser);
+            if (!chat_params.parser.empty()) {
+                task.params.chat_parser_params.parser.load(chat_params.parser);
+            }
 
             rd.post_task({std::move(task)});
         }


### PR DESCRIPTION
fix #19018 

@ngxson I would like to refactor the common interface eventually to avoid serializing the definition. For now, we have to deserialize the PEG parser definition because the server passes params through a `nholmann::json` object.