### PR TITLE
fix dots.ocr: correct RoPE sections and FFN tensor mapping

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -10095,7 +10095,6 @@ class DotsOCRVisionModel(MmprojModel):
         del bid  # unused
 
         if name.startswith("vision_tower."):
-            print(name)
             return [(self.map_tensor_name(name), data_torch)]
 
         return [] # skip other tensors

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -280,6 +280,8 @@ class Keys:
 
     class ClipVision:
         IMAGE_SIZE          = "clip.vision.image_size"
+        IMAGE_MIN_PIXELS    = "clip.vision.image_min_pixels"
+        IMAGE_MAX_PIXELS    = "clip.vision.image_max_pixels"
         PREPROC_IMAGE_SIZE  = "clip.vision.preproc_image_size"
         PATCH_SIZE          = "clip.vision.patch_size"
         EMBEDDING_LENGTH    = "clip.vision.embedding_length"
@@ -3304,6 +3306,7 @@ class VisionProjectorType:
     LIGHTONOCR = "lightonocr"
     COGVLM = "cogvlm"
     JANUS_PRO = "janus_pro"
+    DOTSOCR = "dots_ocr"
 
 
 # Items here are (block size, type size)

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -1118,6 +1118,12 @@ class GGUFWriter:
     def add_vision_is_deepstack_layers(self, layers: Sequence[bool]) -> None:
         self.add_array(Keys.ClipVision.IS_DEEPSTACK_LAYERS, layers)
 
