### PR TITLE
Add a build target to generate ROCm artifacts using ROCm 7.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,6 +516,102 @@ jobs:
           path: llama-bin-win-sycl-x64.zip
           name: llama-bin-win-sycl-x64.zip
 
+  ubuntu-22-rocm:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        include:
+          - ROCM_VERSION: "7.11.0"
+            gpu_targets: "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
+            build: x64
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.16
+        with:
+          key: ubuntu-rocm-cmake-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}
+          evict-old-files: 1d
+
+      - name: Dependencies
+        id: depends
+        run: |
+          sudo apt install -y build-essential git cmake wget
+
+      - name: Setup Legacy ROCm
+        if: matrix.ROCM_VERSION == '7.2'
+        id: legacy_env
+        run: |
+          sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+          wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+            gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+
+          sudo tee /etc/apt/sources.list.d/rocm.list << EOF
+          deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${{ matrix.ROCM_VERSION }} jammy main
+          EOF
+
+          sudo tee /etc/apt/preferences.d/rocm-pin-600 << EOF
+          Package: *
+          Pin: release o=repo.radeon.com
+          Pin-Priority: 600
+          EOF
+
+          sudo apt update
+          sudo apt-get install -y libssl-dev rocm-hip-sdk
+
+      - name: Setup TheRock
+        if: matrix.ROCM_VERSION != '7.2'
+        id: therock_env
+        run: |
+          wget https://repo.amd.com/rocm/tarball/therock-dist-linux-gfx1151-${{ matrix.ROCM_VERSION }}.tar.gz
+          mkdir install
+          tar -xf *.tar.gz -C install
+          export ROCM_PATH=$(pwd)/install
+          echo ROCM_PATH=$ROCM_PATH >> $GITHUB_ENV
+          echo PATH=$PATH:$ROCM_PATH/bin >> $GITHUB_ENV
+          echo LD_LIBRARY_PATH=$ROCM_PATH/lib:$ROCM_PATH/llvm/lib:$ROCM_PATH/lib/rocprofiler-systems >> $GITHUB_ENV
+
+      - name: Build with native CMake HIP support
+        id: cmake_build
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
+            -DCMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_STATIC=OFF \
+            -DGPU_TARGETS="${{ matrix.gpu_targets }}" \
+            -DGGML_HIP=ON \
+            -DHIP_PLATFORM=amd \
+            -DGGML_HIP_ROCWMMA_FATTN=ON \
+            -DLLAMA_CURL=OFF \
+            -DGGML_RPC=ON \
+            -DLLAMA_BUILD_BORINGSSL=ON
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Determine tag name
+        id: tag
+        uses: ./.github/actions/get-tag-name
+
+      - name: Pack artifacts
+        id: pack_artifacts
+        run: |
+          cp LICENSE ./build/bin/
+          tar -czvf llama-bin-ubuntu-rocm-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}.tar.gz --transform "s,./,llama-${{ steps.tag.outputs.name }}/," -C ./build/bin .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          path: llama-bin-ubuntu-rocm-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}.tar.gz
+          name: llama-bin-ubuntu-rocm-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}.tar.gz
+
   windows-hip:
     runs-on: windows-2022
 
@@ -784,6 +880,7 @@ jobs:
       - windows-cuda
       - windows-sycl
       - windows-hip
+      - ubuntu-22-rocm
       - ubuntu-22-cpu
       - ubuntu-22-vulkan
       - macOS-arm64
@@ -868,6 +965,7 @@ jobs:
             **Linux:**
             - [Ubuntu x64 (CPU)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-x64.tar.gz)
             - [Ubuntu x64 (Vulkan)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-vulkan-x64.tar.gz)
+            - [Ubuntu x64 (ROCm 7.11.0)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-rocm-7.11.0-x64.tar.gz)
             - [Ubuntu s390x (CPU)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-s390x.tar.gz)
 
             **Windows:**


### PR DESCRIPTION
This builds the following targets:
 * gfx906
 * gfx908
 * gfx90a
 * gfx942
 * gfx950
 * gfx1100
 * gfx1101
 * gfx1102
 * gfx1150
 * gfx1151
 * gfx1152
 * gfx1200
 * gfx1201

For size reasons this artifact does NOT contain the ROCm stack, the user will be required to install that separately from AMD or their distro to use the binaries in the artifact.

This is an ALTERNATIVE to using 7.2 (https://github.com/ggml-org/llama.cpp/pull/19433).  Let me explain.

AMD has made a change to the [build system](https://github.com/rocm/therock) and rather than doing monolithic builds now generates per-architecture builds.  This allows supporting more ISAs.  You can read more about it in the [release notes for 7.11](https://rocm.docs.amd.com/en/7.11.0-preview/about/release-notes.html) and various [blogs](https://rocm.blogs.amd.com/software-tools-optimization/therock/README.html) and documentation linked to them.

Because of this users don't need to install a very large stack that includes ALL of CDNA, RDNA3, RDNA4 ISAs etc for a single GPU ISA.

Because of this transition happening with AMD ROCm builds, I think it makes sense to NOT distribute ROCm "inside" a llama.cpp artifact.  The requirement should be a user installs ROCm first, and then can use the artifact.

1. Install ROCm per [AMD's documentation](https://rocm.docs.amd.com/en/7.11.0-preview/install/rocm.html?fam=ryzen&gpu=max-pro-395&os=ubuntu&os-version=24.04&i=pkgman) (or in some cases distros have it in native repos too).  This can be done via `apt`, `pip` or a tarball.
2. If using tarball set up LD_LIBRARY_PATH so that all libraries can be found.  This is part of AMD's documentation.
3. Download artifact
4. Run llama.cpp

You'll notice that I downloaded the GFX1151 tarball in the CI target.  To prove this approach works this is what I did.
1. Build the artifact using GFX1151 tarball (you can see CI run here: https://github.com/superm1/llama.cpp/actions/runs/21990274735)
2. Downloaded and extracted TheRock tarball for GFX1150 (very intentionally NOT GFX1151).
3. Set up `LD_LIBRARY_PATH` to cover the place I extracted the tarball (in my case `LD_LIBRARY_PATH=~/src/therock-install/lib`
4. Downloaded and extracted github artifact
5. Added path of github artifact to `LD_LIBRARY_PATH` as well
6. Ran `llama-server` and verified it works.

---
I _feel_ that this approach is scalable for AMD's future ROCm release strategy.  When there is a 7.12 release, a new matrix entry can be made for building ROCm 7.12 llama.cpp artifacts the same way.  Same thing with 7.13, etc.

CC @slojosic-amd and @IMbackK for comments as well