### PR TITLE
webui : add option to copy assistant response without thinking content

### DIFF
--- a/tools/server/webui/src/lib/components/app/chat/ChatMessages/ChatMessage.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatMessages/ChatMessage.svelte
@@ -6,6 +6,9 @@
 	import { conversationsStore } from '$lib/stores/conversations.svelte';
 	import { DatabaseService } from '$lib/services';
 	import { SYSTEM_MESSAGE_PLACEHOLDER } from '$lib/constants';
+	import { AGENTIC_REGEX, TRIM_NEWLINES_REGEX } from '$lib/constants/agentic';
+	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { config } from '$lib/stores/settings.svelte';
 	import { MessageRole, AttachmentType } from '$lib/enums';
 	import {
 		ChatMessageAssistant,
@@ -128,6 +131,18 @@
 	}
 
 	function handleCopy() {
+		if (
+			config().copyWithoutThinking &&
+			message.role === MessageRole.ASSISTANT &&
+			message.content
+		) {
+			const stripped = message.content
+				.replace(AGENTIC_REGEX.REASONING_BLOCK, '')
+				.replace(AGENTIC_REGEX.REASONING_OPEN, '')
+				.replace(TRIM_NEWLINES_REGEX, '');
+			void copyToClipboard(stripped);
+			return;
+		}
 		chatActions.copy(message);
 	}
 

--- a/tools/server/webui/src/lib/components/app/chat/ChatSettings/ChatSettings.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatSettings/ChatSettings.svelte
@@ -70,6 +70,11 @@
 					type: SettingsFieldType.CHECKBOX
 				},
 				{
+					key: SETTINGS_KEYS.COPY_WITHOUT_THINKING,
+					label: 'Copy response without thinking content',
+					type: SettingsFieldType.CHECKBOX
+				},
+				{
 					key: SETTINGS_KEYS.ENABLE_CONTINUE_GENERATION,
 					label: 'Enable "Continue" button',
 					type: SettingsFieldType.CHECKBOX,

--- a/tools/server/webui/src/lib/constants/settings-config.ts
+++ b/tools/server/webui/src/lib/constants/settings-config.ts
@@ -16,6 +16,7 @@ export const SETTING_CONFIG_DEFAULT: Record<string, string | number | boolean> =
 	askForTitleConfirmation: false,
 	pasteLongTextToFileLen: 2500,
 	copyTextAttachmentsAsPlainText: false,
+    copyWithoutThinking: false,
 	pdfAsImage: false,
 	disableAutoScroll: false,
 	renderUserContentAsMarkdown: false,
@@ -67,6 +68,8 @@ export const SETTING_CONFIG_INFO: Record<string, string> = {
 		'On pasting long text, it will be converted to a file. You can control the file length by setting the value of this parameter. Value 0 means disable.',
 	copyTextAttachmentsAsPlainText:
 		'When copying a message with text attachments, combine them into a single plain text string instead of a special format that can be pasted back as attachments.',
+	copyWithoutThinking:
+		'When copying an assistant message, strip the thinking/reasoning block and only copy the final response.',
 	samplers:
 		'The order at which samplers are applied, in simplified way. Default is "top_k;typ_p;top_p;min_p;temperature": top_k->typ_p->top_p->min_p->temperature',
 	backend_sampling:

--- a/tools/server/webui/src/lib/constants/settings-keys.ts
+++ b/tools/server/webui/src/lib/constants/settings-keys.ts
@@ -11,6 +11,7 @@ export const SETTINGS_KEYS = {
 	SYSTEM_MESSAGE: 'systemMessage',
 	PASTE_LONG_TEXT_TO_FILE_LEN: 'pasteLongTextToFileLen',
 	COPY_TEXT_ATTACHMENTS_AS_PLAIN_TEXT: 'copyTextAttachmentsAsPlainText',
+    COPY_WITHOUT_THINKING: 'copyWithoutThinking',
 	ENABLE_CONTINUE_GENERATION: 'enableContinueGeneration',
 	PDF_AS_IMAGE: 'pdfAsImage',
 	ASK_FOR_TITLE_CONFIRMATION: 'askForTitleConfirmation',


### PR DESCRIPTION
## Summary

Add a setting to copy assistant messages without thinking/reasoning content.

Close #19982

## Changes

- `settings-keys.ts`: add `COPY_WITHOUT_THINKING` key constant
- `settings-config.ts`: add default value (`false`) and description for the new setting
- `ChatSettings.svelte`: add checkbox in the General section
- `ChatMessage.svelte`: strip reasoning blocks before copying when the setting is enabled

## Behavior

When **"Copy response without thinking content"** is enabled in Settings → General, clicking the copy button on an assistant message will strip the `<<<reasoning_content_start>>>...<<<reasoning_content_end>>>` block and only copy the final response.

The implementation adheres to the **minimum modification principle**,  reuses the existing `AGENTIC_REGEX.REASONING_BLOCK`, `AGENTIC_REGEX.REASONING_OPEN`, and `TRIM_NEWLINES_REGEX` from `agentic.ts`. No new parsing logic is introduced.

The default value is `false`, so existing behavior is unchanged.

## Testing

Tested with a reasoning model (Qwen3.5-35B-A3B). With the setting off, the full message (including thinking) is copied. With the setting on, only the final response is copied.

---

This patch was developed with the assistance of Claude (Anthropic).