+    def add_vision_image_max_pixels(self, value: int) -> None:
+        self.add_uint32(Keys.ClipVision.IMAGE_MAX_PIXELS, value)
+
+    def add_vision_image_min_pixels(self, value: int) -> None:
+        self.add_uint32(Keys.ClipVision.IMAGE_MIN_PIXELS, value)
+
     # audio models
 
     def add_audio_projection_dim(self, value: int) -> None:

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -1351,14 +1351,14 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc1", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc0", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc1", # cogvlm
-            "vision_tower.blocks.{bid}.mlp.fc3", # dots.ocr
+            "vision_tower.blocks.{bid}.mlp.fc2", # dots.ocr (up_proj)
         ),
 
         MODEL_TENSOR.V_ENC_FFN_GATE: (
             "vision_tower.transformer.layers.{bid}.feed_forward.gate_proj", # pixtral-hf
             "vision_encoder.transformer.layers.{bid}.feed_forward.w1", # pixtral
             "visual.blocks.{bid}.mlp.gate_proj", # qwen2.5vl
-            "vision_tower.blocks.{bid}.mlp.fc1", # dots.ocr
+            "vision_tower.blocks.{bid}.mlp.fc1", # dots.ocr (gate_proj, SiLU)
         ),
 
         MODEL_TENSOR.V_ENC_FFN_DOWN: (
@@ -1374,7 +1374,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc2", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc1", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc2", # cogvlm
-            "vision_tower.blocks.{bid}.mlp.fc2", # dots.ocr
+            "vision_tower.blocks.{bid}.mlp.fc3", # dots.ocr (down_proj)
         ),
 
         MODEL_TENSOR.V_LAYER_SCALE_1: (

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -1351,7 +1351,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc1", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc0", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc1", # cogvlm
-            "vision_tower.blocks.{bid}.mlp.fc2", # dots.ocr
+            "vision_tower.blocks.{bid}.mlp.fc3", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_FFN_GATE: (
@@ -1374,7 +1374,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc2", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc1", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc2", # cogvlm
-            "vision_tower.blocks.{bid}.mlp.fc3", # dots.ocr
+            "vision_tower.blocks.{bid}.mlp.fc2", # dots.ocr
         ),
 
         MODEL_TENSOR.V_LAYER_SCALE_1: (

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -1189,6 +1189,7 @@ class TensorNameMap:
         MODEL_TENSOR.V_MMPROJ: (
             "multi_modal_projector.linear_{bid}",
             "visual.merger.mlp.{bid}", # qwen2vl
+            "vision_tower.merger.mlp.{bid}", # dots.ocr
         ),
 
         MODEL_TENSOR.V_MMPROJ_FC: (
@@ -1225,6 +1226,7 @@ class TensorNameMap:
             "visual.patch_embed.proj", # qwen2vl
             "vision_tower.patch_embed.proj", # kimi-vl
             "model.vision.patch_embedding.proj", # cogvlm
+            "vision_tower.patch_embed.patchifier.proj", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_EMBD_POS: (
@@ -1240,6 +1242,7 @@ class TensorNameMap:
 
         MODEL_TENSOR.V_ENC_ATTN_QKV: (
             "visual.blocks.{bid}.attn.qkv", # qwen3vl
+            "vision_tower.blocks.{bid}.attn.qkv", # dots.ocr
             "model.vision.transformer.layers.{bid}.attention.query_key_value", # cogvlm
         ),
 
@@ -1301,6 +1304,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.norm1", # qwen2vl
             "vision_tower.encoder.blocks.{bid}.norm0", # kimi-vl (norm0/norm1)
             "model.vision.transformer.layers.{bid}.input_layernorm", # cogvlm
+            "vision_tower.blocks.{bid}.norm1", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_ATTN_O: (
@@ -1316,6 +1320,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.attn.proj", # qwen2vl
             "vision_tower.encoder.blocks.{bid}.wo", # kimi-vl
             "model.vision.transformer.layers.{bid}.attention.dense", # cogvlm
+            "vision_tower.blocks.{bid}.attn.proj", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_POST_ATTN_NORM: (
@@ -1330,6 +1335,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.norm2", # qwen2vl
             "vision_tower.encoder.blocks.{bid}.norm1", # kimi-vl (norm0/norm1)
             "model.vision.transformer.layers.{bid}.post_attention_layernorm", # cogvlm
+            "vision_tower.blocks.{bid}.norm2", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_FFN_UP: (
@@ -1345,12 +1351,14 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc1", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc0", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc1", # cogvlm
+            "vision_tower.blocks.{bid}.mlp.fc2", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_FFN_GATE: (
             "vision_tower.transformer.layers.{bid}.feed_forward.gate_proj", # pixtral-hf
             "vision_encoder.transformer.layers.{bid}.feed_forward.w1", # pixtral
             "visual.blocks.{bid}.mlp.gate_proj", # qwen2.5vl
+            "vision_tower.blocks.{bid}.mlp.fc1", # dots.ocr
         ),
 
         MODEL_TENSOR.V_ENC_FFN_DOWN: (
@@ -1366,6 +1374,7 @@ class TensorNameMap:
             "visual.blocks.{bid}.mlp.linear_fc2", # qwen3vl
             "vision_tower.encoder.blocks.{bid}.mlp.fc1", # kimi-vl (fc0/fc1)
             "model.vision.transformer.layers.{bid}.mlp.fc2", # cogvlm
+            "vision_tower.blocks.{bid}.mlp.fc3", # dots.ocr
         ),
 
         MODEL_TENSOR.V_LAYER_SCALE_1: (
@@ -1383,6 +1392,7 @@ class TensorNameMap:
             "vision_tower.ln_pre", # pixtral-hf
             "vision_encoder.ln_pre", # pixtral
             "vision_model.layernorm_pre", # llama4
+            "vision_tower.patch_embed.patchifier.norm", # dots.ocr
         ),
 
         MODEL_TENSOR.V_POST_NORM: (
@@ -1391,6 +1401,7 @@ class TensorNameMap:
             "vision_model.layernorm_post", # llama4
             "visual.merger.ln_q", # qwen2vl
             "vision_tower.encoder.final_layernorm", # kimi-vl
+            "vision_tower.post_trunk_norm", # dots.ocr
         ),
 
         MODEL_TENSOR.V_MM_INP_PROJ: (
@@ -1403,6 +1414,7 @@ class TensorNameMap:
             "multi_modal_projector.pre_norm",
             "pre_mm_projector_norm",
             "model.vision.linear_proj.norm1", # cogvlm
+            "vision_tower.merger.ln_q", # dots.ocr
         ),
 
         MODEL_TENSOR.V_MM_SOFT_EMB_NORM: (

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -158,6 +158,7 @@ enum projector_type {
     PROJECTOR_TYPE_LIGHTONOCR,
     PROJECTOR_TYPE_COGVLM,
     PROJECTOR_TYPE_JANUS_PRO,
+    PROJECTOR_TYPE_DOTS_OCR,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -184,6 +185,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_LIGHTONOCR,"lightonocr"},
     { PROJECTOR_TYPE_COGVLM,    "cogvlm"},
     { PROJECTOR_TYPE_JANUS_PRO, "janus_pro"},
+    { PROJECTOR_TYPE_DOTS_OCR,  "dots_ocr"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -32,6 +32,8 @@
 // vision-specific
 #define KEY_VISION_PROJ_TYPE    "clip.vision.projector_type" // for models with mixed modalities
 #define KEY_IMAGE_SIZE          "clip.vision.image_size"
+#define KEY_IMAGE_MIN_PIXELS    "clip.vision.image_min_pixels"
+#define KEY_IMAGE_MAX_PIXELS    "clip.vision.image_max_pixels"
 #define KEY_PREPROC_IMAGE_SIZE  "clip.vision.preproc_image_size"
 #define KEY_PATCH_SIZE          "clip.vision.patch_size"
 #define KEY_IMAGE_MEAN          "clip.vision.image_mean"

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2663,6 +2663,11 @@ struct clip_model_loader {
 
             if (is_vision) {
                 get_u32(KEY_IMAGE_SIZE, hparams.image_size);
+                get_u32(KEY_IMAGE_MIN_PIXELS, hparams.image_min_pixels, false);
+                get_u32(KEY_IMAGE_MAX_PIXELS, hparams.image_max_pixels, false);
+                if (hparams.image_size == 0 && hparams.image_min_pixels == -1 && hparams.image_max_pixels == -1) {
+                    throw std::runtime_error("one of: image_size, image_min_pixels, and image_max_pixels must be defined\n");
+                }
                 get_u32(KEY_PATCH_SIZE, hparams.patch_size);
                 get_u32(KEY_IMAGE_CROP_RESOLUTION, hparams.image_crop_resolution, false);
                 get_i32(KEY_MINICPMV_VERSION, hparams.minicpmv_version, false); // legacy

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -304,6 +304,11 @@ struct mtmd_context {
             img_beg = "<|im_start|>";
             img_end = "<|im_end|>";
 
+        } else if (proj == PROJECTOR_TYPE_DOTS_OCR) {
+            // <|img|> ... (image embeddings) ... <|endofimg|>
+            img_beg = "<|img|>";
+            img_end = "<|endofimg|>";
+
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes two critical bugs in #17575 (dots.ocr support) that prevent inference from working.

### Bug 1: RoPE sections are wrong
`build_rope_2d` rotates **all** `d_head` dimensions (splitting into two halves of `d_head/2`, rotating each fully). But dots.ocr uses 2D RoPE with sections `[d_head/4, d_head/4, 0, 0]` — only the **first half** of head dimensions should be rotated (height and width), the rest are left unrotated.

**Fix:** Replace `build_rope_2d` with `ggml_rope_multi` using the correct `mrope_sections`, and change position input from separate `pos_h`/`pos_w` tensors to a single 4-component `positions` tensor `[h, w, 0, 0]`.

### Bug 2: FFN tensor mapping fc2/fc3 are swapped
In the dots.ocr SiLU-gated MLP:
- `fc1` = gate projection (SiLU activation) → `V_ENC_FFN_GATE` ✓
- `fc2` = up projection (hidden → intermediate) → should be `V_ENC_FFN_UP` ✗ currently mapped to `V_ENC_FFN_DOWN`
- `fc3` = down projection (intermediate → hidden) → should be `V_ENC_FFN_DOWN` ✗ currently mapped to `V_ENC_FFN_UP`

Since fc2 and fc3 have **different shapes** (`[intermediate, hidden]` vs `[hidden, intermediate]`), this swap causes dimension mismatches.

**Fix:** Swap the fc2/fc3 entries in `tensor_mapping.py`.

## Test plan
- [x] Verified with end-to-end conversion and inference using [rednote-hilab/dots.ocr](https://huggingface.co/rednote-hilab/dots.ocr)
- [ ] CI tests

## Reference
- [chatllm.cpp dots.cpp](https://github.com/foldl/chatllm.cpp/blob/master/models/dots.cpp) confirms fc1=gate, fc2=up, fc3=down mapping
- Converted GGUFs available at [anthonym21/dots.ocr-GGUF](https://huggingface.co/anthonym21/dots.ocr-GGUF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)