### PR TITLE
ggml: add GGML_OP_ISTFT with CPU (PocketFFT) and Vulkan backends

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -529,6 +529,7 @@ extern "C" {
         GGML_OP_CONV_3D,
         GGML_OP_CONV_2D_DW,
         GGML_OP_CONV_TRANSPOSE_2D,
+        GGML_OP_ISTFT,
         GGML_OP_POOL_1D,
         GGML_OP_POOL_2D,
         GGML_OP_POOL_2D_BACK,
@@ -2109,6 +2110,17 @@ extern "C" {
             int                   n_channels,
             int                   n_batch,
             int                   n_channels_out);
+
+    // inverse short-time Fourier transform
+    // spectrogram: [n_fft, n_frames, 2] complex (interleaved re/im in last dim)
+    // output: [n_samples] real PCM audio
+    // includes irfft + Hann window + overlap-add
+    GGML_API struct ggml_tensor * ggml_istft(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * spectrogram,
+            int                   n_fft,
+            int                   hop_length,
+            int                   win_length);
 
     enum ggml_op_pool {
         GGML_OP_POOL_MAX,

--- a/ggml/src/ggml-cpu/ops.h
+++ b/ggml/src/ggml-cpu/ops.h
@@ -71,6 +71,7 @@ void ggml_compute_forward_conv_2d(const struct ggml_compute_params * params, str
 void ggml_compute_forward_conv_3d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_conv_transpose_2d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_conv_2d_dw(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_istft(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_pool_1d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_pool_2d(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_pool_2d_back(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/istft.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/istft.comp
@@ -1,0 +1,95 @@
+#version 450
+
+// iSTFT single-pass compute shader — one thread per output sample
+//
+// Each thread computes one output PCM sample by gathering contributions from
+// all overlapping spectrogram frames. For each frame, it evaluates the
+// inverse DFT at the sample's position within that frame.
+//
+// Complexity per output sample: O(overlap_count * n_freq)
+//   where overlap_count = win_length / hop_length (typically 4)
+//   and n_freq = n_fft/2 + 1 (typically 641)
+//
+// This is O(n^2) per frame but fully parallelized across all output samples.
+// For the TTS workload (~80K output samples), the GPU fills easily.
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly  buffer Src { float data_src[]; };  // complex spectrogram [2, n_freq, n_frames]
+layout(binding = 1) writeonly buffer Dst { float data_dst[]; };  // output audio [n_out]
+
+layout(push_constant) uniform PushConstants {
+    uint32_t n_fft;
+    uint32_t n_freq;       // n_fft/2 + 1
+    uint32_t n_frames;
+    uint32_t hop_length;
+    uint32_t win_length;
+    uint32_t n_pad;
+    uint32_t n_out;
+} p;
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= p.n_out) return;
+
+    // Map output index to pre-trim position
+    uint i_full = i + p.n_pad;
+
+    float audio_sum = 0.0;
+    float env_sum   = 0.0;
+
+    // Find overlapping frames: frame l covers samples [l*hop .. l*hop + win - 1]
+    // This sample is at i_full, so l*hop <= i_full < l*hop + win
+    int l_min = max(0, int(i_full) - int(p.win_length) + 1);
+    l_min = (l_min + int(p.hop_length) - 1) / int(p.hop_length);  // ceil division
+    int l_max = min(int(p.n_frames) - 1, int(i_full) / int(p.hop_length));
+
+    float inv_n_freq = 1.0 / float(p.n_freq);
+    float two_pi_over_n = 6.28318530718 / float(p.n_fft);
+
+    for (int l = l_min; l <= l_max; l++) {
+        uint frame_start = uint(l) * p.hop_length;
+        uint j = i_full - frame_start;  // position within this frame's window
+
+        // Hann window at position j
+        float hann = 0.5 * (1.0 - cos(6.28318530718 * float(j) / float(p.win_length)));
+
+        // Compute inverse DFT at position j for this frame's spectrum
+        // irfft: out[j] = (1/N) * sum_{k=0}^{N-1} X[k] * exp(i*2*pi*k*j/n_fft)
+        // For real signal, using Hermitian symmetry:
+        // out[j] = (1/n_freq) * (X[0].re + 2*sum_{k=1}^{n_freq-2} (X[k].re*cos - X[k].im*sin) + X[n_freq-1].re * cos)
+        uint src_offset = uint(l) * p.n_freq * 2;
+
+        float val = 0.0;
+        float angle_base = two_pi_over_n * float(j);
+
+        // DC component (k=0)
+        val += data_src[src_offset + 0];  // X[0].real, cos(0)=1
+
+        // Middle frequencies (k=1 to n_freq-2): count twice due to Hermitian symmetry
+        for (uint k = 1; k < p.n_freq - 1; k++) {
+            float re = data_src[src_offset + k * 2 + 0];
+            float im = data_src[src_offset + k * 2 + 1];
+            float angle = angle_base * float(k);
+            val += 2.0 * (re * cos(angle) - im * sin(angle));
+        }
+
+        // Nyquist component (k=n_freq-1)
+        {
+            uint k = p.n_freq - 1;
+            float re = data_src[src_offset + k * 2 + 0];
+            float im = data_src[src_offset + k * 2 + 1];
+            float angle = angle_base * float(k);
+            val += re * cos(angle) - im * sin(angle);
+        }
+
+        val *= inv_n_freq;
+
+        audio_sum += val * hann;
+        env_sum   += hann * hann;
+    }
+
+    data_dst[i] = (env_sum > 0.0) ? audio_sum / env_sum : 0.0;
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -965,6 +965,8 @@ void process_shaders() {
 
     string_to_spv("conv_transpose_1d_f32", "conv_transpose_1d.comp", {{"A_TYPE", "float"},  {"B_TYPE", "float"}, {"D_TYPE", "float"}});
 
+    string_to_spv("istft_f32", "istft.comp", {});
+
     string_to_spv("pool2d_f32", "pool2d.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
 
     string_to_spv("rwkv_wkv6_f32", "wkv6.comp", merge_maps(base_dict, {{"A_TYPE", "float"}}));


### PR DESCRIPTION
## Summary

Add inverse Short-Time Fourier Transform (iSTFT) as a native ggml op. This moves the spectral-to-audio
reconstruction out of `tools/tts` and into the ggml compute graph, enabling GPU acceleration for TTS.

- **CPU backend**: Uses PocketFFT `c2r` for the inverse FFT, Hann window, and overlap-add
- **Vulkan backend**: Single-pass compute shader — one thread per output sample, evaluates inverse DFT
  directly from the complex spectrogram
- **Unit tests**: 4 eval cases + 2 perf cases in `test-backend-ops` covering different FFT sizes and frame counts
- **TTS simplification**: `tools/tts/tts.cpp` now calls `ggml_istft()` instead of doing manual iSTFT in application code

### Bug fix discovered during testing

The Vulkan shader had a sign error in the inverse DFT's imaginary component:
```glsl
// Was (wrong):
val += 2.0 * (re * cos(angle) + im * sin(angle));
// Now (correct):
val += 2.0 * (re * cos(angle) - im * sin(angle));
```
This produced NMSE ≈ 2.0 against the CPU reference (essentially uncorrelated output). The shader's own
comment documented the correct formula with a minus sign, but the code used plus. This went unnoticed
because typical TTS spectrograms have near-zero imaginary components for speech, masking the error.

## Files changed (11)

| File | What |
|------|------|
| `ggml/include/ggml.h` | `ggml_istft()` API declaration |
| `ggml/src/ggml.c` | Op registration, output shape computation |
| `ggml/src/ggml-cpu/ops.{h,cpp}` | CPU implementation (PocketFFT c2r + overlap-add) |
| `ggml/src/ggml-cpu/ggml-cpu.c` | CPU backend dispatch |
| `ggml/src/ggml-cpu/pocketfft_hdronly.h` | PocketFFT header-only library (BSD 3-clause) |
| `ggml/src/ggml-vulkan/ggml-vulkan.cpp` | Vulkan backend dispatch |
| `ggml/src/ggml-vulkan/vulkan-shaders/istft.comp` | Vulkan compute shader |
| `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp` | Shader registration |
| `tests/test-backend-ops.cpp` | Unit tests (4 eval + 2 perf) |
| `tools/tts/tts.cpp` | Simplified to use `ggml_istft()` |

## Caveats

- **PocketFFT vendoring**: This bundles `pocketfft_hdronly.h` (3744 lines, BSD 3-clause) into ggml-cpu.
  If the project prefers a different FFT library or wants this as a submodule, happy to adjust.
- **No Metal/CUDA backends**: Only CPU and Vulkan are implemented. Metal and CUDA would need their own
  kernels — didn't want to scope-creep.
- **Vulkan shader is O(n²) per frame**: It evaluates the DFT directly instead of using FFT. This is fine
  for TTS workloads (the GPU fills easily at ~80K output samples) but wouldn't scale to very large FFT sizes.
  A proper FFT-based Vulkan implementation could replace it later.

## Test results

```
Backend 1/4: Vulkan0 (AMD Radeon Pro 5300M)
  ISTFT(n_fft=1280,hop_length=320,win_length=1280,n_frames=87): OK
  ISTFT(n_fft=1280,hop_length=320,win_length=1280,n_frames=10): OK
  ISTFT(n_fft=512,hop_length=128,win_length=512,n_frames=50):   OK
  ISTFT(n_fft=1024,hop_length=256,win_length=1024,n_frames=30): OK
  4/4 tests passed

Backend 2/4: Vulkan1 (Intel UHD Graphics 630)
  4/4 tests passed

All backends: OK
```

## How to test

```bash
cmake --build build --config Release -t test-backend-ops
./build/bin/test-backend-ops test -o ISTFT
./build/bin/test-backend-ops test -o ISTFT -b Vulkan
./build/bin/test-backend-ops perf -o ISTFT
```