### PR TITLE
server: add `--log-output` option

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3060,6 +3060,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
     add_opt(common_arg(
+        {"--log-output"},
+        {"--no-log-output"},
+        "log generated text to stdout (and to --log-file if set) (default: disabled)",
+        [](common_params & params, bool value) {
+            params.log_output = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_LOG_OUTPUT"));
+    add_opt(common_arg(
         {"-sps", "--slot-prompt-similarity"}, "SIMILARITY",
         string_format("how much the prompt of a request must match the prompt of a slot in order to use that slot (default: %.2f, 0.0 = disabled)\n", params.slot_prompt_similarity),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -534,6 +534,7 @@ struct common_params {
     int reasoning_budget = -1;
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    bool log_output = false;       // if true, log generated text to stdout/log file
 
     std::vector<std::string> api_keys;
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -114,6 +114,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-lv, --verbosity, --log-verbosity N` | Set the verbosity threshold. Messages with a higher verbosity will be ignored. Values:<br/> - 0: generic output<br/> - 1: error<br/> - 2: warning<br/> - 3: info<br/> - 4: debug<br/>(default: 3)<br/><br/>(env: LLAMA_LOG_VERBOSITY) |
 | `--log-prefix` | Enable prefix in log messages<br/>(env: LLAMA_LOG_PREFIX) |
 | `--log-timestamps` | Enable timestamps in log messages<br/>(env: LLAMA_LOG_TIMESTAMPS) |
+| `--log-output`, `--no-log-output` | Log generated text to stdout<br/>(env: LLAMA_ARG_LOG_OUTPUT) |
 | `-ctkd, --cache-type-k-draft TYPE` | KV cache data type for K for the draft model<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_K_DRAFT) |
 | `-ctvd, --cache-type-v-draft TYPE` | KV cache data type for V for the draft model<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_V_DRAFT) |
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1223,6 +1223,9 @@ private:
             }
 
             slot.add_token(result);
+            if (params_base.log_output && !result.text_to_send.empty()) {
+                LOG("%s", result.text_to_send.c_str());
+            }
             if (slot.task->params.stream) {
                 send_partial_response(slot, result, false);
             }


### PR DESCRIPTION
This options enables logging of the LLM output to stdout, which makes it more convenient to inspect what is being generated on the server side. I'm aware of `--verbose`, but it also mixes llm output with a lot of other stats.

Here's an example of it being used with lm-evaluation-harness:

<img width="988" height="357" alt="image" src="https://github.com/user-attachments/assets/ca62b0bc-9731-46ea-9ab7-50e34bf2e2a1" />

