### PR TITLE
quantize : do not quantize patch_embd related tensors

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -837,6 +837,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
 
         // do not quantize specific multimodal tensors
         quantize &= name.find(".position_embd.") == std::string::npos;
+        quantize &= name.find(".patch_embd.") == std::string::npos;
 
         ggml_type new_type;
         void * new_data;


### PR DESCRIPTION
Fix the error that occurred during the quantization of the PaddleOCR-VL-1.5 model mmproj (`./build/bin/llama-quantize PaddleOCR-VL-1.5-GGUF-mmproj.gguf PaddleOCR-VL-1.5-GGUF-mmproj-Q4.gguf Q4_K_M`)

```
llama_model_quantize_impl : tensor cols 1152 x 4304 are not divisible by 256, required for q4_K - using fallback quantization q5_0
converting to q5_0 .. size =     9.46 MiB ->     3.25 MiB
[ 435/ 443]                     v.blk.9.ln1.bias - [  1152,      1,      1,      1], type =    f32, size =    0.004 MiB
[ 436/ 443]                   v.blk.9.ln1.weight - [  1152,      1,      1,      1], type =    f32, size =    0.004 MiB
[ 437/ 443]                     v.blk.9.ln2.bias - [  1152,      1,      1,      1], type =    f32, size =    0.004 MiB
[ 438/ 443]                   v.blk.9.ln2.weight - [  1152,      1,      1,      1], type =    f32, size =    0.004 MiB
[ 439/ 443]                    v.patch_embd.bias - [  1152,      1,      1,      1], type =    f32, size =    0.004 MiB
[ 440/ 443]                  v.patch_embd.weight - [    14,     14,      3,   1152], type =    f32,

llama_model_quantize_impl : tensor cols 14 x 14 are not divisible by 256, required for q4_K - using fallback quantization f16
converting to f16 .. size =     2.58 MiB ->     0.00 MiB
/data_nvme0n1/llm/llama.cpp/src/llama-quant.cpp:1054: GGML_ASSERT(gguf_get_tensor_size(ctx_outs[cur_split].get(), gguf_find_tensor(ctx_outs[cur_split].get(), name.c_str())) == new_size) failed

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Enable debuginfod for this session? (y or [n]) [answered N; input not from terminal]
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x000073a52d910813 in __GI___wait4 (pid=3328223, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
warning: 30     ../sysdeps/unix/sysv/linux/wait4.c: No such file or directory
#0  0x000073a52d910813 in __GI___wait4 (pid=3328223, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30      in ../sysdeps/unix/sysv/linux/wait4.c
#1  0x000073a52e350b9b in ggml_print_backtrace () from /data_nvme0n1/llm/llama.cpp/build/bin/libggml-base.so.0
#2  0x000073a52e350d32 in ggml_abort () from /data_nvme0n1/llm/llama.cpp/build/bin/libggml-base.so.0
#3  0x000073a52e1a23c7 in llama_model_quantize_impl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, llama_model_quantize_params const*) () from /data_nvme0n1/llm/llama.cpp/build/bin/libllama.so.0
#4  0x000073a52e1a2754 in llama_model_quantize () from /data_nvme0n1/llm/llama.cpp/build/bin/libllama.so.0
#5  0x000057028fb3d579 in main ()
[Inferior 1 (process 3317888) detached]
Aborted (core dumped)
```