### PR TITLE
Vulkan Flash Attention Coopmat1 Refactor

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8363,7 +8363,6 @@ static bool ggml_vk_flash_attn_coopmat_shmem_support(const vk_device& device, co
     const uint32_t MatBr = 16, MatBc = 16;
 
     const uint32_t row_split = Bc / MatBc;
-    const uint32_t wg_size = row_split * device->subgroup_size;
 
     const uint32_t hsk_pad = ROUNDUP_POW2(hsk, 16);
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2763,10 +2763,7 @@ static std::array<uint32_t, 2> fa_rows_cols(FaCodePath path, uint32_t hsk, uint3
         if (small_rows) {
             return {scalar_flash_attention_num_small_rows, scalar_flash_attention_Bc};
         } else {
-            if ((ggml_is_quantized(type) && (hsk >= 256 || hsv >= 256)) || hsk >= 512 || hsv >= 512) {
-                return {16, 32};
-            }
-            return {16, 64};
+            return {coopmat1_flash_attention_num_large_rows, scalar_flash_attention_Bc};
         }
     }
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -8,6 +8,7 @@ layout (constant_id = 3) const uint32_t HSK = 32;
 layout (constant_id = 4) const uint32_t HSV = 32;
 layout (constant_id = 5) const uint32_t Clamp = 0;
 layout (constant_id = 6) const uint32_t D_split = 16;
+layout (constant_id = 7) const uint32_t SubGroupSize = 32;
 
 // Round up head sizes to a multiple of 16, for coopmat1/coopmat2 paths
 const uint32_t HSK_pad = (HSK + 15) & ~15;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -9,6 +9,7 @@ layout (constant_id = 4) const uint32_t HSV = 32;
 layout (constant_id = 5) const uint32_t Clamp = 0;
 layout (constant_id = 6) const uint32_t D_split = 16;
 layout (constant_id = 7) const uint32_t SubGroupSize = 32;
+layout (constant_id = 8) const uint32_t K_LOAD_SHMEM = 0;
 
 // Round up head sizes to a multiple of 16, for coopmat1/coopmat2 paths
 const uint32_t HSK_pad = (HSK + 15) & ~15;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -74,6 +74,10 @@ layout (binding = 1) readonly buffer K_PACKED16 {A_TYPE_PACKED16 k_data_packed16
 layout (binding = 2) readonly buffer V_PACKED16 {A_TYPE_PACKED16 v_data_packed16[];} v_packed;
 #endif
 
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 1
+#endif
+
 #if defined(DATA_A_F32)
 #undef BLOCK_SIZE
 #define BLOCK_SIZE 4

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -362,8 +362,8 @@ void main() {
                 if (KV_bounds_check && j * Bc + col >= KV) {
                     Psh[col * psh_stride + row / 4] = f16vec4(0.0f);
                 } else {
-                    const f16vec4 mfvec = f16vec4(Mf[r], Mf[r + 1], Mf[r + 2], Mf[r + 3]);
-                    const f16vec4 Pf = f16vec4(exp(sfsh[row / 4 + col * sfshstride] - mfvec));
+                    const vec4 mfvec = vec4(Mf[r], Mf[r + 1], Mf[r + 2], Mf[r + 3]);
+                    const f16vec4 Pf = f16vec4(exp(vec4(sfsh[row / 4 + col * sfshstride]) - mfvec));
                     [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
                         Lf[r + vec_idx] += Pf[vec_idx];
                     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -275,6 +275,107 @@ void main() {
             Lf[r] = eMf[r]*Lf[r];
         }
 
+#if 1
+        const uint psh_stride = Br / 4; // No space for padding, maybe increase Qf size?
+
+        // Calculate and store Pf in Qf
+        [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
+            const uint col = c * cols_per_iter + col_tid;
+
+            [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
+                const uint row = tile_row(r);
+                f16vec4 Pfvec;
+                [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
+                    const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                    Lf[r + vec_idx] += Pf;
+                    Pfvec[vec_idx] = Pf;
+                }
+                Qf[col * psh_stride + row / 4] = Pfvec;
+            }
+        }
+
+        const uint num_hsv_tiles = HSV / MatBc / row_split;
+
+        // Each subgroup handles HSV/4 columns
+        [[unroll]] for (uint32_t hsv_tile = 0; hsv_tile < num_hsv_tiles; ++hsv_tile) {
+            const uint hsv_offset = (hsv_tile * row_split + gl_SubgroupID) * 16;
+
+            SfMat = coopmat<ACC_TYPE, gl_ScopeSubgroup, MatBr, MatBc, gl_MatrixUseAccumulator>(0);
+
+#if BLOCK_SIZE > 1
+            // Preload V tiles for [Bc, 16 * num subgroups]
+            const uint v_rows = Bc;
+            const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
+            const uint v_total = v_rows * v_cols;
+            const uint v_loads_per_thread = v_total / gl_WorkGroupSize.x;
+
+            const uint vsh_stride = v_cols;
+
+            [[unroll]] for (uint32_t i = 0; i < v_loads_per_thread; ++i) {
+                const uint idx = i * gl_WorkGroupSize.x + tid;
+                const uint row = idx / v_cols;
+                const uint col = idx % v_cols;
+
+                const uint v_row = j * Bc + row;
+                const uint v_col = hsv_tile * MatBc * row_split + col * 4;
+
+                const uint coord = v_row * v_stride * BLOCK_SIZE + v_col;
+                const uint ib = coord / BLOCK_SIZE;
+                const uint iqs = coord % BLOCK_SIZE;
+
+                ksh[row * vsh_stride + col] = f16vec4(dequantize4(ib, iqs, v_offset, BINDING_IDX_V));
+            }
+
+            barrier();
+#endif
+
+            [[unroll]] for (uint32_t bc_chunk = 0; bc_chunk < Bc / MatBc; ++bc_chunk) {
+                coopMatLoad(KMat, Qf, bc_chunk * MatBc * psh_stride, psh_stride, gl_CooperativeMatrixLayoutColumnMajor);
+
+#if BLOCK_SIZE > 1
+                const uint v_tile_offset = bc_chunk * MatBr * v_cols + gl_SubgroupID * (MatBc / 4);
+                coopMatLoad(QMat, ksh, v_tile_offset, vsh_stride, gl_CooperativeMatrixLayoutRowMajor);
+#else
+                // F16 values can be loaded directly from global memory
+                const uint v_tile_row = j * Bc + bc_chunk * MatBc;
+                const uint v_tile_offset = v_offset / 4 + v_tile_row * v_stride / 4 + hsv_offset / 4;
+                coopMatLoad(QMat, data_vv4, v_tile_offset, v_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+#endif
+
+                SfMat = coopMatMulAdd(KMat, QMat, SfMat);
+            }
+
+            // Store SfMat to sfsh and load into Of
+            const uint osh_stride = row_split * MatBc + 8;
+            const uint o_offset = gl_SubgroupID * MatBc;
+            coopMatStore(SfMat, sfsh, o_offset, osh_stride, gl_CooperativeMatrixLayoutRowMajor);
+
+            barrier();
+
+            const uint hsv_per_tile = row_split * MatBc;
+            const uint hsv_base = hsv_tile * hsv_per_tile;
+            const uint d_values_per_tile = hsv_per_tile / 4 / D_split;
+
+            const uint d_start = hsv_tile * d_values_per_tile;
+            const uint d_end = d_start + d_values_per_tile;
+
+            [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
+                const uint row = tile_row(r);
+
+                [[unroll]] for (uint32_t d = d_start; d < d_end; ++d) {
+                    const uint hsv_col = 4 * (d * D_split + d_tid);
+                    const uint local_hsv = hsv_col - hsv_base;
+
+                    Of[r][d] += ACC_TYPEV4(
+                        sfsh[row * osh_stride + local_hsv],
+                        sfsh[row * osh_stride + local_hsv + 1],
+                        sfsh[row * osh_stride + local_hsv + 2],
+                        sfsh[row * osh_stride + local_hsv + 3]
+                    );
+                }
+            }
+        }
+#else
         [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
             if (KV_bounds_check && j * Bc + c * cols_per_iter + col_tid >= KV) {
                 continue;
@@ -298,6 +399,7 @@ void main() {
                 }
             }
         }
+#endif
 
         barrier();
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -327,9 +327,9 @@ void main() {
 
                 ksh[row * vsh_stride + col] = f16vec4(dequantize4(ib, iqs, v_offset, BINDING_IDX_V));
             }
+#endif
 
             barrier();
-#endif
 
             [[unroll]] for (uint32_t bc_chunk = 0; bc_chunk < Bc / MatBc; ++bc_chunk) {
                 coopMatLoad(KMat, Qf, bc_chunk * MatBc * psh_stride, psh_stride, gl_CooperativeMatrixLayoutColumnMajor);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -54,7 +54,7 @@ shared f16vec4 Psh[Bc * psh_stride];
 const uint32_t sfshstride = (HSK <= 128) ? (Br / 4 + 2) : Br / 4;
 shared ACC_TYPEV4 sfsh[Bc * sfshstride];
 
-const uint32_t kshstride = HSK_pad / 4 + 2; // in units of f16vec4
+const uint32_t kshstride = MatBr / 4 + 2; // in units of f16vec4
 const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
 const uint vsh_stride = v_cols;
 shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
@@ -182,27 +182,6 @@ void main() {
             }
         }
 
-        [[unroll]] for (uint32_t idx = 0; idx < Bc * HSK / 4; idx += gl_WorkGroupSize.x) {
-            uint32_t d = (idx + tid) % (HSK / 4);
-            uint32_t c = (idx + tid) / (HSK / 4);
-            if (c < Bc && d < HSK / 4) {
-                f16vec4 K_Tf = f16vec4(0);
-                if (!KV_bounds_check || j * Bc + c < KV) {
-#if BLOCK_SIZE > 1
-                    uint coord = (j * Bc + c) * k_stride * BLOCK_SIZE + 4 * d;
-                    uint ib = coord / BLOCK_SIZE;
-                    uint iqs = (coord % BLOCK_SIZE);
-                    K_Tf = f16vec4(dequantize4(ib, iqs, k_offset, BINDING_IDX_K));
-#else
-                    K_Tf = f16vec4(data_kv4[k_offset / 4 + (j * Bc + c) * k_stride / 4 + d]);
-#endif
-                }
-
-                ksh[c * kshstride + d] = K_Tf;
-            }
-        }
-        barrier();
-
         // K * Q^T -> S^T: Bc x HSK_pad * HSK_pad x Br -> Bc x Br
         // Bc split across workgroup (four subgroups), loop over HSK in chunks of 16: 16 x 16 * 16 x 16 -> 16 x 16
         // This is written transposed in order to allow for N being 8 if implementations need it
@@ -211,10 +190,48 @@ void main() {
         coopmat<float16_t, gl_ScopeSubgroup, 16, MatBr, gl_MatrixUseB> QMat;
 
         [[unroll]] for (uint32_t d = 0; d < HSK_pad / 16; ++d) {
-            coopMatLoad(QMat, Qf, d * 16 / 4, qstride, gl_CooperativeMatrixLayoutColumnMajor);
+#if BLOCK_SIZE == 1
+            if (KV_bounds_check) {
+#endif
+            [[unroll]] for (uint32_t idx = 0; idx < Bc * MatBr / 4; idx += gl_WorkGroupSize.x) {
+                uint32_t col_vec = (idx + tid) % (MatBr / 4);
+                uint32_t row = (idx + tid) / (MatBr / 4);
+                if (idx + tid < Bc * MatBr / 4) {
+                    f16vec4 K_Tf = f16vec4(0);
+                    if (!KV_bounds_check || j * Bc + row < KV) {
+#if BLOCK_SIZE > 1
+                        uint coord = (j * Bc + row) * k_stride * BLOCK_SIZE + d * 16 + col_vec * 4;
+                        uint ib = coord / BLOCK_SIZE;
+                        uint iqs = (coord % BLOCK_SIZE);
+                        K_Tf = f16vec4(dequantize4(ib, iqs, k_offset, BINDING_IDX_K));
+#else
+                        K_Tf = f16vec4(data_kv4[k_offset / 4 + (j * Bc + row) * k_stride / 4 + d * 16 / 4 + col_vec]);
+#endif
+                    }
 
-            uint coord = (gl_SubgroupID * MatBc) * kshstride + d * 16 / 4;
-            coopMatLoad(KMat, ksh, coord, kshstride, gl_CooperativeMatrixLayoutRowMajor);
+                    ksh[row * kshstride + col_vec] = K_Tf;
+                }
+            }
+            barrier();
+#if BLOCK_SIZE == 1
+            }
+#endif
+
+#if BLOCK_SIZE == 1
+            if (KV_bounds_check)
+#endif
+            {
+                uint coord = (gl_SubgroupID * MatBc) * kshstride;
+                coopMatLoad(KMat, ksh, coord, kshstride, gl_CooperativeMatrixLayoutRowMajor);
+            }
+#if BLOCK_SIZE == 1
+            else {
+                const uint coord = k_offset / 4 + (j * Bc + gl_SubgroupID * MatBc) * k_stride / 4 + d * 16 / 4;
+                coopMatLoad(KMat, data_kv4, coord, k_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+            }
+#endif
+
+            coopMatLoad(QMat, Qf, d * 16 / 4, qstride, gl_CooperativeMatrixLayoutColumnMajor);
 
             SfMat = coopMatMulAdd(KMat, QMat, SfMat);
         }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -191,14 +191,15 @@ void main() {
 
         [[unroll]] for (uint32_t d = 0; d < HSK_pad / 16; ++d) {
 #if BLOCK_SIZE == 1
-            if (KV_bounds_check) {
+            if (KV_bounds_check || d * 16 + 16 > HSK) {
 #endif
+            barrier();
             [[unroll]] for (uint32_t idx = 0; idx < Bc * MatBr / 4; idx += gl_WorkGroupSize.x) {
                 uint32_t col_vec = (idx + tid) % (MatBr / 4);
                 uint32_t row = (idx + tid) / (MatBr / 4);
                 if (idx + tid < Bc * MatBr / 4) {
                     f16vec4 K_Tf = f16vec4(0);
-                    if (!KV_bounds_check || j * Bc + row < KV) {
+                    if ((!KV_bounds_check || j * Bc + row < KV) && (HSK == HSK_pad || d * 16 + col_vec * 4 < HSK)) {
 #if BLOCK_SIZE > 1
                         uint coord = (j * Bc + row) * k_stride * BLOCK_SIZE + d * 16 + col_vec * 4;
                         uint ib = coord / BLOCK_SIZE;
@@ -218,7 +219,7 @@ void main() {
 #endif
 
 #if BLOCK_SIZE == 1
-            if (KV_bounds_check)
+            if (KV_bounds_check || d * 16 + 16 > HSK)
 #endif
             {
                 uint coord = (gl_SubgroupID * MatBc) * kshstride;
@@ -421,15 +422,12 @@ void main() {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 const uint row = tile_row(r);
 
-                [[unroll]] for (uint32_t d0 = d_start; d0 < d_end; d0 += threads_per_rowgroup) {
-                    const uint d = d0 + col_tid;
-                    if (d >= d_end) break;
-
+                [[unroll]] for (uint32_t d_local = 0; d_local < d_per_thread; ++d_local) {
+                    const uint d = d_local * threads_per_rowgroup + col_tid;
                     const uint hsv_col = 4 * d;
-                    const uint local_hsv = (hsv_col - hsv_base) / 4;
 
-                    if (!KV_bounds_check || hsv_col < HSV) {
-                        const uint d_local = d0 / threads_per_rowgroup;
+                    if (hsv_col >= hsv_base && hsv_col < hsv_base + hsv_per_tile && hsv_col < HSV) {
+                        const uint local_hsv = (hsv_col - hsv_base) / 4;
                         Of[r][d_local] += ACC_TYPEV4(sfsh[row * osh_stride + local_hsv]);
                     }
                 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -453,6 +453,7 @@ void main() {
         barrier();
     }
 
+#if 0
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
         [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
 
@@ -470,6 +471,7 @@ void main() {
             barrier();
         }
     }
+#endif
 
     // If there is split_k, then the split_k resolve shader does the final
     // division by L. Store the intermediate O value and per-row m and L values.

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -286,7 +286,6 @@ void main() {
             }
         }
 
-#if 1
         const uint psh_stride = Br / 4; // No space for padding, maybe increase Qf size?
 
         // Calculate and store Pf in Qf
@@ -406,31 +405,6 @@ void main() {
                 }
             }
         }
-#else
-        [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
-            if (KV_bounds_check && j * Bc + c * cols_per_iter + col_tid >= KV) {
-                continue;
-            }
-            float Pf[rows_per_thread];
-            [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                Pf[r] = exp(sfsh[tile_row(r) + (c * cols_per_iter + col_tid) * sfshstride] - Mf[r]);
-                Lf[r] += Pf[r];
-            }
-            [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
-#if BLOCK_SIZE > 1
-                uint coord = (j * Bc + c * cols_per_iter + col_tid) * v_stride * BLOCK_SIZE + 4 * (d * D_split + d_tid);
-                uint ib = coord / BLOCK_SIZE;
-                uint iqs = (coord % BLOCK_SIZE);
-                vec4 Vf = dequantize4(ib, iqs, v_offset, BINDING_IDX_V);
-#else
-                vec4 Vf = vec4(data_vv4[v_offset / 4 + (j * Bc + c * cols_per_iter + col_tid) * v_stride / 4 + d * D_split + d_tid]);
-#endif
-                [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                    Of[r][d] += ACC_TYPE(Pf[r]) * ACC_TYPEV4(Vf);
-                }
-            }
-        }
-#endif
 
         barrier();
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -7,8 +7,8 @@
 #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
 
 #extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
 #extension GL_KHR_shader_subgroup_vote : enable
-#extension GL_KHR_shader_subgroup_shuffle : enable
 #extension GL_KHR_memory_scope_semantics : enable
 #extension GL_KHR_cooperative_matrix : enable
 
@@ -19,12 +19,9 @@
 const uint32_t MatBr = 16;
 const uint32_t MatBc = 16;
 
-const uint32_t HSK_per_thread = HSK / D_split;
-const uint32_t HSV_per_thread = HSV / D_split;
-
 const uint32_t row_split = Bc / MatBc;
 const uint32_t rows_per_thread = Br / row_split;
-const uint32_t cols_per_iter = gl_WorkGroupSize.x / D_split / row_split;
+const uint32_t cols_per_iter = gl_WorkGroupSize.x / row_split;
 const uint32_t cols_per_thread = Bc / cols_per_iter;
 
 
@@ -75,8 +72,7 @@ void main() {
 
     const uint32_t threads_per_rowgroup = gl_WorkGroupSize.x / row_split;
     const uint32_t row_tid = gl_LocalInvocationIndex / threads_per_rowgroup;
-    const uint32_t d_tid = gl_LocalInvocationIndex % D_split;
-    const uint32_t col_tid = (gl_LocalInvocationIndex % threads_per_rowgroup) / D_split;
+    const uint32_t col_tid = gl_LocalInvocationIndex % threads_per_rowgroup;
 
 #define tile_row(r) (row_tid * rows_per_thread + (r))
 
@@ -107,8 +103,8 @@ void main() {
     }
     barrier();
 
-    ACC_TYPEV4 Of[rows_per_thread][HSV_per_thread / 4];
-    [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+    ACC_TYPEV4 Of[rows_per_thread][HSV / 4];
+    [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             Of[r][d] = ACC_TYPEV4(0.0);
         }
@@ -262,9 +258,7 @@ void main() {
             float Moldf = Mf[r];
 
             // Compute max across the row
-            [[unroll]] for (uint s = D_split; s < SubGroupSize; s *= 2) {
-                rowmaxf = max(rowmaxf, subgroupShuffleXor(rowmaxf, s));
-            }
+            rowmaxf = subgroupMax(rowmaxf);
 
             // M = max(rowmax, Mold)
             // P = e^(S - M)
@@ -275,7 +269,7 @@ void main() {
             Lf[r] = eMf[r]*Lf[r];
         }
 
-        [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+        [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 Of[r][d] = ACC_TYPE(eMf[r]) * Of[r][d];
             }
@@ -299,9 +293,7 @@ void main() {
                         Pfvec[vec_idx] = Pf;
                     }
                 }
-                if (d_tid == 0) {  // All other threads have the same P values
-                    Psh[col * psh_stride + row / 4] = Pfvec;
-                }
+                Psh[col * psh_stride + row / 4] = Pfvec;
             }
         }
 
@@ -378,16 +370,16 @@ void main() {
 
             const uint hsv_per_tile = row_split * MatBc;
             const uint hsv_base = hsv_tile * hsv_per_tile;
-            const uint d_values_per_tile = hsv_per_tile / 4 / D_split;
+            const uint d_values_per_tile = hsv_per_tile / 4;
 
             const uint d_start = hsv_tile * d_values_per_tile;
-            const uint d_end = min(d_start + d_values_per_tile, HSV_per_thread / 4);
+            const uint d_end = min(d_start + d_values_per_tile, HSV / 4);
 
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 const uint row = tile_row(r);
 
                 [[unroll]] for (uint32_t d = d_start; d < d_end; ++d) {
-                    const uint hsv_col = 4 * (d * D_split + d_tid);
+                    const uint hsv_col = 4 * d;
                     const uint local_hsv = hsv_col - hsv_base;
 
                     if (!KV_bounds_check || hsv_col < HSV) {
@@ -406,9 +398,7 @@ void main() {
     }
 
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        [[unroll]] for (uint s = D_split; s < SubGroupSize; s *= 2) {
-            Lf[r] += subgroupShuffleXor(Lf[r], s);
-        }
+        Lf[r] = subgroupAdd(Lf[r]);
     }
 
     // If there is split_k, then the split_k resolve shader does the final
@@ -419,9 +409,9 @@ void main() {
 
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4*(d * D_split + d_tid) + comp, float(Of[r][d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -448,7 +438,7 @@ void main() {
             if (sink > Mf[r]) {
                 ms = exp(Mf[r] - sink);
 
-                [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     Of[r][d] *= ACC_TYPE(ms);
                 }
             } else {
@@ -464,7 +454,7 @@ void main() {
         Lfrcp[r] = (Lf[r] == 0.0) ? 0.0 : (1.0 / Lf[r]);
     }
 
-    [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+    [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             Of[r][d] *= ACC_TYPE(Lfrcp[r]);
 #if defined(ACC_TYPE_MAX)
@@ -478,9 +468,9 @@ void main() {
     if (p.gqa_ratio > 1) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4*(d * D_split + d_tid) + comp, float(Of[r][d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -488,9 +478,9 @@ void main() {
     } else {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (i * Br + tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
+                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4*(d * D_split + d_tid) + comp] = D_TYPE(Of[r][d][comp]);
+                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Of[r][d][comp]);
                     }
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -313,7 +313,7 @@ void main() {
         [[unroll]] for (uint32_t hsv_tile = 0; hsv_tile < num_hsv_tiles; ++hsv_tile) {
             const uint hsv_offset = (hsv_tile * row_split + gl_SubgroupID) * 16;
 
-            SfMat = coopmat<ACC_TYPE, gl_ScopeSubgroup, MatBr, MatBc, gl_MatrixUseAccumulator>(0);
+            SfMat = coopmat<ACC_TYPE, gl_ScopeSubgroup, MatBc, MatBr, gl_MatrixUseAccumulator>(0);
 
 #if BLOCK_SIZE > 1
             // Preload V tiles for [Bc, 16 * num subgroups]
@@ -359,7 +359,7 @@ void main() {
             }
 
             // Store SfMat to sfsh and load into Of
-            const uint osh_stride = row_split * MatBc + 8;
+            const uint osh_stride = row_split * MatBc;
             const uint o_offset = gl_SubgroupID * MatBc;
             coopMatStore(SfMat, sfsh, o_offset, osh_stride, gl_CooperativeMatrixLayoutRowMajor);
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -8,6 +8,7 @@
 
 #extension GL_KHR_shader_subgroup_basic : enable
 #extension GL_KHR_shader_subgroup_vote : enable
+#extension GL_KHR_shader_subgroup_shuffle : enable
 #extension GL_KHR_memory_scope_semantics : enable
 #extension GL_KHR_cooperative_matrix : enable
 
@@ -44,8 +45,7 @@ D_TYPE perElemOpGqaStore(const in uint32_t r, const in uint32_t c, const in D_TY
 const uint32_t MatBr = 16;
 const uint32_t MatBc = 16;
 
-shared FLOAT_TYPE tmpsh[gl_WorkGroupSize.x];
-shared ACC_TYPEV4 tmpshv4[gl_WorkGroupSize.x];
+shared FLOAT_TYPE tmpsh[WorkGroupSize / row_split];
 
 const uint32_t qstride = HSK_pad / 4 + 2; // in units of f16vec4
 shared f16vec4 Qf[Br * qstride];
@@ -264,17 +264,10 @@ void main() {
             }
             float Moldf = Mf[r];
 
-            tmpsh[tid] = rowmaxf;
             // Compute max across the row
-            barrier();
-            [[unroll]] for (int s = int(gl_WorkGroupSize.x / row_split) / 2; s >= D_split; s >>= 1) {
-                rowmaxf = max(rowmaxf, tmpsh[tid ^ s]);
-                barrier();
-                tmpsh[tid] = rowmaxf;
-                barrier();
+            [[unroll]] for (uint s = D_split; s < 32; s *= 2) {
+                rowmaxf = max(rowmaxf, subgroupShuffleXor(rowmaxf, s));
             }
-            rowmaxf = tmpsh[d_tid + row_tid * threads_per_rowgroup];
-            barrier();
 
             // M = max(rowmax, Mold)
             // P = e^(S - M)
@@ -415,18 +408,9 @@ void main() {
     }
 
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        float L = Lf[r];
-        tmpsh[tid] = L;
-        // Compute sum across the row
-        barrier();
-        [[unroll]] for (int s = int(gl_WorkGroupSize.x / row_split) / 2; s >= D_split; s >>= 1) {
-            L += tmpsh[tid ^ s];
-            barrier();
-            tmpsh[tid] = L;
-            barrier();
+        [[unroll]] for (uint s = D_split; s < 32; s *= 2) {
+            Lf[r] += subgroupShuffleXor(Lf[r], s);
         }
-        Lf[r] = tmpsh[d_tid + row_tid * threads_per_rowgroup];
-        barrier();
     }
 
     // If there is split_k, then the split_k resolve shader does the final

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -259,11 +259,25 @@ void main() {
             }
             float Moldf = Mf[r];
 
+            tmpsh[tid] = rowmaxf;
+            // Compute max across the row
+            barrier();
+            [[unroll]] for (int s = int(gl_WorkGroupSize.x / row_split) / 2; s >= D_split; s >>= 1) {
+                rowmaxf = max(rowmaxf, tmpsh[tid ^ s]);
+                barrier();
+                tmpsh[tid] = rowmaxf;
+                barrier();
+            }
+            rowmaxf = tmpsh[d_tid + row_tid * threads_per_rowgroup];
+            barrier();
+
             // M = max(rowmax, Mold)
             // P = e^(S - M)
             // eM = e^(Mold - M)
             Mf[r] = max(rowmaxf, Moldf);
             eMf[r] = exp(Moldf - Mf[r]);
+
+            Lf[r] = eMf[r]*Lf[r];
         }
 
         [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
@@ -271,26 +285,23 @@ void main() {
                 Of[r][d] = ACC_TYPE(eMf[r]) * Of[r][d];
             }
         }
-        [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-            Lf[r] = eMf[r]*Lf[r];
-        }
 
 #if 1
         const uint psh_stride = Br / 4; // No space for padding, maybe increase Qf size?
 
         // Calculate and store Pf in Qf
-        if (d_tid == 0) {  // All other threads have the same P values
-            [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
-                const uint col = c * cols_per_iter + col_tid;
+        [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
+            const uint col = c * cols_per_iter + col_tid;
 
-                [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
-                    const uint row = tile_row(r);
-                    f16vec4 Pfvec;
-                    [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                        const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
-                        Lf[r + vec_idx] += Pf;
-                        Pfvec[vec_idx] = Pf;
-                    }
+            [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
+                const uint row = tile_row(r);
+                f16vec4 Pfvec;
+                [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
+                    const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                    Lf[r + vec_idx] += Pf;
+                    Pfvec[vec_idx] = Pf;
+                }
+                if (d_tid == 0) {  // All other threads have the same P values
                     Qf[col * psh_stride + row / 4] = Pfvec;
                 }
             }
@@ -406,40 +417,8 @@ void main() {
         barrier();
     }
 
-    // prevent race on tmpsh
-    barrier();
-
-    // reduce across threads
-
-    float rowmaxf[rows_per_thread], eMf[rows_per_thread], Moldf[rows_per_thread];
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        FLOAT_TYPE M = Mf[r];
-        tmpsh[tid] = M;
-        // Compute max across the row
-        barrier();
-        [[unroll]] for (int s = int(gl_WorkGroupSize.x / row_split) / 2; s >= D_split; s >>= 1) {
-            M = max(M, tmpsh[tid ^ s]);
-            barrier();
-            tmpsh[tid] = M;
-            barrier();
-        }
-        rowmaxf[r] = tmpsh[d_tid + row_tid * threads_per_rowgroup];
-        barrier();
-    }
-
-    [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        Moldf[r] = Mf[r];
-
-        // M = max(rowmax, Mold)
-        // eM = e^(Mold - M)
-        Mf[r] = max(rowmaxf[r], Moldf[r]);
-        eMf[r] = exp(Moldf[r] - Mf[r]);
-
-        Lf[r] = eMf[r]*Lf[r];
-    }
-
-    [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        FLOAT_TYPE L = Lf[r];
+        float L = Lf[r];
         tmpsh[tid] = L;
         // Compute sum across the row
         barrier();
@@ -452,26 +431,6 @@ void main() {
         Lf[r] = tmpsh[d_tid + row_tid * threads_per_rowgroup];
         barrier();
     }
-
-#if 0
-    [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
-
-            Of[r][d] = ACC_TYPE(eMf[r]) * Of[r][d];
-            tmpshv4[tid] = Of[r][d];
-
-            barrier();
-            [[unroll]] for (int s = int(gl_WorkGroupSize.x / row_split) / 2; s >= D_split; s >>= 1) {
-                Of[r][d] += tmpshv4[tid ^ s];
-                barrier();
-                tmpshv4[tid] = Of[r][d];
-                barrier();
-            }
-            Of[r][d] = tmpshv4[d_tid + row_tid * threads_per_rowgroup];
-            barrier();
-        }
-    }
-#endif
 
     // If there is split_k, then the split_k resolve shader does the final
     // division by L. Store the intermediate O value and per-row m and L values.

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -170,6 +170,7 @@ void main() {
             }
             // skip the block if the mask is entirely -inf
             bool all_less = subgroupAll(max_mask <= NEG_FLT_MAX_OVER_2);
+            barrier();
             if (gl_SubgroupInvocationID == 0) {
                 tmpsh[gl_SubgroupID] = all_less ? NEG_FLT_MAX_OVER_2 : 0.0f;
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -158,13 +158,36 @@ void main() {
                 uint32_t c = (idx + tid) / (Br / 4);
                 uint32_t r = (idx + tid) % (Br / 4);
                 if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
-                    if ((!KV_bounds_check || j * Bc + c < KV) && (!nem1_bounds_check || i * Br + r * 4 < p.nem1)) {
-                        const f16vec4 m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
-                                                  data_m[m_offset + (i * Br + r * 4 + 1) * m_stride + (j * Bc + c)],
-                                                  data_m[m_offset + (i * Br + r * 4 + 2) * m_stride + (j * Bc + c)],
-                                                  data_m[m_offset + (i * Br + r * 4 + 3) * m_stride + (j * Bc + c)]);
+                    if ((!KV_bounds_check || j * Bc + c < KV)) {
+                        f16vec4 m;
+                        if (!nem1_bounds_check || i * Br + r * 4 + 3 < p.nem1) {
+                            m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 1) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 2) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 3) * m_stride + (j * Bc + c)]);
+                            max_mask = max(max(max(max(max_mask, float(m[0])), float(m[1])), float(m[2])), float(m[3]));
+                        } else if (i * Br + r * 4 + 2 < p.nem1) {
+                            m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 1) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 2) * m_stride + (j * Bc + c)],
+                                        0.0);
+                            max_mask = max(max(max(max_mask, float(m[0])), float(m[1])), float(m[2]));
+                        } else if (i * Br + r * 4 + 1 < p.nem1) {
+                            m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
+                                        data_m[m_offset + (i * Br + r * 4 + 1) * m_stride + (j * Bc + c)],
+                                        0.0,
+                                        0.0);
+                            max_mask = max(max(max_mask, float(m[0])), float(m[1]));
+                        } else if (i * Br + r * 4 < p.nem1) {
+                            m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
+                                        0.0,
+                                        0.0,
+                                        0.0);
+                            max_mask = max(max_mask, float(m[0]));
+                        } else {
+                            m = f16vec4(0.0);
+                        }
                         mask_cache[idx / WorkGroupSize] = m;
-                        max_mask = max(max(max(max(max_mask, float(m[0])), float(m[1])), float(m[2])), float(m[3]));
                     }
                 }
             }
@@ -282,36 +305,15 @@ void main() {
         }
 
         if ((p.mask_n_head_log2 & MASK_ENABLE_BIT) != 0) {
-            bool nem1_bounds_check = !(p.gqa_ratio > 1) && (p.nem1 % Br) != 0;
-
             [[unroll]] for (uint32_t idx = 0; idx < Bc * Br / 4; idx += gl_WorkGroupSize.x) {
                 uint32_t c = (idx + tid) / (Br / 4);
                 uint32_t r = (idx + tid) % (Br / 4);
                 if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
                     if (!KV_bounds_check || j * Bc + c < KV) {
-                        if (!nem1_bounds_check || i * Br + r * 4 + 3 < p.nem1) {
-                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
-                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
-                            sfsh[c * sfshstride + r] += slopes * masks;
-                        } else if (i * Br + r * 4 + 2 < p.nem1) {
-                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
-                            masks.w = ACC_TYPE(0.0f);
-                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
-                            sfsh[c * sfshstride + r] += slopes * masks;
-                        } else if (i * Br + r * 4 + 1 < p.nem1) {
-                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
-                            masks.z = ACC_TYPE(0.0f);
-                            masks.w = ACC_TYPE(0.0f);
-                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
-                            sfsh[c * sfshstride + r] += slopes * masks;
-                        } else if (i * Br + r * 4 < p.nem1) {
-                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
-                            masks.y = ACC_TYPE(0.0f);
-                            masks.z = ACC_TYPE(0.0f);
-                            masks.w = ACC_TYPE(0.0f);
-                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
-                            sfsh[c * sfshstride + r] += slopes * masks;
-                        }
+                        // Mask nem1 bounds check is handled when loading masks
+                        ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
+                        ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
+                        sfsh[c * sfshstride + r] += slopes * masks;
                     }
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -299,7 +299,12 @@ void main() {
                 const uint row = tile_row(r);
                 f16vec4 Pfvec;
                 [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                    const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                    float16_t Pf;
+                    if (KV_bounds_check && j * Bc + col >= KV) {
+                        Pf = float16_t(0.0f);
+                    } else {
+                        Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                    }
                     Lf[r + vec_idx] += Pf;
                     Pfvec[vec_idx] = Pf;
                 }
@@ -338,7 +343,7 @@ void main() {
                 const uint ib = coord / BLOCK_SIZE;
                 const uint iqs = coord % BLOCK_SIZE;
 
-                if (!KV_bounds_check || v_col < HSV) {
+                if (!KV_bounds_check || (v_row < KV && v_col < HSV)) {
 #if BLOCK_SIZE > 1
                     ksh[row * vsh_stride + col] = f16vec4(dequantize4(ib, iqs, v_offset, BINDING_IDX_V));
 #else

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -54,7 +54,7 @@ shared f16vec4 Psh[Bc * psh_stride];
 const uint32_t sfshstride = (HSK <= 128) ? (Br / 4 + 2) : Br / 4;
 shared ACC_TYPEV4 sfsh[Bc * sfshstride];
 
-const uint32_t kshstride = MatBr / 4 + 2; // in units of f16vec4
+const uint32_t kshstride = (K_LOAD_SHMEM != 0 ? HSK_pad : MatBr) / 4 + 2; // in units of f16vec4
 const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
 const uint vsh_stride = v_cols;
 shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
@@ -182,6 +182,29 @@ void main() {
             }
         }
 
+        if (K_LOAD_SHMEM != 0) {
+            [[unroll]] for (uint32_t idx = 0; idx < Bc * HSK / 4; idx += gl_WorkGroupSize.x) {
+                uint32_t d = (idx + tid) % (HSK / 4);
+                uint32_t c = (idx + tid) / (HSK / 4);
+                if (c < Bc && d < HSK / 4) {
+                    f16vec4 K_Tf = f16vec4(0);
+                    if (!KV_bounds_check || j * Bc + c < KV) {
+#if BLOCK_SIZE > 1
+                        uint coord = (j * Bc + c) * k_stride * BLOCK_SIZE + 4 * d;
+                        uint ib = coord / BLOCK_SIZE;
+                        uint iqs = (coord % BLOCK_SIZE);
+                        K_Tf = f16vec4(dequantize4(ib, iqs, k_offset, BINDING_IDX_K));
+#else
+                        K_Tf = f16vec4(data_kv4[k_offset / 4 + (j * Bc + c) * k_stride / 4 + d]);
+#endif
+                    }
+
+                    ksh[c * kshstride + d] = K_Tf;
+                }
+            }
+            barrier();
+        }
+
         // K * Q^T -> S^T: Bc x HSK_pad * HSK_pad x Br -> Bc x Br
         // Bc split across workgroup (four subgroups), loop over HSK in chunks of 16: 16 x 16 * 16 x 16 -> 16 x 16
         // This is written transposed in order to allow for N being 8 if implementations need it
@@ -190,6 +213,7 @@ void main() {
         coopmat<float16_t, gl_ScopeSubgroup, 16, MatBr, gl_MatrixUseB> QMat;
 
         [[unroll]] for (uint32_t d = 0; d < HSK_pad / 16; ++d) {
+            if (K_LOAD_SHMEM == 0) {
 #if BLOCK_SIZE == 1
             if (KV_bounds_check || d * 16 + 16 > HSK) {
 #endif
@@ -231,6 +255,10 @@ void main() {
                 coopMatLoad(KMat, data_kv4, coord, k_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
             }
 #endif
+            } else {
+                uint coord = (gl_SubgroupID * MatBc) * kshstride + d * 16 / 4;
+                coopMatLoad(KMat, ksh, coord, kshstride, gl_CooperativeMatrixLayoutRowMajor);
+            }
 
             coopMatLoad(QMat, Qf, d * 16 / 4, qstride, gl_CooperativeMatrixLayoutColumnMajor);
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -279,18 +279,20 @@ void main() {
         const uint psh_stride = Br / 4; // No space for padding, maybe increase Qf size?
 
         // Calculate and store Pf in Qf
-        [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
-            const uint col = c * cols_per_iter + col_tid;
+        if (d_tid == 0) {  // All other threads have the same P values
+            [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
+                const uint col = c * cols_per_iter + col_tid;
 
-            [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
-                const uint row = tile_row(r);
-                f16vec4 Pfvec;
-                [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                    const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
-                    Lf[r + vec_idx] += Pf;
-                    Pfvec[vec_idx] = Pf;
+                [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
+                    const uint row = tile_row(r);
+                    f16vec4 Pfvec;
+                    [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
+                        const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                        Lf[r + vec_idx] += Pf;
+                        Pfvec[vec_idx] = Pf;
+                    }
+                    Qf[col * psh_stride + row / 4] = Pfvec;
                 }
-                Qf[col * psh_stride + row / 4] = Pfvec;
             }
         }
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -48,14 +48,17 @@ shared FLOAT_TYPE tmpsh[gl_WorkGroupSize.x];
 shared ACC_TYPEV4 tmpshv4[gl_WorkGroupSize.x];
 
 const uint32_t qstride = HSK_pad / 4 + 2; // in units of f16vec4
-shared f16vec4 Qf[Br * qstride];
+const uint psh_stride = Br / 4 + 2;
+shared f16vec4 Qf[(Br * qstride >= Bc * psh_stride) ? (Br * qstride) : (Bc * psh_stride)];
 
 // Avoid padding for hsk==256 to make it fit in 48KB shmem.
 const uint32_t sfshstride = (HSK <= 128) ? (Br + 8) : Br;
 shared ACC_TYPE sfsh[Bc * sfshstride];
 
 const uint32_t kshstride = HSK_pad / 4 + 2; // in units of f16vec4
-shared f16vec4 ksh[Bc * kshstride];
+const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
+const uint vsh_stride = v_cols;
+shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
 
 shared float slope[Br];
 
@@ -286,8 +289,6 @@ void main() {
             }
         }
 
-        const uint psh_stride = Br / 4; // No space for padding, maybe increase Qf size?
-
         // Calculate and store Pf in Qf
         [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
             const uint col = c * cols_per_iter + col_tid;
@@ -306,7 +307,7 @@ void main() {
             }
         }
 
-        const uint num_hsv_tiles = max(HSV / MatBc / row_split, 1);
+        const uint num_hsv_tiles = (HSV + MatBc * row_split - 1) / (MatBc * row_split); // round up
 
         // Each subgroup handles HSV/4 columns
         [[unroll]] for (uint32_t hsv_tile = 0; hsv_tile < num_hsv_tiles; ++hsv_tile) {
@@ -316,11 +317,8 @@ void main() {
 
             // Preload V tiles for [Bc, 16 * num subgroups]
             const uint v_rows = Bc;
-            const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
             const uint v_total = v_rows * v_cols;
             const uint v_loads_per_thread = v_total / gl_WorkGroupSize.x;
-
-            const uint vsh_stride = v_cols;
 
 #if BLOCK_SIZE == 1
             // For f16, only preload if not aligned
@@ -385,7 +383,7 @@ void main() {
             const uint d_values_per_tile = hsv_per_tile / 4 / D_split;
 
             const uint d_start = hsv_tile * d_values_per_tile;
-            const uint d_end = d_start + d_values_per_tile;
+            const uint d_end = min(d_start + d_values_per_tile, HSV_per_thread / 4);
 
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 const uint row = tile_row(r);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -130,13 +130,11 @@ void main() {
             uint r = tid;
             slope[r] = perElemOpComputeSlope(r, col_tid, ACC_TYPE(0), iq2);
         }
-        barrier();
     } else {
         if (tid < Br) {
             uint r = tid;
             slope[r] = 1.0;
         }
-        barrier();
     }
 
 #if BLOCK_SIZE > 1
@@ -290,15 +288,16 @@ void main() {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
                 const uint row = tile_row(r);
                 f16vec4 Pfvec;
-                [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                    float16_t Pf;
-                    if (KV_bounds_check && j * Bc + col >= KV) {
-                        Pf = float16_t(0.0f);
-                    } else {
-                        Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                if (KV_bounds_check && j * Bc + col >= KV) {
+                    [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
+                        Pfvec[vec_idx] = float16_t(0.0f);
                     }
-                    Lf[r + vec_idx] += Pf;
-                    Pfvec[vec_idx] = Pf;
+                } else {
+                    [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
+                        const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
+                        Lf[r + vec_idx] += Pf;
+                        Pfvec[vec_idx] = Pf;
+                    }
                 }
                 if (d_tid == 0) {  // All other threads have the same P values
                     Psh[col * psh_stride + row / 4] = Pfvec;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -48,8 +48,10 @@ shared FLOAT_TYPE tmpsh[gl_WorkGroupSize.x];
 shared ACC_TYPEV4 tmpshv4[gl_WorkGroupSize.x];
 
 const uint32_t qstride = HSK_pad / 4 + 2; // in units of f16vec4
+shared f16vec4 Qf[Br * qstride];
+
 const uint psh_stride = Br / 4 + 2;
-shared f16vec4 Qf[(Br * qstride >= Bc * psh_stride) ? (Br * qstride) : (Bc * psh_stride)];
+shared f16vec4 Psh[Bc * psh_stride];
 
 // Avoid padding for hsk==256 to make it fit in 48KB shmem.
 const uint32_t sfshstride = (HSK <= 128) ? (Br + 8) : Br;
@@ -289,7 +291,7 @@ void main() {
             }
         }
 
-        // Calculate and store Pf in Qf
+        // Calculate and store Pf in Psh
         [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
             const uint col = c * cols_per_iter + col_tid;
 
@@ -302,7 +304,7 @@ void main() {
                     Pfvec[vec_idx] = Pf;
                 }
                 if (d_tid == 0) {  // All other threads have the same P values
-                    Qf[col * psh_stride + row / 4] = Pfvec;
+                    Psh[col * psh_stride + row / 4] = Pfvec;
                 }
             }
         }
@@ -353,7 +355,7 @@ void main() {
             barrier();
 
             [[unroll]] for (uint32_t bc_chunk = 0; bc_chunk < Bc / MatBc; ++bc_chunk) {
-                coopMatLoad(KMat, Qf, bc_chunk * MatBc * psh_stride, psh_stride, gl_CooperativeMatrixLayoutColumnMajor);
+                coopMatLoad(KMat, Psh, bc_chunk * MatBc * psh_stride, psh_stride, gl_CooperativeMatrixLayoutColumnMajor);
 
 #if BLOCK_SIZE == 1
                 if (!KV_bounds_check) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -42,7 +42,7 @@ D_TYPE perElemOpGqaStore(const in uint32_t r, const in uint32_t c, const in D_TY
     return elem;
 }
 
-shared FLOAT_TYPE tmpsh[row_split];
+shared float tmpsh[row_split];
 
 const uint32_t qstride = HSK_pad / 4 + 2; // in units of f16vec4
 shared f16vec4 Qf[Br * qstride];

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -45,7 +45,7 @@ D_TYPE perElemOpGqaStore(const in uint32_t r, const in uint32_t c, const in D_TY
 const uint32_t MatBr = 16;
 const uint32_t MatBc = 16;
 
-shared FLOAT_TYPE tmpsh[WorkGroupSize / row_split];
+shared FLOAT_TYPE tmpsh[row_split];
 
 const uint32_t qstride = HSK_pad / 4 + 2; // in units of f16vec4
 shared f16vec4 Qf[Br * qstride];
@@ -172,7 +172,6 @@ void main() {
             }
             // skip the block if the mask is entirely -inf
             bool all_less = subgroupAll(max_mask <= NEG_FLT_MAX_OVER_2);
-            barrier();
             if (gl_SubgroupInvocationID == 0) {
                 tmpsh[gl_SubgroupID] = all_less ? NEG_FLT_MAX_OVER_2 : 0.0f;
             }
@@ -213,7 +212,7 @@ void main() {
         coopmat<float16_t, gl_ScopeSubgroup, MatBc, 16, gl_MatrixUseA> KMat;
         coopmat<float16_t, gl_ScopeSubgroup, 16, MatBr, gl_MatrixUseB> QMat;
 
-        for (uint32_t d = 0; d < HSK_pad / 16; ++d) {
+        [[unroll]] for (uint32_t d = 0; d < HSK_pad / 16; ++d) {
             coopMatLoad(QMat, Qf, d * 16 / 4, qstride, gl_CooperativeMatrixLayoutColumnMajor);
 
             uint coord = (gl_SubgroupID * MatBc) * kshstride + d * 16 / 4;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -272,7 +272,9 @@ void main() {
             Lf[r] = eMf[r]*Lf[r];
         }
 
-        [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+        [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+            const uint d = d0 + col_tid;
+            if (d >= HSV / 4) break;
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 Ofsh[tile_row(r) * ofsh_stride + d] = ACC_TYPE(eMf[r]) * Ofsh[tile_row(r) * ofsh_stride + d];
             }
@@ -381,7 +383,10 @@ void main() {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 const uint row = tile_row(r);
 
-                [[unroll]] for (uint32_t d = d_start; d < d_end; ++d) {
+                [[unroll]] for (uint32_t d0 = d_start; d0 < d_end; d0 += threads_per_rowgroup) {
+                    const uint d = d0 + col_tid;
+                    if (d >= d_end) break;
+
                     const uint hsv_col = 4 * d;
                     const uint local_hsv = hsv_col - hsv_base;
 
@@ -412,7 +417,9 @@ void main() {
 
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+                [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+                    const uint d = d0 + col_tid;
+                    if (d >= HSV/4) break;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
                         perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
                     }
@@ -441,7 +448,9 @@ void main() {
             if (sink > Mf[r]) {
                 ms = exp(Mf[r] - sink);
 
-                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+                [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+                    const uint d = d0 + col_tid;
+                    if (d >= HSV / 4) break;
                     Ofsh[tile_row(r) * ofsh_stride + d] *= ACC_TYPE(ms);
                 }
             } else {
@@ -457,7 +466,9 @@ void main() {
         Lfrcp[r] = (Lf[r] == 0.0) ? 0.0 : (1.0 / Lf[r]);
     }
 
-    [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+    [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+        const uint d = d0 + col_tid;
+        if (d >= HSV / 4) break;
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             ACC_TYPEV4 Of = Ofsh[tile_row(r) * ofsh_stride + d] * ACC_TYPE(Lfrcp[r]);
 #if defined(ACC_TYPE_MAX)
@@ -472,7 +483,9 @@ void main() {
     if (p.gqa_ratio > 1) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+                [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+                    const uint d = d0 + col_tid;
+                    if (d >= HSV / 4) break;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
                         perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
                     }
@@ -482,7 +495,9 @@ void main() {
     } else {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (i * Br + tile_row(r) < N) {
-                [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
+                [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
+                    const uint d = d0 + col_tid;
+                    if (d >= HSV / 4) break;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
                         data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Ofsh[tile_row(r) * ofsh_stride + d][comp]);
                     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -307,7 +307,7 @@ void main() {
             }
         }
 
-        const uint num_hsv_tiles = HSV / MatBc / row_split;
+        const uint num_hsv_tiles = max(HSV / MatBc / row_split, 1);
 
         // Each subgroup handles HSV/4 columns
         [[unroll]] for (uint32_t hsv_tile = 0; hsv_tile < num_hsv_tiles; ++hsv_tile) {
@@ -315,7 +315,6 @@ void main() {
 
             SfMat = coopmat<ACC_TYPE, gl_ScopeSubgroup, MatBc, MatBr, gl_MatrixUseAccumulator>(0);
 
-#if BLOCK_SIZE > 1
             // Preload V tiles for [Bc, 16 * num subgroups]
             const uint v_rows = Bc;
             const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
@@ -324,6 +323,10 @@ void main() {
 
             const uint vsh_stride = v_cols;
 
+#if BLOCK_SIZE == 1
+            // For f16, only preload if not aligned
+            if (KV_bounds_check) {
+#endif
             [[unroll]] for (uint32_t i = 0; i < v_loads_per_thread; ++i) {
                 const uint idx = i * gl_WorkGroupSize.x + tid;
                 const uint row = idx / v_cols;
@@ -336,7 +339,17 @@ void main() {
                 const uint ib = coord / BLOCK_SIZE;
                 const uint iqs = coord % BLOCK_SIZE;
 
-                ksh[row * vsh_stride + col] = f16vec4(dequantize4(ib, iqs, v_offset, BINDING_IDX_V));
+                if (!KV_bounds_check || v_col < HSV) {
+#if BLOCK_SIZE > 1
+                    ksh[row * vsh_stride + col] = f16vec4(dequantize4(ib, iqs, v_offset, BINDING_IDX_V));
+#else
+                    ksh[row * vsh_stride + col] = data_vv4[(v_offset + v_row * v_stride + v_col) / 4];
+#endif
+                } else {
+                    ksh[row * vsh_stride + col] = f16vec4(0.0f);
+                }
+            }
+#if BLOCK_SIZE == 1
             }
 #endif
 
@@ -345,15 +358,18 @@ void main() {
             [[unroll]] for (uint32_t bc_chunk = 0; bc_chunk < Bc / MatBc; ++bc_chunk) {
                 coopMatLoad(KMat, Qf, bc_chunk * MatBc * psh_stride, psh_stride, gl_CooperativeMatrixLayoutColumnMajor);
 
-#if BLOCK_SIZE > 1
-                const uint v_tile_offset = bc_chunk * MatBr * v_cols + gl_SubgroupID * (MatBc / 4);
-                coopMatLoad(QMat, ksh, v_tile_offset, vsh_stride, gl_CooperativeMatrixLayoutRowMajor);
-#else
-                // F16 values can be loaded directly from global memory
-                const uint v_tile_row = j * Bc + bc_chunk * MatBc;
-                const uint v_tile_offset = v_offset / 4 + v_tile_row * v_stride / 4 + hsv_offset / 4;
-                coopMatLoad(QMat, data_vv4, v_tile_offset, v_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+#if BLOCK_SIZE == 1
+                if (!KV_bounds_check) {
+                    // F16 values can be loaded directly from global memory
+                    const uint v_tile_row = j * Bc + bc_chunk * MatBc;
+                    const uint v_tile_offset = v_offset / 4 + v_tile_row * v_stride / 4 + hsv_offset / 4;
+                    coopMatLoad(QMat, data_vv4, v_tile_offset, v_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+                } else
 #endif
+                {
+                    const uint v_tile_offset = bc_chunk * MatBr * v_cols + gl_SubgroupID * (MatBc / 4);
+                    coopMatLoad(QMat, ksh, v_tile_offset, vsh_stride, gl_CooperativeMatrixLayoutRowMajor);
+                }
 
                 SfMat = coopMatMulAdd(KMat, QMat, SfMat);
             }
@@ -379,12 +395,14 @@ void main() {
                     const uint hsv_col = 4 * (d * D_split + d_tid);
                     const uint local_hsv = hsv_col - hsv_base;
 
-                    Of[r][d] += ACC_TYPEV4(
-                        sfsh[row * osh_stride + local_hsv],
-                        sfsh[row * osh_stride + local_hsv + 1],
-                        sfsh[row * osh_stride + local_hsv + 2],
-                        sfsh[row * osh_stride + local_hsv + 3]
-                    );
+                    if (!KV_bounds_check || hsv_col < HSV) {
+                        Of[r][d] += ACC_TYPEV4(
+                            sfsh[row * osh_stride + local_hsv],
+                            sfsh[row * osh_stride + local_hsv + 1],
+                            sfsh[row * osh_stride + local_hsv + 2],
+                            sfsh[row * osh_stride + local_hsv + 3]
+                        );
+                    }
                 }
             }
         }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -59,6 +59,10 @@ const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * nu
 const uint vsh_stride = v_cols;
 shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
 
+// Output buffer
+const uint32_t ofsh_stride = HSV / 4 + 2;
+shared ACC_TYPEV4 Ofsh[Br * ofsh_stride];
+
 shared float slope[Br];
 
 void main() {
@@ -101,14 +105,13 @@ void main() {
             Qf[r * qstride + d] = f16vec4(data_qv4[q_offset / 4 + (i * Br + r) * q_stride / 4 + d] * p.scale);
         }
     }
-    barrier();
 
-    ACC_TYPEV4 Of[rows_per_thread][HSV / 4];
-    [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
-        [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-            Of[r][d] = ACC_TYPEV4(0.0);
+    [[unroll]] for (uint idx = 0; idx < Br * ofsh_stride; idx += gl_WorkGroupSize.x) {
+        if (idx + tid < Br * ofsh_stride) {
+            Ofsh[idx + tid] = ACC_TYPEV4(0.0);
         }
     }
+    barrier();
 
     float Lf[rows_per_thread], Mf[rows_per_thread];
 
@@ -271,7 +274,7 @@ void main() {
 
         [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                Of[r][d] = ACC_TYPE(eMf[r]) * Of[r][d];
+                Ofsh[tile_row(r) * ofsh_stride + d] = ACC_TYPE(eMf[r]) * Ofsh[tile_row(r) * ofsh_stride + d];
             }
         }
 
@@ -361,7 +364,7 @@ void main() {
                 SfMat = coopMatMulAdd(KMat, QMat, SfMat);
             }
 
-            // Store SfMat to sfsh and load into Of
+            // Store SfMat to sfsh and load into Ofsh
             const uint osh_stride = row_split * MatBc;
             const uint o_offset = gl_SubgroupID * MatBc;
             coopMatStore(SfMat, sfsh, o_offset, osh_stride, gl_CooperativeMatrixLayoutRowMajor);
@@ -383,7 +386,7 @@ void main() {
                     const uint local_hsv = hsv_col - hsv_base;
 
                     if (!KV_bounds_check || hsv_col < HSV) {
-                        Of[r][d] += ACC_TYPEV4(
+                        Ofsh[tile_row(r) * ofsh_stride + d] += ACC_TYPEV4(
                             sfsh[row * osh_stride + local_hsv],
                             sfsh[row * osh_stride + local_hsv + 1],
                             sfsh[row * osh_stride + local_hsv + 2],
@@ -411,7 +414,7 @@ void main() {
             if (tile_row(r) < N) {
                 [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -439,7 +442,7 @@ void main() {
                 ms = exp(Mf[r] - sink);
 
                 [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
-                    Of[r][d] *= ACC_TYPE(ms);
+                    Ofsh[tile_row(r) * ofsh_stride + d] *= ACC_TYPE(ms);
                 }
             } else {
                 vs = exp(sink - Mf[r]);
@@ -456,10 +459,11 @@ void main() {
 
     [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-            Of[r][d] *= ACC_TYPE(Lfrcp[r]);
+            ACC_TYPEV4 Of = Ofsh[tile_row(r) * ofsh_stride + d] * ACC_TYPE(Lfrcp[r]);
 #if defined(ACC_TYPE_MAX)
-            Of[r][d] = clamp(Of[r][d], -ACC_TYPE_MAX, ACC_TYPE_MAX);
+            Of = clamp(Of, -ACC_TYPE_MAX, ACC_TYPE_MAX);
 #endif
+            Ofsh[tile_row(r) * ofsh_stride + d] = Of;
         }
     }
 
@@ -470,7 +474,7 @@ void main() {
             if (tile_row(r) < N) {
                 [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -480,7 +484,7 @@ void main() {
             if (i * Br + tile_row(r) < N) {
                 [[unroll]] for (uint32_t d = 0; d < HSV / 4; ++d) {
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Of[r][d][comp]);
+                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Ofsh[tile_row(r) * ofsh_stride + d][comp]);
                     }
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -15,10 +15,14 @@
 #include "types.glsl"
 #include "flash_attn_base.glsl"
 
+// These need to be supported N,M values for a MatBc x MatBr x 16 coopmatmuladd
+const uint32_t MatBr = 16;
+const uint32_t MatBc = 16;
+
 const uint32_t HSK_per_thread = HSK / D_split;
 const uint32_t HSV_per_thread = HSV / D_split;
 
-const uint32_t row_split = 4;
+const uint32_t row_split = Bc / MatBc;
 const uint32_t rows_per_thread = Br / row_split;
 const uint32_t cols_per_iter = gl_WorkGroupSize.x / D_split / row_split;
 const uint32_t cols_per_thread = Bc / cols_per_iter;
@@ -40,10 +44,6 @@ D_TYPE perElemOpGqaStore(const in uint32_t r, const in uint32_t c, const in D_TY
     data_o[o_offset + offset] = D_TYPE(elem);
     return elem;
 }
-
-// These need to be supported N,M values for a MatBc x MatBr x 16 coopmatmuladd
-const uint32_t MatBr = 16;
-const uint32_t MatBc = 16;
 
 shared FLOAT_TYPE tmpsh[row_split];
 
@@ -262,7 +262,7 @@ void main() {
             float Moldf = Mf[r];
 
             // Compute max across the row
-            [[unroll]] for (uint s = D_split; s < 32; s *= 2) {
+            [[unroll]] for (uint s = D_split; s < SubGroupSize; s *= 2) {
                 rowmaxf = max(rowmaxf, subgroupShuffleXor(rowmaxf, s));
             }
 
@@ -406,7 +406,7 @@ void main() {
     }
 
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-        [[unroll]] for (uint s = D_split; s < 32; s *= 2) {
+        [[unroll]] for (uint s = D_split; s < SubGroupSize; s *= 2) {
             Lf[r] += subgroupShuffleXor(Lf[r], s);
         }
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -59,10 +59,6 @@ const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * nu
 const uint vsh_stride = v_cols;
 shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
 
-// Output buffer
-const uint32_t ofsh_stride = HSV / 4 + 2;
-shared ACC_TYPEV4 Ofsh[Br * ofsh_stride];
-
 shared float slope[Br];
 
 void main() {
@@ -75,6 +71,7 @@ void main() {
     const uint32_t tid = gl_LocalInvocationIndex;
 
     const uint32_t threads_per_rowgroup = gl_WorkGroupSize.x / row_split;
+    const uint32_t d_per_thread = (HSV/4 + threads_per_rowgroup - 1) / threads_per_rowgroup;
     const uint32_t row_tid = gl_LocalInvocationIndex / threads_per_rowgroup;
     const uint32_t col_tid = gl_LocalInvocationIndex % threads_per_rowgroup;
 
@@ -105,13 +102,14 @@ void main() {
             Qf[r * qstride + d] = f16vec4(data_qv4[q_offset / 4 + (i * Br + r) * q_stride / 4 + d] * p.scale);
         }
     }
+    barrier();
 
-    [[unroll]] for (uint idx = 0; idx < Br * ofsh_stride; idx += gl_WorkGroupSize.x) {
-        if (idx + tid < Br * ofsh_stride) {
-            Ofsh[idx + tid] = ACC_TYPEV4(0.0);
+    ACC_TYPEV4 Of[rows_per_thread][d_per_thread];
+    [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
+        [[unroll]] for (uint32_t d = 0; d < d_per_thread; ++d) {
+            Of[r][d] = ACC_TYPEV4(0.0);
         }
     }
-    barrier();
 
     float Lf[rows_per_thread], Mf[rows_per_thread];
 
@@ -273,10 +271,9 @@ void main() {
         }
 
         [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
-            const uint d = d0 + col_tid;
-            if (d >= HSV / 4) break;
+            const uint d_local = d0 / threads_per_rowgroup;
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                Ofsh[tile_row(r) * ofsh_stride + d] = ACC_TYPE(eMf[r]) * Ofsh[tile_row(r) * ofsh_stride + d];
+                Of[r][d_local] = ACC_TYPE(eMf[r]) * Of[r][d_local];
             }
         }
 
@@ -366,7 +363,7 @@ void main() {
                 SfMat = coopMatMulAdd(KMat, QMat, SfMat);
             }
 
-            // Store SfMat to sfsh and load into Ofsh
+            // Store SfMat to sfsh and load into Of
             const uint osh_stride = row_split * MatBc;
             const uint o_offset = gl_SubgroupID * MatBc;
             coopMatStore(SfMat, sfsh, o_offset, osh_stride, gl_CooperativeMatrixLayoutRowMajor);
@@ -391,7 +388,8 @@ void main() {
                     const uint local_hsv = hsv_col - hsv_base;
 
                     if (!KV_bounds_check || hsv_col < HSV) {
-                        Ofsh[tile_row(r) * ofsh_stride + d] += ACC_TYPEV4(
+                        const uint d_local = d0 / threads_per_rowgroup;
+                        Of[r][d_local] += ACC_TYPEV4(
                             sfsh[row * osh_stride + local_hsv],
                             sfsh[row * osh_stride + local_hsv + 1],
                             sfsh[row * osh_stride + local_hsv + 2],
@@ -420,8 +418,9 @@ void main() {
                 [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
                     const uint d = d0 + col_tid;
                     if (d >= HSV/4) break;
+                    const uint d_local = d0 / threads_per_rowgroup;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d_local][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -449,9 +448,8 @@ void main() {
                 ms = exp(Mf[r] - sink);
 
                 [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
-                    const uint d = d0 + col_tid;
-                    if (d >= HSV / 4) break;
-                    Ofsh[tile_row(r) * ofsh_stride + d] *= ACC_TYPE(ms);
+                    const uint d_local = d0 / threads_per_rowgroup;
+                    Of[r][d_local] *= ACC_TYPE(ms);
                 }
             } else {
                 vs = exp(sink - Mf[r]);
@@ -467,14 +465,12 @@ void main() {
     }
 
     [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
-        const uint d = d0 + col_tid;
-        if (d >= HSV / 4) break;
+        const uint d_local = d0 / threads_per_rowgroup;
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-            ACC_TYPEV4 Of = Ofsh[tile_row(r) * ofsh_stride + d] * ACC_TYPE(Lfrcp[r]);
+            Of[r][d_local] *= ACC_TYPE(Lfrcp[r]);
 #if defined(ACC_TYPE_MAX)
-            Of = clamp(Of, -ACC_TYPE_MAX, ACC_TYPE_MAX);
+            Of[r][d_local] = clamp(Of[r][d_local], -ACC_TYPE_MAX, ACC_TYPE_MAX);
 #endif
-            Ofsh[tile_row(r) * ofsh_stride + d] = Of;
         }
     }
 
@@ -486,8 +482,9 @@ void main() {
                 [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
                     const uint d = d0 + col_tid;
                     if (d >= HSV / 4) break;
+                    const uint d_local = d0 / threads_per_rowgroup;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Ofsh[tile_row(r) * ofsh_stride + d][comp]), o_offset, iq2, N);
+                        perElemOpGqaStore(tile_row(r), 4 * d + comp, float(Of[r][d_local][comp]), o_offset, iq2, N);
                     }
                 }
             }
@@ -498,8 +495,9 @@ void main() {
                 [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
                     const uint d = d0 + col_tid;
                     if (d >= HSV / 4) break;
+                    const uint d_local = d0 / threads_per_rowgroup;
                     [[unroll]] for (uint32_t comp = 0; comp < 4; ++comp) {
-                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Ofsh[tile_row(r) * ofsh_stride + d][comp]);
+                        data_o[o_offset + iq2 * HSV + (i * Br + tile_row(r)) * p.ne1 * HSV + 4 * d + comp] = D_TYPE(Of[r][d_local][comp]);
                     }
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -51,15 +51,15 @@ const uint psh_stride = Br / 4 + 2;
 shared f16vec4 Psh[Bc * psh_stride];
 
 // Avoid padding for hsk==256 to make it fit in 48KB shmem.
-const uint32_t sfshstride = (HSK <= 128) ? (Br + 8) : Br;
-shared ACC_TYPE sfsh[Bc * sfshstride];
+const uint32_t sfshstride = (HSK <= 128) ? (Br / 4 + 2) : Br / 4;
+shared ACC_TYPEV4 sfsh[Bc * sfshstride];
 
 const uint32_t kshstride = HSK_pad / 4 + 2; // in units of f16vec4
 const uint v_cols = MatBc / 4 * row_split; // total cols, 4 vec4s per MatBc * number of subgroups
 const uint vsh_stride = v_cols;
 shared f16vec4 ksh[(kshstride >= vsh_stride) ? (Bc * kshstride) : (Bc * vsh_stride)];
 
-shared float slope[Br];
+shared ACC_TYPE slope[Br];
 
 void main() {
 #ifdef NEEDS_INIT_IQ_SHMEM
@@ -130,7 +130,7 @@ void main() {
     } else {
         if (tid < Br) {
             uint r = tid;
-            slope[r] = 1.0;
+            slope[r] = ACC_TYPE(1.0);
         }
     }
 
@@ -149,19 +149,22 @@ void main() {
     [[dont_unroll]]
     for (uint32_t j = start_j; j < end_j; ++j) {
 
-        float mask_cache[Bc * Br / WorkGroupSize];
+        f16vec4 mask_cache[Bc * Br / 4 / WorkGroupSize];
         if ((p.mask_n_head_log2 & MASK_ENABLE_BIT) != 0) {
             bool nem1_bounds_check = !(p.gqa_ratio > 1) && (p.nem1 % Br) != 0;
 
             float max_mask = NEG_FLT_MAX_OVER_2;
-            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br; idx += gl_WorkGroupSize.x) {
-                uint32_t c = (idx + tid) % Bc;
-                uint32_t r = (idx + tid) / Bc;
-                if (idx + tid < Bc * Br || idx + gl_WorkGroupSize.x <= Bc * Br) {
-                    if ((!KV_bounds_check || j * Bc + c < KV) && (!nem1_bounds_check || i * Br + r < p.nem1)) {
-                        float m = float(data_m[m_offset + (i * Br + r) * m_stride + (j * Bc + c)]);
+            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br / 4; idx += gl_WorkGroupSize.x) {
+                uint32_t c = (idx + tid) / (Br / 4);
+                uint32_t r = (idx + tid) % (Br / 4);
+                if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
+                    if ((!KV_bounds_check || j * Bc + c < KV) && (!nem1_bounds_check || i * Br + r * 4 < p.nem1)) {
+                        const f16vec4 m = f16vec4(data_m[m_offset + (i * Br + r * 4    ) * m_stride + (j * Bc + c)],
+                                                  data_m[m_offset + (i * Br + r * 4 + 1) * m_stride + (j * Bc + c)],
+                                                  data_m[m_offset + (i * Br + r * 4 + 2) * m_stride + (j * Bc + c)],
+                                                  data_m[m_offset + (i * Br + r * 4 + 3) * m_stride + (j * Bc + c)]);
                         mask_cache[idx / WorkGroupSize] = m;
-                        max_mask = max(max_mask, m);
+                        max_mask = max(max(max(max(max_mask, float(m[0])), float(m[1])), float(m[2])), float(m[3]));
                     }
                 }
             }
@@ -221,11 +224,11 @@ void main() {
         barrier();
 
         if (p.logit_softcap != 0.0f) {
-            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br; idx += gl_WorkGroupSize.x) {
-                uint32_t c = (idx + tid) / Br;
-                uint32_t r = (idx + tid) % Br;
-                if (idx + tid < Bc * Br || idx + gl_WorkGroupSize.x <= Bc * Br) {
-                    sfsh[c * sfshstride + r] = ACC_TYPE(p.logit_softcap * tanh(sfsh[c * sfshstride + r]));
+            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br / 4; idx += gl_WorkGroupSize.x) {
+                uint32_t c = (idx + tid) / (Br / 4);
+                uint32_t r = (idx + tid) % (Br / 4);
+                if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
+                    sfsh[c * sfshstride + r] = ACC_TYPEV4(p.logit_softcap * tanh(sfsh[c * sfshstride + r]));
                 }
             }
             barrier();
@@ -234,13 +237,34 @@ void main() {
         if ((p.mask_n_head_log2 & MASK_ENABLE_BIT) != 0) {
             bool nem1_bounds_check = !(p.gqa_ratio > 1) && (p.nem1 % Br) != 0;
 
-            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br; idx += gl_WorkGroupSize.x) {
-                uint32_t c = (idx + tid) % Bc;
-                uint32_t r = (idx + tid) / Bc;
-                if (idx + tid < Bc * Br || idx + gl_WorkGroupSize.x <= Bc * Br) {
-                    if ((!KV_bounds_check || j * Bc + c < KV) && (!nem1_bounds_check || i * Br + r < p.nem1)) {
-                        float f = mask_cache[idx / WorkGroupSize];
-                        sfsh[c * sfshstride + r] += ACC_TYPE(slope[r] * f);
+            [[unroll]] for (uint32_t idx = 0; idx < Bc * Br / 4; idx += gl_WorkGroupSize.x) {
+                uint32_t c = (idx + tid) / (Br / 4);
+                uint32_t r = (idx + tid) % (Br / 4);
+                if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
+                    if (!KV_bounds_check || j * Bc + c < KV) {
+                        if (!nem1_bounds_check || i * Br + r * 4 + 3 < p.nem1) {
+                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
+                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
+                            sfsh[c * sfshstride + r] += slopes * masks;
+                        } else if (i * Br + r * 4 + 2 < p.nem1) {
+                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
+                            masks.w = ACC_TYPE(0.0f);
+                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
+                            sfsh[c * sfshstride + r] += slopes * masks;
+                        } else if (i * Br + r * 4 + 1 < p.nem1) {
+                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
+                            masks.z = ACC_TYPE(0.0f);
+                            masks.w = ACC_TYPE(0.0f);
+                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
+                            sfsh[c * sfshstride + r] += slopes * masks;
+                        } else if (i * Br + r * 4 < p.nem1) {
+                            ACC_TYPEV4 masks = ACC_TYPEV4(mask_cache[idx / WorkGroupSize]);
+                            masks.y = ACC_TYPE(0.0f);
+                            masks.z = ACC_TYPE(0.0f);
+                            masks.w = ACC_TYPE(0.0f);
+                            ACC_TYPEV4 slopes = ACC_TYPEV4(slope[r * 4], slope[r * 4 + 1], slope[r * 4 + 2], slope[r * 4 + 3]);
+                            sfsh[c * sfshstride + r] += slopes * masks;
+                        }
                     }
                 }
             }
@@ -249,12 +273,15 @@ void main() {
 
         float eMf[rows_per_thread];
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
+            const uint r_vec  = tile_row(r) / 4;
+            const uint r_comp = tile_row(r) % 4;
+
             float rowmaxf = NEG_FLT_MAX_OVER_2;
             [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
                 if (KV_bounds_check && j * Bc + c * cols_per_iter + col_tid >= KV) {
                     continue;
                 }
-                rowmaxf = max(rowmaxf, float(sfsh[tile_row(r) + (c * cols_per_iter + col_tid) * sfshstride]));
+                rowmaxf = max(rowmaxf, float(sfsh[r_vec + (c * cols_per_iter + col_tid) * sfshstride][r_comp]));
             }
             float Moldf = Mf[r];
 
@@ -283,19 +310,16 @@ void main() {
 
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; r += 4) {
                 const uint row = tile_row(r);
-                f16vec4 Pfvec;
                 if (KV_bounds_check && j * Bc + col >= KV) {
-                    [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                        Pfvec[vec_idx] = float16_t(0.0f);
-                    }
+                    Psh[col * psh_stride + row / 4] = f16vec4(0.0f);
                 } else {
+                    const f16vec4 mfvec = f16vec4(Mf[r], Mf[r + 1], Mf[r + 2], Mf[r + 3]);
+                    const f16vec4 Pf = f16vec4(exp(sfsh[row / 4 + col * sfshstride] - mfvec));
                     [[unroll]] for (uint32_t vec_idx = 0; vec_idx < 4; ++vec_idx) {
-                        const float16_t Pf = float16_t(exp(sfsh[row + vec_idx + col * sfshstride] - Mf[r + vec_idx]));
-                        Lf[r + vec_idx] += Pf;
-                        Pfvec[vec_idx] = Pf;
+                        Lf[r + vec_idx] += Pf[vec_idx];
                     }
+                    Psh[col * psh_stride + row / 4] = Pf;
                 }
-                Psh[col * psh_stride + row / 4] = Pfvec;
             }
         }
 
@@ -364,8 +388,8 @@ void main() {
             }
 
             // Store SfMat to sfsh and load into Of
-            const uint osh_stride = row_split * MatBc;
-            const uint o_offset = gl_SubgroupID * MatBc;
+            const uint osh_stride = row_split * MatBc / 4;
+            const uint o_offset = gl_SubgroupID * MatBc / 4;
             coopMatStore(SfMat, sfsh, o_offset, osh_stride, gl_CooperativeMatrixLayoutRowMajor);
 
             barrier();
@@ -385,16 +409,11 @@ void main() {
                     if (d >= d_end) break;
 
                     const uint hsv_col = 4 * d;
-                    const uint local_hsv = hsv_col - hsv_base;
+                    const uint local_hsv = (hsv_col - hsv_base) / 4;
 
                     if (!KV_bounds_check || hsv_col < HSV) {
                         const uint d_local = d0 / threads_per_rowgroup;
-                        Of[r][d_local] += ACC_TYPEV4(
-                            sfsh[row * osh_stride + local_hsv],
-                            sfsh[row * osh_stride + local_hsv + 1],
-                            sfsh[row * osh_stride + local_hsv + 2],
-                            sfsh[row * osh_stride + local_hsv + 3]
-                        );
+                        Of[r][d_local] += ACC_TYPEV4(sfsh[row * osh_stride + local_hsv]);
                     }
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
@@ -85,7 +85,7 @@ void main() {
 
     tensorViewNV<2, false, 1, 0> tensorViewTranspose = createTensorViewNV(2, false, 1, 0);
 
-#if defined(BLOCK_SIZE)
+#if BLOCK_SIZE > 1
     tensorLayoutK = setTensorLayoutBlockSizeNV(tensorLayoutK, 1, BLOCK_SIZE);
     tensorLayoutV = setTensorLayoutBlockSizeNV(tensorLayoutV, 1, BLOCK_SIZE);
 #endif
@@ -98,7 +98,7 @@ void main() {
     if (Clamp != gl_CooperativeMatrixClampModeConstantNV)
     {
         q_stride &= ~7;
-#if !defined(BLOCK_SIZE)
+#if BLOCK_SIZE == 1
         k_stride &= ~7;
         v_stride &= ~7;
 #endif

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm2.comp
@@ -55,7 +55,7 @@ ACC_TYPE Max(const in uint32_t row, const in uint32_t col, const in ACC_TYPE ele
     return max(elem0, elem1);
 }
 
-#if defined(BLOCK_SIZE)
+#if BLOCK_SIZE > 1
 #define DECODEFUNC , DEQUANTFUNC
 #else
 #define DECODEFUNC


### PR DESCRIPTION
I finally had the time to go through Jeff's Flash Attention shaders in detail and used the chance to refactor the Coopmat1 for AMD. It started out as an attempt to use Coopmats for the Softmax * V matrix multiplication as well and then escalated into a refactor of the whole shader structure.

It now uses coopmats for the Softmax result * V matrix multiplication, and I vectorized some variables, changed how shared memory is used, load K and V directly from global memory if possible, otherwise streamed through a shared memory cache.

Tests are passing. Performance is up significantly on AMD RX 8060S (Strix Halo). Draft because there is a regression on Nvidia. Let me know if you see anything obvious @jeffbolznv. More tuning is likely required.

AMD 8060S:
| model                 | size      | params  | ngl | fa | test          | t/s (ROCm)      | t/s (before)    | t/s (after)     | diff   |
|-----------------------|-----------|---------|-----|----|---------------|-----------------|-----------------|-----------------|--------|
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | pp512         | 1087.56 ± 41.81 | 1004.49 ± 44.19 | 1020.70 ± 46.87 | +1.6%  |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | tg128         | 40.38 ± 0.28    | 43.02 ± 0.25    | 43.91 ± 0.44    | +2.1%  |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | pp512 @ d8192 | 604.32 ± 4.11   | 418.94 ± 1.64   | 556.71 ± 3.25   | +32.9% |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | tg128 @ d8192 | 33.96 ± 0.04    | 33.34 ± 0.08    | 35.88 ± 0.14    | +7.6%  |
| gpt-oss 20B MXFP4 MoE | 11.27 GiB | 20.91 B | 99  | 1  | pp512         | 1037.80 ± 33.87 | 1316.13 ± 23.00 | 1285.66 ± 30.56 | -2.3%  |
| gpt-oss 20B MXFP4 MoE | 11.27 GiB | 20.91 B | 99  | 1  | tg128         | 70.82 ± 0.06    | 76.86 ± 0.12    | 76.17 ± 1.36    | -0.9%  |
| gpt-oss 20B MXFP4 MoE | 11.27 GiB | 20.91 B | 99  | 1  | pp512 @ d8192 | 734.15 ± 3.78   | 854.11 ± 2.40   | 967.79 ± 4.56   | +13.3% |
| gpt-oss 20B MXFP4 MoE | 11.27 GiB | 20.91 B | 99  | 1  | tg128 @ d8192 | 65.34 ± 0.09    | 67.96 ± 0.36    | 70.87 ± 0.30    | +4.3%  |

Nvidia 3090:
| model                 | size      | params  | ngl | fa | test          | t/s (before)    | t/s (after)     | diff  |
|-----------------------|-----------|---------|-----|----|---------------|-----------------|-----------------|-------|
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | pp512         | 3482.02 ± 7.00  | 3497.43 ± 10.06 | +0.4% |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | tg128         | 126.31 ± 0.36   | 119.71 ± 1.53   | -5.2% |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | pp512 @ d8192 | 1528.77 ± 10.40 | 1664.99 ± 7.69  | +8.9% |
| llama 8B Q4_K - Small | 4.36 GiB  | 8.03 B  | 99  | 1  | tg128 @ d8192 | 103.77 ± 0.83   | 96.24 ± 0.76    | -7.3% |
| gpt-oss 20B Q8_0      | 11.27 GiB | 20.91 B | 99  | 1  | pp512         | 3114.63 ± 62.70 | 3151.79 ± 22.70 | +1.2% |
| gpt-oss 20B Q8_0      | 11.27 GiB | 20.91 B | 99  | 1  | tg128         | 182.60 ± 1.21   | 172.98 ± 1.47   | -5.3% |
| gpt-oss 20B Q8_0      | 11.27 GiB | 20.91 B | 99  | 1  | pp512 @ d8192 | 2143.15 ± 26.05 | 2272.91 ± 10.81 | +6.1% |
| gpt-oss 20B Q8_0      | 11.27 GiB | 20.91 B | 99  | 1  | tg128 @ d8192 | 159.97 ± 0.65   | 145.73 ± 1.31   | -8.9% |

Claude Code was used for debugging and code analysis, but I wrote the code.