### PR TITLE
ggml-cpu: optimize ggml_vec_dot_bf16 for s390x

### DIFF
--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -1160,6 +1160,14 @@ static inline void __lsx_f16x4_store(ggml_fp16_t * x, __m128 y) {
     float32x4_t tmp = x[0] + vec_reve(x[0]);        \
     res = tmp[0] + tmp[1];                          \
 }
+#define GGML_F32x4_REDUCE_4(res, s0, s1, s2, s3) \
+{                                                \
+    float32x4_t v = vec_add(vec_add(s0, s1),     \
+                            vec_add(s2, s3));    \
+    v = vec_add(v, vec_sld(v, v, 8));            \
+    v = vec_add(v, vec_sld(v, v, 4));            \
+    res += (ggml_float)vec_extract(v, 0);        \
+}
 
 #define GGML_F32_VEC        GGML_F32x4
 #define GGML_F32_VEC_ZERO   GGML_F32x4_ZERO
@@ -1208,6 +1216,24 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t v_y) {
 #define GGML_F16_VEC_ADD            GGML_F32x4_ADD
 #define GGML_F16_VEC_MUL            GGML_F32x4_MUL
 #define GGML_F16_VEC_REDUCE         GGML_F32x4_REDUCE
+
+// BF16 s390x
+#define GGML_BF16_STEP 16
+#define GGML_BF16_EPR  8
+
+#define GGML_BF16x8         __vector unsigned short
+#define GGML_BF16x8_ZERO    vec_splats((unsigned short)0)
+#define GGML_BF16x8_LOAD(p) vec_xl(0, (const unsigned short *)p)
+
+#define GGML_BF16_VEC      GGML_BF16x8
+#define GGML_BF16_VEC_ZERO GGML_BF16x8_ZERO
+#define GGML_BF16_VEC_LOAD GGML_BF16x8_LOAD
+#define GGML_BF16_TO_F32_LO(v) ((float32x4_t) vec_mergel((v), GGML_BF16_VEC_ZERO))
+#define GGML_BF16_TO_F32_HI(v) ((float32x4_t) vec_mergeh((v), GGML_BF16_VEC_ZERO))
+#define GGML_BF16_FMA_LO(acc, x, y) \
+    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_FP32_LO(x), GGML_BF16_TO_FP32_LO(y))
+#define GGML_BF16_FMA_HI(acc, x, y) \
+    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_FP32_HI(x), GGML_BF16_TO_FP32_HI(y))
 
 #elif defined(__riscv_v_intrinsic)
 

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -1223,7 +1223,7 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t v_y) {
 
 #define GGML_BF16x8         __vector unsigned short
 #define GGML_BF16x8_ZERO    vec_splats((unsigned short)0)
-#define GGML_BF16x8_LOAD(p) vec_xl(0, (const unsigned short *)p)
+#define GGML_BF16x8_LOAD(p) vec_xl(0, (const unsigned short *)(p))
 
 #define GGML_BF16_VEC      GGML_BF16x8
 #define GGML_BF16_VEC_ZERO GGML_BF16x8_ZERO
@@ -1231,9 +1231,9 @@ static inline void __lzs_f16cx4_store(ggml_fp16_t * x, float32x4_t v_y) {
 #define GGML_BF16_TO_F32_LO(v) ((float32x4_t) vec_mergel((v), GGML_BF16_VEC_ZERO))
 #define GGML_BF16_TO_F32_HI(v) ((float32x4_t) vec_mergeh((v), GGML_BF16_VEC_ZERO))
 #define GGML_BF16_FMA_LO(acc, x, y) \
-    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_FP32_LO(x), GGML_BF16_TO_FP32_LO(y))
+    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_F32_LO(x), GGML_BF16_TO_F32_LO(y))
 #define GGML_BF16_FMA_HI(acc, x, y) \
-    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_FP32_HI(x), GGML_BF16_TO_FP32_HI(y))
+    (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_F32_HI(x), GGML_BF16_TO_F32_HI(y))
 
 #elif defined(__riscv_v_intrinsic)
 

--- a/ggml/src/ggml-cpu/vec.cpp
+++ b/ggml/src/ggml-cpu/vec.cpp
@@ -236,8 +236,7 @@ void ggml_vec_dot_bf16(int n, float * GGML_RESTRICT s, size_t bs, ggml_bf16_t * 
     vfloat32m1_t redsum = __riscv_vfredusum_vs_f32m4_f32m1(vsum0, __riscv_vfmv_v_f_f32m1(0.0f, 1), vl);
     sumf += __riscv_vfmv_f_s_f32m1_f32(redsum);
 
-#endif
-#if defined(__POWER9_VECTOR__)
+#elif defined(__POWER9_VECTOR__) || defined(__VXE__) || defined(__VXE2__)
     const int np = (n & ~(GGML_BF16_STEP - 1));
     if (np > 0) {
         GGML_F32_VEC sum[4] = {GGML_F32_VEC_ZERO};


### PR DESCRIPTION
Similar to #18837, this pull request integrates the SIMD instruction set for BF16 on the s390x platform. We notice a 154.86% performance improvement for Prompt Processing. No performance difference was noticed for Token Generation.

### Before SIMD Benchmark

| model                          |       size |     params | backend    | threads | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ---: | --------------: | -------------------: |
| granite 3B BF16                |   4.72 GiB |     2.53 B | CPU        |       1 |    1 |           pp512 |          0.29 ± 0.00 |
| granite 3B BF16                |   4.72 GiB |     2.53 B | CPU        |       1 |    1 |           tg128 |          0.03 ± 0.00 |

build: 423cf0b26 (8029)

### After SIMD Benchmark

| model                          |       size |     params | backend    | threads | mmap |            test | t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ---: | --------------: | -------------: |                                                                                 
| granite 3B BF16                |   4.72 GiB |     2.53 B | CPU        |       1 |    1 |           pp512 |          2.28 ± 0.20 |
| granite 3B BF16                |   4.72 GiB |     2.53 B | CPU        |       1 |    1 |           tg128 |          0.03 ± 0.00 |

build: b4bc24e58 (8004)  

### Verification

This PR was tested against the IBM Granite 3.3 2B Instruct BF16 model.

`test-quantize-fns`

```console
$ build/bin/test-quantize-fns

Testing f32
Testing f16
Testing q4_0
Testing q4_1
Testing q5_0
Testing q5_1
Testing q8_0
Testing q8_1
Testing q2_K
Testing q3_K
Testing q4_K
Testing q5_K
Testing q6_K
Testing q8_K
Testing iq2_xxs
Testing iq2_xs
Testing iq3_xxs
Testing iq1_s
Testing iq4_nl
Testing iq3_s
Testing iq2_s
Testing iq4_xs
Testing i8
Testing i16
Testing i32
Testing i64
Testing f64
Testing iq1_m
Testing bf16
Testing tq1_0
Testing tq2_0
Testing mxfp4
```