### PR TITLE
tools: Implement --output flag on cli to save response

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2704,7 +2704,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.out_file = value;
         }
     ).set_examples({LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_CVECTOR_GENERATOR, LLAMA_EXAMPLE_EXPORT_LORA, LLAMA_EXAMPLE_TTS, LLAMA_EXAMPLE_FINETUNE,
-                    LLAMA_EXAMPLE_RESULTS, LLAMA_EXAMPLE_EXPORT_GRAPH_OPS}));
+                    LLAMA_EXAMPLE_RESULTS, LLAMA_EXAMPLE_EXPORT_GRAPH_OPS, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
         {"-ofreq", "--output-frequency"}, "N",
         string_format("output the imatrix every N iterations (default: %d)", params.n_out_freq),

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -38,6 +38,7 @@
 | `--perf, --no-perf` | whether to enable internal libllama performance timings (default: false)<br/>(env: LLAMA_ARG_PERF) |
 | `-f, --file FNAME` | a file containing the prompt (default: none) |
 | `-bf, --binary-file FNAME` | binary file containing the prompt (default: none) |
+| `-o, --output FNAME` | output file to save the conversation (default: none) |
 | `-e, --escape, --no-escape` | whether to process escapes sequences (\n, \r, \t, \', \", \\) (default: true) |
 | `--rope-scaling {none,linear,yarn}` | RoPE frequency scaling method, defaults to linear unless specified by the model<br/>(env: LLAMA_ARG_ROPE_SCALING_TYPE) |
 | `--rope-scale N` | RoPE context scaling factor, expands context by a factor of N<br/>(env: LLAMA_ARG_ROPE_SCALE) |

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -127,10 +127,8 @@ struct cli_context {
             console::set_display(DISPLAY_TYPE_RESET);
         }
 
-        append_file_out(
-            "[Prompt]: " + messages.back()["content"].get<std::string>() + "\n\n",
-            chat_params.prompt
-        );
+        append_file_out("[Prompt]: " + messages.back()["content"].get<std::string>() + "\n\n", false);
+        append_file_out(chat_params.prompt, true);
 
         // wait for first result
         console::spinner::start();
@@ -162,24 +160,27 @@ struct cli_context {
                         if (is_thinking) {
                             console::log("\n[End thinking]\n\n");
                             console::set_display(DISPLAY_TYPE_RESET);
-                            append_file_out("\n\n", "</think>");
+                            append_file_out("\n\n", false);
+                            append_file_out("</think>", true);
                             is_thinking = false;
                         }
                         curr_content += diff.content_delta;
                         console::log("%s", diff.content_delta.c_str());
                         console::flush();
                         if (!content_started) {
-                            append_file_out("[Assistant]: ", "");
+                            append_file_out("[Assistant]: ", false);
                             content_started = true;
                         }
-                        append_file_out(diff.content_delta);
+                        append_file_out(diff.content_delta, false);
+                        append_file_out(diff.content_delta, true);
                     }
                     if (!diff.reasoning_content_delta.empty()) {
                         console::set_display(DISPLAY_TYPE_REASONING);
                         std::string reasoning_delta = diff.reasoning_content_delta;
                         if (!is_thinking) {
                             console::log("[Start thinking]\n");
-                            append_file_out("[Thinking]: ", "<think>");
+                            append_file_out("[Thinking]: ", false);
+                            append_file_out("<think>", true);
                             if (reasoning_delta == "<think>") {
                                 reasoning_delta = "";
                             }
@@ -187,14 +188,15 @@ struct cli_context {
                         is_thinking = true;
                         console::log("%s", reasoning_delta.c_str());
                         console::flush();
-                        append_file_out(reasoning_delta);
+                        append_file_out(reasoning_delta, false);
+                        append_file_out(reasoning_delta, true);
                     }
                 }
             }
             auto res_final = dynamic_cast<server_task_result_cmpl_final *>(result.get());
             if (res_final) {
                 out_timings = std::move(res_final->timings);
-                append_file_out("\n\n", "");
+                append_file_out("\n\n", false);
                 break;
             }
             result = rd.next(should_stop);
@@ -221,13 +223,11 @@ struct cli_context {
         }
     }
 
