### PR TITLE
[server] save generated text for the /slots endpoint (for LLAMA_SERVER_SLOTS_DEBUG=1)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -426,7 +426,7 @@ struct server_slot {
 
             if (!only_metrics) {
                 res["prompt"] = ptask->tokens.detokenize(ctx, true);
-                res["generated"] = generated_text.empty()?debug_generated_text:generated_text;
+                res["generated"] = generated_text.empty() ? debug_generated_text : generated_text;
             }
         }
 
@@ -1445,7 +1445,7 @@ private:
         res->index           = slot.task->index;
 
         // keep copy of last generated text for debugging purposes
-        if (slots_debug > 0) {
+        if (slots_debug) {
             slot.debug_generated_text = slot.generated_text;
         }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1445,7 +1445,9 @@ private:
         res->index           = slot.task->index;
 
         // keep copy of last generated text for debugging purposes
-        slot.debug_generated_text = slot.generated_text;
+        if (slots_debug > 0) {
+            slot.debug_generated_text = slot.generated_text;
+        }
 
         // in stream mode, content and tokens are already in last partial chunk
         if (slot.task->params.stream) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -77,6 +77,7 @@ struct server_slot {
     size_t last_nl_pos = 0;
 
     std::string  generated_text;
+    std::string  debug_generated_text;
     llama_tokens generated_tokens;
 
     // idx of draft tokens in the main batch
@@ -425,7 +426,7 @@ struct server_slot {
 
             if (!only_metrics) {
                 res["prompt"] = ptask->tokens.detokenize(ctx, true);
-                res["generated"] = generated_text;
+                res["generated"] = generated_text.empty()?debug_generated_text:generated_text;
             }
         }
 
@@ -1442,6 +1443,10 @@ private:
         res->id_slot = slot.id;
 
         res->index           = slot.task->index;
+
+        // keep copy of last generated text for debugging purposes
+        slot.debug_generated_text = slot.generated_text;
+
         // in stream mode, content and tokens are already in last partial chunk
         if (slot.task->params.stream) {
             res->content     = "";


### PR DESCRIPTION
when the environment variable `LLAMA_SERVER_SLOTS_DEBUG=1` is set, the `/slots` endpoint allows reading the last prompt and the last generated text.

The slot reset also deletes the generated text, so it always looks empty when the slot is idle.

This PR adds a variable to allow keeping the data until a new generation is started.