### PR TITLE
grammars: fix README - non-terminals can contain uppercase

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -36,7 +36,7 @@ castle ::= ...
 
 ## Non-Terminals and Terminals
 
-Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. They are required to be a dashed lowercase word, like `move`, `castle`, or `check-mate`.
+Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. They are required to be an identifier (a word containing letters, digits, and underscores), like `move`, `castle`, or `check_mate`.
 
 Terminals are actual characters ([code points](https://en.wikipedia.org/wiki/Code_point)). They can be specified as a sequence like `"1"` or `"O-O"` or as ranges like `[1-9]` or `[NBKQR]`.
 


### PR DESCRIPTION
The documentation incorrectly stated that non-terminal symbols must be lowercase. They can contain uppercase letters, digits, and underscores (e.g., `dataType` in c.gbnf).

Fixes ggml-org/llama.cpp#7720