### PR TITLE
common : fix gpt-oss Jinja error with content and thinking on tool-call messages

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2032,6 +2032,7 @@ static common_chat_params common_chat_params_init_gpt_oss(const common_chat_temp
         if (has_reasoning_content && has_tool_calls) {
             auto adjusted_message = msg;
             adjusted_message["thinking"] = msg.at("reasoning_content");
+            adjusted_message.erase("content");
             adjusted_messages.push_back(adjusted_message);
         } else {
             adjusted_messages.push_back(msg);


### PR DESCRIPTION
Erase the `content` from the adjusted message after copying `reasoning_content` to `thinking`.

Regression from #16937

Fixes #19703.

All four tests related to chat have passed in this fix:

- test-chat
- test-chat-parser
- test-chat-peg-parser
- test-chat-template

AI was used in an assistive capacity to help trace the regression source.