### PR TITLE
tools: add quant-bench for profiling raw kernel performance

### DIFF
--- a/tools/llama-bench/CMakeLists.txt
+++ b/tools/llama-bench/CMakeLists.txt
@@ -3,6 +3,11 @@ add_executable(${TARGET} llama-bench.cpp)
 target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
+set(TARGET_QUANT quant-bench)
+add_executable(${TARGET_QUANT} quant-bench.cpp)
+target_link_libraries(${TARGET_QUANT} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_compile_features(${TARGET_QUANT} PRIVATE cxx_std_17)
+
 if(LLAMA_TOOLS_INSTALL)
-    install(TARGETS ${TARGET} RUNTIME)
+    install(TARGETS ${TARGET} ${TARGET_QUANT} RUNTIME)
 endif()

--- a/tools/llama-bench/quant-bench.cpp
+++ b/tools/llama-bench/quant-bench.cpp
@@ -1,0 +1,262 @@
+#include "ggml.h"
+#include "ggml-backend.h"
+#include "ggml-alloc.h"
+#include "common.h"
+
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <chrono>
+#include <map>
+#include <cmath>
+#include <algorithm>
+#include <thread>
+#include <memory>
+#include <cstring>
+
+// Smart pointers for RAII cleanup
+struct ggml_context_deleter {
+    void operator()(ggml_context * ctx) { ggml_free(ctx); }
+};
+using ggml_context_ptr = std::unique_ptr<ggml_context, ggml_context_deleter>;
+
+struct ggml_backend_buffer_deleter {
+    void operator()(ggml_backend_buffer_t buf) { ggml_backend_buffer_free(buf); }
+};
+using ggml_backend_buffer_ptr = std::unique_ptr<struct ggml_backend_buffer, ggml_backend_buffer_deleter>;
+
+struct ggml_backend_deleter {
+    void operator()(ggml_backend_t backend) { ggml_backend_free(backend); }
+};
+using ggml_backend_ptr = std::unique_ptr<struct ggml_backend, ggml_backend_deleter>;
+
+// Utils
+static uint64_t get_time_ns() {
+    using clock = std::chrono::high_resolution_clock;
+    return std::chrono::nanoseconds(clock::now().time_since_epoch()).count();
+}
+
+struct BenchmarkParams {
+    int64_t m = 4096;
+    int64_t k = 14336;
+    int64_t n_prefill = 512;
+    int64_t n_decode = 1;
+    int reps = 5;
+    bool verbose = false;
+    std::string device_arg = "auto";
+};
+
+static void print_usage(const char * argv0) {
+    printf("usage: %s [options]\n", argv0);
+    printf("\n");
+    printf("options:\n");
+    printf("  -h, --help            show this help message and exit\n");
+    printf("  -v, --verbose         verbose output\n");
+    printf("  -d, --device <dev>    device ID (int) or name (str) to use (default: auto)\n");
+    printf("\n");
+}
+
+static void run_benchmark(ggml_backend_t backend, const BenchmarkParams & params, ggml_type type_a, const std::string & phase_name, int64_t n) {
+    if (params.verbose) {
+        printf("Benchmarking %s %s: m=%ld n=%ld k=%ld\n", phase_name.c_str(), ggml_type_name(type_a), params.m, n, params.k);
+    }
+
+    // Init context
+    size_t ctx_size = ggml_tensor_overhead() * 16 + ggml_graph_overhead();
+    struct ggml_init_params init_params = {
+        /*.mem_size   =*/ ctx_size,
+        /*.mem_base   =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx(ggml_init(init_params));
+
+    // Create tensors
+    // A: Weight matrix (Quantized) [k, m]
+    // B: Input matrix [k, n]
+    struct ggml_tensor * a = ggml_new_tensor_2d(ctx.get(), type_a, params.k, params.m);
+    struct ggml_tensor * b = ggml_new_tensor_2d(ctx.get(), GGML_TYPE_F32, params.k, n);
+    
+    // Check support
+    if (!ggml_backend_supports_op(backend, a) || !ggml_backend_supports_op(backend, b)) {
+        if (params.verbose) printf("Backend does not support input tensors for %s\n", ggml_type_name(type_a));
+        return;
+    }
+
+    // Build graph: C = A * B
+    struct ggml_tensor * c = ggml_mul_mat(ctx.get(), a, b);
+    
+    if (!ggml_backend_supports_op(backend, c)) {
+        if (params.verbose) printf("Backend does not support MUL_MAT for %s\n", ggml_type_name(type_a));
+        return;
+    }
+
+    struct ggml_cgraph * gf = ggml_new_graph(ctx.get());
+    ggml_build_forward_expand(gf, c);
+
+    // Allocate memory
+    ggml_backend_buffer_ptr buffer(ggml_backend_alloc_ctx_tensors(ctx.get(), backend));
+    if (!buffer) {
+        printf("Failed to allocate memory\n");
+        return;
+    }
+
+    // Warmup
+    ggml_backend_graph_compute(backend, gf);
+
+    // Run benchmark
+    uint64_t t_start = get_time_ns();
+    for (int i = 0; i < params.reps; i++) {
+        ggml_backend_graph_compute(backend, gf);
+    }
+    uint64_t t_end = get_time_ns();
+    
+    double t_ns = (double)(t_end - t_start) / params.reps;
+    double t_us = t_ns / 1000.0;
+
+    // Stats
+    // TOPS: 2*m*n*k
+    double ops = 2.0 * params.m * n * params.k;
+    double tops = (ops / t_ns) * 1e9 / 1e12; // TOPS
+
+    // Print Row
+    if (n > 1) {
+        // Prompt Processing: Bandwidth is less relevant, compute bound
+        printf("| %-10s | %10.2f | %10.2f |\n", 
+               ggml_type_name(type_a), t_us, tops);
+    } else {
+        // Token Generation: Bandwidth is critical
+        // Bandwidth: Size(A) + Size(B) + Size(C)
+        size_t size_a = ggml_nbytes(a);
+        size_t size_b = ggml_nbytes(b);
+        size_t size_c = ggml_nbytes(c);
+        size_t total_bytes = size_a + size_b + size_c;
+        double gb_s = (double)total_bytes / t_ns; // GB/s
+        
+        printf("| %-10s | %10.2f | %10.2f | %10.2f |\n", 
+               ggml_type_name(type_a), t_us, tops, gb_s);
+    }
+}
+
+int main(int argc, char ** argv) {
+    BenchmarkParams params;
+
+    // Parse args
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            print_usage(argv[0]);
+            return 0;
+        } else if (arg == "-v" || arg == "--verbose") {
+            params.verbose = true;
+        } else if (arg == "-d" || arg == "--device") {
+            if (++i >= argc) {
+                fprintf(stderr, "error: missing argument for %s\n", arg.c_str());
+                return 1;
+            }
+            params.device_arg = argv[i];
+        } else {
+            fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    ggml_backend_load_all();
+
+    // Pick backend
+    ggml_backend_ptr backend_ptr;
+    
+    if (params.device_arg != "auto") {
+        // Try to parse as integer index
+        try {
+            int id = std::stoi(params.device_arg);
+            if (id >= 0 && id < (int)ggml_backend_dev_count()) {
+                ggml_backend_dev_t dev = ggml_backend_dev_get(id);
+                printf("Using device %d: %s\n", id, ggml_backend_dev_name(dev));
+                backend_ptr.reset(ggml_backend_dev_init(dev, NULL));
+            }
+        } catch (...) {
+            // Not a number, try name lookup
+        }
+
+        if (!backend_ptr) {
+            // Try by name
+            ggml_backend_dev_t dev = ggml_backend_dev_by_name(params.device_arg.c_str());
+            if (dev) {
+                printf("Using device: %s\n", ggml_backend_dev_name(dev));
+                backend_ptr.reset(ggml_backend_dev_init(dev, NULL));
+            } else {
+                fprintf(stderr, "error: device '%s' not found\n", params.device_arg.c_str());
+                fprintf(stderr, "Available devices:\n");
+                for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+                    ggml_backend_dev_t d = ggml_backend_dev_get(i);
+                    fprintf(stderr, "  %zu: %s\n", i, ggml_backend_dev_name(d));
+                }
+                return 1;
+            }
+        }
+    } else {
+        // Auto-detect: Prioritize GPU
+        if (ggml_backend_dev_count() > 0) {
+            for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+                ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+                if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
+                    printf("Using auto-detected device %zu: %s\n", i, ggml_backend_dev_name(dev));
+                    backend_ptr.reset(ggml_backend_dev_init(dev, NULL));
+                    break;
+                }
+            }
+        }
+    }
+
+    // Fallback to CPU
+    if (!backend_ptr) {
+        backend_ptr.reset(ggml_backend_init_by_name("CPU", NULL));
+        if (!backend_ptr) {
+             // Try fetching CPU backend by index if name fails (fallback)
+             for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+                ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+                if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+                    backend_ptr.reset(ggml_backend_dev_init(dev, NULL));
+                    break;
+                }
+             }
+        }
+        printf("Using backend: CPU\n");
+    }
+
+    if (!backend_ptr) {
+        fprintf(stderr, "error: failed to initialize backend\n");
+        return 1;
+    }
+
+    // Quant types to test
+    std::vector<ggml_type> quants = {
+        GGML_TYPE_Q4_0, GGML_TYPE_Q4_K, 
+        GGML_TYPE_Q5_0, GGML_TYPE_Q5_K,
+        GGML_TYPE_Q6_K,
+        GGML_TYPE_Q8_0,
+        GGML_TYPE_IQ2_XXS, GGML_TYPE_IQ2_XS, GGML_TYPE_IQ2_S,
+        GGML_TYPE_IQ3_XXS, GGML_TYPE_IQ3_S,
+        GGML_TYPE_IQ4_NL, GGML_TYPE_IQ4_XS,
+        GGML_TYPE_MXFP4
+    };
+
+    printf("\n=== Prompt Processing (Prefill) Phase (Batch Size = %ld) ===\n", params.n_prefill);
+    printf("| %-10s | %-10s | %-10s |\n", "Quant", "Time (us)", "TOPS");
+    printf("|-%-10s-|-%-10s-|-%-10s-|\n", "----------", "----------", "----------");
+    
+    for (auto type : quants) {
+        run_benchmark(backend_ptr.get(), params, type, "Prefill", params.n_prefill);
+    }
+
+    printf("\n=== Token Generation (Decoding) Phase (Batch Size = %ld) ===\n", params.n_decode);
+    printf("| %-10s | %-10s | %-10s | %-10s |\n", "Quant", "Time (us)", "TOPS", "Eff. BW (GB/s)");
+    printf("|-%-10s-|-%-10s-|-%-10s-|-%-14s-|\n", "----------", "----------", "----------", "--------------");
+
+    for (auto type : quants) {
+        run_benchmark(backend_ptr.get(), params, type, "Decoding", params.n_decode);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
# Add `quant-bench` - Quantization Performance Benchmarking Tool

This PR adds a new standalone tool `quant-bench` to `tools/llama-bench/`.

Unlike `llama-bench` which tests end-to-end inference and requires GGUF models, `quant-bench` isolates and benchmarks the matrix multiplication kernels for **Prefill** (compute-bound) and **Decoding** (bandwidth-bound) phases across all supported quantization types.

## Motivation

This tool helps users identify the optimal quantization for their specific hardware by measuring:
- Throughput (TOPS - Tera Operations Per Second)
- Effective bandwidth (GB/s)
- Performance characteristics close to what large LLMs of the same quantization type would achieve

This is particularly useful for understanding quantization performance on different hardware (e.g., MXFP4 performance on older GPUs).

## AI Disclosure

Mostly vibecoded with Gemini CLI, though I reviewed most functions and understand their implementation. The design and many edits were done by me. Started from a personal Python script I've maintained that used `test-backend-ops`, and today decided it would be valuable as a separate tool.

## Example Output (AMD MI50)

```
ggml_cuda_init: found 1 ROCm devices:
  Device 0: AMD Radeon Graphics, gfx906:sramecc+:xnack- (0x906), VMM: no, Wave Size: 64
Using auto-detected device 0: ROCm0

=== Prompt Processing (Prefill) Phase (Batch Size = 512) ===
| Quant      | Time (us)  | TOPS       |
|------------|------------|------------|
| q4_0       |    4096.31 |      14.68 |
| q4_K       |    4086.66 |      14.71 |
| q5_0       |    8073.84 |       7.45 |
| q5_K       |    8145.09 |       7.38 |
| q6_K       |    7012.98 |       8.57 |
| q8_0       |    8888.17 |       6.77 |
| iq2_xxs    |    6283.85 |       9.57 |
| iq2_xs     |    7761.70 |       7.75 |
| iq2_s      |    6826.44 |       8.81 |
| iq3_xxs    |    7065.85 |       8.51 |
| iq3_s      |    6486.67 |       9.27 |
| iq4_nl     |    7532.94 |       7.98 |
| iq4_xs     |    5662.28 |      10.62 |
| mxfp4      |    5681.54 |      10.58 |

=== Token Generation (Decoding) Phase (Batch Size = 1) ===
| Quant      | Time (us)  | TOPS       | Eff. BW (GB/s) |
|------------|------------|------------|----------------|
| q4_0       |      95.23 |       1.23 |         347.61 |
| q4_K       |      90.61 |       1.30 |         365.34 |
| q5_0       |     115.41 |       1.02 |         350.43 |
| q5_K       |      94.94 |       1.24 |         425.98 |
| q6_K       |     111.91 |       1.05 |         431.10 |
| q8_0       |     120.51 |       0.97 |         518.33 |
| iq2_xxs    |     143.03 |       0.82 |         106.36 |
| iq2_xs     |     114.28 |       1.03 |         149.17 |
| iq2_s      |     148.77 |       0.79 |         126.92 |
| iq3_xxs    |     113.13 |       1.04 |         199.35 |
| iq3_s      |     155.40 |       0.76 |         162.84 |
| iq4_nl     |      89.45 |       1.31 |         370.07 |
| iq4_xs     |      69.55 |       1.69 |         449.56 |
| mxfp4      |     105.51 |       1.11 |         296.36 |
```
