### PR TITLE
ggml-blas: report memory when calling ggml_backend_blas_device_get_memory.

### DIFF
--- a/ggml/src/ggml-blas/ggml-blas.cpp
+++ b/ggml/src/ggml-blas/ggml-blas.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <cstring>
 
+#include <sys/sysinfo.h>
+
 #if defined(GGML_BLAS_USE_ACCELERATE)
 #   include <Accelerate/Accelerate.h>
 #elif defined(GGML_BLAS_USE_MKL)
@@ -338,11 +340,24 @@ static const char * ggml_backend_blas_device_get_description(ggml_backend_dev_t 
     GGML_UNUSED(dev);
 }
 
-static void ggml_backend_blas_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
-    // TODO
-    *free = 0;
-    *total = 0;
+static bool get_meminfo(size_t *total, size_t *free) {
+    struct sysinfo info;
+    if (sysinfo(&info) != 0) {
+        return false;
+    }
 
+    if (total) {
+        *total = info.totalram;
+    }
+    if (free) {
+        *free = info.freeram;
+    }
+
+    return true;
+}
+
+static void ggml_backend_blas_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
+    get_meminfo(total, free);
     GGML_UNUSED(dev);
 }
 

--- a/ggml/src/ggml-blas/ggml-blas.cpp
+++ b/ggml/src/ggml-blas/ggml-blas.cpp
@@ -20,6 +20,16 @@
 #   include <cblas.h>
 #endif
 
+#if defined(_WIN32)
+#    define WIN32_LEAN_AND_MEAN
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
+#else
+#    include <unistd.h>
+#endif
+
 struct ggml_backend_blas_context {
     int n_threads = GGML_DEFAULT_N_THREADS;
     std::unique_ptr<char[]> work_data;
@@ -341,6 +351,13 @@ static const char * ggml_backend_blas_device_get_description(ggml_backend_dev_t 
 }
 
 static bool get_meminfo(size_t *total, size_t *free) {
+#ifdef _WIN32
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    *total = status.ullTotalPhys;
+    *free = status.ullAvailPhys;
+#else
     struct sysinfo info;
     if (sysinfo(&info) != 0) {
         return false;
@@ -354,6 +371,7 @@ static bool get_meminfo(size_t *total, size_t *free) {
     }
 
     return true;
+#endif // _WIN32
 }
 
 static void ggml_backend_blas_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {


### PR DESCRIPTION
Implement memory information retrieval for ggml_backend_blas_device_get_memory. It uses sysinfo on linux, which I tested.

I copied the windows version from #18578. I have no desire to test it on windows and the implementation looks sane. I am also assuming the original author was more familiar with windows.

My reason for fixing this bug is to allow for light weight testing of code that requires querying the currently used memory of a device using BLAS on my laptop.