### PR TITLE
gguf: include MTP tensors for Qwen3-Next and Qwen3.5 models

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4662,9 +4662,49 @@ class Qwen3NextModel(Qwen2MoeModel):
             rope_dim = self.hparams["hidden_size"] // self.hparams["num_attention_heads"]
         self.gguf_writer.add_rope_dimension_count(int(rope_dim * self.hparams.get("partial_rotary_factor", 0.25)))
 
+        # MTP (multi-token prediction) support
+        n_mtp = self.hparams.get("mtp_num_hidden_layers", 0)
+        if n_mtp > 0:
+            self.block_count = self.hparams["num_hidden_layers"] + n_mtp
+            self.gguf_writer.add_block_count(self.block_count)
+            self.gguf_writer.add_nextn_predict_layers(n_mtp)
+
+    _mtp_remapper = {
+        "mtp.fc":                  "model.layers.{bid}.eh_proj",
+        "mtp.pre_fc_norm_embedding": "model.layers.{bid}.enorm",
+        "mtp.pre_fc_norm_hidden":  "model.layers.{bid}.hnorm",
+        "mtp.norm":                "model.layers.{bid}.shared_head.norm",
+    }
+
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        if name.startswith("mtp"):
-            return  # ignore MTP layers for now
+        if name.startswith("mtp."):
+            n_main = self.hparams["num_hidden_layers"]
+            n_mtp = self.hparams.get("mtp_num_hidden_layers", 0)
+            if n_mtp == 0:
+                return  # MTP not configured
+
+            if "layers." in name:
+                # mtp.layers.{i}.* -> model.layers.{n_main + i}.*
+                import re
+                m = re.match(r"mtp\.layers\.(\d+)\.(.*)", name)
+                if m:
+                    mtp_idx = int(m.group(1))
+                    rest = m.group(2)
+                    name = f"model.layers.{n_main + mtp_idx}.{rest}"
+                    bid = n_main + mtp_idx
+            else:
+                # Non-layer MTP tensors (fc, norms): map to NEXTN names
+                stem = name.rsplit(".", 1)[0]  # e.g. "mtp.fc"
+                suffix = "." + name.rsplit(".", 1)[1]  # e.g. ".weight"
+                if stem in self._mtp_remapper:
+                    template = self._mtp_remapper[stem]
+                    for mtp_bid in range(n_main, n_main + n_mtp):
+                        new_name = template.format(bid=mtp_bid) + suffix
+                        yield from super().modify_tensors(data_torch, new_name, mtp_bid)
+                    return
+                else:
+                    logger.warning(f"Unknown MTP tensor: {name}")
+                    return
         if name.endswith(".A_log"):
             data_torch = -torch.exp(data_torch)
         elif name.endswith(".dt_bias"):

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1024,6 +1024,13 @@ static std::set<llm_tensor> llm_get_tensor_names(llm_arch arch) {
                 LLM_TENSOR_SSM_IN,
                 LLM_TENSOR_SSM_NORM,
                 LLM_TENSOR_SSM_OUT,
+                LLM_TENSOR_FFN_NORM,
+                LLM_TENSOR_NEXTN_EH_PROJ,
+                LLM_TENSOR_NEXTN_EMBED_TOKENS,
+                LLM_TENSOR_NEXTN_ENORM,
+                LLM_TENSOR_NEXTN_HNORM,
+                LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,
+                LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,
             };
         case LLM_ARCH_QWEN35:
             return {
@@ -1082,6 +1089,13 @@ static std::set<llm_tensor> llm_get_tensor_names(llm_arch arch) {
                 LLM_TENSOR_SSM_ALPHA,
                 LLM_TENSOR_SSM_NORM,
                 LLM_TENSOR_SSM_OUT,
+                LLM_TENSOR_FFN_NORM,
+                LLM_TENSOR_NEXTN_EH_PROJ,
+                LLM_TENSOR_NEXTN_EMBED_TOKENS,
+                LLM_TENSOR_NEXTN_ENORM,
+                LLM_TENSOR_NEXTN_HNORM,
+                LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,
+                LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,
             };
         case LLM_ARCH_QWEN3VL:
         case LLM_ARCH_CHAMELEON:


### PR DESCRIPTION
## Summary

Qwen3-Next and Qwen3.5 models ship with multi-token prediction (MTP) heads, but the GGUF converter currently ignores them (`if name.startswith("mtp"): return`). This prevents any MTP-based speculative decoding from being tested on these architectures.

This PR includes the MTP tensors in the GGUF output:

- **convert_hf_to_gguf.py**: Map `mtp.layers.{i}.*` tensors to block indices above `num_hidden_layers`, and map non-layer MTP tensors (`mtp.fc`, `mtp.pre_fc_norm_*`, `mtp.norm`) to NEXTN tensor names. Set `nextn_predict_layers` metadata from `mtp_num_hidden_layers` config.
- **llama-arch.cpp**: Add `FFN_NORM` and `NEXTN_*` tensors to `QWEN3NEXT` and `QWEN35MOE` architecture definitions.

## Details

The MTP layer in Qwen3.5-122B-A10B is a full attention + MoE block (not DeltaNet), matching the model's `full_attention_interval=4` pattern. At layer index 48 (= `num_hidden_layers`), `48 % 4 == 0`, so it naturally falls on an attention layer slot.

Verified tensor mapping against [Qwen3.5-122B-A10B](https://huggingface.co/Qwen/Qwen3.5-122B-A10B): 785 MTP tensors (768 expert + 17 non-expert) are correctly remapped.

Follows the same pattern used by DeepSeek V3 MTP conversion (line 9683+).

## Scope

**Conversion-only.** No graph builder or inference changes. The tensors are loaded but unused until a MTP graph builder is added. This unblocks:
- PR #18886 (MTP API by ngxson) for Qwen3.5 support
- Community testing of MTP on DeltaNet+MoE hybrid models
- GGUF files that include MTP weights for future use

## Test plan

- [ ] Convert Qwen3.5-122B-A10B with MTP tensors included, verify GGUF loads without errors
- [ ] Verify `nextn_predict_layers=1` in GGUF metadata
- [ ] Verify existing inference (without MTP) is unaffected (MTP tensors loaded but not used in graph)
- [ ] Convert Qwen3-Coder-Next model, verify same behavior