### PR TITLE
ci : use less jobs when building with sanitizers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,9 +295,11 @@ jobs:
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
           J=$(( $(nproc) / 2 ))
           if [ $J -lt 1 ]; then J=1; fi
           echo "Using -j $J"
+
           cmake --build build --config ${{ matrix.build_type }} -j $J
 
       - name: Build (no OpenMP)
@@ -310,9 +312,11 @@ jobs:
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
+
           J=$(( $(nproc) / 2 ))
           if [ $J -lt 1 ]; then J=1; fi
           echo "Using -j $J"
+
           cmake --build build --config ${{ matrix.build_type }} -j $J
 
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
-          J=$(( $(nproc) / 2 ))
+          J=$(( ($(nproc) + 1) / 2 ))
           if [ $J -lt 1 ]; then J=1; fi
           echo "Using -j $J"
 
@@ -313,7 +313,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
 
-          J=$(( $(nproc) / 2 ))
+          J=$(( ($(nproc) + 1) / 2 ))
           if [ $J -lt 1 ]; then J=1; fi
           echo "Using -j $J"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,11 +296,7 @@ jobs:
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
-          J=$(( ($(nproc) + 1) / 2 ))
-          if [ $J -lt 1 ]; then J=1; fi
-          echo "Using -j $J"
-
-          cmake --build build --config ${{ matrix.build_type }} -j $J
+          cmake --build build --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Build (no OpenMP)
         id: cmake_build_no_openmp
@@ -313,11 +309,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
 
-          J=$(( ($(nproc) + 1) / 2 ))
-          if [ $J -lt 1 ]; then J=1; fi
-          echo "Using -j $J"
-
-          cmake --build build --config ${{ matrix.build_type }} -j $J
+          cmake --build build --config ${{ matrix.build_type }} -j $(nproc)
 
       - name: Test
         id: cmake_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,10 @@ jobs:
             -DLLAMA_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          cmake --build build --config ${{ matrix.build_type }} -j $(nproc)
+          J=$(( $(nproc) / 2 ))
+          if [ $J -lt 1 ]; then J=1; fi
+          echo "Using -j $J"
+          cmake --build build --config ${{ matrix.build_type }} -j $J
 
       - name: Build (no OpenMP)
         id: cmake_build_no_openmp
@@ -307,7 +310,10 @@ jobs:
             -DGGML_SANITIZE_${{ matrix.sanitizer }}=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DGGML_OPENMP=OFF
-          cmake --build build --config ${{ matrix.build_type }} -j $(nproc)
+          J=$(( $(nproc) / 2 ))
+          if [ $J -lt 1 ]; then J=1; fi
+          echo "Using -j $J"
+          cmake --build build --config ${{ matrix.build_type }} -j $J
 
       - name: Test
         id: cmake_test

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -72,10 +72,6 @@ jobs:
       - name: Build
         id: cmake_build
         run: |
-          J=$(( ($(nproc) + 1) / 2 ))
-          if [ $J -lt 1 ]; then J=1; fi
-          echo "Using -j $J"
-
           cmake -B build \
             -DLLAMA_BUILD_BORINGSSL=ON \
             -DGGML_SCHED_NO_REALLOC=ON \
@@ -85,7 +81,7 @@ jobs:
             -DLLAMA_SANITIZE_ADDRESS=${{ matrix.sanitizer == 'ADDRESS' }} \
             -DLLAMA_SANITIZE_THREAD=${{ matrix.sanitizer == 'THREAD' }} \
             -DLLAMA_SANITIZE_UNDEFINED=${{ matrix.sanitizer == 'UNDEFINED' }}
-          cmake --build build --config ${{ matrix.build_type }} -j $J --target llama-server
+          cmake --build build --config ${{ matrix.build_type }} -j $(nproc) --target llama-server
 
       - name: Python setup
         id: setup_python

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Build
         id: cmake_build
         run: |
+          J=$(( (${env:NUMBER_OF_PROCESSORS} + 1) / 2 ))
+          if [ $J -lt 1 ]; then J=1; fi
+          echo "Using -j $J"
           cmake -B build \
             -DLLAMA_BUILD_BORINGSSL=ON \
             -DGGML_SCHED_NO_REALLOC=ON \
@@ -81,7 +84,7 @@ jobs:
             -DLLAMA_SANITIZE_ADDRESS=${{ matrix.sanitizer == 'ADDRESS' }} \
             -DLLAMA_SANITIZE_THREAD=${{ matrix.sanitizer == 'THREAD' }} \
             -DLLAMA_SANITIZE_UNDEFINED=${{ matrix.sanitizer == 'UNDEFINED' }}
-          cmake --build build --config ${{ matrix.build_type }} -j ${env:NUMBER_OF_PROCESSORS} --target llama-server
+          cmake --build build --config ${{ matrix.build_type }} -j $J --target llama-server
 
       - name: Python setup
         id: setup_python

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -121,7 +121,7 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build -DLLAMA_BUILD_BORINGSSL=ON -DGGML_SCHED_NO_REALLOC=ON
-          cmake --build build --config Release -j $(nproc) --target llama-server
+          cmake --build build --config Release -j ${env:NUMBER_OF_PROCESSORS} --target llama-server
 
       - name: Python setup
         id: setup_python

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -72,9 +72,10 @@ jobs:
       - name: Build
         id: cmake_build
         run: |
-          J=$(( (${env:NUMBER_OF_PROCESSORS} + 1) / 2 ))
+          J=$(( ($(nproc) + 1) / 2 ))
           if [ $J -lt 1 ]; then J=1; fi
           echo "Using -j $J"
+
           cmake -B build \
             -DLLAMA_BUILD_BORINGSSL=ON \
             -DGGML_SCHED_NO_REALLOC=ON \
@@ -120,7 +121,7 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build -DLLAMA_BUILD_BORINGSSL=ON -DGGML_SCHED_NO_REALLOC=ON
-          cmake --build build --config Release -j ${env:NUMBER_OF_PROCESSORS} --target llama-server
+          cmake --build build --config Release -j $(nproc) --target llama-server
 
       - name: Python setup
         id: setup_python


### PR DESCRIPTION
ref https://github.com/ggml-org/llama.cpp/pull/19291#issuecomment-3862954095

I think this might help with sanitizer jobs being randomly terminated (such as https://github.com/ggml-org/llama.cpp/actions/runs/21761592313/job/62786390511).