### PR TITLE
devops: force Python 3.13 in Vulkan container

### DIFF
--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update \
     python3-pip \
     python3-wheel \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 100 \
-    && update-alternatives --set python3 /usr/bin/python3.13 \
     && pip install --break-system-packages --upgrade setuptools \
     && pip install --break-system-packages -r requirements.txt \
     && apt autoremove -y \

--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -53,10 +53,12 @@ RUN apt-get update \
     && apt-get install -y \
     build-essential \
     git \
-    python3 \
-    python3-dev \
+    python3.13 \
+    python3.13-dev \
     python3-pip \
     python3-wheel \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 100 \
+    && update-alternatives --set python3 /usr/bin/python3.13 \
     && pip install --break-system-packages --upgrade setuptools \
     && pip install --break-system-packages -r requirements.txt \
     && apt autoremove -y \


### PR DESCRIPTION
Forces Python 3.13 in the Vulkan container image build to support PyTorch 2.6.

Fixes #20524.