### PR TITLE
cli, server: apply --prio process priority setting

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -163,8 +163,12 @@ void common_preset::merge(const common_preset & other) {
     }
 }
 
-void common_preset::apply_to_params(common_params & params) const {
+void common_preset::apply_to_params(common_params & params,
+                                    const std::map<common_arg, std::string> & cli_overrides) const {
     for (const auto & [opt, val] : options) {
+        if (cli_overrides.find(opt) != cli_overrides.end()) {
+            continue; // CLI takes precedence over preset value
+        }
         // apply each option to params
         if (opt.handler_string) {
             opt.handler_string(params, val);

--- a/common/preset.h
+++ b/common/preset.h
@@ -43,7 +43,10 @@ struct common_preset {
     void merge(const common_preset & other);
 
     // apply preset options to common_params
-    void apply_to_params(common_params & params) const;
+    // options whose key appears in cli_overrides are skipped, so values already
+    // provided on the command line take precedence over preset values
+    void apply_to_params(common_params & params,
+                         const std::map<common_arg, std::string> & cli_overrides = {}) const;
 };
 
 // interface for multiple presets in one file

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -365,6 +365,10 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
+    if (!set_process_priority(params.cpuparams.priority)) {
+        LOG_WRN("%s: failed to set process priority\n", __func__);
+    }
+
     // TODO: avoid using atexit() here by making `console` a singleton
     console::init(params.simple_io, params.use_color);
     atexit([]() { console::cleanup(); });

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -10,6 +10,7 @@
 #include "fit.h"
 #include "llama.h"
 #include "log.h"
+#include "preset.h"
 
 #include <atomic>
 #include <clocale>
@@ -81,6 +82,28 @@ int main(int argc, char ** argv) {
 
     if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_SERVER)) {
         return 1;
+    }
+
+    // apply the [*] section of --models-preset to params so that router-level
+    // options (prio, threads, host, etc.) set in the INI are honored by this
+    // process. CLI arguments keep the highest precedence.
+    if (!params.models_preset.empty()) {
+        try {
+            common_preset_context ctx_preset(LLAMA_EXAMPLE_SERVER);
+            common_preset global;
+            (void) ctx_preset.load_from_ini(params.models_preset, global);
+
+            std::map<common_arg, std::string> cli_overrides;
+            if (!common_params_to_map(argc, argv, LLAMA_EXAMPLE_SERVER, cli_overrides)) {
+                throw std::runtime_error("failed to collect CLI overrides");
+            }
+
+            global.apply_to_params(params, cli_overrides);
+        } catch (const std::exception & e) {
+            LOG_ERR("%s: failed to apply [*] preset from %s: %s\n",
+                    __func__, params.models_preset.c_str(), e.what());
+            return 1;
+        }
     }
 
     // validate batch size for embeddings

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -110,6 +110,10 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
+    if (!set_process_priority(params.cpuparams.priority)) {
+        LOG_WRN("%s: failed to set process priority\n", __func__);
+    }
+
     LOG_INF("build_info: %s\n", llama_build_info());
     LOG_INF("%s\n", common_params_get_system_info(params).c_str());
 


### PR DESCRIPTION
Fixes #20360

The `--prio` flag is parsed by `common_params_parse()` for all tools, but
`set_process_priority()` was only called in `llama-completion` and `llama-bench`.
This means `--prio` had no effect in `llama-server` and `llama-cli`.

Changes:
- Add `set_process_priority()` call in `llama-server` after backend initialization
- Add `set_process_priority()` call in `llama-cli` after backend initialization
- Use `LOG_WRN` on failure instead of aborting, since priority is non-critical

Tested by:
- building on macOS (Apple Silicon) with Metal backend
- verifying both binaries compile and link correctly
- confirming `--prio` flag is listed in help output for both tools