### PR TITLE
vulkan: Add vendor id for Qualcomm drivers

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -92,6 +92,7 @@ static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
 #define VK_VENDOR_ID_APPLE 0x106b
 #define VK_VENDOR_ID_INTEL 0x8086
 #define VK_VENDOR_ID_NVIDIA 0x10de
+#define VK_VENDOR_ID_QUALCOMM 0x5143
 
 #define VK_DEVICE_DESCRIPTOR_POOL_SIZE 256
 
@@ -5640,6 +5641,10 @@ static void ggml_vk_instance_init() {
 #if defined(VK_API_VERSION_1_3) && VK_HEADER_VERSION >= 235
                             driver_priorities[vk::DriverId::eMesaNvk] = 2;
 #endif
+                            break;
+                        case VK_VENDOR_ID_QUALCOMM:
+                            driver_priorities[vk::DriverId::eQualcommProprietary] = 1;
+                            driver_priorities[vk::DriverId::eMesaTurnip] = 2;
                             break;
                     }
                     driver_priorities[vk::DriverId::eMesaDozen] = 100;


### PR DESCRIPTION
This PR allows Qualcomm native vulkan driver to be used on Windows instead of Mesa Dozen.

Before this change, Mesa Dozen will be chosen by default:

```
ggml_vk_instance_init()
Device 1 and device 0 have the same deviceUUID
Prioritize device 1 driver Dozen over device 1 driver Qualcomm Technologies Inc. Adreno Vulkan Driver
ggml_vulkan: Found 1 Vulkan devices:
ggml_vk_print_gpu_info(1)
ggml_vulkan: 0 = Microsoft Direct3D12 (Qualcomm(R) Adreno(TM) X1-85 GPU) (Dozen) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 32768 | int dot: 1 | matrix cores: none
```

vulkaninfo output:

```
Devices:
========
GPU0:
        apiVersion         = 1.3.295
        driverVersion      = 0.851.0
        vendorID           = 0x5143
        deviceID           = 0x36334330
        deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
        deviceName         = Qualcomm(R) Adreno(TM) X1-85 GPU
        driverID           = DRIVER_ID_QUALCOMM_PROPRIETARY
        driverName         = Qualcomm Technologies Inc. Adreno Vulkan Driver
        driverInfo         = Driver Build: b674a1bb7c, I20d9b72c2f, 1764667494
Date: 12/02/2025
Compiler Version: E031.50.28.02
Driver Branch: hamoa

        conformanceVersion = 1.3.9.1
        deviceUUID         = 43510000-0600-0000-12c5-6000140012c5
        driverUUID         = 04000000-0100-0000-0300-000000000000
GPU1:
        apiVersion         = 1.2.340
        driverVersion      = 26.0.99
        vendorID           = 0x4d4f4351
        deviceID           = 0x36334330
        deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
        deviceName         = Microsoft Direct3D12 (Qualcomm(R) Adreno(TM) X1-85 GPU)
        driverID           = DRIVER_ID_MESA_DOZEN
        driverName         = Dozen
        driverInfo         = Mesa 26.1.0-devel (git-219807d38d)
        conformanceVersion = 0.0.0.0
        deviceUUID         = 476207f0-994f-41c1-aca3-206f4394572f
        driverUUID         = b30bd6a0-24da-0477-389b-cfab42d98252
GPU2:
        apiVersion         = 1.2.340
        driverVersion      = 26.0.99
        vendorID           = 0x1414
        deviceID           = 0x008c
        deviceType         = PHYSICAL_DEVICE_TYPE_CPU
        deviceName         = Microsoft Direct3D12 (Microsoft Basic Render Driver)
        driverID           = DRIVER_ID_MESA_DOZEN
        driverName         = Dozen
        driverInfo         = Mesa 26.1.0-devel (git-219807d38d)
        conformanceVersion = 0.0.0.0
        deviceUUID         = cbf97468-ccff-654e-83d8-6647a64581c2
        driverUUID         = b30bd6a0-24da-0477-389b-cfab42d98252
```