### PR TITLE
spec : fix the check-rate logic of ngram-simple

### DIFF
--- a/common/ngram-map.cpp
+++ b/common/ngram-map.cpp
@@ -53,11 +53,12 @@ llama_tokens common_ngram_simple_draft(
     // Simple implementation of self-speculative decoding without a draft model.
     //
     const size_t cur_len = tokens.size();
+
     // Only check every check_rate tokens to save compute
-    // i.e., perform check if (cur_len - idx_last_check) >= check_rate
-    if (state.idx_last_check + state.config.check_rate > cur_len) {
-        llama_tokens draft_tokens;
-        return draft_tokens;
+    if (state.check_id++ >= state.config.check_rate) {
+        state.check_id = 0;
+
+        return {};
     }
 
     size_t n_draft_min = state.config.size_ngram; // size of n-gram to lookup in token history
@@ -79,9 +80,6 @@ llama_tokens common_ngram_simple_draft(
         pattern.push_back(tokens[j]);
     }
     pattern.push_back(sampled); // add the last token to the pattern
-
-    // We do a search in the token history.
-    state.idx_last_check = cur_len;
 
     size_t match_pos = 0; // we ignore position 0, position 0 == no match
                           // search backwards, but skip the current match (we are currently there)

--- a/common/ngram-map.cpp
+++ b/common/ngram-map.cpp
@@ -47,22 +47,15 @@ static std::string common_tokens_to_str(const llama_tokens & inp, size_t start, 
  * @return Vector of draft tokens, empty if no matching pattern is found
  */
 llama_tokens common_ngram_simple_draft(
-        common_ngram_simple_state & state,
+        const common_ngram_simple_config & config,
         const llama_tokens & tokens, llama_token sampled) {
 
     // Simple implementation of self-speculative decoding without a draft model.
     //
     const size_t cur_len = tokens.size();
 
-    // Only check every check_rate tokens to save compute
-    if (state.check_id++ >= state.config.check_rate) {
-        state.check_id = 0;
-
-        return {};
-    }
-
-    size_t n_draft_min = state.config.size_ngram; // size of n-gram to lookup in token history
-    size_t n_draft_max = state.config.size_mgram; // the m-gram following the found n-gram is used for draft
+    const size_t n_draft_min = config.size_ngram; // size of n-gram to lookup in token history
+    const size_t n_draft_max = config.size_mgram; // the m-gram following the found n-gram is used for draft
 
     // vector for tokens we want to verify.
     // return empty vector if there is no match.

--- a/common/ngram-map.h
+++ b/common/ngram-map.h
@@ -27,23 +27,9 @@ struct common_ngram_simple_config {
     uint16_t   check_rate;      // check for speculative decoding without draft model for each check_rate token
 };
 
-// current state (and config) of n-gram simple.
-struct common_ngram_simple_state {
-    common_ngram_simple_config config;
-
-    size_t check_id = 0; // used to control the frequency of generating drafts
-
-    common_ngram_simple_state(const common_ngram_simple_config & config)
-        : config(config) {}
-};
-
 // Searches for a n-gram in the history and checks whether a draft sequence should be generated.
-// state:              the ngram simple state to search in.
-// inp:                the tokens generated so far.
-// sampled:            the token that was just sampled.
-// draft:              vector to store the draft tokens, initially empty.
 llama_tokens common_ngram_simple_draft(
-        common_ngram_simple_state & state,
+        const common_ngram_simple_config & config,
         const llama_tokens & tokens, llama_token sampled);
 
 

--- a/common/ngram-map.h
+++ b/common/ngram-map.h
@@ -31,7 +31,7 @@ struct common_ngram_simple_config {
 struct common_ngram_simple_state {
     common_ngram_simple_config config;
 
-    size_t idx_last_check = 0; // index of last check in context history (mutable)
+    size_t check_id = 0; // used to control the frequency of generating drafts
 
     common_ngram_simple_state(const common_ngram_simple_config & config)
         : config(config) {}


### PR DESCRIPTION
fix #19231

For the `spec-simple` method, we don't need to keep track of the last length to rate-limit the generations. We can simply use an incremental counter. This makes the speculator work with "Regenerate" of last message or branching the conversation from previous messages.

Also, removed `struct common_ngram_simple_state` - seemed a bit redundant.