### PR TITLE
add `"verbose": true` flag to completion requests to return `__verbose` field

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -255,7 +255,7 @@ task_params server_task::params_from_json_cmpl(
     defaults.antiprompt    = params_base.antiprompt;
 
     // enabling this will output extra debug information in the HTTP responses from the server
-    params.verbose           = params_base.verbosity > 9;
+    params.verbose           = params_base.verbosity > 9 || json_value(data, "verbose", false);
     params.timings_per_token = json_value(data, "timings_per_token", false);
 
     params.stream           = json_value(data,       "stream",             false);


### PR DESCRIPTION
Currently to get the `__verbose` field on a completion response, you'd have to use `llama-server --verbose`

How about add a flag to the request to opt-in to receive `__verbose` even if the server wasn't started with `--verbose`?

## Example

```sh
curl http://localhost:8013/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "max_tokens": 10,
    "messages": [
      {"role": "user", "content": "Hello!"}
    ],
    "verbose": true
  }' | jq
```

Now, if you attach `"verbose": true` to your request, you will get back the `__verbose` object when generating completions (both streaming and non-streaming).

## Questions

- Is the name ok? I am not attached to any particular name.
- Right now I use either-or logic, if you pass `--verbose` or `"verbose": true` then you get the `__verbose` field. Should setting `"verbose": false` result in disabling the `__verbose` field when the server is started with `llama-server --verbose`?