### PR TITLE
Fix wrong cli-argument in documentation

### DIFF
--- a/tools/server/webui/README.md
+++ b/tools/server/webui/README.md
@@ -101,7 +101,7 @@ In a separate terminal, start the backend server:
 ./llama-server -m model.gguf
 
 # Multi-model (ROUTER mode)
-./llama-server --model-store /path/to/models
+./llama-server --models-dir /path/to/models
 ```
 
 ### 3. Start Development Servers


### PR DESCRIPTION
The CLI option does not exist, as described in #19786.

Closes #19786
