### PR TITLE
ggml : add fallback to CPU for unsupported ops in scheduler

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1127,6 +1127,10 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
             *cur_backend_id = tensor_backend_id(node->view_src);
             SET_CAUSE(node, "4.vsrc");
         }
+        if (*cur_backend_id == -1) {
+            *cur_backend_id = sched->n_backends - 1;
+            SET_CAUSE(node, "4.force");
+        }
         for (int j = 0; j < GGML_MAX_SRC; j++) {
             struct ggml_tensor * src = node->src[j];
             if (src == NULL) {


### PR DESCRIPTION
I found this while fixing:
```
llama-server -v -hf unsloth/LFM2.5-VL-1.6B-GGUF:Q8_0
```
with this PR: https://github.com/ggml-org/llama.cpp/pull/19867

I guess it's a fallback of the fallback mechanism somehow and might not be the real root cause.

anyway, with that, I have `llama-server` running:

```
...
llama_context: enumerating backends
llama_context: backend_ptrs.size() = 1
sched_reserve: reserving ...
sched_reserve: max_nodes = 1192
sched_reserve: reserving full memory module
sched_reserve: worst-case: n_tokens = 512, n_seqs = 4, n_outputs = 4
graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  4, n_outputs =    4
graph_reserve: making n_tokens a multiple of n_seqs - n_tokens = 4, n_seqs = 4, n_outputs = 4
sched_reserve: Flash Attention was auto, set to enabled
graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  4, n_outputs =  512
graph_reserve: reserving a graph for ubatch with n_tokens =    4, n_seqs =  4, n_outputs =    4
graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  4, n_outputs =  512
sched_reserve:        CPU compute buffer size =   395.01 MiB
sched_reserve: graph nodes  = 549
sched_reserve: graph splits = 1
sched_reserve: reserve took 1.47 ms, sched copies = 1
...
```
and at the end:
```
que    start_loop: terminate
srv    operator(): operator(): cleaning up before exit...
llama_memory_breakdown_print: | memory breakdown [MiB] | total   free    self   model   context   compute    unaccounted |
llama_memory_breakdown_print: |   - Host               |                 3064 =  1169 +    1500 +     395                |
llama_memory_breakdown_print: |   - AMX                |                 1325 =  1325 +       0 +       0                |
~llama_context:        CPU compute buffer size is 395.0137 MiB, matches expectation of 395.0137 MiB
```
