### PR TITLE
completion : fix prompt cache for recurrent models

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2559,6 +2559,7 @@ size_t llama_context::state_write_data(llama_io_write_i & io) {
         }
     }
 
+    // [TAG_CONTEXT_STATE_LOGITS]
     // write logits
     {
         LLAMA_LOG_DEBUG("%s: - writing logits\n", __func__);


### PR DESCRIPTION
fix #19041

Recurrent memory does not support `llama_memory_seq_rm()`. Perform it only if necessary.