### PR TITLE
gguf-py : bump version to 0.18.0

### DIFF
--- a/gguf-py/pyproject.toml
+++ b/gguf-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gguf"
-version = "0.17.1"
+version = "0.18.0"
 description = "Read and write ML models in GGUF for GGML"
 authors = ["GGML <ggml@ggml.ai>"]
 packages = [


### PR DESCRIPTION
This commit updates the gguf-py package version to 0.18.0 in preparation for a new release to PyPI.

Refs: https://github.com/ggml-org/llama.cpp/discussions/19948
