### PR TITLE
common: fix 32-bit overflow for avoiding year 2038 problem

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -426,10 +426,18 @@ std::string string_strip(const std::string & str) {
 std::string string_get_sortable_timestamp() {
     using clock = std::chrono::system_clock;
 
-    const clock::time_point current_time = clock::now();
-    const time_t as_time_t = clock::to_time_t(current_time);
+    const auto current_time = clock::now();
+    const auto as_time_t = std::chrono::duration_cast<std::chrono::seconds>(current_time.time_since_epoch()).count();
+
+    struct tm timeinfo;
+#ifdef _WIN32
+    gmtime_s(&timeinfo, &as_time_t);
+#else
+    gmtime_r(&as_time_t, &timeinfo);
+#endif
+
     char timestamp_no_ns[100];
-    std::strftime(timestamp_no_ns, 100, "%Y_%m_%d-%H_%M_%S", std::localtime(&as_time_t));
+    std::strftime(timestamp_no_ns, 100, "%Y_%m_%d-%H_%M_%S", &timeinfo);
 
     const int64_t ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         current_time.time_since_epoch() % 1000000000).count();


### PR DESCRIPTION
`std::chrono::system_clock_::to_time_t()` does not guarantee 64-bit time.

More info: https://stackoverflow.com/questions/79248038/c-chrono-store-and-retrieve-date-and-time-in-64-bit-format-for-2038-rollover

References:
- https://en.wikipedia.org/wiki/Year_2038_problem
- https://www.gnu.org/software/gnulib/manual/html_node/Avoiding-the-year-2038-problem.html
