### PR TITLE
ci : reduce webgpu tests timeout to 900s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -542,7 +542,7 @@ jobs:
         run: |
           cd build
           # This is using llvmpipe and runs slower than other backends
-          ctest -L main --verbose --timeout 3600
+          ctest -L main --verbose --timeout 900
 
   ubuntu-24-wasm-webgpu:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The `test-thread-safety` test has been recently getting stuck with the WebGPU backend causing long runs. Reduce the timeout from 3600s -> 900s to reduce the CI hangs.

https://github.com/ggml-org/llama.cpp/actions/runs/23063874570/job/66997161164#step:10:17552
https://github.com/ggml-org/llama.cpp/actions/runs/23045127401/job/66932266420#step:10:17632
https://github.com/ggml-org/llama.cpp/actions/runs/22998877128/job/66778103540#step:10:17630

cc @reeselevine 