### PR TITLE
ggml:  WIP - Add native NVFP4 for CPU

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -56,6 +56,54 @@ except ImportError:
 
 logger = logging.getLogger("hf-to-gguf")
 
+_NVFP4_EXTERNAL_METHODS = ("modelopt", "tensorrt", "llm-compressor", "transformers", "sft","compressed-tensors")
+
+_TORCH_FP8_DTYPES: tuple[torch.dtype, ...] = tuple(
+    getattr(torch, dtype_name)
+    for dtype_name in ("float8_e4m3fn", "float8_e5m2")
+    if hasattr(torch, dtype_name)
+)
+
+
+def _is_torch_fp8_dtype(dtype: torch.dtype) -> bool:
+    return any(dtype == fp8_dtype for fp8_dtype in _TORCH_FP8_DTYPES)
+
+
+def _nvfp4_to_uint8_bytes(x: Any, *, name: str, field: str, allow_fp8: bool) -> Tensor:
+    if isinstance(x, gguf.LazyBase):
+        x = type(x).to_eager(x)
+
+    if not torch.is_tensor(x):
+        raise TypeError(f"{name}: NVFP4 {field} must be a torch.Tensor, got {type(x).__name__}")
+
+    t = x.detach().cpu().contiguous()
+    if t.dtype == torch.uint8:
+        return t
+    if t.dtype == torch.int8:
+        return t.view(torch.uint8)
+    if allow_fp8 and _is_torch_fp8_dtype(t.dtype):
+        return t.view(torch.uint8)
+
+    raise TypeError(f"{name}: NVFP4 {field} dtype {t.dtype} is unsupported for raw-byte packing")
+
+
+def is_nvfp4_quant_config(quant_config: Any) -> bool:
+    if not isinstance(quant_config, dict):
+        return False
+    algo = str(quant_config.get("quant_algo", "")).upper()
+    fmt = str(quant_config.get("format", "")).lower()
+    method = str(quant_config.get("quant_method", "")).lower()
+    if algo == "NVFP4":
+        return True
+    if fmt in ("nvfp4-pack-quantized", "nvfp4"):
+        return True
+    if method in _NVFP4_EXTERNAL_METHODS and ("nvfp4" in fmt or algo == "NVFP4"):
+        return True
+    # Some SFT exports only tag as "sft" while still carrying NVFP4 payload tensors.
+    if fmt == "sft" or method == "sft":
+        return True
+    return False
+
 
 ###### MODEL DEFINITIONS ######
 
@@ -92,6 +140,7 @@ class ModelBase:
     dry_run: bool
     hparams: dict[str, Any]
     model_tensors: dict[str, Callable[[], Tensor]]
+    is_external_nvfp4: bool
     gguf_writer: gguf.GGUFWriter
     model_name: str | None
     metadata_override: Path | None
@@ -141,6 +190,8 @@ class ModelBase:
         self._up_exp_buffer: dict[int, Tensor] = {}
         self.hparams = ModelBase.load_hparams(self.dir_model, self.is_mistral_format) if hparams is None else hparams
         self.model_tensors = self.index_tensors(remote_hf_model_id=remote_hf_model_id)
+        self.is_external_nvfp4 = False
+        self._refresh_nvfp4_detection()
         self.metadata_override = metadata_override
         self.model_name = model_name
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
@@ -164,6 +215,9 @@ class ModelBase:
                 self.ftype = gguf.LlamaFileType.MOSTLY_F16
                 logger.info("heuristics unable to detect tensor dtype, defaulting to --outtype f16")
 
+        self.dequant_model()
+        self._refresh_nvfp4_detection()
+
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
                                            split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard)
@@ -184,6 +238,39 @@ class ModelBase:
         if optional:
             return None
         raise KeyError(f"could not find any of: {keys}")
+
+    def _detect_nvfp4_component_tensors(self) -> bool:
+        keys = set(self.model_tensors.keys())
+        if len(keys) == 0:
+            return False
+
+        if any(k.endswith(".qscale_weight") for k in keys):
+            return True
+
+        packed_bases = [k.removesuffix(".weight_packed") for k in keys if k.endswith(".weight_packed")]
+        if any(f"{base}.weight_scale" in keys or f"{base}.qscale_weight" in keys for base in packed_bases):
+            return True
+
+        for k in keys:
+            if k.endswith(".weight_scale"):
+                base = k.removesuffix(".weight_scale")
+                if f"{base}.weight_packed" in keys or f"{base}.weight" in keys:
+                    return True
+
+        if any(k.endswith(".tensor_scale") for k in keys) and any(k.endswith(".weight_scale") or k.endswith(".qscale_weight") for k in keys):
+            return True
+        if any(k.endswith(".input_scale") for k in keys) and any(k.endswith(".weight_scale") or k.endswith(".qscale_weight") for k in keys):
+                return True
+
+        return False
+
+    def _refresh_nvfp4_detection(self) -> None:
+        quant_cfg = self.hparams.get("quantization_config")
+        cfg_nvfp4 = is_nvfp4_quant_config(quant_cfg)
+        comp_nvfp4 = self._detect_nvfp4_component_tensors()
+        self.is_external_nvfp4 = cfg_nvfp4 or comp_nvfp4
+        if comp_nvfp4 and not cfg_nvfp4:
+            logger.info("Detected NVFP4 tensor components without NVFP4 quantization_config; enabling NVFP4 conversion path")
 
     def index_tensors(self, remote_hf_model_id: str | None = None) -> dict[str, Callable[[], Tensor]]:
         tensors: dict[str, Callable[[], Tensor]] = {}
@@ -275,6 +362,10 @@ class ModelBase:
         new_tensors: dict[str, Callable[[], Tensor]] = {}
 
         if (quant_config := self.hparams.get("quantization_config")) and isinstance(quant_config, dict):
+            if is_nvfp4_quant_config(quant_config) or self._detect_nvfp4_component_tensors():
+                logger.info("NVFP4 tensors detected; skipping generic dequant_model transforms")
+                return
+
             quant_method = quant_config.get("quant_method")
 
             def dequant_bitnet(weight: Tensor, scale: Tensor) -> Tensor:
@@ -468,8 +559,14 @@ class ModelBase:
                             tensors_to_remove += [base_name + n for n in ("_packed", "_shape", "_scale")]
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
+                elif quant_format == "nvfp4-pack-quantized":
+                    return
                 else:
                     raise NotImplementedError(f"Quant format {quant_format!r} for method {quant_method!r} is not yet supported")
+            elif quant_method in _NVFP4_EXTERNAL_METHODS:
+                # NVFP4 models from external tools (modelopt, tensorrt, llm-compressor, transformers)
+                # Data transfer only - actual repacking happens in prepare_tensors via repack_nvfp4
+                return
             else:
                 raise NotImplementedError(f"Quant method is not yet supported: {quant_method!r}")
 
@@ -479,6 +576,12 @@ class ModelBase:
 
         for name, value in new_tensors.items():
             self.model_tensors[name] = value
+
+    def tensor_force_quant(self, name: str, new_name: str, bid: int | None, n_dims: int) -> gguf.GGMLQuantizationType | bool:
+        return False
+
+    def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
+        return []
 
     def get_tensors(self) -> Iterator[tuple[str, Tensor]]:
         for name, gen in self.model_tensors.items():
@@ -515,50 +618,119 @@ class ModelBase:
     def set_gguf_parameters(self):
         raise NotImplementedError("set_gguf_parameters() must be implemented in subclasses")
 
+
+    def repack_nvfp4(self, name, qs, scales, input_scale=None, tensor_scale=None):
+        qs = _nvfp4_to_uint8_bytes(qs, name=name, field="qs", allow_fp8=False)
+        scales = _nvfp4_to_uint8_bytes(scales, name=name, field="scales", allow_fp8=True)
+
+        # HF emits NVFP4 as separate components:
+        # - qs: packed fp4 codes (nibbles) => last dim is K/2 bytes
+        # - scales: fp8 ue4m3 per 16 values => last dim is K/16 bytes
+        # Repack into llama.cpp's native `block_nvfp4` pack-of-4 storage.
+        orig_s = list(qs.shape)
+        k = orig_s[-1] * 2
+
+        if k % 256 != 0:
+            raise ValueError(f"{name}: NVFP4 requires K%256==0, got K={k}")
+
+        n_packs = (k + 1023) // 1024
+        k_pad = n_packs * 4 * 256
+
+        qs_2d = qs.reshape(-1, orig_s[-1])
+        sc_expected_cols = k // 16
+        if scales.numel() != qs_2d.shape[0] * sc_expected_cols:
+            raise ValueError(
+                f"{name}: NVFP4 scales byte count mismatch, got {scales.numel()} expected {qs_2d.shape[0] * sc_expected_cols}"
+            )
+        sc_2d = scales.reshape(-1, sc_expected_cols)
+
+        if k_pad != k:
+            qs_2d = torch.nn.functional.pad(qs_2d, (0, (k_pad - k) // 2))
+            sc_2d = torch.nn.functional.pad(sc_2d, (0, (k_pad - k) // 16))
+
+        n_row = qs_2d.shape[0]
+        qs_p = qs_2d.reshape(n_row, n_packs, 4, 128).numpy()
+        sc_p = sc_2d.reshape(n_row, n_packs, 4, 16).numpy()
+        packed = np.empty((n_row, n_packs, 576), dtype=np.uint8)
+        packed[:, :, :512] = qs_p.reshape(n_row, n_packs, 512)
+        packed[:, :, 512:] = sc_p.reshape(n_row, n_packs, 64)
+
+        # Byte-shape of the stored blob.
+        b_shp = list(orig_s)
+        b_shp[-1] = n_packs * 576
+
+        # Element-shape that ggml should see after unpacking the native NVFP4 packs.
+        raw_shape = list(orig_s)
+        raw_shape[-1] = k
+
+        data = packed.view(np.int8).reshape(b_shp)
+        self.gguf_writer.add_tensor(name, data, raw_shape=raw_shape, raw_dtype=gguf.GGMLQuantizationType.NVFP4)
+        logger.info(f"{name}, NVFP4 components --> NVFP4, K = {k} (stored with K_pad = {k_pad})")
+
+        out_scale = self._tensor_scalar_to_float(tensor_scale, 1.0)
+        if not (np.isfinite(out_scale) and out_scale > 0.0):
+            out_scale = 1.0
+        self.gguf_writer.add_float32(f"{name}.tensor_scale", float(out_scale))
+
+        in_scale = self._tensor_scalar_to_float(input_scale, 1.0)
+        if not (np.isfinite(in_scale) and in_scale > 0.0):
+            in_scale = 1.0
+        self.gguf_writer.add_float32(f"{name}.input_scale", float(in_scale))
+
+    def _tensor_scalar_to_float(self, data_torch: Tensor | gguf.LazyBase | Any, default: float = 1.0) -> float:
+        if data_torch is None:
+            return default
+        try:
+            if isinstance(data_torch, gguf.LazyBase):
+                data_torch = type(data_torch).to_eager(data_torch)
+            if torch.is_tensor(data_torch):
+                t = data_torch
+                if _is_torch_fp8_dtype(t.dtype) and t.numel() != 1:
+                    raise ValueError(f"non-scalar FP8 tensor cannot be used as scalar metadata (shape={tuple(t.shape)})")
+                arr = t.detach().cpu().reshape(-1)
+                if arr.numel() > 0:
+                    val = float(arr[0].item())
+                    return val if np.isfinite(val) else default
+                return default
+            arr = np.array(data_torch, dtype=np.float32).reshape(-1)
+            if arr.size > 0:
+                val = float(arr[0])
+                return val if np.isfinite(val) else default
+            return default
+        except ValueError:
+            raise
+        except Exception:
+            return default
+
+    def _add_proj_scale_metadata(self, name: str, data_torch: Tensor | gguf.LazyBase | Any) -> bool:
+        if not (name.endswith(".k_proj.k_scale") or name.endswith(".v_proj.v_scale")):
+            return False
+
+        suffix = "k_scale" if name.endswith(".k_proj.k_scale") else "v_scale"
+        proj_base = name[:-len(f".{suffix}")]
+        weight_name = f"{proj_base}.weight"
+
+        mapped_weight_name = self.map_tensor_name(weight_name)
+        mapped_scale_name = mapped_weight_name[:-len(".weight")] + ".scale" if mapped_weight_name.endswith(".weight") else mapped_weight_name + ".scale"
+        scale_val = self._tensor_scalar_to_float(data_torch, 1.0)
+        if not (np.isfinite(scale_val) and scale_val > 0.0):
+            scale_val = 1.0
+        self.gguf_writer.add_tensor(mapped_scale_name, np.array([scale_val], dtype=np.float32), raw_dtype=gguf.GGMLQuantizationType.F32)
+        return True
+
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        new_name = self.map_tensor_name(name)
-
-        # Handle gate/up expert tensor fusion if enabled
-        if self.fuse_gate_up_exps and bid is not None:
-            if self.match_model_tensor_name(new_name, gguf.MODEL_TENSOR.FFN_GATE_EXP, bid):
-                self._gate_exp_buffer[bid] = data_torch
-            elif self.match_model_tensor_name(new_name, gguf.MODEL_TENSOR.FFN_UP_EXP, bid):
-                self._up_exp_buffer[bid] = data_torch
-
-            # Check if both gate and up are buffered for this layer
-            if bid in self._gate_exp_buffer and bid in self._up_exp_buffer:
-                gate_data = self._gate_exp_buffer.pop(bid)
-                up_data = self._up_exp_buffer.pop(bid)
-                # gate/up shape: (n_expert, n_ff, n_embd), concatenate to (n_expert, n_ff*2, n_embd)
-                fused_data = torch.cat([gate_data, up_data], dim=1)
-                fused_name = self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_UP_EXP, bid)
-                logger.info(f"Fused gate_exps and up_exps for layer {bid}")
-                return [(fused_name, fused_data)]
-
-            # If we buffered a gate/up tensor, wait for the other
-            if self.match_model_tensor_name(new_name, gguf.MODEL_TENSOR.FFN_GATE_EXP, bid) or \
-               self.match_model_tensor_name(new_name, gguf.MODEL_TENSOR.FFN_UP_EXP, bid):
-                return []
-
-        return [(new_name, data_torch)]
-
-    def tensor_force_quant(self, name: str, new_name: str, bid: int | None, n_dims: int) -> gguf.GGMLQuantizationType | bool:
-        del name, new_name, bid, n_dims  # unused
-
-        return False
-
-    # some models need extra generated tensors (like rope_freqs)
-    def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
-        return ()
+        return [(self.map_tensor_name(name), data_torch)]
 
     def prepare_tensors(self):
-        self.dequant_model()
-
         # Handle empty tensor_map for models with block_count=0 (like MobileNetV5)
         if self.tensor_map.mapping:
             max_name_len = max(len(s) for _, s in self.tensor_map.mapping.values()) + len(".weight,")
         else:
             max_name_len = len("vision_encoder.weight,")  # Default reasonable length
+
+        is_external_nvfp4 = self.is_external_nvfp4
+        if is_external_nvfp4:
+            logger.info("NVFP4 conversion path active: preserving packed NVFP4 components for repack")
 
         for name, data_torch in chain(self.generate_extra_tensors(), self.get_tensors()):
             # we don't need these
@@ -567,8 +739,26 @@ class ModelBase:
 
             old_dtype = data_torch.dtype
 
+            preserve_nvfp4_raw = False
+            if is_external_nvfp4:
+                if name.endswith(".weight"):
+                    base = name.removesuffix(".weight")
+                    preserve_nvfp4_raw = (
+                        f"{base}.weight_scale" in self.model_tensors
+                        or f"{base}.qscale_weight" in self.model_tensors
+                    )
+                else:
+                    preserve_nvfp4_raw = name.endswith((
+                        ".weight_packed",
+                        ".weight_scale",
+                        ".qscale_weight",
+                        ".tensor_scale",
+                        ".input_scale",
+                        ".input_global_scale",
+                    ))
+
             # convert any unsupported data types to float32
-            if data_torch.dtype not in (torch.float16, torch.float32):
+            if data_torch.dtype not in (torch.float16, torch.float32, torch.bfloat16) and not preserve_nvfp4_raw:
                 data_torch = data_torch.to(torch.float32)
 
             # use the first number-like part of the tensor name as the block id
@@ -578,21 +768,19 @@ class ModelBase:
                     bid = int(part)
                     break
 
+            if is_external_nvfp4:
+                result = handle_nvfp4_helper(self, data_torch, name, bid)
+                if result is not None:
+                    continue
+
             for new_name, data_torch in (self.modify_tensors(data_torch, name, bid)):
                 # TODO: why do we squeeze here?
                 # data = data_torch.squeeze().numpy()
-                data = data_torch.numpy()
+                data = data_torch.float().numpy() if data_torch.dtype == torch.bfloat16 else data_torch.numpy()
 
                 n_dims = len(data.shape)
                 data_qtype: gguf.GGMLQuantizationType | bool = self.tensor_force_quant(name, new_name, bid, n_dims)
-
-                # Most of the codebase that takes in 1D tensors or norms only handles F32 tensors
-                if n_dims <= 1 or new_name.endswith("_norm.weight"):
-                    data_qtype = gguf.GGMLQuantizationType.F32
-
-                # Conditions should closely match those in llama_model_quantize_internal in llama.cpp
-                # Some tensor types are always in float32
-                if data_qtype is False and (
+                force_f32 = (
                     any(
                         self.match_model_tensor_name(new_name, key, bid)
                         for key in (
@@ -614,14 +802,27 @@ class ModelBase:
                             gguf.MODEL_TENSOR.A_ENC_EMBD_POS,
                             gguf.MODEL_TENSOR.ALTUP_CORRECT_COEF,
                             gguf.MODEL_TENSOR.ALTUP_PREDICT_COEF,
-                            # Kimi KDA conv weights should be F32
                             gguf.MODEL_TENSOR.SSM_CONV1D_Q,
                             gguf.MODEL_TENSOR.SSM_CONV1D_K,
                             gguf.MODEL_TENSOR.SSM_CONV1D_V,
                         )
                     )
                     or new_name[-7:] not in (".weight", ".lora_a", ".lora_b")
-                ):
+                )
+                preserve_bf16 = (
+                    is_external_nvfp4 and
+                    self.ftype == gguf.LlamaFileType.MOSTLY_BF16 and
+                    data_torch.dtype == torch.bfloat16 and
+                    n_dims > 1 and
+                    new_name.endswith(".weight") and
+                    not new_name.endswith("_norm.weight") and
+                    not force_f32
+                )
+
+                if (n_dims <= 1 or new_name.endswith("_norm.weight")) and not preserve_bf16:
+                    data_qtype = gguf.GGMLQuantizationType.F32
+
+                if data_qtype is False and force_f32 and not preserve_bf16:
                     data_qtype = gguf.GGMLQuantizationType.F32
 
                 if data_qtype is False and any(
@@ -642,6 +843,9 @@ class ModelBase:
                         # TODO: use Q4_K and Q6_K
                         data_qtype = gguf.GGMLQuantizationType.F16
 
+                if preserve_bf16 and data_qtype is False:
+                    data_qtype = gguf.GGMLQuantizationType.BF16
+
                 # No override (data_qtype is False), or wants to be quantized (data_qtype is True)
                 if isinstance(data_qtype, bool):
                     if self.ftype == gguf.LlamaFileType.ALL_F32:
@@ -656,6 +860,8 @@ class ModelBase:
                         data_qtype = gguf.GGMLQuantizationType.TQ1_0
                     elif self.ftype == gguf.LlamaFileType.MOSTLY_TQ2_0:
                         data_qtype = gguf.GGMLQuantizationType.TQ2_0
+                    elif self.ftype == gguf.LlamaFileType.NVFP4:
+                        data_qtype = gguf.GGMLQuantizationType.F16
                     else:
                         raise ValueError(f"Unknown file type: {self.ftype.name}")
 
@@ -1112,6 +1318,9 @@ class TextModel(ModelBase):
         if chkhsh == "b3d1dd861f1d4c5c0d2569ce36baf3f90fe8a102db3de50dd71ff860d91be3df":
             # ref: https://huggingface.co/aari1995/German_Semantic_V3
             res = "jina-v2-de"
+        if chkhsh == "cdf5f35325780597efd76153d4d1c16778f766173908894c04afc20108536267":
+            # ref: https://huggingface.co/zai-org/GLM-4.7-Flash
+            res = "glm4"
         if chkhsh == "0ef9807a4087ebef797fc749390439009c3b9eda9ad1a097abbe738f486c01e5":
             # ref: https://huggingface.co/meta-llama/Meta-Llama-3-8B
             res = "llama-bpe"
@@ -1235,6 +1444,9 @@ class TextModel(ModelBase):
         if chkhsh == "b3f499bb4255f8ca19fccd664443283318f2fd2414d5e0b040fbdd0cc195d6c5":
             # ref: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
             res = "deepseek-r1-qwen"
+        if chkhsh == "d30d75d9059f1aa2c19359de71047b3ae408c70875e8a3ccf8c5fba56c9d8af4":
+            # ref: https://huggingface.co/Qwen/Qwen3.5-0.6B
+            res = "qwen35"
         if chkhsh == "ccc2ef013c104be7bae2965776d611e1d7a8a2a9c547dd93a682c9a9fc80352e":
             # ref: https://huggingface.co/Xenova/gpt-4o
             res = "gpt-4o"
@@ -1298,15 +1510,6 @@ class TextModel(ModelBase):
         if chkhsh == "6c81ce329e0802883b22eabab0d3fa48357337ef1ecb45443828bf1f6254833f":
             # ref: https://huggingface.co/LGAI-EXAONE/K-EXAONE-236B-A23B
             res = "exaone-moe"
-        if chkhsh == "d30d75d9059f1aa2c19359de71047b3ae408c70875e8a3ccf8c5fba56c9d8af4":
-            # ref: https://huggingface.co/Qwen/Qwen3.5-9B-Instruct
-            res = "qwen35"
-        if chkhsh == "b4b8ca1f9769494fbd956ebc4c249de6131fb277a4a3345a7a92c7dd7a55808d":
-            # ref: https://huggingface.co/jdopensource/JoyAI-LLM-Flash
-            res = "joyai-llm"
-        if chkhsh == "e4d54df1ebc1f2b91acd986c5b51aa50837d5faf7c7398e73c1f9e9ee5d19869":
-            # ref: https://huggingface.co/kakaocorp/kanana-2-30b-a3b-instruct-2601
-            res = "kanana2"
 
         if res is None:
             logger.warning("\n")
@@ -2809,7 +3012,7 @@ class AfmoeModel(LlamaModel):
 
                     data_torch = torch.stack(datas, dim=0)
                     merged_name = f"model.layers.{bid}.mlp.experts.{w_name}.weight"
-                    yield from ModelBase.modify_tensors(self, data_torch, merged_name, bid)
+                    yield from super().modify_tensors(data_torch, merged_name, bid)
 
                 return
             else:
@@ -2818,7 +3021,7 @@ class AfmoeModel(LlamaModel):
         if name.endswith(".expert_bias"):
             name = name.replace(".expert_bias", ".expert_bias.bias")
 
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
 
 @ModelBase.register(
@@ -3591,6 +3794,10 @@ class Qwen2Model(TextModel):
                 or name.startswith("model.vision_tower") or name.startswith("model.multi_modal_projector"):
             # skip vision and audio tensors
             return
+
+        if self._add_proj_scale_metadata(name, data_torch):
+            return
+
         yield from super().modify_tensors(data_torch, name, bid)
 
 
@@ -3883,7 +4090,7 @@ class Ernie4_5MoeModel(Ernie4_5Model):
                     merged_name = f"model.layers.{bid}.mlp.experts.{w_name}.weight"
                     yield from super().modify_tensors(data_torch, merged_name, bid)
         else:
-            yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+            yield from super().modify_tensors(data_torch, name, bid)
 
     def prepare_tensors(self):
         super().prepare_tensors()
@@ -4167,87 +4374,6 @@ class InternVisionModel(MmprojModel):
                 yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register(
-    "NemotronH_Nano_VL_V2",
-    "RADIOModel",
-)
-class NemotronNanoV2VLModel(MmprojModel):
-    # ViT-Huge architecture parameters for RADIO v2.5-h
-    _vit_hidden_size = 1280
-    _vit_intermediate_size = 5120
-    _vit_num_layers = 32
-    _vit_num_heads = 16
-
-    def get_vision_config(self) -> dict[str, Any] | None:
-        # RADIO config doesn't have standard ViT parameters, so they need to be constructed manually
-        vision_config = self.global_config.get("vision_config")
-        if vision_config is None:
-            return None
-        # Add ViT-H parameters
-        vision_config = {
-            **vision_config,
-            "hidden_size": self._vit_hidden_size,
-            "intermediate_size": self._vit_intermediate_size,
-            "num_hidden_layers": self._vit_num_layers,
-            "num_attention_heads": self._vit_num_heads,
-            "image_size": self.global_config.get("force_image_size", 512),
-        }
-        return vision_config
-
-    def set_gguf_parameters(self):
-        if "image_mean" not in self.preprocessor_config:
-            self.preprocessor_config["image_mean"] = [0.485, 0.456, 0.406]
-        if "image_std" not in self.preprocessor_config:
-            self.preprocessor_config["image_std"] = [0.229, 0.224, 0.225]
-
-        super().set_gguf_parameters()
-        hparams = self.global_config
-        self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.NEMOTRON_V2_VL)
-        self.gguf_writer.add_vision_attention_layernorm_eps(1e-6)
-        self.gguf_writer.add_vision_use_gelu(True)
-        downsample_ratio = hparams.get("downsample_ratio", 0.5)
-        self.gguf_writer.add_vision_projector_scale_factor(int(1.0 / downsample_ratio))
-
-    def tensor_force_quant(self, name, new_name, bid, n_dims):
-        if ".position_embd." in new_name or "pos_embed" in new_name:
-            return gguf.GGMLQuantizationType.F32
-        return super().tensor_force_quant(name, new_name, bid, n_dims)
-
-    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        if "input_conditioner" in name:
-            return
-
-        # RADIO's pos_embed doesn't have .weight suffix, but clip.cpp expects it
-        if "patch_generator.pos_embed" in name:
-            if not name.endswith(".weight"):
-                name += ".weight"
-            # Downsample position embeddings for fixed 512x512 image size
-            import torch.nn.functional as F
-            n_embd = self.hparams["hidden_size"]
-            image_size = self.global_config.get("force_image_size", 512)
-            patch_size = self.hparams["patch_size"]
-            target_patches_per_side = image_size // patch_size  # 32
-            max_patches_per_side = int((data_torch.shape[1]) ** 0.5)  # 128
-            if target_patches_per_side != max_patches_per_side:
-                # Reshape to grid, interpolate, flatten back
-                data_torch = data_torch.reshape(1, max_patches_per_side, max_patches_per_side, n_embd)
-                data_torch = data_torch.permute(0, 3, 1, 2).float()  # [1, n_embd, 128, 128]
-                data_torch = F.interpolate(data_torch, size=(target_patches_per_side, target_patches_per_side),
-                                           mode='bilinear', align_corners=True)
-                data_torch = data_torch.permute(0, 2, 3, 1)  # [1, 32, 32, n_embd]
-                data_torch = data_torch.reshape(1, target_patches_per_side * target_patches_per_side, n_embd)
-
-        # Reshape linear patch embedding to conv2d format for ggml_conv_2d
-        # From [n_embd, patch_size*patch_size*3] to [n_embd, 3, patch_size, patch_size]
-        if "patch_generator.embedder" in name:
-            patch_size = self.hparams["patch_size"]
-            n_embd = self.hparams["hidden_size"]
-            data_torch = data_torch.reshape(n_embd, 3, patch_size, patch_size)
-
-        if name.startswith("vision_model.radio_model.model.") or name.startswith("mlp1."):
-            yield from super().modify_tensors(data_torch, name, bid)
-
-
 @ModelBase.register("WavTokenizerDec")
 class WavTokenizerDecModel(TextModel):
     model_arch = gguf.MODEL_ARCH.WAVTOKENIZER_DEC
@@ -4303,6 +4429,9 @@ class Qwen2MoeModel(TextModel):
         # process the experts separately
         name = name.replace("language_model.", "") # InternVL
 
+        if self._add_proj_scale_metadata(name, data_torch):
+            return
+
         # handle aggregated expert tensors
         # GGUF stores dimensions reversed from PyTorch, so:
         # PyTorch (A,B,C) -> GGUF writes [C,B,A] -> GGML reads ne={C,B,A}
@@ -4310,29 +4439,28 @@ class Qwen2MoeModel(TextModel):
         # Expected GGML ne: {n_embd, n_ff_exp, n_expert} for gate/up, {n_ff_exp, n_embd, n_expert} for down
         if name.endswith("mlp.experts.down_proj") or name.endswith("mlp.experts.down_proj.weight"):
             mapped = f"{name}.weight" if not name.endswith(".weight") else name
-            # HF: [n_expert, n_embd, n_ff] -> GGML: {n_ff, n_embd, n_expert}
-            yield from super().modify_tensors(data_torch, mapped, bid)
+            # Input: (n_expert=128, n_ff_exp=768, n_embd=2048)
+            # Want GGML ne: {n_ff_exp, n_embd, n_expert} = {768, 2048, 128}
+            # Need PyTorch: (128, 2048, 768) [reversed of GGML]
+            # So: permute(0, 2, 1): (128, 768, 2048) -> (128, 2048, 768)
+            permuted = data_torch.permute(0, 2, 1).contiguous()
+            yield from super().modify_tensors(permuted, mapped, bid)
             return
 
         if name.endswith("mlp.experts.gate_up_proj") or name.endswith("mlp.experts.gate_up_proj.weight"):
             if data_torch.ndim < 3 or data_torch.shape[-2] % 2 != 0:
                 raise ValueError(f"Unexpected gate_up_proj shape for {name}: {tuple(data_torch.shape)}")
-            # HF: [n_expert, 2*n_ff, n_embd] -> split on dim=-2
-            n_ff = data_torch.shape[-2] // 2
-            gate = data_torch[..., :n_ff, :].contiguous()
-            up = data_torch[..., n_ff:, :].contiguous()
-            # gate/up: [n_expert, n_ff, n_embd] -> GGML: {n_embd, n_ff, n_expert}
-            base_name = name.removesuffix(".weight").removesuffix(".gate_up_proj")
-            mapped_gate = f"{base_name}.gate_proj.weight"
-            mapped_up = f"{base_name}.up_proj.weight"
-            yield from super().modify_tensors(gate, mapped_gate, bid)
-            yield from super().modify_tensors(up, mapped_up, bid)
+            mapped = f"{name}.weight" if not name.endswith(".weight") else name
+            # Input gate_up: (n_expert, n_embd, 2*n_ff_exp)
+            # Want GGML ne: {n_embd, 2*n_ff_exp, n_expert}
+            # Need PyTorch: (n_expert, 2*n_ff_exp, n_embd)
+            permuted = data_torch.permute(0, 2, 1).contiguous()
+            yield from super().modify_tensors(permuted, mapped, bid)
             return
 
         if name.startswith("mlp") or name.startswith("vision_model") or name.startswith("model.vision_tower") or name.startswith("model.multi_modal_projector") or name.startswith("model.visual"):
             # skip visual tensors
             return
-
         if name.find("experts") != -1:
             n_experts = self.find_hparam(["num_local_experts", "num_experts"])
             assert bid is not None
@@ -4599,10 +4727,6 @@ class Qwen3VLVisionModel(MmprojModel):
         if name.startswith("model.language_model.") or name.startswith("lm_head."):
             return
 
-        # Skip MTP tensors
-        if name.startswith("mtp."):
-            return
-
         if name.startswith("model.visual."):
             name = name.replace("model.visual.", "visual.", 1)
 
@@ -4733,54 +4857,14 @@ class Qwen3VLMoeTextModel(Qwen3MoeModel):
         if name.startswith("model.visual."):
             return
 
-        # Qwen3VL has transposed packed tensors, so we treat it differently from general Qwen2MoE packed tensors
-        if name.endswith("mlp.experts.down_proj") or name.endswith("mlp.experts.down_proj.weight"):
-            name = name.replace("language_model.", "")
-            mapped = f"{name}.weight" if not name.endswith(".weight") else name
-            permuted = data_torch.permute(0, 2, 1).contiguous()
-            yield from ModelBase.modify_tensors(self, permuted, mapped, bid)
-            return
-
-        if name.endswith("mlp.experts.gate_up_proj") or name.endswith("mlp.experts.gate_up_proj.weight"):
-            name = name.replace("language_model.", "")
-            if data_torch.ndim < 3 or data_torch.shape[-1] % 2 != 0:
-                raise ValueError(f"Unexpected gate_up_proj shape for {name}: {tuple(data_torch.shape)}")
-            split_dim = data_torch.shape[-1] // 2
-            gate = data_torch[..., :split_dim].contiguous()
-            up = data_torch[..., split_dim:].contiguous()
-            # Input gate/up: (n_expert=128, n_embd=2048, n_ff_exp=768)
-            # Want GGML ne: {n_embd, n_ff_exp, n_expert} = {2048, 768, 128}
-            # Need PyTorch: (128, 768, 2048) [reversed of GGML]
-            # So: permute(0, 2, 1): (128, 2048, 768) -> (128, 768, 2048)
-            base_name = name.removesuffix(".weight")
-            base = base_name.rsplit('.', 1)[0]
-            mapped_gate = f"{base}.gate_proj.weight"
-            mapped_up = f"{base}.up_proj.weight"
-            perm_gate = gate.permute(0, 2, 1).contiguous()
-            perm_up = up.permute(0, 2, 1).contiguous()
-            yield from ModelBase.modify_tensors(self, perm_gate, mapped_gate, bid)
-            yield from ModelBase.modify_tensors(self, perm_up, mapped_up, bid)
-            return
-
         yield from super().modify_tensors(data_torch, name, bid)
 
 
 class _LinearAttentionVReorderBase(Qwen3NextModel):
     model_arch = gguf.MODEL_ARCH.QWEN3NEXT  # overridden by subclasses
-    """reorders V heads from grouped to tiled order for ggml broadcast
-
-    see https://github.com/ggml-org/llama.cpp/pull/19468#discussion_r2786394306
-
-    Linear attention may has num_k_heads < num_v_heads. The HF weights store
-    V heads grouped by K head: [G0_v0..v{r-1}, G1_v0..v{r-1}, ...].
-    ggml binary ops use tiled broadcast: [K0, K1, ..., K0, K1, ...].
-    We reorder V heads to tiled order so ggml_repeat can replace the expensive
-    interleaved repeat: [G0_v0, G1_v0, ..., G0_v1, G1_v1, ...].
-    """
 
     @staticmethod
     def _reorder_v_heads(tensor: Tensor, dim: int, num_k_heads: int, num_v_per_k: int, head_dim: int) -> Tensor:
-        """Reorder V heads from grouped (by K head) to tiled order along the given dimension."""
         shape = list(tensor.shape)
         if dim < 0:
             dim += len(shape)
@@ -4800,7 +4884,6 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
             num_v_per_k = num_v_heads // num_k_heads
 
             if ".in_proj_qkv." in name:
-                # QKV weight: reorder only the V rows
                 q_dim = head_k_dim * num_k_heads
                 k_dim = head_k_dim * num_k_heads
                 q = data_torch[:q_dim]
@@ -4808,35 +4891,25 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
                 v = data_torch[q_dim + k_dim:]
                 v = self._reorder_v_heads(v, 0, num_k_heads, num_v_per_k, head_v_dim)
                 data_torch = torch.cat([q, k, v], dim=0)
-
             elif ".in_proj_z." in name:
-                # Z gate weight: reorder rows (num_v_heads * head_v_dim)
                 data_torch = self._reorder_v_heads(data_torch, 0, num_k_heads, num_v_per_k, head_v_dim)
-
             elif ".in_proj_b." in name or ".in_proj_a." in name:
-                # Beta/Alpha weight: reorder rows (num_v_heads, head_dim=1)
                 data_torch = self._reorder_v_heads(data_torch, 0, num_k_heads, num_v_per_k, 1)
-
             elif ".A_log" in name or ".dt_bias" in name or ".dt_proj" in name:
-                # A_log / dt_bias: 1D parameters with num_v_heads elements
                 if data_torch.ndim == 1:
                     data_torch = self._reorder_v_heads(
                         data_torch.unsqueeze(-1), 0, num_k_heads, num_v_per_k, 1
                     ).squeeze(-1)
                 else:
                     data_torch = self._reorder_v_heads(data_torch, -1, num_k_heads, num_v_per_k, 1)
-
             elif ".conv1d" in name:
-                # Conv1d kernel: reorder only the V channel portion
                 data = data_torch.squeeze()
                 qk_channels = head_k_dim * num_k_heads * 2
                 qk_part = data[:qk_channels]
                 v_part = data[qk_channels:]
                 v_part = self._reorder_v_heads(v_part, 0, num_k_heads, num_v_per_k, head_v_dim)
                 data_torch = torch.cat([qk_part, v_part], dim=0)
-
             elif ".out_proj." in name:
-                # Out projection weight: reorder columns (input dimension)
                 data_torch = self._reorder_v_heads(data_torch, 1, num_k_heads, num_v_per_k, head_v_dim)
 
         yield from super().modify_tensors(data_torch, name, bid)
@@ -6155,7 +6228,7 @@ class NeoBert(BertModel):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("EuroBertModel", "JinaEmbeddingsV5Model")
+@ModelBase.register("XLMRobertaModel", "XLMRobertaForSequenceClassification")
 class EuroBertModel(TextModel):
     model_arch = gguf.MODEL_ARCH.EUROBERT
 
@@ -6704,8 +6777,7 @@ class Gemma3nVisionAudioModel(ConformerAudioModel):
 
         if name.startswith("model.vision_tower.timm_model.blocks."):
             # Double-indexed block tensors through custom logic
-            yield (self.custom_map(name), data_torch)
-            return
+            new_name = self.custom_map(name)
         else:
             # Route non-repeating (conv_stem, msfa, embedding, etc.) and un-catched through tensor_mapping.py
             new_name = self.map_tensor_name(name)
@@ -6713,7 +6785,7 @@ class Gemma3nVisionAudioModel(ConformerAudioModel):
         if new_name.endswith("conv_stem.conv.bias") or new_name.endswith("layer_scale.gamma"):
             data_torch = data_torch.unsqueeze(0).unsqueeze(-1).unsqueeze(-1) # [1, C, 1, 1]
 
-        yield from ModelBase.modify_tensors(self, data_torch, new_name, bid)
+        yield from super().modify_tensors(data_torch, new_name, bid)
 
 
 @ModelBase.register("Gemma3nForCausalLM", "Gemma3nForConditionalGeneration")
@@ -6813,7 +6885,7 @@ class Gemma3NModel(Gemma3Model):
 
             # Continue with normal processing
             name = name.replace("language_model.", "")
-            yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+            yield from super().modify_tensors(data_torch, name, bid)
             return
 
         if "altup_unembed_projections" in name:
@@ -6830,7 +6902,7 @@ class Gemma3NModel(Gemma3Model):
                 raise ValueError(f"Unknown name: {name}")
             out = self._stack_matrices(self._altup_unembd)
             if out is not None:
-                yield from ModelBase.modify_tensors(self, out, "model.altup_unembed_projections.weight", bid)
+                yield from super().modify_tensors(out, "model.altup_unembed_projections.weight", bid)
                 return
             else:
                 return
@@ -6847,7 +6919,7 @@ class Gemma3NModel(Gemma3Model):
                 raise ValueError(f"Unknown name: {name}")
             out = self._stack_matrices(self._altup_proj)
             if out is not None:
-                yield from ModelBase.modify_tensors(self, out, "model.altup_projections.weight", bid)
+                yield from super().modify_tensors(out, "model.altup_projections.weight", bid)
                 return
             else:
                 return
@@ -7308,7 +7380,6 @@ class Mamba2Model(TextModel):
         self.gguf_writer.add_file_type(self.ftype)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-
         if name.startswith("model.backbone") or name.startswith("model.lm_head"):
             # map Mamba-Codestral-7B-v0.1 tensor names to the names used by Mamba-2
             name = name.removeprefix("model.")
@@ -7926,14 +7997,226 @@ class DeepseekModel(TextModel):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
+def pad_dim(t, dim, amount):
+    if amount == 0:
+        return t
+    pads = [0] * (2 * len(t.shape))
+    rev_dim = len(t.shape) - 1 - dim
+    pads[2 * rev_dim + 1] = amount
+    return torch.nn.functional.pad(t, tuple(pads))
+
+
+def handle_nvfp4_helper(model, data_torch, name, bid):
+    def map_nvfp4_name(raw_name: str) -> str:
+        mapped_name = raw_name
+        if "language_model." in mapped_name:
+            mapped_name = mapped_name.replace("language_model.", "")
+        if getattr(model, "hf_arch", None) == "Qwen2Model":
+            mapped_name = f"model.{mapped_name}"
+        return model.map_tensor_name(mapped_name)
+
+    def maybe_transform_nvfp4_weight(raw_weight_name: str, qs: Tensor, scales: Tensor) -> tuple[str, Tensor, Tensor]:
+        try:
+            transformed = list(model.modify_tensors(torch.arange(qs.shape[0], dtype=torch.float32).reshape(-1, 1), raw_weight_name, bid))
+        except Exception:
+            return map_nvfp4_name(raw_weight_name), qs, scales
+
+        if len(transformed) != 1:
+            return map_nvfp4_name(raw_weight_name), qs, scales
+
+        gguf_name, row_ids = transformed[0]
+        if not torch.is_tensor(row_ids) or row_ids.shape != (qs.shape[0], 1):
+            return gguf_name, qs, scales
+
+        row_ids = row_ids.reshape(-1).detach().cpu()
+        if row_ids.dtype.is_floating_point:
+            rounded = row_ids.round()
+            if not torch.allclose(row_ids, rounded):
+                return gguf_name, qs, scales
+            row_ids = rounded
+
+        if row_ids.numel() != qs.shape[0]:
+            return gguf_name, qs, scales
+
+        row_ids = row_ids.to(dtype=torch.long)
+        if row_ids.min().item() < 0 or row_ids.max().item() >= qs.shape[0]:
+            return gguf_name, qs, scales
+
+        if not torch.equal(torch.sort(row_ids).values, torch.arange(qs.shape[0], dtype=torch.long)):
+            return gguf_name, qs, scales
+
+        if not torch.equal(row_ids, torch.arange(qs.shape[0], dtype=torch.long)):
+            qs = qs.index_select(0, row_ids.to(device=qs.device))
+            scales = scales.index_select(0, row_ids.to(device=scales.device))
+
+        return gguf_name, qs, scales
+
+    if name.endswith((
+        ".weight_global_scale",
+        ".global_scale",
+        "._global_scale",
+        ".weight_scale_1",
+        ".d",
+        ".input_global_scale",
+    )):
+        # Strict metadata policy: conversion semantics only consume .tensor_scale/.input_scale.
+        return []
+
+    is_nvfp4_weight = False
+    if name.endswith(".weight"):
+        base = name.removesuffix(".weight")
+        is_nvfp4_weight = (
+            f"{base}.weight_scale" in model.model_tensors
+            or f"{base}.qscale_weight" in model.model_tensors
+        )
+
+    if is_nvfp4_weight or any(name.endswith(s) for s in [".weight_packed", ".weight_scale", ".qscale_weight", ".tensor_scale", ".weight_scale_2", ".input_scale"]):
+        assert bid is not None
+
+        if not hasattr(model, "_experts") or model._experts is None:
+            model._experts = [{} for _ in range(model.block_count)]
+        experts = model._experts[bid]
+        experts[name] = data_torch
+
+        n_experts = model.find_hparam(["n_routed_experts", "num_local_experts", "num_experts"], optional=True)
+
+        def repack_proj(proj_name: str, ws: list[Tensor], s1s: list[Tensor], keys_to_remove: list[str], tensor_scale_value: float | None, input_scale_value: float | None) -> bool:
+            if len(ws) != n_experts or len(s1s) != n_experts:
+                return False
+            raw_weight_name = f"model.layers.{bid}.mlp.experts.{proj_name}.weight"
+            try:
+                gguf_name = map_nvfp4_name(raw_weight_name)
+            except ValueError:
+                return False
+            model.repack_nvfp4(
+                gguf_name,
+                torch.stack(ws, dim=0),
+                torch.stack(s1s, dim=0),
+                input_scale=input_scale_value,
+                tensor_scale=tensor_scale_value,
+            )
+            for k in keys_to_remove:
+                experts.pop(k, None)
+            return True
+
+        def collect_proj(proj_name: str, expert_prefix: str) -> tuple[list[Tensor], list[Tensor], list[str], float | None, float | None]:
+            ws: list[Tensor] = []
+            s1s: list[Tensor] = []
+            keys_to_remove: list[str] = []
+            tensor_scale_value: float | None = None
+            input_scale_value: float | None = None
+            for xid in range(n_experts):
+                base = f"{expert_prefix}.{xid}.{proj_name}"
+                w_key = f"{base}.weight_packed"
+                if w_key not in experts:
+                    w_key = f"{base}.weight"
+                s1_key = f"{base}.weight_scale"
+                if s1_key not in experts:
+                    s1_key = f"{base}.qscale_weight"
+                if w_key not in experts or s1_key not in experts:
+                    return [], [], [], None, None
+
+                ts_key = f"{base}.tensor_scale"
+                if ts_key not in experts:
+                    ts_key = f"{base}.weight_scale_2"
+                in_key = f"{base}.input_scale"
+                expect_ts = f"{base}.tensor_scale" in model.model_tensors or f"{base}.weight_scale_2" in model.model_tensors
+                expect_in = in_key in model.model_tensors
+                if expect_ts and ts_key not in experts:
+                    return [], [], [], None, None
+                if expect_in and in_key not in experts:
+                    return [], [], [], None, None
+
+                ws.append(experts[w_key])
+                s1s.append(experts[s1_key])
+                keys_to_remove.extend([w_key, s1_key, ts_key, in_key])
+                if tensor_scale_value is None and ts_key in experts:
+                    tensor_scale_value = model._tensor_scalar_to_float(experts[ts_key], 1.0)
+                if input_scale_value is None and in_key in experts:
+                    input_scale_value = model._tensor_scalar_to_float(experts[in_key], 1.0)
+            return ws, s1s, keys_to_remove, tensor_scale_value, input_scale_value
+
+        expert_tag = "mlp.experts" if "mlp.experts" in name else "mixer.experts" if "mixer.experts" in name else None
+        if expert_tag is not None:
+            if n_experts is None:
+                return []
+            expert_prefix = name.split(expert_tag)[0] + expert_tag
+            down_ws, down_s1s, down_keys, down_ts, down_in = collect_proj("down_proj", expert_prefix)
+            repack_proj("down_proj", down_ws, down_s1s, down_keys, down_ts, down_in)
+
+            gate_up_ws, gate_up_s1s, gate_up_keys, gate_up_ts, gate_up_in = collect_proj("gate_up_proj", expert_prefix)
+            gate_up_done = repack_proj("gate_up_proj", gate_up_ws, gate_up_s1s, gate_up_keys, gate_up_ts, gate_up_in)
+
+            if not gate_up_done:
+                gate_ws, gate_s1s, gate_keys, gate_ts, gate_in = collect_proj("gate_proj", expert_prefix)
+                up_ws, up_s1s, up_keys, up_ts, up_in = collect_proj("up_proj", expert_prefix)
+                if len(gate_ws) == n_experts and len(up_ws) == n_experts:
+                    cat_dim_w = gate_ws[0].ndim - 2 if gate_ws[0].ndim >= 2 else 0
+                    cat_dim_s = gate_s1s[0].ndim - 2 if gate_s1s[0].ndim >= 2 else 0
+                    fused_ws = [torch.cat((g, u), dim=cat_dim_w) for g, u in zip(gate_ws, up_ws)]
+                    fused_s1s = [torch.cat((g, u), dim=cat_dim_s) for g, u in zip(gate_s1s, up_s1s)]
+                    fused_ts = gate_ts if gate_ts is not None else up_ts
+                    fused_in = gate_in if gate_in is not None else up_in
+                    gate_up_done = repack_proj("gate_up_proj", fused_ws, fused_s1s, gate_keys + up_keys, fused_ts, fused_in)
+
+            if not gate_up_done:
+                gate_ws, gate_s1s, gate_keys, gate_ts, gate_in = collect_proj("gate_proj", expert_prefix)
+                repack_proj("gate_proj", gate_ws, gate_s1s, gate_keys, gate_ts, gate_in)
+                up_ws, up_s1s, up_keys, up_ts, up_in = collect_proj("up_proj", expert_prefix)
+                repack_proj("up_proj", up_ws, up_s1s, up_keys, up_ts, up_in)
+
+        else:
+            base = name
+            suffixes = [".weight_packed", ".weight_scale", ".qscale_weight", ".weight", ".tensor_scale", ".weight_scale_2", ".input_scale", ".input_global_scale"]
+            for s in suffixes:
+                if base.endswith(s):
+                    base = base[:-len(s)]
+                    break
+
+            w_key = base + ".weight_packed"
+            if w_key not in experts:
+                w_key = base + ".weight"
+            s1_key = base + ".weight_scale"
+            if s1_key not in experts:
+                s1_key = base + ".qscale_weight"
+            ts_key = base + ".tensor_scale"
+            if ts_key not in experts:
+                ts_key = base + ".weight_scale_2"
+            in_key = base + ".input_scale"
+            expect_ts = (base + ".tensor_scale") in model.model_tensors or (base + ".weight_scale_2") in model.model_tensors
+            expect_in = in_key in model.model_tensors
+
+            if w_key in experts and s1_key in experts and (not expect_ts or ts_key in experts) and (not expect_in or in_key in experts):
+                qs = experts[w_key]
+                scales = experts[s1_key]
+                input_scale = experts[in_key] if expect_in else None
+                tensor_scale = experts[ts_key] if expect_ts else None
+
+                raw_weight_name = base + ".weight"
+                gguf_name, qs, scales = maybe_transform_nvfp4_weight(raw_weight_name, qs, scales)
+                model.repack_nvfp4(gguf_name, qs, scales, input_scale=input_scale, tensor_scale=tensor_scale)
+
+                keys_to_remove = [w_key, s1_key, base + ".weight_scale", base + ".qscale_weight", base + ".tensor_scale", base + ".weight_scale_2", base + ".input_scale", base + ".input_global_scale"]
+                for k in keys_to_remove:
+                    experts.pop(k, None)
+
+        return []
+    return None
+
+
+@ModelBase.register("Glm4ForCausalLM", "Glm4vForConditionalGeneration")
+
+
+
+
 @ModelBase.register(
     "DeepseekV2ForCausalLM",
     "DeepseekV3ForCausalLM",
     "KimiVLForConditionalGeneration",
-    "KimiK25ForConditionalGeneration",
     "YoutuForCausalLM",
     "YoutuVLForConditionalGeneration",
 )
+# Isolated NVFP4 Handler
 class DeepseekV2Model(TextModel):
     model_arch = gguf.MODEL_ARCH.DEEPSEEK2
 
@@ -8052,8 +8335,9 @@ class DeepseekV2Model(TextModel):
     _experts: list[dict[str, Tensor]] | None = None
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        # skip vision tensors and remove "language_model." for Kimi-VL and Kimi-K2.5
-        if "vision_tower" in name or "multi_modal_projector" in name or "mm_projector" in name:
+
+        # skip vision tensors and remove "language_model." for Kimi-VL
+        if "vision_tower" in name or "multi_modal_projector" in name:
             return
         if name.startswith("siglip2.") or name.startswith("merger."):
             return
@@ -8071,11 +8355,10 @@ class DeepseekV2Model(TextModel):
             name = name.replace("e_score_correction_bias", "e_score_correction.bias")
 
         # skip Multi-Token Prediction (MTP) layers
-        if self.skip_mtp:
-            block_count = self.hparams["num_hidden_layers"]
-            match = re.match(r"model.layers.(\d+)", name)
-            if match and int(match.group(1)) >= block_count:
-                return
+        block_count = self.hparams["num_hidden_layers"]
+        match = re.match(r"model.layers.(\d+)", name)
+        if match and int(match.group(1)) >= block_count:
+            return
 
         # process the experts separately
         if name.find("mlp.experts") != -1:
@@ -8264,7 +8547,7 @@ class MimoV2Model(TextModel):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
-@ModelBase.register("Step3p5ForCausalLM")
+@ModelBase.register("PanguEmbeddedForCausalLM")
 class Step35Model(TextModel):
     model_arch = gguf.MODEL_ARCH.STEP35
 
@@ -8336,7 +8619,7 @@ class Step35Model(TextModel):
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None):
         # remove mtp layers
-        if (m := re.match(r"model\.layers\.(\d+)\.", name)) is not None:
+        if (m := re.match(r"model\\.layers\\.(\\d+)\\.", name)) is not None:
             il = int(m.group(1))
             n_main = int(self.hparams.get("num_hidden_layers", self.block_count))
             if il >= n_main:
@@ -8748,7 +9031,7 @@ class T5EncoderModel(TextModel):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Jais2ForCausalLM")
+@ModelBase.register("PanguEmbeddedForCausalLM")
 class Jais2Model(TextModel):
     model_arch = gguf.MODEL_ARCH.JAIS2
 
@@ -8836,6 +9119,7 @@ class JaisModel(TextModel):
         self.gguf_writer.add_max_alibi_bias(self.max_alibi_bias)
 
 
+
 @ModelBase.register("Glm4ForCausalLM", "Glm4vForConditionalGeneration")
 class Glm4Model(TextModel):
     model_arch = gguf.MODEL_ARCH.GLM4
@@ -8909,27 +9193,6 @@ class Glm4Model(TextModel):
             if name.endswith(("k_proj.weight", "k_proj.bias")):
                 data_torch = Glm4Model.normal_to_neox(data_torch, n_head, n_kv_head, head_dim, self.partial_rotary_factor)
         yield from super().modify_tensors(data_torch, name, bid)
-
-
-@ModelBase.register("GlmOcrForConditionalGeneration")
-class GlmOCRModel(Glm4Model):
-    model_arch = gguf.MODEL_ARCH.GLM4
-    use_mrope = False
-    partial_rotary_factor = 0.5
-
-    # Note: GLM-OCR is the same as GLM4, but with an extra NextN/MTP prediction layer
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # GLM-OCR has num_hidden_layers + 1 actual layers (including NextN layer)
-        self.block_count = self.hparams["num_hidden_layers"] + self.hparams.get("num_nextn_predict_layers", 0)
-        self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
-
-    def set_gguf_parameters(self):
-        super().set_gguf_parameters()
-        # NextN/MTP prediction layers
-        if (num_nextn_predict_layers := self.hparams.get("num_nextn_predict_layers")) is not None:
-            self.gguf_writer.add_nextn_predict_layers(num_nextn_predict_layers)
 
 
 @ModelBase.register("Glm4MoeForCausalLM", "Glm4vMoeForConditionalGeneration")
@@ -9043,11 +9306,38 @@ class Glm4MoeModel(TextModel):
 class Glm4MoeLiteModel(DeepseekV2Model):
     model_arch = gguf.MODEL_ARCH.DEEPSEEK2
 
+    # aligned with pack of 4 SoA layout requirements
+    def set_gguf_parameters(self):
+        # note: deepseek2 using MLA converts into MQA (ie: GQA with 1 group)
+        self.hparams["num_key_value_heads"] = 1
+
+        super().set_gguf_parameters()
+
+    # copied from Glm4MoeModel
     def set_vocab(self):
-        return self._set_vocab_glm()
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(self.dir_model)
+        special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=True)
+        tokens, toktypes, tokpre = self.get_vocab_base()
+        self.gguf_writer.add_tokenizer_model("gpt2")
+        self.gguf_writer.add_tokenizer_pre(tokpre)
+        self.gguf_writer.add_token_list(tokens)
+        self.gguf_writer.add_token_types(toktypes)
+
+        # Special tokens
+        # Note: Using <|endoftext|> (151329) for eot causes endless generation
+        special_vocab._set_special_token("bos", tokenizer.get_added_vocab()["[gMASK]"])  # 151331
+        special_vocab._set_special_token("eot", tokenizer.get_added_vocab()["<|user|>"])  # 151336
+        special_vocab._set_special_token("unk", tokenizer.get_added_vocab()["<|endoftext|>"]) # 151329
+        special_vocab._set_special_token("eom", tokenizer.get_added_vocab()["<|observation|>"])  # 151338
+
+        special_vocab.add_to_gguf(self.gguf_writer)
 
 
-@ModelBase.register("GlmMoeDsaForCausalLM")
+
+
+@ModelBase.register("JAISLMHeadModel")
 class GlmMoeDsaModel(DeepseekV2Model):
     model_arch = gguf.MODEL_ARCH.GLM_DSA
     skip_mtp = False
@@ -9391,6 +9681,7 @@ class ExaoneMoEModel(Exaone4Model):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
+        self.gguf_writer.add_expert_count(self.hparams["num_experts"])
         moe_intermediate_size = self.hparams["moe_intermediate_size"]
         num_shared_experts = self.hparams["num_shared_experts"]
         self.gguf_writer.add_expert_feed_forward_length(moe_intermediate_size)
@@ -9431,7 +9722,7 @@ class ExaoneMoEModel(Exaone4Model):
             name = name.replace("e_score_correction_bias", "e_score_correction.bias")
 
         if name.find("mlp.experts") != -1:
-            n_experts = self.find_hparam(["num_local_experts", "num_experts"])
+            n_experts = self.hparams["num_experts"]
             assert bid is not None
 
             if self._experts is None:
@@ -9530,9 +9821,8 @@ class GraniteMoeModel(GraniteModel):
             ffn_dim = self.hparams["intermediate_size"]
             assert data_torch.shape[-2] == 2 * ffn_dim, "Merged FFN tensor size must be 2 * intermediate_size"
             gate, up = data_torch.split(ffn_dim, dim=-2)
-            yield from ModelBase.modify_tensors(self, gate, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_EXP, bid), bid)
-            yield from ModelBase.modify_tensors(self, up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP_EXP, bid), bid)
-            return
+            yield from super().modify_tensors(gate, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_EXP, bid), bid)
+            yield from super().modify_tensors(up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP_EXP, bid), bid)
 
         has_experts = bool(self.hparams.get('num_local_experts'))
 
@@ -9541,15 +9831,15 @@ class GraniteMoeModel(GraniteModel):
             assert data_torch.shape[-2] == 2 * ffn_dim, "Merged FFN tensor size must be 2 * shared_intermediate_size"
             gate, up = data_torch.split(ffn_dim, dim=-2)
             if has_experts:
-                yield from ModelBase.modify_tensors(self, gate,self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_SHEXP, bid), bid)
-                yield from ModelBase.modify_tensors(self, up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP_SHEXP, bid), bid)
+                yield from super().modify_tensors(gate,self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_SHEXP, bid), bid)
+                yield from super().modify_tensors(up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP_SHEXP, bid), bid)
                 return
-            yield from ModelBase.modify_tensors(self, gate, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE, bid), bid)
-            yield from ModelBase.modify_tensors(self, up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP, bid), bid)
+            yield from super().modify_tensors(gate, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE, bid), bid)
+            yield from super().modify_tensors(up, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP, bid), bid)
             return
 
         if not has_experts and name.endswith("shared_mlp.output_linear.weight"):
-            yield from ModelBase.modify_tensors(self, data_torch, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_DOWN, bid), bid)
+            yield from super().modify_tensors(data_torch, self.format_tensor_name(gguf.MODEL_TENSOR.FFN_DOWN, bid), bid)
             return
 
         yield from super().modify_tensors(data_torch, name, bid)
@@ -9647,9 +9937,8 @@ class GraniteHybridModel(Mamba2Model, GraniteMoeModel):
             yield from Mamba2Model.modify_tensors(self, data_torch, name, bid)
             return
         elif bid in self._attn_layers:
-            yield from GraniteMoeModel.modify_tensors(self, data_torch, name, bid)
-            return
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+            return GraniteMoeModel.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
     def set_gguf_parameters(self):
         """This method merges params from both parents and some that are
@@ -9789,61 +10078,34 @@ class NemotronHModel(GraniteHybridModel):
         if self.is_moe and bid is not None:
             if name.endswith("mixer.gate.e_score_correction_bias"):
                 new_name = name.replace("e_score_correction_bias", "e_score_correction.bias")
-                yield from ModelBase.modify_tensors(self, data_torch, new_name, bid)
+                yield from super().modify_tensors(data_torch, new_name, bid)
                 return
 
             if name.endswith("mixer.dt_bias"):
                 new_name = name.replace("dt_bias", "dt.bias")
-                yield from ModelBase.modify_tensors(self, data_torch, new_name, bid)
+                yield from super().modify_tensors(data_torch, new_name, bid)
                 return
 
             if name.endswith("mixer.conv1d.weight"):
                 squeezed_data = data_torch.squeeze()
-                yield from ModelBase.modify_tensors(self, squeezed_data, name, bid)
+                yield from super().modify_tensors(squeezed_data, name, bid)
                 return
 
             if name.endswith("mixer.A_log"):
                 transformed_data = -torch.exp(data_torch)
                 reshaped_data = transformed_data.squeeze().reshape(-1, 1)
-                yield from ModelBase.modify_tensors(self, reshaped_data, name, bid)
+                yield from super().modify_tensors(reshaped_data, name, bid)
                 return
 
             if name.endswith("mixer.D"):
                 reshaped_data = data_torch.squeeze().reshape(-1, 1)
-                yield from ModelBase.modify_tensors(self, reshaped_data, name, bid)
+                yield from super().modify_tensors(reshaped_data, name, bid)
                 return
 
             if name.endswith("mixer.norm.weight"):
                 reshaped_data = data_torch.reshape(self.n_group, -1)
-                yield from ModelBase.modify_tensors(self, reshaped_data, name, bid)
+                yield from super().modify_tensors(reshaped_data, name, bid)
                 return
-
-            if name.find("mixer.experts") != -1:
-                n_experts = self.hparams["n_routed_experts"]
-                assert bid is not None
-
-                if self._experts is None:
-                    self._experts = [{} for _ in range(self.block_count)]
-
-                self._experts[bid][name] = data_torch
-
-                if len(self._experts[bid]) >= n_experts * 2:
-                    # merge the experts into a single tensor
-                    for w_name in ["down_proj", "up_proj"]:
-                        datas: list[Tensor] = []
-
-                        for xid in range(n_experts):
-                            ename = f"backbone.layers.{bid}.mixer.experts.{xid}.{w_name}.weight"
-                            datas.append(self._experts[bid][ename])
-                            del self._experts[bid][ename]
-
-                        data_torch = torch.stack(datas, dim=0)
-                        merged_name = f"model.layers.{bid}.mlp.experts.{w_name}.weight"
-
-                        yield from ModelBase.modify_tensors(self, data_torch, merged_name, bid)
-                    return
-                else:
-                    return
 
         yield from super().modify_tensors(data_torch, name, bid)
 
@@ -10775,13 +11037,17 @@ class GptOssModel(TextModel):
                 new_name = self.map_tensor_name(name.replace("_scales", ".weight"))
                 self.repack_mxfp4(new_name, blocks0, data_torch)
             elif "mlp.experts.gate_up_proj_blocks" in name:
-                blocks0, blocks1 = data_torch[:, ::2, :, :], data_torch[:, 1::2, :, :]
+                # de-interleave and concatenate blocks: HF has interleaved layout
+                gate_blocks = data_torch[:, ::2, :, :]   # gate at even indices
+                up_blocks = data_torch[:, 1::2, :, :]    # up at odd indices
+                blocks0 = torch.cat([gate_blocks, up_blocks], dim=1)
             elif "mlp.experts.gate_up_proj_scales" in name:
-                scales0, scales1 = data_torch[:, ::2, :], data_torch[:, 1::2, :]
-                new_name_gate = self.map_tensor_name(name.replace("gate_up_proj_scales", "gate_proj.weight"))
-                new_name_up = self.map_tensor_name(name.replace("gate_up_proj_scales", "up_proj.weight"))
-                self.repack_mxfp4(new_name_gate, blocks0, scales0)
-                self.repack_mxfp4(new_name_up, blocks1, scales1)
+                # de-interleave and concatenate scales: HF has interleaved layout
+                gate_scales = data_torch[:, ::2, :]   # gate at even indices
+                up_scales = data_torch[:, 1::2, :]    # up at odd indices
+                scales0 = torch.cat([gate_scales, up_scales], dim=1)
+                new_name = self.map_tensor_name(name.replace("_scales", ".weight"))
+                self.repack_mxfp4(new_name, blocks0, scales0)
         return []
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
@@ -10800,24 +11066,29 @@ class GptOssModel(TextModel):
                 # otherwise, it should already be repacked to ggml MXFP4 format
                 return
 
-        # split the gate_up into gate and up
+        # keep gate_up merged (don't split into gate and up)
+        # HF has interleaved layout, we need concatenated layout for inference
         if "gate_up_proj" in name:
             if name.endswith("_bias"):
-                name_up = name.replace("gate_up_proj_bias", "up_proj.bias")
-                name_gate = name.replace("gate_up_proj_bias", "gate_proj.bias")
-                gate_proj_bias, up_proj_bias = data_torch[..., ::2], data_torch[..., 1::2]
-                yield from super().modify_tensors(gate_proj_bias, name_gate, bid)
-                yield from super().modify_tensors(up_proj_bias, name_up, bid)
+                name = name.replace("gate_up_proj_bias", "gate_up_proj.bias")
+                # de-interleave and concatenate: [n_expert, 2*n_ff_interleaved] -> [n_expert, 2*n_ff_concatenated]
+                gate_bias = data_torch[..., ::2]   # gate at even indices
+                up_bias = data_torch[..., 1::2]    # up at odd indices
+                data_torch = torch.cat([gate_bias, up_bias], dim=-1)
+                return [(self.map_tensor_name(name), data_torch)]
             elif "_blocks" not in name and "_scales" not in name:
                 logger.warning(f"{name} is not in MXFP4, performance may be degraded")
-                name_up = name.replace("gate_up_proj", "up_proj.weight")
-                name_gate = name.replace("gate_up_proj", "gate_proj.weight")
+                name = name.replace("gate_up_proj", "gate_up_proj.weight")
                 data_torch = data_torch.transpose(-1, -2)
-                gate_proj_weight, up_proj_weight = data_torch[:, ::2, :], data_torch[:, 1::2, :]
-                yield from super().modify_tensors(gate_proj_weight, name_gate, bid)
-                yield from super().modify_tensors(up_proj_weight, name_up, bid)
-        else:
-            yield from super().modify_tensors(data_torch, name, bid)
+                # de-interleave and concatenate: [n_expert, 2*n_ff_interleaved, n_embd] -> [n_expert, 2*n_ff_concatenated, n_embd]
+                gate_weight = data_torch[:, ::2, :]   # gate at even indices
+                up_weight = data_torch[:, 1::2, :]    # up at odd indices
+                data_torch = torch.cat([gate_weight, up_weight], dim=1)
+                return [(self.map_tensor_name(name), data_torch)]
+            else:
+                # otherwise, it should already be repacked to ggml MXFP4 format
+                return []
+        return [(self.map_tensor_name(name), data_torch)]
 
     def set_vocab(self):
         self._set_vocab_gpt2()
@@ -11038,28 +11309,6 @@ class LFM2AudioModel(ConformerAudioModel):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Lfm25AudioTokenizer")
-class LFM25AudioTokenizer(LFM2Model):
-    model_arch = gguf.MODEL_ARCH.LFM2
-
-    def set_vocab(self):
-        self._set_vocab_none()
-
-    def set_gguf_parameters(self):
-        super().set_gguf_parameters()
-        self.gguf_writer.add_sliding_window(self.hparams["sliding_window"])
-        self.gguf_writer.add_embedding_length_out(self.hparams["output_size"])
-
-    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        if name == "istft.window" or name.startswith("emb.emb"):
-            return
-
-        if name.startswith("lin"):
-            name = name.replace("lin", "dense_2_out")
-
-        yield from super().modify_tensors(data_torch, name, bid)
-
-
 @ModelBase.register("SmallThinkerForCausalLM")
 class SmallThinkerModel(TextModel):
     model_arch = gguf.MODEL_ARCH.SMALLTHINKER
@@ -11151,16 +11400,12 @@ class ModernBertModel(BertModel):
         self.gguf_writer.add_vocab_size(self.hparams["vocab_size"])
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # these layers act as MLM head, so we don't need them
+        if name.startswith("decoder."):
+            return
+
         if name.startswith("model."):
             name = name[6:]
-
-        if self.cls_out_labels:
-            # For BertForSequenceClassification (direct projection layer)
-            if name == "classifier.weight":
-                name = "classifier.out_proj.weight"
-
-            if name == "classifier.bias":
-                name = "classifier.out_proj.bias"
 
         yield from super().modify_tensors(data_torch, name, bid)
 
@@ -11459,103 +11704,6 @@ class KimiVLModel(MmprojModel):
                 yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("KimiK25ForConditionalGeneration")
-class KimiK25Model(MmprojModel):
-    """Kimi-K2.5 with MoonViT3d vision encoder"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        assert self.hparams_vision is not None, "Kimi-K2.5 requires vision_config in model config"
-
-        self.merge_kernel_size = tuple(self.hparams_vision.get("merge_kernel_size", [2, 2]))
-        self.patch_size = self.hparams_vision.get("patch_size", 14)
-
-        # Set image_size for compatibility with base class
-        # Use position embedding dimensions as image_size reference
-        pos_emb_h = self.hparams_vision.get("init_pos_emb_height", 64)
-        self.hparams_vision["image_size"] = pos_emb_h * self.patch_size
-
-    def set_gguf_parameters(self):
-        # Base class MmprojModel.set_gguf_parameters() already writes:
-        # - vision_block_count, vision_head_count, vision_embedding_length
-        # - vision_feed_forward_length, vision_patch_size, image_mean, image_std
-        # via find_vparam() which handles the vt_* prefixed keys in Kimi-K2.5's config
-        super().set_gguf_parameters()
-        assert self.hparams_vision is not None
-
-        self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.KIMIK25)
-
-        # Position embedding parameters (for interpolation)
-        self.gguf_writer.add_uint32("vision.pos_emb_height", self.hparams_vision.get("init_pos_emb_height", 64))
-        self.gguf_writer.add_uint32("vision.pos_emb_width", self.hparams_vision.get("init_pos_emb_width", 64))
-        self.gguf_writer.add_uint32("vision.pos_emb_time", self.hparams_vision.get("init_pos_emb_time", 4))
-
-        # Projector parameters
-        self.gguf_writer.add_vision_use_gelu(self.hparams_vision.get("projector_hidden_act", "gelu") == "gelu")
-        self.gguf_writer.add_vision_attention_layernorm_eps(self.hparams_vision.get("projector_ln_eps", 1e-5))
-        self.gguf_writer.add_vision_projector_scale_factor(self.merge_kernel_size[0])
-
-        # Image size limits
-        # Note: in_patch_limit is for images, in_patch_limit_each_frame is for video (not supported yet)
-        in_patch_limit = self.preprocessor_config.get("in_patch_limit", 16384)
-        min_patches = 8  # reasonable minimum
-        pixels_per_patch = self.patch_size ** 2
-        self.gguf_writer.add_vision_min_pixels(min_patches * pixels_per_patch)
-        self.gguf_writer.add_vision_max_pixels(in_patch_limit * pixels_per_patch)
-
-    @staticmethod
-    def permute(weights: Tensor, n_head: int) -> Tensor:
-        out_dim, in_dim = weights.shape
-        head_dim = out_dim // n_head
-        w = weights.reshape(n_head, head_dim // 4, 2, 2, in_dim)
-        w = w.permute(0, 2, 1, 3, 4)
-        return w.reshape(out_dim, in_dim)
-
-    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        # Only process vision and projector tensors
-        is_vision = any(x in name for x in ["vision_tower", "mm_projector"])
-
-        if not is_vision:
-            return
-
-        assert self.hparams_vision is not None
-        n_head = self.hparams_vision.get("num_attention_heads", 16)
-
-        # Permute Q/K weights/biases from interleaved to split RoPE format
-        # This allows using build_rope_2d at runtime without post-permutation.
-        if "wqkv" in name:
-            out_dim = data_torch.shape[0]
-            qkv_dim = out_dim // 3
-            head_dim = qkv_dim // n_head
-
-            if "weight" in name:
-                wq, wk, wv = data_torch[:qkv_dim, :], data_torch[qkv_dim:2 * qkv_dim, :], data_torch[2 * qkv_dim:, :]
-                wq = self.permute(wq, n_head)
-                wk = self.permute(wk, n_head)
-                data_torch = torch.cat([wq, wk, wv], dim=0)
-            elif "bias" in name:
-                bq, bk, bv = data_torch[:qkv_dim], data_torch[qkv_dim:2 * qkv_dim], data_torch[2 * qkv_dim:]
-                bq = bq.reshape(n_head, head_dim // 4, 2, 2).permute(0, 2, 1, 3).reshape(-1)
-                bk = bk.reshape(n_head, head_dim // 4, 2, 2).permute(0, 2, 1, 3).reshape(-1)
-                data_torch = torch.cat([bq, bk, bv], dim=0)
-
-        # Temporal embeddings: (T, 1, C) → (T, C)
-        if "pos_emb.time_weight" in name:
-            T, _, C = data_torch.shape
-            data_torch = data_torch.reshape(T, C)
-
-        # PatchMergerMLP tensor name mapping
-        # proj.0.weight → proj.linear_1.weight
-        # proj.2.weight → proj.linear_2.weight
-        if "mm_projector.proj.0." in name:
-            name = name.replace(".proj.0.", ".proj.linear_1.")
-        elif "mm_projector.proj.2." in name:
-            name = name.replace(".proj.2.", ".proj.linear_2.")
-
-        yield from super().modify_tensors(data_torch, name, bid)
-
-
 @ModelBase.register("CogVLMForCausalLM")
 class CogVLMVisionModel(MmprojModel):
 
@@ -11580,7 +11728,7 @@ class CogVLMModel(LlamaModel):
         if name.startswith("model.vision."):
             return
 
-        yield from ModelBase.modify_tensors(self, data_torch, name, bid)
+        yield from super().modify_tensors(data_torch, name, bid)
 
 
 @ModelBase.register("JanusForConditionalGeneration")
@@ -11890,7 +12038,7 @@ def parse_args() -> argparse.Namespace:
         help="path to write to; default: based on input. {ftype} will be replaced by the outtype.",
     )
     parser.add_argument(
-        "--outtype", type=str, choices=["f32", "f16", "bf16", "q8_0", "tq1_0", "tq2_0", "auto"], default="auto",
+        "--outtype", type=str, choices=["f32", "f16", "bf16", "q8_0", "tq1_0", "tq2_0", "nvfp4", "auto"], default="auto",
         help="output format - use f32 for float32, f16 for float16, bf16 for bfloat16, q8_0 for Q8_0, tq1_0 or tq2_0 for ternary, and auto for the highest-fidelity 16-bit float type",
     )
     parser.add_argument(
@@ -12060,6 +12208,7 @@ def main() -> None:
         "q8_0": gguf.LlamaFileType.MOSTLY_Q8_0,
         "tq1_0": gguf.LlamaFileType.MOSTLY_TQ1_0,
         "tq2_0": gguf.LlamaFileType.MOSTLY_TQ2_0,
+        "nvfp4": gguf.LlamaFileType.NVFP4,
         "auto": gguf.LlamaFileType.GUESSED,
     }
 

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -427,7 +427,8 @@ extern "C" {
         // GGML_TYPE_IQ4_NL_4_8 = 37,
         // GGML_TYPE_IQ4_NL_8_8 = 38,
         GGML_TYPE_MXFP4   = 39, // MXFP4 (1 block)
-        GGML_TYPE_COUNT   = 40,
+        GGML_TYPE_NVFP4   = 40, // NVFP4 (K quant)
+        GGML_TYPE_COUNT   = 41,
     };
 
     // precision
@@ -463,6 +464,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_IQ1_M   = 23, // except 1d tensors
         GGML_FTYPE_MOSTLY_BF16    = 24, // except 1d tensors
         GGML_FTYPE_MOSTLY_MXFP4   = 25, // except 1d tensors
+        GGML_FTYPE_MOSTLY_NVFP4   = 26, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -651,6 +651,7 @@ static struct ggml_tensor * ggml_dup_tensor_layout(struct ggml_context * ctx, co
     for (int i = 0; i < GGML_MAX_DIMS; i++) {
         dup->nb[i] = tensor->nb[i];
     }
+    memcpy(dup->op_params, tensor->op_params, GGML_MAX_OP_PARAMS);
     return dup;
 }
 

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -102,6 +102,10 @@ typedef sycl::half2 ggml_half2;
 #define QI_MXFP4 (QK_MXFP4 / (4 * QR_MXFP4))
 #define QR_MXFP4 2
 
+#define QI_NVFP4 (QK_K / (4 * QR_NVFP4))
+#define QR_NVFP4 2
+
+
 #define QI5_0 (QK5_0 / (4 * QR5_0))
 #define QR5_0 2
 
@@ -167,6 +171,13 @@ typedef sycl::half2 ggml_half2;
 #define GGML_EXTENSION __extension__
 #endif // _MSC_VER
 
+// Note: CUDA provides __align__(N),  host compilers (gcc/clang) do not.
+#if defined(_MSC_VER)
+#define GGML_ALIGN(N) __declspec(align(N))
+#else
+#define GGML_ALIGN(N) __attribute__((aligned(N)))
+#endif
+
 #define QK4_0 32
 typedef struct {
     ggml_half d;           // delta
@@ -193,6 +204,24 @@ typedef struct {
     uint8_t qs[QK_MXFP4/2];
 } block_mxfp4;
 static_assert(sizeof(block_mxfp4) == sizeof(uint8_t) + QK_MXFP4/2, "wrong mxfp4 block size/padding");
+
+#define QK_NVFP4 16
+typedef struct GGML_ALIGN(16) {
+    // 256 FP4 codes packed (2 per byte) => 128 bytes
+    uint8_t qs[4][QK_K/2];
+    uint8_t scales[4][QK_NVFP4];
+} block_nvfp4;  // struct block_nvfp4
+
+static_assert(sizeof(block_nvfp4) == 576, "block_nvfp4 must be 4×144 bytes (one pack)");
+static_assert(sizeof(block_nvfp4) % 16 == 0, "block_nvfp4 must be 16B aligned");
+
+#define GGML_NVFP4_BYTES_PER_BLOCK 144
+#define GGML_NVFP4_BYTES_PER_PACK  ((int) sizeof(block_nvfp4))
+#define GGML_NVFP4_INTS_PER_BLOCK  36
+#define GGML_NVFP4_INTS_PER_PACK   (GGML_NVFP4_BYTES_PER_PACK / (int) sizeof(int))
+
+static_assert(GGML_NVFP4_BYTES_PER_PACK     == 576, "NVFP4 pack bytes mismatch");
+static_assert(GGML_NVFP4_INTS_PER_PACK      == 144, "NVFP4 pack ints mismatch");
 
 #define QK5_0 32
 typedef struct {
@@ -1093,6 +1122,10 @@ GGML_TABLE_END()
 // ref: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 GGML_TABLE_BEGIN(int8_t, kvalues_mxfp4, 16)
     0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12,
+GGML_TABLE_END()
+GGML_TABLE_BEGIN(float, kvalues_fp4_float, 16)
+     0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
 GGML_TABLE_END()
 
 #define NGRID_IQ1S 2048

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -78,6 +78,21 @@ float ggml_table_f32_f16[1 << 16];
 // precomputed f32 table for e8m0 half (1 KB) (simd-mappings.h)
 float ggml_table_f32_e8m0_half[1 << 8];
 
+static float ggml_nvfp4_tensor_scale_from_op_params(const struct ggml_tensor * tensor) {
+    if (tensor == NULL || tensor->type != GGML_TYPE_NVFP4) {
+        return 1.0f;
+    }
+
+    const int op_param_idx_nvfp4_tensor_scale = GGML_MAX_OP_PARAMS / (int) sizeof(int32_t) - 2;
+    float tensor_scale = 1.0f;
+    memcpy(&tensor_scale, &tensor->op_params[op_param_idx_nvfp4_tensor_scale], sizeof(tensor_scale));
+    if (!isfinite(tensor_scale) || tensor_scale <= 0.0f) {
+        return 1.0f;
+    }
+
+    return tensor_scale;
+}
+
 #if defined(__ARM_ARCH)
 struct ggml_arm_arch_features_type {
     int sve_cnt;
@@ -267,6 +282,12 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
     [GGML_TYPE_MXFP4] = {
         .from_float               = quantize_row_mxfp4,
         .vec_dot                  = ggml_vec_dot_mxfp4_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+    },
+    [GGML_TYPE_NVFP4] = {
+        .from_float               = quantize_row_nvfp4,
+        .vec_dot                  = ggml_vec_dot_nvfp4_q8_0,
         .vec_dot_type             = GGML_TYPE_Q8_0,
         .nrows                    = 1,
     },
@@ -1155,6 +1176,7 @@ static void ggml_compute_forward_mul_mat_one_chunk(
 
     ggml_vec_dot_t const vec_dot      = type_traits_cpu[type].vec_dot;
     enum ggml_type const vec_dot_type = type_traits_cpu[type].vec_dot_type;
+    const float nvfp4_tensor_scale = ggml_nvfp4_tensor_scale_from_op_params(src0);
 
     // broadcast factors
     const int64_t r2 = ne12 / ne02;
@@ -1218,6 +1240,16 @@ static void ggml_compute_forward_mul_mat_one_chunk(
                     vec_dot(ne00, &tmp[ir0 - iir0], (num_rows_per_vec_dot > 1 ? 16 : 0), src0_row + ir0 * nb01, (num_rows_per_vec_dot > 1 ? nb01 : 0), src1_col, (num_rows_per_vec_dot > 1 ? src1_col_stride : 0), num_rows_per_vec_dot);
                 }
 
+                if (type == GGML_TYPE_NVFP4 && nvfp4_tensor_scale != 1.0f) {
+                    const int64_t ncopy = MIN(iir0 + blck_0, ir0_end) - iir0;
+                    for (int cn = 0; cn < num_rows_per_vec_dot; ++cn) {
+                        float * row = tmp + cn * 16;
+                        for (int64_t k = 0; k < ncopy; ++k) {
+                            row[k] *= nvfp4_tensor_scale;
+                        }
+                    }
+                }
+
                 for (int cn = 0; cn < num_rows_per_vec_dot; ++cn) {
                     memcpy(&dst_col[iir0 + cn * nb1 / nb0], tmp + (cn * 16), (MIN(iir0 + blck_0, ir0_end) - iir0) * sizeof(float));
                 }
@@ -1241,6 +1273,8 @@ void ggml_compute_forward_mul_mat(
     enum ggml_type           const vec_dot_type         = type_traits_cpu[src0->type].vec_dot_type;
     ggml_from_float_t        const from_float           = type_traits_cpu[vec_dot_type].from_float;
     int64_t                  const vec_dot_num_rows     = type_traits_cpu[src0->type].nrows;
+
+    GGML_UNUSED(vec_dot_num_rows);
 
     GGML_ASSERT(ne0 == ne01);
     GGML_ASSERT(ne1 == ne11);
@@ -1267,6 +1301,9 @@ void ggml_compute_forward_mul_mat(
     const int64_t r3 = ne13 / ne03;
 
     const bool src1_cont = ggml_is_contiguous(src1);
+    if (src0->type == GGML_TYPE_NVFP4) {
+        goto UseGgmlGemm1;
+    }
 
     if (src1_cont) {
         for (int64_t i13 = 0; i13 < ne13; i13++)
@@ -1316,6 +1353,15 @@ UseGgmlGemm1:;
                     size_t bs = ggml_blck_size(vec_dot_type);
                     int64_t ne10_block_start = (ith * ne10/bs) / nth;
                     int64_t ne10_block_end   = ((ith + 1) * ne10/bs) / nth;
+                    if (vec_dot_type == GGML_TYPE_NVFP4) {
+                        // NVFP4: force single-threaded full-row quantization.
+                        if (ith != 0) {
+                            continue;
+                        }
+                        ne10_block_start = 0;
+                        ne10_block_end   = ne10 / bs;
+                    }
+
                     from_float((float *)((char *) src1->data + i13*nb13 + i12*nb12 + i11*nb11 + ne10_block_start*bs*nb10),
                                (void *)               (wdata + i13*nbw3 + i12*nbw2 + i11*nbw1 + ne10_block_start*nbw0),
                                (ne10_block_end - ne10_block_start) * bs);
@@ -1333,6 +1379,9 @@ UseGgmlGemm1:;
     ggml_barrier(params->threadpool);
 
 #if GGML_USE_LLAMAFILE
+    if (src0->type == GGML_TYPE_NVFP4) {
+        goto UseGgmlGemm2;
+    }
     if (src1->type != vec_dot_type) {
         const void* wdata = (src1->type == vec_dot_type) ? src1->data : params->wdata;
         const size_t row_size = ggml_row_size(vec_dot_type, ne10);
@@ -1410,6 +1459,7 @@ UseGgmlGemm2:;
         if ((nr0 % 2 != 0) || (ne11 % 2 != 0) || ((ir0_end - ir0_start) % 2 != 0) || ((ir1_end - ir1_start) % 2 != 0)) {
             num_rows_per_vec_dot = 1;
         }
+
         ggml_compute_forward_mul_mat_one_chunk(params, dst, src0->type, num_rows_per_vec_dot, ir0_start, ir0_end, ir1_start, ir1_end);
 
         if (nth >= nchunk0 * nchunk1) {
@@ -1451,6 +1501,7 @@ static void ggml_compute_forward_mul_mat_id_one_chunk(
 
     ggml_vec_dot_t    const vec_dot      = type_traits_cpu[type].vec_dot;
     enum ggml_type    const vec_dot_type = type_traits_cpu[type].vec_dot_type;
+    const float nvfp4_tensor_scale = ggml_nvfp4_tensor_scale_from_op_params(src0);
 
     const int64_t blck_0 = 16;
     const int64_t blck_1 = 16;
@@ -1484,6 +1535,13 @@ static void ggml_compute_forward_mul_mat_id_one_chunk(
 
                 for (int64_t ir0 = iir0; ir0 < iir0 + blck_0 && ir0 < ir0_end; ++ir0) {
                     vec_dot(ne00, &tmp[ir0 - iir0], 0, src0_cur + ir0*nb01, 0, src1_col, 0, 1);
+                }
+
+                if (type == GGML_TYPE_NVFP4 && nvfp4_tensor_scale != 1.0f) {
+                    const int64_t ncopy = MIN(iir0 + blck_0, ir0_end) - iir0;
+                    for (int64_t k = 0; k < ncopy; ++k) {
+                        tmp[k] *= nvfp4_tensor_scale;
+                    }
                 }
 
                 memcpy(&dst_col[iir0], tmp, (MIN(iir0 + blck_0, ir0_end) - iir0)*sizeof(float));

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -11,6 +11,22 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstring>
+
+static float ggml_nvfp4_tensor_scale_from_op_params(const ggml_tensor * tensor) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_NVFP4) {
+        return 1.0f;
+    }
+
+    constexpr int op_param_idx_nvfp4_tensor_scale = GGML_MAX_OP_PARAMS / sizeof(int32_t) - 2;
+    float tensor_scale = 1.0f;
+    std::memcpy(&tensor_scale, &tensor->op_params[op_param_idx_nvfp4_tensor_scale], sizeof(tensor_scale));
+    if (!std::isfinite(tensor_scale) || tensor_scale <= 0.0f) {
+        return 1.0f;
+    }
+
+    return tensor_scale;
+}
 
 // ggml_compute_forward_dup
 
@@ -670,6 +686,7 @@ void ggml_compute_forward_add(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1119,6 +1136,7 @@ void ggml_compute_forward_add1(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1247,6 +1265,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4350,6 +4369,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ3_S:
         case GGML_TYPE_IQ2_S:
+        case GGML_TYPE_NVFP4:
             {
                 ggml_compute_forward_out_prod_q_f32(params, dst);
             } break;
@@ -4609,6 +4629,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4664,6 +4685,8 @@ static void ggml_compute_forward_get_rows_q(
 
     const ggml_type type = src0->type;
     ggml_to_float_t const dequantize_row_q = ggml_get_type_traits(type)->to_float;
+    const float nvfp4_tensor_scale = ggml_nvfp4_tensor_scale_from_op_params(src0);
+    const bool has_nvfp4_tensor_scale = type == GGML_TYPE_NVFP4 && nvfp4_tensor_scale != 1.0f;
 
     assert(ne0  == nc);
     assert(ne02 == ne11);
@@ -4691,6 +4714,12 @@ static void ggml_compute_forward_get_rows_q(
         dequantize_row_q(
                 (const void *) ((char *) src0->data + i01*nb01 + i11*nb02 + i12*nb03),
                      (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3), nc);
+        if (has_nvfp4_tensor_scale) {
+            ggml_vec_scale_f32(
+                    nc,
+                    (float *) ((char *)  dst->data + i10*nb1  + i11*nb2  + i12*nb3),
+                    nvfp4_tensor_scale);
+        }
     }
 }
 
@@ -4831,6 +4860,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -5555,6 +5585,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -13,6 +13,7 @@
 #include <float.h>
 #include <stdlib.h> // for qsort
 #include <stdio.h>  // for GGML_ASSERT
+#include "ggml-nvfp4-helpers.h"
 
 #define GROUP_MAX_EPS 1e-15f
 #define GROUP_MAX_EPS_IQ3_XXS 1e-8f
@@ -50,6 +51,9 @@ void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, i
     quantize_row_mxfp4_ref(x, y, k);
 }
 
+void quantize_row_nvfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_nvfp4_ref(x, y, k);
+}
 //
 // 2-6 bit quantization in super-blocks
 //
@@ -215,6 +219,230 @@ void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, 
     }
     *s = sumf;
 }
+
+// NVFP4 x Q8 dot LUT:
+// index = [fp4_code (0..15)][q8_byte (0..255 as uint8_t/int8_t bit pattern)]
+// value = fp4_code_value_doubled * q8_value
+// 16 * 256 = 4096 entries.
+static int16_t ggml_nvfp4_q8_dot_lut[16][256];
+static int8_t  ggml_nvfp4_sum_byte_lut[256];
+static int32_t ggml_nvfp4_cpu_lut_state = 0; // 0=not started, 1=initializing, 2=ready
+
+static inline void ggml_nvfp4_cpu_relax(void) {
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield" ::: "memory");
+#else
+    // best-effort: nothing
+#endif
+}
+
+static inline void ggml_nvfp4_cpu_init_luts(void) {
+    if (__atomic_load_n(&ggml_nvfp4_cpu_lut_state, __ATOMIC_ACQUIRE) == 2) {
+        return;
+    }
+
+    int32_t expected = 0;
+    if (__atomic_compare_exchange_n(&ggml_nvfp4_cpu_lut_state, &expected, 1, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        for (int c = 0; c < 16; ++c) {
+            const int32_t w = (int32_t) ggml_nvfp4_lut_i8_dbl_bytes[c];
+            for (int u = 0; u < 256; ++u) {
+                const int32_t q = (int32_t) (int8_t) (uint8_t) u;
+                ggml_nvfp4_q8_dot_lut[c][u] = (int16_t) (w * q);
+            }
+        }
+
+        for (int b = 0; b < 256; ++b) {
+            ggml_nvfp4_sum_byte_lut[b] =
+                (int8_t) ((int32_t) ggml_nvfp4_lut_i8_dbl_bytes[b & 0x0F] +
+                          (int32_t) ggml_nvfp4_lut_i8_dbl_bytes[b >> 4]);
+        }
+
+        __atomic_store_n(&ggml_nvfp4_cpu_lut_state, 2, __ATOMIC_RELEASE);
+        return;
+    }
+
+    while (__atomic_load_n(&ggml_nvfp4_cpu_lut_state, __ATOMIC_ACQUIRE) != 2) {
+        ggml_nvfp4_cpu_relax();
+    }
+}
+
+static inline int32_t ggml_dot16_nvfp4(
+    const uint8_t * GGML_RESTRICT q4_packed8,
+    const int8_t  * GGML_RESTRICT q8_16) {
+#if defined(__SSE4_1__)
+    const __m128i lut   = _mm_loadu_si128((const __m128i *) ggml_nvfp4_lut_i8_dbl_bytes);
+    const __m128i mask0 = _mm_set1_epi8(0x0f);
+
+    const __m128i bx = _mm_loadl_epi64((const __m128i *) q4_packed8);
+    const __m128i b_lo = _mm_and_si128(bx, mask0);
+    const __m128i b_hi = _mm_and_si128(_mm_srli_epi16(bx, 4), mask0);
+    const __m128i b_idx = _mm_unpacklo_epi8(b_lo, b_hi);
+    const __m128i x_i8  = _mm_shuffle_epi8(lut, b_idx);
+
+    const __m128i y_i8 = _mm_loadu_si128((const __m128i *) q8_16);
+
+    const __m128i x16_0 = _mm_cvtepi8_epi16(x_i8);
+    const __m128i y16_0 = _mm_cvtepi8_epi16(y_i8);
+    const __m128i x16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(x_i8, 8));
+    const __m128i y16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(y_i8, 8));
+
+    __m128i s = _mm_add_epi32(_mm_madd_epi16(x16_0, y16_0),
+                              _mm_madd_epi16(x16_1, y16_1));
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 8));
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 4));
+    return _mm_cvtsi128_si32(s);
+#else
+    int32_t sum = 0;
+    for (int j = 0; j < 8; ++j) {
+        const uint8_t a = q4_packed8[j];
+        const int16_t * GGML_RESTRICT lut_lo = ggml_nvfp4_q8_dot_lut[a & 0x0F];
+        const int16_t * GGML_RESTRICT lut_hi = ggml_nvfp4_q8_dot_lut[a >> 4];
+        sum += (int32_t) lut_lo[(uint8_t) q8_16[2*j + 0]];
+        sum += (int32_t) lut_hi[(uint8_t) q8_16[2*j + 1]];
+    }
+    return sum;
+#endif
+}
+
+static inline int32_t ggml_sum16_nvfp4_dbl(const uint8_t * GGML_RESTRICT q4_packed8) {
+    int32_t sum = 0;
+    for (int j = 0; j < 8; ++j) {
+        sum += (int32_t) ggml_nvfp4_sum_byte_lut[q4_packed8[j]];
+    }
+    return sum;
+}
+
+void ggml_vec_dot_nvfp4_q8_0_generic(
+    int n, float * GGML_RESTRICT s, size_t bs,
+    const void * GGML_RESTRICT vx, size_t bx,
+    const void * GGML_RESTRICT vy, size_t by,
+    int nrc
+) {
+    GGML_UNUSED(bx);
+    GGML_UNUSED(by);
+
+    GGML_ASSERT(nrc == 1);
+    GGML_ASSERT(n % QK_K == 0);
+    if (bs == 0) bs = sizeof(float);
+
+    const block_nvfp4 * GGML_RESTRICT x = (const block_nvfp4 *) vx;
+    const block_q8_0  * GGML_RESTRICT y = (const block_q8_0  *) vy;
+
+    ggml_nvfp4_cpu_init_luts();
+
+    const int nb = n / QK_K; // number of logical 256-value NVFP4 blocks
+    float sumf = 0.0f;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        const block_nvfp4 * GGML_RESTRICT p = &x[ib >> 2];
+        const int il = ib & 3;
+
+        const uint8_t * GGML_RESTRICT ql = p->qs[il];
+        const uint8_t * GGML_RESTRICT sc = p->scales[il];
+
+        // One 256-value NVFP4 logical block aligns with 8 Q8_0 blocks.
+        const block_q8_0 * GGML_RESTRICT y_blk = y + ib * 8;
+
+        // Predecode the 16 UE4M3 sub-scales for this block.
+        float sf[QK_NVFP4];
+        for (int sb = 0; sb < QK_NVFP4; ++sb) {
+            sf[sb] = GGML_FP8_UE4M3_TO_FP32(sc[sb]);
+        }
+
+        float blk_sum = 0.0f;
+
+        for (int qb = 0; qb < 8; ++qb) {
+            const float d_q8 = GGML_CPU_FP16_TO_FP32(y_blk[qb].d);
+            const int8_t * GGML_RESTRICT q8 = y_blk[qb].qs;
+
+            float dot = 0.0f;
+            for (int t = 0; t < 32; ++t) {
+                const int idx = qb * 32 + t;
+                const int sb = idx / QK_NVFP4;
+                const uint8_t q4 = ggml_nvfp4_get_q4(ql, idx);
+                dot += sf[sb] * kvalues_nvfp4_float(q4) * (float) q8[t];
+            }
+            blk_sum += d_q8 * dot;
+        }
+
+        sumf += blk_sum;
+    }
+
+    *(float *) ((char *) s) = sumf;
+}
+
+
+void ggml_vec_dot_nvfp4_nvfp4_generic(
+    int n, float * GGML_RESTRICT s, size_t bs,
+    const void * GGML_RESTRICT vx, size_t bx,
+    const void * GGML_RESTRICT vy, size_t by,
+    int nrc
+) {
+    GGML_ASSERT(nrc > 0);
+    GGML_ASSERT(n % QK_K == 0);
+
+    const int nb = n / QK_K;
+    GGML_ASSERT(nb % 4 == 0);
+
+    ggml_nvfp4_cpu_init_luts();
+
+    const size_t expect = (size_t) nb * (size_t) GGML_NVFP4_BYTES_PER_BLOCK;
+
+    // ggml convention: 0 stride means "contiguous default"
+    if (bs == 0) bs = sizeof(float);
+    if (bx == 0) bx = expect;
+    if (by == 0) by = expect;
+
+    for (int ir = 0; ir < nrc; ++ir) {
+        const block_nvfp4 * GGML_RESTRICT x =
+            (const block_nvfp4 *) ((const char *) vx + (size_t) ir * bx);
+        const block_nvfp4 * GGML_RESTRICT y =
+            (const block_nvfp4 *) ((const char *) vy + (size_t) ir * by);
+
+        float sum = 0.0f;
+
+        for (int i = 0; i < nb; ++i) {
+            const block_nvfp4 * GGML_RESTRICT px = &x[i >> 2];
+            const block_nvfp4 * GGML_RESTRICT py = &y[i >> 2];
+            const int il = i & 3;
+
+            // BOTH sides are doubled int table => compensate 1/4
+            const uint8_t * GGML_RESTRICT qx = px->qs[il];
+            const uint8_t * GGML_RESTRICT qy = py->qs[il];
+            const uint8_t * GGML_RESTRICT sx = px->scales[il];
+            const uint8_t * GGML_RESTRICT sy = py->scales[il];
+
+            float sxf[QK_NVFP4];
+            float syf[QK_NVFP4];
+            for (int sb = 0; sb < QK_NVFP4; ++sb) {
+                sxf[sb] = GGML_FP8_UE4M3_TO_FP32(sx[sb]);
+                syf[sb] = GGML_FP8_UE4M3_TO_FP32(sy[sb]);
+            }
+            for (int g32 = 0; g32 < 8; ++g32) {
+                for (int t = 0; t < 32; ++t) {
+                    const int idx = g32 * 32 + t;
+                    const int sb = idx / QK_NVFP4;
+                    const float vx_f = sxf[sb] * kvalues_nvfp4_float(ggml_nvfp4_get_q4(qx, idx));
+                    const float vy_f = syf[sb] * kvalues_nvfp4_float(ggml_nvfp4_get_q4(qy, idx));
+                    sum += vx_f * vy_f;
+                }
+            }
+        }
+
+        *(float *) ((char *) s + (size_t) ir * bs) = sum;
+    }
+}
+
+void ggml_vec_dot_nvfp4_nvfp4(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    ggml_vec_dot_nvfp4_nvfp4_generic(n, s, bs, vx, bx, vy, by, nrc);
+}
+
+void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    ggml_vec_dot_nvfp4_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+}
+
 
 void ggml_vec_dot_q5_0_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK8_0;

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -20,6 +20,7 @@ void quantize_row_q8_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, in
 void quantize_row_q8_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_nvfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_q2_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_q3_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
@@ -42,6 +43,9 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const voi
 void ggml_vec_dot_q8_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_nvfp4_nvfp4(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 
 void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_q3_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
@@ -61,6 +65,7 @@ void ggml_vec_dot_iq1_m_q8_K  (int n, float * GGML_RESTRICT s, size_t bs, const 
 void ggml_vec_dot_iq4_nl_q8_0 (int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_iq4_xs_q8_K (int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_iq3_s_q8_K  (int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_nvfp4_q8_0  (int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 // Generic implementation
 void quantize_row_q8_0_generic(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k);
@@ -73,6 +78,8 @@ void ggml_vec_dot_q5_1_q8_1_generic(int n, float * GGML_RESTRICT s, size_t bs, c
 void ggml_vec_dot_q8_0_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_nvfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_nvfp4_nvfp4_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_tq1_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_tq2_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml-nvfp4-helpers.h
+++ b/ggml/src/ggml-nvfp4-helpers.h
@@ -1,0 +1,1028 @@
+#pragma once
+
+#include <stdint.h>
+#include <float.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>  // For NAN and ldexpf
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#include <immintrin.h>
+#endif
+
+#if defined(__CUDACC__)
+#   include <cuda_fp16.h>
+#   include <cuda_fp8.h>
+    // cuda_fp4.h requires CUDA 13
+#   if __CUDACC_VER_MAJOR__ >= 13
+#       include <cuda_fp4.h>
+#       define GGML_CUDA_FP4_NATIVE 1
+#   else
+#       define GGML_CUDA_FP4_NATIVE 0
+#   endif
+#   define GGML_HD __host__ __device__ __forceinline__
+#   define GGML_DEVICE __device__ __forceinline__
+#else
+#   define GGML_HD static inline
+#   define GGML_DEVICE static inline
+#   define GGML_CUDA_FP4_NATIVE 0
+#endif
+
+
+#define GGML_FP8_UE4M3_TO_FP32(x)  ggml_fp8_ue4m3_to_fp32(x)
+#define GGML_FP8_UE4M3_TO_FP32_HALF(x)  ggml_fp8_ue4m3_to_fp32_half(x)
+#define GGML_FP32_TO_UE4M3(v) ggml_fp8_ue4m3_from_fp32(v)
+
+// Four-over-Six (MIT) constants
+#define NVFP4_E2M1_MAX_VALUE 6.0f
+
+// Forward declarations for functions used in macros
+GGML_HD uint8_t ggml_fp8_ue4m3_from_fp32(float v);
+GGML_HD float ggml_fp8_ue4m3_to_fp32(uint8_t b);
+#define NVFP4_E4M3_MAX_VALUE 448.0f
+
+#ifndef GGML_NVFP4_MAX_FP8_TENSOR_SCALE
+// Keep 448 as the default tensor-scale cap to match feb5 quantizer behavior.
+// Per-run overrides are still available via MAX_FP8_TENSOR_SCALE / GGML_NVFP4_MAX_FP8_TENSOR_SCALE.
+#define GGML_NVFP4_MAX_FP8_TENSOR_SCALE 448.0f
+#endif
+
+// can use on both host and device to avoid double definitions across files
+#define KVALUES_NVFP4_FLOAT_LIST { \
+     0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f, \
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f  \
+}
+#define KVALUES_NVFP4_VAL2_LIST { 0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12 }
+
+GGML_HD float kvalues_nvfp4_float(int i) {
+#if defined(__cplusplus)
+    constexpr float t[16] = KVALUES_NVFP4_FLOAT_LIST;
+#else
+    static const float t[16] = KVALUES_NVFP4_FLOAT_LIST;
+#endif
+    return t[i & 15];
+}
+
+static inline float ggml_fp8_ue4m3_to_fp32_half(uint8_t u) {
+    uint8_t b = u & 0x7Fu;          // unsigned UE4M3
+    if (b == 0) return 0.0f;
+    if (b == 0x7F) b = 0x7E;        // clamp NaN code -> max finite
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+    const __nv_fp8_storage_t fp8 = (__nv_fp8_storage_t) b;
+    const __half_raw hr = __nv_cvt_fp8_to_halfraw(fp8, __NV_E4M3);
+    __half h;
+    memcpy(&h, &hr, sizeof(h));
+    return __half2float(h);
+#else
+    const uint32_t exp8  = b >> 3;
+    const uint32_t mant8 = b & 7u;
+
+    uint32_t bits;
+    if (exp8) {
+        bits = ((exp8 + 120u) << 23) | (mant8 << 20);
+    } else {
+        // subnormal: mant * 2^-9, prebuilt exact fp32 patterns
+        static const uint32_t sub_bits[8] = {
+            0x00000000u, // 0
+            0x3B000000u, // 1 * 2^-9
+            0x3B800000u, // 2 * 2^-9
+            0x3BC00000u, // 3 * 2^-9
+            0x3C000000u, // 4 * 2^-9
+            0x3C200000u, // 5 * 2^-9
+            0x3C400000u, // 6 * 2^-9
+            0x3C600000u, // 7 * 2^-9
+        };
+        bits = sub_bits[mant8];
+    }
+
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+#endif
+}
+
+GGML_HD uint8_t ggml_fp8_ue4m3_from_fp32(float v);
+
+// ============================================================================
+// FP4 (E2M1) Conversion Functions - Native intrinsics when available
+// ============================================================================
+
+
+// Convert FP4 (E2M1) nibble to float
+GGML_DEVICE float ggml_fp4_to_fp32(uint8_t fp4_nibble) {
+#if GGML_CUDA_FP4_NATIVE
+    __half_raw hr = __nv_cvt_fp4_to_halfraw(fp4_nibble, __NV_E2M1);
+    __half h;
+    memcpy(&h, &hr, sizeof(__half));
+    return __half2float(h);
+#else
+    // Use lookup table on cpu or non-blackwell 
+    return kvalues_nvfp4_float(fp4_nibble & 0xF);
+#endif
+}
+
+// Convert float to FP4 (E2M1) nibble
+GGML_DEVICE uint8_t ggml_fp32_to_fp4(float v) {
+#if GGML_CUDA_FP4_NATIVE
+    return __nv_cvt_float_to_fp4(v, __NV_E2M1, cudaRoundNearest);
+#else
+    // Software fallback: find best matching FP4 value
+    float best_err = FLT_MAX;
+    uint8_t best = 0;
+    for (int i = 0; i < 16; ++i) {
+        const float qi = kvalues_nvfp4_float(i);
+        const float err = (v - qi) * (v - qi);
+        if (err < best_err) {
+            best_err = err;
+            best = (uint8_t)i;
+        }
+    }
+    return best;
+#endif
+}
+
+// device-native and fallback is host bit-identical .
+GGML_HD float ggml_nvfp4_fp16_to_fp32(const ggml_half h) {
+    uint16_t hu;
+    memcpy(&hu, &h, sizeof(hu));
+
+#    if defined(__CUDA_ARCH__)
+    // Use CUDA's half conversion helpers directly for bit-stable decode on device.
+    __half_raw hr;
+    hr.x = hu;
+    __half hv;
+    memcpy(&hv, &hr, sizeof(hv));
+    return __half2float(hv);
+#    else
+    unsigned int sign     = (hu >> 15) & 1u;
+    unsigned int exponent = (hu >> 10) & 0x1fu;
+    unsigned int mantissa = (unsigned int) (hu & 0x3ffu) << 13;
+
+    if (exponent == 0x1fu) {  // NaN/Inf
+        sign     = mantissa ? (sign >> 1) : sign;
+        mantissa = mantissa ? 0x7fffffu : 0u;
+        exponent = 0xffu;
+    } else if (exponent == 0u) {  // denorm/zero
+        if (mantissa) {
+            unsigned int msb;
+            exponent = 0x71u;
+            do {
+                msb = mantissa & 0x400000u;
+                mantissa <<= 1;
+                --exponent;
+            } while (!msb);
+            mantissa &= 0x7fffffu;
+        }
+    } else {
+        exponent += 0x70u;
+    }
+
+    const unsigned int u = (sign << 31) | (exponent << 23) | mantissa;
+    float              f;
+    memcpy(&f, &u, sizeof(u));
+    return f;
+#    endif
+}
+
+// NVFP4 code layout (current packed nibble order within each 32-value group):
+// byte j stores nibble pair (code[j], code[j + 16]), j in [0, 15].
+// This is repeated for 8 groups to cover 256 values.
+GGML_HD int ggml_nvfp4_qbyte_from_elem(const int i) {
+    return i / 2;
+}
+
+GGML_HD int ggml_nvfp4_qshift_from_elem(const int i) {
+    return (i % 2) * 4;
+}
+
+GGML_HD uint8_t ggml_nvfp4_get_q4(const uint8_t qs[QK_K/2], const int i) {
+    const int qb = ggml_nvfp4_qbyte_from_elem(i);
+    const int sh = ggml_nvfp4_qshift_from_elem(i);
+    return (uint8_t) ((qs[qb] >> sh) & 0x0F);
+}
+
+GGML_HD int ggml_nvfp4_q4_to_val2(const uint8_t q) {
+    static const int8_t v2[16] = KVALUES_NVFP4_VAL2_LIST;
+    return (int) v2[q & 0x0F];
+}
+
+GGML_HD void ggml_nvfp4_pack_codes_256(const uint8_t codes[QK_K], uint8_t qs[QK_K/2]) {
+    for (int j = 0; j < QK_K/2; ++j) {
+        qs[j] = (uint8_t) ((codes[2*j] & 0x0F) | ((codes[2*j + 1] & 0x0F) << 4));
+    }
+}
+
+
+
+
+// Pack 8 consecutive NVFP4 codes into 4 bytes (q0|q1<<4, q2|q3<<4, ...), returned as a little-endian u32.
+// Current NVFP4 layout is contiguous nibble-pair packing:
+//   qs[j] = codes[2*j] | (codes[2*j + 1] << 4)
+// so chunk8 maps directly to 4 consecutive bytes.
+GGML_HD uint32_t ggml_nvfp4_pack8(const uint8_t qs[QK_K/2], const int chunk8) {
+    const int base = chunk8 * 4;
+    return ((uint32_t) qs[base + 0])
+        | (((uint32_t) qs[base + 1]) << 8)
+        | (((uint32_t) qs[base + 2]) << 16)
+        | (((uint32_t) qs[base + 3]) << 24);
+}
+
+
+GGML_HD uint8_t best_index_nvfp4(float v, float s) {
+#if GGML_CUDA_FP4_NATIVE
+    // UE4M3 scale => must be positive
+    if (!(s > 0.0f) || !isfinite(s) || !isfinite(v)) return 0;
+    float scaled = v / s;
+    if (!isfinite(scaled)) return 0;
+    // CUDA docs: out-of-range saturates; NaN becomes +MAXNORM :contentReference[oaicite:1]{index=1}
+    const __nv_fp4_storage_t fp4 = __nv_cvt_float_to_fp4(scaled, __NV_E2M1, cudaRoundNearest);
+    return ((uint8_t) fp4) & 0x0F;
+#else
+    if (!(s > 0.0f) || !isfinite(s) || !isfinite(v)) return 0;
+    float best_err = FLT_MAX;
+    uint8_t best = 0;
+    for (int i = 0; i < 16; ++i) {
+        const float qi  = s * kvalues_nvfp4_float(i);
+        const float err = (v - qi) * (v - qi);
+        if (err < best_err) { best_err = err; best = (uint8_t) i; }
+    }
+    return best;
+#endif
+}
+
+
+GGML_HD float ggml_fp8_ue4m3_to_fp32(uint8_t b) {
+    // Native conversion: interpret as +E4M3 (sign bit is 0 after masking).
+ #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+    uint8_t u = b & 0x7Fu;      // force unsigned
+    if (u == 0x7Fu)
+       {
+          u = 0x7Eu;  // never allow NaN code
+       }
+    const __nv_fp8_storage_t fp8 = (__nv_fp8_storage_t) u;
+    const __half_raw hr = __nv_cvt_fp8_to_halfraw(fp8, __NV_E4M3);
+
+    __half h;
+    memcpy(&h, &hr, sizeof(__half));
+    return __half2float(h);
+#else
+    const uint32_t u = b & 0x7Fu;          // unsigned UE4M3 (force sign=0)
+    if (u == 0) return 0.0f;
+
+    const uint32_t exp  = u >> 3;          // 0..15
+    const uint32_t mant = u & 0x7u;        // 0..7
+    // Clamp NaN code 0x7F to max finite UE4M3 value.
+    // Important: this is format decode (always max=448), not tensor-scale policy.
+    if (exp == 0xFu && mant == 0x7u) return NVFP4_E4M3_MAX_VALUE;
+
+    uint32_t bits;
+
+    if (exp != 0) {
+        // normal: (1 + mant/8) * 2^(exp-7)
+        // fp32 exponent = (exp-7)+127 = exp+120
+        bits = ((exp + 120u) << 23) | (mant << 20);  // mant: 3 -> 23 bits (shift 20)
+    } else {
+        // subnormal: mant * 2^-9
+        // normalize mant (1..7) without a loop
+        // p = floor(log2(mant)) in {0,1,2}
+        const uint32_t p = 31u - (uint32_t)__builtin_clz(mant);
+        const uint32_t r = mant - (1u << p);
+        // value = (1 + r/2^p) * 2^(p-9)
+        const uint32_t exp32  = (p + 118u);                 // (p-9)+127 = p+118
+        const uint32_t mant32 = r << (23u - p);             // fraction bits
+        bits = (exp32 << 23) | mant32;
+    }
+
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+#endif
+}
+
+GGML_HD uint8_t ggml_fp8_e4m3_from_fp32(float v) {
+    uint32_t i;
+    memcpy(&i, &v, sizeof(uint32_t));
+
+    uint32_t sign = (i >> 31) & 1;
+    uint32_t exp  = (i >> 23) & 0xFF;
+    uint32_t mant = i & 0x7FFFFF;
+
+    if (exp == 0xFF) {
+        return (uint8_t)((sign << 7) | 0x7E);
+    }
+
+    if (exp == 0 && mant == 0) {
+        return (uint8_t)(sign << 7);
+    }
+
+    int e = (int)exp - 127;
+    int biased_exp = e + 7;
+
+    if (biased_exp > 15) {
+        return (uint8_t)((sign << 7) | 0x7E);
+    }
+
+    uint32_t m = mant | 0x800000;
+
+    if (biased_exp < 1) {
+        int shift = 1 - biased_exp;
+        if (shift > 24) {
+            return (uint8_t)(sign << 7);
+        }
+
+        int total_shift = 20 + shift;
+
+        if (total_shift >= 24) {
+             if (total_shift > 25) return (uint8_t)(sign << 7);
+        }
+
+        uint32_t round_bit_mask = 1 << (total_shift - 1);
+        uint32_t sticky_mask = round_bit_mask - 1;
+        uint32_t lsb_mask = 1 << total_shift;
+
+        uint32_t round_bit = m & round_bit_mask;
+        uint32_t sticky_bit = (m & sticky_mask) != 0;
+        uint32_t lsb = m & lsb_mask;
+
+        m >>= total_shift;
+
+        if (round_bit && (sticky_bit || lsb)) {
+            m++;
+        }
+
+        return (uint8_t)((sign << 7) | m);
+    }
+
+    uint32_t round_bit_mask = 1 << 19;
+    uint32_t sticky_mask = round_bit_mask - 1;
+    uint32_t lsb_mask = 1 << 20;
+
+    uint32_t round_bit = m & round_bit_mask;
+    uint32_t sticky_bit = (m & sticky_mask) != 0;
+    uint32_t lsb = m & lsb_mask;
+
+    m >>= 20;
+    m &= 0x7;
+
+    if (round_bit && (sticky_bit || lsb)) {
+        m++;
+        if (m > 7) {
+            m = 0;
+            biased_exp++;
+        }
+    }
+
+    if (biased_exp > 15) {
+        return (uint8_t)((sign << 7) | 0x7E);
+    }
+
+    if (biased_exp == 15 && m == 7) {
+        return (uint8_t)((sign << 7) | 0x7E);
+    }
+
+    return (uint8_t)((sign << 7) | (biased_exp << 3) | m);
+}
+static const int8_t ggml_nvfp4_lut_i8_dbl_bytes[16] = {
+     0,   1,   2,   3,
+     4,   6,   8,  12,
+     0,  -1,  -2,  -3,
+    -4,  -6,  -8, -12,
+};
+
+#if defined(__CUDACC__)
+__device__ __constant__ int8_t ksum2_nvfp4_byte[256];
+
+static __device__ __forceinline__ int sum2_nvfp4_byte(uint8_t b) {
+    return (int) ksum2_nvfp4_byte[b];
+}
+
+static inline void ggml_cuda_init_nvfp4_sum2_lut(void) {
+    int8_t v2[16] = KVALUES_NVFP4_VAL2_LIST;
+    int8_t h[256];
+
+    for (int b = 0; b < 256; ++b) {
+        h[b] = (int8_t) (v2[b & 0x0F] + v2[b >> 4]);
+    }
+
+    cudaMemcpyToSymbol(ksum2_nvfp4_byte, h, sizeof(h));
+}
+#else
+static inline void ggml_cuda_init_nvfp4_sum2_lut(void) {}
+#endif
+
+static inline int32_t ggml_dot16_nvfp4_nvfp4(const uint8_t * qx, const uint8_t * qy) {
+#if defined(__SSE4_1__)
+    const __m128i lut   = _mm_loadu_si128((const __m128i *) ggml_nvfp4_lut_i8_dbl_bytes);
+    const __m128i mask0 = _mm_set1_epi8(0x0f);
+
+    const __m128i bx = _mm_loadl_epi64((const __m128i *) qx);
+    const __m128i by = _mm_loadl_epi64((const __m128i *) qy);
+
+    const __m128i x_lo  = _mm_and_si128(bx, mask0);
+    const __m128i x_hi  = _mm_and_si128(_mm_srli_epi16(bx, 4), mask0);
+    const __m128i y_lo  = _mm_and_si128(by, mask0);
+    const __m128i y_hi  = _mm_and_si128(_mm_srli_epi16(by, 4), mask0);
+
+    const __m128i x_idx = _mm_unpacklo_epi8(x_lo, x_hi);
+    const __m128i y_idx = _mm_unpacklo_epi8(y_lo, y_hi);
+
+    const __m128i x_i8  = _mm_shuffle_epi8(lut, x_idx);
+    const __m128i y_i8  = _mm_shuffle_epi8(lut, y_idx);
+
+    const __m128i x16_0 = _mm_cvtepi8_epi16(x_i8);
+    const __m128i y16_0 = _mm_cvtepi8_epi16(y_i8);
+    const __m128i x16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(x_i8, 8));
+    const __m128i y16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(y_i8, 8));
+
+    __m128i s = _mm_add_epi32(_mm_madd_epi16(x16_0, y16_0),
+                             _mm_madd_epi16(x16_1, y16_1));
+
+    // horizontal sum 4x int32 -> int32
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 8));
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 4));
+    return _mm_cvtsi128_si32(s);
+#else
+    int32_t sum = 0;
+    for (int j = 0; j < 8; ++j) {
+        const uint8_t ax = qx[j];
+        const uint8_t ay = qy[j];
+
+        const int8_t x0 = ggml_nvfp4_lut_i8_dbl_bytes[ax & 0x0f];
+        const int8_t x1 = ggml_nvfp4_lut_i8_dbl_bytes[ax >> 4];
+        const int8_t y0 = ggml_nvfp4_lut_i8_dbl_bytes[ay & 0x0f];
+        const int8_t y1 = ggml_nvfp4_lut_i8_dbl_bytes[ay >> 4];
+
+        sum += (int32_t) x0 * (int32_t) y0;
+        sum += (int32_t) x1 * (int32_t) y1;
+    }
+    return sum;
+#endif
+}
+
+
+#if !defined(__CUDACC__)
+// Dot product of 16 int8 values.
+static inline int32_t ggml_dot16_i8(const int8_t * x, const int8_t * y) {
+#if defined(__SSE4_1__)
+    const __m128i vx = _mm_loadu_si128((const __m128i *) x);
+    const __m128i vy = _mm_loadu_si128((const __m128i *) y);
+
+    const __m128i x16_0 = _mm_cvtepi8_epi16(vx);
+    const __m128i y16_0 = _mm_cvtepi8_epi16(vy);
+    const __m128i x16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(vx, 8));
+    const __m128i y16_1 = _mm_cvtepi8_epi16(_mm_srli_si128(vy, 8));
+
+    __m128i s = _mm_add_epi32(_mm_madd_epi16(x16_0, y16_0),
+                             _mm_madd_epi16(x16_1, y16_1));
+
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 8));
+    s = _mm_add_epi32(s, _mm_srli_si128(s, 4));
+    return _mm_cvtsi128_si32(s);
+#else
+    int32_t sum = 0;
+    for (int i = 0; i < 16; ++i) sum += (int32_t) x[i] * (int32_t) y[i];
+    return sum;
+#endif
+}
+
+#endif
+
+
+// ============================================================================
+// NVFP4 adaptive 4/6 sub-block scaling chooser (HOST-ONLY)
+//
+// This is used by the CPU quantizers (compiled by the host compiler).
+// CUDA quantization has an in-kernel implementation and does not need this.
+//
+// Chooses per-16-value sub-block scale: M=6 (normal) vs M=4 ("zoom").
+// Scores using REALIZED scales (after FP8 UE4M3 encode+decode) and a mild
+// gap-bias term around the FP4 E2M1 gap between 4.0 and 6.0.
+//
+// Returns chosen FP8 scale byte (UE4M3).
+// ============================================================================
+// NOTE: This logic is used by both CPU and CUDA paths. Keep it GGML_HD.
+GGML_HD float nvfp4_sse_16_for_scale(
+    const float * GGML_RESTRICT x16,
+    const float * GGML_RESTRICT qw16,
+    const float scale
+) {
+    if (!(scale > 0.0f) || !isfinite(scale)) return INFINITY;
+
+    float sse = 0.0f;
+    for (int i = 0; i < 16; ++i) {
+        float w = 1.0f;
+        if (qw16) {
+            const float qi = qw16[i];
+            w = (isfinite(qi) && qi > 0.0f) ? qi : 0.0f;
+        }
+        if (w == 0.0f) continue;
+
+        const float v = x16[i];
+        const uint8_t code = best_index_nvfp4(v, scale);
+        const float q = kvalues_nvfp4_float(code & 0xF) * scale;
+        const float e = v - q;
+        sse += w * e * e;
+    }
+    return sse;
+}
+
+// MIT Four-over-Six reference quantizer for E2M1 rounding.
+GGML_HD float nvfp4_fake_quantize_positive_e2m1(float x) {
+    if (x <= 0.0f) {
+        return 0.0f;
+    }
+
+    float step1 = roundf(2.0f * x) * 0.5f;
+    float step2 = roundf(x);
+    float step3 = 2.0f * roundf(x * 0.5f);
+
+    if (step3 > NVFP4_E2M1_MAX_VALUE) {
+        step3 = NVFP4_E2M1_MAX_VALUE;
+    }
+
+    if (x < 2.0f) {
+        return step1;
+    }
+    if (x < 4.0f) {
+        return step2;
+    }
+    return step3;
+}
+
+GGML_HD float nvfp4_fake_quantize_signed_e2m1(float x) {
+    const float ax = fabsf(x);
+    const float q = nvfp4_fake_quantize_positive_e2m1(ax);
+    return copysignf(q, x);
+}
+
+// MIT-style local objective with optional imatrix weighting.
+// This mirrors Q4_K's weighted local-fit spirit: better preserve important weights.
+GGML_HD float nvfp4_mse_16_for_scale_mit(
+    const float * GGML_RESTRICT x16,
+    const float scale
+) {
+    if (!(scale > 0.0f) || !isfinite(scale)) return INFINITY;
+
+    float sse = 0.0f;
+    for (int i = 0; i < 16; ++i) {
+        const float v = x16[i];
+        const float q = nvfp4_fake_quantize_signed_e2m1(v / scale);
+        const float deq = q * scale;
+        const float e = deq - v;
+        sse += e * e;
+    }
+    return sse;
+}
+
+GGML_HD float nvfp4_mse_16_for_scale_mit_w(
+    const float * GGML_RESTRICT x16,
+    const float * GGML_RESTRICT qw16,
+    const float scale
+) {
+    if (!(scale > 0.0f) || !isfinite(scale)) return INFINITY;
+
+    float sse = 0.0f;
+    for (int i = 0; i < 16; ++i) {
+        float w = 1.0f;
+        if (qw16) {
+            const float qi = qw16[i];
+            w = (isfinite(qi) && qi > 0.0f) ? qi : 0.0f;
+        }
+        if (w == 0.0f) continue;
+        const float v = x16[i];
+        const float q = nvfp4_fake_quantize_signed_e2m1(v / scale);
+        const float deq = q * scale;
+        const float e = deq - v;
+        sse += w * e * e;
+    }
+    return sse;
+}
+
+// Adaptive chooser logic for  NVFP4 scale chooser "Four over Six" with WMSE scoring.
+// Credit goes to authors of the paper:
+// Four Over Six: More Accurate NVFP4 Quantization with Adaptive Block Scaling
+// Jack Cook and Junxian Guo and Guangxuan Xiao and Yujun Lin and Song Han
+// (2025): See https://arxiv.org/abs/2512.02010} and https://github.com/mit-han-lab/fouroversix 
+/* MIT License
+Copyright (c) 2025 Jack Cook
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/ 
+GGML_HD uint8_t adaptive_block_scale_4_or_6(const float * GGML_RESTRICT x16, const float * GGML_RESTRICT qw16, const float d_fp32) {
+    const float eps        = 1e-20f;
+    const float m6_anchor  = 6.00f;
+    const float m4_anchor  = 4.00f;
+    const float u_guard    = 7.00;
+    const float tail_thr   = 0.609f;
+    const int   tail_min   = 2;
+    const float gap_lo     = 4.409f;
+    const float gap_hi     = 5.474f;
+    const float gap_lambda = 0.02f;
+    const float top2_thr   = 0.957f;
+
+    if (!(d_fp32 > 0.0f) || !isfinite(d_fp32)) return 0;
+
+    float max_abs = 0.0f;
+    for (int i = 0; i < 16; ++i) {
+        const float ax = fabsf(x16[i]);
+        if (ax > max_abs) max_abs = ax;
+    }
+    if (!(max_abs > 0.0f)) return 0;
+
+    // ideal sb in "units of d"
+    const float sb6_ideal = (max_abs * (1.0f / m6_anchor)) / d_fp32;
+    const float sb4_ideal = (max_abs * (1.0f / m4_anchor)) / d_fp32;
+
+    const uint8_t b6 = GGML_FP32_TO_UE4M3(sb6_ideal);
+    const uint8_t b4 = GGML_FP32_TO_UE4M3(sb4_ideal);
+
+    if (b6 == b4) return b4;
+
+    const float s6u = GGML_FP8_UE4M3_TO_FP32(b6);
+    const float s4u = GGML_FP8_UE4M3_TO_FP32(b4);
+
+    if (s6u == 0.0f) return b4;
+    if (s4u == 0.0f) return b6;
+
+    const float scale6 = d_fp32 * s6u;
+    const float scale4 = d_fp32 * s4u;
+    const float u_max6 = max_abs / (scale6 + eps);
+
+    float max1 = 0.0f;
+    float max2 = 0.0f;
+    for (int i = 0; i < 16; ++i) {
+        float ax = fabsf(x16[i]);
+        if (ax > max1) { max2 = max1; max1 = ax; }
+        else if (ax > max2) { max2 = ax; }
+    }
+
+    int tail_cnt = 0;
+    const float tail_cut = tail_thr * max_abs;
+    for (int i = 0; i < 16; ++i) {
+        const float ax = fabsf(x16[i]);
+        if (ax >= tail_cut) {
+            ++tail_cnt;
+        }
+    }
+
+    // Q4_K-style weighted local objective: use imatrix weights when available.
+    float L6 = nvfp4_mse_16_for_scale_mit_w(x16, qw16, scale6);
+    float L4 = nvfp4_mse_16_for_scale_mit_w(x16, qw16, scale4);
+
+    // Heuristic penalties
+    if (max2 >= top2_thr * max1) {
+        const float u6_2 = max2 / (scale6 + eps);
+        if (u6_2 >= gap_lo && u6_2 <= gap_hi) {
+            L6 += gap_lambda * (scale6 * scale6);
+        }
+    }
+    if (u_max6 > u_guard) {
+        L6 += gap_lambda * (scale6 * scale6);
+    }
+
+    if (tail_cnt >= tail_min) {
+        for (int i = 0; i < 16; ++i) {
+            const float u = x16[i] / (scale6 + eps);
+            const float ua = fabsf(u);
+            if (ua >= gap_lo && ua <= gap_hi) {
+                L6 += gap_lambda * (scale6 * scale6);
+            }
+        }
+    }
+
+    return (L4 < L6) ? b4 : b6;
+}
+
+// Shared host/device tensor-scale cap chooser for NVFP4 256-element blocks.
+// Keeps cap decision logic identical across CPU and CUDA quantization paths.
+GGML_HD float ggml_nvfp4_pick_max_fp8_tensor_scale(
+    const float * GGML_RESTRICT x256,
+    const float * GGML_RESTRICT qw256,
+    const float gmax,
+    const float max_fp8_tensor_4) {
+
+    const float high = 448.0f;
+    const float low = (isfinite(max_fp8_tensor_4) && max_fp8_tensor_4 > 0.0f) ? fminf(max_fp8_tensor_4, high) : high;
+
+    const float d_min_guess = (gmax * 0.25f) / high;
+    if (!(d_min_guess > 0.0f) || !isfinite(d_min_guess)) {
+        return high;
+    }
+
+    int use_fp4_4 = 0;
+    for (int sub = 0; sub < 16; ++sub) {
+        const float * GGML_RESTRICT x16 = x256 + sub * 16;
+        const float * GGML_RESTRICT qw16 = qw256 ? (qw256 + sub * 16) : NULL;
+
+        float max_abs = 0.0f;
+        for (int j = 0; j < 16; ++j) {
+            const float ax = fabsf(x16[j]);
+            if (ax > max_abs) {
+                max_abs = ax;
+            }
+        }
+
+        if (!(max_abs > 0.0f)) {
+            continue;
+        }
+
+        const float sb6_ideal = (max_abs * (1.0f / 6.0f)) / d_min_guess;
+        const float sb4_ideal = (max_abs * (1.0f / 4.0f)) / d_min_guess;
+
+        const uint8_t b6 = ggml_fp8_ue4m3_from_fp32(sb6_ideal);
+        const uint8_t b4 = ggml_fp8_ue4m3_from_fp32(sb4_ideal);
+        const uint8_t b = adaptive_block_scale_4_or_6(x16, qw16, d_min_guess);
+
+        if (b == b4 && b4 != b6) {
+            use_fp4_4 = 1;
+            break;
+        }
+    }
+
+    return use_fp4_4 ? low : high;
+}
+
+// Per-16 sub-block cap chooser used by both CPU/CUDA quantization paths.
+// If adaptive 4/6 chooses the M=4 branch (and it is distinguishable from M=6),
+// enforce the lower cap (typically 256) for that sub-block; otherwise use high cap.
+GGML_HD float ggml_nvfp4_pick_subblock_fp8_cap(
+    const float * GGML_RESTRICT x16,
+    const float * GGML_RESTRICT qw16,
+    const float d_fp32,
+    const float max_fp8_high,
+    const float max_fp8_low) {
+
+    const float high = (isfinite(max_fp8_high) && max_fp8_high > 0.0f) ? max_fp8_high : 448.0f;
+    const float low = (isfinite(max_fp8_low) && max_fp8_low > 0.0f) ? fminf(max_fp8_low, high) : high;
+    if (!(d_fp32 > 0.0f) || !isfinite(d_fp32)) {
+        return high;
+    }
+
+    float max_abs = 0.0f;
+    for (int j = 0; j < 16; ++j) {
+        const float ax = fabsf(x16[j]);
+        if (ax > max_abs) {
+            max_abs = ax;
+        }
+    }
+    if (!(max_abs > 0.0f)) {
+        return high;
+    }
+
+    const float sb6_ideal = (max_abs * (1.0f / 6.0f)) / d_fp32;
+    const float sb4_ideal = (max_abs * (1.0f / 4.0f)) / d_fp32;
+
+    const uint8_t b6 = ggml_fp8_ue4m3_from_fp32(sb6_ideal);
+    const uint8_t b4 = ggml_fp8_ue4m3_from_fp32(sb4_ideal);
+    const uint8_t b = adaptive_block_scale_4_or_6(x16, qw16, d_fp32);
+
+    return (b == b4 && b4 != b6) ? low : high;
+}
+
+GGML_HD uint8_t ggml_fp8_ue4m3_from_fp32(float v) {
+    if (!(v > 0.0f)) return 0;
+    if (!(v < NVFP4_E4M3_MAX_VALUE)) return 0x7E;
+    if (!isfinite(v)) return 0x7E;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+    const __nv_fp8_storage_t s = __nv_cvt_float_to_fp8(v, __NV_SATFINITE, __NV_E4M3);
+    uint8_t c = (uint8_t) s & 0x7Fu;
+    return (c == 0x7Fu) ? 0x7Eu : c;
+#else
+ // this seems unnecessarily omplex, but it is an exact CPU replica of the CUDA native __nv_cvt_float_to_fp8
+ // this avoids even the tiniest discrepancies so CPU=GPU at all times
+
+    uint32_t u;
+    memcpy(&u, &v, sizeof(u));
+
+    if (u & 0x80000000u) {
+        return 0;
+    }
+
+    const uint32_t exp  = (u >> 23) & 0xFFu;
+    const uint32_t mant =  u        & 0x7FFFFFu;
+
+    if (exp == 0) {
+        return 0;
+    }
+
+    // NaN/Inf goes to SATFINITE which is return MAXNORM
+    if (exp == 0xFFu) {
+        return 0x7Eu;
+    }
+
+    const int e  = (int)exp - 127;   // unbiased 
+    int e4 = e + 7;                  // FP8 E4 with bias=7
+
+    // if any overflow goes to MAXNORM
+    if (e4 > 15) {
+        return 0x7Eu;
+    }
+
+    // 24-bit mantissa with hidden leading 1
+    const uint32_t m24 = (1u << 23) | mant;
+
+    // subnormal 
+    if (e4 <= 0) {
+        // mant3 = RNE( m24 * 2^(e-14) )
+        // since e4<=0 => e<=-7 => (e-14)<=-21 => right shift by (14-e)
+        const int s = 14 - e;  // >= 1
+        uint32_t q;
+
+        if (s >= 32) {
+            q = 0;
+        } else {
+            const uint32_t r   = m24 >> s;
+            const uint32_t rem = m24 & ((1u << s) - 1u);
+            const uint32_t half = 1u << (s - 1);
+
+            q = r + (rem > half || (rem == half && (r & 1u)));
+        }
+
+        // if round reaches 8, reduce to the smallest smallest normal
+        if (q >= 8u) {
+            return 0x08u;
+        }
+        return (uint8_t) q; //
+    }
+
+    // "Normal FP8" has exp4 in [1..14], mant3 is top 3 mantissa bits with RNE
+    uint32_t mant3 = mant >> 20;              // 3 bits
+    const uint32_t rem  = mant & ((1u << 20) - 1u);
+    const uint32_t half = 1u << 19;
+
+    // Round NE for  mant3
+    if (rem > half || (rem == half && (mant3 & 1u))) {
+        mant3 += 1u;
+        if (mant3 == 8u) {
+            mant3 = 0u;
+            e4 += 1;
+            if (e4 > 15) {
+                return 0x7Eu;
+            }
+        }
+    }
+
+    uint8_t out = (uint8_t)(((uint32_t)e4 << 3) | mant3);
+
+    // reduce to max finite if NaN code
+    if (out == 0x7Fu) out = 0x7Eu;
+    return out;
+#endif
+}
+
+
+// ============================================================================
+// Shared NVFP4 helpers (CPU/CUDA)
+// ============================================================================
+
+GGML_HD float ggml_nvfp4_qw(const float * qw, int idx) {
+    if (!qw) return 1.0f;
+    const float w = qw[idx];
+    if (!isfinite(w) || w <= 0.0f) return 0.0f;
+    return w > 64.0f ? 64.0f : w;
+}
+
+GGML_HD float ggml_nvfp4_qw16(const float * qw16, int j) {
+    if (!qw16) return 1.0f;
+    const float w = qw16[j];
+    return (isfinite(w) && w > 0.0f) ? w : 0.0f;
+}
+
+GGML_HD float ggml_nvfp4_subblock_sse_w_best(
+        const float * x16,
+        const float * qw16,
+        const float scale) {
+    if (!(scale > 0.0f) || !isfinite(scale)) {
+        float sse = 0.0f;
+        for (int j = 0; j < 16; ++j) {
+            const float w = ggml_nvfp4_qw16(qw16, j);
+            if (w == 0.0f) {
+                continue;
+            }
+            const float v = x16[j];
+            sse += w * (v * v);
+        }
+        return sse;
+    }
+
+    float sse = 0.0f;
+    for (int j = 0; j < 16; ++j) {
+        const float w = ggml_nvfp4_qw16(qw16, j);
+        if (w == 0.0f) {
+            continue;
+        }
+        const float v = x16[j];
+        const uint8_t code = best_index_nvfp4(v, scale);
+        const float q = scale * kvalues_nvfp4_float(code & 0xF);
+        const float e = v - q;
+        sse += w * (e * e);
+    }
+    return sse;
+}
+
+GGML_HD uint8_t ggml_nvfp4_refine_sbscale_fp8_local(
+    const float * x16,
+    const float * qw16,
+    const float d,
+    uint8_t b_init
+) {
+    if (!(d > 0.0f) || !isfinite(d)) {
+        return 0;
+    }
+
+    uint8_t best_b = b_init;
+    float best_sse = ggml_nvfp4_subblock_sse_w_best(x16, qw16, d * GGML_FP8_UE4M3_TO_FP32(best_b));
+
+    // neighborhood search to fix FP8 round-to-nearest ties.
+    for (int delta = 1; delta <= 2; ++delta) {
+        const int cand0 = (int) b_init - delta;
+        const int cand1 = (int) b_init + delta;
+
+        if (cand0 >= 0) {
+            const uint8_t b = (uint8_t) cand0;
+            const float sse = ggml_nvfp4_subblock_sse_w_best(x16, qw16, d * GGML_FP8_UE4M3_TO_FP32(b));
+            if (sse < best_sse) {
+                best_sse = sse;
+                best_b = b;
+            }
+        }
+
+        if (cand1 <= 0x7E) {
+            const uint8_t b = (uint8_t) cand1;
+            const float sse = ggml_nvfp4_subblock_sse_w_best(x16, qw16, d * GGML_FP8_UE4M3_TO_FP32(b));
+            if (sse < best_sse) {
+                best_sse = sse;
+                best_b = b;
+            }
+        }
+    }
+
+    return best_b;
+}
+
+GGML_HD float ggml_nvfp4_obj_256_codes(
+    const float * x256,
+    const float * qw256,
+    const uint8_t * codes256,
+    const float d,
+    const uint8_t * sb_scales
+) {
+    float sse = 0.0f;
+    float sum_err = 0.0f;
+    float sum_w = 0.0f;
+
+    for (int sub = 0; sub < 16; ++sub) {
+        const float scale = d * GGML_FP8_UE4M3_TO_FP32(sb_scales[sub]);
+        if (!(scale > 0.0f) || !isfinite(scale)) continue;
+
+        const float * x16 = x256 + sub * 16;
+        const float * qw16 = qw256 ? (qw256 + sub * 16) : NULL;
+
+        for (int j = 0; j < 16; ++j) {
+            const float w = ggml_nvfp4_qw(qw16, j);
+            const uint8_t qi = codes256[sub * 16 + j] & 0xF;
+            const float q = scale * kvalues_nvfp4_float(qi & 0xF);
+            const float e = x16[j] - q;
+            sse     += w * e * e;
+            sum_err += w * e;
+            sum_w   += w;
+        }
+    }
+
+    float obj = sse;
+    if (sum_w > 0.0f && isfinite(sum_w)) {
+        const float mean_err = sum_err / sum_w;
+        obj = sse + 32.0f * sum_w * mean_err * mean_err;
+    }
+    return obj;
+}
+
+GGML_HD float ggml_nvfp4_sse_256_codes(
+    const float * x256,
+    const float * qw256,
+    const uint8_t * codes256,
+    const float d,
+    const uint8_t * sb_scales
+) {
+    float sse = 0.0f;
+
+    for (int sub = 0; sub < 16; ++sub) {
+        const float scale = d * GGML_FP8_UE4M3_TO_FP32(sb_scales[sub]);
+        if (!(scale > 0.0f) || !isfinite(scale)) continue;
+
+        const float * x16 = x256 + sub * 16;
+        const float * qw16 = qw256 ? (qw256 + sub * 16) : NULL;
+
+        for (int j = 0; j < 16; ++j) {
+            const float w = ggml_nvfp4_qw(qw16, j);
+            const uint8_t qi = codes256[sub * 16 + j] & 0xF;
+            const float q = scale * kvalues_nvfp4_float(qi & 0xF);
+            const float e = x16[j] - q;
+            sse += w * e * e;
+        }
+    }
+
+    return sse;
+}

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -5,13 +5,16 @@
 #include "ggml-impl.h"
 #include "ggml-cpu/ggml-cpu-impl.h"
 #include "ggml-cpu.h"
-
+#include "../include/ggml-cuda.h"
+#include "ggml-nvfp4-helpers.h"
 #include <math.h>
 #include <string.h>
 #include <assert.h>
 #include <float.h>
 #include <stdlib.h> // for qsort
 #include <stdio.h>  // for GGML_ASSERT
+
+extern bool nvfp4_autotune(const float * x, const float * qw, int64_t n, float * best_a, float * best_b);
 
 #define GROUP_MAX_EPS 1e-15f
 #define GROUP_MAX_EPS_IQ3_XXS 1e-8f
@@ -20,6 +23,33 @@
 #define GROUP_MAX_EPS_IQ1_S 1e-12f
 
 #define UNUSED GGML_UNUSED
+
+static int g_nvfp4_tune_state = 0;
+static float g_nvfp4_scale_mul[] = {
+    0.9918823242f,
+    0.9864501953f,
+    0.875f,
+    0.9375f,
+    0.96875f,
+    1.0f,
+    1.015625f,
+    1.03125f,
+    1.046875f,
+    1.0625f,
+    1.09375f,
+    1.125f,
+    1.1875f,
+    1.25f,
+};
+
+static const int g_nvfp4_scale_mul_count = (int)(sizeof(g_nvfp4_scale_mul) / sizeof(g_nvfp4_scale_mul[0]));
+static const float g_nvfp4_tune_tail_weight = 0.20f;
+static const float g_nvfp4_max_block_scale = 448.0f;
+static const float g_nvfp4_max_tensor_scale = 256.0f;
+#define NVFP4_TUNE_GUARD_TOPK_CPU 32
+#define NVFP4_TUNE_GUARD_BLOCKS_CPU 16
+#define NVFP4_TUNE_GUARD_MAX_OBJ_FRAC_CPU 1.05f
+#define NVFP4_REFIT_ROUNDS 9
 
 static inline int best_index_int8(int n, const int8_t * val, float x) {
     if (x <= val[0]) return 0;
@@ -324,6 +354,460 @@ void dequantize_row_q4_0(const block_q4_0 * GGML_RESTRICT x, float * GGML_RESTRI
     }
 }
 
+static inline float nvfp4_block_max_abs(const float * GGML_RESTRICT block) {
+    float max_abs = 0.0f;
+    for (int i = 0; i < QK_K; ++i) {
+        max_abs = fmaxf(max_abs, fabsf(block[i]));
+    }
+    return max_abs;
+}
+
+static inline void nvfp4_refit_block_scales(
+    const float * GGML_RESTRICT block,
+    const float * GGML_RESTRICT weights,
+    uint8_t * GGML_RESTRICT codes,
+    const float min_tensor_scale,
+    float * GGML_RESTRICT tensor_scale_out,
+    uint8_t * GGML_RESTRICT block_scales_out,
+    const float max_fp8_tensor
+) {
+    float sub_scale[QK_K / QK_NVFP4];
+
+    float max_sub_scale = 0.0f;
+    for (int subblock = 0; subblock < QK_K / QK_NVFP4; ++subblock) {
+        const float * GGML_RESTRICT values = block + subblock * QK_NVFP4;
+
+        float num = 0.0f;
+        float den = 0.0f;
+
+        for (int j = 0; j < QK_NVFP4; ++j) {
+            const int idx = subblock * QK_NVFP4 + j;
+            const float weight = ggml_nvfp4_qw(weights, idx);
+            const float code_value = kvalues_fp4_float[codes[idx] & 0xF];
+            num += weight * values[j] * code_value;
+            den += weight * code_value * code_value;
+        }
+
+        float scale = 0.0f;
+        if (den != 0.0f && isfinite(den) && isfinite(num)) {
+            scale = num / den;
+        }
+
+        if (scale < 0.0f) {
+            scale = -scale;
+            for (int j = 0; j < QK_NVFP4; ++j) {
+                codes[subblock * QK_NVFP4 + j] ^= 0x8;
+            }
+        }
+
+        if (!isfinite(scale) || scale < 0.0f) {
+            scale = 0.0f;
+        }
+
+        sub_scale[subblock] = scale;
+        max_sub_scale = fmaxf(max_sub_scale, scale);
+    }
+
+    const float safe_min_tensor_scale = (isfinite(min_tensor_scale) && min_tensor_scale > 0.0f) ? min_tensor_scale : 0.0f;
+
+    float required_tensor_scale = 0.0f;
+    if (max_sub_scale > 0.0f && isfinite(max_sub_scale)) {
+        required_tensor_scale = max_sub_scale / max_fp8_tensor;
+        if (!isfinite(required_tensor_scale) || required_tensor_scale < 0.0f) {
+            required_tensor_scale = 0.0f;
+        }
+    }
+
+    const float start_tensor_scale = fmaxf(safe_min_tensor_scale, required_tensor_scale);
+    if (!(start_tensor_scale > 0.0f) || !isfinite(start_tensor_scale)) {
+        *tensor_scale_out = 0.0f;
+        memset(block_scales_out, 0, QK_K / QK_NVFP4);
+        return;
+    }
+
+    float best_tensor_scale = start_tensor_scale;
+    float best_objective = INFINITY;
+    uint8_t best_block_scales[QK_K / QK_NVFP4] = { 0 };
+
+    uint8_t trial_block_scales[QK_K / QK_NVFP4];
+
+    for (int factor_idx = 0; factor_idx < g_nvfp4_scale_mul_count; ++factor_idx) {
+        const float trial_tensor_scale = start_tensor_scale * g_nvfp4_scale_mul[factor_idx];
+        if (!(trial_tensor_scale > 0.0f) || !isfinite(trial_tensor_scale)) {
+            continue;
+        }
+
+        for (int subblock = 0; subblock < QK_K / QK_NVFP4; ++subblock) {
+            float block_scale = sub_scale[subblock] / trial_tensor_scale;
+            if (!isfinite(block_scale) || block_scale < 0.0f) {
+                block_scale = 0.0f;
+            } else if (block_scale > g_nvfp4_max_block_scale) {
+                block_scale = g_nvfp4_max_block_scale;
+            }
+
+            const uint8_t initial_block_scale = GGML_FP32_TO_UE4M3(block_scale);
+            const float * values = block + subblock * QK_NVFP4;
+            const float * sub_weights = weights ? (weights + subblock * QK_NVFP4) : NULL;
+            trial_block_scales[subblock] = ggml_nvfp4_refine_sbscale_fp8_local(values, sub_weights, trial_tensor_scale, initial_block_scale);
+        }
+
+        const float objective = ggml_nvfp4_obj_256_codes(block, weights, codes, trial_tensor_scale, trial_block_scales);
+        if (objective < best_objective) {
+            best_objective = objective;
+            best_tensor_scale = trial_tensor_scale;
+            memcpy(best_block_scales, trial_block_scales, sizeof(best_block_scales));
+        }
+    }
+
+    *tensor_scale_out = best_tensor_scale;
+    memcpy(block_scales_out, best_block_scales, sizeof(best_block_scales));
+}
+
+static inline void nvfp4_assign_block_codes(
+        const float * GGML_RESTRICT block,
+        const float tensor_scale,
+        const uint8_t * GGML_RESTRICT block_scales,
+        uint8_t * GGML_RESTRICT codes
+) {
+    for (int subblock = 0; subblock < QK_K / QK_NVFP4; ++subblock) {
+        const float scale = tensor_scale * GGML_FP8_UE4M3_TO_FP32(block_scales[subblock]);
+        const float * GGML_RESTRICT values = block + subblock * QK_NVFP4;
+
+        if (!(scale > 0.0f) || !isfinite(scale)) {
+            memset(codes + subblock * QK_NVFP4, 0, QK_NVFP4);
+            continue;
+        }
+
+        for (int j = 0; j < QK_NVFP4; ++j) {
+            codes[subblock * QK_NVFP4 + j] = best_index_nvfp4(values[j], scale);
+        }
+    }
+}
+
+static inline bool nvfp4_quantize_block(
+        const float * GGML_RESTRICT block,
+        const float * GGML_RESTRICT weights,
+        uint8_t * GGML_RESTRICT codes,
+        uint8_t * GGML_RESTRICT block_scales,
+        float * GGML_RESTRICT tensor_scale_out,
+        float * GGML_RESTRICT objective_out) {
+    const float max_abs = nvfp4_block_max_abs(block);
+    if (max_abs < GROUP_MAX_EPS) {
+        if (tensor_scale_out) {
+            *tensor_scale_out = 0.0f;
+        }
+        if (objective_out) {
+            *objective_out = 0.0f;
+        }
+        memset(codes, 0, QK_K);
+        memset(block_scales, 0, QK_K / QK_NVFP4);
+        return false;
+    }
+
+    const float max_tensor_scale = ggml_nvfp4_pick_max_fp8_tensor_scale(
+        block, weights, max_abs, g_nvfp4_max_tensor_scale);
+
+    const float min_tensor_scale = (max_abs / 4.0f) / max_tensor_scale;
+    float tensor_scale = min_tensor_scale;
+
+    for (int subblock = 0; subblock < QK_K / QK_NVFP4; ++subblock) {
+        const float * values = block + subblock * QK_NVFP4;
+        const float * sub_weights = weights ? (weights + subblock * QK_NVFP4) : NULL;
+        block_scales[subblock] = adaptive_block_scale_4_or_6(values, sub_weights, tensor_scale);
+    }
+
+    nvfp4_assign_block_codes(block, tensor_scale, block_scales, codes);
+
+    for (int round = 0; round < NVFP4_REFIT_ROUNDS; ++round) {
+        nvfp4_refit_block_scales(block, weights, codes, min_tensor_scale, &tensor_scale, block_scales, max_tensor_scale);
+        nvfp4_assign_block_codes(block, tensor_scale, block_scales, codes);
+    }
+
+    if (tensor_scale_out) {
+        *tensor_scale_out = tensor_scale;
+    }
+    if (objective_out) {
+        *objective_out = ggml_nvfp4_obj_256_codes(block, weights, codes, tensor_scale, block_scales);
+    }
+    return true;
+}
+
+static inline int64_t nvfp4_sample_block_index(int64_t is, int64_t nb, int64_t sample_nb) {
+    if (nb <= 1 || sample_nb <= 1) {
+        return 0;
+    }
+    return (is * (nb - 1)) / (sample_nb - 1);
+}
+
+static float nvfp4_eval_candidate_max_obj_on_guard(
+        const float * GGML_RESTRICT x,
+        const float * GGML_RESTRICT quant_weights,
+        int64_t nb,
+        int64_t sample_nb,
+        int64_t guard_nb,
+        float a,
+        float b) {
+    if (sample_nb <= 0 || guard_nb <= 0) {
+        return INFINITY;
+    }
+
+    const int64_t guard_off = sample_nb > guard_nb ? (sample_nb - guard_nb) : 0;
+    float max_obj = 0.0f;
+    int used = 0;
+
+    uint8_t codes[QK_K];
+    uint8_t block_scales[QK_K / QK_NVFP4];
+
+    g_nvfp4_scale_mul[0] = a;
+    g_nvfp4_scale_mul[1] = b;
+
+    for (int64_t is = guard_off; is < sample_nb; ++is) {
+        const int64_t ib = nvfp4_sample_block_index(is, nb, sample_nb);
+        const float * GGML_RESTRICT block = x + ib * QK_K;
+        const float * GGML_RESTRICT weights = quant_weights ? (quant_weights + ib * QK_K) : NULL;
+
+        float block_obj = 0.0f;
+        if (nvfp4_quantize_block(block, weights, codes, block_scales, NULL, &block_obj) &&
+                isfinite(block_obj) && block_obj >= 0.0f) {
+            max_obj = fmaxf(max_obj, block_obj);
+            used += 1;
+        }
+    }
+
+    return used > 0 ? max_obj : INFINITY;
+}
+
+static void nvfp4_autotune_scale_mul_on_row(
+        const float * GGML_RESTRICT x,
+        int64_t n,
+        const float * GGML_RESTRICT quant_weights
+) {
+    if (getenv("LLAMA_NVFP4_TUNE_EVERY") == NULL) {
+        return;
+    }
+    
+    float tuned_a, tuned_b;
+    if (nvfp4_autotune(x, quant_weights, n, &tuned_a, &tuned_b)) {
+        g_nvfp4_scale_mul[0] = tuned_a;
+        g_nvfp4_scale_mul[1] = tuned_b;
+        return;
+    }
+
+    const int64_t nb = n / QK_K;
+    const int64_t sample_cap = nb >= 8192 ? 256 : (nb >= 2048 ? 128 : 64);
+    const int64_t sample_nb = nb < sample_cap ? nb : sample_cap;
+
+    const float base_a = 0.9918823242f;
+    const float base_b = 0.9864501953f;
+    const float step = 1.0f / 32768.0f;
+
+    float best_score = INFINITY;
+    float best_a = base_a;
+    float best_b = base_b;
+    float base_score = INFINITY;
+
+    uint8_t codes[QK_K];
+    uint8_t block_scales[QK_K / QK_NVFP4];
+
+    int top_ai[NVFP4_TUNE_GUARD_TOPK_CPU];
+    int top_bi[NVFP4_TUNE_GUARD_TOPK_CPU];
+    float top_score[NVFP4_TUNE_GUARD_TOPK_CPU];
+    for (int i = 0; i < NVFP4_TUNE_GUARD_TOPK_CPU; ++i) {
+        top_ai[i] = 0;
+        top_bi[i] = 0;
+        top_score[i] = INFINITY;
+    }
+
+    for (int ai = -24; ai <= 24; ++ai) {
+        const float a = base_a + (float) ai * step;
+        for (int bi = -24; bi <= 24; ++bi) {
+            const float b = base_b + (float) bi * step;
+
+            g_nvfp4_scale_mul[0] = a;
+            g_nvfp4_scale_mul[1] = b;
+
+            float sum_obj = 0.0f;
+            float sum_obj2 = 0.0f;
+
+            for (int64_t is = 0; is < sample_nb; ++is) {
+                const int64_t ib = nvfp4_sample_block_index(is, nb, sample_nb);
+
+                const float * GGML_RESTRICT block = x + ib * QK_K;
+                const float * GGML_RESTRICT weights = quant_weights ? (quant_weights + ib * QK_K) : NULL;
+                float block_obj = 0.0f;
+                if (!nvfp4_quantize_block(block, weights, codes, block_scales, NULL, &block_obj)) {
+                    continue;
+                }
+                sum_obj += block_obj;
+                sum_obj2 += block_obj * block_obj;
+            }
+
+            const float rms_obj = (sample_nb > 0) ? sqrtf(sum_obj2 / (float) sample_nb) : 0.0f;
+            const float score = sum_obj + g_nvfp4_tune_tail_weight * (float) sample_nb * rms_obj;
+
+            if (ai == 0 && bi == 0) {
+                base_score = score;
+            }
+
+            if (score < best_score) {
+                best_score = score;
+                best_a = a;
+                best_b = b;
+            }
+
+            int pos = -1;
+            for (int i = 0; i < NVFP4_TUNE_GUARD_TOPK_CPU; ++i) {
+                if (score < top_score[i]) {
+                    pos = i;
+                    break;
+                }
+            }
+            if (pos >= 0) {
+                for (int j = NVFP4_TUNE_GUARD_TOPK_CPU - 1; j > pos; --j) {
+                    top_score[j] = top_score[j - 1];
+                    top_ai[j] = top_ai[j - 1];
+                    top_bi[j] = top_bi[j - 1];
+                }
+                top_score[pos] = score;
+                top_ai[pos] = ai;
+                top_bi[pos] = bi;
+            }
+        }
+    }
+
+    bool base_in_topk = false;
+    for (int i = 0; i < NVFP4_TUNE_GUARD_TOPK_CPU; ++i) {
+        if (top_ai[i] == 0 && top_bi[i] == 0) {
+            base_in_topk = true;
+            break;
+        }
+    }
+    if (!base_in_topk) {
+        top_ai[NVFP4_TUNE_GUARD_TOPK_CPU - 1] = 0;
+        top_bi[NVFP4_TUNE_GUARD_TOPK_CPU - 1] = 0;
+        top_score[NVFP4_TUNE_GUARD_TOPK_CPU - 1] = base_score;
+    }
+
+    const int64_t guard_nb = sample_nb < NVFP4_TUNE_GUARD_BLOCKS_CPU ? sample_nb : NVFP4_TUNE_GUARD_BLOCKS_CPU;
+    const float base_max_obj = nvfp4_eval_candidate_max_obj_on_guard(
+        x, quant_weights, nb, sample_nb, guard_nb, base_a, base_b);
+    const float guard_max_obj =
+        (isfinite(base_max_obj) && base_max_obj > 0.0f)
+            ? (base_max_obj * NVFP4_TUNE_GUARD_MAX_OBJ_FRAC_CPU)
+            : INFINITY;
+
+    best_a = base_a;
+    best_b = base_b;
+    best_score = base_score;
+
+    for (int i = 0; i < NVFP4_TUNE_GUARD_TOPK_CPU; ++i) {
+        if (!isfinite(top_score[i])) {
+            continue;
+        }
+
+        const float a = base_a + (float) top_ai[i] * step;
+        const float b = base_b + (float) top_bi[i] * step;
+        const float max_obj = nvfp4_eval_candidate_max_obj_on_guard(
+            x, quant_weights, nb, sample_nb, guard_nb, a, b);
+
+        if (!isfinite(max_obj)) {
+            continue;
+        }
+
+        if (max_obj <= guard_max_obj) {
+            best_a = a;
+            best_b = b;
+            best_score = top_score[i];
+            break;
+        }
+    }
+
+    g_nvfp4_scale_mul[0] = best_a;
+    g_nvfp4_scale_mul[1] = best_b;
+
+}
+static inline void nvfp4_quantize_subblock(
+        const float * GGML_RESTRICT values,
+        const float * GGML_RESTRICT weights,
+        uint8_t * GGML_RESTRICT block_scale_out,
+        uint8_t * GGML_RESTRICT codes_out) {
+    uint8_t block_scale = adaptive_block_scale_4_or_6(values, weights, 1.0f);
+    block_scale = ggml_nvfp4_refine_sbscale_fp8_local(values, weights, 1.0f, block_scale);
+    *block_scale_out = block_scale;
+
+    const float scale = GGML_FP8_UE4M3_TO_FP32(block_scale);
+    if (!(scale > 0.0f) || !isfinite(scale)) {
+        memset(codes_out, 0, 16);
+        return;
+    }
+
+    for (int j = 0; j < 16; ++j) {
+        codes_out[j] = best_index_nvfp4(values[j], scale);
+    }
+}
+
+static void quantize_row_nvfp4_impl(
+        const float * GGML_RESTRICT x,
+        block_nvfp4 * GGML_RESTRICT y,
+        int64_t n,
+        const float * GGML_RESTRICT quant_weights) {
+    assert(n % QK_K == 0);
+    #ifdef GGML_USE_CUDA
+    if (nvfp4_quantize_cuda(x, false, (void *) y, n / QK_K, QK_K, quant_weights, 1.0f, NULL)) {
+        return;
+    }
+    #endif
+
+    const int64_t nb = n / QK_K;
+    const int64_t packed_block_count = (nb + 3) / 4;
+
+    block_nvfp4 * GGML_RESTRICT packed = (block_nvfp4 *) y;
+    memset(packed, 0, (size_t) packed_block_count * sizeof(block_nvfp4));
+
+    if (__atomic_load_n(&g_nvfp4_tune_state, __ATOMIC_ACQUIRE) != 2) {
+        int expected = 0;
+        if (__atomic_compare_exchange_n(&g_nvfp4_tune_state, &expected, 1, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            nvfp4_autotune_scale_mul_on_row(x, n, quant_weights);
+            __atomic_store_n(&g_nvfp4_tune_state, 2, __ATOMIC_RELEASE);
+        } else {
+            while (__atomic_load_n(&g_nvfp4_tune_state, __ATOMIC_ACQUIRE) != 2) { }
+        }
+    }
+
+    for (int64_t ib = 0; ib < nb; ++ib) {
+        const int64_t packed_idx = ib / 4;
+        const int slot = (int) (ib % 4);
+
+        const float * GGML_RESTRICT block = x + ib * QK_K;
+        const float * GGML_RESTRICT weights = quant_weights ? (quant_weights + ib * QK_K) : NULL;
+        uint8_t * GGML_RESTRICT block_scales = packed[packed_idx].scales[slot];
+        uint8_t * GGML_RESTRICT packed_codes = packed[packed_idx].qs[slot];
+        uint8_t codes[QK_K] = { 0 };
+
+        if (nvfp4_block_max_abs(block) < GROUP_MAX_EPS) {
+            continue;
+        }
+
+        for (int pair_idx = 0; pair_idx < 8; ++pair_idx) {
+            const int pair_offset = pair_idx * 32;
+            const float * GGML_RESTRICT pair_values = block + pair_offset;
+            const float * GGML_RESTRICT pair_weights = weights ? (weights + pair_offset) : NULL;
+
+            nvfp4_quantize_subblock(pair_values + 0,  pair_weights ? (pair_weights + 0)  : NULL, block_scales + 2 * pair_idx + 0, codes + pair_offset + 0);
+            nvfp4_quantize_subblock(pair_values + 16, pair_weights ? (pair_weights + 16) : NULL, block_scales + 2 * pair_idx + 1, codes + pair_offset + 16);
+        }
+
+        ggml_nvfp4_pack_codes_256(codes, packed_codes);
+    }
+}
+
+void quantize_row_nvfp4_ref(
+        const float * GGML_RESTRICT x,
+        block_nvfp4 * GGML_RESTRICT y,
+        int64_t k) {
+    quantize_row_nvfp4_impl(x, y, k, NULL);
+}
+
 void dequantize_row_q4_1(const block_q4_1 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK4_1;
 
@@ -431,6 +915,32 @@ void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_REST
             y[i*qk + j + 0   ] = x0*d;
             y[i*qk + j + qk/2] = x1*d;
         }
+    }
+}
+
+
+void dequantize_row_nvfp4(const block_nvfp4 * GGML_RESTRICT x,
+                         float * GGML_RESTRICT y,
+                         int64_t k)
+{
+    assert(k % QK_K == 0);
+    const int64_t nb = k / QK_K;
+
+    for (int64_t ib = 0; ib < nb; ++ib) {
+        const block_nvfp4 * GGML_RESTRICT xp = (const block_nvfp4 *) x;
+        const block_nvfp4 * GGML_RESTRICT p = &xp[ib / 4];
+        const int il = (int) (ib % 4);
+
+        const uint8_t * GGML_RESTRICT ql = p->qs[il];
+        const uint8_t * GGML_RESTRICT sc = p->scales[il];
+        for (int i0 = 0; i0 < QK_K; ++i0) {
+            const int sub_block = i0 / QK_NVFP4;
+            const float scale = GGML_FP8_UE4M3_TO_FP32(sc[sub_block]);
+
+            const uint8_t q = ggml_nvfp4_get_q4(ql, i0);
+            y[i0] = scale * kvalues_fp4_float[q];
+        }
+        y += QK_K;
     }
 }
 
@@ -2096,6 +2606,25 @@ size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
     GGML_UNUSED(quant_weights);
     quantize_row_mxfp4_ref(src, dst, (int64_t)nrow*n_per_row);
     return nrow * ggml_row_size(GGML_TYPE_MXFP4, n_per_row);
+}
+
+
+size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrow,int64_t n_per_row, const float * quant_weights) {
+    size_t row_size = ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
+#ifdef GGML_USE_CUDA
+    if (nvfp4_quantize_cuda(src, false, dst, nrow, n_per_row, quant_weights, 1.0f, NULL)) {
+        return nrow * row_size;
+    }
+#endif // GGML_USE_CUDA
+
+    char * qrow = (char *) dst;
+    const float * qw_row = quant_weights;
+        for (int64_t row = 0; row < nrow; ++row) {
+        quantize_row_nvfp4_impl(src, (block_nvfp4 *) qrow, n_per_row, qw_row);
+            src  += n_per_row;
+            qrow += row_size;
+    }
+    return nrow * row_size;
 }
 
 // ====================== Ternary (de)-quantization (BitNet b1.58 and TriLMs)
@@ -5044,6 +5573,15 @@ static bool validate_e_e8m0(uint8_t e, size_t i) {
     return true;
 }
 
+static inline bool validate_e_fp8_ue4m3(uint8_t e, size_t idx) {
+    GGML_UNUSED(idx);
+
+    const float s = GGML_FP8_UE4M3_TO_FP32(e);
+    return isfinite(s) && s >= 0.0f;
+}
+
+
+
 #define VALIDATE_ROW_DATA_D_F16_IMPL(type, data, nb) \
     const type * q = (const type *) (data); \
     for (size_t i = 0; i < (nb); ++i) { \
@@ -5068,6 +5606,17 @@ static bool validate_e_e8m0(uint8_t e, size_t i) {
         } \
     }
 
+#define VALIDATE_ROW_DATA_E_FP8_UE4M3_NVFP4(block_type, data, nb)          \
+    do {                                                                   \
+        const block_type * __restrict__ q = (const block_type *)(data);    \
+        for (int i = 0; i < (nb); ++i) {                                   \
+            for (int s = 0; s < QK_K / QK_NVFP4; ++s) {                    \
+                if (!validate_e_fp8_ue4m3(q[i].scales[s], i)) {            \
+                    GGML_ASSERT(false && "invalid NVFP4 scale");          \
+                }                                                          \
+            }                                                              \
+        }                                                                  \
+    } while (0)
 #define VALIDATE_ROW_DATA_DVEC_F16_IMPL(type, data, nb, nr) \
     const type * q = (const type *) (data); \
     for (size_t i = 0; i < (nb); ++i) { \
@@ -5224,6 +5773,32 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_MXFP4:
             {
                 VALIDATE_ROW_DATA_E_E8M0_IMPL(block_mxfp4, data, nb);
+            } break;
+        case GGML_TYPE_NVFP4:
+            {
+                // NVFP4 storage is 4 logical 256-value blocks per 576B pack.
+                // ggml_type_size(NVFP4) is per logical block (144B), so `nb` here is number of blocks.
+                if (nbytes % GGML_NVFP4_BYTES_PER_PACK != 0) {
+                    fprintf(stderr, "%s: invalid size %zu for type %s (expected multiple of %d bytes per pack)\n",
+                            __func__, nbytes, ggml_type_name(type), GGML_NVFP4_BYTES_PER_PACK);
+                    return false;
+                }
+
+                const size_t np = nbytes / GGML_NVFP4_BYTES_PER_PACK;
+                const block_nvfp4 * q = (const block_nvfp4 *) data;
+
+                for (size_t ip = 0; ip < np; ++ip) {
+                    for (int il = 0; il < 4; ++il) {
+                        const size_t bi = ip * 4 + (size_t) il;
+                        for (int s = 0; s < QK_K / QK_NVFP4; ++s) {
+                            if (!validate_e_fp8_ue4m3(q[ip].scales[il][s], bi)) {
+                                fprintf(stderr, "%s: found invalid NVFP4 scale=%u at block %zu sub=%d\n",
+                                        __func__, (unsigned) q[ip].scales[il][s], bi, s);
+                                return false;
+                            }
+                        }
+                    }
+                }
             } break;
         case GGML_TYPE_Q2_K:
             {

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -22,6 +22,7 @@ GGML_API void quantize_row_q8_0_ref(const float * GGML_RESTRICT x, block_q8_0 * 
 GGML_API void quantize_row_q8_1_ref(const float * GGML_RESTRICT x, block_q8_1 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RESTRICT y, int64_t k);
+GGML_API void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_q2_K_ref(const float * GGML_RESTRICT x, block_q2_K * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_q3_K_ref(const float * GGML_RESTRICT x, block_q3_K * GGML_RESTRICT y, int64_t k);
@@ -48,6 +49,7 @@ GGML_API void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GG
 //GGML_API void dequantize_row_q8_1(const block_q8_1 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_nvfp4(const block_nvfp4* GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_q2_K(const block_q2_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_q3_K(const block_q3_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -95,6 +97,7 @@ GGML_API size_t quantize_q5_1(const float * GGML_RESTRICT src, void * GGML_RESTR
 GGML_API size_t quantize_q8_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API void iq2xs_init_impl(enum ggml_type type);
 GGML_API void iq2xs_free_impl(enum ggml_type type);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -718,6 +718,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_mxfp4,
         .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp4_ref,
     },
+[GGML_TYPE_NVFP4] = {
+        .type_name                = "nvfp4",
+        .blck_size                = QK_K,
+        .type_size                = GGML_NVFP4_BYTES_PER_BLOCK,
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_nvfp4,
+        .from_float_ref           = (ggml_from_float_t) quantize_row_nvfp4_ref,
+    },
     [GGML_TYPE_Q2_K] = {
         .type_name                = "q2_K",
         .blck_size                = QK_K,
@@ -1252,7 +1260,12 @@ size_t ggml_nbytes(const struct ggml_tensor * tensor) {
         }
     }
     else {
-        nbytes = tensor->ne[0]*tensor->nb[0]/blck_size;
+        if (tensor->type == GGML_TYPE_NVFP4) {
+            nbytes = ggml_row_size(tensor->type, tensor->ne[0]);
+        } else {
+            nbytes = tensor->ne[0]*tensor->nb[0]/blck_size;
+         
+        }
         for (int i = 1; i < GGML_MAX_DIMS; ++i) {
             nbytes += (tensor->ne[i] - 1)*tensor->nb[i];
         }
@@ -1281,6 +1294,11 @@ size_t ggml_row_size(enum ggml_type type, int64_t ne) {
     assert(type >= 0);
     assert(type < GGML_TYPE_COUNT);
     assert(ne % ggml_blck_size(type) == 0);
+    if (type == GGML_TYPE_NVFP4) {
+        const int64_t nb = ne / QK_K;
+        const int64_t np = (nb + 3) / 4;
+        return (size_t) np * sizeof(block_nvfp4);
+    }
     return ggml_type_size(type)*ne/ggml_blck_size(type);
 }
 
@@ -1372,6 +1390,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q5_1:          wtype = GGML_TYPE_Q5_1;  break;
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
+        case GGML_FTYPE_MOSTLY_NVFP4:         wtype = GGML_TYPE_NVFP4; break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
         case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;
@@ -1751,7 +1770,11 @@ static struct ggml_tensor * ggml_new_tensor_impl(
     }
 
     result->nb[0] = ggml_type_size(type);
-    result->nb[1] = result->nb[0]*(result->ne[0]/ggml_blck_size(type));
+    if (type == GGML_TYPE_NVFP4) {
+        result->nb[1] = ggml_row_size(type, result->ne[0]);
+    } else {
+        result->nb[1] = result->nb[0]*(result->ne[0]/ggml_blck_size(type));
+    }
     for (int i = 2; i < GGML_MAX_DIMS; i++) {
         result->nb[i] = result->nb[i - 1]*result->ne[i - 1];
     }
@@ -1813,7 +1836,9 @@ void * ggml_new_buffer(struct ggml_context * ctx, size_t nbytes) {
 }
 
 struct ggml_tensor * ggml_dup_tensor(struct ggml_context * ctx, const struct ggml_tensor * src) {
-    return ggml_new_tensor(ctx, src->type, GGML_MAX_DIMS, src->ne);
+    struct ggml_tensor * result = ggml_new_tensor(ctx, src->type, GGML_MAX_DIMS, src->ne);
+    memcpy(result->op_params, src->op_params, sizeof(result->op_params));
+    return result;
 }
 
 void ggml_unravel_index(const struct ggml_tensor * tensor, int64_t i, int64_t * i0, int64_t * i1, int64_t * i2, int64_t * i3) {
@@ -1885,6 +1910,7 @@ struct ggml_tensor * ggml_view_tensor(
         struct ggml_tensor  * src) {
     struct ggml_tensor * result = ggml_new_tensor_impl(ctx, src->type, GGML_MAX_DIMS, src->ne, src, 0);
     ggml_format_name(result, "%s (view)", src->name);
+    memcpy(result->op_params, src->op_params, sizeof(result->op_params));
 
     for (int i = 0; i < GGML_MAX_DIMS; i++) {
         result->nb[i] = src->nb[i];
@@ -3209,6 +3235,10 @@ struct ggml_tensor * ggml_mul_mat(
     result->op     = GGML_OP_MUL_MAT;
     result->src[0] = a;
     result->src[1] = b;
+    // stream_k_mode: -1 auto (default), 0 force off, 1 force on.
+    ggml_set_op_params_i32(result, 1, -1);
+    // stream_k_nblocks: 0 auto (nsm), >0 absolute blocks, <0 multiplier of nsm.
+    ggml_set_op_params_i32(result, 2, 0);
 
     return result;
 }
@@ -3259,6 +3289,10 @@ struct ggml_tensor * ggml_mul_mat_id(
     result->src[0] = as;
     result->src[1] = b;
     result->src[2] = ids;
+    // stream_k_mode: -1 auto (default), 0 force off, 1 force on.
+    ggml_set_op_params_i32(result, 1, -1);
+    // stream_k_nblocks: 0 auto (nsm), >0 absolute blocks, <0 multiplier of nsm.
+    ggml_set_op_params_i32(result, 2, 0);
 
     return result;
 }
@@ -7588,6 +7622,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_Q5_1:    result = quantize_q5_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q8_0:    result = quantize_q8_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_MXFP4:   result = quantize_mxfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_NVFP4:   result = quantize_nvfp4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q2_K:    result = quantize_q2_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q3_K:    result = quantize_q3_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_K:    result = quantize_q4_K(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/ggml/src/ggml.cpp
+++ b/ggml/src/ggml.cpp
@@ -24,3 +24,77 @@ static bool ggml_uncaught_exception_init = []{
     std::set_terminate(ggml_uncaught_exception);
     return true;
 }();
+
+extern "C" bool nvfp4_autotune(const float * x, const float * qw, int64_t n, float * best_a, float * best_b) {
+    // This is the public CUDA autotune hook for NVFP4 export.
+    // The nvfp4-cpu branch keeps CUDA disabled and leaves CPU tuning in place.
+    GGML_UNUSED(x);
+    GGML_UNUSED(qw);
+    GGML_UNUSED(n);
+    GGML_UNUSED(best_a);
+    GGML_UNUSED(best_b);
+    return false;
+}
+
+extern "C" bool nvfp4_autotune_cuda(const float * x, const float * qw, int64_t n, float * best_a, float * best_b, void * stream) {
+    // This is the stream-aware CUDA autotune hook for NVFP4 export.
+    // The nvfp4-cpu branch leaves the symbol in place but does not use CUDA.
+    GGML_UNUSED(x);
+    GGML_UNUSED(qw);
+    GGML_UNUSED(n);
+    GGML_UNUSED(best_a);
+    GGML_UNUSED(best_b);
+    GGML_UNUSED(stream);
+    return false;
+}
+
+extern "C" void nvfp4_set_ab(float a, float b) {
+    // This stores CUDA-side tuning parameters for NVFP4 quantization.
+    // The nvfp4-cpu branch keeps the API but does not retain CUDA state.
+    GGML_UNUSED(a);
+    GGML_UNUSED(b);
+}
+
+extern "C" void nvfp4_clear_ab(void) {
+    // This clears CUDA-side tuning parameters for NVFP4 quantization.
+    // The nvfp4-cpu branch keeps the API but has no CUDA state to clear.
+}
+
+extern "C" bool nvfp4_quantize_cuda_cfg(
+    const void * x, bool x_bf16, void * vy,
+    int64_t nrow, int64_t n_per_row,
+    const float * qw, float x_scale,
+    const void * cfg, void * stream) {
+    // This is the configurable CUDA quantization hook for NVFP4 export.
+    // The nvfp4-cpu branch keeps the call shape stable and always falls back to CPU.
+    GGML_UNUSED(x);
+    GGML_UNUSED(x_bf16);
+    GGML_UNUSED(vy);
+    GGML_UNUSED(nrow);
+    GGML_UNUSED(n_per_row);
+    GGML_UNUSED(qw);
+    GGML_UNUSED(x_scale);
+    GGML_UNUSED(cfg);
+    GGML_UNUSED(stream);
+    return false;
+}
+
+extern "C" bool nvfp4_quantize_cuda(const void * x, bool x_bf16, void * vy, int64_t nrow, int64_t n_per_row, const float * qw, float x_scale, void * stream) {
+    return nvfp4_quantize_cuda_cfg(x, x_bf16, vy, nrow, n_per_row, qw, x_scale, nullptr, stream);
+}
+
+extern "C" bool nvfp4_quantize_cuda_ab(const void * x, bool x_bf16, void * vy, int64_t nrow, int64_t n_per_row, const float * qw, float x_scale, float a, float b, void * stream) {
+    // This is the explicit-(a,b) CUDA quantization hook for NVFP4 export.
+    // The nvfp4-cpu branch keeps the API but always declines CUDA quantization.
+    GGML_UNUSED(x);
+    GGML_UNUSED(x_bf16);
+    GGML_UNUSED(vy);
+    GGML_UNUSED(nrow);
+    GGML_UNUSED(n_per_row);
+    GGML_UNUSED(qw);
+    GGML_UNUSED(x_scale);
+    GGML_UNUSED(a);
+    GGML_UNUSED(b);
+    GGML_UNUSED(stream);
+    return false;
+}

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -673,7 +673,11 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
             // calculate byte offsets given the tensor shape and type
             info.t.nb[0] = type_size;
-            info.t.nb[1] = info.t.nb[0]*(info.t.ne[0]/blck_size);
+            if (info.t.type == GGML_TYPE_NVFP4) {
+                info.t.nb[1] = ggml_row_size(info.t.type, info.t.ne[0]);
+            } else {
+                info.t.nb[1] = info.t.nb[0]*(info.t.ne[0]/blck_size);
+            }
             for (int j = 2; j < GGML_MAX_DIMS; ++j) {
                 info.t.nb[j] = info.t.nb[j - 1]*info.t.ne[j - 1];
             }
@@ -1252,10 +1256,16 @@ void gguf_set_tensor_type(struct gguf_context * ctx, const char * name, enum ggm
     const int64_t blck_size = ggml_blck_size(type);
 
     tensor->type = type;
-    GGML_ASSERT(tensor->ne[0] % blck_size == 0 && "tensor row size not divisible by block size of new type");
+    if (type != GGML_TYPE_NVFP4) {
+        GGML_ASSERT(tensor->ne[0] % blck_size == 0 && "tensor row size not divisible by block size of new type");
+    }
 
     tensor->nb[0] = type_size;
-    tensor->nb[1] = tensor->nb[0]*(tensor->ne[0]/blck_size);
+    if (type == GGML_TYPE_NVFP4) {
+        tensor->nb[1] = ggml_row_size(type, tensor->ne[0]);
+    } else {
+        tensor->nb[1] = tensor->nb[0]*(tensor->ne[0]/blck_size);
+    }
     for (int i = 2; i < GGML_MAX_DIMS; i++) {
         tensor->nb[i] = tensor->nb[i - 1]*tensor->ne[i - 1];
     }

--- a/include/llama.h
+++ b/include/llama.h
@@ -152,7 +152,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_TQ1_0         = 36, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_TQ2_0         = 37, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_MXFP4_MOE     = 38, // except 1d tensors
-
+        LLAMA_FTYPE_MOSTLY_NVFP4         = 39, // except 1d tensors
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };
 
@@ -309,7 +309,7 @@ extern "C" {
         // Keep the booleans together to avoid misalignment during copy-by-value.
         bool vocab_only;      // only load the vocabulary, no weights
         bool use_mmap;        // use mmap if possible
-        bool use_direct_io;   // use direct io, takes precedence over use_mmap when supported
+        bool use_direct_io;   // use direct io, takes precedence over use_mmap
         bool use_mlock;       // force system to keep model in RAM
         bool check_tensors;   // validate model tensor data
         bool use_extra_bufts; // use extra buffer types (used for weight repacking)
@@ -483,14 +483,13 @@ extern "C" {
     enum llama_params_fit_status {
         LLAMA_PARAMS_FIT_STATUS_SUCCESS = 0, // found allocations that are projected to fit
         LLAMA_PARAMS_FIT_STATUS_FAILURE = 1, // could not find allocations that are projected to fit
-        LLAMA_PARAMS_FIT_STATUS_ERROR   = 2, // a hard error occurred, e.g. because no model could be found at the specified path
+        LLAMA_PARAMS_FIT_STATUS_ERROR   = 2, // a hard error occured, e.g. because no model could be found at the specified path
     };
 
     // fits mparams and cparams to free device memory (assumes system memory is unlimited)
     //   - returns true if the parameters could be successfully modified to fit device memory
     //   - this function is NOT thread safe because it modifies the global llama logger state
     //   - only parameters that have the same value as in llama_default_model_params are modified
-    //     with the exception of the context size which is modified if and only if equal to 0
     LLAMA_API enum llama_params_fit_status llama_params_fit(
                                    const char   * path_model,
                     struct llama_model_params   * mparams,

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -899,7 +899,8 @@ ggml_tensor * llm_graph_context::build_cvec(
 
 ggml_tensor * llm_graph_context::build_lora_mm(
           ggml_tensor * w,
-          ggml_tensor * cur) const {
+          ggml_tensor * cur,
+          ggml_tensor * w_scale) const {
     ggml_tensor * res = ggml_mul_mat(ctx0, w, cur);
 
     for (const auto & lora : *loras) {
@@ -920,13 +921,18 @@ ggml_tensor * llm_graph_context::build_lora_mm(
         res = ggml_add(ctx0, res, ab_cur);
     }
 
+    if (w_scale) {
+        res = ggml_mul(ctx0, res, w_scale);
+    }
+
     return res;
 }
 
 ggml_tensor * llm_graph_context::build_lora_mm_id(
           ggml_tensor * w,   // ggml_tensor * as
           ggml_tensor * cur, // ggml_tensor * b
-          ggml_tensor * ids) const {
+          ggml_tensor * ids,
+          ggml_tensor * w_scale) const {
     ggml_tensor * res = ggml_mul_mat_id(ctx0, w, cur, ids);
     for (const auto & lora : *loras) {
         llama_adapter_lora_weight * lw = lora.first->get_weight(w);
@@ -946,6 +952,24 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
 
         ab_cur = ggml_scale(ctx0, ab_cur, scale);
         res = ggml_add(ctx0, res, ab_cur);
+    }
+
+    if (w_scale) {
+        ggml_tensor * scale = w_scale;
+
+        if (scale->ne[0] == 1 && scale->ne[1] == 1 && scale->ne[2] == 1 && scale->ne[3] == 1) {
+            res = ggml_mul(ctx0, res, scale);
+            return res;
+        }
+
+        if (ggml_is_vector(scale)) {
+            scale = ggml_reshape_3d(ctx0, scale, 1, scale->ne[0], 1);
+        } else if (ggml_n_dims(scale) == 2 && scale->ne[0] == 1) {
+            scale = ggml_reshape_3d(ctx0, scale, 1, scale->ne[1], 1);
+        }
+
+        scale = ggml_get_rows(ctx0, scale, ids);
+        res = ggml_mul(ctx0, res, scale);
     }
 
     return res;
@@ -1204,7 +1228,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
                 bool   norm_w,
                 bool   scale_w,
                float   w_scale,
-        llama_expert_gating_func_type gating_op,
+         llama_expert_gating_func_type gating_op,
                  int   il,
          ggml_tensor * probs_in,
          ggml_tensor * gate_up_exps,

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -767,13 +767,15 @@ struct llm_graph_context {
     // do mat_mul, while optionally apply lora
     ggml_tensor * build_lora_mm(
               ggml_tensor * w,
-              ggml_tensor * cur) const;
+              ggml_tensor * cur,
+              ggml_tensor * w_scale = nullptr) const;
 
     // do mat_mul_id, while optionally apply lora
     ggml_tensor * build_lora_mm_id(
               ggml_tensor * w,   // ggml_tensor * as
               ggml_tensor * cur, // ggml_tensor * b
-              ggml_tensor * ids) const;
+              ggml_tensor * ids,
+              ggml_tensor * w_scale = nullptr) const;
 
     ggml_tensor * build_norm(
              ggml_tensor * cur,

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1,9 +1,19 @@
+#ifdef GGML_COMMON_DECL
+#undef GGML_COMMON_DECL
+#endif
+#define GGML_COMMON_DECL_CPP
+#include "../ggml/src/ggml-common.h"
+
 #include "llama-model-loader.h"
 
 #include "ggml.h"
+#include "ggml-cpu.h"
+
+#include "../ggml/src/ggml-nvfp4-helpers.h"
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cinttypes>
 #include <cstring>
 #include <future>
@@ -11,6 +21,79 @@
 static const size_t kiB = 1024;
 static const size_t MiB = 1024*kiB;
 static const size_t GiB = 1024*MiB;
+
+static float llama_get_nvfp4_tensor_scale(const gguf_context * meta, const std::string & name) {
+    const std::string key_tensor_scale = name + ".tensor_scale";
+    const int kid_tensor_scale = gguf_find_key(meta, key_tensor_scale.c_str());
+    if (kid_tensor_scale >= 0 && gguf_get_kv_type(meta, kid_tensor_scale) == GGUF_TYPE_FLOAT32) {
+        float tensor_scale = gguf_get_val_f32(meta, kid_tensor_scale);
+        if (std::isfinite(tensor_scale) && tensor_scale > 0.0f) {
+            return tensor_scale;
+        }
+    }
+
+    const std::string key2 = name + ".weight_scale_2";
+    const int kid2 = gguf_find_key(meta, key2.c_str());
+    if (kid2 >= 0 && gguf_get_kv_type(meta, kid2) == GGUF_TYPE_FLOAT32) {
+        float tensor_scale = gguf_get_val_f32(meta, kid2);
+        if (std::isfinite(tensor_scale) && tensor_scale > 0.0f) {
+            return tensor_scale;
+        }
+    }
+
+    return 1.0f;
+}
+
+static float llama_get_nvfp4_input_scale(const gguf_context * meta, const std::string & name) {
+    const std::string key_input_scale = name + ".input_scale";
+    const int kid_input_scale = gguf_find_key(meta, key_input_scale.c_str());
+    if (kid_input_scale >= 0 && gguf_get_kv_type(meta, kid_input_scale) == GGUF_TYPE_FLOAT32) {
+        const float input_scale = gguf_get_val_f32(meta, kid_input_scale);
+        if (std::isfinite(input_scale) && input_scale > 0.0f) {
+            return input_scale;
+        }
+    }
+
+    return 1.0f;
+}
+
+static void llama_set_nvfp4_runtime_scale(struct ggml_tensor * tensor, float scale, int op_param_idx) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_NVFP4) {
+        return;
+    }
+
+    if (!std::isfinite(scale) || scale <= 0.0f) {
+        scale = 1.0f;
+    }
+
+    int32_t scale_bits = 0;
+    std::memcpy(&scale_bits, &scale, sizeof(scale_bits));
+    tensor->op_params[op_param_idx] = scale_bits;
+}
+
+static void llama_set_nvfp4_runtime_tensor_scale(const gguf_context * meta, struct ggml_tensor * tensor) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_NVFP4) {
+        return;
+    }
+
+    constexpr int op_param_idx_nvfp4_tensor_scale = GGML_MAX_OP_PARAMS / sizeof(int32_t) - 2;
+    llama_set_nvfp4_runtime_scale(
+        tensor,
+        llama_get_nvfp4_tensor_scale(meta, ggml_get_name(tensor)),
+        op_param_idx_nvfp4_tensor_scale);
+}
+
+static void llama_set_nvfp4_runtime_input_scale(const gguf_context * meta, struct ggml_tensor * tensor) {
+    if (tensor == nullptr || tensor->type != GGML_TYPE_NVFP4) {
+        return;
+    }
+
+    constexpr int op_param_idx_nvfp4_input_scale = GGML_MAX_OP_PARAMS / sizeof(int32_t) - 1;
+    llama_set_nvfp4_runtime_scale(
+        tensor,
+        llama_get_nvfp4_input_scale(meta, ggml_get_name(tensor)),
+        op_param_idx_nvfp4_input_scale);
+}
 
 const char * llama_file_version_name(llama_fver version) {
     switch (version) {
@@ -37,6 +120,7 @@ static std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q5_1:     return "Q5_1";
         case LLAMA_FTYPE_MOSTLY_Q8_0:     return "Q8_0";
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return "MXFP4 MoE";
+        case LLAMA_FTYPE_MOSTLY_NVFP4:    return "NVFP4";
         case LLAMA_FTYPE_MOSTLY_Q2_K:     return "Q2_K - Medium";
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:   return "Q2_K - Small";
         case LLAMA_FTYPE_MOSTLY_Q3_K_S:   return "Q3_K - Small";
@@ -541,15 +625,12 @@ llama_model_loader::llama_model_loader(
 
     if (use_mmap && use_direct_io) {
         if (files.back()->has_direct_io()) {
-            LLAMA_LOG_WARN("%s: direct I/O is enabled, disabling mmap\n", __func__);
-            use_mmap = false;
+            // Keep direct I/O handles for reads and open parallel buffered handles for mmap.
+            mmap_files.emplace_back(new llama_file(fname.c_str(), "rb", false));
+            LLAMA_LOG_INFO("%s: enabling mmap + direct I/O with dual file handles\n", __func__);
         } else {
-            LLAMA_LOG_WARN("%s: direct I/O is not available, using mmap\n", __func__);
+            LLAMA_LOG_WARN("%s: direct I/O is not available, using mmap only\n", __func__);
             use_direct_io = false;
-
-            // reopen file using std::fopen for mmap
-            files.pop_back();
-            files.emplace_back(new llama_file(fname.c_str(), "rb", false));
         }
     }
 
@@ -619,6 +700,9 @@ llama_model_loader::llama_model_loader(
             }
 
             files.emplace_back(new llama_file(fname_split, "rb", use_direct_io));
+            if (!mmap_files.empty()) {
+                mmap_files.emplace_back(new llama_file(fname_split, "rb", false));
+            }
             contexts.emplace_back(ctx);
 
             // Save tensors data offset info of the shard.
@@ -668,7 +752,6 @@ llama_model_loader::llama_model_loader(
             const ggml_tensor * tensor = w.tensor;
 
             enum ggml_type type = tensor->type;
-
             n_type[type]++;
 
             if (n_type_max < n_type[type]) {
@@ -688,6 +771,7 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_F32:     ftype = LLAMA_FTYPE_ALL_F32;        break;
             case GGML_TYPE_F16:     ftype = LLAMA_FTYPE_MOSTLY_F16;     break;
             case GGML_TYPE_BF16:    ftype = LLAMA_FTYPE_MOSTLY_BF16;    break;
+            case GGML_TYPE_NVFP4:   ftype = LLAMA_FTYPE_MOSTLY_NVFP4;   break;
             case GGML_TYPE_Q4_0:    ftype = LLAMA_FTYPE_MOSTLY_Q4_0;    break;
             case GGML_TYPE_Q4_1:    ftype = LLAMA_FTYPE_MOSTLY_Q4_1;    break;
             case GGML_TYPE_Q5_0:    ftype = LLAMA_FTYPE_MOSTLY_Q5_0;    break;
@@ -761,10 +845,14 @@ llama_model_loader::llama_model_loader(
         use_mmap = false;
     }
 
+    has_nvfp4_tensor_scales = false;
+
     this->use_mmap = use_mmap;
     this->use_direct_io = use_direct_io;
+    this->has_nvfp4_tensor_scales = has_nvfp4_tensor_scales;
     this->check_tensors = check_tensors;
     this->no_alloc = no_alloc;
+
 }
 
 std::string llama_model_loader::get_arch_name() const {
@@ -850,6 +938,8 @@ struct ggml_tensor * llama_model_loader::create_tensor(struct ggml_context * ctx
 
     struct ggml_tensor * tensor = ggml_dup_tensor(ctx, cur);
     ggml_set_name(tensor, ggml_get_name(cur));
+    llama_set_nvfp4_runtime_tensor_scale(meta.get(), tensor);
+    llama_set_nvfp4_runtime_input_scale(meta.get(), tensor);
 
     if (duplicated) {
         size_data += ggml_nbytes(cur);
@@ -883,6 +973,8 @@ struct ggml_tensor * llama_model_loader::create_tensor_as_view(struct ggml_conte
                                     offset);
 
     ggml_set_name(tensor, name.c_str());
+    llama_set_nvfp4_runtime_tensor_scale(meta.get(), tensor);
+    llama_set_nvfp4_runtime_input_scale(meta.get(), tensor);
 
     n_created++;
 
@@ -897,9 +989,10 @@ void llama_model_loader::done_getting_tensors() const {
 
 void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps) {
     if (use_mmap) {
-        mappings.reserve(files.size());
-        mmaps_used.reserve(files.size());
-        for (const auto & file : files) {
+        const auto & files_for_mmap = mmap_files.empty() ? files : mmap_files;
+        mappings.reserve(files_for_mmap.size());
+        mmaps_used.reserve(files_for_mmap.size());
+        for (const auto & file : files_for_mmap) {
             bool is_numa = false;
 
             auto * dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
@@ -941,7 +1034,7 @@ void llama_model_loader::get_mapping_range(size_t * first, size_t * last, void *
             continue;
         }
         *first = std::min(*first, weight->offs);
-        *last  = std::max(*last,  weight->offs + ggml_nbytes(tensor));
+        *last  = std::max(*last,  weight->offs + ggml_nbytes(weight->tensor));
     }
 }
 
@@ -950,10 +1043,12 @@ void llama_model_loader::load_data_for(struct ggml_tensor * cur) const {
 
     if (use_mmap) {
         const auto & mapping = mappings.at(w.idx);
+        const uint8_t * src = (const uint8_t *) mapping->addr() + w.offs;
+
         if (cur->data == nullptr) {
-            cur->data = (uint8_t *)mapping->addr() + w.offs;
+            cur->data = const_cast<uint8_t *>(src);
         } else {
-            memcpy(cur->data, (uint8_t *)mapping->addr() + w.offs, ggml_nbytes(cur));
+            memcpy(cur->data, src, ggml_nbytes(cur));
         }
     } else {
         GGML_ASSERT(cur->data != nullptr);
@@ -966,6 +1061,7 @@ void llama_model_loader::load_data_for(struct ggml_tensor * cur) const {
     if (check_tensors && !ggml_validate_row_data(cur->type, cur->data, ggml_nbytes(cur))) {
         throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
     }
+
 }
 
 bool llama_model_loader::load_all_data(
@@ -1091,7 +1187,7 @@ bool llama_model_loader::load_all_data(
         }
 
         size_t n_size = ggml_nbytes(cur);
-
+        const size_t src_size = ggml_nbytes(weight->tensor);
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);
             ggml_backend_buffer_t buf_mmap = nullptr;
@@ -1111,12 +1207,12 @@ bool llama_model_loader::load_all_data(
                 ggml_backend_tensor_alloc(buf_mmap, cur, data);
                 if (lmlocks) {
                     const auto & lmlock = lmlocks->at(weight->idx);
-                    lmlock->grow_to(weight->offs + n_size);
+                    lmlock->grow_to(weight->offs + src_size);
                 }
 
                 auto & mmap_used = mmaps_used[weight->idx];
                 mmap_used.first  = std::min(mmap_used.first,  weight->offs);
-                mmap_used.second = std::max(mmap_used.second, weight->offs + n_size);
+                mmap_used.second = std::max(mmap_used.second, weight->offs + src_size);
             } else {
                 ggml_backend_tensor_set(cur, data, 0, n_size);
             }
@@ -1132,7 +1228,6 @@ bool llama_model_loader::load_all_data(
                     }));
                 }
             } else {
-                // If upload_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
                 if (upload_backend) {
                     size_t offset = weight->offs;
                     alignment = file->read_alignment();
@@ -1197,7 +1292,7 @@ bool llama_model_loader::load_all_data(
             }
         }
 
-        size_done += n_size;
+        size_done += src_size;
     }
 
     // free temporary resources used for async uploads

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -71,10 +71,12 @@ struct llama_model_loader {
 
     bool use_mmap = false;
     bool use_direct_io = false;
+    bool has_nvfp4_tensor_scales = false;
     bool check_tensors;
     bool no_alloc;
 
     llama_files files;
+    llama_files mmap_files;
     llama_ftype ftype;
     llama_fver  fver;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2995,6 +2995,21 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                 layer.ffn_up_exps   = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", bid), {n_embd_, n_ff_, n_expert_}, flags);
             }
         };
+
+        auto create_scale_tensor = [&](const LLM_TN_IMPL & tn_scale) -> ggml_tensor * {
+            const ggml_tensor * t_meta = ml.get_tensor_meta(tn_scale.str().c_str());
+            if (t_meta == nullptr) {
+                return nullptr;
+            }
+            return create_tensor(tn_scale, { t_meta->ne[0], t_meta->ne[1], t_meta->ne[2], t_meta->ne[3] }, 0);
+        };
+
+        auto create_nvfp4_scale_tensor = [&](const LLM_TN_IMPL & tn_scale, const ggml_tensor * weight) -> ggml_tensor * {
+            if (weight == nullptr) {
+                return nullptr;
+            }
+            return create_scale_tensor(tn_scale);
+        };
         switch (arch) {
             case LLM_ARCH_LLAMA:
             case LLM_ARCH_REFACT:
@@ -3927,7 +3942,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
                         layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head}, 0);
                         layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_gqa}, 0);
+                        layer.wk_scale = create_tensor(tn(LLM_TENSOR_ATTN_K,   "scale",  i), {1}, TENSOR_NOT_REQUIRED);
                         layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_gqa}, 0);
+                        layer.wv_scale = create_tensor(tn(LLM_TENSOR_ATTN_V,   "scale",  i), {1}, TENSOR_NOT_REQUIRED);
                         layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd}, 0);
 
                         layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
@@ -3935,8 +3952,11 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
                         layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
                         layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, 0);
+                        layer.ffn_gate_scale = create_tensor(tn(LLM_TENSOR_FFN_GATE, "scale", i), {1}, TENSOR_NOT_REQUIRED);
                         layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, 0);
+                        layer.ffn_down_scale = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "scale", i), {1}, TENSOR_NOT_REQUIRED);
                         layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, 0);
+                        layer.ffn_up_scale = create_tensor(tn(LLM_TENSOR_FFN_UP, "scale", i), {1}, TENSOR_NOT_REQUIRED);
                     }
                 } break;
             case LLM_ARCH_QWEN3MOE:
@@ -3960,7 +3980,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
                         layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head}, 0);
                         layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_gqa}, 0);
+                        layer.wk_scale = create_tensor(tn(LLM_TENSOR_ATTN_K,   "scale",  i), {1}, TENSOR_NOT_REQUIRED);
                         layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_gqa}, 0);
+                        layer.wv_scale = create_tensor(tn(LLM_TENSOR_ATTN_V,   "scale",  i), {1}, TENSOR_NOT_REQUIRED);
                         layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd}, 0);
 
                         layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
@@ -7416,9 +7438,13 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                         if (!hparams.is_recurrent(i)) {
                             // Attention layers
                             layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), { n_embd, n_embd_head_k * n_head * 2 }, 0);
+                            layer.wq_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_Q, "scale", i), layer.wq);
                             layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), { n_embd, n_embd_k_gqa }, 0);
+                            layer.wk_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_K, "scale", i), layer.wk);
                             layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), { n_embd, n_embd_v_gqa }, 0);
+                            layer.wv_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_V, "scale", i), layer.wv);
                             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_k * n_head, n_embd }, 0);
+                            layer.wo_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_OUT, "scale", i), layer.wo);
 
                             // Q/K normalization for attention layers
                             layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), { n_embd_head_k }, 0);
@@ -7483,7 +7509,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             // Attention layers
                             layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), { n_embd, n_embd_head_k * n_head * 2 }, 0);
                             layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), { n_embd, n_embd_k_gqa }, 0);
+                            layer.wk_scale = create_tensor(tn(LLM_TENSOR_ATTN_K, "scale", i), {1}, TENSOR_NOT_REQUIRED);
                             layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), { n_embd, n_embd_v_gqa }, 0);
+                            layer.wv_scale = create_tensor(tn(LLM_TENSOR_ATTN_V, "scale", i), {1}, TENSOR_NOT_REQUIRED);
                             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_k * n_head, n_embd }, 0);
 
                             // Q/K normalization for attention layers
@@ -7493,19 +7521,33 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             // Linear attention (gated delta net) specific tensors
                             // Create tensors with calculated dimensions
                             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", i), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
+                            layer.wqkv_scale     = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_QKV, "scale", i), layer.wqkv);
                             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", i), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
+                            layer.wqkv_gate_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_GATE, "scale", i), layer.wqkv_gate);
                             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", i), { hparams.ssm_d_conv, conv_dim }, 0);
                             layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   i), { hparams.ssm_dt_rank }, 0);
                             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             i), { hparams.ssm_dt_rank }, 0);
                             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", i), { n_embd, n_v_heads }, 0);
+                            layer.ssm_beta_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_BETA, "scale", i), layer.ssm_beta);
                             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", i), { n_embd, n_v_heads }, 0);
+                            layer.ssm_alpha_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_ALPHA, "scale", i), layer.ssm_alpha);
                             layer.ssm_norm       = create_tensor(tn(LLM_TENSOR_SSM_NORM,       "weight", i), { head_v_dim }, 0);
                             layer.ssm_out        = create_tensor(tn(LLM_TENSOR_SSM_OUT,        "weight", i), { value_dim, n_embd }, 0);
+                            layer.ssm_out_scale  = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_OUT, "scale", i), layer.ssm_out);
                         }
 
                         layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert }, 0);
                         layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), { n_ff_exp, n_embd, n_expert }, 0);
                         create_tensor_gate_up_exps(layer, i, n_embd, n_ff_exp, n_expert, 0);
+                        layer.ffn_down_exps_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "scale", i), layer.ffn_down_exps);
+                        layer.ffn_gate_up_exps_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_GATE_UP_EXPS, "scale", i), layer.ffn_gate_up_exps);
+                        if (layer.ffn_gate_up_exps == nullptr) {
+                            layer.ffn_gate_exps_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_GATE_EXPS, "scale", i), layer.ffn_gate_exps);
+                            layer.ffn_up_exps_scale   = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "scale", i), layer.ffn_up_exps);
+                        } else {
+                            layer.ffn_gate_exps_scale = layer.ffn_gate_up_exps_scale;
+                            layer.ffn_up_exps_scale   = layer.ffn_gate_up_exps_scale;
+                        }
 
                         // Shared experts
                         const int64_t n_ff_shexp = hparams.n_ff_shexp ? hparams.n_ff_shexp : n_ff;
@@ -7547,9 +7589,13 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                         if (!hparams.is_recurrent(i)) {
                             // Attention layers
                             layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), { n_embd, n_embd_head_k * n_head * 2 }, 0);
+                            layer.wq_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_Q, "scale", i), layer.wq);
                             layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), { n_embd, n_embd_k_gqa }, 0);
+                            layer.wk_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_K, "scale", i), layer.wk);
                             layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), { n_embd, n_embd_v_gqa }, 0);
+                            layer.wv_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_V, "scale", i), layer.wv);
                             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_k * n_head, n_embd }, 0);
+                            layer.wo_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_OUT, "scale", i), layer.wo);
 
                             // Q/K normalization for attention layers
                             layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), { n_embd_head_k }, 0);
@@ -7558,19 +7604,27 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             // Linear attention (gated delta net) specific tensors
                             // Create tensors with calculated dimensions
                             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", i), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
+                            layer.wqkv_scale     = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_QKV, "scale", i), layer.wqkv);
                             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", i), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
+                            layer.wqkv_gate_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_ATTN_GATE, "scale", i), layer.wqkv_gate);
                             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", i), { hparams.ssm_d_conv, conv_dim }, 0);
                             layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   i), { hparams.ssm_dt_rank }, 0);
                             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             i), { hparams.ssm_dt_rank }, 0);
                             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", i), { n_embd, n_v_heads }, 0);
+                            layer.ssm_beta_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_BETA, "scale", i), layer.ssm_beta);
                             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", i), { n_embd, n_v_heads }, 0);
+                            layer.ssm_alpha_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_ALPHA, "scale", i), layer.ssm_alpha);
                             layer.ssm_norm       = create_tensor(tn(LLM_TENSOR_SSM_NORM,       "weight", i), { head_v_dim }, 0);
                             layer.ssm_out        = create_tensor(tn(LLM_TENSOR_SSM_OUT,        "weight", i), { value_dim, n_embd }, 0);
+                            layer.ssm_out_scale  = create_nvfp4_scale_tensor(tn(LLM_TENSOR_SSM_OUT, "scale", i), layer.ssm_out);
                         }
 
                         layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, 0);
+                        layer.ffn_gate_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_GATE, "scale", i), layer.ffn_gate);
                         layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, 0);
+                        layer.ffn_down_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_DOWN, "scale", i), layer.ffn_down);
                         layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, 0);
+                        layer.ffn_up_scale = create_nvfp4_scale_tensor(tn(LLM_TENSOR_FFN_UP, "scale", i), layer.ffn_up);
                     }
                 } break;
             case LLM_ARCH_MIMO2:

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -288,6 +288,10 @@ struct llama_layer {
     struct ggml_tensor * ffn_down_exps     = nullptr;
     struct ggml_tensor * ffn_up_exps       = nullptr;
     struct ggml_tensor * ffn_gate_up_exps  = nullptr;
+    struct ggml_tensor * ffn_gate_exps_scale    = nullptr;
+    struct ggml_tensor * ffn_down_exps_scale    = nullptr;
+    struct ggml_tensor * ffn_up_exps_scale      = nullptr;
+    struct ggml_tensor * ffn_gate_up_exps_scale = nullptr;
     struct ggml_tensor * ffn_gate_inp_b    = nullptr;
     struct ggml_tensor * ffn_gate_exps_b   = nullptr;
     struct ggml_tensor * ffn_down_exps_b   = nullptr;
@@ -391,6 +395,11 @@ struct llama_layer {
     struct ggml_tensor * wk_scale       = nullptr;
     struct ggml_tensor * wv_scale       = nullptr;
     struct ggml_tensor * wo_scale       = nullptr;
+    struct ggml_tensor * wqkv_scale      = nullptr;
+    struct ggml_tensor * wqkv_gate_scale = nullptr;
+    struct ggml_tensor * ssm_alpha_scale = nullptr;
+    struct ggml_tensor * ssm_beta_scale  = nullptr;
+    struct ggml_tensor * ssm_out_scale   = nullptr;
     struct ggml_tensor * ffn_gate_scale = nullptr;
     struct ggml_tensor * ffn_up_scale   = nullptr;
     struct ggml_tensor * ffn_down_scale = nullptr;

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -1,17 +1,43 @@
+#ifdef GGML_COMMON_DECL
+#undef GGML_COMMON_DECL
+#endif
+#define GGML_COMMON_DECL_CPP
+#include "../ggml/src/ggml-common.h"
+#include "../ggml/src/ggml-impl.h"
+
 #include "llama-quant.h"
 #include "llama-impl.h"
 #include "llama-model.h"
 #include "llama-model-loader.h"
 
+#include "../ggml/include/ggml-cuda.h"
+
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cctype>
 #include <cmath>
+#include <cfloat>
+#include <cstdlib>
 #include <cstring>
 #include <cinttypes>
+#include <cstdio>
 #include <fstream>
 #include <mutex>
 #include <regex>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "../ggml/src/ggml-nvfp4-helpers.h"
+
+#ifndef NVFP4_A0
+#define NVFP4_A0 0.9918823242f
+#endif
+#ifndef NVFP4_B0
+#define NVFP4_B0 0.9864501953f
+#endif
 
 // Quantization types. Changes to this struct must be replicated in quantize.cpp
 struct tensor_quantization {
@@ -19,11 +45,326 @@ struct tensor_quantization {
     ggml_type quant = GGML_TYPE_COUNT;
 };
 
+static int64_t llama_nvfp4_autotune_sample_blocks(const int64_t nb_total) {
+    if (nb_total <= 0) {
+        return 0;
+    }
+    // Keep a larger host sample pool so CUDA adaptive-resample can escalate
+    // from the 256-block initial pass to 512/1024 when tensors are risky.
+    const int64_t cap =
+        nb_total >= 16384 ? 1024 :
+        nb_total >= 8192  ? 512  :
+        nb_total >= 2048  ? 256  : 128;
+    return std::min(nb_total, cap);
+}
+
+static inline int64_t llama_nvfp4_sample_block_index(const int64_t is, const int64_t sample_nb, const int64_t nb_total) {
+    if (nb_total <= 1 || sample_nb <= 1) {
+        return 0;
+    }
+    // Deterministic uniform coverage across full tensor block range [0, nb_total - 1].
+    return (is * (nb_total - 1)) / (sample_nb - 1);
+}
+
 static void zeros(std::ofstream & file, size_t n) {
     char zero = 0;
     for (size_t i = 0; i < n; ++i) {
         file.write(&zero, 1);
     }
+}
+
+static inline float llama_tensor_absmax(const float * data, size_t n) {
+    float max_abs = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        const float v = std::fabs(data[i]);
+        if (v > max_abs) max_abs = v;
+    }
+    return max_abs;
+}
+
+static float llama_tensor_absmax_f32_mt(const float * data, size_t n, int nthread) {
+    if (nthread < 2 || n < 1024) {
+        return llama_tensor_absmax(data, n);
+    }
+
+    const int nthreads = std::max(1, nthread);
+    std::vector<std::thread> threads;
+    threads.reserve(nthreads - 1);
+    std::vector<float> partials((size_t) nthreads, 0.0f);
+
+    auto worker = [&](int tid, size_t start, size_t end) {
+        float m = 0.0f;
+        for (size_t i = start; i < end; ++i) {
+            const float v = std::fabs(data[i]);
+            if (v > m) m = v;
+        }
+        partials[(size_t) tid] = m;
+    };
+
+    const size_t chunk = (n + (size_t) nthreads - 1) / (size_t) nthreads;
+    for (int t = 0; t < nthreads - 1; ++t) {
+        const size_t start = (size_t) t * chunk;
+        const size_t end = std::min(n, start + chunk);
+        threads.emplace_back(worker, t, start, end);
+    }
+    {
+        const size_t start = (size_t) (nthreads - 1) * chunk;
+        const size_t end = std::min(n, start + chunk);
+        worker(nthreads - 1, start, end);
+    }
+
+    for (auto & th : threads) th.join();
+
+    float max_abs = 0.0f;
+    for (int t = 0; t < nthreads; ++t) {
+        if (partials[(size_t) t] > max_abs) max_abs = partials[(size_t) t];
+    }
+    return max_abs;
+}
+
+static float llama_tensor_absmax_bf16_mt(const ggml_bf16_t * data, size_t n, int nthread) {
+    if (nthread < 2 || n < 1024) {
+        float max_abs = 0.0f;
+        for (size_t i = 0; i < n; ++i) {
+            const float v = std::fabs(ggml_bf16_to_fp32(data[i]));
+            if (v > max_abs) max_abs = v;
+        }
+        return max_abs;
+    }
+
+    const int nthreads = std::max(1, nthread);
+    std::vector<std::thread> threads;
+    threads.reserve(nthreads - 1);
+    std::vector<float> partials((size_t) nthreads, 0.0f);
+
+    auto worker = [&](int tid, size_t start, size_t end) {
+        float m = 0.0f;
+        for (size_t i = start; i < end; ++i) {
+            const float v = std::fabs(ggml_bf16_to_fp32(data[i]));
+            if (v > m) m = v;
+        }
+        partials[(size_t) tid] = m;
+    };
+
+    const size_t chunk = (n + (size_t) nthreads - 1) / (size_t) nthreads;
+    for (int t = 0; t < nthreads - 1; ++t) {
+        const size_t start = (size_t) t * chunk;
+        const size_t end = std::min(n, start + chunk);
+        threads.emplace_back(worker, t, start, end);
+    }
+    {
+        const size_t start = (size_t) (nthreads - 1) * chunk;
+        const size_t end = std::min(n, start + chunk);
+        worker(nthreads - 1, start, end);
+    }
+
+    for (auto & th : threads) th.join();
+
+    float max_abs = 0.0f;
+    for (int t = 0; t < nthreads; ++t) {
+        if (partials[(size_t) t] > max_abs) max_abs = partials[(size_t) t];
+    }
+    return max_abs;
+}
+
+static constexpr float LLAMA_NVFP4_MAX_FP4 = 6.0f;
+static constexpr float LLAMA_NVFP4_TENSOR_CAP_FIXED = 448.0f;
+
+// Exact UE4M3 decode (QA path; supports subnormals).
+static inline float nvfp4_qa_fp8_to_fp32(uint8_t b) {
+    const uint32_t u = b & 0x7Fu;
+    if (u == 0) return 0.0f;
+
+    const uint32_t exp  = u >> 3;
+    const uint32_t mant = u & 0x7u;
+
+    if (exp == 0xFu && mant == 0x7u) return 448.0f;
+
+    uint32_t bits;
+    if (exp != 0) {
+        bits = ((exp + 120u) << 23) | (mant << 20);
+    } else {
+        const uint32_t p = 31u - (uint32_t)__builtin_clz(mant);
+        const uint32_t r = mant - (1u << p);
+        const uint32_t exp32  = (p + 118u);
+        const uint32_t mant32 = r << (23u - p);
+        bits = (exp32 << 23) | mant32;
+    }
+
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+// Quantize sb_ideal -> UE4M3 byte, then bump upward if needed to avoid FP4 clipping after rounding.
+// invM = 1/6 or 1/4.
+struct nvfp4_qa_stats {
+    uint64_t n16 = 0;
+    uint64_t choose4 = 0;
+    uint64_t choose6 = 0;
+    uint64_t clip6_m4 = 0;
+    uint64_t clip6_m6 = 0;
+    uint64_t round_down = 0;
+
+    double sum_mse = 0.0;
+    double sum_sq  = 0.0;
+    float  max_err = 0.0f;
+
+    uint64_t b0 = 0;
+    uint64_t bsub = 0;     // 0x01..0x07
+    uint64_t bminnorm = 0; // 0x08
+    uint64_t bmax = 0;     // 0x7E
+
+    uint64_t hist[256] = {};
+};
+
+struct nvfp4_qa_context {
+    FILE * file = nullptr;
+    bool q4k = false;
+    mutable std::mutex mutex;
+};
+
+struct nvfp4_qa_tensor_ctx {
+    const nvfp4_qa_context * qa = nullptr;
+    const char * tensor_name = nullptr;
+    std::atomic<int64_t> * chunk_id = nullptr;
+    int64_t n_per_row = 0;
+};
+
+static void nvfp4_qa_accum(
+    nvfp4_qa_stats & st,
+    const float * GGML_RESTRICT x,
+    int64_t nrows,
+    int64_t n_per_row,
+    const void * GGML_RESTRICT qdata
+) {
+    const int64_t nblocks = n_per_row / QK_K;
+    const size_t row_size = ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
+    const auto * qbytes = (const uint8_t *) qdata;
+
+    for (int64_t r = 0; r < nrows; ++r) {
+        const float * xrow = x + r * n_per_row;
+        const block_nvfp4 * row_packs = (const block_nvfp4 *)(qbytes + r * row_size);
+
+        for (int64_t b = 0; b < nblocks; ++b) {
+            const int64_t pack = b >> 2;
+            const int lane = (int) (b & 3);
+            const block_nvfp4 * p = &row_packs[pack];
+            const float pack_scale = 1.0f;
+            const uint8_t * scales = p->scales[lane];
+
+            for (int sb = 0; sb < (QK_K / QK_NVFP4); ++sb) {
+                const float * x16 = xrow + b * QK_K + sb * QK_NVFP4;
+
+                float max_abs = 0.0f;
+                for (int k = 0; k < QK_NVFP4; ++k) {
+                    const float a = std::fabs(x16[k]);
+                    if (a > max_abs) max_abs = a;
+                }
+
+                const uint8_t bscale = scales[sb];
+                st.hist[bscale]++;
+
+                if (bscale == 0x00) st.b0++;
+                else if (bscale <= 0x07) st.bsub++;
+                else if (bscale == 0x08) st.bminnorm++;
+                else if (bscale == 0x7E) st.bmax++;
+
+                const float sb_dec = nvfp4_qa_fp8_to_fp32(bscale);
+                const float scale = pack_scale * sb_dec;
+
+                const float ideal6 = (max_abs > 0.0f) ? (max_abs * (1.0f / 6.0f)) : 0.0f;
+                const float ideal4 = (max_abs > 0.0f) ? (max_abs * (1.0f / 4.0f)) : 0.0f;
+
+                const float e6 = std::fabs(scale - ideal6);
+                const float e4 = std::fabs(scale - ideal4);
+                if (e4 < e6) st.choose4++;
+                else         st.choose6++;
+
+                if (pack_scale > 0.0f && max_abs > 0.0f) {
+                    const float sb_ideal6 = ideal6 / pack_scale;
+                    const float sb_ideal4 = ideal4 / pack_scale;
+                    const float sb_ideal = (e4 < e6) ? sb_ideal4 : sb_ideal6;
+                    if (sb_dec < sb_ideal) st.round_down++;
+                }
+
+                if (max_abs > 0.0f && scale > 0.0f) {
+                    float sub_mse = 0.0f;
+                    for (int k = 0; k < QK_NVFP4; ++k) {
+                        const float v   = x16[k];
+                        const uint8_t qi = best_index_nvfp4(v, scale);
+                        const float deq = kvalues_nvfp4_float(qi & 0xF) * scale;
+                        const float err = deq - v;
+                        const float ae  = std::fabs(err);
+                        sub_mse += err * err;
+                        if (ae > st.max_err) st.max_err = ae;
+                        st.sum_sq += (double) v * v;
+                    }
+                    st.sum_mse += sub_mse;
+
+                    if (max_abs > LLAMA_NVFP4_MAX_FP4 * scale) {
+                        if (e4 < e6) st.clip6_m4++;
+                        else         st.clip6_m6++;
+                    }
+                }
+
+                st.n16++;
+            }
+        }
+    }
+}
+
+static std::string nvfp4_qa_hist_to_string(const nvfp4_qa_stats & st) {
+    std::string out;
+    char buf[64];
+    for (int b = 0; b < 256; ++b) {
+        const uint64_t count = st.hist[b];
+        if (!count) continue;
+        if (!out.empty()) out.push_back(',');
+        std::snprintf(buf, sizeof(buf), "%02x:%llu", b, (unsigned long long) count);
+        out.append(buf);
+    }
+    return out;
+}
+
+static void nvfp4_qa_write_line(
+    const nvfp4_qa_context & qa,
+    const char * tensor_name,
+    int64_t chunk_id,
+    const nvfp4_qa_stats & st
+) {
+    if (!qa.file) return;
+
+    const double n16 = (double) st.n16;
+    const double clip4_rate = n16 ? (100.0 * (double) st.clip6_m4 / n16) : 0.0;
+    const double clip6_rate = n16 ? (100.0 * (double) st.clip6_m6 / n16) : 0.0;
+    const double down_rate  = n16 ? (100.0 * (double) st.round_down / n16) : 0.0;
+    const double c4_rate    = n16 ? (100.0 * (double) st.choose4 / n16) : 0.0;
+
+    const double mse = n16 ? (st.sum_mse / (n16 * QK_NVFP4)) : 0.0;
+    const double snr = (st.sum_mse > 0.0) ? (10.0 * std::log10(st.sum_sq / st.sum_mse)) : 99.0;
+
+    const std::string hist = nvfp4_qa_hist_to_string(st);
+
+    std::lock_guard<std::mutex> lock(qa.mutex);
+    std::fprintf(qa.file,
+        "%s\t%lld\t%llu\t%.8e\t%.4f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%llu\t%llu\t%llu\t%llu\t%s\n",
+        tensor_name,
+        (long long) chunk_id,
+        (unsigned long long) st.n16,
+        mse,
+        snr,
+        (double) st.max_err,
+        clip4_rate,
+        clip6_rate,
+        down_rate,
+        c4_rate,
+        (unsigned long long) st.bsub,
+        (unsigned long long) st.bminnorm,
+        (unsigned long long) st.bmax,
+        (unsigned long long) st.b0,
+        hist.c_str());
+    std::fflush(qa.file);
 }
 
 static std::string remap_layer(const std::string & orig_name, const std::vector<int> & prune, std::map<int, std::string> & mapped, int & next_id) {
@@ -175,6 +516,9 @@ static void llama_tensor_dequantize_impl(
     workers.clear();
 }
 
+//
+static constexpr size_t LLAMA_QUANT_MIN_SAVINGS_BYTES = 4u * 1024u * 1024u;
+
 static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_type, const ggml_tensor * tensor, llama_ftype ftype) {
     const std::string name = ggml_get_name(tensor);
 
@@ -210,23 +554,24 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
         } else {
             const int64_t nx = tensor->ne[0];
             const int64_t qk_k = ggml_blck_size(new_type);
-
-            if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE) {
+            if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
+                new_type = GGML_TYPE_Q8_0;
+            }
+            else if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE) {
                 new_type = GGML_TYPE_Q8_0;
             }
             else if (arch == LLM_ARCH_FALCON || nx % qk_k != 0) {
                 new_type = GGML_TYPE_Q8_0;
-            }
-            else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS ||
-                     ftype == LLAMA_FTYPE_MOSTLY_IQ1_S   || ftype == LLAMA_FTYPE_MOSTLY_IQ2_S  || ftype == LLAMA_FTYPE_MOSTLY_IQ2_M   ||
-                     ftype == LLAMA_FTYPE_MOSTLY_IQ1_M) {
+            } else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS ||
+                       ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ1_S ||
+                       ftype == LLAMA_FTYPE_MOSTLY_IQ2_S || ftype == LLAMA_FTYPE_MOSTLY_IQ2_M ||
+                       ftype == LLAMA_FTYPE_MOSTLY_IQ1_M) {
                 new_type = GGML_TYPE_Q5_K;
-            }
-            else if (new_type != GGML_TYPE_Q8_0) {
+            } else if (new_type != GGML_TYPE_Q8_0) {
                 new_type = GGML_TYPE_Q6_K;
             }
         }
-    } else if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE) {
+    } else if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE ) {
         // MoE   tensors -> MXFP4
         // other tensors -> Q8_0
         if (tensor->ne[2] > 1) {
@@ -252,7 +597,22 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
                 new_type = GGML_TYPE_Q4_K;
             }
         }
-    } else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ1_S ||
+    } /* else if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
+        new_type = GGML_TYPE_NVFP4;
+        if (name.find("attn_v.weight") != std::string::npos) {
+            if (use_more_bits(qs.i_attention_wv, qs.n_attention_wv)) {
+                new_type = GGML_TYPE_Q6_K;
+            }
+            ++qs.i_attention_wv;
+        } else if (name.find("ffn_down") != std::string::npos) {
+            auto info = layer_info(qs.i_ffn_down, qs.n_ffn_down, name.c_str());
+            int i_layer = info.first, n_layer = info.second;
+            if (use_more_bits(i_layer, n_layer)) {
+                new_type = GGML_TYPE_Q6_K;
+            }
+            ++qs.i_ffn_down;
+        }
+    } */ else if (ftype == LLAMA_FTYPE_MOSTLY_IQ2_XXS || ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ1_S ||
                ftype == LLAMA_FTYPE_MOSTLY_IQ2_S || ftype == LLAMA_FTYPE_MOSTLY_IQ2_M    || ftype == LLAMA_FTYPE_MOSTLY_IQ1_M) {
         if (name.find("attn_v.weight") != std::string::npos) {
             if (qs.model.hparams.n_gqa() >= 4 || qs.model.hparams.n_expert >= 4) new_type = GGML_TYPE_Q4_K;
@@ -298,10 +658,12 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q5_K;
         else if ((ftype == LLAMA_FTYPE_MOSTLY_IQ4_NL || ftype == LLAMA_FTYPE_MOSTLY_IQ4_XS) && qs.model.hparams.n_gqa() >= 4) {
             new_type = GGML_TYPE_Q5_K;
-        }
-        else if ((ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q5_K_M) &&
-                use_more_bits(qs.i_attention_wv, qs.n_attention_wv)) new_type = GGML_TYPE_Q6_K;
-        else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S && qs.i_attention_wv < 4) new_type = GGML_TYPE_Q5_K;
+        } else if ((ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M ||
+                    ftype == LLAMA_FTYPE_MOSTLY_Q5_K_M) &&
+                   use_more_bits(qs.i_attention_wv, qs.n_attention_wv)) {
+            new_type = GGML_TYPE_Q6_K;
+        } else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S && qs.i_attention_wv < 4)
+            new_type = GGML_TYPE_Q5_K;
         if (qs.model.type == LLM_TYPE_70B) {
             // In the 70B model we have 8 heads sharing the same attn_v weights. As a result, the attn_v.weight tensor is
             // 8x smaller compared to attn_q.weight. Hence, we can get a nice boost in quantization accuracy with
@@ -326,6 +688,7 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
         else if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_XXS) {
             new_type = GGML_TYPE_IQ2_S;
         }
+    
     } else if (name.find("attn_q.weight") != std::string::npos) {
         if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_XS) {
             new_type = GGML_TYPE_IQ3_XXS;
@@ -361,7 +724,7 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
                            use_more_bits(i_layer, n_layer) ? GGML_TYPE_Q5_K : GGML_TYPE_Q4_K;
             } else {
                 if (use_more_bits(i_layer, n_layer)) new_type = GGML_TYPE_Q6_K;
-            }
+                }
         }
         else if (i_layer < n_layer/8 && (ftype == LLAMA_FTYPE_MOSTLY_IQ4_NL || ftype == LLAMA_FTYPE_MOSTLY_IQ4_XS) && !qs.has_imatrix) {
             new_type = GGML_TYPE_Q5_K;
@@ -394,26 +757,22 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
                 else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L ) new_type = GGML_TYPE_Q5_K;
                 else if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_M  ) new_type = GGML_TYPE_Q4_K;
             }
-        } else {
-            if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q4_K;
-        }
-    }
-    else if (name.find("attn_qkv.weight") != std::string::npos) {
+        } else if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L) new_type = GGML_TYPE_Q4_K;
+    
+    } else if (name.find("attn_qkv.weight") != std::string::npos) {
         if (ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L || ftype == LLAMA_FTYPE_MOSTLY_IQ3_M) {
             new_type = GGML_TYPE_Q4_K;
         }
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M) new_type = GGML_TYPE_Q5_K;
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q5_K_M) new_type = GGML_TYPE_Q6_K;
-    }
-    else if (name.find("ffn_gate") != std::string::npos) {
+    } else if (name.find("ffn_gate") != std::string::npos) {
         auto info = layer_info(qs.i_ffn_gate, qs.n_ffn_gate, name.c_str());
         int i_layer = info.first, n_layer = info.second;
         if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_XS && (i_layer >= n_layer/8 && i_layer < 7*n_layer/8)) {
             new_type = GGML_TYPE_IQ3_XXS;
         }
         ++qs.i_ffn_gate;
-    }
-    else if (name.find("ffn_up") != std::string::npos) {
+    } else if (name.find("ffn_up") != std::string::npos) {
         auto info = layer_info(qs.i_ffn_up, qs.n_ffn_up, name.c_str());
         int i_layer = info.first, n_layer = info.second;
         if (ftype == LLAMA_FTYPE_MOSTLY_IQ3_XS && (i_layer >= n_layer/8 && i_layer < 7*n_layer/8)) {
@@ -425,13 +784,427 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, ggml_type new_t
     return new_type;
 }
 
-static size_t llama_tensor_quantize_impl(enum ggml_type new_type, const float * f32_data, void * new_data, const int64_t chunk_size, int64_t nrows, int64_t n_per_row, const float * imatrix, std::vector<std::thread> & workers, const int nthread) {
-    if (nthread < 2) {
-        // single-thread
-        size_t new_size = ggml_quantize_chunk(new_type, f32_data, new_data, 0, nrows, n_per_row, imatrix);
-        if (!ggml_validate_row_data(new_type, new_data, new_size)) {
-            throw std::runtime_error("quantized data validation failed");
+static size_t llama_tensor_quantize_impl(
+    enum ggml_type new_type,
+    const float * f32_data,
+    const ggml_bf16_t * bf16_data,
+    float tensor_scale,
+    void * new_data,
+    const int64_t chunk_size,
+    int64_t nrows,
+    int64_t n_per_row,
+    const float * imatrix,
+    std::vector<std::thread> & workers,
+    const int nthread,
+    const nvfp4_qa_tensor_ctx * qa_tensor,
+    const char * tensor_name) {
+
+    const bool do_qa = qa_tensor && qa_tensor->qa && qa_tensor->qa->file && new_type == GGML_TYPE_NVFP4;
+    if (nrows <= 0 || n_per_row <= 0) return 0;
+
+    const size_t row_size = ggml_row_size(new_type, n_per_row);
+#ifdef GGML_USE_CUDA
+    const bool nvfp4_cuda_direct = (new_type == GGML_TYPE_NVFP4) && (bf16_data || f32_data);
+#endif
+    auto nvfp4_progress_bar = [](double pct) {
+        constexpr int k_bar_w = 28;
+        const double p = std::max(0.0, std::min(100.0, pct));
+        int fill = (int) std::llround((p / 100.0) * k_bar_w);
+        fill = std::max(0, std::min(k_bar_w, fill));
+        std::string bar((size_t) k_bar_w, '.');
+        for (int i = 0; i < fill; ++i) bar[(size_t) i] = '=';
+        if (fill > 0 && fill < k_bar_w) bar[(size_t) (fill - 1)] = '>';
+        return bar;
+    };
+    auto nvfp4_format_eta = [](double sec) {
+        char buf[64];
+        if (!(sec >= 0.0) || !std::isfinite(sec)) {
+            snprintf(buf, sizeof(buf), "n/a");
+            return std::string(buf);
         }
+        const int s = (int) std::llround(sec);
+        if (s >= 3600) {
+            snprintf(buf, sizeof(buf), "%dh %02dm %02ds", s / 3600, (s % 3600) / 60, s % 60);
+        } else if (s >= 60) {
+            snprintf(buf, sizeof(buf), "%dm %02ds", s / 60, s % 60);
+        } else {
+            snprintf(buf, sizeof(buf), "%ds", s);
+        }
+        return std::string(buf);
+    };
+
+    float nvfp4_a = NVFP4_A0;
+    float nvfp4_b = NVFP4_B0;
+    void * nvfp4_stream = reinterpret_cast<void *>(2); // per-thread default CUDA stream token
+#ifdef GGML_USE_CUDA
+    if (new_type == GGML_TYPE_NVFP4) {
+        const int64_t nb_total  = (nrows * n_per_row) / QK_K;
+        const int64_t sample_nb = llama_nvfp4_autotune_sample_blocks(nb_total);
+        const int64_t sample_n  = sample_nb * QK_K;
+
+        if (sample_n > 0) {
+            const float inv_scale =
+                (std::isfinite(tensor_scale) && tensor_scale > 0.0f) ? (1.0f / tensor_scale) : 1.0f;
+            const int64_t nb_per_row = n_per_row / QK_K;
+            const bool build_tune_qw = imatrix && nb_per_row > 0;
+            const bool tune_unweighted_for_gate = tensor_name && strstr(tensor_name, "ffn_gate.weight") != nullptr;
+            const bool use_tune_qw = build_tune_qw && !tune_unweighted_for_gate;
+
+            std::vector<float> tune_x((size_t) sample_n);
+            std::vector<float> tune_qw;
+            const float * tune_qw_ptr = nullptr;
+            if (use_tune_qw) {
+                tune_qw.resize((size_t) sample_n);
+                tune_qw_ptr = tune_qw.data();
+            }
+
+            int prep_threads = std::max(1, nthread);
+            prep_threads = std::min<int>(prep_threads, (int) sample_nb);
+
+            auto prep_worker = [&](int tid) {
+                const int64_t ib0 = (sample_nb * tid) / prep_threads;
+                const int64_t ib1 = (sample_nb * (tid + 1)) / prep_threads;
+                for (int64_t ib = ib0; ib < ib1; ++ib) {
+                    const int64_t src_block = llama_nvfp4_sample_block_index(ib, sample_nb, nb_total);
+
+                    const int64_t src_off = src_block * QK_K;
+                    const int64_t dst_off = ib * QK_K;
+
+                    if (bf16_data) {
+                        ggml_bf16_to_fp32_row(bf16_data + src_off, tune_x.data() + dst_off, QK_K);
+                    } else {
+                        memcpy(tune_x.data() + dst_off, f32_data + src_off, (size_t) QK_K * sizeof(float));
+                    }
+
+                    if (inv_scale != 1.0f) {
+                        float * dst = tune_x.data() + dst_off;
+                        for (int j = 0; j < QK_K; ++j) {
+                            dst[j] *= inv_scale;
+                        }
+                    }
+
+                    if (use_tune_qw) {
+                        const int64_t ib_row = src_block % nb_per_row;
+                        memcpy(tune_qw.data() + dst_off, imatrix + ib_row * QK_K, QK_K * sizeof(float));
+                    }
+                }
+            };
+
+            if (prep_threads > 1) {
+                std::vector<std::thread> prep;
+                prep.reserve((size_t) prep_threads - 1);
+                for (int t = 1; t < prep_threads; ++t) {
+                    prep.emplace_back(prep_worker, t);
+                }
+                prep_worker(0);
+                for (auto & th : prep) {
+                    th.join();
+                }
+            } else {
+                prep_worker(0);
+            }
+            if (nvfp4_autotune_cuda(tune_x.data(), tune_qw_ptr, sample_n, &nvfp4_a, &nvfp4_b, nvfp4_stream)) {
+                // tuned values are passed explicitly to CUDA quantize path
+            }
+        }
+    }
+#endif
+    bool batched_cuda_success = false;
+#ifdef GGML_USE_CUDA
+    static constexpr size_t NVFP4_BATCHED_MAX_BYTES = (size_t) 1536 * 1024 * 1024;
+    const size_t bytes_x_cuda = nvfp4_cuda_direct
+        ? (size_t) nrows * (size_t) n_per_row * (bf16_data ? sizeof(ggml_bf16_t) : sizeof(float))
+        : 0;
+    const size_t bytes_y_cuda = nvfp4_cuda_direct ? (size_t) nrows * row_size : 0;
+    const bool prefer_chunked_multistream = nvfp4_cuda_direct && (nthread > 1) && (nrows >= 4096);
+    const bool can_fit_batched = nvfp4_cuda_direct && (bytes_x_cuda + bytes_y_cuda <= NVFP4_BATCHED_MAX_BYTES);
+    const bool use_batched_cuda = can_fit_batched && !prefer_chunked_multistream;
+    if (new_type == GGML_TYPE_NVFP4 && nrows > 0 && n_per_row > 0 && use_batched_cuda) {
+        static thread_local struct {
+            float learned_rate = 0.0f;  // rows/sec from previous tensors
+            int tensor_count = 0;       // number of tensors processed
+        } rate_tracker;
+
+        auto t_start = std::chrono::high_resolution_clock::now();
+        std::atomic<bool> batched_done{false};
+        std::thread batched_progress;
+        const bool show_batched_progress = nrows > 0;
+        if (show_batched_progress) {
+            const char * tn = tensor_name ? tensor_name : "(unknown)";
+            const bool have_eta = rate_tracker.learned_rate > 0.0f;
+            const double est_total = have_eta ? (double) nrows / rate_tracker.learned_rate : 0.0;
+            LLAMA_LOG_INFO("nvfp4 quantize: start %s chunks=1 rows=%lld cols=%lld [batched]\n",
+                tn, (long long) nrows, (long long) n_per_row);
+            batched_progress = std::thread([&]() {
+                static const char spin[] = {'|', '/', '-', '\\'};
+                int si = 0;
+                while (!batched_done.load(std::memory_order_relaxed)) {
+                    std::this_thread::sleep_for(std::chrono::seconds(3));
+                    if (batched_done.load(std::memory_order_relaxed)) {
+                        break;
+                    }
+                    const auto now = std::chrono::high_resolution_clock::now();
+                    const double elapsed = std::chrono::duration<double>(now - t_start).count();
+                    const double pct = (have_eta && est_total > 0.0)
+                        ? std::max(0.0, std::min(99.0, 100.0 * elapsed / est_total))
+                        : 0.0;
+                    const std::string bar = nvfp4_progress_bar(pct);
+                    const std::string eta = (have_eta && est_total > 0.0)
+                        ? nvfp4_format_eta(std::max(0.0, est_total - elapsed))
+                        : "n/a";
+                    LLAMA_LOG_CONT("\r\033[Knvfp4 quantize: %s %c [%s] %5.1f%% 0/1 elapsed %.1fs eta %s [batched]",
+                        tn, spin[si], bar.c_str(), pct, elapsed, eta.c_str());
+                    si = (si + 1) & 3;
+                }
+            });
+        }
+
+        // a_val / b_val removed; no-op
+
+        if (bf16_data) {          // BF16 direct path
+        const float x_scale = tensor_scale;
+        if (nvfp4_quantize_cuda_ab(bf16_data, true, new_data, nrows, n_per_row,
+                        imatrix, x_scale, nvfp4_a, nvfp4_b, nvfp4_stream)) 
+                batched_cuda_success = true;
+            
+        }
+    else if  (f32_data) {
+    const float x_scale_f32 = tensor_scale;
+    if (nvfp4_quantize_cuda_ab(f32_data, false, new_data, nrows, n_per_row,
+                                imatrix, x_scale_f32, nvfp4_a, nvfp4_b, nvfp4_stream)) {
+            batched_cuda_success = true;
+    
+        }
+    }
+
+        if (batched_cuda_success) {
+            auto t_end = std::chrono::high_resolution_clock::now();
+            float seconds = std::chrono::duration<float>(t_end - t_start).count();
+            float rows_per_sec = seconds > 0.001f ? (float) nrows / seconds : (float) nrows * 1000.0f;
+
+            batched_done.store(true, std::memory_order_relaxed);
+            if (batched_progress.joinable()) {
+                batched_progress.join();
+            }
+            if (show_batched_progress) {
+                const std::string bar = nvfp4_progress_bar(100.0);
+                LLAMA_LOG_CONT("\r\033[Knvfp4 quantize: %s [%s] 100.0%% 1/1 elapsed %.3fs eta 0s [batched]\n",
+                    tensor_name ? tensor_name : "(unknown)", bar.c_str(), seconds);
+            }
+
+            if (rows_per_sec > 0.0f) {
+                if (rate_tracker.learned_rate <= 0.0f) {
+                    rate_tracker.learned_rate = rows_per_sec;
+                } else {
+                    rate_tracker.learned_rate = 0.3f * rows_per_sec + 0.7f * rate_tracker.learned_rate;
+                }
+                rate_tracker.tensor_count++;
+            }
+
+            return nrows * row_size;
+        } else {
+            batched_done.store(true, std::memory_order_relaxed);
+            if (batched_progress.joinable()) {
+                batched_progress.join();
+            }
+            LLAMA_LOG_INFO("nvfp4 batched: %s failed, falling back to chunked processing\n",
+                tensor_name ? tensor_name : "(unknown)");
+        }
+    }
+#endif
+    const double log_every_s = 3.0;
+    const int64_t nrows_per_chunk = chunk_size / n_per_row;
+    const int64_t total_chunks = (nrows + nrows_per_chunk - 1) / nrows_per_chunk;
+
+    const bool show_progress = (new_type == GGML_TYPE_NVFP4) && (total_chunks > 0);
+    const auto progress_start = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point start_steady = progress_start;
+    std::atomic<int64_t> done_chunks{0};
+    std::mutex progress_mutex;
+    std::chrono::steady_clock::time_point last_log = progress_start;
+    double last_pct_log = 0.0;
+    bool logged_pass_eta = false;
+
+    auto log_progress = [&](int64_t done, bool force) {
+        if (!show_progress) return;
+        auto now = std::chrono::steady_clock::now();
+
+        const double elapsed = std::chrono::duration<double>(now - progress_start).count();
+        const double since_last = std::chrono::duration<double>(now - last_log).count();
+        
+        const double pct = 100.0 * (double) done / (double) total_chunks;
+        
+        if (!force && since_last < log_every_s && (pct - last_pct_log < 5.0)) return;
+        
+        last_log = now;
+        last_pct_log = pct;
+
+        if (!logged_pass_eta && done > 0) {
+            const double t_pass = elapsed / (double) done;
+            LLAMA_LOG_INFO("nvfp4 quantize: %.2f seconds per pass - ETA ", t_pass);
+            int total_seconds = (int) (t_pass * (double) total_chunks);
+            if (total_seconds >= 60*60) {
+                LLAMA_LOG_CONT("%d hours ", total_seconds / (60*60));
+                total_seconds = total_seconds % (60*60);
+            }
+            LLAMA_LOG_CONT("%.2f minutes\n", total_seconds / 60.0);
+            logged_pass_eta = true;
+        }
+
+        // Use steady state rate if possible (ignoring first chunk overhead)
+        double rate;
+        if (done > 1) {
+             const double elapsed_steady = std::chrono::duration<double>(now - start_steady).count();
+             rate = (double)(done - 1) / std::max(elapsed_steady, 1e-6);
+        } else {
+             rate = done > 0 ? (double) done / std::max(elapsed, 1e-6) : 0.0;
+        }
+
+        const double eta = rate > 0 ? (double) (total_chunks - done) / rate : 0.0;
+        const std::string bar = nvfp4_progress_bar(pct);
+        const std::string eta_s = (done > 1 && rate > 0)
+            ? nvfp4_format_eta(eta)
+            : std::string("n/a");
+        LLAMA_LOG_CONT("\r\033[Knvfp4 quantize: %s [%s] %5.1f%% %lld/%lld elapsed %.1fs eta %s",
+            tensor_name ? tensor_name : "(unknown)",
+            bar.c_str(),
+            pct,
+            (long long) done, (long long) total_chunks,
+            elapsed,
+            eta_s.c_str());
+    };
+
+    if (show_progress) {
+        LLAMA_LOG_INFO("nvfp4 quantize: start %s chunks=%lld rows=%lld cols=%lld\n",
+            tensor_name ? tensor_name : "(unknown)",
+            (long long) total_chunks, (long long) nrows, (long long) n_per_row);
+        log_progress(0, true);
+    }
+
+    auto quantize_chunk = [&](int64_t first_row, int64_t this_nrow, size_t & this_size, std::vector<float> & fallback_buf) {
+        this_size = 0;
+
+        void * q_chunk = (char *) new_data + first_row * row_size;
+        
+        // NVFP4 BF16-direct CUDA fast path (chunked fallback)
+        if (new_type == GGML_TYPE_NVFP4 && bf16_data) {
+            const ggml_bf16_t * x_chunk = bf16_data + first_row * n_per_row;
+#ifdef GGML_USE_CUDA
+            if (!nvfp4_quantize_cuda_ab(x_chunk, true, q_chunk, this_nrow, n_per_row, imatrix, tensor_scale, nvfp4_a, nvfp4_b, nvfp4_stream)) {
+                const size_t chunk_elems = (size_t) this_nrow * (size_t) n_per_row;
+                if (fallback_buf.size() < chunk_elems) fallback_buf.resize(chunk_elems);
+                ggml_bf16_to_fp32_row(x_chunk, fallback_buf.data(), (int64_t) chunk_elems);
+                if (tensor_scale != 1.0f) {
+                    const float inv_scale = 1.0f / tensor_scale;
+                    for (size_t i = 0; i < chunk_elems; ++i) {
+                        fallback_buf[i] *= inv_scale;
+                    }
+                }
+                this_size = ggml_quantize_chunk(new_type, fallback_buf.data(), q_chunk, 0, this_nrow, n_per_row, imatrix);
+            } else {
+                this_size = (size_t) this_nrow * row_size;
+            }
+#else
+            const size_t chunk_elems = (size_t) this_nrow * (size_t) n_per_row;
+            if (fallback_buf.size() < chunk_elems) fallback_buf.resize(chunk_elems);
+            ggml_bf16_to_fp32_row(x_chunk, fallback_buf.data(), (int64_t) chunk_elems);
+            if (tensor_scale != 1.0f) {
+                const float inv_scale = 1.0f / tensor_scale;
+                for (size_t i = 0; i < chunk_elems; ++i) {
+                    fallback_buf[i] *= inv_scale;
+                }
+            }
+            this_size = ggml_quantize_chunk(new_type, fallback_buf.data(), q_chunk, 0, this_nrow, n_per_row, imatrix);
+#endif
+            return;
+        }
+
+        // CPU quant path (all other types, or NVFP4 CUDA fallback)
+        if (f32_data) {
+            if (new_type == GGML_TYPE_NVFP4 && tensor_scale != 1.0f) {
+                const size_t chunk_elems = (size_t) this_nrow * (size_t) n_per_row;
+                if (fallback_buf.size() < chunk_elems) fallback_buf.resize(chunk_elems);
+
+                const float * x_chunk = f32_data + (size_t) first_row * (size_t) n_per_row;
+                memcpy(fallback_buf.data(), x_chunk, chunk_elems * sizeof(float));
+
+                const float inv_scale = 1.0f / tensor_scale;
+                for (size_t i = 0; i < chunk_elems; ++i) {
+                    fallback_buf[i] *= inv_scale;
+                }
+
+                this_size = ggml_quantize_chunk(new_type, fallback_buf.data(), q_chunk, 0, this_nrow, n_per_row, imatrix);
+            } else {
+                this_size = ggml_quantize_chunk(new_type, f32_data, new_data, first_row * n_per_row, this_nrow, n_per_row, imatrix);
+            }
+            return;
+        }
+
+        if (bf16_data) { // still conver tto fp32 on cpu
+            const ggml_bf16_t * x_chunk = bf16_data + first_row * n_per_row;
+            const size_t chunk_elems = (size_t) this_nrow * (size_t) n_per_row;
+            if (fallback_buf.size() < chunk_elems) fallback_buf.resize(chunk_elems);
+            ggml_bf16_to_fp32_row(x_chunk, fallback_buf.data(), (int64_t) chunk_elems);
+            if (new_type == GGML_TYPE_NVFP4 && tensor_scale != 1.0f) {
+                const float inv_scale = 1.0f / tensor_scale;
+                for (size_t i = 0; i < chunk_elems; ++i) {
+                    fallback_buf[i] *= inv_scale;
+                }
+            }
+
+            this_size = ggml_quantize_chunk(new_type, fallback_buf.data(), q_chunk, 0, this_nrow, n_per_row, imatrix);
+            return;
+        }
+
+        // no source data at all -> hard fail
+        this_size = 0;
+    };
+
+    // single-thread
+    if (nthread < 2) {
+        size_t new_size = 0;
+        std::vector<float> fallback_buf;
+
+        for (int64_t first_row = 0; first_row < nrows; first_row += nrows_per_chunk) {
+            const int64_t this_nrow = std::min(nrows - first_row, nrows_per_chunk);
+
+            size_t this_size = 0;
+            quantize_chunk(first_row, this_nrow, this_size, fallback_buf);
+
+            // if we ever got 0 here, that's a fatal condition for GGUF sizing
+            if (this_size == 0) {
+                throw std::runtime_error("quantize returned 0 bytes (missing source data or invalid path)");
+            }
+
+            new_size += this_size;
+
+            if (do_qa && f32_data) {
+                nvfp4_qa_stats st;
+                const float * x_chunk = f32_data + first_row * n_per_row;
+                const uint8_t * q_chunk = (const uint8_t *) new_data + (size_t) first_row * row_size;
+                nvfp4_qa_accum(st, x_chunk, this_nrow, n_per_row, q_chunk);
+                const int64_t chunk_id = qa_tensor->chunk_id ? qa_tensor->chunk_id->fetch_add(1) : first_row / nrows_per_chunk;
+                nvfp4_qa_write_line(*qa_tensor->qa, qa_tensor->tensor_name, chunk_id, st);
+            }
+
+            GGML_UNUSED((char *) new_data + first_row * row_size);
+            if (!ggml_validate_row_data(new_type, new_data, new_size)) {
+                throw std::runtime_error("quantized data validation failed");
+            }
+
+            const int64_t done = done_chunks.fetch_add(1) + 1;
+            if (show_progress) {
+                std::lock_guard<std::mutex> lock(progress_mutex);
+                log_progress(done, false);
+            }
+        }
+
+        if (show_progress) {
+            std::lock_guard<std::mutex> lock(progress_mutex);
+            log_progress(total_chunks, true);
+            LLAMA_LOG_CONT("\n");
+        }
+
         return new_size;
     }
 
@@ -439,43 +1212,76 @@ static size_t llama_tensor_quantize_impl(enum ggml_type new_type, const float * 
     int64_t counter = 0;
     size_t new_size = 0;
     bool valid = true;
-    auto compute = [&mutex, &counter, &new_size, &valid, new_type, f32_data, new_data, chunk_size,
-            nrows, n_per_row, imatrix]() {
+    auto compute = [&]() {
         const int64_t nrows_per_chunk = chunk_size / n_per_row;
         size_t local_size = 0;
+        std::vector<float> fallback_buf;
         while (true) {
-            std::unique_lock<std::mutex> lock(mutex);
-            int64_t first_row = counter; counter += nrows_per_chunk;
+            int64_t first_row = 0;
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                first_row = counter;
+                counter += nrows_per_chunk;
+            }
             if (first_row >= nrows) {
                 if (local_size > 0) {
+                    std::unique_lock<std::mutex> lock(mutex);
                     new_size += local_size;
                 }
                 break;
             }
-            lock.unlock();
+
             const int64_t this_nrow = std::min(nrows - first_row, nrows_per_chunk);
-            size_t this_size = ggml_quantize_chunk(new_type, f32_data, new_data, first_row * n_per_row, this_nrow, n_per_row, imatrix);
+            size_t this_size = 0;
+            quantize_chunk(first_row, this_nrow, this_size, fallback_buf);
+            if (this_size == 0) {
+                std::unique_lock<std::mutex> lock(mutex);
+                valid = false;
+                break;
+            }
             local_size += this_size;
 
             // validate the quantized data
-            const size_t row_size  = ggml_row_size(new_type, n_per_row);
             void * this_data = (char *) new_data + first_row * row_size;
             if (!ggml_validate_row_data(new_type, this_data, this_size)) {
                 std::unique_lock<std::mutex> lock(mutex);
                 valid = false;
                 break;
             }
+
+            if (do_qa && f32_data) {
+                nvfp4_qa_stats st;
+                const float * x_chunk = f32_data + first_row * n_per_row;
+                const uint8_t * q_chunk = (const uint8_t *) new_data + (size_t) first_row * row_size;
+                nvfp4_qa_accum(st, x_chunk, this_nrow, n_per_row, q_chunk);
+                const int64_t chunk_id = qa_tensor && qa_tensor->chunk_id ? qa_tensor->chunk_id->fetch_add(1) : first_row / nrows_per_chunk;
+                nvfp4_qa_write_line(*qa_tensor->qa, qa_tensor->tensor_name, chunk_id, st);
+            }
+
+            const int64_t done = done_chunks.fetch_add(1) + 1;
+            if (show_progress) {
+                std::lock_guard<std::mutex> lock_progress(progress_mutex);
+                log_progress(done, false);
+            }
         }
     };
     for (int it = 0; it < nthread - 1; ++it) {
         workers.emplace_back(compute);
     }
+
     compute();
     for (auto & w : workers) { w.join(); }
     workers.clear();
     if (!valid) {
         throw std::runtime_error("quantized data validation failed");
     }
+
+    if (show_progress) {
+        std::lock_guard<std::mutex> lock(progress_mutex);
+        log_progress(total_chunks, true);
+        LLAMA_LOG_CONT("\n");
+    }
+
     return new_size;
 }
 
@@ -505,6 +1311,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
         case LLAMA_FTYPE_ALL_F32:     default_type = GGML_TYPE_F32;  break;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: default_type = GGML_TYPE_MXFP4; break;
+        case LLAMA_FTYPE_MOSTLY_NVFP4:     default_type = GGML_TYPE_NVFP4; break;
 
         // K-quants
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:
@@ -556,7 +1363,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     }
 
     std::vector<std::string> splits = {};
-    llama_model_loader ml(fname_inp, splits, use_mmap, /*use_direct_io*/ false, /*check_tensors*/ true, /*no_alloc*/ false, kv_overrides, nullptr);
+    llama_model_loader ml(fname_inp, splits, use_mmap, /*use_direct_io*/ true, /*check_tensors*/ true, /*no_alloc*/ false, kv_overrides, nullptr);
     ml.init_mappings(false); // no prefetching
 
     llama_model model(llama_model_default_params());
@@ -566,6 +1373,8 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     model.load_stats  (ml);
 
     quantize_state_impl qs(model, params);
+
+    nvfp4_qa_context qa_ctx;
 
     if (params->only_copy) {
         ftype = ml.ftype;
@@ -627,6 +1436,45 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     std::map<int, std::string> mapped;
     int blk_id = 0;
 
+    struct moe_gate_up_merge_info {
+        const llama_model_loader::llama_tensor_weight * gate = nullptr;
+        std::string out_name;
+    };
+    std::unordered_map<const llama_model_loader::llama_tensor_weight *, moe_gate_up_merge_info> moe_gate_up_merges;
+
+    const bool merge_moe_gate_up_for_nvfp4 =
+        ftype == LLAMA_FTYPE_MOSTLY_NVFP4 &&
+        params->tensor_types == nullptr &&
+        params->token_embedding_type == GGML_TYPE_COUNT &&
+        params->output_tensor_type == GGML_TYPE_COUNT;
+
+    auto name_ends_with = [](const std::string & name, const std::string & suffix) -> bool {
+        return name.size() >= suffix.size() &&
+               name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+    auto is_float_source_type = [](ggml_type t) -> bool {
+        return t == GGML_TYPE_F32 || t == GGML_TYPE_F16 || t == GGML_TYPE_BF16;
+    };
+    auto build_merged_gate_up_meta = [](const ggml_tensor * base, const std::string & out_name) -> ggml_tensor {
+        ggml_tensor out = *base;
+        ggml_set_name(&out, out_name.c_str());
+        out.ne[1] *= 2;
+
+        const size_t  type_size = ggml_type_size(out.type);
+        const int64_t blck_size = ggml_blck_size(out.type);
+        out.nb[0] = type_size;
+        if (out.type == GGML_TYPE_NVFP4) {
+            out.nb[1] = ggml_row_size(out.type, out.ne[0]);
+        } else {
+            out.nb[1] = out.nb[0]*(out.ne[0]/blck_size);
+        }
+        for (int i = 2; i < GGML_MAX_DIMS; ++i) {
+            out.nb[i] = out.nb[i - 1]*out.ne[i - 1];
+        }
+
+        return out;
+    };
+
     // make a list of weights
     std::vector<const llama_model_loader::llama_tensor_weight *> tensors;
     tensors.reserve(ml.weights_map.size());
@@ -645,6 +1493,78 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     }
     if (!prune_list.empty()) {
         gguf_set_val_u32(ctx_out.get(), ml.llm_kv(LLM_KV_BLOCK_COUNT).c_str(), blk_id);
+    }
+
+    if (merge_moe_gate_up_for_nvfp4) {
+        std::unordered_map<std::string, const llama_model_loader::llama_tensor_weight *> by_name;
+        by_name.reserve(tensors.size());
+        for (const auto * it : tensors) {
+            by_name.emplace(ggml_get_name(it->tensor), it);
+        }
+
+        std::unordered_set<const llama_model_loader::llama_tensor_weight *> skip;
+        skip.reserve(tensors.size() / 16 + 1);
+
+        const std::string suffix_up = "ffn_up_exps.weight";
+        const std::string suffix_gate = "ffn_gate_exps.weight";
+        const std::string suffix_gate_up = "ffn_gate_up_exps.weight";
+
+        for (const auto * it : tensors) {
+            const std::string up_name = ggml_get_name(it->tensor);
+            if (!name_ends_with(up_name, suffix_up)) {
+                continue;
+            }
+
+            const size_t suffix_pos = up_name.size() - suffix_up.size();
+            std::string gate_name = up_name;
+            gate_name.replace(suffix_pos, suffix_up.size(), suffix_gate);
+            std::string merged_name = up_name;
+            merged_name.replace(suffix_pos, suffix_up.size(), suffix_gate_up);
+
+            auto gate_it = by_name.find(gate_name);
+            if (gate_it == by_name.end()) {
+                continue;
+            }
+            if (by_name.find(merged_name) != by_name.end()) {
+                continue;
+            }
+            if (gate_it->second->idx != it->idx) {
+                continue;
+            }
+
+            const ggml_tensor * up_t = it->tensor;
+            const ggml_tensor * gate_t = gate_it->second->tensor;
+            if (!is_float_source_type(up_t->type) || up_t->type != gate_t->type) {
+                continue;
+            }
+
+            if (ggml_n_dims(up_t) < 3 || ggml_n_dims(gate_t) < 3) {
+                continue;
+            }
+            if (up_t->ne[0] != gate_t->ne[0] ||
+                up_t->ne[1] != gate_t->ne[1] ||
+                up_t->ne[2] != gate_t->ne[2] ||
+                up_t->ne[3] != gate_t->ne[3]) {
+                continue;
+            }
+
+            moe_gate_up_merges[it] = { gate_it->second, merged_name };
+            skip.insert(gate_it->second);
+
+            LLAMA_LOG_INFO("%s: merging split MoE tensors %s + %s -> %s\n",
+                __func__, gate_name.c_str(), up_name.c_str(), merged_name.c_str());
+        }
+
+        if (!skip.empty()) {
+            std::vector<const llama_model_loader::llama_tensor_weight *> merged_tensors;
+            merged_tensors.reserve(tensors.size() - skip.size());
+            for (const auto * it : tensors) {
+                if (skip.find(it) == skip.end()) {
+                    merged_tensors.push_back(it);
+                }
+            }
+            tensors.swap(merged_tensors);
+        }
     }
 
     // keep_split requires that the weights are sorted by split index
@@ -683,8 +1603,11 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     int idx = 0;
 
     std::vector<no_init<uint8_t>> read_data;
+    std::vector<no_init<uint8_t>> read_data_gate;
     std::vector<no_init<uint8_t>> work;
     std::vector<no_init<float>> f32_conv_buf;
+    std::vector<float> merged_f32_buf;
+    std::vector<ggml_bf16_t> merged_bf16_buf;
 
     uint16_t n_split = 1;
 
@@ -704,7 +1627,16 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
         if (!ctx_outs[i_split]) {
             ctx_outs[i_split].reset(gguf_init_empty());
         }
-        gguf_add_tensor(ctx_outs[i_split].get(), tensor);
+
+        auto it_merge = moe_gate_up_merges.find(it);
+        const bool is_merged_moe_gate_up = it_merge != moe_gate_up_merges.end();
+        ggml_tensor merged_meta;
+        if (is_merged_moe_gate_up) {
+            merged_meta = build_merged_gate_up_meta(tensor, it_merge->second.out_name);
+            gguf_add_tensor(ctx_outs[i_split].get(), &merged_meta);
+        } else {
+            gguf_add_tensor(ctx_outs[i_split].get(), tensor);
+        }
     }
 
     // Set split info if needed
@@ -713,6 +1645,109 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
             gguf_set_val_u16(ctx_outs[i].get(), ml.llm_kv(LLM_KV_SPLIT_NO).c_str(), i);
             gguf_set_val_u16(ctx_outs[i].get(), ml.llm_kv(LLM_KV_SPLIT_COUNT).c_str(), n_split);
             gguf_set_val_i32(ctx_outs[i].get(), ml.llm_kv(LLM_KV_SPLIT_TENSORS_COUNT).c_str(), (int32_t)tensors.size());
+        }
+    }
+
+    // Pre-register NVFP4 tensor-scale keys so metadata size is final before writing any data.
+    {
+        quantize_state_impl qs_meta(model, params);
+        qs_meta.has_imatrix    = qs.has_imatrix;
+        qs_meta.has_output     = qs.has_output;
+        qs_meta.n_attention_wv = qs.n_attention_wv;
+        qs_meta.n_ffn_down     = qs.n_ffn_down;
+        qs_meta.n_ffn_gate     = qs.n_ffn_gate;
+        qs_meta.n_ffn_up       = qs.n_ffn_up;
+
+        for (const auto * it : tensors) {
+            const struct ggml_tensor * tensor = it->tensor;
+            auto it_merge = moe_gate_up_merges.find(it);
+            const bool is_merged_moe_gate_up = it_merge != moe_gate_up_merges.end();
+            ggml_tensor merged_meta;
+            if (is_merged_moe_gate_up) {
+                merged_meta = build_merged_gate_up_meta(tensor, it_merge->second.out_name);
+                tensor = &merged_meta;
+            }
+            const std::string name = ggml_get_name(tensor);
+            const uint16_t i_split = params->keep_split ? it->idx : 0;
+
+            bool quantize = name.rfind("weight") == name.size() - 6; // ends with 'weight'?
+            quantize &= (ggml_n_dims(tensor) >= 2);
+            quantize &= name.find("_norm.weight") == std::string::npos;
+            quantize &= params->quantize_output_tensor || name != "output.weight";
+            quantize &= !params->only_copy;
+            quantize &= name.find("ffn_gate_inp.weight") == std::string::npos;
+            quantize &= name.find("altup")  == std::string::npos;
+            quantize &= name.find("laurel") == std::string::npos;
+            quantize &= name.find("per_layer_model_proj") == std::string::npos;
+            quantize &= name != LLM_TN(model.arch)(LLM_TENSOR_POS_EMBD,    "weight");
+            quantize &= name != LLM_TN(model.arch)(LLM_TENSOR_TOKEN_TYPES, "weight");
+            quantize &= name.find("ssm_conv1d.weight") == std::string::npos;
+            quantize &= name.find("shortconv.conv.weight") == std::string::npos;
+            quantize &= name.find("time_mix_first.weight") == std::string::npos;
+            quantize &= name.find("time_mix_w0.weight") == std::string::npos;
+            quantize &= name.find("time_mix_w1.weight") == std::string::npos;
+            quantize &= name.find("time_mix_w2.weight") == std::string::npos;
+            quantize &= name.find("time_mix_v0.weight") == std::string::npos;
+            quantize &= name.find("time_mix_v1.weight") == std::string::npos;
+            quantize &= name.find("time_mix_v2.weight") == std::string::npos;
+            quantize &= name.find("time_mix_a0.weight") == std::string::npos;
+            quantize &= name.find("time_mix_a1.weight") == std::string::npos;
+            quantize &= name.find("time_mix_a2.weight") == std::string::npos;
+            quantize &= name.find("time_mix_g1.weight") == std::string::npos;
+            quantize &= name.find("time_mix_g2.weight") == std::string::npos;
+            quantize &= name.find("time_mix_decay_w1.weight") == std::string::npos;
+            quantize &= name.find("time_mix_decay_w2.weight") == std::string::npos;
+            quantize &= name.find("time_mix_lerp_fused.weight") == std::string::npos;
+            quantize &= name.find("attn_rel_b.weight") == std::string::npos;
+            quantize &= name.find(".position_embd.") == std::string::npos;
+
+            ggml_type new_type = default_type;
+            if (quantize) {
+                if (!params->pure && ggml_is_quantized(default_type)) {
+                    int fallback = qs_meta.n_fallback;
+                    new_type = llama_tensor_get_type(qs_meta, new_type, tensor, ftype);
+                    if (params->tensor_types && qs_meta.n_fallback - fallback == 0) {
+                        const std::vector<tensor_quantization> & tensor_types = *static_cast<const std::vector<tensor_quantization> *>(params->tensor_types);
+                        const std::string tensor_name(tensor->name);
+                        for (const auto & [tname, qtype] : tensor_types) {
+                            if (std::regex pattern(tname); std::regex_search(tensor_name, pattern)) {
+                                new_type = qtype;
+                            }
+                        }
+                    }
+                }
+                if (params->token_embedding_type < GGML_TYPE_COUNT && strcmp(tensor->name, "token_embd.weight") == 0) {
+                    new_type = params->token_embedding_type;
+                }
+                if (params->output_tensor_type < GGML_TYPE_COUNT && strcmp(tensor->name, "output.weight") == 0) {
+                    new_type = params->output_tensor_type;
+                }
+
+                quantize = tensor->type != new_type;
+
+                if (quantize && (tensor->type == GGML_TYPE_F32 || tensor->type == GGML_TYPE_F16 || tensor->type == GGML_TYPE_BF16) && ggml_is_quantized(new_type)) {
+                    const size_t src_nbytes = ggml_nbytes(tensor);
+                    const size_t dst_nbytes = (size_t) ggml_row_size(new_type, tensor->ne[0]) * (size_t) tensor->ne[1] * (size_t) tensor->ne[2] * (size_t) tensor->ne[3];
+                    if (src_nbytes > dst_nbytes && (src_nbytes - dst_nbytes) < LLAMA_QUANT_MIN_SAVINGS_BYTES) {
+                        quantize = false;
+                        new_type = tensor->type;
+                    }
+                }
+            }
+
+            if (is_merged_moe_gate_up) {
+                new_type = GGML_TYPE_NVFP4;
+                quantize = true;
+            }
+
+            if (!quantize) {
+                new_type = tensor->type;
+            }
+
+            if (new_type == GGML_TYPE_NVFP4) {
+                const std::string k1 = name + ".tensor_scale";
+                gguf_set_val_f32(ctx_outs[i_split].get(), k1.c_str(), 1.0f);
+            }
         }
     }
 
@@ -759,35 +1794,56 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     for (const auto * it : tensors) {
         const auto & weight = *it;
         ggml_tensor * tensor = weight.tensor;
-        if (!params->dry_run && (weight.idx != cur_split && params->keep_split)) {
+        auto it_merge = moe_gate_up_merges.find(it);
+        const bool is_merged_moe_gate_up = it_merge != moe_gate_up_merges.end();
+        ggml_tensor merged_meta;
+        const ggml_tensor * tensor_meta = tensor;
+        if (is_merged_moe_gate_up) {
+            merged_meta = build_merged_gate_up_meta(tensor, it_merge->second.out_name);
+            tensor_meta = &merged_meta;
+        }
+        ggml_tensor * gate_tensor = is_merged_moe_gate_up ? it_merge->second.gate->tensor : nullptr;
+
+        if (weight.idx != cur_split && params->keep_split) {
             close_ofstream();
             new_ofstream(weight.idx);
         }
 
-        const std::string name = ggml_get_name(tensor);
-        const size_t tensor_size = ggml_nbytes(tensor);
+        const std::string name = ggml_get_name(tensor_meta);
 
-        if (!params->dry_run) {
-            if (!ml.use_mmap) {
-                if (read_data.size() < tensor_size) {
-                    read_data.resize(tensor_size);
-                }
-                tensor->data = read_data.data();
+        const bool tensor_needs_staging = !ml.use_mmap ||
+            (ml.use_mmap && ml.has_nvfp4_tensor_scales && tensor->type == GGML_TYPE_NVFP4);
+        if (tensor_needs_staging) {
+            if (read_data.size() < ggml_nbytes(tensor)) {
+                read_data.resize(ggml_nbytes(tensor));
             }
             ml.load_data_for(tensor);
+        }
+        ml.load_data_for(tensor);
+        if (is_merged_moe_gate_up) {
+            GGML_ASSERT(gate_tensor != nullptr);
+            const bool gate_needs_staging = !ml.use_mmap ||
+                (ml.use_mmap && ml.has_nvfp4_tensor_scales && gate_tensor->type == GGML_TYPE_NVFP4);
+            if (gate_needs_staging) {
+                if (read_data_gate.size() < ggml_nbytes(gate_tensor)) {
+                    read_data_gate.resize(ggml_nbytes(gate_tensor));
+                }
+                gate_tensor->data = read_data_gate.data();
+            }
+            ml.load_data_for(gate_tensor);
         }
 
         LLAMA_LOG_INFO("[%4d/%4d] %36s - [%s], type = %6s, ",
                ++idx, ml.n_tensors,
-               ggml_get_name(tensor),
-               llama_format_tensor_shape(tensor).c_str(),
-               ggml_type_name(tensor->type));
+               name.c_str(),
+               llama_format_tensor_shape(tensor_meta).c_str(),
+               ggml_type_name(tensor_meta->type));
 
         // This used to be a regex, but <regex> has an extreme cost to compile times.
         bool quantize = name.rfind("weight") == name.size() - 6; // ends with 'weight'?
 
         // quantize only 2D and 3D tensors (experts)
-        quantize &= (ggml_n_dims(tensor) >= 2);
+        quantize &= (ggml_n_dims(tensor_meta) >= 2);
 
         // do not quantize norm tensors
         quantize &= name.find("_norm.weight") == std::string::npos;
@@ -841,6 +1897,8 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
         ggml_type new_type;
         void * new_data;
         size_t new_size;
+        bool nvfp4_quantized = false;
+        float tensor_scale = 1.0f;
 
         if (quantize) {
             new_type = default_type;
@@ -865,16 +1923,16 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                 }
 
                 // if not manual - use the standard logic for choosing the quantization type based on the selected mixture
-                if (!manual) {
-                    new_type = llama_tensor_get_type(qs, new_type, tensor, ftype);
-                }
+                    if (!manual) {
+                        new_type = llama_tensor_get_type(qs, new_type, tensor_meta, ftype);
+                    }
 
                 // incompatible tensor shapes are handled here - fallback to a compatible type
                 {
                     bool convert_incompatible_tensor = false;
 
-                    const int64_t nx = tensor->ne[0];
-                    const int64_t ny = tensor->ne[1];
+                    const int64_t nx = tensor_meta->ne[0];
+                    const int64_t ny = tensor_meta->ne[1];
                     const int64_t qk_k = ggml_blck_size(new_type);
 
                     if (nx % qk_k != 0) {
@@ -901,9 +1959,12 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                             case GGML_TYPE_Q4_K:   new_type = GGML_TYPE_Q5_0;   break;
                             case GGML_TYPE_Q5_K:   new_type = GGML_TYPE_Q5_1;   break;
                             case GGML_TYPE_Q6_K:   new_type = GGML_TYPE_Q8_0;   break;
+                            case GGML_TYPE_NVFP4: new_type =
+                            GGML_TYPE_Q4_K; break;
+
                             default: throw std::runtime_error("\nUnsupported tensor size encountered\n");
                         }
-                        if (tensor->ne[0] % ggml_blck_size(new_type) != 0) {
+                        if (tensor_meta->ne[0] % ggml_blck_size(new_type) != 0) {
                             new_type = GGML_TYPE_F16;
                         }
                         LLAMA_LOG_WARN(" - using fallback quantization %s\n", ggml_type_name(new_type));
@@ -911,80 +1972,132 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                     }
                 }
             }
-            if (params->token_embedding_type < GGML_TYPE_COUNT && strcmp(tensor->name, "token_embd.weight") == 0) {
+            if (params->token_embedding_type < GGML_TYPE_COUNT && name == "token_embd.weight") {
                 new_type = params->token_embedding_type;
             }
-            if (params->output_tensor_type < GGML_TYPE_COUNT && strcmp(tensor->name, "output.weight") == 0) {
+            if (params->output_tensor_type < GGML_TYPE_COUNT && name == "output.weight") {
                 new_type = params->output_tensor_type;
+            }
+
+            // no point to quantize if we only save 1mb.
+            if (!is_merged_moe_gate_up &&
+                tensor_meta->type != new_type &&
+                (tensor_meta->type == GGML_TYPE_F32 || tensor_meta->type == GGML_TYPE_F16 || tensor_meta->type == GGML_TYPE_BF16) &&
+                ggml_is_quantized(new_type)) {
+                const size_t src_nbytes = ggml_nbytes(tensor_meta);
+                const size_t dst_nbytes = (size_t) ggml_row_size(new_type, tensor_meta->ne[0]) * (size_t) tensor_meta->ne[1] * (size_t) tensor_meta->ne[2] * (size_t) tensor_meta->ne[3];
+                if (src_nbytes > dst_nbytes && (src_nbytes - dst_nbytes) < LLAMA_QUANT_MIN_SAVINGS_BYTES) {
+                    new_type = tensor_meta->type;
+                }
             }
 
             // If we've decided to quantize to the same type the tensor is already
             // in then there's nothing to do.
-            quantize = tensor->type != new_type;
+            quantize = tensor_meta->type != new_type;
         }
 
-        // we have now decided on the target type for this tensor
-        if (params->dry_run) {
-            // the --dry-run option calculates the final quantization size without quantizting
-            if (quantize) {
-                new_size = ggml_nrows(tensor) * ggml_row_size(new_type, tensor->ne[0]);
-                LLAMA_LOG_INFO("size = %8.2f MiB -> %8.2f MiB (%s)\n",
-                               tensor_size/1024.0/1024.0,
-                               new_size/1024.0/1024.0,
-                               ggml_type_name(new_type));
-                if (!will_require_imatrix && tensor_type_requires_imatrix(tensor, new_type, params->ftype)) {
-                    will_require_imatrix = true;
-                }
-            } else {
-                new_size = tensor_size;
-                LLAMA_LOG_INFO("size = %8.3f MiB\n", new_size/1024.0/1024.0);
-            }
-            total_size_org += tensor_size;
-            total_size_new += new_size;
-            continue;
+        if (is_merged_moe_gate_up) {
+            new_type = GGML_TYPE_NVFP4;
+            quantize = true;
+        }
+
+        if (!quantize) {
+            new_type = tensor_meta->type;
+            new_data = tensor->data;
+            new_size = ggml_nbytes(tensor_meta);
+            LLAMA_LOG_INFO("size = %8.3f MiB\n", ggml_nbytes(tensor_meta)/1024.0/1024.0);
         } else {
-            // no --dry-run, perform quantization
-            if (!quantize) {
-                new_type = tensor->type;
-                new_data = tensor->data;
-                new_size = tensor_size;
-                LLAMA_LOG_INFO("size = %8.3f MiB\n", tensor_size/1024.0/1024.0);
-            } else {
-                const int64_t nelements = ggml_nelements(tensor);
+            const int64_t nelements = ggml_nelements(tensor_meta);
 
-                const float * imatrix = nullptr;
-                if (imatrix_data) {
-                    auto it = imatrix_data->find(remap_imatrix(tensor->name, mapped));
-                    if (it == imatrix_data->end()) {
-                        LLAMA_LOG_INFO("\n====== %s: did not find weights for %s\n", __func__, tensor->name);
+            const float * imatrix = nullptr;
+            if (imatrix_data) {
+                const char * imatrix_name = is_merged_moe_gate_up ? tensor->name : tensor_meta->name;
+                auto it = imatrix_data->find(remap_imatrix(imatrix_name, mapped));
+                if (it == imatrix_data->end()) {
+                    LLAMA_LOG_INFO("\n====== %s: did not find weights for %s\n", __func__, name.c_str());
+                } else {
+                    const size_t expected_imatrix = (size_t) tensor_meta->ne[0] * (size_t) tensor_meta->ne[2] * (size_t) tensor_meta->ne[3];
+                    if (it->second.size() == expected_imatrix) {
+                        imatrix = it->second.data();
                     } else {
-                        if (it->second.size() == (size_t)tensor->ne[0]*tensor->ne[2]) {
-                            imatrix = it->second.data();
-                        } else {
-                            LLAMA_LOG_INFO("\n====== %s: imatrix size %d is different from tensor size %d for %s\n", __func__,
-                                    int(it->second.size()), int(tensor->ne[0]*tensor->ne[2]), tensor->name);
+                        LLAMA_LOG_INFO("\n====== %s: imatrix size %d is different from tensor size %d for %s\n", __func__,
+                                int(it->second.size()), int(expected_imatrix), name.c_str());
 
-                            // this can happen when quantizing an old mixtral model with split tensors with a new incompatible imatrix
-                            // this is a significant error and it may be good idea to abort the process if this happens,
-                            // since many people will miss the error and not realize that most of the model is being quantized without an imatrix
-                            // tok_embd should be ignored in this case, since it always causes this warning
-                            if (name != tn(LLM_TENSOR_TOKEN_EMBD, "weight")) {
-                                throw std::runtime_error(format("imatrix size %d is different from tensor size %d for %s",
-                                        int(it->second.size()), int(tensor->ne[0]*tensor->ne[2]), tensor->name));
-                            }
+                        // this can happen when quantizing an old mixtral model with split tensors with a new incompatible imatrix
+                        // this is a significant error and it may be good idea to abort the process if this happens,
+                        // since many people will miss the error and not realize that most of the model is being quantized without an imatrix
+                        // tok_embd should be ignored in this case, since it always causes this warning
+                        if (name != tn(LLM_TENSOR_TOKEN_EMBD, "weight")) {
+                            throw std::runtime_error(format("imatrix size %d is different from tensor size %d for %s",
+                                    int(it->second.size()), int(expected_imatrix), name.c_str()));
                         }
                     }
                 }
-                if (!imatrix && tensor_type_requires_imatrix(tensor, new_type, params->ftype)) {
-                    LLAMA_LOG_ERROR("\n\n============================================================\n");
-                    LLAMA_LOG_ERROR("Missing importance matrix for tensor %s in a very low-bit quantization\n", tensor->name);
-                    LLAMA_LOG_ERROR("The result will be garbage, so bailing out\n");
-                    LLAMA_LOG_ERROR("============================================================\n\n");
-                    throw std::runtime_error(format("Missing importance matrix for tensor %s in a very low-bit quantization", tensor->name));
+            }
+            if ((new_type == GGML_TYPE_IQ2_XXS ||
+                 new_type == GGML_TYPE_IQ2_XS  ||
+                 new_type == GGML_TYPE_IQ2_S   ||
+                 new_type == GGML_TYPE_IQ1_S   ||
+                (new_type == GGML_TYPE_IQ1_M && name != "token_embd.weight" && name != "output.weight")  ||
+                (new_type == GGML_TYPE_Q2_K && params->ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S && name != "token_embd.weight")) && !imatrix) {
+                LLAMA_LOG_ERROR("\n\n============================================================\n");
+                LLAMA_LOG_ERROR("Missing importance matrix for tensor %s in a very low-bit quantization\n", name.c_str());
+                LLAMA_LOG_ERROR("The result will be garbage, so bailing out\n");
+                LLAMA_LOG_ERROR("============================================================\n\n");
+                throw std::runtime_error(format("Missing importance matrix for tensor %s in a very low-bit quantization", name.c_str()));
+            }
+
+            float * f32_data = nullptr;
+            const ggml_bf16_t * bf16_data = nullptr;
+            if (is_merged_moe_gate_up) {
+                const size_t src_slice_elems = (size_t) tensor->ne[0] * (size_t) tensor->ne[1];
+                const size_t dst_slice_elems = src_slice_elems * 2;
+                const size_t n_slices = (size_t) tensor->ne[2] * (size_t) tensor->ne[3];
+
+                if (tensor->type == GGML_TYPE_BF16 && new_type == GGML_TYPE_NVFP4 && !qa_ctx.file) {
+                    merged_bf16_buf.resize((size_t) nelements);
+                    const auto * gate_src = (const ggml_bf16_t *) gate_tensor->data;
+                    const auto * up_src   = (const ggml_bf16_t *) tensor->data;
+                    auto * dst = merged_bf16_buf.data();
+                    for (size_t is = 0; is < n_slices; ++is) {
+                        std::memcpy(dst + is*dst_slice_elems, gate_src + is*src_slice_elems, src_slice_elems*sizeof(ggml_bf16_t));
+                        std::memcpy(dst + is*dst_slice_elems + src_slice_elems, up_src + is*src_slice_elems, src_slice_elems*sizeof(ggml_bf16_t));
+                    }
+                    bf16_data = merged_bf16_buf.data();
+                } else {
+                    merged_f32_buf.resize((size_t) nelements);
+                    auto convert_slice = [&](const ggml_tensor * src_t, size_t src_offs, size_t n, float * dst) {
+                        if (src_t->type == GGML_TYPE_F32) {
+                            const auto * src = (const float *) src_t->data + src_offs;
+                            std::memcpy(dst, src, n*sizeof(float));
+                        } else if (src_t->type == GGML_TYPE_F16) {
+                            const auto * src = (const ggml_fp16_t *) src_t->data + src_offs;
+                            for (size_t i = 0; i < n; ++i) {
+                                dst[i] = ggml_fp16_to_fp32(src[i]);
+                            }
+                        } else if (src_t->type == GGML_TYPE_BF16) {
+                            const auto * src = (const ggml_bf16_t *) src_t->data + src_offs;
+                            for (size_t i = 0; i < n; ++i) {
+                                dst[i] = ggml_bf16_to_fp32(src[i]);
+                            }
+                        } else {
+                            GGML_ABORT("unsupported source type for merged MoE gate_up: %s", ggml_type_name(src_t->type));
+                        }
+                    };
+
+                    for (size_t is = 0; is < n_slices; ++is) {
+                        const size_t src_offs = is*src_slice_elems;
+                        float * dst = merged_f32_buf.data() + is*dst_slice_elems;
+                        convert_slice(gate_tensor, src_offs, src_slice_elems, dst);
+                        convert_slice(tensor, src_offs, src_slice_elems, dst + src_slice_elems);
+                    }
+                    f32_data = merged_f32_buf.data();
                 }
+            } else if (tensor->type == GGML_TYPE_BF16 && new_type == GGML_TYPE_NVFP4 && !qa_ctx.file) {
+                bf16_data = (const ggml_bf16_t *) tensor->data;
+            }
 
-                float * f32_data;
-
+            if (!bf16_data && !is_merged_moe_gate_up) {
                 if (tensor->type == GGML_TYPE_F32) {
                     f32_data = (float *) tensor->data;
                 } else if (ggml_is_quantized(tensor->type) && !params->allow_requantize) {
@@ -993,71 +2106,175 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                     llama_tensor_dequantize_impl(tensor, f32_conv_buf, workers, nelements, nthread);
                     f32_data = (float *) f32_conv_buf.data();
                 }
-
-                LLAMA_LOG_INFO("converting to %s .. ", ggml_type_name(new_type));
-                fflush(stdout);
-
-                if (work.size() < (size_t)nelements * 4) {
-                    work.resize(nelements * 4); // upper bound on size
-                }
-                new_data = work.data();
-
-                const int64_t n_per_row = tensor->ne[0];
-                const int64_t nrows = tensor->ne[1];
-
-                static const int64_t min_chunk_size = 32 * 512;
-                const int64_t chunk_size = (n_per_row >= min_chunk_size ? n_per_row : n_per_row * ((min_chunk_size + n_per_row - 1)/n_per_row));
-
-                const int64_t nelements_matrix = tensor->ne[0] * tensor->ne[1];
-                const int64_t nchunk = (nelements_matrix + chunk_size - 1)/chunk_size;
-                const int64_t nthread_use = nthread > 1 ? std::max((int64_t)1, std::min((int64_t)nthread, nchunk)) : 1;
-
-                // quantize each expert separately since they have different importance matrices
-                new_size = 0;
-                for (int64_t i03 = 0; i03 < tensor->ne[2]; ++i03) {
-                    const float * f32_data_03 = f32_data + i03 * nelements_matrix;
-                    void * new_data_03 = (char *)new_data + ggml_row_size(new_type, n_per_row) * i03 * nrows;
-                    const float * imatrix_03 = imatrix ? imatrix + i03 * n_per_row : nullptr;
-
-                    new_size += llama_tensor_quantize_impl(new_type, f32_data_03, new_data_03, chunk_size, nrows, n_per_row, imatrix_03, workers, nthread_use);
-
-                    // TODO: temporary sanity check that the F16 -> MXFP4 is lossless
-#if 0
-                    if (new_type == GGML_TYPE_MXFP4) {
-                        auto * x = f32_data_03;
-
-                        //LLAMA_LOG_INFO("nrows = %d, n_per_row = %d\n", nrows, n_per_row);
-                        std::vector<float> deq(nrows*n_per_row);
-                        const ggml_type_traits * qtype = ggml_get_type_traits(new_type);
-                        qtype->to_float(new_data_03, deq.data(), deq.size());
-
-                        double err = 0.0f;
-                        for (int i = 0; i < (int) deq.size(); ++i) {
-                            err += fabsf(deq[i] - x[i]);
-                            //if (fabsf(deq[i] - x[i]) > 0.00001 && i < 256) {
-                            if (deq[i] != x[i]) {
-                                LLAMA_LOG_INFO("deq[%d] = %f, x[%d] = %f\n", i, deq[i], i, x[i]);
-                            }
-                        }
-                        //LLAMA_LOG_INFO("err = %f\n", err);
-                        GGML_ASSERT(err == 0.00000);
-                    }
-#endif
-                }
-                LLAMA_LOG_INFO("size = %8.2f MiB -> %8.2f MiB\n", tensor_size/1024.0/1024.0, new_size/1024.0/1024.0);
             }
-            total_size_org += tensor_size;
-            total_size_new += new_size;
 
-            // update the gguf meta data as we go
-            gguf_set_tensor_type(ctx_outs[cur_split].get(), name.c_str(), new_type);
+            const float * f32_quant_data = f32_data;
+            if (new_type == GGML_TYPE_NVFP4) {
+                nvfp4_quantized = true;
+                float absmax = 0.0f;
+
+                if (bf16_data) {
+                    absmax = llama_tensor_absmax_bf16_mt(bf16_data, (size_t) nelements, nthread);
+                } else {
+                    absmax = llama_tensor_absmax_f32_mt(f32_data, (size_t) nelements, nthread);
+                }
+
+                const float cap_ts = LLAMA_NVFP4_TENSOR_CAP_FIXED;
+                tensor_scale = absmax / (LLAMA_NVFP4_MAX_FP4 * cap_ts);
+                if (!std::isfinite(tensor_scale) || tensor_scale <= 0.0f) {
+                    tensor_scale = 1.0f;
+                }
+            }
+            const int64_t n_per_row = tensor_meta->ne[0];
+            const int64_t nrows = tensor_meta->ne[1];
+            const size_t new_data_size =
+                (size_t) ggml_row_size(new_type, n_per_row) *
+                (size_t) nrows *
+                (size_t) tensor_meta->ne[2] *
+                (size_t) tensor_meta->ne[3];
+
+            if (work.size() < new_data_size) {
+                work.resize(new_data_size);
+            }
+            new_data = work.data();
+
+            static const int64_t min_chunk_size = 32 * 512;
+            int64_t chunk_size = (n_per_row >= min_chunk_size ? n_per_row : n_per_row * ((min_chunk_size + n_per_row - 1)/n_per_row));
+
+            const int64_t nelements_matrix = tensor_meta->ne[0] * tensor_meta->ne[1];
+#ifdef GGML_USE_CUDA
+            if (new_type == GGML_TYPE_NVFP4 && (bf16_data || f32_data)) {
+                const int64_t target_rows = std::clamp<int64_t>(
+                    nelements_matrix / std::max<int64_t>(1, (int64_t) nthread * 6),
+                    256,
+                    1024);
+                const int64_t tuned_chunk_size = target_rows * n_per_row;
+                chunk_size = std::max(chunk_size, tuned_chunk_size);
+            }
+#endif
+            const int64_t nchunk = (nelements_matrix + chunk_size - 1)/chunk_size;
+            int64_t nthread_use = nthread > 1 ? std::max((int64_t) 1, std::min((int64_t) nthread, nchunk)) : 1;
+#ifdef GGML_USE_CUDA
+            if (new_type == GGML_TYPE_NVFP4 && (bf16_data || f32_data)) {
+                nthread_use = std::min<int64_t>(nthread_use, 8);
+            }
+#endif
+
+            new_size = 0;
+            std::atomic<int64_t> qa_chunk_id{0};
+            nvfp4_qa_tensor_ctx qa_tensor;
+            if (qa_ctx.file && new_type == GGML_TYPE_NVFP4) {
+                qa_tensor.qa = &qa_ctx;
+                qa_tensor.tensor_name = tensor_meta->name;
+                qa_tensor.chunk_id = &qa_chunk_id;
+                qa_tensor.n_per_row = n_per_row;
+            }
+
+            const int64_t ne2 = tensor_meta->ne[2];
+            const int64_t ne3 = tensor_meta->ne[3];
+            const size_t slice_elems = (size_t) nelements_matrix;
+            const size_t slice_bytes = (size_t) ggml_row_size(new_type, n_per_row) * (size_t) nrows;
+
+            const int64_t n_slices = ne2 * ne3;
+            const bool parallel_nvfp4_slices = (new_type == GGML_TYPE_NVFP4) && (n_slices > 1) && !qa_ctx.file;
+
+            if (parallel_nvfp4_slices) {
+                const int slice_threads = (int) std::min<int64_t>(std::min<int64_t>(8, nthread), n_slices);
+                std::atomic<int64_t> next_slice{0};
+                std::atomic<size_t> new_size_atomic{0};
+                std::atomic<bool> failed{false};
+                std::mutex err_mtx;
+                std::string err_msg;
+
+                auto run_slice = [&](int /*tid*/) {
+                    std::vector<std::thread> local_workers;
+                    while (true) {
+                        if (failed.load(std::memory_order_acquire)) {
+                            return;
+                        }
+
+                        const int64_t is = next_slice.fetch_add(1, std::memory_order_relaxed);
+                        if (is >= n_slices) {
+                            return;
+                        }
+
+                        const float * f32_data_s = f32_quant_data ? (f32_quant_data + (size_t) is * slice_elems) : nullptr;
+                        const ggml_bf16_t * bf16_data_s = bf16_data ? (bf16_data + (size_t) is * slice_elems) : nullptr;
+                        void * new_data_s = (char *) new_data + (size_t) is * slice_bytes;
+                        const float * imatrix_s = imatrix ? (imatrix + (size_t) is * (size_t) n_per_row) : nullptr;
+
+                        try {
+                            const size_t slice_size = llama_tensor_quantize_impl(
+                                new_type, f32_data_s, bf16_data_s, tensor_scale,
+                                new_data_s, chunk_size, nrows, n_per_row, imatrix_s, local_workers, 1,
+                                (qa_ctx.file && new_type == GGML_TYPE_NVFP4) ? &qa_tensor : nullptr, tensor_meta->name);
+                            new_size_atomic.fetch_add(slice_size, std::memory_order_relaxed);
+                        } catch (const std::exception & e) {
+                            std::lock_guard<std::mutex> lock(err_mtx);
+                            if (!failed.exchange(true, std::memory_order_acq_rel)) {
+                                err_msg = e.what();
+                            }
+                            return;
+                        }
+                    }
+                };
+
+                std::vector<std::thread> slice_workers;
+                slice_workers.reserve((size_t) std::max(0, slice_threads - 1));
+                for (int t = 1; t < slice_threads; ++t) {
+                    slice_workers.emplace_back(run_slice, t);
+                }
+                run_slice(0);
+                for (auto & th : slice_workers) {
+                    th.join();
+                }
+
+                if (failed.load(std::memory_order_acquire)) {
+                    throw std::runtime_error(err_msg.empty() ? "parallel NVFP4 slice quantization failed" : err_msg);
+                }
+
+                new_size += new_size_atomic.load(std::memory_order_relaxed);
+            } else {
+                for (int64_t i04 = 0; i04 < ne3; ++i04) {
+                    for (int64_t i03 = 0; i03 < ne2; ++i03) {
+                        const int64_t is = i03 + ne2 * i04;
+
+                        const float * f32_data_s = f32_quant_data ? (f32_quant_data + (size_t) is * slice_elems) : nullptr;
+                        const ggml_bf16_t * bf16_data_s = bf16_data ? (bf16_data + (size_t) is * slice_elems) : nullptr;
+                        void * new_data_s = (char *) new_data + (size_t) is * slice_bytes;
+                        const float * imatrix_s = imatrix ? (imatrix + (size_t) is * (size_t) n_per_row) : nullptr;
+
+                        new_size += llama_tensor_quantize_impl(
+                            new_type, f32_data_s, bf16_data_s, tensor_scale,
+                            new_data_s, chunk_size, nrows, n_per_row, imatrix_s, workers, nthread_use,
+                            (qa_ctx.file && new_type == GGML_TYPE_NVFP4) ? &qa_tensor : nullptr, tensor_meta->name);
+                    }
+                }
+            }
+
+            const size_t src_nbytes = ggml_nbytes(tensor) + (is_merged_moe_gate_up ? ggml_nbytes(gate_tensor) : 0);
+            LLAMA_LOG_INFO("size = %8.2f MiB -> %8.2f MiB\n", src_nbytes/1024.0/1024.0, new_size/1024.0/1024.0);
+        }
+        total_size_org += ggml_nbytes(tensor) + (is_merged_moe_gate_up ? ggml_nbytes(gate_tensor) : 0);
+        total_size_new += new_size;
+
+        // update the gguf meta data as we go
+        gguf_set_tensor_type(ctx_outs[cur_split].get(), name.c_str(), new_type);
+        if (nvfp4_quantized) {
+            const std::string k1 = name + ".tensor_scale";
+
+            gguf_set_val_f32(ctx_outs[cur_split].get(), k1.c_str(), tensor_scale);
+        }
+
+        if (new_type != GGML_TYPE_NVFP4) {
             GGML_ASSERT(gguf_get_tensor_size(ctx_outs[cur_split].get(), gguf_find_tensor(ctx_outs[cur_split].get(), name.c_str())) == new_size);
-            gguf_set_tensor_data(ctx_outs[cur_split].get(), name.c_str(), new_data);
+        }
+        gguf_set_tensor_data(ctx_outs[cur_split].get(), name.c_str(), new_data);
 
-            // write tensor data + padding
+        if (!params->dry_run) {
             fout.write((const char *) new_data, new_size);
             zeros(fout, GGML_PAD(new_size, align) - new_size);
-        } // no --dry-run
+        }
     } // iterate over tensors
 
     if (!params->dry_run) {
@@ -1076,6 +2293,11 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     if (qs.n_fallback > 0) {
         LLAMA_LOG_WARN("%s: WARNING: %d of %d tensor(s) required fallback quantization\n",
                 __func__, qs.n_fallback, qs.n_k_quantized + qs.n_fallback);
+    }
+
+    if (qa_ctx.file) {
+        std::fclose(qa_ctx.file);
+        qa_ctx.file = nullptr;
     }
 }
 
@@ -1097,7 +2319,7 @@ llama_model_quantize_params llama_model_quantize_default_params() {
         /*.dry_run                     =*/ false,
         /*.imatrix                     =*/ nullptr,
         /*.kv_overrides                =*/ nullptr,
-        /*.tensor_type                 =*/ nullptr,
+        /*.tensor_types                =*/ nullptr,
         /*.prune_layers                =*/ nullptr
     };
 

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -33,10 +33,10 @@ llm_build_qwen3::llm_build_qwen3(const llama_model & model, const llm_graph_para
             ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
@@ -83,9 +83,9 @@ llm_build_qwen3::llm_build_qwen3(const llama_model & model, const llm_graph_para
         cb(cur, "ffn_norm", il);
 
         cur = build_ffn(cur,
-                model.layers[il].ffn_up,   NULL, NULL,
-                model.layers[il].ffn_gate, NULL, NULL,
-                model.layers[il].ffn_down, NULL, NULL,
+                model.layers[il].ffn_up,   NULL, model.layers[il].ffn_up_scale,
+                model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_scale,
+                model.layers[il].ffn_down, NULL, model.layers[il].ffn_down_scale,
                 NULL,
                 LLM_FFN_SILU, LLM_FFN_PAR, il);
         cb(cur, "ffn_out", il);

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -90,11 +90,11 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen35::build_qkvz(
     const int64_t n_seqs       = ubatch.n_seqs;
     const int64_t n_seq_tokens = ubatch.n_seq_tokens;
 
-    ggml_tensor * qkv_mixed = build_lora_mm(model.layers[il].wqkv, input);
+    ggml_tensor * qkv_mixed = build_lora_mm(model.layers[il].wqkv, input, model.layers[il].wqkv_scale);
     qkv_mixed = ggml_reshape_3d(ctx0, qkv_mixed, qkv_mixed->ne[0], n_seq_tokens, n_seqs);
     cb(qkv_mixed, "linear_attn_qkv_mixed", il);
 
-    ggml_tensor * z = build_lora_mm(model.layers[il].wqkv_gate, input);
+    ggml_tensor * z = build_lora_mm(model.layers[il].wqkv_gate, input, model.layers[il].wqkv_gate_scale);
     cb(z, "z", il);
 
     return { qkv_mixed, z };
@@ -123,7 +123,7 @@ ggml_tensor * llm_build_qwen35::build_layer_attn(
     // Order: joint QG projection, QG split, Q norm, KV projection, K norm, RoPE, attention
 
     // Qwen3Next uses a single Q projection that outputs query + gate
-    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur); // [ (n_embd_head * 2) * n_head, n_tokens ]
+    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur, model.layers[il].wq_scale); // [ (n_embd_head * 2) * n_head, n_tokens ]
     cb(Qcur_full, "Qcur_full", il);
 
     ggml_tensor * Qcur = ggml_view_3d(ctx0, Qcur_full, n_embd_head, n_head, n_tokens,
@@ -135,10 +135,10 @@ ggml_tensor * llm_build_qwen35::build_layer_attn(
     Qcur = build_norm(Qcur, model.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, il);
     cb(Qcur, "Qcur_normed", il);
 
-    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
     cb(Kcur, "Kcur", il);
 
-    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
     cb(Vcur, "Vcur", il);
 
     // Apply K normalization
@@ -186,7 +186,7 @@ ggml_tensor * llm_build_qwen35::build_layer_attn(
     cur = ggml_mul(ctx0, cur, gate_sigmoid);
     cb(cur, "attn_gated", il);
 
-    cur = build_lora_mm(model.layers[il].wo, cur);
+    cur = build_lora_mm(model.layers[il].wo, cur, model.layers[il].wo_scale);
     cb(cur, "attn_output", il);
 
     return cur;
@@ -217,13 +217,13 @@ ggml_tensor * llm_build_qwen35::build_layer_attn_linear(
     ggml_tensor * qkv_mixed = qkvz.first;
     ggml_tensor * z         = qkvz.second;
 
-    ggml_tensor * beta = build_lora_mm(model.layers[il].ssm_beta, cur);
+    ggml_tensor * beta = build_lora_mm(model.layers[il].ssm_beta, cur, model.layers[il].ssm_beta_scale);
     beta = ggml_reshape_4d(ctx0, beta, 1, num_v_heads, n_seq_tokens, n_seqs);
     cb(beta, "beta", il);
 
     beta = ggml_sigmoid(ctx0, beta);
 
-    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur);
+    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur, model.layers[il].ssm_alpha_scale);
     alpha = ggml_cont_3d(ctx0, alpha, num_v_heads, n_seq_tokens, n_seqs);
     cb(alpha, "alpha", il);
 
@@ -361,7 +361,7 @@ ggml_tensor * llm_build_qwen35::build_layer_attn_linear(
     cb(final_output, "final_output", il);
 
     // Output projection
-    cur = build_lora_mm(model.layers[il].ssm_out, final_output);
+    cur = build_lora_mm(model.layers[il].ssm_out, final_output, model.layers[il].ssm_out_scale);
     cb(cur, "linear_attn_out", il);
 
     // Reshape back to original dimensions
@@ -375,9 +375,9 @@ ggml_tensor * llm_build_qwen35::build_layer_ffn(ggml_tensor * cur, const int il)
     GGML_ASSERT(model.layers[il].ffn_gate_inp == nullptr);
 
     cur = build_ffn(cur,
-        model.layers[il].ffn_up, NULL, NULL,
-        model.layers[il].ffn_gate, NULL, NULL,
-        model.layers[il].ffn_down, NULL, NULL,
+        model.layers[il].ffn_up, NULL, model.layers[il].ffn_up_scale,
+        model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_scale,
+        model.layers[il].ffn_down, NULL, model.layers[il].ffn_down_scale,
         NULL,
         LLM_FFN_SILU, LLM_FFN_PAR, il);
     cb(cur, "ffn_out", il);

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -2,6 +2,141 @@
 
 #include "llama-memory-recurrent.h"
 
+namespace {
+
+static bool qwen35moe_has_nvfp4_expert_scales(const llama_layer & layer) {
+    return (layer.ffn_gate_up_exps != nullptr && layer.ffn_gate_up_exps->type == GGML_TYPE_NVFP4 && layer.ffn_gate_up_exps_scale != nullptr) ||
+           (layer.ffn_gate_exps    != nullptr && layer.ffn_gate_exps->type    == GGML_TYPE_NVFP4 && layer.ffn_gate_exps_scale    != nullptr) ||
+           (layer.ffn_up_exps      != nullptr && layer.ffn_up_exps->type      == GGML_TYPE_NVFP4 && layer.ffn_up_exps_scale      != nullptr) ||
+           (layer.ffn_down_exps    != nullptr && layer.ffn_down_exps->type    == GGML_TYPE_NVFP4 && layer.ffn_down_exps_scale    != nullptr);
+}
+
+static ggml_tensor * qwen35moe_build_moe_ffn_nvfp4_scaled(
+        llm_build_qwen35moe & gctx,
+        ggml_tensor *         cur,
+        const llama_layer &   layer,
+        const int             il) {
+    const int64_t n_embd   = cur->ne[0];
+    const int64_t n_tokens = cur->ne[1];
+
+    ggml_tensor * logits = gctx.build_lora_mm(layer.ffn_gate_inp, cur); // [n_expert, n_tokens]
+    gctx.cb(logits, "ffn_moe_logits", il);
+
+    ggml_tensor * probs = ggml_soft_max(gctx.ctx0, logits); // [n_expert, n_tokens]
+    gctx.cb(probs, "ffn_moe_probs", il);
+
+    ggml_tensor * selection_probs = probs;
+
+    if (gctx.hparams.n_expert_groups > 1 && n_tokens > 0) {
+        const int64_t n_exp_per_group = gctx.n_expert / gctx.hparams.n_expert_groups;
+
+        ggml_tensor * selection_groups = ggml_reshape_3d(gctx.ctx0, selection_probs, n_exp_per_group, gctx.hparams.n_expert_groups, n_tokens); // [n_exp_per_group, n_expert_groups, n_tokens]
+
+        ggml_tensor * group_scores = ggml_argsort_top_k(gctx.ctx0, selection_groups, 2); // [2, n_expert_groups, n_tokens]
+        group_scores = ggml_get_rows(gctx.ctx0, ggml_reshape_4d(gctx.ctx0, selection_groups, 1, selection_groups->ne[0], selection_groups->ne[1], selection_groups->ne[2]), group_scores); // [1, 2, n_expert_groups, n_tokens]
+
+        group_scores = ggml_sum_rows(gctx.ctx0, ggml_reshape_3d(gctx.ctx0, group_scores, group_scores->ne[1], group_scores->ne[2], group_scores->ne[3])); // [1, n_expert_groups, n_tokens]
+        group_scores = ggml_reshape_2d(gctx.ctx0, group_scores, group_scores->ne[1], group_scores->ne[2]); // [n_expert_groups, n_tokens]
+
+        ggml_tensor * expert_groups = ggml_argsort_top_k(gctx.ctx0, group_scores, gctx.hparams.n_group_used); // [n_group_used, n_tokens]
+        gctx.cb(expert_groups, "ffn_moe_group_topk", il);
+
+        selection_probs = ggml_get_rows(gctx.ctx0, selection_groups, expert_groups); // [n_exp_per_group, n_group_used, n_tokens]
+        selection_probs = ggml_set_rows(gctx.ctx0, ggml_fill(gctx.ctx0, selection_groups, -INFINITY), selection_probs, expert_groups); // [n_exp_per_group, n_expert_groups, n_tokens]
+        selection_probs = ggml_reshape_2d(gctx.ctx0, selection_probs, gctx.n_expert, n_tokens); // [n_expert, n_tokens]
+        gctx.cb(selection_probs, "ffn_moe_probs_masked", il);
+    }
+
+    ggml_tensor * selected_experts = ggml_argsort_top_k(gctx.ctx0, selection_probs, gctx.n_expert_used); // [n_expert_used, n_tokens]
+    gctx.cb(selected_experts->src[0], "ffn_moe_argsort", il);
+    gctx.cb(selected_experts, "ffn_moe_topk", il);
+
+    probs = ggml_reshape_3d(gctx.ctx0, probs, 1, gctx.n_expert, n_tokens);
+
+    ggml_tensor * weights = ggml_get_rows(gctx.ctx0, probs, selected_experts); // [1, n_expert_used, n_tokens]
+    gctx.cb(weights, "ffn_moe_weights", il);
+
+    weights = ggml_reshape_2d(gctx.ctx0, weights, gctx.n_expert_used, n_tokens);
+
+    ggml_tensor * weights_sum = ggml_sum_rows(gctx.ctx0, weights); // [1, n_tokens]
+    gctx.cb(weights_sum, "ffn_moe_weights_sum", il);
+
+    weights_sum = ggml_clamp(gctx.ctx0, weights_sum, 6.103515625e-5f, INFINITY);
+    gctx.cb(weights_sum, "ffn_moe_weights_sum_clamped", il);
+
+    weights = ggml_div(gctx.ctx0, weights, weights_sum); // [n_expert_used, n_tokens]
+    gctx.cb(weights, "ffn_moe_weights_norm", il);
+
+    weights = ggml_reshape_3d(gctx.ctx0, weights, 1, gctx.n_expert_used, n_tokens);
+
+    // build early so topk-moe can use it
+    ggml_build_forward_expand(gctx.gf, weights);
+
+    cur = ggml_reshape_3d(gctx.ctx0, cur, n_embd, 1, n_tokens);
+
+    ggml_tensor * up = nullptr;
+
+    if (layer.ffn_gate_up_exps) {
+        ggml_tensor * gate_up = gctx.build_lora_mm_id(layer.ffn_gate_up_exps, cur, selected_experts, layer.ffn_gate_up_exps_scale); // [n_ff*2, n_expert_used, n_tokens]
+        gctx.cb(gate_up, "ffn_moe_gate_up", il);
+
+        const int64_t n_ff = gate_up->ne[0] / 2;
+        cur = ggml_view_3d(gctx.ctx0, gate_up, n_ff, gate_up->ne[1], gate_up->ne[2], gate_up->nb[1], gate_up->nb[2], 0);
+        gctx.cb(cur, "ffn_moe_gate", il);
+        up  = ggml_view_3d(gctx.ctx0, gate_up, n_ff, gate_up->ne[1], gate_up->ne[2], gate_up->nb[1], gate_up->nb[2], n_ff * gate_up->nb[0]);
+        gctx.cb(up, "ffn_moe_up", il);
+    } else {
+        up = gctx.build_lora_mm_id(layer.ffn_up_exps, cur, selected_experts, layer.ffn_up_exps_scale); // [n_ff, n_expert_used, n_tokens]
+        gctx.cb(up, "ffn_moe_up", il);
+
+        if (layer.ffn_gate_exps) {
+            cur = gctx.build_lora_mm_id(layer.ffn_gate_exps, cur, selected_experts, layer.ffn_gate_exps_scale); // [n_ff, n_expert_used, n_tokens]
+            gctx.cb(cur, "ffn_moe_gate", il);
+        } else {
+            cur = up;
+        }
+    }
+
+    const bool has_gate = layer.ffn_gate_exps || layer.ffn_gate_up_exps;
+    if (has_gate) {
+        cur = ggml_swiglu_split(gctx.ctx0, cur, up);
+        gctx.cb(cur, "ffn_moe_swiglu", il);
+    } else {
+        cur = ggml_silu(gctx.ctx0, cur);
+        gctx.cb(cur, "ffn_moe_silu", il);
+    }
+
+    ggml_tensor * experts = gctx.build_lora_mm_id(layer.ffn_down_exps, cur, selected_experts, layer.ffn_down_exps_scale); // [n_embd, n_expert_used, n_tokens]
+    gctx.cb(experts, "ffn_moe_down", il);
+
+    experts = ggml_mul(gctx.ctx0, experts, weights);
+    gctx.cb(cur, "ffn_moe_weighted", il);
+
+    ggml_tensor * cur_experts[LLAMA_MAX_EXPERTS] = { nullptr };
+
+    GGML_ASSERT(gctx.n_expert_used > 0);
+
+    // Keep add-node count stable by using configured expert count here.
+    for (uint32_t i = 0; i < gctx.hparams.n_expert_used; ++i) {
+        cur_experts[i] = ggml_view_2d(gctx.ctx0, experts, n_embd, n_tokens, experts->nb[2], i*experts->nb[1]);
+        ggml_build_forward_expand(gctx.gf, cur_experts[i]);
+    }
+
+    ggml_tensor * moe_out = cur_experts[0];
+    for (uint32_t i = 1; i < gctx.hparams.n_expert_used; ++i) {
+        moe_out = ggml_add(gctx.ctx0, moe_out, cur_experts[i]);
+    }
+
+    if (gctx.hparams.n_expert_used == 1) {
+        moe_out = ggml_cont(gctx.ctx0, moe_out);
+    }
+
+    gctx.cb(moe_out, "ffn_moe_out", il);
+    return moe_out;
+}
+
+} // namespace
+
 llm_build_qwen35moe::llm_build_qwen35moe(const llama_model & model, const llm_graph_params & params) :
     llm_build_delta_net_base(params), model(model) {
     const int64_t n_embd_head = hparams.n_embd_head_v;
@@ -90,11 +225,11 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_qwen35moe::build_qkvz(
     const int64_t n_seqs       = ubatch.n_seqs;
     const int64_t n_seq_tokens = ubatch.n_seq_tokens;
 
-    ggml_tensor * qkv_mixed = build_lora_mm(model.layers[il].wqkv, input);
+    ggml_tensor * qkv_mixed = build_lora_mm(model.layers[il].wqkv, input, model.layers[il].wqkv_scale);
     qkv_mixed = ggml_reshape_3d(ctx0, qkv_mixed, qkv_mixed->ne[0], n_seq_tokens, n_seqs);
     cb(qkv_mixed, "linear_attn_qkv_mixed", il);
 
-    ggml_tensor * z = build_lora_mm(model.layers[il].wqkv_gate, input);
+    ggml_tensor * z = build_lora_mm(model.layers[il].wqkv_gate, input, model.layers[il].wqkv_gate_scale);
     cb(z, "z", il);
 
     return { qkv_mixed, z };
@@ -123,7 +258,7 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn(
     // Order: joint QG projection, QG split, Q norm, KV projection, K norm, RoPE, attention
 
     // Qwen3Next uses a single Q projection that outputs query + gate
-    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur); // [ (n_embd_head * 2) * n_head, n_tokens ]
+    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur, model.layers[il].wq_scale); // [ (n_embd_head * 2) * n_head, n_tokens ]
     cb(Qcur_full, "Qcur_full", il);
 
     ggml_tensor * Qcur = ggml_view_3d(ctx0, Qcur_full, n_embd_head, n_head, n_tokens,
@@ -135,10 +270,10 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn(
     Qcur = build_norm(Qcur, model.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, il);
     cb(Qcur, "Qcur_normed", il);
 
-    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
     cb(Kcur, "Kcur", il);
 
-    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
     cb(Vcur, "Vcur", il);
 
     // Apply K normalization
@@ -186,7 +321,7 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn(
     cur = ggml_mul(ctx0, cur, gate_sigmoid);
     cb(cur, "attn_gated", il);
 
-    cur = build_lora_mm(model.layers[il].wo, cur);
+    cur = build_lora_mm(model.layers[il].wo, cur, model.layers[il].wo_scale);
     cb(cur, "attn_output", il);
 
     return cur;
@@ -217,13 +352,13 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn_linear(
     ggml_tensor * qkv_mixed = qkvz.first;
     ggml_tensor * z         = qkvz.second;
 
-    ggml_tensor * beta = build_lora_mm(model.layers[il].ssm_beta, cur);
+    ggml_tensor * beta = build_lora_mm(model.layers[il].ssm_beta, cur, model.layers[il].ssm_beta_scale);
     beta = ggml_reshape_4d(ctx0, beta, 1, num_v_heads, n_seq_tokens, n_seqs);
     cb(beta, "beta", il);
 
     beta = ggml_sigmoid(ctx0, beta);
 
-    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur);
+    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur, model.layers[il].ssm_alpha_scale);
     alpha = ggml_cont_3d(ctx0, alpha, num_v_heads, n_seq_tokens, n_seqs);
     cb(alpha, "alpha", il);
 
@@ -361,7 +496,7 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn_linear(
     cb(final_output, "final_output", il);
 
     // Output projection
-    cur = build_lora_mm(model.layers[il].ssm_out, final_output);
+    cur = build_lora_mm(model.layers[il].ssm_out, final_output, model.layers[il].ssm_out_scale);
     cb(cur, "linear_attn_out", il);
 
     // Reshape back to original dimensions
@@ -374,14 +509,20 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_ffn(ggml_tensor * cur, const int
     // Check if this is an MoE layer
     GGML_ASSERT(model.layers[il].ffn_gate_inp != nullptr);
 
-    ggml_tensor * moe_out =
-        build_moe_ffn(cur,
-            model.layers[il].ffn_gate_inp, model.layers[il].ffn_up_exps,
-            model.layers[il].ffn_gate_exps, model.layers[il].ffn_down_exps,
-            nullptr,
-            n_expert, n_expert_used, LLM_FFN_SILU,
-            true, false, 0.0, LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX, il,
-            nullptr, model.layers[il].ffn_gate_up_exps);
+    const auto & layer = model.layers[il];
+    ggml_tensor * moe_out = nullptr;
+
+    if (qwen35moe_has_nvfp4_expert_scales(layer)) {
+        moe_out = qwen35moe_build_moe_ffn_nvfp4_scaled(*this, cur, layer, il);
+    } else {
+        moe_out = build_moe_ffn(cur,
+                layer.ffn_gate_inp, layer.ffn_up_exps,
+                layer.ffn_gate_exps, layer.ffn_down_exps,
+                nullptr,
+                n_expert, n_expert_used, LLM_FFN_SILU,
+                true, false, 0.0f, LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX, il,
+                nullptr, layer.ffn_gate_up_exps);
+    }
     cb(moe_out, "ffn_moe_out", il);
 
     // Add shared experts if present - following Qwen3Next reference implementation

--- a/src/models/qwen3moe.cpp
+++ b/src/models/qwen3moe.cpp
@@ -33,10 +33,10 @@ llm_build_qwen3moe::llm_build_qwen3moe(const llama_model & model, const llm_grap
             ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -122,10 +122,10 @@ ggml_tensor * llm_build_qwen3next::build_layer_attn(
                      Qcur_full->nb[1], Qcur_full->nb[2], Qcur_full->nb[3], n_embd_head * ggml_element_size(Qcur_full));
     cb(gate, "gate", il);
 
-    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
     cb(Kcur, "Kcur", il);
 
-    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
     cb(Vcur, "Vcur", il);
 
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
@@ -514,9 +514,9 @@ ggml_tensor * llm_build_qwen3next::build_layer_ffn(ggml_tensor * cur, const int 
     } else {
         // Dense FFN branch (not currently used I believe)
         cur = build_ffn(cur,
-            model.layers[il].ffn_up, NULL, NULL,
-            model.layers[il].ffn_gate, NULL, NULL,
-            model.layers[il].ffn_down, NULL, NULL,
+            model.layers[il].ffn_up, NULL, model.layers[il].ffn_up_scale,
+            model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_scale,
+            model.layers[il].ffn_down, NULL, model.layers[il].ffn_down_scale,
             NULL,
             LLM_FFN_SILU, LLM_FFN_PAR, il);
         cb(cur, "ffn_out", il);

--- a/src/models/qwen3vl-moe.cpp
+++ b/src/models/qwen3vl-moe.cpp
@@ -39,10 +39,10 @@ llm_build_qwen3vlmoe::llm_build_qwen3vlmoe(const llama_model & model, const llm_
             ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
@@ -137,4 +137,3 @@ llm_build_qwen3vlmoe::llm_build_qwen3vlmoe(const llama_model & model, const llm_
 
     ggml_build_forward_expand(gf, cur);
 }
-

--- a/src/models/qwen3vl.cpp
+++ b/src/models/qwen3vl.cpp
@@ -39,10 +39,10 @@ llm_build_qwen3vl::llm_build_qwen3vl(const llama_model & model, const llm_graph_
             ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
@@ -91,9 +91,9 @@ llm_build_qwen3vl::llm_build_qwen3vl(const llama_model & model, const llm_graph_
         cb(cur, "ffn_norm", il);
 
         cur = build_ffn(cur,
-                model.layers[il].ffn_up,   NULL, NULL,
-                model.layers[il].ffn_gate, NULL, NULL,
-                model.layers[il].ffn_down, NULL, NULL,
+                model.layers[il].ffn_up,   NULL, model.layers[il].ffn_up_scale,
+                model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_scale,
+                model.layers[il].ffn_down, NULL, model.layers[il].ffn_down_scale,
                 NULL,
                 LLM_FFN_SILU, LLM_FFN_PAR, il);
         cb(cur, "ffn_out", il);

--- a/src/models/rnd1.cpp
+++ b/src/models/rnd1.cpp
@@ -35,10 +35,10 @@ llm_build_rnd1::llm_build_rnd1(const llama_model & model, const llm_graph_params
             ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
             cb(Qcur, "Qcur", il);
 
-            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_scale);
             cb(Kcur, "Kcur", il);
 
-            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_scale);
             cb(Vcur, "Vcur", il);
 
             Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -28,6 +28,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "NVFP4",    LLAMA_FTYPE_MOSTLY_NVFP4,    " NVFP4",                             },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },
@@ -753,4 +754,3 @@ int main(int argc, char ** argv) {
 
     return 0;
 }
-


### PR DESCRIPTION
Very pleased to share my version of NVFP4 for llama.cpp.  This has been a big WIP starting since about October 2025 and this is the most recent update.  About 75% of this code has been AI generated under highly focused specific directions and I did the rest.  I did some recent edits in the last 24 hours to push this out fast so it will need more refactoring to be less 'bloaty'. 
This version uses a SoA block with a pack of 4 layout.
About 95% of development was done with Qwen3 only , and in the last week, Qwen3.5 as well, which is working well.
There is a separate CUDA version that I will post shortly.  All  CPU math ops was designed to be bit identical to CUDA fp4 native intrinsic ops 
I will also post a lot more details and testing in a follow up comment soon but wanted to share ASAP.  Have to run to work in 2 minutes but wanted to share ASAP since it's taken me so long to provide this to llama.cpp. A lot of testing has been done for CUDA and CPU :-)
I am hopeful we can combine this with the also excellent  implementation in #19769 for Metal and work on a combined super high performance CUDA/CUDA SM120/Metal/ CPU version combined.  It's very very fast on CPU and CUDA.
This version is quite a bit different but I believe properly handles all of the tensor scales, weight scales, kv scaling (when present), and kproj layers too.  It also has much lower error.  This is the fourth and final block layout design I've gone through that I've found best works with Sm120 Blackwell.
The CUDA version of this implementation uses NVFP4 for activations and the activation scales supplied by the model, and CPU is on Q8.  You can also convert most NVFP4 models from HF with the py script.  It was engineered to be platform agnostic but sometimes has needed edits as model arches change and new ones come out.
I have a side branch I was working on that will make compacted partial tensors out of the block packs, so only 1, 2, or 3 packs need to be filled and the rest ignored, so many tensor shapes can be used and it will not pad or waste VRAM or disk space.
There is a working llama quantizer that uses an auto-tuner to come up with multiple candidates of scales, and it will come up with the best quant parameters that makes many options and then refits itself to have the least error and this will reduce outliers, increase same topp, and lower pp and kld.  It is not perfect but I have tuned some models to be superior to ModelOpt.  Because of that complexity, it requires CUDA and is parallel thread and fully CUDA accelerated to make it go fast.    You can do it with the CPU version too for correctness and formality, but it is not worth the time and will take hours on a small model.  A 0.8B model takes a few minutes with imatrix.
I have a suite of 'test-nvfp4' tools that I will post in a different PR.  These decode nvfp4 from various files and formats, including GGUF, and show you the bytes and nibble order, scales, and weights directly and compare CPU=GPU and identify packs and lanes for use with optimizing on GPU.