### PR TITLE
cmake: fix ARM feature detection hang on platforms without SVE/SME

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -148,12 +148,28 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                     message(STATUS "ARM detected flags: ${ARM_NATIVE_FLAG}")
                 endif()
 
+                include(CheckCXXSourceCompiles)
                 include(CheckCXXSourceRuns)
 
                 macro(check_arm_feature tag feature code)
                     set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
-                    set(CMAKE_REQUIRED_FLAGS "${ARM_NATIVE_FLAG}+${tag}")
-                    check_cxx_source_runs("${code}" GGML_MACHINE_SUPPORTS_${tag})
+                    # check if the feature is available natively before running the
+                    # test binary — avoids hangs when the runtime test traps (e.g. SVE on macOS)
+                    set(CMAKE_REQUIRED_FLAGS "${ARM_NATIVE_FLAG}")
+                    check_cxx_source_compiles(
+                        "
+                        #if !defined(__ARM_FEATURE_${feature})
+                        #  error \"${feature} not supported\"
+                        #endif
+                        int main() { return 0; }
+                        "
+                        GGML_COMPILER_SUPPORTS_${tag}
+                    )
+                    if (GGML_COMPILER_SUPPORTS_${tag})
+                        # feature is supported, override CMAKE_REQUIRED_FLAGS to include +tag
+                        set(CMAKE_REQUIRED_FLAGS "${ARM_NATIVE_FLAG}+${tag}")
+                        check_cxx_source_runs("${code}" GGML_MACHINE_SUPPORTS_${tag})
+                    endif()
                     if (GGML_MACHINE_SUPPORTS_${tag})
                         set(ARM_NATIVE_FLAG_FIX "${ARM_NATIVE_FLAG_FIX}+${tag}")
                     else()


### PR DESCRIPTION
Add a compile-time pre-check before the runtime feature test in check_arm_feature. Before running a test binary with -mcpu=native+<tag>, first check if -mcpu=native (without the forced +tag) defines the compiler's __ARM_FEATURE_* macro.

If the compiler doesn't think the native CPU has the feature, skip the runtime test entirely. This prevents hangs on platforms where the compiler can compile the feature code (via forced +tag) but the binary traps at an OS level without delivering SIGILL to userspace — as happens on macOS/Apple Silicon with SVE instructions.

When the compiler does report native support, the runtime test still runs as before to verify actual hardware capability.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
