### PR TITLE
llama : use n_parallel to select the correct backend

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1320,6 +1320,7 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.main_gpu        = params.main_gpu;
     mparams.split_mode      = params.split_mode;
     mparams.tensor_split    = params.tensor_split;
+    mparams.n_parallel      = params.n_parallel;
     mparams.use_mmap        = params.use_mmap;
     mparams.use_direct_io   = params.use_direct_io;
     mparams.use_mlock       = params.use_mlock;

--- a/include/llama.h
+++ b/include/llama.h
@@ -295,6 +295,9 @@ extern "C" {
         // proportion of the model (layers or rows) to offload to each GPU, size: llama_max_devices()
         const float * tensor_split;
 
+        // n_parallel to correctly select the backend
+        int32_t n_parallel;
+
         // Called with a progress value between 0.0 and 1.0. Pass NULL to disable.
         // If the provided progress_callback returns true, model loading continues.
         // If it returns false, model loading is immediately aborted.


### PR DESCRIPTION
This is an alternative to https://github.com/ggml-org/llama.cpp/pull/19884.
