### PR TITLE
Add workaround for templates requiring non-null content

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2783,8 +2783,8 @@ static void system_message_not_supported(json & messages) {
 static void requires_non_null_content(json & messages) {
     GGML_ASSERT(messages.is_array());
     for (auto & message : messages) {
-        if (message.contains("tool_calls") && !messages.contains("content")) {
-            messages["content"] = "";
+        if (message.contains("tool_calls") && !message.contains("content")) {
+            message["content"] = "";
         }
     }
 }

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2894,7 +2894,10 @@ static common_chat_params common_chat_templates_apply_jinja(
         workaround::system_message_not_supported(params.messages);
     }
 
-    if (!tmpl.original_caps().requires_non_null_content) {
+    if (tmpl.original_caps().supports_tool_calls) {
+        // some templates will require the content field in tool call messages
+        // to still be non-null, this puts an empty string everywhere where the 
+        // content field is null
         workaround::requires_non_null_content(params.messages);
     }
 

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2780,6 +2780,15 @@ static void system_message_not_supported(json & messages) {
     }
 }
 
+static void requires_non_null_content(json & messages) {
+    GGML_ASSERT(messages.is_array());
+    for (auto & message : messages) {
+        if (message.contains("tool_calls") && !messages.contains("content")) {
+            messages["content"] = "";
+        }
+    }
+}
+
 static void func_args_not_string(json & messages) {
     GGML_ASSERT(messages.is_array());
     for (auto & message : messages) {
@@ -2883,6 +2892,10 @@ static common_chat_params common_chat_templates_apply_jinja(
 
     if (!tmpl.original_caps().supports_system_role) {
         workaround::system_message_not_supported(params.messages);
+    }
+
+    if (!tmpl.original_caps().requires_non_null_content) {
+        workaround::requires_non_null_content(params.messages);
     }
 
     params.extra_context = json::object();

--- a/common/jinja/caps.cpp
+++ b/common/jinja/caps.cpp
@@ -240,65 +240,81 @@ caps caps_get(jinja::program & prog) {
     );
 
     // case: requires non-null content in tool calls
-    caps_try_execute(
-        prog,
-        [&]() {
-            // messages
-            return json::array({
-                {
-                    {"role", "user"},
-                    {"content", "User message"},
-                },
-                {
-                    {"role", "assistant"},
-                    {"tool_calls", json::array({
-                        {
-                            {"id", "call0001"},
-                            {"type", "function"},
-                            {"function", {
-                                {"name", "tool1"},
-                                {"arguments", {
-                                    {"arg", "value"}
-                                }}
-                            }}
+    if (result.supports_tool_calls) {
+        caps_try_execute(
+            prog,
+            [&]() {
+                // messages
+                return json::array({
+                    {
+                        { "role", "user" },
+                        { "content", "User message" },
+                    },
+                    {
+                        { "role", "assistant" },
+                        { "tool_calls",
+                            json::array({
+                                {
+                                    { "id", "call0001" },
+                                    { "type", "function" },
+                                    { "function",
+                                        {
+                                            { "name", "tool1" },
+                                            { "arguments",
+                                                {
+                                                    { "arg", "value" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                            })
+                        }
+                    },
+                    {
+                        { "role", "user" },
+                        { "content", "User message" },
+                    },
+                });
+            },
+            [&]() {
+                // tools
+                return json::array({
+                    {
+                        { "name", "tool" },
+                        { "type", "function" },
+                        { "function",
+                            {
+                                { "name", "tool1" },
+                                { "description", "Tool description" },
+                                { "parameters",
+                                    {
+                                        { "type", "object" },
+                                        { "properties",
+                                            {
+                                                { "arg",
+                                                    {
+                                                        { "type", "string" },
+                                                        { "description", "Arg description" },
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        { "required", json::array({ "arg" }) },
+                                    }
+                                },
+                            }
                         },
-                    })}
-                },
-                {
-                    {"role", "user"},
-                    {"content", "User message"},
-                },
-            });
-        },
-        [&]() {
-            // tools
-            return json::array({
-                {
-                    {"name", "tool"},
-                    {"type", "function"},
-                    {"function", {
-                        {"name", "tool1"},
-                        {"description", "Tool description"},
-                        {"parameters", {
-                            {"type", "object"},
-                            {"properties", {
-                                {"arg", {
-                                    {"type", "string"},
-                                    {"description", "Arg description"},
-                                }},
-                            }},
-                            {"required", json::array({ "arg" })},
-                        }},
-                    }},
-                },
-            });
-        },
-        [&](bool success, value & messages, value & tools) {
-            if (!success) {
-                result.requires_non_null_content = true;
+                    },
+                });
+            },
+            [&](bool success, value & /* messages */, value & /* tools */) {
+                if (!success) {
+                    result.requires_non_null_content = true;
+                }
             }
-        }
-    );
+        );
+    }
 
     // case: preserve reasoning content in chat history
     caps_try_execute(

--- a/common/jinja/caps.cpp
+++ b/common/jinja/caps.cpp
@@ -64,7 +64,6 @@ static void caps_print_stats(value & v, const std::string & path) {
 std::map<std::string, bool> caps::to_map() const {
     return {
         {"requires_typed_content", requires_typed_content},
-        {"requires_non_null_content", requires_non_null_content},
         {"supports_tools", supports_tools},
         {"supports_tool_calls", supports_tool_calls},
         {"supports_parallel_tool_calls", supports_parallel_tool_calls},
@@ -238,83 +237,6 @@ caps caps_get(jinja::program & prog) {
             }
         }
     );
-
-    // case: requires non-null content in tool calls
-    if (result.supports_tool_calls) {
-        caps_try_execute(
-            prog,
-            [&]() {
-                // messages
-                return json::array({
-                    {
-                        { "role", "user" },
-                        { "content", "User message" },
-                    },
-                    {
-                        { "role", "assistant" },
-                        { "tool_calls",
-                            json::array({
-                                {
-                                    { "id", "call00001" },
-                                    { "type", "function" },
-                                    { "function",
-                                        {
-                                            { "name", "tool1" },
-                                            { "arguments",
-                                                {
-                                                    { "arg", "value" }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                            })
-                        }
-                    },
-                    {
-                        { "role", "user" },
-                        { "content", "User message" },
-                    },
-                });
-            },
-            [&]() {
-                // tools
-                return json::array({
-                    {
-                        { "name", "tool" },
-                        { "type", "function" },
-                        { "function",
-                            {
-                                { "name", "tool1" },
-                                { "description", "Tool description" },
-                                { "parameters",
-                                    {
-                                        { "type", "object" },
-                                        { "properties",
-                                            {
-                                                { "arg",
-                                                    {
-                                                        { "type", "string" },
-                                                        { "description", "Arg description" },
-                                                    }
-                                                },
-                                            }
-                                        },
-                                        { "required", json::array({ "arg" }) },
-                                    }
-                                },
-                            }
-                        },
-                    },
-                });
-            },
-            [&](bool success, value & /* messages */, value & /* tools */) {
-                if (!success) {
-                    result.requires_non_null_content = true;
-                }
-            }
-        );
-    }
 
     // case: preserve reasoning content in chat history
     caps_try_execute(

--- a/common/jinja/caps.cpp
+++ b/common/jinja/caps.cpp
@@ -161,7 +161,7 @@ caps caps_get(jinja::program & prog) {
                     {"content", "Assistant message"},
                     {"tool_calls", json::array({
                         {
-                            {"id", "call0001"},
+                            {"id", "call00001"},
                             {"type", "function"},
                             {"function", {
                                 {"name", "tool1"},
@@ -171,7 +171,7 @@ caps caps_get(jinja::program & prog) {
                             }}
                         },
                         {
-                            {"id", "call0002"},
+                            {"id", "call00002"},
                             {"type", "function"},
                             {"function", {
                                 {"name", "tool1"},
@@ -255,7 +255,7 @@ caps caps_get(jinja::program & prog) {
                         { "tool_calls",
                             json::array({
                                 {
-                                    { "id", "call0001" },
+                                    { "id", "call00001" },
                                     { "type", "function" },
                                     { "function",
                                         {

--- a/common/jinja/caps.h
+++ b/common/jinja/caps.h
@@ -15,6 +15,7 @@ struct caps {
     bool supports_preserve_reasoning = false; // support assistant message with reasoning_content
 
     bool requires_typed_content = false; // default: use string content
+    bool requires_non_null_content = false; // requires "" instead of null for content in tool calls
 
     // for reporting on server
     std::map<std::string, bool> to_map() const;

--- a/common/jinja/caps.h
+++ b/common/jinja/caps.h
@@ -15,7 +15,6 @@ struct caps {
     bool supports_preserve_reasoning = false; // support assistant message with reasoning_content
 
     bool requires_typed_content = false; // default: use string content
-    bool requires_non_null_content = false; // requires "" instead of null for content in tool calls
 
     // for reporting on server
     std::map<std::string, bool> to_map() const;

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -949,6 +949,19 @@ static void test_tests(testing & t) {
         {{"x", {{"a", 1}}}},
         "yes"
     );
+
+    test_template(t, "something in undefined",
+        "{% if x in y %}yes{% else %}no{% endif %}",
+        {{"x", 1}},
+        "no"
+    );
+
+    test_template(t, "null is undefined",
+        "{% if null is not defined %}yes{% else %}no{% endif %}",
+        json::object(),
+        "yes"
+    );
+
 }
 
 static void test_string_methods(testing & t) {


### PR DESCRIPTION
As in topic, even though OpenAI standard is null content when assistant message contains tool calls, some templates explicitly require it to be non-null or they'll fail with an error.