### PR TITLE
mtmd : chat : Fix extra \n between text and media marker

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -84,7 +84,7 @@ json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
                     text += '\n';
                 }
 
-                text           += part.text;
+                text += part.text;
             }
             jmsg["content"] = text;
         } else {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -68,14 +68,22 @@ json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
             bool last_was_media_marker = false;
             // join parts with newline, do not add newline before or after media markers
             for (const auto & part : content_parts) {
-                if (part.type != "text" && part.type != "media_marker") {
+                bool add_new_line = true;
+                if (part.type == "text") {
+                    add_new_line = !last_was_media_marker && !text.empty();
+                    last_was_media_marker = false;
+                } else if (part.type == "media_marker") {
+                    add_new_line = false;
+                    last_was_media_marker = true;
+                } else {
                     LOG_WRN("Ignoring content part type: %s\n", part.type.c_str());
                     continue;
                 }
-                if (part.type != "media_marker" && !last_was_media_marker && !text.empty()) {
+
+                if (add_new_line) {
                     text += '\n';
                 }
-                last_was_media_marker  = (part.type == "media_marker");
+
                 text           += part.text;
             }
             jmsg["content"] = text;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3318,7 +3318,7 @@ static common_chat_params common_chat_templates_apply_legacy(
     for (const auto & msg : inputs.messages) {
         auto content = msg.content;
         for (const auto & part : msg.content_parts) {
-            if (part.type != "text") {
+            if (part.type != "text" && part.type != "media_marker") {
                 LOG_WRN("Ignoring non-text content part: %s\n", part.type.c_str());
                 continue;
             }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -916,8 +916,7 @@ json oaicompat_chat_params_parse(
                 json image_url = json_value(p, "image_url", json::object());
                 handle_media(out_files, image_url, opt.media_path);
 
-                // replace this chunk with a marker
-                p["type"] = "text";
+                p["type"] = "media_marker";
                 p["text"] = mtmd_default_marker();
                 p.erase("image_url");
 
@@ -938,8 +937,7 @@ json oaicompat_chat_params_parse(
 
                 // TODO: add audio_url support by reusing handle_media()
 
-                // replace this chunk with a marker
-                p["type"] = "text";
+                p["type"] = "media_marker";
                 p["text"] = mtmd_default_marker();
                 p.erase("input_audio");
 


### PR DESCRIPTION
Thanks to @tugot17 for detecting and reporting the issue.

For vision models (e.g. LFM2.5-VL-1.6B and Qwen/Qwen3-VL-4B-Instruct) `llama-mtmd-cli` produces identical output to HF implementation.

However `llama-server` doesn't. I traced it down to extra newline inserted after `<__media__>`.

This happens in `to_json_oaicompat`, that treats media markers as text and joins all parts with `\n` separator.

PR introduces new type `media_marker` and uses it for media markers. Extra logic is added to prevent insertion of newlines before and after media markers.

With this change number of input tokens is identical to HF implementation and as a result the output is also identical.

I explored other ways to address the issue
* remove completely `\n` between text parts in `to_json_oaicompat`
* merge text messages in server-common.cpp before sending them to `to_json_oaicompat`

Please propose alternative ways of fixing this issue.