### PR TITLE
model: qwen3next add inplace operations in gated delta net (#17822)

### DIFF
--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -409,7 +409,7 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_aut
 
     // Apply the gated delta rule for the single timestep
     // last_recurrent_state = last_recurrent_state * g_t
-    state = ggml_mul(ctx0, state, g_t);
+    state = ggml_mul_inplace(ctx0, state, g_t);
 
     // kv_mem = (last_recurrent_state * k_t.unsqueeze(-1)).sum(dim=-2)
     ggml_tensor * k_t_unsqueezed = ggml_reshape_4d(ctx0, k, 1, S_v, H_v, n_seqs);
@@ -424,8 +424,8 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_aut
     ggml_tensor * delta  = ggml_mul(ctx0, v_diff, beta_t);
 
     // last_recurrent_state = last_recurrent_state + k_t.unsqueeze(-1) * delta
-    ggml_tensor * k_t_delta = ggml_mul(ctx0, ggml_repeat_4d(ctx0, k_t_unsqueezed, S_v, S_v, H_v, n_seqs), delta);
-    state                   = ggml_add(ctx0, state, k_t_delta);
+    ggml_tensor * k_t_delta = ggml_mul_inplace(ctx0, ggml_repeat_4d(ctx0, k_t_unsqueezed, S_v, S_v, H_v, n_seqs), delta);
+    ggml_add_inplace(ctx0, state, k_t_delta);
 
     // Compute the attention output
     // core_attn_out = (last_recurrent_state * q_t.unsqueeze(-1)).sum(dim=-2)


### PR DESCRIPTION
We were able to significantly improve the tps for the qwen3next architecture. 
Measurements demonstrated the following improvements for Qwen3-Next-80B-A3B-Instruct-Q4_K_M.gguf:
1. CPU (8threads): 4.78 tps -> 7.19 tps (+50%)
2. GPU (A100): 58.25 tps -> 69.44 tps (+20%)
3. GPU (A100 x 4): 55.73 tps -> 66.33 tps (+20%)

The system description, tests results with llama-bench and llama-perplexity are attached (see https://gist.github.com/sber-risk-research/3980c582a56b33c6aadd46b405bb5bfc)


AI use disclosure:

The possibility of the token generation improvement was found and pointed out to the authors of this Pull Request by a custom in-house research and coding agent.
The agent identified the nature of the necessary change and its precise location in the code base.
The change itself was reviewed and implemented by the authors followed by exhaustive ablation studies and testing.


