### PR TITLE
common : fix SIGSEGV in _visit_pattern when quantifier follows empty seq

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -450,7 +450,11 @@ private:
                     seq.emplace_back("|", false);
                     i++;
                 } else if (c == '*' || c == '+' || c == '?') {
-                    seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
+                    if (!seq.empty()) {
+                        seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
+                    } else {
+                        _warnings.push_back("Quantifier without preceding element in pattern");
+                    }
                     i++;
                 } else if (c == '{') {
                     std::string curly_brackets = std::string(1, c);


### PR DESCRIPTION
## Problem

`llama-server` crashes with SIGSEGV when processing requests containing tool definitions with a JSON schema `pattern` like:

```json
"pattern": "^$|^(?:-?\\d+[:-]-?\\d+)$"
```

This pattern is used in MCP tool servers (e.g. Figma MCP) for `nodeId` parameters. The crash happens on the **first request** that includes such tools.

## Root Cause

In `_visit_pattern()`, the `transform()` lambda is called recursively when a `(` is encountered. When the pattern contains `(?:`, the parser:

1. Sees `(`, increments `i`, sees `?`, pushes a warning — but does **not** increment `i` past `?`
2. Calls `transform()` recursively — `seq` is empty in the new frame
3. The recursive `transform()` immediately sees `?` as the first character
4. Falls into the quantifier branch: `seq.back() = ...` — **undefined behavior on empty vector → SIGSEGV**

## Fix

Add a guard before `seq.back()` in the quantifier case:

```cpp
} else if (c == '*' || c == '+' || c == '?') {
    if (!seq.empty()) {
        seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
    } else {
        _warnings.push_back("Quantifier without preceding element in pattern");
    }
    i++;
```

## Reproduction

Any request to `/v1/chat/completions` with a tool schema containing `"pattern": "^$|^(?:...)$"`.

GDB backtrace shows:
```
Thread received signal SIGSEGV
#0  common_schema_converter::_visit_pattern::{lambda#1}::operator()
#5  common_schema_converter::_visit_pattern
#6  common_schema_converter::visit
#7  common_schema_converter::_build_object_rule
#20 autoparser::peg_generator::generate_parser
#21 common_chat_templates_apply_jinja
#23 oaicompat_chat_params_parse
```

Tested and confirmed fixed on A100 SXM4-80GB (CUDA 12.6).