### PR TITLE
Autoparser: add optional argument reshuffle capability

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -4,6 +4,7 @@
 #include "json-schema-to-grammar.h"
 #include "nlohmann/json.hpp"
 
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -302,8 +303,9 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
             params.at("required").get_to(required);
         }
 
-        // Build parser for each argument
-        std::vector<common_peg_parser> arg_parsers;
+        // Build parser for each argument, separating required and optional
+        std::vector<common_peg_parser> required_parsers;
+        std::vector<common_peg_parser> optional_parsers;
         for (const auto & [param_name, param_schema] : properties.items()) {
             bool        is_required = required.find(param_name) != required.end();
             std::string type        = "object";
@@ -328,20 +330,63 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
                                         p.space()) +
                 p.tool_arg_close(p.literal(arguments.value_suffix)));
 
+            auto named_arg = p.rule("tool-" + name + "-arg-" + param_name, arg);
             if (is_required) {
-                arg_parsers.push_back(p.rule("tool-" + name + "-arg-" + param_name, arg));
+                required_parsers.push_back(named_arg);
             } else {
-                arg_parsers.push_back(p.optional(p.rule("tool-" + name + "-arg-" + param_name, arg)));
+                optional_parsers.push_back(named_arg);
             }
         }
 
-        // Build arg sequence with space() between consecutive args
+        // Build required arg sequence in definition order
         common_peg_parser args_seq = p.eps();
-        for (size_t i = 0; i < arg_parsers.size(); i++) {
+        for (size_t i = 0; i < required_parsers.size(); i++) {
             if (i > 0) {
                 args_seq = args_seq + p.space();
             }
-            args_seq = args_seq + arg_parsers[i];
+            args_seq = args_seq + required_parsers[i];
+        }
+
+        // Build optional args with flexible ordering
+        if (!optional_parsers.empty()) {
+            if (optional_parsers.size() <= 4) {
+                // For up to 4 optional params, generate a recursive choice tree
+                // that allows any permutation without duplicates.
+                // Each level: choice(space+opt[i]+recurse(remaining-i) for each i, eps)
+                std::function<common_peg_parser(std::vector<size_t>)> build_opt_choices;
+                build_opt_choices = [&](std::vector<size_t> remaining) -> common_peg_parser {
+                    if (remaining.empty()) {
+                        return p.eps();
+                    }
+                    common_peg_parser choices = p.choice();
+                    for (size_t i = 0; i < remaining.size(); i++) {
+                        auto idx = remaining[i];
+                        std::vector<size_t> next;
+                        for (size_t j = 0; j < remaining.size(); j++) {
+                            if (j != i) {
+                                next.push_back(remaining[j]);
+                            }
+                        }
+                        choices |= p.space() + optional_parsers[idx] + build_opt_choices(next);
+                    }
+                    choices |= p.eps();
+                    return choices;
+                };
+                std::vector<size_t> all_indices(optional_parsers.size());
+                for (size_t i = 0; i < optional_parsers.size(); i++) {
+                    all_indices[i] = i;
+                }
+                args_seq = args_seq + build_opt_choices(all_indices);
+            } else {
+                // For 5+ optional params, use choice-of-any repeated up to N times.
+                // This may allow duplicate params as a trade-off for avoiding
+                // combinatorial explosion of permutations.
+                common_peg_parser any_opt = p.choice();
+                for (const auto & opt : optional_parsers) {
+                    any_opt |= opt;
+                }
+                args_seq = args_seq + p.repeat(p.space() + any_opt, 0, (int) optional_parsers.size());
+            }
         }
 
         // Build call_id parser based on position (if supported)

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -349,44 +349,11 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
         // Build optional args with flexible ordering
         if (!optional_parsers.empty()) {
-            if (optional_parsers.size() <= 4) {
-                // For up to 4 optional params, generate a recursive choice tree
-                // that allows any permutation without duplicates.
-                // Each level: choice(space+opt[i]+recurse(remaining-i) for each i, eps)
-                std::function<common_peg_parser(std::vector<size_t>)> build_opt_choices;
-                build_opt_choices = [&](std::vector<size_t> remaining) -> common_peg_parser {
-                    if (remaining.empty()) {
-                        return p.eps();
-                    }
-                    common_peg_parser choices = p.choice();
-                    for (size_t i = 0; i < remaining.size(); i++) {
-                        auto idx = remaining[i];
-                        std::vector<size_t> next;
-                        for (size_t j = 0; j < remaining.size(); j++) {
-                            if (j != i) {
-                                next.push_back(remaining[j]);
-                            }
-                        }
-                        choices |= p.space() + optional_parsers[idx] + build_opt_choices(next);
-                    }
-                    choices |= p.eps();
-                    return choices;
-                };
-                std::vector<size_t> all_indices(optional_parsers.size());
-                for (size_t i = 0; i < optional_parsers.size(); i++) {
-                    all_indices[i] = i;
-                }
-                args_seq = args_seq + build_opt_choices(all_indices);
-            } else {
-                // For 5+ optional params, use choice-of-any repeated up to N times.
-                // This may allow duplicate params as a trade-off for avoiding
-                // combinatorial explosion of permutations.
-                common_peg_parser any_opt = p.choice();
-                for (const auto & opt : optional_parsers) {
-                    any_opt |= opt;
-                }
-                args_seq = args_seq + p.repeat(p.space() + any_opt, 0, (int) optional_parsers.size());
+            common_peg_parser any_opt = p.choice();
+            for (const auto & opt : optional_parsers) {
+                any_opt |= opt;
             }
+            args_seq = args_seq + p.repeat(p.space() + any_opt, 0, (int) optional_parsers.size());
         }
 
         // Build call_id parser based on position (if supported)

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -4,7 +4,6 @@
 #include "json-schema-to-grammar.h"
 #include "nlohmann/json.hpp"
 
-#include <functional>
 #include <stdexcept>
 #include <string>
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -637,6 +637,41 @@ static common_chat_tool quoted_unquoted_tool{
 };
 
 
+static common_chat_tool tool_2req_4opt{
+    /* .name = */ "tool_2req_4opt",
+    /* .description = */ "Tool with 2 required and 4 optional params",
+    /* .parameters = */ R"({
+        "type": "object",
+        "properties": {
+            "req1": { "type": "string", "description": "Required string" },
+            "req2": { "type": "integer", "description": "Required int" },
+            "opt1": { "type": "string", "description": "Optional string 1" },
+            "opt2": { "type": "integer", "description": "Optional int 1" },
+            "opt3": { "type": "string", "description": "Optional string 2" },
+            "opt4": { "type": "integer", "description": "Optional int 2" }
+        },
+        "required": ["req1", "req2"]
+    })",
+};
+
+static common_chat_tool tool_2req_5opt{
+    /* .name = */ "tool_2req_5opt",
+    /* .description = */ "Tool with 2 required and 5 optional params",
+    /* .parameters = */ R"({
+        "type": "object",
+        "properties": {
+            "req1": { "type": "string", "description": "Required string" },
+            "req2": { "type": "integer", "description": "Required int" },
+            "opt1": { "type": "string", "description": "Optional string 1" },
+            "opt2": { "type": "integer", "description": "Optional int 1" },
+            "opt3": { "type": "string", "description": "Optional string 2" },
+            "opt4": { "type": "integer", "description": "Optional int 2" },
+            "opt5": { "type": "string", "description": "Optional string 3" }
+        },
+        "required": ["req1", "req2"]
+    })",
+};
+
 static std::vector<common_chat_tool> tools{ special_function_tool, special_function_tool_with_optional_param,
                                             python_tool, html_tool, todo_list };
 
