### PR TITLE
chore: Use const references in range-based for loops 

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1365,7 +1365,7 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
     }
 
     params.extra_context = common_chat_extra_context();
-    for (auto el : inputs.chat_template_kwargs) {
+    for (const auto & el : inputs.chat_template_kwargs) {
         params.extra_context[el.first] = json::parse(el.second);
     }
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -598,7 +598,7 @@ struct llm_graph_params {
             return false;
         }
 
-        if (samplers.size() > 0) {
+        if (!samplers.empty()) {
             if (!ubatch.data || !other.ubatch.data) {
                 return false;
             }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -8004,7 +8004,7 @@ void llama_model::print_info() const {
             LLAMA_LOG_INFO("%s: n_cls_out             = %u\n", __func__, hparams.n_cls_out);
 
             size_t i = 0;
-            for (auto label : classifier_labels) {
+            for (const auto & label : classifier_labels) {
                 LLAMA_LOG_INFO("%s: cls_label[%2zu]         = %s\n", __func__, i++, label.c_str());
             }
         }
@@ -8284,7 +8284,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             /* n_seq_max         */ cparams.n_seq_max,
                             /* offload           */ cparams.offload_kqv,
                             /* unified           */ cparams.kv_unified,
-                            /* filter_attn       */ std::move(filter_attn),
+                            /* filter_attn       */ filter_attn,
                             /* filter_recr       */ std::move(filter_recr));
                     } else {
                         res = new llama_memory_hybrid(
@@ -8302,7 +8302,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             /* n_seq_max         */ cparams.n_seq_max,
                             /* offload           */ cparams.offload_kqv,
                             /* unified           */ cparams.kv_unified,
-                            /* filter_attn       */ std::move(filter_attn),
+                            /* filter_attn       */ filter_attn,
                             /* filter_recr       */ std::move(filter_recr));
                     }
                 } else {


### PR DESCRIPTION
Use const references in range-based for loops  and improve condition checks


