### PR TITLE
 ggml/hip: fix APU compatibility - soft error handling for hipMemAdviseSetCoarseGrain

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -119,12 +119,6 @@ int ggml_cuda_get_device() {
 
 static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
     ggml_cuda_set_device(device);
-    {
-        size_t mem_free = 0, mem_total = 0;
-        cudaMemGetInfo(&mem_free, &mem_total);
-        GGML_LOG_DEBUG("%s: before alloc %.2f MiB, free %.2f MiB / total %.2f MiB\n",
-            __func__, size/1024.0/1024.0, mem_free/1024.0/1024.0, mem_total/1024.0/1024.0);
-    }
     cudaError_t err;
     if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
         err = cudaMallocManaged(ptr, size);
@@ -247,7 +241,6 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
-        info.devices[id].total_vram = prop.totalGlobalMem;
         info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
         info.devices[id].nsm        = prop.multiProcessorCount;
         info.devices[id].smpb       = prop.sharedMemPerBlock;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -119,12 +119,21 @@ int ggml_cuda_get_device() {
 
 static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
     ggml_cuda_set_device(device);
+    {
+        size_t mem_free = 0, mem_total = 0;
+        cudaMemGetInfo(&mem_free, &mem_total);
+        GGML_LOG_DEBUG("%s: before alloc %.2f MiB, free %.2f MiB / total %.2f MiB\n",
+            __func__, size/1024.0/1024.0, mem_free/1024.0/1024.0, mem_total/1024.0/1024.0);
+    }
     cudaError_t err;
     if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
         err = cudaMallocManaged(ptr, size);
 #if defined(GGML_USE_HIP)
         if (err == hipSuccess) {
-            CUDA_CHECK(cudaMemAdvise(*ptr, size, hipMemAdviseSetCoarseGrain, device));
+            // hipMemAdviseSetCoarseGrain is an optional performance hint;
+            // ignore errors (e.g. hipErrorInvalidValue on some APU/iGPU configs).
+            cudaMemAdvise(*ptr, size, hipMemAdviseSetCoarseGrain, device);
+            (void)hipGetLastError(); // clear any error
         }
 
         // fall back to cudaMalloc if not supported (e.g. on Windows)
@@ -238,6 +247,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
+        info.devices[id].total_vram = prop.totalGlobalMem;
         info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
         info.devices[id].nsm        = prop.multiProcessorCount;
         info.devices[id].smpb       = prop.sharedMemPerBlock;


### PR DESCRIPTION
 Description:
  ## Problem

  On AMD APU/iGPU devices (unified memory architecture, e.g. AMD Strix Halo gfx1151), `hipMemAdviseSetCoarseGrain` returns
  `hipErrorInvalidValue` because this hint is not applicable to UMA systems. The current code wraps this call in `CUDA_CHECK()`, which treats
  it as a fatal error and crashes.

  ## Fix

  Treat `hipMemAdviseSetCoarseGrain` as an **optional performance hint**:
  - Remove `CUDA_CHECK()` wrapper
  - Clear any resulting error with `hipGetLastError()` to prevent propagation

  This matches the intent of the existing comment ("fall back to cudaMalloc if not supported") and is consistent with how optional hints are
  handled elsewhere.

  ## Additional Changes

  - Add `GGML_LOG_DEBUG` pre-allocation memory logging to help diagnose memory issues on APU systems
  - Store `totalGlobalMem` in device info struct for future use

  ## Testing

  Tested on AMD Strix Halo (gfx1151), 128GB unified memory, Windows 11:
  - ✅ Before: crash on `hipMemAdviseSetCoarseGrain` with `hipErrorInvalidValue`
  - ✅ After: runs successfully, no error propagation

  ## Context: ROCm APU Large BAR Bug

  AMD APUs on Windows are currently limited to ~64GB `hipMallocManaged` allocations due to a ROCm runtime bug where `largeBar_` is
  unconditionally disabled for all APU devices in HIP mode. This causes the Windows GART allocator's 50%-of-RAM cap to trigger prematurely.

  A fix has been submitted to ROCm upstream:
  **https://github.com/ROCm/rocm-systems/pull/4077**

  Without that ROCm fix, APUs are still limited to ~64GB regardless of this change. However, this PR is independently valuable:
  1. Prevents crashes on APUs with current ROCm versions
  2. Enables full functionality once users update to a patched ROCm runtime
  3. The debug logging helps users diagnose memory allocation issues

  ## Impact

  - ✅ APU/iGPU users: no more crashes when using `GGML_CUDA_ENABLE_UNIFIED_MEMORY`
  - ✅ Discrete GPU users: no change (hint is valid and still applied)
  - ✅ No performance regression