### PR TITLE
common : add --sched-n-copies parameter for pipeline parallelism configuration

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -893,6 +893,11 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
             common_params_print_completion(ctx_arg);
             exit(0);
         }
+
+        if (ctx_arg.params.sched_n_copies > 0) {
+            ggml_backend_sched_set_n_copies(ctx_arg.params.sched_n_copies);
+        }
+
         params.lr.init();
     } catch (const std::invalid_argument & ex) {
         fprintf(stderr, "%s\n", ex.what());
@@ -1167,6 +1172,17 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         string_format("use polling level to wait for work (0 - no polling, default: %u)\n", (unsigned) params.cpuparams.poll),
         [](common_params & params, const std::string & value) {
             params.cpuparams.poll = std::stoul(value);
+        }
+    ));
+    add_opt(common_arg(
+        {"--sched-n-copies"}, "N",
+        "scheduler input copies for pipeline parallelism (default: 4, max: 16)",
+        [](common_params & params, int value) {
+            if (value <= 0) {
+                throw std::invalid_argument("invalid value");
+            }
+
+            params.sched_n_copies = value;
         }
     ));
     add_opt(common_arg(

--- a/common/common.h
+++ b/common/common.h
@@ -402,6 +402,8 @@ struct common_params {
     struct cpu_params cpuparams;
     struct cpu_params cpuparams_batch;
 
+    int32_t sched_n_copies = 0;
+
     ggml_backend_sched_eval_callback cb_eval = nullptr;
     void * cb_eval_user_data                 = nullptr;
 

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -181,7 +181,7 @@ set(GGML_CPU_ARM_ARCH        "" CACHE STRING "ggml: CPU architecture for ARM")
 set(GGML_CPU_POWERPC_CPUTYPE "" CACHE STRING "ggml: CPU type for PowerPC")
 
 # ggml core
-set(GGML_SCHED_MAX_COPIES  "4" CACHE STRING "ggml: max input copies for pipeline parallelism")
+set(GGML_SCHED_MAX_COPIES  "16" CACHE STRING "ggml: max input copies for pipeline parallelism")
 option(GGML_CPU                             "ggml: enable CPU backend"                        ON)
 option(GGML_SCHED_NO_REALLOC                "ggml: disallow reallocations in ggml-alloc (for debugging)" OFF)
 

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -302,6 +302,10 @@ extern "C" {
     //
     typedef bool (*ggml_backend_sched_eval_callback)(struct ggml_tensor * t, bool ask, void * user_data);
 
+    // Override the number of input copies used by the scheduler when parallel execution is enabled.
+    // Set to 0 to disable the override.
+    GGML_API void                 ggml_backend_sched_set_n_copies(int n_copies);
+
     // Initialize a backend scheduler, backends with low index are given priority over backends with high index
     GGML_API ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, ggml_backend_buffer_type_t * bufts, int n_backends, size_t graph_size, bool parallel, bool op_offload);
     GGML_API void                 ggml_backend_sched_free(ggml_backend_sched_t sched);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -669,8 +669,10 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #endif
 
 #ifndef GGML_SCHED_MAX_COPIES
-#define GGML_SCHED_MAX_COPIES 4
+#define GGML_SCHED_MAX_COPIES 16
 #endif
+
+static int sched_n_copies_override = 0;
 
 struct ggml_backend_sched_split {
     int backend_id;
@@ -1656,7 +1658,22 @@ ggml_backend_sched_t ggml_backend_sched_new(
     sched->debug_realloc = GGML_SCHED_DEBUG_REALLOC ? atoi(GGML_SCHED_DEBUG_REALLOC) : sched->debug_realloc;
 
     sched->n_backends = n_backends;
-    sched->n_copies = parallel ? GGML_SCHED_MAX_COPIES : 1;
+    int n_copies = parallel ? 4 : 1;
+ 
+    if (parallel) {
+        const int override = sched_n_copies_override;
+        if (override > 0) {
+            n_copies = override;
+        }
+    
+        if (n_copies < 1) {
+            n_copies = 1;
+        } else if (n_copies > GGML_SCHED_MAX_COPIES) {
+            n_copies = GGML_SCHED_MAX_COPIES;
+        }
+    }
+ 
+    sched->n_copies = n_copies;
 
     // initialize hash table
     // FIXME: needs to be size*2 to account for leafs (do it in graph_split instead)
@@ -1836,6 +1853,10 @@ int ggml_backend_sched_get_n_splits(ggml_backend_sched_t sched) {
 int ggml_backend_sched_get_n_copies(ggml_backend_sched_t sched) {
     GGML_ASSERT(sched);
     return sched->n_copies;
+}
+
+void ggml_backend_sched_set_n_copies(int n_copies) {
+    sched_n_copies_override = n_copies;
 }
 
 int ggml_backend_sched_get_n_backends(ggml_backend_sched_t sched) {

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -328,6 +328,7 @@ struct cmd_params {
     std::vector<std::string>         cpu_mask;
     std::vector<bool>                cpu_strict;
     std::vector<int>                 poll;
+    std::vector<int>                 sched_n_copies;
     std::vector<int>                 n_gpu_layers;
     std::vector<int>                 n_cpu_moe;
     std::vector<llama_split_mode>    split_mode;
@@ -370,6 +371,7 @@ static const cmd_params cmd_params_defaults = {
     /* cpu_mask             */ { "0x0" },
     /* cpu_strict           */ { false },
     /* poll                 */ { 50 },
+    /* sched_n_copies       */ { 0 },
     /* n_gpu_layers         */ { 99 },
     /* n_cpu_moe            */ { 0 },
     /* split_mode           */ { LLAMA_SPLIT_MODE_LAYER },
@@ -436,6 +438,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -C, --cpu-mask <hex,hex>                    (default: %s)\n", join(cmd_params_defaults.cpu_mask, ",").c_str());
     printf("  --cpu-strict <0|1>                          (default: %s)\n", join(cmd_params_defaults.cpu_strict, ",").c_str());
     printf("  --poll <0...100>                            (default: %s)\n", join(cmd_params_defaults.poll, ",").c_str());
+    printf("  --sched-n-copies <n>                        ggml scheduler input copies, 0 = auto (default: %s)\n", join(cmd_params_defaults.sched_n_copies, ",").c_str());
     printf("  -ngl, --n-gpu-layers <n>                    (default: %s)\n", join(cmd_params_defaults.n_gpu_layers, ",").c_str());
     printf("  -ncmoe, --n-cpu-moe <n>                     (default: %s)\n", join(cmd_params_defaults.n_cpu_moe, ",").c_str());
     printf("  -sm, --split-mode <none|layer|row>          (default: %s)\n", join(transform_to_str(cmd_params_defaults.split_mode, split_mode_str), ",").c_str());
@@ -695,6 +698,13 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 }
                 auto p = parse_int_range(argv[i]);
                 params.poll.insert(params.poll.end(), p.begin(), p.end());
+            } else if (arg == "--sched-n-copies") {
+                if (++i >= argc) {
+                    invalid_param = true;
+                    break;
+                }
+                auto p = parse_int_range(argv[i]);
+                params.sched_n_copies.insert(params.sched_n_copies.end(), p.begin(), p.end());
             } else if (arg == "-ngl" || arg == "--n-gpu-layers") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1095,6 +1105,9 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     if (params.poll.empty()) {
         params.poll = cmd_params_defaults.poll;
     }
+    if (params.sched_n_copies.empty()) {
+        params.sched_n_copies = cmd_params_defaults.sched_n_copies;
+    }
 
     return params;
 }
@@ -1112,6 +1125,7 @@ struct cmd_params_instance {
     std::string        cpu_mask;
     bool               cpu_strict;
     int                poll;
+    int                sched_n_copies;
     int                n_gpu_layers;
     int                n_cpu_moe;
     llama_split_mode   split_mode;
@@ -1236,6 +1250,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
     for (const auto & cm : params.cpu_mask)
     for (const auto & cs : params.cpu_strict)
     for (const auto & nd : params.n_depth)
+    for (const auto & snc : params.sched_n_copies)
     for (const auto & pl : params.poll) {
         for (const auto & n_prompt : params.n_prompt) {
             if (n_prompt == 0) {
@@ -1254,6 +1269,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .cpu_mask     = */ cm,
                 /* .cpu_strict   = */ cs,
                 /* .poll         = */ pl,
+                /* .sched_n_copies = */ snc,
                 /* .n_gpu_layers = */ nl,
                 /* .n_cpu_moe    = */ ncmoe,
                 /* .split_mode   = */ sm,
@@ -1289,6 +1305,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .cpu_mask     = */ cm,
                 /* .cpu_strict   = */ cs,
                 /* .poll         = */ pl,
+                /* .sched_n_copies = */ snc,
                 /* .n_gpu_layers = */ nl,
                 /* .n_cpu_moe    = */ ncmoe,
                 /* .split_mode   = */ sm,
@@ -1324,6 +1341,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .cpu_mask     = */ cm,
                 /* .cpu_strict   = */ cs,
                 /* .poll         = */ pl,
+                /* .sched_n_copies = */ snc,
                 /* .n_gpu_layers = */ nl,
                 /* .n_cpu_moe    = */ ncmoe,
                 /* .split_mode   = */ sm,
@@ -1362,6 +1380,7 @@ struct test {
     std::string              cpu_mask;
     bool                     cpu_strict;
     int                      poll;
+    int                      sched_n_copies;
     ggml_type                type_k;
     ggml_type                type_v;
     int                      n_gpu_layers;
@@ -1400,6 +1419,7 @@ struct test {
         cpu_mask       = inst.cpu_mask;
         cpu_strict     = inst.cpu_strict;
         poll           = inst.poll;
+        sched_n_copies = inst.sched_n_copies;
         type_k         = inst.type_k;
         type_v         = inst.type_v;
         n_gpu_layers   = inst.n_gpu_layers;
@@ -1470,6 +1490,7 @@ struct test {
             "build_commit",   "build_number",   "cpu_info",      "gpu_info",       "backends",
             "model_filename", "model_type",     "model_size",    "model_n_params", "n_batch",
             "n_ubatch",       "n_threads",      "cpu_mask",      "cpu_strict",     "poll",
+            "sched_n_copies",
             "type_k",         "type_v",         "n_gpu_layers",  "n_cpu_moe",      "split_mode",
             "main_gpu",       "no_kv_offload",  "flash_attn",    "devices",        "tensor_split",
             "tensor_buft_overrides",            "use_mmap",      "use_direct_io",  "embeddings",
@@ -1483,7 +1504,7 @@ struct test {
 
     static field_type get_field_type(const std::string & field) {
         if (field == "build_number" || field == "n_batch" || field == "n_ubatch" || field == "n_threads" ||
-            field == "poll" || field == "model_size" || field == "model_n_params" || field == "n_gpu_layers" ||
+            field == "poll" || field == "sched_n_copies" || field == "model_size" || field == "model_n_params" || field == "n_gpu_layers" ||
             field == "main_gpu" || field == "n_prompt" || field == "n_gen" || field == "n_depth" || field == "avg_ns" ||
             field == "stddev_ns" || field == "no_op_offload" || field == "n_cpu_moe") {
             return INT;
@@ -1550,6 +1571,7 @@ struct test {
                                             cpu_mask,
                                             std::to_string(cpu_strict),
                                             std::to_string(poll),
+                                            std::to_string(sched_n_copies),
                                             ggml_type_name(type_k),
                                             ggml_type_name(type_v),
                                             std::to_string(n_gpu_layers),
@@ -1838,6 +1860,9 @@ struct markdown_printer : public printer {
         }
         if (params.poll.size() > 1 || params.poll != cmd_params_defaults.poll) {
             fields.emplace_back("poll");
+        }
+        if (params.sched_n_copies.size() > 1 || params.sched_n_copies != cmd_params_defaults.sched_n_copies) {
+            fields.emplace_back("sched_n_copies");
         }
         if (params.n_batch.size() > 1 || params.n_batch != cmd_params_defaults.n_batch) {
             fields.emplace_back("n_batch");
@@ -2170,6 +2195,10 @@ int main(int argc, char ** argv) {
                 return 1;
             }
             prev_inst = &inst;
+        }
+
+        if (inst.sched_n_copies > 0) {
+            ggml_backend_sched_set_n_copies(inst.sched_n_copies);
         }
 
         llama_context * ctx = llama_init_from_model(lmodel, inst.to_llama_cparams());


### PR DESCRIPTION
Replace compile-time GGML_SCHED_MAX_COPIES with runtime configuration. Add --sched-n-copies parameter to control scheduler input copies (default: 4, max: 16). Implement ggml_backend_sched_set_n_copies() to override the number of copies used for parallel execution. Update llama-bench to support the new parameter.

Changing this parameter can give quiet a bit of performance.

<details>
<summary>Benchmarks</summary>

```
| model                          |       size |     params | backend    | ngl | sched_n_copies | n_ubatch | fa | mmap | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -------------: | -------: | -: | ---: | --: | --------------: | -------------------: |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |          pp1024 |        641.02 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |          pp2048 |       1111.21 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |          pp8096 |       2053.24 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |         pp16384 |       2165.73 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |         pp32768 |       2112.82 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |         pp65536 |       1792.52 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              4 |     1024 |  1 |    0 |   1 |        pp131072 |       1316.19 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |          pp1024 |        636.88 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |          pp2048 |       1110.96 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |          pp8096 |       2336.29 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |         pp16384 |       2705.89 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |         pp32768 |       2705.33 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |         pp65536 |       2313.66 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |              8 |     1024 |  1 |    0 |   1 |        pp131072 |       1698.53 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |          pp1024 |        641.25 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |          pp2048 |       1100.32 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |          pp8096 |       2355.55 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |         pp16384 |       2699.75 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |         pp32768 |       2706.86 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |         pp65536 |       2313.20 ± 0.00 |
| gpt-oss 120B MXFP4 MoE         |  59.02 GiB |   116.83 B | ROCm       |  99 |             16 |     1024 |  1 |    0 |   1 |        pp131072 |       1699.27 ± 0.00 |
```
</details>