### PR TITLE
CUDA: Add BF16 path to CUBLAS and increase precision of FP16 path

### DIFF
--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -81,6 +81,52 @@ static __global__ void dequantize_block_q8_0_f16(const void * __restrict__ vx, h
 #endif // __CUDA_ARCH__ >= GGML_CUDA_CC_PASCAL
 }
 
+template <bool need_check>
+static __global__ void dequantize_block_q8_0_bf16(const void * __restrict__ vx,
+                                                  nv_bfloat16 * __restrict__ y,
+                                                  const int64_t k) {
+#if __CUDA_ARCH__ >= GGML_CUDA_CC_AMPERE
+    constexpr int nint = CUDA_Q8_0_NE_ALIGN / sizeof(int) + WARP_SIZE;
+
+    const int64_t    i0 = CUDA_Q8_0_NE_ALIGN * blockIdx.x;
+    const int *      x0 = ((int *) vx) + blockIdx.x * nint;
+    __nv_bfloat162 * y2 = (__nv_bfloat162 *) (y + i0);
+
+    __shared__ int vals[nint];
+
+#    pragma unroll
+    for (int ix0 = 0; ix0 < nint; ix0 += WARP_SIZE) {
+        if (need_check &&
+            i0 * sizeof(block_q8_0) / QK8_0 + sizeof(int) * (ix0 + threadIdx.x) >= k * sizeof(block_q8_0) / QK8_0) {
+            break;
+        }
+
+        const int ix = ix0 + threadIdx.x;
+        vals[ix]     = x0[ix];
+    }
+
+    __syncthreads();
+
+#    pragma unroll
+    for (int iy = 0; iy < CUDA_Q8_0_NE_ALIGN; iy += 2 * WARP_SIZE) {
+        if (need_check && i0 + iy + 2 * threadIdx.x >= k) {
+            return;
+        }
+
+        const half * b0 =
+            ((const half *) vals) + (sizeof(block_q8_0) / sizeof(half)) * ((iy + 2 * threadIdx.x) / QK8_0);
+        const half        d     = *b0;
+        const nv_bfloat16 d_b16 = nv_bfloat16(d);
+        const char2       qs    = ((const char2 *) (b0 + 1))[threadIdx.x % (QK8_0 / 2)];
+
+        y2[iy / 2 + threadIdx.x] = __hmul2(make_bfloat162(qs.x, qs.y), __bfloat162bfloat162(d_b16));
+    }
+#else
+    GGML_UNUSED_VARS(vx, y, k);
+    NO_DEVICE_CODE;
+#endif  // __CUDA_ARCH__ >= GGML_CUDA_CC_AMPERE
+}
+
 template<typename dst_t>
 static __global__ void dequantize_block_q4_0(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb32) {
 
@@ -513,6 +559,20 @@ static void dequantize_block_q8_0_f16_cuda(const void * __restrict__ vx, half * 
     }
 }
 
+static void dequantize_block_q8_0_bf16_cuda(const void * __restrict__ vx,
+                                            nv_bfloat16 * __restrict__ y,
+                                            const int64_t k,
+                                            cudaStream_t  stream) {
+    const int num_blocks = (k + CUDA_Q8_0_NE_ALIGN - 1) / CUDA_Q8_0_NE_ALIGN;
+    if (k % CUDA_Q8_0_NE_ALIGN == 0) {
+        const bool need_check = false;
+        dequantize_block_q8_0_bf16<need_check><<<num_blocks, WARP_SIZE, 0, stream>>>(vx, y, k);
+    } else {
+        const bool need_check = true;
+        dequantize_block_q8_0_bf16<need_check><<<num_blocks, WARP_SIZE, 0, stream>>>(vx, y, k);
+    }
+}
+
 template<typename dst_t>
 static void dequantize_row_q2_K_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb = k / QK_K;
