### PR TITLE
templates : fix double-escaping in gpt-oss tool call arguments and responses

### DIFF
--- a/models/templates/openai-gpt-oss-120b.jinja
+++ b/models/templates/openai-gpt-oss-120b.jinja
@@ -296,7 +296,11 @@
             {{- "<|start|>assistant to=" }}
             {{- "functions." + tool_call.name + "<|channel|>commentary " }}
             {{- (tool_call.content_type if tool_call.content_type is defined else "json") + "<|message|>" }}
-            {{- tool_call.arguments|tojson }}
+            {%- if tool_call.arguments is string -%}
+                {{- tool_call.arguments }}
+            {%- else -%}
+                {{- tool_call.arguments | tojson }}
+            {%- endif -%}
             {{- "<|call|>" }}
             {%- set last_tool_call.name = tool_call.name %}
         {%- elif loop.last and not add_generation_prompt %}
@@ -319,7 +323,7 @@
             {{- raise_exception("Message has tool role, but there was no previous assistant message with a tool call!") }}
         {%- endif %}
         {{- "<|start|>functions." + last_tool_call.name }}
-        {{- " to=assistant<|channel|>commentary<|message|>" + message.content|tojson + "<|end|>" }}
+        {{- " to=assistant<|channel|>commentary<|message|>" + message.content + "<|end|>" }}
     {%- elif message.role == 'user' -%}
         {{- "<|start|>user<|message|>" + message.content + "<|end|>" }}
     {%- endif -%}


### PR DESCRIPTION
## Summary

- Add `is string` guard to `tool_call.arguments` rendering in the GPT-OSS template to prevent double-escaping
- Remove `|tojson` from tool response `message.content` which is always a string from the API

## Problem

When using the OpenAI-compatible API with tool calls, both `tool_call.arguments` and tool response `message.content` arrive as JSON **strings**. The template unconditionally applies `|tojson` to these values, which wraps them in quotes and escapes internal quotes, producing:

```
"{\"input\":\"\",\"id\":\"fzHJ5PUy6fpkvMT4FhAtBKWdQRC0r5rJ\"}"
```

instead of the correct:

```
{"input":"","id":"fzHJ5PUy6fpkvMT4FhAtBKWdQRC0r5rJ"}
```

This causes the model to receive double-escaped JSON, leading to incorrect outputs.

## Fix

Follow the established pattern used by other templates (Hermes-2-Pro, Hermes-3, Qwen3):

```jinja
{%- if tool_call.arguments is string -%}
    {{- tool_call.arguments }}
{%- else -%}
    {{- tool_call.arguments | tojson }}
{%- endif -%}
```

This handles both cases:
- **String** (from API round-trip): output as-is
- **Dict/object** (from internal representation): serialize via `tojson`

For tool response content, simply remove `|tojson` since `message.content` is always a string per the OpenAI API spec.

## Test plan

- [ ] Verify tool call arguments are not double-escaped when passed as strings via the API
- [ ] Verify tool response content is not double-escaped
- [ ] Verify template still works when arguments are passed as dict/object (training use case)

Fixes #19520