### PR TITLE
Correctly fetch q8_1 quantize pipeline in test as needed by 8a3519b

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -11956,7 +11956,8 @@ static void ggml_vk_test_dequant_matmul(ggml_backend_vk_context * ctx, size_t m,
         }
     }
     if (mmq) {
-        ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_quantize_q8_1, num_it);
+        vk_pipeline pipeline_quantize_q8_1 = ggml_vk_get_quantize_pipeline(ctx, GGML_TYPE_Q8_1);
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline_quantize_q8_1, num_it);
     }
 
     ggml_pipeline_allocate_descriptor_sets(ctx);


### PR DESCRIPTION
#17108 removed the `pipeline_quantize_q8_1` from the vk_device struct. Based on other changes in that PR, I believe this is the correct way to retrieve the pipeline now.

This requires building with the `GGML_VULKAN_RUN_TESTS` option to expose the previous build break.

This PR was not prepared with the help of AI, but still please don't ask me too many hard questions or else the cracks will appear :smiling_face_with_tear:.