### PR TITLE
Add #pragma once to mean.hpp and pca.hpp

### DIFF
--- a/tools/cvector-generator/mean.hpp
+++ b/tools/cvector-generator/mean.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common.h"
 #include "llama.h"
 #include "ggml.h"

--- a/tools/cvector-generator/pca.hpp
+++ b/tools/cvector-generator/pca.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common.h"
 #include "llama.h"
 #include "ggml.h"


### PR DESCRIPTION
Summary
This PR adds a #pragma once guard to mean.hpp and pca.hpp.

Reasoning
While debugging the cvector-generator tool to produce control_vector.gguf files, I noticed that this header currently lacks an include guard; adding #pragma once is a fundamental best practice that ensures the header is idempotent, follows standard programming conventions, and prevents potential redefinition errors to improve the codebase's overall robustness.