### PR TITLE
ggml/gguf : prevent integer overflows

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -730,10 +730,6 @@ extern "C" {
     GGML_API size_t  ggml_type_size(enum ggml_type type);             // size in bytes for all elements in a block
     GGML_API size_t  ggml_row_size (enum ggml_type type, int64_t ne); // size in bytes for all elements in a row
 
-    GGML_DEPRECATED(
-    GGML_API double ggml_type_sizef(enum ggml_type type), // ggml_type_size()/ggml_blck_size() as float
-    "use ggml_row_size() instead");
-
     GGML_API const char * ggml_type_name(enum ggml_type type);
     GGML_API const char * ggml_op_name  (enum ggml_op   op);
     GGML_API const char * ggml_op_symbol(enum ggml_op   op);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1282,13 +1282,6 @@ size_t ggml_row_size(enum ggml_type type, int64_t ne) {
     return ggml_type_size(type)*ne/ggml_blck_size(type);
 }
 
-double ggml_type_sizef(enum ggml_type type) {
-    if (type < 0 || type >= GGML_TYPE_COUNT) {
-        return 0.0;
-    }
-    return ((double)(type_traits[type].type_size))/type_traits[type].blck_size;
-}
-
 const char * ggml_type_name(enum ggml_type type) {
     return type >= 0 && type < GGML_TYPE_COUNT ? type_traits[type].type_name : "NONE";
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1648,11 +1648,12 @@ static struct ggml_object * ggml_new_object(struct ggml_context * ctx, enum ggml
 
     // integer overflow checks
     if (cur_end > SIZE_MAX - size_needed) {
-        GGML_LOG_WARN("%s: overflow detected in cur_end + size_needed\n", __func__);
+        GGML_LOG_WARN("%s: overflow detected in cur_end (%zu) + size_needed (%zu)\n", __func__, cur_end, size_needed);
         return NULL;
     }
     if (cur_end + size_needed > SIZE_MAX - GGML_OBJECT_SIZE) {
-        GGML_LOG_WARN("%s: overflow detected in cur_end + size_needed + GGML_OBJECT_SIZE\n", __func__);
+        GGML_LOG_WARN("%s: overflow detected in cur_end (%zu) + size_needed (%zu) + GGML_OBJECT_SIZE (%zu)\n", __func__,
+                cur_end, size_needed, (size_t) GGML_OBJECT_SIZE);
         return NULL;
     }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1266,30 +1266,33 @@ size_t ggml_nbytes_pad(const struct ggml_tensor * tensor) {
 }
 
 int64_t ggml_blck_size(enum ggml_type type) {
-    GGML_ASSERT(type >= 0);
-    GGML_ASSERT(type < GGML_TYPE_COUNT);
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
     return type_traits[type].blck_size;
 }
 
 size_t ggml_type_size(enum ggml_type type) {
-    GGML_ASSERT(type >= 0);
-    GGML_ASSERT(type < GGML_TYPE_COUNT);
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
     return type_traits[type].type_size;
 }
 
 size_t ggml_row_size(enum ggml_type type, int64_t ne) {
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
     assert(ne % ggml_blck_size(type) == 0);
     return ggml_type_size(type)*ne/ggml_blck_size(type);
 }
 
 const char * ggml_type_name(enum ggml_type type) {
-    return type >= 0 && type < GGML_TYPE_COUNT ? type_traits[type].type_name : "NONE";
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
+    return type_traits[type].type_name;
 }
 
 bool ggml_is_quantized(enum ggml_type type) {
-    if (type < 0 || type >= GGML_TYPE_COUNT) {
-        return false;
-    }
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
     return type_traits[type].is_quantized;
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -899,8 +899,8 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
 };
 
 const struct ggml_type_traits * ggml_get_type_traits(enum ggml_type type) {
-    GGML_ASSERT(type >= 0);
-    GGML_ASSERT(type < GGML_TYPE_COUNT);
+    assert(type >= 0);
+    assert(type < GGML_TYPE_COUNT);
     return &type_traits[type];
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -899,6 +899,7 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
 };
 
 const struct ggml_type_traits * ggml_get_type_traits(enum ggml_type type) {
+    GGML_ASSERT(type >= 0);
     GGML_ASSERT(type < GGML_TYPE_COUNT);
     return &type_traits[type];
 }
@@ -1265,10 +1266,14 @@ size_t ggml_nbytes_pad(const struct ggml_tensor * tensor) {
 }
 
 int64_t ggml_blck_size(enum ggml_type type) {
+    GGML_ASSERT(type >= 0);
+    GGML_ASSERT(type < GGML_TYPE_COUNT);
     return type_traits[type].blck_size;
 }
 
 size_t ggml_type_size(enum ggml_type type) {
+    GGML_ASSERT(type >= 0);
+    GGML_ASSERT(type < GGML_TYPE_COUNT);
     return type_traits[type].type_size;
 }
 
@@ -1278,14 +1283,20 @@ size_t ggml_row_size(enum ggml_type type, int64_t ne) {
 }
 
 double ggml_type_sizef(enum ggml_type type) {
+    if (type < 0 || type >= GGML_TYPE_COUNT) {
+        return 0.0;
+    }
     return ((double)(type_traits[type].type_size))/type_traits[type].blck_size;
 }
 
 const char * ggml_type_name(enum ggml_type type) {
-    return type < GGML_TYPE_COUNT ? type_traits[type].type_name : "NONE";
+    return type >= 0 && type < GGML_TYPE_COUNT ? type_traits[type].type_name : "NONE";
 }
 
 bool ggml_is_quantized(enum ggml_type type) {
+    if (type < 0 || type >= GGML_TYPE_COUNT) {
+        return false;
+    }
     return type_traits[type].is_quantized;
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1634,6 +1634,16 @@ static struct ggml_object * ggml_new_object(struct ggml_context * ctx, enum ggml
     char * const mem_buffer = ctx->mem_buffer;
     struct ggml_object * const obj_new = (struct ggml_object *)(mem_buffer + cur_end);
 
+    // integer overflow checks
+    if (cur_end > SIZE_MAX - size_needed) {
+        GGML_LOG_WARN("%s: overflow detected in cur_end + size_needed\n", __func__);
+        return NULL;
+    }
+    if (cur_end + size_needed > SIZE_MAX - GGML_OBJECT_SIZE) {
+        GGML_LOG_WARN("%s: overflow detected in cur_end + size_needed + GGML_OBJECT_SIZE\n", __func__);
+        return NULL;
+    }
+
     if (cur_end + size_needed + GGML_OBJECT_SIZE > ctx->mem_size) {
         GGML_LOG_WARN("%s: not enough space in the context's memory pool (needed %zu, available %zu)\n",
                 __func__, cur_end + size_needed + GGML_OBJECT_SIZE, ctx->mem_size);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1640,6 +1640,7 @@ static struct ggml_object * ggml_new_object(struct ggml_context * ctx, enum ggml
     const size_t cur_end  = cur_offs + cur_size;
 
     // align to GGML_MEM_ALIGN
+    GGML_ASSERT(size <= SIZE_MAX - (GGML_MEM_ALIGN - 1));
     size_t size_needed = GGML_PAD(size, GGML_MEM_ALIGN);
 
     char * const mem_buffer = ctx->mem_buffer;
@@ -1722,6 +1723,8 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         // allocate tensor data in the context's memory pool
         obj_alloc_size = data_size;
     }
+
+    GGML_ASSERT(GGML_TENSOR_SIZE <= SIZE_MAX - obj_alloc_size);
 
     struct ggml_object * const obj_new = ggml_new_object(ctx, GGML_OBJECT_TYPE_TENSOR, GGML_TENSOR_SIZE + obj_alloc_size);
     GGML_ASSERT(obj_new);

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -234,13 +234,20 @@ struct gguf_reader {
         if (n > GGUF_MAX_ARRAY_ELEMENTS) {
             return false;
         }
+        const uint64_t nbytes = nbytes_remain();
         if constexpr (std::is_same<T, std::string>::value) {
             // strings are prefixed with their length, so we need to account for that
             if (n > SIZE_MAX / sizeof(uint64_t)) {
                 return false;
             }
+            if (nbytes < n * sizeof(uint64_t)) {
+                return false;
+            }
         } else {
             if (n > SIZE_MAX / sizeof(T)) {
+                return false;
+            }
+            if (nbytes < n * sizeof(T)) {
                 return false;
             }
         }

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -614,8 +614,8 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
             // check that tensor type is within defined range
             if (info.t.type < 0 || info.t.type >= GGML_TYPE_COUNT) {
-                GGML_LOG_ERROR("%s: tensor '%s' has invalid ggml type %d (%s)\n",
-                    __func__, info.t.name, info.t.type, ggml_type_name(info.t.type));
+                GGML_LOG_ERROR("%s: tensor '%s' has invalid ggml type %d. should be in [0, %d)\n",
+                    __func__, info.t.name, info.t.type, GGML_TYPE_COUNT);
                 ok = false;
                 break;
             }

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -297,9 +297,9 @@ struct gguf_reader {
             GGML_LOG_ERROR("%s: string length %" PRIu64 " exceeds maximum %d\n", __func__, size, GGUF_MAX_STRING_LENGTH);
             return false;
         }
-        const uint64_t n_remain = remain();
-        if (size > n_remain) {
-            GGML_LOG_ERROR("%s: string length %" PRIu64 " exceeds remaining file size %" PRIu64 "\n", __func__, size, n_remain);
+        const uint64_t nbytes = nbytes_remain();
+        if (size > nbytes) {
+            GGML_LOG_ERROR("%s: string length %" PRIu64 " exceeds remaining file size %" PRIu64 " bytes\n", __func__, size, nbytes);
             return false;
         }
         dst.resize(static_cast<size_t>(size));
@@ -311,8 +311,8 @@ struct gguf_reader {
     }
 
     // remaining bytes in the file
-    uint64_t remain() const {
-        long cur = ftell(file);
+    uint64_t nbytes_remain() const {
+        const long cur = ftell(file);
         if (cur < 0) {
             return 0;
         }

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -294,7 +294,7 @@ struct gguf_reader {
             return false;
         }
         if (size > GGUF_MAX_STRING_LENGTH) {
-            GGML_LOG_ERROR("%s: string length %" PRIu64 " exceeds maximum %d\n", __func__, size, GGUF_MAX_STRING_LENGTH);
+            GGML_LOG_ERROR("%s: string length %" PRIu64 " exceeds maximum %" PRIu64 "\n", __func__, size, (uint64_t) GGUF_MAX_STRING_LENGTH);
             return false;
         }
         const uint64_t nbytes = nbytes_remain();

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -203,11 +203,11 @@ class GGUFReader:
 
     def _push_field(self, field: ReaderField, skip_sum: bool = False) -> int:
         if field.name in self.fields:
-            # TODO: add option to generate error on duplicate keys
-            # raise KeyError(f'Duplicate {field.name} already in list at offset {field.offset}')
+            # TODO: add option to make this a warning and accept duplicate keys like below
+            raise KeyError(f'Duplicate {field.name} already in list at offset {field.offset}')
 
-            logger.warning(f'Duplicate key {field.name} at offset {field.offset}')
-            self.fields[field.name + '_{}'.format(field.offset)] = field
+            #logger.warning(f'Duplicate key {field.name} at offset {field.offset}')
+            #self.fields[field.name + '_{}'.format(field.offset)] = field
         else:
             self.fields[field.name] = field
         return 0 if skip_sum else sum(int(part.nbytes) for part in field.parts)

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -168,6 +168,8 @@ class GGUFReader:
         tensor_count, kv_count = temp_counts
         offs = self._build_fields(offs, kv_count)
 
+        # Build Tensor Info Fields
+        offs, tensors_fields = self._build_tensor_info(offs, tensor_count)
         new_align = self.fields.get('general.alignment')
         if new_align is not None:
             if new_align.types != [GGUFValueType.UINT32]:

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -168,13 +168,14 @@ class GGUFReader:
         tensor_count, kv_count = temp_counts
         offs = self._build_fields(offs, kv_count)
 
-        # Build Tensor Info Fields
-        offs, tensors_fields = self._build_tensor_info(offs, tensor_count)
         new_align = self.fields.get('general.alignment')
         if new_align is not None:
             if new_align.types != [GGUFValueType.UINT32]:
                 raise ValueError('Bad type for general.alignment field')
             self.alignment = new_align.parts[-1][0]
+            # Ensure alignment is a non-zero power of two
+            if self.alignment == 0 or (self.alignment & (self.alignment - 1)) != 0:
+                raise ValueError('Invalid alignment: must be a non-zero power of two')
         padding = offs % self.alignment
         if padding != 0:
             offs += self.alignment - padding

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -208,8 +208,8 @@ class GGUFReader:
             # TODO: add option to make this a warning and accept duplicate keys like below
             raise KeyError(f'Duplicate {field.name} already in list at offset {field.offset}')
 
-            #logger.warning(f'Duplicate key {field.name} at offset {field.offset}')
-            #self.fields[field.name + '_{}'.format(field.offset)] = field
+            # logger.warning(f'Duplicate key {field.name} at offset {field.offset}')
+            # self.fields[field.name + '_{}'.format(field.offset)] = field
         else:
             self.fields[field.name] = field
         return 0 if skip_sum else sum(int(part.nbytes) for part in field.parts)

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -501,6 +501,8 @@ class GGUFWriter:
         self.add_uint32(Keys.General.QUANTIZATION_VERSION, quantization_version)
 
     def add_custom_alignment(self, alignment: int) -> None:
+        if alignment <= 0 or (alignment & (alignment - 1)) != 0:
+            raise ValueError('Invalid alignment: must be a non-zero power of two')
         self.data_alignment = alignment
         self.add_uint32(Keys.General.ALIGNMENT, alignment)
 


### PR DESCRIPTION
- Strengthen integer overflow validation in ggml/gguf
- Impose max limits for string length and array elements of GGUF metadata
- Remove deprecated `ggml_type_sizef()`
