### PR TITLE
chat: fix thinking support for Kimi K2 Thinking and K2.5

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1167,19 +1167,30 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
                                                           const autoparser::templates_params & inputs) {
     common_chat_params data;
 
-    data.prompt             = common_chat_template_direct_apply(tmpl, inputs);
-    data.format             = COMMON_CHAT_FORMAT_PEG_NATIVE;
-    data.supports_thinking  = true;
-    data.thinking_start_tag = "<think>";
-    data.thinking_end_tag   = "</think>";
-    data.preserved_tokens  = {
-        "<|tool_calls_section_begin|>",
-        "<|tool_calls_section_end|>",
-        "<|tool_call_begin|>",
-        "<|tool_call_argument_begin|>",
-        "<|tool_call_end|>",
-        "<think>",
-        "</think>",
+    // Tool call markers
+    const std::string SECTION_BEGIN = "<|tool_calls_section_begin|>";
+    const std::string SECTION_END   = "<|tool_calls_section_end|>";
+    const std::string CALL_BEGIN    = "<|tool_call_begin|>";
+    const std::string ARGS_BEGIN    = "<|tool_call_argument_begin|>";
+    const std::string CALL_END      = "<|tool_call_end|>";
+
+    const std::string THINK_START   = "<think>";
+    const std::string THINK_END     = "</think>";
+
+    data.prompt               = common_chat_template_direct_apply(tmpl, inputs);
+    data.format               = COMMON_CHAT_FORMAT_PEG_NATIVE;
+    data.supports_thinking    = true;
+    data.thinking_forced_open = inputs.enable_thinking;
+    data.thinking_start_tag   = THINK_START;
+    data.thinking_end_tag     = THINK_END;
+    data.preserved_tokens     = {
+        SECTION_BEGIN,
+        SECTION_END,
+        CALL_BEGIN,
+        ARGS_BEGIN,
+        CALL_END,
+        THINK_START,
+        THINK_END,
     };
 
     auto has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
@@ -1197,24 +1208,16 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
         //   <|tool_calls_section_end|>
         // The ID format is: functions.<function_name>:<counter> where counter is 0, 1, 2, ...
 
-                // Tool call markers
-        const std::string SECTION_BEGIN = "<|tool_calls_section_begin|>";
-        const std::string SECTION_END   = "<|tool_calls_section_end|>";
-        const std::string CALL_BEGIN    = "<|tool_call_begin|>";
-        const std::string ARGS_BEGIN    = "<|tool_call_argument_begin|>";
-        const std::string CALL_END      = "<|tool_call_end|>";
-
-        const std::string THINK_START   = "<think>";
-        const std::string THINK_END     = "</think>";
-
         auto end = p.end();
 
         // Note: this model is CRAZY. It can diverge from its supposed tool calling pattern in so many ways it's not funny.
         // For example, it can call tools at the end of reasoning without closing reasoning...
-        auto reasoning = extract_reasoning ? p.optional(THINK_START + p.reasoning(
-            p.until_one_of({ THINK_END, "<|tool_calls_section_begin|>", "<|tool_call_begin|>" })) +
-            p.optional(p.literal(THINK_END))) : p.eps();
-
+        auto reasoning = p.eps();
+        if (extract_reasoning && inputs.enable_thinking) {
+            reasoning = p.optional(p.literal(THINK_START)) +
+                        p.reasoning(p.until_one_of({ THINK_END, SECTION_BEGIN, CALL_BEGIN })) +
+                        p.literal(THINK_END);
+        }
 
         // Content only parser (no tools)
         if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
@@ -1271,7 +1274,7 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
         });
 
         data.grammar_triggers = {
-            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<|tool_call_begin|>" }
+            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, CALL_BEGIN }
         };
     }
 


### PR DESCRIPTION
After the recent chat template parser refactoring, the Kimi K2 Thinking/K2.5 thinking/reasoning support remained broken. The template injects the <think> tag in the prompt, but the parser was not correctly handling reasoning extraction. Please see the issue #20008 for details.

I also moved tool call and thinking marker constants to function scope for reuse. I also used "if" block instead of a ternary operator, but the logic is the same, except now it properly handles thinking.

Fixes #20008

The previous attempt at fixing this (PR #19234) no longer applies after the refactoring and remained unupdated. I wrote this implementation to fix the #20008 issue in the new refactored code after the autoparser was added.

I have tested with `--reasoning-budget` set to both `-1` (enable thinking) and `0` (disabled thinking) using Kimi K2.5 and Kimi K2 Thinking. I also verified that K2 0905 (the non-thinking model) still works correctly.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
