### PR TITLE
[SYCL] fix segmentation fault on consumer CPUs without bfloat16 hardware

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -241,6 +241,7 @@ option(GGML_OPENMP                          "ggml: use OpenMP"                  
 option(GGML_RPC                             "ggml: use RPC"                                   OFF)
 option(GGML_SYCL                            "ggml: use SYCL"                                  OFF)
 option(GGML_SYCL_F16                        "ggml: use 16 bit floats for sycl calculations"   OFF)
+option(GGML_SYCL_HAS_BF16                   "ggml: enable support for bfloat16 type"          OFF)
 option(GGML_SYCL_GRAPH                      "ggml: enable graphs in the SYCL backend"         ON)
 option(GGML_SYCL_DNN                        "ggml: enable oneDNN in the SYCL backend"         ON)
 set   (GGML_SYCL_TARGET "INTEL" CACHE STRING

--- a/ggml/src/ggml-sycl/CMakeLists.txt
+++ b/ggml/src/ggml-sycl/CMakeLists.txt
@@ -131,6 +131,10 @@ if (GGML_SYCL_F16)
     add_compile_definitions(GGML_SYCL_F16)
 endif()
 
+if (GGML_SYCL_HAS_BF16)
+    add_compile_definitions(GGML_SYCL_HAS_BF16)
+endif()
+
 if (GGML_SYCL_TARGET STREQUAL "INTEL")
     add_compile_definitions(GGML_SYCL_WARP_SIZE=16)
     target_link_options(ggml-sycl PRIVATE  -Xs   -ze-intel-greater-than-4GB-buffer-required)

--- a/ggml/src/ggml-sycl/convert.cpp
+++ b/ggml/src/ggml-sycl/convert.cpp
@@ -5,7 +5,6 @@
 #if defined(__INTEL_LLVM_COMPILER)
     #if __has_include(<sycl/ext/oneapi/bfloat16.hpp>)
         #include <sycl/ext/oneapi/bfloat16.hpp>
-        #define GGML_SYCL_HAS_BF16
     #endif
 #endif
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/ggml-org/llama.cpp/pull/17780 due to an issue in the oneAPI toolkit.

The original PR automatically enabled bfloat16 support by simply checking for the existence of the include file:
`sycl/ext/oneapi/bfloat16.hpp`

However, bfloat16 is only supported on server class CPUs and this include file does not seem to correctly fallback to software emulation. (Tested with oneAPI 2025.3.1 and also in 2025.3.0 on a Meteor Lake CPU)

Have tried to avoid making this PR by undefining `__SYCL_USE_NATIVE_BFLOAT16__` during compilation to overcome this issue, but this also did not work - still resulting in segmentation fault.

This PR simply turns off the bfloat16 option by default for the majority of users with consumer class Intel CPUs while still allowing those with server class CPUs to enable it by compiling with the `-DGGML_SYCL_HAS_BF16` option