### PR TITLE
Adding LLMKube to Infrastructure list on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [llama-swap](https://github.com/mostlygeek/llama-swap) - transparent proxy that adds automatic model switching with llama-server
 - [Kalavai](https://github.com/kalavai-net/kalavai-client) - Crowdsource end to end LLM deployment at any scale
 - [llmaz](https://github.com/InftyAI/llmaz) - ☸️ Easy, advanced inference platform for large language models on Kubernetes.
+- [LLMKube](https://github.com/defilantech/llmkube) - Kubernetes operator for llama.cpp with multi-GPU and Apple Silicon Metal
+  support"
 </details>
 
 <details>


### PR DESCRIPTION
LLMKube is a Kubernetes operator for llama.cpp. It handles model downloads, GPU scheduling (Nvidia CUDA and Apple Silicon Metal), health probes, and Prometheus metrics through Metal and InferenceService CRDs.

Related: #6546