### PR TITLE
cuda : fix nkvo, offload and cuda graph node properties matching

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1127,7 +1127,9 @@ struct ggml_cuda_graph_node_properties {
     int32_t flags;
     int64_t ne[GGML_MAX_DIMS];
     size_t nb[GGML_MAX_DIMS];
-    void * src_address[GGML_MAX_SRC];
+    void * src_data[GGML_MAX_SRC];
+    int64_t src_ne[GGML_MAX_SRC][GGML_MAX_DIMS];
+    size_t src_nb[GGML_MAX_SRC][GGML_MAX_DIMS];
     int32_t op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];
 };
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1128,8 +1128,6 @@ struct ggml_cuda_graph_node_properties {
     int64_t ne[GGML_MAX_DIMS];
     size_t nb[GGML_MAX_DIMS];
     void * src_data[GGML_MAX_SRC];
-    int64_t src_ne[GGML_MAX_SRC][GGML_MAX_DIMS];
-    size_t src_nb[GGML_MAX_SRC][GGML_MAX_DIMS];
     int32_t op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];
 };
 
@@ -1151,6 +1149,7 @@ struct ggml_cuda_graph {
     bool disable_due_to_too_many_updates = false;
     int number_consecutive_updates = 0;
     std::vector<ggml_cuda_graph_node_properties> props;
+    std::vector<ggml_cuda_graph_node_properties> extra;
 
     void record_update(bool use_graph, bool update_required) {
         if (use_graph && update_required) {

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -310,8 +310,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         }
     }
 
-    const bool V_is_K_view = V->view_src && (V->view_src == K || (V->view_src == K->view_src && V->view_offs == K->view_offs));
-
     const int cc = ggml_cuda_info().devices[device].cc;
 
     switch (K->ne[0]) {
@@ -332,9 +330,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
                 return BEST_FATTN_KERNEL_NONE;
             }
             if (!gqa_opt_applies) {
-                return BEST_FATTN_KERNEL_NONE;
-            }
-            if (!V_is_K_view) {
                 return BEST_FATTN_KERNEL_NONE;
             }
             break;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2918,7 +2918,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 
 static void ggml_cuda_graph_node_set_properties(ggml_cuda_graph_node_properties * props, ggml_tensor * node) {
     memset(props, 0, sizeof(ggml_cuda_graph_node_properties));
-    props->node_address = node->data;
+    props->node_data = node->data;
     props->node_op = node->op;
     props->flags = node->flags;
     for (int i = 0; i < GGML_MAX_DIMS; i++) {
@@ -2936,8 +2936,7 @@ static void ggml_cuda_graph_node_set_properties(ggml_cuda_graph_node_properties 
 }
 
 static bool ggml_cuda_graph_node_properties_match(ggml_tensor * node, ggml_cuda_graph_node_properties * props) {
-    if (node->data != props->node_address &&
-          node->op != GGML_OP_VIEW) {
+    if (node->data != props->node_data && node->op != GGML_OP_VIEW) {
         return false;
     }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2916,6 +2916,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 }
 
 static void ggml_cuda_graph_node_set_properties(ggml_cuda_graph_node_properties * props, ggml_tensor * node) {
+    memset(props, 0, sizeof(ggml_cuda_graph_node_properties));
     props->node_address = node->data;
     props->node_op = node->op;
     props->flags = node->flags;
@@ -2924,7 +2925,16 @@ static void ggml_cuda_graph_node_set_properties(ggml_cuda_graph_node_properties 
         props->nb[i] = node->nb[i];
     }
     for (int i = 0; i < GGML_MAX_SRC; i++) {
-        props->src_address[i] = node->src[i] ? node->src[i]->data : nullptr;
+        if (!node->src[i]) {
+            continue;
+        }
+
+        props->src_data[i] = node->src[i]->data;
+
+        for (int j = 0; j < GGML_MAX_DIMS; j++) {
+            props->src_ne[i][j] = node->src[i]->ne[j];
+            props->src_nb[i][j] = node->src[i]->nb[j];
+        }
     }
     memcpy(props->op_params, node->op_params, GGML_MAX_OP_PARAMS);
 }
@@ -2948,12 +2958,27 @@ static bool ggml_cuda_graph_node_properties_match(ggml_tensor * node, ggml_cuda_
         }
     }
 
-    for (int i = 0; i < GGML_MAX_SRC; i++) {
-        if (node->src[i] &&
-            node->src[i]->data != props->src_address[i] &&
-            node->op != GGML_OP_VIEW
-        ) {
-            return false;
+    if (node->op != GGML_OP_VIEW) {
+        for (int i = 0; i < GGML_MAX_SRC; i++) {
+            if (!node->src[i]) {
+                if (props->src_data[i] != nullptr) {
+                    return false;
+                }
+                continue;
+            }
+
+            if (node->src[i]->data != props->src_data[i]) {
+                return false;
+            }
+
+            // TODO: this is not ideal since it requires too much memory - figure out an optimization
+            // ref: https://github.com/ggml-org/llama.cpp/pull/19165
+            for (int j = 0; j < GGML_MAX_DIMS; j++) {
+                if (node->src[i]->ne[j] != props->src_ne[i][j] ||
+                    node->src[i]->nb[j] != props->src_nb[i][j]) {
+                    return false;
+                }
+            }
         }
     }
 
@@ -2974,7 +2999,6 @@ static const void * ggml_cuda_graph_get_key(ggml_cgraph * cgraph) {
 }
 
 static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph) {
-
     bool res = false;
 
     const void * graph_key = ggml_cuda_graph_get_key(cgraph);
@@ -2985,9 +3009,9 @@ static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx
     }
 
     // Check if the graph size has changed
-    if (graph->props.size() != (size_t)cgraph->n_nodes + cgraph->n_leafs) {
+    if (graph->props.size() != (size_t)cgraph->n_nodes) {
         res = true;
-        graph->props.resize(cgraph->n_nodes + cgraph->n_leafs);
+        graph->props.resize(cgraph->n_nodes);
     }
 
     // Loop over nodes in GGML graph to determine if CUDA graph update is required
@@ -3001,17 +3025,6 @@ static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx
             res = true;
         }
         ggml_cuda_graph_node_set_properties(&graph->props[i], cgraph->nodes[i]);
-    }
-
-    for (int i = 0; i < cgraph->n_leafs; i++) {
-        bool props_match = true;
-        if (!res) {
-            props_match = ggml_cuda_graph_node_properties_match(cgraph->leafs[i], &graph->props[cgraph->n_nodes + i]);
-        }
-        if (!props_match) {
-            res = true;
-        }
-        ggml_cuda_graph_node_set_properties(&graph->props[cgraph->n_nodes + i], cgraph->leafs[i]);
     }
 
     return res;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1630,11 +1630,6 @@ ggml_tensor * llm_graph_context::build_attn_mha(
                                   hparams.attn_soft_cap ? hparams.f_attn_logit_softcapping : 0.0f);
         cb(cur, LLAMA_TENSOR_NAME_FATTN, il);
 
-        if (!cparams.offload_kqv) {
-            // all nodes between the KV store and the attention output are run on the CPU
-            ggml_backend_sched_set_tensor_backend(sched, cur, backend_cpu);
-        }
-
         ggml_flash_attn_ext_add_sinks(cur, sinks);
         ggml_flash_attn_ext_set_prec (cur, GGML_PREC_F32);
 


### PR DESCRIPTION
fix #19158 
fix #19169
cont #19105
cont #18934

The assumption that all graph input nodes will be available as leafs (https://github.com/ggml-org/llama.cpp/pull/18583#pullrequestreview-3625052039) is not always correct. When individual ops are offloaded, the created splits do not have leafs so the leaf checks introduced in #18583 are not enough to validate that the CUDA graph does not need update.

I have restored the [original logic](https://github.com/ggml-org/llama.cpp/commit/27efdad7532acf7389d80c97b6fa2787e9faeaa9) that @am17an implemented in #18583, before I made the suggestion to use the leafs.
