### PR TITLE
ggml-zendnn : update ZenDNN git tag to main branch

### DIFF
--- a/ggml/src/ggml-zendnn/CMakeLists.txt
+++ b/ggml/src/ggml-zendnn/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT ZENDNN_ROOT OR ZENDNN_ROOT STREQUAL "" OR ZENDNN_ROOT STREQUAL "OFF")
     ExternalProject_Add(
         zendnn
         GIT_REPOSITORY https://github.com/amd/ZenDNN.git
-        GIT_TAG zendnnl
+        GIT_TAG 21ce8f7879c86bf3637f707fae6f29e0951db5fe
         PREFIX      ${ZENDNN_PREFIX}
         SOURCE_DIR  ${ZENDNN_SOURCE_DIR}
         BINARY_DIR  ${ZENDNN_BUILD_DIR}


### PR DESCRIPTION
This PR is related to ZenDNN removed their zendnnl branch and moved all the code to main

Right now our code is still looking for the old zendnnl branch which no longer exists, so builds break. 

This fixes it by pointing to the new main branch instead

cc: @amukho @avinashcpandey