### PR TITLE
context: ignore zero scale LoRAs when checking sameness

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1039,16 +1039,24 @@ void llama_context::set_adapters_lora(llama_adapter_lora ** adapters, size_t n_a
 bool llama_context::adapters_lora_are_same(llama_adapter_lora ** adapters, size_t n_adapters, float * scales) {
     LLAMA_LOG_DEBUG("%s: adapters = %p\n", __func__, (void *) adapters);
 
-    if (n_adapters != loras->size()) {
-        return false;
-    }
+    // Adapters with a zero scale are never added to `loras`, so also ignore them for the comparison.
+    size_t n_non_zero = 0;
 
     for (size_t i = 0; i < n_adapters; i ++) {
+        if (scales[i] == 0.0f) {
+            continue;
+        }
+        n_non_zero++;
+
         auto it = loras->find(adapters[i]);
 
         if (it == loras->end() || it->second != scales[i]) {
             return false;
         }
+    }
+
+    if (n_non_zero != loras->size()) {
+        return false;
     }
 
     return true;


### PR DESCRIPTION
When passed a set of input LoRAs, `set_adapters_lora` never stores zero scale LoRAs in the `loras` field, but `adapters_lora_are_same` expects the number of inputs to be equal to the number of stored LoRAs. So there will always be a mismatch if zero scale adapters are passed repeatedly.

This causes a server started with `--lora-init-without-apply` to re-reserve the graph for every token when handling requests with `"lora": [{"id": 0, "scale": 0.0}]`.

Tested:

* Started a server with `llama-server --model tmp/ggml-org_stories15M_MOE_stories15M_MOE-F16.gguf --lora tmp/moe_shakespeare15M.gguf --lora-init-without-apply`
* Sent a chat request with `"lora": [{"id": 0, "scale": 0.0}]` via the Web UI
* Results without this patch: The server logs print `sched_reserve: reserving ...` for every token
* Results with this patch: The server prints `sched_reserve: reserving ...` just once (or not at all)

The server unit tests still pass, but I don't know how to add a test specifically for this bug (unless I want to rely on inference performance, which seems suboptimal).

Alternative fixes considered:

* Filter the list of adapters in `set_adapters_lora` before calling `adapters_lora_are_same`. However, that would require allocating even for the not-modified case, which it seemed better to avoid.
* Filter the list of adapters in the server code. However, this functionality is exposed via the public `llama_set_adapters_lora` API, so it seemed better to fix this for everyone.

AI Disclaimer: Claude Code was used to identify the problem after describing the symptoms. The patch was authored by a human (me).