### PR TITLE
llama-server: Support `--verbose-prompt`

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2967,8 +2967,9 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         std::vector<server_task> tasks;
 
         const auto & prompt = data.at("prompt");
-        // TODO: this log can become very long, put it behind a flag or think about a more compact format
-        //SRV_DBG("Prompt: %s\n", prompt.is_string() ? prompt.get<std::string>().c_str() : prompt.dump(2).c_str());
+        if (params.verbose_prompt) {
+            SRV_INF("prompt: '%s'\n", prompt.is_string() ? prompt.get<std::string>().c_str() : prompt.dump(2).c_str());
+        }
 
         // process prompt
         std::vector<server_tokens> inputs;


### PR DESCRIPTION
llama-server has the option `--verbose-prompt` but was ineffective.

This commit recovers the logger for full prompt input (gated behind the non-default option `--verbose-prompt`) which was originally commented out.

<!--
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
-->