### PR TITLE
Add compiler flags for UWP

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -41,6 +41,7 @@
 #   define NOMINMAX
 #endif
 #include <locale>
+#include <winapifamily.h>
 #include <windows.h>
 #include <string.h>
 #include <fcntl.h>
@@ -101,7 +102,7 @@ int32_t cpu_get_num_physical_cores() {
     if (result == 0) {
         return num_physical_cores;
     }
-#elif defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) // windows 7 and later
+#elif defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && !defined(LLAMA_UWP) // windows 7 and later
     // TODO: windows + arm64 + mingw64
     unsigned int n_threads_win = std::thread::hardware_concurrency();
     unsigned int default_threads = n_threads_win > 0 ? (n_threads_win <= 4 ? n_threads_win : n_threads_win / 2) : 4;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -102,7 +102,7 @@ int32_t cpu_get_num_physical_cores() {
     if (result == 0) {
         return num_physical_cores;
     }
-#elif defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && !defined(LLAMA_UWP) // windows 7 and later
+#elif defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) // windows 7 and later
     // TODO: windows + arm64 + mingw64
     unsigned int n_threads_win = std::thread::hardware_concurrency();
     unsigned int default_threads = n_threads_win > 0 ? (n_threads_win <= 4 ? n_threads_win : n_threads_win / 2) : 4;
@@ -382,7 +382,7 @@ std::string common_params_get_system_info(const common_params & params) {
     if (params.cpuparams_batch.n_threads != -1) {
         os << " (n_threads_batch = " << params.cpuparams_batch.n_threads << ")";
     }
-#if defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) // windows 7 and later
+#if defined(_WIN32) && (_WIN32_WINNT >= 0x0601) && !defined(__MINGW64__) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && !defined(LLAMA_UWP) // windows 7 and later
     // TODO: windows + arm64 + mingw64
     DWORD logicalProcessorCount = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
     os << " / " << logicalProcessorCount << " | " << llama_print_system_info();

--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -29,6 +29,7 @@
     #ifndef NOMINMAX
         #define NOMINMAX
     #endif
+    #include <winapifamily.h>
     #include <windows.h>
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH
@@ -660,6 +661,7 @@ struct llama_mlock::impl {
                 return false;
             }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && !defined(LLAMA_UWP)
             SIZE_T min_ws_size, max_ws_size;
             if (!GetProcessWorkingSetSize(GetCurrentProcess(), &min_ws_size, &max_ws_size)) {
                 LLAMA_LOG_WARN("warning: GetProcessWorkingSetSize failed: %s\n",
@@ -674,6 +676,10 @@ struct llama_mlock::impl {
                         llama_format_win_err(GetLastError()).c_str());
                 return false;
             }
+#else
+            LLAMA_LOG_WARN("warning: MMAP is not supported for UWP\n");
+            return false;
+#endif
         }
     }
 


### PR DESCRIPTION
Added compiler flags to allow llama.cpp to be compiled without calls that aren't supported in UWP (GetLogicalProcessorInformationEx, GetProcessWorkingSetSize and SetProcessWorkingSetSize).
This allows llama.cpp to be integrated in UWP projects like apps targeting Windows Phone and Xbox with mmap disabled.