### PR TITLE
llama : use n_embd_features for input embedding dimension if specified

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1447,7 +1447,8 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
 // input embeddings with optional lora
 ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
     const int64_t n_embd_inp = hparams.n_embd_inp();
-    const int64_t n_embd     = hparams.n_embd;
+    // Use initial token embedding dimension (n_embd_features) if different from final dimension (n_embd)
+    const int64_t n_embd     = hparams.n_embd_features != 0 ? hparams.n_embd_features : hparams.n_embd;
 
     assert(n_embd_inp >= n_embd);
 


### PR DESCRIPTION
This commit updates build_inp_embd to use the models n_embd_features parameter if it is set.

The motivation for this is that some models, like WavTokenizer, have both n_embd_features and n_embd parameters, where n_embd_features is the dimension of the input token embedding, and n_embd output dimension.

This will cause a mismatch when using the WavTokenizer as the n_embd_inp and n_embd values will be the same size and no padding will be applied, which will cause the following assertion to be triggered. For example, this currently happens when running llama-tts with the WavTokenizer model:
```console
common_init_result: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on
llama-tts: /home/danbev/work/ai/llama.cpp/src/llama-graph.cpp:1507: ggml_tensor* llm_graph_context::build_inp_embd(ggml_tensor*) const: Assertion `ggml_are_same_shape (inps[0], inps[1])' failed.

Thread 1 "llama-tts" received signal SIGABRT, Aborted.
```
With the changes in this commit llama-tts can be run successfully.
