### PR TITLE
common: force C locale for numeric formatting

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <chrono>
 #include <cstdarg>
+#include <clocale>
 #include <cstring>
 #include <ctime>
 #include <filesystem>
@@ -360,6 +361,10 @@ bool parse_cpu_mask(const std::string & mask, bool (&boolmask)[GGML_MAX_N_THREAD
 
 void common_init() {
     llama_log_set(common_log_default_callback, NULL);
+
+    // Force C locale for numeric formatting to ensure consistent decimal points
+    // across all tools regardless of user locale settings (e.g. de_DE uses comma).
+    std::setlocale(LC_NUMERIC, "C");
 
 #ifdef NDEBUG
     const char * build_type = "";

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <cwctype>
 #include <cstdint>
+#include <clocale>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -143,6 +144,10 @@ namespace console {
         }
 
         setlocale(LC_ALL, "");
+        // Override LC_NUMERIC to ensure decimal points (not commas) in output.
+        // Without this, locales like de_DE format 10000.0 as "10000,0" which
+        // breaks machine-readable output and causes inconsistency across tools.
+        setlocale(LC_NUMERIC, "C");
 #endif
     }
 


### PR DESCRIPTION
## Summary

Ensure consistent decimal point formatting across all llama.cpp tools by forcing `LC_NUMERIC` to `"C"` locale.

## Problem

On systems with non-English `LC_NUMERIC` locale (e.g. `de_DE.UTF-8`), different llama.cpp tools produce inconsistent decimal formatting:

| Tool | Output | Reason |
|------|--------|--------|
| `llama-cli` | `10000,0` (comma) | `console::init()` calls `setlocale(LC_ALL, "")` |
| `llama-perplexity` | `10000.0` (period) | Default C locale unchanged |

This affects all floating-point output including sampler parameters, performance stats, and model metadata — not just GGUF KV data.

## Fix

Two-pronged approach:

1. **`common_init()`** in `common.cpp`: Set `LC_NUMERIC` to `"C"` early — catches all tools on startup
2. **`console::init()`** in `console.cpp`: Override `LC_NUMERIC` back to `"C"` after `setlocale(LC_ALL, "")` — prevents the user locale call from re-overriding the numeric locale

This keeps the user's locale for character handling (UTF-8, wide chars) while forcing consistent period-as-decimal-separator for all numeric output.

## Testing

To verify on a system with German locale:
```bash
export LC_NUMERIC=de_DE.UTF-8
./llama-cli -m model.gguf -p "test" -n 1 2>&1 | grep -E '[0-9][,\.][0-9]'
# Before: 10000,0 (comma)
# After:  10000.0 (period)
```

Fixes #10613

🤖 Generated with [Claude Code](https://claude.com/claude-code)