### PR TITLE
docs: ban AI for issues and discussions [no CI]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If AI is used to generate any portion of the code, contributors must adhere to t
 1. Explicitly disclose the manner in which AI was employed.
 2. Perform a comprehensive manual review prior to submitting the pull request.
 3. Be prepared to explain every line of code they submitted when asked about it by a maintainer.
-4. Using AI to write pull request descriptions or to respond to human reviewers is strictly prohibited.
+4. It is strictly prohibited to use AI to write your posts for you (bug reports, feature requests, pull request descriptions, Github discussions, responding to humans, ...).
 
 For more info, please refer to the [AGENTS.md](AGENTS.md) file.
 


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/discussions/19505 .

Technically right now we are not prohibiting the use of language models to generate posts in the issues and discussion tabs. But I would consider this to be an oversight since the same logic of wasting the time of maintainers applies there as well.