### PR TITLE
build : fix case in dSYMs path for build-macos [no ci]

### DIFF
--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -534,7 +534,7 @@ xcodebuild -create-xcframework \
     -framework $(pwd)/build-ios-device/framework/llama.framework \
     -debug-symbols $(pwd)/build-ios-device/dSYMs/llama.dSYM \
     -framework $(pwd)/build-macos/framework/llama.framework \
-    -debug-symbols $(pwd)/build-macos/dSYMS/llama.dSYM \
+    -debug-symbols $(pwd)/build-macos/dSYMs/llama.dSYM \
     -framework $(pwd)/build-visionos/framework/llama.framework \
     -debug-symbols $(pwd)/build-visionos/dSYMs/llama.dSYM \
     -framework $(pwd)/build-visionos-sim/framework/llama.framework \


### PR DESCRIPTION
This commit updates an incorrect dSYMs where the the 's' was uppercase by mistake.

The motivation for fixing this is that this can cause issues on case sensitive operating systems.

Refs: https://github.com/ggml-org/whisper.cpp/pull/3630