### PR TITLE
ggml-vulkan: limit the number of command buffers to transfer data to 4

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -13417,6 +13417,9 @@ static void ggml_backend_vk_set_tensor_async(ggml_backend_t backend, ggml_tensor
         deferred_memcpy(ctx->sync_staging->ptr, data, size, &compute_ctx->in_memcpys);
         ggml_vk_synchronize(ctx);
     }
+    if (compute_ctx->p->cmd_buffer_idx > 4) {
+        ggml_vk_command_pool_cleanup(ctx->device, *compute_ctx->p);
+    }
 }
 
 static void ggml_backend_vk_get_tensor_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {


### PR DESCRIPTION
This PR introduces a limit to the amount of command buffers to force reusing them instead of creating a new command buffer for each megabyte of data to transfer.

I stumbled upon this limitation while trying to launch GPT-OSS-120B MXFP4 via Vulkan backend, which failed during the model loading stage. 

Adding the proposed fix allows for a command buffer reuse instead of creating a new one for every transfer, which result in a lot of command buffers for larger models and might hit GPU hardware limitations. A number 4 is taken from the number of staging buffers for async uploads, but can be adjusted. No performance or accuracy implications were observed. 