### PR TITLE
ci: disable coopmat on ubuntu-24-cmake-vulkan job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,6 +469,7 @@ jobs:
           cd build
           export GGML_VK_VISIBLE_DEVICES=0
           export GGML_VK_DISABLE_F16=1
+          export GGML_VK_DISABLE_COOPMAT=1
           # This is using llvmpipe and runs slower than other backends
           ctest -L main --verbose --timeout 4800
 


### PR DESCRIPTION
There's some issue with the new barrier in the coopmat llvmpipe driver. But coopmat support in llvmpipe isn't really needed for it and wasn't around when the CI was set up anyways, so disable it to work around the problem.