### PR TITLE
jinja: add missing tojson filter for undefined type

### DIFF
--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -1096,6 +1096,7 @@ const func_builtins & value_undefined_t::get_builtins() const {
         {"strip", empty_value_fn<value_string>},
         {"sum", empty_value_fn<value_int>},
         {"title", empty_value_fn<value_string>},
+        {"tojson", tojson},
         {"truncate", empty_value_fn<value_string>},
         {"unique", empty_value_fn<value_array>},
         {"upper", empty_value_fn<value_string>},


### PR DESCRIPTION
jinja: add missing tojson filter for undefined type                                                                                                                                                                                                                                                                                                                                                                                                                               

value_undefined_t::get_builtins() was the only type missing the
tojson filter, causing "unknown filter 'tojson' for type Undefined"
when templates reference undefined variables (e.g. tools | tojson
with no tools defined).