### PR TITLE
llama: disable repack by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1482,7 +1482,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+          LLAMA_ARG_THREADS=$(nproc) LLAMA_ARG_REPACK=1 GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-low-perf:
     runs-on: ubuntu-22.04-arm
@@ -1508,7 +1508,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+          LLAMA_ARG_THREADS=$(nproc) LLAMA_ARG_REPACK=1 GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-x64-cpu-high-perf:
     runs-on: ubuntu-22.04
@@ -1534,7 +1534,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+          LLAMA_ARG_THREADS=$(nproc) LLAMA_ARG_REPACK=1 GG_BUILD_HIGH_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf:
     runs-on: ubuntu-22.04-arm
@@ -1560,7 +1560,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 GG_BUILD_NO_SVE=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+          LLAMA_ARG_THREADS=$(nproc) LLAMA_ARG_REPACK=1 GG_BUILD_HIGH_PERF=1 GG_BUILD_NO_SVE=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf-sve:
     runs-on: ubuntu-22.04-arm
@@ -1586,7 +1586,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          LLAMA_ARG_THREADS=$(nproc) GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+          LLAMA_ARG_THREADS=$(nproc) LLAMA_ARG_REPACK=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-x64-nvidia-cuda:
     runs-on: [self-hosted, Linux, X64, NVIDIA]
@@ -1641,7 +1641,7 @@ jobs:
       - name: Test
         id: ggml-ci
         run: |
-          bash ./ci/run.sh ~/results/llama.cpp /mnt/llama.cpp
+          LLAMA_ARG_REPACK=1 bash ./ci/run.sh ~/results/llama.cpp /mnt/llama.cpp
 
   # ggml-ci-x64-amd-vulkan:
   #   runs-on: [self-hosted, Linux, X64, AMD]
@@ -1727,30 +1727,30 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   ggml-ci-arm64-cpu-kleidiai:
-     runs-on: ubuntu-22.04-arm
+      runs-on: ubuntu-22.04-arm
 
-     steps:
-       - name: Clone
-         id: checkout
-         uses: actions/checkout@v6
+      steps:
+        - name: Clone
+          id: checkout
+          uses: actions/checkout@v6
 
-       - name: ccache
-         uses: ggml-org/ccache-action@v1.2.16
-         with:
-           key: ggml-ci-arm64-cpu-kleidiai
-           evict-old-files: 1d
-           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        - name: ccache
+          uses: ggml-org/ccache-action@v1.2.16
+          with:
+            key: ggml-ci-arm64-cpu-kleidiai
+            evict-old-files: 1d
+            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
-       - name: Dependencies
-         id: depends
-         run: |
-           sudo apt-get update
-           sudo apt-get install -y build-essential
+        - name: Dependencies
+          id: depends
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y build-essential
 
-       - name: Test
-         id: ggml-ci
-         run: |
-           GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+        - name: Test
+          id: ggml-ci
+          run: |
+            LLAMA_ARG_REPACK=1 GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ubuntu-cpu-cmake-riscv64-native:
     runs-on: RISCV64
@@ -2088,49 +2088,50 @@ jobs:
           ctest -L main --verbose
 
   ggml-ci-arm64-graviton4-kleidiai:
-     runs-on: ah-ubuntu_22_04-c8g_8x
+      runs-on: ah-ubuntu_22_04-c8g_8x
 
-     steps:
-       - name: Clone
-         id: checkout
-         uses: actions/checkout@v6
+      steps:
+        - name: Clone
+          id: checkout
+          uses: actions/checkout@v6
 
-       - name: Dependencies
-         id: depends
-         run: |
-           set -euxo pipefail
-           sudo apt-get update
-           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
-           apt-get install -y \
-            build-essential \
-            python3-venv \
-            gpg \
-            wget \
-            time \
-            git-lfs
+        - name: Dependencies
+          id: depends
+          run: |
+            set -euxo pipefail
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+            apt-get install -y \
+             build-essential \
+             python3-venv \
+             gpg \
+             wget \
+             time \
+             git-lfs
 
-           git lfs install
+            git lfs install
 
-           # install the latest cmake
-           sudo install -d /usr/share/keyrings
-           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
-            | sudo tee /etc/apt/sources.list.d/kitware.list
-           sudo apt-get update
-           sudo apt-get install -y cmake
+            # install the latest cmake
+            sudo install -d /usr/share/keyrings
+            wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+             | gpg --dearmor \
+             | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+            echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+             | sudo tee /etc/apt/sources.list.d/kitware.list
+            sudo apt-get update
+            sudo apt-get install -y cmake
 
-       - name: ccache
-         uses: ggml-org/ccache-action@v1.2.16
-         with:
-           key: ggml-ci-arm64-graviton4-kleidiai
-           evict-old-files: 1d
-           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        - name: ccache
+          uses: ggml-org/ccache-action@v1.2.16
+          with:
+            key: ggml-ci-arm64-graviton4-kleidiai
+            evict-old-files: 1d
+            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
-       - name: Test
-         id: ggml-ci
-         run: |
-           GG_BUILD_KLEIDIAI=1 \
-           GG_BUILD_EXTRA_TESTS_0=1 \
-           bash ./ci/run.sh ./tmp/results ./tmp/mnt
+        - name: Test
+          id: ggml-ci
+          run: |
+            LLAMA_ARG_REPACK=1 \
+            GG_BUILD_KLEIDIAI=1 \
+            GG_BUILD_EXTRA_TESTS_0=1 \
+            bash ./ci/run.sh ./tmp/results ./tmp/mnt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1727,30 +1727,30 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   ggml-ci-arm64-cpu-kleidiai:
-      runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-22.04-arm
 
