### PR TITLE
server : add default-model preset and fallback logic

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4156,6 +4156,12 @@ void common_params_add_preset_options(std::vector<common_arg> & args) {
     ).set_env(COMMON_ARG_PRESET_LOAD_ON_STARTUP).set_preset_only());
 
     args.push_back(common_arg(
+        {"default-model"}, "NAME",
+        "in server router mode, this model will be used if model not found",
+        [](common_params &, const std::string &) { /* unused */ }
+    ).set_env(COMMON_ARG_PRESET_DEFAULT_MODEL).set_preset_only());
+
+    args.push_back(common_arg(
         {"stop-timeout"}, "SECONDS",
         "in server router mode, force-kill model instance after this many seconds of graceful shutdown",
         [](common_params &, int) { /* unused */ }

--- a/common/arg.h
+++ b/common/arg.h
@@ -11,6 +11,7 @@
 // pseudo-env variable to identify preset-only arguments
 #define COMMON_ARG_PRESET_LOAD_ON_STARTUP "__PRESET_LOAD_ON_STARTUP"
 #define COMMON_ARG_PRESET_STOP_TIMEOUT    "__PRESET_STOP_TIMEOUT"
+#define COMMON_ARG_PRESET_DEFAULT_MODEL   "__PRESET_DEFAULT_MODEL"
 
 //
 // CLI argument parsing

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1625,6 +1625,8 @@ The precedence rule for preset options is as follows:
 
 We also offer additional options that are exclusive to presets (these aren't treated as command-line arguments):
 - `load-on-startup` (boolean): Controls whether the model loads automatically when the server starts
+- `default-model` (boolean): Use this model as the fallback when the request doesn't specify a model or the requested model is not found.
+   If multiple presets set `default-model` to true, the first one in iteration order will be selected and a warning will be logged.
 - `stop-timeout` (int, seconds): After requested unload, wait for this many seconds before forcing termination (default: 10)
 
 ### Routing requests

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -296,6 +296,16 @@ void server_models::load_models() {
         SRV_INF("Loaded %zu custom model presets from %s\n", custom_presets.size(), base_params.models_preset.c_str());
     }
 
+    // prohibit default-model in the global preset section
+    {
+        std::string val;
+        if (global.get_option(COMMON_ARG_PRESET_DEFAULT_MODEL, val)) {
+            throw std::runtime_error(
+                string_format("default-model must be set per-model, "
+                "not in the global preset section"));
+        }
+    }
+
     // cascade, apply global preset first
     cached_models  = ctx_preset.cascade(global, cached_models);
     local_models   = ctx_preset.cascade(global, local_models);
@@ -316,6 +326,29 @@ void server_models::load_models() {
     for (auto & [name, preset] : final_presets) {
         preset.merge(base_preset);
     }
+
+    auto resolve_default_model = [&]() {
+        std::string first_default;
+        for (const auto & [name, inst] : mapping) {
+            std::string val;
+            if (!inst.meta.preset.get_option(COMMON_ARG_PRESET_DEFAULT_MODEL, val)) {
+                continue;
+            }
+            if (first_default.empty()) {
+                default_model_name = name;
+                SRV_INF("Default preset model: %s\n", name.c_str());
+                first_default = name;
+            } else {
+                SRV_WRN(
+                    "Multiple default models detected: '%s' and '%s'; "
+                    "using '%s' as default\n",
+                    name.c_str(),
+                    first_default.c_str(),
+                    first_default.c_str()
+                );
+            }
+        }
+    };
 
     // Helpers that read `mapping` — must be called while holding the lock.
     std::unordered_set<std::string> custom_names;
@@ -387,6 +420,7 @@ void server_models::load_models() {
             add_model(std::move(meta));
         }
         apply_stop_timeout();
+        resolve_default_model();
         log_available_models();
 
         std::vector<std::string> models_to_load;
@@ -550,6 +584,7 @@ void server_models::load_models() {
         cv.notify_all();
 
         log_available_models();
+        resolve_default_model();
 
         // collect autoload candidates while still under the lock
         std::vector<std::string> to_autoload;
@@ -569,6 +604,15 @@ void server_models::load_models() {
             load(name);
         }
     }
+}
+
+std::string server_models::resolve_model_name(const std::string & requested) {
+    // If a non‑empty request matches a known model, use it.
+    if (!requested.empty() && has_model(requested)) {
+        return requested;
+    }
+    // Otherwise fall back to the default model if one is set.
+    return default_model_name.empty() ? requested : default_model_name;
 }
 
 void server_models::update_meta(const std::string & name, const server_model_meta & meta) {
@@ -1183,6 +1227,7 @@ void server_models_routes::init_routes() {
     this->proxy_get = [this](const server_http_req & req) {
         std::string method = "GET";
         std::string name = req.get_param("model");
+        name = models.resolve_model_name(name);
         bool autoload = is_autoload(params, req);
         auto error_res = std::make_unique<server_http_res>();
         if (!router_validate_model(name, models, autoload, error_res)) {
@@ -1195,6 +1240,7 @@ void server_models_routes::init_routes() {
         std::string method = "POST";
         json body = json::parse(req.body);
         std::string name = json_value(body, "model", std::string());
+        name = models.resolve_model_name(name);
         bool autoload = is_autoload(params, req);
         auto error_res = std::make_unique<server_http_res>();
         if (!router_validate_model(name, models, autoload, error_res)) {

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -112,6 +112,7 @@ private:
     std::string bin_path;
     std::vector<std::string> base_env;
     common_preset base_preset; // base preset from llama-server CLI args
+    std::string default_model_name;
 
     void update_meta(const std::string & name, const server_model_meta & meta);
 
@@ -171,6 +172,9 @@ public:
 
     // notify the router server that the sleeping state has changed
     static void notify_router_sleeping_state(bool sleeping);
+
+    // Resolve model name: fallback to default if requested name is empty or not found
+    std::string resolve_model_name(const std::string & requested);
 };
 
 struct server_models_routes {


### PR DESCRIPTION
# Summary

- Introduced a new preset option `default-model = true` that can be used in server router mode to specify a default model. 
- When multiple `default-model` options are found only the first one will be used.
- Updated common/arg.cpp/common/arg.h to expose the option.
- Enhanced server_models to detect the default model during model loading and store it in default_model_name.
- Added server_models::resolve_model_name() to return the requested model if it exists, otherwise fall back to the default model.
- Updated routing logic (server-models.cpp) to call resolve_model_name() for both GET and POST requests, ensuring requests without a model parameter or with an unknown model use the default.

## Motivation

When the server runs in router mode, clients may omit the model field or request a model that isn’t loaded.
Previously this caused an error; the new preset allows the server to automatically use a pre‑selected default model, improving robustness and usability.

### How to test:
1. Start the server in router mode with `default-model = true` in required preset in presets file.
2. Send a request to /v1/chat/completions without a model query or JSON field – the server should use `<your-default-model>`.
3. Send a request specifying a non‑existent model – the server should fall back to `<your-default-model>` instead of returning an error.
4. Verify that requests that do specify a valid model still use the requested model.

Example:
```
$ cat models.ini 
[preset1]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true

[preset2]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true

[preset3]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true
$ ./build/bin/llama-server --models-preset models.ini --host 0.0.0.0 
0.00.130.494 I log_info: verbosity = 3 (adjust with the `-lv N` CLI arg)
0.00.130.546 I system_info: n_threads = 8 (n_threads_batch = 8) / 16 | CUDA : ARCHS = 750 | USE_GRAPHS = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
0.00.130.550 I srv  llama_server: n_parallel is set to auto, using n_parallel = 4 and kv_unified = true
0.00.130.613 I srv          init: running without SSL
0.00.130.660 I srv          init: using 15 threads for HTTP server
0.00.132.272 I srv   load_models: Loaded 2 cached model presets
0.00.132.529 I srv   load_models: Loaded 3 custom model presets from models.ini
0.00.134.294 I srv    operator(): Default preset model: preset1
0.00.134.296 W srv    operator(): Multiple default models detected: 'preset2' and 'preset1'; using 'preset1' as default
0.00.134.296 W srv    operator(): Multiple default models detected: 'preset3' and 'preset1'; using 'preset1' as default
0.00.134.297 I srv    operator(): Available models (5) (*: custom preset)
0.00.134.323 I srv    operator():     ggml-org/Qwen3-0.6B-GGUF:Q4_0
0.00.134.323 I srv    operator():     ggml-org/Qwen3-0.6B-GGUF:Q8_0
0.00.134.324 I srv    operator():   * preset1
0.00.134.324 I srv    operator():   * preset2
0.00.134.325 I srv    operator():   * preset3
0.00.134.499 I srv  llama_server: starting router server, no model will be loaded in this process
0.00.134.502 I srv         start: binding port with default address family
0.00.135.673 I srv  llama_server: router server is listening on http://0.0.0.0:8080
0.00.135.675 W srv  llama_server: NOTE: router mode is experimental
0.00.135.675 W srv  llama_server:       it is not recommended to use this mode in untrusted environments
```

`default-model` is prohibited in `global` settings:

```
$ cat models.ini 
[*]
default-model = true

[preset1]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true

[preset2]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true

[preset3]
hf = ggml-org/Qwen3-0.6B-GGUF
default-model = true
$ ./build/bin/llama-server --models-preset models.ini --host 0.0.0.0 
0.00.125.035 I log_info: verbosity = 3 (adjust with the `-lv N` CLI arg)
0.00.125.089 I system_info: n_threads = 8 (n_threads_batch = 8) / 16 | CUDA : ARCHS = 750 | USE_GRAPHS = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
0.00.125.092 I srv  llama_server: n_parallel is set to auto, using n_parallel = 4 and kv_unified = true
0.00.125.135 I srv          init: running without SSL
0.00.125.221 I srv          init: using 15 threads for HTTP server
0.00.126.673 I srv   load_models: Loaded 2 cached model presets
0.00.126.954 I srv   load_models: Loaded 3 custom model presets from models.ini
0.00.127.214 E srv  llama_server: failed to initialize router models: default-model must be set per-model, not in the global preset section
```



### Impact
- Existing behavior for clients that supply a model name remains unchanged.
- Clients that omit the model will now automatically use the configured default model (if set).
- Backwards compatibility is preserved when the preset is not set; the server behaves as before.

# Requirements

I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
AI usage disclosure: YES - `qwen3.6 27b` - with manual review and testing.