### PR TITLE
server: print actual model name in 'model not found" error

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -767,7 +767,7 @@ static bool router_validate_model(const std::string & name, server_models & mode
     }
     auto meta = models.get_meta(name);
     if (!meta.has_value()) {
-        res_err(res, format_error_response("model not found", ERROR_TYPE_INVALID_REQUEST));
+        res_err(res, format_error_response(string_format("model '%s' not found", name.c_str()), ERROR_TYPE_INVALID_REQUEST));
         return false;
     }
     if (models_autoload) {


### PR DESCRIPTION
Experimenting with AI, my environment gets messy fast and it's not always easy to know what model my software is trying to load. This helps with troubleshooting.


Before:

```
> Who are you ?


Error: {
  code = 400,
  message = "model not found",
  type = "invalid_request_error"
}
```

after

```
> Who are you ?


Error: {
  code = 400,
  message = "model 'toto' is not found",
  type = "invalid_request_error"
}
```


NB: I couldn't find a target to run linting (usually `make lint` / or `make format`) so tried to run the CI locally as explained  in contributing.md with 
```
GG_BUILD_CUDA=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
Warning: Using fallback CUDA architectures
./ci/run.sh: ligne 651: python3 : commande introuvable
```
I am developing from within the repo flake.nix so I expected all devtools present (I noticed the flake didn't provide ccache either, not sure if that's a conscious decision or not). I can submit a patch to add python3.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
