### PR TITLE
common : fix gpt-oss Jinja error with content and thinking on tool-call messages

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2032,6 +2032,7 @@ static common_chat_params common_chat_params_init_gpt_oss(const common_chat_temp
         if (has_reasoning_content && has_tool_calls) {
             auto adjusted_message = msg;
             adjusted_message["thinking"] = msg.at("reasoning_content");
+            adjusted_message.erase("content");
             adjusted_messages.push_back(adjusted_message);
         } else {
             adjusted_messages.push_back(msg);


### PR DESCRIPTION
## Summary

- Fix Jinja template error "Cannot pass both content and thinking in an assistant message with tool calls" when using gpt-oss models (e.g. [ggml-org/gpt-oss-120b-GGUF](https://huggingface.co/ggml-org/gpt-oss-120b-GGUF)) with `--reasoning-format auto` in multi-turn tool-call conversations
- Erase `content` from the adjusted message after copying `reasoning_content` to `thinking` in `common_chat_params_init_gpt_oss()`
- Regression from #16937

Fixes #19701

## Details

When a client sends back conversation history containing assistant messages with `content`, `reasoning_content`, and `tool_calls`, the gpt-oss input processing copies `reasoning_content` → `thinking` but leaves `content` in place. The gpt-oss Jinja template forbids having both `content` and `thinking` on tool-call messages (they render to the same `<|channel|>analysis` slot), causing an HTTP 500 error.

The fix is a single line: `adjusted_message.erase("content")` after setting `thinking`.

## Test plan

- [x] Served `ggml-org/gpt-oss-120b-GGUF` with `--reasoning-format auto --jinja`
- [x] Sent multi-turn chat completions with tool calls — confirmed no more 500 errors
- [x] First-turn requests continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)