### PR TITLE
context : add compute type to config intermediate computation precision

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1332,6 +1332,23 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                                    string_format("error: unknown value for --flash-attn: '%s'\n", value.c_str()));
                            }
                        }).set_env("LLAMA_ARG_FLASH_ATTN"));
+    add_opt(common_arg({ "-ct", "--compute-type" }, "[f32|f16|bf16|default]",
+                       string_format("set intermediate computation precision ('f32', 'f16', 'bf16' or 'default', default: '%s')",
+                                     llama_compute_type_name(params.compute_type)),
+                       [](common_params & params, const std::string & value) {
+                           if (value == "f32") {
+                               params.compute_type = LLAMA_COMPUTE_TYPE_F32;
+                           } else if (value == "f16") {
+                               params.compute_type = LLAMA_COMPUTE_TYPE_F16;
+                           } else if (value == "bf16") {
+                               params.compute_type = LLAMA_COMPUTE_TYPE_BF16;
+                           } else if (value == "default") {
+                               params.compute_type = LLAMA_COMPUTE_TYPE_DEFAULT;
+                           } else {
+                               throw std::runtime_error(
+                                   string_format("error: unknown value for --compute-type: '%s'\n", value.c_str()));
+                           }
+                       }).set_env("LLAMA_ARG_COMPUTE_TYPE"));
     add_opt(common_arg(
         {"-p", "--prompt"}, "PROMPT",
         "prompt to start generation with; for system message, use -sys",

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1412,6 +1412,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.pooling_type      = params.pooling_type;
     cparams.attention_type    = params.attention_type;
     cparams.flash_attn_type   = params.flash_attn_type;
+    cparams.compute_type      = params.compute_type;
     cparams.cb_eval           = params.cb_eval;
     cparams.cb_eval_user_data = params.cb_eval_user_data;
     cparams.offload_kqv       = !params.no_kv_offload;

--- a/common/common.h
+++ b/common/common.h
@@ -402,6 +402,7 @@ struct common_params {
     enum llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED; // pooling type for embeddings
     enum llama_attention_type    attention_type    = LLAMA_ATTENTION_TYPE_UNSPECIFIED; // attention type for embeddings
     enum llama_flash_attn_type   flash_attn_type   = LLAMA_FLASH_ATTN_TYPE_AUTO; // whether to use Flash Attention
+    enum llama_compute_type      compute_type      = LLAMA_COMPUTE_TYPE_DEFAULT; // intermediate computation precision
 
     struct common_params_sampling    sampling;
     struct common_params_speculative speculative;

--- a/include/llama.h
+++ b/include/llama.h
@@ -188,6 +188,15 @@ extern "C" {
 
     LLAMA_API const char * llama_flash_attn_type_name(enum llama_flash_attn_type flash_attn_type);
 
+    enum llama_compute_type {
+        LLAMA_COMPUTE_TYPE_DEFAULT = 0, // no override, use model's native precision.
+        LLAMA_COMPUTE_TYPE_F32     = 1,
+        LLAMA_COMPUTE_TYPE_F16     = 2,
+        LLAMA_COMPUTE_TYPE_BF16    = 3,
+    };
+
+    LLAMA_API const char * llama_compute_type_name(enum llama_compute_type compute_type);
+
     enum llama_split_mode {
         LLAMA_SPLIT_MODE_NONE  = 0, // single GPU
         LLAMA_SPLIT_MODE_LAYER = 1, // split layers and KV across GPUs
@@ -336,6 +345,7 @@ extern "C" {
         enum llama_pooling_type      pooling_type;      // whether to pool (sum) embedding results by sequence id
         enum llama_attention_type    attention_type;    // attention type to use for embeddings
         enum llama_flash_attn_type   flash_attn_type;   // when to enable Flash Attention
+        enum llama_compute_type      compute_type;      // intermediate activation precision [EXPERIMENTAL]
 
         // ref: https://github.com/ggml-org/llama.cpp/pull/2054
         float    rope_freq_base;   // RoPE base frequency, 0 = from model

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -14,32 +14,6 @@
 #include <limits>
 #include <stdexcept>
 
-static bool model_supports_compute_type(enum llm_arch arch, ggml_type compute_type) {
-    // F32 is always supported - it's the default/safe precision
-    if (compute_type == GGML_TYPE_F32) {
-        return true;
-    }
-
-    // Nowadays FP16 and BF16 support is model-specific.
-    // Add models here as their required ops are 'compute_type' implemented and validated.
-    // Example (uncomment when ready):
-    // if (compute_type == GGML_TYPE_F16 || compute_type == GGML_TYPE_BF16) {
-    //     switch (arch) {
-    //         case LLM_ARCH_QWEN2:
-    //         case LLM_ARCH_QWEN2MOE:
-    //         case LLM_ARCH_QWEN3:
-    //         // ... other validated models
-    //             return true;
-    //         default:
-    //             return false;
-    //     }
-    // }
-
-    // No models enabled yet for non-F32 compute types
-    (void)arch;
-    return false;
-}
-
 //
 // llama_context
 //
@@ -192,15 +166,33 @@ llama_context::llama_context(
             break;
     }
 
-    // check if the model supports the requested compute type
-    if (cparams.compute_type != GGML_TYPE_F32) {
-        if (!model_supports_compute_type(model.arch, cparams.compute_type)) {
-            LLAMA_LOG_WARN("%s: model arch '%s' does not yet support compute_type %s, "
-                           "falling back to F32. To enable, the required ops must be implemented first.\n",
-                           __func__, llm_arch_name(model.arch),
-                           ggml_type_name(cparams.compute_type));
-            cparams.compute_type = GGML_TYPE_F32;
+    // Nowadays FP16 and BF16 support is model-specific.
+    // Add models here as their required ops are 'compute_type' implemented and validated.
+    auto model_supports_compute_type = [&](ggml_type ct) -> bool {
+        if (ct == GGML_TYPE_F32) {
+            return true;  // F32 is always supported
         }
+        // Example (uncomment when ready):
+        // if (ct == GGML_TYPE_F16 || ct == GGML_TYPE_BF16) {
+        //     switch (model.arch) {
+        //         case LLM_ARCH_QWEN2:
+        //         case LLM_ARCH_QWEN2MOE:
+        //         case LLM_ARCH_QWEN3:
+        //             return true;
+        //         default:
+        //             return false;
+        //     }
+        // }
+        (void)model.arch;  // no models enabled yet for non-F32 compute types
+        return false;
+    };
+
+    if (!model_supports_compute_type(cparams.compute_type)) {
+        LLAMA_LOG_WARN("%s: model arch '%s' does not yet support compute_type %s, "
+                       "falling back to F32. To enable, the required ops must be implemented first.\n",
+                       __func__, llm_arch_name(model.arch),
+                       ggml_type_name(cparams.compute_type));
+        cparams.compute_type = GGML_TYPE_F32;
     }
 
     // with causal attention, the batch size is limited by the context size

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -39,6 +39,8 @@ struct llama_cparams {
 
     enum llama_pooling_type pooling_type;
 
+    ggml_type compute_type;
+
     ggml_backend_sched_eval_callback cb_eval;
     void * cb_eval_user_data;
 };

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -862,6 +862,24 @@ void llm_graph_context::cb(ggml_tensor * cur, const char * name, int il) const {
     }
 }
 
+ggml_tensor * llm_graph_context::build_cast_to_compute_type(
+        ggml_context * ctx,
+         ggml_tensor * cur) const {
+    if (cparams.compute_type == GGML_TYPE_F32 || cur->type == cparams.compute_type) {
+        return cur;
+    }
+    return ggml_cast(ctx, cur, cparams.compute_type);
+}
+
+ggml_tensor * llm_graph_context::build_cast_to_f32(
+        ggml_context * ctx,
+         ggml_tensor * cur) const {
+    if (cur->type == GGML_TYPE_F32) {
+        return cur;
+    }
+    return ggml_cast(ctx, cur, GGML_TYPE_F32);
+}
+
 ggml_tensor * llm_graph_context::build_cvec(
          ggml_tensor * cur,
                  int   il) const {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -880,6 +880,12 @@ ggml_tensor * llm_graph_context::build_cast_to_f32(
     return ggml_cast(ctx, cur, GGML_TYPE_F32);
 }
 
+ggml_tensor * llm_graph_context::set_result_logits(ggml_tensor * cur) {
+    cur = build_cast_to_f32(ctx0, cur);
+    res->t_logits = cur;
+    return cur;
+}
+
 ggml_tensor * llm_graph_context::build_cvec(
          ggml_tensor * cur,
                  int   il) const {
@@ -1543,6 +1549,9 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
     // make sure the produced embeddings are immediately materialized in the ggml graph
     // ref: https://github.com/ggml-org/llama.cpp/pull/18599
     ggml_build_forward_expand(gf, cur);
+
+    // cast to compute_type if needed (e.g., F16 for intermediate activations)
+    cur = build_cast_to_compute_type(ctx0, cur);
 
     return cur;
 }

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -756,13 +756,16 @@ struct llm_graph_context {
 
     void cb(ggml_tensor * cur, const char * name, int il) const;
 
-    ggml_tensor * build_cast_to_compute_type( // intermediate computation precision.
+    // intermediate computation precision.
+    ggml_tensor * build_cast_to_compute_type(
             ggml_context * ctx,
              ggml_tensor * cur) const;
 
     ggml_tensor * build_cast_to_f32(
             ggml_context * ctx,
              ggml_tensor * cur) const;
+
+    ggml_tensor * set_result_logits(ggml_tensor * cur);
 
     //
     // common

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -756,6 +756,14 @@ struct llm_graph_context {
 
     void cb(ggml_tensor * cur, const char * name, int il) const;
 
+    ggml_tensor * build_cast_to_compute_type( // intermediate computation precision.
+            ggml_context * ctx,
+             ggml_tensor * cur) const;
+
+    ggml_tensor * build_cast_to_f32(
+            ggml_context * ctx,
+             ggml_tensor * cur) const;
+
     //
     // common
     //

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -43,6 +43,20 @@ const char * llama_flash_attn_type_name(enum llama_flash_attn_type flash_attn_ty
     GGML_ABORT("fatal error");
 }
 
+const char * llama_compute_type_name(enum llama_compute_type compute_type) {
+    switch (compute_type) {
+        case LLAMA_COMPUTE_TYPE_DEFAULT:
+            return "default";
+        case LLAMA_COMPUTE_TYPE_F32:
+            return "f32";
+        case LLAMA_COMPUTE_TYPE_F16:
+            return "f16";
+        case LLAMA_COMPUTE_TYPE_BF16:
+            return "bf16";
+    }
+    GGML_ABORT("fatal error");
+}
+
 struct llama_device_memory_data {
     int64_t total;
     int64_t free;


### PR DESCRIPTION
rel [#19505 ](https://github.com/ggml-org/llama.cpp/discussions/19505)
rel [#15013 ](https://github.com/ggml-org/llama.cpp/discussions/15013)

nowadays use fp32 as intermediate computation precision

Chip:  NVIDIA A40，48GB / GDDR6 / 384-bit
CUDA_VISIBLE_DEVICES=0 ./llama-bench -m ../../../llama-2-7b.Q4_0.gguf -ngl 99 -fa 0,1
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA A40, compute capability 8.6, VMM: yes
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |           pp512 |       4458.81 ± 3.89 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |           tg128 |        121.04 ± 0.05 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  1 |           pp512 |       5085.82 ± 7.97 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  1 |           tg128 |        125.71 ± 0.04 |

build: 233f5ab82 (8008)

---

I will add the performace benchmark use fp16/ (bf16 WIP) as intermediate computation precision in the feature pr.

---

- [x] *Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
