### PR TITLE
scripts : use official split.py for cpp-httplib

### DIFF
--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
 import urllib.request
+import os
+import sys
+import subprocess
 
 HTTPLIB_VERSION = "f80864ca031932351abef49b74097c67f14719c6"
 
@@ -14,7 +17,8 @@ vendor = {
     # "https://github.com/mackron/miniaudio/raw/refs/tags/0.11.23/miniaudio.h": "vendor/miniaudio/miniaudio.h",
     "https://github.com/mackron/miniaudio/raw/669ed3e844524fcd883231b13095baee9f6de304/miniaudio.h": "vendor/miniaudio/miniaudio.h",
 
-    f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/httplib.h": "vendor/cpp-httplib/httplib.h",
+    f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/httplib.h": "httplib.h",
+    f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/split.py":  "split.py",
     f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/LICENSE":   "vendor/cpp-httplib/LICENSE",
 
     "https://raw.githubusercontent.com/sheredom/subprocess.h/b49c56e9fe214488493021017bf3954b91c7c1f5/subprocess.h": "vendor/sheredom/subprocess.h",
@@ -24,19 +28,15 @@ for url, filename in vendor.items():
     print(f"downloading {url} to {filename}") # noqa: NP100
     urllib.request.urlretrieve(url, filename)
 
-    # split cpp/h files for httplib
-    # see: https://github.com/yhirose/cpp-httplib/blob/master/split.py
-    if 'httplib.h' in filename:
-        border = '// ----------------------------------------------------------------------------'
-        with open(filename, 'r') as f:
-            content = f.read()
-        header, implementation, footer = content.split(border, 2)
-        fname_cpp = filename.replace('.h', '.cpp')
-        with open(filename, 'w') as fh:
-            fh.write(header)
-            fh.write(footer)
-        with open(fname_cpp, 'w') as fc:
-            fc.write('#include "httplib.h"\n')
-            fc.write('namespace httplib {\n')
-            fc.write(implementation.replace('\ninline ', '\n'))
-            fc.write('} // namespace httplib\n')
+print("Splitting httplib.h...")
+try:
+    subprocess.check_call([
+        sys.executable, "split.py",
+        "--extension", "cpp",
+        "--out", "vendor/cpp-httplib"
+    ])
+    os.remove("split.py")
+    os.remove("httplib.h")
+except subprocess.CalledProcessError as e:
+    print(f"Error running split.py: {e}")
+    sys.exit(1)

--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -28,7 +28,7 @@ for url, filename in vendor.items():
     print(f"downloading {url} to {filename}") # noqa: NP100
     urllib.request.urlretrieve(url, filename)
 
-print("Splitting httplib.h...")
+print("Splitting httplib.h...") # noqa: NP100
 try:
     subprocess.check_call([
         sys.executable, "split.py",
@@ -38,5 +38,5 @@ try:
     os.remove("split.py")
     os.remove("httplib.h")
 except Exception as e:
-    print(f"Error: {e}")
+    print(f"Error: {e}") # noqa: NP100
     sys.exit(1)

--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -35,8 +35,9 @@ try:
         "--extension", "cpp",
         "--out", "vendor/cpp-httplib"
     ])
-    os.remove("split.py")
-    os.remove("httplib.h")
 except Exception as e:
     print(f"Error: {e}") # noqa: NP100
     sys.exit(1)
+finally:
+    os.remove("split.py")
+    os.remove("httplib.h")

--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -37,6 +37,6 @@ try:
     ])
     os.remove("split.py")
     os.remove("httplib.h")
-except subprocess.CalledProcessError as e:
-    print(f"Error running split.py: {e}")
+except Exception as e:
+    print(f"Error: {e}")
     sys.exit(1)

--- a/vendor/cpp-httplib/httplib.cpp
+++ b/vendor/cpp-httplib/httplib.cpp
@@ -1,7 +1,6 @@
 #include "httplib.h"
 namespace httplib {
 
-
 /*
  * Implementation that will be part of the .cc file if split into .h + .cc.
  */
@@ -1219,7 +1218,7 @@ int close_socket(socket_t sock) {
 #endif
 }
 
-template <typename T> inline ssize_t handle_EINTR(T fn) {
+template <typename T> ssize_t handle_EINTR(T fn) {
   ssize_t res = 0;
   while (true) {
     res = fn();

--- a/vendor/cpp-httplib/httplib.h
+++ b/vendor/cpp-httplib/httplib.h
@@ -3336,7 +3336,6 @@ private:
 } // namespace sse
 
 
-
 } // namespace httplib
 
 #endif // CPPHTTPLIB_HTTPLIB_H


### PR DESCRIPTION
Using the official script is safer and ensures the generated code aligns with the library's standards.
