### PR TITLE
Add Jinja support for "indent" string filter

### DIFF
--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -741,7 +741,7 @@ const func_builtins & value_string_t::get_builtins() const {
                 if (!indented.empty()) {
                     indented.push_back('\n');
                 }
-                if ((indented.empty() && first) || !line.empty() || blank) {
+                if ((indented.empty() ? first : (!line.empty() || blank))) {
                     indented += indent;
                 }
                 indented += line;

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -737,25 +737,19 @@ const func_builtins & value_string_t::get_builtins() const {
             std::string input = val_input->as_string().str();
             std::istringstream iss = std::istringstream(input);
             std::string line;
-            bool first_line = true;
             while (std::getline(iss, line)) {
-                bool do_indent = true;
-                if (first_line) {
-                    first_line = false;
-                    do_indent &= first;
-                } else {
-                    indented.append("\n");
+                if (!indented.empty()) {
+                    indented.push_back('\n');
                 }
-                do_indent &= blank || !line.empty();
-                if (do_indent) {
-                   indented.append(indent);
+                if ((indented.empty() && first) || !line.empty() || blank) {
+                    indented += indent;
                 }
-                indented.append(line);
+                indented += line;
             }
             if (!input.empty() && input.back() == '\n') {
-                indented.append("\n");
+                indented.push_back('\n');
                 if (blank) {
-                    indented.append(indent);
+                    indented += indent;
                 }
             }
 

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -715,8 +715,26 @@ const func_builtins & value_string_t::get_builtins() const {
             return args.get_pos(0);
         }},
         {"tojson", tojson},
-        {"indent", [](const func_args &) -> value {
-            throw not_implemented_exception("String indent builtin not implemented");
+        {"indent", [](const func_args &args) -> value {
+            // no support for "first" as that would require us to somehow access generation context
+            args.ensure_count(2, 4);
+            args.ensure_vals<value_string, value_int, value_bool, value_bool>(true, true, false, false);
+
+            auto input = args.get_pos(0);
+            auto arg0 = args.get_pos(1);
+
+            int count = arg0->as_int();
+            if (count <= 0) {
+                throw raised_exception("indent must be a positive number");
+            }
+            std::string indented;
+            for (int i = 0; i < count; i++) {
+                indented.append(" ");
+            }
+            indented.append(input->as_string().str());
+            auto res = mk_val<value_string>(indented);
+            res->val_str.mark_input_based_on(input->as_string());
+            return res;
         }},
         {"join", [](const func_args &) -> value {
             throw not_implemented_exception("String join builtin not implemented");

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -734,7 +734,8 @@ const func_builtins & value_string_t::get_builtins() const {
                 indent = "    ";
             }
             std::string indented;
-            std::istringstream iss = std::istringstream(val_input->as_string().str());
+            std::string input = val_input->as_string().str();
+            std::istringstream iss = std::istringstream(input);
             std::string line;
             bool first_line = true;
             while (std::getline(iss, line)) {
@@ -751,6 +752,13 @@ const func_builtins & value_string_t::get_builtins() const {
                 }
                 indented.append(line);
             }
+            if (!input.empty() && input.back() == '\n') {
+                indented.append("\n");
+                if (blank) {
+                    indented.append(indent);
+                }
+            }
+
             auto res = mk_val<value_string>(indented);
             res->val_str.mark_input_based_on(val_input->as_string());
             return res;

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -692,21 +692,33 @@ static void test_filters(testing & t) {
     );
 
     test_template(t, "indent",
-        "{{ data|indent(4) }}",
+        "{{ data|indent(2) }}",
+        {{ "data", "foo\nbar" }},
+        "foo\n  bar"
+    );
+
+    test_template(t, "indent first only",
+        "{{ data|indent(width=3,first=true) }}",
+        {{ "data", "foo\nbar" }},
+        "   foo\n   bar"
+    );
+
+    test_template(t, "indent blank lines and first line",
+        "{{ data|indent(width=5,blank=true,first=true) }}",
+        {{ "data", "foo\n\nbar" }},
+        "     foo\n     \n     bar"
+    );
+
+    test_template(t, "indent with default width",
+        "{{ data|indent() }}",
         {{ "data", "foo\nbar" }},
         "foo\n    bar"
     );
 
-    test_template(t, "indent first only",
-        "{{ data|indent(width=4,first=true) }}",
+    test_template(t, "indent with string",
+        "{{ data|indent(width='>>>>') }}",
         {{ "data", "foo\nbar" }},
-        "    foo\n    bar"
-    );
-
-    test_template(t, "indent blank lines and first line",
-        "{{ data|indent(width=4,blank=true,first=true) }}",
-        {{ "data", "foo\n\nbar" }},
-        "    foo\n    \n    bar"
+        "foo\n>>>>bar"
     );
 
     test_template(t, "chained filters",

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -692,9 +692,21 @@ static void test_filters(testing & t) {
     );
 
     test_template(t, "indent",
-        "{{ data|indent(4)}}",
-        { "data", "foo" },
-        "    foo"
+        "{{ data|indent(4) }}",
+        {{ "data", "foo\nbar" }},
+        "foo\n    bar"
+    );
+
+    test_template(t, "indent first only",
+        "{{ data|indent(width=4,first=true) }}",
+        {{ "data", "foo\nbar" }},
+        "    foo\n    bar"
+    );
+
+    test_template(t, "indent blank lines and first line",
+        "{{ data|indent(width=4,blank=true,first=true) }}",
+        {{ "data", "foo\n\nbar" }},
+        "    foo\n    \n    bar"
     );
 
     test_template(t, "chained filters",

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -691,6 +691,12 @@ static void test_filters(testing & t) {
         "{\n  \"a\": 1,\n  \"b\": [\n    1,\n    2\n  ]\n}"
     );
 
+    test_template(t, "indent",
+        "{{ data|indent(4)}}",
+        { "data", "foo" },
+        "    foo"
+    );
+
     test_template(t, "chained filters",
         "{{ '  HELLO  '|trim|lower }}",
         json::object(),

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -715,6 +715,18 @@ static void test_filters(testing & t) {
         "foo\n    bar"
     );
 
+    test_template(t, "indent with no newline",
+        "{{ data|indent }}",
+        {{ "data", "foo" }},
+        "foo"
+    );
+
+    test_template(t, "indent with trailing newline",
+        "{{ data|indent(blank=true) }}",
+        {{ "data", "foo\n" }},
+        "foo\n    "
+    );
+
     test_template(t, "indent with string",
         "{{ data|indent(width='>>>>') }}",
         {{ "data", "foo\nbar" }},


### PR DESCRIPTION
Only pure `| indent` supported for now, without the `first` flag since that would require massive changes to the Jinja engine.