### PR TITLE
common : fix improper trimming in XML parser on complete message

### DIFF
--- a/common/chat-parser-xml-toolcall.cpp
+++ b/common/chat-parser-xml-toolcall.cpp
@@ -803,7 +803,7 @@ inline void parse_msg_with_xml_tool_calls(common_chat_msg_parser & builder, cons
         }
 
         // remove potential partial suffix
-        if (builder.pos() == builder.input().size()) {
+        if (builder.pos() == builder.input().size() && builder.is_partial()) {
             if (unclosed_reasoning_content.empty()) {
                 rstrip(content);
                 trim_potential_partial_word(content);


### PR DESCRIPTION
Fix courtesy of @julio75012. Although his use case has already been fixed, I'm submitting this PR to address other models that exhibit similar behavior.

The issue is that the XML parser trims partially matched tags. The reason `>` was trimmed from Seed-OSS is because `tool_sep = >`, and the reason a trailing `"` is trimmed from MiniMax/Kimi-K2 is because `tool_sep = ">`. This trimming should only happen when the message is still partial. Once the full message has been received, no trimming should occur.

Fixes #19795

cc @hksdpc255