### PR TITLE
models : optimizing qwen3next graph

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4544,6 +4544,8 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_CEIL:
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
+                    // TODO: should become:
+                    //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
                 default:
                     return false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2872,6 +2872,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
     const std::string ffn_moe_down_bias_prefix = "ffn_moe_down_biased";
     const std::string nemotron_h_block_out_prefix = "nemotron_h_block_out";
     const std::string mamba2_y_add_d_prefix = "mamba2_y_add_d";
+    const std::string delta_net_prefix = "dnet_add";
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -2902,7 +2903,8 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
             strncmp(node->name, ffn_moe_up_bias_prefix.c_str(), ffn_moe_up_bias_prefix.size()) != 0 &&
             strncmp(node->name, ffn_moe_down_bias_prefix.c_str(), ffn_moe_down_bias_prefix.size()) != 0 &&
             strncmp(node->name, nemotron_h_block_out_prefix.c_str(), nemotron_h_block_out_prefix.size()) != 0 &&
-            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0) {
+            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0 &&
+            strncmp(node->name, delta_net_prefix.c_str(), delta_net_prefix.size()) != 0) {
             // disable CUDA graphs for batch size > 1 for now while excluding the matrix-matrix addition as part of Gemma3n's `project_per_layer_input` operation
             // by means of matching node names. See
             // https://github.com/ggml-org/llama.cpp/blob/f9a31eea06a859e34cecb88b4d020c7f03d86cc4/src/llama-model.cpp#L10199-L10241 and

--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -273,6 +273,7 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
             case GGML_OP_DIAG:
             case GGML_OP_MUL:
             case GGML_OP_ADD:
+            case GGML_OP_SUB:
             case GGML_OP_DIV:
             case GGML_OP_GLU:
             case GGML_OP_SCALE:

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -489,9 +489,6 @@ private:
     ggml_tensor * build_layer_attn_linear(
          llm_graph_input_rs * inp,
                 ggml_tensor * cur,
-                ggml_tensor * causal_mask,
-                ggml_tensor * identity,
-                ggml_tensor * diag_mask,
                         int   il);
 
     ggml_tensor * build_layer_ffn(
@@ -506,9 +503,6 @@ private:
                 ggml_tensor * g,
                 ggml_tensor * beta,
                 ggml_tensor * state,
-                ggml_tensor * causal_mask,
-                ggml_tensor * identity,
-                ggml_tensor * diag_mask,
                         int   il);
 
     // returns pair of output and new state

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -214,15 +214,17 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_chu
 
     v = ggml_mul_mat(ctx0, attn, ggml_cont(ctx0, ggml_transpose(ctx0, v_beta)));
 
-    ggml_tensor * gexp = ggml_exp(ctx0, g_cumsum);
+    ggml_tensor * g_exp = ggml_exp(ctx0, g_cumsum);
 
     k_beta = ggml_cont(ctx0, ggml_transpose(ctx0, k_beta));
 
-    ggml_tensor * kbeta_gexp = ggml_mul(ctx0, k_beta, gexp);
-    cb(kbeta_gexp, "kbeta_gexp", il); // shape: (S_k, chunk_size, n_chunks, H_v * n_seqs)
+    ggml_tensor * kbeta_g_exp = ggml_mul(ctx0, k_beta, g_exp);
+    cb(kbeta_g_exp, "kbeta_g_exp", il); // shape: (S_k, chunk_size, n_chunks, H_v * n_seqs)
 
-    ggml_tensor * k_cumdecay = ggml_mul_mat(ctx0, kbeta_gexp, attn);
+    ggml_tensor * k_cumdecay = ggml_mul_mat(ctx0, kbeta_g_exp, attn);
     cb(k_cumdecay, "k_cumdecay", il); // shape: (chunk_size, chunk_size, n_chunks, H_v * n_seqs)
+
+    ggml_tensor * q_g_exp = ggml_mul(ctx0, q, ggml_transpose(ctx0, g_exp));
 
     ggml_tensor * attn_kq = ggml_mul_mat(ctx0, k, q);
     attn_kq = ggml_mul(ctx0, attn_kq, decay_mask);
@@ -266,14 +268,8 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_chu
     state = ggml_cont_4d(ctx0, ggml_transpose(ctx0, state), S_v, S_v, 1, H_v * n_seqs);
 
     for (int64_t chunk = 0; chunk < n_chunks; chunk++) {
-        // shape: (S_k, chunk_size, 1, H_k * n_seqs)
-        ggml_tensor * q_chunk = get_slice_2d(ctx0, q, chunk); // (no cont), next op: ggml_mul
-
         // shape: (S_v, chunk_size, 1, H_v * n_seqs)
         ggml_tensor * v_chunk = get_slice_2d(ctx0, v, chunk); // (no cont), next op: ggml_repeat
-
-        // shape: (chunk_size, 1, n_chunks, H_v * n_seqs)
-        ggml_tensor * gexp_chunk = get_slice_2d(ctx0, gexp, chunk); // (no cont), next op: ggml_mul
 
         // shape: (chunk_size, 1, H_v * n_seqs)
         ggml_tensor * k_cumdecay_chunk = get_slice_2d(ctx0, k_cumdecay, chunk); // (no cont), next op: ggml_mul_mat
@@ -292,8 +288,8 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_chu
         cb(v_new_t, "v_new_chunk_t", il);
 
         // attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
-        ggml_tensor * q_g_exp    = ggml_mul(ctx0, q_chunk, ggml_transpose(ctx0, gexp_chunk));
-        ggml_tensor * attn_inter = ggml_mul_mat(ctx0, state, q_g_exp);
+        ggml_tensor * q_g_exp_chunk = get_slice_2d(ctx0, q_g_exp, chunk);
+        ggml_tensor * attn_inter = ggml_mul_mat(ctx0, state, q_g_exp_chunk);
         cb(attn_inter, "attn_inter_chunk", il);
 
         // core_attn_out[:, :, i] = attn_inter + attn @ v_new

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -225,8 +225,8 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen3next::build_delta_net_chu
     cb(k_cumdecay, "k_cumdecay", il); // shape: (chunk_size, chunk_size, n_chunks, H_v * n_seqs)
 
     ggml_tensor * attn_kq = ggml_mul_mat(ctx0, k, q);
-    attn_kq = ggml_mul(ctx0, decay_mask, attn_kq);
-    attn_kq = ggml_mul(ctx0, attn_kq,    diag_mask);
+    attn_kq = ggml_mul(ctx0, attn_kq, decay_mask);
+    attn_kq = ggml_mul(ctx0, attn_kq, diag_mask);
     cb(attn_kq, "attn_kq", il); // shape: (chunk_size, chunk_size, n_chunks, H_v * n_seqs)
 
     // vectorized calculation of key_gdiff

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -504,6 +504,9 @@ ggml_tensor * llm_build_qwen3next::build_layer_attn(
     cb(Qcur, "Qcur", il);
     cb(gate, "gate", il);
 
+    // TODO: CUDA is missing non-contiguous unary ops. when implemented: remove this cont
+    gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
+
     gate = ggml_sigmoid(ctx0, gate);
     cb(gate, "gate_sigmoid", il);
 


### PR DESCRIPTION
Rewording the ggml compute graph to avoid too many unnecessary copies.

M2 Ultra:

| Model                    | Test   |   t/s b7946 |   t/s gg/qwen3-next-opt |   Speedup |
|:-------------------------|:-------|------------:|------------------------:|----------:|
| qwen3next 80B.A3B Q4_0   | pp1    |       37.92 |                   51.99 |      1.37 |
| qwen3next 80B.A3B Q4_0   | pp2    |       43.20 |                   57.55 |      1.33 |
| qwen3next 80B.A3B Q4_0   | pp3    |       60.03 |                   78.88 |      1.31 |
| qwen3next 80B.A3B Q4_0   | pp4    |       77.27 |                  100.71 |      1.30 |
| qwen3next 80B.A3B Q4_0   | pp5    |       89.65 |                  119.23 |      1.33 |
| qwen3next 80B.A3B Q4_0   | pp6    |      109.17 |                  140.88 |      1.29 |
| qwen3next 80B.A3B Q4_0   | pp7    |      122.24 |                  156.66 |      1.28 |
| qwen3next 80B.A3B Q4_0   | pp8    |      137.75 |                  176.36 |      1.28 |
| qwen3next 80B.A3B Q4_0   | pp512  |      930.70 |                 1125.73 |      1.21 |
| qwen3next 80B.A3B Q4_0   | pp2048 |     1049.91 |                 1352.31 |      1.29 |
| qwen3next 80B.A3B Q4_0   | tg32   |       38.02 |                   50.39 |      1.33 |
| qwen3next 80B.A3B Q4_K_M | pp1    |       34.00 |                   46.47 |      1.37 |
| qwen3next 80B.A3B Q4_K_M | pp2    |       40.94 |                   52.84 |      1.29 |
| qwen3next 80B.A3B Q4_K_M | pp3    |       56.43 |                   72.38 |      1.28 |
| qwen3next 80B.A3B Q4_K_M | pp4    |       68.36 |                   87.54 |      1.28 |
| qwen3next 80B.A3B Q4_K_M | pp5    |       81.44 |                  104.15 |      1.28 |
| qwen3next 80B.A3B Q4_K_M | pp6    |       96.56 |                  121.09 |      1.25 |
| qwen3next 80B.A3B Q4_K_M | pp7    |      105.85 |                  131.26 |      1.24 |
| qwen3next 80B.A3B Q4_K_M | pp8    |      117.27 |                  145.61 |      1.24 |
| qwen3next 80B.A3B Q4_K_M | pp512  |      842.57 |                 1001.46 |      1.19 |
| qwen3next 80B.A3B Q4_K_M | pp2048 |      977.30 |                 1232.47 |      1.26 |
| qwen3next 80B.A3B Q4_K_M | tg32   |       34.63 |                   46.43 |      1.34 |
| qwen3next 80B.A3B Q8_0   | pp1    |       34.38 |                   43.98 |      1.28 |
| qwen3next 80B.A3B Q8_0   | pp2    |       39.88 |                   50.97 |      1.28 |
| qwen3next 80B.A3B Q8_0   | pp3    |       52.48 |                   67.62 |      1.29 |
| qwen3next 80B.A3B Q8_0   | pp4    |       66.37 |                   83.92 |      1.26 |
| qwen3next 80B.A3B Q8_0   | pp5    |       75.80 |                   95.88 |      1.26 |
| qwen3next 80B.A3B Q8_0   | pp6    |       89.07 |                  109.19 |      1.23 |
| qwen3next 80B.A3B Q8_0   | pp7    |       98.05 |                  118.99 |      1.21 |
| qwen3next 80B.A3B Q8_0   | pp8    |      107.72 |                  130.04 |      1.21 |
| qwen3next 80B.A3B Q8_0   | pp512  |      928.72 |                 1113.64 |      1.20 |
| qwen3next 80B.A3B Q8_0   | pp2048 |     1047.39 |                 1338.82 |      1.28 |
| qwen3next 80B.A3B Q8_0   | tg32   |       33.75 |                   43.78 |      1.30 |

DGX Spark:

| Model                  | Test   |   t/s b7946 |   t/s gg/qwen3-next-opt |   Speedup |
|:-----------------------|:-------|------------:|------------------------:|----------:|
| qwen3next 80B.A3B Q4_0 | pp512  |     1055.58 |                 1161.67 |      1.10 |
| qwen3next 80B.A3B Q4_0 | pp2048 |     1059.00 |                 1324.66 |      1.25 |
| qwen3next 80B.A3B Q4_0 | tg32   |       43.11 |                   59.58 |      1.38 |
| qwen3next 80B.A3B Q8_0 | pp512  |      886.51 |                  965.89 |      1.09 |
| qwen3next 80B.A3B Q8_0 | pp2048 |     1009.43 |                 1246.61 |      1.23 |
| qwen3next 80B.A3B Q8_0 | tg32   |       31.13 |                   39.68 |      1.27 |

Related backend optimizations and refactorings:

- https://github.com/ggml-org/llama.cpp/pull/19369
- https://github.com/ggml-org/llama.cpp/pull/19390
- https://github.com/ggml-org/llama.cpp/pull/19490
- https://github.com/ggml-org/llama.cpp/pull/19429
- https://github.com/ggml-org/llama.cpp/pull/19484
- https://github.com/ggml-org/llama.cpp/pull/19502
- https://github.com/ggml-org/llama.cpp/pull/19511
- https://github.com/ggml-org/llama.cpp/pull/19548
- https://github.com/ggml-org/llama.cpp/pull/19555
- https://github.com/ggml-org/llama.cpp/pull/19566
- https://github.com/ggml-org/llama.cpp/pull/19521
- https://github.com/ggml-org/llama.cpp/pull/19604
- https://github.com/ggml-org/llama.cpp/pull/19584

Notes:

- Some GGUFs can incorrectly have 1D BF16 tensors. These can hurt the performance in some backends such as Metal and should instead be converted to F32

  <img width="641" height="29" alt="image" src="https://github.com/user-attachments/assets/dc85983c-d9c3-4318-88f8-97b5c6482cb6" />

  Fix: https://github.com/ggml-org/llama.cpp/pull/19606

## Next PRs

- [x] Deduplicate code across the Qwen3 family (#19597)
- [ ] Utilize `ggml_build_forward_select()` to make the graph constant
- [ ] Introduce dedicated delta net ggml op (#19504)