-    void append_file_out(const std::string & content, const std::optional<std::string> & special_content = std::nullopt) {
+    void append_file_out(const std::string & content, bool is_special_tokens = false) {
         if (!file_out.has_value()) {
             return;
         }
-        if (defaults.special_characters && special_content.has_value()) {
-            file_out.value() << special_content.value();
-        } else {
+        if ((defaults.special_characters && is_special_tokens) || (!defaults.special_characters && !is_special_tokens)) {
             file_out.value() << content;
         }
         file_out.value().flush();

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <thread>
 #include <signal.h>
 
@@ -59,6 +60,7 @@ struct cli_context {
     std::vector<raw_buffer> input_files;
     task_params defaults;
     bool verbose_prompt;
+    std::optional<std::ofstream> file_out = std::nullopt;
 
     // thread for showing "loading" animation
     std::atomic<bool> loading_show;
@@ -75,6 +77,7 @@ struct cli_context {
         // defaults.return_progress = true; // TODO: show progress
 
         verbose_prompt = params.verbose_prompt;
+        defaults.special_characters = params.special;
     }
 
     std::string generate_completion(result_timings & out_timings) {
@@ -124,6 +127,11 @@ struct cli_context {
             console::set_display(DISPLAY_TYPE_RESET);
         }
 
+        append_file_out(
+            "[Prompt]: " + messages.back()["content"].get<std::string>() + "\n\n",
+            chat_params.prompt
+        );
+
         // wait for first result
         console::spinner::start();
         server_task_result_ptr result = rd.next(should_stop);
@@ -131,6 +139,7 @@ struct cli_context {
         console::spinner::stop();
         std::string curr_content;
         bool is_thinking = false;
+        bool content_started = false;
 
         while (result) {
             if (should_stop()) {
@@ -153,26 +162,39 @@ struct cli_context {
                         if (is_thinking) {
                             console::log("\n[End thinking]\n\n");
                             console::set_display(DISPLAY_TYPE_RESET);
+                            append_file_out("\n\n", "</think>");
                             is_thinking = false;
                         }
                         curr_content += diff.content_delta;
                         console::log("%s", diff.content_delta.c_str());
                         console::flush();
+                        if (!content_started) {
+                            append_file_out("[Assistant]: ", "");
+                            content_started = true;
+                        }
+                        append_file_out(diff.content_delta);
                     }
                     if (!diff.reasoning_content_delta.empty()) {
                         console::set_display(DISPLAY_TYPE_REASONING);
+                        std::string reasoning_delta = diff.reasoning_content_delta;
                         if (!is_thinking) {
                             console::log("[Start thinking]\n");
+                            append_file_out("[Thinking]: ", "<think>");
+                            if (reasoning_delta == "<think>") {
+                                reasoning_delta = "";
+                            }
                         }
                         is_thinking = true;
-                        console::log("%s", diff.reasoning_content_delta.c_str());
+                        console::log("%s", reasoning_delta.c_str());
                         console::flush();
+                        append_file_out(reasoning_delta);
                     }
                 }
             }
             auto res_final = dynamic_cast<server_task_result_cmpl_final *>(result.get());
             if (res_final) {
                 out_timings = std::move(res_final->timings);
+                append_file_out("\n\n", "");
                 break;
             }
             result = rd.next(should_stop);
@@ -197,6 +219,18 @@ struct cli_context {
             std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
             return content;
         }
+    }
+
+    void append_file_out(const std::string & content, const std::optional<std::string> & special_content = std::nullopt) {
+        if (!file_out.has_value()) {
+            return;
+        }
+        if (defaults.special_characters && special_content.has_value()) {
+            file_out.value() << special_content.value();
+        } else {
+            file_out.value() << content;
+        }
+        file_out.value().flush();
     }
 
     common_chat_params format_chat() {
@@ -368,6 +402,16 @@ int main(int argc, char ** argv) {
     // TODO: avoid using atexit() here by making `console` a singleton
     console::init(params.simple_io, params.use_color);
     atexit([]() { console::cleanup(); });
+
+    // open output file early to fail fast
+    if (!params.out_file.empty()) {
+        ctx_cli.file_out.emplace(params.out_file, std::ios::binary);
+
+        if (!ctx_cli.file_out.has_value() || !ctx_cli.file_out->is_open()) {
+            console::error("Failed to open output file '%s'\n", params.out_file.c_str());
+            return 1;
+        }
+    }
 
     console::set_display(DISPLAY_TYPE_RESET);
     console::set_completion_callback(auto_completion_callback);

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -52,6 +52,7 @@ struct task_params {
     bool cache_prompt    = true; // remember the prompt to avoid reprocessing all prompt
     bool return_tokens   = false;
     bool return_progress = false;
+    bool special_characters = false;
 
     int32_t n_keep    =  0; // number of tokens to keep from initial prompt
     int32_t n_discard =  0; // number of tokens after n_keep that may be discarded when shifting context, 0 defaults to half


### PR DESCRIPTION
Adjustments to the llama-cli to support the --output flag. When the flag is specified the output will be written to a file as well as to the screen. When specified in conjunction with --special the raw output will be written.