### PR TITLE
Hybrid model loading with DirectIO and MMAP

### DIFF
--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -48,6 +48,7 @@ struct llama_mmap {
     void * addr() const;
 
     void unmap_fragment(size_t first, size_t last);
+    void prefetch(size_t offset, size_t len) const;
 
     static const bool SUPPORTED;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6985,7 +6985,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
     ml.done_getting_tensors();
 
-    ml.init_mappings(true, use_mlock ? &pimpl->mlock_mmaps : nullptr);
+    ml.init_mappings(false, use_mlock ? &pimpl->mlock_mmaps : nullptr);
     pimpl->mappings.reserve(ml.mappings.size());
 
     // create the backend buffers


### PR DESCRIPTION
This is a draft of the hybrid model loading. It combines `mmap` for host buffers and `DirectIO` for device buffers.

- Allows weight streaming from disk with the CPU backend
- In case the backend is not capable of asynchronous updating the loading falls back to `mmap` (allows backends to decide whether it supports DirectIO or not) 

Currently only the non-Windows path is implemented. Windows path will follow.