### PR TITLE
[HIP] Updates the ROCm/HIP toolchain versions used in CI pipelines

### DIFF
--- a/.github/actions/windows-setup-rocm/action.yml
+++ b/.github/actions/windows-setup-rocm/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Setup ROCm
       uses: ./.github/actions/install-exe
       with:
-        url: https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ inputs.version }}-WinSvr2022-For-HIP.exe
+        url: https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ inputs.version }}-Win11-For-HIP.exe
         args: -install

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -68,7 +68,7 @@ jobs:
 
     env:
       # Make sure this is in sync with build.yml
-      HIPSDK_INSTALLER_VERSION: "25.Q3"
+      HIPSDK_INSTALLER_VERSION: "26.Q1"
 
     steps:
       - name: Clone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -586,7 +586,7 @@ jobs:
 
   ubuntu-22-cmake-hip:
     runs-on: ubuntu-22.04
-    container: rocm/dev-ubuntu-22.04:7.2
+    container: rocm/dev-ubuntu-22.04:6.1.2
 
     steps:
       - name: Clone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -586,7 +586,7 @@ jobs:
 
   ubuntu-22-cmake-hip:
     runs-on: ubuntu-22.04
-    container: rocm/dev-ubuntu-22.04:6.1.2
+    container: rocm/dev-ubuntu-22.04:7.2
 
     steps:
       - name: Clone
@@ -1175,10 +1175,8 @@ jobs:
     runs-on: windows-2022
 
     env:
-      # The ROCm version must correspond to the version used in the HIP SDK.
-      ROCM_VERSION: "6.4.2"
       # Make sure this is in sync with build-cache.yml
-      HIPSDK_INSTALLER_VERSION: "25.Q3"
+      HIPSDK_INSTALLER_VERSION: "26.Q1"
 
     steps:
       - name: Clone
@@ -1188,7 +1186,7 @@ jobs:
       - name: Grab rocWMMA package
         id: grab_rocwmma
         run: |
-          curl -o rocwmma.deb "https://repo.radeon.com/rocm/apt/${{ env.ROCM_VERSION }}/pool/main/r/rocwmma-dev/rocwmma-dev_1.7.0.60402-120~24.04_amd64.deb"
+          curl -o rocwmma.deb "https://repo.radeon.com/rocm/apt/7.2/pool/main/r/rocwmma-dev/rocwmma-dev_2.2.0.70200-43~24.04_amd64.deb"
           7z x rocwmma.deb
           7z x data.tar
 
@@ -1231,7 +1229,7 @@ jobs:
           cmake -G "Unix Makefiles" -B build -S . `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\bin\clang++.exe" `
-            -DCMAKE_CXX_FLAGS="-I$($PWD.Path.Replace('\', '/'))/opt/rocm-${{ env.ROCM_VERSION }}/include/" `
+            -DCMAKE_CXX_FLAGS="-I$($PWD.Path.Replace('\', '/'))/opt/rocm-7.2.0/include/" `
             -DCMAKE_BUILD_TYPE=Release `
             -DLLAMA_BUILD_BORINGSSL=ON `
             -DROCM_DIR="${env:HIP_PATH}" `


### PR DESCRIPTION
## Summary
Updates the ROCm/HIP toolchain versions used in CI pipelines to bring them up to date.
This PR is an add-on for https://github.com/ggml-org/llama.cpp/pull/19433 and https://github.com/ggml-org/llama.cpp/pull/19810

### Changes
#### Linux (`ubuntu-22-cmake-hip`)

Updated Docker container from `rocm/dev-ubuntu-22.04:6.1.2` → `rocm/dev-ubuntu-22.04:7.2`
Updated rocWMMA package to `2.2.0.70200` (from `1.7.0.60402`), fetched from the `rocm/apt/7.2` repo

#### Windows (`windows-cmake-hip` / `build-cache`)

Bumped `HIPSDK_INSTALLER_VERSION` from `25.Q3` → `26.Q1` (kept in sync between `build.yml` and `build-cache.yml`)
Updated the HIP SDK installer URL target from `WinSvr2022` → `Win11`

### Notes
Removed the `ROCM_VERSION` env variable — it was previously used for both the rocWMMA apt repo path and the `CMAKE_CXX_FLAGS` include path. However, these two uses require different formats: the apt repo uses `rocm/apt/7.2` while the include directory is `rocm-7.2.0` (with a trailing `.0`). Since a single variable can't satisfy both formats, the values are now hardcoded directly at each usage site.

### Motivation
Keeps the CI environment aligned with the latest AMD ROCm 7.2 / HIP SDK 26.Q1 release.
