### PR TITLE
common : clarify HTTPS build options in error message

### DIFF
--- a/common/http.h
+++ b/common/http.h
@@ -63,7 +63,7 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
             "HTTPS is not supported. Please rebuild with one of:\n"
             "  -DLLAMA_BUILD_BORINGSSL=ON\n"
             "  -DLLAMA_BUILD_LIBRESSL=ON\n"
-            "  -DLLAMA_OPENSSL=ON (requires OpenSSL dev files installed)"
+            "  -DLLAMA_OPENSSL=ON (default, requires OpenSSL dev files installed)"
         );
     }
 #endif

--- a/common/http.h
+++ b/common/http.h
@@ -60,10 +60,10 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
 #ifndef CPPHTTPLIB_OPENSSL_SUPPORT
     if (parts.scheme == "https") {
         throw std::runtime_error(
-            "HTTPS is not supported. Please rebuild with:\n"
+            "HTTPS is not supported. Please rebuild with one of:\n"
             "  -DLLAMA_BUILD_BORINGSSL=ON\n"
             "  -DLLAMA_BUILD_LIBRESSL=ON\n"
-            "or ensure dev files of an OpenSSL-compatible library are available when building."
+            "  -DLLAMA_OPENSSL=ON (requires OpenSSL dev files installed)"
         );
     }
 #endif


### PR DESCRIPTION
This commit updates the https error message to provide clearer instructions for users who encounter the "HTTPS is not supported" error.

The motivation for this is that it might not be clear to users that only one of these options are needed to enable HTTPS support. The LLAMA_OPENSSL option is also added to the message to cover all possible build configurations.
