### PR TITLE
server: pass --models-dir to child process in spawn (#18885)

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -477,6 +477,12 @@ void server_models::load(const std::string & name) {
         inst.meta.update_args(ctx_preset, bin_path); // render args
 
         std::vector<std::string> child_args = inst.meta.args; // copy
+
+        if (!base_params.models_dir.empty()) {
+            child_args.push_back("--models-dir");
+            child_args.push_back(base_params.models_dir);
+        }
+
         std::vector<std::string> child_env  = base_env; // copy
         child_env.push_back("LLAMA_SERVER_ROUTER_PORT=" + std::to_string(base_params.port));
 


### PR DESCRIPTION
### Motivation
I ran the server following the steps described in issue #18885 and confirmed that the `--models-dir` argument is ignored when spawning a child process. After analyzing the code, I found that while the parent process receives the path, it is not passed along to the spawned instance.

### The Fix
I modified `tools/server/server-models.cpp` to explicitly pass the `models-dir` argument from `base_params` to the `child_args` vector during the spawning process.

### Verification
I recompiled the project and verified that models now load correctly from the specified directory when using presets.

### Disclosure
I used AI assistance to help navigate the codebase and identify the specific location where arguments were being filtered. The logic, implementation, and testing were performed and verified by me.

Fixes #18885
