### PR TITLE
model-conversion : add option to print tensor values

### DIFF
--- a/examples/model-conversion/scripts/utils/tensor-info.py
+++ b/examples/model-conversion/scripts/utils/tensor-info.py
@@ -78,7 +78,7 @@ def list_all_tensors(model_path: Path, unique: bool = False):
             print(tensor_name)
 
 
-def print_tensor_info(model_path: Path, tensor_name: str):
+def print_tensor_info(model_path: Path, tensor_name: str, num_values: Optional[int] = None):
     tensor_file = find_tensor_file(model_path, tensor_name)
 
     if tensor_file is None:
@@ -96,6 +96,12 @@ def print_tensor_info(model_path: Path, tensor_name: str):
                 print(f"Tensor: {tensor_name}")
                 print(f"File:   {tensor_file}")
                 print(f"Shape:  {shape}")
+                if num_values is not None:
+                    tensor = f.get_tensor(tensor_name)
+                    print(f"Dtype:  {tensor.dtype}")
+                    flat = tensor.flatten()
+                    n = min(num_values, flat.numel())
+                    print(f"Values: {flat[:n].tolist()}")
             else:
                 print(f"Error: Tensor '{tensor_name}' not found in {tensor_file}")
                 sys.exit(1)
@@ -127,6 +133,15 @@ def main():
         action="store_true",
         help="List unique tensor patterns in the model (layer numbers replaced with #)"
     )
+    parser.add_argument(
+        "-n", "--num-values",
+        nargs="?",
+        const=10,
+        default=None,
+        type=int,
+        metavar="N",
+        help="Print the first N values of the tensor flattened (default: 10 if flag is given without a number)"
+    )
 
     args = parser.parse_args()
 
@@ -152,7 +167,7 @@ def main():
         if args.tensor_name is None:
             print("Error: tensor_name is required when not using --list")
             sys.exit(1)
-        print_tensor_info(model_path, args.tensor_name)
+        print_tensor_info(model_path, args.tensor_name, args.num_values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit updates the tensor-info.py script to support the option to print the first N values of a tensor when displaying its information.

The motivation for this is that it can be useful to inspect some actual values in addition to the shapes of the tensors.

----
Example usage:
```console
./scripts/utils/tensor-info.py -m ~/work/models/moonshotai/Kimi-Linear model.layers.0.self_attn.A_log -n 32

Tensor: model.layers.0.self_attn.A_log
File:   model-00001-of-00020.safetensors
Shape:  [1, 1, 32, 1]
Dtype:  torch.float32
Values: [1.103968620300293, -0.20674507319927216, 0.06409236788749695, 2.277034282684326, 3.3999674320220947, 4.209522724151611, 1.915040135383606, 3.1779892444610596, 3.0966317653656006, 1.5971810817718506, 4.7506303787231445, -0.4733889102935791, 2.5522594451904297, 5.304281234741211, -0.31161242723464966, 2.7692441940307617, 2.7018637657165527, 2.3136250972747803, 1.659307837486267, 3.121227741241455, -1.488243579864502, 2.63500714302063, -0.8697880506515503, 3.5412185192108154, 2.9536848068237305, 2.9326748847961426, 2.8871192932128906, 2.265052080154419, 3.379794120788574, 2.962221622467041, 3.7428195476531982, 3.0271267890930176]
```