### PR TITLE
Reset graph on control vector change

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1165,9 +1165,11 @@ bool llama_context::set_adapter_cvec(
                 int32_t   il_end) {
     LLAMA_LOG_DEBUG("%s: il_start = %d, il_end = %d\n", __func__, il_start, il_end);
 
-    // TODO: should we reserve?
+    bool res = cvec->apply(model, data, len, n_embd, il_start, il_end);
 
-    return cvec->apply(model, data, len, n_embd, il_start, il_end);
+    sched_need_reserve = true;
+
+    return res;
 }
 
 llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, llm_graph_type gtype, llama_memory_context_i * mctx, ggml_status & ret) {


### PR DESCRIPTION
This PR makes an existing context pick up a change to its control vector configuration via  `llama_context::set_adapter_cvec`.

The issue in short:
- Initial call to `set_adapter_cvec` works, steering vector applies to generation.
- Any further calls to it after the initial generation, including attempting to unset it via nullptr vector or chaging layers/strength, do not apply

Background: When I ran a [script](https://github.com/withcatai/node-llama-cpp/compare/master...iimez:node-llama-cpp:controlVectors#diff-2f60cdc91bc3c40f0e81aee1bdcf7e0606296a04ac6b2b8a63b7de38e773e693R978-R997) to sweep control vector configurations I noticed that *only the initial* configuration would be picked up, with repeated calls to `llama_context::set_adapter_cvec` (in between generations) being ignored and generation continuing with the initial config.

Recreating the context for every iteration in a sweep would have been an alternative, but much slower than necessary.

While looking to speed it up I saw the TODO in `set_adapter_cvec`, compared with the LoRA logic and tried around to find the minimal invalidation required to make generation pick up the changes. Resetting the graph appears to be enough for cvec and I'm suspecting the TODO could be removed.

I tested this change (extensively while sweeping steering vector configurations) on various model architectures and cpu/vulkan/cuda backends.

AI Disclaimer: Opus suggested this.