### PR TITLE
chat: add thinking/reasoning support for Kimi K2

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1882,8 +1882,21 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
     common_chat_params data;
     data.grammar_lazy = params.tools.is_array() && !params.tools.empty() && params.tool_choice != COMMON_CHAT_TOOL_CHOICE_REQUIRED;
 
-    data.prompt = apply(tmpl, params);
+    json additional_context = {
+        {"thinking", params.enable_thinking},
+    };
+
+    data.prompt = apply(tmpl, params, /* messages_override= */ std::nullopt, /* tools_override= */ std::nullopt, additional_context);
     data.format = COMMON_CHAT_FORMAT_KIMI_K2;
+
+    // Handle thinking tags based on prompt ending
+    if (string_ends_with(data.prompt, "<think>\n") || string_ends_with(data.prompt, "<think>")) {
+        if (!params.enable_thinking) {
+            data.prompt += "</think>";
+        } else {
+            data.thinking_forced_open = true;
+        }
+    }
 
     data.preserved_tokens = {
         "<think>",


### PR DESCRIPTION
## Summary

- Pass `enable_thinking` to the Kimi K2 chat template via `additional_context`, so the Jinja template can render thinking-related tokens correctly
- Handle `<think>` tags at the end of the generated prompt: when thinking is disabled, immediately close with `</think>`; when enabled, set `thinking_forced_open = true`
- Enables proper reasoning mode support for Kimi 2.5 / K2 models (consistent with how other models like DeepSeek and QwQ handle thinking)

## Context

Currently the Kimi K2 handler in `common_chat_params_init_kimi_k2` does not pass the `enable_thinking` flag to the template, and does not manage the `<think>` tag lifecycle. This means reasoning mode doesn't work correctly for Kimi 2.5 models — the model either always thinks or never does, regardless of the `--reasoning` flag.

This patch aligns Kimi K2's thinking support with the pattern already used by other model handlers in `chat.cpp`.

## Test plan

- [ ] Run `llama-server` with a Kimi 2.5 GGUF and `--reasoning` enabled, verify `<think>...</think>` blocks appear in output
- [ ] Run without `--reasoning`, verify thinking is suppressed (prompt ends with `</think>` immediately)
- [ ] Verify tool calling still works correctly with and without reasoning enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)