### PR TITLE
ci : revert slim runner for winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update:
     name: Update Winget Package
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'ggml-org'
 
     steps:


### PR DESCRIPTION
Looks like `ubuntu-slim` is missing `cargo` required for this job. While it's possible to install via `rustup` it's better to just revert due to limited testing capabilities.