### PR TITLE
kv-cache : fix can_shift() check to take into account M-RoPE

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -978,6 +978,9 @@ bool llama_kv_cache::get_can_shift() const {
     if (model.arch == LLM_ARCH_STEP35) {
         return false;
     }
+    if (hparams.n_pos_per_embd() > 1) {
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
fix #19915

KV cache shift is not supported with M-RoPE (yet).