### PR TITLE
Guard against sumq2 being 0 in IQ4_NL resulting in nan values

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -4767,7 +4767,7 @@ static void quantize_row_iq4_nl_impl(const int super_block_size, const int block
             sumqx += w*q*xb[j];
             sumq2 += w*q*q;
         }
-        d = sumqx/sumq2;
+        d = sumq2 > 0 ? sumqx/sumq2 : 0.f;
         float best = d*sumqx;
         for (int itry = -ntry; itry <= ntry; ++itry) {
             id = (itry + values[0])/max;


### PR DESCRIPTION
With `IQ4_NL` on several recent models there have been issues where during quantization NaN blocks are being found which crashes the quant

It seems to be stemming from a scenario where `sumq2` is 0 for a given block, likely from not having imatrix data for some obscure expert, or the weights themselves being 0 as we've seen with some recent Qwen models

This change guards against dividing by 0, instead setting `d` to 0, which would then just set the block of weights to 0, which seems appropriate

Most recently observed in nvidia's Nemotron-3-Super-120B-A12B, `blk.3.ffn_down_exps` has a block that never sees imatrix data, and that results in `sumq2` being 0

I added some debug information to look at what those weights are like (to ensure that setting them to 0 wouldn't present a new issue) and the `amax` at this time is in the order of 1e-11 so they're likely rounding down to 0 during imatrix calculations anyways