### PR TITLE
CUDA: Enable cuda graphs for qwen3 next-style architectures

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -82,6 +82,7 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
+#include <regex>
 
 static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
 
@@ -2872,6 +2873,8 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
     const std::string ffn_moe_down_bias_prefix = "ffn_moe_down_biased";
     const std::string nemotron_h_block_out_prefix = "nemotron_h_block_out";
     const std::string mamba2_y_add_d_prefix = "mamba2_y_add_d";
+    const std::string qwen3next_diag_mask              = "diag_mask";
+    const std::regex  delta_net_linear_attn(R"(new_state-\d+)");
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -2902,7 +2905,9 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
             strncmp(node->name, ffn_moe_up_bias_prefix.c_str(), ffn_moe_up_bias_prefix.size()) != 0 &&
             strncmp(node->name, ffn_moe_down_bias_prefix.c_str(), ffn_moe_down_bias_prefix.size()) != 0 &&
             strncmp(node->name, nemotron_h_block_out_prefix.c_str(), nemotron_h_block_out_prefix.size()) != 0 &&
-            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0) {
+            strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0 &&
+            strncmp(node->name, qwen3next_diag_mask.c_str(), qwen3next_diag_mask.size()) != 0 &&
+            !std::regex_match(node->name, delta_net_linear_attn)) {
             // disable CUDA graphs for batch size > 1 for now while excluding the matrix-matrix addition as part of Gemma3n's `project_per_layer_input` operation
             // by means of matching node names. See
             // https://github.com/ggml-org/llama.cpp/blob/f9a31eea06a859e34cecb88b4d020c7f03d86cc4/src/llama-model.cpp#L10199-L10241 and

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -82,7 +82,6 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
-#include <regex>
 
 static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
 
@@ -2874,7 +2873,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
     const std::string nemotron_h_block_out_prefix      = "nemotron_h_block_out";
     const std::string mamba2_y_add_d_prefix            = "mamba2_y_add_d";
     const std::string qwen3next_diag_mask              = "diag_mask";
-    const std::regex  delta_net_linear_attn(R"(new_state-\d+)");
+    const std::string delta_net_linear_attn_prefix     = "new_state-";
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -2906,7 +2905,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
             strncmp(node->name, nemotron_h_block_out_prefix.c_str(), nemotron_h_block_out_prefix.size()) != 0 &&
             strncmp(node->name, mamba2_y_add_d_prefix.c_str(), mamba2_y_add_d_prefix.size()) != 0 &&
             strncmp(node->name, qwen3next_diag_mask.c_str(), qwen3next_diag_mask.size()) != 0 &&
-            !std::regex_match(node->name, delta_net_linear_attn)) {
+            strncmp(node->name, delta_net_linear_attn_prefix.c_str(), delta_net_linear_attn_prefix.size()) != 0) {
             // disable CUDA graphs for batch size > 1 for now while excluding the matrix-matrix addition as part of Gemma3n's `project_per_layer_input` operation
             // by means of matching node names. See
             // https://github.com/ggml-org/llama.cpp/blob/f9a31eea06a859e34cecb88b4d020c7f03d86cc4/src/llama-model.cpp#L10199-L10241 and

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2868,11 +2868,11 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 
     const std::string gemma3n_per_layer_proj_src0_name = "inp_per_layer_selected";
     const std::string gemma3n_per_layer_proj_src1_name = "per_layer_proj";
-    const std::string ffn_moe_gate_bias_prefix = "ffn_moe_gate_biased";
-    const std::string ffn_moe_up_bias_prefix = "ffn_moe_up_biased";
-    const std::string ffn_moe_down_bias_prefix = "ffn_moe_down_biased";
-    const std::string nemotron_h_block_out_prefix = "nemotron_h_block_out";
-    const std::string mamba2_y_add_d_prefix = "mamba2_y_add_d";
+    const std::string ffn_moe_gate_bias_prefix         = "ffn_moe_gate_biased";
+    const std::string ffn_moe_up_bias_prefix           = "ffn_moe_up_biased";
+    const std::string ffn_moe_down_bias_prefix         = "ffn_moe_down_biased";
+    const std::string nemotron_h_block_out_prefix      = "nemotron_h_block_out";
+    const std::string mamba2_y_add_d_prefix            = "mamba2_y_add_d";
     const std::string qwen3next_diag_mask              = "diag_mask";
     const std::regex  delta_net_linear_attn(R"(new_state-\d+)");
 
@@ -2897,8 +2897,7 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 #endif
         }
 
