### PR TITLE
Read the persisted llama_kv_cell_ext for n_pos_per_embd > 1 on state_read for all sequence ids

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1955,6 +1955,12 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
 
             cells.pos_set(i, pos);
 
+            if (hparams.n_pos_per_embd() > 1) {
+                llama_kv_cell_ext ext;
+                io.read_to(&ext, sizeof(ext));
+                cells.ext_set(i, ext);
+            }
+
             for (uint32_t j = 0; j < n_seq_id; ++j) {
                 llama_seq_id seq_id;
                 io.read_to(&seq_id, sizeof(seq_id));


### PR DESCRIPTION
cont #20132

Attempting to call llama_kv_cache::state_read fails when n_pos_per_embd is greater than 1, since llama_kv_cell_ext data is serialised in `state_save` but not read back in `state_read`, leading to deserialisation failure since the cell_ext data is being parsed as a seq_id.

I assume the attached fix is correct -- kv cache persistence to host memory is now working as expected.
