### PR TITLE
speculative : enable checkpoint-based rollback for hybrid/recurrent models

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -740,6 +740,10 @@ struct common_speculative_state_ngram_cache : public common_speculative_state {
 struct common_speculative {
     std::vector<std::unique_ptr<common_speculative_state>> impls; // list of implementations to use and their states
     common_speculative_state * curr_impl = nullptr; // current implementation in use (for stats)
+
+    // checkpoint-based rollback for hybrid/recurrent models
+    bool needs_checkpoint = false;
+    std::vector<uint8_t> checkpoint_buf;
 };
 
 static common_ngram_map get_common_ngram_map(const common_speculative_config & config) {
@@ -822,9 +826,14 @@ bool common_speculative_is_compat(llama_context * ctx_tgt) {
 
     // try to remove the last tokens
     if (!llama_memory_seq_rm(mem, 0, 1, -1)) {
-        LOG_WRN("%s: the target context does not support partial sequence removal\n", __func__);
-        res = false;
-        goto done;
+        const auto * model = llama_get_model(ctx_tgt);
+        if (llama_model_is_hybrid(model) || llama_model_is_recurrent(model)) {
+            LOG_INF("%s: hybrid/recurrent model -- will use checkpoint-based rollback\n", __func__);
+        } else {
+            LOG_WRN("%s: the target context does not support partial sequence removal\n", __func__);
+            res = false;
+            goto done;
+        }
     }
 
 done:
@@ -966,8 +975,15 @@ common_speculative * common_speculative_init(
     }
 
     auto * result = new common_speculative {
-        /* .impls = */ std::move(impls)
+        /* .impls            = */ std::move(impls),
+        /* .curr_impl        = */ nullptr,
+        /* .needs_checkpoint = */ false,
+        /* .checkpoint_buf   = */ {},
     };
+
+    const auto * model = llama_get_model(ctx_tgt);
+    result->needs_checkpoint = llama_model_is_hybrid(model)
+                            || llama_model_is_recurrent(model);
 
     return result;
 }
@@ -1043,6 +1059,35 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
         impl->accept(n_accepted);
         impl->n_call_accept++;
     }
+}
+
+bool common_speculative_needs_checkpoint(const common_speculative * spec) {
+    return spec && spec->needs_checkpoint;
+}
+
+void common_speculative_checkpoint_save(
+        common_speculative * spec, llama_context * ctx, llama_seq_id seq_id) {
+    if (!spec || !spec->needs_checkpoint) {
+        return;
+    }
+
+    const size_t size = llama_state_seq_get_size_ext(
+        ctx, seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+    spec->checkpoint_buf.resize(size);
+    llama_state_seq_get_data_ext(
+        ctx, spec->checkpoint_buf.data(), size,
+        seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+}
+
+void common_speculative_checkpoint_restore(
+        common_speculative * spec, llama_context * ctx, llama_seq_id seq_id) {
+    if (!spec || !spec->needs_checkpoint || spec->checkpoint_buf.empty()) {
+        return;
+    }
+
+    llama_state_seq_set_data_ext(
+        ctx, spec->checkpoint_buf.data(), spec->checkpoint_buf.size(),
+        seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 }
 
 void common_speculative_print_stats(const common_speculative * spec) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -39,3 +39,12 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec);
+
+// checkpoint/restore for hybrid/recurrent models during speculative verification
+bool common_speculative_needs_checkpoint(const common_speculative * spec);
+
+void common_speculative_checkpoint_save(
+    common_speculative * spec, llama_context * ctx, llama_seq_id seq_id);
+
+void common_speculative_checkpoint_restore(
+    common_speculative * spec, llama_context * ctx, llama_seq_id seq_id);

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -242,7 +242,11 @@ int main(int argc, char ** argv) {
                     common_batch_add(batch_redo, prompt_tgt[prompt_tgt.size() - n_redo + i],
                                      n_past_before + i, { 0 }, false);
                 }
-                llama_decode(ctx_tgt, batch_redo);
+                if (llama_decode(ctx_tgt, batch_redo) != 0) {
+                    LOG_ERR("checkpoint re-decode failed\n");
+                    llama_batch_free(batch_redo);
+                    return 1;
+                }
                 llama_batch_free(batch_redo);
 
                 LOG_DBG("checkpoint rollback: restored and re-decoded %d tokens\n", n_redo);

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -156,6 +156,8 @@ int main(int argc, char ** argv) {
         //LOG_DBG("draft: %s\n", string_from(ctx_dft, draft).c_str());
 
         // always have a token to evaluate from before - id_last
+        const int n_past_before = n_past;
+
         common_batch_clear(batch_tgt);
         common_batch_add  (batch_tgt, id_last, n_past++, { 0 }, true);
 
@@ -168,6 +170,11 @@ int main(int argc, char ** argv) {
 
             for (size_t i = 0; i < draft.size(); ++i) {
                 common_batch_add(batch_tgt, draft[i], n_past + i, { 0 }, true);
+            }
+
+            // save recurrent state checkpoint before verification decode
+            if (!draft.empty()) {
+                common_speculative_checkpoint_save(spec, ctx_tgt, 0);
             }
 
             //LOG_DBG("target batch: %s\n", string_from(ctx_tgt, batch_tgt).c_str());
@@ -222,7 +229,26 @@ int main(int argc, char ** argv) {
         {
             LOG_DBG("clear kv cache from any extra tokens, n_past = %d\n", n_past);
 
-            llama_memory_seq_rm(llama_get_memory(ctx_tgt), 0, n_past, -1);
+            if (common_speculative_needs_checkpoint(spec) && !draft.empty() && (int) ids.size() <= (int) draft.size()) {
+                // some draft tokens were rejected -- checkpoint-based rollback for hybrid/recurrent models
+                common_speculative_checkpoint_restore(spec, ctx_tgt, 0);
+                llama_memory_seq_rm(llama_get_memory(ctx_tgt), 0, n_past_before, -1);
+
+                // re-decode accepted tokens to rebuild KV + advance recurrent state
+                const int n_redo = (int) ids.size();
+                llama_batch batch_redo = llama_batch_init(n_redo, 0, 1);
+                common_batch_clear(batch_redo);
+                for (int i = 0; i < n_redo; ++i) {
+                    common_batch_add(batch_redo, prompt_tgt[prompt_tgt.size() - n_redo + i],
+                                     n_past_before + i, { 0 }, false);
+                }
+                llama_decode(ctx_tgt, batch_redo);
+                llama_batch_free(batch_redo);
+
+                LOG_DBG("checkpoint rollback: restored and re-decoded %d tokens\n", n_redo);
+            } else {
+                llama_memory_seq_rm(llama_get_memory(ctx_tgt), 0, n_past, -1);
+            }
         }
 
         if ((params.n_predict >= 0 && n_predict > params.n_predict) || has_eos) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2828,7 +2828,7 @@ private:
                 slot.prompt.tokens.insert({ids.begin(), ids.end() - 1});
                 slot.sampled = ids.back(); // last accepted token
 
-                if (common_speculative_needs_checkpoint(slot.spec) && ids.size() <= n_draft) {
+                if (common_speculative_needs_checkpoint(slot.spec) && !slot.drafted.empty() && ids.size() <= n_draft) {
                     // some draft tokens were rejected -- checkpoint-based rollback for hybrid/recurrent
                     common_speculative_checkpoint_restore(slot.spec, ctx, slot.id);
 
@@ -2844,7 +2844,11 @@ private:
                         common_batch_add(batch_redo, slot.prompt.tokens[pos_start + i],
                                          pos_start + i, { slot.id }, false);
                     }
-                    llama_decode(ctx, batch_redo);
+                    if (llama_decode(ctx, batch_redo) != 0) {
+                        SLT_ERR(slot, "%s", "checkpoint re-decode failed\n");
+                        llama_batch_free(batch_redo);
+                        break;
+                    }
                     llama_batch_free(batch_redo);
 
                     SLT_DBG(slot, "checkpoint rollback: restored and re-decoded %d tokens\n", n_redo);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2602,6 +2602,13 @@ private:
             llama_set_embeddings(ctx, slot_batched->task->need_embd());
         }
 
+        // save recurrent state checkpoint for slots with draft tokens (before decode)
+        for (auto & slot : slots) {
+            if (slot.state == SLOT_STATE_GENERATING && !slot.drafted.empty()) {
+                common_speculative_checkpoint_save(slot.spec, ctx, slot.id);
+            }
+        }
+
         if (batch.n_tokens == 0) {
             SRV_WRN("%s", "no tokens to decode\n");
         }
@@ -2821,7 +2828,29 @@ private:
                 slot.prompt.tokens.insert({ids.begin(), ids.end() - 1});
                 slot.sampled = ids.back(); // last accepted token
 
-                llama_memory_seq_rm(llama_get_memory(ctx), slot.id, slot.prompt.n_tokens(), -1);
+                if (common_speculative_needs_checkpoint(slot.spec) && ids.size() <= n_draft) {
+                    // some draft tokens were rejected -- checkpoint-based rollback for hybrid/recurrent
+                    common_speculative_checkpoint_restore(slot.spec, ctx, slot.id);
+
+                    // clear KV entries for sampled + draft tokens (recurrent state already restored)
+                    const int n_redo  = (int) ids.size();
+                    const int pos_start = (int) slot.prompt.n_tokens() - n_redo;
+                    llama_memory_seq_rm(llama_get_memory(ctx), slot.id, pos_start, -1);
+
+                    // re-decode accepted tokens to rebuild KV + advance recurrent state
+                    llama_batch batch_redo = llama_batch_init(n_redo, 0, 1);
+                    common_batch_clear(batch_redo);
+                    for (int i = 0; i < n_redo; ++i) {
+                        common_batch_add(batch_redo, slot.prompt.tokens[pos_start + i],
+                                         pos_start + i, { slot.id }, false);
+                    }
+                    llama_decode(ctx, batch_redo);
+                    llama_batch_free(batch_redo);
+
+                    SLT_DBG(slot, "checkpoint rollback: restored and re-decoded %d tokens\n", n_redo);
+                } else {
+                    llama_memory_seq_rm(llama_get_memory(ctx), slot.id, slot.prompt.n_tokens(), -1);
+                }
 
                 for (size_t i = 0; i < ids.size(); ++i) {
                     completion_token_output result;


### PR DESCRIPTION
## Summary

Speculative decoding is silently blocked for all hybrid/recurrent architectures (Qwen3.5, Mamba, RWKV, Jamba) because `common_speculative_is_compat()` tests `seq_rm` which returns `false` for recurrent memory on partial tail removal.

**Fix:** Checkpoint recurrent state before verification, restore on rejection, then `seq_rm` succeeds because the recurrent tail position is back behind the removal range. Re-decode accepted tokens at prompt speed to rebuild KV cache and advance recurrent state.

- Uses existing `llama_state_seq_get/set_data_ext` with `LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY`
- Zero overhead on non-hybrid models (guarded by `needs_checkpoint` flag)
- ~120 insertions across 4 files, no new public API

## How it works

```
Before spec:      ctx at position P
After verify:     ctx at P + k + 1 (KV + recurrent advanced)
Rejection at j:
  1. Restore checkpoint       -- recurrent back to P
  2. seq_rm(0, P+1, -1)       -- KV cleared; recurrent finds nothing in range, returns true
  3. Re-decode accepted tokens -- rebuilds KV + advances recurrent to P + j + 1
```

After checkpoint restore, `cell.pos = P` (pre-speculation), so `seq_rm(0, P+1, -1)` finds no recurrent cells in range `[P+1, inf)` and returns `true`. The guard at `llama_memory_recurrent::seq_rm` line 165 evaluates `P+1 <= P` -> `false`, so it doesn't trigger.

## What this unblocks

| Speculation type | Status |
|-----------------|--------|
| N-gram on hybrid/recurrent models | Works |
| Draft model on hybrid/recurrent models | Works |
| MTP on Qwen3.5/DeepSeek/GLM | Needs MTP graph + GGUF tensors (separate PR) |
| EAGLE3 on hybrid models | Needs EAGLE3 impl (separate PR) |

## Benchmarks (Apple Silicon M4 Max, 128GB)

### Qwen3.5-0.8B (hybrid) -- correctness & regression

| Config | Speed | Accept | Notes |
|--------|------:|-------:|-------|
| Baseline (no speculation) | 172 t/s | -- | llama-bench tg128 |
| Self-draft (Q4_K_M + Q4_K_M) | 149 t/s | 100% | Overhead measurement |
| Cross-quant (Q4_K_M + IQ2_XXS) | 122 t/s | 78.2% | Rejection path exercised |

### Qwen3.5-27B (hybrid) -- large model

| Config | Speed | Accept | Notes |
|--------|------:|-------:|-------|
| Baseline (no speculation) | 14.6 t/s | -- | Memory-bandwidth bound |
| Cross-model (27B + 0.8B draft, max 4) | 11.1 t/s | 73.9% | |
| Cross-model (27B + 0.8B draft, max 8) | 11.3 t/s | 75.3% | |

On Apple Silicon unified memory, speculation does not provide a speedup -- batch evaluation scales linearly with token count (memory-bandwidth bound), so verifying 5 tokens costs ~5x a single token. The benefit of speculation emerges on discrete GPUs where batch eval is nearly free (weights loaded once, compute multiple tokens), on offloaded/split models, or via MTP (zero-cost internal drafting).

**The story here is feature enablement, not speed.** Before: hybrid models exit with "context does not support partial sequence removal." After: they run and produce correct output. Going from "doesn't work" to "works" is the metric.

### Non-hybrid regression (standard transformers)

All tested with self-draft at 100% acceptance, confirming zero impact on the existing path:

| Model | Result |
|-------|--------|
| Qwen3-0.6B | Pass |
| GLM-4.7-Flash | Pass |
| Ministral-3B | Pass |
| Ministral-8B | Pass |

### Output correctness

Speculative output matches non-speculative baseline with greedy sampling (`--temp 0`) across all tested configurations, including configurations with heavy rejections (cross-architecture Qwen3.5-27B target + Qwen3.5-0.8B draft at 74% acceptance).

### Limitation

No pure recurrent model (Mamba, RWKV) was available for testing. The checkpoint mechanism uses the same `llama_state_seq_get/set_data_ext` API and the `PARTIAL_ONLY` flag is ignored for pure recurrent (see `GGML_UNUSED(flags)` in `llama_memory_recurrent::state_write/state_read`), so it should work identically, but this is unverified.

## Files changed

- `common/speculative.h` -- checkpoint helper declarations
- `common/speculative.cpp` -- struct fields, `is_compat` bypass, init detection, checkpoint save/restore/needs helpers
- `examples/speculative-simple/speculative-simple.cpp` -- checkpoint save before verify, restore + re-decode on rejection
- `tools/server/server-context.cpp` -- same pattern for server slots

## Disclosure

AI (Claude Code) was used as a coding assistant for this PR: code generation from a human-authored design, debugging build issues, and running test iterations. The algorithmic approach (checkpoint-before-verify, restore-on-reject, re-decode-accepted) was human-conceived based on analysis of the existing `llama_state_seq` API and recurrent memory internals. The PR description was drafted collaboratively. All code was reviewed, tested, and validated by a human contributor who can explain and debug every line.