### PR TITLE
Fix missing includes in metal build

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -7,6 +7,9 @@
 #include "ggml-metal-context.h"
 #include "ggml-metal-ops.h"
 
+#include <mutex>
+#include <string>
+
 #define GGML_METAL_NAME "MTL"
 #define GGML_METAL_MAX_DEVICES 16
 


### PR DESCRIPTION
Since commit https://github.com/ggml-org/llama.cpp/commit/6fdddb498780dbda2a14f8b49b92d25601e14764, I get errors when building on Mac.

This PR adds the missing includes for `mutex` and `string` to fix the build.

```
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:180:17: error: implicit instantiation of undefined template 'std::basic_string<char>'
    std::string name;
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__fwd/string.h:45:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS basic_string;
                           ^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:272:17: error: no type named 'mutex' in namespace 'std'
    static std::mutex mutex;
           ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:273:10: error: no member named 'lock_guard' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:273:26: error: no member named 'mutex' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
                    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:287:60: error: no member named 'to_string' in namespace 'std'
                    /* .name   = */ GGML_METAL_NAME + std::to_string(i),
                                                      ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:348:17: error: no type named 'mutex' in namespace 'std'
    static std::mutex mutex;
           ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:349:10: error: no member named 'lock_guard' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:349:26: error: no member named 'mutex' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
                    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:362:56: error: no member named 'to_string' in namespace 'std'
                /* .name   = */ GGML_METAL_NAME + std::to_string(i) + "_Private"
                                                  ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:424:17: error: no type named 'mutex' in namespace 'std'
    static std::mutex mutex;
           ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:425:10: error: no member named 'lock_guard' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:425:26: error: no member named 'mutex' in namespace 'std'
    std::lock_guard<std::mutex> lock(mutex);
                    ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:438:56: error: no member named 'to_string' in namespace 'std'
                /* .name   = */ GGML_METAL_NAME + std::to_string(i) + "_Mapped"
                                                  ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:901:21: error: no type named 'mutex' in namespace 'std'
        static std::mutex mutex;
               ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:902:14: error: no member named 'lock_guard' in namespace 'std'
        std::lock_guard<std::mutex> lock(mutex);
        ~~~~~^
/path/to/llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp:902:30: error: no member named 'mutex' in namespace 'std'
        std::lock_guard<std::mutex> lock(mutex);
                        ~~~~~^
16 errors generated.
```