### PR TITLE
imatrix : prevent division by zero in statistics output

### DIFF
--- a/tools/imatrix/imatrix.cpp
+++ b/tools/imatrix/imatrix.cpp
@@ -143,9 +143,17 @@ static void compute_statistics(std::vector<tensor_statistics> & tstats, const st
     activations.reserve(e.values.size());
 
     for (int i = 0; i < n_mat; ++i) {
+        if (e.counts[i] == 0) {
+            continue;
+        }
         for (int j = 0; j < row_size; ++j) {
             activations.push_back(e.values[i*row_size + j] / e.counts[i]);
         }
+    }
+
+    if (activations.empty()) {
+        LOG_ERR("%s: all activations for tensor %s have zero count. The imatrix may be suboptimal\n", __func__, name.c_str());
+        return;
     }
 
     const float act_total     = std::accumulate(activations.begin(), activations.end(), 0.0f);


### PR DESCRIPTION
When using `--show-statistics` with an imatrix file generated from a MoE model, some expert matrices may have never been activated during calibration, leaving their counts[i] at zero. Dividing by a zero count caused a crash.

Skip entries with zero count during the activations loop. Also add an early return if all entries were skipped (activations is empty), which would otherwise cause undefined behavior in std::max_element and std::min_element on an empty range.

The core imatrix computation logic is not affected.

Fixes #19190

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
