### PR TITLE
fix(server): respect `load-on-startup` option in router mode

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -291,7 +291,9 @@ void server_models::load_models() {
     for (const auto & [name, inst] : mapping) {
         std::string val;
         if (inst.meta.preset.get_option(COMMON_ARG_PRESET_LOAD_ON_STARTUP, val)) {
-            models_to_load.push_back(name);
+            if (common_arg_utils::is_truthy(val)) {
+                models_to_load.push_back(name);
+            }
         }
     }
     if ((int)models_to_load.size() > base_params.models_max) {


### PR DESCRIPTION
### Problem
When running `llama-server` in router mode with a custom model preset (`.ini` file), the `load-on-startup` option was being ignored. The server attempted to load **all** defined models at startup, regardless of whether `load-on-startup = false` was set for specific models.

This caused the server to fail initialization if the total number of models exceeded the `--models-max` limit, even if the user intended to load only a subset (or zero) of models initially.

**Example Error:**
```text
main: failed to initialize router models: number of models to load on startup (5) exceeds models_max (1)
```

In this scenario, the user set `load-on-startup = false` for 5 models, expecting none to load on startup, but the server counted them as 5 models to load.

### Solution
Modified `tools/server/server-models.cpp` to explicitly check the value of the `load-on-startup` option using `common_arg_utils::is_truthy(val)` before adding a model to the startup list.

Previously, the code simply pushed the model name if the option key existed:
```cpp
// Before
if (inst.meta.preset.get_option(COMMON_ARG_PRESET_LOAD_ON_STARTUP, val)) {
    models_to_load.push_back(name);
}
```

Now it validates the boolean value:
```cpp
// After
if (inst.meta.preset.get_option(COMMON_ARG_PRESET_LOAD_ON_STARTUP, val)) {
    if (common_arg_utils::is_truthy(val)) {
        models_to_load.push_back(name);
    }
}
```

### Testing
1. Created a test `.ini` file with multiple models, setting `load-on-startup = false` for all of them.
2. Launched the server with `--models-max 1`.
3. **Result:** The server starts successfully without attempting to load any models, ignoring the `models_max` limit for non-startup models.
4. Verified that models with `load-on-startup = true` are still correctly loaded.

### Related
This fix ensures that the `load-on-startup` parameter works as documented in the preset configuration, preventing initialization crashes for users managing large model pools with strict VRAM limits.