### PR TITLE
grammar : fix grammar trigger crash when token extends beyond trigger pattern

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2747,7 +2747,13 @@ private:
 
                 slot.i_batch = -1;
 
-                common_sampler_accept(slot.smpl.get(), id, true);
+                try {
+                    common_sampler_accept(slot.smpl.get(), id, true);
+                } catch (const std::exception & e) {
+                    send_error(slot, std::string("Grammar error: ") + e.what());
+                    slot.release();
+                    continue;
+                }
 
                 // here we have synchronized the llama_context (due to the sampling above), so we can do time measurement
                 const int64_t t_current = ggml_time_us();
@@ -2791,7 +2797,19 @@ private:
                 const size_t n_draft = slot.drafted.size();
 
                 // the accepted tokens from the speculation
-                const auto ids = common_sampler_sample_and_accept_n(slot.smpl.get(), ctx, slot.i_batch_dft, slot.drafted);
+                std::vector<llama_token> ids;
+                try {
+                    ids = common_sampler_sample_and_accept_n(slot.smpl.get(), ctx, slot.i_batch_dft, slot.drafted);
+                } catch (const std::exception & e) {
+                    send_error(slot, std::string("Grammar error: ") + e.what());
+                    slot.i_batch_dft.clear();
+                    slot.drafted.clear();
+                    // n_draft is still valid: rollback speculative tokens and clean up KV cache
+                    slot.prompt.tokens.keep_first(slot.prompt.n_tokens() - n_draft);
+                    llama_memory_seq_rm(llama_get_memory(ctx), slot.id, slot.prompt.n_tokens(), -1);
+                    slot.release();
+                    continue;
+                }
                 slot.i_batch_dft.clear();
                 slot.drafted.clear();
 


### PR DESCRIPTION
This fixes a crash when the model emits a tool call that a) completes the grammar trigger pattern, but also b) contains invalid extra text in the same token. An example would be: we're at `<function` in the buffer and match the prefix of the trigger pattern `<function=`. If then the next token comes in as `=list`, the `=` matches and completes the trigger, while the `list` part turns it into an invalid tool call, within the same token. (For the example we assume this tool is not available) I believe some models have per-tool-name triggers for their tool calls and are not susceptible to the bug, but the Qwen3 models and a few others are.

* This PR fixes the main issue in `src/llama-grammar.cpp`, by gracefully trying and failing calls to hallucinated tools. The resulting output will most likely be an invalid tool call to the client, but that is what the model generates.

* As a complementary improvement it adds basic exception handling to `tools/server/server-context.cpp`. This was missing and in turn resulted in llama-server crashing.

Resolves #19353 and resolves #19304.

Minimal reproducer:
```
#!/usr/bin/env python3
"""Reproducer: grammar crash when a token completes a trigger AND contains
text beyond it (e.g. token "=list" completing trigger "<function=").
Requires a running llama-server with a Qwen3 model (e.g. Qwen3-4B)."""
import requests, sys, time

URL = "http://127.0.0.1:8080"
PAYLOAD = {
    "prompt": """<|im_start|>system
You must use the tool to answer.
<tools><function><name>list</name><description>List files</description>
<parameters><parameter><name>path</name><type>string</type></parameter>
<required>["path"]</required></parameters></function></tools>
Reply format: <tool_call>\n<function=name>\n<parameter=p>v</parameter>\n</function>\n</tool_call><|im_end|>
<|im_start|>user
List /tmp<|im_end|>
<|im_start|>assistant
""",
    # grammar only allows specific tool names — "list" is intentionally missing
    "grammar": 'root ::= "<tool_call>\\n<function=" ("bash"|"search") ">" [^<]* "</function>\\n</tool_call>"',
    "grammar_lazy": True,
    "grammar_triggers": [{"type": 2, "value": r"<tool_call>\n<function="}],
    "n_predict": 256, "temperature": 0.7,
}

for i in range(1, 6):
    try:
        r = requests.post(f"{URL}/completion", json=PAYLOAD, timeout=60)
        print(f"{i}: {r.json().get('content', '')[:100]}")
    except requests.exceptions.ConnectionError:
        print(f"{i}: SERVER CRASHED"); sys.exit(1)
print("No crash after 5 attempts.")
```
[repro_min.py](https://github.com/user-attachments/files/25226109/repro_min.py)
