### PR TITLE
fix: correct EXAONE3 FFN_DOWN tensor mapping prefix

### DIFF
--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -574,7 +574,7 @@ class TensorNameMap:
         # Feed-forward down
         MODEL_TENSOR.FFN_DOWN: (
             "gpt_neox.layers.{bid}.mlp.dense_4h_to_h",                # gptneox
-            "transformer.h.{bid}.mlp.c_proj",                         # gpt2 refact qwen jais
+            "transformer.h.{bid}.mlp.c_proj",                         # gpt2 refact qwen jais exaone
             "transformer.blocks.{bid}.ffn.down_proj",                 # mpt
             "transformer.h.{bid}.mlp.dense_4h_to_h",                  # falcon
             "h.{bid}.mlp.dense_4h_to_h",                              # bloom
@@ -599,7 +599,6 @@ class TensorNameMap:
             "model.layers.{bid}.residual_mlp.w2",                     # arctic
             "encoder.layer.{bid}.mlp.down_layer",                     # jina-bert-v2
             "encoder.layers.{bid}.mlp.dense_4h_to_h",                 # chatglm
-            "model.layers.h.{bid}.mlp.c_proj",                        # exaone
             "model.layers.{bid}.feed_forward.down_proj",              # llama4 jamba granite-hybrid
             "transformer_encoder.{bid}.ffn.w3",                       # neobert
             "model.layers.{bid}.block_sparse_moe.down",               # smallthinker


### PR DESCRIPTION
## Summary
- The EXAONE3 FFN_DOWN tensor mapping used incorrect prefix `model.layers.h.{bid}.mlp.c_proj` (note the extra `.h` after `layers`)
- EXAONE3 actually uses `transformer.h.{bid}.mlp.c_proj` — a correct mapping already existed but without the "exaone" comment tag
- The wrong mapping was dead code (never reached at runtime) because the correct path matched first

## Changes
- Remove dead mapping entry with wrong prefix `model.layers.h.{bid}.mlp.c_proj` (line 602)
- Add "exaone" tag to the existing correct mapping `transformer.h.{bid}.mlp.c_proj` (line 577)