### PR TITLE
tests: Fix invalid iterator::end() dereference in common_regex

### DIFF
--- a/common/regex-partial.cpp
+++ b/common/regex-partial.cpp
@@ -102,7 +102,7 @@ std::string regex_to_reversed_partial_regex(const std::string & pattern) {
                 auto is_star = *it == '*';
                 ++it;
                 if (is_star) {
-                    if (*it == '?') {
+                    if (it != end && *it == '?') {
                         ++it;
                     }
                 }


### PR DESCRIPTION
When compiling with VS2026 18.4 I noticed `test-regex-partial` crashes immediately with debug build. 

<img width="478" height="355" alt="image" src="https://github.com/user-attachments/assets/e5d3b7b3-95f4-491f-a28a-a105678eb72f" />

I tracked this down to an iterator::end() dereference in the following test case which was [occurring here.](https://github.com/ggml-org/llama.cpp/blob/de190154c85d20e24dbeae8c8af1849402ae5098/common/regex-partial.cpp#L105)

```cpp
    assert_equals<std::string>(
        "^(a*)",
        regex_to_reversed_partial_regex("a*"));
```

This fix adds bounds checking to prevent such dereferencing.