### PR TITLE
model-conversion : make printing of config values optional

### DIFF
--- a/examples/model-conversion/scripts/causal/run-org-model.py
+++ b/examples/model-conversion/scripts/causal/run-org-model.py
@@ -42,11 +42,15 @@ def load_model_and_tokenizer(model_path, device="auto"):
         config = config.text_config
         multimodal = True
 
-    print("Vocab size:       ", config.vocab_size)
-    print("Hidden size:      ", config.hidden_size)
-    print("Number of layers: ", config.num_hidden_layers)
-    print("BOS token id:     ", config.bos_token_id)
-    print("EOS token id:     ", config.eos_token_id)
+    def print_if_exists(label, obj, attr, default="N/A"):
+        if (val := getattr(obj, attr, None)) is not None:
+            print(f"{label}", val)
+
+    print_if_exists("Vocab size:       ", config, "vocab_size")
+    print_if_exists("Hidden size:      ", config, "hidden_size")
+    print_if_exists("Number of layers: ", config, "num_hidden_layers")
+    print_if_exists("BOS token id:     ", config, "bos_token_id")
+    print_if_exists("EOS token id:     ", config, "eos_token_id")
 
     unreleased_model_name = os.getenv("UNRELEASED_MODEL_NAME")
     if unreleased_model_name:

--- a/examples/model-conversion/scripts/causal/run-org-model.py
+++ b/examples/model-conversion/scripts/causal/run-org-model.py
@@ -43,8 +43,8 @@ def load_model_and_tokenizer(model_path, device="auto"):
         multimodal = True
 
     def print_if_exists(label, obj, attr, default="N/A"):
-        if (val := getattr(obj, attr, None)) is not None:
-            print(f"{label}", val)
+        val = getattr(obj, attr) if hasattr(obj, attr) else default
+        print(f"{label}", val)
 
     print_if_exists("Vocab size:       ", config, "vocab_size")
     print_if_exists("Hidden size:      ", config, "hidden_size")


### PR DESCRIPTION
This commit updates run-org-model.py to make the printing of model configuration values optional.

The motivation for this change is that not all models have these configuration values defined and those that do not will error when running this script. With these changes we only print the values if they exist.

We could optionally just remove them but it can be useful to see these values when running the original model.