### PR TITLE
server: Add OpenRouter-compatible reasoning API

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1085,6 +1085,55 @@ json oaicompat_chat_params_parse(
         throw std::invalid_argument("invalid type for \"enable_thinking\" (expected boolean, got string)");
     }
 
+    // Reasoning budget: pass parameters through to sampling layer
+    int reasoning_budget = json_value(body, "thinking_budget_tokens", -1);
+    if (reasoning_budget == -1) {
+        reasoning_budget = opt.reasoning_budget;
+    }
+
+    // OpenAI-compatible reasoning API
+    if (body.contains("reasoning")) {
+        const auto& reasoning = body["reasoning"];
+
+        if (reasoning.is_boolean()) {
+            bool enabled = reasoning.get<bool>();
+            inputs.enable_thinking = enabled;
+        }
+        else if (reasoning.is_object()) {
+            bool enabled = reasoning.value("enabled", true);
+            inputs.enable_thinking = enabled;
+            if (!enabled) goto or_reason_check_end;
+
+            auto reasoning_max_tokens = reasoning.value("max_tokens", -1);
+            // if specified
+            if (reasoning_max_tokens >= 0) {
+                reasoning_budget = reasoning_max_tokens;
+                goto or_reason_check_end;
+            }
+
+            auto effort = reasoning.value("effort", "auto");
+            if (effort != "auto") {
+                float percent = 0.5;
+                if (effort == "xhigh") {percent = 0.95;
+                } else if (effort == "high") {percent = 0.80;
+                } else if (effort == "medium") {percent = 0.50;
+                } else if (effort == "low") {percent = 0.20;
+                } else if (effort == "minimal") {percent = 0.10;
+                } else if (effort == "none") {
+                    inputs.enable_thinking = false;
+                    goto or_reason_check_end;
+                } else {
+                    throw std::invalid_argument("invalid enum for \"reasoning.effort\" (expected one of [xhigh, high, medium, low, minimal, none], got "+effort+")");
+                }
+
+                // apply this param until server_task::params_from_json_cmpl
+                llama_params["reasoning_budget_percent"] = percent;
+                reasoning_budget = 0;
+            }
+        }
+    }
+    or_reason_check_end:
+
     inputs.force_pure_content = opt.force_pure_content;
 
     // Apply chat template to the list of messages
@@ -1116,12 +1165,7 @@ json oaicompat_chat_params_parse(
 
     // Reasoning budget: pass parameters through to sampling layer
     {
-        int reasoning_budget = json_value(body, "thinking_budget_tokens", -1);
-        if (reasoning_budget == -1) {
-            reasoning_budget = opt.reasoning_budget;
-        }
-
-        if (!chat_params.thinking_end_tag.empty()) {
+        if (reasoning_budget >= 0 && !chat_params.thinking_end_tag.empty()) {
             llama_params["reasoning_budget_tokens"] = reasoning_budget;
             llama_params["reasoning_budget_start_tag"] = chat_params.thinking_start_tag;
             llama_params["reasoning_budget_end_tag"] = chat_params.thinking_end_tag;

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -383,6 +383,14 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
         ->set_hard_limits(-1, INT32_MAX)
         ->set_desc("Number of tokens in the reasoning budget (-1 = disabled)"));
 
+    add((new field_json("reasoning_budget_percent"))
+        ->set_desc("Percent of reasoning_budget")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            const auto percent  = json_value(data, "reasoning_budget_percent", 0.);
+            ctx.params.sampling.reasoning_budget_tokens = ctx.params.n_predict * percent;
+        }));
+
+
     add((new field_str("reasoning_budget_start_tag"))
         ->set_desc("Token string marking the start of the reasoning budget section")
         ->set_handler([&](field_eval_context & ctx, const json & data) {


### PR DESCRIPTION
Use `reasoning: false` or `reasoning: { enabled: false }` or `reasoning: { effort: 'none' }` to toggle reasoning instead of `chat_template_kwargs`