### PR TITLE
metal : fix API availability warnings for legacy iOS/macOS targets

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -785,8 +785,12 @@ ggml_metal_device_t ggml_metal_device_init(void) {
             dev->props.op_offload_min_batch_size  = getenv("GGML_OP_OFFLOAD_MIN_BATCH") ? atoi(getenv("GGML_OP_OFFLOAD_MIN_BATCH")) : 32;
 
             dev->props.max_buffer_size            = dev->mtl_device.maxBufferLength;
-            dev->props.max_working_set_size       = dev->mtl_device.recommendedMaxWorkingSetSize;
             dev->props.max_theadgroup_memory_size = dev->mtl_device.maxThreadgroupMemoryLength;
+            if (@available(macOS 10.12, iOS 16.0, *)) {
+                dev->props.max_working_set_size   = dev->mtl_device.recommendedMaxWorkingSetSize;
+            } else {
+                dev->props.max_working_set_size   = dev->mtl_device.maxBufferLength;
+            }
 
             strncpy(dev->props.name, [[dev->mtl_device name] UTF8String], sizeof(dev->props.name) - 1);
 


### PR DESCRIPTION
This PR resolves a compiler warning in ggml-metal-device.m where recommendedMaxWorkingSetSize is accessed on iOS versions earlier than 16.0 or macOS earlier than 10.12.

Technical Rationale: While llama.cpp moves towards supporting modern APIs, maintaining build health for established deployment targets (e.g., iOS 15.0) remains essential for broader hardware compatibility.

Key Changes:

Wrapped recommendedMaxWorkingSetSize in @available guards to silence availability warnings.

Implemented a heuristic fallback to maxBufferLength. On legacy systems, this provides the inference engine with a valid physical boundary, ensuring robust model loading instead of defaulting to an uninitialized or zero value.

Testing:

Verified zero warnings with Xcode 16 on a deployment target of iOS 15.0.

Confirmed successful compilation on macOS.
