### PR TITLE
spec: ngram-mod, score-based pruning

### DIFF
--- a/common/ngram-mod.cpp
+++ b/common/ngram-mod.cpp
@@ -99,11 +99,13 @@ void common_ngram_mod::dec_score_by_index(size_t i) {
 void common_ngram_mod::prune_low_score() {
     used = 0;
     for (size_t i = 0; i < entries.size(); ++i) {
-        if (scores[i] < common_ngram_mod::SCORE_THR) {
-            entries[i] = EMPTY;
-            scores[i] = 0;
-        } else {
-            ++used;
+        if (entries[i] != EMPTY) {
+            if (scores[i] < common_ngram_mod::SCORE_THR) {
+                entries[i] = EMPTY;
+                scores[i] = 0;
+            } else {
+                ++used;
+            }
         }
     }
 }

--- a/common/ngram-mod.cpp
+++ b/common/ngram-mod.cpp
@@ -6,6 +6,7 @@
 
 common_ngram_mod::common_ngram_mod(uint16_t n, size_t size) : n(n), used(0) {
     entries.resize(size);
+    scores.resize(size, SCORE_INIT);
 
     reset();
 }
@@ -27,8 +28,12 @@ void common_ngram_mod::add(const entry_t * tokens) {
 
     if (entries[i] == EMPTY) {
         used++;
+        scores[i] = SCORE_INS;
+    } else if (entries[i] != tokens[n]) {
+        // a different token hashes to the same bucket
+        ++collisions;
     }
-
+    // keep existing score if entry already occupied
     entries[i] = tokens[n];
 }
 
@@ -40,7 +45,9 @@ common_ngram_mod::entry_t common_ngram_mod::get(const entry_t * tokens) const {
 
 void common_ngram_mod::reset() {
     std::fill(entries.begin(), entries.end(), EMPTY);
+    std::fill(scores.begin(),   scores.end(),   0);
     used = 0;
+    collisions = 0;
 }
 
 size_t common_ngram_mod::get_n() const {
@@ -56,5 +63,83 @@ size_t common_ngram_mod::size() const {
 }
 
 size_t common_ngram_mod::size_bytes() const {
-    return entries.size() * sizeof(entries[0]);
+    return entries.size() * sizeof(entries[0]) + scores.size() * sizeof(scores[0]);
+}
+
+size_t common_ngram_mod::index(const entry_t * tokens) const {
+    return idx(tokens);
+}
+
+void common_ngram_mod::inc_score(const entry_t * tokens) {
+    const size_t i = idx(tokens);
+    if (scores[i] < common_ngram_mod::SCORE_MAX) {
+        ++scores[i];
+    }
+}
+
+void common_ngram_mod::dec_score(const entry_t * tokens) {
+    const size_t i = idx(tokens);
+    if (scores[i] > common_ngram_mod::SCORE_MIN) {
+        --scores[i];
+    }
+}
+
+void common_ngram_mod::inc_score_by_index(size_t i) {
+    if (i < scores.size() && scores[i] < common_ngram_mod::SCORE_MAX) {
+        ++scores[i];
+    }
+}
+
+void common_ngram_mod::dec_score_by_index(size_t i) {
+    if (i < scores.size() && scores[i] > common_ngram_mod::SCORE_MIN) {
+        --scores[i];
+    }
+}
+
+void common_ngram_mod::prune_low_score() {
+    used = 0;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (scores[i] < common_ngram_mod::SCORE_THR) {
+            entries[i] = EMPTY;
+            scores[i] = 0;
+        } else {
+            ++used;
+        }
+    }
+}
+
+size_t common_ngram_mod::get_collisions() const {
+    return collisions;
+}
+
+size_t common_ngram_mod::get_below_thr() const {
+    return count_below_thr;
+}
+
+size_t common_ngram_mod::get_at_min() const {
+    return count_at_min;
+}
+
+size_t common_ngram_mod::get_at_max() const {
+    return count_at_max;
+}
+
+size_t common_ngram_mod::get_at_ins() const {
+    return count_at_ins;
+}
+
+void common_ngram_mod::update_score_stats() {
+    // reset counters
+    count_below_thr = 0;
+    count_at_min   = 0;
+    count_at_max   = 0;
+    count_at_ins  = 0;
+
+    for (size_t i = 0; i < scores.size(); ++i) {
+        const int8_t s = scores[i];
+        if (s < SCORE_THR) ++count_below_thr;
+        if (s == SCORE_MIN) ++count_at_min;
+        if (s == SCORE_MAX) ++count_at_max;
+        if (s == SCORE_INS) ++count_at_ins;
+    }
 }

--- a/common/ngram-mod.cpp
+++ b/common/ngram-mod.cpp
@@ -45,7 +45,7 @@ common_ngram_mod::entry_t common_ngram_mod::get(const entry_t * tokens) const {
 
 void common_ngram_mod::reset() {
     std::fill(entries.begin(), entries.end(), EMPTY);
-    std::fill(scores.begin(),   scores.end(),   0);
+    std::fill(scores.begin(), scores.end(), SCORE_INIT);
     used = 0;
     collisions = 0;
 }

--- a/common/ngram-mod.h
+++ b/common/ngram-mod.h
@@ -15,6 +15,12 @@ struct common_ngram_mod {
 
     static constexpr entry_t EMPTY = -1;
 
+    static constexpr int8_t SCORE_INIT = 0;
+    static constexpr int8_t SCORE_MIN  = -5;
+    static constexpr int8_t SCORE_MAX  = 20;
+    static constexpr int8_t SCORE_THR  = 0; // keep equal or lower than SCORE_INIT
+    static constexpr int8_t SCORE_INS  = 3;
+
     common_ngram_mod(uint16_t n, size_t size);
 
     size_t  idx(const entry_t * tokens) const;
@@ -23,8 +29,26 @@ struct common_ngram_mod {
 
     void reset();
 
+    // expose the hash index for external bookkeeping
+    size_t index(const entry_t * tokens) const;
+
+    // score handling
+    void inc_score(const entry_t * tokens);
+    void dec_score(const entry_t * tokens);
+    void inc_score_by_index(size_t i);
+    void dec_score_by_index(size_t i);
+    void prune_low_score(); // remove entries below SCORE_THR
+
     size_t get_n()    const;
     size_t get_used() const;
+
+    void update_score_stats();
+
+    size_t get_collisions() const;
+    size_t get_below_thr()  const;
+    size_t get_at_min()     const;
+    size_t get_at_max()     const;
+    size_t get_at_ins()    const;
 
     size_t size()       const;
     size_t size_bytes() const;
@@ -35,4 +59,15 @@ private:
     size_t used;
 
     std::vector<entry_t> entries;
+    // per-entry score, range SCORE_MIN .. SCORE_MAX
+    std::vector<int8_t> scores;
+
+    // stats
+    // count of hash collisions
+    size_t collisions = 0;
+    // counts for score
+    size_t count_below_thr = 0;
+    size_t count_at_min   = 0;
+    size_t count_at_max   = 0;
+    size_t count_at_ins  = 0;
 };

--- a/common/ngram-mod.h
+++ b/common/ngram-mod.h
@@ -18,7 +18,7 @@ struct common_ngram_mod {
     static constexpr int8_t SCORE_INIT = 0;
     static constexpr int8_t SCORE_MIN  = -5;
     static constexpr int8_t SCORE_MAX  = 20;
-    static constexpr int8_t SCORE_THR  = 0; // keep equal or lower than SCORE_INIT
+    static constexpr int8_t SCORE_THR  = 0;
     static constexpr int8_t SCORE_INS  = 3;
 
     common_ngram_mod(uint16_t n, size_t size);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -527,6 +527,8 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
 
     // consecutive accept rounds with low acceptance fraction (< 0.5)
     int n_low = 0;
+    // hash indices of ngrams consulted during the most recent draft
+    std::vector<size_t> used_hashes;
 
     // enable trace logging if LLAMA_TRACE is set
     const bool verbose;
@@ -558,7 +560,7 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
 
         constexpr double f_thold = 0.25;
         if (f > f_thold) {
-            LOG_WRN("%s: ngram_mod occupancy %.2f exceeds threshold (%.2f) - resetting\n", __func__, f, f_thold);
+            LOG_WRN("%s: ngram_mod occupancy %.2f exceeds threshold (%.2f) - resetting (collisions=%zu)\n", __func__, f, f_thold, mod.get_collisions());
 
             mod.reset();
         }
@@ -572,6 +574,7 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
         GGML_UNUSED(params);
 
         n_draft_last = 0;
+        used_hashes.clear();
 
         const size_t cur_len = prompt_tgt.size();
         if (cur_len < mod.get_n()) {
@@ -607,6 +610,8 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
                 break;
             }
             result[n + i] = token;
+            // remember which hash entry produced this token
+            used_hashes.push_back(mod.index(result.data() + i));
         }
 
         // only return the m tokens that were drafted
@@ -627,18 +632,37 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
         // compute acceptance fraction if we have a recorded draft length
         if (n_draft_last > 0) {
             const double f_acc = (double)n_accepted / (double)n_draft_last;
+
+            // update per-ngram scores based on acceptance outcome
+            for (size_t i = 0; i < n_draft_last; ++i) {
+                if (i < static_cast<size_t>(n_accepted)) {
+                    mod.inc_score_by_index(used_hashes[i]);
+                } else {
+                    mod.dec_score_by_index(used_hashes[i]);
+                }
+            }
+
             if (f_acc < 0.5) {
                 n_low++;
                 if (n_low >= 3) {
-                    LOG_WRN("%s: low acceptance streak (%d) – resetting ngram_mod\n", __func__, n_low);
+                    LOG_WRN("%s: low acceptance streak (%d) - pruning ngram_mod (collisions=%zu)\n", __func__, n_low, mod.get_collisions());
+                    // Log detailed score metrics before pruning
+                    mod.update_score_stats();
+                    LOG_WRN("%s: before prune scores - below_thr=%zu, at_min=%zu, at_max=%zu, at_ins=%zu\n",
+                            __func__,
+                            mod.get_below_thr(),
+                            mod.get_at_min(),
+                            mod.get_at_max(),
+                            mod.get_at_ins());
 
-                    mod.reset();
+                    mod.prune_low_score();
                     n_low = 0;
                 }
             } else {
                 n_low = 0;
             }
         }
+        used_hashes.clear();
     }
 };
 


### PR DESCRIPTION
related to #19164, PoC of https://github.com/ggml-org/llama.cpp/pull/19164#issuecomment-3830614717

Track for each ngram in the pool a capped score, initially set to SCORE_INS on insert. If an ngram was used successfully in a draft, count its score up. If the draft was rejected count its score down. On streaks remove all ngrams with a score lower than SCORE_THR.

I did superficial testing and speedup is more consistent throughout processing the whole request; no more sudden drops of speed-up after (early) low acceptance streaks. Pruning currently goes through all 4M cache pool entries + the scoring has a minor but noticeable effect on performance; there is still optimization potential.

Also added some hash pool stats (scoring state + collisions) that might be helpful to further fine-tune the parameters (SCORE_MIN, SCORE_MAX, SCORE_INS, ..).


Here logs where the prompt looked like this: [GIVEN_SOURCE_CODE|TASK] and the model was tasked to generate [A|GIVEN_SOURCE_CODE|B|GIVEN_SOURCE_CODE]. A, and B is something sampled stochastically, GIVEN_SOURCE_CODE is known to be in the hash pool. Before the change sometimes the streak was encountered (early), the entire hash pool was cleared and there was no speed-up afterwards (see: https://github.com/ggml-org/llama.cpp/pull/19164#issuecomment-3828080222). With this change we only prune low-scored ngrams on streaks and (still useful) ngrams above or equal SCORE_THR remain in the hash pool. 

<details>
<summary>Log</summary>

```
srv  params_from_: Chat format: GPT-OSS
slot get_availabl: id  3 | task -1 | selected slot by LCP similarity, sim_best = 1.000 (> 0.100 thold), f_keep = 0.317
srv  get_availabl: updating prompt cache
srv   prompt_save:  - saving prompt with length 4415, total state size = 191.067 MiB
srv          load:  - looking for better prompt, base f_keep = 0.317, sim = 1.000
srv        update:  - cache state: 7 prompts, 1576.120 MiB (limits: 8192.000 MiB, 64000 tokens, 158645 est)
srv        update:    - prompt 0x560874484e20:    4353 tokens, checkpoints:  1,   224.899 MiB
srv        update:    - prompt 0x560874652c40:    4356 tokens, checkpoints:  1,   225.004 MiB
srv        update:    - prompt 0x560865f90410:    4302 tokens, checkpoints:  1,   223.105 MiB
srv        update:    - prompt 0x560874bb1f50:    4288 tokens, checkpoints:  1,   222.613 MiB
srv        update:    - prompt 0x560874aa4050:    4377 tokens, checkpoints:  1,   225.743 MiB
srv        update:    - prompt 0x560874ce33e0:    4432 tokens, checkpoints:  1,   227.677 MiB
srv        update:    - prompt 0x560874647ca0:    4415 tokens, checkpoints:  1,   227.079 MiB
srv  get_availabl: prompt cache update took 46.56 ms
slot launch_slot_: id  3 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> ?top-k -> ?typical -> ?top-p -> min-p -> ?xtc -> ?temp-ext -> dist 
slot launch_slot_: id  3 | task 4301 | processing task, is_child = 0
slot update_slots: id  3 | task 4301 | new prompt, n_ctx_slot = 64000, n_keep = 0, task.n_tokens = 1401
slot update_slots: id  3 | task 4301 | n_past = 1401, slot.prompt.tokens.size() = 4415, seq_id = 3, pos_min = 3397, n_swa = 128
slot update_slots: id  3 | task 4301 | restored context checkpoint (pos_min = 313, pos_max = 1336, size = 36.012 MiB)
slot update_slots: id  3 | task 4301 | n_tokens = 1336, memory_seq_rm [1336, end)
slot update_slots: id  3 | task 4301 | prompt processing progress, n_tokens = 1337, batch.n_tokens = 1, progress = 0.954318
slot update_slots: id  3 | task 4301 | n_tokens = 1337, memory_seq_rm [1337, end)
slot update_slots: id  3 | task 4301 | prompt processing progress, n_tokens = 1401, batch.n_tokens = 64, progress = 1.000000
slot update_slots: id  3 | task 4301 | prompt done, n_tokens = 1401, batch.n_tokens = 64
slot init_sampler: id  3 | task 4301 | init sampler, took 0.17 ms, tokens: text = 1401, total = 1401
begin: ngram_mod occupancy = 4050/4194304 (0.00)
accept: accepted 4 tokens from 64 drafted tokens
accept: accepted 43 tokens from 64 drafted tokens
accept: accepted 3 tokens from 64 drafted tokens
accept: accepted 3 tokens from 64 drafted tokens
accept: accepted 8 tokens from 64 drafted tokens
accept: low acceptance streak (3) - pruning ngram_mod (collisions=140)
accept: before prune scores - below_thr=26, at_min=16, at_max=0, at_ins=2029
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 57 tokens from 57 drafted tokens
accept: accepted 8 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 64 tokens from 64 drafted tokens
accept: accepted 57 tokens from 64 drafted tokens
slot print_timing: id  3 | task 4301 | 
prompt eval time =      54.12 ms /    65 tokens (    0.83 ms per token,  1201.15 tokens per second)
       eval time =    6246.35 ms /  3056 tokens (    2.04 ms per token,   489.25 tokens per second)
      total time =    6300.47 ms /  3121 tokens
draft acceptance rate = 0.83980 ( 2359 accepted /  2809 generated)
statistics ngram_mod: #calls = 4976, #gen drafts = 322, #acc drafts = 316, #gen tokens = 20601, #acc tokens = 18795, dur(b,g,a) = 1.101, 7.910, 4.906 ms
slot      release: id  3 | task 4301 | stop processing: n_tokens = 4456, truncated = 0
srv  update_slots: all slots are idle
```

</details>