### PR TITLE
server: add OpenAI Responses API compliance

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1191,16 +1191,17 @@ json convert_responses_to_chatcmpl(const json & response_body) {
                 //     item.at("status") == "completed" ||
                 //     item.at("status") == "incomplete") &&
                 // item["status"] not sent by codex-cli
-                exists_and_is_string(item, "type") &&
-                item.at("type") == "message"
+                // item["type"] == "message" for OutputMessage, absent for EasyInputMessage
+                (!item.contains("type") || item.at("type") == "message")
             ) {
                 // #responses_create-input-input_item_list-item-output_message
+                // Also handles AssistantMessageItemParam / EasyInputMessage with role "assistant"
                 std::vector<json> chatcmpl_content;
 
                 for (const auto & output_text : item.at("content")) {
                     const std::string type = json_value(output_text, "type", std::string());
-                    if (type != "output_text") {
-                        throw std::invalid_argument("'type' must be 'output_text'");
+                    if (type != "output_text" && type != "input_text") {
+                        throw std::invalid_argument("'type' must be 'output_text' or 'input_text'");
                     }
                     if (!exists_and_is_string(output_text, "text")) {
                         throw std::invalid_argument("'Output text' requires 'text'");

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -109,6 +109,7 @@ struct task_result_state {
     const std::string oai_resp_reasoning_id;
     const std::string oai_resp_message_id;
     std::string oai_resp_fc_id; // function call ID for current args delta
+    int oai_resp_seq_num = 0;  // sequence number counter for streaming events
 
     task_result_state(const common_chat_parser_params & chat_parser_params)
         : chat_parser_params(chat_parser_params)
@@ -367,6 +368,7 @@ struct server_task_result_cmpl_final : server_task_result {
     std::string oai_resp_id;
     std::string oai_resp_reasoning_id;
     std::string oai_resp_message_id;
+    int oai_resp_seq_num = 0;
 
     virtual bool is_stop() override {
         return true; // in stream mode, final responses are considered stop
@@ -381,6 +383,7 @@ struct server_task_result_cmpl_final : server_task_result {
         oai_resp_id = state.oai_resp_id;
         oai_resp_reasoning_id = state.oai_resp_reasoning_id;
         oai_resp_message_id = state.oai_resp_message_id;
+        oai_resp_seq_num = state.oai_resp_seq_num;
     }
 
     json to_json_non_oaicompat();
@@ -430,6 +433,7 @@ struct server_task_result_cmpl_partial : server_task_result {
     std::string oai_resp_reasoning_id;
     std::string oai_resp_message_id;
     std::string oai_resp_fc_id;
+    int * oai_resp_seq_num_ptr = nullptr; // pointer to persistent counter in task_result_state
 
     // for Anthropic API: track if any reasoning content has been generated
     bool anthropic_has_reasoning = false;


### PR DESCRIPTION
Fix Response object schema, streaming event schema, and multi-turn conversation input parsing for /v1/responses endpoint.

- Add 24 missing fields to Response object (tools, truncation, temperature, etc.)
- Add sequence_number, output_index, content_index, item_id, logprobs to all streaming events
- Add annotations and logprobs to content part objects
- Fix completed_at and usage fields on response.created/in_progress events
- Fix function_call output item structure (id vs call_id)
- Fix multi-turn input parsing to handle both OutputMessage and AssistantMessageItemParam

Passes 5/6 compliance tests (Image Input requires mmproj, not a code issue).

Fixes #19138

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
