### PR TITLE
Re-enable manual LoRA adapter free

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1067,7 +1067,7 @@ common_init_result::common_init_result(common_params & params) :
 
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
-    // load and optionally apply lora adapters (must be loaded before context creation)
+    // load and optionally apply lora adapters
     for (auto & la : params.lora_adapters) {
         llama_adapter_lora_ptr lora;
         lora.reset(llama_adapter_lora_init(model, la.path.c_str()));

--- a/include/llama-cpp.h
+++ b/include/llama-cpp.h
@@ -21,9 +21,7 @@ struct llama_sampler_deleter {
 };
 
 struct llama_adapter_lora_deleter {
-    void operator()(llama_adapter_lora *) {
-        // llama_adapter_lora_free is deprecated
-    }
+    void operator()(llama_adapter_lora * adapter) { llama_adapter_lora_free(adapter); }
 };
 
 typedef std::unique_ptr<llama_model, llama_model_deleter> llama_model_ptr;

--- a/include/llama.h
+++ b/include/llama.h
@@ -647,9 +647,8 @@ extern "C" {
     LLAMA_API int32_t llama_adapter_meta_val_str_by_index(const struct llama_adapter_lora * adapter, int32_t i, char * buf, size_t buf_size);
 
     // Manually free a LoRA adapter
-    // NOTE: loaded adapters will be free when the associated model is deleted
-    LLAMA_API DEPRECATED(void llama_adapter_lora_free(struct llama_adapter_lora * adapter),
-            "adapters are now freed together with the associated model");
+    // NOTE: loaded adapters that are not manually freed will be freed when the associated model is deleted
+    LLAMA_API void llama_adapter_lora_free(struct llama_adapter_lora * adapter);
 
     // Get the invocation tokens if the current lora is an alora
     LLAMA_API uint64_t            llama_adapter_get_alora_n_invocation_tokens(const struct llama_adapter_lora * adapter);

--- a/include/llama.h
+++ b/include/llama.h
@@ -623,7 +623,6 @@ extern "C" {
 
     // Load a LoRA adapter from file
     // The adapter is valid as long as the associated model is not freed
-    // All adapters must be loaded before context creation
     LLAMA_API struct llama_adapter_lora * llama_adapter_lora_init(
             struct llama_model * model,
             const char * path_lora);

--- a/src/llama-adapter.cpp
+++ b/src/llama-adapter.cpp
@@ -418,7 +418,7 @@ static void llama_adapter_lora_init_impl(llama_model & model, const char * path_
 }
 
 llama_adapter_lora * llama_adapter_lora_init(llama_model * model, const char * path_lora) {
-    llama_adapter_lora * adapter = new llama_adapter_lora();
+    llama_adapter_lora * adapter = new llama_adapter_lora(model);
 
     try {
         llama_adapter_lora_init_impl(*model, path_lora, *adapter);
@@ -471,8 +471,17 @@ int32_t llama_adapter_meta_val_str_by_index(const llama_adapter_lora * adapter, 
     return snprintf(buf, buf_size, "%s", it->second.c_str());
 }
 
-void llama_adapter_lora_free(llama_adapter_lora *) {
-    // deprecated: adapters are freed by llama_model's destructor
+void llama_adapter_lora_free(llama_adapter_lora * adapter) {
+    if (adapter == nullptr) {
+        return;
+    }
+
+    if (adapter->model != nullptr) {
+        adapter->model->loras.erase(adapter);
+        adapter->model = nullptr;
+    }
+
+    delete adapter;
 }
 
 uint64_t llama_adapter_get_alora_n_invocation_tokens(const struct llama_adapter_lora * adapter) {

--- a/src/llama-adapter.h
+++ b/src/llama-adapter.h
@@ -61,6 +61,8 @@ struct llama_adapter_lora_weight {
 };
 
 struct llama_adapter_lora {
+    llama_model * model = nullptr;
+
     // map tensor name to lora_a_b
     std::unordered_map<std::string, llama_adapter_lora_weight> ab_map;
 
@@ -75,7 +77,7 @@ struct llama_adapter_lora {
     // activated lora (aLoRA)
     std::vector<llama_token> alora_invocation_tokens;
 
-    llama_adapter_lora() = default;
+    explicit llama_adapter_lora(llama_model * model) : model(model) {}
     ~llama_adapter_lora() = default;
 
     llama_adapter_lora_weight * get_weight(ggml_tensor * w);


### PR DESCRIPTION
This PR proposes re-enabling manual LoRA adapter free (the `llama_adapter_lora_free` function), that had been previously deprecated as part of #18490.

# Motivation
After reading the discussion on why `llama_adapter_lora_free` was deprecated and made a no-op, my understanding is that it was considered that this had no real use case, however I am currently working on a project where having the ability to unload adapters is very important due to memory constraints (mobile devices).

Without `llama_adapter_lora_free`, we have to fully unload and re-load the model, as well as lose any contexts (and their cached tokens) associated with it, just to free the memory associated with those LoRAs. I am not aware of any other way to achieve this.

# Summary of changes
The `llama_adapter_lora_free` function has been re-enabled and un-deprecated; calling `llama_adapter_lora_free` stays optional as the LoRA will still be freed if necessary when its parent model is released. Documentation comments have been updated to reflect this new behavior.

Concretely we make sure to remove the freed LoRA from the ownership list of its owning model to prevent double frees.

# Other related issues
Issue #19153 would benefit from this change as well, since I don't think the requested feature would be implementable without `llama_adapter_lora_free`.