### PR TITLE
ISWA: Switch to base cache for position tracking

### DIFF
--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -107,12 +107,14 @@ void llama_kv_cache_iswa::seq_div(llama_seq_id seq_id, llama_pos p0, llama_pos p
 }
 
 llama_pos llama_kv_cache_iswa::seq_pos_min(llama_seq_id seq_id) const {
-    // the base cache is a superset of the SWA cache, so we can just check the SWA cache
-    return kv_swa->seq_pos_min(seq_id);
+    // base cache preserves all positions (no SWA cell reuse), making it the ground truth for position tracking
+    // SWA cache can lose older positions when cells are reused for new tokens outside the SWA window
+    return kv_base->seq_pos_min(seq_id);
 }
 
 llama_pos llama_kv_cache_iswa::seq_pos_max(llama_seq_id seq_id) const {
-    return kv_swa->seq_pos_max(seq_id);
+    // base cache preserves all positions (no SWA cell reuse), making it the ground truth for position tracking
+    return kv_base->seq_pos_max(seq_id);
 }
 
 std::map<ggml_backend_buffer_type_t, size_t> llama_kv_cache_iswa::memory_breakdown() const {


### PR DESCRIPTION
seq_pos_min/max should report logical range: updated position tracking to use base cache instead of SWA cache

The API should return seq position range but returns internal SWA-cache state instead of logical sequence range

During kv cache manipulations (seq_rm etc) I've ran into the bug that alternating swa model (gpt-oss-20b) wrongly freed up tokens from kv_swa that were in use (before the 128 window

This fix solved my issues (no more token losses) but I'm not familiar with that area of the codebase.