### PR TITLE
Fix conversion for models inherit from LlamaModel calling super().modify_tensors()

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10719,7 +10719,7 @@ class CogVLMVisionModel(MmprojModel):
         if not name.startswith("model.vision."):
             return
 
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
 
 @ModelBase.register("CogVLMForCausalLM")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2688,6 +2688,7 @@ class ArceeModel(LlamaModel):
 @ModelBase.register("AfmoeForCausalLM")
 class AfmoeModel(LlamaModel):
     model_arch = gguf.MODEL_ARCH.AFMOE
+    undo_permute = False
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
@@ -10725,6 +10726,7 @@ class CogVLMVisionModel(MmprojModel):
 @ModelBase.register("CogVLMForCausalLM")
 class CogVLMModel(LlamaModel):
     model_arch = gguf.MODEL_ARCH.COGVLM
+    undo_permute = False
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         # block vision tensors

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -9106,7 +9106,7 @@ class NemotronHModel(GraniteHybridModel):
                 else:
                     return
 
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
     def prepare_tensors(self):
         super().prepare_tensors()

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10756,7 +10756,7 @@ class JanusProModel(LlamaModel):
         elif name.startswith('language_model.'):
             name = name.replace('language_model.', '')
 
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
 
 @ModelBase.register("JanusForConditionalGeneration")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10719,7 +10719,7 @@ class CogVLMVisionModel(MmprojModel):
         if not name.startswith("model.vision."):
             return
 
-        yield from super().modify_tensors(data_torch, name, bid)
+        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
 
 
 @ModelBase.register("CogVLMForCausalLM")


### PR DESCRIPTION
After #18866 modify_tensors was altered to call the super function

Previously, Afmoe and CogVLM both returned the tensors directly, bypassing the `super().modify_tensors()` function

LlamaModel causes `undo_permute` to be set to `True`, which breaks the model by applying the Q/K permutation when the super function is called, as well as other potential side effects

This change replaces super() with ModelBase in order to bypass inheritance 