### PR TITLE
common : fix XML tool calls with duplicate parameter keys

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -3522,6 +3522,26 @@ Hey there!<|im_end|>
                 "  </function>\n"
                 "</tool_call>",
             [&](const std::string &msg) { return test_chat_parse(msg, /* is_partial= */ true, {COMMON_CHAT_FORMAT_QWEN3_CODER_XML}); });
+
+        // Non-unique parameter keys (As seen in some Qwen3-Coder-Next tool calls)
+        common_chat_msg expected_dup_key;
+        expected_dup_key.role = "assistant";
+        expected_dup_key.tool_calls = {
+            { "write_to_file", R"({"filePath":"a.py","filePath":"b.py"})", "" }
+        };
+
+        test_parser_with_streaming(expected_dup_key,
+                "<tool_call>\n"
+                "  <function=write_to_file>\n"
+                "    <parameter=filePath>\n"
+                "      a.py\n"
+                "    </parameter>\n"
+                "    <parameter=filePath>\n"
+                "      b.py\n"
+                "    </parameter>\n"
+                "  </function>\n"
+                "</tool_call>",
+            [&](const std::string &msg) { return test_chat_parse(msg, /* is_partial= */ true, {COMMON_CHAT_FORMAT_QWEN3_CODER_XML}); });
     }
 
     {


### PR DESCRIPTION
Qwen3-Coder-Next can emit duplicate parameters in tool calls. The XML tool call parser stored parameters in an ordered_json object using operator[], which overwrites any previous values for the same key. This caused streaming diffs to fail when the duplicate key was partially streamed before the full duplicate was parsed.

This change replaces operator[] with .emplace_back() in the XML tool call parser logic, ensuring that the streamed JSON object only grows monotonically. Duplicate keys are preserved and accurately streamed to the output.

Fixes #19382 