### PR TITLE
ggml-cuda : fix UMA memory detection for HIP/ROCm on AMD APUs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4607,7 +4607,14 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
 
     // Check if UMA is explicitly enabled via environment variable
     bool uma_env = getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr;
+
+#if defined(GGML_USE_HIP)
+    // On AMD APUs, prop.integrated is true but hipMemGetInfo() already returns
+    // the correct TTM-backed memory. Only use the UMA path when explicitly requested.
+    bool is_uma = uma_env;
+#else
     bool is_uma = prop.integrated > 0 || uma_env;
+#endif
 
     if (is_uma) {
         // For UMA systems (like DGX Spark), use system memory info

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4608,21 +4608,19 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
     // Check if UMA is explicitly enabled via environment variable
     bool uma_env = getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr;
 
-#if defined(GGML_USE_HIP)
-    // On AMD APUs, prop.integrated is true but hipMemGetInfo() already returns
-    // the correct TTM-backed memory. Only use the UMA path when explicitly requested.
-    bool is_uma = uma_env;
-#else
     bool is_uma = prop.integrated > 0 || uma_env;
-#endif // defined(GGML_USE_HIP)
 
     if (is_uma) {
-        // For UMA systems (like DGX Spark), use system memory info
         long available_memory_kb = 0;
         long free_swap_kb = 0;
 
         if (ggml_backend_cuda_get_available_uma_memory(&available_memory_kb, &free_swap_kb) && available_memory_kb > 0) {
-            *free = (size_t)available_memory_kb * 1024;
+            // use whichever value is higher — on some AMD APUs hipMemGetInfo already
+            // accounts for TTM-backed memory and returns more than /proc/meminfo
+            size_t proc_free = (size_t)available_memory_kb * 1024;
+            if (proc_free > *free) {
+                *free = proc_free;
+            }
         } else {
             GGML_LOG_ERROR("%s: /proc/meminfo reading failed, using cudaMemGetInfo\n", __func__);
         }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4614,7 +4614,7 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
     bool is_uma = uma_env;
 #else
     bool is_uma = prop.integrated > 0 || uma_env;
-#endif
+#endif // defined(GGML_USE_HIP)
 
     if (is_uma) {
         // For UMA systems (like DGX Spark), use system memory info


### PR DESCRIPTION
AMD APUs report `prop.integrated == 1`, which triggers the UMA memory detection from #17368. This replaces the accurate `hipMemGetInfo()` value with `MemAvailable` from `/proc/meminfo`, which reports significantly less memory on systems with large TTM allocations (e.g. 122 GiB vs 91 GiB on a 128GB Strix Halo system).

For HIP builds, skip the `prop.integrated` check and only enter the UMA path when `GGML_CUDA_ENABLE_UNIFIED_MEMORY` is explicitly set. This way `hipMemGetInfo()` is used by default (which correctly reports TTM-backed memory), while the explicit env var override still works for users who need it.

Verified on AMD Ryzen AI MAX+ 395 (gfx1151, 128GB unified memory, ROCm 7.1) that `prop.integrated` returns 1 and `hipMemGetInfo()` returns 122880 MiB while `MemAvailable` reports ~91 GiB.

Fixes #18159

Related: #19818, #19764, #18650