### PR TITLE
CUDA: tune GLM 4.7 Flash FA kernel selection logic (DGX Spark)

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -53,6 +53,7 @@
 // While BW spans CC 1000, 1100 & 1200, we are integrating Tensor Core instructions available to 1200 family, see
 // https://docs.nvidia.com/cutlass/media/docs/cpp/blackwell_functionality.html#blackwell-sm120-gemms
 #define GGML_CUDA_CC_BLACKWELL       1200
+#define GGML_CUDA_CC_DGX_SPARK       1210
 #define GGML_CUDA_CC_RUBIN           1300
 #define GGML_CUDA_CC_OFFSET_AMD      0x1000000
 #define GGML_CUDA_CC_OFFSET_MTHREADS 0x0100000

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -147,6 +147,14 @@ static void ggml_cuda_flash_attn_ext_mma_f16(ggml_backend_cuda_context & ctx, gg
             GGML_ASSERT(Q->ne[2] % K->ne[2] == 0);
             const int gqa_ratio = Q->ne[2] / K->ne[2];
             if (gqa_ratio == 20) { // GLM 4.7 Flash
+                if (cc >= GGML_CUDA_CC_DGX_SPARK) {
+                    if (Q->ne[1] <= 8) {
+                        ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<576, 512, 16>(ctx, dst);
+                        break;
+                    }
+                    ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<576, 512, 4>(ctx, dst);
+                    break;
+                }
                 if (cc >= GGML_CUDA_CC_BLACKWELL) {
                     if (Q->ne[1] <= 4 && K->ne[1] >= 65536) {
                         ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<576, 512, 16>(ctx, dst);


### PR DESCRIPTION
cont #19097 

This is similar to #19097, but for DGX Spark. I used only the `Q8_0` model for the measurements.

```bash
GGML_CUDA=1 ./scripts/compare-commits.sh master gg/cuda-tune-dgx llama-bench -m ~/models/ggml-org_GLM-4.7-Flash-GGUF_GLM-4.7-Flash-Q8_0.gguf -p 512 -d 1024,2048,4096,8192,16384,32768,65536 -ub 4096 -b 4096 -n 32 -mmp 0 -dio 1 -fa 1 -ngl 99 -r 1
```

| Model                  | Test         |   t/s gg/cuda-fa-tune-spark |   t/s gg/cuda-tune-dgx |   Speedup |
|:-----------------------|:-------------|----------------------------:|-----------------------:|----------:|
| deepseek2 30B.A3B Q8_0 | pp512@d1024  |                     1763.43 |                1789.58 |      1.01 |
| deepseek2 30B.A3B Q8_0 | pp512@d2048  |                     1631.89 |                1619.55 |      0.99 |
| deepseek2 30B.A3B Q8_0 | pp512@d4096  |                     1438.50 |                1436.78 |      1.00 |
| deepseek2 30B.A3B Q8_0 | pp512@d8192  |                     1155.97 |                1156.45 |      1.00 |
| deepseek2 30B.A3B Q8_0 | pp512@d16384 |                      798.93 |                 799.48 |      1.00 |
| deepseek2 30B.A3B Q8_0 | pp512@d32768 |                      525.18 |                 525.73 |      1.00 |
| deepseek2 30B.A3B Q8_0 | pp512@d65536 |                      300.56 |                 299.86 |      1.00 |
| deepseek2 30B.A3B Q8_0 | tg32@d1024   |                       46.06 |                  45.64 |      0.99 |
| deepseek2 30B.A3B Q8_0 | tg32@d2048   |                       43.38 |                  43.51 |      1.00 |
| deepseek2 30B.A3B Q8_0 | tg32@d4096   |                       41.84 |                  42.35 |      1.01 |
| deepseek2 30B.A3B Q8_0 | tg32@d8192   |                       38.71 |                  40.43 |      1.04 |
| deepseek2 30B.A3B Q8_0 | tg32@d16384  |                       34.00 |                  36.90 |      1.09 |
| deepseek2 30B.A3B Q8_0 | tg32@d32768  |                       15.21 |                  31.51 |      2.07 |
| deepseek2 30B.A3B Q8_0 | tg32@d65536  |                       24.60 |                  24.48 |      1.00 |


```bash
GGML_CUDA=1 ./scripts/compare-commits.sh master gg/cuda-tune-dgx llama-bench -m ~/models/ggml-org_GLM-4.7-Flash-GGUF_GLM-4.7-Flash-Q8_0.gguf -d 32768 -n 0 -b 4096 -ub "4096,512,1-256*2" -mmp 0 -dio 1 -fa 1 -ngl 99 -r 1
```

| Model                  |   Microbatch size | Test         |   t/s gg/cuda-fa-tune-spark |   t/s gg/cuda-tune-dgx |   Speedup |
|:-----------------------|------------------:|:-------------|----------------------------:|-----------------------:|----------:|
| deepseek2 30B.A3B Q8_0 |                 1 | pp512@d32768 |                       15.88 |                  33.89 |      2.13 |
| deepseek2 30B.A3B Q8_0 |                 2 | pp512@d32768 |                       25.92 |                  44.47 |      1.72 |
| deepseek2 30B.A3B Q8_0 |                 4 | pp512@d32768 |                       46.20 |                  70.09 |      1.52 |
| deepseek2 30B.A3B Q8_0 |                 8 | pp512@d32768 |                       76.11 |                 100.07 |      1.31 |
| deepseek2 30B.A3B Q8_0 |                16 | pp512@d32768 |                      130.68 |                 130.74 |      1.00 |
| deepseek2 30B.A3B Q8_0 |                32 | pp512@d32768 |                      210.03 |                 209.48 |      1.00 |
| deepseek2 30B.A3B Q8_0 |                64 | pp512@d32768 |                      300.25 |                 300.76 |      1.00 |
| deepseek2 30B.A3B Q8_0 |               128 | pp512@d32768 |                      388.98 |                 387.92 |      1.00 |
| deepseek2 30B.A3B Q8_0 |               256 | pp512@d32768 |                      456.58 |                 458.92 |      1.01 |
| deepseek2 30B.A3B Q8_0 |               512 | pp512@d32768 |                      529.26 |                 522.65 |      0.99 |
| deepseek2 30B.A3B Q8_0 |              4096 | pp512@d32768 |                      528.32 |                 523.40 |      0.99 |