### PR TITLE
metal : fix incorrect output on AMD discrete GPUs

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-context.m
+++ b/ggml/src/ggml-metal/ggml-metal-context.m
@@ -130,7 +130,8 @@ ggml_metal_t ggml_metal_init(ggml_metal_device_t dev) {
     res->d_queue = dispatch_queue_create("ggml-metal", DISPATCH_QUEUE_CONCURRENT);
 
     res->use_fusion      = getenv("GGML_METAL_FUSION_DISABLE") == nil;
-    res->use_concurrency = getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;
+    // non-UMA GPUs (AMD discrete) produce incorrect results with concurrent encoders
+    res->use_concurrency = props_dev->has_unified_memory && getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;
 
     {
         const char * val = getenv("GGML_METAL_GRAPH_DEBUG");

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1595,7 +1595,7 @@ void ggml_metal_buffer_memset_tensor(ggml_metal_buffer_t buf, struct ggml_tensor
             id<MTLBlitCommandEncoder> encoder = [cmd_buf blitCommandEncoder];
 
             [encoder fillBuffer:bid_dst.metal
-                          range:NSMakeRange(bid_dst.offs, bid_dst.offs + size)
+                          range:NSMakeRange(bid_dst.offs, size)
                           value:value];
 
             [encoder endEncoding];


### PR DESCRIPTION
## Summary

Fixes Metal backend producing garbage output on AMD discrete GPUs (e.g. Radeon Pro 5300M). Two bugs fixed:

1. **Concurrent compute encoders break on non-UMA GPUs** — root cause of garbage output
2. **`NSMakeRange` buffer overwrite in `memset_tensor`** — secondary bug on private buffer path

Closes #19563

## Root Cause

The Metal backend enables concurrent compute command encoders by default (`MTLDispatchTypeConcurrent`), relying on `memoryBarrierWithScope:MTLBarrierScopeBuffers` to synchronize between dependent dispatches. This works on Apple Silicon but **produces incorrect results on AMD discrete GPUs** — the barriers don't properly synchronize memory on these devices.

### How we found it

Bisected by GPU layer count:
- `ngl=0` (CPU): correct
- `ngl=1`: correct  
- `ngl=2`: **garbage starts** — more layers = more concurrent dispatches = more stale reads
- `ngl=99, n=1`: first token plausible (PP completes before read-back)
- `ngl=99, n=2+`: all garbage (`@@@@@`)

This pattern pointed to an intra-command-buffer synchronization issue rather than buffer allocation, KV cache, or kernel correctness. Tested with `GGML_METAL_CONCURRENCY_DISABLE=1` — output became correct immediately.

### The fix

Gate `use_concurrency` on `has_unified_memory` (same pattern used for `use_shared_buffers`). This cleanly separates Apple Silicon (UMA, concurrency works) from AMD discrete (non-UMA, concurrency broken). The `GGML_METAL_CONCURRENCY_DISABLE` env var still works as an override.

```objc
// before
res->use_concurrency = getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;

// after
res->use_concurrency = props_dev->has_unified_memory && getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;
```

### Secondary fix: `memset_tensor` NSMakeRange

`NSMakeRange(location, length)` was called as `NSMakeRange(bid_dst.offs, bid_dst.offs + size)` — second arg should be `size`, not `offset + size`. Overwrites past intended range when tensor is at non-zero offset in a private buffer. Only affects the private buffer path (non-UMA GPUs).

## Test Results

Tested on AMD Radeon Pro 5300M, macOS 26.2, Qwen2.5-1.5B-Instruct Q4_K_M:

| Test | Before | After |
|------|--------|-------|
| ngl=99, "capital of France" | `@@@@@` garbage | "Paris" ✓ |
| ngl=99, haiku (50 tokens) | garbage | coherent output ✓ |
| ngl=2 (failure boundary) | garbage | "Paris" ✓ |
| Bench pp512/tg128 | 99/63 t/s | 99/59 t/s (no meaningful regression) |

No impact on Apple Silicon — `has_unified_memory = true` so behavior is unchanged.