### PR TITLE
Fix link failures in s390x

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -676,6 +676,7 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
     message(STATUS "Adding CPU backend variant ${GGML_CPU_NAME}: ${ARCH_FLAGS} ${ARCH_DEFINITIONS}")
     target_sources(${GGML_CPU_NAME} PRIVATE ${GGML_CPU_SOURCES})
     target_compile_options(${GGML_CPU_NAME} PRIVATE ${ARCH_FLAGS})
+    target_link_options(${GGML_CPU_NAME} PRIVATE ${ARCH_FLAGS})
     target_compile_definitions(${GGML_CPU_NAME} PRIVATE ${ARCH_DEFINITIONS})
 
     if (EMSCRIPTEN)


### PR DESCRIPTION
Linking in s390x fails with:

    [48/351] Linking CXX shared module bin/libggml-cpu-z15.so
    ninja: job failed: : && /usr/bin/c++ -fPIC -Os -fstack-clash-protection -Wformat -Werror=format-security -D_GLIBCXX_ASSERTIONS=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -O3 -DNDEBUG -flto=auto -fno-fat-lto-objects  -shared -Wl,--as-needed,-O1,--sort-common  -o bin/libggml-cpu-z16.so src/CMakeFiles/ggml-cpu-z16-feats.dir/ggml-cpu/arch/s390/cpu-feats.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/ggml-cpu.c.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/ggml-cpu.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/repack.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/hbm.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/quants.c.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/traits.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/amx/amx.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/amx/mmq.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/binary-ops.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/unary-ops.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/vec.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/ops.cpp.o src/CMakeFiles/ggml-cpu-z16.dir/ggml-cpu/arch/s390/quants.c.o  -Wl,-rpath,/builds/WhyNotHugo/aports/testing/libggml/src/llama.cpp-b7931/build/src:  src/libggml-base.so.0.9.5  /usr/lib/libgomp.so  /usr/lib/libpthread.a && :
    lto1: error: hardware vector support not available on z196
    lto-wrapper: fatal error: /usr/bin/c++ returned 1 exit status
    compilation terminated.
    /usr/lib/gcc/s390x-alpine-linux-musl/15.2.0/../../../../s390x-alpine-linux-musl/bin/ld: error: lto-wrapper failed
    collect2: error: ld returned 1 exit status
    ninja: job failed: : && /usr/bin/c++ -fPIC -Os -fstack-clash-protection -Wformat -Werror=format-security -D_GLIBCXX_ASSERTIONS=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -O3 -DNDEBUG -flto=auto -fno-fat-lto-objects  -shared -Wl,--as-needed,-O1,--sort-common  -o bin/libggml-cpu-z15.so src/CMakeFiles/ggml-cpu-z15-feats.dir/ggml-cpu/arch/s390/cpu-feats.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/ggml-cpu.c.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/ggml-cpu.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/repack.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/hbm.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/quants.c.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/traits.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/amx/amx.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/amx/mmq.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/binary-ops.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/unary-ops.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/vec.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/ops.cpp.o src/CMakeFiles/ggml-cpu-z15.dir/ggml-cpu/arch/s390/quants.c.o  -Wl,-rpath,/builds/WhyNotHugo/aports/testing/libggml/src/llama.cpp-b7931/build/src:  src/libggml-base.so.0.9.5  /usr/lib/libgomp.so  /usr/lib/libpthread.a && :
    lto1: error: hardware vector support not available on z196
    lto-wrapper: fatal error: /usr/bin/c++ returned 1 exit status
    compilation terminated.
    /usr/lib/gcc/s390x-alpine-linux-musl/15.2.0/../../../../s390x-alpine-linux-musl/bin/ld: error: lto-wrapper failed
    collect2: error: ld returned 1 exit status
    [1/2] Building CXX object CMakeFiles/vulkan-shaders-gen.dir/vulkan-shaders-gen.cpp.o
    [2/2] Linking CXX executable vulkan-shaders-gen
    ninja: subcommands failed

This change fixes the build error.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
