### PR TITLE
Mirroring /v1/responses to /responses

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -178,6 +178,7 @@ int main(int argc, char ** argv) {
     ctx_http.post("/v1/chat/completions", ex_wrapper(routes.post_chat_completions));
     ctx_http.post("/api/chat",            ex_wrapper(routes.post_chat_completions)); // ollama specific endpoint
     ctx_http.post("/v1/responses",        ex_wrapper(routes.post_responses_oai));
+    ctx_http.post("/responses",           ex_wrapper(routes.post_responses_oai));
     ctx_http.post("/v1/messages",         ex_wrapper(routes.post_anthropic_messages)); // anthropic messages API
     ctx_http.post("/v1/messages/count_tokens", ex_wrapper(routes.post_anthropic_count_tokens)); // anthropic token counting
     ctx_http.post("/infill",              ex_wrapper(routes.post_infill));


### PR DESCRIPTION
This one-line PR enables /responses route to match other routes such as /chat/completions. I noticed that some agents drop /v1/ prefix when making API calls. Most OAI API routes have bindings without /v1/ prefix but responses were missing.