### PR TITLE
feat: add --spec-ngram-adaptive flag for dynamic draft bounds

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -5,49 +5,48 @@
 #include "download.h"
 #include "json-schema-to-grammar.h"
 #include "log.h"
+#include "preset.h"
 #include "sampling.h"
 #include "speculative.h"
-#include "preset.h"
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#   define NOMINMAX
-#endif
-#include <windows.h>
+#    define WIN32_LEAN_AND_MEAN
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
 #endif
 
 #define JSON_ASSERT GGML_ASSERT
-#include <nlohmann/json.hpp>
-
 #include <algorithm>
 #include <cinttypes>
 #include <climits>
 #include <cstdarg>
 #include <fstream>
 #include <list>
+#include <nlohmann/json.hpp>
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
+#include <thread>  // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
-#ifdef __linux__
-#include <linux/limits.h>
-#elif defined(_WIN32)
-#   if !defined(PATH_MAX)
-#   define PATH_MAX MAX_PATH
-#   endif
-#elif defined(_AIX)
-#include <sys/limits.h>
-#else
-#include <sys/syslimits.h>
-#endif
+#    ifdef __linux__
+#        include <linux/limits.h>
+#    elif defined(_WIN32)
+#        if !defined(PATH_MAX)
+#            define PATH_MAX MAX_PATH
+#        endif
+#    elif defined(_AIX)
+#        include <sys/limits.h>
+#    else
+#        include <sys/syslimits.h>
+#    endif
 #endif
 
-#define LLAMA_MAX_URL_LENGTH 2084 // Maximum URL Length in Chrome: 2083
+#define LLAMA_MAX_URL_LENGTH 2084  // Maximum URL Length in Chrome: 2083
 
 extern const char * LICENSES[];
 
