### PR TITLE
vulkan: fix SSM_CONV crash on multi-GPU (#20462)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4607,7 +4607,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
         ggml_vk_create_pipeline(device, device->pipeline_ssm_scan_f32_d256, "ssm_scan_256_f32", ssm_scan_f32_len, ssm_scan_f32_data, "main", 8, sizeof(vk_op_ssm_scan_push_constants), {1, 1, 1}, {256, device->subgroup_size, 16}, 1, true, true);
     }
 
-    ggml_vk_create_pipeline(device, device->pipeline_ssm_conv_f32, "ssm_conv_f32", ssm_conv_f32_len, ssm_conv_f32_data, "main", 3, sizeof(vk_op_ssm_conv_push_constants), {32, 16, 1}, {32, 16}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_ssm_conv_f32, "ssm_conv_f32", ssm_conv_f32_len, ssm_conv_f32_data, "main", 3, sizeof(vk_op_ssm_conv_push_constants), {32, 1, 1}, {32}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_opt_step_adamw_f32, "opt_step_adamw_f32", opt_step_adamw_f32_len, opt_step_adamw_f32_data, "main", 5, sizeof(vk_op_push_constants), {512, 1, 1}, {}, 1);
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/ssm_conv.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/ssm_conv.comp
@@ -5,9 +5,8 @@
 #include "types.glsl"
 
 layout(constant_id = 0) const uint BLOCK_SIZE = 32;
-layout(constant_id = 1) const uint TOKENS_PER_WG = 16;
 
-layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer Src0 { float src0[]; };
 layout(binding = 1) readonly buffer Src1 { float src1[]; };
@@ -22,7 +21,7 @@ layout(push_constant) uniform PushConstants {
 
 void main() {
     const uint i1 = gl_GlobalInvocationID.x;
-    const uint i2 = gl_WorkGroupID.y * TOKENS_PER_WG + gl_LocalInvocationID.y;
+    const uint i2 = gl_WorkGroupID.y;
     const uint i3 = gl_WorkGroupID.z;
 
     if (i1 >= nr || i2 >= n_t || i3 >= n_s) {


### PR DESCRIPTION
Reverts the 2D workgroup tiling (32x16) from #20379 which causes `vk::DeviceLostError` on multi-GPU RADV setups. Keeps the vec4 dot product fast path for nc=4.

The 2D tiling reduced workgroup launch overhead at large ubatch sizes, but triggers a driver-level fault on multi-GPU configurations (confirmed on dual 7900 XTX, bisected to 40c550d).

Based on master at 983df14.

Fixes #20462

## Test plan
- [ ] @itterative: confirm crash reproduces on master (983df14) with multi-GPU
- [ ] @itterative: confirm this branch fixes the crash
- [ ] Single-GPU SSM_CONV test-backend-ops pass (verified, 45/45)