### PR TITLE
Finish “TODO: avoid using atexit() here by making `console` a singleton”

### DIFF
--- a/common/console.cpp
+++ b/common/console.cpp
@@ -1,5 +1,6 @@
 #include "console.h"
 #include "log.h"
+#include <memory>
 #include <vector>
 #include <iostream>
 #include <cassert>
@@ -77,6 +78,8 @@
     static FILE*        tty              = nullptr;
     static termios      initial_state;
 #endif
+
+    std::unique_ptr<console> console::instance = nullptr;
 
     console::console() {
         console::instance = std::make_unique<console>(console());

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -1082,7 +1082,7 @@
         replace_last(LOADING_CHARS[frame]);
         fflush(out);
     }
-    void console::start() {
+    void console::spinner::start() {
         std::unique_lock<std::mutex> lock(mtx);
         if (simple_io || running) {
             return;
@@ -1102,7 +1102,7 @@
             }
         });
     }
-    void console::stop() {
+    void console::spinner::stop() {
         {
             std::unique_lock<std::mutex> lock(mtx);
             if (simple_io || !running) {

--- a/common/console.h
+++ b/common/console.h
@@ -48,32 +48,3 @@ public:
 private:
     static std::unique_ptr<console> instance;
 };
-
-//
-// old code(without RAII and reling on code !<atexit([]() { console::cleanup(); });> to clean after program finishing)
-//
-
-// namespace console {
-//     void init(bool use_simple_io, bool use_advanced_display);
-//     void cleanup();
-//     void set_display(display_type display);
-//     bool readline(std::string & line, bool multiline_input);
-
-//     namespace spinner {
-//         void start();
-//         void stop();
-//     }
-
-//     // note: the logging API below output directly to stdout
-//     // it can negatively impact performance if used on inference thread
-//     // only use in in a dedicated CLI thread
-//     // for logging in inference thread, use log.h instead
-
-//     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
-//     void log(const char * fmt, ...);
-
-//     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
-//     void error(const char * fmt, ...);
-
-//     void flush();
-// }

--- a/common/console.h
+++ b/common/console.h
@@ -28,8 +28,11 @@ public:
 
     static void set_display(display_type display);
     static bool readline(std::string & line, bool multiline_input);
-    static void start();
-    static void stop();
+
+    struct spinner {
+        static void start();
+        static void stop();
+    };
 
 
     // note: the logging API below output directly to stdout

--- a/common/console.h
+++ b/common/console.h
@@ -4,6 +4,7 @@
 
 #include "common.h"
 
+#include <memory>
 #include <string>
 
 enum display_type {
@@ -15,16 +16,21 @@ enum display_type {
     DISPLAY_TYPE_ERROR
 };
 
-namespace console {
-    void init(bool use_simple_io, bool use_advanced_display);
-    void cleanup();
-    void set_display(display_type display);
-    bool readline(std::string & line, bool multiline_input);
+class console {
+private:
+    console();
 
-    namespace spinner {
-        void start();
-        void stop();
-    }
+public:
+    ~console();
+
+    static void init(bool use_simple_io, bool use_advanced_display);
+    static void cleanup();
+
+    static void set_display(display_type display);
+    static bool readline(std::string & line, bool multiline_input);
+    static void start();
+    static void stop();
+
 
     // note: the logging API below output directly to stdout
     // it can negatively impact performance if used on inference thread
@@ -32,10 +38,42 @@ namespace console {
     // for logging in inference thread, use log.h instead
 
     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
-    void log(const char * fmt, ...);
+    static void log(const char * fmt, ...);
 
     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
-    void error(const char * fmt, ...);
+    static void error(const char * fmt, ...);
 
-    void flush();
-}
+    static void flush();
+
+private:
+    static std::unique_ptr<console> instance;
+};
+
+//
+// old code(without RAII and reling on code !<atexit([]() { console::cleanup(); });> to clean after program finishing)
+//
+
+// namespace console {
+//     void init(bool use_simple_io, bool use_advanced_display);
+//     void cleanup();
+//     void set_display(display_type display);
+//     bool readline(std::string & line, bool multiline_input);
+
+//     namespace spinner {
+//         void start();
+//         void stop();
+//     }
+
+//     // note: the logging API below output directly to stdout
+//     // it can negatively impact performance if used on inference thread
+//     // only use in in a dedicated CLI thread
+//     // for logging in inference thread, use log.h instead
+
+//     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
+//     void log(const char * fmt, ...);
+
+//     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
+//     void error(const char * fmt, ...);
+
+//     void flush();
+// }

--- a/tests/test-tokenizer-0.cpp
+++ b/tests/test-tokenizer-0.cpp
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    atexit([]() { console::cleanup(); });
+    // atexit([]() { console::cleanup(); });
 #endif
 
     bool success = true;

--- a/tests/test-tokenizer-0.cpp
+++ b/tests/test-tokenizer-0.cpp
@@ -173,7 +173,6 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    // atexit([]() { console::cleanup(); });
 #endif
 
     bool success = true;

--- a/tests/test-tokenizer-1-bpe.cpp
+++ b/tests/test-tokenizer-1-bpe.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    atexit([]() { console::cleanup(); });
+    // atexit([]() { console::cleanup(); });
 #endif
 
     const int n_vocab = llama_vocab_n_tokens(vocab);

--- a/tests/test-tokenizer-1-bpe.cpp
+++ b/tests/test-tokenizer-1-bpe.cpp
@@ -75,7 +75,6 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    // atexit([]() { console::cleanup(); });
 #endif
 
     const int n_vocab = llama_vocab_n_tokens(vocab);

--- a/tests/test-tokenizer-1-spm.cpp
+++ b/tests/test-tokenizer-1-spm.cpp
@@ -63,7 +63,7 @@ int main(int argc, char ** argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    atexit([]() { console::cleanup(); });
+    // atexit([]() { console::cleanup(); });
 #endif
 
     const int n_vocab = llama_vocab_n_tokens(vocab);

--- a/tests/test-tokenizer-1-spm.cpp
+++ b/tests/test-tokenizer-1-spm.cpp
@@ -63,7 +63,6 @@ int main(int argc, char ** argv) {
 #ifdef _WIN32
     // We need this for unicode console support
     console::init(false, false);
-    // atexit([]() { console::cleanup(); });
 #endif
 
     const int n_vocab = llama_vocab_n_tokens(vocab);

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -92,10 +92,10 @@ struct cli_context {
         }
 
         // wait for first result
-        console::spinner::start();
+        console::start();
         server_task_result_ptr result = rd.next(should_stop);
 
-        console::spinner::stop();
+        console::stop();
         std::string curr_content;
         bool is_thinking = false;
 
@@ -211,7 +211,7 @@ int main(int argc, char ** argv) {
 
     // TODO: avoid using atexit() here by making `console` a singleton
     console::init(params.simple_io, params.use_color);
-    atexit([]() { console::cleanup(); });
+    // atexit([]() { console::cleanup(); });
 
     console::set_display(DISPLAY_TYPE_RESET);
 
@@ -230,14 +230,14 @@ int main(int argc, char ** argv) {
 #endif
 
     console::log("\nLoading model... "); // followed by loading animation
-    console::spinner::start();
+    console::start();
     if (!ctx_cli.ctx_server.load_model(params)) {
-        console::spinner::stop();
+        console::stop();
         console::error("\nFailed to load the model\n");
         return 1;
     }
 
-    console::spinner::stop();
+    console::stop();
     console::log("\n");
 
     std::thread inference_thread([&ctx_cli]() {

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -92,10 +92,10 @@ struct cli_context {
         }
 
         // wait for first result
-        console::start();
+        console::spinner::start();
         server_task_result_ptr result = rd.next(should_stop);
 
-        console::stop();
+        console::spinner::stop();
         std::string curr_content;
         bool is_thinking = false;
 
@@ -228,14 +228,14 @@ int main(int argc, char ** argv) {
 #endif
 
     console::log("\nLoading model... "); // followed by loading animation
-    console::start();
+    console::spinner::start();
     if (!ctx_cli.ctx_server.load_model(params)) {
-        console::stop();
+        console::spinner::stop();
         console::error("\nFailed to load the model\n");
         return 1;
     }
 
-    console::stop();
+    console::spinner::stop();
     console::log("\n");
 
     std::thread inference_thread([&ctx_cli]() {

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -209,9 +209,7 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
-    // TODO: avoid using atexit() here by making `console` a singleton
     console::init(params.simple_io, params.use_color);
-    // atexit([]() { console::cleanup(); });
 
     console::set_display(DISPLAY_TYPE_RESET);
 


### PR DESCRIPTION
## Changed:
- move functions in namespace console to static class console
- clean up the console after cli program finished automatically by RAII(static single instance)

## note:
- without test in Windows (because my Windows development environment is not complete)