### PR TITLE
fix: translate "developer" role to "system" for chat template compatibility

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -317,6 +317,11 @@ std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messa
                 throw std::invalid_argument("Missing 'role' in message: " + message.dump());
             }
             msg.role = message.at("role");
+            // OpenAI uses "developer" as an alias for "system" in the Responses API;
+            // remap it so chat templates that only handle "system" don't break.
+            if (msg.role == "developer") {
+                msg.role = "system";
+            }
 
             auto has_content = message.contains("content");
             auto has_tool_calls = message.contains("tool_calls");

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -944,6 +944,11 @@ json oaicompat_chat_params_parse(
     }
     for (auto & msg : messages) {
         std::string role = json_value(msg, "role", std::string());
+        // Remap "developer" → "system" for chat template compatibility
+        if (role == "developer") {
+            msg["role"] = "system";
+            role = "system";
+        }
         if (role != "assistant" && !msg.contains("content")) {
             throw std::invalid_argument("All non-assistant messages must contain 'content'");
         }
@@ -1239,8 +1244,39 @@ json convert_responses_to_chatcmpl(const json & response_body) {
                     item.erase("status");
                 }
                 item["content"] = chatcmpl_content;
-
-                chatcmpl_messages.push_back(item);
+                // Remap "developer" → "system" for chat template compatibility.
+                // Also ensure system messages end up at position 0 (merge with
+                // any existing system message created from the "instructions" field).
+                if (item.at("role") == "developer" || item.at("role") == "system") {
+                    item["role"] = "system";
+                    // Extract plain text from the content parts
+                    std::string sys_text;
+                    for (const auto & part : chatcmpl_content) {
+                        if (part.value("type", "") == "text" && part.contains("text")) {
+                            if (!sys_text.empty()) {
+                                sys_text += "\n";
+                            }
+                            sys_text += part.at("text").get<std::string>();
+                        }
+                    }
+                    if (!chatcmpl_messages.empty() && chatcmpl_messages.front().value("role", "") == "system") {
+                        // Merge into existing system message
+                        std::string existing = chatcmpl_messages.front().value("content", "");
+                        if (!existing.empty() && !sys_text.empty()) {
+                            existing += "\n\n";
+                        }
+                        existing += sys_text;
+                        chatcmpl_messages.front()["content"] = existing;
+                    } else {
+                        // Insert system message at position 0
+                        chatcmpl_messages.insert(chatcmpl_messages.begin(), {
+                            {"role", "system"},
+                            {"content", sys_text},
+                        });
+                    }
+                } else {
+                    chatcmpl_messages.push_back(item);
+                }
             } else if (exists_and_is_array(item, "content") &&
                 exists_and_is_string(item, "role") &&
                 item.at("role") == "assistant" &&


### PR DESCRIPTION
## Summary

- OpenAI's Responses API uses `"developer"` as an alias for `"system"`, but llama.cpp passed this role through verbatim to Jinja chat templates
- Templates that validate roles strictly (e.g. Qwen3.5 MoE) crashed with `raise_exception('Unexpected message role.')`, while permissive templates silently lost the system prompt
- Adds `developer` → `system` remapping in three places: `common_chat_msgs_parse_oaicompat()`, the chat completions message loop, and the Responses API conversion layer
- The Responses API fix also merges developer/system messages with the `instructions`-derived system message to prevent duplicate system messages that trigger "System message must be at the beginning" template errors

## Test plan

- [x] Verified with Qwen3.5-35B-A3B-UD GGUF — `POST /v1/chat/completions` with `role: "developer"` + tools returns 200 (was 500)
- [x] Verified `POST /v1/responses` with `instructions` + `developer` role input + tools returns 200 (was 500)
- [x] Verified Codex CLI v0.107.0 (`wire_api = "responses"`) works end-to-end with Qwen3.5
- [ ] Run existing server tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)