### PR TITLE
Add --tool-args-object to serve tool call arguments as objects, revert to OpenAI compatible mode by default (return as strings)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3092,6 +3092,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
     add_opt(common_arg(
+        {"-tac", "--tool-args-compat"},
+        {"--no-tool-args-compat"},
+        "return tool call arguments as JSON strings instead of JSON objects (default: disabled)",
+        [](common_params & params, bool value) {
+            params.tool_args_compat = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TOOL_ARGS_COMPAT"));
+    add_opt(common_arg(
         {"-sps", "--slot-prompt-similarity"}, "SIMILARITY",
         string_format("how much the prompt of a request must match the prompt of a slot in order to use that slot (default: %.2f, 0.0 = disabled)\n", params.slot_prompt_similarity),
         [](common_params & params, const std::string & value) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3092,13 +3092,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
     add_opt(common_arg(
-        {"-tac", "--tool-args-compat"},
-        {"--no-tool-args-compat"},
-        "return tool call arguments as JSON strings instead of JSON objects (default: disabled)",
+        {"-tao", "--tool-args-object"},
+        {"--no-tool-args-object"},
+        "return tool call arguments as objects instead of JSON strings (default: disabled)",
         [](common_params & params, bool value) {
-            params.tool_args_compat = value;
+            params.tool_args_object = value;
         }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TOOL_ARGS_COMPAT"));
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TOOL_ARGS_OBJECT"));
     add_opt(common_arg(
         {"-sps", "--slot-prompt-similarity"}, "SIMILARITY",
         string_format("how much the prompt of a request must match the prompt of a slot in order to use that slot (default: %.2f, 0.0 = disabled)\n", params.slot_prompt_similarity),

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -66,7 +66,7 @@ static bool has_content_or_tool_calls(const common_chat_msg & msg) {
     return !msg.content.empty() || !msg.tool_calls.empty();
 }
 
-json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
+json common_chat_msg::to_json_oaicompat(bool concat_typed_text, bool tool_args_as_string) const {
     if (!content.empty() && !content_parts.empty()) {
         throw std::runtime_error("Cannot specify both content and content_parts");
     }
@@ -129,7 +129,7 @@ json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
                 {"type", "function"},
                 {"function", {
                     {"name", tool_call.name},
-                    {"arguments", json::parse(tool_call.arguments)},
+                    {"arguments", tool_args_as_string ? json(tool_call.arguments) : json::parse(tool_call.arguments)},
                 }},
             };
             if (!tool_call.id.empty()) {

--- a/common/chat.h
+++ b/common/chat.h
@@ -121,7 +121,7 @@ struct common_chat_msg {
     std::string                               tool_name;
     std::string                               tool_call_id;
 
-    nlohmann::ordered_json to_json_oaicompat(bool concat_typed_text = false) const;
+    nlohmann::ordered_json to_json_oaicompat(bool concat_typed_text = false, bool tool_args_as_string = false) const;
 
     bool empty() const {
         return content.empty() && content_parts.empty() && tool_calls.empty() && reasoning_content.empty() &&

--- a/common/common.h
+++ b/common/common.h
@@ -535,6 +535,7 @@ struct common_params {
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
     int reasoning_budget = -1;
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
+    bool tool_args_compat = false; // if true, tool call arguments are returned as JSON strings (OpenAI-standard)
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
 
     std::vector<std::string> api_keys;

--- a/common/common.h
+++ b/common/common.h
@@ -535,7 +535,7 @@ struct common_params {
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
     int reasoning_budget = -1;
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
-    bool tool_args_compat = false; // if true, tool call arguments are returned as JSON strings (OpenAI-standard)
+    bool tool_args_object = false; // if true, tool call arguments are returned as JSON objects instead of strings
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
 
     std::vector<std::string> api_keys;

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1284,15 +1284,15 @@ static void test_peg_parser(common_chat_templates *                      tmpls,
 // Global template filter for --template flag
 static std::string g_template_filter;
 
-// Global flag for tool args compat mode (--tool-args-compat / -tac)
-static bool g_tool_args_compat = false;
+// Global flag for tool args compat mode (--tool-args-object / -tao)
+static bool g_tool_args_object = false;
 
-// Helper: convert a single message to OAI-compat JSON, respecting g_tool_args_compat
+// Helper: convert a single message to OAI-compat JSON, respecting g_tool_args_object
 static json msg_to_json_oaicompat(const common_chat_msg & msg) {
-    return msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ g_tool_args_compat);
+    return msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ !g_tool_args_object);
 }
 
-// Helper: convert a vector of messages to OAI-compat JSON array, respecting g_tool_args_compat
+// Helper: convert a vector of messages to OAI-compat JSON array, respecting g_tool_args_object
 static json msgs_to_json_oaicompat(const std::vector<common_chat_msg> & msgs) {
     json result = json::array();
     for (const auto & msg : msgs) {
@@ -1442,7 +1442,7 @@ static void test_msgs_oaicompat_json_conversion() {
                   msgs_to_json_oaicompat({ message_user_parts }).dump(2));
 
     // Note: content is "" instead of null due to workaround for templates that render null as "None"
-    std::string expected_python_args = g_tool_args_compat
+    std::string expected_python_args = !g_tool_args_object
         ? "          \"arguments\": \"{\\\"code\\\":\\\"print('hey')\\\"}\"\n"
         : "          \"arguments\": {\n"
           "            \"code\": \"print('hey')\"\n"
@@ -3062,8 +3062,8 @@ int main(int argc, char ** argv) {
         } else if (arg == "--detailed") {
             detailed_debug = true;
             common_log_set_verbosity_thold(999);
-        } else if (arg == "--tool-args-compat" || arg == "-tac") {
-            g_tool_args_compat = true;
+        } else if (arg == "--tool-args-object" || arg == "-tao") {
+            g_tool_args_object = true;
         } else {
             n_unrecognized_args++;
         }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1284,6 +1284,23 @@ static void test_peg_parser(common_chat_templates *                      tmpls,
 // Global template filter for --template flag
 static std::string g_template_filter;
 
+// Global flag for tool args compat mode (--tool-args-compat / -tac)
+static bool g_tool_args_compat = false;
+
+// Helper: convert a single message to OAI-compat JSON, respecting g_tool_args_compat
+static json msg_to_json_oaicompat(const common_chat_msg & msg) {
+    return msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ g_tool_args_compat);
+}
+
+// Helper: convert a vector of messages to OAI-compat JSON array, respecting g_tool_args_compat
+static json msgs_to_json_oaicompat(const std::vector<common_chat_msg> & msgs) {
+    json result = json::array();
+    for (const auto & msg : msgs) {
+        result.push_back(msg_to_json_oaicompat(msg));
+    }
+    return result;
+}
+
 // Fluent builder for PEG parser tests
 class peg_test_builder;
 
@@ -1401,7 +1418,7 @@ static void test_msgs_oaicompat_json_conversion() {
         message_assist_call_python,
     };
     for (const auto & msg : msgs) {
-        auto oai_json = common_chat_msgs_to_json_oaicompat({ msg });
+        auto oai_json = msgs_to_json_oaicompat({ msg });
         auto msgs2    = common_chat_msgs_parse_oaicompat(oai_json);
         assert_equals((size_t) 1, msgs2.size());
         const auto & msg2 = msgs2[0];
@@ -1422,9 +1439,14 @@ static void test_msgs_oaicompat_json_conversion() {
                               "    ]\n"
                               "  }\n"
                               "]"),
-                  common_chat_msgs_to_json_oaicompat({ message_user_parts }).dump(2));
+                  msgs_to_json_oaicompat({ message_user_parts }).dump(2));
 
     // Note: content is "" instead of null due to workaround for templates that render null as "None"
+    std::string expected_python_args = g_tool_args_compat
+        ? "          \"arguments\": \"{\\\"code\\\":\\\"print('hey')\\\"}\"\n"
+        : "          \"arguments\": {\n"
+          "            \"code\": \"print('hey')\"\n"
+          "          }\n";
     assert_equals(std::string("[\n"
                               "  {\n"
                               "    \"role\": \"assistant\",\n"
@@ -1434,15 +1456,13 @@ static void test_msgs_oaicompat_json_conversion() {
                               "        \"type\": \"function\",\n"
                               "        \"function\": {\n"
                               "          \"name\": \"python\",\n"
-                              "          \"arguments\": {\n"
-                              "            \"code\": \"print('hey')\"\n"
-                              "          }\n"
+                              + expected_python_args +
                               "        }\n"
                               "      }\n"
                               "    ]\n"
                               "  }\n"
                               "]"),
-                  common_chat_msgs_to_json_oaicompat({ message_assist_call_python }).dump(2));
+                  msgs_to_json_oaicompat({ message_assist_call_python }).dump(2));
 
     auto res = common_chat_msgs_parse_oaicompat(json::parse("[{\"role\": \"assistant\", \"tool_calls\": []}]"));
     assert_equals<size_t>(1, res.size());
@@ -3031,17 +3051,21 @@ int main(int argc, char ** argv) {
     bool detailed_debug    = false;
     bool only_run_filtered = false;
 
-    // Check for --template flag
+    // Check for flags
+    int n_unrecognized_args = 0;
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
         if (arg == "--template" && i + 1 < argc) {
             g_template_filter = argv[++i];
             // Only run PEG parser tests with the filter
             only_run_filtered = true;
-        }
-        if (arg == "--detailed") {
+        } else if (arg == "--detailed") {
             detailed_debug = true;
             common_log_set_verbosity_thold(999);
+        } else if (arg == "--tool-args-compat" || arg == "-tac") {
+            g_tool_args_compat = true;
+        } else {
+            n_unrecognized_args++;
         }
     }
 
@@ -3052,7 +3076,7 @@ int main(int argc, char ** argv) {
     }
 
 #ifndef _WIN32
-    if (argc > 1) {
+    if (n_unrecognized_args > 0) {
         common_chat_templates_inputs inputs;
         common_chat_msg              msg;
         msg.role        = "user";

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1473,6 +1473,7 @@ private:
         res->post_sampling_probs = slot.task->params.post_sampling_probs;
 
         res->verbose           = slot.task->params.verbose;
+        res->tool_args_compat  = slot.task->params.tool_args_compat;
         res->stream            = slot.task->params.stream;
         res->include_usage     = slot.task->params.include_usage;
         res->res_type          = slot.task->params.res_type;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1473,7 +1473,7 @@ private:
         res->post_sampling_probs = slot.task->params.post_sampling_probs;
 
         res->verbose           = slot.task->params.verbose;
-        res->tool_args_compat  = slot.task->params.tool_args_compat;
+        res->tool_args_object  = slot.task->params.tool_args_object;
         res->stream            = slot.task->params.stream;
         res->include_usage     = slot.task->params.include_usage;
         res->res_type          = slot.task->params.res_type;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -254,7 +254,7 @@ task_params server_task::params_from_json_cmpl(
 
     // enabling this will output extra debug information in the HTTP responses from the server
     params.verbose           = params_base.verbosity > 9;
-    params.tool_args_compat  = params_base.tool_args_compat;
+    params.tool_args_object  = params_base.tool_args_object;
     params.timings_per_token = json_value(data, "timings_per_token", false);
 
     params.stream           = json_value(data,       "stream",             false);
@@ -779,7 +779,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat() {
     json choice {
         {"finish_reason", finish_reason},
         {"index", index},
-        {"message", msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ tool_args_compat)},
+        {"message", msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ !tool_args_object)},
     };
 
     if (!stream && probs_output.size() > 0) {

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -254,6 +254,7 @@ task_params server_task::params_from_json_cmpl(
 
     // enabling this will output extra debug information in the HTTP responses from the server
     params.verbose           = params_base.verbosity > 9;
+    params.tool_args_compat  = params_base.tool_args_compat;
     params.timings_per_token = json_value(data, "timings_per_token", false);
 
     params.stream           = json_value(data,       "stream",             false);
@@ -778,7 +779,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat() {
     json choice {
         {"finish_reason", finish_reason},
         {"index", index},
-        {"message", msg.to_json_oaicompat()},
+        {"message", msg.to_json_oaicompat(/* concat_typed_text= */ false, /* tool_args_as_string= */ tool_args_compat)},
     };
 
     if (!stream && probs_output.size() > 0) {

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -76,7 +76,7 @@ struct task_params {
 
     // response formatting
     bool               verbose          = false;
-    bool               tool_args_compat = false;
+    bool               tool_args_object = false;
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
@@ -358,7 +358,7 @@ struct server_task_result_cmpl_final : server_task_result {
 
     // response formatting
     bool               verbose          = false;
-    bool               tool_args_compat = false;
+    bool               tool_args_object = false;
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -75,7 +75,8 @@ struct task_params {
     struct common_params_speculative speculative;
 
     // response formatting
-    bool               verbose  = false;
+    bool               verbose          = false;
+    bool               tool_args_compat = false;
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
@@ -356,7 +357,8 @@ struct server_task_result_cmpl_final : server_task_result {
     task_params generation_params;
 
     // response formatting
-    bool               verbose  = false;
+    bool               verbose          = false;
+    bool               tool_args_compat = false;
     task_response_type res_type = TASK_RESPONSE_TYPE_NONE;
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;


### PR DESCRIPTION
Currently, due to testing with numerous clients, the behavior of the API has been changed to output tool call arguments as JSON objects. However, this breaks compatibility with several clients that actually *do* expect OpenAI-compatible behavior. Therefore, I'm adding the option to return the OpenAI-compatible version via `--tool-args-compat` (or `-tac` for short).