@@ -73,7 +72,7 @@ static std::string read_file(const std::string & fname) {
 static const std::vector<common_arg> & get_common_arg_defs() {
     static const std::vector<common_arg> options = [] {
         common_params params;
-        auto ctx = common_params_parser_init(params, LLAMA_EXAMPLE_SERVER, nullptr);
+        auto          ctx = common_params_parser_init(params, LLAMA_EXAMPLE_SERVER, nullptr);
         return ctx.options;
     }();
     return options;
@@ -90,7 +89,7 @@ common_arg & common_arg::set_excludes(std::initializer_list<enum llama_example> 
 }
 
 common_arg & common_arg::set_env(const char * env) {
-    help = help + "\n(env: " + env + ")";
+    help      = help + "\n(env: " + env + ")";
     this->env = env;
     return *this;
 }
@@ -114,14 +113,16 @@ bool common_arg::is_exclude(enum llama_example ex) {
 }
 
 bool common_arg::get_value_from_env(std::string & output) const {
-    if (env == nullptr) return false;
+    if (env == nullptr) {
+        return false;
+    }
     if (!args_neg.empty()) {
         // for compatibility, we need to check LLAMA_ARG_NO_ env as well
         std::string neg_env = env;
         string_replace_all(neg_env, "LLAMA_ARG_", "LLAMA_ARG_NO_");
         char * neg_value = std::getenv(neg_env.c_str());
         if (neg_value) {
-            output = "0"; // falsey
+            output = "0";  // falsey
             return true;
         }
     }
@@ -147,23 +148,27 @@ bool common_arg::has_value_from_env() const {
 
 static std::vector<std::string> break_str_into_lines(std::string input, size_t max_char_per_line) {
     std::vector<std::string> result;
-    std::istringstream iss(input);
-    std::string line;
-    auto add_line = [&](const std::string& l) {
+    std::istringstream       iss(input);
+    std::string              line;
+    auto                     add_line = [&](const std::string & l) {
         if (l.length() <= max_char_per_line) {
             result.push_back(l);
         } else {
             std::istringstream line_stream(l);
-            std::string word, current_line;
+            std::string        word, current_line;
             while (line_stream >> word) {
                 if (current_line.length() + !current_line.empty() + word.length() > max_char_per_line) {
-                    if (!current_line.empty()) result.push_back(current_line);
+                    if (!current_line.empty()) {
+                        result.push_back(current_line);
+                    }
                     current_line = word;
                 } else {
                     current_line += (!current_line.empty() ? " " : "") + word;
                 }
             }
-            if (!current_line.empty()) result.push_back(current_line);
+            if (!current_line.empty()) {
+                result.push_back(current_line);
+            }
         }
     };
     while (std::getline(iss, line)) {
@@ -174,28 +179,32 @@ static std::vector<std::string> break_str_into_lines(std::string input, size_t m
 
 std::string common_arg::to_string() const {
     // params for printing to console
-    const static int n_leading_spaces = 40;
-    const static int n_char_per_line_help = 70; // TODO: detect this based on current console
-    std::string leading_spaces(n_leading_spaces, ' ');
+    const static int n_leading_spaces     = 40;
+    const static int n_char_per_line_help = 70;  // TODO: detect this based on current console
+    std::string      leading_spaces(n_leading_spaces, ' ');
 
     std::ostringstream ss;
-    auto all_args = get_args(); // also contains args_neg
+    auto               all_args = get_args();  // also contains args_neg
     for (const auto & arg : all_args) {
         if (arg == all_args.front()) {
             if (all_args.size() == 1) {
                 ss << arg;
             } else {
                 // first arg is usually abbreviation, we need padding to make it more beautiful
-                auto tmp = std::string(arg) + ", ";
-                auto spaces = std::string(std::max(0, 7 - (int)tmp.size()), ' ');
+                auto tmp    = std::string(arg) + ", ";
+                auto spaces = std::string(std::max(0, 7 - (int) tmp.size()), ' ');
                 ss << tmp << spaces;
             }
         } else {
             ss << arg << (arg != all_args.back() ? ", " : "");
         }
     }
-    if (value_hint) ss << " " << value_hint;
-    if (value_hint_2) ss << " " << value_hint_2;
+    if (value_hint) {
+        ss << " " << value_hint;
+    }
+    if (value_hint_2) {
+        ss << " " << value_hint_2;
+    }
     if (ss.tellp() > n_leading_spaces - 3) {
         // current line is too long, add new line
         ss << "\n" << leading_spaces;
@@ -240,10 +249,11 @@ std::vector<std::string> common_arg::get_env() const {
 //
 
 // Helper function to parse tensor buffer override strings
-static void parse_tensor_buffer_overrides(const std::string & value, std::vector<llama_model_tensor_buft_override> & overrides) {
+static void parse_tensor_buffer_overrides(const std::string &                             value,
+                                          std::vector<llama_model_tensor_buft_override> & overrides) {
     std::map<std::string, ggml_backend_buffer_type_t> buft_list;
     for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-        auto * dev = ggml_backend_dev_get(i);
+        auto * dev  = ggml_backend_dev_get(i);
         auto * buft = ggml_backend_dev_buffer_type(dev);
         if (buft) {
             buft_list[ggml_backend_buft_name(buft)] = buft;
@@ -268,7 +278,7 @@ static void parse_tensor_buffer_overrides(const std::string & value, std::vector
         // keep strings alive and avoid leaking memory by storing them in a static vector
         static std::list<std::string> buft_overrides;
         buft_overrides.push_back(tensor_name);
-        overrides.push_back({buft_overrides.back().c_str(), buft_list.at(buffer_type)});
+        overrides.push_back({ buft_overrides.back().c_str(), buft_list.at(buffer_type) });
     }
 }
 
@@ -290,26 +300,26 @@ static bool common_params_handle_remote_preset(common_params & params, llama_exa
         hf_tag = "default";
     }
 
-    const bool offline = params.offline;
+    const bool  offline        = params.offline;
     std::string model_endpoint = get_model_endpoint();
-    auto preset_url = model_endpoint + hf_repo + "/resolve/main/preset.ini";
+    auto        preset_url     = model_endpoint + hf_repo + "/resolve/main/preset.ini";
 
     // prepare local path for caching
-    auto preset_fname = clean_file_name(hf_repo + "_preset.ini");
-    auto preset_path = fs_get_cache_file(preset_fname);
-    const int status = common_download_file_single(preset_url, preset_path, params.hf_token, offline);
-    const bool has_preset = status >= 200 && status < 400;
+    auto       preset_fname = clean_file_name(hf_repo + "_preset.ini");
+    auto       preset_path  = fs_get_cache_file(preset_fname);
+    const int  status       = common_download_file_single(preset_url, preset_path, params.hf_token, offline);
+    const bool has_preset   = status >= 200 && status < 400;
 
     // remote preset is optional, so we don't error out if not found
     if (has_preset) {
         LOG_INF("applying remote preset from %s\n", preset_url.c_str());
         common_preset_context ctx(ex, /* only_remote_allowed */ true);
-        common_preset global;
-        auto remote_presets = ctx.load_from_ini(preset_path, global);
-        remote_presets = ctx.cascade(global, remote_presets);
+        common_preset         global;
+        auto                  remote_presets = ctx.load_from_ini(preset_path, global);
+        remote_presets                       = ctx.cascade(global, remote_presets);
         if (remote_presets.find(hf_tag) != remote_presets.end()) {
             common_preset preset = remote_presets.at(hf_tag);
-            LOG_INF("\n%s", preset.to_ini().c_str()); // to_ini already added trailing newline
+            LOG_INF("\n%s", preset.to_ini().c_str());  // to_ini already added trailing newline
             preset.apply_to_params(params);
         } else {
             throw std::runtime_error("Remote preset.ini does not contain [" + std::string(hf_tag) + "] section");
@@ -322,30 +332,29 @@ static bool common_params_handle_remote_preset(common_params & params, llama_exa
 }
 
 struct handle_model_result {
-    bool found_mmproj = false;
+    bool                found_mmproj = false;
     common_params_model mmproj;
 };
 
-static handle_model_result common_params_handle_model(
-        struct common_params_model & model,
-        const std::string & bearer_token,
-        bool offline) {
+static handle_model_result common_params_handle_model(struct common_params_model & model,
+                                                      const std::string &          bearer_token,
+                                                      bool                         offline) {
     handle_model_result result;
     // handle pre-fill default model path and url based on hf_repo and hf_file
     {
-        if (!model.docker_repo.empty()) {  // Handle Docker URLs by resolving them to local paths
+        if (!model.docker_repo.empty()) {    // Handle Docker URLs by resolving them to local paths
             model.path = common_docker_resolve_model(model.docker_repo);
-            model.name = model.docker_repo; // set name for consistency
+            model.name = model.docker_repo;  // set name for consistency
         } else if (!model.hf_repo.empty()) {
             // short-hand to avoid specifying --hf-file -> default it to --model
             if (model.hf_file.empty()) {
                 if (model.path.empty()) {
                     auto auto_detected = common_get_hf_file(model.hf_repo, bearer_token, offline);
                     if (auto_detected.repo.empty() || auto_detected.ggufFile.empty()) {
-                        exit(1); // error message already printed
+                        exit(1);                         // error message already printed
                     }
-                    model.name    = model.hf_repo;      // repo name with tag
-                    model.hf_repo = auto_detected.repo; // repo name without tag
+                    model.name    = model.hf_repo;       // repo name with tag
+                    model.hf_repo = auto_detected.repo;  // repo name without tag
                     model.hf_file = auto_detected.ggufFile;
                     if (!auto_detected.mmprojFile.empty()) {
                         result.found_mmproj   = true;
@@ -358,21 +367,20 @@ static handle_model_result common_params_handle_model(
             }
 
             std::string model_endpoint = get_model_endpoint();
-            model.url = model_endpoint + model.hf_repo + "/resolve/main/" + model.hf_file;
+            model.url                  = model_endpoint + model.hf_repo + "/resolve/main/" + model.hf_file;
             // make sure model path is present (for caching purposes)
             if (model.path.empty()) {
                 // this is to avoid different repo having same file name, or same file name in different subdirs
                 std::string filename = clean_file_name(model.hf_repo + "_" + model.hf_file);
-                model.path = fs_get_cache_file(filename);
+                model.path           = fs_get_cache_file(filename);
             }
 
         } else if (!model.url.empty()) {
             if (model.path.empty()) {
-                auto f = string_split<std::string>(model.url, '#').front();
-                f = string_split<std::string>(f, '?').front();
+                auto f     = string_split<std::string>(model.url, '#').front();
+                f          = string_split<std::string>(f, '?').front();
                 model.path = fs_get_cache_file(string_split<std::string>(f, '/').back());
             }
-
         }
     }
 
@@ -389,15 +397,8 @@ static handle_model_result common_params_handle_model(
 }
 
 const std::vector<ggml_type> kv_cache_types = {
-    GGML_TYPE_F32,
-    GGML_TYPE_F16,
-    GGML_TYPE_BF16,
-    GGML_TYPE_Q8_0,
-    GGML_TYPE_Q4_0,
-    GGML_TYPE_Q4_1,
-    GGML_TYPE_IQ4_NL,
-    GGML_TYPE_Q5_0,
-    GGML_TYPE_Q5_1,
+    GGML_TYPE_F32,  GGML_TYPE_F16,    GGML_TYPE_BF16, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0,
+    GGML_TYPE_Q4_1, GGML_TYPE_IQ4_NL, GGML_TYPE_Q5_0, GGML_TYPE_Q5_1,
 };
 
 static ggml_type kv_cache_type_from_str(const std::string & s) {
@@ -437,10 +438,10 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
     std::unordered_map<std::string, std::pair<common_arg *, bool>> arg_to_options;
     for (auto & opt : ctx_arg.options) {
         for (const auto & arg : opt.args) {
-            arg_to_options[arg] = {&opt, /* is_positive */ true};
+            arg_to_options[arg] = { &opt, /* is_positive */ true };
         }
         for (const auto & arg : opt.args_neg) {
-            arg_to_options[arg] = {&opt, /* is_positive */ false};
+            arg_to_options[arg] = { &opt, /* is_positive */ false };
         }
     }
 
@@ -463,15 +464,15 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
                     continue;
                 }
             } catch (std::exception & e) {
-                throw std::invalid_argument(string_format(
-                    "error while handling environment variable \"%s\": %s\n\n", opt.env, e.what()));
+                throw std::invalid_argument(
+                    string_format("error while handling environment variable \"%s\": %s\n\n", opt.env, e.what()));
             }
         }
     }
 
     // handle command line arguments
     auto check_arg = [&](int i) {
-        if (i+1 >= argc) {
+        if (i + 1 >= argc) {
             throw std::invalid_argument("expected value for argument");
         }
     };
@@ -490,13 +491,18 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
                 throw std::invalid_argument(string_format("error: invalid argument: %s", arg.c_str()));
             }
             if (!seen_args.insert(arg).second) {
-                LOG_WRN("DEPRECATED: argument '%s' specified multiple times, use comma-separated values instead (only last value will be used)\n", arg.c_str());
+                LOG_WRN(
+                    "DEPRECATED: argument '%s' specified multiple times, use comma-separated values instead (only last "
+                    "value will be used)\n",
+                    arg.c_str());
             }
-            auto & tmp = arg_to_options[arg];
-            auto opt = *tmp.first;
-            bool is_positive = tmp.second;
+            auto & tmp         = arg_to_options[arg];
+            auto   opt         = *tmp.first;
+            bool   is_positive = tmp.second;
             if (opt.has_value_from_env()) {
-                fprintf(stderr, "warn: %s environment variable is set, but will be overwritten by command line argument %s\n", opt.env, arg.c_str());
+                fprintf(stderr,
+                        "warn: %s environment variable is set, but will be overwritten by command line argument %s\n",
+                        opt.env, arg.c_str());
             }
             try {
                 if (opt.handler_void) {
@@ -528,10 +534,10 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
                     continue;
                 }
             } catch (std::exception & e) {
-                throw std::invalid_argument(string_format(
-                    "error while handling argument \"%s\": %s\n\n"
-                    "usage:\n%s\n\nto show complete usage, run with -h",
-                    arg.c_str(), e.what(), opt.to_string().c_str()));
+                throw std::invalid_argument(
+                    string_format("error while handling argument \"%s\": %s\n\n"
+                                  "usage:\n%s\n\nto show complete usage, run with -h",
+                                  arg.c_str(), e.what(), opt.to_string().c_str()));
             }
         }
     };
@@ -542,12 +548,12 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
     // maybe handle remote preset
     if (!params.model.hf_repo.empty()) {
         std::string cli_hf_repo = params.model.hf_repo;
-        bool has_preset = common_params_handle_remote_preset(params, ctx_arg.ex);
+        bool        has_preset  = common_params_handle_remote_preset(params, ctx_arg.ex);
 
         // special case: if hf_repo explicitly set by preset, we need to preserve it (ignore CLI value)
         // this is useful when we have one HF repo pointing to other HF repos (one model - multiple GGUFs)
-        std::string preset_hf_repo = params.model.hf_repo;
-        bool preset_has_hf_repo = preset_hf_repo != cli_hf_repo;
+        std::string preset_hf_repo     = params.model.hf_repo;
+        bool        preset_has_hf_repo = preset_hf_repo != cli_hf_repo;
 
         if (has_preset) {
             // re-parse CLI args to override preset values
@@ -560,10 +566,10 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         }
     }
 
-    postprocess_cpu_params(params.cpuparams,       nullptr);
+    postprocess_cpu_params(params.cpuparams, nullptr);
     postprocess_cpu_params(params.cpuparams_batch, &params.cpuparams);
 
-    postprocess_cpu_params(params.speculative.cpuparams,       &params.cpuparams);
+    postprocess_cpu_params(params.speculative.cpuparams, &params.cpuparams);
     postprocess_cpu_params(params.speculative.cpuparams_batch, &params.cpuparams_batch);
 
     if (params.prompt_cache_all && (params.interactive || params.interactive_first)) {
@@ -582,12 +588,12 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         // only download mmproj if the current example is using it
         for (const auto & ex : mmproj_examples) {
             if (ctx_arg.ex == ex) {
-                common_params_handle_model(params.mmproj,    params.hf_token, params.offline);
+                common_params_handle_model(params.mmproj, params.hf_token, params.offline);
                 break;
             }
         }
         common_params_handle_model(params.speculative.mparams_dft, params.hf_token, params.offline);
-        common_params_handle_model(params.vocoder.model,           params.hf_token, params.offline);
+        common_params_handle_model(params.vocoder.model, params.hf_token, params.offline);
     }
 
     // model is required (except for server)
@@ -620,19 +626,19 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
     // pad tensor_buft_overrides for llama_params_fit:
     const size_t ntbo = llama_max_tensor_buft_overrides();
     while (params.tensor_buft_overrides.size() < ntbo) {
-        params.tensor_buft_overrides.push_back({nullptr, nullptr});
+        params.tensor_buft_overrides.push_back({ nullptr, nullptr });
     }
 
     if (!params.speculative.tensor_buft_overrides.empty()) {
-        params.speculative.tensor_buft_overrides.push_back({nullptr, nullptr});
+        params.speculative.tensor_buft_overrides.push_back({ nullptr, nullptr });
     }
 
     if (!params.chat_template.empty() && !common_chat_verify_template(params.chat_template, params.use_jinja)) {
         throw std::runtime_error(string_format(
-            "error: the supplied chat template is not supported: %s%s\n",
-            params.chat_template.c_str(),
-            params.use_jinja ? "" : "\nnote: llama.cpp was started without --jinja, we only support commonly used templates"
-        ));
+            "error: the supplied chat template is not supported: %s%s\n", params.chat_template.c_str(),
+            params.use_jinja ?
+                "" :
+                "\nnote: llama.cpp was started without --jinja, we only support commonly used templates"));
     }
 
     common_log_set_verbosity_thold(params.verbosity);
@@ -724,57 +730,55 @@ static void common_params_print_completion(common_params_context & ctx_arg) {
     printf("    esac\n");
     printf("}\n\n");
 
-    std::set<std::string> executables = {
-        "llama-batched",
-        "llama-batched-bench",
-        "llama-bench",
-        "llama-cli",
-        "llama-completion",
-        "llama-convert-llama2c-to-ggml",
-        "llama-cvector-generator",
-        "llama-embedding",
-        "llama-eval-callback",
-        "llama-export-lora",
-        "llama-gen-docs",
-        "llama-gguf",
-        "llama-gguf-hash",
-        "llama-gguf-split",
-        "llama-gritlm",
-        "llama-imatrix",
-        "llama-infill",
-        "llama-mtmd-cli",
-        "llama-llava-clip-quantize-cli",
-        "llama-lookahead",
-        "llama-lookup",
-        "llama-lookup-create",
-        "llama-lookup-merge",
-        "llama-lookup-stats",
-        "llama-parallel",
-        "llama-passkey",
-        "llama-perplexity",
-        "llama-q8dot",
-        "llama-quantize",
-        "llama-qwen2vl-cli",
-        "llama-retrieval",
-        "llama-save-load-state",
-        "llama-server",
-        "llama-simple",
-        "llama-simple-chat",
-        "llama-speculative",
-        "llama-speculative-simple",
-        "llama-tokenize",
-        "llama-tts",
-        "llama-vdot"
-    };
+    std::set<std::string> executables = { "llama-batched",
+                                          "llama-batched-bench",
+                                          "llama-bench",
+                                          "llama-cli",
+                                          "llama-completion",
+                                          "llama-convert-llama2c-to-ggml",
+                                          "llama-cvector-generator",
+                                          "llama-embedding",
+                                          "llama-eval-callback",
+                                          "llama-export-lora",
+                                          "llama-gen-docs",
+                                          "llama-gguf",
+                                          "llama-gguf-hash",
+                                          "llama-gguf-split",
+                                          "llama-gritlm",
+                                          "llama-imatrix",
+                                          "llama-infill",
+                                          "llama-mtmd-cli",
+                                          "llama-llava-clip-quantize-cli",
+                                          "llama-lookahead",
+                                          "llama-lookup",
+                                          "llama-lookup-create",
+                                          "llama-lookup-merge",
+                                          "llama-lookup-stats",
+                                          "llama-parallel",
+                                          "llama-passkey",
+                                          "llama-perplexity",
+                                          "llama-q8dot",
+                                          "llama-quantize",
+                                          "llama-qwen2vl-cli",
+                                          "llama-retrieval",
+                                          "llama-save-load-state",
+                                          "llama-server",
+                                          "llama-simple",
+                                          "llama-simple-chat",
+                                          "llama-speculative",
+                                          "llama-speculative-simple",
+                                          "llama-tokenize",
+                                          "llama-tts",
+                                          "llama-vdot" };
 
-    for (const auto& exe : executables) {
+    for (const auto & exe : executables) {
         printf("complete -F _llama_completions %s\n", exe.c_str());
     }
 }
 
 static std::vector<ggml_backend_dev_t> parse_device_list(const std::string & value) {
     std::vector<ggml_backend_dev_t> devices;
-    auto dev_names = string_split<std::string>(value, ',');
+    auto                            dev_names = string_split<std::string>(value, ',');
     if (dev_names.empty()) {
         throw std::invalid_argument("no devices specified");
     }
@@ -803,7 +807,8 @@ static void add_rpc_devices(const std::string & servers) {
         throw std::invalid_argument("failed to find RPC backend");
     }
     typedef ggml_backend_reg_t (*ggml_backend_rpc_add_server_t)(const char * endpoint);
-    ggml_backend_rpc_add_server_t ggml_backend_rpc_add_server_fn = (ggml_backend_rpc_add_server_t) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_add_server");
+    ggml_backend_rpc_add_server_t ggml_backend_rpc_add_server_fn =
+        (ggml_backend_rpc_add_server_t) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_add_server");
     if (!ggml_backend_rpc_add_server_fn) {
         throw std::invalid_argument("failed to find RPC add server function");
     }
@@ -814,7 +819,7 @@ static void add_rpc_devices(const std::string & servers) {
 }
 
 bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<common_arg, std::string> & out_map) {
-    common_params dummy_params;
+    common_params         dummy_params;
     common_params_context ctx_arg = common_params_parser_init(dummy_params, ex, nullptr);
 
     std::unordered_map<std::string, common_arg *> arg_to_options;
@@ -831,7 +836,7 @@ bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<com
 
     // handle command line arguments
     auto check_arg = [&](int i) {
-        if (i+1 >= argc) {
+        if (i + 1 >= argc) {
             throw std::invalid_argument("expected value for argument");
         }
     };
@@ -849,14 +854,17 @@ bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<com
             throw std::invalid_argument(string_format("error: invalid argument: %s", arg.c_str()));
         }
         if (!seen_args.insert(arg).second) {
-            LOG_WRN("DEPRECATED: argument '%s' specified multiple times, use comma-separated values instead (only last value will be used)\n", arg.c_str());
+            LOG_WRN(
+                "DEPRECATED: argument '%s' specified multiple times, use comma-separated values instead (only last "
+                "value will be used)\n",
+                arg.c_str());
         }
-        auto opt = *arg_to_options[arg];
+        auto        opt = *arg_to_options[arg];
         std::string val;
         if (opt.value_hint == nullptr && opt.value_hint_2 == nullptr) {
             // bool arg (need to reverse the meaning for negative args)
             bool is_neg = std::find(opt.args_neg.begin(), opt.args_neg.end(), arg) != opt.args_neg.end();
-            val = is_neg ? "0" : "1";
+            val         = is_neg ? "0" : "1";
         }
         if (opt.value_hint != nullptr) {
             // arg with single value
@@ -873,9 +881,13 @@ bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<com
     return true;
 }
 
-bool common_params_parse(int argc, char ** argv, common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
-    auto ctx_arg = common_params_parser_init(params, ex, print_usage);
-    const common_params params_org = ctx_arg.params; // the example can modify the default params
+bool common_params_parse(int             argc,
+                         char **         argv,
+                         common_params & params,
+                         llama_example   ex,
+                         void (*print_usage)(int, char **)) {
+    auto                ctx_arg    = common_params_parser_init(params, ex, print_usage);
+    const common_params params_org = ctx_arg.params;  // the example can modify the default params
 
     try {
         if (!common_params_parse_ex(argc, argv, ctx_arg)) {
@@ -900,7 +912,7 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
         return false;
     } catch (std::exception & ex) {
         fprintf(stderr, "%s\n", ex.what());
-        exit(1); // for other exceptions, we exit with status code 1
+        exit(1);  // for other exceptions, we exit with status code 1
     }
 
     return true;
@@ -908,7 +920,7 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
 
 static std::string list_builtin_chat_templates() {
     std::vector<const char *> supported_tmpl;
-    int32_t res = llama_chat_builtin_templates(nullptr, 0);
+    int32_t                   res = llama_chat_builtin_templates(nullptr, 0);
     supported_tmpl.resize(res);
     res = llama_chat_builtin_templates(supported_tmpl.data(), supported_tmpl.size());
     std::ostringstream msg;
@@ -934,10 +946,10 @@ bool common_arg_utils::is_autoy(const std::string & value) {
 // example:
 //    input:  value1,"value, with, commas","value with ""escaped"" quotes",value4
 //    output: [value1] [value, with, commas] [value with "escaped" quotes] [value4]
-static std::vector<std::string> parse_csv_row(const std::string& input) {
+static std::vector<std::string> parse_csv_row(const std::string & input) {
     std::vector<std::string> fields;
-    std::string field;
-    bool in_quotes = false;
+    std::string              field;
+    bool                     in_quotes = false;
 
     for (size_t i = 0; i < input.length(); ++i) {
         char ch = input[i];
@@ -949,15 +961,15 @@ static std::vector<std::string> parse_csv_row(const std::string& input) {
                     // quote appeared in middle of unquoted field, treat as literal
                     field += '"';
                 } else {
-                    in_quotes = true; // start
+                    in_quotes = true;  // start
                 }
             } else {
                 if (i + 1 < input.length() && input[i + 1] == '"') {
                     // escaped quote: ""
                     field += '"';
-                    ++i; // skip the next quote
+                    ++i;                // skip the next quote
                 } else {
-                    in_quotes = false; // end
+                    in_quotes = false;  // end
                 }
             }
         } else if (ch == ',') {
@@ -978,18 +990,20 @@ static std::vector<std::string> parse_csv_row(const std::string& input) {
     return fields;
 }
 
-common_params_context common_params_parser_init(common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
+common_params_context common_params_parser_init(common_params & params,
+                                                llama_example   ex,
+                                                void (*print_usage)(int, char **)) {
     // per-example default params
     // we define here to make sure it's included in llama-gen-docs
     if (ex == LLAMA_EXAMPLE_COMPLETION) {
-        params.use_jinja = false;   // disable jinja by default
+        params.use_jinja = false;  // disable jinja by default
 
     } else if (ex == LLAMA_EXAMPLE_MTMD) {
-        params.use_jinja = false;   // disable jinja by default
-        params.sampling.temp = 0.2; // lower temp by default for better quality
+        params.use_jinja     = false;  // disable jinja by default
+        params.sampling.temp = 0.2;    // lower temp by default for better quality
 
     } else if (ex == LLAMA_EXAMPLE_SERVER) {
-        params.n_parallel = -1;     // auto by default
+        params.n_parallel = -1;  // auto by default
     }
 
     params.use_color = tty_can_use_colors();
@@ -1008,9 +1022,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         sampler_type_names += common_sampler_type_to_str(sampler) + ";";
     }
     if (!sampler_type_names.empty()) {
-        sampler_type_names.pop_back(); // remove last semicolon
+        sampler_type_names.pop_back();  // remove last semicolon
     }
-
 
     /**
      * filter options by example
@@ -1025,298 +1038,229 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     };
 
-
-    add_opt(common_arg(
-        {"-h", "--help", "--usage"},
-        "print usage and exit",
-        [](common_params & params) {
-            params.usage = true;
+    add_opt(common_arg({ "-h", "--help", "--usage" }, "print usage and exit",
+                       [](common_params & params) { params.usage = true; }));
+    add_opt(common_arg({ "--version" }, "show version and build info", [](common_params &) {
+        fprintf(stderr, "version: %d (%s)\n", LLAMA_BUILD_NUMBER, LLAMA_COMMIT);
+        fprintf(stderr, "built with %s for %s\n", LLAMA_COMPILER, LLAMA_BUILD_TARGET);
+        exit(0);
+    }));
+    add_opt(common_arg({ "--license" }, "show source code license and dependencies", [](common_params &) {
+        for (int i = 0; LICENSES[i]; ++i) {
+            printf("%s\n", LICENSES[i]);
         }
-    ));
-    add_opt(common_arg(
-        {"--version"},
-        "show version and build info",
-        [](common_params &) {
-            fprintf(stderr, "version: %d (%s)\n", LLAMA_BUILD_NUMBER, LLAMA_COMMIT);
-            fprintf(stderr, "built with %s for %s\n", LLAMA_COMPILER, LLAMA_BUILD_TARGET);
-            exit(0);
+        exit(0);
+    }));
+    add_opt(common_arg({ "-cl", "--cache-list" }, "show list of models in cache", [](common_params &) {
+        printf("model cache directory: %s\n", fs_get_cache_directory().c_str());
+        auto models = common_list_cached_models();
+        printf("number of models in cache: %zu\n", models.size());
+        for (size_t i = 0; i < models.size(); i++) {
+            auto & model = models[i];
+            printf("%4d. %s\n", (int) i + 1, model.to_string().c_str());
         }
-    ));
+        exit(0);
+    }));
+    add_opt(common_arg({ "--completion-bash" }, "print source-able bash completion script for llama.cpp",
+                       [](common_params & params) { params.completion = true; }));
+    add_opt(common_arg({ "--verbose-prompt" },
+                       string_format("print a verbose prompt before generation (default: %s)",
+                                     params.verbose_prompt ? "true" : "false"),
+                       [](common_params & params) { params.verbose_prompt = true; }));
+    add_opt(common_arg({ "--display-prompt" }, { "--no-display-prompt" },
+                       string_format("whether to print prompt at generation (default: %s)",
+                                     params.display_prompt ? "true" : "false"),
+                       [](common_params & params, bool value) { params.display_prompt = value; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "-co", "--color" }, "[on|off|auto]",
+                       "Colorize output to distinguish prompt and user input from generations ('on', 'off', or 'auto', "
+                       "default: 'auto')\n"
+                       "'auto' enables colors when output is to a terminal",
+                       [](common_params & params, const std::string & value) {
+                           if (is_truthy(value)) {
+                               params.use_color = true;
+                           } else if (is_falsey(value)) {
+                               params.use_color = false;
+                           } else if (is_autoy(value)) {
+                               params.use_color = tty_can_use_colors();
+                           } else {
+                               throw std::invalid_argument(
+                                   string_format("error: unknown value for --color: '%s'\n", value.c_str()));
+                           }
+                       })
+                .set_examples(
+                    { LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP }));
+    add_opt(common_arg({ "-t", "--threads" }, "N",
+                       string_format("number of CPU threads to use during generation (default: %d)",
+                                     params.cpuparams.n_threads),
+                       [](common_params & params, int value) {
+                           params.cpuparams.n_threads = value;
+                           if (params.cpuparams.n_threads <= 0) {
+                               params.cpuparams.n_threads = std::thread::hardware_concurrency();
+                           }
+                       })
+                .set_env("LLAMA_ARG_THREADS"));
+    add_opt(common_arg({ "-tb", "--threads-batch" }, "N",
+                       "number of threads to use during batch and prompt processing (default: same as --threads)",
+                       [](common_params & params, int value) {
+                           params.cpuparams_batch.n_threads = value;
+                           if (params.cpuparams_batch.n_threads <= 0) {
+                               params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                           }
+                       }));
+    add_opt(common_arg({ "-C", "--cpu-mask" }, "M",
+                       "CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: \"\")",
+                       [](common_params & params, const std::string & mask) {
+                           params.cpuparams.mask_valid = true;
+                           if (!parse_cpu_mask(mask, params.cpuparams.cpumask)) {
+                               throw std::invalid_argument("invalid cpumask");
+                           }
+                       }));
+    add_opt(common_arg({ "-Cr", "--cpu-range" }, "lo-hi", "range of CPUs for affinity. Complements --cpu-mask",
+                       [](common_params & params, const std::string & range) {
+                           params.cpuparams.mask_valid = true;
+                           if (!parse_cpu_range(range, params.cpuparams.cpumask)) {
+                               throw std::invalid_argument("invalid range");
+                           }
+                       }));
     add_opt(common_arg(
-        {"--license"},
-        "show source code license and dependencies",
-        [](common_params &) {
-            for (int i = 0; LICENSES[i]; ++i) {
-                printf("%s\n", LICENSES[i]);
-            }
-            exit(0);
-        }
-    ));
-    add_opt(common_arg(
-        {"-cl", "--cache-list"},
-        "show list of models in cache",
-        [](common_params &) {
-            printf("model cache directory: %s\n", fs_get_cache_directory().c_str());
-            auto models = common_list_cached_models();
-            printf("number of models in cache: %zu\n", models.size());
-            for (size_t i = 0; i < models.size(); i++) {
-                auto & model = models[i];
-                printf("%4d. %s\n", (int) i + 1, model.to_string().c_str());
-            }
-            exit(0);
-        }
-    ));
-    add_opt(common_arg(
-        {"--completion-bash"},
-        "print source-able bash completion script for llama.cpp",
-        [](common_params & params) {
-            params.completion = true;
-        }
-    ));
-    add_opt(common_arg(
-        {"--verbose-prompt"},
-        string_format("print a verbose prompt before generation (default: %s)", params.verbose_prompt ? "true" : "false"),
-        [](common_params & params) {
-            params.verbose_prompt = true;
-        }
-    ));
-    add_opt(common_arg(
-        {"--display-prompt"},
-        {"--no-display-prompt"},
-        string_format("whether to print prompt at generation (default: %s)", params.display_prompt ? "true" : "false"),
-        [](common_params & params, bool value) {
-            params.display_prompt = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-co", "--color"}, "[on|off|auto]",
-        "Colorize output to distinguish prompt and user input from generations ('on', 'off', or 'auto', default: 'auto')\n"
-        "'auto' enables colors when output is to a terminal",
-        [](common_params & params, const std::string & value) {
-            if (is_truthy(value)) {
-                params.use_color = true;
-            } else if (is_falsey(value)) {
-                params.use_color = false;
-            } else if (is_autoy(value)) {
-                params.use_color = tty_can_use_colors();
-            } else {
-                throw std::invalid_argument(
-                    string_format("error: unknown value for --color: '%s'\n", value.c_str()));
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP}));
-    add_opt(common_arg(
-        {"-t", "--threads"}, "N",
-        string_format("number of CPU threads to use during generation (default: %d)", params.cpuparams.n_threads),
-        [](common_params & params, int value) {
-            params.cpuparams.n_threads = value;
-            if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
-            }
-        }
-    ).set_env("LLAMA_ARG_THREADS"));
-    add_opt(common_arg(
-        {"-tb", "--threads-batch"}, "N",
-        "number of threads to use during batch and prompt processing (default: same as --threads)",
-        [](common_params & params, int value) {
-            params.cpuparams_batch.n_threads = value;
-            if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"-C", "--cpu-mask"}, "M",
-        "CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: \"\")",
-        [](common_params & params, const std::string & mask) {
-            params.cpuparams.mask_valid = true;
-            if (!parse_cpu_mask(mask, params.cpuparams.cpumask)) {
-                throw std::invalid_argument("invalid cpumask");
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"-Cr", "--cpu-range"}, "lo-hi",
-        "range of CPUs for affinity. Complements --cpu-mask",
-        [](common_params & params, const std::string & range) {
-            params.cpuparams.mask_valid = true;
-            if (!parse_cpu_range(range, params.cpuparams.cpumask)) {
-                throw std::invalid_argument("invalid range");
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"--cpu-strict"}, "<0|1>",
+        { "--cpu-strict" }, "<0|1>",
         string_format("use strict CPU placement (default: %u)\n", (unsigned) params.cpuparams.strict_cpu),
-        [](common_params & params, const std::string & value) {
-            params.cpuparams.strict_cpu = std::stoul(value);
-        }
-    ));
+        [](common_params & params, const std::string & value) { params.cpuparams.strict_cpu = std::stoul(value); }));
     add_opt(common_arg(
-        {"--prio"}, "N",
-        string_format("set process/thread priority : low(-1), normal(0), medium(1), high(2), realtime(3) (default: %d)\n", params.cpuparams.priority),
+        { "--prio" }, "N",
+        string_format(
+            "set process/thread priority : low(-1), normal(0), medium(1), high(2), realtime(3) (default: %d)\n",
+            params.cpuparams.priority),
         [](common_params & params, int prio) {
             if (prio < GGML_SCHED_PRIO_LOW || prio > GGML_SCHED_PRIO_REALTIME) {
                 throw std::invalid_argument("invalid value");
             }
             params.cpuparams.priority = (enum ggml_sched_priority) prio;
-        }
-    ));
+        }));
     add_opt(common_arg(
-        {"--poll"}, "<0...100>",
-        string_format("use polling level to wait for work (0 - no polling, default: %u)\n", (unsigned) params.cpuparams.poll),
-        [](common_params & params, const std::string & value) {
-            params.cpuparams.poll = std::stoul(value);
-        }
-    ));
+        { "--poll" }, "<0...100>",
+        string_format("use polling level to wait for work (0 - no polling, default: %u)\n",
+                      (unsigned) params.cpuparams.poll),
+        [](common_params & params, const std::string & value) { params.cpuparams.poll = std::stoul(value); }));
+    add_opt(
+        common_arg({ "-Cb", "--cpu-mask-batch" }, "M",
+                   "CPU affinity mask: arbitrarily long hex. Complements cpu-range-batch (default: same as --cpu-mask)",
+                   [](common_params & params, const std::string & mask) {
+                       params.cpuparams_batch.mask_valid = true;
+                       if (!parse_cpu_mask(mask, params.cpuparams_batch.cpumask)) {
+                           throw std::invalid_argument("invalid cpumask");
+                       }
+                   }));
+    add_opt(common_arg({ "-Crb", "--cpu-range-batch" }, "lo-hi",
+                       "ranges of CPUs for affinity. Complements --cpu-mask-batch",
+                       [](common_params & params, const std::string & range) {
+                           params.cpuparams_batch.mask_valid = true;
+                           if (!parse_cpu_range(range, params.cpuparams_batch.cpumask)) {
+                               throw std::invalid_argument("invalid range");
+                           }
+                       }));
+    add_opt(common_arg({ "--cpu-strict-batch" }, "<0|1>", "use strict CPU placement (default: same as --cpu-strict)",
+                       [](common_params & params, int value) { params.cpuparams_batch.strict_cpu = value; }));
+    add_opt(
+        common_arg({ "--prio-batch" }, "N",
+                   string_format("set process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n",
+                                 params.cpuparams_batch.priority),
+                   [](common_params & params, int prio) {
+                       if (prio < 0 || prio > 3) {
+                           throw std::invalid_argument("invalid value");
+                       }
+                       params.cpuparams_batch.priority = (enum ggml_sched_priority) prio;
+                   }));
+    add_opt(common_arg({ "--poll-batch" }, "<0|1>", "use polling to wait for work (default: same as --poll)",
+                       [](common_params & params, int value) { params.cpuparams_batch.poll = value; }));
+    add_opt(common_arg({ "-lcs", "--lookup-cache-static" }, "FNAME",
+                       "path to static lookup cache to use for lookup decoding (not updated by generation)",
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.lookup_cache_static = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-lcd", "--lookup-cache-dynamic" }, "FNAME",
+                       "path to dynamic lookup cache to use for lookup decoding (updated by generation)",
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.lookup_cache_dynamic = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-c", "--ctx-size" }, "N",
+                       string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
+                       [](common_params & params, int value) {
+                           params.n_ctx = value;
+                           if (value == 0) {
+                               // disable context reduction in llama_params_fit if the user explicitly requests the full context size:
+                               params.fit_params_min_ctx = UINT32_MAX;
+                           }
+                       })
+                .set_env("LLAMA_ARG_CTX_SIZE"));
+    add_opt(common_arg({ "-n", "--predict", "--n-predict" }, "N",
+                       string_format(
+                           ex == LLAMA_EXAMPLE_COMPLETION ?
+                               "number of tokens to predict (default: %d, -1 = infinity, -2 = until context filled)" :
+                               "number of tokens to predict (default: %d, -1 = infinity)",
+                           params.n_predict),
+                       [](common_params & params, int value) { params.n_predict = value; })
+                .set_env("LLAMA_ARG_N_PREDICT"));
+    add_opt(common_arg({ "-b", "--batch-size" }, "N",
+                       string_format("logical maximum batch size (default: %d)", params.n_batch),
+                       [](common_params & params, int value) { params.n_batch = value; })
+                .set_env("LLAMA_ARG_BATCH"));
+    add_opt(common_arg({ "-ub", "--ubatch-size" }, "N",
+                       string_format("physical maximum batch size (default: %d)", params.n_ubatch),
+                       [](common_params & params, int value) { params.n_ubatch = value; })
+                .set_env("LLAMA_ARG_UBATCH"));
     add_opt(common_arg(
-        {"-Cb", "--cpu-mask-batch"}, "M",
-        "CPU affinity mask: arbitrarily long hex. Complements cpu-range-batch (default: same as --cpu-mask)",
-        [](common_params & params, const std::string & mask) {
-            params.cpuparams_batch.mask_valid = true;
-            if (!parse_cpu_mask(mask, params.cpuparams_batch.cpumask)) {
-                throw std::invalid_argument("invalid cpumask");
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"-Crb", "--cpu-range-batch"}, "lo-hi",
-        "ranges of CPUs for affinity. Complements --cpu-mask-batch",
-        [](common_params & params, const std::string & range) {
-            params.cpuparams_batch.mask_valid = true;
-            if (!parse_cpu_range(range, params.cpuparams_batch.cpumask)) {
-                throw std::invalid_argument("invalid range");
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"--cpu-strict-batch"}, "<0|1>",
-        "use strict CPU placement (default: same as --cpu-strict)",
-        [](common_params & params, int value) {
-            params.cpuparams_batch.strict_cpu = value;
-        }
-    ));
-    add_opt(common_arg(
-        {"--prio-batch"}, "N",
-        string_format("set process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n", params.cpuparams_batch.priority),
-        [](common_params & params, int prio) {
-            if (prio < 0 || prio > 3) {
-                throw std::invalid_argument("invalid value");
-            }
-            params.cpuparams_batch.priority = (enum ggml_sched_priority) prio;
-        }
-    ));
-    add_opt(common_arg(
-        {"--poll-batch"}, "<0|1>",
-        "use polling to wait for work (default: same as --poll)",
-        [](common_params & params, int value) {
-            params.cpuparams_batch.poll = value;
-        }
-    ));
-    add_opt(common_arg(
-        {"-lcs", "--lookup-cache-static"}, "FNAME",
-        "path to static lookup cache to use for lookup decoding (not updated by generation)",
-        [](common_params & params, const std::string & value) {
-            params.speculative.lookup_cache_static = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-lcd", "--lookup-cache-dynamic"}, "FNAME",
-        "path to dynamic lookup cache to use for lookup decoding (updated by generation)",
-        [](common_params & params, const std::string & value) {
-            params.speculative.lookup_cache_dynamic = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-c", "--ctx-size"}, "N",
-        string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
-        [](common_params & params, int value) {
-            params.n_ctx = value;
-            if (value == 0) {
-                // disable context reduction in llama_params_fit if the user explicitly requests the full context size:
-                params.fit_params_min_ctx = UINT32_MAX;
-            }
-        }
-    ).set_env("LLAMA_ARG_CTX_SIZE"));
-    add_opt(common_arg(
-        {"-n", "--predict", "--n-predict"}, "N",
-        string_format(
-            ex == LLAMA_EXAMPLE_COMPLETION
-                ? "number of tokens to predict (default: %d, -1 = infinity, -2 = until context filled)"
-                : "number of tokens to predict (default: %d, -1 = infinity)",
-            params.n_predict),
-        [](common_params & params, int value) {
-            params.n_predict = value;
-        }
-    ).set_env("LLAMA_ARG_N_PREDICT"));
-    add_opt(common_arg(
-        {"-b", "--batch-size"}, "N",
-        string_format("logical maximum batch size (default: %d)", params.n_batch),
-        [](common_params & params, int value) {
-            params.n_batch = value;
-        }
-    ).set_env("LLAMA_ARG_BATCH"));
-    add_opt(common_arg(
-        {"-ub", "--ubatch-size"}, "N",
-        string_format("physical maximum batch size (default: %d)", params.n_ubatch),
-        [](common_params & params, int value) {
-            params.n_ubatch = value;
-        }
-    ).set_env("LLAMA_ARG_UBATCH"));
-    add_opt(common_arg(
-        {"--keep"}, "N",
+        { "--keep" }, "N",
         string_format("number of tokens to keep from the initial prompt (default: %d, -1 = all)", params.n_keep),
-        [](common_params & params, int value) {
-            params.n_keep = value;
-        }
-    ));
+        [](common_params & params, int value) { params.n_keep = value; }));
     add_opt(common_arg(
-        {"--swa-full"},
-        string_format("use full-size SWA cache (default: %s)\n"
-            "[(more info)](https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)", params.swa_full ? "true" : "false"),
-        [](common_params & params) {
-            params.swa_full = true;
-        }
-    ).set_env("LLAMA_ARG_SWA_FULL"));
-    add_opt(common_arg(
-        {"--ctx-checkpoints", "--swa-checkpoints"}, "N",
-        string_format("max number of context checkpoints to create per slot (default: %d)"
-            "[(more info)](https://github.com/ggml-org/llama.cpp/pull/15293)", params.n_ctx_checkpoints),
-        [](common_params & params, int value) {
-            params.n_ctx_checkpoints = value;
-        }
-    ).set_env("LLAMA_ARG_CTX_CHECKPOINTS").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-cram", "--cache-ram"}, "N",
-        string_format("set the maximum cache size in MiB (default: %d, -1 - no limit, 0 - disable)"
-            "[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)", params.cache_ram_mib),
-        [](common_params & params, int value) {
-            params.cache_ram_mib = value;
-        }
-    ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-kvu", "--kv-unified"},
-        {"-no-kvu", "--no-kv-unified"},
-        "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",
-        [](common_params & params, bool value) {
-            params.kv_unified = value;
-        }
-    ).set_env("LLAMA_ARG_KV_UNIFIED").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_BATCHED, LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL}));
-    add_opt(common_arg(
-        {"--context-shift"},
-        {"--no-context-shift"},
-        string_format("whether to use context shift on infinite text generation (default: %s)", params.ctx_shift ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.ctx_shift = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY}).set_env("LLAMA_ARG_CONTEXT_SHIFT"));
-    add_opt(common_arg(
-        {"--chunks"}, "N",
-        string_format("max number of chunks to process (default: %d, -1 = all)", params.n_chunks),
-        [](common_params & params, int value) {
-            params.n_chunks = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_RETRIEVAL}));
+                { "--swa-full" },
+                string_format("use full-size SWA cache (default: %s)\n"
+                              "[(more info)](https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)",
+                              params.swa_full ? "true" : "false"),
+                [](common_params & params) { params.swa_full = true; })
+                .set_env("LLAMA_ARG_SWA_FULL"));
+    add_opt(common_arg({ "--ctx-checkpoints", "--swa-checkpoints" }, "N",
+                       string_format("max number of context checkpoints to create per slot (default: %d)"
+                                     "[(more info)](https://github.com/ggml-org/llama.cpp/pull/15293)",
+                                     params.n_ctx_checkpoints),
+                       [](common_params & params, int value) { params.n_ctx_checkpoints = value; })
+                .set_env("LLAMA_ARG_CTX_CHECKPOINTS")
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "-cram", "--cache-ram" }, "N",
+                       string_format("set the maximum cache size in MiB (default: %d, -1 - no limit, 0 - disable)"
+                                     "[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)",
+                                     params.cache_ram_mib),
+                       [](common_params & params, int value) { params.cache_ram_mib = value; })
+                .set_env("LLAMA_ARG_CACHE_RAM")
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "-cev", "--cache-eviction" }, "N",
+                       "set the prompt cache eviction policy: 0 = FIFO (default), 1 = LRU, 2 = LFU",
+                       [](common_params & params, int value) { params.cache_eviction_policy = value; })
+                .set_env("LLAMA_ARG_CACHE_EVICTION")
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg(
+            { "-kvu", "--kv-unified" }, { "-no-kvu", "--no-kv-unified" },
+            "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",
+            [](common_params & params, bool value) { params.kv_unified = value; })
+            .set_env("LLAMA_ARG_KV_UNIFIED")
+            .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_BATCHED, LLAMA_EXAMPLE_BENCH,
+                            LLAMA_EXAMPLE_PARALLEL }));
+    add_opt(common_arg({ "--context-shift" }, { "--no-context-shift" },
+                       string_format("whether to use context shift on infinite text generation (default: %s)",
+                                     params.ctx_shift ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.ctx_shift = value; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER,
+                                LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY })
+                .set_env("LLAMA_ARG_CONTEXT_SHIFT"));
+    add_opt(common_arg({ "--chunks" }, "N",
+                       string_format("max number of chunks to process (default: %d, -1 = all)", params.n_chunks),
+                       [](common_params & params, int value) { params.n_chunks = value; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_RETRIEVAL }));
     add_opt(common_arg({ "-fa", "--flash-attn" }, "[on|off|auto]",
                        string_format("set Flash Attention use ('on', 'off', or 'auto', default: '%s')",
                                      llama_flash_attn_type_name(params.flash_attn_type)),
@@ -1331,2465 +1275,2152 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                                throw std::runtime_error(
                                    string_format("error: unknown value for --flash-attn: '%s'\n", value.c_str()));
                            }
-                       }).set_env("LLAMA_ARG_FLASH_ATTN"));
+                       })
+                .set_env("LLAMA_ARG_FLASH_ATTN"));
+    add_opt(common_arg({ "-p", "--prompt" }, "PROMPT", "prompt to start generation with; for system message, use -sys",
+                       [](common_params & params, const std::string & value) { params.prompt = value; })
+                .set_excludes({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-sys", "--system-prompt" }, "PROMPT",
+                       "system prompt to use with model (if applicable, depending on chat template)",
+                       [](common_params & params, const std::string & value) { params.system_prompt = value; })
+                .set_examples(
+                    { LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_DIFFUSION, LLAMA_EXAMPLE_MTMD }));
+    add_opt(common_arg({ "--perf" }, { "--no-perf" },
+                       string_format("whether to enable internal libllama performance timings (default: %s)",
+                                     params.no_perf ? "true" : "false"),
+                       [](common_params & params, bool value) {
+                           params.no_perf          = !value;
+                           params.sampling.no_perf = !value;
+                       })
+                .set_env("LLAMA_ARG_PERF"));
+    add_opt(common_arg({ "--show-timings" }, { "--no-show-timings" },
+                       string_format("whether to show timing information after each response (default: %s)",
+                                     params.show_timings ? "true" : "false"),
+                       [](common_params & params, bool value) { params.show_timings = value; })
+                .set_examples({ LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_SHOW_TIMINGS"));
+    add_opt(common_arg({ "-f", "--file" }, "FNAME", "a file containing the prompt (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           params.prompt      = read_file(value);
+                           // store the external file name in params
+                           params.prompt_file = value;
+                           if (!params.prompt.empty() && params.prompt.back() == '\n') {
+                               params.prompt.pop_back();
+                           }
+                       })
+                .set_excludes({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-sysf", "--system-prompt-file" }, "FNAME",
+                       "a file containing the system prompt (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           params.system_prompt = read_file(value);
+                           if (!params.system_prompt.empty() && params.system_prompt.back() == '\n') {
+                               params.system_prompt.pop_back();
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(common_arg({ "--in-file" }, "FNAME", "an input file (use comma-separated values to specify multiple files)",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               std::ifstream file(item);
+                               if (!file) {
+                                   throw std::runtime_error(
+                                       string_format("error: failed to open file '%s'\n", item.c_str()));
+                               }
+                               params.in_files.push_back(item);
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "-bf", "--binary-file" }, "FNAME", "binary file containing the prompt (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           std::ifstream file(value, std::ios::binary);
+                           if (!file) {
+                               throw std::runtime_error(
+                                   string_format("error: failed to open file '%s'\n", value.c_str()));
+                           }
+                           // store the external file name in params
+                           params.prompt_file = value;
+                           std::ostringstream ss;
+                           ss << file.rdbuf();
+                           params.prompt = ss.str();
+                           fprintf(stderr, "Read %zu bytes from binary file %s\n", params.prompt.size(), value.c_str());
+                       })
+                .set_excludes({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg({ "-e", "--escape" }, { "--no-escape" },
+                   string_format("whether to process escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\) (default: %s)",
+                                 params.escape ? "true" : "false"),
+                   [](common_params & params, bool value) { params.escape = value; }));
+    add_opt(common_arg({ "-ptc", "--print-token-count" }, "N",
+                       string_format("print token count every N tokens (default: %d)", params.n_print),
+                       [](common_params & params, int value) { params.n_print = value; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--prompt-cache" }, "FNAME", "file to cache prompt state for faster startup (default: none)",
+                       [](common_params & params, const std::string & value) { params.path_prompt_cache = value; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--prompt-cache-all" }, "if specified, saves user input and generations to cache as well\n",
+                       [](common_params & params) { params.prompt_cache_all = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--prompt-cache-ro" }, "if specified, uses the prompt cache but does not update it",
+                       [](common_params & params) { params.prompt_cache_ro = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "-r", "--reverse-prompt" }, "PROMPT",
+                       "halt generation at PROMPT, return control in interactive mode\n",
+                       [](common_params & params, const std::string & value) { params.antiprompt.emplace_back(value); })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-sp", "--special" },
+                       string_format("special tokens output enabled (default: %s)", params.special ? "true" : "false"),
+                       [](common_params & params) { params.special = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-cnv", "--conversation" }, { "-no-cnv", "--no-conversation" },
+                       "whether to run in conversation mode:\n"
+                       "- does not print special tokens and suffix/prefix\n"
+                       "- interactive mode is also enabled\n"
+                       "(default: auto enabled if chat template is available)",
+                       [](common_params & params, bool value) {
+                           params.conversation_mode =
+                               value ? COMMON_CONVERSATION_MODE_ENABLED : COMMON_CONVERSATION_MODE_DISABLED;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "-st", "--single-turn" },
+                       "run conversation for a single turn only, then exit when done\n"
+                       "will not be interactive if first turn is predefined with --prompt\n"
+                       "(default: false)",
+                       [](common_params & params) { params.single_turn = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "-i", "--interactive" },
+                       string_format("run in interactive mode (default: %s)", params.interactive ? "true" : "false"),
+                       [](common_params & params) { params.interactive = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "-if", "--interactive-first" },
+                       string_format("run in interactive mode and wait for input right away (default: %s)",
+                                     params.interactive_first ? "true" : "false"),
+                       [](common_params & params) { params.interactive_first = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "-mli", "--multiline-input" },
+                       "allows you to write or paste multiple lines without ending each in '\\'",
+                       [](common_params & params) { params.multiline_input = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "--in-prefix-bos" }, "prefix BOS to user inputs, preceding the `--in-prefix` string",
+                       [](common_params & params) {
+                           params.input_prefix_bos     = true;
+                           params.enable_chat_template = false;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--in-prefix" }, "STRING", "string to prefix user inputs with (default: empty)",
+                       [](common_params & params, const std::string & value) {
+                           params.input_prefix         = value;
+                           params.enable_chat_template = false;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--in-suffix" }, "STRING", "string to suffix after user inputs with (default: empty)",
+                       [](common_params & params, const std::string & value) {
+                           params.input_suffix         = value;
+                           params.enable_chat_template = false;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "--warmup" }, { "--no-warmup" },
+                       string_format("whether to perform warmup with an empty run (default: %s)",
+                                     params.warmup ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.warmup = value; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MTMD,
+                                LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_RETRIEVAL, LLAMA_EXAMPLE_PERPLEXITY,
+                                LLAMA_EXAMPLE_DEBUG }));
+    add_opt(common_arg({ "--spm-infill" },
+                       string_format("use Suffix/Prefix/Middle pattern for infill (instead of Prefix/Suffix/Middle) as "
+                                     "some models prefer this. (default: %s)",
+                                     params.spm_infill ? "enabled" : "disabled"),
+                       [](common_params & params) { params.spm_infill = true; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--samplers" }, "SAMPLERS",
+                       string_format(
+                           "samplers that will be used for generation in the order, separated by \';\'\n(default: %s)",
+                           sampler_type_names.c_str()),
+                       [](common_params & params, const std::string & value) {
+                           const auto sampler_names = string_split<std::string>(value, ';');
+                           params.sampling.samplers = common_sampler_types_from_names(sampler_names, true);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_SAMPLERS;
+                       })
+                .set_sparam());
+    add_opt(
+        common_arg(
+            { "-s", "--seed" }, "SEED",
+            string_format("RNG seed (default: %d, use random seed for %d)", params.sampling.seed, LLAMA_DEFAULT_SEED),
+            [](common_params & params, const std::string & value) { params.sampling.seed = std::stoul(value); })
+            .set_sparam());
+    add_opt(common_arg({ "--sampler-seq", "--sampling-seq" }, "SEQUENCE",
+                       string_format("simplified sequence for samplers that will be used (default: %s)",
+                                     sampler_type_chars.c_str()),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.samplers = common_sampler_types_from_chars(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--ignore-eos" },
+                       "ignore end of stream token and continue generating (implies --logit-bias EOS-inf)",
+                       [](common_params & params) { params.sampling.ignore_eos = true; })
+                .set_sparam());
+    add_opt(common_arg({ "--temp" }, "N", string_format("temperature (default: %.2f)", (double) params.sampling.temp),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.temp = std::stof(value);
+                           params.sampling.temp = std::max(params.sampling.temp, 0.0f);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--top-k" }, "N",
+                       string_format("top-k sampling (default: %d, 0 = disabled)", params.sampling.top_k),
+                       [](common_params & params, int value) {
+                           params.sampling.top_k = value;
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+                       })
+                .set_sparam()
+                .set_env("LLAMA_ARG_TOP_K"));
+    add_opt(common_arg({ "--top-p" }, "N",
+                       string_format("top-p sampling (default: %.2f, 1.0 = disabled)", (double) params.sampling.top_p),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.top_p = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TOP_P;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--min-p" }, "N",
+                       string_format("min-p sampling (default: %.2f, 0.0 = disabled)", (double) params.sampling.min_p),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.min_p = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIN_P;
+                       })
+                .set_sparam());
+    add_opt(
+        common_arg(
+            { "--top-nsigma" }, "N",
+            string_format("top-n-sigma sampling (default: %.2f, -1.0 = disabled)", params.sampling.top_n_sigma),
+            [](common_params & params, const std::string & value) { params.sampling.top_n_sigma = std::stof(value); })
+            .set_sparam());
+    add_opt(common_arg({ "--xtc-probability" }, "N",
+                       string_format("xtc probability (default: %.2f, 0.0 = disabled)",
+                                     (double) params.sampling.xtc_probability),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.xtc_probability = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY;
+                       })
+                .set_sparam());
     add_opt(common_arg(
-        {"-p", "--prompt"}, "PROMPT",
-        "prompt to start generation with; for system message, use -sys",
-        [](common_params & params, const std::string & value) {
-            params.prompt = value;
-        }
-    ).set_excludes({LLAMA_EXAMPLE_SERVER}));
+                { "--xtc-threshold" }, "N",
+                string_format("xtc threshold (default: %.2f, 1.0 = disabled)", (double) params.sampling.xtc_threshold),
+                [](common_params & params, const std::string & value) {
+                    params.sampling.xtc_threshold = std::stof(value);
+                    params.sampling.user_sampling_config |=
+                        common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
+                })
+                .set_sparam());
+    add_opt(
+        common_arg({ "--typical" }, "N",
+                   string_format("locally typical sampling, parameter p (default: %.2f, 1.0 = disabled)",
+                                 (double) params.sampling.typ_p),
+                   [](common_params & params, const std::string & value) { params.sampling.typ_p = std::stof(value); })
+            .set_sparam());
+    add_opt(
+        common_arg({ "--repeat-last-n" }, "N",
+                   string_format("last n tokens to consider for penalize (default: %d, 0 = disabled, -1 = ctx_size)",
+                                 params.sampling.penalty_last_n),
+                   [](common_params & params, int value) {
+                       if (value < -1) {
+                           throw std::runtime_error(string_format("error: invalid repeat-last-n = %d\n", value));
+                       }
+                       params.sampling.penalty_last_n = value;
+                       params.sampling.n_prev = std::max(params.sampling.n_prev, params.sampling.penalty_last_n);
+                       params.sampling.user_sampling_config |=
+                           common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N;
+                   })
+            .set_sparam());
+    add_opt(common_arg({ "--repeat-penalty" }, "N",
+                       string_format("penalize repeat sequence of tokens (default: %.2f, 1.0 = disabled)",
+                                     (double) params.sampling.penalty_repeat),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.penalty_repeat = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--presence-penalty" }, "N",
+                       string_format("repeat alpha presence penalty (default: %.2f, 0.0 = disabled)",
+                                     (double) params.sampling.penalty_present),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.penalty_present = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--frequency-penalty" }, "N",
+                       string_format("repeat alpha frequency penalty (default: %.2f, 0.0 = disabled)",
+                                     (double) params.sampling.penalty_freq),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.penalty_freq = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--dry-multiplier" }, "N",
+                       string_format("set DRY sampling multiplier (default: %.2f, 0.0 = disabled)",
+                                     (double) params.sampling.dry_multiplier),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.dry_multiplier = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--dry-base" }, "N",
+                       string_format("set DRY sampling base value (default: %.2f)", (double) params.sampling.dry_base),
+                       [](common_params & params, const std::string & value) {
+                           float potential_base = std::stof(value);
+                           if (potential_base >= 1.0f) {
+                               params.sampling.dry_base = potential_base;
+                           }
+                       })
+                .set_sparam());
     add_opt(common_arg(
-        {"-sys", "--system-prompt"}, "PROMPT",
-        "system prompt to use with model (if applicable, depending on chat template)",
-        [](common_params & params, const std::string & value) {
-            params.system_prompt = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_DIFFUSION, LLAMA_EXAMPLE_MTMD}));
-    add_opt(common_arg(
-        {"--perf"},
-        {"--no-perf"},
-        string_format("whether to enable internal libllama performance timings (default: %s)", params.no_perf ? "true" : "false"),
-        [](common_params & params, bool value) {
-            params.no_perf = !value;
-            params.sampling.no_perf = !value;
-        }
-    ).set_env("LLAMA_ARG_PERF"));
-    add_opt(common_arg(
-        {"--show-timings"},
-        {"--no-show-timings"},
-        string_format("whether to show timing information after each response (default: %s)", params.show_timings ? "true" : "false"),
-        [](common_params & params, bool value) {
-            params.show_timings = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SHOW_TIMINGS"));
-    add_opt(common_arg(
-        {"-f", "--file"}, "FNAME",
-        "a file containing the prompt (default: none)",
-        [](common_params & params, const std::string & value) {
-            params.prompt = read_file(value);
-            // store the external file name in params
-            params.prompt_file = value;
-            if (!params.prompt.empty() && params.prompt.back() == '\n') {
-                params.prompt.pop_back();
-            }
-        }
-    ).set_excludes({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-sysf", "--system-prompt-file"}, "FNAME",
-        "a file containing the system prompt (default: none)",
-        [](common_params & params, const std::string & value) {
-            params.system_prompt = read_file(value);
-            if (!params.system_prompt.empty() && params.system_prompt.back() == '\n') {
-                params.system_prompt.pop_back();
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_DIFFUSION}));
-    add_opt(common_arg(
-        {"--in-file"}, "FNAME",
-        "an input file (use comma-separated values to specify multiple files)",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                std::ifstream file(item);
-                if (!file) {
-                    throw std::runtime_error(string_format("error: failed to open file '%s'\n", item.c_str()));
-                }
-                params.in_files.push_back(item);
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"-bf", "--binary-file"}, "FNAME",
-        "binary file containing the prompt (default: none)",
-        [](common_params & params, const std::string & value) {
-            std::ifstream file(value, std::ios::binary);
-            if (!file) {
-                throw std::runtime_error(string_format("error: failed to open file '%s'\n", value.c_str()));
-            }
-            // store the external file name in params
-            params.prompt_file = value;
-            std::ostringstream ss;
-            ss << file.rdbuf();
-            params.prompt = ss.str();
-            fprintf(stderr, "Read %zu bytes from binary file %s\n", params.prompt.size(), value.c_str());
-        }
-    ).set_excludes({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-e", "--escape"},
-        {"--no-escape"},
-        string_format("whether to process escapes sequences (\\n, \\r, \\t, \\', \\\", \\\\) (default: %s)", params.escape ? "true" : "false"),
-        [](common_params & params, bool value) {
-            params.escape = value;
-        }
-    ));
-    add_opt(common_arg(
-        {"-ptc", "--print-token-count"}, "N",
-        string_format("print token count every N tokens (default: %d)", params.n_print),
-        [](common_params & params, int value) {
-            params.n_print = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--prompt-cache"}, "FNAME",
-        "file to cache prompt state for faster startup (default: none)",
-        [](common_params & params, const std::string & value) {
-            params.path_prompt_cache = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--prompt-cache-all"},
-        "if specified, saves user input and generations to cache as well\n",
-        [](common_params & params) {
-            params.prompt_cache_all = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--prompt-cache-ro"},
-        "if specified, uses the prompt cache but does not update it",
-        [](common_params & params) {
-            params.prompt_cache_ro = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"-r", "--reverse-prompt"}, "PROMPT",
-        "halt generation at PROMPT, return control in interactive mode\n",
-        [](common_params & params, const std::string & value) {
-            params.antiprompt.emplace_back(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-sp", "--special"},
-        string_format("special tokens output enabled (default: %s)", params.special ? "true" : "false"),
-        [](common_params & params) {
-            params.special = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-cnv", "--conversation"},
-        {"-no-cnv", "--no-conversation"},
-        "whether to run in conversation mode:\n"
-        "- does not print special tokens and suffix/prefix\n"
-        "- interactive mode is also enabled\n"
-        "(default: auto enabled if chat template is available)",
-        [](common_params & params, bool value) {
-            params.conversation_mode = value ? COMMON_CONVERSATION_MODE_ENABLED : COMMON_CONVERSATION_MODE_DISABLED;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-st", "--single-turn"},
-        "run conversation for a single turn only, then exit when done\n"
-        "will not be interactive if first turn is predefined with --prompt\n"
-        "(default: false)",
-        [](common_params & params) {
-            params.single_turn = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-i", "--interactive"},
-        string_format("run in interactive mode (default: %s)", params.interactive ? "true" : "false"),
-        [](common_params & params) {
-            params.interactive = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"-if", "--interactive-first"},
-        string_format("run in interactive mode and wait for input right away (default: %s)", params.interactive_first ? "true" : "false"),
-        [](common_params & params) {
-            params.interactive_first = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"-mli", "--multiline-input"},
-        "allows you to write or paste multiple lines without ending each in '\\'",
-        [](common_params & params) {
-            params.multiline_input = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"--in-prefix-bos"},
-        "prefix BOS to user inputs, preceding the `--in-prefix` string",
-        [](common_params & params) {
-            params.input_prefix_bos = true;
-            params.enable_chat_template = false;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--in-prefix"}, "STRING",
-        "string to prefix user inputs with (default: empty)",
-        [](common_params & params, const std::string & value) {
-            params.input_prefix = value;
-            params.enable_chat_template = false;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--in-suffix"}, "STRING",
-        "string to suffix after user inputs with (default: empty)",
-        [](common_params & params, const std::string & value) {
-            params.input_suffix = value;
-            params.enable_chat_template = false;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"--warmup"},
-        {"--no-warmup"},
-        string_format("whether to perform warmup with an empty run (default: %s)", params.warmup ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.warmup = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MTMD, LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_RETRIEVAL, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_DEBUG}));
-    add_opt(common_arg(
-        {"--spm-infill"},
-        string_format(
-            "use Suffix/Prefix/Middle pattern for infill (instead of Prefix/Suffix/Middle) as some models prefer this. (default: %s)",
-            params.spm_infill ? "enabled" : "disabled"
-        ),
-        [](common_params & params) {
-            params.spm_infill = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--samplers"}, "SAMPLERS",
-        string_format("samplers that will be used for generation in the order, separated by \';\'\n(default: %s)", sampler_type_names.c_str()),
-        [](common_params & params, const std::string & value) {
-            const auto sampler_names = string_split<std::string>(value, ';');
-            params.sampling.samplers = common_sampler_types_from_names(sampler_names, true);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_SAMPLERS;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"-s", "--seed"}, "SEED",
-        string_format("RNG seed (default: %d, use random seed for %d)", params.sampling.seed, LLAMA_DEFAULT_SEED),
-        [](common_params & params, const std::string & value) {
-            params.sampling.seed = std::stoul(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--sampler-seq", "--sampling-seq"}, "SEQUENCE",
-        string_format("simplified sequence for samplers that will be used (default: %s)", sampler_type_chars.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.sampling.samplers = common_sampler_types_from_chars(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--ignore-eos"},
-        "ignore end of stream token and continue generating (implies --logit-bias EOS-inf)",
-        [](common_params & params) {
-            params.sampling.ignore_eos = true;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--temp"}, "N",
-        string_format("temperature (default: %.2f)", (double)params.sampling.temp),
-        [](common_params & params, const std::string & value) {
-            params.sampling.temp = std::stof(value);
-            params.sampling.temp = std::max(params.sampling.temp, 0.0f);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--top-k"}, "N",
-        string_format("top-k sampling (default: %d, 0 = disabled)", params.sampling.top_k),
-        [](common_params & params, int value) {
-            params.sampling.top_k = value;
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
-        }
-    ).set_sparam().set_env("LLAMA_ARG_TOP_K"));
-    add_opt(common_arg(
-        {"--top-p"}, "N",
-        string_format("top-p sampling (default: %.2f, 1.0 = disabled)", (double)params.sampling.top_p),
-        [](common_params & params, const std::string & value) {
-            params.sampling.top_p = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_TOP_P;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--min-p"}, "N",
-        string_format("min-p sampling (default: %.2f, 0.0 = disabled)", (double)params.sampling.min_p),
-        [](common_params & params, const std::string & value) {
-            params.sampling.min_p = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIN_P;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--top-nsigma"}, "N",
-        string_format("top-n-sigma sampling (default: %.2f, -1.0 = disabled)", params.sampling.top_n_sigma),
-        [](common_params & params, const std::string & value) {
-            params.sampling.top_n_sigma = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--xtc-probability"}, "N",
-        string_format("xtc probability (default: %.2f, 0.0 = disabled)", (double)params.sampling.xtc_probability),
-        [](common_params & params, const std::string & value) {
-            params.sampling.xtc_probability = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--xtc-threshold"}, "N",
-        string_format("xtc threshold (default: %.2f, 1.0 = disabled)", (double)params.sampling.xtc_threshold),
-        [](common_params & params, const std::string & value) {
-            params.sampling.xtc_threshold = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--typical"}, "N",
-        string_format("locally typical sampling, parameter p (default: %.2f, 1.0 = disabled)", (double)params.sampling.typ_p),
-        [](common_params & params, const std::string & value) {
-            params.sampling.typ_p = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--repeat-last-n"}, "N",
-        string_format("last n tokens to consider for penalize (default: %d, 0 = disabled, -1 = ctx_size)", params.sampling.penalty_last_n),
-        [](common_params & params, int value) {
-            if (value < -1) {
-                throw std::runtime_error(string_format("error: invalid repeat-last-n = %d\n", value));
-            }
-            params.sampling.penalty_last_n = value;
-            params.sampling.n_prev = std::max(params.sampling.n_prev, params.sampling.penalty_last_n);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--repeat-penalty"}, "N",
-        string_format("penalize repeat sequence of tokens (default: %.2f, 1.0 = disabled)", (double)params.sampling.penalty_repeat),
-        [](common_params & params, const std::string & value) {
-            params.sampling.penalty_repeat = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--presence-penalty"}, "N",
-        string_format("repeat alpha presence penalty (default: %.2f, 0.0 = disabled)", (double)params.sampling.penalty_present),
-        [](common_params & params, const std::string & value) {
-            params.sampling.penalty_present = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--frequency-penalty"}, "N",
-        string_format("repeat alpha frequency penalty (default: %.2f, 0.0 = disabled)", (double)params.sampling.penalty_freq),
-        [](common_params & params, const std::string & value) {
-            params.sampling.penalty_freq = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dry-multiplier"}, "N",
-        string_format("set DRY sampling multiplier (default: %.2f, 0.0 = disabled)", (double)params.sampling.dry_multiplier),
-        [](common_params & params, const std::string & value) {
-            params.sampling.dry_multiplier = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dry-base"}, "N",
-        string_format("set DRY sampling base value (default: %.2f)", (double)params.sampling.dry_base),
-        [](common_params & params, const std::string & value) {
-            float potential_base = std::stof(value);
-            if (potential_base >= 1.0f)
-            {
-                params.sampling.dry_base = potential_base;
-            }
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dry-allowed-length"}, "N",
-        string_format("set allowed length for DRY sampling (default: %d)", params.sampling.dry_allowed_length),
-        [](common_params & params, int value) {
-            params.sampling.dry_allowed_length = value;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dry-penalty-last-n"}, "N",
-        string_format("set DRY penalty for the last n tokens (default: %d, 0 = disable, -1 = context size)", params.sampling.dry_penalty_last_n),
-        [](common_params & params, int value) {
-            if (value < -1) {
-                throw std::runtime_error(string_format("error: invalid dry-penalty-last-n = %d\n", value));
-            }
-            params.sampling.dry_penalty_last_n = value;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dry-sequence-breaker"}, "STRING",
-        string_format("add sequence breaker for DRY sampling, clearing out default breakers (%s) in the process; use \"none\" to not use any sequence breakers\n",
-            params.sampling.dry_sequence_breakers.empty() ? "none" :
-            std::accumulate(std::next(params.sampling.dry_sequence_breakers.begin()),
-                params.sampling.dry_sequence_breakers.end(),
-                std::string("'") + (params.sampling.dry_sequence_breakers[0] == "\n" ? "\\n" : params.sampling.dry_sequence_breakers[0]) + "'",
-                [](const std::string& a, const std::string& b) {
-                    std::string formatted_b = (b == "\n") ? "\\n" : b;
-                    return a + ", '" + formatted_b + "'";
-                }).c_str()),
-        [](common_params & params, const std::string & value) {
-            static bool defaults_cleared = false;
+                { "--dry-allowed-length" }, "N",
+                string_format("set allowed length for DRY sampling (default: %d)", params.sampling.dry_allowed_length),
+                [](common_params & params, int value) { params.sampling.dry_allowed_length = value; })
+                .set_sparam());
+    add_opt(
+        common_arg({ "--dry-penalty-last-n" }, "N",
+                   string_format("set DRY penalty for the last n tokens (default: %d, 0 = disable, -1 = context size)",
+                                 params.sampling.dry_penalty_last_n),
+                   [](common_params & params, int value) {
+                       if (value < -1) {
+                           throw std::runtime_error(string_format("error: invalid dry-penalty-last-n = %d\n", value));
+                       }
+                       params.sampling.dry_penalty_last_n = value;
+                   })
+            .set_sparam());
+    add_opt(common_arg({ "--dry-sequence-breaker" }, "STRING",
+                       string_format("add sequence breaker for DRY sampling, clearing out default breakers (%s) in the "
+                                     "process; use \"none\" to not use any sequence breakers\n",
+                                     params.sampling.dry_sequence_breakers.empty() ?
+                                         "none" :
+                                         std::accumulate(std::next(params.sampling.dry_sequence_breakers.begin()),
+                                                         params.sampling.dry_sequence_breakers.end(),
+                                                         std::string("'") +
+                                                             (params.sampling.dry_sequence_breakers[0] == "\n" ?
+                                                                  "\\n" :
+                                                                  params.sampling.dry_sequence_breakers[0]) +
+                                                             "'",
+                                                         [](const std::string & a, const std::string & b) {
+                                                             std::string formatted_b = (b == "\n") ? "\\n" : b;
+                                                             return a + ", '" + formatted_b + "'";
+                                                         })
+                                             .c_str()),
+                       [](common_params & params, const std::string & value) {
+                           static bool defaults_cleared = false;
 
-            if (!defaults_cleared) {
-                params.sampling.dry_sequence_breakers.clear();
-                defaults_cleared = true;
-            }
+                           if (!defaults_cleared) {
+                               params.sampling.dry_sequence_breakers.clear();
+                               defaults_cleared = true;
+                           }
 
-            if (value == "none") {
-                params.sampling.dry_sequence_breakers.clear();
-            } else {
-                params.sampling.dry_sequence_breakers.emplace_back(value);
-            }
-        }
-    ).set_sparam());
+                           if (value == "none") {
+                               params.sampling.dry_sequence_breakers.clear();
+                           } else {
+                               params.sampling.dry_sequence_breakers.emplace_back(value);
+                           }
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--adaptive-target" }, "N",
+                       string_format("adaptive-p: select tokens near this probability (valid range 0.0 "
+                                     "to 1.0; negative = disabled) (default: %.2f)\n"
+                                     "[(more info)](https://github.com/ggml-org/llama.cpp/pull/17927)",
+                                     (double) params.sampling.adaptive_target),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.adaptive_target = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--adaptive-decay" }, "N",
+                       string_format("adaptive-p: decay rate for target adaptation over time. lower values "
+                                     "are more reactive, higher values are more stable.\n"
+                                     "(valid range 0.0 to 0.99) (default: %.2f)",
+                                     (double) params.sampling.adaptive_decay),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.adaptive_decay = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--dynatemp-range" }, "N",
+                       string_format("dynamic temperature range (default: %.2f, 0.0 = disabled)",
+                                     (double) params.sampling.dynatemp_range),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.dynatemp_range = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--dynatemp-exp" }, "N",
+                       string_format("dynamic temperature exponent (default: %.2f)",
+                                     (double) params.sampling.dynatemp_exponent),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.dynatemp_exponent = std::stof(value);
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--mirostat" }, "N",
+                       string_format(
+                           "use Mirostat sampling.\nTop K, Nucleus and Locally Typical samplers are ignored if used.\n"
+                           "(default: %d, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)",
+                           params.sampling.mirostat),
+                       [](common_params & params, int value) {
+                           params.sampling.mirostat = value;
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--mirostat-lr" }, "N",
+                       string_format("Mirostat learning rate, parameter eta (default: %.2f)",
+                                     (double) params.sampling.mirostat_eta),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.mirostat_eta = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--mirostat-ent" }, "N",
+                       string_format("Mirostat target entropy, parameter tau (default: %.2f)",
+                                     (double) params.sampling.mirostat_tau),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.mirostat_tau = std::stof(value);
+                           params.sampling.user_sampling_config |=
+                               common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "-l", "--logit-bias" }, "TOKEN_ID(+/-)BIAS",
+                       "modifies the likelihood of token appearing in the completion,\n"
+                       "i.e. `--logit-bias 15043+1` to increase likelihood of token ' Hello',\n"
+                       "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'",
+                       [](common_params & params, const std::string & value) {
+                           std::stringstream ss(value);
+                           llama_token       key;
+                           char              sign;
+                           std::string       value_str;
+                           try {
+                               if (ss >> key && ss >> sign && std::getline(ss, value_str) &&
+                                   (sign == '+' || sign == '-')) {
+                                   const float bias = std::stof(value_str) * ((sign == '-') ? -1.0f : 1.0f);
+                                   params.sampling.logit_bias.push_back({ key, bias });
+                               } else {
+                                   throw std::invalid_argument("invalid input format");
+                               }
+                           } catch (const std::exception &) {
+                               throw std::invalid_argument("invalid input format");
+                           }
+                       })
+                .set_sparam());
+    add_opt(common_arg({ "--grammar" }, "GRAMMAR",
+                       string_format(
+                           "BNF-like grammar to constrain generations (see samples in grammars/ dir) (default: '%s')",
+                           params.sampling.grammar.c_str()),
+                       [](common_params & params, const std::string & value) { params.sampling.grammar = value; })
+                .set_sparam());
     add_opt(common_arg(
-        {"--adaptive-target"}, "N",
-        string_format("adaptive-p: select tokens near this probability (valid range 0.0 "
-                      "to 1.0; negative = disabled) (default: %.2f)\n"
-                      "[(more info)](https://github.com/ggml-org/llama.cpp/pull/17927)",
-                      (double)params.sampling.adaptive_target),
-        [](common_params & params, const std::string & value) {
-            params.sampling.adaptive_target = std::stof(value);
-        }
-    ).set_sparam());
+                { "--grammar-file" }, "FNAME", "file to read grammar from",
+                [](common_params & params, const std::string & value) { params.sampling.grammar = read_file(value); })
+                .set_sparam());
+    add_opt(
+        common_arg({ "-j", "--json-schema" }, "SCHEMA",
+                   "JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON "
+                   "object\nFor schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead",
+                   [](common_params & params, const std::string & value) {
+                       params.sampling.grammar = json_schema_to_grammar(json::parse(value));
+                   })
+            .set_sparam());
     add_opt(common_arg(
-        {"--adaptive-decay"}, "N",
-        string_format("adaptive-p: decay rate for target adaptation over time. lower values "
-                      "are more reactive, higher values are more stable.\n"
-                      "(valid range 0.0 to 0.99) (default: %.2f)",
-                      (double)params.sampling.adaptive_decay),
-        [](common_params & params, const std::string & value) {
-            params.sampling.adaptive_decay = std::stof(value);
-        }
-    ).set_sparam());
+                { "-jf", "--json-schema-file" }, "FILE",
+                "File containing a JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any "
+                "JSON object\nFor schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead",
+                [](common_params & params, const std::string & value) {
+                    std::ifstream file(value);
+                    if (!file) {
+                        throw std::runtime_error(string_format("error: failed to open file '%s'\n", value.c_str()));
+                    }
+                    std::string schema;
+                    std::copy(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(),
+                              std::back_inserter(schema));
+                    params.sampling.grammar = json_schema_to_grammar(json::parse(schema));
+                })
+                .set_sparam());
+    add_opt(common_arg({ "-bs", "--backend-sampling" }, "enable backend sampling (experimental) (default: disabled)",
+                       [](common_params & params) { params.sampling.backend_sampling = true; })
+                .set_sparam()
+                .set_env("LLAMA_ARG_BACKEND_SAMPLING"));
+    add_opt(common_arg({ "--pooling" }, "{none,mean,cls,last,rank}",
+                       "pooling type for embeddings, use model default if unspecified",
+                       [](common_params & params, const std::string & value) {
+                           /**/ if (value == "none") {
+                               params.pooling_type = LLAMA_POOLING_TYPE_NONE;
+                           } else if (value == "mean") {
+                               params.pooling_type = LLAMA_POOLING_TYPE_MEAN;
+                           } else if (value == "cls") {
+                               params.pooling_type = LLAMA_POOLING_TYPE_CLS;
+                           } else if (value == "last") {
+                               params.pooling_type = LLAMA_POOLING_TYPE_LAST;
+                           } else if (value == "rank") {
+                               params.pooling_type = LLAMA_POOLING_TYPE_RANK;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                       })
+                .set_examples(
+                    { LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_RETRIEVAL, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG })
+                .set_env("LLAMA_ARG_POOLING"));
+    add_opt(common_arg({ "--attention" }, "{causal,non-causal}",
+                       "attention type for embeddings, use model default if unspecified",
+                       [](common_params & params, const std::string & value) {
+                           /**/ if (value == "causal") {
+                               params.attention_type = LLAMA_ATTENTION_TYPE_CAUSAL;
+                           } else if (value == "non-causal") {
+                               params.attention_type = LLAMA_ATTENTION_TYPE_NON_CAUSAL;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING }));
+    add_opt(common_arg({ "--rope-scaling" }, "{none,linear,yarn}",
+                       "RoPE frequency scaling method, defaults to linear unless specified by the model",
+                       [](common_params & params, const std::string & value) {
+                           /**/ if (value == "none") {
+                               params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_NONE;
+                           } else if (value == "linear") {
+                               params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_LINEAR;
+                           } else if (value == "yarn") {
+                               params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_YARN;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                       })
+                .set_env("LLAMA_ARG_ROPE_SCALING_TYPE"));
+    add_opt(common_arg({ "--rope-scale" }, "N", "RoPE context scaling factor, expands context by a factor of N",
+                       [](common_params & params, const std::string & value) {
+                           params.rope_freq_scale = 1.0f / std::stof(value);
+                       })
+                .set_env("LLAMA_ARG_ROPE_SCALE"));
+    add_opt(
+        common_arg({ "--rope-freq-base" }, "N",
+                   "RoPE base frequency, used by NTK-aware scaling (default: loaded from model)",
+                   [](common_params & params, const std::string & value) { params.rope_freq_base = std::stof(value); })
+            .set_env("LLAMA_ARG_ROPE_FREQ_BASE"));
+    add_opt(
+        common_arg({ "--rope-freq-scale" }, "N", "RoPE frequency scaling factor, expands context by a factor of 1/N",
+                   [](common_params & params, const std::string & value) { params.rope_freq_scale = std::stof(value); })
+            .set_env("LLAMA_ARG_ROPE_FREQ_SCALE"));
+    add_opt(common_arg({ "--yarn-orig-ctx" }, "N",
+                       string_format("YaRN: original context size of model (default: %d = model training context size)",
+                                     params.yarn_orig_ctx),
+                       [](common_params & params, int value) { params.yarn_orig_ctx = value; })
+                .set_env("LLAMA_ARG_YARN_ORIG_CTX"));
+    add_opt(
+        common_arg({ "--yarn-ext-factor" }, "N",
+                   string_format("YaRN: extrapolation mix factor (default: %.2f, 0.0 = full interpolation)",
+                                 (double) params.yarn_ext_factor),
+                   [](common_params & params, const std::string & value) { params.yarn_ext_factor = std::stof(value); })
+            .set_env("LLAMA_ARG_YARN_EXT_FACTOR"));
     add_opt(common_arg(
-        {"--dynatemp-range"}, "N",
-        string_format("dynamic temperature range (default: %.2f, 0.0 = disabled)", (double)params.sampling.dynatemp_range),
-        [](common_params & params, const std::string & value) {
-            params.sampling.dynatemp_range = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--dynatemp-exp"}, "N",
-        string_format("dynamic temperature exponent (default: %.2f)", (double)params.sampling.dynatemp_exponent),
-        [](common_params & params, const std::string & value) {
-            params.sampling.dynatemp_exponent = std::stof(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--mirostat"}, "N",
-        string_format("use Mirostat sampling.\nTop K, Nucleus and Locally Typical samplers are ignored if used.\n"
-        "(default: %d, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)", params.sampling.mirostat),
-        [](common_params & params, int value) {
-            params.sampling.mirostat = value;
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--mirostat-lr"}, "N",
-        string_format("Mirostat learning rate, parameter eta (default: %.2f)", (double)params.sampling.mirostat_eta),
-        [](common_params & params, const std::string & value) {
-            params.sampling.mirostat_eta = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--mirostat-ent"}, "N",
-        string_format("Mirostat target entropy, parameter tau (default: %.2f)", (double)params.sampling.mirostat_tau),
-        [](common_params & params, const std::string & value) {
-            params.sampling.mirostat_tau = std::stof(value);
-            params.sampling.user_sampling_config |= common_params_sampling_config::COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"-l", "--logit-bias"}, "TOKEN_ID(+/-)BIAS",
-        "modifies the likelihood of token appearing in the completion,\n"
-        "i.e. `--logit-bias 15043+1` to increase likelihood of token ' Hello',\n"
-        "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'",
-        [](common_params & params, const std::string & value) {
-            std::stringstream ss(value);
-            llama_token key;
-            char sign;
-            std::string value_str;
-            try {
-                if (ss >> key && ss >> sign && std::getline(ss, value_str) && (sign == '+' || sign == '-')) {
-                    const float bias = std::stof(value_str) * ((sign == '-') ? -1.0f : 1.0f);
-                    params.sampling.logit_bias.push_back({key, bias});
-                } else {
-                    throw std::invalid_argument("invalid input format");
-                }
-            } catch (const std::exception&) {
-                throw std::invalid_argument("invalid input format");
-            }
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--grammar"}, "GRAMMAR",
-        string_format("BNF-like grammar to constrain generations (see samples in grammars/ dir) (default: '%s')", params.sampling.grammar.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.sampling.grammar = value;
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"--grammar-file"}, "FNAME",
-        "file to read grammar from",
-        [](common_params & params, const std::string & value) {
-            params.sampling.grammar = read_file(value);
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"-j", "--json-schema"}, "SCHEMA",
-        "JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object\nFor schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead",
-        [](common_params & params, const std::string & value) {
-            params.sampling.grammar = json_schema_to_grammar(json::parse(value));
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"-jf", "--json-schema-file"}, "FILE",
-        "File containing a JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object\nFor schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead",
-        [](common_params & params, const std::string & value) {
-            std::ifstream file(value);
-            if (!file) {
-                throw std::runtime_error(string_format("error: failed to open file '%s'\n", value.c_str()));
-            }
-            std::string schema;
-            std::copy(
-                std::istreambuf_iterator<char>(file),
-                std::istreambuf_iterator<char>(),
-                std::back_inserter(schema)
-            );
-            params.sampling.grammar = json_schema_to_grammar(json::parse(schema));
-        }
-    ).set_sparam());
-    add_opt(common_arg(
-        {"-bs", "--backend-sampling"},
-        "enable backend sampling (experimental) (default: disabled)",
-        [](common_params & params) {
-            params.sampling.backend_sampling = true;
-        }
-    ).set_sparam().set_env("LLAMA_ARG_BACKEND_SAMPLING"));
-    add_opt(common_arg(
-        {"--pooling"}, "{none,mean,cls,last,rank}",
-        "pooling type for embeddings, use model default if unspecified",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "none") { params.pooling_type = LLAMA_POOLING_TYPE_NONE; }
-            else if (value == "mean") { params.pooling_type = LLAMA_POOLING_TYPE_MEAN; }
-            else if (value == "cls")  { params.pooling_type = LLAMA_POOLING_TYPE_CLS;  }
-            else if (value == "last") { params.pooling_type = LLAMA_POOLING_TYPE_LAST; }
-            else if (value == "rank") { params.pooling_type = LLAMA_POOLING_TYPE_RANK; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_RETRIEVAL, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG}).set_env("LLAMA_ARG_POOLING"));
-    add_opt(common_arg(
-        {"--attention"}, "{causal,non-causal}",
-        "attention type for embeddings, use model default if unspecified",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "causal") { params.attention_type = LLAMA_ATTENTION_TYPE_CAUSAL; }
-            else if (value == "non-causal") { params.attention_type = LLAMA_ATTENTION_TYPE_NON_CAUSAL; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
-    add_opt(common_arg(
-        {"--rope-scaling"}, "{none,linear,yarn}",
-        "RoPE frequency scaling method, defaults to linear unless specified by the model",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "none") { params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_NONE; }
-            else if (value == "linear") { params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_LINEAR; }
-            else if (value == "yarn") { params.rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_YARN; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_env("LLAMA_ARG_ROPE_SCALING_TYPE"));
-    add_opt(common_arg(
-        {"--rope-scale"}, "N",
-        "RoPE context scaling factor, expands context by a factor of N",
-        [](common_params & params, const std::string & value) {
-            params.rope_freq_scale = 1.0f / std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_ROPE_SCALE"));
-    add_opt(common_arg(
-        {"--rope-freq-base"}, "N",
-        "RoPE base frequency, used by NTK-aware scaling (default: loaded from model)",
-        [](common_params & params, const std::string & value) {
-            params.rope_freq_base = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_ROPE_FREQ_BASE"));
-    add_opt(common_arg(
-        {"--rope-freq-scale"}, "N",
-        "RoPE frequency scaling factor, expands context by a factor of 1/N",
-        [](common_params & params, const std::string & value) {
-            params.rope_freq_scale = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_ROPE_FREQ_SCALE"));
-    add_opt(common_arg(
-        {"--yarn-orig-ctx"}, "N",
-        string_format("YaRN: original context size of model (default: %d = model training context size)", params.yarn_orig_ctx),
-        [](common_params & params, int value) {
-            params.yarn_orig_ctx = value;
-        }
-    ).set_env("LLAMA_ARG_YARN_ORIG_CTX"));
-    add_opt(common_arg(
-        {"--yarn-ext-factor"}, "N",
-        string_format("YaRN: extrapolation mix factor (default: %.2f, 0.0 = full interpolation)", (double)params.yarn_ext_factor),
-        [](common_params & params, const std::string & value) {
-            params.yarn_ext_factor = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_YARN_EXT_FACTOR"));
-    add_opt(common_arg(
-        {"--yarn-attn-factor"}, "N",
-        string_format("YaRN: scale sqrt(t) or attention magnitude (default: %.2f)", (double)params.yarn_attn_factor),
-        [](common_params & params, const std::string & value) {
-            params.yarn_attn_factor = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_YARN_ATTN_FACTOR"));
-    add_opt(common_arg(
-        {"--yarn-beta-slow"}, "N",
-        string_format("YaRN: high correction dim or alpha (default: %.2f)", (double)params.yarn_beta_slow),
-        [](common_params & params, const std::string & value) {
-            params.yarn_beta_slow = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_YARN_BETA_SLOW"));
-    add_opt(common_arg(
-        {"--yarn-beta-fast"}, "N",
-        string_format("YaRN: low correction dim or beta (default: %.2f)", (double)params.yarn_beta_fast),
-        [](common_params & params, const std::string & value) {
-            params.yarn_beta_fast = std::stof(value);
-        }
-    ).set_env("LLAMA_ARG_YARN_BETA_FAST"));
-    add_opt(common_arg(
-        {"-gan", "--grp-attn-n"}, "N",
-        string_format("group-attention factor (default: %d)", params.grp_attn_n),
-        [](common_params & params, int value) {
-            params.grp_attn_n = value;
-        }
-    ).set_env("LLAMA_ARG_GRP_ATTN_N").set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_PASSKEY}));
-    add_opt(common_arg(
-        {"-gaw", "--grp-attn-w"}, "N",
-        string_format("group-attention width (default: %d)", params.grp_attn_w),
-        [](common_params & params, int value) {
-            params.grp_attn_w = value;
-        }
-    ).set_env("LLAMA_ARG_GRP_ATTN_W").set_examples({LLAMA_EXAMPLE_COMPLETION}));
-    add_opt(common_arg(
-        {"-kvo", "--kv-offload"},
-        {"-nkvo", "--no-kv-offload"},
-        string_format("whether to enable KV cache offloading (default: %s)", params.no_kv_offload ? "disabled" : "enabled"),
-        [](common_params & params, bool value) {
-            params.no_kv_offload = !value;
-        }
-    ).set_env("LLAMA_ARG_KV_OFFLOAD"));
-    add_opt(common_arg(
-        {"--repack"},
-        {"-nr", "--no-repack"},
-        string_format("whether to enable weight repacking (default: %s)", params.no_extra_bufts ? "disabled" : "enabled"),
-        [](common_params & params, bool value) {
-            params.no_extra_bufts = !value;
-        }
-    ).set_env("LLAMA_ARG_REPACK"));
-    add_opt(common_arg(
-        {"--no-host"},
-        "bypass host buffer allowing extra buffers to be used",
-        [](common_params & params) {
+                { "--yarn-attn-factor" }, "N",
+                string_format("YaRN: scale sqrt(t) or attention magnitude (default: %.2f)",
+                              (double) params.yarn_attn_factor),
+                [](common_params & params, const std::string & value) { params.yarn_attn_factor = std::stof(value); })
+                .set_env("LLAMA_ARG_YARN_ATTN_FACTOR"));
+    add_opt(
+        common_arg({ "--yarn-beta-slow" }, "N",
+                   string_format("YaRN: high correction dim or alpha (default: %.2f)", (double) params.yarn_beta_slow),
+                   [](common_params & params, const std::string & value) { params.yarn_beta_slow = std::stof(value); })
+            .set_env("LLAMA_ARG_YARN_BETA_SLOW"));
+    add_opt(
+        common_arg({ "--yarn-beta-fast" }, "N",
+                   string_format("YaRN: low correction dim or beta (default: %.2f)", (double) params.yarn_beta_fast),
+                   [](common_params & params, const std::string & value) { params.yarn_beta_fast = std::stof(value); })
+            .set_env("LLAMA_ARG_YARN_BETA_FAST"));
+    add_opt(common_arg({ "-gan", "--grp-attn-n" }, "N",
+                       string_format("group-attention factor (default: %d)", params.grp_attn_n),
+                       [](common_params & params, int value) { params.grp_attn_n = value; })
+                .set_env("LLAMA_ARG_GRP_ATTN_N")
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_PASSKEY }));
+    add_opt(common_arg({ "-gaw", "--grp-attn-w" }, "N",
+                       string_format("group-attention width (default: %d)", params.grp_attn_w),
+                       [](common_params & params, int value) { params.grp_attn_w = value; })
+                .set_env("LLAMA_ARG_GRP_ATTN_W")
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION }));
+    add_opt(common_arg({ "-kvo", "--kv-offload" }, { "-nkvo", "--no-kv-offload" },
+                       string_format("whether to enable KV cache offloading (default: %s)",
+                                     params.no_kv_offload ? "disabled" : "enabled"),
+                       [](common_params & params, bool value) { params.no_kv_offload = !value; })
+                .set_env("LLAMA_ARG_KV_OFFLOAD"));
+    add_opt(common_arg({ "--repack" }, { "-nr", "--no-repack" },
+                       string_format("whether to enable weight repacking (default: %s)",
+                                     params.no_extra_bufts ? "disabled" : "enabled"),
+                       [](common_params & params, bool value) { params.no_extra_bufts = !value; })
+                .set_env("LLAMA_ARG_REPACK"));
+    add_opt(
+        common_arg({ "--no-host" }, "bypass host buffer allowing extra buffers to be used", [](common_params & params) {
             params.no_host = true;
-        }
-    ).set_env("LLAMA_ARG_NO_HOST"));
-    add_opt(common_arg(
-        {"-ctk", "--cache-type-k"}, "TYPE",
-        string_format(
-            "KV cache data type for K\n"
-            "allowed values: %s\n"
-            "(default: %s)",
-            get_all_kv_cache_types().c_str(),
-            ggml_type_name(params.cache_type_k)
-        ),
-        [](common_params & params, const std::string & value) {
-            params.cache_type_k = kv_cache_type_from_str(value);
-        }
-    ).set_env("LLAMA_ARG_CACHE_TYPE_K"));
-    add_opt(common_arg(
-        {"-ctv", "--cache-type-v"}, "TYPE",
-        string_format(
-            "KV cache data type for V\n"
-            "allowed values: %s\n"
-            "(default: %s)",
-            get_all_kv_cache_types().c_str(),
-            ggml_type_name(params.cache_type_v)
-        ),
-        [](common_params & params, const std::string & value) {
-            params.cache_type_v = kv_cache_type_from_str(value);
-        }
-    ).set_env("LLAMA_ARG_CACHE_TYPE_V"));
-    add_opt(common_arg(
-        {"--hellaswag"},
-        "compute HellaSwag score over random tasks from datafile supplied with -f",
-        [](common_params & params) {
-            params.hellaswag = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--hellaswag-tasks"}, "N",
-        string_format("number of tasks to use when computing the HellaSwag score (default: %zu)", params.hellaswag_tasks),
-        [](common_params & params, int value) {
-            params.hellaswag_tasks = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--winogrande"},
-        "compute Winogrande score over random tasks from datafile supplied with -f",
-        [](common_params & params) {
-            params.winogrande = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--winogrande-tasks"}, "N",
-        string_format("number of tasks to use when computing the Winogrande score (default: %zu)", params.winogrande_tasks),
-        [](common_params & params, int value) {
-            params.winogrande_tasks = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--multiple-choice"},
-        "compute multiple choice score over random tasks from datafile supplied with -f",
-        [](common_params & params) {
-            params.multiple_choice = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--multiple-choice-tasks"}, "N",
-        string_format("number of tasks to use when computing the multiple choice score (default: %zu)", params.multiple_choice_tasks),
-        [](common_params & params, int value) {
-            params.multiple_choice_tasks = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--kl-divergence"},
-        "computes KL-divergence to logits provided via --kl-divergence-base",
-        [](common_params & params) {
-            params.kl_divergence = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--save-all-logits", "--kl-divergence-base"}, "FNAME",
-        "set logits file",
-        [](common_params & params, const std::string & value) {
-            params.logits_file = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--ppl-stride"}, "N",
-        string_format("stride for perplexity calculation (default: %d)", params.ppl_stride),
-        [](common_params & params, int value) {
-            params.ppl_stride = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"--ppl-output-type"}, "<0|1>",
-        string_format("output type for perplexity calculation (default: %d)", params.ppl_output_type),
-        [](common_params & params, int value) {
-            params.ppl_output_type = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PERPLEXITY}));
-    add_opt(common_arg(
-        {"-dt", "--defrag-thold"}, "N",
-        string_format("KV cache defragmentation threshold (DEPRECATED)"),
-        [](common_params & params, const std::string & value) {
-            GGML_UNUSED(params);
-            GGML_UNUSED(value);
-            LOG_WRN("DEPRECATED: --defrag-thold is deprecated and no longer necessary to specify\n");
-        }
-    ).set_env("LLAMA_ARG_DEFRAG_THOLD"));
+        }).set_env("LLAMA_ARG_NO_HOST"));
+    add_opt(common_arg({ "-ctk", "--cache-type-k" }, "TYPE",
+                       string_format("KV cache data type for K\n"
+                                     "allowed values: %s\n"
+                                     "(default: %s)",
+                                     get_all_kv_cache_types().c_str(), ggml_type_name(params.cache_type_k)),
+                       [](common_params & params, const std::string & value) {
+                           params.cache_type_k = kv_cache_type_from_str(value);
+                       })
+                .set_env("LLAMA_ARG_CACHE_TYPE_K"));
+    add_opt(common_arg({ "-ctv", "--cache-type-v" }, "TYPE",
+                       string_format("KV cache data type for V\n"
+                                     "allowed values: %s\n"
+                                     "(default: %s)",
+                                     get_all_kv_cache_types().c_str(), ggml_type_name(params.cache_type_v)),
+                       [](common_params & params, const std::string & value) {
+                           params.cache_type_v = kv_cache_type_from_str(value);
+                       })
+                .set_env("LLAMA_ARG_CACHE_TYPE_V"));
+    add_opt(common_arg({ "--hellaswag" }, "compute HellaSwag score over random tasks from datafile supplied with -f",
+                       [](common_params & params) { params.hellaswag = true; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--hellaswag-tasks" }, "N",
+                       string_format("number of tasks to use when computing the HellaSwag score (default: %zu)",
+                                     params.hellaswag_tasks),
+                       [](common_params & params, int value) { params.hellaswag_tasks = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--winogrande" }, "compute Winogrande score over random tasks from datafile supplied with -f",
+                       [](common_params & params) { params.winogrande = true; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--winogrande-tasks" }, "N",
+                       string_format("number of tasks to use when computing the Winogrande score (default: %zu)",
+                                     params.winogrande_tasks),
+                       [](common_params & params, int value) { params.winogrande_tasks = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--multiple-choice" },
+                       "compute multiple choice score over random tasks from datafile supplied with -f",
+                       [](common_params & params) { params.multiple_choice = true; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--multiple-choice-tasks" }, "N",
+                       string_format("number of tasks to use when computing the multiple choice score (default: %zu)",
+                                     params.multiple_choice_tasks),
+                       [](common_params & params, int value) { params.multiple_choice_tasks = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--kl-divergence" }, "computes KL-divergence to logits provided via --kl-divergence-base",
+                       [](common_params & params) { params.kl_divergence = true; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--save-all-logits", "--kl-divergence-base" }, "FNAME", "set logits file",
+                       [](common_params & params, const std::string & value) { params.logits_file = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--ppl-stride" }, "N",
+                       string_format("stride for perplexity calculation (default: %d)", params.ppl_stride),
+                       [](common_params & params, int value) { params.ppl_stride = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "--ppl-output-type" }, "<0|1>",
+                       string_format("output type for perplexity calculation (default: %d)", params.ppl_output_type),
+                       [](common_params & params, int value) { params.ppl_output_type = value; })
+                .set_examples({ LLAMA_EXAMPLE_PERPLEXITY }));
+    add_opt(common_arg({ "-dt", "--defrag-thold" }, "N",
+                       string_format("KV cache defragmentation threshold (DEPRECATED)"),
+                       [](common_params & params, const std::string & value) {
+                           GGML_UNUSED(params);
+                           GGML_UNUSED(value);
+                           LOG_WRN("DEPRECATED: --defrag-thold is deprecated and no longer necessary to specify\n");
+                       })
+                .set_env("LLAMA_ARG_DEFRAG_THOLD"));
     if (ex == LLAMA_EXAMPLE_SERVER) {
         // this is to make sure this option appears in the server-specific section of the help message
-        add_opt(common_arg(
-            {"-np", "--parallel"}, "N",
-            string_format("number of server slots (default: %d, -1 = auto)", params.n_parallel),
-            [](common_params & params, int value) {
-                if (value == 0) {
-                    throw std::invalid_argument("error: invalid value for n_parallel\n");
-                }
-                params.n_parallel = value;
-            }
-        ).set_env("LLAMA_ARG_N_PARALLEL").set_examples({LLAMA_EXAMPLE_SERVER}));
+        add_opt(common_arg({ "-np", "--parallel" }, "N",
+                           string_format("number of server slots (default: %d, -1 = auto)", params.n_parallel),
+                           [](common_params & params, int value) {
+                               if (value == 0) {
+                                   throw std::invalid_argument("error: invalid value for n_parallel\n");
+                               }
+                               params.n_parallel = value;
+                           })
+                    .set_env("LLAMA_ARG_N_PARALLEL")
+                    .set_examples({ LLAMA_EXAMPLE_SERVER }));
     } else {
-        add_opt(common_arg(
-            {"-np", "--parallel"}, "N",
-            string_format("number of parallel sequences to decode (default: %d)", params.n_parallel),
-            [](common_params & params, int value) {
-                params.n_parallel = value;
-            }
-        ).set_env("LLAMA_ARG_N_PARALLEL"));
+        add_opt(common_arg({ "-np", "--parallel" }, "N",
+                           string_format("number of parallel sequences to decode (default: %d)", params.n_parallel),
+                           [](common_params & params, int value) { params.n_parallel = value; })
+                    .set_env("LLAMA_ARG_N_PARALLEL"));
     }
-    add_opt(common_arg(
-        {"-ns", "--sequences"}, "N",
-        string_format("number of sequences to decode (default: %d)", params.n_sequences),
-        [](common_params & params, int value) {
-            params.n_sequences = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PARALLEL}));
-    add_opt(common_arg(
-        {"-cb", "--cont-batching"},
-        {"-nocb", "--no-cont-batching"},
-        string_format("whether to enable continuous batching (a.k.a dynamic batching) (default: %s)", params.cont_batching ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.cont_batching = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_CONT_BATCHING"));
-    add_opt(common_arg(
-        {"-mm", "--mmproj"}, "FILE",
-        "path to a multimodal projector file. see tools/mtmd/README.md\n"
-        "note: if -hf is used, this argument can be omitted",
-        [](common_params & params, const std::string & value) {
-            params.mmproj.path = value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ"));
-    add_opt(common_arg(
-        {"-mmu", "--mmproj-url"}, "URL",
-        "URL to a multimodal projector file. see tools/mtmd/README.md",
-        [](common_params & params, const std::string & value) {
-            params.mmproj.url = value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_URL"));
-    add_opt(common_arg(
-        {"--mmproj-auto"},
-        {"--no-mmproj", "--no-mmproj-auto"},
-        string_format("whether to use multimodal projector file (if available), useful when using -hf (default: %s)", params.no_mmproj ? "disabled" : "enabled"),
-        [](common_params & params, bool value) {
-            params.no_mmproj = !value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_AUTO"));
-    add_opt(common_arg(
-        {"--mmproj-offload"},
-        {"--no-mmproj-offload"},
-        string_format("whether to enable GPU offloading for multimodal projector (default: %s)", params.mmproj_use_gpu ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.mmproj_use_gpu = value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_OFFLOAD"));
-    add_opt(common_arg(
-        {"--image", "--audio"}, "FILE",
-        "path to an image or audio file. use with multimodal models, use comma-separated values for multiple files\n",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                params.image.emplace_back(item);
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_MTMD, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"--image-min-tokens"}, "N",
-        "minimum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)",
-        [](common_params & params, int value) {
-            params.image_min_tokens = value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MIN_TOKENS"));
-    add_opt(common_arg(
-        {"--image-max-tokens"}, "N",
-        "maximum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)",
-        [](common_params & params, int value) {
-            params.image_max_tokens = value;
-        }
-    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MAX_TOKENS"));
+    add_opt(common_arg({ "-ns", "--sequences" }, "N",
+                       string_format("number of sequences to decode (default: %d)", params.n_sequences),
+                       [](common_params & params, int value) { params.n_sequences = value; })
+                .set_examples({ LLAMA_EXAMPLE_PARALLEL }));
+    add_opt(common_arg({ "-cb", "--cont-batching" }, { "-nocb", "--no-cont-batching" },
+                       string_format("whether to enable continuous batching (a.k.a dynamic batching) (default: %s)",
+                                     params.cont_batching ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.cont_batching = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_CONT_BATCHING"));
+    add_opt(common_arg({ "-mm", "--mmproj" }, "FILE",
+                       "path to a multimodal projector file. see tools/mtmd/README.md\n"
+                       "note: if -hf is used, this argument can be omitted",
+                       [](common_params & params, const std::string & value) { params.mmproj.path = value; })
+                .set_examples(mmproj_examples)
+                .set_env("LLAMA_ARG_MMPROJ"));
+    add_opt(common_arg({ "-mmu", "--mmproj-url" }, "URL",
+                       "URL to a multimodal projector file. see tools/mtmd/README.md",
+                       [](common_params & params, const std::string & value) { params.mmproj.url = value; })
+                .set_examples(mmproj_examples)
+                .set_env("LLAMA_ARG_MMPROJ_URL"));
+    add_opt(
+        common_arg({ "--mmproj-auto" }, { "--no-mmproj", "--no-mmproj-auto" },
+                   string_format(
+                       "whether to use multimodal projector file (if available), useful when using -hf (default: %s)",
+                       params.no_mmproj ? "disabled" : "enabled"),
+                   [](common_params & params, bool value) { params.no_mmproj = !value; })
+            .set_examples(mmproj_examples)
+            .set_env("LLAMA_ARG_MMPROJ_AUTO"));
+    add_opt(common_arg({ "--mmproj-offload" }, { "--no-mmproj-offload" },
+                       string_format("whether to enable GPU offloading for multimodal projector (default: %s)",
+                                     params.mmproj_use_gpu ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.mmproj_use_gpu = value; })
+                .set_examples(mmproj_examples)
+                .set_env("LLAMA_ARG_MMPROJ_OFFLOAD"));
+    add_opt(common_arg({ "--image", "--audio" }, "FILE",
+                       "path to an image or audio file. use with multimodal models, use comma-separated values for "
+                       "multiple files\n",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               params.image.emplace_back(item);
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_MTMD, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "--image-min-tokens" }, "N",
+                       "minimum number of tokens each image can take, only used by vision models with dynamic "
+                       "resolution (default: read from model)",
+                       [](common_params & params, int value) { params.image_min_tokens = value; })
+                .set_examples(mmproj_examples)
+                .set_env("LLAMA_ARG_IMAGE_MIN_TOKENS"));
+    add_opt(common_arg({ "--image-max-tokens" }, "N",
+                       "maximum number of tokens each image can take, only used by vision models with dynamic "
+                       "resolution (default: read from model)",
+                       [](common_params & params, int value) { params.image_max_tokens = value; })
+                .set_examples(mmproj_examples)
+                .set_env("LLAMA_ARG_IMAGE_MAX_TOKENS"));
     if (llama_supports_rpc()) {
-        add_opt(common_arg(
-            {"--rpc"}, "SERVERS",
-            "comma separated list of RPC servers (host:port)",
-            [](common_params & params, const std::string & value) {
-                add_rpc_devices(value);
-                GGML_UNUSED(params);
-            }
-        ).set_env("LLAMA_ARG_RPC"));
+        add_opt(common_arg({ "--rpc" }, "SERVERS", "comma separated list of RPC servers (host:port)",
+                           [](common_params & params, const std::string & value) {
+                               add_rpc_devices(value);
+                               GGML_UNUSED(params);
+                           })
+                    .set_env("LLAMA_ARG_RPC"));
     }
-    add_opt(common_arg(
-        {"--mlock"},
-        "force system to keep model in RAM rather than swapping or compressing",
-        [](common_params & params) {
-            params.use_mlock = true;
-        }
-    ).set_env("LLAMA_ARG_MLOCK"));
-    add_opt(common_arg(
-        {"--mmap"},
-        {"--no-mmap"},
-        string_format("whether to memory-map model. (if mmap disabled, slower load but may reduce pageouts if not using mlock) (default: %s)", params.use_mmap ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.use_mmap = value;
-        }
-    ).set_env("LLAMA_ARG_MMAP"));
-    add_opt(common_arg(
-        {"-dio", "--direct-io"},
-        {"-ndio", "--no-direct-io"},
-        string_format("use DirectIO if available. (default: %s)", params.use_direct_io ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.use_direct_io = value;
-        }
-    ).set_env("LLAMA_ARG_DIO"));
-    add_opt(common_arg(
-        {"--numa"}, "TYPE",
-        "attempt optimizations that help on some NUMA systems\n"
-        "- distribute: spread execution evenly over all nodes\n"
-        "- isolate: only spawn threads on CPUs on the node that execution started on\n"
-        "- numactl: use the CPU map provided by numactl\n"
-        "if run without this previously, it is recommended to drop the system page cache before using this\n"
-        "see https://github.com/ggml-org/llama.cpp/issues/1437",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "distribute" || value == "") { params.numa = GGML_NUMA_STRATEGY_DISTRIBUTE; }
-            else if (value == "isolate") { params.numa = GGML_NUMA_STRATEGY_ISOLATE; }
-            else if (value == "numactl") { params.numa = GGML_NUMA_STRATEGY_NUMACTL; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_env("LLAMA_ARG_NUMA"));
-    add_opt(common_arg(
-        {"-dev", "--device"}, "<dev1,dev2,..>",
-        "comma-separated list of devices to use for offloading (none = don't offload)\n"
-        "use --list-devices to see a list of available devices",
-        [](common_params & params, const std::string & value) {
-            params.devices = parse_device_list(value);
-        }
-    ).set_env("LLAMA_ARG_DEVICE"));
-    add_opt(common_arg(
-        {"--list-devices"},
-        "print list of available devices and exit",
-        [](common_params &) {
-            std::vector<ggml_backend_dev_t> devices;
-            for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-                auto * dev = ggml_backend_dev_get(i);
-                if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU) {
-                    devices.push_back(dev);
-                }
-            }
-            printf("Available devices:\n");
-            for (auto * dev : devices) {
-                size_t free, total;
-                ggml_backend_dev_memory(dev, &free, &total);
-                printf("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev), total / 1024 / 1024, free / 1024 / 1024);
-            }
-            exit(0);
-        }
-    ));
-    add_opt(common_arg(
-        {"-ot", "--override-tensor"}, "<tensor name pattern>=<buffer type>,...",
-        "override tensor buffer type", [](common_params & params, const std::string & value) {
-            parse_tensor_buffer_overrides(value, params.tensor_buft_overrides);
-        }
-    ).set_env("LLAMA_ARG_OVERRIDE_TENSOR"));
-    add_opt(common_arg(
-        {"-otd", "--override-tensor-draft"}, "<tensor name pattern>=<buffer type>,...",
-        "override tensor buffer type for draft model", [](common_params & params, const std::string & value) {
-            parse_tensor_buffer_overrides(value, params.speculative.tensor_buft_overrides);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"-cmoe", "--cpu-moe"},
-        "keep all Mixture of Experts (MoE) weights in the CPU",
-        [](common_params & params) {
-            params.tensor_buft_overrides.push_back(llm_ffn_exps_cpu_override());
-        }
-    ).set_env("LLAMA_ARG_CPU_MOE"));
-    add_opt(common_arg(
-        {"-ncmoe", "--n-cpu-moe"}, "N",
-        "keep the Mixture of Experts (MoE) weights of the first N layers in the CPU",
-        [](common_params & params, int value) {
-            if (value < 0) {
-                throw std::invalid_argument("invalid value");
-            }
-            for (int i = 0; i < value; ++i) {
-                // keep strings alive and avoid leaking memory by storing them in a static vector
-                static std::list<std::string> buft_overrides;
-                buft_overrides.push_back(llm_ffn_exps_block_regex(i));
-                params.tensor_buft_overrides.push_back({buft_overrides.back().c_str(), ggml_backend_cpu_buffer_type()});
+    add_opt(common_arg({ "--mlock" }, "force system to keep model in RAM rather than swapping or compressing",
+                       [](common_params & params) { params.use_mlock = true; })
+                .set_env("LLAMA_ARG_MLOCK"));
+    add_opt(common_arg({ "--mmap" }, { "--no-mmap" },
+                       string_format("whether to memory-map model. (if mmap disabled, slower load but may reduce "
+                                     "pageouts if not using mlock) (default: %s)",
+                                     params.use_mmap ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.use_mmap = value; })
+                .set_env("LLAMA_ARG_MMAP"));
+    add_opt(common_arg({ "-dio", "--direct-io" }, { "-ndio", "--no-direct-io" },
+                       string_format("use DirectIO if available. (default: %s)",
+                                     params.use_direct_io ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.use_direct_io = value; })
+                .set_env("LLAMA_ARG_DIO"));
+    add_opt(
+        common_arg({ "--numa" }, "TYPE",
+                   "attempt optimizations that help on some NUMA systems\n"
+                   "- distribute: spread execution evenly over all nodes\n"
+                   "- isolate: only spawn threads on CPUs on the node that execution started on\n"
+                   "- numactl: use the CPU map provided by numactl\n"
+                   "if run without this previously, it is recommended to drop the system page cache before using this\n"
+                   "see https://github.com/ggml-org/llama.cpp/issues/1437",
+                   [](common_params & params, const std::string & value) {
+                       /**/ if (value == "distribute" || value == "") {
+                           params.numa = GGML_NUMA_STRATEGY_DISTRIBUTE;
+                       } else if (value == "isolate") {
+                           params.numa = GGML_NUMA_STRATEGY_ISOLATE;
+                       } else if (value == "numactl") {
+                           params.numa = GGML_NUMA_STRATEGY_NUMACTL;
+                       } else {
+                           throw std::invalid_argument("invalid value");
+                       }
+                   })
+            .set_env("LLAMA_ARG_NUMA"));
+    add_opt(
+        common_arg({ "-dev", "--device" }, "<dev1,dev2,..>",
+                   "comma-separated list of devices to use for offloading (none = don't offload)\n"
+                   "use --list-devices to see a list of available devices",
+                   [](common_params & params, const std::string & value) { params.devices = parse_device_list(value); })
+            .set_env("LLAMA_ARG_DEVICE"));
+    add_opt(common_arg({ "--list-devices" }, "print list of available devices and exit", [](common_params &) {
+        std::vector<ggml_backend_dev_t> devices;
+        for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+            auto * dev = ggml_backend_dev_get(i);
+            if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU) {
+                devices.push_back(dev);
             }
         }
-    ).set_env("LLAMA_ARG_N_CPU_MOE"));
-    add_opt(common_arg(
-        {"-cmoed", "--cpu-moe-draft"},
-        "keep all Mixture of Experts (MoE) weights in the CPU for the draft model",
-        [](common_params & params) {
-            params.speculative.tensor_buft_overrides.push_back(llm_ffn_exps_cpu_override());
+        printf("Available devices:\n");
+        for (auto * dev : devices) {
+            size_t free, total;
+            ggml_backend_dev_memory(dev, &free, &total);
+            printf("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev),
+                   total / 1024 / 1024, free / 1024 / 1024);
         }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_CPU_MOE_DRAFT"));
-    add_opt(common_arg(
-        {"-ncmoed", "--n-cpu-moe-draft"}, "N",
-        "keep the Mixture of Experts (MoE) weights of the first N layers in the CPU for the draft model",
-        [](common_params & params, int value) {
-            if (value < 0) {
-                throw std::invalid_argument("invalid value");
-            }
-            for (int i = 0; i < value; ++i) {
-                static std::list<std::string> buft_overrides_draft;
-                buft_overrides_draft.push_back(llm_ffn_exps_block_regex(i));
-                params.speculative.tensor_buft_overrides.push_back({buft_overrides_draft.back().c_str(), ggml_backend_cpu_buffer_type()});
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_N_CPU_MOE_DRAFT"));
-    GGML_ASSERT(params.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
-    add_opt(common_arg(
-        {"-ngl", "--gpu-layers", "--n-gpu-layers"}, "N",
-        string_format("max. number of layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)", params.n_gpu_layers == -1 ? "auto" : "all"),
-        [](common_params & params, const std::string & value) {
-            if (value == "auto") {
-                params.n_gpu_layers = -1;
-            } else if (value == "all") {
-                params.n_gpu_layers = -2;
-            } else {
-                params.n_gpu_layers = std::stoi(value);
-            }
-            if (!llama_supports_gpu_offload()) {
-                fprintf(stderr, "warning: no usable GPU found, --gpu-layers option will be ignored\n");
-                fprintf(stderr, "warning: one possible reason is that llama.cpp was compiled without GPU support\n");
-                fprintf(stderr, "warning: consult docs/build.md for compilation instructions\n");
-            }
-        }
-    ).set_env("LLAMA_ARG_N_GPU_LAYERS"));
-    add_opt(common_arg(
-        {"-sm", "--split-mode"}, "{none,layer,row}",
-        "how to split the model across multiple GPUs, one of:\n"
-        "- none: use one GPU only\n"
-        "- layer (default): split layers and KV across GPUs\n"
-        "- row: split rows across GPUs",
-        [](common_params & params, const std::string & value) {
-            std::string arg_next = value;
-            if (arg_next == "none") {
-                params.split_mode = LLAMA_SPLIT_MODE_NONE;
-            } else if (arg_next == "layer") {
-                params.split_mode = LLAMA_SPLIT_MODE_LAYER;
-            } else if (arg_next == "row") {
-                params.split_mode = LLAMA_SPLIT_MODE_ROW;
-            } else {
-                throw std::invalid_argument("invalid value");
-            }
-            if (!llama_supports_gpu_offload()) {
-                fprintf(stderr, "warning: llama.cpp was compiled without support for GPU offload. Setting the split mode has no effect.\n");
-            }
-        }
-    ).set_env("LLAMA_ARG_SPLIT_MODE"));
-    add_opt(common_arg(
-        {"-ts", "--tensor-split"}, "N0,N1,N2,...",
-        "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",
-        [](common_params & params, const std::string & value) {
-            std::string arg_next = value;
+        exit(0);
+    }));
+    add_opt(common_arg({ "-ot", "--override-tensor" }, "<tensor name pattern>=<buffer type>,...",
+                       "override tensor buffer type",
+                       [](common_params & params, const std::string & value) {
+                           parse_tensor_buffer_overrides(value, params.tensor_buft_overrides);
+                       })
+                .set_env("LLAMA_ARG_OVERRIDE_TENSOR"));
+    add_opt(common_arg({ "-otd", "--override-tensor-draft" }, "<tensor name pattern>=<buffer type>,...",
+                       "override tensor buffer type for draft model",
+                       [](common_params & params, const std::string & value) {
+                           parse_tensor_buffer_overrides(value, params.speculative.tensor_buft_overrides);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
+    add_opt(
+        common_arg({ "-cmoe", "--cpu-moe" }, "keep all Mixture of Experts (MoE) weights in the CPU",
+                   [](common_params & params) { params.tensor_buft_overrides.push_back(llm_ffn_exps_cpu_override()); })
+            .set_env("LLAMA_ARG_CPU_MOE"));
+    add_opt(common_arg({ "-ncmoe", "--n-cpu-moe" }, "N",
+                       "keep the Mixture of Experts (MoE) weights of the first N layers in the CPU",
+                       [](common_params & params, int value) {
+                           if (value < 0) {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           for (int i = 0; i < value; ++i) {
+                               // keep strings alive and avoid leaking memory by storing them in a static vector
+                               static std::list<std::string> buft_overrides;
+                               buft_overrides.push_back(llm_ffn_exps_block_regex(i));
+                               params.tensor_buft_overrides.push_back(
+                                   { buft_overrides.back().c_str(), ggml_backend_cpu_buffer_type() });
+                           }
+                       })
+                .set_env("LLAMA_ARG_N_CPU_MOE"));
+    add_opt(common_arg({ "-cmoed", "--cpu-moe-draft" },
+                       "keep all Mixture of Experts (MoE) weights in the CPU for the draft model",
+                       [](common_params & params) {
+                           params.speculative.tensor_buft_overrides.push_back(llm_ffn_exps_cpu_override());
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_CPU_MOE_DRAFT"));
+    add_opt(common_arg({ "-ncmoed", "--n-cpu-moe-draft" }, "N",
+                       "keep the Mixture of Experts (MoE) weights of the first N layers in the CPU for the draft model",
+                       [](common_params & params, int value) {
+                           if (value < 0) {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           for (int i = 0; i < value; ++i) {
+                               static std::list<std::string> buft_overrides_draft;
+                               buft_overrides_draft.push_back(llm_ffn_exps_block_regex(i));
+                               params.speculative.tensor_buft_overrides.push_back(
+                                   { buft_overrides_draft.back().c_str(), ggml_backend_cpu_buffer_type() });
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_N_CPU_MOE_DRAFT"));
+    GGML_ASSERT(params.n_gpu_layers < 0);  // string_format would need to be extended for a default >= 0
+    add_opt(
+        common_arg({ "-ngl", "--gpu-layers", "--n-gpu-layers" }, "N",
+                   string_format(
+                       "max. number of layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)",
+                       params.n_gpu_layers == -1 ? "auto" : "all"),
+                   [](common_params & params, const std::string & value) {
+                       if (value == "auto") {
+                           params.n_gpu_layers = -1;
+                       } else if (value == "all") {
+                           params.n_gpu_layers = -2;
+                       } else {
+                           params.n_gpu_layers = std::stoi(value);
+                       }
+                       if (!llama_supports_gpu_offload()) {
+                           fprintf(stderr, "warning: no usable GPU found, --gpu-layers option will be ignored\n");
+                           fprintf(stderr,
+                                   "warning: one possible reason is that llama.cpp was compiled without GPU support\n");
+                           fprintf(stderr, "warning: consult docs/build.md for compilation instructions\n");
+                       }
+                   })
+            .set_env("LLAMA_ARG_N_GPU_LAYERS"));
+    add_opt(common_arg({ "-sm", "--split-mode" }, "{none,layer,row}",
+                       "how to split the model across multiple GPUs, one of:\n"
+                       "- none: use one GPU only\n"
+                       "- layer (default): split layers and KV across GPUs\n"
+                       "- row: split rows across GPUs",
+                       [](common_params & params, const std::string & value) {
+                           std::string arg_next = value;
+                           if (arg_next == "none") {
+                               params.split_mode = LLAMA_SPLIT_MODE_NONE;
+                           } else if (arg_next == "layer") {
+                               params.split_mode = LLAMA_SPLIT_MODE_LAYER;
+                           } else if (arg_next == "row") {
+                               params.split_mode = LLAMA_SPLIT_MODE_ROW;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           if (!llama_supports_gpu_offload()) {
+                               fprintf(stderr,
+                                       "warning: llama.cpp was compiled without support for GPU offload. Setting the "
+                                       "split mode has no effect.\n");
+                           }
+                       })
+                .set_env("LLAMA_ARG_SPLIT_MODE"));
+    add_opt(common_arg({ "-ts", "--tensor-split" }, "N0,N1,N2,...",
+                       "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",
+                       [](common_params & params, const std::string & value) {
+                           std::string arg_next = value;
 
-            // split string by , and /
-            const std::regex regex{ R"([,/]+)" };
-            std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
-            std::vector<std::string> split_arg{ it, {} };
-            if (split_arg.size() >= llama_max_devices()) {
-                throw std::invalid_argument(
-                    string_format("got %zu input configs, but system only has %zu devices", split_arg.size(), llama_max_devices())
-                );
-            }
-            for (size_t i = 0; i < llama_max_devices(); ++i) {
-                if (i < split_arg.size()) {
-                    params.tensor_split[i] = std::stof(split_arg[i]);
+                           // split string by , and /
+                           const std::regex           regex{ R"([,/]+)" };
+                           std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
+                           std::vector<std::string>   split_arg{ it, {} };
+                           if (split_arg.size() >= llama_max_devices()) {
+                               throw std::invalid_argument(
+                                   string_format("got %zu input configs, but system only has %zu devices",
+                                                 split_arg.size(), llama_max_devices()));
+                           }
+                           for (size_t i = 0; i < llama_max_devices(); ++i) {
+                               if (i < split_arg.size()) {
+                                   params.tensor_split[i] = std::stof(split_arg[i]);
+                               } else {
+                                   params.tensor_split[i] = 0.0f;
+                               }
+                           }
+                           if (!llama_supports_gpu_offload()) {
+                               fprintf(stderr,
+                                       "warning: llama.cpp was compiled without support for GPU offload. Setting a "
+                                       "tensor split has no effect.\n");
+                           }
+                       })
+                .set_env("LLAMA_ARG_TENSOR_SPLIT"));
+    add_opt(common_arg({ "-mg", "--main-gpu" }, "INDEX",
+                       string_format("the GPU to use for the model (with split-mode = none), or for intermediate "
+                                     "results and KV (with split-mode = row) (default: %d)",
+                                     params.main_gpu),
+                       [](common_params & params, int value) {
+                           params.main_gpu = value;
+                           if (!llama_supports_gpu_offload()) {
+                               fprintf(stderr,
+                                       "warning: llama.cpp was compiled without support for GPU offload. Setting the "
+                                       "main GPU has no effect.\n");
+                           }
+                       })
+                .set_env("LLAMA_ARG_MAIN_GPU"));
+    add_opt(
+        common_arg(
+            { "-fit", "--fit" }, "[on|off]",
+            string_format("whether to adjust unset arguments to fit in device memory ('on' or 'off', default: '%s')",
+                          params.fit_params ? "on" : "off"),
+            [](common_params & params, const std::string & value) {
+                if (is_truthy(value)) {
+                    params.fit_params = true;
+                } else if (is_falsey(value)) {
+                    params.fit_params = false;
                 } else {
-                    params.tensor_split[i] = 0.0f;
+                    throw std::runtime_error(string_format("error: unkown value for --fit: '%s'\n", value.c_str()));
                 }
-            }
-            if (!llama_supports_gpu_offload()) {
-                fprintf(stderr, "warning: llama.cpp was compiled without support for GPU offload. Setting a tensor split has no effect.\n");
-            }
-        }
-    ).set_env("LLAMA_ARG_TENSOR_SPLIT"));
-    add_opt(common_arg(
-        {"-mg", "--main-gpu"}, "INDEX",
-        string_format("the GPU to use for the model (with split-mode = none), or for intermediate results and KV (with split-mode = row) (default: %d)", params.main_gpu),
-        [](common_params & params, int value) {
-            params.main_gpu = value;
-            if (!llama_supports_gpu_offload()) {
-                fprintf(stderr, "warning: llama.cpp was compiled without support for GPU offload. Setting the main GPU has no effect.\n");
-            }
-        }
-    ).set_env("LLAMA_ARG_MAIN_GPU"));
-    add_opt(common_arg(
-        { "-fit", "--fit" }, "[on|off]",
-        string_format("whether to adjust unset arguments to fit in device memory ('on' or 'off', default: '%s')", params.fit_params ? "on" : "off"),
-        [](common_params & params, const std::string & value) {
-            if (is_truthy(value)) {
-                params.fit_params = true;
-            } else if (is_falsey(value)) {
-                params.fit_params = false;
-            } else {
-                throw std::runtime_error(
-                    string_format("error: unkown value for --fit: '%s'\n", value.c_str()));
-            }
-        }
-    ).set_env("LLAMA_ARG_FIT"));
-    add_opt(common_arg(
-        { "-fitt", "--fit-target" }, "MiB0,MiB1,MiB2,...",
-        string_format("target margin per device for --fit, comma-separated list of values, "
-            "single value is broadcast across all devices, default: %zu", params.fit_params_target[0]/(1024*1024)),
-        [](common_params & params, const std::string & value) {
-            std::string arg_next = value;
+            })
+            .set_env("LLAMA_ARG_FIT"));
+    add_opt(common_arg({ "-fitt", "--fit-target" }, "MiB0,MiB1,MiB2,...",
+                       string_format("target margin per device for --fit, comma-separated list of values, "
+                                     "single value is broadcast across all devices, default: %zu",
+                                     params.fit_params_target[0] / (1024 * 1024)),
+                       [](common_params & params, const std::string & value) {
+                           std::string arg_next = value;
 
-            // split string by , and /
-            const std::regex regex{ R"([,/]+)" };
-            std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
-            std::vector<std::string> split_arg{ it, {} };
-            if (split_arg.size() >= llama_max_devices()) {
-                throw std::invalid_argument(
-                    string_format("got %zu input configs, but system only has %zu devices", split_arg.size(), llama_max_devices())
-                );
-            }
-            if (split_arg.size() == 1) {
-                std::fill(params.fit_params_target.begin(), params.fit_params_target.end(), std::stoul(split_arg[0]) * 1024*1024);
-                return;
-            }
-            for (size_t i = 0; i < split_arg.size(); i++) {
-                params.fit_params_target[i] = std::stoul(split_arg[i]) * 1024*1024;
-            }
-        }
-    ).set_env("LLAMA_ARG_FIT_TARGET"));
-    add_opt(common_arg(
-        { "-fitc", "--fit-ctx" }, "N",
-        string_format("minimum ctx size that can be set by --fit option, default: %" PRIu32, params.fit_params_min_ctx),
-        [](common_params & params, int value) {
-            params.fit_params_min_ctx = value;
-        }
-    ).set_env("LLAMA_ARG_FIT_CTX"));
-    add_opt(common_arg(
-        {"--check-tensors"},
-        string_format("check model tensor data for invalid values (default: %s)", params.check_tensors ? "true" : "false"),
-        [](common_params & params) {
-            params.check_tensors = true;
-        }
-    ));
-    add_opt(common_arg(
-        {"--override-kv"}, "KEY=TYPE:VALUE,...",
-        "advanced option to override model metadata by key. to specify multiple overrides, either use comma-separated values.\n"
-        "types: int, float, bool, str. example: --override-kv tokenizer.ggml.add_bos_token=bool:false,tokenizer.ggml.add_eos_token=bool:false",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                if (!string_parse_kv_override(item.c_str(), params.kv_overrides)) {
-                    throw std::runtime_error(string_format("error: Invalid type for KV override: %s\n", item.c_str()));
+                           // split string by , and /
+                           const std::regex           regex{ R"([,/]+)" };
+                           std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
+                           std::vector<std::string>   split_arg{ it, {} };
+                           if (split_arg.size() >= llama_max_devices()) {
+                               throw std::invalid_argument(
+                                   string_format("got %zu input configs, but system only has %zu devices",
+                                                 split_arg.size(), llama_max_devices()));
+                           }
+                           if (split_arg.size() == 1) {
+                               std::fill(params.fit_params_target.begin(), params.fit_params_target.end(),
+                                         std::stoul(split_arg[0]) * 1024 * 1024);
+                               return;
+                           }
+                           for (size_t i = 0; i < split_arg.size(); i++) {
+                               params.fit_params_target[i] = std::stoul(split_arg[i]) * 1024 * 1024;
+                           }
+                       })
+                .set_env("LLAMA_ARG_FIT_TARGET"));
+    add_opt(common_arg({ "-fitc", "--fit-ctx" }, "N",
+                       string_format("minimum ctx size that can be set by --fit option, default: %" PRIu32,
+                                     params.fit_params_min_ctx),
+                       [](common_params & params, int value) { params.fit_params_min_ctx = value; })
+                .set_env("LLAMA_ARG_FIT_CTX"));
+    add_opt(common_arg({ "--check-tensors" },
+                       string_format("check model tensor data for invalid values (default: %s)",
+                                     params.check_tensors ? "true" : "false"),
+                       [](common_params & params) { params.check_tensors = true; }));
+    add_opt(common_arg({ "--override-kv" }, "KEY=TYPE:VALUE,...",
+                       "advanced option to override model metadata by key. to specify multiple overrides, either use "
+                       "comma-separated values.\n"
+                       "types: int, float, bool, str. example: --override-kv "
+                       "tokenizer.ggml.add_bos_token=bool:false,tokenizer.ggml.add_eos_token=bool:false",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               if (!string_parse_kv_override(item.c_str(), params.kv_overrides)) {
+                                   throw std::runtime_error(
+                                       string_format("error: Invalid type for KV override: %s\n", item.c_str()));
+                               }
+                           }
+                       }));
+    add_opt(common_arg({ "--op-offload" }, { "--no-op-offload" },
+                       string_format("whether to offload host tensor operations to device (default: %s)",
+                                     params.no_op_offload ? "false" : "true"),
+                       [](common_params & params, bool value) { params.no_op_offload = !value; }));
+    add_opt(
+        common_arg(
+            { "--lora" }, "FNAME", "path to LoRA adapter (use comma-separated values to load multiple adapters)",
+            [](common_params & params, const std::string & value) {
+                for (const auto & item : parse_csv_row(value)) {
+                    params.lora_adapters.push_back({ item, 1.0, "", "", nullptr });
                 }
             }
-        }
-    ));
-    add_opt(common_arg(
-        {"--op-offload"},
-        {"--no-op-offload"},
-        string_format("whether to offload host tensor operations to device (default: %s)", params.no_op_offload ? "false" : "true"),
-        [](common_params & params, bool value) {
-            params.no_op_offload = !value;
-        }
-    ));
-    add_opt(common_arg(
-        {"--lora"}, "FNAME",
-        "path to LoRA adapter (use comma-separated values to load multiple adapters)",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr });
-            }
-        }
-        // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
-    ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}));
-    add_opt(common_arg(
-        {"--lora-scaled"}, "FNAME:SCALE,...",
-        "path to LoRA adapter with user defined scaling (format: FNAME:SCALE,...)\n"
-        "note: use comma-separated values",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                auto parts = string_split<std::string>(item, ':');
-                if (parts.size() != 2) {
-                    throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
-                }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr });
-            }
-        }
-        // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
-    ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}));
-    add_opt(common_arg(
-        {"--control-vector"}, "FNAME",
-        "add a control vector\nnote: use comma-separated values to add multiple control vectors",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                params.control_vectors.push_back({ 1.0f, item, });
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"--control-vector-scaled"}, "FNAME:SCALE,...",
-        "add a control vector with user defined scaling SCALE\n"
-        "note: use comma-separated values (format: FNAME:SCALE,...)",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                auto parts = string_split<std::string>(item, ':');
-                if (parts.size() != 2) {
-                    throw std::invalid_argument("control-vector-scaled format: FNAME:SCALE");
-                }
-                params.control_vectors.push_back({ std::stof(parts[1]), parts[0] });
-            }
-        }
-    ));
-    add_opt(common_arg(
-        {"--control-vector-layer-range"}, "START", "END",
-        "layer range to apply the control vector(s) to, start and end inclusive",
-        [](common_params & params, const std::string & start, const std::string & end) {
-            params.control_vector_layer_start = std::stoi(start);
-            params.control_vector_layer_end = std::stoi(end);
-        }
-    ));
-    add_opt(common_arg(
-        {"-a", "--alias"}, "STRING",
-        "set alias for model name (to be used by REST API)",
-        [](common_params & params, const std::string & value) {
-            params.model_alias = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ALIAS"));
-    add_opt(common_arg(
-        {"-m", "--model"}, "FNAME",
-        ex == LLAMA_EXAMPLE_EXPORT_LORA
-            ? "model path from which to load base model"
-            : "model path to load",
-        [](common_params & params, const std::string & value) {
-            params.model.path = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}).set_env("LLAMA_ARG_MODEL"));
-    add_opt(common_arg(
-        {"-mu", "--model-url"}, "MODEL_URL",
-        "model download url (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.model.url = value;
-        }
-    ).set_env("LLAMA_ARG_MODEL_URL"));
-    add_opt(common_arg(
-        { "-dr", "--docker-repo" }, "[<repo>/]<model>[:quant]",
-        "Docker Hub model repository. repo is optional, default to ai/. quant is optional, default to :latest.\n"
-        "example: gemma3\n"
-        "(default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.model.docker_repo = value;
-        }
-    ).set_env("LLAMA_ARG_DOCKER_REPO"));
-    add_opt(common_arg(
-        {"-hf", "-hfr", "--hf-repo"}, "<user>/<model>[:quant]",
-        "Hugging Face model repository; quant is optional, case-insensitive, default to Q4_K_M, or falls back to the first file in the repo if Q4_K_M doesn't exist.\n"
-        "mmproj is also downloaded automatically if available. to disable, add --no-mmproj\n"
-        "example: unsloth/phi-4-GGUF:q4_k_m\n"
-        "(default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.model.hf_repo = value;
-        }
-    ).set_env("LLAMA_ARG_HF_REPO"));
-    add_opt(common_arg(
-        {"-hfd", "-hfrd", "--hf-repo-draft"}, "<user>/<model>[:quant]",
-        "Same as --hf-repo, but for the draft model (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.speculative.mparams_dft.hf_repo = value;
-        }
-    ).set_env("LLAMA_ARG_HFD_REPO"));
-    add_opt(common_arg(
-        {"-hff", "--hf-file"}, "FILE",
-        "Hugging Face model file. If specified, it will override the quant in --hf-repo (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.model.hf_file = value;
-        }
-    ).set_env("LLAMA_ARG_HF_FILE"));
-    add_opt(common_arg(
-        {"-hfv", "-hfrv", "--hf-repo-v"}, "<user>/<model>[:quant]",
-        "Hugging Face model repository for the vocoder model (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.vocoder.model.hf_repo = value;
-        }
-    ).set_env("LLAMA_ARG_HF_REPO_V"));
-    add_opt(common_arg(
-        {"-hffv", "--hf-file-v"}, "FILE",
-        "Hugging Face model file for the vocoder model (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.vocoder.model.hf_file = value;
-        }
-    ).set_env("LLAMA_ARG_HF_FILE_V"));
-    add_opt(common_arg(
-        {"-hft", "--hf-token"}, "TOKEN",
-        "Hugging Face access token (default: value from HF_TOKEN environment variable)",
-        [](common_params & params, const std::string & value) {
-            params.hf_token = value;
-        }
-    ).set_env("HF_TOKEN"));
-    add_opt(common_arg(
-        {"--context-file"}, "FNAME",
-        "file to load context from (use comma-separated values to specify multiple files)",
-        [](common_params & params, const std::string & value) {
-            for (const auto & item : parse_csv_row(value)) {
-                std::ifstream file(item, std::ios::binary);
-                if (!file) {
-                    throw std::runtime_error(string_format("error: failed to open file '%s'\n", item.c_str()));
-                }
-                params.context_files.push_back(item);
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_RETRIEVAL}));
-    add_opt(common_arg(
-        {"--chunk-size"}, "N",
-        string_format("minimum length of embedded text chunks (default: %d)", params.chunk_size),
-        [](common_params & params, int value) {
-            params.chunk_size = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_RETRIEVAL}));
-    add_opt(common_arg(
-        {"--chunk-separator"}, "STRING",
-        string_format("separator between chunks (default: '%s')", params.chunk_separator.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.chunk_separator = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_RETRIEVAL}));
-    add_opt(common_arg(
-        {"--junk"}, "N",
-        string_format("number of times to repeat the junk text (default: %d)", params.n_junk),
-        [](common_params & params, int value) {
-            params.n_junk = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PASSKEY, LLAMA_EXAMPLE_PARALLEL}));
-    add_opt(common_arg(
-        {"--pos"}, "N",
-        string_format("position of the passkey in the junk text (default: %d)", params.i_pos),
-        [](common_params & params, int value) {
-            params.i_pos = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_PASSKEY}));
-    add_opt(common_arg(
-        {"-o", "--output", "--output-file"}, "FNAME",
-        string_format("output file (default: '%s')", params.out_file.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.out_file = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_CVECTOR_GENERATOR, LLAMA_EXAMPLE_EXPORT_LORA, LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_FINETUNE}));
-    add_opt(common_arg(
-        {"-ofreq", "--output-frequency"}, "N",
-        string_format("output the imatrix every N iterations (default: %d)", params.n_out_freq),
-        [](common_params & params, int value) {
-            params.n_out_freq = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--output-format"}, "{gguf,dat}",
-        string_format("output format for imatrix file (default: %s)", params.imat_dat > 0 ? "dat" : "gguf"),
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "gguf") { params.imat_dat = -1; }
-            else if (value == "dat")  { params.imat_dat = 1;  }
-            else { throw std::invalid_argument("invalid output format"); }
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--save-frequency"}, "N",
-        string_format("save an imatrix copy every N iterations (default: %d)", params.n_save_freq),
-        [](common_params & params, int value) {
-            params.n_save_freq = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--process-output"},
-        string_format("collect data for the output tensor (default: %s)", params.process_output ? "true" : "false"),
-        [](common_params & params) {
-            params.process_output = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--ppl"},
-        {"--no-ppl"},
-        string_format("whether to compute perplexity (default: %s)", params.compute_ppl ? "true" : "false"),
-        [](common_params & params, bool value) {
-            params.compute_ppl = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--chunk", "--from-chunk"}, "N",
-        string_format("start processing the input from chunk N (default: %d)", params.i_chunk),
-        [](common_params & params, int value) {
-            params.i_chunk = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--show-statistics"},
-        string_format("show imatrix statistics and then exit (default: %s)", params.show_statistics ? "true" : "false"),
-        [](common_params & params) {
-            params.show_statistics = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"--parse-special"},
-        string_format("parse special tokens (chat, tool, etc) (default: %s)", params.parse_special ? "true" : "false"),
-        [](common_params & params) {
-            params.parse_special = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
-    add_opt(common_arg(
-        {"-pps"},
-        string_format("is the prompt shared across parallel sequences (default: %s)", params.is_pp_shared ? "true" : "false"),
-        [](common_params & params) {
-            params.is_pp_shared = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL}));
-    add_opt(common_arg(
-        {"-tgs"},
-        string_format("is the text generation separated across the different sequences (default: %s)", params.is_tg_separate ? "true" : "false"),
-        [](common_params & params) {
-            params.is_tg_separate = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL}));
-    add_opt(common_arg(
-        {"-npp"}, "n0,n1,...",
-        "number of prompt tokens",
-        [](common_params & params, const std::string & value) {
-            auto p = string_split<int>(value, ',');
-            params.n_pp.insert(params.n_pp.end(), p.begin(), p.end());
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH}));
-    add_opt(common_arg(
-        {"-ntg"}, "n0,n1,...",
-        "number of text generation tokens",
-        [](common_params & params, const std::string & value) {
-            auto p = string_split<int>(value, ',');
-            params.n_tg.insert(params.n_tg.end(), p.begin(), p.end());
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH}));
-    add_opt(common_arg(
-        {"-npl"}, "n0,n1,...",
-        "number of parallel prompts",
-        [](common_params & params, const std::string & value) {
-            auto p = string_split<int>(value, ',');
-            params.n_pl.insert(params.n_pl.end(), p.begin(), p.end());
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH}));
-    add_opt(common_arg(
-        {"--embd-normalize"}, "N",
-        string_format("normalisation for embeddings (default: %d) (-1=none, 0=max absolute int16, 1=taxicab, 2=euclidean, >2=p-norm)", params.embd_normalize),
-        [](common_params & params, int value) {
-            params.embd_normalize = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_DEBUG}));
-    add_opt(common_arg(
-        {"--embd-output-format"}, "FORMAT",
-        "empty = default, \"array\" = [[],[]...], \"json\" = openai style, \"json+\" = same \"json\" + cosine similarity matrix, \"raw\" = plain whitespace-delimited output (one embedding per line)",
-        [](common_params & params, const std::string & value) {
-            params.embd_out = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
-    add_opt(common_arg(
-        {"--embd-separator"}, "STRING",
-        "separator of embeddings (default \\n) for example \"<#sep#>\"",
-        [](common_params & params, const std::string & value) {
-            params.embd_sep = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
-    add_opt(common_arg(
-        {"--cls-separator"}, "STRING",
-        "separator of classification sequences (default \\t) for example \"<#seq#>\"",
-        [](common_params & params, const std::string & value) {
-            params.cls_sep = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
-    add_opt(common_arg(
-        {"--host"}, "HOST",
-        string_format("ip address to listen, or bind to an UNIX socket if the address ends with .sock (default: %s)", params.hostname.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.hostname = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_HOST"));
-    add_opt(common_arg(
-        {"--port"}, "PORT",
-        string_format("port to listen (default: %d)", params.port),
-        [](common_params & params, int value) {
-            params.port = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PORT"));
-    add_opt(common_arg(
-        {"--path"}, "PATH",
-        string_format("path to serve static files from (default: %s)", params.public_path.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.public_path = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_STATIC_PATH"));
-    add_opt(common_arg(
-        {"--api-prefix"}, "PREFIX",
-        string_format("prefix path the server serves from, without the trailing slash (default: %s)", params.api_prefix.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.api_prefix = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_API_PREFIX"));
-    add_opt(common_arg(
-        {"--webui-config"}, "JSON",
-        "JSON that provides default WebUI settings (overrides WebUI defaults)",
-        [](common_params & params, const std::string & value) {
-            params.webui_config_json = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_WEBUI_CONFIG"));
-    add_opt(common_arg(
-        {"--webui-config-file"}, "PATH",
-        "JSON file that provides default WebUI settings (overrides WebUI defaults)",
-        [](common_params & params, const std::string & value) {
-            params.webui_config_json = read_file(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_WEBUI_CONFIG_FILE"));
-    add_opt(common_arg(
-        {"--webui"},
-        {"--no-webui"},
-        string_format("whether to enable the Web UI (default: %s)", params.webui ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.webui = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_WEBUI"));
-    add_opt(common_arg(
-        {"--embedding", "--embeddings"},
-        string_format("restrict to only support embedding use case; use only with dedicated embedding models (default: %s)", params.embedding ? "enabled" : "disabled"),
-        [](common_params & params) {
-            params.embedding = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG}).set_env("LLAMA_ARG_EMBEDDINGS"));
-    add_opt(common_arg(
-        {"--rerank", "--reranking"},
-        string_format("enable reranking endpoint on server (default: %s)", "disabled"),
-        [](common_params & params) {
-            params.embedding = true;
-            params.pooling_type = LLAMA_POOLING_TYPE_RANK;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_RERANKING"));
-    add_opt(common_arg(
-        {"--api-key"}, "KEY",
-        "API key to use for authentication, multiple keys can be provided as a comma-separated list (default: none)",
-        [](common_params & params, const std::string & value) {
-            for (const auto & key : parse_csv_row(value)) {
-                if (!key.empty()) {
-                    params.api_keys.push_back(key);
+            // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
+            )
+            .set_examples({ LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA }));
+    add_opt(
+        common_arg(
+            { "--lora-scaled" }, "FNAME:SCALE,...",
+            "path to LoRA adapter with user defined scaling (format: FNAME:SCALE,...)\n"
+            "note: use comma-separated values",
+            [](common_params & params, const std::string & value) {
+                for (const auto & item : parse_csv_row(value)) {
+                    auto parts = string_split<std::string>(item, ':');
+                    if (parts.size() != 2) {
+                        throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
+                    }
+                    params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr });
                 }
             }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_API_KEY"));
+            // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
+            )
+            .set_examples({ LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA }));
+    add_opt(common_arg({ "--control-vector" }, "FNAME",
+                       "add a control vector\nnote: use comma-separated values to add multiple control vectors",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               params.control_vectors.push_back({
+                                   1.0f,
+                                   item,
+                               });
+                           }
+                       }));
+    add_opt(common_arg({ "--control-vector-scaled" }, "FNAME:SCALE,...",
+                       "add a control vector with user defined scaling SCALE\n"
+                       "note: use comma-separated values (format: FNAME:SCALE,...)",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               auto parts = string_split<std::string>(item, ':');
+                               if (parts.size() != 2) {
+                                   throw std::invalid_argument("control-vector-scaled format: FNAME:SCALE");
+                               }
+                               params.control_vectors.push_back({ std::stof(parts[1]), parts[0] });
+                           }
+                       }));
+    add_opt(common_arg({ "--control-vector-layer-range" }, "START", "END",
+                       "layer range to apply the control vector(s) to, start and end inclusive",
+                       [](common_params & params, const std::string & start, const std::string & end) {
+                           params.control_vector_layer_start = std::stoi(start);
+                           params.control_vector_layer_end   = std::stoi(end);
+                       }));
+    add_opt(common_arg({ "-a", "--alias" }, "STRING", "set alias for model name (to be used by REST API)",
+                       [](common_params & params, const std::string & value) { params.model_alias = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_ALIAS"));
+    add_opt(
+        common_arg({ "-m", "--model" }, "FNAME",
+                   ex == LLAMA_EXAMPLE_EXPORT_LORA ? "model path from which to load base model" : "model path to load",
+                   [](common_params & params, const std::string & value) { params.model.path = value; })
+            .set_examples({ LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA })
+            .set_env("LLAMA_ARG_MODEL"));
+    add_opt(common_arg({ "-mu", "--model-url" }, "MODEL_URL", "model download url (default: unused)",
+                       [](common_params & params, const std::string & value) { params.model.url = value; })
+                .set_env("LLAMA_ARG_MODEL_URL"));
+    add_opt(
+        common_arg(
+            { "-dr", "--docker-repo" }, "[<repo>/]<model>[:quant]",
+            "Docker Hub model repository. repo is optional, default to ai/. quant is optional, default to :latest.\n"
+            "example: gemma3\n"
+            "(default: unused)",
+            [](common_params & params, const std::string & value) { params.model.docker_repo = value; })
+            .set_env("LLAMA_ARG_DOCKER_REPO"));
+    add_opt(common_arg({ "-hf", "-hfr", "--hf-repo" }, "<user>/<model>[:quant]",
+                       "Hugging Face model repository; quant is optional, case-insensitive, default to Q4_K_M, or "
+                       "falls back to the first file in the repo if Q4_K_M doesn't exist.\n"
+                       "mmproj is also downloaded automatically if available. to disable, add --no-mmproj\n"
+                       "example: unsloth/phi-4-GGUF:q4_k_m\n"
+                       "(default: unused)",
+                       [](common_params & params, const std::string & value) { params.model.hf_repo = value; })
+                .set_env("LLAMA_ARG_HF_REPO"));
+    add_opt(common_arg({ "-hfd", "-hfrd", "--hf-repo-draft" }, "<user>/<model>[:quant]",
+                       "Same as --hf-repo, but for the draft model (default: unused)",
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.mparams_dft.hf_repo = value;
+                       })
+                .set_env("LLAMA_ARG_HFD_REPO"));
+    add_opt(
+        common_arg({ "-hff", "--hf-file" }, "FILE",
+                   "Hugging Face model file. If specified, it will override the quant in --hf-repo (default: unused)",
+                   [](common_params & params, const std::string & value) { params.model.hf_file = value; })
+            .set_env("LLAMA_ARG_HF_FILE"));
+    add_opt(common_arg({ "-hfv", "-hfrv", "--hf-repo-v" }, "<user>/<model>[:quant]",
+                       "Hugging Face model repository for the vocoder model (default: unused)",
+                       [](common_params & params, const std::string & value) { params.vocoder.model.hf_repo = value; })
+                .set_env("LLAMA_ARG_HF_REPO_V"));
+    add_opt(common_arg({ "-hffv", "--hf-file-v" }, "FILE",
+                       "Hugging Face model file for the vocoder model (default: unused)",
+                       [](common_params & params, const std::string & value) { params.vocoder.model.hf_file = value; })
+                .set_env("LLAMA_ARG_HF_FILE_V"));
+    add_opt(common_arg({ "-hft", "--hf-token" }, "TOKEN",
+                       "Hugging Face access token (default: value from HF_TOKEN environment variable)",
+                       [](common_params & params, const std::string & value) { params.hf_token = value; })
+                .set_env("HF_TOKEN"));
+    add_opt(common_arg({ "--context-file" }, "FNAME",
+                       "file to load context from (use comma-separated values to specify multiple files)",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & item : parse_csv_row(value)) {
+                               std::ifstream file(item, std::ios::binary);
+                               if (!file) {
+                                   throw std::runtime_error(
+                                       string_format("error: failed to open file '%s'\n", item.c_str()));
+                               }
+                               params.context_files.push_back(item);
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_RETRIEVAL }));
+    add_opt(common_arg({ "--chunk-size" }, "N",
+                       string_format("minimum length of embedded text chunks (default: %d)", params.chunk_size),
+                       [](common_params & params, int value) { params.chunk_size = value; })
+                .set_examples({ LLAMA_EXAMPLE_RETRIEVAL }));
+    add_opt(common_arg({ "--chunk-separator" }, "STRING",
+                       string_format("separator between chunks (default: '%s')", params.chunk_separator.c_str()),
+                       [](common_params & params, const std::string & value) { params.chunk_separator = value; })
+                .set_examples({ LLAMA_EXAMPLE_RETRIEVAL }));
+    add_opt(common_arg({ "--junk" }, "N",
+                       string_format("number of times to repeat the junk text (default: %d)", params.n_junk),
+                       [](common_params & params, int value) { params.n_junk = value; })
+                .set_examples({ LLAMA_EXAMPLE_PASSKEY, LLAMA_EXAMPLE_PARALLEL }));
+    add_opt(common_arg({ "--pos" }, "N",
+                       string_format("position of the passkey in the junk text (default: %d)", params.i_pos),
+                       [](common_params & params, int value) { params.i_pos = value; })
+                .set_examples({ LLAMA_EXAMPLE_PASSKEY }));
+    add_opt(common_arg({ "-o", "--output", "--output-file" }, "FNAME",
+                       string_format("output file (default: '%s')", params.out_file.c_str()),
+                       [](common_params & params, const std::string & value) { params.out_file = value; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_CVECTOR_GENERATOR, LLAMA_EXAMPLE_EXPORT_LORA,
+                                LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_FINETUNE }));
+    add_opt(common_arg({ "-ofreq", "--output-frequency" }, "N",
+                       string_format("output the imatrix every N iterations (default: %d)", params.n_out_freq),
+                       [](common_params & params, int value) { params.n_out_freq = value; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(
+        common_arg({ "--output-format" }, "{gguf,dat}",
+                   string_format("output format for imatrix file (default: %s)", params.imat_dat > 0 ? "dat" : "gguf"),
+                   [](common_params & params, const std::string & value) {
+                       /**/ if (value == "gguf") {
+                           params.imat_dat = -1;
+                       } else if (value == "dat") {
+                           params.imat_dat = 1;
+                       } else {
+                           throw std::invalid_argument("invalid output format");
+                       }
+                   })
+            .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "--save-frequency" }, "N",
+                       string_format("save an imatrix copy every N iterations (default: %d)", params.n_save_freq),
+                       [](common_params & params, int value) { params.n_save_freq = value; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "--process-output" },
+                       string_format("collect data for the output tensor (default: %s)",
+                                     params.process_output ? "true" : "false"),
+                       [](common_params & params) { params.process_output = true; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(
+        common_arg({ "--ppl" }, { "--no-ppl" },
+                   string_format("whether to compute perplexity (default: %s)", params.compute_ppl ? "true" : "false"),
+                   [](common_params & params, bool value) { params.compute_ppl = value; })
+            .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "--chunk", "--from-chunk" }, "N",
+                       string_format("start processing the input from chunk N (default: %d)", params.i_chunk),
+                       [](common_params & params, int value) { params.i_chunk = value; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "--show-statistics" },
+                       string_format("show imatrix statistics and then exit (default: %s)",
+                                     params.show_statistics ? "true" : "false"),
+                       [](common_params & params) { params.show_statistics = true; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "--parse-special" },
+                       string_format("parse special tokens (chat, tool, etc) (default: %s)",
+                                     params.parse_special ? "true" : "false"),
+                       [](common_params & params) { params.parse_special = true; })
+                .set_examples({ LLAMA_EXAMPLE_IMATRIX }));
+    add_opt(common_arg({ "-pps" },
+                       string_format("is the prompt shared across parallel sequences (default: %s)",
+                                     params.is_pp_shared ? "true" : "false"),
+                       [](common_params & params) { params.is_pp_shared = true; })
+                .set_examples({ LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL }));
+    add_opt(common_arg({ "-tgs" },
+                       string_format("is the text generation separated across the different sequences (default: %s)",
+                                     params.is_tg_separate ? "true" : "false"),
+                       [](common_params & params) { params.is_tg_separate = true; })
+                .set_examples({ LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL }));
+    add_opt(common_arg({ "-npp" }, "n0,n1,...", "number of prompt tokens",
+                       [](common_params & params, const std::string & value) {
+                           auto p = string_split<int>(value, ',');
+                           params.n_pp.insert(params.n_pp.end(), p.begin(), p.end());
+                       })
+                .set_examples({ LLAMA_EXAMPLE_BENCH }));
+    add_opt(common_arg({ "-ntg" }, "n0,n1,...", "number of text generation tokens",
+                       [](common_params & params, const std::string & value) {
+                           auto p = string_split<int>(value, ',');
+                           params.n_tg.insert(params.n_tg.end(), p.begin(), p.end());
+                       })
+                .set_examples({ LLAMA_EXAMPLE_BENCH }));
+    add_opt(common_arg({ "-npl" }, "n0,n1,...", "number of parallel prompts",
+                       [](common_params & params, const std::string & value) {
+                           auto p = string_split<int>(value, ',');
+                           params.n_pl.insert(params.n_pl.end(), p.begin(), p.end());
+                       })
+                .set_examples({ LLAMA_EXAMPLE_BENCH }));
+    add_opt(common_arg({ "--embd-normalize" }, "N",
+                       string_format("normalisation for embeddings (default: %d) (-1=none, 0=max absolute int16, "
+                                     "1=taxicab, 2=euclidean, >2=p-norm)",
+                                     params.embd_normalize),
+                       [](common_params & params, int value) { params.embd_normalize = value; })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_DEBUG }));
+    add_opt(common_arg({ "--embd-output-format" }, "FORMAT",
+                       "empty = default, \"array\" = [[],[]...], \"json\" = openai style, \"json+\" = same \"json\" + "
+                       "cosine similarity matrix, \"raw\" = plain whitespace-delimited output (one embedding per line)",
+                       [](common_params & params, const std::string & value) { params.embd_out = value; })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING }));
+    add_opt(common_arg({ "--embd-separator" }, "STRING",
+                       "separator of embeddings (default \\n) for example \"<#sep#>\"",
+                       [](common_params & params, const std::string & value) { params.embd_sep = value; })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING }));
+    add_opt(common_arg({ "--cls-separator" }, "STRING",
+                       "separator of classification sequences (default \\t) for example \"<#seq#>\"",
+                       [](common_params & params, const std::string & value) { params.cls_sep = value; })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING }));
+    add_opt(
+        common_arg({ "--host" }, "HOST",
+                   string_format(
+                       "ip address to listen, or bind to an UNIX socket if the address ends with .sock (default: %s)",
+                       params.hostname.c_str()),
+                   [](common_params & params, const std::string & value) { params.hostname = value; })
+            .set_examples({ LLAMA_EXAMPLE_SERVER })
+            .set_env("LLAMA_ARG_HOST"));
+    add_opt(common_arg({ "--port" }, "PORT", string_format("port to listen (default: %d)", params.port),
+                       [](common_params & params, int value) { params.port = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_PORT"));
+    add_opt(common_arg({ "--path" }, "PATH",
+                       string_format("path to serve static files from (default: %s)", params.public_path.c_str()),
+                       [](common_params & params, const std::string & value) { params.public_path = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_STATIC_PATH"));
+    add_opt(common_arg({ "--api-prefix" }, "PREFIX",
+                       string_format("prefix path the server serves from, without the trailing slash (default: %s)",
+                                     params.api_prefix.c_str()),
+                       [](common_params & params, const std::string & value) { params.api_prefix = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_API_PREFIX"));
+    add_opt(common_arg({ "--webui-config" }, "JSON",
+                       "JSON that provides default WebUI settings (overrides WebUI defaults)",
+                       [](common_params & params, const std::string & value) { params.webui_config_json = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_WEBUI_CONFIG"));
     add_opt(common_arg(
-        {"--api-key-file"}, "FNAME",
-        "path to file containing API keys (default: none)",
-        [](common_params & params, const std::string & value) {
-            std::ifstream key_file(value);
-            if (!key_file) {
-                throw std::runtime_error(string_format("error: failed to open file '%s'\n", value.c_str()));
-            }
-            std::string key;
-            while (std::getline(key_file, key)) {
-                if (!key.empty()) {
-                    params.api_keys.push_back(key);
-                }
-            }
-            key_file.close();
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+                { "--webui-config-file" }, "PATH",
+                "JSON file that provides default WebUI settings (overrides WebUI defaults)",
+                [](common_params & params, const std::string & value) { params.webui_config_json = read_file(value); })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_WEBUI_CONFIG_FILE"));
+    add_opt(
+        common_arg({ "--webui" }, { "--no-webui" },
+                   string_format("whether to enable the Web UI (default: %s)", params.webui ? "enabled" : "disabled"),
+                   [](common_params & params, bool value) { params.webui = value; })
+            .set_examples({ LLAMA_EXAMPLE_SERVER })
+            .set_env("LLAMA_ARG_WEBUI"));
+    add_opt(
+        common_arg(
+            { "--embedding", "--embeddings" },
+            string_format(
+                "restrict to only support embedding use case; use only with dedicated embedding models (default: %s)",
+                params.embedding ? "enabled" : "disabled"),
+            [](common_params & params) { params.embedding = true; })
+            .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG })
+            .set_env("LLAMA_ARG_EMBEDDINGS"));
+    add_opt(common_arg({ "--rerank", "--reranking" },
+                       string_format("enable reranking endpoint on server (default: %s)", "disabled"),
+                       [](common_params & params) {
+                           params.embedding    = true;
+                           params.pooling_type = LLAMA_POOLING_TYPE_RANK;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_RERANKING"));
+    add_opt(common_arg({ "--api-key" }, "KEY",
+                       "API key to use for authentication, multiple keys can be provided as a comma-separated list "
+                       "(default: none)",
+                       [](common_params & params, const std::string & value) {
+                           for (const auto & key : parse_csv_row(value)) {
+                               if (!key.empty()) {
+                                   params.api_keys.push_back(key);
+                               }
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_API_KEY"));
+    add_opt(common_arg({ "--api-key-file" }, "FNAME", "path to file containing API keys (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           std::ifstream key_file(value);
+                           if (!key_file) {
+                               throw std::runtime_error(
+                                   string_format("error: failed to open file '%s'\n", value.c_str()));
+                           }
+                           std::string key;
+                           while (std::getline(key_file, key)) {
+                               if (!key.empty()) {
+                                   params.api_keys.push_back(key);
+                               }
+                           }
+                           key_file.close();
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--ssl-key-file" }, "FNAME", "path to file a PEM-encoded SSL private key",
+                       [](common_params & params, const std::string & value) { params.ssl_file_key = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_SSL_KEY_FILE"));
+    add_opt(common_arg({ "--ssl-cert-file" }, "FNAME", "path to file a PEM-encoded SSL certificate",
+                       [](common_params & params, const std::string & value) { params.ssl_file_cert = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_SSL_CERT_FILE"));
+    add_opt(common_arg({ "--chat-template-kwargs" }, "STRING",
+                       "sets additional params for the json template parser, must be a valid json object string, e.g. "
+                       "'{\"key1\":\"value1\",\"key2\":\"value2\"}'",
+                       [](common_params & params, const std::string & value) {
+                           auto parsed = json::parse(value);
+                           for (const auto & item : parsed.items()) {
+                               params.default_template_kwargs[item.key()] = item.value().dump();
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_CHAT_TEMPLATE_KWARGS"));
+    add_opt(common_arg({ "-to", "--timeout" }, "N",
+                       string_format("server read/write timeout in seconds (default: %d)", params.timeout_read),
+                       [](common_params & params, int value) {
+                           params.timeout_read  = value;
+                           params.timeout_write = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_TIMEOUT"));
     add_opt(common_arg(
-        {"--ssl-key-file"}, "FNAME",
-        "path to file a PEM-encoded SSL private key",
-        [](common_params & params, const std::string & value) {
-            params.ssl_file_key = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SSL_KEY_FILE"));
+                { "--threads-http" }, "N",
+                string_format("number of threads used to process HTTP requests (default: %d)", params.n_threads_http),
+                [](common_params & params, int value) { params.n_threads_http = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_THREADS_HTTP"));
+    add_opt(common_arg({ "--cache-prompt" }, { "--no-cache-prompt" },
+                       string_format("whether to enable prompt caching (default: %s)",
+                                     params.cache_prompt ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.cache_prompt = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_CACHE_PROMPT"));
+    add_opt(common_arg({ "--cache-reuse" }, "N",
+                       string_format("min chunk size to attempt reusing from the cache via KV shifting, requires "
+                                     "prompt caching to be enabled (default: %d)\n"
+                                     "[(card)](https://ggml.ai/f0.png)",
+                                     params.n_cache_reuse),
+                       [](common_params & params, int value) { params.n_cache_reuse = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_CACHE_REUSE"));
+    add_opt(common_arg({ "--metrics" },
+                       string_format("enable prometheus compatible metrics endpoint (default: %s)",
+                                     params.endpoint_metrics ? "enabled" : "disabled"),
+                       [](common_params & params) { params.endpoint_metrics = true; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_ENDPOINT_METRICS"));
+    add_opt(common_arg({ "--props" },
+                       string_format("enable changing global properties via POST /props (default: %s)",
+                                     params.endpoint_props ? "enabled" : "disabled"),
+                       [](common_params & params) { params.endpoint_props = true; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_ENDPOINT_PROPS"));
+    add_opt(common_arg({ "--slots" }, { "--no-slots" },
+                       string_format("expose slots monitoring endpoint (default: %s)",
+                                     params.endpoint_slots ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.endpoint_slots = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_ENDPOINT_SLOTS"));
+    add_opt(common_arg({ "--slot-save-path" }, "PATH", "path to save slot kv cache (default: disabled)",
+                       [](common_params & params, const std::string & value) {
+                           params.slot_save_path = value;
+                           if (!fs_is_directory(params.slot_save_path)) {
+                               throw std::invalid_argument("not a directory: " + value);
+                           }
+                           // if doesn't end with DIRECTORY_SEPARATOR, add it
+                           if (!params.slot_save_path.empty() &&
+                               params.slot_save_path[params.slot_save_path.size() - 1] != DIRECTORY_SEPARATOR) {
+                               params.slot_save_path += DIRECTORY_SEPARATOR;
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--media-path" }, "PATH",
+                       "directory for loading local media files; files can be accessed via file:// URLs using relative "
+                       "paths (default: disabled)",
+                       [](common_params & params, const std::string & value) {
+                           params.media_path = value;
+                           if (!fs_is_directory(params.media_path)) {
+                               throw std::invalid_argument("not a directory: " + value);
+                           }
+                           // if doesn't end with DIRECTORY_SEPARATOR, add it
+                           if (!params.media_path.empty() &&
+                               params.media_path[params.media_path.size() - 1] != DIRECTORY_SEPARATOR) {
+                               params.media_path += DIRECTORY_SEPARATOR;
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--models-dir" }, "PATH",
+                       "directory containing models for the router server (default: disabled)",
+                       [](common_params & params, const std::string & value) { params.models_dir = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_MODELS_DIR"));
+    add_opt(common_arg({ "--models-preset" }, "PATH",
+                       "path to INI file containing model presets for the router server (default: disabled)",
+                       [](common_params & params, const std::string & value) { params.models_preset = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_MODELS_PRESET"));
     add_opt(common_arg(
-        {"--ssl-cert-file"}, "FNAME",
-        "path to file a PEM-encoded SSL certificate",
-        [](common_params & params, const std::string & value) {
-            params.ssl_file_cert = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SSL_CERT_FILE"));
+                { "--models-max" }, "N",
+                string_format(
+                    "for router server, maximum number of models to load simultaneously (default: %d, 0 = unlimited)",
+                    params.models_max),
+                [](common_params & params, int value) { params.models_max = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_MODELS_MAX"));
+    add_opt(common_arg({ "--models-autoload" }, { "--no-models-autoload" },
+                       string_format("for router server, whether to automatically load models (default: %s)",
+                                     params.models_autoload ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.models_autoload = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
+    add_opt(common_arg({ "--jinja" }, { "--no-jinja" },
+                       string_format("whether to use jinja template engine for chat (default: %s)",
+                                     params.use_jinja ? "enabled" : "disabled"),
+                       [](common_params & params, bool value) { params.use_jinja = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_MTMD })
+                .set_env("LLAMA_ARG_JINJA"));
+    add_opt(common_arg({ "--reasoning-format" }, "FORMAT",
+                       "controls whether thought tags are allowed and/or extracted from the response, and in which "
+                       "format they're returned; one of:\n"
+                       "- none: leaves thoughts unparsed in `message.content`\n"
+                       "- deepseek: puts thoughts in `message.reasoning_content`\n"
+                       "- deepseek-legacy: keeps `<think>` tags in `message.content` while also populating "
+                       "`message.reasoning_content`\n"
+                       "(default: auto)",
+                       [](common_params & params, const std::string & value) {
+                           params.reasoning_format = common_reasoning_format_from_name(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK"));
+    add_opt(common_arg({ "--reasoning-budget" }, "N",
+                       "controls the amount of thinking allowed; currently only one of: -1 for unrestricted thinking "
+                       "budget, or 0 to disable thinking (default: -1)",
+                       [](common_params & params, int value) {
+                           if (value != 0 && value != -1) {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           params.reasoning_budget = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET"));
+    add_opt(
+        common_arg({ "--chat-template" }, "JINJA_TEMPLATE",
+                   string_format("set custom jinja chat template (default: template taken from model's metadata)\n"
+                                 "if suffix/prefix are specified, template will be disabled\n"
+                                 "only commonly used templates are accepted (unless --jinja is set before this flag):\n"
+                                 "list of built-in templates:\n%s",
+                                 list_builtin_chat_templates().c_str()),
+                   [](common_params & params, const std::string & value) { params.chat_template = value; })
+            .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MTMD })
+            .set_env("LLAMA_ARG_CHAT_TEMPLATE"));
+    add_opt(
+        common_arg({ "--chat-template-file" }, "JINJA_TEMPLATE_FILE",
+                   string_format("set custom jinja chat template file (default: template taken from model's metadata)\n"
+                                 "if suffix/prefix are specified, template will be disabled\n"
+                                 "only commonly used templates are accepted (unless --jinja is set before this flag):\n"
+                                 "list of built-in templates:\n%s",
+                                 list_builtin_chat_templates().c_str()),
+                   [](common_params & params, const std::string & value) { params.chat_template = read_file(value); })
+            .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER })
+            .set_env("LLAMA_ARG_CHAT_TEMPLATE_FILE"));
+    add_opt(common_arg({ "--prefill-assistant" }, { "--no-prefill-assistant" },
+                       string_format("whether to prefill the assistant's response if the last message is an assistant "
+                                     "message (default: prefill enabled)\n"
+                                     "when this flag is set, if the last message is an assistant message then it will "
+                                     "be treated as a full message and not prefilled\n"),
+                       [](common_params & params, bool value) { params.prefill_assistant = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER })
+                .set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
+    add_opt(common_arg({ "-sps", "--slot-prompt-similarity" }, "SIMILARITY",
+                       string_format("how much the prompt of a request must match the prompt of a slot in order to use "
+                                     "that slot (default: %.2f, 0.0 = disabled)\n",
+                                     params.slot_prompt_similarity),
+                       [](common_params & params, const std::string & value) {
+                           params.slot_prompt_similarity = std::stof(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg({ "--lora-init-without-apply" },
+                   string_format(
+                       "load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: %s)",
+                       params.lora_init_without_apply ? "enabled" : "disabled"),
+                   [](common_params & params) { params.lora_init_without_apply = true; })
+            .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg({ "--sleep-idle-seconds" }, "SECONDS",
+                   string_format(
+                       "number of seconds of idleness after which the server will sleep (default: %d; -1 = disabled)",
+                       params.sleep_idle_seconds),
+                   [](common_params & params, int value) {
+                       if (value == 0 || value < -1) {
+                           throw std::invalid_argument("invalid value: cannot be 0 or less than -1");
+                       }
+                       params.sleep_idle_seconds = value;
+                   })
+            .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--simple-io" }, "use basic IO for better compatibility in subprocesses and limited consoles",
+                       [](common_params & params) { params.simple_io = true; })
+                .set_examples({ LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI }));
+    add_opt(common_arg({ "--positive-file" }, "FNAME",
+                       string_format("positive prompts file, one prompt per line (default: '%s')",
+                                     params.cvector_positive_file.c_str()),
+                       [](common_params & params, const std::string & value) { params.cvector_positive_file = value; })
+                .set_examples({ LLAMA_EXAMPLE_CVECTOR_GENERATOR }));
+    add_opt(common_arg({ "--negative-file" }, "FNAME",
+                       string_format("negative prompts file, one prompt per line (default: '%s')",
+                                     params.cvector_negative_file.c_str()),
+                       [](common_params & params, const std::string & value) { params.cvector_negative_file = value; })
+                .set_examples({ LLAMA_EXAMPLE_CVECTOR_GENERATOR }));
     add_opt(common_arg(
-        {"--chat-template-kwargs"}, "STRING",
-        "sets additional params for the json template parser, must be a valid json object string, e.g. '{\"key1\":\"value1\",\"key2\":\"value2\"}'",
-        [](common_params & params, const std::string & value) {
-            auto parsed = json::parse(value);
-            for (const auto & item : parsed.items()) {
-                params.default_template_kwargs[item.key()] = item.value().dump();
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_CHAT_TEMPLATE_KWARGS"));
+                { "--pca-batch" }, "N",
+                string_format("batch size used for PCA. Larger batch runs faster, but uses more memory (default: %d)",
+                              params.n_pca_batch),
+                [](common_params & params, int value) { params.n_pca_batch = value; })
+                .set_examples({ LLAMA_EXAMPLE_CVECTOR_GENERATOR }));
+    add_opt(common_arg({ "--pca-iter" }, "N",
+                       string_format("number of iterations used for PCA (default: %d)", params.n_pca_iterations),
+                       [](common_params & params, int value) { params.n_pca_iterations = value; })
+                .set_examples({ LLAMA_EXAMPLE_CVECTOR_GENERATOR }));
+    add_opt(common_arg({ "--method" }, "{pca, mean}", "dimensionality reduction method to be used (default: pca)",
+                       [](common_params & params, const std::string & value) {
+                           /**/ if (value == "pca") {
+                               params.cvector_dimre_method = DIMRE_METHOD_PCA;
+                           } else if (value == "mean") {
+                               params.cvector_dimre_method = DIMRE_METHOD_MEAN;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_CVECTOR_GENERATOR }));
+    add_opt(common_arg({ "--output-format" }, "{md,jsonl}", "output format for batched-bench results (default: md)",
+                       [](common_params & params, const std::string & value) {
+                           /**/ if (value == "jsonl") {
+                               params.batched_bench_output_jsonl = true;
+                           } else if (value == "md") {
+                               params.batched_bench_output_jsonl = false;
+                           } else {
+                               throw std::invalid_argument("invalid value");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_BENCH }));
+    add_opt(
+        common_arg({ "--log-disable" }, "Log disable", [](common_params &) { common_log_pause(common_log_main()); }));
+    add_opt(common_arg({ "--log-file" }, "FNAME", "Log to file", [](common_params &, const std::string & value) {
+                common_log_set_file(common_log_main(), value.c_str());
+            }).set_env("LLAMA_LOG_FILE"));
+    add_opt(common_arg({ "--log-colors" }, "[on|off|auto]",
+                       "Set colored logging ('on', 'off', or 'auto', default: 'auto')\n"
+                       "'auto' enables colors when output is to a terminal",
+                       [](common_params &, const std::string & value) {
+                           if (is_truthy(value)) {
+                               common_log_set_colors(common_log_main(), LOG_COLORS_ENABLED);
+                           } else if (is_falsey(value)) {
+                               common_log_set_colors(common_log_main(), LOG_COLORS_DISABLED);
+                           } else if (is_autoy(value)) {
+                               common_log_set_colors(common_log_main(), LOG_COLORS_AUTO);
+                           } else {
+                               throw std::invalid_argument(
+                                   string_format("error: unknown value for --log-colors: '%s'\n", value.c_str()));
+                           }
+                       })
+                .set_env("LLAMA_LOG_COLORS"));
+    add_opt(common_arg({ "-v", "--verbose", "--log-verbose" },
+                       "Set verbosity level to infinity (i.e. log all messages, useful for debugging)",
+                       [](common_params & params) { params.verbosity = INT_MAX; }));
+    add_opt(common_arg({ "--offline" }, "Offline mode: forces use of cache, prevents network access",
+                       [](common_params & params) { params.offline = true; })
+                .set_env("LLAMA_OFFLINE"));
     add_opt(common_arg(
-        {"-to", "--timeout"}, "N",
-        string_format("server read/write timeout in seconds (default: %d)", params.timeout_read),
-        [](common_params & params, int value) {
-            params.timeout_read  = value;
-            params.timeout_write = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TIMEOUT"));
-    add_opt(common_arg(
-        {"--threads-http"}, "N",
-        string_format("number of threads used to process HTTP requests (default: %d)", params.n_threads_http),
-        [](common_params & params, int value) {
-            params.n_threads_http = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_THREADS_HTTP"));
-    add_opt(common_arg(
-        {"--cache-prompt"},
-        {"--no-cache-prompt"},
-        string_format("whether to enable prompt caching (default: %s)", params.cache_prompt ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.cache_prompt = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_CACHE_PROMPT"));
-    add_opt(common_arg(
-        {"--cache-reuse"}, "N",
-        string_format(
-            "min chunk size to attempt reusing from the cache via KV shifting, requires prompt caching to be enabled (default: %d)\n"
-            "[(card)](https://ggml.ai/f0.png)", params.n_cache_reuse
-        ),
-        [](common_params & params, int value) {
-            params.n_cache_reuse = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_CACHE_REUSE"));
-    add_opt(common_arg(
-        {"--metrics"},
-        string_format("enable prometheus compatible metrics endpoint (default: %s)", params.endpoint_metrics ? "enabled" : "disabled"),
-        [](common_params & params) {
-            params.endpoint_metrics = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_METRICS"));
-    add_opt(common_arg(
-        {"--props"},
-        string_format("enable changing global properties via POST /props (default: %s)", params.endpoint_props ? "enabled" : "disabled"),
-        [](common_params & params) {
-            params.endpoint_props = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_PROPS"));
-    add_opt(common_arg(
-        {"--slots"},
-        {"--no-slots"},
-        string_format("expose slots monitoring endpoint (default: %s)", params.endpoint_slots ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.endpoint_slots = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_SLOTS"));
-    add_opt(common_arg(
-        {"--slot-save-path"}, "PATH",
-        "path to save slot kv cache (default: disabled)",
-        [](common_params & params, const std::string & value) {
-            params.slot_save_path = value;
-            if (!fs_is_directory(params.slot_save_path)) {
-                throw std::invalid_argument("not a directory: " + value);
-            }
-            // if doesn't end with DIRECTORY_SEPARATOR, add it
-            if (!params.slot_save_path.empty() && params.slot_save_path[params.slot_save_path.size() - 1] != DIRECTORY_SEPARATOR) {
-                params.slot_save_path += DIRECTORY_SEPARATOR;
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--media-path"}, "PATH",
-        "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",
-        [](common_params & params, const std::string & value) {
-            params.media_path = value;
-            if (!fs_is_directory(params.media_path)) {
-                throw std::invalid_argument("not a directory: " + value);
-            }
-            // if doesn't end with DIRECTORY_SEPARATOR, add it
-            if (!params.media_path.empty() && params.media_path[params.media_path.size() - 1] != DIRECTORY_SEPARATOR) {
-                params.media_path += DIRECTORY_SEPARATOR;
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--models-dir"}, "PATH",
-        "directory containing models for the router server (default: disabled)",
-        [](common_params & params, const std::string & value) {
-            params.models_dir = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_DIR"));
-    add_opt(common_arg(
-        {"--models-preset"}, "PATH",
-        "path to INI file containing model presets for the router server (default: disabled)",
-        [](common_params & params, const std::string & value) {
-            params.models_preset = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_PRESET"));
-    add_opt(common_arg(
-        {"--models-max"}, "N",
-        string_format("for router server, maximum number of models to load simultaneously (default: %d, 0 = unlimited)", params.models_max),
-        [](common_params & params, int value) {
-            params.models_max = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_MAX"));
-    add_opt(common_arg(
-        {"--models-autoload"},
-        {"--no-models-autoload"},
-        string_format("for router server, whether to automatically load models (default: %s)", params.models_autoload ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.models_autoload = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
-    add_opt(common_arg(
-        {"--jinja"},
-        {"--no-jinja"},
-        string_format("whether to use jinja template engine for chat (default: %s)", params.use_jinja ? "enabled" : "disabled"),
-        [](common_params & params, bool value) {
-            params.use_jinja = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_MTMD}).set_env("LLAMA_ARG_JINJA"));
-    add_opt(common_arg(
-        {"--reasoning-format"}, "FORMAT",
-        "controls whether thought tags are allowed and/or extracted from the response, and in which format they're returned; one of:\n"
-        "- none: leaves thoughts unparsed in `message.content`\n"
-        "- deepseek: puts thoughts in `message.reasoning_content`\n"
-        "- deepseek-legacy: keeps `<think>` tags in `message.content` while also populating `message.reasoning_content`\n"
-        "(default: auto)",
-        [](common_params & params, const std::string & value) {
-            params.reasoning_format = common_reasoning_format_from_name(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK"));
-    add_opt(common_arg(
-        {"--reasoning-budget"}, "N",
-        "controls the amount of thinking allowed; currently only one of: -1 for unrestricted thinking budget, or 0 to disable thinking (default: -1)",
-        [](common_params & params, int value) {
-            if (value != 0 && value != -1) { throw std::invalid_argument("invalid value"); }
-            params.reasoning_budget = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET"));
-    add_opt(common_arg(
-        {"--chat-template"}, "JINJA_TEMPLATE",
-        string_format(
-            "set custom jinja chat template (default: template taken from model's metadata)\n"
-            "if suffix/prefix are specified, template will be disabled\n"
-            "only commonly used templates are accepted (unless --jinja is set before this flag):\n"
-            "list of built-in templates:\n%s", list_builtin_chat_templates().c_str()
-        ),
-        [](common_params & params, const std::string & value) {
-            params.chat_template = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_MTMD}).set_env("LLAMA_ARG_CHAT_TEMPLATE"));
-    add_opt(common_arg(
-        {"--chat-template-file"}, "JINJA_TEMPLATE_FILE",
-        string_format(
-            "set custom jinja chat template file (default: template taken from model's metadata)\n"
-            "if suffix/prefix are specified, template will be disabled\n"
-            "only commonly used templates are accepted (unless --jinja is set before this flag):\n"
-            "list of built-in templates:\n%s", list_builtin_chat_templates().c_str()
-        ),
-        [](common_params & params, const std::string & value) {
-            params.chat_template = read_file(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_CHAT_TEMPLATE_FILE"));
-    add_opt(common_arg(
-        {"--prefill-assistant"},
-        {"--no-prefill-assistant"},
-        string_format(
-            "whether to prefill the assistant's response if the last message is an assistant message (default: prefill enabled)\n"
-            "when this flag is set, if the last message is an assistant message then it will be treated as a full message and not prefilled\n"
-        ),
-        [](common_params & params, bool value) {
-            params.prefill_assistant = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
-    add_opt(common_arg(
-        {"-sps", "--slot-prompt-similarity"}, "SIMILARITY",
-        string_format("how much the prompt of a request must match the prompt of a slot in order to use that slot (default: %.2f, 0.0 = disabled)\n", params.slot_prompt_similarity),
-        [](common_params & params, const std::string & value) {
-            params.slot_prompt_similarity = std::stof(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--lora-init-without-apply"},
-        string_format("load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: %s)", params.lora_init_without_apply ? "enabled" : "disabled"),
-        [](common_params & params) {
-            params.lora_init_without_apply = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--sleep-idle-seconds"}, "SECONDS",
-        string_format("number of seconds of idleness after which the server will sleep (default: %d; -1 = disabled)", params.sleep_idle_seconds),
-        [](common_params & params, int value) {
-            if (value == 0 || value < -1) {
-                throw std::invalid_argument("invalid value: cannot be 0 or less than -1");
-            }
-            params.sleep_idle_seconds = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--simple-io"},
-        "use basic IO for better compatibility in subprocesses and limited consoles",
-        [](common_params & params) {
-            params.simple_io = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"--positive-file"}, "FNAME",
-        string_format("positive prompts file, one prompt per line (default: '%s')", params.cvector_positive_file.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.cvector_positive_file = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_CVECTOR_GENERATOR}));
-    add_opt(common_arg(
-        {"--negative-file"}, "FNAME",
-        string_format("negative prompts file, one prompt per line (default: '%s')", params.cvector_negative_file.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.cvector_negative_file = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_CVECTOR_GENERATOR}));
-    add_opt(common_arg(
-        {"--pca-batch"}, "N",
-        string_format("batch size used for PCA. Larger batch runs faster, but uses more memory (default: %d)", params.n_pca_batch),
-        [](common_params & params, int value) {
-            params.n_pca_batch = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_CVECTOR_GENERATOR}));
-    add_opt(common_arg(
-        {"--pca-iter"}, "N",
-        string_format("number of iterations used for PCA (default: %d)", params.n_pca_iterations),
-        [](common_params & params, int value) {
-            params.n_pca_iterations = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_CVECTOR_GENERATOR}));
-    add_opt(common_arg(
-        {"--method"}, "{pca, mean}",
-        "dimensionality reduction method to be used (default: pca)",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "pca") { params.cvector_dimre_method = DIMRE_METHOD_PCA; }
-            else if (value == "mean") { params.cvector_dimre_method = DIMRE_METHOD_MEAN; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_examples({LLAMA_EXAMPLE_CVECTOR_GENERATOR}));
-    add_opt(common_arg(
-        {"--output-format"}, "{md,jsonl}",
-        "output format for batched-bench results (default: md)",
-        [](common_params & params, const std::string & value) {
-            /**/ if (value == "jsonl") { params.batched_bench_output_jsonl = true; }
-            else if (value == "md") { params.batched_bench_output_jsonl = false; }
-            else { throw std::invalid_argument("invalid value"); }
-        }
-    ).set_examples({LLAMA_EXAMPLE_BENCH}));
-    add_opt(common_arg(
-        {"--log-disable"},
-        "Log disable",
-        [](common_params &) {
-            common_log_pause(common_log_main());
-        }
-    ));
-    add_opt(common_arg(
-        {"--log-file"}, "FNAME",
-        "Log to file",
-        [](common_params &, const std::string & value) {
-            common_log_set_file(common_log_main(), value.c_str());
-        }
-    ).set_env("LLAMA_LOG_FILE"));
-    add_opt(common_arg(
-        {"--log-colors"}, "[on|off|auto]",
-        "Set colored logging ('on', 'off', or 'auto', default: 'auto')\n"
-        "'auto' enables colors when output is to a terminal",
-        [](common_params &, const std::string & value) {
-            if (is_truthy(value)) {
-                common_log_set_colors(common_log_main(), LOG_COLORS_ENABLED);
-            } else if (is_falsey(value)) {
-                common_log_set_colors(common_log_main(), LOG_COLORS_DISABLED);
-            } else if (is_autoy(value)) {
-                common_log_set_colors(common_log_main(), LOG_COLORS_AUTO);
-            } else {
-                throw std::invalid_argument(
-                    string_format("error: unknown value for --log-colors: '%s'\n", value.c_str()));
-            }
-        }
-    ).set_env("LLAMA_LOG_COLORS"));
-    add_opt(common_arg(
-        {"-v", "--verbose", "--log-verbose"},
-        "Set verbosity level to infinity (i.e. log all messages, useful for debugging)",
-        [](common_params & params) {
-            params.verbosity = INT_MAX;
-        }
-    ));
-    add_opt(common_arg(
-        {"--offline"},
-        "Offline mode: forces use of cache, prevents network access",
-        [](common_params & params) {
-            params.offline = true;
-        }
-    ).set_env("LLAMA_OFFLINE"));
-    add_opt(common_arg(
-        {"-lv", "--verbosity", "--log-verbosity"}, "N",
-        string_format("Set the verbosity threshold. Messages with a higher verbosity will be ignored. Values:\n"
-            " - 0: generic output\n"
-            " - 1: error\n"
-            " - 2: warning\n"
-            " - 3: info\n"
-            " - 4: debug\n"
-            "(default: %d)\n", params.verbosity),
-        [](common_params & params, int value) {
-            params.verbosity = value;
-        }
-    ).set_env("LLAMA_LOG_VERBOSITY"));
-    add_opt(common_arg(
-        {"--log-prefix"},
-        "Enable prefix in log messages",
-        [](common_params &) {
-            common_log_set_prefix(common_log_main(), true);
-        }
-    ).set_env("LLAMA_LOG_PREFIX"));
-    add_opt(common_arg(
-        {"--log-timestamps"},
-        "Enable timestamps in log messages",
-        [](common_params &) {
-            common_log_set_timestamps(common_log_main(), true);
-        }
-    ).set_env("LLAMA_LOG_TIMESTAMPS"));
+                { "-lv", "--verbosity", "--log-verbosity" }, "N",
+                string_format("Set the verbosity threshold. Messages with a higher verbosity will be ignored. Values:\n"
+                              " - 0: generic output\n"
+                              " - 1: error\n"
+                              " - 2: warning\n"
+                              " - 3: info\n"
+                              " - 4: debug\n"
+                              "(default: %d)\n",
+                              params.verbosity),
+                [](common_params & params, int value) { params.verbosity = value; })
+                .set_env("LLAMA_LOG_VERBOSITY"));
+    add_opt(common_arg({ "--log-prefix" }, "Enable prefix in log messages", [](common_params &) {
+                common_log_set_prefix(common_log_main(), true);
+            }).set_env("LLAMA_LOG_PREFIX"));
+    add_opt(common_arg({ "--log-timestamps" }, "Enable timestamps in log messages", [](common_params &) {
+                common_log_set_timestamps(common_log_main(), true);
+            }).set_env("LLAMA_LOG_TIMESTAMPS"));
 
     // speculative parameters
+    add_opt(common_arg({ "-td", "--threads-draft" }, "N",
+                       "number of threads to use during generation (default: same as --threads)",
+                       [](common_params & params, int value) {
+                           params.speculative.cpuparams.n_threads = value;
+                           if (params.speculative.cpuparams.n_threads <= 0) {
+                               params.speculative.cpuparams.n_threads = std::thread::hardware_concurrency();
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-tbd", "--threads-batch-draft" }, "N",
+                       "number of threads to use during batch and prompt processing (default: same as --threads-draft)",
+                       [](common_params & params, int value) {
+                           params.speculative.cpuparams_batch.n_threads = value;
+                           if (params.speculative.cpuparams_batch.n_threads <= 0) {
+                               params.speculative.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-Cd", "--cpu-mask-draft" }, "M",
+                       "Draft model CPU affinity mask. Complements cpu-range-draft (default: same as --cpu-mask)",
+                       [](common_params & params, const std::string & mask) {
+                           params.speculative.cpuparams.mask_valid = true;
+                           if (!parse_cpu_mask(mask, params.speculative.cpuparams.cpumask)) {
+                               throw std::invalid_argument("invalid cpumask");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "-Crd", "--cpu-range-draft" }, "lo-hi",
+                       "Ranges of CPUs for affinity. Complements --cpu-mask-draft",
+                       [](common_params & params, const std::string & range) {
+                           params.speculative.cpuparams.mask_valid = true;
+                           if (!parse_cpu_range(range, params.speculative.cpuparams.cpumask)) {
+                               throw std::invalid_argument("invalid range");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--cpu-strict-draft" }, "<0|1>",
+                       "Use strict CPU placement for draft model (default: same as --cpu-strict)",
+                       [](common_params & params, int value) { params.speculative.cpuparams.strict_cpu = value; })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--prio-draft" }, "N",
+                       string_format(
+                           "set draft process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n",
+                           params.speculative.cpuparams.priority),
+                       [](common_params & params, int prio) {
+                           if (prio < 0 || prio > 3) {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           params.speculative.cpuparams.priority = (enum ggml_sched_priority) prio;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--poll-draft" }, "<0|1>",
+                       "Use polling to wait for draft model work (default: same as --poll])",
+                       [](common_params & params, int value) { params.speculative.cpuparams.poll = value; })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "-Cbd", "--cpu-mask-batch-draft" }, "M",
+                       "Draft model CPU affinity mask. Complements cpu-range-draft (default: same as --cpu-mask)",
+                       [](common_params & params, const std::string & mask) {
+                           params.speculative.cpuparams_batch.mask_valid = true;
+                           if (!parse_cpu_mask(mask, params.speculative.cpuparams_batch.cpumask)) {
+                               throw std::invalid_argument("invalid cpumask");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "-Crbd", "--cpu-range-batch-draft" }, "lo-hi",
+                       "Ranges of CPUs for affinity. Complements --cpu-mask-draft-batch)",
+                       [](common_params & params, const std::string & range) {
+                           params.speculative.cpuparams_batch.mask_valid = true;
+                           if (!parse_cpu_range(range, params.speculative.cpuparams_batch.cpumask)) {
+                               throw std::invalid_argument("invalid cpumask");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--cpu-strict-batch-draft" }, "<0|1>",
+                       "Use strict CPU placement for draft model (default: --cpu-strict-draft)",
+                       [](common_params & params, int value) { params.speculative.cpuparams_batch.strict_cpu = value; })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--prio-batch-draft" }, "N",
+                       string_format(
+                           "set draft process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n",
+                           params.speculative.cpuparams_batch.priority),
+                       [](common_params & params, int prio) {
+                           if (prio < 0 || prio > 3) {
+                               throw std::invalid_argument("invalid value");
+                           }
+                           params.speculative.cpuparams_batch.priority = (enum ggml_sched_priority) prio;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(common_arg({ "--poll-batch-draft" }, "<0|1>",
+                       "Use polling to wait for draft model work (default: --poll-draft)",
+                       [](common_params & params, int value) { params.speculative.cpuparams_batch.poll = value; })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE }));
+    add_opt(
+        common_arg(
+            { "--draft", "--draft-n", "--draft-max" }, "N",
+            string_format("number of tokens to draft for speculative decoding (default: %d)", params.speculative.n_max),
+            [](common_params & params, int value) { params.speculative.n_max = value; })
+            .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+            .set_env("LLAMA_ARG_DRAFT_MAX"));
+    add_opt(
+        common_arg({ "--draft-min", "--draft-n-min" }, "N",
+                   string_format("minimum number of draft tokens to use for speculative decoding (default: %d)",
+                                 params.speculative.n_min),
+                   [](common_params & params, int value) { params.speculative.n_min = value; })
+            .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+            .set_env("LLAMA_ARG_DRAFT_MIN"));
+    add_opt(common_arg({ "--draft-p-split" }, "P",
+                       string_format("speculative decoding split probability (default: %.2f)",
+                                     (double) params.speculative.p_split),
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.p_split = std::stof(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE })
+                .set_env("LLAMA_ARG_DRAFT_P_SPLIT"));
     add_opt(common_arg(
-        {"-td", "--threads-draft"}, "N",
-        "number of threads to use during generation (default: same as --threads)",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams.n_threads = value;
-            if (params.speculative.cpuparams.n_threads <= 0) {
-                params.speculative.cpuparams.n_threads = std::thread::hardware_concurrency();
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));
+                { "--draft-p-min" }, "P",
+                string_format("minimum speculative decoding probability (greedy) (default: %.2f)",
+                              (double) params.speculative.p_min),
+                [](common_params & params, const std::string & value) { params.speculative.p_min = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_DRAFT_P_MIN"));
+    add_opt(
+        common_arg({ "-cd", "--ctx-size-draft" }, "N",
+                   string_format("size of the prompt context for the draft model (default: %d, 0 = loaded from model)",
+                                 params.speculative.n_ctx),
+                   [](common_params & params, int value) { params.speculative.n_ctx = value; })
+            .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+            .set_env("LLAMA_ARG_CTX_SIZE_DRAFT"));
+    add_opt(common_arg({ "-devd", "--device-draft" }, "<dev1,dev2,..>",
+                       "comma-separated list of devices to use for offloading the draft model (none = don't offload)\n"
+                       "use --list-devices to see a list of available devices",
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.devices = parse_device_list(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
+    GGML_ASSERT(params.speculative.n_gpu_layers < 0);  // string_format would need to be extended for a default >= 0
+    add_opt(
+        common_arg({ "-ngld", "--gpu-layers-draft", "--n-gpu-layers-draft" }, "N",
+                   string_format("max. number of draft model layers to store in VRAM, either an exact number, 'auto', "
+                                 "or 'all' (default: %s)",
+                                 params.speculative.n_gpu_layers == -1 ? "auto" : "all"),
+                   [](common_params & params, const std::string & value) {
+                       if (value == "auto") {
+                           params.speculative.n_gpu_layers = -1;
+                       } else if (value == "all") {
+                           params.speculative.n_gpu_layers = -2;
+                       } else {
+                           params.speculative.n_gpu_layers = std::stoi(value);
+                       }
+                       if (!llama_supports_gpu_offload()) {
+                           fprintf(stderr, "warning: no usable GPU found, --gpu-layers-draft option will be ignored\n");
+                           fprintf(stderr,
+                                   "warning: one possible reason is that llama.cpp was compiled without GPU support\n");
+                           fprintf(stderr, "warning: consult docs/build.md for compilation instructions\n");
+                       }
+                   })
+            .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+            .set_env("LLAMA_ARG_N_GPU_LAYERS_DRAFT"));
     add_opt(common_arg(
-        {"-tbd", "--threads-batch-draft"}, "N",
-        "number of threads to use during batch and prompt processing (default: same as --threads-draft)",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams_batch.n_threads = value;
-            if (params.speculative.cpuparams_batch.n_threads <= 0) {
-                params.speculative.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-Cd", "--cpu-mask-draft"}, "M",
-        "Draft model CPU affinity mask. Complements cpu-range-draft (default: same as --cpu-mask)",
-        [](common_params & params, const std::string & mask) {
-            params.speculative.cpuparams.mask_valid = true;
-            if (!parse_cpu_mask(mask, params.speculative.cpuparams.cpumask)) {
-                throw std::invalid_argument("invalid cpumask");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"-Crd", "--cpu-range-draft"}, "lo-hi",
-        "Ranges of CPUs for affinity. Complements --cpu-mask-draft",
-        [](common_params & params, const std::string & range) {
-            params.speculative.cpuparams.mask_valid = true;
-            if (!parse_cpu_range(range, params.speculative.cpuparams.cpumask)) {
-                throw std::invalid_argument("invalid range");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--cpu-strict-draft"}, "<0|1>",
-        "Use strict CPU placement for draft model (default: same as --cpu-strict)",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams.strict_cpu = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--prio-draft"}, "N",
-        string_format("set draft process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n", params.speculative.cpuparams.priority),
-        [](common_params & params, int prio) {
-            if (prio < 0 || prio > 3) {
-                throw std::invalid_argument("invalid value");
-            }
-            params.speculative.cpuparams.priority = (enum ggml_sched_priority) prio;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--poll-draft"}, "<0|1>",
-        "Use polling to wait for draft model work (default: same as --poll])",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams.poll = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"-Cbd", "--cpu-mask-batch-draft"}, "M",
-        "Draft model CPU affinity mask. Complements cpu-range-draft (default: same as --cpu-mask)",
-        [](common_params & params, const std::string & mask) {
-            params.speculative.cpuparams_batch.mask_valid = true;
-            if (!parse_cpu_mask(mask, params.speculative.cpuparams_batch.cpumask)) {
-                throw std::invalid_argument("invalid cpumask");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"-Crbd", "--cpu-range-batch-draft"}, "lo-hi",
-        "Ranges of CPUs for affinity. Complements --cpu-mask-draft-batch)",
-        [](common_params & params, const std::string & range) {
-            params.speculative.cpuparams_batch.mask_valid = true;
-            if (!parse_cpu_range(range, params.speculative.cpuparams_batch.cpumask)) {
-                throw std::invalid_argument("invalid cpumask");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--cpu-strict-batch-draft"}, "<0|1>",
-        "Use strict CPU placement for draft model (default: --cpu-strict-draft)",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams_batch.strict_cpu = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--prio-batch-draft"}, "N",
-        string_format("set draft process/thread priority : 0-normal, 1-medium, 2-high, 3-realtime (default: %d)\n", params.speculative.cpuparams_batch.priority),
-        [](common_params & params, int prio) {
-            if (prio < 0 || prio > 3) {
-                throw std::invalid_argument("invalid value");
-            }
-            params.speculative.cpuparams_batch.priority = (enum ggml_sched_priority) prio;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--poll-batch-draft"}, "<0|1>",
-        "Use polling to wait for draft model work (default: --poll-draft)",
-        [](common_params & params, int value) {
-            params.speculative.cpuparams_batch.poll = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}));
-    add_opt(common_arg(
-        {"--draft", "--draft-n", "--draft-max"}, "N",
-        string_format("number of tokens to draft for speculative decoding (default: %d)", params.speculative.n_max),
-        [](common_params & params, int value) {
-            params.speculative.n_max = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DRAFT_MAX"));
-    add_opt(common_arg(
-        {"--draft-min", "--draft-n-min"}, "N",
-        string_format("minimum number of draft tokens to use for speculative decoding (default: %d)", params.speculative.n_min),
-        [](common_params & params, int value) {
-            params.speculative.n_min = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DRAFT_MIN"));
-    add_opt(common_arg(
-        {"--draft-p-split"}, "P",
-        string_format("speculative decoding split probability (default: %.2f)", (double)params.speculative.p_split),
-        [](common_params & params, const std::string & value) {
-            params.speculative.p_split = std::stof(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE}).set_env("LLAMA_ARG_DRAFT_P_SPLIT"));
-    add_opt(common_arg(
-        {"--draft-p-min"}, "P",
-        string_format("minimum speculative decoding probability (greedy) (default: %.2f)", (double)params.speculative.p_min),
-        [](common_params & params, const std::string & value) {
-            params.speculative.p_min = std::stof(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DRAFT_P_MIN"));
-    add_opt(common_arg(
-        {"-cd", "--ctx-size-draft"}, "N",
-        string_format("size of the prompt context for the draft model (default: %d, 0 = loaded from model)", params.speculative.n_ctx),
-        [](common_params & params, int value) {
-            params.speculative.n_ctx = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_CTX_SIZE_DRAFT"));
-    add_opt(common_arg(
-        {"-devd", "--device-draft"}, "<dev1,dev2,..>",
-        "comma-separated list of devices to use for offloading the draft model (none = don't offload)\n"
-        "use --list-devices to see a list of available devices",
-        [](common_params & params, const std::string & value) {
-            params.speculative.devices = parse_device_list(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    GGML_ASSERT(params.speculative.n_gpu_layers < 0); // string_format would need to be extended for a default >= 0
-    add_opt(common_arg(
-        {"-ngld", "--gpu-layers-draft", "--n-gpu-layers-draft"}, "N",
-        string_format("max. number of draft model layers to store in VRAM, either an exact number, 'auto', or 'all' (default: %s)",
-            params.speculative.n_gpu_layers == -1 ? "auto" : "all"),
-        [](common_params & params, const std::string & value) {
-            if (value == "auto") {
-                params.speculative.n_gpu_layers = -1;
-            } else if (value == "all") {
-                params.speculative.n_gpu_layers = -2;
-            } else {
-                params.speculative.n_gpu_layers = std::stoi(value);
-            }
-            if (!llama_supports_gpu_offload()) {
-                fprintf(stderr, "warning: no usable GPU found, --gpu-layers-draft option will be ignored\n");
-                fprintf(stderr, "warning: one possible reason is that llama.cpp was compiled without GPU support\n");
-                fprintf(stderr, "warning: consult docs/build.md for compilation instructions\n");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_N_GPU_LAYERS_DRAFT"));
-    add_opt(common_arg(
-        {"-md", "--model-draft"}, "FNAME",
-        "draft model for speculative decoding (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.speculative.mparams_dft.path = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_MODEL_DRAFT"));
-    add_opt(common_arg(
-        {"--spec-replace"}, "TARGET", "DRAFT",
-        "translate the string in TARGET into DRAFT if the draft model and main model are not compatible",
-        [](common_params & params, const std::string & tgt, const std::string & dft) {
-            params.speculative.replacements.push_back({ tgt, dft });
-        }
-    ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
-    add_opt(common_arg(
-        {"--spec-type"}, "[none|ngram-cache|ngram-simple|ngram-map-k|ngram-map-k4v|ngram-mod]",
-        string_format("type of speculative decoding to use when no draft model is provided (default: %s)\n",
-            common_speculative_type_to_str(params.speculative.type).c_str()),
-        [](common_params & params, const std::string & value) {
-            if (value == "none") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NONE;
-            } else if (value == "ngram-cache") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_CACHE;
-            } else if (value == "ngram-simple") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE;
-            } else if (value == "ngram-map-k") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K;
-            } else if (value == "ngram-map-k4v") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V;
-            } else if (value == "ngram-mod") {
-                params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MOD;
-            } else {
-                throw std::invalid_argument("unknown speculative decoding type without draft model");
-            }
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--spec-ngram-size-n"}, "N",
-        string_format("ngram size N for ngram-simple/ngram-map speculative decoding, length of lookup n-gram (default: %d)", params.speculative.ngram_size_n),
-        [](common_params & params, int value) {
-            if (value < 1 || value > 1024) {
-                throw std::invalid_argument("ngram size N must be between 1 and 1024 inclusive");
-            }
-            params.speculative.ngram_size_n = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--spec-ngram-size-m"}, "N",
-        string_format("ngram size M for ngram-simple/ngram-map speculative decoding, length of draft m-gram (default: %d)", params.speculative.ngram_size_m),
-        [](common_params & params, int value) {
-            if (value < 1 || value > 1024) {
-                throw std::invalid_argument("ngram size M must be between 1 and 1024 inclusive");
-            }
-            params.speculative.ngram_size_m = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--spec-ngram-min-hits"}, "N",
-        string_format("minimum hits for ngram-map speculative decoding (default: %d)", params.speculative.ngram_min_hits),
-        [](common_params & params, int value) {
-            if (value < 1) {
-                throw std::invalid_argument("ngram min hits must be at least 1");
-            }
-            params.speculative.ngram_min_hits = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"-ctkd", "--cache-type-k-draft"}, "TYPE",
-        string_format(
-            "KV cache data type for K for the draft model\n"
-            "allowed values: %s\n"
-            "(default: %s)",
-            get_all_kv_cache_types().c_str(),
-            ggml_type_name(params.speculative.cache_type_k)
-        ),
-        [](common_params & params, const std::string & value) {
-            params.speculative.cache_type_k = kv_cache_type_from_str(value);
-        }
-    ).set_env("LLAMA_ARG_CACHE_TYPE_K_DRAFT"));
-    add_opt(common_arg(
-        {"-ctvd", "--cache-type-v-draft"}, "TYPE",
-        string_format(
-            "KV cache data type for V for the draft model\n"
-            "allowed values: %s\n"
-            "(default: %s)",
-            get_all_kv_cache_types().c_str(),
-            ggml_type_name(params.speculative.cache_type_v)
-        ),
-        [](common_params & params, const std::string & value) {
-            params.speculative.cache_type_v = kv_cache_type_from_str(value);
-        }
-    ).set_env("LLAMA_ARG_CACHE_TYPE_V_DRAFT"));
+                { "-md", "--model-draft" }, "FNAME", "draft model for speculative decoding (default: unused)",
+                [](common_params & params, const std::string & value) { params.speculative.mparams_dft.path = value; })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_MODEL_DRAFT"));
+    add_opt(common_arg({ "--spec-replace" }, "TARGET", "DRAFT",
+                       "translate the string in TARGET into DRAFT if the draft model and main model are not compatible",
+                       [](common_params & params, const std::string & tgt, const std::string & dft) {
+                           params.speculative.replacements.push_back({ tgt, dft });
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
+    add_opt(
+        common_arg({ "--spec-type" }, "[none|ngram-cache|ngram-simple|ngram-map-k|ngram-map-k4v|ngram-mod]",
+                   string_format("type of speculative decoding to use when no draft model is provided (default: %s)\n",
+                                 common_speculative_type_to_str(params.speculative.type).c_str()),
+                   [](common_params & params, const std::string & value) {
+                       if (value == "none") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NONE;
+                       } else if (value == "ngram-cache") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_CACHE;
+                       } else if (value == "ngram-simple") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE;
+                       } else if (value == "ngram-map-k") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K;
+                       } else if (value == "ngram-map-k4v") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V;
+                       } else if (value == "ngram-mod") {
+                           params.speculative.type = COMMON_SPECULATIVE_TYPE_NGRAM_MOD;
+                       } else {
+                           throw std::invalid_argument("unknown speculative decoding type without draft model");
+                       }
+                   })
+            .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg(
+            { "--spec-ngram-size-n" }, "N",
+            string_format(
+                "ngram size N for ngram-simple/ngram-map speculative decoding, length of lookup n-gram (default: %d)",
+                params.speculative.ngram_size_n),
+            [](common_params & params, int value) {
+                if (value < 1 || value > 1024) {
+                    throw std::invalid_argument("ngram size N must be between 1 and 1024 inclusive");
+                }
+                params.speculative.ngram_size_n = value;
+            })
+            .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(
+        common_arg(
+            { "--spec-ngram-size-m" }, "N",
+            string_format(
+                "ngram size M for ngram-simple/ngram-map speculative decoding, length of draft m-gram (default: %d)",
+                params.speculative.ngram_size_m),
+            [](common_params & params, int value) {
+                if (value < 1 || value > 1024) {
+                    throw std::invalid_argument("ngram size M must be between 1 and 1024 inclusive");
+                }
+                params.speculative.ngram_size_m = value;
+            })
+            .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--spec-ngram-min-hits" }, "N",
+                       string_format("minimum hits for ngram-map speculative decoding (default: %d)",
+                                     params.speculative.ngram_min_hits),
+                       [](common_params & params, int value) {
+                           if (value < 1) {
+                               throw std::invalid_argument("ngram min hits must be at least 1");
+                           }
+                           params.speculative.ngram_min_hits = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--spec-ngram-adaptive" },
+                       "enable adaptive adjustment of draft-min/draft-max for ngram-mod based on acceptance rate",
+                       [](common_params & params) { params.speculative.ngram_adaptive = true; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "-ctkd", "--cache-type-k-draft" }, "TYPE",
+                       string_format("KV cache data type for K for the draft model\n"
+                                     "allowed values: %s\n"
+                                     "(default: %s)",
+                                     get_all_kv_cache_types().c_str(), ggml_type_name(params.speculative.cache_type_k)),
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.cache_type_k = kv_cache_type_from_str(value);
+                       })
+                .set_env("LLAMA_ARG_CACHE_TYPE_K_DRAFT"));
+    add_opt(common_arg({ "-ctvd", "--cache-type-v-draft" }, "TYPE",
+                       string_format("KV cache data type for V for the draft model\n"
+                                     "allowed values: %s\n"
+                                     "(default: %s)",
+                                     get_all_kv_cache_types().c_str(), ggml_type_name(params.speculative.cache_type_v)),
+                       [](common_params & params, const std::string & value) {
+                           params.speculative.cache_type_v = kv_cache_type_from_str(value);
+                       })
+                .set_env("LLAMA_ARG_CACHE_TYPE_V_DRAFT"));
 
-    add_opt(common_arg(
-        {"-mv", "--model-vocoder"}, "FNAME",
-        "vocoder model for audio generation (default: unused)",
-        [](common_params & params, const std::string & value) {
-            params.vocoder.model.path = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_SERVER}));
-     add_opt(common_arg(
-        {"--tts-use-guide-tokens"},
-        "Use guide tokens to improve TTS word recall",
-        [](common_params & params) {
-            params.vocoder.use_guide_tokens = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_SERVER}));
-    add_opt(common_arg(
-        {"--tts-speaker-file"}, "FNAME",
-        "speaker file path for audio generation",
-        [](common_params & params, const std::string & value) {
-            params.vocoder.speaker_file = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_TTS}));
+    add_opt(common_arg({ "-mv", "--model-vocoder" }, "FNAME", "vocoder model for audio generation (default: unused)",
+                       [](common_params & params, const std::string & value) { params.vocoder.model.path = value; })
+                .set_examples({ LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--tts-use-guide-tokens" }, "Use guide tokens to improve TTS word recall",
+                       [](common_params & params) { params.vocoder.use_guide_tokens = true; })
+                .set_examples({ LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_SERVER }));
+    add_opt(common_arg({ "--tts-speaker-file" }, "FNAME", "speaker file path for audio generation",
+                       [](common_params & params, const std::string & value) { params.vocoder.speaker_file = value; })
+                .set_examples({ LLAMA_EXAMPLE_TTS }));
 
+    add_opt(common_arg({ "--diffusion-steps" }, "N",
+                       string_format("number of diffusion steps (default: %d)", params.diffusion.steps),
+                       [](common_params & params, int value) { params.diffusion.steps = value; })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(common_arg({ "--diffusion-visual" },
+                       string_format("enable visual diffusion mode (show progressive generation) (default: %s)",
+                                     params.diffusion.visual_mode ? "true" : "false"),
+                       [](common_params & params) { params.diffusion.visual_mode = true; })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(
+        common_arg({ "--diffusion-eps" }, "F",
+                   string_format("epsilon for timesteps (default: %.6f)", (double) params.diffusion.eps),
+                   [](common_params & params, const std::string & value) { params.diffusion.eps = std::stof(value); })
+            .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(common_arg({ "--diffusion-algorithm" }, "N",
+                       string_format("diffusion algorithm: 0=ORIGIN, 1=ENTROPY_BASED, 2=MARGIN_BASED, 3=RANDOM, "
+                                     "4=LOW_CONFIDENCE (default: %d)",
+                                     params.diffusion.algorithm),
+                       [](common_params & params, int value) { params.diffusion.algorithm = value; })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
     add_opt(common_arg(
-        {"--diffusion-steps"}, "N",
-        string_format("number of diffusion steps (default: %d)", params.diffusion.steps),
-        [](common_params & params, int value) { params.diffusion.steps = value; }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-visual"},
-        string_format("enable visual diffusion mode (show progressive generation) (default: %s)", params.diffusion.visual_mode ? "true" : "false"),
-        [](common_params & params) { params.diffusion.visual_mode = true; }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-eps"}, "F",
-        string_format("epsilon for timesteps (default: %.6f)", (double) params.diffusion.eps),
-        [](common_params & params, const std::string & value) { params.diffusion.eps = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-algorithm"}, "N",
-        string_format("diffusion algorithm: 0=ORIGIN, 1=ENTROPY_BASED, 2=MARGIN_BASED, 3=RANDOM, 4=LOW_CONFIDENCE (default: %d)", params.diffusion.algorithm),
-        [](common_params & params, int value) { params.diffusion.algorithm = value; }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-alg-temp"}, "F",
-        string_format("dream algorithm temperature (default: %.3f)", (double) params.diffusion.alg_temp),
-        [](common_params & params, const std::string & value) { params.diffusion.alg_temp = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-block-length"}, "N",
-        string_format("llada block length for generation (default: %d)", params.diffusion.block_length),
-        [](common_params & params, int value) { params.diffusion.block_length = value; }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-cfg-scale"}, "F",
-        string_format("llada classifier-free guidance scale (default: %.3f)", (double) params.diffusion.cfg_scale),
-        [](common_params & params, const std::string & value) { params.diffusion.cfg_scale = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        {"--diffusion-add-gumbel-noise"}, "F",
-        string_format("add gumbel noise to the logits if temp > 0.0 (default: %s)", params.diffusion.add_gumbel_noise ? "true" : "false"),
-        [](common_params & params, const std::string & value) { params.diffusion.add_gumbel_noise = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
-    add_opt(common_arg(
-        { "-lr", "--learning-rate" }, "ALPHA",
-        string_format("adamw or sgd optimizer alpha (default: %.2g); note: sgd alpha recommended ~10x (no momentum)", (double) params.lr.lr0),
-        [](common_params & params, const std::string & value) { params.lr.lr0 = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+                { "--diffusion-alg-temp" }, "F",
+                string_format("dream algorithm temperature (default: %.3f)", (double) params.diffusion.alg_temp),
+                [](common_params & params, const std::string & value) { params.diffusion.alg_temp = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(common_arg({ "--diffusion-block-length" }, "N",
+                       string_format("llada block length for generation (default: %d)", params.diffusion.block_length),
+                       [](common_params & params, int value) { params.diffusion.block_length = value; })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(
+        common_arg(
+            { "--diffusion-cfg-scale" }, "F",
+            string_format("llada classifier-free guidance scale (default: %.3f)", (double) params.diffusion.cfg_scale),
+            [](common_params & params, const std::string & value) { params.diffusion.cfg_scale = std::stof(value); })
+            .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(common_arg({ "--diffusion-add-gumbel-noise" }, "F",
+                       string_format("add gumbel noise to the logits if temp > 0.0 (default: %s)",
+                                     params.diffusion.add_gumbel_noise ? "true" : "false"),
+                       [](common_params & params, const std::string & value) {
+                           params.diffusion.add_gumbel_noise = std::stof(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_DIFFUSION }));
+    add_opt(
+        common_arg({ "-lr", "--learning-rate" }, "ALPHA",
+                   string_format(
+                       "adamw or sgd optimizer alpha (default: %.2g); note: sgd alpha recommended ~10x (no momentum)",
+                       (double) params.lr.lr0),
+                   [](common_params & params, const std::string & value) { params.lr.lr0 = std::stof(value); })
+            .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
     add_opt(common_arg({ "-lr-min", "--learning-rate-min" }, "ALPHA",
-        string_format("(if >0) final learning rate after decay (if -decay-epochs is set, default=%.2g)",
-            (double) params.lr.lr_min),
-        [](common_params & params, const std::string & value) { params.lr.lr_min = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+                       string_format("(if >0) final learning rate after decay (if -decay-epochs is set, default=%.2g)",
+                                     (double) params.lr.lr_min),
+                       [](common_params & params, const std::string & value) { params.lr.lr_min = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
     add_opt(common_arg(
-        {"-decay-epochs", "--learning-rate-decay-epochs"}, "ALPHA",
-        string_format("(if >0) decay learning rate to -lr-min after this many epochs (exponential decay, default=%.2g)", (double) params.lr.decay_epochs),
-        [](common_params & params, const std::string & value) { params.lr.decay_epochs = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+                { "-decay-epochs", "--learning-rate-decay-epochs" }, "ALPHA",
+                string_format(
+                    "(if >0) decay learning rate to -lr-min after this many epochs (exponential decay, default=%.2g)",
+                    (double) params.lr.decay_epochs),
+                [](common_params & params, const std::string & value) { params.lr.decay_epochs = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
     add_opt(common_arg(
-        {"-wd", "--weight-decay"}, "WD",
-        string_format("adamw or sgd optimizer weight decay (0 is off; recommend very small e.g. 1e-9) (default: %.2g).", (double) params.lr.wd),
-        [](common_params & params, const std::string & value) { params.lr.wd = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
-    add_opt(common_arg(
-        {"-val-split", "--val-split"}, "FRACTION",
-        string_format("fraction of data to use as validation set for training (default: %.2g).", (double) params.val_split),
-        [](common_params & params, const std::string & value) { params.val_split = std::stof(value); }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
-    add_opt(common_arg(
-        {"-epochs", "--epochs"}, "N",
-        string_format("optimizer max # of epochs (default: %d)", params.lr.epochs),
-        [](common_params & params, int epochs) { params.lr.epochs = epochs; }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
-    add_opt(common_arg(
-        {"-opt", "--optimizer"}, "sgd|adamw", "adamw or sgd",
-        [](common_params & params, const std::string & name) {
-            params.optimizer = common_opt_get_optimizer(name.c_str());
-            if (params.optimizer == GGML_OPT_OPTIMIZER_TYPE_COUNT) {
-                throw std::invalid_argument("invalid --optimizer, valid options: adamw, sgd");
-            }
-        }
-    ).set_examples({ LLAMA_EXAMPLE_FINETUNE }));
-    add_opt(common_arg(
-        {"--save-logits"},
-        string_format("save final logits to files for verification (default: %s)", params.save_logits ? "true" : "false"),
-        [](common_params & params) {
-            params.save_logits = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_DEBUG}));
-    add_opt(common_arg(
-        {"--logits-output-dir"}, "PATH",
-        string_format("directory for saving logits output files (default: %s)", params.logits_output_dir.c_str()),
-        [](common_params & params, const std::string & value) {
-            params.logits_output_dir = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_DEBUG}));
-    add_opt(common_arg(
-        {"--tensor-filter"}, "REGEX",
-        "filter tensor names for debug output (regex pattern, can be specified multiple times)",
-        [](common_params & params, const std::string & value) {
-            params.tensor_filter.push_back(value);
-        }
-    ).set_examples({LLAMA_EXAMPLE_DEBUG}));
+                { "-wd", "--weight-decay" }, "WD",
+                string_format(
+                    "adamw or sgd optimizer weight decay (0 is off; recommend very small e.g. 1e-9) (default: %.2g).",
+                    (double) params.lr.wd),
+                [](common_params & params, const std::string & value) { params.lr.wd = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+    add_opt(common_arg({ "-val-split", "--val-split" }, "FRACTION",
+                       string_format("fraction of data to use as validation set for training (default: %.2g).",
+                                     (double) params.val_split),
+                       [](common_params & params, const std::string & value) { params.val_split = std::stof(value); })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+    add_opt(common_arg({ "-epochs", "--epochs" }, "N",
+                       string_format("optimizer max # of epochs (default: %d)", params.lr.epochs),
+                       [](common_params & params, int epochs) { params.lr.epochs = epochs; })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+    add_opt(common_arg({ "-opt", "--optimizer" }, "sgd|adamw", "adamw or sgd",
+                       [](common_params & params, const std::string & name) {
+                           params.optimizer = common_opt_get_optimizer(name.c_str());
+                           if (params.optimizer == GGML_OPT_OPTIMIZER_TYPE_COUNT) {
+                               throw std::invalid_argument("invalid --optimizer, valid options: adamw, sgd");
+                           }
+                       })
+                .set_examples({ LLAMA_EXAMPLE_FINETUNE }));
+    add_opt(common_arg({ "--save-logits" },
+                       string_format("save final logits to files for verification (default: %s)",
+                                     params.save_logits ? "true" : "false"),
+                       [](common_params & params) { params.save_logits = true; })
+                .set_examples({ LLAMA_EXAMPLE_DEBUG }));
+    add_opt(common_arg({ "--logits-output-dir" }, "PATH",
+                       string_format("directory for saving logits output files (default: %s)",
+                                     params.logits_output_dir.c_str()),
+                       [](common_params & params, const std::string & value) { params.logits_output_dir = value; })
+                .set_examples({ LLAMA_EXAMPLE_DEBUG }));
+    add_opt(common_arg({ "--tensor-filter" }, "REGEX",
+                       "filter tensor names for debug output (regex pattern, can be specified multiple times)",
+                       [](common_params & params, const std::string & value) { params.tensor_filter.push_back(value); })
+                .set_examples({ LLAMA_EXAMPLE_DEBUG }));
 
     // presets
-    add_opt(common_arg(
-        {"--tts-oute-default"},
-        string_format("use default OuteTTS models (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "OuteAI/OuteTTS-0.2-500M-GGUF";
-            params.model.hf_file = "OuteTTS-0.2-500M-Q8_0.gguf";
-            params.vocoder.model.hf_repo = "ggml-org/WavTokenizer";
-            params.vocoder.model.hf_file = "WavTokenizer-Large-75-F16.gguf";
-        }
-    ).set_examples({LLAMA_EXAMPLE_TTS}));
+    add_opt(common_arg({ "--tts-oute-default" },
+                       string_format("use default OuteTTS models (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo         = "OuteAI/OuteTTS-0.2-500M-GGUF";
+                           params.model.hf_file         = "OuteTTS-0.2-500M-Q8_0.gguf";
+                           params.vocoder.model.hf_repo = "ggml-org/WavTokenizer";
+                           params.vocoder.model.hf_file = "WavTokenizer-Large-75-F16.gguf";
+                       })
+                .set_examples({ LLAMA_EXAMPLE_TTS }));
 
-    add_opt(common_arg(
-        {"--embd-gemma-default"},
-        string_format("use default EmbeddingGemma model (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/embeddinggemma-300M-qat-q4_0-GGUF";
-            params.model.hf_file = "embeddinggemma-300M-qat-Q4_0.gguf";
-            params.port = 8011;
-            params.n_ubatch = 2048;
-            params.n_batch = 2048;
-            params.n_parallel = 32;
-            params.n_ctx = 2048*params.n_parallel;
-            params.verbose_prompt = true;
-            params.embedding = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--embd-gemma-default" },
+                       string_format("use default EmbeddingGemma model (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo  = "ggml-org/embeddinggemma-300M-qat-q4_0-GGUF";
+                           params.model.hf_file  = "embeddinggemma-300M-qat-Q4_0.gguf";
+                           params.port           = 8011;
+                           params.n_ubatch       = 2048;
+                           params.n_batch        = 2048;
+                           params.n_parallel     = 32;
+                           params.n_ctx          = 2048 * params.n_parallel;
+                           params.verbose_prompt = true;
+                           params.embedding      = true;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-1.5b-default"},
-        string_format("use default Qwen 2.5 Coder 1.5B (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF";
-            params.model.hf_file = "qwen2.5-coder-1.5b-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-1.5b-default" },
+                       string_format("use default Qwen 2.5 Coder 1.5B (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF";
+                           params.model.hf_file = "qwen2.5-coder-1.5b-q8_0.gguf";
+                           params.port          = 8012;
+                           params.n_ubatch      = 1024;
+                           params.n_batch       = 1024;
+                           params.n_ctx         = 0;
+                           params.n_cache_reuse = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-3b-default"},
-        string_format("use default Qwen 2.5 Coder 3B (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-3B-Q8_0-GGUF";
-            params.model.hf_file = "qwen2.5-coder-3b-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-3b-default" },
+                       string_format("use default Qwen 2.5 Coder 3B (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/Qwen2.5-Coder-3B-Q8_0-GGUF";
+                           params.model.hf_file = "qwen2.5-coder-3b-q8_0.gguf";
+                           params.port          = 8012;
+                           params.n_ubatch      = 1024;
+                           params.n_batch       = 1024;
+                           params.n_ctx         = 0;
+                           params.n_cache_reuse = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-7b-default"},
-        string_format("use default Qwen 2.5 Coder 7B (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
-            params.model.hf_file = "qwen2.5-coder-7b-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-7b-default" },
+                       string_format("use default Qwen 2.5 Coder 7B (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
+                           params.model.hf_file = "qwen2.5-coder-7b-q8_0.gguf";
+                           params.port          = 8012;
+                           params.n_ubatch      = 1024;
+                           params.n_batch       = 1024;
+                           params.n_ctx         = 0;
+                           params.n_cache_reuse = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-7b-spec"},
-        string_format("use Qwen 2.5 Coder 7B + 0.5B draft for speculative decoding (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
-            params.model.hf_file = "qwen2.5-coder-7b-q8_0.gguf";
-            params.speculative.mparams_dft.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
-            params.speculative.mparams_dft.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-7b-spec" },
+                       string_format("use Qwen 2.5 Coder 7B + 0.5B draft for speculative decoding (note: can download "
+                                     "weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo                   = "ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF";
+                           params.model.hf_file                   = "qwen2.5-coder-7b-q8_0.gguf";
+                           params.speculative.mparams_dft.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
+                           params.speculative.mparams_dft.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
+                           params.port                            = 8012;
+                           params.n_ubatch                        = 1024;
+                           params.n_batch                         = 1024;
+                           params.n_ctx                           = 0;
+                           params.n_cache_reuse                   = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-14b-spec"},
-        string_format("use Qwen 2.5 Coder 14B + 0.5B draft for speculative decoding (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen2.5-Coder-14B-Q8_0-GGUF";
-            params.model.hf_file = "qwen2.5-coder-14b-q8_0.gguf";
-            params.speculative.mparams_dft.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
-            params.speculative.mparams_dft.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-14b-spec" },
+                       string_format("use Qwen 2.5 Coder 14B + 0.5B draft for speculative decoding (note: can download "
+                                     "weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo                   = "ggml-org/Qwen2.5-Coder-14B-Q8_0-GGUF";
+                           params.model.hf_file                   = "qwen2.5-coder-14b-q8_0.gguf";
+                           params.speculative.mparams_dft.hf_repo = "ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF";
+                           params.speculative.mparams_dft.hf_file = "qwen2.5-coder-0.5b-q8_0.gguf";
+                           params.port                            = 8012;
+                           params.n_ubatch                        = 1024;
+                           params.n_batch                         = 1024;
+                           params.n_ctx                           = 0;
+                           params.n_cache_reuse                   = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--fim-qwen-30b-default"},
-        string_format("use default Qwen 3 Coder 30B A3B Instruct (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/Qwen3-Coder-30B-A3B-Instruct-Q8_0-GGUF";
-            params.model.hf_file = "qwen3-coder-30b-a3b-instruct-q8_0.gguf";
-            params.port = 8012;
-            params.n_ubatch = 1024;
-            params.n_batch = 1024;
-            params.n_ctx = 0;
-            params.n_cache_reuse = 256;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg({ "--fim-qwen-30b-default" },
+                       string_format(
+                           "use default Qwen 3 Coder 30B A3B Instruct (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/Qwen3-Coder-30B-A3B-Instruct-Q8_0-GGUF";
+                           params.model.hf_file = "qwen3-coder-30b-a3b-instruct-q8_0.gguf";
+                           params.port          = 8012;
+                           params.n_ubatch      = 1024;
+                           params.n_batch       = 1024;
+                           params.n_ctx         = 0;
+                           params.n_cache_reuse = 256;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER }));
 
-    add_opt(common_arg(
-        {"--gpt-oss-20b-default"},
-        string_format("use gpt-oss-20b (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/gpt-oss-20b-GGUF";
-            params.model.hf_file = "gpt-oss-20b-mxfp4.gguf";
-            params.port = 8013;
-            params.n_ubatch = 2048;
-            params.n_batch = 32768;
-            params.n_parallel = 2;
-            params.n_ctx = 131072*params.n_parallel;
-            params.sampling.temp = 1.0f;
-            params.sampling.top_p = 1.0f;
-            params.sampling.top_k = 0;
-            params.sampling.min_p = 0.01f;
-            params.use_jinja = true;
-            //params.default_template_kwargs["reasoning_effort"] = "\"high\"";
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg({ "--gpt-oss-20b-default" },
+                       string_format("use gpt-oss-20b (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo  = "ggml-org/gpt-oss-20b-GGUF";
+                           params.model.hf_file  = "gpt-oss-20b-mxfp4.gguf";
+                           params.port           = 8013;
+                           params.n_ubatch       = 2048;
+                           params.n_batch        = 32768;
+                           params.n_parallel     = 2;
+                           params.n_ctx          = 131072 * params.n_parallel;
+                           params.sampling.temp  = 1.0f;
+                           params.sampling.top_p = 1.0f;
+                           params.sampling.top_k = 0;
+                           params.sampling.min_p = 0.01f;
+                           params.use_jinja      = true;
+                           //params.default_template_kwargs["reasoning_effort"] = "\"high\"";
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
 
-    add_opt(common_arg(
-        {"--gpt-oss-120b-default"},
-        string_format("use gpt-oss-120b (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/gpt-oss-120b-GGUF";
-            params.port = 8013;
-            params.n_ubatch = 2048;
-            params.n_batch = 32768;
-            params.n_parallel = 2;
-            params.n_ctx = 131072*params.n_parallel;
-            params.sampling.temp = 1.0f;
-            params.sampling.top_p = 1.0f;
-            params.sampling.top_k = 0;
-            params.sampling.min_p = 0.01f;
-            params.use_jinja = true;
-            //params.default_template_kwargs["reasoning_effort"] = "\"high\"";
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg({ "--gpt-oss-120b-default" },
+                       string_format("use gpt-oss-120b (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo  = "ggml-org/gpt-oss-120b-GGUF";
+                           params.port           = 8013;
+                           params.n_ubatch       = 2048;
+                           params.n_batch        = 32768;
+                           params.n_parallel     = 2;
+                           params.n_ctx          = 131072 * params.n_parallel;
+                           params.sampling.temp  = 1.0f;
+                           params.sampling.top_p = 1.0f;
+                           params.sampling.top_k = 0;
+                           params.sampling.min_p = 0.01f;
+                           params.use_jinja      = true;
+                           //params.default_template_kwargs["reasoning_effort"] = "\"high\"";
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
 
-    add_opt(common_arg(
-        {"--vision-gemma-4b-default"},
-        string_format("use Gemma 3 4B QAT (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/gemma-3-4b-it-qat-GGUF";
-            params.port = 8014;
-            params.n_ctx = 0;
-            params.use_jinja = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg({ "--vision-gemma-4b-default" },
+                       string_format("use Gemma 3 4B QAT (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/gemma-3-4b-it-qat-GGUF";
+                           params.port          = 8014;
+                           params.n_ctx         = 0;
+                           params.use_jinja     = true;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
 
-    add_opt(common_arg(
-        {"--vision-gemma-12b-default"},
-        string_format("use Gemma 3 12B QAT (note: can download weights from the internet)"),
-        [](common_params & params) {
-            params.model.hf_repo = "ggml-org/gemma-3-12b-it-qat-GGUF";
-            params.port = 8014;
-            params.n_ctx = 0;
-            params.use_jinja = true;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg({ "--vision-gemma-12b-default" },
+                       string_format("use Gemma 3 12B QAT (note: can download weights from the internet)"),
+                       [](common_params & params) {
+                           params.model.hf_repo = "ggml-org/gemma-3-12b-it-qat-GGUF";
+                           params.port          = 8014;
+                           params.n_ctx         = 0;
+                           params.use_jinja     = true;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI }));
 
     return ctx_arg;
 }
 
 void common_params_add_preset_options(std::vector<common_arg> & args) {
     // arguments below won't be treated as CLI args, only preset options
-    args.push_back(common_arg(
-        {"load-on-startup"}, "NAME",
-        "in server router mode, autoload this model on startup",
-        [](common_params &, const std::string &) { /* unused */ }
-    ).set_env(COMMON_ARG_PRESET_LOAD_ON_STARTUP).set_preset_only());
+    args.push_back(common_arg({ "load-on-startup" }, "NAME", "in server router mode, autoload this model on startup",
+                              [](common_params &, const std::string &) { /* unused */ })
+                       .set_env(COMMON_ARG_PRESET_LOAD_ON_STARTUP)
+                       .set_preset_only());
 
-    args.push_back(common_arg(
-        {"stop-timeout"}, "SECONDS",
-        "in server router mode, force-kill model instance after this many seconds of graceful shutdown",
-        [](common_params &, int) { /* unused */ }
-    ).set_env(COMMON_ARG_PRESET_STOP_TIMEOUT).set_preset_only());
+    args.push_back(
+        common_arg({ "stop-timeout" }, "SECONDS",
+                   "in server router mode, force-kill model instance after this many seconds of graceful shutdown",
+                   [](common_params &, int) { /* unused */ })
+            .set_env(COMMON_ARG_PRESET_STOP_TIMEOUT)
+            .set_preset_only());
 
     // args.push_back(common_arg(
     //     {"pin"},

--- a/common/common.h
+++ b/common/common.h
@@ -5,30 +5,39 @@
 #include "ggml-opt.h"
 #include "llama-cpp.h"
 
+#include <map>
 #include <set>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <map>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
-#define _WIN32_WINNT 0x0A00
+#    define _WIN32_WINNT 0x0A00
 #endif
 
 #ifdef _WIN32
-#define DIRECTORY_SEPARATOR '\\'
+#    define DIRECTORY_SEPARATOR '\\'
 #else
-#define DIRECTORY_SEPARATOR '/'
-#endif // _WIN32
+#    define DIRECTORY_SEPARATOR '/'
+#endif  // _WIN32
 
-#define die(msg)          do { fputs("error: " msg "\n", stderr);                exit(1); } while (0)
-#define die_fmt(fmt, ...) do { fprintf(stderr, "error: " fmt "\n", __VA_ARGS__); exit(1); } while (0)
+#define die(msg)                           \
+    do {                                   \
+        fputs("error: " msg "\n", stderr); \
+        exit(1);                           \
+    } while (0)
+#define die_fmt(fmt, ...)                                 \
+    do {                                                  \
+        fprintf(stderr, "error: " fmt "\n", __VA_ARGS__); \
+        exit(1);                                          \
+    } while (0)
 
-#define print_build_info() do {                                                                     \
-    fprintf(stderr, "%s: build = %d (%s)\n",      __func__, LLAMA_BUILD_NUMBER, LLAMA_COMMIT);      \
-    fprintf(stderr, "%s: built with %s for %s\n", __func__, LLAMA_COMPILER, LLAMA_BUILD_TARGET);    \
-} while(0)
+#define print_build_info()                                                                           \
+    do {                                                                                             \
+        fprintf(stderr, "%s: build = %d (%s)\n", __func__, LLAMA_BUILD_NUMBER, LLAMA_COMMIT);        \
+        fprintf(stderr, "%s: built with %s for %s\n", __func__, LLAMA_COMPILER, LLAMA_BUILD_TARGET); \
+    } while (0)
 
 struct common_time_meas {
     common_time_meas(int64_t & t_acc, bool disable = false);
@@ -41,7 +50,7 @@ struct common_time_meas {
 
 struct common_adapter_lora_info {
     std::string path;
-    float scale;
+    float       scale;
 
     std::string task_name;
     std::string prompt_prefix;
@@ -52,7 +61,7 @@ struct common_adapter_lora_info {
 using llama_tokens = std::vector<llama_token>;
 
 // build info
-extern int LLAMA_BUILD_NUMBER;
+extern int          LLAMA_BUILD_NUMBER;
 extern const char * LLAMA_COMMIT;
 extern const char * LLAMA_COMPILER;
 extern const char * LLAMA_BUILD_TARGET;
@@ -66,12 +75,13 @@ struct common_control_vector_load_info;
 //
 
 struct cpu_params {
-    int      n_threads                   = -1;
-    bool     cpumask[GGML_MAX_N_THREADS] = {false}; // CPU affinity mask.
-    bool     mask_valid                  = false;   // Default: any CPU
-    enum ggml_sched_priority  priority   = GGML_SCHED_PRIO_NORMAL;  // Scheduling prio : (0 - normal, 1 - medium, 2 - high, 3 - realtime)
-    bool     strict_cpu                  = false;   // Use strict CPU placement
-    uint32_t poll                        = 50;      // Polling (busywait) level (0 - no polling, 100 - mostly polling)
+    int                      n_threads                   = -1;
+    bool                     cpumask[GGML_MAX_N_THREADS] = { false };  // CPU affinity mask.
+    bool                     mask_valid                  = false;      // Default: any CPU
+    enum ggml_sched_priority priority =
+        GGML_SCHED_PRIO_NORMAL;   // Scheduling prio : (0 - normal, 1 - medium, 2 - high, 3 - realtime)
+    bool     strict_cpu = false;  // Use strict CPU placement
+    uint32_t poll       = 50;     // Polling (busywait) level (0 - no polling, 100 - mostly polling)
 };
 
 int32_t cpu_get_num_physical_cores();
@@ -114,7 +124,7 @@ enum common_sampler_type {
     COMMON_SAMPLER_TYPE_TOP_K       = 2,
     COMMON_SAMPLER_TYPE_TOP_P       = 3,
     COMMON_SAMPLER_TYPE_MIN_P       = 4,
-  //COMMON_SAMPLER_TYPE_TFS_Z       = 5,
+    //COMMON_SAMPLER_TYPE_TFS_Z       = 5,
     COMMON_SAMPLER_TYPE_TYPICAL_P   = 6,
     COMMON_SAMPLER_TYPE_TEMPERATURE = 7,
     COMMON_SAMPLER_TYPE_XTC         = 8,
@@ -145,8 +155,8 @@ enum common_grammar_trigger_type {
 
 struct common_grammar_trigger {
     common_grammar_trigger_type type;
-    std::string value;
-    llama_token token = LLAMA_TOKEN_NULL;
+    std::string                 value;
+    llama_token                 token = LLAMA_TOKEN_NULL;
 };
 
 enum common_params_sampling_config : uint64_t {
@@ -165,191 +175,185 @@ enum common_params_sampling_config : uint64_t {
 };
 
 enum common_speculative_type {
-    COMMON_SPECULATIVE_TYPE_NONE,          // no speculative decoding
-    COMMON_SPECULATIVE_TYPE_DRAFT,         // draft model
-    COMMON_SPECULATIVE_TYPE_EAGLE3,        // eagle draft model
-    COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE,  // simple self-speculative decoding
-    COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K,   // self-speculative decoding with n-gram keys only
-    COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V, // self-speculative decoding with n-gram keys and 4 m-gram values
+    COMMON_SPECULATIVE_TYPE_NONE,           // no speculative decoding
+    COMMON_SPECULATIVE_TYPE_DRAFT,          // draft model
+    COMMON_SPECULATIVE_TYPE_EAGLE3,         // eagle draft model
+    COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE,   // simple self-speculative decoding
+    COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K,    // self-speculative decoding with n-gram keys only
+    COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V,  // self-speculative decoding with n-gram keys and 4 m-gram values
     COMMON_SPECULATIVE_TYPE_NGRAM_MOD,
-    COMMON_SPECULATIVE_TYPE_NGRAM_CACHE,   // self-speculative decoding with 3-level n-gram cache
-    COMMON_SPECULATIVE_TYPE_COUNT          // number of types, unknown type
+    COMMON_SPECULATIVE_TYPE_NGRAM_CACHE,    // self-speculative decoding with 3-level n-gram cache
+    COMMON_SPECULATIVE_TYPE_COUNT           // number of types, unknown type
 };
 
 // sampling parameters
 struct common_params_sampling {
-    uint32_t seed = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampler
+    uint32_t seed = LLAMA_DEFAULT_SEED;  // the seed used to initialize llama_sampler
 
-    int32_t n_prev             = 64;     // number of previous tokens to remember
-    int32_t n_probs            = 0;      // if greater than 0, output the probabilities of top n_probs tokens.
-    int32_t min_keep           = 0;      // 0 = disabled, otherwise samplers should return at least min_keep tokens
-    int32_t top_k              = 40;     // <= 0 to use vocab size
-    float   top_p              = 0.95f;  // 1.0 = disabled
-    float   min_p              = 0.05f;  // 0.0 = disabled
-    float   xtc_probability    = 0.00f;  // 0.0 = disabled
-    float   xtc_threshold      = 0.10f;  // > 0.5 disables XTC
-    float   typ_p              = 1.00f;  // typical_p, 1.0 = disabled
-    float   temp               = 0.80f;  // <= 0.0 to sample greedily, 0.0 to not output probabilities
-    float   dynatemp_range     = 0.00f;  // 0.0 = disabled
-    float   dynatemp_exponent  = 1.00f;  // controls how entropy maps to temperature in dynamic temperature sampler
-    int32_t penalty_last_n     = 64;     // last n tokens to penalize (0 = disable penalty, -1 = context size)
-    float   penalty_repeat     = 1.00f;  // 1.0 = disabled
-    float   penalty_freq       = 0.00f;  // 0.0 = disabled
-    float   penalty_present    = 0.00f;  // 0.0 = disabled
-    float   dry_multiplier     = 0.0f;   // 0.0 = disabled;      DRY repetition penalty for tokens extending repetition:
-    float   dry_base           = 1.75f;  // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
-    int32_t dry_allowed_length = 2;      // tokens extending repetitions beyond this receive penalty
-    int32_t dry_penalty_last_n = -1;     // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
-    float   adaptive_target    = -1.0f;  // select tokens near this probability (valid range 0.0 to 1.0; negative = disabled)
-    float   adaptive_decay     = 0.90f;  // EMA decay for adaptation; history ≈ 1/(1-decay) tokens (0.0 - 0.99)
-    int32_t mirostat           = 0;      // 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
-    float   top_n_sigma        = -1.00f; // -1.0 = disabled
-    float   mirostat_tau       = 5.00f;  // target entropy
-    float   mirostat_eta       = 0.10f;  // learning rate
-    bool    ignore_eos         = false;
-    bool    no_perf            = false;  // disable performance metrics
-    bool    timing_per_token   = false;
+    int32_t n_prev            = 64;      // number of previous tokens to remember
+    int32_t n_probs           = 0;       // if greater than 0, output the probabilities of top n_probs tokens.
+    int32_t min_keep          = 0;       // 0 = disabled, otherwise samplers should return at least min_keep tokens
+    int32_t top_k             = 40;      // <= 0 to use vocab size
+    float   top_p             = 0.95f;   // 1.0 = disabled
+    float   min_p             = 0.05f;   // 0.0 = disabled
+    float   xtc_probability   = 0.00f;   // 0.0 = disabled
+    float   xtc_threshold     = 0.10f;   // > 0.5 disables XTC
+    float   typ_p             = 1.00f;   // typical_p, 1.0 = disabled
+    float   temp              = 0.80f;   // <= 0.0 to sample greedily, 0.0 to not output probabilities
+    float   dynatemp_range    = 0.00f;   // 0.0 = disabled
+    float   dynatemp_exponent = 1.00f;   // controls how entropy maps to temperature in dynamic temperature sampler
+    int32_t penalty_last_n    = 64;      // last n tokens to penalize (0 = disable penalty, -1 = context size)
+    float   penalty_repeat    = 1.00f;   // 1.0 = disabled
+    float   penalty_freq      = 0.00f;   // 0.0 = disabled
+    float   penalty_present   = 0.00f;   // 0.0 = disabled
+    float   dry_multiplier    = 0.0f;    // 0.0 = disabled;      DRY repetition penalty for tokens extending repetition:
+    float   dry_base =
+        1.75f;  // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
+    int32_t dry_allowed_length = 2;  // tokens extending repetitions beyond this receive penalty
+    int32_t dry_penalty_last_n =
+        -1;                          // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
+    float adaptive_target = -1.0f;  // select tokens near this probability (valid range 0.0 to 1.0; negative = disabled)
+    float adaptive_decay  = 0.90f;  // EMA decay for adaptation; history ≈ 1/(1-decay) tokens (0.0 - 0.99)
+    int32_t mirostat      = 0;      // 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
+    float   top_n_sigma   = -1.00f;  // -1.0 = disabled
+    float   mirostat_tau  = 5.00f;   // target entropy
+    float   mirostat_eta  = 0.10f;   // learning rate
+    bool    ignore_eos    = false;
+    bool    no_perf       = false;   // disable performance metrics
+    bool    timing_per_token = false;
 
-    uint64_t user_sampling_config = 0; // bitfield to track user-specified samplers
+    uint64_t user_sampling_config = 0;  // bitfield to track user-specified samplers
 
-    std::vector<std::string> dry_sequence_breakers = {"\n", ":", "\"", "*"};     // default sequence breakers for DRY
+    std::vector<std::string> dry_sequence_breakers = { "\n", ":", "\"", "*" };  // default sequence breakers for DRY
 
     std::vector<enum common_sampler_type> samplers = {
-        COMMON_SAMPLER_TYPE_PENALTIES,
-        COMMON_SAMPLER_TYPE_DRY,
-        COMMON_SAMPLER_TYPE_TOP_N_SIGMA,
-        COMMON_SAMPLER_TYPE_TOP_K,
-        COMMON_SAMPLER_TYPE_TYPICAL_P,
-        COMMON_SAMPLER_TYPE_TOP_P,
-        COMMON_SAMPLER_TYPE_MIN_P,
-        COMMON_SAMPLER_TYPE_XTC,
-        COMMON_SAMPLER_TYPE_TEMPERATURE,
+        COMMON_SAMPLER_TYPE_PENALTIES, COMMON_SAMPLER_TYPE_DRY,       COMMON_SAMPLER_TYPE_TOP_N_SIGMA,
+        COMMON_SAMPLER_TYPE_TOP_K,     COMMON_SAMPLER_TYPE_TYPICAL_P, COMMON_SAMPLER_TYPE_TOP_P,
+        COMMON_SAMPLER_TYPE_MIN_P,     COMMON_SAMPLER_TYPE_XTC,       COMMON_SAMPLER_TYPE_TEMPERATURE,
     };
 
-    std::string                         grammar; // optional BNF-like grammar to constrain sampling
+    std::string                         grammar;           // optional BNF-like grammar to constrain sampling
     bool                                grammar_lazy = false;
-    std::vector<common_grammar_trigger> grammar_triggers; // optional triggers (for lazy grammars)
+    std::vector<common_grammar_trigger> grammar_triggers;  // optional triggers (for lazy grammars)
     std::set<llama_token>               preserved_tokens;
 
-    std::vector<llama_logit_bias> logit_bias;     // logit biases to apply
-    std::vector<llama_logit_bias> logit_bias_eog; // pre-calculated logit biases for EOG tokens
+    std::vector<llama_logit_bias> logit_bias;      // logit biases to apply
+    std::vector<llama_logit_bias> logit_bias_eog;  // pre-calculated logit biases for EOG tokens
 
     bool backend_sampling = false;
 
-    bool has_logit_bias() const {
-        return !logit_bias.empty();
-    }
+    bool has_logit_bias() const { return !logit_bias.empty(); }
 
     // print the parameters into a string
     std::string print() const;
 };
 
 struct common_params_model {
-    std::string path        = ""; // model local path                                       // NOLINT
-    std::string url         = ""; // model url to download                                  // NOLINT
-    std::string hf_repo     = ""; // HF repo                                                // NOLINT
-    std::string hf_file     = ""; // HF file                                                // NOLINT
-    std::string docker_repo = ""; // Docker repo                                            // NOLINT
-    std::string name        = ""; // in format <user>/<model>[:<tag>] (tag is optional)     // NOLINT
+    std::string path        = "";  // model local path                                       // NOLINT
+    std::string url         = "";  // model url to download                                  // NOLINT
+    std::string hf_repo     = "";  // HF repo                                                // NOLINT
+    std::string hf_file     = "";  // HF file                                                // NOLINT
+    std::string docker_repo = "";  // Docker repo                                            // NOLINT
+    std::string name        = "";  // in format <user>/<model>[:<tag>] (tag is optional)     // NOLINT
 };
 
 struct common_ngram_mod;
 
 struct common_params_speculative {
-    common_speculative_type type = COMMON_SPECULATIVE_TYPE_NONE; // type of speculative decoding
+    common_speculative_type type = COMMON_SPECULATIVE_TYPE_NONE;  // type of speculative decoding
 
     // general-purpose speculative decoding parameters
 
-    int32_t n_max   = 16; // maximum number of tokens to draft during speculative decoding
-    int32_t n_min   = 0; // minimum number of draft tokens to use for speculative decoding
-    float   p_split = 0.1f; // speculative decoding split probability
-    float   p_min   = 0.75f; // minimum speculative decoding probability (greedy)
+    int32_t n_max   = 16;     // maximum number of tokens to draft during speculative decoding
+    int32_t n_min   = 0;      // minimum number of draft tokens to use for speculative decoding
+    float   p_split = 0.1f;   // speculative decoding split probability
+    float   p_min   = 0.75f;  // minimum speculative decoding probability (greedy)
 
     // ngram-based speculative decoding
 
-    uint16_t ngram_size_n     = 12; // ngram size for lookup
-    uint16_t ngram_size_m     = 48; // mgram size for speculative tokens
-    uint16_t ngram_min_hits   =  1; // minimum hits at ngram/mgram lookup for mgram to be proposed
+    uint16_t ngram_size_n   = 12;     // ngram size for lookup
+    uint16_t ngram_size_m   = 48;     // mgram size for speculative tokens
+    uint16_t ngram_min_hits = 1;      // minimum hits at ngram/mgram lookup for mgram to be proposed
+    bool     ngram_adaptive = false;  // dynamically adjust n_min/n_max based on acceptance rate
 
     std::shared_ptr<common_ngram_mod> ngram_mod;
 
-    std::string lookup_cache_static;  // path of static ngram cache file for lookup decoding           // NOLINT
-    std::string lookup_cache_dynamic; // path of dynamic ngram cache file for lookup decoding          // NOLINT
+    std::string lookup_cache_static;   // path of static ngram cache file for lookup decoding           // NOLINT
+    std::string lookup_cache_dynamic;  // path of dynamic ngram cache file for lookup decoding          // NOLINT
 
     // draft-model speculative decoding
 
     struct common_params_model mparams_dft;
 
-    llama_model * model_dft = nullptr; // a llama_model that can be shared by multiple speculative contexts
+    llama_model * model_dft = nullptr;       // a llama_model that can be shared by multiple speculative contexts
 
-    llama_context_params cparams_dft; // these are the parameters for the draft llama_context
+    llama_context_params cparams_dft;        // these are the parameters for the draft llama_context
 
-    int32_t n_ctx        = 0;  // draft context size
-    int32_t n_gpu_layers = -1; // number of layers to store in VRAM for the draft model (-1 - use default)
+    int32_t n_ctx        = 0;                // draft context size
+    int32_t n_gpu_layers = -1;               // number of layers to store in VRAM for the draft model (-1 - use default)
 
-    ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
-    ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V
+    ggml_type cache_type_k = GGML_TYPE_F16;  // KV cache data type for the K
+    ggml_type cache_type_v = GGML_TYPE_F16;  // KV cache data type for the V
 
     struct cpu_params cpuparams;
     struct cpu_params cpuparams_batch;
 
-    std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
+    std::vector<ggml_backend_dev_t> devices;                        // devices to use for offloading
 
-    std::vector<std::pair<std::string, std::string>> replacements; // main to speculative model replacements
-    std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
+    std::vector<std::pair<std::string, std::string>> replacements;  // main to speculative model replacements
+    std::vector<llama_model_tensor_buft_override>    tensor_buft_overrides;
 
-    bool has_dft() const {
-        return !mparams_dft.path.empty() || !mparams_dft.hf_repo.empty();
-    }
+    bool has_dft() const { return !mparams_dft.path.empty() || !mparams_dft.hf_repo.empty(); }
 };
 
 struct common_params_vocoder {
     struct common_params_model model;
 
-    std::string speaker_file = ""; // speaker file path                                      // NOLINT
+    std::string speaker_file = "";  // speaker file path                                      // NOLINT
 
-    bool use_guide_tokens = false; // enable guide tokens to improve TTS accuracy            // NOLINT
+    bool use_guide_tokens = false;  // enable guide tokens to improve TTS accuracy            // NOLINT
 };
 
 struct common_params_diffusion {
-    int32_t steps         = 128;
-    bool    visual_mode   = false;
+    int32_t steps       = 128;
+    bool    visual_mode = false;
 
-    float   eps           = 0;        // epsilon for timesteps
-    int32_t block_length  = 0;        // block length for generation
+    float   eps          = 0;        // epsilon for timesteps
+    int32_t block_length = 0;        // block length for generation
 
-    int32_t algorithm     = 4;        // default algorithm: low-confidence
-    float   alg_temp      = 0.0f;     // algorithm temperature
+    int32_t algorithm = 4;           // default algorithm: low-confidence
+    float   alg_temp  = 0.0f;        // algorithm temperature
 
-    float   cfg_scale     = 0;        // classifier-free guidance scale
-    bool    add_gumbel_noise = false; // add gumbel noise to the logits if temp > 0.0
+    float cfg_scale        = 0;      // classifier-free guidance scale
+    bool  add_gumbel_noise = false;  // add gumbel noise to the logits if temp > 0.0
 };
 
 // reasoning API response format (not to be confused as chat template's reasoning format)
 // only used by server
 enum common_reasoning_format {
     COMMON_REASONING_FORMAT_NONE,
-    COMMON_REASONING_FORMAT_AUTO,            // Same as deepseek, using `message.reasoning_content`
-    COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY, // Extract thinking tag contents and return as `message.reasoning_content`, or leave inline in <think> tags in stream mode
-    COMMON_REASONING_FORMAT_DEEPSEEK,        // Extract thinking tag contents and return as `message.reasoning_content`, including in streaming deltas.
+    COMMON_REASONING_FORMAT_AUTO,             // Same as deepseek, using `message.reasoning_content`
+    COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY,  // Extract thinking tag contents and return as `message.reasoning_content`, or leave inline in <think> tags in stream mode
+    COMMON_REASONING_FORMAT_DEEPSEEK,  // Extract thinking tag contents and return as `message.reasoning_content`, including in streaming deltas.
     // do not extend this enum unless you absolutely have to
     // in most cases, use COMMON_REASONING_FORMAT_AUTO
     // see: https://github.com/ggml-org/llama.cpp/pull/15408
 };
 
-
 struct lr_opt {
-    float    lr0          = 1e-5; // learning rate at first epoch
+    float    lr0          = 1e-5;  // learning rate at first epoch
     float    lr_min       = -1;
-    float    decay_epochs = -1;   // if >0, the learning rate starts at lr0 and decays to lr_min after this many epochs
+    float    decay_epochs = -1;    // if >0, the learning rate starts at lr0 and decays to lr_min after this many epochs
     float    scale_epoch  = 0;
     float    wd           = 0;
     unsigned epochs       = 2;
 
-    unsigned epoch; // set by optimizer outer (epochs) loop
+    unsigned epoch;  // set by optimizer outer (epochs) loop
     // learning rate decay - constant LR per epoch only for now
-    float get_lr(float e) const;
+    float    get_lr(float e) const;
+
     float get_lr() const { return get_lr(epoch); }
+
     // must call after arg parse, before get_lr
     void init();
 };
@@ -357,51 +361,51 @@ struct lr_opt {
 struct ggml_opt_optimizer_params common_opt_lr_pars(void * userdata);
 
 struct common_params {
-    int32_t n_predict             =    -1; // max. number of new tokens to predict, -1 == no limit
-    int32_t n_ctx                 =     0; // context size, 0 == context the model was trained with
-    int32_t n_batch               =  2048; // logical batch size for prompt processing (must be >=32 to use BLAS)
-    int32_t n_ubatch              =   512; // physical batch size for prompt processing (must be >=32 to use BLAS)
-    int32_t n_keep                =     0; // number of tokens to keep from initial prompt
-    int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
-    int32_t n_parallel            =     1; // number of parallel sequences to decode
-    int32_t n_sequences           =     1; // number of sequences to decode
-    int32_t grp_attn_n            =     1; // group-attention factor
-    int32_t grp_attn_w            =   512; // group-attention width
-    int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)
-    float   rope_freq_base        =  0.0f; // RoPE base frequency
-    float   rope_freq_scale       =  0.0f; // RoPE frequency scaling factor
-    float   yarn_ext_factor       = -1.0f; // YaRN extrapolation mix factor
-    float   yarn_attn_factor      = -1.0f; // YaRN magnitude scaling factor
-    float   yarn_beta_fast        = -1.0f; // YaRN low correction dim
-    float   yarn_beta_slow        = -1.0f; // YaRN high correction dim
-    int32_t yarn_orig_ctx         =     0; // YaRN original context length
+    int32_t n_predict        = -1;     // max. number of new tokens to predict, -1 == no limit
+    int32_t n_ctx            = 0;      // context size, 0 == context the model was trained with
+    int32_t n_batch          = 2048;   // logical batch size for prompt processing (must be >=32 to use BLAS)
+    int32_t n_ubatch         = 512;    // physical batch size for prompt processing (must be >=32 to use BLAS)
+    int32_t n_keep           = 0;      // number of tokens to keep from initial prompt
+    int32_t n_chunks         = -1;     // max number of chunks to process (-1 = unlimited)
+    int32_t n_parallel       = 1;      // number of parallel sequences to decode
+    int32_t n_sequences      = 1;      // number of sequences to decode
+    int32_t grp_attn_n       = 1;      // group-attention factor
+    int32_t grp_attn_w       = 512;    // group-attention width
+    int32_t n_print          = -1;     // print token count every n tokens (-1 = disabled)
+    float   rope_freq_base   = 0.0f;   // RoPE base frequency
+    float   rope_freq_scale  = 0.0f;   // RoPE frequency scaling factor
+    float   yarn_ext_factor  = -1.0f;  // YaRN extrapolation mix factor
+    float   yarn_attn_factor = -1.0f;  // YaRN magnitude scaling factor
+    float   yarn_beta_fast   = -1.0f;  // YaRN low correction dim
+    float   yarn_beta_slow   = -1.0f;  // YaRN high correction dim
+    int32_t yarn_orig_ctx    = 0;      // YaRN original context length
 
     // offload params
-    std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
+    std::vector<ggml_backend_dev_t> devices;  // devices to use for offloading
 
-    int32_t n_gpu_layers       = -1;   // number of layers to store in VRAM, -1 is auto, <= -2 is all
-    int32_t main_gpu           = 0;    // the GPU that is used for scratch and small tensors
-    float   tensor_split[128]  = {0};  // how split tensors should be distributed across GPUs
-    bool    fit_params         = true; // whether to fit unset model/context parameters to free device memory
-    int32_t fit_params_min_ctx = 4096; // minimum context size to set when trying to reduce memory use
+    int32_t n_gpu_layers       = -1;          // number of layers to store in VRAM, -1 is auto, <= -2 is all
+    int32_t main_gpu           = 0;           // the GPU that is used for scratch and small tensors
+    float   tensor_split[128]  = { 0 };       // how split tensors should be distributed across GPUs
+    bool    fit_params         = true;        // whether to fit unset model/context parameters to free device memory
+    int32_t fit_params_min_ctx = 4096;        // minimum context size to set when trying to reduce memory use
 
     // margin per device in bytes for fitting parameters to free memory:
-    std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024*1024);
+    std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024 * 1024);
 
-    enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
+    enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER;  // how to split the model across GPUs
 
     struct cpu_params cpuparams;
     struct cpu_params cpuparams_batch;
 
-    ggml_backend_sched_eval_callback cb_eval = nullptr;
-    void * cb_eval_user_data                 = nullptr;
+    ggml_backend_sched_eval_callback cb_eval           = nullptr;
+    void *                           cb_eval_user_data = nullptr;
 
     ggml_numa_strategy numa = GGML_NUMA_STRATEGY_DISABLED;
 
     enum llama_rope_scaling_type rope_scaling_type = LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED;
-    enum llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED; // pooling type for embeddings
-    enum llama_attention_type    attention_type    = LLAMA_ATTENTION_TYPE_UNSPECIFIED; // attention type for embeddings
-    enum llama_flash_attn_type   flash_attn_type   = LLAMA_FLASH_ATTN_TYPE_AUTO; // whether to use Flash Attention
+    enum llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED;    // pooling type for embeddings
+    enum llama_attention_type    attention_type    = LLAMA_ATTENTION_TYPE_UNSPECIFIED;  // attention type for embeddings
+    enum llama_flash_attn_type   flash_attn_type   = LLAMA_FLASH_ATTN_TYPE_AUTO;  // whether to use Flash Attention
 
     struct common_params_sampling    sampling;
     struct common_params_speculative speculative;
@@ -410,157 +414,165 @@ struct common_params {
 
     struct common_params_model model;
 
-    std::string model_alias          = ""; // model alias                                                   // NOLINT
-    std::string hf_token             = ""; // HF token                                                      // NOLINT
-    std::string prompt               = "";                                                                  // NOLINT
-    std::string system_prompt        = "";                                                                  // NOLINT
-    std::string prompt_file          = ""; // store the external prompt file name                           // NOLINT
-    std::string path_prompt_cache    = ""; // path to file for saving/loading prompt eval state             // NOLINT
-    std::string input_prefix         = ""; // string to prefix user inputs with                             // NOLINT
-    std::string input_suffix         = ""; // string to suffix user inputs with                             // NOLINT
-    std::string logits_file          = ""; // file for saving *all* logits                                  // NOLINT
+    std::string model_alias       = "";  // model alias                                                   // NOLINT
+    std::string hf_token          = "";  // HF token                                                      // NOLINT
+    std::string prompt            = "";  // NOLINT
+    std::string system_prompt     = "";  // NOLINT
+    std::string prompt_file       = "";  // store the external prompt file name                           // NOLINT
+    std::string path_prompt_cache = "";  // path to file for saving/loading prompt eval state             // NOLINT
+    std::string input_prefix      = "";  // string to prefix user inputs with                             // NOLINT
+    std::string input_suffix      = "";  // string to suffix user inputs with                             // NOLINT
+    std::string logits_file       = "";  // file for saving *all* logits                                  // NOLINT
 
     // llama-debug specific options
-    std::string logits_output_dir = "data"; // directory for saving logits output files                     // NOLINT
-    bool        save_logits       = false;  // whether to save logits to files                              // NOLINT
-    std::vector<std::string> tensor_filter; // filter tensor names for debug output (regex)                 // NOLINT
+    std::string logits_output_dir = "data";  // directory for saving logits output files                     // NOLINT
+    bool        save_logits       = false;   // whether to save logits to files                              // NOLINT
+    std::vector<std::string> tensor_filter;  // filter tensor names for debug output (regex)                 // NOLINT
 
-    std::vector<std::string> in_files;   // all input files
-    std::vector<std::string> antiprompt; // strings upon which more user input is prompted (a.k.a. reverse prompts)
-    std::vector<llama_model_kv_override> kv_overrides;
+    std::vector<std::string> in_files;       // all input files
+    std::vector<std::string> antiprompt;     // strings upon which more user input is prompted (a.k.a. reverse prompts)
+    std::vector<llama_model_kv_override>          kv_overrides;
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
 
-    bool lora_init_without_apply = false; // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_adapter_lora_apply)
-    std::vector<common_adapter_lora_info> lora_adapters; // lora adapter path with user defined scale
+    bool lora_init_without_apply =
+        false;  // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_adapter_lora_apply)
+    std::vector<common_adapter_lora_info> lora_adapters;           // lora adapter path with user defined scale
 
-    std::vector<common_control_vector_load_info> control_vectors; // control vector with user defined scale
+    std::vector<common_control_vector_load_info> control_vectors;  // control vector with user defined scale
 
-    int32_t verbosity                  = 3;  // LOG_LEVEL_INFO
-    int32_t control_vector_layer_start = -1; // layer range for control vector
-    int32_t control_vector_layer_end   = -1; // layer range for control vector
+    int32_t verbosity                  = 3;                        // LOG_LEVEL_INFO
+    int32_t control_vector_layer_start = -1;                       // layer range for control vector
+    int32_t control_vector_layer_end   = -1;                       // layer range for control vector
     bool    offline                    = false;
 
-    int32_t ppl_stride      = 0;     // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.
-    int32_t ppl_output_type = 0;     // = 0 -> ppl output is as usual, = 1 -> ppl output is num_tokens, ppl, one per line
-                                     //                                       (which is more convenient to use for plotting)
-                                     //
-    bool   hellaswag        = false; // compute HellaSwag score over random tasks from datafile supplied in prompt
-    size_t hellaswag_tasks  = 400;   // number of tasks to use when computing the HellaSwag score
+    int32_t ppl_stride =
+        0;  // stride for perplexity calculations. If left at 0, the pre-existing approach will be used.
+    int32_t ppl_output_type = 0;  // = 0 -> ppl output is as usual, = 1 -> ppl output is num_tokens, ppl, one per line
+    //                                       (which is more convenient to use for plotting)
+    //
+    bool    hellaswag       = false;  // compute HellaSwag score over random tasks from datafile supplied in prompt
+    size_t  hellaswag_tasks = 400;    // number of tasks to use when computing the HellaSwag score
 
-    bool   winogrande       = false; // compute Winogrande score over random tasks from datafile supplied in prompt
-    size_t winogrande_tasks = 0;     // number of tasks to use when computing the Winogrande score. If 0, all tasks will be computed
+    bool   winogrande = false;        // compute Winogrande score over random tasks from datafile supplied in prompt
+    size_t winogrande_tasks =
+        0;  // number of tasks to use when computing the Winogrande score. If 0, all tasks will be computed
 
-    bool   multiple_choice  = false;  // compute TruthfulQA score over random tasks from datafile supplied in prompt
-    size_t multiple_choice_tasks = 0; // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
+    bool   multiple_choice = false;  // compute TruthfulQA score over random tasks from datafile supplied in prompt
+    size_t multiple_choice_tasks =
+        0;  // number of tasks to use when computing the TruthfulQA score. If 0, all tasks will be computed
 
-    bool   kl_divergence    = false; // compute KL divergence
+    bool kl_divergence = false;      // compute KL divergence
 
-    bool usage             = false; // print usage
-    bool completion        = false; // print source-able completion script
-    bool use_color         = false; // use color to distinguish generations and inputs
-    bool special           = false; // enable special token output
-    bool interactive       = false; // interactive mode
-    bool interactive_first = false; // wait for user input immediately
-    bool prompt_cache_all  = false; // save user input and generations to prompt cache
-    bool prompt_cache_ro   = false; // open the prompt cache read-only and do not update it
+    bool usage             = false;  // print usage
+    bool completion        = false;  // print source-able completion script
+    bool use_color         = false;  // use color to distinguish generations and inputs
+    bool special           = false;  // enable special token output
+    bool interactive       = false;  // interactive mode
+    bool interactive_first = false;  // wait for user input immediately
+    bool prompt_cache_all  = false;  // save user input and generations to prompt cache
+    bool prompt_cache_ro   = false;  // open the prompt cache read-only and do not update it
 
-    bool escape            = true;  // escape "\n", "\r", "\t", "\'", "\"", and "\\"
-    bool multiline_input   = false; // reverse the usage of `\`
-    bool simple_io         = false; // improves compatibility with subprocesses and limited consoles
-    bool cont_batching     = true;  // insert new sequences for decoding on-the-fly
-    bool no_perf           = false; // disable performance metrics
-    bool show_timings      = true;  // show timing information on CLI
-    bool ctx_shift         = false; // context shift on infinite text generation
-    bool swa_full          = false; // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
-    bool kv_unified        = false; // enable unified KV cache
+    bool escape          = true;     // escape "\n", "\r", "\t", "\'", "\"", and "\\"
+    bool multiline_input = false;    // reverse the usage of `\`
+    bool simple_io       = false;    // improves compatibility with subprocesses and limited consoles
+    bool cont_batching   = true;     // insert new sequences for decoding on-the-fly
+    bool no_perf         = false;    // disable performance metrics
+    bool show_timings    = true;     // show timing information on CLI
+    bool ctx_shift       = false;    // context shift on infinite text generation
+    bool swa_full =
+        false;  // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+    bool kv_unified = false;                 // enable unified KV cache
 
-    bool input_prefix_bos  = false; // prefix BOS to user inputs, preceding input_prefix
-    bool use_mmap          = true;  // enable mmap to use filesystem cache
-    bool use_direct_io     = false; // read from disk without buffering
-    bool use_mlock         = false; // use mlock to keep model in memory
-    bool verbose_prompt    = false; // print prompt tokens before generation
-    bool display_prompt    = true;  // print prompt before generation
-    bool no_kv_offload     = false; // disable KV offloading
-    bool warmup            = true;  // warmup run
-    bool check_tensors     = false; // validate tensor data
-    bool no_op_offload     = false; // globally disable offload host tensor operations to device
-    bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
-    bool no_host           = false; // bypass host buffer allowing extra buffers to be used
+    bool input_prefix_bos = false;           // prefix BOS to user inputs, preceding input_prefix
+    bool use_mmap         = true;            // enable mmap to use filesystem cache
+    bool use_direct_io    = false;           // read from disk without buffering
+    bool use_mlock        = false;           // use mlock to keep model in memory
+    bool verbose_prompt   = false;           // print prompt tokens before generation
+    bool display_prompt   = true;            // print prompt before generation
+    bool no_kv_offload    = false;           // disable KV offloading
+    bool warmup           = true;            // warmup run
+    bool check_tensors    = false;           // validate tensor data
+    bool no_op_offload    = false;           // globally disable offload host tensor operations to device
+    bool no_extra_bufts   = false;           // disable extra buffer types (used for weight repacking)
+    bool no_host          = false;           // bypass host buffer allowing extra buffers to be used
 
-    bool single_turn       = false; // single turn chat conversation
+    bool single_turn = false;                // single turn chat conversation
 
-    ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
-    ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V
+    ggml_type cache_type_k = GGML_TYPE_F16;  // KV cache data type for the K
+    ggml_type cache_type_v = GGML_TYPE_F16;  // KV cache data type for the V
 
     common_conversation_mode conversation_mode = COMMON_CONVERSATION_MODE_AUTO;
 
     // multimodal models (see tools/mtmd)
     struct common_params_model mmproj;
-    bool mmproj_use_gpu = true;     // use GPU for multimodal model
-    bool no_mmproj = false;         // explicitly disable multimodal model
-    std::vector<std::string> image; // path to image file(s)
-    int image_min_tokens = -1;
-    int image_max_tokens = -1;
+    bool                       mmproj_use_gpu = true;   // use GPU for multimodal model
+    bool                       no_mmproj      = false;  // explicitly disable multimodal model
+    std::vector<std::string>   image;                   // path to image file(s)
+    int                        image_min_tokens = -1;
+    int                        image_max_tokens = -1;
 
     // finetune
-    struct lr_opt lr;
+    struct lr_opt                lr;
     enum ggml_opt_optimizer_type optimizer = GGML_OPT_OPTIMIZER_TYPE_ADAMW;
-    float val_split = 0.05f; // fraction of the data used for the validation set
+    float                        val_split = 0.05f;  // fraction of the data used for the validation set
 
     // embedding
-    bool embedding         = false; // get only sentence embedding
-    int32_t embd_normalize = 2;     // normalisation for embeddings (-1=none, 0=max absolute int16, 1=taxicab, 2=euclidean, >2=p-norm)
-    std::string embd_out   = "";    // empty = default, "array" = [[],[]...], "json" = openai style, "json+" = same "json" + cosine similarity matrix
-    std::string embd_sep   = "\n";  // separator of embeddings
-    std::string cls_sep    = "\t";  // separator of classification sequences
+    bool    embedding = false;  // get only sentence embedding
+    int32_t embd_normalize =
+        2;  // normalisation for embeddings (-1=none, 0=max absolute int16, 1=taxicab, 2=euclidean, >2=p-norm)
+    std::string embd_out =
+        "";  // empty = default, "array" = [[],[]...], "json" = openai style, "json+" = same "json" + cosine similarity matrix
+    std::string embd_sep = "\n";  // separator of embeddings
+    std::string cls_sep  = "\t";  // separator of classification sequences
 
     // server params
-    int32_t port              = 8080;         // server listens on this network port
-    int32_t timeout_read      = 600;          // http read timeout in seconds
-    int32_t timeout_write     = timeout_read; // http write timeout in seconds
-    int32_t n_threads_http    = -1;           // number of threads to process HTTP requests (TODO: support threadpool)
-    int32_t n_cache_reuse     = 0;            // min chunk size to reuse from the cache via KV shifting
-    bool    cache_prompt      = true;         // whether to enable prompt caching
-    int32_t n_ctx_checkpoints = 8;            // max number of context checkpoints per slot
-    int32_t cache_ram_mib     = 8192;         // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+    int32_t port                  = 8080;          // server listens on this network port
+    int32_t timeout_read          = 600;           // http read timeout in seconds
+    int32_t timeout_write         = timeout_read;  // http write timeout in seconds
+    int32_t n_threads_http        = -1;    // number of threads to process HTTP requests (TODO: support threadpool)
+    int32_t n_cache_reuse         = 0;     // min chunk size to reuse from the cache via KV shifting
+    bool    cache_prompt          = true;  // whether to enable prompt caching
+    int32_t n_ctx_checkpoints     = 8;     // max number of context checkpoints per slot
+    int32_t cache_ram_mib         = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+    int32_t cache_eviction_policy = 0;     // 0 = FIFO (default), 1 = LRU, 2 = LFU
 
-    std::string hostname      = "127.0.0.1";
-    std::string public_path   = "";                                                                         // NOLINT
-    std::string api_prefix    = "";                                                                         // NOLINT
-    std::string chat_template = "";                                                                         // NOLINT
-    bool use_jinja = true;                                                                                  // NOLINT
-    bool enable_chat_template = true;
-    common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
-    int reasoning_budget = -1;
-    bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
-    int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    std::string             hostname             = "127.0.0.1";
+    std::string             public_path          = "";    // NOLINT
+    std::string             api_prefix           = "";    // NOLINT
+    std::string             chat_template        = "";    // NOLINT
+    bool                    use_jinja            = true;  // NOLINT
+    bool                    enable_chat_template = true;
+    common_reasoning_format reasoning_format     = COMMON_REASONING_FORMAT_DEEPSEEK;
+    int                     reasoning_budget     = -1;
+    bool prefill_assistant  = true;  // if true, any trailing assistant message will be prefilled into the response
+    int  sleep_idle_seconds = -1;    // if >0, server will sleep after this many seconds of idle time
 
     std::vector<std::string> api_keys;
 
-    std::string ssl_file_key  = "";                                                                         // NOLINT
-    std::string ssl_file_cert = "";                                                                         // NOLINT
+    std::string ssl_file_key  = "";  // NOLINT
+    std::string ssl_file_cert = "";  // NOLINT
 
     std::map<std::string, std::string> default_template_kwargs;
 
     // webui configs
-    bool webui = true;
+    bool        webui = true;
     std::string webui_config_json;
 
     // "advanced" endpoints are disabled by default for better security
     bool endpoint_slots   = true;
-    bool endpoint_props   = false; // only control POST requests, not GET
+    bool endpoint_props   = false;  // only control POST requests, not GET
     bool endpoint_metrics = false;
 
     // router server configs
-    std::string models_dir    = ""; // directory containing models for the router server
-    std::string models_preset = ""; // directory containing model presets for the router server
-    int models_max = 4;             // maximum number of models to load simultaneously
-    bool models_autoload = true;    // automatically load models when requested via the router server
+    std::string models_dir      = "";    // directory containing models for the router server
+    std::string models_preset   = "";    // directory containing model presets for the router server
+    int         models_max      = 4;     // maximum number of models to load simultaneously
+    bool        models_autoload = true;  // automatically load models when requested via the router server
 
     bool log_json = false;
 
     std::string slot_save_path;
-    std::string media_path; // path to directory for loading media files
+    std::string media_path;  // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;
 
@@ -573,45 +585,45 @@ struct common_params {
     std::vector<int32_t> n_pl;
 
     // retrieval params
-    std::vector<std::string> context_files; // context files to embed
+    std::vector<std::string> context_files;  // context files to embed
 
-    int32_t chunk_size = 64; // chunk size for context embedding
+    int32_t chunk_size = 64;                 // chunk size for context embedding
 
-    std::string chunk_separator = "\n"; // chunk separator for context embedding
+    std::string chunk_separator = "\n";      // chunk separator for context embedding
 
     // passkey params
-    int32_t n_junk = 250; // number of times to repeat the junk text
-    int32_t i_pos  = -1;  // position of the passkey in the junk text
+    int32_t n_junk = 250;  // number of times to repeat the junk text
+    int32_t i_pos  = -1;   // position of the passkey in the junk text
 
     // imatrix params
-    int32_t n_out_freq  = 10; // output the imatrix every n_out_freq iterations
-    int32_t n_save_freq =  0; // save the imatrix every n_save_freq iterations
-    int32_t i_chunk     =  0; // start processing from this chunk
-    int8_t  imat_dat    =  0; // whether the legacy imatrix.dat format should be output (gguf <= 0 < dat)
+    int32_t n_out_freq  = 10;      // output the imatrix every n_out_freq iterations
+    int32_t n_save_freq = 0;       // save the imatrix every n_save_freq iterations
+    int32_t i_chunk     = 0;       // start processing from this chunk
+    int8_t  imat_dat    = 0;       // whether the legacy imatrix.dat format should be output (gguf <= 0 < dat)
 
-    bool process_output  = false; // collect data for the output tensor
-    bool compute_ppl     = true;  // whether to compute perplexity
-    bool show_statistics = false; // show imatrix statistics per tensor
-    bool parse_special   = false; // whether to parse special tokens during imatrix tokenization
+    bool process_output  = false;  // collect data for the output tensor
+    bool compute_ppl     = true;   // whether to compute perplexity
+    bool show_statistics = false;  // show imatrix statistics per tensor
+    bool parse_special   = false;  // whether to parse special tokens during imatrix tokenization
 
     // cvector-generator params
-    int n_pca_batch = 100;
-    int n_pca_iterations = 1000;
-    dimre_method cvector_dimre_method = DIMRE_METHOD_PCA;
-    std::string cvector_positive_file = "tools/cvector-generator/positive.txt";
-    std::string cvector_negative_file = "tools/cvector-generator/negative.txt";
+    int          n_pca_batch           = 100;
+    int          n_pca_iterations      = 1000;
+    dimre_method cvector_dimre_method  = DIMRE_METHOD_PCA;
+    std::string  cvector_positive_file = "tools/cvector-generator/positive.txt";
+    std::string  cvector_negative_file = "tools/cvector-generator/negative.txt";
 
-    bool spm_infill = false; // suffix/prefix/middle pattern for infill
+    bool spm_infill = false;  // suffix/prefix/middle pattern for infill
 
     // batched-bench params
     bool batched_bench_output_jsonl = false;
 
     // common params
-    std::string out_file; // output filename for all example programs
+    std::string             out_file;  // output filename for all example programs
     // optional callback for model loading progress and cancellation:
     // called with a progress value between 0.0 and 1.0.
     // return false from callback to abort model loading or true to continue
-    llama_progress_callback load_progress_callback = NULL;
+    llama_progress_callback load_progress_callback           = NULL;
     void *                  load_progress_callback_user_data = NULL;
 };
 
@@ -621,8 +633,8 @@ void common_init();
 
 std::string common_params_get_system_info(const common_params & params);
 
-bool parse_cpu_range(const std::string & range, bool(&boolmask)[GGML_MAX_N_THREADS]);
-bool parse_cpu_mask(const std::string & mask, bool(&boolmask)[GGML_MAX_N_THREADS]);
+bool parse_cpu_range(const std::string & range, bool (&boolmask)[GGML_MAX_N_THREADS]);
+bool parse_cpu_mask(const std::string & mask, bool (&boolmask)[GGML_MAX_N_THREADS]);
 void postprocess_cpu_params(cpu_params & cpuparams, const cpu_params * role_model = nullptr);
 bool set_process_priority(enum ggml_sched_priority prio);
 
@@ -646,22 +658,21 @@ std::string string_format(const char * fmt, ...);
 std::string string_strip(const std::string & str);
 std::string string_get_sortable_timestamp();
 
-std::string string_join(const std::vector<std::string> & values, const std::string & separator);
+std::string              string_join(const std::vector<std::string> & values, const std::string & separator);
 std::vector<std::string> string_split(const std::string & str, const std::string & delimiter);
-std::string string_repeat(const std::string & str, size_t n);
+std::string              string_repeat(const std::string & str, size_t n);
 
 void string_replace_all(std::string & s, const std::string & search, const std::string & replace);
 
 std::string regex_escape(const std::string & s);
 
-template<class T>
-static std::vector<T> string_split(const std::string & str, char delim) {
+template <class T> static std::vector<T> string_split(const std::string & str, char delim) {
     static_assert(!std::is_same<T, std::string>::value, "Please use the specialized version for std::string");
-    std::vector<T> values;
+    std::vector<T>     values;
     std::istringstream str_stream(str);
-    std::string token;
+    std::string        token;
     while (std::getline(str_stream, token, delim)) {
-        T value;
+        T                  value;
         std::istringstream token_stream(token);
         token_stream >> value;
         values.push_back(value);
@@ -669,30 +680,28 @@ static std::vector<T> string_split(const std::string & str, char delim) {
     return values;
 }
 
-template<>
-std::vector<std::string> string_split<std::string>(const std::string & input, char separator)
-{
+template <> inline std::vector<std::string> string_split<std::string>(const std::string & input, char separator) {
     std::vector<std::string> parts;
-    size_t begin_pos = 0;
-    size_t separator_pos = input.find(separator);
+    size_t                   begin_pos     = 0;
+    size_t                   separator_pos = input.find(separator);
     while (separator_pos != std::string::npos) {
         std::string part = input.substr(begin_pos, separator_pos - begin_pos);
         parts.emplace_back(part);
-        begin_pos = separator_pos + 1;
+        begin_pos     = separator_pos + 1;
         separator_pos = input.find(separator, begin_pos);
     }
     parts.emplace_back(input.substr(begin_pos, separator_pos - begin_pos));
     return parts;
 }
 
-static bool string_starts_with(const std::string & str,
+inline bool string_starts_with(const std::string & str,
                                const std::string & prefix) {  // While we wait for C++20's std::string::starts_with...
     return str.rfind(prefix, 0) == 0;
 }
 
 // While we wait for C++20's std::string::ends_with...
-bool string_ends_with(const std::string_view & str, const std::string_view & suffix);
-bool string_remove_suffix(std::string & str, const std::string_view & suffix);
+bool   string_ends_with(const std::string_view & str, const std::string_view & suffix);
+bool   string_remove_suffix(std::string & str, const std::string_view & suffix);
 size_t string_find_partial_stop(const std::string_view & str, const std::string_view & stop);
 
 bool string_parse_kv_override(const char * data, std::vector<llama_model_kv_override> & overrides);
@@ -717,9 +726,10 @@ std::string fs_get_cache_file(const std::string & filename);
 struct common_file_info {
     std::string path;
     std::string name;
-    size_t      size = 0; // in bytes
+    size_t      size   = 0;  // in bytes
     bool        is_dir = false;
 };
+
 std::vector<common_file_info> fs_list(const std::string & path, bool include_directories);
 
 //
@@ -740,15 +750,15 @@ struct common_init_result {
     common_init_result(common_params & params);
     ~common_init_result();
 
-    llama_model * model();
+    llama_model *   model();
     llama_context * context();
 
     common_sampler * sampler(llama_seq_id seq_id);
-    void reset_samplers();
+    void             reset_samplers();
 
     std::vector<llama_adapter_lora_ptr> & lora();
 
-private:
+  private:
     struct impl;
     std::unique_ptr<impl> pimpl;
 };
@@ -757,14 +767,14 @@ using common_init_result_ptr = std::unique_ptr<common_init_result>;
 
 common_init_result_ptr common_init_from_params(common_params & params);
 
-struct llama_model_params     common_model_params_to_llama  (      common_params & params);
+struct llama_model_params     common_model_params_to_llama(common_params & params);
 struct llama_context_params   common_context_params_to_llama(const common_params & params);
 struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const cpu_params & params);
 
 // clear LoRA adapters from context, then apply new list of adapters
 void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adapter_lora_info> & lora);
 
-std::string                   get_model_endpoint();
+std::string get_model_endpoint();
 
 //
 // Batch utils
@@ -772,12 +782,11 @@ std::string                   get_model_endpoint();
 
 void common_batch_clear(struct llama_batch & batch);
 
-void common_batch_add(
-                 struct llama_batch & batch,
-                        llama_token   id,
-                          llama_pos   pos,
-    const std::vector<llama_seq_id> & seq_ids,
-                               bool   logits);
+void common_batch_add(struct llama_batch &              batch,
+                      llama_token                       id,
+                      llama_pos                         pos,
+                      const std::vector<llama_seq_id> & seq_ids,
+                      bool                              logits);
 
 //
 // Vocab utils
@@ -785,42 +794,32 @@ void common_batch_add(
 
 // tokenizes a string into a vector of tokens
 // should work similar to Python's `tokenizer.encode`
-std::vector<llama_token> common_tokenize(
-  const struct llama_context * ctx,
-           const std::string & text,
-                        bool   add_special,
-                        bool   parse_special = false);
+std::vector<llama_token> common_tokenize(const struct llama_context * ctx,
+                                         const std::string &          text,
+                                         bool                         add_special,
+                                         bool                         parse_special = false);
 
-std::vector<llama_token> common_tokenize(
-    const struct llama_vocab * vocab,
-           const std::string & text,
-                        bool   add_special,
-                        bool   parse_special = false);
+std::vector<llama_token> common_tokenize(const struct llama_vocab * vocab,
+                                         const std::string &        text,
+                                         bool                       add_special,
+                                         bool                       parse_special = false);
 
 // tokenizes a token into a piece, optionally renders special/control tokens
 // should work similar to Python's `tokenizer.id_to_piece`
-std::string common_token_to_piece(
-        const struct llama_context * ctx,
-                       llama_token   token,
-                       bool          special = true);
+std::string common_token_to_piece(const struct llama_context * ctx, llama_token token, bool special = true);
 
-std::string common_token_to_piece(
-          const struct llama_vocab * vocab,
-                       llama_token   token,
-                       bool          special = true);
+std::string common_token_to_piece(const struct llama_vocab * vocab, llama_token token, bool special = true);
 
 // detokenizes a vector of tokens into a string
 // should work similar to Python's `tokenizer.decode`
 // optionally renders special/control tokens
-std::string common_detokenize(
-            const struct llama_context * ctx,
-        const std::vector<llama_token> & tokens,
-                                  bool   special = true);
+std::string common_detokenize(const struct llama_context *     ctx,
+                              const std::vector<llama_token> & tokens,
+                              bool                             special = true);
 
-std::string common_detokenize(
-              const struct llama_vocab * vocab,
-        const std::vector<llama_token> & tokens,
-                                  bool   special = true);
+std::string common_detokenize(const struct llama_vocab *       vocab,
+                              const std::vector<llama_token> & tokens,
+                              bool                             special = true);
 
 //
 // Embedding utils
@@ -862,7 +861,7 @@ const char * const LLM_KV_SPLIT_NO            = "split.no";
 const char * const LLM_KV_SPLIT_COUNT         = "split.count";
 const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
 
-}
+}  // namespace
 
 //
 // MoE utils
@@ -870,11 +869,11 @@ const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
 
 const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate)_(ch|)exps";
 
-static std::string llm_ffn_exps_block_regex(int idx) {
+inline std::string llm_ffn_exps_block_regex(int idx) {
     return string_format("blk\\.%d%s", idx, LLM_FFN_EXPS_REGEX);
 }
 
-static llama_model_tensor_buft_override llm_ffn_exps_cpu_override() {
+inline llama_model_tensor_buft_override llm_ffn_exps_cpu_override() {
     return { LLM_FFN_EXPS_REGEX, ggml_backend_cpu_buffer_type() };
 }
 
@@ -882,7 +881,9 @@ static llama_model_tensor_buft_override llm_ffn_exps_cpu_override() {
 // training utils
 //
 
-ggml_opt_dataset_t common_opt_dataset_init(struct llama_context * ctx, const std::vector<llama_token> & tokens, int64_t stride);
+ggml_opt_dataset_t common_opt_dataset_init(struct llama_context *           ctx,
+                                           const std::vector<llama_token> & tokens,
+                                           int64_t                          stride);
 
 // "adamw" or "sgd" (case insensitive)
 enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);


### PR DESCRIPTION
## Summary

- Adds `--spec-ngram-adaptive` boolean flag for ngram-mod speculative decoding
- Dynamically adjusts draft-min and draft-max based on acceptance rate using EMA tracking
- High acceptance rate (>0.7) → increases n_max, decreases n_min (more aggressive drafting)
- Low acceptance rate (<0.4) → decreases n_max, increases n_min (more conservative drafting)

## Implementation Details

The adaptive mechanism tracks acceptance rate using Exponential Moving Average (EMA) with decay factor 0.9, providing smooth adaptation over ~10 recent draft rounds.

**Key behaviors:**
- Bounds are clamped: `n_max >= 4`, `n_max <= 2 * base_n_max`
- `n_min` always stays less than `n_max`
- When the ngram_mod cache resets (due to low acceptance streak), adaptive bounds also reset to base values

## Usage

```bash
./llama-server -m model.gguf --speculative ngram-mod --spec-ngram-adaptive
```

The flag works with the existing `--draft-max` and `--draft-min` flags as the base values for adaptation.

## Testing

Built successfully with CUDA support. Ready for integration testing with various models and workloads.