### PR TITLE
hexagon: fix typo in vtcm_needs_release

### DIFF
--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -189,7 +189,7 @@ static int vtcm_release_callback(unsigned int rctx, void * state) {
     // otherwise we'll release it once we're done with the current Op.
 
     if (ctx->vtcm_inuse) {
-        ctx->vtcm_needs_release = false;
+        ctx->vtcm_needs_release = true;
         return 0;
     }
 


### PR DESCRIPTION
This is very likely a typo. I'm not very familiar with hexagon, hopefully someone more familiar could confirm it.

Another question on HAP_compute_res_attr_set_release_callback:
In which context the callback is invoked?

If the callback is called from another thread, the code suffers from potential data races (The uses atomic_bool individually, but they are not guarded by a mutex all together, the classic data races problem in multi-thread code). Hexagon documentation says little on it, hopefully someone very familiar with hexagon could answer it.
