### PR TITLE
server: support chunked transfer encoding

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1155,6 +1155,10 @@ server_http_proxy::server_http_proxy(
                 // disable Accept-Encoding to avoid compressed responses
                 continue;
             }
+            if (key == "Transfer-Encoding") {
+                // the body is already decoded
+                continue;
+            }
             if (key == "Host" || key == "host") {
                 req.set_header(key, host);
             } else {


### PR DESCRIPTION
This PR fixes #20264. It turns out if client uses chunked transfer encoding, the request hangs there and will timeout. 

E.g. this works:
```bash
curl 'https://llama.home/v1/chat/completions' \
  -X POST \
  --data '{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"model":"Qwen3.5-4B"}'
```

this **doesn't** work:
```bash
curl 'https://llama.home/v1/chat/completions' \
  -X POST \
  --data '{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"model":"Qwen3.5-4B"}' -H "Transfer-Encoding: chunked"
```
**Root Cause:**

In `server_http_proxy::server_http_proxy` (tools/server/server-models.cpp), when forwarding proxied requests to upstream servers, the `Transfer-Encoding` header from the original client request is being copied to the outgoing request, causing a protocol mismatch.

1. When the llama.cpp server receives a request with `Transfer-Encoding: chunked`, cpp-httplib correctly decodes the chunked body before passing it to the handler.

2. In the proxy constructor, the request headers are copied to a new `httplib::Request` object (line 1153-1162), including the `Transfer-Encoding: chunked` header.

3. However, the `body` parameter (line 1164) contains the **already-decoded** (non-chunked) body.

4. When `cli->send(req)` sends the request to the upstream server:
   - The httplib client sees the `Transfer-Encoding: chunked` header
   - It expects the body to be in chunked encoding format
   - But the actual body is in regular (non-chunked) format
   - This causes the upstream server to wait indefinitely for chunked data that will never arrive in the expected format


