### PR TITLE
cuda: pass dummy total_mem instead of NULL to cudaMemGetInfo

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -253,8 +253,11 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         // cudaMemGetInfo returns info for the current device
         size_t free_mem;
+        // Pass a dummy variable for total memory instead of NULL, because some third-party
+        // CUDA implementations do not validate the pointer and will segfault on NULL.
+        size_t total_mem_dummy;
         CUDA_CHECK(cudaSetDevice(id));
-        CUDA_CHECK(cudaMemGetInfo(&free_mem, NULL));
+        CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem_dummy));
 
 #if defined(GGML_USE_HIP)
         info.devices[id].smpbo = prop.sharedMemPerBlock;


### PR DESCRIPTION
We use [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to limit the gpu vram of k8s containers, but the hook of HAMI-core expect the `free` and `total` params of `cudaMemGetInfo` not to be NULL. And it does not check for the case where a null `total` is passed in. When I run llama.cpp inside containers, I just got a segfault:

```
Starting program: /root/llama.cpp/build/bin/llama-cli 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7fffb3e14000 (LWP 3063409)]
[New Thread 0x7fffb0bff000 (LWP 3063413)]
[Thread 0x7fffb0bff000 (LWP 3063413) exited]
[New Thread 0x7fffb0bff000 (LWP 3063414)]
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 32768 MiB):
[New Thread 0x7fffa5fff000 (LWP 3063415)]

Thread 1 "llama-cli" received signal SIGSEGV, Segmentation fault.
0x00007ffff7f9133b in cuMemGetInfo_v2 (free=0x7ffffffe8a28, total=0x0) at /libvgpu/src/cuda/memory.c:512
```

The meminfo hook code source of HAMI-core: 

https://github.com/Project-HAMi/HAMi-core/blob/54b0ca3c777b5125e21ae602c82c59bc243be696/src/cuda/memory.c#L491-L519

In case of some other third-party cuda or vgpu implementions may also have the same issues, there should be a dummy `total_mem` passing to the `cudaMemGetInfo`.