### PR TITLE
json-schema: handle typeless schema nodes as any-value

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -963,6 +963,11 @@ public:
             return _add_rule(rule_name, out.str());
         } else if (schema.empty() || schema_type == "object") {
             return _add_rule(rule_name, _add_primitive("object", PRIMITIVE_RULES.at("object")));
+        } else if (schema_type.is_null()) {
+            // Schema has no type keyword and no type-constraining keywords (properties, items,
+            // allOf, oneOf, anyOf, $ref, const, enum, pattern) matched above.
+            // Per JSON Schema, this accepts any JSON value.
+            return _add_rule(rule_name, _add_primitive("value", PRIMITIVE_RULES.at("value")));
         } else {
             if (!schema_type.is_string() || PRIMITIVE_RULES.find(schema_type.get<std::string>()) == PRIMITIVE_RULES.end()) {
                 _errors.push_back("Unrecognized schema: " + schema.dump());

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -350,6 +350,28 @@ static void test_all(const std::string & lang, std::function<void(const TestCase
 
     test({
         SUCCESS,
+        "typeless schema with description only (any value)",
+        R"""({
+            "description": "Value for add/replace/test operations"
+        })""",
+        R"""(
+            array ::= "[" space ( value ("," space value)* )? "]" space
+            boolean ::= ("true" | "false") space
+            char ::= [^"\\\x7F\x00-\x1F] | [\\] (["\\bfnrt] | "u" [0-9a-fA-F]{4})
+            decimal-part ::= [0-9]{1,16}
+            integral-part ::= [0] | [1-9] [0-9]{0,15}
+            null ::= "null" space
+            number ::= ("-"? integral-part) ("." decimal-part)? ([eE] [-+]? integral-part)? space
+            object ::= "{" space ( string ":" space value ("," space string ":" space value)* )? "}" space
+            root ::= value
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+            string ::= "\"" char* "\"" space
+            value ::= object | array | string | number | boolean | null
+        )"""
+    });
+
+    test({
+        SUCCESS,
         "exotic formats",
         R"""({
             "items": [


### PR DESCRIPTION
## Summary

Fix `Unrecognized schema` error when JSON schemas contain properties with no `type` keyword. This is valid JSON Schema (drafts 4 through 2020-12) and commonly produced by schema generators.

## Problem

`llama-server` returns HTTP 400 when a tool's JSON Schema contains a property that has metadata (like `description`) but no `type` field:

```json
"value": {
  "description": "Value for add/replace/test operations"
}
```

Error:
```
JSON schema conversion failed:
Unrecognized schema: {"description":"Value for add/replace/test operations"}
```

This pattern is commonly produced by:
- **Rust `schemars`** for `serde_json::Value` fields
- **Python `pydantic`** for `Any` typed fields
- Any schema generator for unconstrained/dynamic value types

## Root Cause

The `visit()` method in `json-schema-to-grammar.cpp` has a long `if/else if` chain checking for type-constraining keywords (`$ref`, `oneOf`, `anyOf`, `allOf`, `const`, `enum`, `properties`, `items`, `pattern`, etc.). When a schema has none of these keywords AND no `type` field, it falls through to the final `else` branch which expects a known type string — and errors because `schema_type` is null.

## Fix

Add a fallback branch before the final `else` that catches schemas with null `schema_type` (no type keyword). Per JSON Schema specification, a schema with no type-constraining keywords accepts **any JSON value**, so it maps to the existing `value` rule — the union of all JSON types:

```
value ::= object | array | string | number | boolean | null
```

This is a 5-line change to the converter + a test case.

## Test

Added test case `"typeless schema with description only (any value)"` that verifies `{"description": "..."}` generates a grammar with `root ::= value`.

Fixes #19716

🤖 Generated with [Claude Code](https://claude.com/claude-code)