### PR TITLE
mtmd : add Step3-VL (Step1.5V) multimodal support

### DIFF
--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -3873,6 +3873,7 @@ class VisionProjectorType:
     GLM4V = "glm4v"
     YOUTUVL = "youtuvl"
     NEMOTRON_V2_VL = "nemotron_v2_vl"
+    STEP3VL = "step3vl"
 
 
 # Items here are (block size, type size)

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -1367,6 +1367,7 @@ class TensorNameMap:
             "model.vision.patch_embedding.proj", # cogvlm
             "siglip2.vision_model.embeddings.patch_embedding",
             "vision_model.radio_model.model.patch_generator.embedder", # Nemotron Nano v2 VL
+            "vision_model.conv1", # Step3-VL
         ),
 
         MODEL_TENSOR.V_ENC_EMBD_NORM: (
@@ -1384,6 +1385,7 @@ class TensorNameMap:
             "model.vision.patch_embedding.position_embedding", # cogvlm
             "visual.embeddings.position_embedding", # glm4v
             "vision_model.radio_model.model.patch_generator.pos_embed", # Nemotron Nano v2 VL
+            "vision_model.positional_embedding", # Step3-VL (no .weight suffix, handled in modify_tensors)
         ),
 
         MODEL_TENSOR.V_ENC_ATTN_QKV: (
@@ -1404,6 +1406,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.attn.q", # qwen2vl, generated
             "vision_tower.encoder.blocks.{bid}.wq", # kimi-vl, generated
             "siglip2.vision_model.encoder.layers.{bid}.self_attn.q_proj", # youtuvl
+            "vision_model.transformer.resblocks.{bid}.attn.q", # Step3-VL, generated from fused QKV
         ),
 
         MODEL_TENSOR.V_ENC_ATTN_Q_NORM: (
@@ -1423,6 +1426,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.attn.k", # qwen2vl, generated
             "vision_tower.encoder.blocks.{bid}.wk", # kimi-vl, generated
             "siglip2.vision_model.encoder.layers.{bid}.self_attn.k_proj",
+            "vision_model.transformer.resblocks.{bid}.attn.k", # Step3-VL, generated from fused QKV
         ),
 
         MODEL_TENSOR.V_ENC_ATTN_K_NORM: (
@@ -1442,6 +1446,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.attn.v", # qwen2vl, generated
             "vision_tower.encoder.blocks.{bid}.wv", # kimi-vl, generated
             "siglip2.vision_model.encoder.layers.{bid}.self_attn.v_proj",
+            "vision_model.transformer.resblocks.{bid}.attn.v", # Step3-VL, generated from fused QKV
         ),
 
         MODEL_TENSOR.V_ENC_INPUT_NORM: (
@@ -1458,6 +1463,7 @@ class TensorNameMap:
             "model.vision.transformer.layers.{bid}.input_layernorm", # cogvlm
             "siglip2.vision_model.encoder.layers.{bid}.layer_norm1",
             "vision_model.radio_model.model.blocks.{bid}.norm1", # Nemotron Nano v2 VL
+            "vision_model.transformer.resblocks.{bid}.ln_1", # Step3-VL
         ),
 
         MODEL_TENSOR.V_ENC_ATTN_O: (
@@ -1475,6 +1481,7 @@ class TensorNameMap:
             "model.vision.transformer.layers.{bid}.attention.dense", # cogvlm
             "siglip2.vision_model.encoder.layers.{bid}.self_attn.out_proj", # youtuvl
             "vision_model.radio_model.model.blocks.{bid}.attn.proj", # Nemotron Nano v2 VL
+            "vision_model.transformer.resblocks.{bid}.attn.out_proj", # Step3-VL
         ),
 
         MODEL_TENSOR.V_ENC_POST_ATTN_NORM: (
@@ -1491,6 +1498,7 @@ class TensorNameMap:
             "model.vision.transformer.layers.{bid}.post_attention_layernorm", # cogvlm
             "siglip2.vision_model.encoder.layers.{bid}.layer_norm2",
             "vision_model.radio_model.model.blocks.{bid}.norm2", # Nemotron Nano v2 VL
+            "vision_model.transformer.resblocks.{bid}.ln_2", # Step3-VL
         ),
 
         MODEL_TENSOR.V_ENC_FFN_UP: (
@@ -1508,6 +1516,7 @@ class TensorNameMap:
             "model.vision.transformer.layers.{bid}.mlp.fc1", # cogvlm
             "siglip2.vision_model.encoder.layers.{bid}.mlp.fc1",
             "vision_model.radio_model.model.blocks.{bid}.mlp.fc1", # Nemotron Nano v2 VL
+            "vision_model.transformer.resblocks.{bid}.mlp.c_fc", # Step3-VL
         ),
 
         MODEL_TENSOR.V_ENC_FFN_GATE: (
@@ -1531,16 +1540,19 @@ class TensorNameMap:
             "model.vision.transformer.layers.{bid}.mlp.fc2", # cogvlm
             "siglip2.vision_model.encoder.layers.{bid}.mlp.fc2",
             "vision_model.radio_model.model.blocks.{bid}.mlp.fc2", # Nemotron Nano v2 VL
+            "vision_model.transformer.resblocks.{bid}.mlp.c_proj", # Step3-VL
         ),
 
         MODEL_TENSOR.V_LAYER_SCALE_1: (
             "vision_tower.vision_model.encoder.layers.{bid}.ls1", # InternVL
             "model.vision_tower.encoder.layer.{bid}.lambda_1", # Intern-S1
+            "vision_model.transformer.resblocks.{bid}.ls_1", # Step3-VL (.gamma suffix handled in modify_tensors)
         ),
 
         MODEL_TENSOR.V_LAYER_SCALE_2: (
             "vision_tower.vision_model.encoder.layers.{bid}.ls2", # InternVL
             "model.vision_tower.encoder.layer.{bid}.lambda_2", # Intern-S1
+            "vision_model.transformer.resblocks.{bid}.ls_2", # Step3-VL (.gamma suffix handled in modify_tensors)
         ),
 
         MODEL_TENSOR.V_PRE_NORM: (
@@ -1548,6 +1560,7 @@ class TensorNameMap:
             "vision_tower.ln_pre", # pixtral-hf
             "vision_encoder.ln_pre", # pixtral
             "vision_model.layernorm_pre", # llama4
+            "vision_model.ln_pre", # Step3-VL
         ),
 
         MODEL_TENSOR.V_POST_NORM: (

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(mtmd
             models/qwen2vl.cpp
             models/qwen3vl.cpp
             models/siglip.cpp
+            models/step3vl.cpp
             models/whisper-enc.cpp
             models/mobilenetv5.cpp
             models/youtuvl.cpp

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -238,6 +238,7 @@ enum projector_type {
     PROJECTOR_TYPE_YOUTUVL,
     PROJECTOR_TYPE_KIMIK25,
     PROJECTOR_TYPE_NEMOTRON_V2_VL,
+    PROJECTOR_TYPE_STEP3VL,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -274,6 +275,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_YOUTUVL,   "youtuvl"},
     { PROJECTOR_TYPE_KIMIK25,   "kimik25"},
     { PROJECTOR_TYPE_NEMOTRON_V2_VL, "nemotron_v2_vl"},
+    { PROJECTOR_TYPE_STEP3VL, "step3vl"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {

--- a/tools/mtmd/models/models.h
+++ b/tools/mtmd/models/models.h
@@ -126,3 +126,8 @@ struct clip_graph_kimik25 : clip_graph {
 
     ggml_tensor * resize_position_embeddings_3d(uint32_t interpolation_mode);
 };
+
+struct clip_graph_step3vl : clip_graph {
+    clip_graph_step3vl(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
+    ggml_cgraph * build() override;
+};

--- a/tools/mtmd/models/step3vl.cpp
+++ b/tools/mtmd/models/step3vl.cpp
@@ -1,0 +1,90 @@
+#include "models.h"
+
+// Step3-VL: PE-lang 1.8B ViT encoder with 2D RoPE + abs pos embd
+// Architecture: 47 transformer blocks, hidden_size=1536, 16 heads, patch_size=14, image_size=728
+// Projector: Conv2d(1536→3072, 3×3, s2) → Conv2d(3072→6144, 3×3, s2) → Linear(6144→4096)
+// NO activations between projector layers
+
+ggml_cgraph * clip_graph_step3vl::build() {
+    // Step3-VL uses learned positional embeddings + 2D RoPE
+    GGML_ASSERT(model.position_embeddings != nullptr);
+    GGML_ASSERT(model.class_embedding == nullptr);  // no CLS token
+
+    // 2D input positions for RoPE
+    ggml_tensor * pos_w = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_w, "pos_w");
+    ggml_set_input(pos_w);
+
+    ggml_tensor * pos_h = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_h, "pos_h");
+    ggml_set_input(pos_h);
+
+    // Step3-VL 2D RoPE: first d_head/2 dims get width positions, second half gets height
+    // freqs = cat([freqs_w, freqs_h], dim=-1), interleave_freq=false, theta=10000
+    auto add_pos = [&](ggml_tensor * cur, const clip_layer &) {
+        return build_rope_2d(ctx0, cur, pos_w, pos_h, hparams.rope_theta, false);
+    };
+
+    ggml_tensor * inp = build_inp();
+
+    // Build ViT with:
+    // - NORM_TYPE_NORMAL (standard LayerNorm, not RMS)
+    // - FFN_GELU_QUICK (quick_gelu activation, default when neither use_gelu nor use_silu)
+    // - Learned positional embeddings (2704 positions = 52×52 grid)
+    // - 2D RoPE callback
+    // - Layer scale (v.blk.N.ls1/ls2.weight) is handled automatically by build_vit
+    // - Pre-norm (v.pre_ln) is handled automatically by build_vit
+    ggml_tensor * cur = build_vit(
+                            inp, n_patches,
+                            NORM_TYPE_NORMAL,
+                            hparams.ffn_op,
+                            model.position_embeddings,
+                            add_pos);
+
+    // No post-LayerNorm in Step3-VL (use_ln_post=false)
+
+    // Step3-VL projector: two stride-2 Conv2d downsamplers + linear projection
+    // NO activations between layers
+    {
+        // Reshape ViT output from [n_embd, n_patches] to spatial [n_embd, W, H]
+        // where W = n_patches_x, H = n_patches_y (both 52 for 728/14)
+        cur = ggml_reshape_3d(ctx0, cur, n_embd, n_patches_x, n_patches_y);
+        // ggml_conv_2d expects [W, H, C, N] layout, but cur is [C, W, H]
+        // ggml_permute semantics: input axis i -> output axis perm[i]
+        // axis 0 (C) -> pos 2, axis 1 (W) -> pos 0, axis 2 (H) -> pos 1
+        cur = ggml_permute(ctx0, cur, 2, 0, 1, 3);
+        cur = ggml_cont(ctx0, cur);
+
+        // Downsampler 1: Conv2d(n_embd → n_embd*2, 3×3, stride=2, padding=1)
+        // mm.0.weight shape: {3, 3, n_embd, n_embd*2} in GGUF
+        cur = ggml_conv_2d(ctx0, model.mm_0_w, cur, 2, 2, 1, 1, 1, 1);
+        if (model.mm_0_b) {
+            // Reshape bias for broadcasting: [1, 1, n_embd*2, 1]
+            ggml_tensor * bias = ggml_reshape_4d(ctx0, model.mm_0_b, 1, 1, model.mm_0_b->ne[0], 1);
+            cur = ggml_add(ctx0, cur, bias);
+        }
+
+        // Downsampler 2: Conv2d(n_embd*2 → n_embd*4, 3×3, stride=2, padding=1)
+        // mm.1.weight shape: {3, 3, n_embd*2, n_embd*4} in GGUF
+        cur = ggml_conv_2d(ctx0, model.mm_1_w, cur, 2, 2, 1, 1, 1, 1);
+        if (model.mm_1_b) {
+            ggml_tensor * bias = ggml_reshape_4d(ctx0, model.mm_1_b, 1, 1, model.mm_1_b->ne[0], 1);
+            cur = ggml_add(ctx0, cur, bias);
+        }
+
+        // Reshape back to 2D: [n_embd*4, n_output_tokens]
+        // After two stride-2 downsamples: spatial dims are n_patches_x/4 × n_patches_y/4
+        const int out_x = n_patches_x / 4;
+        const int out_y = n_patches_y / 4;
+        // cur is [W_out, H_out, C_out, 1], need [C_out, W_out*H_out]
+        // axis 0 (W) -> pos 1, axis 1 (H) -> pos 2, axis 2 (C) -> pos 0
+        cur = ggml_permute(ctx0, cur, 1, 2, 0, 3);
+        cur = ggml_cont_2d(ctx0, cur, cur->ne[0], out_x * out_y);
+
+        // Linear projection: mm.2.weight shape [n_embd*4, text_hidden_size]
+        cur = ggml_mul_mat(ctx0, model.mm_2_w, cur);
+    }
+
+    ggml_build_forward_expand(gf, cur);
+    return gf;
+}


### PR DESCRIPTION
Add GGUF conversion and multimodal inference support for the StepFun Step3-VL / Step1.5V vision-language model family.

Changes:
- convert_hf_to_gguf.py: Add Step3VLModel converter with mmproj extraction, SiglipVisionModel weight mapping, and Step1.5V architecture detection
- gguf-py/gguf/constants.py: Register MODEL_ARCH.STEP3VL
- gguf-py/gguf/tensor_mapping.py: Add Step3-VL tensor name mappings for vision encoder, projector, and language model
- tools/mtmd/: Add step3vl.cpp clip preprocessor with SigLIP2 vision encoder, 2D RoPE, multi-scale adaptive cropping, and dynamic resolution (384-1536px)

Tested with:
- Step3-VL-10B (Q4_K_M, Q6_K, F16)
- Text + single image + multi-image inference verified
- mmproj (3.70GB F16) loads correctly via llama-server --mmproj

hf repo: https://huggingface.co/kraven1109/Step3-VL-10B-GGUF