### PR TITLE
models : fix assert in mamba2 graph

### DIFF
--- a/src/models/mamba-base.cpp
+++ b/src/models/mamba-base.cpp
@@ -155,7 +155,6 @@ ggml_tensor * llm_build_mamba_base::build_mamba2_layer(llm_graph_input_rs * inp,
 
     const auto kv_head = mctx_cur->get_head();
 
-    const int64_t n_embd   = hparams.n_embd;
     const int64_t d_conv   = hparams.ssm_d_conv;
     const int64_t d_inner  = hparams.ssm_d_inner;
     const int64_t d_state  = hparams.ssm_d_state;
@@ -170,7 +169,7 @@ ggml_tensor * llm_build_mamba_base::build_mamba2_layer(llm_graph_input_rs * inp,
     GGML_ASSERT(ubatch.equal_seqs());
     GGML_ASSERT(ubatch.n_tokens == n_seq_tokens * n_seqs);
     GGML_ASSERT(d_inner % n_head == 0);
-    GGML_ASSERT(d_inner % (n_group*n_embd) == 0);
+    GGML_ASSERT(d_inner % (n_group*d_state) == 0);
 
     ggml_tensor * conv_states_all = mctx_cur->get_r_l(il);
     ggml_tensor * ssm_states_all  = mctx_cur->get_s_l(il);


### PR DESCRIPTION
cont #19802 
fix #20268

This fixes the model loading, but the reasoning parsing seems to be broken because the post-reasoning contents are not being displayed in the WebUI:

<img width="887" height="1205" alt="image" src="https://github.com/user-attachments/assets/bc8a0725-8ad4-4fb0-969f-2bdac8649494" />

cc @pwilkin 