### PR TITLE
server: fix multi-turn cache reuse for hybrid/recurrent models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2651,11 +2651,20 @@ private:
                     const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx), slot.id);
                     const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx), slot.id);
 
-                    // no need for empty or small checkpoints
-                    do_checkpoint = do_checkpoint && (pos_min >= 0 && pos_max >= 64);
+                    {
+                        // for hybrid/recurrent models, even short prompts need checkpoints
+                        // to enable multi-turn cache reuse (recurrent state can't be rolled
+                        // back without one). SWA-only models can use a higher threshold.
+                        const bool is_hybrid_or_recurrent = llama_model_is_hybrid(model) || llama_model_is_recurrent(model);
+                        const int min_pos_max = is_hybrid_or_recurrent ? 0 : 64;
+                        const int min_spacing = is_hybrid_or_recurrent ? 0 : 64;
 
-                    // no need to create checkpoints that are too close together
-                    do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || pos_max > slot.prompt.checkpoints.back().pos_max + 64);
+                        // no need for empty or small checkpoints
+                        do_checkpoint = do_checkpoint && (pos_min >= 0 && pos_max >= min_pos_max);
+
+                        // no need to create checkpoints that are too close together
+                        do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || pos_max > slot.prompt.checkpoints.back().pos_max + min_spacing);
+                    }
 
                     // note: we create the checkpoint before calling llama_decode(), so the current batch is not
                     //       yet processed and therefore it is not part of the checkpoint.

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2444,12 +2444,64 @@ private:
                     SLT_INF(slot, "n_tokens = %d, memory_seq_rm [%d, end)\n", slot.prompt.n_tokens(), p0);
 
                     if (!llama_memory_seq_rm(llama_get_memory(ctx), slot.id, p0, -1)) {
-                        SLT_WRN(slot, "failed to truncate tokens with position >= %d - clearing the memory\n", p0);
+                        SLT_WRN(slot, "failed to truncate tokens with position >= %d, searching for a checkpoint to restore\n", p0);
 
-                        slot.prompt_clear(true);
+                        // for hybrid/recurrent models, seq_rm fails because the recurrent
+                        // memory has no cell-level checkpoint at position p0.
+                        // try to restore the nearest server-level checkpoint before p0.
+                        bool restored = false;
 
-                        // there is no common part left
-                        slot.n_prompt_tokens_cache = 0;
+                        if (!slot.prompt.checkpoints.empty()) {
+                            const auto it = std::find_if(
+                                slot.prompt.checkpoints.rbegin(),
+                                slot.prompt.checkpoints.rend(),
+                                [&](const auto & cur) {
+                                    return cur.pos_max < p0;
+                                }
+                            );
+
+                            if (it != slot.prompt.checkpoints.rend()) {
+                                const size_t checkpoint_size = it->data.size();
+                                const size_t n = llama_state_seq_set_data_ext(ctx, it->data.data(), checkpoint_size, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+
+                                if (n == checkpoint_size) {
+                                    const llama_pos pos_restored = std::max(it->pos_min + 1, it->pos_max);
+                                    size_t n_past_new = std::min(slot.prompt.tokens.size_up_to_pos(pos_restored), (size_t) it->n_tokens);
+
+                                    // [TAG_PROMPT_LOGITS] guarantee at least 1 token for evaluation
+                                    if (n_past_new == (size_t) slot.task->n_tokens() && n_past_new > 0) {
+                                        n_past_new--;
+                                    }
+
+                                    SLT_WRN(slot, "restored checkpoint at seq_rm failure (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB), n_past: %d -> %zu\n",
+                                            it->pos_min, it->pos_max, it->n_tokens, (float) checkpoint_size / 1024 / 1024,
+                                            slot.prompt.n_tokens(), n_past_new);
+
+                                    slot.prompt.tokens.keep_first(n_past_new);
+                                    slot.n_prompt_tokens_cache = n_past_new;
+                                    restored = true;
+
+                                    // erase checkpoints beyond the restored position
+                                    for (auto cit = slot.prompt.checkpoints.begin(); cit != slot.prompt.checkpoints.end();) {
+                                        if (cit->pos_max >= p0) {
+                                            cit = slot.prompt.checkpoints.erase(cit);
+                                        } else {
+                                            ++cit;
+                                        }
+                                    }
+                                } else {
+                                    SLT_ERR(slot, "failed to restore checkpoint (pos_min = %d, pos_max = %d, size = %.3f MiB)\n",
+                                            it->pos_min, it->pos_max, (float) checkpoint_size / 1024 / 1024);
+                                }
+                            }
+                        }
+
+                        if (!restored) {
+                            SLT_WRN(slot, "no suitable checkpoint found for p0 = %d, clearing the memory\n", p0);
+
+                            slot.prompt_clear(true);
+                            slot.n_prompt_tokens_cache = 0;
+                        }
                     }
 
                     bool do_checkpoint = params_base.n_ctx_checkpoints > 0;


### PR DESCRIPTION
## Summary

Multi-turn conversations with hybrid models (e.g. Qwen3.5-A3B) currently force full prompt reprocessing on every turn because:

1. **Short prompts never get checkpoints**: The `pos_max >= 64` minimum threshold prevents checkpoint creation for prompts shorter than ~68 tokens. For hybrid models, even short prompts need checkpoints since the recurrent state cannot be rolled back without one.

2. **`seq_rm` failure clears everything**: When `llama_memory_seq_rm` fails (the recurrent memory has no cell-level checkpoint at the trim position), the server clears all memory instead of trying to restore from a server-level checkpoint.

### Changes

- **Lower checkpoint thresholds for hybrid/recurrent models**: Remove the `pos_max >= 64` and spacing `>= 64` minimums for hybrid/recurrent models while keeping them for SWA-only models. This ensures checkpoints are always created during prompt processing, enabling multi-turn reuse.

- **Restore checkpoint on `seq_rm` failure**: When `seq_rm` fails, search for the nearest server-level checkpoint before the trim position and restore it, instead of clearing all memory. This is a safety net for cases where the primary checkpoint restore path (the `pos_min > pos_min_thold` check) doesn't trigger.

### Test results (Qwen3.5-35B-A3B, macOS Apple Silicon)

**Q4_K_XL quantization:**

| Turn | Total prompt | Cached | New processed |
|------|-------------|--------|---------------|
| 1    | 31          | 0      | 31            |
| 2    | 48          | 27     | 21            |

**Q8_K_XL quantization:**

| Turn | Total prompt | Cached | New processed |
|------|-------------|--------|---------------|
| 1    | 31          | 0      | 31            |
| 2    | 48          | 27     | 21            |
| 3    | 65          | 44     | 21            |

Server logs confirm checkpoints are created and restored:
```
slot update_slots: created context checkpoint 1 of 32 (pos_min = 26, pos_max = 26, n_tokens = 27, size = 62.813 MiB)
slot update_slots: restored context checkpoint (pos_min = 26, pos_max = 26, n_tokens = 27, n_past = 27, size = 62.813 MiB)
```

Previously, the logs showed:
```
slot update_slots: forcing full prompt re-processing due to lack of cache data
```

### Prior work and acknowledgments

This PR builds on the checkpoint infrastructure developed across several PRs:

- #13194 @ggerganov — kv-cache: add SWA support (foundation)
- #13833 @ggerganov — SWA cache sizing
- #13979 @gabe-l-hart — hybrid recurrent cache abstraction
- #15293 @ggerganov — server: add SWA checkpoints (introduced the checkpoint mechanism this PR extends)
- #16382 @ddh0 — generalized context checkpointing to all hybrid/recurrent models
- #17009 @gabe-l-hart — hybrid context shift for multi-turn
- #18391 @o7si — fix server crash when `seq_rm` fails for hybrid models
- #19408 @ggerganov — improved checkpoint logic
- #20087 @pwilkin — `--checkpoint-every-nb` for finer-grained rollback
- #20288 @ggerganov — make 2 checkpoints near end of prompt

Related: #20075 @eauchs — speculative decoding fixes for hybrid SSM/MoE (Qwen3.5)