### PR TITLE
feat(mtmd-cli): enable readline with arrow key support

### DIFF
--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -291,6 +291,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // Initialize console for advanced input (arrow keys, history, etc.)
+    console::init(params.simple_io, params.use_color);
+    atexit([]() { console::cleanup(); });
+
     mtmd_cli_context ctx(params);
     LOG_INF("%s: loading model: %s\n", __func__, params.model.path.c_str());
 


### PR DESCRIPTION
Add console::init() to mtmd-cli to enable advanced input features:
- Up/Down arrows for command history navigation
- Left/Right arrows for cursor movement within line
- Home/End keys for line start/end
- Ctrl+Left/Right for word-by-word navigation

These features were already implemented in console.cpp but were not activated in mtmd-cli due to missing initialization.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
