### PR TITLE
metal: convert shutdown assertion to warning log

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -604,8 +604,11 @@ void ggml_metal_rsets_free(ggml_metal_rsets_t rsets) {
         return;
     }
 
-    // note: if you hit this assert, most likely you haven't deallocated all Metal resources before exiting
-    GGML_ASSERT([rsets->data count] == 0);
+    // During process exit, resources may not be fully cleaned up - log warning instead of asserting
+    if ([rsets->data count] != 0) {
+        GGML_LOG_WARN("%s: %lu Metal residency sets not freed before shutdown (expected during process exit)\n",
+                      __func__, (unsigned long)[rsets->data count]);
+    }
 
     atomic_store_explicit(&rsets->d_stop, true, memory_order_relaxed);
 


### PR DESCRIPTION
## Summary

During process exit, Metal residency sets may not be fully cleaned up due to static destructor ordering. This converts the fatal assertion in `ggml_metal_rsets_free()` to a warning log, as the OS will reclaim GPU resources anyway.

## Problem

When embedding llama.cpp in applications that use `exit()`, receive SIGINT, or don't perfectly clean up all contexts before shutdown, the assertion at line 608 fires:

```
GGML_ASSERT([rsets->data count] == 0) failed
```

This happens because:
1. The Metal device is a singleton (static `unique_ptr` in `ggml_metal_device_get()`)
2. It's only freed via C++ static destructor during process exit
3. Application-level cleanup may not run (e.g., Rust's `Drop` impls are skipped when `std::process::exit()` is called)

## Solution

Replace the assertion with a warning log. This:
- Preserves the diagnostic value (developers can see if resources weren't freed)
- Doesn't crash applications during normal shutdown
- Is safe because the OS reclaims all GPU resources on process exit

## Test

1. Build llama.cpp with Metal enabled
2. Run any application that loads a model
3. Send SIGINT (Ctrl+C) during or after inference
4. Verify clean shutdown with warning instead of assertion crash