### PR TITLE
fix(jinja): enforce recursion limit to prevent stack overflow

### DIFF
--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -53,6 +53,9 @@ struct context {
 
     bool is_get_stats = false; // whether to collect stats
 
+    int recursion_depth = 0;
+    static constexpr int max_recursion_depth = 100;
+
     // src is optional, used for error reporting
     context(std::string src = "") : src(std::make_shared<std::string>(std::move(src))) {
         env = mk_val<value_object>();
@@ -76,6 +79,7 @@ struct context {
         current_time = parent.current_time;
         is_get_stats = parent.is_get_stats;
         src = parent.src;
+        recursion_depth = parent.recursion_depth;
     }
 
     value get_val(const std::string & name) {


### PR DESCRIPTION
This PR introduces a recursion depth limit (100) for Jinja2 macro execution to prevent stack overflow crashes caused by infinitely recursive templates (DoS vulnerability). Validated with a new test case `tests/test-jinja-dos.cpp`.

This vulnerability was identified as part of the huntr bug bounty program and the proof of concept is available here: https://huggingface.co/paperboygold/gguf-dos-poc

## AI Disclosure
This PR was implemented with AI assistance. The vulnerability was identified and the fix logic (recursion counter) was co-authored by an AI agent under human supervision. The code has been manually reviewed and verified with the included regression test.