### PR TITLE
nix: fix allowUnfreePredicate for packages with multiple licenses

### DIFF
--- a/.devops/nix/nixpkgs-instances.nix
+++ b/.devops/nix/nixpkgs-instances.nix
@@ -4,7 +4,7 @@
   # the module `{ pkgs ... }: { /* config */ }` implicitly uses
   # `_module.args.pkgs` (defined in this case by flake-parts).
   perSystem =
-    { system, ... }:
+    { lib, system, ... }:
     {
       _module.args = {
         # Note: bringing up https://zimbatm.com/notes/1000-instances-of-nixpkgs
@@ -33,7 +33,7 @@
                 "CUDA EULA"
                 "cuDNN EULA"
               ]
-            ) (p.meta.licenses or [ p.meta.license ]);
+            ) (p.meta.licenses or (lib.toList p.meta.license));
         };
         # Ensure dependencies use ROCm consistently
         pkgsRocm = import inputs.nixpkgs {


### PR DESCRIPTION
The `allowUnfreePredicate` in `pkgsCuda` wraps `p.meta.license` in a list, but `meta.license` can already be a list for packages with multiple licenses. This causes flake evaluation to fail when it tries to access `.free` on the nested list.

Fix by using `lib.toList` which handles both single licenses and license lists.