### PR TITLE
arg : use cpu_get_num_math() for --threads fallback instead of hardware_concurrency()

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -28,7 +28,6 @@
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
@@ -977,7 +976,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams.n_threads = value;
             if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams.n_threads = cpu_get_num_math();
             }
         }
     ).set_env("LLAMA_ARG_THREADS"));
@@ -987,7 +986,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams_batch.n_threads = value;
             if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams_batch.n_threads = cpu_get_num_math();
             }
         }
     ));
@@ -3030,7 +3029,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.cpuparams.n_threads = value;
             if (params.speculative.cpuparams.n_threads <= 0) {
-                params.speculative.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.speculative.cpuparams.n_threads = cpu_get_num_math();
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));
@@ -3040,7 +3039,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.cpuparams_batch.n_threads = value;
             if (params.speculative.cpuparams_batch.n_threads <= 0) {
-                params.speculative.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.speculative.cpuparams_batch.n_threads = cpu_get_num_math();
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));


### PR DESCRIPTION
## Summary

- Replace `std::thread::hardware_concurrency()` with `cpu_get_num_math()` in 4 thread-count fallback locations in `common/arg.cpp`
- Remove unused `#include <thread>` (was only needed for `hardware_concurrency`)

## Problem

When `--threads -1` (or `--threads-batch`, `--threads-draft`, `--threads-batch-draft`) is passed, the argument parser falls back to `std::thread::hardware_concurrency()` which returns the **logical** core count (including hyper-threads). On hyper-threaded CPUs, this spawns too many threads, causing context switching overhead and significant performance degradation (reported: 9 tok/s → 2.5 tok/s at 100% CPU utilization).

## Fix

Use `cpu_get_num_math()` instead, which returns the number of **physical/performance** cores. This function already exists in `common/common.cpp` and correctly handles:
- Linux: reads `/sys/devices/system/cpu/*/topology/thread_siblings` + hybrid CPU detection
- macOS: uses `sysctl hw.perflevel0.physicalcpu` / `hw.physicalcpu`
- Windows: uses `GetLogicalProcessorInformationEx(RelationProcessorCore)`

This is consistent with:
- `postprocess_cpu_params()` which already uses `cpu_get_num_math()` for the default `n_threads = -1` case
- `llama-bench` which already uses `cpu_get_num_math()` for its default thread count

## Test plan

- [ ] Verify `--threads -1` reports physical core count (not logical) in server log output
- [ ] Verify no regression on non-HT systems (physical == logical)
- [ ] Verify `--threads N` (explicit positive value) still works unchanged

Closes #19110