@@ -1956,6 +1991,58 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         })
             .expect_tool_calls({
                 { "todo_list", "{\"todos\": [{\"item\": \"Check stuff\", \"selected\": false}, {\"item\": \"Prepare stuff\", \"selected\": true}]}", {} },
+            })
+            .run();
+
+        // Test flexible optional argument ordering (2 required + 4 optional, reversed optional order)
+        tst.test(
+               "<tool_call>\n"
+               "<function=tool_2req_4opt>\n"
+               "<parameter=req1>\nhello\n</parameter>\n"
+               "<parameter=req2>\n42\n</parameter>\n"
+               "<parameter=opt4>\n100\n</parameter>\n"
+               "<parameter=opt2>\n200\n</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ tool_2req_4opt })
+            .expect_tool_calls({
+                { "tool_2req_4opt", R"({"req1": "hello", "req2": 42, "opt4": 100, "opt2": 200})", {} },
+            })
+            .run();
+
+        // Test flexible optional argument ordering (2 required + 5 optional, reversed optional order)
+        tst.test(
+               "<tool_call>\n"
+               "<function=tool_2req_5opt>\n"
+               "<parameter=req1>\nworld\n</parameter>\n"
+               "<parameter=req2>\n7\n</parameter>\n"
+               "<parameter=opt5>\nlast\n</parameter>\n"
+               "<parameter=opt3>\nmiddle\n</parameter>\n"
+               "<parameter=opt1>\nfirst\n</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ tool_2req_5opt })
+            .expect_tool_calls({
+                { "tool_2req_5opt", R"({"req1": "world", "req2": 7, "opt5": "last", "opt3": "middle", "opt1": "first"})", {} },
+            })
+            .run();
+
+        // Test flexible optional argument ordering (2 required + 5 optional, all 5 in shuffled order)
+        tst.test(
+               "<tool_call>\n"
+               "<function=tool_2req_5opt>\n"
+               "<parameter=req1>\ntest\n</parameter>\n"
+               "<parameter=req2>\n99\n</parameter>\n"
+               "<parameter=opt3>\nc\n</parameter>\n"
+               "<parameter=opt1>\na\n</parameter>\n"
+               "<parameter=opt5>\ne\n</parameter>\n"
+               "<parameter=opt4>\n4\n</parameter>\n"
+               "<parameter=opt2>\n2\n</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ tool_2req_5opt })
+            .expect_tool_calls({
+                { "tool_2req_5opt", R"({"req1": "test", "req2": 99, "opt3": "c", "opt1": "a", "opt5": "e", "opt4": 4, "opt2": 2})", {} },
             })
             .run();
     }


### PR DESCRIPTION
Requires #18675 

Some of the models that use tagged parsers (i.e. those that use quasi-XML tags for the arguments and their values) prefer a certain argument order with certain common tools. However, currently the grammar enforces the order in which the arguments are declared. If the tool tries to fill one optional argument first, it will be unable due to the grammar constraint to fill the other argument.

This manifests most often in failed calls to `read_file` tools which have an optional `limit` and `offset` parameter.

Fixes #20164 
