### PR TITLE
server: preserve --logit-bias as default for API requests

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -405,10 +405,11 @@ task_params server_task::params_from_json_cmpl(
     }
 
     {
-        params.sampling.logit_bias.clear();
+        params.sampling.logit_bias = params_base.sampling.logit_bias;
 
         const auto & logit_bias = data.find("logit_bias");
         if (logit_bias != data.end() && logit_bias->is_array()) {
+            params.sampling.logit_bias.clear();
             const int n_vocab = llama_vocab_n_tokens(vocab);
             for (const auto & el : *logit_bias) {
                 // TODO: we may want to throw errors here, in case "el" is incorrect
@@ -436,6 +437,7 @@ task_params server_task::params_from_json_cmpl(
                 }
             }
         } else if (logit_bias != data.end() && logit_bias->is_object()) {
+            params.sampling.logit_bias.clear();
             const int n_vocab = llama_vocab_n_tokens(vocab);
             for (const auto & el : logit_bias->items()) {
                 float bias;


### PR DESCRIPTION
## Summary

The `--logit-bias` CLI flag is unconditionally cleared on every API request (`params.sampling.logit_bias.clear()`), making it ineffective as a server-level default.

Other sampling defaults like `ignore_eos` correctly fall back to `params_base` when the client omits them:
```cpp
params.sampling.ignore_eos = json_value(data, "ignore_eos", params_base.sampling.ignore_eos);
```

But `logit_bias` always starts empty regardless of the CLI flag.

## Fix

- Initialize `params.sampling.logit_bias` from `params_base` (the server defaults) instead of clearing it
- If the client provides `logit_bias` in the request body (array or object format), clear and use the client's value instead

This makes `--logit-bias` work as expected when running `llama-server` — the bias applies to all requests unless explicitly overridden per-request.

## Use case

When serving models that tend to generate premature EOS in specific contexts (e.g. tool-calling), a server-level `--logit-bias EOS_TOKEN-5` should apply as a default to all API requests without requiring client-side changes.