### PR TITLE
metal : fix q5_k mul_mv register spill

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -35,7 +35,7 @@
 #define N_R0_Q4_K 2
 #define N_SG_Q4_K 2
 
-#define N_R0_Q5_K 2
+#define N_R0_Q5_K 1
 #define N_SG_Q5_K 2
 
 #define N_R0_Q6_K 2


### PR DESCRIPTION
cont #20398 

Noticed too high register pressure in the q5_k vec kernel:

```bash
METAL_CAPTURE_ENABLED=1 GGML_METAL_CAPTURE_COMPUTE=8 ./bin/llama-completion -m ~/models/qwen2.5-3b-coder/ggml-model-q5_k.gguf -fa 1 -p "hello" -n 10 -no-cnv --top-k 1
```

Before:

<img width="1106" height="188" alt="image" src="https://github.com/user-attachments/assets/37b42660-2064-428e-ae52-15c8bbc2f8a3" />

After:

<img width="1108" height="188" alt="image" src="https://github.com/user-attachments/assets/cebcec41-527f-4e91-bebc-929945f28c68" />

Perf:

| Model             | Test   |   t/s master |   t/s gg/metal-mul-mv-q5_k-spill |   Speedup |
|:------------------|:-------|-------------:|---------------------------------:|----------:|
| gemma2 9B Q5_K_M  | pp1    |        56.27 |                            61.67 |      1.10 |
| gemma2 9B Q5_K_M  | pp2    |        74.87 |                            80.06 |      1.07 |
| gemma2 9B Q5_K_M  | pp3    |        83.92 |                            89.26 |      1.06 |
| gemma2 9B Q5_K_M  | pp4    |       128.29 |                           127.65 |      0.99 |
| gemma2 9B Q5_K_M  | tg32   |        57.22 |                            62.00 |      1.08 |
| gemma3 4B Q5_K_M  | pp1    |        99.76 |                           109.82 |      1.10 |
| gemma3 4B Q5_K_M  | pp2    |       146.22 |                           159.29 |      1.09 |
| gemma3 4B Q5_K_M  | pp3    |       173.88 |                           185.46 |      1.07 |
| gemma3 4B Q5_K_M  | pp4    |       236.71 |                           236.36 |      1.00 |
| gemma3 4B Q5_K_M  | tg32   |       103.52 |                           114.42 |      1.11 |
| llama 8B Q5_K_M   | pp1    |        78.57 |                            84.24 |      1.07 |
| llama 8B Q5_K_M   | pp2    |       100.28 |                           104.78 |      1.04 |
| llama 8B Q5_K_M   | pp3    |       112.15 |                           114.89 |      1.02 |
| llama 8B Q5_K_M   | pp4    |       166.52 |                           166.64 |      1.00 |
| llama 8B Q5_K_M   | tg32   |        79.30 |                            84.32 |      1.06 |
| qwen2 3B Q5_K_M   | pp1    |       127.54 |                           136.71 |      1.07 |
| qwen2 3B Q5_K_M   | pp2    |       183.02 |                           196.62 |      1.07 |
| qwen2 3B Q5_K_M   | pp3    |       216.24 |                           226.41 |      1.05 |
| qwen2 3B Q5_K_M   | pp4    |       276.70 |                           276.13 |      1.00 |
| qwen2 3B Q5_K_M   | tg32   |       128.72 |                           140.52 |      1.09 |
| qwen2 7B Q5_K_M   | pp1    |        79.31 |                            86.19 |      1.09 |
| qwen2 7B Q5_K_M   | pp2    |       100.62 |                           107.88 |      1.07 |
| qwen2 7B Q5_K_M   | pp3    |       110.58 |                           117.67 |      1.06 |
| qwen2 7B Q5_K_M   | pp4    |       179.16 |                           179.97 |      1.00 |
| qwen2 7B Q5_K_M   | tg32   |        79.47 |                            86.58 |      1.09 |
| qwen3 0.6B Q5_K_M | pp1    |       266.12 |                           292.98 |      1.10 |
| qwen3 0.6B Q5_K_M | pp2    |       483.89 |                           503.42 |      1.04 |
| qwen3 0.6B Q5_K_M | pp3    |       634.80 |                           667.10 |      1.05 |
| qwen3 0.6B Q5_K_M | pp4    |       733.00 |                           733.70 |      1.00 |
| qwen3 0.6B Q5_K_M | tg32   |       280.87 |                           300.45 |      1.07 |

