### PR TITLE
model : add correct type for GLM 4.7 Flash

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1737,6 +1737,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
 
                 switch (hparams.n_layer) {
                     case 27: type = LLM_TYPE_16B; break;
+                    case 47: type = LLM_TYPE_30B_A3B; break;
                     case 60: type = LLM_TYPE_236B; break;
                     case 61: type = LLM_TYPE_671B; break;
                     default: type = LLM_TYPE_UNKNOWN;


### PR DESCRIPTION
Fix the displayed model type in the logs:

```bash
# before
deepseek2 ?B Q8_0  

# after
deepseek2 30B.A3B Q8_0  
```