### PR TITLE
Make tests windows compatible.

### DIFF
--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -1964,6 +1964,9 @@ static void test_template_py(testing & t, const std::string & name, const std::s
             return;
         }
 
+        // Normalize line endings for cross-platform compatibility (Windows Python outputs \r\n)
+        jinja::string_replace_all(output, "\r\n", "\n");
+
         if (!t.assert_true("Template render mismatch", expect == output)) {
             t.log("Template: " + json(tmpl).dump());
             t.log("Expected: " + json(expect).dump());


### PR DESCRIPTION
On Windows, Python outputs \r\n line endings, but the test expects \n. This caused string comparisons to fail.

Fix: Added normalize line endings before comparing:
      jinja::string_replace_all(output, "\r\n", "\n");

This replaces Windows line endings (\r\n) with Unix line endings (\n) so the comparison works cross-platform.
