### PR TITLE
ggml-vulkan: disable transfer queue on UMA

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5401,7 +5401,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         ggml_vk_load_shaders(device);
 
-        const bool prefers_transfer_queue = device->vendor_id == VK_VENDOR_ID_AMD && device->architecture != AMD_GCN;
+        const bool prefers_transfer_queue = device->vendor_id == VK_VENDOR_ID_AMD && device->architecture != AMD_GCN && !device->uma;
 
         if (!device->single_queue) {
             const uint32_t transfer_queue_index = compute_queue_family_index == transfer_queue_family_index ? 1 : 0;


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/20439 .

I am unsure why transfer queues add such a huge overhead(it was at least 10GB as tried reserving that much when loading the model and it still choked)

Summary from big C:

Using the separate SDMA/transfer queue for async copies is counterproductive here because:

1. There's no separate device memory to transfer to/from — it's all unified memory
2. The SDMA engine and its associated driver structures (kernel buffer objects for command streams, page table entries, cross-queue synchronization state) consume memory from the same pool
3. The timeline semaphore synchronization between compute and transfer queues adds driver overhead with no benefit — the compute queue can issue buffer copies just as efficiently on UMA
4. The transfer queue's command pool (`transfer_cmd_pool`) and its command buffers accumulate during model loading alongside compute_cmd_pool, effectively doubling the command infrastructure