### PR TITLE
gguf: add big-endian magic "FUGG" for explicit endianness detection

### DIFF
--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -38,7 +38,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define GGUF_MAGIC   "GGUF"
+#define GGUF_MAGIC    "GGUF"
+#define GGUF_MAGIC_BE "FUGG"
 #define GGUF_VERSION 3
 
 #define GGUF_KEY_GENERAL_ALIGNMENT "general.alignment"

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -7,7 +7,8 @@ from typing import Any
 # constants
 #
 
-GGUF_MAGIC             = 0x46554747  # "GGUF"
+GGUF_MAGIC             = 0x46554747  # "GGUF" (little-endian)
+GGUF_MAGIC_BE          = 0x47475546  # "FUGG" (big-endian)
 GGUF_VERSION           = 3
 GGUF_DEFAULT_ALIGNMENT = 32
 GGML_QUANT_VERSION     = 2  # GGML_QNT_VERSION from ggml.h

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -154,9 +154,8 @@ class GGUFReader:
             # This handles old big-endian files created before FUGG magic support.
             self.byte_order = 'S'
             temp_version = temp_version.view(temp_version.dtype.newbyteorder(self.byte_order))
-        elif self.byte_order == 'S':
-            # Already detected as swapped via FUGG magic - fix version byte order
-            temp_version = temp_version.view(temp_version.dtype.newbyteorder(self.byte_order))
+        # Note: when byte_order is already 'S' (from FUGG magic detection above),
+        # _get() already returns the correctly swapped value - no extra view needed.
         version = temp_version[0]
         if version not in READER_SUPPORTED_VERSIONS:
             raise ValueError(f'Sorry, file appears to be version {version} which we cannot handle')

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -19,6 +19,7 @@ import numpy as np
 from .constants import (
     GGUF_DEFAULT_ALIGNMENT,
     GGUF_MAGIC,
+    GGUF_MAGIC_BE,
     GGUF_VERSION,
     GGMLQuantizationType,
     GGUFEndian,
@@ -224,7 +225,8 @@ class GGUFWriter:
         self.add_shard_kv_data()
 
         for fout, tensors, kv_data in zip(self.fout, self.tensors, self.kv_data):
-            fout.write(self._pack("<I", GGUF_MAGIC, skip_pack_prefix = True))
+            magic = GGUF_MAGIC_BE if self.endianess == GGUFEndian.BIG else GGUF_MAGIC
+            fout.write(self._pack("<I", magic, skip_pack_prefix = True))
             fout.write(self._pack("I", GGUF_VERSION))
             fout.write(self._pack("Q", len(tensors)))
             fout.write(self._pack("Q", len(kv_data)))

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -173,7 +173,8 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
     uint32_t alignment = GGUF_DEFAULT_ALIGNMENT;
 
     if (hft == HANDCRAFTED_HEADER_BAD_MAGIC) {
-        const char bad_magic[4] = {'F', 'U', 'G', 'G'};
+        // Use truly invalid magic (not "FUGG" which is now valid big-endian magic)
+        const char bad_magic[4] = {'X', 'X', 'X', 'X'};
         helper_write(file, bad_magic, sizeof(bad_magic));
     } else {
         helper_write(file, GGUF_MAGIC, 4);


### PR DESCRIPTION
## Summary

Resolves #3957 — GGUF files currently use the same magic (`GGUF`) regardless of byte order, making endianness detection impossible from the header alone.

This PR adds `FUGG` (byte-reversed `GGUF`) as the magic number for big-endian GGUF files, providing explicit endianness detection.

## Changes

### C++ (`ggml/include/gguf.h`, `ggml/src/gguf.cpp`)
- Add `GGUF_MAGIC_BE "FUGG"` constant
- **Reader**: accepts both `GGUF` (LE) and `FUGG` (BE) magic
  - `FUGG` on LE host → clear error with conversion command
  - `FUGG` on BE host → proceeds normally (native endian)
  - Legacy version-field heuristic preserved as fallback for old BE files
- **Writer**: emits correct magic based on host endianness
- Improved error messages with actionable conversion commands

### Python (`gguf-py/gguf/`)
- `constants.py`: Add `GGUF_MAGIC_BE = 0x47475546`
- `gguf_reader.py`: Detect endianness from magic (primary) with version-field fallback (legacy)
- `gguf_writer.py`: Write `FUGG` magic when target endianness is big-endian
- `scripts/gguf_convert_endian.py`: Update magic bytes during LE↔BE conversion

### Tests (`tests/test-gguf.cpp`)
- Bad magic test updated from `FUGG` → `XXXX` (since `FUGG` is now valid)

## Design Decisions

1. **Semantics**: `GGUF` = little-endian file, `FUGG` = big-endian file (always, regardless of host)
2. **Backward compatible**: Old BE files with `GGUF` magic still detected via version-field heuristic
3. **C++ reader doesn't byte-swap** (too large a change) — gives clear error pointing to `gguf_convert_endian.py`
4. **Python reader handles both** natively (already had cross-endian support)

## Test Results

Tested on real big-endian hardware: **Power Mac G5** (Darwin 9.8.0, PowerPC ppc64, big-endian) and **x86_64** (Ubuntu, little-endian).

### C standalone test (5 cases)

| Test | G5 (BE) | x86_64 (LE) |
|------|---------|-------------|
| Native-endian write/read | PASS | PASS |
| Cross-endian detection | PASS | PASS |
| Legacy BE file (GGUF magic + BE data) | PASS | PASS |
| Invalid magic rejection | PASS | PASS |
| Magic byte layout verification | PASS | PASS |

Key result: G5 natively writes `FUGG` magic (`46 55 47 47`), x86_64 writes `GGUF` (`47 47 55 46`).

### Cross-platform file transfer

Copied G5-generated big-endian GGUF file to x86_64 host. Hex dump confirms FUGG magic:
```
00000000: 4655 4747 0000 0003 0000 0000 0000 0000  FUGG............
00000010: 0000 0000 0000 0000                      ........
```

### Python gguf_reader (4 cases, on x86_64 LE host)

| Test | Result | Details |
|------|--------|---------|
| LE file (GGUF magic) | PASS | byte_order='I', version=3 |
| BE file (FUGG magic, from G5) | PASS | byte_order='S', version=3 |
| Legacy BE file (GGUF magic + BE data) | PASS | byte_order='S', version=3 (detected via version-field heuristic) |
| Invalid magic | PASS | Correctly raises ValueError |

### Bug found and fixed during testing

The initial implementation had a double byte-swap bug in `gguf_reader.py`: when FUGG magic set `byte_order='S', `_get()` already applied the swap via `newbyteorder()`. An `elif` branch was re-swapping, un-doing the correction (version 3 read as 50,331,648). Fixed in second commit.

## Test Hardware

- **Power Mac G5** (192.168.0.179): Darwin 9.8.0, PowerPC ppc64, big-endian, GCC 10.5.0
- **x86_64 workstation**: Ubuntu, little-endian, Python 3.x with numpy

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>