@@ -665,6 +725,49 @@ to_bf16_cuda_t ggml_get_to_bf16_cuda(ggml_type type) {
             return convert_unary_cont_cuda<float>;
         case GGML_TYPE_F16:
             return convert_unary_cont_cuda<half>;
+        case GGML_TYPE_Q8_0:
+            if (bf16_mma_hardware_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
+                return dequantize_block_q8_0_bf16_cuda;
+            }
+            return dequantize_block_cont_cuda<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_Q4_0:
+            return dequantize_row_q4_0_cuda;
+        case GGML_TYPE_Q4_1:
+            return dequantize_row_q4_1_cuda;
+        case GGML_TYPE_Q5_0:
+            return dequantize_block_cont_cuda<QK5_0, QR5_0, dequantize_q5_0>;
+        case GGML_TYPE_Q5_1:
+            return dequantize_block_cont_cuda<QK5_1, QR5_1, dequantize_q5_1>;
+        case GGML_TYPE_Q2_K:
+            return dequantize_row_q2_K_cuda;
+        case GGML_TYPE_Q3_K:
+            return dequantize_row_q3_K_cuda;
+        case GGML_TYPE_Q4_K:
+            return dequantize_row_q4_K_cuda;
+        case GGML_TYPE_Q5_K:
+            return dequantize_row_q5_K_cuda;
+        case GGML_TYPE_Q6_K:
+            return dequantize_row_q6_K_cuda;
+        case GGML_TYPE_IQ2_XXS:
+            return dequantize_row_iq2_xxs_cuda;
+        case GGML_TYPE_IQ2_XS:
+            return dequantize_row_iq2_xs_cuda;
+        case GGML_TYPE_IQ2_S:
+            return dequantize_row_iq2_s_cuda;
+        case GGML_TYPE_IQ3_XXS:
+            return dequantize_row_iq3_xxs_cuda;
+        case GGML_TYPE_IQ1_S:
+            return dequantize_row_iq1_s_cuda;
+        case GGML_TYPE_IQ1_M:
+            return dequantize_row_iq1_m_cuda;
+        case GGML_TYPE_IQ4_NL:
+            return dequantize_row_iq4_nl_cuda;
+        case GGML_TYPE_IQ4_XS:
+            return dequantize_row_iq4_xs_cuda;
+        case GGML_TYPE_IQ3_S:
+            return dequantize_row_iq3_s_cuda;
+        case GGML_TYPE_MXFP4:
+            return dequantize_row_mxfp4_cuda;
         default:
             return nullptr;
     }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1283,6 +1283,38 @@ static void ggml_cuda_op_mul_mat_cublas(
 
         const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
         to_fp32_cuda(dst_bf16.get(), dst_dd_i, row_diff*src1_ncols, stream);
+    } else if (bf16_mma_hardware_available(cc) && use_fp16) {
+        // bf16 is numerically more stable than fp16, so it's the preferable option if available (requires Ampere or RDNA3 or newer)
+        // convert src0 and src1 to bf16, multiply as bf16, convert dst to fp32
+        ggml_cuda_pool_alloc<nv_bfloat16> src0_as_bf16(ctx.pool(id));
+        if (src0->type != GGML_TYPE_BF16) {
+            const to_bf16_cuda_t to_bf16_cuda = ggml_get_to_bf16_cuda(src0->type);
+            GGML_ASSERT(to_bf16_cuda != nullptr);
+            size_t ne = row_diff * ne00;
+            src0_as_bf16.alloc(ne);
+            to_bf16_cuda(src0_dd_i, src0_as_bf16.get(), ne, stream);
+        }
+        const nv_bfloat16 * src0_ptr =
+            src0->type == GGML_TYPE_BF16 ? (const nv_bfloat16 *) src0_dd_i : src0_as_bf16.get();
+
+        ggml_cuda_pool_alloc<nv_bfloat16> src1_as_bf16(ctx.pool(id));
+        if (src1->type != GGML_TYPE_BF16) {
+            const to_bf16_cuda_t to_bf16_cuda = ggml_get_to_bf16_cuda(src1->type);
+            GGML_ASSERT(to_bf16_cuda != nullptr);
+            size_t ne = src1_ncols * ne10;
+            src1_as_bf16.alloc(ne);
+            to_bf16_cuda(src1_ddf_i, src1_as_bf16.get(), ne, stream);
+        }
+        const nv_bfloat16 * src1_ptr =
+            src1->type == GGML_TYPE_BF16 ? (const nv_bfloat16 *) src1_ddf_i : src1_as_bf16.get();
+
+        const float alpha_f32 = 1.0f;
+        const float beta_f32  = 0.0f;
+
+        CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
+        CUBLAS_CHECK(cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N, row_diff, src1_ncols, ne10,
+                                  &alpha_f32, src0_ptr, CUDA_R_16BF, ne00, src1_ptr, CUDA_R_16BF, ne10, &beta_f32,
+                                  dst_dd_i, CUDA_R_32F, ldc, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT));
     } else if (fast_fp16_hardware_available(cc) && use_fp16) {
         // convert src0 and src1 to fp16, multiply as fp16, convert dst to fp32
         ggml_cuda_pool_alloc<half> src0_as_f16(ctx.pool(id));

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1339,35 +1339,11 @@ static void ggml_cuda_op_mul_mat_cublas(
 
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
 
-        if (GGML_CUDA_CC_IS_CDNA(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
-            const float alpha = 1.0f;
-            const float beta = 0.0f;
-            CUBLAS_CHECK(
-                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
-                        row_diff, src1_ncols, ne10,
-                        &alpha, src0_ptr,  CUDA_R_16F, ne00,
-                                src1_ptr,  CUDA_R_16F, ne10,
-                        &beta,   dst_dd_i, CUDA_R_32F, ldc,
-                        CUBLAS_COMPUTE_32F,
-                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-        } else {
-            ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
-
-            const half alpha_f16 = 1.0f;
-            const half beta_f16 = 0.0f;
-
-            CUBLAS_CHECK(
-                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
-                        row_diff, src1_ncols, ne10,
-                        &alpha_f16, src0_ptr,      CUDA_R_16F, ne00,
-                                    src1_ptr,      CUDA_R_16F, ne10,
-                        &beta_f16,  dst_f16.get(), CUDA_R_16F, ldc,
-                        CUBLAS_COMPUTE_16F,
-                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-
-            const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_F16);
-            to_fp32_cuda(dst_f16.get(), dst_dd_i, row_diff*src1_ncols, stream);
-        }
+        const float alpha = 1.0f;
+        const float beta  = 0.0f;
+        CUBLAS_CHECK(cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N, row_diff, src1_ncols, ne10, &alpha,
+                                  src0_ptr, CUDA_R_16F, ne00, src1_ptr, CUDA_R_16F, ne10, &beta, dst_dd_i, CUDA_R_32F,
+                                  ldc, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT));
     } else {
         ggml_cuda_pool_alloc<float> src0_ddq_as_f32(ctx.pool(id));
         ggml_cuda_pool_alloc<float> src1_ddq_as_f32(ctx.pool(id));


### PR DESCRIPTION
BF16 has better numerical stability than FP16 and is thus the preferred path if available. Since we require the output to be FP32, we avoid loss of precision by skipping FP32 -> BF16 -> FP32 round-trip. This was also a bit more performant on my GPU:

```
➜  llama.cpp git:(master) ✗ ./build-x64-linux-gcc-reldbg/bin/llama-bench -m /mnt/share/gguf/Nemotron-Nano-3-30B-A3B-Q8_0.gguf -fa 1 -ub 2048 -b 8192 -d 8000 -dio 1 -p 8096 -n 0
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, compute capability 12.0, VMM: yes
| model                          |       size |     params | backend    | ngl | n_batch | n_ubatch | fa | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | -: | --: | --------------: | -------------------: |
| nemotron_h_moe 31B.A3.5B Q8_0  |  31.27 GiB |    31.58 B | CUDA       |  99 |    8192 |     2048 |  1 |   1 |  pp8096 @ d8000 |       6853.30 ± 6.78 |

build: https://github.com/ggml-org/llama.cpp/commit/ec88c3ceeaaa037dc8a80413c566ed6d71d9e85c (8186)

FP32 -> BF16 -> FP32 path
➜  llama.cpp git:(master) ✗ ./build-x64-linux-gcc-reldbg/bin/llama-bench -m /mnt/share/gguf/Nemotron-Nano-3-30B-A3B-Q8_0.gguf -fa 1 -ub 2048 -b 8192 -d 8000 -dio 1 -p 8096 -n 0
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, compute capability 12.0, VMM: yes
| model                          |       size |     params | backend    | ngl | n_batch | n_ubatch | fa | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | -: | --: | --------------: | -------------------: |
| nemotron_h_moe 31B.A3.5B Q8_0  |  31.27 GiB |    31.58 B | CUDA       |  99 |    8192 |     2048 |  1 |   1 |  pp8096 @ d8000 |      6467.15 ± 18.85 |

build: https://github.com/ggml-org/llama.cpp/commit/ec88c3ceeaaa037dc8a80413c566ed6d71d9e85c (8186)
```

The avoidance of FP16 -> FP32 upcast was also applied to the FP16-path for increased stability and perf (should affect only pre-Ampere GPUs). This was added already in #11356 for the ROCm path. This PR should fix numerical instabilities observed in #19659, though only for Ampere+ GPUs. I did not evaluate potential impact for pre-VOLTA GPUs that do not possess tensor-cores.