### PR TITLE
vendors: update miniaudio library to 0.11.24

### DIFF
--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -14,8 +14,8 @@ vendor = {
     "https://raw.githubusercontent.com/nothings/stb/refs/heads/master/stb_image.h": "vendor/stb/stb_image.h",
 
     # not using latest tag to avoid this issue: https://github.com/ggml-org/llama.cpp/pull/17179#discussion_r2515877926
-    # "https://github.com/mackron/miniaudio/raw/refs/tags/0.11.23/miniaudio.h": "vendor/miniaudio/miniaudio.h",
-    "https://github.com/mackron/miniaudio/raw/669ed3e844524fcd883231b13095baee9f6de304/miniaudio.h": "vendor/miniaudio/miniaudio.h",
+    # "https://github.com/mackron/miniaudio/raw/refs/tags/0.11.24/miniaudio.h": "vendor/miniaudio/miniaudio.h",
+    "https://github.com/mackron/miniaudio/raw/13d161bc8d856ad61ae46b798bbeffc0f49808e8/miniaudio.h": "vendor/miniaudio/miniaudio.h",
 
     f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/httplib.h": "httplib.h",
     f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/split.py":  "split.py",


### PR DESCRIPTION
https://github.com/mackron/miniaudio/releases/tag/0.11.24.

# v0.11.24 - 2026-01-17

-   Fixed a possible glitch when processing the audio of a `ma_sound` when doing resampling.
-   Fixed a possible crash in the node graph relating to scheduled starts and stops.
-   Fixed a bug where MA\_NO\_DECODING would disable the WAV encoder.
-   Fixed a pthread compatibility issue, particularly with Android.
-   Fixed a possible crash in the resource manager.
-   Fixed a possible double-uninit error when a decoder fails to initialize.
-   Fixed a compilation error with the MSVC Aarch64 build.
-   Addressed a few errors found through static analysis, particularly around possible null pointer dereferences.
-   `ma_sound_is_playing()` will now correctly return false when called from inside the end callback of a sound.
-   Miscellaneous compiler compatibility and warning fixes.
-   PulseAudio: Fix a resource leak when a context fails to connect.
-   Web: Fixed an error when uninitializing a context.

---

Also, please take a look at https://github.com/ggml-org/whisper.cpp/pull/3672.