### PR TITLE
cuda: fix ggml_cuda_cpy crash on partial GPU offload

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -412,7 +412,7 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
         } else
 #endif // GGML_USE_MUSA && GGML_MUSA_MUDNN_COPY
         {
-            CUDA_CHECK(cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream));
+            CUDA_CHECK(cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDefault, main_stream));
         }
     } else if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32) {
         if (can_be_transposed) {


### PR DESCRIPTION
The contiguous same-type fast path in `ggml_cuda_cpy` uses `cudaMemcpyDeviceToDevice`, which crashes when one or both pointers are host pointers.

This happens with partial GPU offload — when a model doesn't fully fit in VRAM, some KV cache tensors stay in host memory. On the second prompt the engine copies cached state back, hitting a tensor pair where at least one side is a host pointer. `cudaMemcpyDeviceToDevice` rejects that with `CUDA error: invalid argument`.

The fix swaps `cudaMemcpyDeviceToDevice` for `cudaMemcpyDefault`, which resolves pointer residency automatically. It's safe for the existing all-on-GPU path too — CUDA just does a page table lookup, negligible overhead.

**Crash log (before fix):**
```
offloading 38 repeating layers to GPU
offloading output layer to CPU

>>> Hello, how are you?
(success)

>>> Talk to me like you're The Dude from The Big Lebowski
CUDA error: invalid argument
  current device: 0, in function ggml_cuda_cpy at cpy.cu:438
  cudaMemcpyAsyncReserve(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream)
```

**After fix:** multi-turn works, no CUDA errors.

**Setup:** RTX 4090 24GB, qwen3.5:35b-a3b (39/41 layers on GPU), Ollama v0.17.4, CUDA 12.6, driver 572.83.

Same crash reported across RTX 4070, RTX 3060, dual 1080 Ti — any config that partially offloads.

Related: ollama/ollama#14444, ollama/ollama#14497, ollama/ollama#14501, ollama/ollama#14433

**Note:** I tried reproducing this with `llama-cli` directly (built from HEAD, same model, partial offload) and couldn't trigger it. The crash only happens through Ollama, so the root cause may be in how Ollama dispatches the CPY op rather than in llama.cpp itself. That said, `cudaMemcpyDefault` costs nothing and makes the op robust against mixed-residency pointers regardless of the caller.
