### PR TITLE
ggml: fix ggml_is_contiguous_n for ne == 1

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1410,16 +1410,14 @@ static bool ggml_is_contiguous_n(const struct ggml_tensor * tensor, int n) {
     }
     next_nb *= tensor->ne[0]/ggml_blck_size(tensor->type);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
-        if (tensor->ne[i] != 1) {
-            if (i > n) {
-                if (tensor->nb[i] != next_nb) {
-                    return false;
-                }
-                next_nb *= tensor->ne[i];
-            } else {
-                // this dimension does not need to be contiguous
-                next_nb = tensor->ne[i]*tensor->nb[i];
+        if (i > n) {
+            if (tensor->ne[i] != 1 && tensor->nb[i] != next_nb) {
+                return false;
             }
+            next_nb *= tensor->ne[i];
+        } else {
+            // this dimension does not need to be contiguous
+            next_nb = tensor->ne[i]*tensor->nb[i];
         }
     }
     return true;


### PR DESCRIPTION
While debugging a test failure for https://github.com/ggml-org/llama.cpp/pull/19802 I found what I believe to be a bug in `ggml_is_contiguous_n`. A test case using the new fused experts from https://github.com/ggml-org/llama.cpp/pull/19139 fails on an assert like `GGML_ASSERT(ggml_is_contiguous_1(a))`. This assertion failure happens specifically because the test case uses only a single expert vs. the real models using >1 experts. So the test case gets a tensor like this: `ne = {192, 1, 128, 1}, nb = {4, 1536, 1536, 196608}`. This should be contiguous in dimensions 1, 2, and 3 but it is not according to `ggml_is_contiguous_1`. The reason is that the code on master entirely skips dimensions that have a size of 1. But this then also skips the fix for `next_nb` if a dimension does not need to be contiguous. This PR adjusts the logic to skip only the check for whether or not the tensor is contiguous if a dimension is equal to 1.