### PR TITLE
ggml-threading: use transactional memory from TSX instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,17 @@ cmake_minimum_required(VERSION 3.14) # for add_link_options and implicit target 
 project("llama.cpp" C CXX)
 include(CheckIncludeFileCXX)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag("-mrtm" C_RTM_SUPPORTED)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-mrtm" CXX_RTM_SUPPORTED)
+    if(C_RTM_SUPPORTED AND CXX_RTM_SUPPORTED)
+        message(STATUS "RTM support detected, adding -mrtm flag")
+        add_compile_options("-mrtm")
+    endif()
+endif()
+
 #set(CMAKE_WARN_DEPRECATED YES)
 set(CMAKE_WARN_UNUSED_CLI YES)
 

--- a/ggml/src/ggml-threading.cpp
+++ b/ggml/src/ggml-threading.cpp
@@ -1,12 +1,27 @@
 #include "ggml-threading.h"
 #include <mutex>
 
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#endif
+
 std::mutex ggml_critical_section_mutex;
 
 void ggml_critical_section_start() {
+#if defined(__x86_64__) || defined(_M_X64)
+    if (_xbegin() == _XBEGIN_STARTED) {
+        return;
+    }
+#endif
     ggml_critical_section_mutex.lock();
 }
 
 void ggml_critical_section_end(void) {
+#if defined(__x86_64__) || defined(_M_X64)
+    if (_xtest()) {
+        _xend();
+        return;
+    }
+#endif
     ggml_critical_section_mutex.unlock();
 }


### PR DESCRIPTION
This has become relevant again, as Linux since version 7.0 makes unlocking TSX instructions automatic.

References:
- https://en.wikipedia.org/wiki/Transactional_Synchronization_Extensions
- https://www.phoronix.com/news/Intel-TSX-Auto-Linux-7.0
- https://natsys-lab.blogspot.com/2013/11/studying-intel-tsx-performance.html
