### PR TITLE
metal : consolidate bin kernels

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1392,34 +1392,73 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_flash_attn_ext_v
     GGML_UNUSED(op);
 }
 
-ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin(
-        ggml_metal_library_t lib,
-        ggml_op op,
-        int32_t n_fuse,
-        bool row) {
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin(ggml_metal_library_t lib, const ggml_tensor * op, int32_t n_fuse) {
     char base[256];
     char name[256];
 
-    const char * op_str = "undefined";
-    switch (op) {
-        case GGML_OP_ADD:   op_str = "add";   break;
-        case GGML_OP_SUB:   op_str = "sub";   break;
-        case GGML_OP_MUL:   op_str = "mul";   break;
-        case GGML_OP_DIV:   op_str = "div";   break;
+    int op_num = -1;
+
+    switch (op->op) {
+        case GGML_OP_ADD: op_num = 0; break;
+        case GGML_OP_SUB: op_num = 1; break;
+        case GGML_OP_MUL: op_num = 2; break;
+        case GGML_OP_DIV: op_num = 3; break;
         default: GGML_ABORT("fatal error");
     };
 
-    if (row) {
-        snprintf(base, 256, "kernel_%s_row_c4_fuse_%d", op_str, n_fuse);
-    } else {
-        snprintf(base, 256, "kernel_%s_fuse_%d", op_str, n_fuse);
-    }
+    const char * t0_str = ggml_type_name(op->src[0]->type);
+    const char * t1_str = ggml_type_name(op->src[1]->type);
+    const char * t_str  = ggml_type_name(op->type);
 
-    snprintf(name, 256, "%s", base);
+    const bool is_c4 = (op->src[0]->ne[0] % 4 == 0) && (op->src[1]->ne[0] % 4 == 0);
+
+    snprintf(base, 256, "kernel_bin_fuse_%s_%s_%s%s", t0_str, t1_str, t_str, is_c4 ? "_4" : "");
+    snprintf(name, 256, "%s_op=%d_nf=%d", base, op_num, n_fuse);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {
-        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+
+        ggml_metal_cv_set_int16(cv, op_num, FC_BIN + 0);
+        ggml_metal_cv_set_int16(cv, n_fuse, FC_BIN + 1);
+
+        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
+
+        ggml_metal_cv_free(cv);
+    }
+
+    res.c4 = is_c4;
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one(ggml_metal_library_t lib, ggml_op op) {
+    char base[256];
+    char name[256];
+
+    int op_num = -1;
+
+    switch (op) {
+        case GGML_OP_ADD: op_num = 0; break;
+        case GGML_OP_SUB: op_num = 1; break;
+        case GGML_OP_MUL: op_num = 2; break;
+        case GGML_OP_DIV: op_num = 3; break;
+        default: GGML_ABORT("fatal error");
+    };
+
+    snprintf(base, 256, "kernel_bin_fuse_%s_%s_%s", "f32", "f32", "f32");
+    snprintf(name, 256, "%s_op=%d_nf=%d", base, op_num, 1);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+
+        ggml_metal_cv_set_int32(cv, op_num, FC_BIN + 0);
+        ggml_metal_cv_set_int32(cv, 1,      FC_BIN + 1);
+
+        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
+
+        ggml_metal_cv_free(cv);
     }
 
     return res;

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1457,8 +1457,9 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one(ggml_met
     if (!res.pipeline) {
         ggml_metal_cv_t cv = ggml_metal_cv_init();
 
-        ggml_metal_cv_set_int32(cv, op_num, FC_BIN + 0);
-        ggml_metal_cv_set_int32(cv, 1,      FC_BIN + 1);
+        ggml_metal_cv_set_int16(cv, op_num, FC_BIN + 0);
+        ggml_metal_cv_set_int16(cv, 1,      FC_BIN + 1);
+        ggml_metal_cv_set_bool (cv, false,  FC_BIN + 2);
 
         res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -53,6 +53,8 @@ struct ggml_metal_pipeline_with_params {
     int nr1;
 
     size_t smem;
+
+    bool c4;
 };
 
 int ggml_metal_pipeline_max_theads_per_threadgroup(struct ggml_metal_pipeline_with_params pipeline);
@@ -134,7 +136,8 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort  
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort_merge     (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k             (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_merge       (ggml_metal_library_t lib, const struct ggml_tensor * op);
-struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin               (ggml_metal_library_t lib, enum ggml_op op, int32_t n_fuse, bool row);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin               (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse );
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one           (ggml_metal_library_t lib, enum ggml_op op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_l2_norm           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_group_norm        (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_norm              (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -55,6 +55,7 @@ struct ggml_metal_pipeline_with_params {
     size_t smem;
 
     bool c4;
+    bool cnt;
 };
 
 int ggml_metal_pipeline_max_theads_per_threadgroup(struct ggml_metal_pipeline_with_params pipeline);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -350,6 +350,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline(ggml_meta
         /*.nr1      =*/ 0,
         /*.nsg      =*/ 0,
         /*.smem     =*/ 0,
+        /*.c4       =*/ false,
     };
 
     res.pipeline = ggml_metal_pipelines_get(lib->pipelines, name);
@@ -366,6 +367,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
         /*.nr1      =*/ 0,
         /*.nsg      =*/ 0,
         /*.smem     =*/ 0,
+        /*.c4       =*/ false,
     };
 
     [lib->lock lock];
@@ -1054,7 +1056,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_MUL:
         case GGML_OP_DIV:
         case GGML_OP_ADD_ID:
-            return op->src[0]->type == GGML_TYPE_F32;
+            return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_ACC:
         case GGML_OP_REPEAT:
         case GGML_OP_SCALE:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -346,11 +346,12 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline(ggml_meta
 
     struct ggml_metal_pipeline_with_params res = {
         /*.pipeline =*/ nil,
+        /*.nsg      =*/ 0,
         /*.nr0      =*/ 0,
         /*.nr1      =*/ 0,
-        /*.nsg      =*/ 0,
         /*.smem     =*/ 0,
         /*.c4       =*/ false,
+        /*.cnt      =*/ false,
     };
 
     res.pipeline = ggml_metal_pipelines_get(lib->pipelines, name);
@@ -363,11 +364,12 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline(ggml_meta
 struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_metal_library_t lib, const char * base, const char * name, ggml_metal_cv_t cv) {
     struct ggml_metal_pipeline_with_params res = {
         /*.pipeline =*/ nil,
+        /*.nsg      =*/ 0,
         /*.nr0      =*/ 0,
         /*.nr1      =*/ 0,
-        /*.nsg      =*/ 0,
         /*.smem     =*/ 0,
         /*.c4       =*/ false,
+        /*.cnt      =*/ false,
     };
 
     [lib->lock lock];

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -80,6 +80,7 @@
 #define FC_SSM_CONV                    900
 #define FC_SOLVE_TRI                   1000
 #define FC_COUNT_EQUAL                 1100
+#define FC_BIN                         1200
 
 // op-specific constants
 #define OP_FLASH_ATTN_EXT_NQPSG 8

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -707,7 +707,7 @@ int ggml_metal_op_acc(ggml_metal_op_t ctx, int idx) {
         /*.o1   =*/ { 0 },
     };
 
-    auto pipeline = ggml_metal_library_get_pipeline_bin(lib, GGML_OP_ADD, 1, false);
+    auto pipeline = ggml_metal_library_get_pipeline_bin_one(lib, GGML_OP_ADD);
 
     ggml_metal_encoder_set_pipeline(enc, pipeline);
     ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
@@ -2895,8 +2895,6 @@ int ggml_metal_op_bin(ggml_metal_op_t ctx, int idx) {
     GGML_ASSERT(ggml_is_contiguous_rows(op->src[0]));
     GGML_ASSERT(ggml_is_contiguous_rows(op->src[1]));
 
-    bool bcast_row = false;
-
     ggml_metal_buffer_id bid_src0 = ggml_metal_get_buffer_id(op->src[0]);
     ggml_metal_buffer_id bid_src1 = ggml_metal_get_buffer_id(op->src[1]);
     ggml_metal_buffer_id bid_dst  = ggml_metal_get_buffer_id(op);
@@ -2990,18 +2988,7 @@ int ggml_metal_op_bin(ggml_metal_op_t ctx, int idx) {
 
     struct ggml_metal_pipeline_with_params pipeline;
 
-    if (ggml_nelements(op->src[1]) == ne10 && ggml_is_contiguous(op->src[1]) && ne00 % 4 == 0 && ne10 % 4 == 0) {
-        GGML_ASSERT(ggml_is_contiguous(op->src[0]));
-
-        // src1 is a row
-        GGML_ASSERT(ne11 == 1);
-
-        pipeline = ggml_metal_library_get_pipeline_bin(lib, op->op, n_fuse, true);
-
-        bcast_row = true;
-    } else {
-        pipeline = ggml_metal_library_get_pipeline_bin(lib, op->op, n_fuse, false);
-    }
+    pipeline = ggml_metal_library_get_pipeline_bin(lib, op, n_fuse);
 
     if (n_fuse > 1) {
         bid_dst = ggml_metal_get_buffer_id(ctx->node(idx + n_fuse - 1));
@@ -3015,25 +3002,32 @@ int ggml_metal_op_bin(ggml_metal_op_t ctx, int idx) {
         }
     }
 
+    if (pipeline.c4) {
+        args.ne00 = ne00/4;
+        args.ne10 = ne10/4;
+        args.ne0  = ne0/4;
+    }
+
     ggml_metal_encoder_set_pipeline(enc, pipeline);
     ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
     ggml_metal_encoder_set_buffer  (enc, bid_src0, 1);
     ggml_metal_encoder_set_buffer  (enc, bid_src1, 2);
     ggml_metal_encoder_set_buffer  (enc, bid_dst,  3);
 
-    if (bcast_row) {
-        const int64_t n = ggml_nelements(op)/4;
+    const int nth_max = MIN(256, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
-        ggml_metal_encoder_dispatch_threadgroups(enc, n, 1, 1, 1, 1, 1);
-    } else {
-        int nth = 32;
+    int nth = 1;
 
-        while (16*nth < ne0 && nth < ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
-            nth *= 2;
-        }
-
-        ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
+    while (4*nth < args.ne0 && nth < nth_max) {
+        nth *= 2;
     }
+
+    int nb = 1;
+    while (4*nb < ne01 && nth*nb < nth_max) {
+        nb *= 2;
+    }
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, (ne01 + nb - 1)/nb, ne02, ne03, nth, nb, 1);
 
     return n_fuse;
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -895,11 +895,156 @@ enum ggml_sort_order {
     GGML_SORT_ORDER_DESC,
 };
 
-// general-purpose kernel for addition, subtraction, multiplication and division of two tensors
-// pros: works for non-contiguous tensors, supports broadcast across all dims
-// cons: not very efficient
-template <int F>
-kernel void kernel_add_fuse_impl(
+//// general-purpose kernel for addition, subtraction, multiplication and division of two tensors
+//// pros: works for non-contiguous tensors, supports broadcast across all dims
+//// cons: not very efficient
+//template <int F>
+//kernel void kernel_add_fuse_impl(
+//        constant ggml_metal_kargs_bin & args,
+//        device const char * src0,
+//        device const char * src1,
+//        device       char * dst,
+//        uint3   tgpig[[threadgroup_position_in_grid]],
+//        ushort3 tpitg[[thread_position_in_threadgroup]],
+//        ushort3   ntg[[threads_per_threadgroup]]) {
+//    const int i03 = tgpig.z;
+//    const int i02 = tgpig.y;
+//    const int i01 = tgpig.x;
+//
+//    const int i13 = i03%args.ne13;
+//    const int i12 = i02%args.ne12;
+//    const int i11 = i01%args.ne11;
+//
+//    device const float * src0_ptr = (device const float *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
+//    device       float * dst_ptr  = (device       float *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
+//
+//    device const float * src1_ptr[F];
+//    for (short j = 0; j < F; ++j) {
+//        src1_ptr[j] = (device const float *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
+//    }
+//
+//    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//        const int i10 = i0%args.ne10;
+//
+//        float res = src0_ptr[i0];
+//
+//#pragma unroll
+//        for (short j = 0; j < F; ++j) {
+//            res += src1_ptr[j][i10];
+//        }
+//
+//        dst_ptr[i0] = res;
+//    }
+//}
+//
+//typedef decltype(kernel_add_fuse_impl<2>) kernel_add_fuse_t;
+//
+//template [[host_name("kernel_add_fuse_1")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<1>;
+//template [[host_name("kernel_add_fuse_2")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<2>;
+//template [[host_name("kernel_add_fuse_3")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<3>;
+//template [[host_name("kernel_add_fuse_4")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<4>;
+//template [[host_name("kernel_add_fuse_5")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<5>;
+//template [[host_name("kernel_add_fuse_6")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<6>;
+//template [[host_name("kernel_add_fuse_7")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<7>;
+//template [[host_name("kernel_add_fuse_8")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<8>;
+//
+//kernel void kernel_sub_fuse_1(
+//        constant ggml_metal_kargs_bin & args,
+//        device const char * src0,
+//        device const char * src1,
+//        device       char * dst,
+//        uint3   tgpig[[threadgroup_position_in_grid]],
+//        ushort3 tpitg[[thread_position_in_threadgroup]],
+//        ushort3   ntg[[threads_per_threadgroup]]) {
+//    const int i03 = tgpig.z;
+//    const int i02 = tgpig.y;
+//    const int i01 = tgpig.x;
+//
+//    const int i13 = i03%args.ne13;
+//    const int i12 = i02%args.ne12;
+//    const int i11 = i01%args.ne11;
+//
+//    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
+//    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
+//    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
+//
+//    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//        const int i10 = i0%args.ne10;
+//        *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) - *((device float *)(src1_ptr + i10*args.nb10));
+//    }
+//}
+//
+//kernel void kernel_mul_fuse_1(
+//        constant ggml_metal_kargs_bin & args,
+//        device const char * src0,
+//        device const char * src1,
+//        device       char * dst,
+//        uint3   tgpig[[threadgroup_position_in_grid]],
+//        ushort3 tpitg[[thread_position_in_threadgroup]],
+//        ushort3   ntg[[threads_per_threadgroup]]) {
+//    const int i03 = tgpig.z;
+//    const int i02 = tgpig.y;
+//    const int i01 = tgpig.x;
+//
+//    const int i13 = i03%args.ne13;
+//    const int i12 = i02%args.ne12;
+//    const int i11 = i01%args.ne11;
+//
+//    device const float * src0_ptr = (device const float *)(src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
+//    device const float * src1_ptr = (device const float *)(src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0]);
+//    device       float * dst_ptr  = (device       float *)(dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
+//
+//    if (args.ne10 == 1) {
+//        const float x = src1_ptr[0];
+//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//            dst_ptr[i0] = src0_ptr[i0] * x;
+//        }
+//    } else {
+//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//            const int i10 = i0 % args.ne10;
+//            dst_ptr[i0] = src0_ptr[i0] * src1_ptr[i10];
+//        }
+//    }
+//}
+//
+//kernel void kernel_div_fuse_1(
+//        constant ggml_metal_kargs_bin & args,
+//        device const char * src0,
+//        device const char * src1,
+//        device       char * dst,
+//        uint3   tgpig[[threadgroup_position_in_grid]],
+//        ushort3 tpitg[[thread_position_in_threadgroup]],
+//        ushort3   ntg[[threads_per_threadgroup]]) {
+//    const int i03 = tgpig.z;
+//    const int i02 = tgpig.y;
+//    const int i01 = tgpig.x;
+//
+//    const int i13 = i03%args.ne13;
+//    const int i12 = i02%args.ne12;
+//    const int i11 = i01%args.ne11;
+//
+//    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
+//    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
+//    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
+//
+//    if (args.ne10 == 1) {
+//        const float x = 1.0f / *((device float *)(src1_ptr));
+//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) * x;
+//        }
+//    } else {
+//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+//            const int i10 = i0%args.ne10;
+//            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) / *((device float *)(src1_ptr + i10*args.nb10));
+//        }
+//    }
+//}
+
+constant short FC_bin_op [[function_constant(FC_BIN + 0)]];
+constant short FC_bin_f  [[function_constant(FC_BIN + 1)]];
+
+template <typename T0, typename T1, typename T>
+kernel void kernel_bin_fuse_impl(
         constant ggml_metal_kargs_bin & args,
         device const char * src0,
         device const char * src1,
@@ -907,138 +1052,150 @@ kernel void kernel_add_fuse_impl(
         uint3   tgpig[[threadgroup_position_in_grid]],
         ushort3 tpitg[[thread_position_in_threadgroup]],
         ushort3   ntg[[threads_per_threadgroup]]) {
+    // OP: 0 - add, 1 - sub, 2 - mul, 3 - div
+    const short OP = FC_bin_op;
+    const short F  = FC_bin_f;
+
     const int i03 = tgpig.z;
     const int i02 = tgpig.y;
-    const int i01 = tgpig.x;
+    const int i01 = tgpig.x*ntg.y + tpitg.y;
+
+    if (i01 >= args.ne01) {
+        return;
+    }
 
     const int i13 = i03%args.ne13;
     const int i12 = i02%args.ne12;
     const int i11 = i01%args.ne11;
 
-    device const float * src0_ptr = (device const float *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
-    device       float * dst_ptr  = (device       float *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
+    device const T0 * src0_ptr = (device const T0 *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
+    device       T  * dst_ptr  = (device       T  *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
 
-    device const float * src1_ptr[F];
-    for (short j = 0; j < F; ++j) {
-        src1_ptr[j] = (device const float *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
-    }
+    if (F == 1) {
+        device const T1 * src1_ptr = (device const T1 *) (src1 + args.o1[0] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
 
-    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-        const int i10 = i0%args.ne10;
+        if (args.ne10 == 1) {
+            T1 src1_cur = src1_ptr[0];
 
-        float res = src0_ptr[i0];
+            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+                if (OP == 0) {
+                    dst_ptr[i0] = src0_ptr[i0] + src1_cur;
+                }
 
-#pragma unroll
-        for (short j = 0; j < F; ++j) {
-            res += src1_ptr[j][i10];
-        }
+                if (OP == 1) {
+                    dst_ptr[i0] = src0_ptr[i0] - src1_cur;
+                }
 
-        dst_ptr[i0] = res;
-    }
-}
+                if (OP == 2) {
+                    dst_ptr[i0] = src0_ptr[i0] * src1_cur;
+                }
 
-typedef decltype(kernel_add_fuse_impl<2>) kernel_add_fuse_t;
+                if (OP == 3) {
+                    dst_ptr[i0] = src0_ptr[i0] / src1_cur;
+                }
+            }
+        } else {
+            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+                const int i10 = i0%args.ne10;
 
-template [[host_name("kernel_add_fuse_1")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<1>;
-template [[host_name("kernel_add_fuse_2")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<2>;
-template [[host_name("kernel_add_fuse_3")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<3>;
-template [[host_name("kernel_add_fuse_4")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<4>;
-template [[host_name("kernel_add_fuse_5")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<5>;
-template [[host_name("kernel_add_fuse_6")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<6>;
-template [[host_name("kernel_add_fuse_7")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<7>;
-template [[host_name("kernel_add_fuse_8")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<8>;
+                if (OP == 0) {
+                    dst_ptr[i0] = src0_ptr[i0] + src1_ptr[i10];
+                }
 
-kernel void kernel_sub_fuse_1(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint3   tgpig[[threadgroup_position_in_grid]],
-        ushort3 tpitg[[thread_position_in_threadgroup]],
-        ushort3   ntg[[threads_per_threadgroup]]) {
-    const int i03 = tgpig.z;
-    const int i02 = tgpig.y;
-    const int i01 = tgpig.x;
+                if (OP == 1) {
+                    dst_ptr[i0] = src0_ptr[i0] - src1_ptr[i10];
+                }
 
-    const int i13 = i03%args.ne13;
-    const int i12 = i02%args.ne12;
-    const int i11 = i01%args.ne11;
+                if (OP == 2) {
+                    dst_ptr[i0] = src0_ptr[i0] * src1_ptr[i10];
+                }
 
-    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
-    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
-    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
-
-    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-        const int i10 = i0%args.ne10;
-        *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) - *((device float *)(src1_ptr + i10*args.nb10));
-    }
-}
-
-kernel void kernel_mul_fuse_1(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint3   tgpig[[threadgroup_position_in_grid]],
-        ushort3 tpitg[[thread_position_in_threadgroup]],
-        ushort3   ntg[[threads_per_threadgroup]]) {
-    const int i03 = tgpig.z;
-    const int i02 = tgpig.y;
-    const int i01 = tgpig.x;
-
-    const int i13 = i03%args.ne13;
-    const int i12 = i02%args.ne12;
-    const int i11 = i01%args.ne11;
-
-    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
-    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
-    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
-
-    if (args.ne10 == 1) {
-        const float x = *((device float *)(src1_ptr));
-        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) * x;
+                if (OP == 3) {
+                    dst_ptr[i0] = src0_ptr[i0] / src1_ptr[i10];
+                }
+            }
         }
     } else {
-        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-            const int i10 = i0%args.ne10;
-            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) * *((device float *)(src1_ptr + i10*args.nb10));
+        device const T1 * src1_ptr[8];
+        FOR_UNROLL (short j = 0; j < F; ++j) {
+            src1_ptr[j] = (device const T1 *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
+        }
+
+        if (args.ne10 == 1) {
+            T1 src1_cur[8];
+            FOR_UNROLL (short j = 0; j < F; ++j) {
+                src1_cur[j] = src1_ptr[j][0];
+            }
+
+            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+                T res = src0_ptr[i0];
+
+                if (OP == 0) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res += src1_cur[j];
+                    }
+                }
+
+                if (OP == 1) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res -= src1_cur[j];
+                    }
+                }
+
+                if (OP == 2) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res *= src1_cur[j];
+                    }
+                }
+
+                if (OP == 3) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res /= src1_cur[j];
+                    }
+                }
+
+                dst_ptr[i0] = res;
+            }
+        } else {
+            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
+                const int i10 = i0%args.ne10;
+
+                T res = src0_ptr[i0];
+
+                if (OP == 0) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res += src1_ptr[j][i10];
+                    }
+                }
+
+                if (OP == 1) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res -= src1_ptr[j][i10];
+                    }
+                }
+
+                if (OP == 2) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res *= src1_ptr[j][i10];
+                    }
+                }
+
+                if (OP == 3) {
+                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                        res /= src1_ptr[j][i10];
+                    }
+                }
+
+                dst_ptr[i0] = res;
+            }
         }
     }
 }
 
-kernel void kernel_div_fuse_1(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint3   tgpig[[threadgroup_position_in_grid]],
-        ushort3 tpitg[[thread_position_in_threadgroup]],
-        ushort3   ntg[[threads_per_threadgroup]]) {
-    const int i03 = tgpig.z;
-    const int i02 = tgpig.y;
-    const int i01 = tgpig.x;
+typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
 
-    const int i13 = i03%args.ne13;
-    const int i12 = i02%args.ne12;
-    const int i11 = i01%args.ne11;
-
-    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
-    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
-    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
-
-    if (args.ne10 == 1) {
-        const float x = 1.0f / *((device float *)(src1_ptr));
-        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) * x;
-        }
-    } else {
-        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-            const int i10 = i0%args.ne10;
-            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) / *((device float *)(src1_ptr + i10*args.nb10));
-        }
-    }
-}
+template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float>;
+template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4>;
 
 kernel void kernel_add_id(
         constant ggml_metal_kargs_add_id & args,
@@ -1057,7 +1214,7 @@ kernel void kernel_add_id(
     const size_t nb1 = args.ne0 * sizeof(float);
     const size_t nb2 = args.ne1 * nb1;
 
-    device       float * dst_row  = (device       float *)((device char *)dst + i1*nb1 + i2*nb2);
+    device       float * dst_row  = (device       float *)((device char *)dst  +  i1*nb1       + i2*nb2);
     device const float * src0_row = (device const float *)((device char *)src0 +  i1*args.nb01 + i2*args.nb02);
     device const float * src1_row = (device const float *)((device char *)src1 + i11*args.nb11);
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -895,153 +895,10 @@ enum ggml_sort_order {
     GGML_SORT_ORDER_DESC,
 };
 
-//// general-purpose kernel for addition, subtraction, multiplication and division of two tensors
-//// pros: works for non-contiguous tensors, supports broadcast across all dims
-//// cons: not very efficient
-//template <int F>
-//kernel void kernel_add_fuse_impl(
-//        constant ggml_metal_kargs_bin & args,
-//        device const char * src0,
-//        device const char * src1,
-//        device       char * dst,
-//        uint3   tgpig[[threadgroup_position_in_grid]],
-//        ushort3 tpitg[[thread_position_in_threadgroup]],
-//        ushort3   ntg[[threads_per_threadgroup]]) {
-//    const int i03 = tgpig.z;
-//    const int i02 = tgpig.y;
-//    const int i01 = tgpig.x;
-//
-//    const int i13 = i03%args.ne13;
-//    const int i12 = i02%args.ne12;
-//    const int i11 = i01%args.ne11;
-//
-//    device const float * src0_ptr = (device const float *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
-//    device       float * dst_ptr  = (device       float *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
-//
-//    device const float * src1_ptr[F];
-//    for (short j = 0; j < F; ++j) {
-//        src1_ptr[j] = (device const float *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
-//    }
-//
-//    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//        const int i10 = i0%args.ne10;
-//
-//        float res = src0_ptr[i0];
-//
-//#pragma unroll
-//        for (short j = 0; j < F; ++j) {
-//            res += src1_ptr[j][i10];
-//        }
-//
-//        dst_ptr[i0] = res;
-//    }
-//}
-//
-//typedef decltype(kernel_add_fuse_impl<2>) kernel_add_fuse_t;
-//
-//template [[host_name("kernel_add_fuse_1")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<1>;
-//template [[host_name("kernel_add_fuse_2")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<2>;
-//template [[host_name("kernel_add_fuse_3")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<3>;
-//template [[host_name("kernel_add_fuse_4")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<4>;
-//template [[host_name("kernel_add_fuse_5")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<5>;
-//template [[host_name("kernel_add_fuse_6")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<6>;
-//template [[host_name("kernel_add_fuse_7")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<7>;
-//template [[host_name("kernel_add_fuse_8")]] kernel kernel_add_fuse_t kernel_add_fuse_impl<8>;
-//
-//kernel void kernel_sub_fuse_1(
-//        constant ggml_metal_kargs_bin & args,
-//        device const char * src0,
-//        device const char * src1,
-//        device       char * dst,
-//        uint3   tgpig[[threadgroup_position_in_grid]],
-//        ushort3 tpitg[[thread_position_in_threadgroup]],
-//        ushort3   ntg[[threads_per_threadgroup]]) {
-//    const int i03 = tgpig.z;
-//    const int i02 = tgpig.y;
-//    const int i01 = tgpig.x;
-//
-//    const int i13 = i03%args.ne13;
-//    const int i12 = i02%args.ne12;
-//    const int i11 = i01%args.ne11;
-//
-//    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
-//    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
-//    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
-//
-//    for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//        const int i10 = i0%args.ne10;
-//        *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) - *((device float *)(src1_ptr + i10*args.nb10));
-//    }
-//}
-//
-//kernel void kernel_mul_fuse_1(
-//        constant ggml_metal_kargs_bin & args,
-//        device const char * src0,
-//        device const char * src1,
-//        device       char * dst,
-//        uint3   tgpig[[threadgroup_position_in_grid]],
-//        ushort3 tpitg[[thread_position_in_threadgroup]],
-//        ushort3   ntg[[threads_per_threadgroup]]) {
-//    const int i03 = tgpig.z;
-//    const int i02 = tgpig.y;
-//    const int i01 = tgpig.x;
-//
-//    const int i13 = i03%args.ne13;
-//    const int i12 = i02%args.ne12;
-//    const int i11 = i01%args.ne11;
-//
-//    device const float * src0_ptr = (device const float *)(src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
-//    device const float * src1_ptr = (device const float *)(src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0]);
-//    device       float * dst_ptr  = (device       float *)(dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
-//
-//    if (args.ne10 == 1) {
-//        const float x = src1_ptr[0];
-//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//            dst_ptr[i0] = src0_ptr[i0] * x;
-//        }
-//    } else {
-//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//            const int i10 = i0 % args.ne10;
-//            dst_ptr[i0] = src0_ptr[i0] * src1_ptr[i10];
-//        }
-//    }
-//}
-//
-//kernel void kernel_div_fuse_1(
-//        constant ggml_metal_kargs_bin & args,
-//        device const char * src0,
-//        device const char * src1,
-//        device       char * dst,
-//        uint3   tgpig[[threadgroup_position_in_grid]],
-//        ushort3 tpitg[[thread_position_in_threadgroup]],
-//        ushort3   ntg[[threads_per_threadgroup]]) {
-//    const int i03 = tgpig.z;
-//    const int i02 = tgpig.y;
-//    const int i01 = tgpig.x;
-//
-//    const int i13 = i03%args.ne13;
-//    const int i12 = i02%args.ne12;
-//    const int i11 = i01%args.ne11;
-//
-//    device const char * src0_ptr = src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs;
-//    device const char * src1_ptr = src1 + i13*args.nb13 + i12*args.nb12 + i11*args.nb11 + args.o1[0];
-//    device       char * dst_ptr  = dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs;
-//
-//    if (args.ne10 == 1) {
-//        const float x = 1.0f / *((device float *)(src1_ptr));
-//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) * x;
-//        }
-//    } else {
-//        for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-//            const int i10 = i0%args.ne10;
-//            *((device float *)(dst_ptr + i0*args.nb0)) = *((device float *)(src0_ptr + i0*args.nb00)) / *((device float *)(src1_ptr + i10*args.nb10));
-//        }
-//    }
-//}
-
+// OP: 0 - add, 1 - sub, 2 - mul, 3 - div
 constant short FC_bin_op [[function_constant(FC_BIN + 0)]];
 constant short FC_bin_f  [[function_constant(FC_BIN + 1)]];
+constant bool  FC_bin_rb [[function_constant(FC_BIN + 2)]];
 
 template <typename T0, typename T1, typename T>
 kernel void kernel_bin_fuse_impl(
@@ -1052,136 +909,134 @@ kernel void kernel_bin_fuse_impl(
         uint3   tgpig[[threadgroup_position_in_grid]],
         ushort3 tpitg[[thread_position_in_threadgroup]],
         ushort3   ntg[[threads_per_threadgroup]]) {
-    // OP: 0 - add, 1 - sub, 2 - mul, 3 - div
-    const short OP = FC_bin_op;
-    const short F  = FC_bin_f;
+#define FC_OP FC_bin_op
+#define FC_F  FC_bin_f
+#define FC_RB FC_bin_rb
 
-    const int i03 = tgpig.z;
-    const int i02 = tgpig.y;
-    const int i01 = tgpig.x*ntg.y + tpitg.y;
+    if (FC_RB) {
+        // row broadcast
+        const uint i0 = tgpig.x;
+        const uint i1 = i0%args.ne10;
 
-    if (i01 >= args.ne01) {
-        return;
-    }
+        device const T0 * src0_row = (device const T0 *) (src0);
+        device       T  * dst_row  = (device       T  *) (dst);
 
-    const int i13 = i03%args.ne13;
-    const int i12 = i02%args.ne12;
-    const int i11 = i01%args.ne11;
+        if (FC_F == 1) {
+            device const T1 * src1_row = (device const T1 *) (src1 + args.o1[0]);
 
-    device const T0 * src0_ptr = (device const T0 *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
-    device       T  * dst_ptr  = (device       T  *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
+            if (FC_OP == 0) {
+                dst_row[i0] = src0_row[i0] + src1_row[i1];
+            }
 
-    if (F == 1) {
-        device const T1 * src1_ptr = (device const T1 *) (src1 + args.o1[0] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
+            if (FC_OP == 1) {
+                dst_row[i0] = src0_row[i0] - src1_row[i1];
+            }
 
-        if (args.ne10 == 1) {
-            T1 src1_cur = src1_ptr[0];
+            if (FC_OP == 2) {
+                dst_row[i0] = src0_row[i0] * src1_row[i1];
+            }
 
-            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-                if (OP == 0) {
-                    dst_ptr[i0] = src0_ptr[i0] + src1_cur;
-                }
-
-                if (OP == 1) {
-                    dst_ptr[i0] = src0_ptr[i0] - src1_cur;
-                }
-
-                if (OP == 2) {
-                    dst_ptr[i0] = src0_ptr[i0] * src1_cur;
-                }
-
-                if (OP == 3) {
-                    dst_ptr[i0] = src0_ptr[i0] / src1_cur;
-                }
+            if (FC_OP == 3) {
+                dst_row[i0] = src0_row[i0] / src1_row[i1];
             }
         } else {
+            T0 res = src0_row[i0];
+
+            if (FC_OP == 0) {
+                FOR_UNROLL (short j = 0; j < FC_F; ++j) {
+                    res += ((device const T1 *) (src1 + args.o1[j]))[i1];
+                }
+            }
+
+            if (FC_OP == 1) {
+                FOR_UNROLL (short j = 0; j < FC_F; ++j) {
+                    res -= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                }
+            }
+
+            if (FC_OP == 2) {
+                FOR_UNROLL (short j = 0; j < FC_F; ++j) {
+                    res *= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                }
+            }
+
+            if (FC_OP == 3) {
+                FOR_UNROLL (short j = 0; j < FC_F; ++j) {
+                    res /= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                }
+            }
+
+            dst_row[i0] = res;
+        }
+    } else {
+        const int i03 = tgpig.z;
+        const int i02 = tgpig.y;
+        const int i01 = tgpig.x;
+
+        if (i01 >= args.ne01) {
+            return;
+        }
+
+        const int i13 = i03%args.ne13;
+        const int i12 = i02%args.ne12;
+        const int i11 = i01%args.ne11;
+
+        device const T0 * src0_ptr = (device const T0 *) (src0 + i03*args.nb03 + i02*args.nb02 + i01*args.nb01 + args.offs);
+        device       T  * dst_ptr  = (device       T  *) (dst  + i03*args.nb3  + i02*args.nb2  + i01*args.nb1  + args.offs);
+
+        if (FC_F == 1) {
+            device const T1 * src1_ptr = (device const T1 *) (src1 + args.o1[0] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
+
             for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
                 const int i10 = i0%args.ne10;
 
-                if (OP == 0) {
+                if (FC_OP == 0) {
                     dst_ptr[i0] = src0_ptr[i0] + src1_ptr[i10];
                 }
 
-                if (OP == 1) {
+                if (FC_OP == 1) {
                     dst_ptr[i0] = src0_ptr[i0] - src1_ptr[i10];
                 }
 
-                if (OP == 2) {
+                if (FC_OP == 2) {
                     dst_ptr[i0] = src0_ptr[i0] * src1_ptr[i10];
                 }
 
-                if (OP == 3) {
+                if (FC_OP == 3) {
                     dst_ptr[i0] = src0_ptr[i0] / src1_ptr[i10];
                 }
             }
-        }
-    } else {
-        device const T1 * src1_ptr[8];
-        FOR_UNROLL (short j = 0; j < F; ++j) {
-            src1_ptr[j] = (device const T1 *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
-        }
-
-        if (args.ne10 == 1) {
-            T1 src1_cur[8];
-            FOR_UNROLL (short j = 0; j < F; ++j) {
-                src1_cur[j] = src1_ptr[j][0];
-            }
-
-            for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
-                T res = src0_ptr[i0];
-
-                if (OP == 0) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
-                        res += src1_cur[j];
-                    }
-                }
-
-                if (OP == 1) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
-                        res -= src1_cur[j];
-                    }
-                }
-
-                if (OP == 2) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
-                        res *= src1_cur[j];
-                    }
-                }
-
-                if (OP == 3) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
-                        res /= src1_cur[j];
-                    }
-                }
-
-                dst_ptr[i0] = res;
-            }
         } else {
+            device const T1 * src1_ptr[8];
+            FOR_UNROLL (short j = 0; j < FC_F; ++j) {
+                src1_ptr[j] = (device const T1 *) (src1 + args.o1[j] + i13*args.nb13 + i12*args.nb12 + i11*args.nb11);
+            }
+
             for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
                 const int i10 = i0%args.ne10;
 
                 T res = src0_ptr[i0];
 
-                if (OP == 0) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                if (FC_OP == 0) {
+                    FOR_UNROLL (short j = 0; j < FC_F; ++j) {
                         res += src1_ptr[j][i10];
                     }
                 }
 
-                if (OP == 1) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                if (FC_OP == 1) {
+                    FOR_UNROLL (short j = 0; j < FC_F; ++j) {
                         res -= src1_ptr[j][i10];
                     }
                 }
 
-                if (OP == 2) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                if (FC_OP == 2) {
+                    FOR_UNROLL (short j = 0; j < FC_F; ++j) {
                         res *= src1_ptr[j][i10];
                     }
                 }
 
-                if (OP == 3) {
-                    FOR_UNROLL (short j = 0; j < F; ++j) {
+                if (FC_OP == 3) {
+                    FOR_UNROLL (short j = 0; j < FC_F; ++j) {
                         res /= src1_ptr[j][i10];
                     }
                 }
@@ -1190,6 +1045,10 @@ kernel void kernel_bin_fuse_impl(
             }
         }
     }
+
+#undef FC_OP
+#undef FC_F
+#undef FC_RB
 }
 
 typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
@@ -1254,141 +1113,6 @@ template [[host_name("kernel_repeat_f32")]] kernel kernel_repeat_t kernel_repeat
 template [[host_name("kernel_repeat_f16")]] kernel kernel_repeat_t kernel_repeat<half>;
 template [[host_name("kernel_repeat_i32")]] kernel kernel_repeat_t kernel_repeat<int>;
 template [[host_name("kernel_repeat_i16")]] kernel kernel_repeat_t kernel_repeat<short>;
-
-// assumption: src1 is a row
-// broadcast src1 into src0
-template <short F>
-kernel void kernel_add_row_c4_fuse_impl(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint tpig[[thread_position_in_grid]]) {
-    const uint nb = args.ne00/4;
-    const uint i  = tpig % nb;
-
-    device const float4 * src0_row = (device const float4 *) (src0);
-    device       float4 *  dst_row = (device       float4 *) (dst);
-
-    float4 res = src0_row[tpig];
-
-#pragma unroll(F)
-    for (short j = 0; j < F; ++j) {
-        res += ((device const float4 *) (src1 + args.o1[j]))[i];
-    }
-
-    dst_row[tpig] = res;
-}
-
-typedef decltype(kernel_add_row_c4_fuse_impl<1>) kernel_add_row_c4_fuse_t;
-
-template [[host_name("kernel_add_row_c4_fuse_1")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<1>;
-template [[host_name("kernel_add_row_c4_fuse_2")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<2>;
-template [[host_name("kernel_add_row_c4_fuse_3")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<3>;
-template [[host_name("kernel_add_row_c4_fuse_4")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<4>;
-template [[host_name("kernel_add_row_c4_fuse_5")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<5>;
-template [[host_name("kernel_add_row_c4_fuse_6")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<6>;
-template [[host_name("kernel_add_row_c4_fuse_7")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<7>;
-template [[host_name("kernel_add_row_c4_fuse_8")]] kernel kernel_add_row_c4_fuse_t kernel_add_row_c4_fuse_impl<8>;
-
-template <short F>
-kernel void kernel_sub_row_c4_fuse_impl(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint tpig[[thread_position_in_grid]]) {
-
-    const uint nb = args.ne00/4;
-    const uint i  = tpig % nb;
-
-    device const float4 * src0_row = (device const float4 *) (src0);
-    device       float4 *  dst_row = (device       float4 *) (dst);
-
-    device const float4 * src1_row[F];
-    for (short j = 0; j < F; ++j) {
-        src1_row[j] = (device const float4 *) (src1 + args.o1[j]);
-    }
-
-    float4 res = src0_row[tpig];
-
-#pragma unroll(F)
-    for (short j = 0; j < F; ++j) {
-        res -= src1_row[j][i];
-    }
-
-    dst_row[tpig] = res;
-}
-
-typedef decltype(kernel_sub_row_c4_fuse_impl<1>) kernel_sub_row_c4_fuse_t;
-
-template [[host_name("kernel_sub_row_c4_fuse_1")]] kernel kernel_sub_row_c4_fuse_t kernel_sub_row_c4_fuse_impl<1>;
-
-template <short F>
-kernel void kernel_mul_row_c4_fuse_impl(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint tpig[[thread_position_in_grid]]) {
-
-    const uint nb = args.ne00/4;
-    const uint i  = tpig % nb;
-
-    device const float4 * src0_row = (device const float4 *) (src0);
-    device       float4 *  dst_row = (device       float4 *) (dst);
-
-    device const float4 * src1_row[F];
-    for (short j = 0; j < F; ++j) {
-        src1_row[j] = (device const float4 *) (src1 + args.o1[j]);
-    }
-
-    float4 res = src0_row[tpig];
-
-#pragma unroll(F)
-    for (short j = 0; j < F; ++j) {
-        res *= src1_row[j][i];
-    }
-
-    dst_row[tpig] = res;
-}
-
-typedef decltype(kernel_mul_row_c4_fuse_impl<1>) kernel_mul_row_c4_fuse_t;
-
-template [[host_name("kernel_mul_row_c4_fuse_1")]] kernel kernel_mul_row_c4_fuse_t kernel_mul_row_c4_fuse_impl<1>;
-
-template <short F>
-kernel void kernel_div_row_c4_fuse_impl(
-        constant ggml_metal_kargs_bin & args,
-        device const char * src0,
-        device const char * src1,
-        device       char * dst,
-        uint tpig[[thread_position_in_grid]]) {
-
-    const uint nb = args.ne00/4;
-    const uint i  = tpig % nb;
-
-    device const float4 * src0_row = (device const float4 *) (src0);
-    device       float4 *  dst_row = (device       float4 *) (dst);
-
-    device const float4 * src1_row[F];
-    for (short j = 0; j < F; ++j) {
-        src1_row[j] = (device const float4 *) (src1 + args.o1[j]);
-    }
-
-    float4 res = src0_row[tpig];
-
-#pragma unroll(F)
-    for (short j = 0; j < F; ++j) {
-        res /= src1_row[j][i];
-    }
-
-    dst_row[tpig] = res;
-}
-
-typedef decltype(kernel_div_row_c4_fuse_impl<1>) kernel_div_row_c4_fuse_t;
-
-template [[host_name("kernel_div_row_c4_fuse_1")]] kernel kernel_div_row_c4_fuse_t kernel_div_row_c4_fuse_impl<1>;
 
 kernel void kernel_scale_f32(
         constant ggml_metal_kargs_scale & args,


### PR DESCRIPTION
Refactor and consolidate the implementation of the binary Metal kernels.

| Model                    | Test   |   t/s master |   t/s gg/metal-bin-opt |   Speedup |
|:-------------------------|:-------|-------------:|-----------------------:|----------:|
| deepseek2 30B.A3B Q8_0   | pp1    |        61.70 |                  62.56 |      1.01 |
| deepseek2 30B.A3B Q8_0   | pp2    |        93.80 |                  98.81 |      1.05 |
| deepseek2 30B.A3B Q8_0   | pp3    |       110.17 |                 114.29 |      1.04 |
| deepseek2 30B.A3B Q8_0   | pp4    |       128.77 |                 132.67 |      1.03 |
| deepseek2 30B.A3B Q8_0   | pp5    |       136.85 |                 140.46 |      1.03 |
| deepseek2 30B.A3B Q8_0   | pp6    |       158.44 |                 161.87 |      1.02 |
| deepseek2 30B.A3B Q8_0   | pp7    |       165.29 |                 169.24 |      1.02 |
| deepseek2 30B.A3B Q8_0   | pp8    |       173.63 |                 177.12 |      1.02 |
| deepseek2 30B.A3B Q8_0   | pp16   |       185.31 |                 186.85 |      1.01 |
| deepseek2 30B.A3B Q8_0   | pp32   |       310.21 |                 313.34 |      1.01 |
| deepseek2 30B.A3B Q8_0   | pp64   |       531.47 |                 534.13 |      1.01 |
| deepseek2 30B.A3B Q8_0   | pp128  |       838.32 |                 838.40 |      1.00 |
| deepseek2 30B.A3B Q8_0   | pp512  |      1477.68 |                1464.33 |      0.99 |
| deepseek2 30B.A3B Q8_0   | tg32   |        63.24 |                  64.34 |      1.02 |
| gemma3 1B Q4_0           | pp1    |       215.76 |                 233.76 |      1.08 |
| gemma3 1B Q4_0           | pp2    |       404.34 |                 405.30 |      1.00 |
| gemma3 1B Q4_0           | pp3    |       532.60 |                 533.82 |      1.00 |
| gemma3 1B Q4_0           | pp4    |       672.13 |                 683.52 |      1.02 |
| gemma3 1B Q4_0           | pp5    |       744.98 |                 748.97 |      1.01 |
| gemma3 1B Q4_0           | pp6    |       984.54 |                 986.85 |      1.00 |
| gemma3 1B Q4_0           | pp7    |      1071.51 |                1080.29 |      1.01 |
| gemma3 1B Q4_0           | pp8    |      1220.31 |                1226.52 |      1.01 |
| gemma3 1B Q4_0           | pp16   |      1204.52 |                1207.10 |      1.00 |
| gemma3 1B Q4_0           | pp32   |      2369.32 |                2394.92 |      1.01 |
| gemma3 1B Q4_0           | pp64   |      3682.32 |                3704.24 |      1.01 |
| gemma3 1B Q4_0           | pp128  |      6337.92 |                6347.59 |      1.00 |
| gemma3 1B Q4_0           | pp512  |     11088.88 |               11104.15 |      1.00 |
| gemma3 1B Q4_0           | tg32   |       227.64 |                 230.65 |      1.01 |
| gemma3 4B Q4_0           | pp1    |       139.20 |                 138.42 |      0.99 |
| gemma3 4B Q4_0           | pp2    |       219.07 |                 217.34 |      0.99 |
| gemma3 4B Q4_0           | pp3    |       262.66 |                 263.25 |      1.00 |
| gemma3 4B Q4_0           | pp4    |       326.40 |                 325.99 |      1.00 |
| gemma3 4B Q4_0           | pp5    |       347.80 |                 346.83 |      1.00 |
| gemma3 4B Q4_0           | pp6    |       440.49 |                 440.66 |      1.00 |
| gemma3 4B Q4_0           | pp7    |       449.09 |                 449.09 |      1.00 |
| gemma3 4B Q4_0           | pp8    |       513.63 |                 511.34 |      1.00 |
| gemma3 4B Q4_0           | pp16   |       460.24 |                 459.71 |      1.00 |
| gemma3 4B Q4_0           | pp32   |       905.19 |                 905.03 |      1.00 |
| gemma3 4B Q4_0           | pp64   |      1480.61 |                1479.00 |      1.00 |
| gemma3 4B Q4_0           | pp128  |      2152.00 |                2151.60 |      1.00 |
| gemma3 4B Q4_0           | pp512  |      2789.92 |                2796.25 |      1.00 |
| gemma3 4B Q4_0           | tg32   |       140.40 |                 140.53 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp1    |        86.98 |                  87.67 |      1.01 |
| gpt-oss 120B MXFP4 MoE   | pp2    |       127.00 |                 128.31 |      1.01 |
| gpt-oss 120B MXFP4 MoE   | pp3    |       152.04 |                 152.74 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp4    |       170.54 |                 171.17 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp5    |       182.20 |                 181.12 |      0.99 |
| gpt-oss 120B MXFP4 MoE   | pp6    |       194.97 |                 194.08 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp7    |       198.97 |                 198.88 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp8    |       206.27 |                 205.57 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp16   |       220.65 |                 220.98 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp32   |       282.04 |                 283.57 |      1.01 |
| gpt-oss 120B MXFP4 MoE   | pp64   |       438.21 |                 439.24 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp128  |       647.15 |                 650.00 |      1.00 |
| gpt-oss 120B MXFP4 MoE   | pp512  |      1212.28 |                1220.79 |      1.01 |
| gpt-oss 120B MXFP4 MoE   | tg32   |        89.86 |                  89.47 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp1    |       131.70 |                 130.78 |      0.99 |
| gpt-oss 20B MXFP4 MoE    | pp2    |       189.90 |                 191.19 |      1.01 |
| gpt-oss 20B MXFP4 MoE    | pp3    |       229.75 |                 232.11 |      1.01 |
| gpt-oss 20B MXFP4 MoE    | pp4    |       258.55 |                 259.00 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp5    |       274.97 |                 274.30 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp6    |       295.82 |                 293.64 |      0.99 |
| gpt-oss 20B MXFP4 MoE    | pp7    |       303.55 |                 301.10 |      0.99 |
| gpt-oss 20B MXFP4 MoE    | pp8    |       314.36 |                 311.21 |      0.99 |
| gpt-oss 20B MXFP4 MoE    | pp16   |       339.29 |                 337.97 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp32   |       573.34 |                 573.44 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp64   |       925.40 |                 923.69 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp128  |      1430.89 |                1433.18 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp512  |      2408.36 |                2412.68 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | tg32   |       134.61 |                 133.25 |      0.99 |
| qwen3 0.6B Q4_0          | pp1    |       274.60 |                 325.97 |      1.19 |
| qwen3 0.6B Q4_0          | pp2    |       510.21 |                 561.30 |      1.10 |
| qwen3 0.6B Q4_0          | pp3    |       650.74 |                 705.36 |      1.08 |
| qwen3 0.6B Q4_0          | pp4    |       811.53 |                 881.11 |      1.09 |
| qwen3 0.6B Q4_0          | pp5    |       891.22 |                 949.36 |      1.07 |
| qwen3 0.6B Q4_0          | pp6    |      1171.68 |                1255.99 |      1.07 |
| qwen3 0.6B Q4_0          | pp7    |      1296.29 |                1380.00 |      1.06 |
| qwen3 0.6B Q4_0          | pp8    |      1472.37 |                1568.10 |      1.07 |
| qwen3 0.6B Q4_0          | pp16   |      1382.63 |                1420.85 |      1.03 |
| qwen3 0.6B Q4_0          | pp32   |      2780.44 |                2872.22 |      1.03 |
| qwen3 0.6B Q4_0          | pp64   |      5477.53 |                5612.91 |      1.02 |
| qwen3 0.6B Q4_0          | pp128  |      8979.15 |                9224.22 |      1.03 |
| qwen3 0.6B Q4_0          | pp512  |     14241.52 |               14392.58 |      1.01 |
| qwen3 0.6B Q4_0          | tg32   |       340.66 |                 343.08 |      1.01 |
| qwen3 0.6B Q8_0          | pp1    |       235.74 |                 251.39 |      1.07 |
| qwen3 0.6B Q8_0          | pp2    |       478.24 |                 525.30 |      1.10 |
| qwen3 0.6B Q8_0          | pp3    |       606.86 |                 636.12 |      1.05 |
| qwen3 0.6B Q8_0          | pp4    |       762.67 |                 823.37 |      1.08 |
| qwen3 0.6B Q8_0          | pp5    |       846.17 |                 898.53 |      1.06 |
| qwen3 0.6B Q8_0          | pp6    |      1103.55 |                1177.57 |      1.07 |
| qwen3 0.6B Q8_0          | pp7    |      1238.70 |                1313.67 |      1.06 |
| qwen3 0.6B Q8_0          | pp8    |      1408.13 |                1495.18 |      1.06 |
| qwen3 0.6B Q8_0          | pp16   |      1298.25 |                1351.78 |      1.04 |
| qwen3 0.6B Q8_0          | pp32   |      2683.00 |                2765.04 |      1.03 |
| qwen3 0.6B Q8_0          | pp64   |      5196.85 |                5371.99 |      1.03 |
| qwen3 0.6B Q8_0          | pp128  |      8662.60 |                8832.74 |      1.02 |
| qwen3 0.6B Q8_0          | pp512  |     14232.47 |               14336.05 |      1.01 |
| qwen3 0.6B Q8_0          | tg32   |       280.66 |                 280.13 |      1.00 |
| qwen3 4B Q8_0            | pp1    |       109.69 |                 109.88 |      1.00 |
| qwen3 4B Q8_0            | pp2    |       194.47 |                 198.33 |      1.02 |
| qwen3 4B Q8_0            | pp3    |       242.96 |                 247.54 |      1.02 |
| qwen3 4B Q8_0            | pp4    |       308.48 |                 314.26 |      1.02 |
| qwen3 4B Q8_0            | pp5    |       320.32 |                 323.35 |      1.01 |
| qwen3 4B Q8_0            | pp6    |       389.99 |                 394.27 |      1.01 |
| qwen3 4B Q8_0            | pp7    |       414.83 |                 417.14 |      1.01 |
| qwen3 4B Q8_0            | pp8    |       467.82 |                 472.08 |      1.01 |
| qwen3 4B Q8_0            | pp16   |       382.28 |                 383.92 |      1.00 |
| qwen3 4B Q8_0            | pp32   |       778.42 |                 780.46 |      1.00 |
| qwen3 4B Q8_0            | pp64   |      1402.92 |                1411.66 |      1.01 |
| qwen3 4B Q8_0            | pp128  |      1875.56 |                1879.44 |      1.00 |
| qwen3 4B Q8_0            | pp512  |      2460.31 |                2468.32 |      1.00 |
| qwen3 4B Q8_0            | tg32   |       113.84 |                 114.32 |      1.00 |
| qwen3moe 30B.A3B Q4_0    | pp1    |       100.00 |                 101.00 |      1.01 |
| qwen3moe 30B.A3B Q4_0    | pp2    |       147.48 |                 158.79 |      1.08 |
| qwen3moe 30B.A3B Q4_0    | pp3    |       185.62 |                 195.54 |      1.05 |
| qwen3moe 30B.A3B Q4_0    | pp4    |       226.62 |                 236.66 |      1.04 |
| qwen3moe 30B.A3B Q4_0    | pp5    |       245.20 |                 256.96 |      1.05 |
| qwen3moe 30B.A3B Q4_0    | pp6    |       292.85 |                 304.86 |      1.04 |
| qwen3moe 30B.A3B Q4_0    | pp7    |       310.21 |                 324.98 |      1.05 |
| qwen3moe 30B.A3B Q4_0    | pp8    |       337.95 |                 352.13 |      1.04 |
| qwen3moe 30B.A3B Q4_0    | pp16   |       348.34 |                 354.88 |      1.02 |
| qwen3moe 30B.A3B Q4_0    | pp32   |       412.62 |                 415.49 |      1.01 |
| qwen3moe 30B.A3B Q4_0    | pp64   |       710.67 |                 707.49 |      1.00 |
| qwen3moe 30B.A3B Q4_0    | pp128  |      1148.62 |                1144.82 |      1.00 |
| qwen3moe 30B.A3B Q4_0    | pp512  |      2155.19 |                2143.51 |      0.99 |
| qwen3moe 30B.A3B Q4_0    | tg32   |       106.99 |                 109.20 |      1.02 |
| qwen3next 80B.A3B Q4_K_M | pp1    |        35.86 |                  37.73 |      1.05 |
| qwen3next 80B.A3B Q4_K_M | pp2    |        43.00 |                  44.27 |      1.03 |
| qwen3next 80B.A3B Q4_K_M | pp3    |        58.85 |                  60.34 |      1.03 |
| qwen3next 80B.A3B Q4_K_M | pp4    |        71.19 |                  72.69 |      1.02 |
| qwen3next 80B.A3B Q4_K_M | pp5    |        84.65 |                  86.38 |      1.02 |
| qwen3next 80B.A3B Q4_K_M | pp6    |       100.78 |                 102.30 |      1.02 |
| qwen3next 80B.A3B Q4_K_M | pp7    |       110.15 |                 111.78 |      1.01 |
| qwen3next 80B.A3B Q4_K_M | pp8    |       121.85 |                 124.00 |      1.02 |
| qwen3next 80B.A3B Q4_K_M | pp16   |       154.53 |                 154.77 |      1.00 |
| qwen3next 80B.A3B Q4_K_M | pp32   |       223.17 |                 222.97 |      1.00 |
| qwen3next 80B.A3B Q4_K_M | pp64   |       361.65 |                 354.28 |      0.98 |
| qwen3next 80B.A3B Q4_K_M | pp128  |       527.05 |                 516.57 |      0.98 |
| qwen3next 80B.A3B Q4_K_M | pp512  |       841.18 |                 845.43 |      1.01 |
| qwen3next 80B.A3B Q4_K_M | tg32   |        36.48 |                  37.39 |      1.03 |