### PR TITLE
chat: fix case where template accepts type content only

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3033,7 +3033,6 @@ static json render_message_to_json(const std::vector<common_chat_msg> & msgs, co
                     }
                 });
             }
-            printf("%s\n", jmsg.dump().c_str());
             messages.push_back(jmsg);
         } else {
             json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ false);

--- a/common/chat.h
+++ b/common/chat.h
@@ -240,6 +240,8 @@ bool common_chat_templates_support_enable_thinking(const common_chat_templates *
 
 // Parses a JSON array of messages in OpenAI's chat completion API format.
 std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const nlohmann::ordered_json & messages);
+
+// DEPRECATED: only used in tests
 nlohmann::ordered_json common_chat_msgs_to_json_oaicompat(const std::vector<common_chat_msg> & msgs, bool concat_typed_text = false);
 
 std::vector<common_chat_tool> common_chat_tools_parse_oaicompat(const nlohmann::ordered_json & tools);

--- a/common/jinja/caps.h
+++ b/common/jinja/caps.h
@@ -14,7 +14,9 @@ struct caps {
     bool supports_parallel_tool_calls = true;
     bool supports_preserve_reasoning = false; // support assistant message with reasoning_content
 
-    bool requires_typed_content = false; // default: use string content
+    // one of the 2 content capabilities must be true
+    bool supports_string_content = true;
+    bool supports_typed_content = false;
 
     // for reporting on server
     std::map<std::string, bool> to_map() const;

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -446,6 +446,12 @@ value for_statement::execute_impl(context & ctx) {
 
     value iterable_val = iter_expr->execute(scope);
 
+    // mark the variable being iterated as used for stats
+    if (ctx.is_get_stats) {
+        iterable_val->stats.used = true;
+        iterable_val->stats.ops.insert("array_access");
+    }
+
     if (iterable_val->is_undefined()) {
         JJ_DEBUG("%s", "For loop iterable is undefined, skipping loop");
         iterable_val = mk_val<value_array>();


### PR DESCRIPTION
Fix chat template of PaddleOCR-VL, which requires content to be an array (see https://github.com/ggml-org/llama.cpp/pull/18825)

This should be able to handle these case:
- Template supports ONLY string content
- Template supports ONLY array content
- Template supports both string AND array content