-        if (node->op == GGML_OP_ADD &&
-            node->src[1] && node->src[1]->ne[1] > 1 &&
+        if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1 &&
             (node->src[0] ? node->src[0]->name != gemma3n_per_layer_proj_src0_name : true) &&
             (node->src[1] ? node->src[1]->name != gemma3n_per_layer_proj_src1_name : true) &&
             strncmp(node->name, ffn_moe_gate_bias_prefix.c_str(), ffn_moe_gate_bias_prefix.size()) != 0 &&

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -22,6 +22,7 @@ llm_build_qwen3next::llm_build_qwen3next(const llama_model & model, const llm_gr
 
     ggml_tensor * identity = ggml_diag(ctx0, ggml_fill_inplace(ctx0, ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, CHUNK_SIZE), 1.0f));
     ggml_tensor * diag_mask = ggml_add(ctx0, causal_mask, identity);
+    ggml_set_name(diag_mask, "diag_mask");
 
     ggml_build_forward_expand(gf, causal_mask);
     ggml_build_forward_expand(gf, identity);


### PR DESCRIPTION
This is achieved via:
1. Adding regex for pico-batched adds that happen even when ubatch is 1
2. Bumping the consecutive updates threshold by 1.

While we already know 1. as tech-debt in cuda backend from other models, 2. was new to me. I did try to investigate what happens with the frequent graph updates and hybrid model, but could not figure it out fully:

1. We seem to build different shapes of `conv_states_updated-0` two times at ˜128 token intervals from 0 -> 24576 -> 0. This seems to come from `llm_graph_input_rs`?. My understanding is that this `conv_states_updated-0` somewhat reflect a per-sequence mapping of our conv states, whereas we will only have a single sequence in llama-bench's token-generation phase (so it should always be 0 in that case? At least in the reused ggml_cgraph-case it ends-up being 0). This change in ggml_cgraph topology is however seemingly captured by `llm_graph_result::can_reuse`.
2. `node_143` (this is somewhere in the first `build_layer_attn_linear` of qwen3next) seems to have additional data added to it despite the graph being denoted as being reusable by `llm_graph_result::can_reuse`. Is this potentially a bug? I was under the impression that graph topology is not allowed to change when its reused in `llama_context::process_ubatch`.

<details>

<summary>Relevant sections from log output and diff patch for above two points</summary>

```
./build-x64-linux-gcc-reldbg/bin/llama-bench -m /mnt/share/gguf/Qwen/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf -mmp 0 -dio 1 -fa 1 -p 0 2>&1 | tee run.txt

Middle of llama-bench
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 0
node->ne[0] mismatch: 24576 vs 0 for node->name: conv_states_updated-0 (reshaped) (view)
node 6 properties do not match, node name: conv_states_updated-0 (reshaped) (view)
can_reuse: can reuse graph = 0
node->ne[0] mismatch: 0 vs 24576 for node->name: conv_states_updated-0 (reshaped) (view)
node 6 properties do not match, node name: conv_states_updated-0 (reshaped) (view)
can_reuse: can reuse graph = 1
node->src[2]->data mismatch: 0x7f41f801d780 vs (nil) for node->name: node_144
node 143 properties do not match, node name: node_144
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
can_reuse: can reuse graph = 1
```

Applied diff to get that log
```diff
diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
index 2ac48ca99..66217ee23 100644
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2961,6 +2961,7 @@ static bool ggml_cuda_graph_node_properties_match(ggml_tensor * node, ggml_cuda_
 
     for (int i = 0; i < GGML_MAX_DIMS; i++) {
         if (node->ne[i] != props->ne[i]) {
+            printf("node->ne[%d] mismatch: %ld vs %ld for node->name: %s\n", i, node->ne[i], props->ne[i], node->name);
             return false;
         }
         if (node->nb[i] != props->nb[i]) {
@@ -2978,6 +2979,7 @@ static bool ggml_cuda_graph_node_properties_match(ggml_tensor * node, ggml_cuda_
             }
 
             if (node->src[i]->data != props->src_data[i]) {
+                printf("node->src[%d]->data mismatch: %p vs %p for node->name: %s\n", i, node->src[i]->data, props->src_data[i], node->name);
                 return false;
             }
         }
@@ -3027,6 +3029,7 @@ static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx
             props_match = ggml_cuda_graph_node_properties_match(cgraph->nodes[i], &graph->props[i]);
         }
         if (!props_match) {
+            printf("node %d properties do not match, node name: %s\n", i, cgraph->nodes[i]->name);
             res = true;
         }
         ggml_cuda_graph_node_set_properties(&graph->props[i], cgraph->nodes[i]);
diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
index bba747d37..f542cdbed 100644
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -795,6 +795,7 @@ bool llm_graph_result::can_reuse(const llm_graph_params & params) {
     if (debug > 0) {
         LLAMA_LOG_DEBUG("%s: can reuse graph = %d\n", __func__, res);
     }
+    printf("%s: can reuse graph = %d\n", __func__, res);
 
     return res;
 }

```

</details>

Maybe folks from #16490 and #16095 (@ggerganov @pwilkin @gabe-l-hart ) could chime in here.

---

I'll try to collect numbers to see if we can remove that consecutive update counter in general. This should be feasible if Capture + Launch of a `cudaGraph` is always faster than naive launch on our workloads under both Linux and Windows. 
In the mean-time, this closes #19345 

I did verify perf

```
./build-x64-linux-gcc-reldbg/bin/llama-bench -m /mnt/share/gguf/Qwen/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q8_0/Qwen3-Coder-Next-Q8_0-00001-of-00004.gguf -mmp 0 -dio 1 -fa 1 -p 0
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, compute capability 12.0, VMM: yes
| model                          |       size |     params | backend    | ngl | fa | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --: | --------------: | -------------------: |
| qwen3next 80B.A3B Q8_0         |  78.98 GiB |    79.67 B | CUDA       |  99 |  1 |   1 |           tg128 |        114.20 ± 0.81 |

build: 2a5964425 (8002)
```
and functional correctness.
```
./build-x64-linux-gcc-reldbg/bin/llama-completion -m /mnt/share/gguf/Qwen/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q8_0/Qwen3-Coder-Next-Q8_0-00001-of-00004.gguf --no-mmap -dio -fa 1 -p "Hello there"
...
- If you want to submit another line, end your input with '\'.
- Not using system message. To change it, set a different value via -sys PROMPT

user
Hello there
assistant
Hello! How can I help you today? 😊
```
