### PR TITLE
fix: only reset LoRa configs when they have changed from previous batch

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1344,12 +1344,15 @@ std::string get_model_endpoint() {
 }
 
 void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora) {
-    llama_clear_adapter_lora(ctx);
-    for (auto & la : lora) {
-        if (la.scale != 0.0f) {
-            llama_set_adapter_lora(ctx, la.ptr, la.scale);
-        }
+    std::vector<llama_adapter_lora*> loras;
+    std::vector<float> scales;
+
+    for (auto & la: lora) {
+        loras.push_back(la.ptr);
+        scales.push_back(la.scale);
     }
+
+    llama_put_adapter_loras(ctx, loras.size(), loras.data(), scales.data());
 }
 
 struct llama_model_params common_model_params_to_llama(common_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1242,7 +1242,7 @@ common_init_result_ptr common_init_from_params(common_params & params) {
             return res;
         }
 
-        int err = llama_apply_adapter_cvec(
+        int err = llama_set_adapter_cvec(
                 lctx,
                 cvec.data.data(),
                 cvec.data.size(),
@@ -1344,7 +1344,7 @@ std::string get_model_endpoint() {
 }
 
 void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora) {
-    std::vector<llama_adapter_lora*> loras;
+    std::vector<llama_adapter_lora *> loras;
     std::vector<float> scales;
 
     for (auto & la: lora) {
@@ -1352,7 +1352,7 @@ void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adap
         scales.push_back(la.scale);
     }
 
-    llama_put_adapter_loras(ctx, loras.size(), loras.data(), scales.data());
+    llama_set_adapters_lora(ctx, loras.data(), loras.size(), scales.data());
 }
 
 struct llama_model_params common_model_params_to_llama(common_params & params) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -672,6 +672,9 @@ extern "C" {
     // Remove all LoRA adapters from given context
     LLAMA_API void llama_clear_adapter_lora(struct llama_context * ctx);
 
+    // Set LoRa adapters on the context. Will only modify if the adapters currently in context are different.
+    LLAMA_API void llama_put_adapter_loras(struct llama_context * ctx, size_t num_adapters, struct llama_adapter_lora ** adapters, float * scales);
+
     // Apply a loaded control vector to a llama_context, or if data is NULL, clear
     // the currently loaded vector.
     // n_embd should be the size of a single layer's control, and data should point

--- a/include/llama.h
+++ b/include/llama.h
@@ -656,24 +656,12 @@ extern "C" {
 
     // The following functions operate on a llama_context, hence the naming: llama_verb_...
 
-    // Add a loaded LoRA adapter to given context
-    // This will not modify model's weight
-    LLAMA_API int32_t llama_set_adapter_lora(
-            struct llama_context * ctx,
-            struct llama_adapter_lora * adapter,
-            float scale);
-
-    // Remove a specific LoRA adapter from given context
-    // Return -1 if the adapter is not present in the context
-    LLAMA_API int32_t llama_rm_adapter_lora(
-            struct llama_context * ctx,
-            struct llama_adapter_lora * adapter);
-
-    // Remove all LoRA adapters from given context
-    LLAMA_API void llama_clear_adapter_lora(struct llama_context * ctx);
-
     // Set LoRa adapters on the context. Will only modify if the adapters currently in context are different.
-    LLAMA_API void llama_put_adapter_loras(struct llama_context * ctx, size_t num_adapters, struct llama_adapter_lora ** adapters, float * scales);
+    LLAMA_API int32_t llama_set_adapters_lora(
+            struct llama_context * ctx,
+            struct llama_adapter_lora ** adapters,
+            size_t n_adapters,
+            float * scales);
 
     // Apply a loaded control vector to a llama_context, or if data is NULL, clear
     // the currently loaded vector.
@@ -681,7 +669,7 @@ extern "C" {
     // to an n_embd x n_layers buffer starting from layer 1.
     // il_start and il_end are the layer range the vector should apply to (both inclusive)
     // See llama_control_vector_load in common to load a control vector.
-    LLAMA_API int32_t llama_apply_adapter_cvec(
+    LLAMA_API int32_t llama_set_adapter_cvec(
             struct llama_context * ctx,
                      const float * data,
                           size_t   len,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1093,6 +1093,40 @@ bool llama_context::rm_adapter_lora(
     return false;
 }
 
+void llama_context::put_adapter_loras(size_t num_adapters, llama_adapter_lora ** adapters, float * scales) {
+    LLAMA_LOG_DEBUG("%s: adapters = %p\n", __func__, (void *) adapters);
+
+    if (are_adapter_loras_same(num_adapters, adapters, scales)) {
+        return;
+    }
+
+    clear_adapter_lora();
+
+    for (size_t i = 0; i < num_adapters; i ++) {
+        if (scales[i] != 0.0f) {
+            set_adapter_lora(adapters[i], scales[i]);
+        }
+    }
+}
+
+bool llama_context::are_adapter_loras_same(size_t num_adapters, llama_adapter_lora ** adapters, float * scales) {
+    LLAMA_LOG_DEBUG("%s: adapters = %p\n", __func__, (void *) adapters);
+
+    if (num_adapters != loras.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < num_adapters; i ++) {
+        auto it = loras.find(adapters[i]);
+
+        if (it == loras.end() || it->second != scales[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void llama_context::clear_adapter_lora() {
     LLAMA_LOG_DEBUG("%s: call\n", __func__);
 
@@ -3241,6 +3275,10 @@ int32_t llama_rm_adapter_lora(
 
 void llama_clear_adapter_lora(llama_context * ctx) {
     ctx->clear_adapter_lora();
+}
+
+void llama_put_adapter_loras(llama_context * ctx, size_t num_adapters, llama_adapter_lora ** adapters, float * scales) {
+    ctx->put_adapter_loras(num_adapters, adapters, scales);
 }
 
 int32_t llama_apply_adapter_cvec(

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -104,20 +104,11 @@ struct llama_context {
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 
-    void set_adapter_lora(
-            llama_adapter_lora * adapter,
-            float scale);
+    void set_adapters_lora(llama_adapter_lora ** adapters, size_t n_adapters, float * scales);
 
-    bool rm_adapter_lora(
-            llama_adapter_lora * adapter);
+    bool adapters_lora_are_same(llama_adapter_lora ** adapters, size_t n_adapters, float * scales);
 
-    void put_adapter_loras(size_t num_adapters, llama_adapter_lora ** adapters, float * scales);
-
-    bool are_adapter_loras_same(size_t num_adapters, llama_adapter_lora ** adapters, float * scales);
-
-    void clear_adapter_lora();
-
-    bool apply_adapter_cvec(
+    bool set_adapter_cvec(
             const float * data,
                  size_t   len,
                 int32_t   n_embd,

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -111,6 +111,10 @@ struct llama_context {
     bool rm_adapter_lora(
             llama_adapter_lora * adapter);
 
+    void put_adapter_loras(size_t num_adapters, llama_adapter_lora ** adapters, float * scales);
+
+    bool are_adapter_loras_same(size_t num_adapters, llama_adapter_lora ** adapters, float * scales);
+
     void clear_adapter_lora();
 
     bool apply_adapter_cvec(


### PR DESCRIPTION
## Overview
Fix for https://github.com/ggml-org/llama.cpp/issues/19217

Currently we are setting the LoRa config for each and every token request, even if the configuration between batches has not changed. It appears in [this PR, in llama-context.cpp, line 1078](https://github.com/ggml-org/llama.cpp/pull/18547) we added schedule reserving for when we set new LoRa configs, and so now when we have a LoRa config, for every batch we are decoding, we are reserving the scheduler.

This change adds a field to the server slot that holds the last batche's LoRa config. For each batch, we run a check to see if the config is the same as the previous batch, and only if it is not do we go ahead and set it. Otherwise, proceed. 

## Testing
I was able to re-produce the issue relatively easily with some debug logs
```
./llama-server -hf bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Q8_0 --lora ~/Downloads/LoRA-Llama-3.1-8B-MultiReflection-f16.gguf -c 1024 --parallel 1 --host 0.0.0.0 --port 8080 --verbose
```

and was able to see this endlessly along with huge memory spikes:

```
Setting sched_need_reserve to TRUE in the set_adapter_lora functionset_embeddings: value = 0
Reserving memory during decoding

sched_reserve: reserving ...
sched_reserve: max_nodes = 3692
srv    operator(): http: streamed chunk: data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" requests"}}],"created":1770077607,"id":"chatcmpl-1gqsKPcqCDHRRMZFNqfWqnl557ARXVc9","model":"bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Q8_0","system_fingerprint":"b7916-0dfcd3b60","object":"chat.completion.chunk","timings":{"cache_n":0,"prompt_n":109,"prompt_ms":628.118,"prompt_per_token_ms":5.762550458715597,"prompt_per_second":173.5342722227352,"predicted_n":2,"predicted_ms":180.088,"predicted_per_token_ms":90.044,"predicted_per_second":11.105681666740704}}


sched_reserve: reserving full memory module
sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
sched_reserve:       MTL0 compute buffer size =   509.12 MiB
sched_reserve:        CPU compute buffer size =    18.01 MiB
sched_reserve: graph nodes  = 1903
sched_reserve: graph splits = 2

```

After these changes, the issue no longer appears and memory remains stable. 