### PR TITLE
Add file existence and type checks for imatrix

### DIFF
--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -243,6 +243,16 @@ static int load_legacy_imatrix(const std::string & imatrix_file, std::vector<std
 
 static int load_imatrix(const std::string & imatrix_file, std::vector<std::string> & imatrix_datasets, std::unordered_map<std::string, std::vector<float>> & imatrix_data) {
 
+    // Check if the imatrix file exists and it is a regular file
+    if (!std::filesystem::exists(imatrix_file)) {
+        fprintf(stderr, "%s: imatrix file '%s' not found\n", __func__, imatrix_file.c_str());
+        exit(1);
+    }
+    if (!std::filesystem::is_regular_file(imatrix_file)) {
+        fprintf(stderr, "%s: imatrix path '%s' is not a regular file\n", __func__, imatrix_file.c_str());
+        exit(1);
+    }
+
     struct ggml_context * ctx = nullptr;
     struct gguf_init_params meta_gguf_params = {
         /* .no_alloc = */ false, // the data is needed


### PR DESCRIPTION
# Summary

If you try to quantize a model using an imatrix and the referenced imatrix file doesn't exit, then you get confusing error messages.

For example:

```
./build/bin/llama-quantize --imatrix ./MISSING_IMATRIX.gguf ./Qwen3-0.6B-f16.gguf ./Qwen3-0.6B-f16-imatrix:Q5_K_M.gguf Q5_K_M
gguf_init_from_file: failed to open GGUF file './MISSING_IMATRIX.gguf' (No such file or directory)
load_imatrix: imatrix file './MISSING_IMATRIX.gguf' is using old format
load_legacy_imatrix: failed to open ./MISSING_IMATRIX.gguf
```
Only the first error is relevant (no such file or directory), and the others are just misleading or wrong.

## The fix

I have added two checks:
- Does the file exist?
- is it a regular file?

If it fails on either, it exits using the same style as the other checks in this function. The error message will now say this:

```
./build/bin/llama-quantize --imatrix ./MISSING_IMATRIX.gguf ./Qwen3-0.6B-f16.gguf ./Qwen3-0.6B-f16-imatrix:Q5_K_M.gguf Q5_K_M
load_imatrix: imatrix file './MISSING_IMATRIX.gguf' not found
```

I couldn't see any related issues for this, so I'm hoping this can be included.
