### PR TITLE
Fix test-jinja on Windows.

### DIFF
--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -673,7 +673,7 @@ static void test_filters(testing & t) {
 
 #ifdef _WIN32
     if (g_python_mode && GetACP() != CP_UTF8) {
-        t.log("Skipping test case \"tojson ensure_ascii=true\" due to Windows' active codepage"
+        t.log("Skipping test case \"tojson ensure_ascii=true\" due to Windows' active codepage "
               "is not being set to UTF-8.\n"
               "It causes subprocesses to misinterpret arguments encoded in UTF-8.");
     } else {


### PR DESCRIPTION
When running test-jinja on Windows in python mode, there are several problems present. They are related to DOS-style line-breaks and UTF-8 handling on Windows.

This PR proposes following changes for test-jinja on Windows in python mode.
1. Expect line breaks to be in DOS style (`"\r\n"` instead of `"\n"`).
2. Skip test that checks jinja's `to_json(ensure_ascii=True)`. Windows by default uses ANSI codepages instead of UTF-8, thus when spawning a subprocess via `CreateProcessA`, Windows will treat command's arguments as in ANSI encoding. This test can still be run successfully on Windows if one turns on system option Use Unicode UTF-8 for worldwide language support, which is still in beta.

After these changes all Windows jinja tests are passed successfully.