### PR TITLE
fix modernBERT conversion to GGUF

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10966,7 +10966,7 @@ class ModernBertModel(BertModel):
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         # these layers act as MLM head, so we don't need them
-        if name.startswith("decoder."):
+        if name.startswith("decoder.") or name.startswith("head.norm"):
             return
 
         if name.startswith("model."):


### PR DESCRIPTION
Fixed bug that was causing conversion to fail: `python convert_hf_to_gguf.py ModernBERT-base --outfile modernbert-base-f16.gguf --outtype f16`

Basically we have to ignore the head decoder norm from `answerdotai/ModernBERT-base`

