### PR TITLE
Server: allow immediate reuse of http port

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -315,10 +315,12 @@ bool server_http_context::start() {
     } else {
         LOG_INF("%s: binding port with default address family\n", __func__);
 
-        // Enable address reuse to allow immediate restart of server
+        // Set linger time to 0 to force close the socket immediately when the server stops
         srv->set_socket_options([](socket_t sock) {
-            const char flag = 1;
-            setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+            linger sl{};
+            sl.l_onoff  = 1;
+            sl.l_linger = 0;
+            setsockopt(sock, SOL_SOCKET, SO_LINGER, reinterpret_cast<const char *>(&sl), sizeof(sl));
         });
 
         // bind HTTP listen port

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -115,7 +115,16 @@ bool server_http_context::init(const common_params & params) {
     srv->set_read_timeout (params.timeout_read);
     srv->set_write_timeout(params.timeout_write);
     srv->set_socket_options([reuse_port = params.reuse_port](socket_t sock) {
+        // Set linger to 0 to avoid TIME_WAIT state after server exits
+        linger sl{};
+        sl.l_onoff  = 1;
+        sl.l_linger = 0;
+        setsockopt(sock, SOL_SOCKET, SO_LINGER, reinterpret_cast<const char *>(&sl), sizeof(sl));
+
+        // Allow binding to port during TIME_WAIT state after server exited
         httplib::set_socket_opt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
+
+        // If flag is set, allow multiple processes to bind to the same port for load balancing
         if (reuse_port) {
 #ifdef SO_REUSEPORT
             httplib::set_socket_opt(sock, SOL_SOCKET, SO_REUSEPORT, 1);
@@ -314,14 +323,6 @@ bool server_http_context::start() {
         was_bound = srv->bind_to_port(hostname, 8080);
     } else {
         LOG_INF("%s: binding port with default address family\n", __func__);
-
-        // Set linger time to 0 to force close the socket immediately when the server stops
-        srv->set_socket_options([](socket_t sock) {
-            linger sl{};
-            sl.l_onoff  = 1;
-            sl.l_linger = 0;
-            setsockopt(sock, SOL_SOCKET, SO_LINGER, reinterpret_cast<const char *>(&sl), sizeof(sl));
-        });
 
         // bind HTTP listen port
         if (port == 0) {

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -76,6 +76,12 @@ bool server_http_context::init(const common_params & params) {
     srv.reset(new httplib::Server());
 #endif
 
+    // Enable address reuse to allow immediate restart of server
+    srv->set_socket_options([](socket_t sock) {
+        int val = 1;
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+    });
+
     srv->set_default_headers({{"Server", "llama.cpp"}});
     srv->set_logger(log_server_request);
     srv->set_exception_handler([](const httplib::Request &, httplib::Response & res, const std::exception_ptr & ep) {

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -76,12 +76,6 @@ bool server_http_context::init(const common_params & params) {
     srv.reset(new httplib::Server());
 #endif
 
-    // Enable address reuse to allow immediate restart of server
-    srv->set_socket_options([](socket_t sock) {
-        int val = 1;
-        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
-    });
-
     srv->set_default_headers({{"Server", "llama.cpp"}});
     srv->set_logger(log_server_request);
     srv->set_exception_handler([](const httplib::Request &, httplib::Response & res, const std::exception_ptr & ep) {
@@ -320,6 +314,13 @@ bool server_http_context::start() {
         was_bound = srv->bind_to_port(hostname, 8080);
     } else {
         LOG_INF("%s: binding port with default address family\n", __func__);
+
+        // Enable address reuse to allow immediate restart of server
+        srv->set_socket_options([](socket_t sock) {
+            int flag = 1;
+            setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+        });
+
         // bind HTTP listen port
         if (port == 0) {
             int bound_port = srv->bind_to_any_port(hostname);

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -317,7 +317,7 @@ bool server_http_context::start() {
 
         // Enable address reuse to allow immediate restart of server
         srv->set_socket_options([](socket_t sock) {
-            int flag = 1;
+            const char flag = 1;
             setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
         });
 


### PR DESCRIPTION
Add the SO_REUSEADDR flag to the http port, similar to what is done on the GRPC port [here](https://github.com/ggml-org/llama.cpp/blob/b908baf1825b1a89afef87b09e22c32af2ca6548/ggml/src/ggml-rpc/ggml-rpc.cpp#L311-L315).

Related:
* Resolves #19758

AI disclosure: Copilot (Claude Sonnet 4.5) was used to triage and fix the issue.