### PR TITLE
Add missing ggml.pc.in

### DIFF
--- a/ggml/ggml.pc.in
+++ b/ggml/ggml.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: ggml
+Description: Tensor library for machine learning
+Version: @GGML_VERSION@
+Libs: -L${libdir} -lggml -lggml-base
+Cflags: -I${includedir}


### PR DESCRIPTION
When compiling libggml in standalone mode, installation then fails due to a missing ggml.pc.in which is referenced in CmakeList.

Add the missing file, using llama.pc.in as a reference.
