### PR TITLE
server : add --host-family to control HTTP bind address family

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2793,6 +2793,21 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_HOST"));
     add_opt(common_arg(
+        {"--host-family"}, "FAMILY",
+        string_format("address family for TCP listen sockets: ipv4, ipv6, or auto (default: auto)"),
+        [](common_params & params, const std::string & value) {
+            if (value == "ipv4") {
+                params.host_family = COMMON_HOST_FAMILY_AF_INET;
+            } else if (value == "ipv6") {
+                params.host_family = COMMON_HOST_FAMILY_AF_INET6;
+            } else if (value == "auto") {
+                params.host_family = COMMON_HOST_FAMILY_AF_UNSPEC;
+            } else {
+                throw std::invalid_argument(string_format("error: unknown value for --host-family: '%s'", value.c_str()));
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_HOST_FAMILY"));
+    add_opt(common_arg(
         {"--port"}, "PORT",
         string_format("port to listen (default: %d)", params.port),
         [](common_params & params, int value) {

--- a/common/common.h
+++ b/common/common.h
@@ -176,6 +176,12 @@ enum common_speculative_type {
     COMMON_SPECULATIVE_TYPE_COUNT          // number of types, unknown type
 };
 
+enum common_host_family {
+    COMMON_HOST_FAMILY_AF_UNSPEC,
+    COMMON_HOST_FAMILY_AF_INET,
+    COMMON_HOST_FAMILY_AF_INET6,
+};
+
 // sampling parameters
 struct common_params_sampling {
     uint32_t seed = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampler
@@ -525,10 +531,11 @@ struct common_params {
     int32_t n_ctx_checkpoints = 8;            // max number of context checkpoints per slot
     int32_t cache_ram_mib     = 8192;         // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
 
-    std::string hostname      = "127.0.0.1";
-    std::string public_path   = "";                                                                         // NOLINT
-    std::string api_prefix    = "";                                                                         // NOLINT
-    std::string chat_template = "";                                                                         // NOLINT
+    std::string hostname           = "127.0.0.1";
+    common_host_family host_family = COMMON_HOST_FAMILY_AF_UNSPEC;                                          // NOLINT
+    std::string public_path        = "";                                                                    // NOLINT
+    std::string api_prefix         = "";                                                                    // NOLINT
+    std::string chat_template      = "";                                                                    // NOLINT
     bool use_jinja = true;                                                                                  // NOLINT
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -187,6 +187,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-a, --alias STRING` | set model name aliases, comma-separated (to be used by API)<br/>(env: LLAMA_ARG_ALIAS) |
 | `--tags STRING` | set model tags, comma-separated (informational, not used for routing)<br/>(env: LLAMA_ARG_TAGS) |
 | `--host HOST` | ip address to listen, or bind to an UNIX socket if the address ends with .sock (default: 127.0.0.1)<br/>(env: LLAMA_ARG_HOST) |
+| `--host-family FAMILY` | address family for TCP listen sockets: ipv4, ipv6, or auto (default: auto)<br/>(env: LLAMA_ARG_HOST_FAMILY) |
 | `--port PORT` | port to listen (default: 8080)<br/>(env: LLAMA_ARG_PORT) |
 | `--path PATH` | path to serve static files from (default: )<br/>(env: LLAMA_ARG_STATIC_PATH) |
 | `--api-prefix PREFIX` | prefix path the server serves from, without the trailing slash (default: )<br/>(env: LLAMA_ARG_API_PREFIX) |

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -51,6 +51,7 @@ bool server_http_context::init(const common_params & params) {
     path_prefix = params.api_prefix;
     port = params.port;
     hostname = params.hostname;
+    host_family = params.host_family;
 
     auto & srv = pimpl->srv;
 
@@ -275,13 +276,27 @@ bool server_http_context::start() {
     bool is_sock = false;
     if (string_ends_with(std::string(hostname), ".sock")) {
         is_sock = true;
+        if (host_family != COMMON_HOST_FAMILY_AF_UNSPEC) {
+            LOG_WRN("%s: --host-family=ipv%s is ignored for UNIX sockets\n", __func__,
+                host_family == COMMON_HOST_FAMILY_AF_INET6 ? "6" : "4");
+        }
         LOG_INF("%s: setting address family to AF_UNIX\n", __func__);
         srv->set_address_family(AF_UNIX);
         // bind_to_port requires a second arg, any value other than 0 should
         // simply get ignored
         was_bound = srv->bind_to_port(hostname, 8080);
     } else {
-        LOG_INF("%s: binding port with default address family\n", __func__);
+        if (host_family == COMMON_HOST_FAMILY_AF_INET) {
+            LOG_INF("%s: setting address family to AF_INET\n", __func__);
+            srv->set_address_family(AF_INET);
+        } else if (host_family == COMMON_HOST_FAMILY_AF_INET6) {
+            LOG_INF("%s: setting address family to AF_INET6\n", __func__);
+            srv->set_address_family(AF_INET6);
+        } else {
+            LOG_INF("%s: setting address family to AF_UNSPEC\n", __func__);
+            srv->set_address_family(AF_UNSPEC);
+        }
+
         // bind HTTP listen port
         if (port == 0) {
             int bound_port = srv->bind_to_any_port(hostname);

--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -59,6 +59,7 @@ struct server_http_context {
 
     std::string path_prefix;
     std::string hostname;
+    int host_family;
     int port;
 
     server_http_context();

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -18,6 +18,14 @@ def test_server_start_simple():
     assert res.status_code == 200
 
 
+def test_server_start_with_host_family():
+    global server
+    server.server_host_family = "ipv4"
+    server.start()
+    res = server.make_request("GET", "/health")
+    assert res.status_code == 200
+
+
 def test_server_props():
     global server
     server.start()

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -47,6 +47,7 @@ class ServerProcess:
     debug: bool = False
     server_port: int = 8080
     server_host: str = "127.0.0.1"
+    server_host_family: str | None = None
     model_hf_repo: str | None = "ggml-org/models"
     model_hf_file: str | None = "tinyllamas/stories260K.gguf"
     model_alias: str = "tinyllama-2"
@@ -137,8 +138,10 @@ class ServerProcess:
             "--seed",
             self.seed,
         ]
+        if self.server_host_family:
+            server_args.extend(["--host-family", self.server_host_family])
         if self.offline:
-            server_args.append("--offline")
+            server_args.extend(["--offline"])
         if self.model_file:
             server_args.extend(["--model", self.model_file])
         if self.model_url:


### PR DESCRIPTION
Introduce a new server option, --host-family (ipv4 | ipv6 | auto), to avoid relying on OS-dependent default address-family behavior.
