### PR TITLE
common : refactor cache to use hierarchical directory layout

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -885,16 +885,6 @@ std::string fs_get_cache_directory() {
     return ensure_trailing_slash(cache_directory);
 }
 
-std::string fs_get_cache_file(const std::string & filename) {
-    GGML_ASSERT(filename.find(DIRECTORY_SEPARATOR) == std::string::npos);
-    std::string cache_directory = fs_get_cache_directory();
-    const bool success = fs_create_directory_with_parents(cache_directory);
-    if (!success) {
-        throw std::runtime_error("failed to create cache directory: " + cache_directory);
-    }
-    return cache_directory + filename;
-}
-
 std::vector<common_file_info> fs_list(const std::string & path, bool include_directories) {
     std::vector<common_file_info> files;
     if (path.empty()) return files;

--- a/common/common.h
+++ b/common/common.h
@@ -705,6 +705,14 @@ inline bool string_remove_suffix(std::string & str, std::string_view suffix) {
     return false;
 }
 
+inline bool string_remove_prefix(std::string & str, std::string_view prefix) {
+    if (string_starts_with(str, prefix)) {
+        str.erase(0, prefix.size());
+        return true;
+    }
+    return false;
+}
+
 inline size_t string_find_partial_stop(std::string_view str, std::string_view stop) {
     if (!str.empty() && !stop.empty()) {
         const size_t max_len = std::min(str.size(), stop.size());
@@ -737,7 +745,6 @@ bool fs_create_directory_with_parents(const std::string & path);
 bool fs_is_directory(const std::string & path);
 
 std::string fs_get_cache_directory();
-std::string fs_get_cache_file(const std::string & filename);
 
 struct common_file_info {
     std::string path;

--- a/common/download.h
+++ b/common/download.h
@@ -23,19 +23,6 @@ std::pair<long, std::vector<char>> common_remote_get_content(const std::string &
 // example: "user/model" -> <"user/model", "latest">
 std::pair<std::string, std::string> common_download_split_repo_tag(const std::string & hf_repo_with_tag);
 
-struct common_cached_model_info {
-    std::string manifest_path;
-    std::string user;
-    std::string model;
-    std::string tag;
-    size_t      size = 0; // GGUF size in bytes
-    // return string representation like "user/model:tag"
-    // if tag is "latest", it will be omitted
-    std::string to_string() const {
-        return user + "/" + model + (tag == "latest" ? "" : ":" + tag);
-    }
-};
-
 struct common_hf_file_res {
     std::string repo; // repo name with ":tag" removed
     std::string ggufFile;
@@ -69,7 +56,7 @@ bool common_download_model(
 );
 
 // returns list of cached models
-std::vector<common_cached_model_info> common_list_cached_models();
+std::vector<std::string> common_list_cached_models();
 
 // download single file from url to local path
 // returns status code or -1 on error

--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -365,8 +365,12 @@ common_presets common_preset_context::load_from_cache() const {
     auto cached_models = common_list_cached_models();
     for (const auto & model : cached_models) {
         common_preset preset;
-        preset.name = model.to_string();
-        preset.set_option(*this, "LLAMA_ARG_HF_REPO", model.to_string());
+        preset.name = model;
+        if (string_ends_with(model, ".gguf")) {
+            preset.set_option(*this, "LLAMA_ARG_MODEL", model);
+        } else {
+            preset.set_option(*this, "LLAMA_ARG_HF_REPO", model);
+        }
         out[preset.name] = preset;
     }
 


### PR DESCRIPTION
before:

    ./gemma-3-270m-it-qat-Q4_0.gguf.etag
    ./ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    ./angt_test-split-model-stories260K_stories260K-f32-00001-of-00002.gguf.etag
    ./angt_test-split-model-stories260K_stories260K-f32-00002-of-00002.gguf
    ./angt_test-split-model-stories260K_stories260K-f32-00001-of-00002.gguf
    ./manifest=ggml-org=SmolVLM2-256M-Video-Instruct-GGUF=latest.json
    ./angt_test-split-model-stories260K_stories260K-f32-00002-of-00002.gguf.etag
    ./ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag
    ./gemma-3-270m-it-qat-Q4_0.gguf
    ./ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    ./manifest=angt=test-split-model-stories260K=latest.json
    ./ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag

--cache-list only display the hf repo:

    number of models in cache: 2
       1. ggml-org/SmolVLM2-256M-Video-Instruct-GGUF
       2. angt/test-split-model-stories260K

starting llama-server with the commit will migrate the old cache to the new layout:

    migrated: manifest=ggml-org=SmolVLM2-256M-Video-Instruct-GGUF=latest.json
    migrated: ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    migrated: ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag
    migrated: ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    migrated: ggml-org_SmolVLM2-256M-Video-Instruct-GGUF_mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag
    migrated: manifest=angt=test-split-model-stories260K=latest.json
    migrated: angt_test-split-model-stories260K_stories260K-f32-00001-of-00002.gguf.etag
    migrated: angt_test-split-model-stories260K_stories260K-f32-00002-of-00002.gguf
    migrated: angt_test-split-model-stories260K_stories260K-f32-00001-of-00002.gguf
    migrated: angt_test-split-model-stories260K_stories260K-f32-00002-of-00002.gguf.etag
    ...
    srv   load_models: Loaded 3 cached model presets
    srv   load_models: Available models (3) (*: custom preset)
    srv   load_models:     angt/test-split-model-stories260K
    srv   load_models:     gemma-3-270m-it-qat-Q4_0.gguf
    srv   load_models:     ggml-org/SmolVLM2-256M-Video-Instruct-GGUF

showing all gguf available. the new layout will become:

    ./ggml-org
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/SmolVLM2-256M-Video-Instruct-Q8_0.gguf
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/manifests
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/manifests/latest.json
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag
    ./ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf.etag
    ./gemma-3-270m-it-qat-Q4_0.gguf.etag
    ./gemma-3-270m-it-qat-Q4_0.gguf
    ./angt
    ./angt/test-split-model-stories260K
    ./angt/test-split-model-stories260K/stories260K-f32-00001-of-00002.gguf
    ./angt/test-split-model-stories260K/stories260K-f32-00002-of-00002.gguf
    ./angt/test-split-model-stories260K/manifests
    ./angt/test-split-model-stories260K/manifests/latest.json
    ./angt/test-split-model-stories260K/stories260K-f32-00001-of-00002.gguf.etag
    ./angt/test-split-model-stories260K/stories260K-f32-00002-of-00002.gguf.etag

llama-server will now allow -m model.gguf to look in the cache (use ./model.gguf to force loading the one in the current directory in case of conflict)
