### PR TITLE
tests : write to binary buffer to avoid newline translation in jinja -py

### DIFF
--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -1915,7 +1915,7 @@ env.globals["raise_exception"] = raise_exception
 
 template = env.from_string(tmpl)
 result = template.render(**vars_json)
-print(result, end='')
+sys.stdout.buffer.write(result.encode())
 )";
 
 static void test_template_py(testing & t, const std::string & name, const std::string & tmpl, const json & vars, const std::string & expect) {


### PR DESCRIPTION
Write directly to `stdout` binary buffer for Python tests to avoid newline translation.

Should fix test on Windows.