### PR TITLE
ggml-cpu: arm64: Fix wrong memcpy length for q4_K block_interleave == 4

### DIFF
--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1916,9 +1916,10 @@ static block_q4_Kx8 make_block_q4_Kx8(block_q4_K * in, unsigned int blck_size_in
         int src_offset = (i / 8) * blck_size_interleave;
         int dst_offset = i * blck_size_interleave;
 
+        // buffer large enough for the max interleave block size (8 bytes)
         uint64_t elems;
-        memcpy(&elems, &in[src_id].qs[src_offset], sizeof(uint64_t));
-        memcpy(&out.qs[dst_offset], &elems, sizeof(uint64_t));
+        memcpy(&elems, &in[src_id].qs[src_offset], blck_size_interleave);
+        memcpy(&out.qs[dst_offset], &elems, blck_size_interleave);
     }
 
     // The below logic is designed so as to unpack and rearrange scales and mins values in Q4_K


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/issues/19561 reports issues with the stack for Q4_K. 
I can't reproduce the issue locally, but the `make_block_q4_Kx8` function would write past the buffer size 4 extra bytes,  which could be the issue. 

@taronaeo, since you found the problem, are you able to check if this patch fixes it?
 
Q6_K and Q5_K (https://github.com/ggml-org/llama.cpp/pull/19356, still opened at the moment this description was written) already address this problem.