### PR TITLE
chat: fix llama-server image placeholder issue for PaddleOCR-VL

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -669,6 +669,12 @@ common_chat_templates_ptr common_chat_templates_init(
             "{%- if false %}");
     }
 
+    // TODO @megemini : this is a temporary fix for PaddleOCR image placeholder
+    if (default_template_src.find("<|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>") != std::string::npos) {
+        string_replace_all(default_template_src, "image", "media_marker");
+        string_replace_all(default_template_src, "\"<|IMAGE_START|><|IMAGE_PLACEHOLDER|><|IMAGE_END|>\"", "content[\"text\"]");
+    }
+
     std::string token_bos = bos_token_override;
     std::string token_eos = eos_token_override;
     bool add_bos = false;


### PR DESCRIPTION
Fix chat template of PaddleOCR-VL for llama-server command, which requires `media_marker` instead of `image` (see https://github.com/ggml-org/llama.cpp/pull/18825#issuecomment-3934457275)

This should be able to handle these case:

- `llama-server` without `--chat-template-file` argument, and clean prompt without `<__media__>`
- `llama-cli` without `--chat-template-file` argument, and clean prompt without `<__media__>`

Tested:

- `llama-server` with command

```bash
./build/bin/llama-server -m /media/shun/bigdata/Models/PaddleOCR_VL_SFT/PaddleOCR-VL-1.5-GGUF.gguf \
  --mmproj /media/shun/bigdata/Models/PaddleOCR_VL_SFT/PaddleOCR-VL-1.5-GGUF-mmproj.gguf \
  --port 8111 --host 0.0.0.0 --ctx-size 131072 -n 4096 --temp 0 --jinja
```

<img width="2489" height="1398" alt="image" src="https://github.com/user-attachments/assets/21018fe8-a45d-4581-919c-5e675e616862" />

- `llama-cli` with command

```bash
./build/bin/llama-cli -m /media/shun/bigdata/Models/PaddleOCR_VL_SFT/PaddleOCR-VL-1.5-GGUF.gguf \
  --mmproj /media/shun/bigdata/Models/PaddleOCR_VL_SFT/PaddleOCR-VL-1.5-GGUF-mmproj.gguf \
  --color on\
  --image /home/shun/Pictures/display_formula_7.png \
  --prompt "Formula Recognition:" --temp 0
```

<img width="2442" height="1166" alt="Screenshot from 2026-02-22 14-24-13" src="https://github.com/user-attachments/assets/4b443189-a9c0-4869-8447-908c67f58ce2" />


@ngxson is this a good way to fix this issue?