### PR TITLE
server : correct index on finish in OAI completion streams

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -827,7 +827,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_stream() {
             {"choices", json::array({
                 json {
                     {"finish_reason", nullptr},
-                    {"index", 0},
+                    {"index", index},
                     {"delta", common_chat_msg_diff_to_json_oaicompat(diff)},
                 },
             })},
@@ -843,7 +843,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_stream() {
         {"choices", json::array({
             json {
                 {"finish_reason", finish_reason},
-                {"index", 0},
+                {"index", index},
                 {"delta", json::object()},
             },
         })},


### PR DESCRIPTION
When calling `/v1/chat/completions` with `"stream": true` and an `n` value greater than 1, the stop message would always have its `index` set to `0` instead of the correct index, making it impossible to tell which stream actually finished.