### PR TITLE
server: reset counter related to kill-switch on client error

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1190,6 +1190,7 @@ private:
             : SLOT_STATE_STARTED;
 
         SLT_INF(slot, "processing task, is_child = %d\n", slot.task->is_child());
+        n_empty_consecutive = 0; // Reset server kill-switch counter
         return true;
     }
 
@@ -2220,7 +2221,6 @@ private:
                                                          "tokens), try increasing it",
                                                          slot.task->n_tokens(), slot.n_ctx),
                                            ERROR_TYPE_EXCEED_CONTEXT_SIZE);
-                                n_empty_consecutive = 0; // Reset server kill-switch counter, client error should not kill the server
                                 slot.release();
                                 continue;
                             }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1189,8 +1189,10 @@ private:
             ? SLOT_STATE_WAIT_OTHER // wait for the parent to process prompt
             : SLOT_STATE_STARTED;
 
+        // reset server kill-switch counter
+        n_empty_consecutive = 0;
+
         SLT_INF(slot, "processing task, is_child = %d\n", slot.task->is_child());
-        n_empty_consecutive = 0; // Reset server kill-switch counter
         return true;
     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2220,6 +2220,7 @@ private:
                                                          "tokens), try increasing it",
                                                          slot.task->n_tokens(), slot.n_ctx),
                                            ERROR_TYPE_EXCEED_CONTEXT_SIZE);
+                                n_empty_consecutive = 0; // Reset server kill-switch counter, client error should not kill the server
                                 slot.release();
                                 continue;
                             }


### PR DESCRIPTION
This avoids inadvertently triggering a server kill switch.

If the client sends a request that exceeds the configured context size, an appropriate HTTP 400 response is provided and no tokens are generated.

However since no tokens are generated, update_slots() increments n_empty_consecutive. If the client sends 4 such messages in a row, the server terminates.

This change resets the counter when the client's request exceeds `--ctx-size`. While I was looking at this, neighboring code had similar patterns relating to the same `ERROR_TYPE_EXCEED_CONTEXT_SIZE`, however I'm not familiar with those other conditions.

Steps to reproduce issue:
1. Start llama-server with a tiny context e.g. `--ctx-size 10`
2. Send text that exceeds the context size 4 times in a row