### PR TITLE
server: add missing #pragma once to server-context.h

### DIFF
--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "server-http.h"
 #include "server-task.h"
 #include "server-queue.h"


### PR DESCRIPTION
**Summary**
This PR adds a `#pragma once` guard to `server-context.h`.

**Reasoning**
The header currently lacks an include guard. While it may not cause issues in standard build configurations, it leads to `redefinition` errors in scenarios where the header is included multiple times within the same translation unit.

I encountered this specifically when attempting a **Unity Build** (combining multiple source files), which triggered the following errors:
- `error: redefinition of 'server_context'`
- `error: redefinition of 'server_routes'`

Adding `#pragma once` ensures the header is idempotent and improves the codebase's overall robustness against different inclusion patterns or build optimizations.
