### PR TITLE
common : fix common_chat_peg_parse for incomplete utf-8 sequence tail

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -3141,6 +3141,12 @@ static void test_template_output_peg_parsers() {
             t.expect.reasoning_content = "I need to output the invoice details in JSON";
             t.expect.content =R"({"amount": 123.45, "date": "2025-12-03"})";
         });
+
+        // Test invalid UTF-8
+        test_peg_parser(tmpls.get(), [&](auto & t) {
+            t.input = "Hello \xE2\x9Cworld\xE2\x9C";
+            t.expect.content = "Hello world";
+        });
     }
 
     {


### PR DESCRIPTION
Sometimes I experience an issue with `mistralai/Ministral-3-3B-Instruct-2512-GGUF:Q8_0` when it hits maximum generated tokens and leaves an incomplete UTF-8 sequence in the end of message (e.g. token IDs 1226 and 1156). This message then causes `common_chat_peg_parse` to fail with `Failed to parse input at pos 0` error.

Claude Sonnet 4.6 was used to analyze the problem and to generate the code. Everything was manually reviewed and tested.
