### PR TITLE
common : improve download error reporting

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -305,7 +305,10 @@ static bool common_pull_file(httplib::Client & cli,
     );
 
     if (!res) {
-        LOG_ERR("%s: error during download. Status: %d\n", __func__, res ? res->status : -1);
+        LOG_ERR("%s: download failed: %s (status: %d)\n",
+                __func__,
+                httplib::to_string(res.error()).c_str(),
+                res ? res->status : -1);
         return false;
     }
 


### PR DESCRIPTION
While debugging the new `cpp-httplib`, the current errors were unusable...
Here is a small patch to make life easier for the next person dealing with HTTP issues :)