### PR TITLE
Unload models based on VRAM usage

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -61,6 +61,7 @@ extern "C" {
     struct llama_model;
     struct llama_context;
     struct llama_sampler;
+    struct llama_memory_breakdown_data;
 
     typedef struct llama_memory_i * llama_memory_t;
 
@@ -1525,6 +1526,7 @@ extern "C" {
     LLAMA_API void                           llama_perf_sampler_print(const struct llama_sampler * chain);
     LLAMA_API void                           llama_perf_sampler_reset(      struct llama_sampler * chain);
 
+    LLAMA_API size_t llama_get_total_memory_usage(const struct llama_context * ctx);
     // print a breakdown of per-device memory use via LLAMA_LOG:
     LLAMA_API void llama_memory_breakdown_print(const struct llama_context * ctx);
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3532,6 +3532,15 @@ void llama_perf_context_reset(llama_context * ctx) {
     ctx->perf_reset();
 }
 
+size_t llama_get_total_memory_usage(const struct llama_context * ctx) {
+    const auto memory_breakdown = ctx->memory_breakdown();
+    size_t total = 0;
+    for (const auto &it : memory_breakdown) {
+        total += it.second.total();
+    }
+    return total;
+}
+
 void llama_memory_breakdown_print(const struct llama_context * ctx) {
     const std::vector<ggml_backend_dev_t> & devices = ctx->get_model().devices;
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -100,6 +100,7 @@ struct server_routes {
     server_http_context::handler_t post_anthropic_count_tokens;
     server_http_context::handler_t post_apply_template;
     server_http_context::handler_t get_models;
+    server_http_context::handler_t get_vram;
     server_http_context::handler_t post_tokenize;
     server_http_context::handler_t post_detokenize;
     server_http_context::handler_t post_embeddings;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -450,6 +450,28 @@ void server_models::load(const std::string & name) {
         throw std::runtime_error("model name=" + name + " is not found");
     }
     unload_lru();
+    // TODO: move this into its own method and somehow use the results to unload models, if necessary.
+    for (const auto &m : mapping) {
+        if (m.second.meta.status != SERVER_MODEL_STATUS_LOADED) {
+            continue;
+        }
+        try {
+            std::unique_ptr<server_http_req> request = std::make_unique<server_http_req>(server_http_req{
+                {},
+                {},
+                "/vram",
+                "",
+                []() { return false; }
+            });
+            server_http_res_ptr res = proxy_request(*request, "GET", m.first, false);
+            std::string chunk;
+            while (res->next(chunk)) {
+                // TODO: accumulate the chunks and parse the JSON
+            }
+        } catch (std::exception &e) {
+            std::cerr << "EXCEPTION " << e.what() << std::endl;
+        }
+    }
 
     std::lock_guard<std::mutex> lk(mutex);
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -171,6 +171,7 @@ int main(int argc, char ** argv) {
     ctx_http.get ("/models",              ex_wrapper(routes.get_models)); // public endpoint (no API key check)
     ctx_http.get ("/v1/models",           ex_wrapper(routes.get_models)); // public endpoint (no API key check)
     ctx_http.get ("/api/tags",            ex_wrapper(routes.get_models)); // ollama specific endpoint. public endpoint (no API key check)
+    ctx_http.get ("/vram",                ex_wrapper(routes.get_vram));
     ctx_http.post("/completion",          ex_wrapper(routes.post_completions)); // legacy
     ctx_http.post("/completions",         ex_wrapper(routes.post_completions));
     ctx_http.post("/v1/completions",      ex_wrapper(routes.post_completions_oai));


### PR DESCRIPTION
This is to track my progress on https://github.com/ggml-org/llama.cpp/discussions/19425. When finished, I'll create a pull request against llama.cpp directly.

llama.cpp currently has a flag to unload models after a fixed number has been reached. I'm trying to implement a strategy that unloads models when there's not enough VRAM to fit the new model. Otherwise, you can load as many models as you want.