### PR TITLE
[WIP] RWKV7 performance optimizations

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -551,6 +551,7 @@ extern "C" {
         GGML_OP_GATED_LINEAR_ATTN,
         GGML_OP_RWKV_WKV7,
         GGML_OP_SOLVE_TRI,
+        GGML_OP_LERP,
 
         GGML_OP_UNARY,
 
@@ -2460,6 +2461,14 @@ extern "C" {
         bool                  left,
         bool                  lower,
         bool                  uni);
+
+    // a + (b - a) * t
+    // used in rwkv7
+    GGML_API struct ggml_tensor * ggml_lerp(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            struct ggml_tensor  * b,
+            struct ggml_tensor  * t);
 
     // custom operators
 

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2437,7 +2437,8 @@ extern "C" {
             struct ggml_tensor  * v,
             struct ggml_tensor  * a,
             struct ggml_tensor  * b,
-            struct ggml_tensor  * state);
+            struct ggml_tensor  * state,
+            bool                  fuse_exp);
 
     /* Solves a specific equation of the form Ax=B, where A is a triangular matrix
     *  without zeroes on the diagonal (i.e. invertible).

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -579,6 +579,7 @@ extern "C" {
         GGML_UNARY_OP_TANH,
         GGML_UNARY_OP_ELU,
         GGML_UNARY_OP_RELU,
+        GGML_UNARY_OP_RELU_SQR,
         GGML_UNARY_OP_SIGMOID,
         GGML_UNARY_OP_GELU,
         GGML_UNARY_OP_GELU_QUICK,
@@ -1125,6 +1126,14 @@ extern "C" {
             struct ggml_tensor  * a, float negative_slope, bool inplace);
 
     GGML_API struct ggml_tensor * ggml_relu_inplace(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a);
+
+    GGML_API struct ggml_tensor * ggml_relu_sqr(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a);
+
+    GGML_API struct ggml_tensor * ggml_relu_sqr_inplace(
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2018,6 +2018,11 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_solve_tri(params, tensor);
             } break;
+        case GGML_OP_LERP:
+            {
+                ggml_compute_forward_lerp(params, tensor);
+            }
+            break;
         case GGML_OP_MAP_CUSTOM1:
             {
                 ggml_compute_forward_map_custom1(params, tensor);
@@ -2179,6 +2184,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
         case GGML_OP_CUMSUM:
         case GGML_OP_TRI:
         case GGML_OP_FILL:
+        case GGML_OP_LERP:
             {
                 n_tasks = n_threads;
             } break;

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2221,6 +2221,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
                 case GGML_UNARY_OP_TANH:
                 case GGML_UNARY_OP_ELU:
                 case GGML_UNARY_OP_RELU:
+                case GGML_UNARY_OP_RELU_SQR:
                 case GGML_UNARY_OP_SIGMOID:
                 case GGML_UNARY_OP_HARDSWISH:
                 case GGML_UNARY_OP_HARDSIGMOID:

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -9144,6 +9144,10 @@ void ggml_compute_forward_unary(
             {
                 ggml_compute_forward_relu(params, dst);
             } break;
+        case GGML_UNARY_OP_RELU_SQR:
+            {
+                ggml_compute_forward_relu_sqr(params, dst);
+            } break;
         case GGML_UNARY_OP_SIGMOID:
             {
                 ggml_compute_forward_sigmoid(params, dst);

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -101,6 +101,7 @@ void ggml_compute_forward_add_rel_pos(const struct ggml_compute_params * params,
 void ggml_compute_forward_rwkv_wkv6(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_rwkv_wkv7(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_lerp(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_gla(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_map_custom1(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_map_custom2(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ggml/src/ggml-cpu/unary-ops.cpp
+++ b/ggml/src/ggml-cpu/unary-ops.cpp
@@ -28,6 +28,11 @@ static inline float op_relu(float x) {
     return (x > 0.f) ? x : 0.f;
 }
 
+static inline float op_relu_sqr(float x) {
+    float r = (x > 0.f) ? x : 0.f;
+    return r * r;
+}
+
 static inline float op_sigmoid(float x) {
     return 1.f / (1.f + expf(-x));
 }
@@ -260,6 +265,10 @@ void ggml_compute_forward_elu(const ggml_compute_params * params, ggml_tensor * 
 
 void ggml_compute_forward_relu(const ggml_compute_params * params, ggml_tensor * dst) {
     unary_op<op_relu>(params, dst);
+}
+
+void ggml_compute_forward_relu_sqr(const ggml_compute_params * params, ggml_tensor * dst) {
+    unary_op<op_relu_sqr>(params, dst);
 }
 
 void ggml_compute_forward_sigmoid(const ggml_compute_params * params, ggml_tensor * dst) {

--- a/ggml/src/ggml-cpu/unary-ops.h
+++ b/ggml/src/ggml-cpu/unary-ops.h
@@ -13,6 +13,7 @@ void ggml_compute_forward_step(const struct ggml_compute_params * params, struct
 void ggml_compute_forward_tanh(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_elu(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_relu(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_relu_sqr(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_sigmoid(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_hardsigmoid(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_exp(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2504,6 +2504,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
                 case GGML_UNARY_OP_RELU:
                     ggml_cuda_op_relu(ctx, dst);
                     break;
+                case GGML_UNARY_OP_RELU_SQR:
+                    ggml_cuda_op_relu_sqr(ctx, dst);
+                    break;
                 case GGML_UNARY_OP_SIGMOID:
                     ggml_cuda_op_sigmoid(ctx, dst);
                     break;
@@ -4322,6 +4325,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_GELU:
                 case GGML_UNARY_OP_SILU:
                 case GGML_UNARY_OP_RELU:
+                case GGML_UNARY_OP_RELU_SQR:
                 case GGML_UNARY_OP_SIGMOID:
                 case GGML_UNARY_OP_HARDSIGMOID:
                 case GGML_UNARY_OP_HARDSWISH:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -52,6 +52,7 @@
 #include "ggml-cuda/unary.cuh"
 #include "ggml-cuda/upscale.cuh"
 #include "ggml-cuda/wkv.cuh"
+#include "ggml-cuda/lerp.cuh"
 #include "ggml-cuda/gla.cuh"
 #include "ggml-cuda/set.cuh"
 #include "ggml-cuda/set-rows.cuh"
@@ -2726,6 +2727,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_RWKV_WKV7:
             ggml_cuda_op_rwkv_wkv7(ctx, dst);
             break;
+        case GGML_OP_LERP:
+            ggml_cuda_op_lerp(ctx, dst);
+            break;
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
             ggml_cuda_cross_entropy_loss_back(ctx, dst);
             break;
@@ -4635,6 +4639,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_RWKV_WKV6:
         case GGML_OP_GATED_LINEAR_ATTN:
         case GGML_OP_RWKV_WKV7:
+        case GGML_OP_LERP:
             return true;
         case GGML_OP_FLASH_ATTN_EXT:
             return ggml_cuda_flash_attn_ext_supported(dev_ctx->device, op);

--- a/ggml/src/ggml-cuda/lerp.cu
+++ b/ggml/src/ggml-cuda/lerp.cu
@@ -1,0 +1,283 @@
+#include "lerp.cuh"
+#include <cstdint>
+
+template <typename src0_t, typename src1_t, typename src2_t, typename dst_t>
+static __global__ void k_lerp(
+    const src0_t * src0,
+    const src1_t * src1,
+    const src2_t * src2,
+    dst_t * dst,
+    const int ne0,
+    const int ne1,
+    const int ne2,
+    const uint3 ne3,
+    const uint3 ne03,
+    const uint3 ne13,
+    const uint3 ne21,
+    const uint3 ne22,
+    const int s1,
+    const int s2,
+    const int s3,
+    const int s01,
+    const int s02,
+    const int s03,
+    const int s11,
+    const int s12,
+    const int s13,
+    const int s21,
+    const int s22,
+    const int s23) {
+
+    const uint32_t i0s = blockDim.x * blockIdx.x + threadIdx.x;
+    const uint32_t i1  = (blockDim.y * blockIdx.y + threadIdx.y);
+    const uint32_t i2  = fastdiv((blockDim.z * blockIdx.z + threadIdx.z), ne3);
+    const uint32_t i3  = (blockDim.z * blockIdx.z + threadIdx.z) - (i2 * ne3.z);
+
+    if (i0s >= (uint32_t)ne0 || i1 >= (uint32_t)ne1 || i2 >= (uint32_t)ne2 || i3 >= ne3.z) {
+        return;
+    }
+
+    // src0/src1 broadcast in dim3
+    const uint32_t i03 = fastmodulo(i3, ne03);
+    const uint32_t i13 = fastmodulo(i3, ne13);
+
+    // src2 broadcast in dim1, dim2
+    const uint32_t i21 = fastmodulo(i1, ne21);
+    const uint32_t i22 = fastmodulo(i2, ne22);
+
+    const size_t i_src0 = i03*s03 + i2*s02  + i1*s01;
+    const size_t i_src1 = i13*s13 + i2*s12  + i1*s11;
+    const size_t i_src2 = i3*s23  + i22*s22 + i21*s21;
+    const size_t i_dst  = i3*s3   + i2*s2   + i1*s1;
+
+    const src0_t * src0_row = src0 + i_src0;
+    const src1_t * src1_row = src1 + i_src1;
+    const src2_t * src2_row = src2 + i_src2;
+    dst_t * dst_row = dst + i_dst;
+
+    for (int i0 = i0s; i0 < ne0; i0 += blockDim.x * gridDim.x) {
+        const float v0 = (float) src0_row[i0];
+        const float v1 = (float) src1_row[i0];
+        const float v2 = (float) src2_row[i0];
+
+        dst_row[i0] = (dst_t) (v0 + (v1 - v0) * v2);
+    }
+}
+
+template <typename src0_t, typename src1_t, typename src2_t, typename dst_t>
+static __global__ void k_lerp_unravel(
+    const src0_t * src0,
+    const src1_t * src1,
+    const src2_t * src2,
+    dst_t * dst,
+    const uint3 ne0,
+    const uint3 ne1,
+    const uint3 ne2,
+    const uint32_t ne3,
+    const uint3 prod_012,
+    const uint3 prod_01,
+    const uint3 ne03,
+    const uint3 ne13,
+    const uint3 ne21,
+    const uint3 ne22,
+    const int s1,
+    const int s2,
+    const int s3,
+    const int s01,
+    const int s02,
+    const int s03,
+    const int s11,
+    const int s12,
+    const int s13,
+    const int s21,
+    const int s22,
+    const int s23) {
+
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    const uint32_t i3 = fastdiv(i, prod_012);
+    const uint32_t i2 = fastdiv(i - i3 * prod_012.z, prod_01);
+    const uint32_t i1 = fastdiv(i - i3 * prod_012.z - i2 * prod_01.z, ne0);
+    const uint32_t i0 = i - i3 * prod_012.z - i2 * prod_01.z - i1 * ne0.z;
+
+    if (i0 >= ne0.z || i1 >= ne1.z || i2 >= ne2.z || i3 >= ne3) {
+        return;
+    }
+
+    // src0/src1 broadcast in dim3
+    const int i03 = fastmodulo(i3, ne03);
+    const int i13 = fastmodulo(i3, ne13);
+
+    // src2 broadcast in dim1, dim2
+    const int i21 = fastmodulo(i1, ne21);
+    const int i22 = fastmodulo(i2, ne22);
+
+    const size_t i_src0 = i03*s03 + i2*s02  + i1*s01;
+    const size_t i_src1 = i13*s13 + i2*s12  + i1*s11;
+    const size_t i_src2 = i3*s23  + i22*s22 + i21*s21;
+    const size_t i_dst  = i3*s3   + i2*s2   + i1*s1;
+
+    const src0_t * src0_row = src0 + i_src0;
+    const src1_t * src1_row = src1 + i_src1;
+    const src2_t * src2_row = src2 + i_src2;
+    dst_t * dst_row = dst + i_dst;
+
+    const float v0 = (float) src0_row[i0];
+    const float v1 = (float) src1_row[i0];
+    const float v2 = (float) src2_row[i0];
+
+    // dst = src0 + (src1 - src0) * src2
+    dst_row[i0] = (dst_t) (v0 + (v1 - v0) * v2);
+}
+
+template <typename src0_t, typename src1_t, typename src2_t, typename dst_t>
+static void launch_lerp(
+    const ggml_tensor * src0,
+    const ggml_tensor * src1,
+    const ggml_tensor * src2,
+    ggml_tensor * dst,
+    const src0_t * src0_dd,
+    const src1_t * src1_dd,
+    const src2_t * src2_dd,
+    dst_t * dst_dd,
+    cudaStream_t stream) {
+
+    GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
+    GGML_TENSOR_LOCALS(int64_t, ne1, src1, ne)
+    GGML_TENSOR_LOCALS(int64_t, ne2, src2, ne)
+    GGML_TENSOR_LOCALS(int64_t, ne,  dst,  ne)
+
+    GGML_TENSOR_LOCALS(size_t, nb0, src0, nb)
+    GGML_TENSOR_LOCALS(size_t, nb1, src1, nb)
+    GGML_TENSOR_LOCALS(size_t, nb2, src2, nb)
+    GGML_TENSOR_LOCALS(size_t, nb,  dst,  nb)
+
+    GGML_ASSERT(ne00 == ne10 && ne00 == ne20 && ne00 == ne0);
+    GGML_ASSERT(ne01 % ne21 == 0);
+    GGML_ASSERT(ne02 % ne22 == 0);
+    GGML_ASSERT(ne3 % ne03 == 0);
+    GGML_ASSERT(ne3 % ne13 == 0);
+    GGML_ASSERT(ne0 == ne00);
+    GGML_ASSERT(ne1 == ne01);
+    GGML_ASSERT(ne2 == ne02);
+    GGML_ASSERT(ne3 == ne23);
+
+    size_t s1 = nb1 / sizeof(dst_t);
+    size_t s2 = nb2 / sizeof(dst_t);
+    size_t s3 = nb3 / sizeof(dst_t);
+
+    size_t s01 = nb01 / sizeof(src0_t);
+    size_t s02 = nb02 / sizeof(src0_t);
+    size_t s03 = nb03 / sizeof(src0_t);
+
+    size_t s11 = nb11 / sizeof(src1_t);
+    size_t s12 = nb12 / sizeof(src1_t);
+    size_t s13 = nb13 / sizeof(src1_t);
+
+    size_t s21 = nb21 / sizeof(src2_t);
+    size_t s22 = nb22 / sizeof(src2_t);
+    size_t s23 = nb23 / sizeof(src2_t);
+
+    GGML_ASSERT(nb0 % sizeof(dst_t) == 0);
+    GGML_ASSERT(nb1 % sizeof(dst_t) == 0);
+    GGML_ASSERT(nb2 % sizeof(dst_t) == 0);
+    GGML_ASSERT(nb3 % sizeof(dst_t) == 0);
+
+    GGML_ASSERT(nb00 % sizeof(src0_t) == 0);
+    GGML_ASSERT(nb01 % sizeof(src0_t) == 0);
+    GGML_ASSERT(nb02 % sizeof(src0_t) == 0);
+    GGML_ASSERT(nb03 % sizeof(src0_t) == 0);
+
+    GGML_ASSERT(nb10 % sizeof(src1_t) == 0);
+    GGML_ASSERT(nb11 % sizeof(src1_t) == 0);
+    GGML_ASSERT(nb12 % sizeof(src1_t) == 0);
+    GGML_ASSERT(nb13 % sizeof(src1_t) == 0);
+
+    GGML_ASSERT(nb20 % sizeof(src2_t) == 0);
+    GGML_ASSERT(nb21 % sizeof(src2_t) == 0);
+    GGML_ASSERT(nb22 % sizeof(src2_t) == 0);
+    GGML_ASSERT(nb23 % sizeof(src2_t) == 0);
+
+    const int block_size = CUDA_LERP_BLOCK_SIZE;
+
+    int64_t hne0 = std::max(ne0 / 2LL, 1LL);
+
+    dim3 block_dims;
+    block_dims.x = std::min<unsigned int>(hne0, block_size);
+    block_dims.y = std::min<unsigned int>(ne1, block_size / block_dims.x);
+    block_dims.z = std::min(std::min<unsigned int>(ne2 * ne3, block_size / block_dims.x / block_dims.y), 64U);
+
+    dim3 block_nums(
+        (hne0 + block_dims.x - 1) / block_dims.x,
+        (ne1 + block_dims.y - 1) / block_dims.y,
+        (ne2 * ne3 + block_dims.z - 1) / block_dims.z);
+
+    const uint3 ne03_fastdiv = init_fastdiv_values((uint32_t) ne03);
+    const uint3 ne13_fastdiv = init_fastdiv_values((uint32_t) ne13);
+    const uint3 ne21_fastdiv = init_fastdiv_values((uint32_t) ne21);
+    const uint3 ne22_fastdiv = init_fastdiv_values((uint32_t) ne22);
+
+    if (block_nums.z > 65535 || block_nums.y > 65535) {
+        int block_num = (ne0 * ne1 * ne2 * ne3 + block_size - 1) / block_size;
+        const uint3 prod_012 = init_fastdiv_values((uint32_t) (ne0 * ne1 * ne2));
+        const uint3 prod_01  = init_fastdiv_values((uint32_t) (ne0 * ne1));
+        const uint3 ne0_fastdiv = init_fastdiv_values((uint32_t) ne0);
+        const uint3 ne1_fastdiv = init_fastdiv_values((uint32_t) ne1);
+        const uint3 ne2_fastdiv = init_fastdiv_values((uint32_t) ne2);
+
+        k_lerp_unravel<src0_t, src1_t, src2_t, dst_t>
+            <<<block_num, block_size, 0, stream>>>(
+                src0_dd, src1_dd, src2_dd, dst_dd,
+                ne0_fastdiv, ne1_fastdiv, ne2_fastdiv, ne3,
+                prod_012, prod_01,
+                ne03_fastdiv, ne13_fastdiv, ne21_fastdiv, ne22_fastdiv,
+                s1, s2, s3,
+                s01, s02, s03,
+                s11, s12, s13,
+                s21, s22, s23);
+    } else {
+        const uint3 ne3_fastdiv = init_fastdiv_values((uint32_t) ne3);
+
+        k_lerp<src0_t, src1_t, src2_t, dst_t>
+            <<<block_nums, block_dims, 0, stream>>>(
+                src0_dd, src1_dd, src2_dd, dst_dd,
+                ne0, ne1, ne2, ne3_fastdiv,
+                ne03_fastdiv, ne13_fastdiv, ne21_fastdiv, ne22_fastdiv,
+                s1, s2, s3,
+                s01, s02, s03,
+                s11, s12, s13,
+                s21, s22, s23);
+    }
+}
+
+void ggml_cuda_op_lerp(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor * src1 = dst->src[1];
+    const ggml_tensor * src2 = dst->src[2];
+
+    cudaStream_t stream = ctx.stream();
+
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+
+    if (src2->type == GGML_TYPE_F32) {
+        launch_lerp<float, float, float, float>(
+            src0, src1, src2, dst,
+            (const float *) src0->data,
+            (const float *) src1->data,
+            (const float *) src2->data,
+            (float *) dst->data,
+            stream);
+    } else if (src2->type == GGML_TYPE_F16) {
+        launch_lerp<float, float, half, float>(
+            src0, src1, src2, dst,
+            (const float *) src0->data,
+            (const float *) src1->data,
+            (const half *) src2->data,
+            (float *) dst->data,
+            stream);
+    } else {
+        GGML_ABORT("fatal error");
+    }
+}

--- a/ggml/src/ggml-cuda/lerp.cuh
+++ b/ggml/src/ggml-cuda/lerp.cuh
@@ -1,0 +1,5 @@
+#include "common.cuh"
+
+#define CUDA_LERP_BLOCK_SIZE 256
+
+void ggml_cuda_op_lerp(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -45,6 +45,11 @@ static __device__ __forceinline__ float op_relu(float x) {
     return fmaxf(x, 0);
 }
 
+static __device__ __forceinline__ float op_relu_sqr(float x) {
+    float r = fmaxf(x, 0);
+    return r * r;
+}
+
 static __device__ __forceinline__ float op_sigmoid(float x) {
     return 1.0f / (1.0f + expf(-x));
 }
@@ -184,6 +189,10 @@ void ggml_cuda_op_tanh(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
 void ggml_cuda_op_relu(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     ggml_cuda_op_unary<op_relu>(ctx, dst);
+}
+
+void ggml_cuda_op_relu_sqr(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    ggml_cuda_op_unary<op_relu_sqr>(ctx, dst);
 }
 
 void ggml_cuda_op_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/unary.cuh
+++ b/ggml/src/ggml-cuda/unary.cuh
@@ -41,6 +41,8 @@ void ggml_cuda_op_tanh(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_relu(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
+void ggml_cuda_op_relu_sqr(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
 void ggml_cuda_op_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_hardsigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1519,6 +1519,8 @@ int ggml_metal_op_rwkv(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
     GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
+    const int32_t fuse_exp = ((const int32_t *) op->op_params)[0];
+
     const int64_t B = op->op == GGML_OP_RWKV_WKV6 ? op->src[5]->ne[1] : op->src[6]->ne[1];
     const int64_t T = op->src[0]->ne[2];
     const int64_t C = op->ne[0];
@@ -1543,6 +1545,9 @@ int ggml_metal_op_rwkv(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_set_bytes   (enc, (void *) &T, sizeof(T), ida++);
     ggml_metal_encoder_set_bytes   (enc, (void *) &C, sizeof(C), ida++);
     ggml_metal_encoder_set_bytes   (enc, (void *) &H, sizeof(H), ida++);
+    if (op->op == GGML_OP_RWKV_WKV7) {
+        ggml_metal_encoder_set_bytes   (enc, (void *) &fuse_exp, sizeof(fuse_exp), ida++);
+    }
 
     ggml_metal_encoder_dispatch_threadgroups(enc, B * H, 1, 1, C/H, 1, 1);
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2657,6 +2657,7 @@ kernel void kernel_rwkv_wkv7_f32(
     constant    uint & T,
     constant    uint & C,
     constant    uint & H,
+    constant    uint & fuse_exp,
     uint3 tgpig[[threadgroup_position_in_grid]],
     uint3 tpitg[[thread_position_in_threadgroup]],
     uint3   ntg[[threads_per_threadgroup]])  {
@@ -2665,6 +2666,8 @@ kernel void kernel_rwkv_wkv7_f32(
     const uint batch_id = tgpig.x / H;
     const uint head_id = tgpig.x % H;
     const uint tid = tpitg.x;
+
+    constexpr float w_scale = -0.6065306597f; // -exp(-0.5)
 
     if (batch_id >= B || head_id >= H) {
         return;
@@ -2692,7 +2695,7 @@ kernel void kernel_rwkv_wkv7_f32(
     for (uint t = start_t; t < end_t; t += C) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         _r[tid] = r[t];
-        _w[tid] = w[t];
+        _w[tid] = fuse_exp ? exp(w_scale / (1 + exp(-w[t]))) : w[t];
         _k[tid] = k[t];
         _a[tid] = a[t];
         _b[tid] = b[t];

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -780,6 +780,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_pool2d_f32;
     vk_pipeline pipeline_rwkv_wkv6_f32;
     vk_pipeline pipeline_rwkv_wkv7_f32;
+    vk_pipeline pipeline_rwkv_wkv7_f32_fuse_exp;
     vk_pipeline pipeline_ssm_scan_f32_d128;
     vk_pipeline pipeline_ssm_scan_f32_d256;
     vk_pipeline pipeline_ssm_conv_f32;
@@ -4299,6 +4300,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
     ggml_vk_create_pipeline(device, device->pipeline_rwkv_wkv6_f32, "rwkv_wkv6_f32", rwkv_wkv6_f32_len, rwkv_wkv6_f32_data, "main", 7, sizeof(vk_op_rwkv_wkv6_push_constants), {1, 1, 1}, {device->subgroup_size}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_rwkv_wkv7_f32, "rwkv_wkv7_f32", rwkv_wkv7_f32_len, rwkv_wkv7_f32_data, "main", 8, sizeof(vk_op_rwkv_wkv7_push_constants), {1, 1, 1}, {device->subgroup_size}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_rwkv_wkv7_f32_fuse_exp, "rwkv_wkv7_f32_fuse_exp", rwkv_wkv7_f32_fuse_exp_len, rwkv_wkv7_f32_fuse_exp_data, "main", 8, sizeof(vk_op_rwkv_wkv7_push_constants), {1, 1, 1}, {device->subgroup_size}, 1);
 
     if (device->subgroup_arithmetic && device->subgroup_require_full_support) {
         ggml_vk_create_pipeline(device, device->pipeline_ssm_scan_f32_d128, "ssm_scan_128_f32", ssm_scan_subgroup_f32_len, ssm_scan_subgroup_f32_data, "main", 8, sizeof(vk_op_ssm_scan_push_constants), {1, 1, 1}, {128, device->subgroup_size, 16}, 1, true, true);
@@ -8992,6 +8994,9 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
         return nullptr;
     case GGML_OP_RWKV_WKV7:
         if (src0->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
+            if (dst->op_params[0] == 1) {
+                return ctx->device->pipeline_rwkv_wkv7_f32_fuse_exp;
+            }
             return ctx->device->pipeline_rwkv_wkv7_f32;
         }
         return nullptr;
@@ -9748,10 +9753,62 @@ static void ggml_vk_add_id(ggml_backend_vk_context * ctx, vk_context& subctx, co
     });
 }
 
-static void ggml_vk_op_f32_wkv(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst, const vk_op_rwkv_wkv6_push_constants&& pc, int version) {
-    GGML_ASSERT(version == 6 || version == 7);
-    int num_srcs = version == 6 ? 6 : 7;
+static void ggml_vk_rwkv_wkv6(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
+    const size_t seq_length = dst->src[0]->ne[2];
+    const size_t n_embed = dst->ne[0];
+    const size_t n_heads = dst->src[0]->ne[1];
+    const size_t n_seqs = dst->src[5]->ne[1];
 
+    const vk_op_rwkv_wkv6_push_constants pc = {
+        (uint32_t)n_seqs,
+        (uint32_t)seq_length,
+        (uint32_t)n_embed,
+        (uint32_t)n_heads,
+    };
+
+    const int num_srcs = 6;
+    for (int i = 0; i < num_srcs; i++) {
+        GGML_ASSERT(!ggml_is_quantized(dst->src[i]->type));
+    }
+
+    GGML_ASSERT(dst->buffer != nullptr);
+
+    vk_pipeline pipeline = ggml_vk_op_get_pipeline(ctx, dst->src[0], dst->src[1], dst->src[2], dst, dst->op);
+    GGML_ASSERT(pipeline != nullptr);
+
+    ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+
+    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst);
+    vk_subbuffer src_buf[6] = {};
+    for (int i = 0; i < num_srcs; i++) {
+        src_buf[i] = ggml_vk_tensor_subbuffer(ctx, dst->src[i]);
+    }
+
+    std::array<uint32_t, 3> elements = {
+        (uint32_t)(pc.B * pc.H),
+        1,
+        1
+    };
+
+    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+        {src_buf[0], src_buf[1], src_buf[2], src_buf[3], src_buf[4], src_buf[5], dst_buf},
+        pc, elements);
+}
+
+static void ggml_vk_rwkv_wkv7(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
+    const size_t seq_length = dst->src[0]->ne[2];
+    const size_t n_embed = dst->ne[0];
+    const size_t n_heads = dst->src[0]->ne[1];
+    const size_t n_seqs = dst->src[6]->ne[1];
+
+    const vk_op_rwkv_wkv7_push_constants pc = {
+        (uint32_t)n_seqs,
+        (uint32_t)seq_length,
+        (uint32_t)n_embed,
+        (uint32_t)n_heads,
+    };
+
+    const int num_srcs = 7;
     for (int i = 0; i < num_srcs; i++) {
         GGML_ASSERT(!ggml_is_quantized(dst->src[i]->type));
     }
@@ -9775,54 +9832,9 @@ static void ggml_vk_op_f32_wkv(ggml_backend_vk_context * ctx, vk_context& subctx
         1
     };
 
-    if (version == 6) {
-        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
-            {src_buf[0], src_buf[1], src_buf[2], src_buf[3], src_buf[4], src_buf[5], dst_buf},
-            pc, elements);
-    } else if (version == 7) {
-        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
-            {src_buf[0], src_buf[1], src_buf[2], src_buf[3], src_buf[4], src_buf[5], src_buf[6], dst_buf},
-            pc, elements);
-    } else {
-        // shouldn't happen
-        GGML_ASSERT(false);
-    }
-}
-
-static void ggml_vk_rwkv_wkv6(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
-    const size_t seq_length = dst->src[0]->ne[2];
-    const size_t n_embed = dst->ne[0];
-    const size_t n_heads = dst->src[0]->ne[1];
-    const size_t n_seqs = dst->src[5]->ne[1];
-
-    ggml_vk_op_f32_wkv(
-        ctx, subctx, dst,
-        {
-            (uint32_t)n_seqs,
-            (uint32_t)seq_length,
-            (uint32_t)n_embed,
-            (uint32_t)n_heads,
-        },
-        6
-    );
-}
-
-static void ggml_vk_rwkv_wkv7(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
-    const size_t seq_length = dst->src[0]->ne[2];
-    const size_t n_embed = dst->ne[0];
-    const size_t n_heads = dst->src[0]->ne[1];
-    const size_t n_seqs = dst->src[6]->ne[1];
-
-    ggml_vk_op_f32_wkv(
-        ctx, subctx, dst,
-        {
-            (uint32_t)n_seqs,
-            (uint32_t)seq_length,
-            (uint32_t)n_embed,
-            (uint32_t)n_heads,
-        },
-        7
-    );
+    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+        {src_buf[0], src_buf[1], src_buf[2], src_buf[3], src_buf[4], src_buf[5], src_buf[6], dst_buf},
+        pc, elements);
 }
 
 static void ggml_vk_ssm_scan(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
@@ -15558,7 +15570,7 @@ static void ggml_vk_check_results_0(ggml_backend_vk_context * ctx, ggml_cgraph *
             src_clone[2], src_clone[3], src_clone[4], src_clone[5]);
         } else if (tensor->op == GGML_OP_RWKV_WKV7) {
             tensor_clone = ggml_rwkv_wkv7(ggml_ctx, src_clone[0], src_clone[1], src_clone[2], src_clone[3],
-            src_clone[4], src_clone[5], src_clone[6]);
+            src_clone[4], src_clone[5], src_clone[6], (uint32_t) tensor->op_params[0]);
         } else if (tensor->op == GGML_OP_OPT_STEP_ADAMW) {
             src_clone[0]->flags = tensor->src[0]->flags;
             tensor_clone = ggml_opt_step_adamw(ggml_ctx, src_clone[0], src_clone[1],

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -967,7 +967,8 @@ void process_shaders() {
 
     string_to_spv("rwkv_wkv6_f32", "wkv6.comp", merge_maps(base_dict, {{"A_TYPE", "float"}}));
 
-    string_to_spv("rwkv_wkv7_f32", "wkv7.comp", merge_maps(base_dict, {{"A_TYPE", "float"}}));
+    string_to_spv("rwkv_wkv7_f32", "wkv7.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"FUSE_EXP", "0"}}));
+    string_to_spv("rwkv_wkv7_f32_fuse_exp", "wkv7.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"FUSE_EXP", "1"}}));
 
     string_to_spv("opt_step_adamw_f32", "opt_step_adamw.comp", merge_maps(base_dict, {{"A_TYPE", "float"}}));
     string_to_spv("opt_step_sgd_f32", "opt_step_sgd.comp", merge_maps(base_dict, {{"A_TYPE", "float"}}));

--- a/ggml/src/ggml-vulkan/vulkan-shaders/wkv7.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/wkv7.comp
@@ -10,6 +10,7 @@ layout(push_constant) uniform Parameters {
     uint T;
     uint C;
     uint H;
+    uint fuse_exp;
 };
 
 layout(binding = 0) readonly buffer RBuf { A_TYPE r[]; };
@@ -45,10 +46,18 @@ void main() {
     const uint start_t = batch_id * n_seq_tokens * C + head_id * head_size + tid;
     const uint end_t = (batch_id + 1) * n_seq_tokens * C + head_id * head_size + tid;
 
+#if FUSE_EXP
+    const float w_scale = -0.6065306597f; // -exp(-0.5)
+#endif
+
     for (uint t = start_t; t < end_t; t += C) {
         barrier();
         _r[tid] = r[t];
+#if FUSE_EXP
+        _w[tid] = exp(w_scale / (1 + exp(-w[t])));
+#else
         _w[tid] = w[t];
+#endif
         _k[tid] = k[t];
         _a[tid] = a[t];
         _b[tid] = b[t];

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1170,6 +1170,7 @@ static const char * GGML_UNARY_OP_NAME[GGML_UNARY_OP_COUNT] = {
     "TANH",
     "ELU",
     "RELU",
+    "RELU_SQR",
     "SIGMOID",
     "GELU",
     "GELU_QUICK",
@@ -1187,7 +1188,7 @@ static const char * GGML_UNARY_OP_NAME[GGML_UNARY_OP_COUNT] = {
     "TRUNC",
 };
 
-static_assert(GGML_UNARY_OP_COUNT == 22, "GGML_UNARY_OP_COUNT != 22");
+static_assert(GGML_UNARY_OP_COUNT == 23, "GGML_UNARY_OP_COUNT != 23");
 
 static const char * GGML_GLU_OP_NAME[GGML_GLU_OP_COUNT] = {
     "REGLU",
@@ -2643,6 +2644,20 @@ struct ggml_tensor * ggml_relu_inplace(
         struct ggml_context * ctx,
         struct ggml_tensor  * a) {
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_RELU);
+}
+
+// ggml_relu_sqr
+
+struct ggml_tensor * ggml_relu_sqr(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a) {
+    return ggml_unary(ctx, a, GGML_UNARY_OP_RELU_SQR);
+}
+
+struct ggml_tensor * ggml_relu_sqr_inplace(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a) {
+    return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_RELU_SQR);
 }
 
 // ggml_leaky_relu

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -919,10 +919,7 @@ ggml_tensor * llm_graph_context::build_ffn(
             } break;
         case LLM_FFN_RELU_SQR:
             {
-                cur = ggml_relu(ctx0, cur);
-                cb(cur, "ffn_relu", il);
-
-                cur = ggml_sqr(ctx0, cur);
+                cur = ggml_relu_sqr(ctx0, cur);
                 cb(cur, "ffn_sqr(relu)", il);
             } break;
         case LLM_FFN_SWIGLU:
@@ -1225,8 +1222,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
                 // TODO: add support for gated squared relu
                 GGML_ABORT("fatal error: gated squared relu not implemented");
             } else {
-                cur = ggml_relu(ctx0, cur);
-                cur = ggml_sqr(ctx0, cur);
+                cur = ggml_relu_sqr(ctx0, cur);
                 cb(cur, "ffn_moe_relu_sqr", il);
             } break;
         default:

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -49,7 +49,8 @@ struct llm_build_rwkv7_base : public llm_graph_context {
     ggml_tensor * build_rwkv7_channel_mix(const llama_layer * layer,
                                           ggml_tensor *       cur,
                                           ggml_tensor *       x_prev,
-                                          llm_arch            arch) const;
+                                          llm_arch            arch,
+                                          int                 il) const;
     ggml_tensor * build_rwkv7_time_mix(llm_graph_input_rs * inp,
                                        ggml_tensor *        cur,
                                        ggml_tensor *        x_prev,

--- a/src/models/rwkv7-base.cpp
+++ b/src/models/rwkv7-base.cpp
@@ -65,7 +65,6 @@ ggml_tensor * llm_build_rwkv7_base::build_rwkv7_time_mix(llm_graph_input_rs * in
     ggml_tensor * w = ggml_add(
         ctx0, ggml_mul_mat(ctx0, layer.time_mix_w2, ggml_tanh(ctx0, ggml_mul_mat(ctx0, layer.time_mix_w1, xw))),
         layer.time_mix_w0);
-    w = ggml_exp(ctx0, ggml_scale(ctx0, ggml_sigmoid(ctx0, w), -0.606531));
 
     ggml_tensor * k = build_lora_mm(layer.time_mix_key, xk);
     ggml_tensor * v = build_lora_mm(layer.time_mix_value, xv);
@@ -95,14 +94,12 @@ ggml_tensor * llm_build_rwkv7_base::build_rwkv7_time_mix(llm_graph_input_rs * in
     k                = ggml_add(ctx0, k, ggml_sub(ctx0, ggml_mul(ctx0, a, ka), ka));
 
     r = ggml_reshape_3d(ctx0, r, head_size, head_count, n_tokens);
-    w = ggml_reshape_3d(ctx0, w, head_size, head_count, n_tokens);
     k = ggml_reshape_3d(ctx0, k, head_size, head_count, n_tokens);
-    v = ggml_reshape_3d(ctx0, v, head_size, head_count, n_tokens);
     a = ggml_reshape_3d(ctx0, a, head_size, head_count, n_tokens);
 
     ggml_tensor * wkv_state = build_rs(inp, mctx_cur->get_s_l(il), hparams.n_embd_s(), n_seqs);
 
-    ggml_tensor * wkv_output = ggml_rwkv_wkv7(ctx0, r, w, k, v, ggml_neg(ctx0, kk), ggml_mul(ctx0, kk, a), wkv_state);
+    ggml_tensor * wkv_output = ggml_rwkv_wkv7(ctx0, r, w, k, v, ggml_neg(ctx0, kk), ggml_mul(ctx0, kk, a), wkv_state, true);
     cur                      = ggml_view_1d(ctx0, wkv_output, n_embd * n_tokens, 0);
     wkv_state = ggml_view_1d(ctx0, wkv_output, n_embd * head_size * n_seqs, n_embd * n_tokens * sizeof(float));
 
@@ -122,6 +119,8 @@ ggml_tensor * llm_build_rwkv7_base::build_rwkv7_time_mix(llm_graph_input_rs * in
     } else {
         cur = ggml_reshape_2d(ctx0, cur, n_embd, n_tokens);
     }
+
+    v = ggml_reshape_3d(ctx0, v, head_size, head_count, n_tokens);
     ggml_tensor * rk = ggml_sum_rows(
         ctx0, ggml_mul(ctx0, ggml_mul(ctx0, k, r), ggml_reshape_2d(ctx0, layer.time_mix_r_k, head_size, head_count)));
     cur = ggml_add(ctx0, cur, ggml_reshape_2d(ctx0, ggml_mul(ctx0, v, rk), n_embd, n_tokens));

--- a/src/models/rwkv7.cpp
+++ b/src/models/rwkv7.cpp
@@ -66,7 +66,7 @@ llm_build_rwkv7::llm_build_rwkv7(const llama_model & model, const llm_graph_para
             ffn_norm = ggml_get_rows(ctx0, ffn_norm, inp_out_ids);
             x_prev   = ggml_get_rows(ctx0, x_prev, inp_out_ids);
         }
-        cur = build_rwkv7_channel_mix(layer, ffn_norm, x_prev, LLM_ARCH_RWKV7);
+        cur = build_rwkv7_channel_mix(layer, ffn_norm, x_prev, LLM_ARCH_RWKV7, il);
         cur = ggml_add(ctx0, cur, ffn_inp);
 
         cur = build_cvec(cur, il);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3650,17 +3650,18 @@ struct test_rwkv_wkv7 : public test_case {
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         const int64_t n_tokens = n_seq_tokens * n_seqs;
+        const int64_t n_embd = head_count * head_size;
         ggml_tensor * r   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
-        ggml_tensor * w   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
+        ggml_tensor * w   = ggml_new_tensor(ctx, type, 2, std::vector<int64_t>{ n_embd, n_tokens }.data());
         ggml_tensor * k   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
-        ggml_tensor * v   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
+        ggml_tensor * v   = ggml_new_tensor(ctx, type, 2, std::vector<int64_t>{ n_embd, n_tokens }.data());
         ggml_tensor * a   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
         ggml_tensor * b   = ggml_new_tensor(ctx, type, 3, std::vector<int64_t>{ head_size, head_count, n_tokens }.data());
         // Outputs may become NaN with long seqlen without these normalization
         a = ggml_l2_norm(ctx, a, 1e-7F);
         b = ggml_l2_norm(ctx, b, 1e-7F);
         ggml_tensor * s   = ggml_new_tensor(ctx, type, 2, std::vector<int64_t>{ head_size * head_size * head_count, n_seqs }.data());
-        ggml_tensor * out = ggml_rwkv_wkv7(ctx, r, w, k, v, a, b, s);
+        ggml_tensor * out = ggml_rwkv_wkv7(ctx, r, w, k, v, a, b, s, true);
         return out;
     }
 };

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3666,6 +3666,35 @@ struct test_rwkv_wkv7 : public test_case {
     }
 };
 
+// GGML_OP_LERP
+struct test_lerp : public test_case {
+    const ggml_type type_t;
+    const ggml_type type_a;
+    const ggml_type type_b;
+    const std::array<int64_t, 4> ne0;
+    const std::array<int64_t, 4> ne1;
+    const std::array<int64_t, 4> ne2;
+
+    std::string vars() override {
+        return VARS_TO_STR6(type_a, type_b, type_t, ne0, ne1, ne2);
+    }
+
+    test_lerp(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
+            ggml_type type_t = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne0 = {10, 10, 1, 1},
+            std::array<int64_t, 4> ne1 = {10, 10, 1, 1},
+            std::array<int64_t, 4> ne2 = {10, 10, 1, 1})
+        : type_a(type_a), type_b(type_b), type_t(type_t), ne0(ne0), ne1(ne1), ne2(ne2) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type_a, 4, ne0.data());
+        ggml_tensor * b = ggml_new_tensor(ctx, type_b, 4, ne1.data());
+        ggml_tensor * c = ggml_new_tensor(ctx, type_t, 4, ne2.data());
+        ggml_tensor * out = ggml_lerp(ctx, a, b, c);
+        return out;
+    }
+};
+
 // GGML_OP_MUL_MAT
 struct test_mul_mat : public test_case {
     const ggml_type type_a;
@@ -7507,6 +7536,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_gla(GGML_TYPE_F32, 32, 64, 32, 1));
     test_cases.emplace_back(new test_gla(GGML_TYPE_F32, 32, 64, 32, 4));
     test_cases.emplace_back(new test_gla(GGML_TYPE_F32, 32, 64, 128, 4));
+
+    test_cases.emplace_back(new test_lerp(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {256, 16, 1, 1}, {256, 16, 1, 1}, {256, 16, 1, 1}));
+    test_cases.emplace_back(new test_lerp(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F32, {256, 16, 1, 1}, {256, 16, 1, 1}, {256, 16, 1, 6}));
+    test_cases.emplace_back(new test_lerp(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F16, {256, 16, 1, 1}, {256, 16, 1, 1}, {256, 16, 1, 1}));
+    test_cases.emplace_back(new test_lerp(GGML_TYPE_F32, GGML_TYPE_F32, GGML_TYPE_F16, {256, 16, 1, 1}, {256, 16, 1, 1}, {256, 16, 1, 6}));
 
 #if 0
     // > 4GB A matrix. Too slow to be enabled by default.


### PR DESCRIPTION
baseline (7B f16 on rtx5090):
cuda: pp512 8947.95 ± 20.26 | tg128 69.95 ± 0.04
vulkan: pp512 7728.50 ± 14.26 | tg128 79.21 ± 0.07

after optimization:
cuda: pp512 9401.99 ± 19.04 (+5.07%) | tg128 72.84 ± 0.01 (+4.13%)
vulkan: pp512 7927.37 ± 15.04 | tg128 81.10 ± 0.07

todolist:
- [x] add option to fuse elementwise operations on time_decay into RWKV_WKV7
- [x] add fused `relu_sqr` op for CUDA and CPU
- [x] add fused `lerp` op for CUDA and CPU
- [ ] add impl of these ops for all other backends
- [ ] add support for f16 state type