-      steps:
-        - name: Clone
-          id: checkout
-          uses: actions/checkout@v6
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
 
-        - name: ccache
-          uses: ggml-org/ccache-action@v1.2.16
-          with:
-            key: ggml-ci-arm64-cpu-kleidiai
-            evict-old-files: 1d
-            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.16
+        with:
+          key: ggml-ci-arm64-cpu-kleidiai
+          evict-old-files: 1d
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
-        - name: Dependencies
-          id: depends
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y build-essential
+      - name: Dependencies
+        id: depends
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
 
-        - name: Test
-          id: ggml-ci
-          run: |
-            LLAMA_ARG_REPACK=1 GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+      - name: Test
+        id: ggml-ci
+        run: |
+          LLAMA_ARG_REPACK=1 GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ubuntu-cpu-cmake-riscv64-native:
     runs-on: RISCV64
@@ -2088,50 +2088,50 @@ jobs:
           ctest -L main --verbose
 
   ggml-ci-arm64-graviton4-kleidiai:
-      runs-on: ah-ubuntu_22_04-c8g_8x
+    runs-on: ah-ubuntu_22_04-c8g_8x
 
-      steps:
-        - name: Clone
-          id: checkout
-          uses: actions/checkout@v6
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
 
-        - name: Dependencies
-          id: depends
-          run: |
-            set -euxo pipefail
-            sudo apt-get update
-            sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
-            apt-get install -y \
-             build-essential \
-             python3-venv \
-             gpg \
-             wget \
-             time \
-             git-lfs
+      - name: Dependencies
+        id: depends
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
+          apt-get install -y \
+           build-essential \
+           python3-venv \
+           gpg \
+           wget \
+           time \
+           git-lfs
 
-            git lfs install
+          git lfs install
 
-            # install the latest cmake
-            sudo install -d /usr/share/keyrings
-            wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
-             | gpg --dearmor \
-             | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-            echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
-             | sudo tee /etc/apt/sources.list.d/kitware.list
-            sudo apt-get update
-            sudo apt-get install -y cmake
+          # install the latest cmake
+          sudo install -d /usr/share/keyrings
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+           | gpg --dearmor \
+           | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+           | sudo tee /etc/apt/sources.list.d/kitware.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
 
-        - name: ccache
-          uses: ggml-org/ccache-action@v1.2.16
-          with:
-            key: ggml-ci-arm64-graviton4-kleidiai
-            evict-old-files: 1d
-            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.16
+        with:
+          key: ggml-ci-arm64-graviton4-kleidiai
+          evict-old-files: 1d
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
-        - name: Test
-          id: ggml-ci
-          run: |
-            LLAMA_ARG_REPACK=1 \
-            GG_BUILD_KLEIDIAI=1 \
+      - name: Test
+        id: ggml-ci
+        run: |
+          LLAMA_ARG_REPACK=1 \
+          GG_BUILD_KLEIDIAI=1 \
             GG_BUILD_EXTRA_TESTS_0=1 \
             bash ./ci/run.sh ./tmp/results ./tmp/mnt

--- a/common/common.h
+++ b/common/common.h
@@ -484,7 +484,7 @@ struct common_params {
     bool warmup            = true;  // warmup run
     bool check_tensors     = false; // validate tensor data
     bool no_op_offload     = false; // globally disable offload host tensor operations to device
-    bool no_extra_bufts    = false; // disable extra buffer types (used for weight repacking)
+    bool no_extra_bufts    = true;  // disable extra buffer types (used for weight repacking)
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
 
     bool single_turn       = false; // single turn chat conversation

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -8850,7 +8850,7 @@ llama_model_params llama_model_default_params() {
         /*.use_direct_io               =*/ false,
         /*.use_mlock                   =*/ false,
         /*.check_tensors               =*/ false,
-        /*.use_extra_bufts             =*/ true,
+        /*.use_extra_bufts             =*/ false,
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
     };

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1003,6 +1003,10 @@ static struct llama_model * llama_model_load_from_file_impl(
                 props.memory_free/1024/1024);
     }
 
+    if (model->devices.empty() && !params.use_extra_bufts) {
+        LLAMA_LOG_WARN("%s: no non-CPU devices found, consider enabling use_extra_bufts for better performance\n", __func__);
+    }
+
     const int status = llama_model_load(path_model, splits, *model, params);
     GGML_ASSERT(status <= 0);
     if (status < 0) {


### PR DESCRIPTION
This PR disable repack by default. The reason to do this is because repack slows stuff down when doing hybrid inference. Users are expected to supply `--repack` argument when doing pure-CPU inference for speedups.
