### PR TITLE
llama-bench: fix case where mmap and direct-io are turned on together

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1072,6 +1072,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     // if so, we disable mmap to avoid the situation where they see no difference
     if (params.use_mmap.empty() && !params.use_direct_io.empty()) {
         params.use_mmap.push_back(false);
+    } else if (params.use_mmap.size() > 0 && params.use_direct_io.empty()) {
+        params.use_direct_io.push_back(false);
     } else if (params.use_mmap.size() != params.use_direct_io.size()) {
         // if both are specified, they must have the same number of values
         fprintf(stderr, "error: --mmap and --direct-io must have the same number of values\n");

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1071,7 +1071,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     // check if user specified `--direct-io` without `--mmap`
     // if so, we disable mmap to avoid the situation where they see no difference
     if (params.use_mmap.empty() && !params.use_direct_io.empty()) {
-        params.use_mmap.push_back(false);  // TODO: DOUBLE CHECK IF WE NEED TO false x params.use_direct_io.size()
+        params.use_mmap.push_back(false);
     } else if (params.use_mmap.size() != params.use_direct_io.size()) {
         // if both are specified, they must have the same number of values
         fprintf(stderr, "error: --mmap and --direct-io must have the same number of values\n");

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1068,6 +1068,22 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     if (params.tensor_buft_overrides.empty()) {
         params.tensor_buft_overrides = cmd_params_defaults.tensor_buft_overrides;
     }
+    // check if user specified `--direct-io` without `--mmap`
+    // if so, we disable mmap to avoid the situation where they see no difference
+    if (params.use_mmap.empty() && !params.use_direct_io.empty()) {
+        params.use_mmap.push_back(false);  // TODO: DOUBLE CHECK IF WE NEED TO false x params.use_direct_io.size()
+    } else if (params.use_mmap.size() != params.use_direct_io.size()) {
+        // if both are specified, they must have the same number of values
+        fprintf(stderr, "error: --mmap and --direct-io must have the same number of values\n");
+        exit(1);
+    } else {
+        for (size_t i = 0; i < params.use_direct_io.size(); ++i) {
+            if (params.use_direct_io[i] == true && params.use_mmap[i] == true) {
+                fprintf(stderr, "error: --direct-io cannot be enabled with --mmap\n");
+                exit(1);
+            }
+        }
+    }
     if (params.use_mmap.empty()) {
         params.use_mmap = cmd_params_defaults.use_mmap;
     }
@@ -2102,10 +2118,11 @@ int main(int argc, char ** argv) {
     fprintf(stderr, "warning: sanitizer enabled, performance may be affected\n");
 #endif
 
+    // parse command line parameters first to exit early if there are problems
+    cmd_params params = parse_cmd_params(argc, argv);
+
     // initialize backends
     ggml_backend_load_all();
-
-    cmd_params params = parse_cmd_params(argc, argv);
 
     auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
     if (!cpu_dev) {
@@ -2155,6 +2172,12 @@ int main(int argc, char ** argv) {
     auto params_count = params_instances.size();
     for (const auto & inst : params_instances) {
         params_idx++;
+
+        // skip test if use_mmap and use_direct_io are turned on
+        if (inst.use_mmap == true && inst.use_direct_io == true) {
+            continue;
+        }
+
         if (params.progress) {
             fprintf(stderr, "llama-bench: benchmark %d/%zu: starting\n", params_idx, params_count);
         }


### PR DESCRIPTION
Ref: https://github.com/ggml-org/llama.cpp/pull/20211#discussion_r2923702030

As mentioned in the thread referenced, users may inadvertently enable both `--mmap` and `--direct-io` together and notice no performance difference.

This PR adds additional safeguards during flag parsing to ensure that both `--mmap` and `--direct-io` cannot have the same enabled state. Also, moved the `ggml_backend_load_all` call just after the flag parsing function for `llama-bench` to fail early if any of the flags has an error.

### Test Cases

1. `--mmap` is enabled by default but the user specifies `--direct-io 1`

```console
$ build/bin/llama-bench -hf ibm-granite/granite-3.3-2b-instruct-GGUF:Q4_K_M --direct-io 1 

...truncated...
common_download_file_single_online: using cached file (same etag): /Users/taronaeo/Library/Caches/llama.cpp/ibm-granite_granite-3.3-2b-instruct-GGUF_granite-3.3-2b-instruct-Q4_K_M.gguf
| model                          |       size |     params | backend    | threads | mmap | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ---: | --: | --------------: | -------------------: |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   1 |           pp512 |       633.47 ± 44.96 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   1 |           tg128 |         59.78 ± 0.94 |

build: a320bed33 (8323)
```

2. `--mmap` and `--direct-io` arguments do not have the same number of values

```console
$ build/bin/llama-bench -hf ibm-granite/granite-3.3-2b-instruct-GGUF:Q4_K_M --mmap 1,0 --direct-io 1

...truncated...
common_download_file_single_online: using cached file (same etag): /Users/taronaeo/Library/Caches/llama.cpp/ibm-granite_granite-3.3-2b-instruct-GGUF_granite-3.3-2b-instruct-Q4_K_M.gguf
error: --mmap and --direct-io must have the same number of values
```

3. `--mmap` and `--direct-io` are turned on together

```console
$ build/bin/llama-bench -hf ibm-granite/granite-3.3-2b-instruct-GGUF:Q4_K_M --mmap 1,0 --direct-io 1,0

...truncated...
common_download_file_single_online: using cached file (same etag): /Users/taronaeo/Library/Caches/llama.cpp/ibm-granite_granite-3.3-2b-instruct-GGUF_granite-3.3-2b-instruct-Q4_K_M.gguf
error: --direct-io cannot be enabled with --mmap
```

4. Valid benchmark run

```console
$ build/bin/llama-bench -hf ibm-granite/granite-3.3-2b-instruct-GGUF:Q4_K_M --mmap 1,0 --direct-io 0,1

...truncated...
common_download_file_single_online: using cached file (same etag): /Users/taronaeo/Library/Caches/llama.cpp/ibm-granite_granite-3.3-2b-instruct-GGUF_granite-3.3-2b-instruct-Q4_K_M.gguf
| model                          |       size |     params | backend    | threads | mmap | dio |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ---: | --: | --------------: | -------------------: |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    1 |   0 |           pp512 |       652.69 ± 12.18 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    1 |   0 |           tg128 |         59.32 ± 0.24 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   0 |           pp512 |        659.92 ± 5.79 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   0 |           tg128 |         60.16 ± 0.13 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   1 |           pp512 |        663.38 ± 0.52 |
| granite 3B Q4_K - Medium       |   1.44 GiB |     2.53 B | MTL,BLAS   |       8 |    0 |   1 |           tg128 |         60.15 ± 0.10 |

build: a320bed33 (8323)
```