### PR TITLE
server: make UI textarea fields resizable

### DIFF
--- a/tools/server/public_legacy/index.html
+++ b/tools/server/public_legacy/index.html
@@ -198,6 +198,7 @@
       padding: 5px;
       flex-grow: 1;
       width: 100%;
+      resize: vertical;
     }
 
     pre code {

--- a/tools/server/public_simplechat/simplechat.css
+++ b/tools/server/public_simplechat/simplechat.css
@@ -49,6 +49,9 @@
 button {
     min-width: 8vw;
 }
+textarea {
+    resize: vertical;
+}
 
 .sameline {
     display: flex;


### PR DESCRIPTION
This adds the ability to resize text input fields in the web UI.

Users can now drag the textarea corner vertically to adjust the size, making it easier to view and edit longer prompts without scrolling. This addresses the accessibility issue raised in #19244 where the chat window wasn't resizable.