### PR TITLE
feat: async pipeline-parallel scheduler + parallel model loading (multi-GPU layer split)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2353,6 +2353,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_SPLIT_MODE"));
     add_opt(common_arg(
+        {"-tl", "--threads-load"}, "N",
+        string_format("number of parallel threads for model loading (default: %d, -1 = unlimited, 1 = sequential)", params.n_threads_load),
+        [](common_params & params, int value) {
+            params.n_threads_load = value;
+            if (params.n_threads_load <= 0) {
+                params.n_threads_load = -1; // unlimited
+            }
+            // Also set env var so llama-model.cpp and ggml-cuda.cu can read it
+#ifdef _WIN32
+            _putenv_s("LLAMA_ARG_THREADS_LOAD", std::to_string(params.n_threads_load).c_str());
+#else
+            setenv("LLAMA_ARG_THREADS_LOAD", std::to_string(params.n_threads_load).c_str(), 1);
+#endif
+        }
+    ).set_env("LLAMA_ARG_THREADS_LOAD"));
+    add_opt(common_arg(
         {"-ts", "--tensor-split"}, "N0,N1,N2,...",
         "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -390,6 +390,8 @@ struct common_params {
 
     enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
 
+    int32_t n_threads_load = -1; // number of threads for parallel model loading (-1 = unlimited, 1 = sequential)
+
     struct cpu_params cpuparams;
     struct cpu_params cpuparams_batch;
 

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -315,7 +315,8 @@ extern "C" {
 
     // Get the number of splits of the last graph
     GGML_API int                  ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched);
-    GGML_API int                  ggml_backend_sched_get_n_copies(ggml_backend_sched_t sched);
+    GGML_API int                  ggml_backend_sched_get_n_copies (ggml_backend_sched_t sched);
+    GGML_API int                  ggml_backend_sched_get_cur_copy (ggml_backend_sched_t sched);
 
     GGML_API ggml_backend_buffer_type_t ggml_backend_sched_get_buffer_type(ggml_backend_sched_t sched, ggml_backend_t backend);
     GGML_API size_t                     ggml_backend_sched_get_buffer_size(ggml_backend_sched_t sched, ggml_backend_t backend);
@@ -328,6 +329,7 @@ extern "C" {
 
     // Allocate and compute graph on the backend scheduler
     GGML_API bool                 ggml_backend_sched_alloc_graph(ggml_backend_sched_t sched, struct ggml_cgraph * graph); // returns success
+    GGML_API bool                 ggml_backend_sched_alloc_graph_reuse(ggml_backend_sched_t sched, struct ggml_cgraph * graph); // advance copy slot without re-splitting (pipeline parallelism)
     GGML_API enum ggml_status     ggml_backend_sched_graph_compute(ggml_backend_sched_t sched, struct ggml_cgraph * graph);
     GGML_API enum ggml_status     ggml_backend_sched_graph_compute_async(ggml_backend_sched_t sched, struct ggml_cgraph * graph);
     GGML_API void                 ggml_backend_sched_synchronize(ggml_backend_sched_t sched);

--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -42,6 +42,9 @@ GGML_BACKEND_API void ggml_backend_cuda_unregister_host_buffer(void * buffer);
 
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_cuda_reg(void);
 
+// Sync all pending async load transfers - call after loading with GGML_CUDA_ASYNC_LOAD=1
+GGML_BACKEND_API void ggml_cuda_sync_load_streams(void);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -126,6 +126,18 @@ struct llama_context {
             llama_memory_context_i * mctx,
                        ggml_status & ret);
 
+    // CPU-only preparation phase: apply mctx, build/reuse graph, set inputs.
+    // Does NOT dispatch to GPU. Call graph_compute(res->get_gf(), ...) separately.
+    // If res_in is nullptr, uses gf_res_prev. Pass gf_res_reserve.get() for the
+    // second pipeline slot to enable double-buffered ubatch overlap.
+    // Returns nullptr on failure (ret is set accordingly).
+    llm_graph_result * prepare_ubatch(
+                const llama_ubatch & ubatch,
+                    llm_graph_type   gtype,
+            llama_memory_context_i * mctx,
+                       ggml_status & ret,
+              llm_graph_result     * res_in = nullptr);
+
     int encode(const llama_batch & batch_inp);
     int decode(const llama_batch & batch_inp);
 

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -10,6 +10,8 @@
 
 #include <cstddef>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -75,6 +77,8 @@ struct llama_model_loader {
     bool no_alloc;
 
     llama_files files;
+    std::vector<std::string> file_paths; // file paths for creating per-thread file handles
+    mutable std::vector<std::unique_ptr<std::mutex>> file_mutexes; // per-file mutexes for thread-safe parallel loading
     llama_ftype ftype;
     llama_fver  fver;
 


### PR DESCRIPTION
This PR improves multi‑GPU layer-split execution by moving the pipeline scheduler toward event-driven, non-blocking coordination and by reducing CPU-side stalls during transfers and submission.

What changed
Async CPU→GPU transfers
Prefer asynchronous host→device transfers when supported, so scheduling can continue while the transfer is in flight.
Non-blocking pipeline scheduling
Reduce CPU-side waiting between split submissions by using streams/events for cross-split dependencies, allowing GPUs to self-synchronize while the CPU prepares the next microbatch.
Queue-throttle for stability
Add a lightweight throttle to prevent the CPU from getting too far ahead of GPU execution, helping keep submission latency stable under fully async pipelining.
Parallel multi-GPU model loading
Add --threads-load/-tl N to load tensors for multiple GPU contexts in parallel (with env-based controls to limit/disable).
ROCm/HIP: disable async upload path to avoid known hipStreamPerThread/event issues.