### PR TITLE
metal : improve concurrency

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -264,15 +264,25 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
             case GGML_OP_NORM:
             case GGML_OP_RMS_NORM:
             case GGML_OP_GROUP_NORM:
+            case GGML_OP_L2_NORM:
             case GGML_OP_SUM_ROWS:
+            case GGML_OP_SSM_CONV:
+            case GGML_OP_SSM_SCAN:
+            case GGML_OP_CLAMP:
+            case GGML_OP_TRI:
+            case GGML_OP_DIAG:
             case GGML_OP_MUL:
             case GGML_OP_ADD:
             case GGML_OP_DIV:
             case GGML_OP_GLU:
             case GGML_OP_SCALE:
+            case GGML_OP_UNARY:
             case GGML_OP_GET_ROWS:
-            case GGML_OP_CPY:
             case GGML_OP_SET_ROWS:
+            case GGML_OP_SET:
+            case GGML_OP_CPY:
+            case GGML_OP_CONT:
+            case GGML_OP_REPEAT:
                 return true;
             default:
                 return ggml_op_is_empty(op);
@@ -312,7 +322,7 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
             h_add(mrs1, node0);
 
             // that many nodes forward to search for a concurrent node
-            constexpr int N_FORWARD = 8;
+            constexpr int N_FORWARD = 64;
 
             for (int i1 = i0 + 1; i1 < i0 + N_FORWARD && i1 < n; i1++) {
                 if (used[i1]) {


### PR DESCRIPTION
cont #15929

- Allow more ops to be reordered during graph optimization
- Look forward a bit further

| Model                    | Test   |   t/s master |   t/s gg/metal-concurrency-opt |   Speedup |
|:-------------------------|:-------|-------------:|-------------------------------:|----------:|
| deepseek2 30B.A3B Q8_0   | pp512  |      1358.98 |                        1406.33 |      1.03 |
| deepseek2 30B.A3B Q8_0   | tg32   |        64.34 |                          65.92 |      1.02 |
| gemma3 1B Q4_0           | pp512  |     11154.61 |                       10889.65 |      0.98 |
| gemma3 1B Q4_0           | tg32   |       231.27 |                         239.56 |      1.04 |
| gemma3 4B Q4_0           | pp512  |      2816.49 |                        2794.43 |      0.99 |
| gemma3 4B Q4_0           | tg32   |       141.79 |                         144.30 |      1.02 |
| gpt-oss 120B MXFP4 MoE   | pp512  |      1221.94 |                        1215.31 |      0.99 |
| gpt-oss 120B MXFP4 MoE   | tg32   |        89.09 |                          88.71 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | pp512  |      2415.52 |                        2422.57 |      1.00 |
| gpt-oss 20B MXFP4 MoE    | tg32   |       133.24 |                         132.79 |      1.00 |
| qwen3 0.6B Q4_0          | pp512  |     14416.27 |                       14747.46 |      1.02 |
| qwen3 0.6B Q4_0          | tg32   |       345.90 |                         342.63 |      0.99 |
| qwen3 0.6B Q8_0          | pp512  |     14326.00 |                       14602.23 |      1.02 |
| qwen3 0.6B Q8_0          | tg32   |       281.99 |                         279.62 |      0.99 |
| qwen3 4B Q8_0            | pp512  |      2479.97 |                        2508.31 |      1.01 |
| qwen3 4B Q8_0            | tg32   |       114.66 |                         114.30 |      1.00 |
| qwen3moe 30B.A3B Q4_0    | pp512  |      2158.07 |                        2171.44 |      1.01 |
| qwen3moe 30B.A3B Q4_0    | tg32   |       110.83 |                         113.80 |      1.03 |
| qwen3next 80B.A3B Q4_K_M | pp512  |       842.82 |                         850.77 |      1.01 |
| qwen3next 80B.A3B Q4_K_M | tg32   |        37.37 |                          41.46 |      1.11 |