### PR TITLE
ci : use ubuntu-latest for gguf-publish workflow

### DIFF
--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
This commit changes the runner for the gguf-publish workflow from ubuntu-slim back to ubuntu-latest, which was updated in Commit 142cbe2ac68978e5dec3a2e19c1b64ef1c5740b1 ("ci : use new 1vCPU runner for lightweight jobs (#19107)").

The motivation for this is that the action used in the workflow depends on the docker daemon, which does not seem not available in the ubuntu-slim runner. This is currently causing an error in the workflow and preventing the gguf-publish workflow from running successfully. Today was the the first time since the original change (I think) that publish task has been run which may be why the issue was not noticed before.

Refs: https://github.com/ggml-org/llama.cpp/actions/runs/22481900566
