### PR TITLE
CUDA: Do not mutate cgraph for fused ADDs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3641,6 +3641,10 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
 
                         if (n_fuse > 1) {
                             ggml_tensor fused_add_node;
+                            // Let's ensure compilation fails should ggml_tensor at one point no-longer be trivially copyable.
+                            static_assert(
+                                std::is_trivially_copyable_v<ggml_tensor>,
+                                "ggml_tensor must be trivially copyable for memcpy usage in fused-add node-creation");
                             memcpy(&fused_add_node, node, sizeof(ggml_tensor));
                             for (int j = 0; j < n_fuse - 1; ++j) {
                                 fused_add_node.src[j + 2] = cgraph->nodes[i + j + 1]->src[1];

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3640,11 +3640,13 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                         n_fuse++;
 
                         if (n_fuse > 1) {
+                            ggml_tensor fused_add_node;
+                            memcpy(&fused_add_node, node, sizeof(ggml_tensor));
                             for (int j = 0; j < n_fuse - 1; ++j) {
-                                node->src[j + 2] = cgraph->nodes[i + j + 1]->src[1];
+                                fused_add_node.src[j + 2] = cgraph->nodes[i + j + 1]->src[1];
                             }
-                            cgraph->nodes[i + n_fuse - 1]->data = node->data;
-                            ggml_cuda_op_fused_add(*cuda_ctx, node, n_fuse);
+                            fused_add_node.data = cgraph->nodes[i + n_fuse - 1]->data;
+                            ggml_cuda_op_fused_add(*cuda_ctx, &fused_add_node, n_fuse);
                             i += n_fuse - 1;
 
                             continue;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3641,10 +3641,6 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
 
                         if (n_fuse > 1) {
                             ggml_tensor fused_add_node;
-                            // Let's ensure compilation fails should ggml_tensor at one point no-longer be trivially copyable.
-                            static_assert(
-                                std::is_trivially_copyable_v<ggml_tensor>,
-                                "ggml_tensor must be trivially copyable for memcpy usage in fused-add node-creation");
                             memcpy(&fused_add_node, node, sizeof(ggml_tensor));
                             for (int j = 0; j < n_fuse - 1; ++j) {
                                 fused_add_node.src[j + 2] = cgraph->nodes[i + j + 1]->src[1];


### PR DESCRIPTION
1. We should try to minimize in-place changes to the incoming ggml_cgraph where possible (those should happen in a backends' `graph_optimize` function)
2. Modifying in-place leads to an additional, unnecessary graph capture step as we store the properties before modifying the graph in-place in the cuda-backend: We hit `ggml_cuda_graph_node_set_properties` via `ggml_cuda_graph_update_required` before entering `ggml_cuda_graph_evaluate_and_capture`. 

Isolated from #19521
