### PR TITLE
docker : fix vulkan build

### DIFF
--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
     build-essential \
     git \
     python3 \
+    python3-dev \
     python3-pip \
     python3-wheel \
     && pip install --break-system-packages --upgrade setuptools \


### PR DESCRIPTION
Add now required `python3-dev` package.

Successful image build:
https://github.com/CISC/llama.cpp/actions/runs/21703843820/job/62590016764